### PR TITLE
fix(status): restore k8s application address in status

### DIFF
--- a/apiserver/facades/client/client/fullstatus_test.go
+++ b/apiserver/facades/client/client/fullstatus_test.go
@@ -446,6 +446,55 @@ func (s *fullStatusSuite) TestFullStatusExposedEndpointsFetchedInBulk(c *tc.C) {
 	})
 }
 
+func (s *fullStatusSuite) TestFullStatusCAASApplicationAddress(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	client := s.client(false)
+	s.expectCheckCanRead(client, true)
+	s.expectCheckIsAdmin(client, false)
+
+	s.applicationService.EXPECT().GetUnitsK8sPodInfo(gomock.Any()).Return(nil, nil)
+	s.modelInfoService.EXPECT().GetModelInfo(c.Context()).Return(model.ModelInfo{
+		Cloud:     "k8s",
+		CloudType: "k8s",
+		Type:      model.CAAS,
+	}, nil)
+	s.statusService.EXPECT().GetModelStatus(gomock.Any()).Return(status.StatusInfo{
+		Status: status.Available,
+	}, nil)
+	s.applicationService.EXPECT().GetAllEndpointBindings(gomock.Any()).Return(nil, nil)
+	s.statusService.EXPECT().GetApplicationAndUnitStatuses(gomock.Any()).Return(map[string]service.Application{
+		"postgresql-k8s": {
+			CharmLocator: charm.CharmLocator{
+				Name:         "postgresql-k8s",
+				Revision:     774,
+				Source:       charm.CharmHubSource,
+				Architecture: architecture.AMD64,
+			},
+			Platform: deployment.Platform{
+				OSType:  deployment.Ubuntu,
+				Channel: "22.04/stable",
+			},
+			Status: status.StatusInfo{
+				Status: status.Active,
+			},
+			Scale:            new(3),
+			K8sProviderID:    new("provider-id"),
+			K8sPublicAddress: new("10.102.137.7"),
+		},
+	}, nil)
+	s.statusService.EXPECT().GetRemoteApplicationOffererStatuses(gomock.Any()).Return(nil, nil)
+	s.portService.EXPECT().GetAllOpenedPorts(gomock.Any()).Return(nil, nil)
+	s.networkService.EXPECT().GetAllSpaces(gomock.Any()).Return(nil, nil)
+	s.networkService.EXPECT().GetAllDevicesByMachineNames(gomock.Any()).Return(nil, nil)
+	s.relationService.EXPECT().GetAllRelationDetails(gomock.Any()).Return(nil, nil)
+
+	output, err := client.FullStatus(c.Context(), params.StatusParams{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(output.Applications["postgresql-k8s"].PublicAddress, tc.Equals, "10.102.137.7")
+	c.Check(output.Applications["postgresql-k8s"].ProviderId, tc.Equals, "provider-id")
+}
+
 func (s *fullStatusSuite) TestFullStatusFilteredByApplicationName(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1094,7 +1094,9 @@ func (c *statusContext) processApplication(ctx context.Context, name string, app
 	// Handle CAAS applications fields independently of the IAAS ones.
 	if providerID := application.K8sProviderID; providerID != nil {
 		processedStatus.ProviderId = *providerID
-		// TODO (stickupkid): Add addresses to the status for k8s applications.
+	}
+	if publicAddress := application.K8sPublicAddress; publicAddress != nil {
+		processedStatus.PublicAddress = *publicAddress
 	}
 
 	if scale := application.Scale; scale != nil {

--- a/domain/status/service/service.go
+++ b/domain/status/service/service.go
@@ -1190,20 +1190,21 @@ func (s *Service) decodeApplicationStatusDetails(app status.Application) (Applic
 	}
 
 	return Application{
-		Life:            life,
-		Status:          decodedStatus,
-		Relations:       app.Relations,
-		Subordinate:     app.Subordinate,
-		CharmLocator:    app.CharmLocator,
-		CharmVersion:    app.CharmVersion,
-		Platform:        app.Platform,
-		Channel:         app.Channel,
-		Exposed:         app.Exposed,
-		LXDProfile:      lxdProfile,
-		Scale:           app.Scale,
-		WorkloadVersion: app.WorkloadVersion,
-		K8sProviderID:   app.K8sProviderID,
-		Units:           units,
+		Life:             life,
+		Status:           decodedStatus,
+		Relations:        app.Relations,
+		Subordinate:      app.Subordinate,
+		CharmLocator:     app.CharmLocator,
+		CharmVersion:     app.CharmVersion,
+		Platform:         app.Platform,
+		Channel:          app.Channel,
+		Exposed:          app.Exposed,
+		LXDProfile:       lxdProfile,
+		Scale:            app.Scale,
+		WorkloadVersion:  app.WorkloadVersion,
+		K8sProviderID:    app.K8sProviderID,
+		K8sPublicAddress: app.K8sPublicAddress,
+		Units:            units,
 	}, nil
 }
 

--- a/domain/status/service/service_test.go
+++ b/domain/status/service/service_test.go
@@ -1466,10 +1466,11 @@ func (s *serviceSuite) TestGetApplicationAndUnitStatuses(c *tc.C) {
 					Risk:   deployment.RiskCandidate,
 					Branch: "test",
 				},
-				LXDProfile:    []byte(`{}`),
-				Exposed:       true,
-				Scale:         new(2),
-				K8sProviderID: new("k8s-provider-id"),
+				LXDProfile:       []byte(`{}`),
+				Exposed:          true,
+				Scale:            new(2),
+				K8sProviderID:    new("k8s-provider-id"),
+				K8sPublicAddress: new("10.102.137.7"),
 				Units: map[coreunit.Name]status.Unit{
 					"foo/666": {
 						Life: life.Alive,
@@ -1541,10 +1542,11 @@ func (s *serviceSuite) TestGetApplicationAndUnitStatuses(c *tc.C) {
 				Risk:   deployment.RiskCandidate,
 				Branch: "test",
 			},
-			LXDProfile:    &internalcharm.LXDProfile{},
-			Exposed:       true,
-			Scale:         new(2),
-			K8sProviderID: new("k8s-provider-id"),
+			LXDProfile:       &internalcharm.LXDProfile{},
+			Exposed:          true,
+			Scale:            new(2),
+			K8sProviderID:    new("k8s-provider-id"),
+			K8sPublicAddress: new("10.102.137.7"),
 			Units: map[coreunit.Name]Unit{
 				"foo/666": {
 					Life: corelife.Alive,
@@ -1619,10 +1621,11 @@ func (s *serviceSuite) TestGetApplicationAndUnitModelStatusesDeriveApplicationSt
 					Risk:   deployment.RiskCandidate,
 					Branch: "test",
 				},
-				LXDProfile:    []byte(`{}`),
-				Exposed:       true,
-				Scale:         new(2),
-				K8sProviderID: new("k8s-provider-id"),
+				LXDProfile:       []byte(`{}`),
+				Exposed:          true,
+				Scale:            new(2),
+				K8sProviderID:    new("k8s-provider-id"),
+				K8sPublicAddress: new("10.102.137.7"),
 				Units: map[coreunit.Name]status.Unit{
 					"foo/666": {
 						Life: life.Alive,
@@ -1694,10 +1697,11 @@ func (s *serviceSuite) TestGetApplicationAndUnitModelStatusesDeriveApplicationSt
 				Risk:   deployment.RiskCandidate,
 				Branch: "test",
 			},
-			LXDProfile:    &internalcharm.LXDProfile{},
-			Exposed:       true,
-			Scale:         new(2),
-			K8sProviderID: new("k8s-provider-id"),
+			LXDProfile:       &internalcharm.LXDProfile{},
+			Exposed:          true,
+			Scale:            new(2),
+			K8sProviderID:    new("k8s-provider-id"),
+			K8sPublicAddress: new("10.102.137.7"),
 			Units: map[coreunit.Name]Unit{
 				"foo/666": {
 					Life: corelife.Alive,

--- a/domain/status/service/types.go
+++ b/domain/status/service/types.go
@@ -23,20 +23,21 @@ import (
 
 // Application represents the status of an application.
 type Application struct {
-	Life            life.Value
-	Status          status.StatusInfo
-	Relations       []relation.UUID
-	Subordinate     bool
-	CharmLocator    charm.CharmLocator
-	CharmVersion    string
-	Platform        deployment.Platform
-	Channel         *deployment.Channel
-	Exposed         bool
-	LXDProfile      *internalcharm.LXDProfile
-	Scale           *int
-	WorkloadVersion *string
-	K8sProviderID   *string
-	Units           map[unit.Name]Unit
+	Life             life.Value
+	Status           status.StatusInfo
+	Relations        []relation.UUID
+	Subordinate      bool
+	CharmLocator     charm.CharmLocator
+	CharmVersion     string
+	Platform         deployment.Platform
+	Channel          *deployment.Channel
+	Exposed          bool
+	LXDProfile       *internalcharm.LXDProfile
+	Scale            *int
+	WorkloadVersion  *string
+	K8sProviderID    *string
+	K8sPublicAddress *string
+	Units            map[unit.Name]Unit
 }
 
 // Unit represents the status of a unit.

--- a/domain/status/state/model/modelstate.go
+++ b/domain/status/state/model/modelstate.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"net"
+	"slices"
 	"sort"
 	"time"
 
@@ -1595,35 +1596,62 @@ func (st *ModelState) GetApplicationAndUnitStatuses(ctx context.Context) (map[st
 func (st *ModelState) getApplicationsStatuses(ctx context.Context, tx *sqlair.TX) (map[string]status.Application, error) {
 	// Get all the applications.
 	query, err := st.Prepare(`
+WITH selected_k8s_service_address AS (
+  -- Pick one CAAS app address for status by display priority, then
+  -- alphabetical order within the chosen class.
+  SELECT DISTINCT
+    svc.application_uuid,
+    (
+      SELECT ipa.address_value
+      FROM   k8s_service AS candidate_svc
+      JOIN   link_layer_device AS lld
+             ON lld.net_node_uuid = candidate_svc.net_node_uuid
+      JOIN   ip_address AS ipa ON ipa.device_uuid = lld.uuid
+      WHERE  candidate_svc.application_uuid = svc.application_uuid
+      AND    ipa.scope_id IN (1, 2) /* public, local-cloud */
+      AND    ipa.type_id IN (0, 1) /* IPv4, IPv6 */
+      ORDER BY
+        CASE
+          WHEN ipa.scope_id = 1 AND ipa.type_id = 0 THEN 1
+          WHEN ipa.scope_id = 1 AND ipa.type_id = 1 THEN 2
+          WHEN ipa.scope_id = 2 AND ipa.type_id = 0 THEN 3
+          WHEN ipa.scope_id = 2 AND ipa.type_id = 1 THEN 4
+        END,
+        ipa.address_value
+      LIMIT 1
+    ) AS address_value
+  FROM   k8s_service AS svc
+)
 SELECT
-	a.name AS &applicationStatusDetails.name,
-	a.uuid AS &applicationStatusDetails.uuid,
-	a.life_id AS &applicationStatusDetails.life_id,
-	ap.os_id AS &applicationStatusDetails.platform_os_id,
-	ap.channel AS &applicationStatusDetails.platform_channel,
-	ap.architecture_id AS &applicationStatusDetails.platform_architecture_id,
-	ac.track AS &applicationStatusDetails.channel_track,
-	ac.risk AS &applicationStatusDetails.channel_risk,
-	ac.branch AS &applicationStatusDetails.channel_branch,
-	cm.subordinate AS &applicationStatusDetails.subordinate,
-	s.status_id AS &applicationStatusDetails.status_id,
-	s.message AS &applicationStatusDetails.message,
-	s.data AS &applicationStatusDetails.data,
-	s.updated_at AS &applicationStatusDetails.updated_at,
-	re.relation_uuid AS &applicationStatusDetails.relation_uuid,
-	c.reference_name AS &applicationStatusDetails.charm_reference_name,
-	c.revision AS &applicationStatusDetails.charm_revision,
-	cs.name AS &applicationStatusDetails.charm_source,
-	c.architecture_id AS &applicationStatusDetails.charm_architecture_id,
-	c.version AS &applicationStatusDetails.charm_version,
-	c.lxd_profile AS &applicationStatusDetails.lxd_profile,
-	aps.scale AS &applicationStatusDetails.scale,
-	k8s.provider_id AS &applicationStatusDetails.k8s_provider_id,
-	EXISTS(
-		SELECT 1 FROM v_application_exposed_endpoint AS ae
-		WHERE ae.application_uuid = a.uuid
-	) AS &applicationStatusDetails.exposed,
-	awv.version AS &applicationStatusDetails.workload_version
+  a.name AS &applicationStatusDetails.name,
+  a.uuid AS &applicationStatusDetails.uuid,
+  a.life_id AS &applicationStatusDetails.life_id,
+  ap.os_id AS &applicationStatusDetails.platform_os_id,
+  ap.channel AS &applicationStatusDetails.platform_channel,
+  ap.architecture_id AS &applicationStatusDetails.platform_architecture_id,
+  ac.track AS &applicationStatusDetails.channel_track,
+  ac.risk AS &applicationStatusDetails.channel_risk,
+  ac.branch AS &applicationStatusDetails.channel_branch,
+  cm.subordinate AS &applicationStatusDetails.subordinate,
+  s.status_id AS &applicationStatusDetails.status_id,
+  s.message AS &applicationStatusDetails.message,
+  s.data AS &applicationStatusDetails.data,
+  s.updated_at AS &applicationStatusDetails.updated_at,
+  re.relation_uuid AS &applicationStatusDetails.relation_uuid,
+  c.reference_name AS &applicationStatusDetails.charm_reference_name,
+  c.revision AS &applicationStatusDetails.charm_revision,
+  cs.name AS &applicationStatusDetails.charm_source,
+  c.architecture_id AS &applicationStatusDetails.charm_architecture_id,
+  c.version AS &applicationStatusDetails.charm_version,
+  c.lxd_profile AS &applicationStatusDetails.lxd_profile,
+  aps.scale AS &applicationStatusDetails.scale,
+  k8s.provider_id AS &applicationStatusDetails.k8s_provider_id,
+  svc_addr.address_value AS &applicationStatusDetails.k8s_public_address,
+  EXISTS(
+    SELECT 1 FROM v_application_exposed_endpoint AS ae
+    WHERE ae.application_uuid = a.uuid
+  ) AS &applicationStatusDetails.exposed,
+  awv.version AS &applicationStatusDetails.workload_version
 FROM application AS a
 JOIN application_platform AS ap ON ap.application_uuid = a.uuid
 LEFT JOIN application_channel AS ac ON ac.application_uuid = a.uuid
@@ -1632,6 +1660,7 @@ JOIN charm_source AS cs ON cs.id = c.source_id
 JOIN charm_metadata AS cm ON cm.charm_uuid = c.uuid
 LEFT JOIN application_status AS s ON s.application_uuid = a.uuid
 LEFT JOIN k8s_service AS k8s ON k8s.application_uuid = a.uuid
+LEFT JOIN selected_k8s_service_address AS svc_addr ON svc_addr.application_uuid = a.uuid
 LEFT JOIN application_scale AS aps ON aps.application_uuid = a.uuid
 LEFT JOIN v_relation_endpoint AS re ON re.application_uuid = a.uuid
 LEFT JOIN application_workload_version AS awv ON awv.application_uuid = a.uuid
@@ -1659,16 +1688,12 @@ ORDER BY a.name, re.relation_uuid;
 			}
 		}
 
-		// If the application already exists, append the relation UUID to its
-		// relations.
-		if entry, exists := result[appName]; exists && s.RelationUUID.Valid {
-			entry.Relations = append(entry.Relations, relationUUID)
+		if entry, exists := result[appName]; exists {
+			if s.RelationUUID.Valid && !slices.Contains(entry.Relations, relationUUID) {
+				entry.Relations = append(entry.Relations, relationUUID)
+			}
 			result[appName] = entry
 			continue
-		} else if exists {
-			// This should never happen, but if it does, we have a duplicate
-			// application name with no relation UUID. This is a problem.
-			return nil, errors.Errorf("duplicate application name %q", appName)
 		}
 
 		// We've got a new application, so create a new status.
@@ -1712,6 +1737,14 @@ ORDER BY a.name, re.relation_uuid;
 			k8sProviderID = &s.K8sProviderID.V
 		}
 
+		// It is possible for a service to have multiple IP addresses, but for
+		// now we just want to return one. Pick one deterministically but
+		// arbitrarily
+		var k8sPublicAddress *string
+		if s.K8sPublicAddress.Valid {
+			k8sPublicAddress = &s.K8sPublicAddress.V
+		}
+
 		var workloadVersion *string
 		if s.WorkloadVersion.Valid && s.WorkloadVersion.V != "" {
 			workloadVersion = &s.WorkloadVersion.V
@@ -1727,16 +1760,17 @@ ORDER BY a.name, re.relation_uuid;
 				Data:    s.Data,
 				Since:   s.UpdatedAt,
 			},
-			Relations:       relations,
-			CharmLocator:    charmLocator,
-			CharmVersion:    s.CharmVersion,
-			LXDProfile:      lxdProfile,
-			Platform:        platform,
-			Channel:         channel,
-			Exposed:         s.Exposed,
-			Scale:           scale,
-			WorkloadVersion: workloadVersion,
-			K8sProviderID:   k8sProviderID,
+			Relations:        relations,
+			CharmLocator:     charmLocator,
+			CharmVersion:     s.CharmVersion,
+			LXDProfile:       lxdProfile,
+			Platform:         platform,
+			Channel:          channel,
+			Exposed:          s.Exposed,
+			Scale:            scale,
+			WorkloadVersion:  workloadVersion,
+			K8sProviderID:    k8sProviderID,
+			K8sPublicAddress: k8sPublicAddress,
 		}
 	}
 

--- a/domain/status/state/model/modelstate_test.go
+++ b/domain/status/state/model/modelstate_test.go
@@ -1977,6 +1977,153 @@ func (s *modelStateSuite) TestGetApplicationAndUnitStatusesWorkloadVersion(c *tc
 	})
 }
 
+func (s *modelStateSuite) TestGetApplicationAndUnitStatusesK8sServiceAddress(c *tc.C) {
+	now := time.Now()
+	appStatus := s.workloadStatus(now)
+	appUUID, _ := s.createCAASApplication(
+		c, "foo", life.Alive, appStatus,
+		s.createCAASUnitArg(c),
+	)
+	s.setK8sServiceAddress(c, "foo", "provider-id", "1.2.3.4")
+
+	statuses, err := s.state.GetApplicationAndUnitStatuses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(statuses, tc.DeepEquals, map[string]status.Application{
+		"foo": {
+			ID:     appUUID,
+			Life:   life.Alive,
+			Status: *appStatus,
+			CharmLocator: charm.CharmLocator{
+				Name:         "foo",
+				Revision:     42,
+				Source:       "charmhub",
+				Architecture: architecture.ARM64,
+			},
+			Platform: deployment.Platform{
+				OSType:       deployment.Ubuntu,
+				Channel:      "22.04/stable",
+				Architecture: architecture.ARM64,
+			},
+			Channel: &deployment.Channel{
+				Track:  "track",
+				Risk:   "stable",
+				Branch: "branch",
+			},
+			Scale:            new(1),
+			K8sProviderID:    new("provider-id"),
+			K8sPublicAddress: new("1.2.3.4"),
+			Units: map[coreunit.Name]status.Unit{
+				"foo/0": {
+					Life:            life.Alive,
+					ApplicationName: "foo",
+					CharmLocator: charm.CharmLocator{
+						Name:         "foo",
+						Revision:     42,
+						Source:       "charmhub",
+						Architecture: architecture.ARM64,
+					},
+				},
+			},
+		},
+	})
+}
+
+func (s *modelStateSuite) TestGetApplicationAndUnitStatusesK8sServiceMultipleAddresses(c *tc.C) {
+	now := time.Now()
+	appStatus := s.workloadStatus(now)
+	s.createCAASApplication(
+		c, "foo", life.Alive, appStatus,
+		s.createCAASUnitArg(c),
+	)
+	s.setK8sServiceAddress(c, "foo", "provider-id",
+		"1.2.3.4",
+		"1.2.3.5",
+	)
+
+	statuses, err := s.state.GetApplicationAndUnitStatuses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(statuses["foo"].K8sPublicAddress, tc.DeepEquals, new("1.2.3.4"))
+}
+
+func (s *modelStateSuite) TestGetApplicationAndUnitStatusesK8sServiceLocalCloudAddress(c *tc.C) {
+	now := time.Now()
+	appStatus := s.workloadStatus(now)
+	s.createCAASApplication(
+		c, "foo", life.Alive, appStatus,
+		s.createCAASUnitArg(c),
+	)
+	s.setK8sServiceAddress(c, "foo", "provider-id", "10.0.0.10")
+
+	statuses, err := s.state.GetApplicationAndUnitStatuses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(statuses["foo"].K8sPublicAddress, tc.DeepEquals, new("10.0.0.10"))
+}
+
+func (s *modelStateSuite) TestGetApplicationAndUnitStatusesK8sServicePrioritisesPublicAddress(c *tc.C) {
+	now := time.Now()
+	appStatus := s.workloadStatus(now)
+	s.createCAASApplication(
+		c, "foo", life.Alive, appStatus,
+		s.createCAASUnitArg(c),
+	)
+	s.setK8sServiceAddress(c, "foo", "provider-id",
+		"8.8.8.8",
+		"10.0.0.10",
+	)
+
+	statuses, err := s.state.GetApplicationAndUnitStatuses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(statuses["foo"].K8sPublicAddress, tc.DeepEquals, new("8.8.8.8"))
+}
+
+func (s *modelStateSuite) TestGetApplicationAndUnitStatusesK8sServicePrioritisesIPv4Address(c *tc.C) {
+	now := time.Now()
+	appStatus := s.workloadStatus(now)
+	s.createCAASApplication(
+		c, "foo", life.Alive, appStatus,
+		s.createCAASUnitArg(c),
+	)
+	s.setK8sServiceAddress(c, "foo", "provider-id",
+		"fd00::10",
+		"10.0.0.10",
+	)
+
+	statuses, err := s.state.GetApplicationAndUnitStatuses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(statuses["foo"].K8sPublicAddress, tc.DeepEquals, new("10.0.0.10"))
+}
+
+func (s *modelStateSuite) TestGetApplicationAndUnitStatusesK8sServiceSelectsAlphabeticalAddress(c *tc.C) {
+	now := time.Now()
+	appStatus := s.workloadStatus(now)
+	s.createCAASApplication(
+		c, "foo", life.Alive, appStatus,
+		s.createCAASUnitArg(c),
+	)
+	s.setK8sServiceAddress(c, "foo", "provider-id",
+		"10.0.0.20",
+		"10.0.0.10",
+	)
+
+	statuses, err := s.state.GetApplicationAndUnitStatuses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(statuses["foo"].K8sPublicAddress, tc.DeepEquals, new("10.0.0.10"))
+}
+
+func (s *modelStateSuite) TestGetApplicationAndUnitStatusesK8sServiceNonLocalAddress(c *tc.C) {
+	now := time.Now()
+	appStatus := s.workloadStatus(now)
+	s.createCAASApplication(
+		c, "foo", life.Alive, appStatus,
+		s.createCAASUnitArg(c),
+	)
+	s.setK8sServiceAddress(c, "foo", "provider-id", "255.255.255.255")
+
+	statuses, err := s.state.GetApplicationAndUnitStatuses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(statuses["foo"].K8sPublicAddress, tc.IsNil)
+}
+
 func (s *modelStateSuite) setWorkloadVersion(c *tc.C, appUUID coreapplication.UUID, unitUUID coreunit.UUID, version string) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx, `UPDATE application_workload_version SET version=? WHERE application_uuid=?`, version, appUUID); err != nil {

--- a/domain/status/state/model/package_test.go
+++ b/domain/status/state/model/package_test.go
@@ -17,6 +17,7 @@ import (
 	corelife "github.com/juju/juju/core/life"
 	coremachine "github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
+	corenetwork "github.com/juju/juju/core/network"
 	corerelation "github.com/juju/juju/core/relation"
 	corerelationtesting "github.com/juju/juju/core/relation/testing"
 	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
@@ -384,6 +385,47 @@ func (s *baseSuite) createCAASApplication(
 	c.Assert(err, tc.ErrorIsNil)
 
 	return appID, unitUUIDs
+}
+
+func (s *baseSuite) setK8sServiceAddress(
+	c *tc.C, appName, providerID string, addresses ...string,
+) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		var count int
+		if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM subnet").Scan(&count); err != nil {
+			return err
+		}
+		if count > 0 {
+			return nil
+		}
+
+		for _, cidr := range []string{"0.0.0.0/0", "::/0"} {
+			if _, err := tx.ExecContext(ctx,
+				"INSERT INTO subnet (uuid, cidr) VALUES (?, ?)",
+				uuid.MustNewUUID().String(), cidr,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	appState := applicationstate.NewState(
+		s.TxnRunnerFactory(), coremodel.UUID(s.ModelUUID()),
+		testclock.NewClock(s.now), loggertesting.WrapCheckLog(c),
+	)
+
+	serviceAddresses := make(corenetwork.ProviderAddresses, len(addresses))
+	for i, address := range addresses {
+		serviceAddresses[i] = corenetwork.ProviderAddress{
+			MachineAddress: corenetwork.NewMachineAddress(address),
+		}
+	}
+	err = appState.UpsertK8sService(c.Context(), appName, providerID,
+		serviceAddresses,
+	)
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *baseSuite) setApplicationLXDProfile(c *tc.C, appUUID coreapplication.UUID, profile string) {

--- a/domain/status/state/model/types.go
+++ b/domain/status/state/model/types.go
@@ -189,6 +189,7 @@ type applicationStatusDetails struct {
 	Scale                  sql.Null[int]        `db:"scale"`
 	WorkloadVersion        sql.Null[string]     `db:"workload_version"`
 	K8sProviderID          sql.Null[string]     `db:"k8s_provider_id"`
+	K8sPublicAddress       sql.Null[string]     `db:"k8s_public_address"`
 }
 
 type unitStatusDetails struct {

--- a/domain/status/types.go
+++ b/domain/status/types.go
@@ -19,21 +19,22 @@ import (
 
 // Application represents the status of an application.
 type Application struct {
-	ID              application.UUID
-	Life            life.Life
-	Status          StatusInfo[WorkloadStatusType]
-	Units           map[unit.Name]Unit
-	Relations       []relation.UUID
-	Subordinate     bool
-	CharmLocator    charm.CharmLocator
-	CharmVersion    string
-	LXDProfile      []byte
-	Platform        deployment.Platform
-	Channel         *deployment.Channel
-	Exposed         bool
-	Scale           *int
-	WorkloadVersion *string
-	K8sProviderID   *string
+	ID               application.UUID
+	Life             life.Life
+	Status           StatusInfo[WorkloadStatusType]
+	Units            map[unit.Name]Unit
+	Relations        []relation.UUID
+	Subordinate      bool
+	CharmLocator     charm.CharmLocator
+	CharmVersion     string
+	LXDProfile       []byte
+	Platform         deployment.Platform
+	Channel          *deployment.Channel
+	Exposed          bool
+	Scale            *int
+	WorkloadVersion  *string
+	K8sProviderID    *string
+	K8sPublicAddress *string
 }
 
 // Unit represents the status of a unit.


### PR DESCRIPTION
Thread the k8s service IP through the status state and service layers so CAAS applications populate the application-level address again in juju status.

This keeps the fix in the status pipeline rather than changing provider networking behavior. The state query now joins the k8s service device and address rows, folds duplicate application rows safely, and preserves the first k8s service address while relation rows are merged. The status service and facade now carry that value through to ApplicationStatus.PublicAddress.

Regression coverage was added for the status state, status service, and full status facade to verify that k8s application addresses are surfaced end to end while unit pod address handling remains unchanged.

Fixes #22458

## QA steps

  ### 1. Bootstrap and deploy a CAAS application

  juju bootstrap minikube minikube
  juju add-model qa
  juju deploy postgresql-k8s -n3 --force

  ### 2. Verify the application address appears in juju status

  juju status

  Expected:

  - postgresql-k8s shows a non-empty Address column
  - unit addresses are still present for each unit

  ### 3. Verify the structured status output

  juju status --format yaml

  Expected under applications.postgresql-k8s:

  - provider-id is present
  - address is present and non-empty

### 4. Verify a service with multiple IPs does not fail

  INSERT INTO ip_address VALUES (...)

  juju status

  Expected:

  - postgresql-k8s shows a non-empty Address column
  - this address is stable
  - unit addresses are still present for each unit
