### PR TITLE
feat: preflight draining validation

### DIFF
--- a/agent/addons/addons.go
+++ b/agent/addons/addons.go
@@ -35,6 +35,7 @@ const IntrospectionSocketName = "introspection.socket"
 // worker reports on or needs to start up.
 type IntrospectionConfig struct {
 	AgentDir           string
+	ControlSocketPath  string
 	Engine             *dependency.Engine
 	MachineLock        machinelock.Lock
 	PrometheusGatherer prometheus.Gatherer
@@ -61,6 +62,7 @@ func StartIntrospection(cfg IntrospectionConfig) error {
 	socketName := path.Join(cfg.AgentDir, IntrospectionSocketName)
 	w, err := cfg.WorkerFunc(introspection.Config{
 		SocketName:         socketName,
+		ControlSocketPath:  cfg.ControlSocketPath,
 		DepEngine:          cfg.Engine,
 		MachineLock:        cfg.MachineLock,
 		PrometheusGatherer: cfg.PrometheusGatherer,

--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -745,6 +745,7 @@ func (a *MachineAgent) makeEngineCreator(
 
 		if err := addons.StartIntrospection(addons.IntrospectionConfig{
 			AgentDir:           agentConfig.Dir(),
+			ControlSocketPath:  filepath.Join(agentConfig.DataDir(), "control.socket"),
 			Engine:             eng,
 			MachineLock:        a.machineLock,
 			PrometheusGatherer: a.prometheusRegistry,

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -918,6 +918,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			SocketName:                      config.ControlSocketPath,
 			GetControllerDomainServices:     controlsocket.GetControllerDomainServices,
 			GetControllerObjectStoreService: controlsocket.GetControllerObjectStoreService,
+			GetObjectStoreServicesGetter:    controlsocket.GetObjectStoreServicesGetter,
 			PrometheusRegisterer:            config.PrometheusRegisterer,
 			NewMetricsCollector:             controlsocket.NewMetricsCollector,
 		})),

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -911,6 +911,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The controlsocket worker runs on the controller machine.
 		controlSocketName: ifDatabaseUpgradeComplete(controlsocket.Manifold(controlsocket.ManifoldConfig{
 			DomainServicesName:              domainServicesName,
+			ObjectStoreName:                 objectStoreName,
 			ObjectStoreServicesName:         objectStoreServicesName,
 			Logger:                          internallogger.GetLogger("juju.worker.controlsocket"),
 			NewWorker:                       controlsocket.NewWorker,
@@ -921,6 +922,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			GetObjectStoreServicesGetter:    controlsocket.GetObjectStoreServicesGetter,
 			PrometheusRegisterer:            config.PrometheusRegisterer,
 			NewMetricsCollector:             controlsocket.NewMetricsCollector,
+			GetReadRepairObjectStoreGetter:  controlsocket.GetReadRepairObjectStoreGetter,
 		})),
 
 		// The ssh server worker runs on the controller machine.

--- a/internal/worker/controlsocket/manifold.go
+++ b/internal/worker/controlsocket/manifold.go
@@ -5,6 +5,7 @@ package controlsocket
 
 import (
 	"context"
+	"io"
 	"path/filepath"
 
 	"github.com/juju/errors"
@@ -14,7 +15,9 @@ import (
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
 	domainobjectstore "github.com/juju/juju/domain/objectstore"
+	objectstoreservice "github.com/juju/juju/domain/objectstore/service"
 	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/socketlistener"
@@ -28,6 +31,23 @@ type ControllerObjectStoreService interface {
 	// credentials. This is used to update the object store information when the
 	// object store is set to use S3 as the backend.
 	TransitionBackendToS3(ctx context.Context, credential domainobjectstore.S3Credentials) error
+
+	// GetActiveObjectStoreBackend returns information about the active backend.
+	GetActiveObjectStoreBackend(ctx context.Context) (objectstoreservice.BackendInfo, error)
+}
+
+// ReadRepairObjectStore describes the subset of object store operations used by
+// read-repair.
+type ReadRepairObjectStore interface {
+	// Get returns an object reader for the specified path.
+	Get(ctx context.Context, path string) (io.ReadCloser, coreobjectstore.Digest, error)
+}
+
+// ReadRepairObjectStoreGetter provides namespaced object stores for
+// read-repair.
+type ReadRepairObjectStoreGetter interface {
+	// GetObjectStore returns the object store for the supplied namespace.
+	GetObjectStore(ctx context.Context, namespace string) (ReadRepairObjectStore, error)
 }
 
 // GetControllerDomainServicesFunc is a function that retrieves the controller
@@ -42,9 +62,14 @@ type GetControllerObjectStoreServiceFunc func(dependency.Getter, string) (Contro
 // store services from the dependency getter.
 type GetObjectStoreServicesGetterFunc func(dependency.Getter, string) (ObjectStoreServicesGetter, error)
 
+// GetReadRepairObjectStoreGetterFunc is a function that retrieves the
+// namespaced object store getter from the dependency getter.
+type GetReadRepairObjectStoreGetterFunc func(dependency.Getter, string) (ReadRepairObjectStoreGetter, error)
+
 // ManifoldConfig describes the dependencies required by the controlsocket worker.
 type ManifoldConfig struct {
 	DomainServicesName      string
+	ObjectStoreName         string
 	ObjectStoreServicesName string
 
 	Logger            logger.Logger
@@ -55,6 +80,7 @@ type ManifoldConfig struct {
 	GetControllerDomainServices     GetControllerDomainServicesFunc
 	GetControllerObjectStoreService GetControllerObjectStoreServiceFunc
 	GetObjectStoreServicesGetter    GetObjectStoreServicesGetterFunc
+	GetReadRepairObjectStoreGetter  GetReadRepairObjectStoreGetterFunc
 	PrometheusRegisterer            prometheus.Registerer
 	NewMetricsCollector             func() *Collector
 }
@@ -64,6 +90,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
 			config.DomainServicesName,
+			config.ObjectStoreName,
 			config.ObjectStoreServicesName,
 		},
 		Start: config.start,
@@ -74,6 +101,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 func (cfg ManifoldConfig) Validate() error {
 	if cfg.DomainServicesName == "" {
 		return errors.NotValidf("empty DomainServicesName")
+	}
+	if cfg.ObjectStoreName == "" {
+		return errors.NotValidf("empty ObjectStoreName")
 	}
 	if cfg.ObjectStoreServicesName == "" {
 		return errors.NotValidf("empty ObjectStoreServicesName")
@@ -98,6 +128,9 @@ func (cfg ManifoldConfig) Validate() error {
 	}
 	if cfg.GetObjectStoreServicesGetter == nil {
 		return errors.NotValidf("nil GetObjectStoreServicesGetter func")
+	}
+	if cfg.GetReadRepairObjectStoreGetter == nil {
+		return errors.NotValidf("nil GetReadRepairObjectStoreGetter func")
 	}
 	if cfg.PrometheusRegisterer == nil {
 		return errors.NotValidf("nil PrometheusRegisterer")
@@ -134,6 +167,11 @@ func (cfg ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (
 		return nil, errors.Trace(err)
 	}
 
+	readRepairObjectStoreGetter, err := cfg.GetReadRepairObjectStoreGetter(getter, cfg.ObjectStoreName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	controllerSerivce := domainServices.Controller()
 	controllerModelUUID, err := controllerSerivce.ControllerModelUUID(ctx)
 	if err != nil {
@@ -160,16 +198,17 @@ func (cfg ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (
 
 	var w worker.Worker
 	w, err = cfg.NewWorker(Config{
-		AccessService:           domainServices.Access(),
-		TracingService:          domainServices.Tracing(),
-		LoggingService:          domainServices.Logging(),
-		ObjectStoreService:      controllerObjectStoreService,
-		DrainPreflightValidator: preflightValidator,
-		Logger:                  cfg.Logger,
-		SocketName:              cfg.SocketName,
-		NewSocketListener:       cfg.NewSocketListener,
-		ControllerModelUUID:     controllerModelUUID,
-		MetricsCollector:        metricsCollector,
+		AccessService:               domainServices.Access(),
+		TracingService:              domainServices.Tracing(),
+		LoggingService:              domainServices.Logging(),
+		ObjectStoreService:          controllerObjectStoreService,
+		DrainPreflightValidator:     preflightValidator,
+		ReadRepairObjectStoreGetter: readRepairObjectStoreGetter,
+		Logger:                      cfg.Logger,
+		SocketName:                  cfg.SocketName,
+		NewSocketListener:           cfg.NewSocketListener,
+		ControllerModelUUID:         controllerModelUUID,
+		MetricsCollector:            metricsCollector,
 	})
 	if err != nil {
 		cfg.PrometheusRegisterer.Unregister(metricsCollector)
@@ -228,6 +267,28 @@ func NewHashFileStoreAccessor(
 	namespace, rootDir string, logger logger.Logger,
 ) HashFileSystemAccessor {
 	return internalobjectstore.NewHashFileStore(namespace, rootDir, logger)
+}
+
+// GetReadRepairObjectStoreGetter retrieves the namespaced object store getter
+// from the dependency getter.
+func GetReadRepairObjectStoreGetter(getter dependency.Getter, name string) (ReadRepairObjectStoreGetter, error) {
+	var objectStoreGetter coreobjectstore.ObjectStoreGetter
+	if err := getter.Get(name, &objectStoreGetter); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return readRepairObjectStoreGetter{
+		getter: objectStoreGetter,
+	}, nil
+}
+
+type readRepairObjectStoreGetter struct {
+	getter coreobjectstore.ObjectStoreGetter
+}
+
+func (g readRepairObjectStoreGetter) GetObjectStore(
+	ctx context.Context, namespace string,
+) (ReadRepairObjectStore, error) {
+	return g.getter.GetObjectStore(ctx, namespace)
 }
 
 type modelMetadataServiceGetter struct {

--- a/internal/worker/controlsocket/manifold.go
+++ b/internal/worker/controlsocket/manifold.go
@@ -5,6 +5,7 @@ package controlsocket
 
 import (
 	"context"
+	"path/filepath"
 
 	"github.com/juju/errors"
 	"github.com/juju/worker/v5"
@@ -12,7 +13,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/model"
 	domainobjectstore "github.com/juju/juju/domain/objectstore"
+	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/socketlistener"
 	"github.com/juju/juju/internal/worker/common"
@@ -35,6 +38,10 @@ type GetControllerDomainServicesFunc func(dependency.Getter, string) (services.C
 // controller object store service from the dependency getter.
 type GetControllerObjectStoreServiceFunc func(dependency.Getter, string) (ControllerObjectStoreService, error)
 
+// GetObjectStoreServicesGetterFunc is a function that retrieves model object
+// store services from the dependency getter.
+type GetObjectStoreServicesGetterFunc func(dependency.Getter, string) (ObjectStoreServicesGetter, error)
+
 // ManifoldConfig describes the dependencies required by the controlsocket worker.
 type ManifoldConfig struct {
 	DomainServicesName      string
@@ -47,6 +54,7 @@ type ManifoldConfig struct {
 
 	GetControllerDomainServices     GetControllerDomainServicesFunc
 	GetControllerObjectStoreService GetControllerObjectStoreServiceFunc
+	GetObjectStoreServicesGetter    GetObjectStoreServicesGetterFunc
 	PrometheusRegisterer            prometheus.Registerer
 	NewMetricsCollector             func() *Collector
 }
@@ -88,6 +96,9 @@ func (cfg ManifoldConfig) Validate() error {
 	if cfg.GetControllerObjectStoreService == nil {
 		return errors.NotValidf("nil GetControllerObjectStoreService func")
 	}
+	if cfg.GetObjectStoreServicesGetter == nil {
+		return errors.NotValidf("nil GetObjectStoreServicesGetter func")
+	}
 	if cfg.PrometheusRegisterer == nil {
 		return errors.NotValidf("nil PrometheusRegisterer")
 	}
@@ -113,6 +124,16 @@ func (cfg ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (
 		return nil, errors.Trace(err)
 	}
 
+	controllerMetadataService, ok := controllerObjectStoreService.(MetadataService)
+	if !ok {
+		return nil, errors.NotValidf("controller object store service does not support metadata listing")
+	}
+
+	objectStoreServicesGetter, err := cfg.GetObjectStoreServicesGetter(getter, cfg.ObjectStoreServicesName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	controllerSerivce := domainServices.Controller()
 	controllerModelUUID, err := controllerSerivce.ControllerModelUUID(ctx)
 	if err != nil {
@@ -124,17 +145,31 @@ func (cfg ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (
 		return nil, errors.Trace(err)
 	}
 
+	preflightValidator, err := NewDrainPreflightValidator(DrainPreflightValidatorConfig{
+		ControllerService:         controllerSerivce,
+		ControllerMetadataService: controllerMetadataService,
+		ObjectStoreServicesGetter: objectStoreServicesGetter,
+		NewHashFileSystemAccessor: NewHashFileStoreAccessor,
+		SelectFileHash:            internalobjectstore.SelectFileHash,
+		RootDir:                   filepath.Dir(cfg.SocketName),
+		Logger:                    cfg.Logger,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	var w worker.Worker
 	w, err = cfg.NewWorker(Config{
-		AccessService:       domainServices.Access(),
-		TracingService:      domainServices.Tracing(),
-		LoggingService:      domainServices.Logging(),
-		ObjectStoreService:  controllerObjectStoreService,
-		Logger:              cfg.Logger,
-		SocketName:          cfg.SocketName,
-		NewSocketListener:   cfg.NewSocketListener,
-		ControllerModelUUID: controllerModelUUID,
-		MetricsCollector:    metricsCollector,
+		AccessService:           domainServices.Access(),
+		TracingService:          domainServices.Tracing(),
+		LoggingService:          domainServices.Logging(),
+		ObjectStoreService:      controllerObjectStoreService,
+		DrainPreflightValidator: preflightValidator,
+		Logger:                  cfg.Logger,
+		SocketName:              cfg.SocketName,
+		NewSocketListener:       cfg.NewSocketListener,
+		ControllerModelUUID:     controllerModelUUID,
+		MetricsCollector:        metricsCollector,
 	})
 	if err != nil {
 		cfg.PrometheusRegisterer.Unregister(metricsCollector)
@@ -173,4 +208,33 @@ func GetControllerObjectStoreService(getter dependency.Getter, name string) (Con
 		return nil, errors.Trace(err)
 	}
 	return services.AgentObjectStore(), nil
+}
+
+// GetObjectStoreServicesGetter retrieves model object store services from the
+// dependency getter.
+func GetObjectStoreServicesGetter(getter dependency.Getter, name string) (ObjectStoreServicesGetter, error) {
+	var servicesGetter services.ObjectStoreServicesGetter
+	if err := getter.Get(name, &servicesGetter); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return modelMetadataServiceGetter{
+		servicesGetter: servicesGetter,
+	}, nil
+}
+
+// NewHashFileStoreAccessor creates a hash accessor rooted at the supplied
+// namespace and root directory.
+func NewHashFileStoreAccessor(
+	namespace, rootDir string, logger logger.Logger,
+) HashFileSystemAccessor {
+	return internalobjectstore.NewHashFileStore(namespace, rootDir, logger)
+}
+
+type modelMetadataServiceGetter struct {
+	servicesGetter services.ObjectStoreServicesGetter
+}
+
+// ObjectStoreForModel returns metadata operations for the supplied model.
+func (s modelMetadataServiceGetter) ObjectStoreForModel(modelUUID model.UUID) MetadataService {
+	return s.servicesGetter.ServicesForModel(modelUUID).ObjectStore()
 }

--- a/internal/worker/controlsocket/manifold_test.go
+++ b/internal/worker/controlsocket/manifold_test.go
@@ -1,0 +1,425 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controlsocket
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	jujuerrors "github.com/juju/errors"
+	"github.com/juju/tc"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/dependency"
+	dependencytesting "github.com/juju/worker/v5/dependency/testing"
+	"github.com/juju/worker/v5/workertest"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/model"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
+	accessservice "github.com/juju/juju/domain/access/service"
+	domaincontroller "github.com/juju/juju/domain/controller"
+	controllerservice "github.com/juju/juju/domain/controller/service"
+	loggingservice "github.com/juju/juju/domain/logging/service"
+	domainobjectstore "github.com/juju/juju/domain/objectstore"
+	objectstoreservice "github.com/juju/juju/domain/objectstore/service"
+	tracingservice "github.com/juju/juju/domain/tracing/service"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/services"
+	"github.com/juju/juju/internal/socketlistener"
+)
+
+type manifoldSuite struct{}
+
+func TestManifoldSuite(t *testing.T) {
+	tc.Run(t, &manifoldSuite{})
+}
+
+func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
+	cfg := s.getConfig(c)
+	c.Check(cfg.Validate(), tc.ErrorIsNil)
+
+	cfg = s.getConfig(c)
+	cfg.DomainServicesName = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.ObjectStoreName = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.ObjectStoreServicesName = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.Logger = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.NewWorker = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.NewSocketListener = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.SocketName = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.GetControllerDomainServices = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.GetControllerObjectStoreService = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.GetObjectStoreServicesGetter = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.GetReadRepairObjectStoreGetter = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+}
+
+func (s *manifoldSuite) TestInputs(c *tc.C) {
+	cfg := s.getConfig(c)
+	c.Check(Manifold(cfg).Inputs, tc.DeepEquals, []string{
+		cfg.DomainServicesName,
+		cfg.ObjectStoreName,
+		cfg.ObjectStoreServicesName,
+	})
+}
+
+func (s *manifoldSuite) TestStart(c *tc.C) {
+	controllerModelUUID := model.UUID("01234567-89ab-cdef-0123-456789abcdef")
+
+	domainServices := manifoldStubControllerDomainServices{
+		controllerService: controllerservice.NewService(manifoldStubControllerState{
+			modelUUID: controllerModelUUID,
+		}),
+	}
+	controllerObjectStore := &manifoldStubControllerObjectStoreService{}
+	objectStoreServicesGetter := manifoldStubObjectStoreServicesGetter{
+		metadataByModel: map[model.UUID]MetadataService{},
+	}
+	readRepairGetter := &manifoldStubReadRepairGetter{}
+
+	var gotWorkerConfig Config
+	cfg := s.getConfig(c)
+	cfg.GetControllerDomainServices = func(
+		dependency.Getter, string,
+	) (services.ControllerDomainServices, error) {
+		return domainServices, nil
+	}
+	cfg.GetControllerObjectStoreService = func(
+		dependency.Getter, string,
+	) (ControllerObjectStoreService, error) {
+		return controllerObjectStore, nil
+	}
+	cfg.GetObjectStoreServicesGetter = func(
+		dependency.Getter, string,
+	) (ObjectStoreServicesGetter, error) {
+		return objectStoreServicesGetter, nil
+	}
+	cfg.GetReadRepairObjectStoreGetter = func(
+		dependency.Getter, string,
+	) (ReadRepairObjectStoreGetter, error) {
+		return readRepairGetter, nil
+	}
+	cfg.NewWorker = func(cfg Config) (worker.Worker, error) {
+		gotWorkerConfig = cfg
+		return workertest.NewErrorWorker(nil), nil
+	}
+
+	w, err := Manifold(cfg).Start(c.Context(), dependencytesting.StubGetter(map[string]any{}))
+	c.Assert(err, tc.ErrorIsNil)
+	workertest.CleanKill(c, w)
+
+	c.Check(gotWorkerConfig.ControllerModelUUID, tc.Equals, controllerModelUUID)
+	c.Check(gotWorkerConfig.ObjectStoreService, tc.Equals, controllerObjectStore)
+	c.Check(gotWorkerConfig.ReadRepairObjectStoreGetter, tc.Equals, readRepairGetter)
+	c.Check(gotWorkerConfig.DrainPreflightValidator, tc.NotNil)
+}
+
+func (s *manifoldSuite) TestStartReadRepairGetterError(c *tc.C) {
+	domainServices := manifoldStubControllerDomainServices{}
+	controllerObjectStore := &manifoldStubControllerObjectStoreService{}
+	objectStoreServicesGetter := manifoldStubObjectStoreServicesGetter{
+		metadataByModel: map[model.UUID]MetadataService{},
+	}
+
+	newWorkerCalled := false
+	cfg := s.getConfig(c)
+	cfg.GetControllerDomainServices = func(
+		dependency.Getter, string,
+	) (services.ControllerDomainServices, error) {
+		return domainServices, nil
+	}
+	cfg.GetControllerObjectStoreService = func(
+		dependency.Getter, string,
+	) (ControllerObjectStoreService, error) {
+		return controllerObjectStore, nil
+	}
+	cfg.GetObjectStoreServicesGetter = func(
+		dependency.Getter, string,
+	) (ObjectStoreServicesGetter, error) {
+		return objectStoreServicesGetter, nil
+	}
+	cfg.GetReadRepairObjectStoreGetter = func(
+		dependency.Getter, string,
+	) (ReadRepairObjectStoreGetter, error) {
+		return nil, jujuerrors.New("boom")
+	}
+	cfg.NewWorker = func(Config) (worker.Worker, error) {
+		newWorkerCalled = true
+		return workertest.NewErrorWorker(nil), nil
+	}
+
+	_, err := Manifold(cfg).Start(c.Context(), dependencytesting.StubGetter(map[string]any{}))
+	c.Assert(err, tc.ErrorMatches, ".*boom.*")
+	c.Check(newWorkerCalled, tc.IsFalse)
+}
+
+func (s *manifoldSuite) TestGetControllerObjectStoreService(c *tc.C) {
+	agentObjectStore := &objectstoreservice.WatchableDrainingService{}
+	storeServices := manifoldStubControllerObjectStoreServices{
+		agentObjectStore: agentObjectStore,
+	}
+	getter := dependencytesting.StubGetter(map[string]any{
+		"object-store-services": storeServices,
+	})
+
+	svc, err := GetControllerObjectStoreService(getter, "object-store-services")
+	c.Assert(err, tc.ErrorIsNil)
+
+	got, ok := svc.(*objectstoreservice.WatchableDrainingService)
+	c.Assert(ok, tc.IsTrue)
+	c.Check(got, tc.Equals, agentObjectStore)
+}
+
+func (s *manifoldSuite) TestGetObjectStoreServicesGetter(c *tc.C) {
+	modelUUID := model.UUID("11111111-2222-3333-4444-555555555555")
+	objectStore := &objectstoreservice.WatchableService{}
+	storeServices := manifoldStubObjectStoreServices{
+		objectStore: objectStore,
+	}
+	servicesGetter := &manifoldStubServicesObjectStoreServicesGetter{
+		servicesForModel: storeServices,
+	}
+	getter := dependencytesting.StubGetter(map[string]any{
+		"object-store-services": servicesGetter,
+	})
+
+	metadataGetter, err := GetObjectStoreServicesGetter(getter, "object-store-services")
+	c.Assert(err, tc.ErrorIsNil)
+
+	got := metadataGetter.ObjectStoreForModel(modelUUID)
+	c.Check(got, tc.Equals, objectStore)
+	c.Check(servicesGetter.modelUUID, tc.Equals, modelUUID)
+}
+
+func (s *manifoldSuite) TestGetReadRepairObjectStoreGetter(c *tc.C) {
+	store := &manifoldStubCoreObjectStore{}
+	coreGetter := &manifoldStubCoreObjectStoreGetter{
+		store: store,
+	}
+	getter := dependencytesting.StubGetter(map[string]any{
+		"object-store": coreGetter,
+	})
+
+	readRepairGetter, err := GetReadRepairObjectStoreGetter(getter, "object-store")
+	c.Assert(err, tc.ErrorIsNil)
+
+	readStore, err := readRepairGetter.GetObjectStore(c.Context(), "controller")
+	c.Assert(err, tc.ErrorIsNil)
+
+	reader, _, err := readStore.Get(c.Context(), "tools/juju")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(reader.Close(), tc.ErrorIsNil)
+
+	c.Check(coreGetter.namespace, tc.Equals, "controller")
+	c.Check(store.path, tc.Equals, "tools/juju")
+}
+
+func (s *manifoldSuite) getConfig(c *tc.C) ManifoldConfig {
+	return ManifoldConfig{
+		DomainServicesName:      "domain-services",
+		ObjectStoreName:         "object-store",
+		ObjectStoreServicesName: "object-store-services",
+		Logger:                  loggertesting.WrapCheckLog(c),
+		NewWorker: func(Config) (worker.Worker, error) {
+			return workertest.NewErrorWorker(nil), nil
+		},
+		NewSocketListener: func(socketlistener.Config) (SocketListener, error) {
+			return nil, nil
+		},
+		SocketName: filepath.Join(c.MkDir(), "control.socket"),
+		GetControllerDomainServices: func(
+			dependency.Getter, string,
+		) (services.ControllerDomainServices, error) {
+			return nil, nil
+		},
+		GetControllerObjectStoreService: func(
+			dependency.Getter, string,
+		) (ControllerObjectStoreService, error) {
+			return &manifoldStubControllerObjectStoreService{}, nil
+		},
+		GetObjectStoreServicesGetter: func(
+			dependency.Getter, string,
+		) (ObjectStoreServicesGetter, error) {
+			return manifoldStubObjectStoreServicesGetter{
+				metadataByModel: map[model.UUID]MetadataService{},
+			}, nil
+		},
+		GetReadRepairObjectStoreGetter: func(
+			dependency.Getter, string,
+		) (ReadRepairObjectStoreGetter, error) {
+			return &manifoldStubReadRepairGetter{}, nil
+		},
+	}
+}
+
+type manifoldStubControllerState struct {
+	modelUUID model.UUID
+}
+
+func (s manifoldStubControllerState) GetControllerModelUUID(context.Context) (model.UUID, error) {
+	return s.modelUUID, nil
+}
+
+func (manifoldStubControllerState) GetControllerAgentInfo(context.Context) (controller.ControllerAgentInfo, error) {
+	return controller.ControllerAgentInfo{}, nil
+}
+
+func (manifoldStubControllerState) GetModelNamespaces(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (manifoldStubControllerState) GetCACert(context.Context) (string, error) {
+	return "", nil
+}
+
+func (manifoldStubControllerState) GetControllerInfo(context.Context) (domaincontroller.ControllerInfo, error) {
+	return domaincontroller.ControllerInfo{}, nil
+}
+
+type manifoldStubControllerDomainServices struct {
+	services.ControllerDomainServices
+	controllerService *controllerservice.Service
+}
+
+func (manifoldStubControllerDomainServices) Access() *accessservice.Service {
+	return nil
+}
+
+func (s manifoldStubControllerDomainServices) Controller() *controllerservice.Service {
+	return s.controllerService
+}
+
+func (manifoldStubControllerDomainServices) Logging() *loggingservice.WatchableService {
+	return nil
+}
+
+func (manifoldStubControllerDomainServices) Tracing() *tracingservice.Service {
+	return nil
+}
+
+type manifoldStubControllerObjectStoreService struct {
+	metadata []coreobjectstore.Metadata
+	err      error
+}
+
+func (*manifoldStubControllerObjectStoreService) GetActiveObjectStoreBackend(
+	context.Context,
+) (objectstoreservice.BackendInfo, error) {
+	return objectstoreservice.BackendInfo{
+		Type: coreobjectstore.FileBackend,
+	}, nil
+}
+
+func (s *manifoldStubControllerObjectStoreService) TransitionBackendToS3(
+	context.Context, domainobjectstore.S3Credentials,
+) error {
+	return nil
+}
+
+func (s *manifoldStubControllerObjectStoreService) ListMetadata(
+	context.Context,
+) ([]coreobjectstore.Metadata, error) {
+	return s.metadata, s.err
+}
+
+type manifoldStubControllerObjectStoreServices struct {
+	services.ControllerObjectStoreServices
+	agentObjectStore *objectstoreservice.WatchableDrainingService
+}
+
+func (s manifoldStubControllerObjectStoreServices) AgentObjectStore() *objectstoreservice.WatchableDrainingService {
+	return s.agentObjectStore
+}
+
+type manifoldStubObjectStoreServicesGetter struct {
+	metadataByModel map[model.UUID]MetadataService
+}
+
+func (s manifoldStubObjectStoreServicesGetter) ObjectStoreForModel(modelUUID model.UUID) MetadataService {
+	return s.metadataByModel[modelUUID]
+}
+
+type manifoldStubReadRepairGetter struct{}
+
+func (*manifoldStubReadRepairGetter) GetObjectStore(
+	context.Context, string,
+) (ReadRepairObjectStore, error) {
+	return nil, nil
+}
+
+type manifoldStubServicesObjectStoreServicesGetter struct {
+	services.ObjectStoreServicesGetter
+	servicesForModel services.ObjectStoreServices
+	modelUUID        model.UUID
+}
+
+func (s *manifoldStubServicesObjectStoreServicesGetter) ServicesForModel(modelUUID model.UUID) services.ObjectStoreServices {
+	s.modelUUID = modelUUID
+	return s.servicesForModel
+}
+
+type manifoldStubObjectStoreServices struct {
+	services.ObjectStoreServices
+	objectStore *objectstoreservice.WatchableService
+}
+
+func (s manifoldStubObjectStoreServices) ObjectStore() *objectstoreservice.WatchableService {
+	return s.objectStore
+}
+
+type manifoldStubCoreObjectStoreGetter struct {
+	store     coreobjectstore.ObjectStore
+	namespace string
+}
+
+func (g *manifoldStubCoreObjectStoreGetter) GetObjectStore(
+	_ context.Context, namespace string,
+) (coreobjectstore.ObjectStore, error) {
+	g.namespace = namespace
+	return g.store, nil
+}
+
+type manifoldStubCoreObjectStore struct {
+	coreobjectstore.ObjectStore
+	path string
+}
+
+func (s *manifoldStubCoreObjectStore) Get(
+	_ context.Context, path string,
+) (io.ReadCloser, coreobjectstore.Digest, error) {
+	s.path = path
+	return io.NopCloser(strings.NewReader("data")), coreobjectstore.Digest{}, nil
+}

--- a/internal/worker/controlsocket/manifold_test.go
+++ b/internal/worker/controlsocket/manifold_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
@@ -84,6 +85,14 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 
 	cfg = s.getConfig(c)
 	cfg.GetReadRepairObjectStoreGetter = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.PrometheusRegisterer = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.NewMetricsCollector = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, jujuerrors.NotValid)
 }
 
@@ -282,6 +291,8 @@ func (s *manifoldSuite) getConfig(c *tc.C) ManifoldConfig {
 		) (ReadRepairObjectStoreGetter, error) {
 			return &manifoldStubReadRepairGetter{}, nil
 		},
+		PrometheusRegisterer: prometheus.NewRegistry(),
+		NewMetricsCollector:  NewMetricsCollector,
 	}
 }
 
@@ -326,7 +337,7 @@ func (manifoldStubControllerDomainServices) Logging() *loggingservice.WatchableS
 	return nil
 }
 
-func (manifoldStubControllerDomainServices) Tracing() *tracingservice.Service {
+func (manifoldStubControllerDomainServices) Tracing() *tracingservice.WatchableService {
 	return nil
 }
 

--- a/internal/worker/controlsocket/preflight.go
+++ b/internal/worker/controlsocket/preflight.go
@@ -1,0 +1,313 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controlsocket
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/model"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
+	"github.com/juju/juju/internal/errors"
+)
+
+const (
+	controllerNamespace      = "controller"
+	maxMissingObjectsInError = 100
+)
+
+// DrainPreflightValidator validates that a drain can start on the current
+// primary controller.
+type DrainPreflightValidator interface {
+	// Validate returns all missing objects that would block a safe drain.
+	Validate(ctx context.Context) ([]MissingObject, error)
+}
+
+// MissingObject identifies an object that is referenced in metadata but not
+// present on local disk for the corresponding namespace.
+type MissingObject struct {
+	Namespace string
+	Path      string
+	Hash      string
+}
+
+// ControllerService provides access to controller model namespaces.
+type ControllerService interface {
+	// GetModelNamespaces returns the model namespaces of all models in state.
+	GetModelNamespaces(ctx context.Context) ([]string, error)
+}
+
+// MetadataService provides object store metadata operations needed by preflight.
+type MetadataService interface {
+	// ListMetadata returns object metadata for the namespace.
+	ListMetadata(ctx context.Context) ([]coreobjectstore.Metadata, error)
+}
+
+// ObjectStoreServicesGetter provides model-scoped metadata services.
+type ObjectStoreServicesGetter interface {
+	// ObjectStoreForModel returns the metadata service for the supplied model.
+	ObjectStoreForModel(modelUUID model.UUID) MetadataService
+}
+
+// HashFileSystemAccessor checks for hash file presence on local disk.
+type HashFileSystemAccessor interface {
+	// HashExists returns nil if hash exists, or NotFound if it does not.
+	HashExists(ctx context.Context, hash string) error
+}
+
+// NewHashFileSystemAccessorFunc creates a hash accessor for namespace/rootDir.
+type NewHashFileSystemAccessorFunc func(
+	namespace, rootDir string, logger logger.Logger,
+) HashFileSystemAccessor
+
+// SelectFileHashFunc selects the hash used by the file-backed object store.
+type SelectFileHashFunc func(coreobjectstore.Metadata) string
+
+// DrainPreflightValidatorConfig contains dependencies for viability checks.
+type DrainPreflightValidatorConfig struct {
+	ControllerService         ControllerService
+	ControllerMetadataService MetadataService
+	ObjectStoreServicesGetter ObjectStoreServicesGetter
+	NewHashFileSystemAccessor NewHashFileSystemAccessorFunc
+	SelectFileHash            SelectFileHashFunc
+	RootDir                   string
+	Logger                    logger.Logger
+}
+
+// Validate returns an error if config cannot drive a preflight validator.
+func (config DrainPreflightValidatorConfig) Validate() error {
+	if config.ControllerService == nil {
+		return errors.New("nil ControllerService").Add(coreerrors.NotValid)
+	}
+	if config.ControllerMetadataService == nil {
+		return errors.New("nil ControllerMetadataService").Add(coreerrors.NotValid)
+	}
+	if config.ObjectStoreServicesGetter == nil {
+		return errors.New("nil ObjectStoreServicesGetter").Add(coreerrors.NotValid)
+	}
+	if config.NewHashFileSystemAccessor == nil {
+		return errors.New("nil NewHashFileSystemAccessor").Add(coreerrors.NotValid)
+	}
+	if config.SelectFileHash == nil {
+		return errors.New("nil SelectFileHash").Add(coreerrors.NotValid)
+	}
+	if config.RootDir == "" {
+		return errors.New("empty RootDir").Add(coreerrors.NotValid)
+	}
+	if config.Logger == nil {
+		return errors.New("nil Logger").Add(coreerrors.NotValid)
+	}
+	return nil
+}
+
+type drainPreflightValidator struct {
+	controllerService         ControllerService
+	controllerMetadataService MetadataService
+	objectStoreServicesGetter ObjectStoreServicesGetter
+	newHashFileSystemAccessor NewHashFileSystemAccessorFunc
+	selectFileHash            SelectFileHashFunc
+	rootDir                   string
+	logger                    logger.Logger
+}
+
+// NewDrainPreflightValidator creates a validator for objectstore drain
+// viability on the primary controller.
+func NewDrainPreflightValidator(config DrainPreflightValidatorConfig) (DrainPreflightValidator, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	return &drainPreflightValidator{
+		controllerService:         config.ControllerService,
+		controllerMetadataService: config.ControllerMetadataService,
+		objectStoreServicesGetter: config.ObjectStoreServicesGetter,
+		newHashFileSystemAccessor: config.NewHashFileSystemAccessor,
+		selectFileHash:            config.SelectFileHash,
+		rootDir:                   config.RootDir,
+		logger:                    config.Logger,
+	}, nil
+}
+
+// Validate checks controller and model namespaces for metadata entries whose
+// backing files are missing on the local primary controller disk.
+func (v *drainPreflightValidator) Validate(ctx context.Context) ([]MissingObject, error) {
+	// Validate the controller namespace first. If controller-local blobs are
+	// missing, draining is unsafe regardless of model state.
+	controllerMissing, err := v.validateNamespace(
+		ctx,
+		controllerNamespace,
+		v.controllerMetadataService,
+	)
+	if err != nil {
+		return nil, errors.Errorf("validating controller object store files: %w", err)
+	}
+
+	namespaces, err := v.controllerService.GetModelNamespaces(ctx)
+	if err != nil {
+		return nil, errors.Errorf("getting model namespaces: %w", err)
+	}
+
+	// Aggregate all missing objects across controller and model namespaces so
+	// callers can return a complete operator-facing error in one response.
+	missing := append([]MissingObject(nil), controllerMissing...)
+	for _, namespace := range uniqueNamespaces(namespaces) {
+		metadataService := v.objectStoreServicesGetter.ObjectStoreForModel(
+			model.UUID(namespace),
+		)
+		if metadataService == nil {
+			return nil, errors.Errorf(
+				"no object store metadata service for model namespace %q",
+				namespace,
+			)
+		}
+
+		namespaceMissing, err := v.validateNamespace(
+			ctx,
+			namespace,
+			metadataService,
+		)
+		if err != nil {
+			return nil, errors.Errorf(
+				"validating object store files for model namespace %q: %w",
+				namespace,
+				err,
+			)
+		}
+
+		missing = append(missing, namespaceMissing...)
+	}
+
+	return missing, nil
+}
+
+func (v *drainPreflightValidator) validateNamespace(
+	ctx context.Context,
+	namespace string,
+	metadataService MetadataService,
+) ([]MissingObject, error) {
+	metadata, err := metadataService.ListMetadata(ctx)
+	if err != nil {
+		return nil, errors.Errorf("listing metadata: %w", err)
+	}
+
+	if len(metadata) == 0 {
+		return nil, nil
+	}
+
+	fileSystem := v.newHashFileSystemAccessor(namespace, v.rootDir, v.logger)
+	if fileSystem == nil {
+		return nil, errors.Errorf("creating hash file system accessor")
+	}
+
+	missing := make([]MissingObject, 0)
+	for _, entry := range metadata {
+		hash := v.selectFileHash(entry)
+		if hash == "" {
+			return nil, errors.Errorf(
+				"empty file hash for namespace %q path %q",
+				namespace,
+				entry.Path,
+			)
+		}
+
+		// A missing local hash means this primary cannot safely perform a full
+		// drain. We collect it and let the caller fail with a full report.
+		if err := fileSystem.HashExists(ctx, hash); errors.Is(err, coreerrors.NotFound) {
+			missing = append(missing, MissingObject{
+				Namespace: namespace,
+				Path:      entry.Path,
+				Hash:      hash,
+			})
+		} else if err != nil {
+			return nil, errors.Errorf(
+				"checking file hash %q for path %q: %w",
+				hash,
+				entry.Path,
+				err,
+			)
+		}
+	}
+
+	return missing, nil
+}
+
+func missingObjectsError(missing []MissingObject) error {
+	if len(missing) == 0 {
+		return errors.New("object store drain is not viable")
+	}
+
+	// Keep output deterministic and bounded so users get stable, readable
+	// feedback even if there are many missing files.
+	sorted := append([]MissingObject(nil), missing...)
+	slices.SortFunc(sorted, compareMissingObjects)
+
+	display := sorted
+	if len(display) > maxMissingObjectsInError {
+		display = display[:maxMissingObjectsInError]
+	}
+
+	details := make([]string, 0, len(display))
+	for _, entry := range display {
+		details = append(
+			details,
+			fmt.Sprintf("%s:%s (hash=%s)", entry.Namespace, entry.Path, entry.Hash),
+		)
+	}
+
+	message := fmt.Sprintf(
+		"object store drain is not viable on the primary controller: %d files are missing locally; run read-repair before retrying: %s",
+		len(sorted),
+		strings.Join(details, ", "),
+	)
+	if len(sorted) > len(display) {
+		message = fmt.Sprintf(
+			"object store drain is not viable on the primary controller: %d files are missing locally; run read-repair before retrying (showing first %d): %s",
+			len(sorted),
+			len(display),
+			strings.Join(details, ", "),
+		)
+	}
+
+	return errors.New(message)
+}
+
+func uniqueNamespaces(values []string) []string {
+	unique := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		unique[value] = struct{}{}
+	}
+
+	result := make([]string, 0, len(unique))
+	for value := range unique {
+		result = append(result, value)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func compareMissingObjects(a, b MissingObject) int {
+	if a.Namespace < b.Namespace {
+		return -1
+	}
+	if a.Namespace > b.Namespace {
+		return 1
+	}
+	if a.Path < b.Path {
+		return -1
+	}
+	if a.Path > b.Path {
+		return 1
+	}
+	if a.Hash < b.Hash {
+		return -1
+	}
+	if a.Hash > b.Hash {
+		return 1
+	}
+	return 0
+}

--- a/internal/worker/controlsocket/preflight_test.go
+++ b/internal/worker/controlsocket/preflight_test.go
@@ -150,7 +150,7 @@ func (s *preflightValidatorSuite) TestMissingObjectsErrorIncludesReadRepair(c *t
 
 func (s *preflightValidatorSuite) TestMissingObjectsErrorCapsOutput(c *tc.C) {
 	missing := make([]MissingObject, 0, maxMissingObjectsInError+1)
-	for i := 0; i < maxMissingObjectsInError+1; i++ {
+	for i := range maxMissingObjectsInError + 1 {
 		missing = append(missing, MissingObject{
 			Namespace: "controller",
 			Path:      fmt.Sprintf("path-%03d", i),

--- a/internal/worker/controlsocket/preflight_test.go
+++ b/internal/worker/controlsocket/preflight_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controlsocket
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"testing"
+
+	jujuerrors "github.com/juju/errors"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/model"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type preflightValidatorSuite struct{}
+
+func TestPreflightValidatorSuite(t *testing.T) {
+	tc.Run(t, &preflightValidatorSuite{})
+}
+
+func (s *preflightValidatorSuite) TestConfigValidateSuccess(c *tc.C) {
+	config := s.validConfig(c)
+	c.Check(config.Validate(), tc.ErrorIsNil)
+}
+
+func (s *preflightValidatorSuite) TestConfigValidateNilControllerService(c *tc.C) {
+	config := s.validConfig(c)
+	config.ControllerService = nil
+	c.Check(config.Validate(), tc.ErrorMatches, ".*nil ControllerService.*")
+}
+
+func (s *preflightValidatorSuite) TestValidateNoMissingFiles(c *tc.C) {
+	config := s.validConfig(c)
+	config.ControllerMetadataService = stubMetadataService{
+		metadata: []coreobjectstore.Metadata{{
+			Path:   "controller-tools",
+			SHA384: "hash-controller",
+		}},
+	}
+	config.ControllerService = stubControllerService{
+		namespaces: []string{"model-1"},
+	}
+	config.ObjectStoreServicesGetter = stubObjectStoreServicesGetter{
+		byModel: map[model.UUID]MetadataService{
+			"model-1": stubMetadataService{
+				metadata: []coreobjectstore.Metadata{{
+					Path:   "model-object",
+					SHA384: "hash-model",
+				}},
+			},
+		},
+	}
+	config.NewHashFileSystemAccessor = makeNamespaceHashAccessor(
+		map[string]map[string]error{},
+	)
+
+	validator, err := NewDrainPreflightValidator(config)
+	c.Assert(err, tc.ErrorIsNil)
+
+	missing, err := validator.Validate(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(missing, tc.HasLen, 0)
+}
+
+func (s *preflightValidatorSuite) TestValidateMissingFiles(c *tc.C) {
+	config := s.validConfig(c)
+	config.ControllerMetadataService = stubMetadataService{
+		metadata: []coreobjectstore.Metadata{{
+			Path:   "controller-tools",
+			SHA384: "hash-controller",
+		}},
+	}
+	config.ControllerService = stubControllerService{
+		namespaces: []string{"model-1"},
+	}
+	config.ObjectStoreServicesGetter = stubObjectStoreServicesGetter{
+		byModel: map[model.UUID]MetadataService{
+			"model-1": stubMetadataService{
+				metadata: []coreobjectstore.Metadata{{
+					Path:   "model-object",
+					SHA384: "hash-model",
+				}},
+			},
+		},
+	}
+	config.NewHashFileSystemAccessor = makeNamespaceHashAccessor(
+		map[string]map[string]error{
+			"controller": {
+				"hash-controller": jujuerrors.NotFoundf("missing"),
+			},
+			"model-1": {
+				"hash-model": jujuerrors.NotFoundf("missing"),
+			},
+		},
+	)
+
+	validator, err := NewDrainPreflightValidator(config)
+	c.Assert(err, tc.ErrorIsNil)
+
+	missing, err := validator.Validate(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(missing, tc.DeepEquals, []MissingObject{
+		{
+			Namespace: "controller",
+			Path:      "controller-tools",
+			Hash:      "hash-controller",
+		},
+		{
+			Namespace: "model-1",
+			Path:      "model-object",
+			Hash:      "hash-model",
+		},
+	})
+}
+
+func (s *preflightValidatorSuite) TestValidateListMetadataError(c *tc.C) {
+	config := s.validConfig(c)
+	config.ControllerService = stubControllerService{
+		namespaces: []string{"model-1"},
+	}
+	config.ObjectStoreServicesGetter = stubObjectStoreServicesGetter{
+		byModel: map[model.UUID]MetadataService{
+			"model-1": stubMetadataService{
+				err: stderrors.New("boom"),
+			},
+		},
+	}
+
+	validator, err := NewDrainPreflightValidator(config)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = validator.Validate(c.Context())
+	c.Assert(err, tc.ErrorMatches, `.*validating object store files for model namespace "model-1".*boom.*`)
+}
+
+func (s *preflightValidatorSuite) TestMissingObjectsErrorIncludesReadRepair(c *tc.C) {
+	err := missingObjectsError([]MissingObject{{
+		Namespace: "controller",
+		Path:      "tools/juju",
+		Hash:      "abc",
+	}})
+	c.Assert(err, tc.ErrorMatches, ".*drain is not viable.*read-repair.*")
+}
+
+func (s *preflightValidatorSuite) TestMissingObjectsErrorCapsOutput(c *tc.C) {
+	missing := make([]MissingObject, 0, maxMissingObjectsInError+1)
+	for i := 0; i < maxMissingObjectsInError+1; i++ {
+		missing = append(missing, MissingObject{
+			Namespace: "controller",
+			Path:      fmt.Sprintf("path-%03d", i),
+			Hash:      fmt.Sprintf("hash-%03d", i),
+		})
+	}
+
+	err := missingObjectsError(missing)
+	c.Assert(err, tc.ErrorMatches, ".*showing first 100.*")
+}
+
+func (s *preflightValidatorSuite) validConfig(c *tc.C) DrainPreflightValidatorConfig {
+	return DrainPreflightValidatorConfig{
+		ControllerService: stubControllerService{},
+		ControllerMetadataService: stubMetadataService{
+			metadata: nil,
+		},
+		ObjectStoreServicesGetter: stubObjectStoreServicesGetter{
+			byModel: map[model.UUID]MetadataService{},
+		},
+		NewHashFileSystemAccessor: makeNamespaceHashAccessor(
+			map[string]map[string]error{},
+		),
+		SelectFileHash: func(m coreobjectstore.Metadata) string {
+			return m.SHA384
+		},
+		RootDir: c.MkDir(),
+		Logger:  loggertesting.WrapCheckLog(c),
+	}
+}
+
+type stubControllerService struct {
+	namespaces []string
+	err        error
+}
+
+func (s stubControllerService) GetModelNamespaces(context.Context) ([]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.namespaces, nil
+}
+
+type stubMetadataService struct {
+	metadata []coreobjectstore.Metadata
+	err      error
+}
+
+func (s stubMetadataService) ListMetadata(context.Context) ([]coreobjectstore.Metadata, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.metadata, nil
+}
+
+type stubObjectStoreServicesGetter struct {
+	byModel map[model.UUID]MetadataService
+}
+
+func (s stubObjectStoreServicesGetter) ObjectStoreForModel(modelUUID model.UUID) MetadataService {
+	return s.byModel[modelUUID]
+}
+
+type stubHashFileSystemAccessor struct {
+	errorsByHash map[string]error
+}
+
+func (s stubHashFileSystemAccessor) HashExists(_ context.Context, hash string) error {
+	if err, ok := s.errorsByHash[hash]; ok {
+		return err
+	}
+	return nil
+}
+
+func makeNamespaceHashAccessor(
+	errorsByNamespace map[string]map[string]error,
+) NewHashFileSystemAccessorFunc {
+	return func(namespace string, _ string, _ logger.Logger) HashFileSystemAccessor {
+		return stubHashFileSystemAccessor{
+			errorsByHash: errorsByNamespace[namespace],
+		}
+	}
+}

--- a/internal/worker/controlsocket/services_mock_test.go
+++ b/internal/worker/controlsocket/services_mock_test.go
@@ -18,7 +18,8 @@ import (
 	service "github.com/juju/juju/domain/access/service"
 	logging "github.com/juju/juju/domain/logging"
 	objectstore "github.com/juju/juju/domain/objectstore"
-	service0 "github.com/juju/juju/domain/tracing/service"
+	service0 "github.com/juju/juju/domain/objectstore/service"
+	service1 "github.com/juju/juju/domain/tracing/service"
 	auth "github.com/juju/juju/internal/auth"
 )
 
@@ -151,8 +152,8 @@ type MockTracingService struct {
 // MockTracingServiceMockRecorder is the mock recorder for MockTracingService.
 type MockTracingServiceMockRecorder struct {
 	mock                            *MockTracingService
-	setCharmTracingConfigExpects    []*gomock.Call2_1[context.Context, service0.CharmTracingConfig, error]
-	setWorkloadTracingConfigExpects []*gomock.Call2_1[context.Context, service0.WorkloadTracingConfig, error]
+	setCharmTracingConfigExpects    []*gomock.Call2_1[context.Context, service1.CharmTracingConfig, error]
+	setWorkloadTracingConfigExpects []*gomock.Call2_1[context.Context, service1.WorkloadTracingConfig, error]
 }
 
 // NewMockTracingService creates a new mock instance.
@@ -168,7 +169,7 @@ func (m *MockTracingService) EXPECT() *MockTracingServiceMockRecorder {
 }
 
 // SetCharmTracingConfig mocks base method.
-func (m *MockTracingService) SetCharmTracingConfig(ctx context.Context, config service0.CharmTracingConfig) error {
+func (m *MockTracingService) SetCharmTracingConfig(ctx context.Context, config service1.CharmTracingConfig) error {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch2_1(&m.recorder.setCharmTracingConfigExpects, m.ctrl, m, "SetCharmTracingConfig", ctx, config)
 }
@@ -176,17 +177,17 @@ func (m *MockTracingService) SetCharmTracingConfig(ctx context.Context, config s
 // SetCharmTracingConfig indicates an expected call of SetCharmTracingConfig.
 func (mr *MockTracingServiceMockRecorder) SetCharmTracingConfig(ctx, config any) *MockTracingServiceSetCharmTracingConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, service0.CharmTracingConfig, error](mr.mock.ctrl.T, mr.mock, "SetCharmTracingConfig", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(config))
+	call := gomock.NewCall2_1[context.Context, service1.CharmTracingConfig, error](mr.mock.ctrl.T, mr.mock, "SetCharmTracingConfig", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(config))
 	mr.setCharmTracingConfigExpects = append(mr.setCharmTracingConfigExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockTracingServiceSetCharmTracingConfigCall is the typed call wrapper for SetCharmTracingConfig.
-type MockTracingServiceSetCharmTracingConfigCall = gomock.Call2_1[context.Context, service0.CharmTracingConfig, error]
+type MockTracingServiceSetCharmTracingConfigCall = gomock.Call2_1[context.Context, service1.CharmTracingConfig, error]
 
 // SetWorkloadTracingConfig mocks base method.
-func (m *MockTracingService) SetWorkloadTracingConfig(ctx context.Context, config service0.WorkloadTracingConfig) error {
+func (m *MockTracingService) SetWorkloadTracingConfig(ctx context.Context, config service1.WorkloadTracingConfig) error {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch2_1(&m.recorder.setWorkloadTracingConfigExpects, m.ctrl, m, "SetWorkloadTracingConfig", ctx, config)
 }
@@ -194,14 +195,14 @@ func (m *MockTracingService) SetWorkloadTracingConfig(ctx context.Context, confi
 // SetWorkloadTracingConfig indicates an expected call of SetWorkloadTracingConfig.
 func (mr *MockTracingServiceMockRecorder) SetWorkloadTracingConfig(ctx, config any) *MockTracingServiceSetWorkloadTracingConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, service0.WorkloadTracingConfig, error](mr.mock.ctrl.T, mr.mock, "SetWorkloadTracingConfig", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(config))
+	call := gomock.NewCall2_1[context.Context, service1.WorkloadTracingConfig, error](mr.mock.ctrl.T, mr.mock, "SetWorkloadTracingConfig", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(config))
 	mr.setWorkloadTracingConfigExpects = append(mr.setWorkloadTracingConfigExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockTracingServiceSetWorkloadTracingConfigCall is the typed call wrapper for SetWorkloadTracingConfig.
-type MockTracingServiceSetWorkloadTracingConfigCall = gomock.Call2_1[context.Context, service0.WorkloadTracingConfig, error]
+type MockTracingServiceSetWorkloadTracingConfigCall = gomock.Call2_1[context.Context, service1.WorkloadTracingConfig, error]
 
 // MockLoggingService is a mock of LoggingService interface.
 type MockLoggingService struct {
@@ -274,8 +275,9 @@ type MockControllerObjectStoreService struct {
 
 // MockControllerObjectStoreServiceMockRecorder is the mock recorder for MockControllerObjectStoreService.
 type MockControllerObjectStoreServiceMockRecorder struct {
-	mock                         *MockControllerObjectStoreService
-	transitionBackendToS3Expects []*gomock.Call2_1[context.Context, objectstore.S3Credentials, error]
+	mock                               *MockControllerObjectStoreService
+	getActiveObjectStoreBackendExpects []*gomock.Call1_2[context.Context, service0.BackendInfo, error]
+	transitionBackendToS3Expects       []*gomock.Call2_1[context.Context, objectstore.S3Credentials, error]
 }
 
 // NewMockControllerObjectStoreService creates a new mock instance.
@@ -289,6 +291,24 @@ func NewMockControllerObjectStoreService(ctrl *gomock.Controller) *MockControlle
 func (m *MockControllerObjectStoreService) EXPECT() *MockControllerObjectStoreServiceMockRecorder {
 	return m.recorder
 }
+
+// GetActiveObjectStoreBackend mocks base method.
+func (m *MockControllerObjectStoreService) GetActiveObjectStoreBackend(ctx context.Context) (service0.BackendInfo, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch1_2(&m.recorder.getActiveObjectStoreBackendExpects, m.ctrl, m, "GetActiveObjectStoreBackend", ctx)
+}
+
+// GetActiveObjectStoreBackend indicates an expected call of GetActiveObjectStoreBackend.
+func (mr *MockControllerObjectStoreServiceMockRecorder) GetActiveObjectStoreBackend(ctx any) *MockControllerObjectStoreServiceGetActiveObjectStoreBackendCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall1_2[context.Context, service0.BackendInfo, error](mr.mock.ctrl.T, mr.mock, "GetActiveObjectStoreBackend", gomock.EnsureMatcher(ctx))
+	mr.getActiveObjectStoreBackendExpects = append(mr.getActiveObjectStoreBackendExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerObjectStoreServiceGetActiveObjectStoreBackendCall is the typed call wrapper for GetActiveObjectStoreBackend.
+type MockControllerObjectStoreServiceGetActiveObjectStoreBackendCall = gomock.Call1_2[context.Context, service0.BackendInfo, error]
 
 // TransitionBackendToS3 mocks base method.
 func (m *MockControllerObjectStoreService) TransitionBackendToS3(ctx context.Context, credential objectstore.S3Credentials) error {

--- a/internal/worker/controlsocket/worker.go
+++ b/internal/worker/controlsocket/worker.go
@@ -129,6 +129,9 @@ type Config struct {
 	LoggingService LoggingService
 	// ObjectStoreService is the object store service for the controller.
 	ObjectStoreService ControllerObjectStoreService
+	// DrainPreflightValidator validates drain viability before starting the
+	// transition to S3.
+	DrainPreflightValidator DrainPreflightValidator
 	// SocketName is the socket file descriptor.
 	SocketName string
 	// NewSocketListener is the function that creates a new socket listener.
@@ -149,6 +152,9 @@ func (config Config) Validate() error {
 	}
 	if config.ObjectStoreService == nil {
 		return internalerrors.New("nil ObjectStoreService").Add(coreerrors.NotValid)
+	}
+	if config.DrainPreflightValidator == nil {
+		return internalerrors.New("nil DrainPreflightValidator").Add(coreerrors.NotValid)
 	}
 	if config.ControllerModelUUID == "" {
 		return internalerrors.New("empty ControllerModelUUID").Add(coreerrors.NotValid)
@@ -176,6 +182,7 @@ type Worker struct {
 	tracingService     TracingService
 	loggingService     LoggingService
 	objectStoreService ControllerObjectStoreService
+	preflightValidator DrainPreflightValidator
 
 	controllerModelUUID model.UUID
 	userCreatorName     user.Name
@@ -200,6 +207,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		tracingService:      config.TracingService,
 		loggingService:      config.LoggingService,
 		objectStoreService:  config.ObjectStoreService,
+		preflightValidator:  config.DrainPreflightValidator,
 		controllerModelUUID: config.ControllerModelUUID,
 		userCreatorName:     userCreatorName,
 
@@ -589,6 +597,16 @@ func (w *Worker) handleAddS3Credentials(resp http.ResponseWriter, req *http.Requ
 			w.writeErrorResponse(ctx, resp, http.StatusBadRequest,
 				internalerrors.Errorf("request body is not valid JSON: %w", err))
 		}
+		return
+	}
+
+	missing, err := w.preflightValidator.Validate(ctx)
+	if err != nil {
+		w.writeErrorResponse(ctx, resp, http.StatusInternalServerError, internalerrors.Errorf("validating object store drain viability: %w", err))
+		return
+	}
+	if len(missing) > 0 {
+		w.writeErrorResponse(ctx, resp, http.StatusConflict, missingObjectsError(missing))
 		return
 	}
 

--- a/internal/worker/controlsocket/worker.go
+++ b/internal/worker/controlsocket/worker.go
@@ -22,6 +22,7 @@ import (
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	usererrors "github.com/juju/juju/domain/access/errors"
@@ -132,6 +133,8 @@ type Config struct {
 	// DrainPreflightValidator validates drain viability before starting the
 	// transition to S3.
 	DrainPreflightValidator DrainPreflightValidator
+	// ReadRepairObjectStoreGetter gets namespaced object stores for read-repair.
+	ReadRepairObjectStoreGetter ReadRepairObjectStoreGetter
 	// SocketName is the socket file descriptor.
 	SocketName string
 	// NewSocketListener is the function that creates a new socket listener.
@@ -155,6 +158,9 @@ func (config Config) Validate() error {
 	}
 	if config.DrainPreflightValidator == nil {
 		return internalerrors.New("nil DrainPreflightValidator").Add(coreerrors.NotValid)
+	}
+	if config.ReadRepairObjectStoreGetter == nil {
+		return internalerrors.New("nil ReadRepairObjectStoreGetter").Add(coreerrors.NotValid)
 	}
 	if config.ControllerModelUUID == "" {
 		return internalerrors.New("empty ControllerModelUUID").Add(coreerrors.NotValid)
@@ -182,6 +188,7 @@ type Worker struct {
 	tracingService     TracingService
 	loggingService     LoggingService
 	objectStoreService ControllerObjectStoreService
+	readRepairGetter   ReadRepairObjectStoreGetter
 	preflightValidator DrainPreflightValidator
 
 	controllerModelUUID model.UUID
@@ -207,6 +214,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		tracingService:      config.TracingService,
 		loggingService:      config.LoggingService,
 		objectStoreService:  config.ObjectStoreService,
+		readRepairGetter:    config.ReadRepairObjectStoreGetter,
 		preflightValidator:  config.DrainPreflightValidator,
 		controllerModelUUID: config.ControllerModelUUID,
 		userCreatorName:     userCreatorName,
@@ -327,6 +335,11 @@ func (w *Worker) registerHandlers(r *mux.Router) {
 		Methods(http.MethodPost)
 	r.Handle("/s3-credentials", w.withMetrics("/s3-credentials", http.HandlerFunc(w.handleRemoveS3Credentials))).
 		Methods(http.MethodDelete)
+
+	// objectstore/read-repair endpoint repairs missing local objectstore blobs
+	// from peer controllers before a file->S3 drain is attempted.
+	r.Handle("/objectstore/read-repair", w.handleJSONPost(w.handleReadRepair)).
+		Methods(http.MethodPost)
 
 	// loki-endpoint endpoint for managing the Loki push API endpoint. This
 	// is a POST endpoint that accepts a JSON body with the following format:
@@ -600,6 +613,18 @@ func (w *Worker) handleAddS3Credentials(resp http.ResponseWriter, req *http.Requ
 		return
 	}
 
+	if err := w.ensureFileObjectStoreBackend(
+		ctx,
+		"object store drain preflight",
+	); err != nil {
+		statusCode := http.StatusInternalServerError
+		if internalerrors.Is(err, coreerrors.NotSupported) {
+			statusCode = http.StatusConflict
+		}
+		w.writeErrorResponse(ctx, resp, statusCode, err)
+		return
+	}
+
 	missing, err := w.preflightValidator.Validate(ctx)
 	if err != nil {
 		w.writeErrorResponse(ctx, resp, http.StatusInternalServerError, internalerrors.Errorf("validating object store drain viability: %w", err))
@@ -630,6 +655,130 @@ func (w *Worker) handleRemoveS3Credentials(resp http.ResponseWriter, req *http.R
 	// be fixed in future requests.
 	w.writeErrorResponse(req.Context(), resp, http.StatusNotImplemented,
 		internalerrors.New("removing s3 credentials is not supported at this time"))
+}
+
+func (w *Worker) handleReadRepair(resp http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	repaired, remaining, err := w.runReadRepair(ctx)
+	if err != nil {
+		statusCode := http.StatusInternalServerError
+		if internalerrors.Is(err, coreerrors.NotSupported) {
+			statusCode = http.StatusConflict
+		}
+		w.writeErrorResponse(
+			ctx,
+			resp,
+			statusCode,
+			internalerrors.Errorf("running object store read-repair: %w", err),
+		)
+		return
+	}
+	if len(remaining) > 0 {
+		w.writeErrorResponse(
+			ctx,
+			resp,
+			http.StatusConflict,
+			internalerrors.Errorf(
+				"read-repair incomplete after repairing %d objects: %w",
+				repaired,
+				missingObjectsError(remaining),
+			),
+		)
+		return
+	}
+
+	w.writeResponse(ctx, resp, http.StatusOK, infof(
+		"completed object store read-repair; repaired %d objects",
+		repaired,
+	))
+}
+
+func (w *Worker) runReadRepair(ctx context.Context) (int, []MissingObject, error) {
+	if err := w.ensureFileObjectStoreBackend(
+		ctx,
+		"object store read-repair",
+	); err != nil {
+		return 0, nil, err
+	}
+
+	missing, err := w.preflightValidator.Validate(ctx)
+	if err != nil {
+		return 0, nil, internalerrors.Errorf("validating object store drain viability: %w", err)
+	}
+	if len(missing) == 0 {
+		return 0, nil, nil
+	}
+
+	stores := make(map[string]ReadRepairObjectStore, len(missing))
+	repaired := 0
+
+	for _, entry := range missing {
+		store, ok := stores[entry.Namespace]
+		if !ok {
+			store, err = w.readRepairGetter.GetObjectStore(ctx, entry.Namespace)
+			if err != nil {
+				return repaired, nil, internalerrors.Errorf(
+					"getting object store for namespace %q: %w",
+					entry.Namespace,
+					err,
+				)
+			}
+			stores[entry.Namespace] = store
+		}
+
+		reader, _, err := store.Get(ctx, entry.Path)
+		if err != nil {
+			w.logger.Warningf(
+				ctx,
+				"read-repair failed for namespace %q path %q: %v",
+				entry.Namespace,
+				entry.Path,
+				err,
+			)
+			continue
+		}
+		if reader != nil {
+			if err := reader.Close(); err != nil {
+				w.logger.Warningf(
+					ctx,
+					"closing read-repair reader for namespace %q path %q: %v",
+					entry.Namespace,
+					entry.Path,
+					err,
+				)
+			}
+		}
+		repaired++
+	}
+
+	remaining, err := w.preflightValidator.Validate(ctx)
+	if err != nil {
+		return repaired, nil, internalerrors.Errorf("validating object store after read-repair: %w", err)
+	}
+	return repaired, remaining, nil
+}
+
+func (w *Worker) ensureFileObjectStoreBackend(
+	ctx context.Context,
+	operation string,
+) error {
+	backend, err := w.objectStoreService.GetActiveObjectStoreBackend(ctx)
+	if err != nil {
+		return internalerrors.Errorf(
+			"getting active object store backend: %w",
+			err,
+		)
+	}
+	if backend.Type != coreobjectstore.FileBackend {
+		return internalerrors.Errorf(
+			"%s requires %q object store backend; current backend is %q",
+			operation,
+			coreobjectstore.FileBackend,
+			backend.Type,
+		).Add(coreerrors.NotSupported)
+	}
+	return nil
 }
 
 type lokiEndpointRequest struct {

--- a/internal/worker/controlsocket/worker_test.go
+++ b/internal/worker/controlsocket/worker_test.go
@@ -21,6 +21,7 @@ import (
 
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/model"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
 	usertesting "github.com/juju/juju/core/user/testing"
@@ -28,6 +29,7 @@ import (
 	"github.com/juju/juju/domain/access/service"
 	"github.com/juju/juju/domain/logging"
 	domainobjectstore "github.com/juju/juju/domain/objectstore"
+	objectstoreservice "github.com/juju/juju/domain/objectstore/service"
 	tracingservice "github.com/juju/juju/domain/tracing/service"
 	auth "github.com/juju/juju/internal/auth"
 	internalerrors "github.com/juju/juju/internal/errors"
@@ -42,6 +44,7 @@ type workerSuite struct {
 	tracingService     *MockTracingService
 	loggingService     *MockLoggingService
 	objectStoreService *MockControllerObjectStoreService
+	readRepairGetter   ReadRepairObjectStoreGetter
 	preflightValidator DrainPreflightValidator
 
 	controllerModelID permission.ID
@@ -91,6 +94,14 @@ func (s *workerSuite) TestConfigValidateNilDrainPreflightValidator(c *tc.C) {
 	cfg := s.newValidConfig(c)
 	cfg.DrainPreflightValidator = nil
 	c.Check(cfg.Validate(), tc.ErrorMatches, ".*nil DrainPreflightValidator.*")
+}
+
+func (s *workerSuite) TestConfigValidateNilReadRepairObjectStoreGetter(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cfg := s.newValidConfig(c)
+	cfg.ReadRepairObjectStoreGetter = nil
+	c.Check(cfg.Validate(), tc.ErrorMatches, ".*nil ReadRepairObjectStoreGetter.*")
 }
 
 func (s *workerSuite) TestConfigValidateEmptyControllerModelUUID(c *tc.C) {
@@ -1080,12 +1091,67 @@ func (s *workerSuite) TestAddS3CredentialsInvalidJSON(c *tc.C) {
 	})
 }
 
+func (s *workerSuite) TestAddS3CredentialsRequiresFileBackend(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	preflightCalled := false
+	s.preflightValidator = staticDrainPreflightValidator{
+		validate: func(context.Context) ([]MissingObject, error) {
+			preflightCalled = true
+			return nil, nil
+		},
+	}
+	s.objectStoreService.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(
+		objectstoreservice.BackendInfo{
+			Type: coreobjectstore.S3Backend,
+		},
+		nil,
+	)
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/s3-credentials",
+		body:       `{"endpoint":"https://example.com","access_key":"foo","secret_key":"bar"}`,
+		statusCode: http.StatusConflict,
+		response:   `.*requires.*file.*object store backend.*current backend.*s3.*`,
+	})
+	c.Check(preflightCalled, tc.IsFalse)
+}
+
+func (s *workerSuite) TestAddS3CredentialsActiveBackendError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.objectStoreService.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(
+		objectstoreservice.BackendInfo{},
+		errors.New("boom"),
+	)
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/s3-credentials",
+		body:       `{"endpoint":"https://example.com","access_key":"foo","secret_key":"bar"}`,
+		statusCode: http.StatusInternalServerError,
+		response:   `.*getting active object store backend.*boom.*`,
+	})
+}
+
 func (s *workerSuite) TestAddS3CredentialsDrainPreflightError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.preflightValidator = staticDrainPreflightValidator{
 		err: errors.New("boom"),
 	}
+	s.expectActiveFileObjectStoreBackend()
 
 	socket := s.newSocket(c)
 
@@ -1111,6 +1177,7 @@ func (s *workerSuite) TestAddS3CredentialsDrainPreflightMissingFiles(c *tc.C) {
 			Hash:      "abc",
 		}},
 	}
+	s.expectActiveFileObjectStoreBackend()
 
 	socket := s.newSocket(c)
 
@@ -1129,6 +1196,7 @@ func (s *workerSuite) TestAddS3CredentialsDrainPreflightMissingFiles(c *tc.C) {
 func (s *workerSuite) TestAddS3CredentialsServiceError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	s.expectActiveFileObjectStoreBackend()
 	s.objectStoreService.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any()).Return(errors.New("boom"))
 
 	socket := s.newSocket(c)
@@ -1148,6 +1216,7 @@ func (s *workerSuite) TestAddS3CredentialsServiceError(c *tc.C) {
 func (s *workerSuite) TestAddS3CredentialsSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	s.expectActiveFileObjectStoreBackend()
 	s.objectStoreService.EXPECT().TransitionBackendToS3(gomock.Any(), domainobjectstore.S3Credentials{
 		Endpoint:  "https://example.com",
 		AccessKey: "foo",
@@ -1171,6 +1240,7 @@ func (s *workerSuite) TestAddS3CredentialsSuccess(c *tc.C) {
 func (s *workerSuite) TestAddS3CredentialsNotValid(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	s.expectActiveFileObjectStoreBackend()
 	s.objectStoreService.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any()).Return(
 		coreerrors.NotValid,
 	)
@@ -1220,6 +1290,335 @@ func (s *workerSuite) TestAddS3CredentialsUnsupportedContentType(c *tc.C) {
 		contentType: "text/plain",
 		statusCode:  http.StatusUnsupportedMediaType,
 		response:    ".*request Content-Type must be application/json.*",
+	})
+}
+
+func (s *workerSuite) TestReadRepairInvalidMethod(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodGet,
+		endpoint:   "/objectstore/read-repair",
+		statusCode: http.StatusMethodNotAllowed,
+		ignoreBody: true,
+	})
+}
+
+func (s *workerSuite) TestReadRepairRequiresFileBackend(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	preflightCalled := false
+	s.preflightValidator = staticDrainPreflightValidator{
+		validate: func(context.Context) ([]MissingObject, error) {
+			preflightCalled = true
+			return nil, nil
+		},
+	}
+	s.objectStoreService.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(
+		objectstoreservice.BackendInfo{
+			Type: coreobjectstore.S3Backend,
+		},
+		nil,
+	)
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/objectstore/read-repair",
+		body:       `{}`,
+		statusCode: http.StatusConflict,
+		response:   `.*running object store read-repair.*requires.*file.*object store backend.*current backend.*s3.*`,
+	})
+	c.Check(preflightCalled, tc.IsFalse)
+}
+
+func (s *workerSuite) TestReadRepairActiveBackendError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.objectStoreService.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(
+		objectstoreservice.BackendInfo{},
+		errors.New("boom"),
+	)
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/objectstore/read-repair",
+		body:       `{}`,
+		statusCode: http.StatusInternalServerError,
+		response:   `.*running object store read-repair.*getting active object store backend.*boom.*`,
+	})
+}
+
+func (s *workerSuite) TestReadRepairPreflightError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectActiveFileObjectStoreBackend()
+	s.preflightValidator = staticDrainPreflightValidator{
+		err: errors.New("boom"),
+	}
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/objectstore/read-repair",
+		body:       `{}`,
+		statusCode: http.StatusInternalServerError,
+		response:   ".*running object store read-repair.*boom.*",
+	})
+}
+
+func (s *workerSuite) TestReadRepairAlreadyHealthy(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectActiveFileObjectStoreBackend()
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/objectstore/read-repair",
+		body:       `{}`,
+		statusCode: http.StatusOK,
+		response:   ".*completed object store read-repair; repaired 0 objects.*",
+	})
+}
+
+func (s *workerSuite) TestReadRepairObjectStoreGetterError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectActiveFileObjectStoreBackend()
+	missing := []MissingObject{{
+		Namespace: "controller",
+		Path:      "tools/juju",
+		Hash:      "abc",
+	}}
+	s.preflightValidator = staticDrainPreflightValidator{
+		validate: func(context.Context) ([]MissingObject, error) {
+			return missing, nil
+		},
+	}
+	s.readRepairGetter = staticReadRepairObjectStoreGetter{
+		errorsByNamespace: map[string]error{
+			"controller": errors.New("boom"),
+		},
+	}
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/objectstore/read-repair",
+		body:       `{}`,
+		statusCode: http.StatusInternalServerError,
+		response:   ".*running object store read-repair.*getting object store for namespace .*boom.*",
+	})
+}
+
+func (s *workerSuite) TestReadRepairPostRepairValidationError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectActiveFileObjectStoreBackend()
+	missing := []MissingObject{{
+		Namespace: "controller",
+		Path:      "tools/juju",
+		Hash:      "abc",
+	}}
+	validateCalls := 0
+	s.preflightValidator = staticDrainPreflightValidator{
+		validate: func(context.Context) ([]MissingObject, error) {
+			validateCalls++
+			if validateCalls == 1 {
+				return missing, nil
+			}
+			return nil, errors.New("boom")
+		},
+	}
+	s.readRepairGetter = staticReadRepairObjectStoreGetter{
+		storesByNamespace: map[string]ReadRepairObjectStore{
+			"controller": staticReadRepairObjectStore{
+				get: func(context.Context, string) (io.ReadCloser, coreobjectstore.Digest, error) {
+					return io.NopCloser(strings.NewReader("data")), coreobjectstore.Digest{}, nil
+				},
+			},
+		},
+	}
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/objectstore/read-repair",
+		body:       `{}`,
+		statusCode: http.StatusInternalServerError,
+		response:   ".*running object store read-repair.*validating object store after read-repair.*boom.*",
+	})
+}
+
+func (s *workerSuite) TestReadRepairSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectActiveFileObjectStoreBackend()
+	missing := []MissingObject{{
+		Namespace: "controller",
+		Path:      "tools/juju",
+		Hash:      "abc",
+	}}
+	validateCalls := 0
+	s.preflightValidator = staticDrainPreflightValidator{
+		validate: func(context.Context) ([]MissingObject, error) {
+			validateCalls++
+			if validateCalls == 1 {
+				return missing, nil
+			}
+			return nil, nil
+		},
+	}
+
+	s.readRepairGetter = staticReadRepairObjectStoreGetter{
+		storesByNamespace: map[string]ReadRepairObjectStore{
+			"controller": staticReadRepairObjectStore{
+				get: func(_ context.Context, path string) (io.ReadCloser, coreobjectstore.Digest, error) {
+					c.Check(path, tc.Equals, "tools/juju")
+					return io.NopCloser(strings.NewReader("data")), coreobjectstore.Digest{}, nil
+				},
+			},
+		},
+	}
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/objectstore/read-repair",
+		body:       `{}`,
+		statusCode: http.StatusOK,
+		response:   ".*completed object store read-repair; repaired 1 objects.*",
+	})
+}
+
+func (s *workerSuite) TestReadRepairReusesStorePerNamespace(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectActiveFileObjectStoreBackend()
+	missing := []MissingObject{
+		{
+			Namespace: "controller",
+			Path:      "tools/juju",
+			Hash:      "abc",
+		},
+		{
+			Namespace: "controller",
+			Path:      "tools/juju-2",
+			Hash:      "def",
+		},
+	}
+	validateCalls := 0
+	s.preflightValidator = staticDrainPreflightValidator{
+		validate: func(context.Context) ([]MissingObject, error) {
+			validateCalls++
+			if validateCalls == 1 {
+				return missing, nil
+			}
+			return nil, nil
+		},
+	}
+
+	requestedPaths := make([]string, 0, len(missing))
+	callsByNamespace := map[string]int{}
+	s.readRepairGetter = staticReadRepairObjectStoreGetter{
+		callsByNamespace: callsByNamespace,
+		storesByNamespace: map[string]ReadRepairObjectStore{
+			"controller": staticReadRepairObjectStore{
+				get: func(_ context.Context, path string) (io.ReadCloser, coreobjectstore.Digest, error) {
+					requestedPaths = append(requestedPaths, path)
+					return io.NopCloser(strings.NewReader("data")), coreobjectstore.Digest{}, nil
+				},
+			},
+		},
+	}
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/objectstore/read-repair",
+		body:       `{}`,
+		statusCode: http.StatusOK,
+		response:   ".*completed object store read-repair; repaired 2 objects.*",
+	})
+
+	c.Check(callsByNamespace["controller"], tc.Equals, 1)
+	c.Check(requestedPaths, tc.DeepEquals, []string{"tools/juju", "tools/juju-2"})
+}
+
+func (s *workerSuite) TestReadRepairIncomplete(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectActiveFileObjectStoreBackend()
+	missing := []MissingObject{{
+		Namespace: "controller",
+		Path:      "tools/juju",
+		Hash:      "abc",
+	}}
+	s.preflightValidator = staticDrainPreflightValidator{
+		validate: func(context.Context) ([]MissingObject, error) {
+			return missing, nil
+		},
+	}
+
+	s.readRepairGetter = staticReadRepairObjectStoreGetter{
+		storesByNamespace: map[string]ReadRepairObjectStore{
+			"controller": staticReadRepairObjectStore{
+				get: func(_ context.Context, _ string) (io.ReadCloser, coreobjectstore.Digest, error) {
+					return nil, coreobjectstore.Digest{}, errors.New("remote not found")
+				},
+			},
+		},
+	}
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/objectstore/read-repair",
+		body:       `{}`,
+		statusCode: http.StatusConflict,
+		response:   ".*read-repair incomplete.*drain is not viable.*controller:tools/juju.*",
 	})
 }
 
@@ -1374,6 +1773,7 @@ func (s *workerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.tracingService = NewMockTracingService(ctrl)
 	s.loggingService = NewMockLoggingService(ctrl)
 	s.objectStoreService = NewMockControllerObjectStoreService(ctrl)
+	s.readRepairGetter = staticReadRepairObjectStoreGetter{}
 	s.preflightValidator = staticDrainPreflightValidator{}
 
 	c.Cleanup(func() {
@@ -1381,6 +1781,7 @@ func (s *workerSuite) setupMocks(c *tc.C) *gomock.Controller {
 		s.tracingService = nil
 		s.loggingService = nil
 		s.objectStoreService = nil
+		s.readRepairGetter = nil
 		s.preflightValidator = nil
 	})
 
@@ -1403,16 +1804,17 @@ type handlerTest struct {
 
 func (s *workerSuite) newValidConfig(c *tc.C) Config {
 	return Config{
-		AccessService:           s.accessService,
-		TracingService:          s.tracingService,
-		LoggingService:          s.loggingService,
-		ObjectStoreService:      s.objectStoreService,
-		DrainPreflightValidator: s.preflightValidator,
-		Logger:                  loggertesting.WrapCheckLog(c),
-		MetricsCollector:        NewMetricsCollector(),
-		SocketName:              "/tmp/test.socket",
-		NewSocketListener:       NewSocketListener,
-		ControllerModelUUID:     model.UUID(jujujujutesting.ModelTag.Id()),
+		AccessService:               s.accessService,
+		TracingService:              s.tracingService,
+		LoggingService:              s.loggingService,
+		ObjectStoreService:          s.objectStoreService,
+		DrainPreflightValidator:     s.preflightValidator,
+		ReadRepairObjectStoreGetter: s.readRepairGetter,
+		Logger:                      loggertesting.WrapCheckLog(c),
+		MetricsCollector:            NewMetricsCollector(),
+		SocketName:                  "/tmp/test.socket",
+		NewSocketListener:           NewSocketListener,
+		ControllerModelUUID:         model.UUID(jujujujutesting.ModelTag.Id()),
 	}
 }
 
@@ -1425,20 +1827,30 @@ func (s *workerSuite) newSocket(c *tc.C) string {
 
 func (s *workerSuite) newWorker(c *tc.C, socket string) *Worker {
 	w, err := NewWorker(Config{
-		AccessService:           s.accessService,
-		TracingService:          s.tracingService,
-		LoggingService:          s.loggingService,
-		ObjectStoreService:      s.objectStoreService,
-		DrainPreflightValidator: s.preflightValidator,
-		Logger:                  loggertesting.WrapCheckLog(c),
-		MetricsCollector:        NewMetricsCollector(),
-		SocketName:              socket,
-		NewSocketListener:       NewSocketListener,
-		ControllerModelUUID:     model.UUID(jujujujutesting.ModelTag.Id()),
+		AccessService:               s.accessService,
+		TracingService:              s.tracingService,
+		LoggingService:              s.loggingService,
+		ObjectStoreService:          s.objectStoreService,
+		DrainPreflightValidator:     s.preflightValidator,
+		ReadRepairObjectStoreGetter: s.readRepairGetter,
+		Logger:                      loggertesting.WrapCheckLog(c),
+		MetricsCollector:            NewMetricsCollector(),
+		SocketName:                  socket,
+		NewSocketListener:           NewSocketListener,
+		ControllerModelUUID:         model.UUID(jujujujutesting.ModelTag.Id()),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	return w.(*Worker)
+}
+
+func (s *workerSuite) expectActiveFileObjectStoreBackend() {
+	s.objectStoreService.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(
+		objectstoreservice.BackendInfo{
+			Type: coreobjectstore.FileBackend,
+		},
+		nil,
+	)
 }
 
 func (s *workerSuite) runHandlerTest(c *tc.C, socket string, test handlerTest) {
@@ -1496,10 +1908,48 @@ func client(socketPath string) *http.Client {
 }
 
 type staticDrainPreflightValidator struct {
-	missing []MissingObject
-	err     error
+	missing  []MissingObject
+	err      error
+	validate func(context.Context) ([]MissingObject, error)
 }
 
-func (v staticDrainPreflightValidator) Validate(context.Context) ([]MissingObject, error) {
+func (v staticDrainPreflightValidator) Validate(ctx context.Context) ([]MissingObject, error) {
+	if v.validate != nil {
+		return v.validate(ctx)
+	}
 	return v.missing, v.err
+}
+
+type staticReadRepairObjectStoreGetter struct {
+	storesByNamespace map[string]ReadRepairObjectStore
+	errorsByNamespace map[string]error
+	callsByNamespace  map[string]int
+}
+
+func (g staticReadRepairObjectStoreGetter) GetObjectStore(
+	_ context.Context, namespace string,
+) (ReadRepairObjectStore, error) {
+	if g.callsByNamespace != nil {
+		g.callsByNamespace[namespace]++
+	}
+	if err, ok := g.errorsByNamespace[namespace]; ok {
+		return nil, err
+	}
+	if store, ok := g.storesByNamespace[namespace]; ok {
+		return store, nil
+	}
+	return nil, errors.New("object store not found")
+}
+
+type staticReadRepairObjectStore struct {
+	get func(context.Context, string) (io.ReadCloser, coreobjectstore.Digest, error)
+}
+
+func (s staticReadRepairObjectStore) Get(
+	ctx context.Context, path string,
+) (io.ReadCloser, coreobjectstore.Digest, error) {
+	if s.get == nil {
+		return nil, coreobjectstore.Digest{}, errors.New("unexpected object store get")
+	}
+	return s.get(ctx, path)
 }

--- a/internal/worker/controlsocket/worker_test.go
+++ b/internal/worker/controlsocket/worker_test.go
@@ -42,6 +42,7 @@ type workerSuite struct {
 	tracingService     *MockTracingService
 	loggingService     *MockLoggingService
 	objectStoreService *MockControllerObjectStoreService
+	preflightValidator DrainPreflightValidator
 
 	controllerModelID permission.ID
 	metricsUserName   coreuser.Name
@@ -82,6 +83,14 @@ func (s *workerSuite) TestConfigValidateNilObjectStoreService(c *tc.C) {
 	cfg := s.newValidConfig(c)
 	cfg.ObjectStoreService = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, coreerrors.NotValid)
+}
+
+func (s *workerSuite) TestConfigValidateNilDrainPreflightValidator(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cfg := s.newValidConfig(c)
+	cfg.DrainPreflightValidator = nil
+	c.Check(cfg.Validate(), tc.ErrorMatches, ".*nil DrainPreflightValidator.*")
 }
 
 func (s *workerSuite) TestConfigValidateEmptyControllerModelUUID(c *tc.C) {
@@ -1071,6 +1080,52 @@ func (s *workerSuite) TestAddS3CredentialsInvalidJSON(c *tc.C) {
 	})
 }
 
+func (s *workerSuite) TestAddS3CredentialsDrainPreflightError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.preflightValidator = staticDrainPreflightValidator{
+		err: errors.New("boom"),
+	}
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/s3-credentials",
+		body:       `{"endpoint":"https://example.com","access_key":"foo","secret_key":"bar"}`,
+		statusCode: http.StatusInternalServerError,
+		response:   ".*validating object store drain viability.*boom.*",
+	})
+}
+
+func (s *workerSuite) TestAddS3CredentialsDrainPreflightMissingFiles(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.preflightValidator = staticDrainPreflightValidator{
+		missing: []MissingObject{{
+			Namespace: "controller",
+			Path:      "tools/juju",
+			Hash:      "abc",
+		}},
+	}
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/s3-credentials",
+		body:       `{"endpoint":"https://example.com","access_key":"foo","secret_key":"bar"}`,
+		statusCode: http.StatusConflict,
+		response:   ".*drain is not viable.*read-repair.*controller:tools/juju.*hash=abc.*",
+	})
+}
+
 func (s *workerSuite) TestAddS3CredentialsServiceError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -1319,12 +1374,14 @@ func (s *workerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.tracingService = NewMockTracingService(ctrl)
 	s.loggingService = NewMockLoggingService(ctrl)
 	s.objectStoreService = NewMockControllerObjectStoreService(ctrl)
+	s.preflightValidator = staticDrainPreflightValidator{}
 
 	c.Cleanup(func() {
 		s.accessService = nil
 		s.tracingService = nil
 		s.loggingService = nil
 		s.objectStoreService = nil
+		s.preflightValidator = nil
 	})
 
 	return ctrl
@@ -1346,15 +1403,16 @@ type handlerTest struct {
 
 func (s *workerSuite) newValidConfig(c *tc.C) Config {
 	return Config{
-		AccessService:       s.accessService,
-		TracingService:      s.tracingService,
-		LoggingService:      s.loggingService,
-		ObjectStoreService:  s.objectStoreService,
-		Logger:              loggertesting.WrapCheckLog(c),
-		MetricsCollector:    NewMetricsCollector(),
-		SocketName:          "/tmp/test.socket",
-		NewSocketListener:   NewSocketListener,
-		ControllerModelUUID: model.UUID(jujujujutesting.ModelTag.Id()),
+		AccessService:           s.accessService,
+		TracingService:          s.tracingService,
+		LoggingService:          s.loggingService,
+		ObjectStoreService:      s.objectStoreService,
+		DrainPreflightValidator: s.preflightValidator,
+		Logger:                  loggertesting.WrapCheckLog(c),
+		MetricsCollector:        NewMetricsCollector(),
+		SocketName:              "/tmp/test.socket",
+		NewSocketListener:       NewSocketListener,
+		ControllerModelUUID:     model.UUID(jujujujutesting.ModelTag.Id()),
 	}
 }
 
@@ -1367,15 +1425,16 @@ func (s *workerSuite) newSocket(c *tc.C) string {
 
 func (s *workerSuite) newWorker(c *tc.C, socket string) *Worker {
 	w, err := NewWorker(Config{
-		AccessService:       s.accessService,
-		TracingService:      s.tracingService,
-		LoggingService:      s.loggingService,
-		ObjectStoreService:  s.objectStoreService,
-		Logger:              loggertesting.WrapCheckLog(c),
-		MetricsCollector:    NewMetricsCollector(),
-		SocketName:          socket,
-		NewSocketListener:   NewSocketListener,
-		ControllerModelUUID: model.UUID(jujujujutesting.ModelTag.Id()),
+		AccessService:           s.accessService,
+		TracingService:          s.tracingService,
+		LoggingService:          s.loggingService,
+		ObjectStoreService:      s.objectStoreService,
+		DrainPreflightValidator: s.preflightValidator,
+		Logger:                  loggertesting.WrapCheckLog(c),
+		MetricsCollector:        NewMetricsCollector(),
+		SocketName:              socket,
+		NewSocketListener:       NewSocketListener,
+		ControllerModelUUID:     model.UUID(jujujujutesting.ModelTag.Id()),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -1434,4 +1493,13 @@ func client(socketPath string) *http.Client {
 			},
 		},
 	}
+}
+
+type staticDrainPreflightValidator struct {
+	missing []MissingObject
+	err     error
+}
+
+func (v staticDrainPreflightValidator) Validate(context.Context) ([]MissingObject, error) {
+	return v.missing, v.err
 }

--- a/internal/worker/introspection/readrepair.go
+++ b/internal/worker/introspection/readrepair.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package introspection
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/juju/juju/juju/sockets"
+)
+
+const objectStoreReadRepairPath = "/objectstore/read-repair"
+
+type objectStoreReadRepairHandler struct {
+	controlSocketPath string
+}
+
+func newObjectStoreReadRepairHandler(controlSocketPath string) http.Handler {
+	return objectStoreReadRepairHandler{
+		controlSocketPath: controlSocketPath,
+	}
+}
+
+func (h objectStoreReadRepairHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	targetURL, err := url.Parse("http://unix.socket" + objectStoreReadRepairPath)
+	if err != nil {
+		http.Error(w, "invalid read-repair endpoint", http.StatusInternalServerError)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(
+		r.Context(),
+		http.MethodPost,
+		targetURL.String(),
+		strings.NewReader("{}"),
+	)
+	if err != nil {
+		http.Error(w, "creating read-repair request failed", http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := objectStoreReadRepairClient(h.controlSocketPath).Do(req)
+	if err != nil {
+		http.Error(w, "requesting read-repair failed", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+	w.WriteHeader(resp.StatusCode)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		logger.Warningf(r.Context(), "copying read-repair response failed: %v", err)
+	}
+}
+
+func objectStoreReadRepairClient(socketPath string) *http.Client {
+	return &http.Client{
+		Transport: objectStoreReadRepairTransport(socketPath),
+	}
+}
+
+func objectStoreReadRepairTransport(socketPath string) *http.Transport {
+	return &http.Transport{
+		DialContext: func(
+			_ context.Context, _, _ string,
+		) (net.Conn, error) {
+			return sockets.Dialer(sockets.Socket{
+				Network: "unix",
+				Address: socketPath,
+			})
+		},
+	}
+}

--- a/internal/worker/introspection/script.go
+++ b/internal/worker/introspection/script.go
@@ -202,6 +202,10 @@ juju_object_store_contents_ () {
   done
 }
 
+juju_object_store_read_repair () {
+  juju_agent --post objectstore/read-repair
+}
+
 juju_api_connection_sources () {
   if [ -x "$(which sudo)" ]; then
     local num=${1:-10}
@@ -253,6 +257,7 @@ if [ "$shell" = "bash" ]; then
   export -f juju_machine_lock
   export -f juju_unit_status
   export -f juju_db_repl
+  export -f juju_object_store_read_repair
   export -f juju_api_connection_sources
   export -f juju_flightrecorder_start
   export -f juju_flightrecorder_stop

--- a/internal/worker/introspection/worker.go
+++ b/internal/worker/introspection/worker.go
@@ -44,6 +44,7 @@ type Reporter interface {
 // Config describes the arguments required to create the introspection worker.
 type Config struct {
 	SocketName         string
+	ControlSocketPath  string
 	DepEngine          DependencyEngine
 	MachineLock        machinelock.Lock
 	PrometheusGatherer prometheus.Gatherer
@@ -68,9 +69,10 @@ func (c *Config) Validate() error {
 type socketListener struct {
 	tomb tomb.Tomb
 
-	listener    net.Listener
-	depEngine   DependencyEngine
-	machineLock machinelock.Lock
+	listener          net.Listener
+	depEngine         DependencyEngine
+	machineLock       machinelock.Lock
+	controlSocketPath string
 
 	prometheusGatherer prometheus.Gatherer
 	flightRecorder     flightrecorder.FlightRecorder
@@ -102,6 +104,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		listener:           l,
 		depEngine:          config.DepEngine,
 		machineLock:        config.MachineLock,
+		controlSocketPath:  config.ControlSocketPath,
 		prometheusGatherer: config.PrometheusGatherer,
 		flightRecorder:     config.FlightRecorder,
 		done:               make(chan struct{}),
@@ -182,6 +185,10 @@ func (w *socketListener) RegisterHTTPHandlers(
 	handle("/flightrecorder/start", introspectionflightrecorder.StartHandler(w.flightRecorder))
 	handle("/flightrecorder/stop", introspectionflightrecorder.StopHandler(w.flightRecorder))
 	handle("/flightrecorder/capture", introspectionflightrecorder.CaptureHandler(w.flightRecorder))
+
+	if w.controlSocketPath != "" {
+		handle("/objectstore/read-repair", newObjectStoreReadRepairHandler(w.controlSocketPath))
+	}
 }
 
 type notSupportedHandler struct {

--- a/internal/worker/introspection/worker_test.go
+++ b/internal/worker/introspection/worker_test.go
@@ -81,11 +81,12 @@ func (s *suite) TestStartStop(c *tc.C) {
 type introspectionSuite struct {
 	testhelpers.IsolationSuite
 
-	name           string
-	worker         worker.Worker
-	depEngine      introspection.DependencyEngine
-	gatherer       prometheus.Gatherer
-	flightRecorder flightrecorder.FlightRecorder
+	name              string
+	controlSocketPath string
+	worker            worker.Worker
+	depEngine         introspection.DependencyEngine
+	gatherer          prometheus.Gatherer
+	flightRecorder    flightrecorder.FlightRecorder
 }
 
 func TestIntrospectionSuite(t *testing.T) {
@@ -99,6 +100,7 @@ func (s *introspectionSuite) SetUpTest(c *tc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.depEngine = nil
 	s.worker = nil
+	s.controlSocketPath = ""
 	s.gatherer = newPrometheusGatherer()
 	s.flightRecorder = flightRecorder{}
 	s.startWorker(c)
@@ -108,6 +110,7 @@ func (s *introspectionSuite) startWorker(c *tc.C) {
 	s.name = path.Join(c.MkDir(), fmt.Sprintf("introspection-test-%d.socket", os.Getpid()))
 	w, err := introspection.NewWorker(introspection.Config{
 		SocketName:         s.name,
+		ControlSocketPath:  s.controlSocketPath,
 		DepEngine:          s.depEngine,
 		PrometheusGatherer: s.gatherer,
 		FlightRecorder:     s.flightRecorder,
@@ -120,12 +123,24 @@ func (s *introspectionSuite) startWorker(c *tc.C) {
 }
 
 func (s *introspectionSuite) call(c *tc.C, path string) *http.Response {
+	return s.request(c, http.MethodGet, path)
+}
+
+func (s *introspectionSuite) post(c *tc.C, path string) *http.Response {
+	return s.request(c, http.MethodPost, path)
+}
+
+func (s *introspectionSuite) request(
+	c *tc.C, method, path string,
+) *http.Response {
 	client := unixSocketHTTPClient(s.name)
 	c.Assert(strings.HasPrefix(path, "/"), tc.IsTrue)
 	targetURL, err := url.Parse("http://unix.socket" + path)
 	c.Assert(err, tc.ErrorIsNil)
 
-	resp, err := client.Get(targetURL.String())
+	req, err := http.NewRequest(method, targetURL.String(), nil)
+	c.Assert(err, tc.ErrorIsNil)
+	resp, err := client.Do(req)
 	c.Assert(err, tc.ErrorIsNil)
 	return resp
 }
@@ -213,6 +228,102 @@ func (s *introspectionSuite) TestPrometheusMetrics(c *tc.C) {
 	s.assertContains(c, body, "# HELP tau Tau")
 	s.assertContains(c, body, "# TYPE tau counter")
 	s.assertContains(c, body, "tau 6.283185")
+}
+
+func (s *introspectionSuite) TestObjectStoreReadRepairNotConfigured(c *tc.C) {
+	response := s.post(c, "/objectstore/read-repair")
+	defer response.Body.Close()
+	c.Assert(response.StatusCode, tc.Equals, http.StatusNotFound)
+}
+
+func (s *introspectionSuite) TestObjectStoreReadRepairInvalidMethod(c *tc.C) {
+	workertest.CleanKill(c, s.worker)
+	s.controlSocketPath = path.Join(c.MkDir(), "control.socket")
+	s.startWorker(c)
+
+	response := s.call(c, "/objectstore/read-repair")
+	defer response.Body.Close()
+	c.Assert(response.StatusCode, tc.Equals, http.StatusMethodNotAllowed)
+	s.assertBody(c, response, "method not allowed")
+}
+
+func (s *introspectionSuite) TestObjectStoreReadRepair(c *tc.C) {
+	socketPath := s.startReadRepairControlSocketServer(c, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, tc.Equals, http.MethodPost)
+		c.Check(r.URL.Path, tc.Equals, "/objectstore/read-repair")
+		c.Check(r.Header.Get("Content-Type"), tc.Equals, "application/json")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"ok"}`))
+	}))
+
+	workertest.CleanKill(c, s.worker)
+	s.controlSocketPath = socketPath
+	s.startWorker(c)
+
+	response := s.post(c, "/objectstore/read-repair")
+	defer response.Body.Close()
+	c.Assert(response.StatusCode, tc.Equals, http.StatusOK)
+	c.Assert(response.Header.Get("Content-Type"), tc.Equals, "application/json")
+	c.Assert(s.body(c, response), tc.Equals, `{"message":"ok"}`)
+}
+
+func (s *introspectionSuite) TestObjectStoreReadRepairProxyError(c *tc.C) {
+	workertest.CleanKill(c, s.worker)
+	s.controlSocketPath = path.Join(c.MkDir(), "control.socket")
+	s.startWorker(c)
+
+	response := s.post(c, "/objectstore/read-repair")
+	defer response.Body.Close()
+	c.Assert(response.StatusCode, tc.Equals, http.StatusInternalServerError)
+	s.assertBody(c, response, "requesting read-repair failed")
+}
+
+func (s *introspectionSuite) TestObjectStoreReadRepairPassesBackendConflict(c *tc.C) {
+	socketPath := s.startReadRepairControlSocketServer(c, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, tc.Equals, http.MethodPost)
+		c.Check(r.URL.Path, tc.Equals, "/objectstore/read-repair")
+		c.Check(r.Header.Get("Content-Type"), tc.Equals, "application/json")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"incomplete"}`))
+	}))
+
+	workertest.CleanKill(c, s.worker)
+	s.controlSocketPath = socketPath
+	s.startWorker(c)
+
+	response := s.post(c, "/objectstore/read-repair")
+	defer response.Body.Close()
+	c.Assert(response.StatusCode, tc.Equals, http.StatusConflict)
+	c.Assert(response.Header.Get("Content-Type"), tc.Equals, "application/json")
+	c.Assert(s.body(c, response), tc.Equals, `{"error":"incomplete"}`)
+}
+
+func (s *introspectionSuite) startReadRepairControlSocketServer(
+	c *tc.C, handler http.Handler,
+) string {
+	socketPath := path.Join(c.MkDir(), "control.socket")
+	listener, err := sockets.Listen(sockets.Socket{
+		Network: "unix",
+		Address: socketPath,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	done := make(chan struct{})
+	server := &http.Server{
+		Handler: handler,
+	}
+	go func() {
+		defer close(done)
+		_ = server.Serve(listener)
+	}()
+	c.Cleanup(func() {
+		_ = server.Close()
+		_ = listener.Close()
+		<-done
+	})
+	return socketPath
 }
 
 type depEngine struct {


### PR DESCRIPTION
 ~~Requires https://github.com/juju/juju/pull/22380~~

----

 This PR adds a preflight viability check before starting object-store draining to S3.

 When `/s3-credentials` is called, the controller now validates that metadata-referenced objects exist locally on the **primary controller** for:
 - the `controller` namespace, and
 - every model namespace.

 If any object is missing, draining is blocked with `409 Conflict` and an operator-facing error that points to `read-repair`.

 ### What changed

 - Added `DrainPreflightValidator` to validate controller/model namespace object availability.
 - Wired validator dependencies through the controlsocket manifold.
 - Gated `handleAddS3Credentials` on preflight success.
 - Added unit tests for preflight behavior and `/s3-credentials` failure paths.

 > [!WARNING]
 > Behavior change: `sync-s3-credentials` can now fail fast before transition if metadata exists but local file-backed blobs are missing.

 > [!NOTE]
 > Missing-object details are deterministic but truncated to the first 100 entries in error output.

 ## QA steps

 Use the same S3 setup/bootstrap flow from https://github.com/juju/juju/pull/22380 through the `s3-integrator` relation and credentials setup.

 1. **Happy path (no missing files):**

 ```sh
$  juju switch controller
$ juju run s3-integrator/leader sync-s3-credentials access-key=<access-key> secret-key=<secret-key>
$  juju debug-log -m controller --replay | grep -E "drain is not viable|read-repair"
```

Expected: no drain is not viable errors; transition flow proceeds.

 2. Preflight rejection (missing local blob):

```
$  juju ssh -m controller 0
$  juju_db_repl
$  repl (controller)> SELECT sha_384 FROM v_object_store_metadata LIMIT 1;
```

```
$  HASH=<sha_384_from_query>
$  sudo find /var/lib/juju -path "*/objectstore/controller/${HASH}" -print -delete
```

```
$ juju switch controller
$ juju run s3-integrator/leader sync-s3-credentials access-key=<access-key> secret-key=<secret-key>
$ juju debug-log -m controller --replay | grep -E "drain is not viable|read-repair|missing locally"
```

Expected: request is blocked with conflict-style error containing drain is not viable and run read-repair before retrying.

 3. Recovery:

This will be done in a follow up to allow us to read-repair against the primary controller.
