### PR TITLE
fix: uninstall lxd-container-provisioner manifold on container machines

### DIFF
--- a/internal/worker/containerprovisioner/manifold.go
+++ b/internal/worker/containerprovisioner/manifold.go
@@ -21,7 +21,13 @@ import (
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
+	internalerors "github.com/juju/juju/internal/errors"
 )
+
+// ErrNotContainerHost is returned by machineSupportsContainers when the
+// machine should not run a container provisioner. Call sites that manage the
+// manifold lifecycle must map this to dependency.ErrUninstall.
+const ErrNotContainerHost = internalerors.ConstError("not a container host")
 
 // GetContainerWatcherFunc is a function that returns a watcher for
 // the containers on a machine.
@@ -95,6 +101,9 @@ func (cfg ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (
 	pr := apiprovisioner.NewClient(apiCaller)
 
 	machine, err := cfg.machineSupportsContainers(ctx, &containerShim{api: pr}, mTag)
+	if errors.Is(err, ErrNotContainerHost) || errors.Is(err, errors.NotFound) {
+		return nil, dependency.ErrUninstall
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -156,15 +165,20 @@ func (cfg ManifoldConfig) machineSupportsContainers(ctx context.Context, pr Cont
 	// Container machines cannot provision further containers.
 	if names.IsContainerMachine(mTag.Id()) {
 		cfg.Logger.Infof(ctx, "uninstalling container provisioner: machine %q is itself a container", mTag)
-		return nil, dependency.ErrUninstall
+		return nil, internalerors.Errorf("machine %q is itself a container", mTag).Add(ErrNotContainerHost)
 	}
 
 	result, err := pr.Machines(ctx, mTag)
 	if err != nil {
 		return nil, errors.Annotatef(err, "loading machine %s from state", mTag)
+	} else if len(result) == 0 {
+		return nil, errors.Errorf("loading machine %s from state: no results", mTag)
 	}
-	if errors.Is(err, errors.NotFound) || (result[0].Err == nil && result[0].Machine.Life() == life.Dead) {
-		return nil, dependency.ErrUninstall
+	if result[0].Err != nil {
+		return nil, errors.Annotatef(result[0].Err, "loading machine %s from state", mTag)
+	}
+	if result[0].Machine.Life() == life.Dead {
+		return nil, internalerors.Errorf("machine %s is dead", mTag).Add(ErrNotContainerHost)
 	}
 	machine := result[0].Machine
 	types, known, err := machine.SupportedContainers(ctx)
@@ -176,7 +190,7 @@ func (cfg ManifoldConfig) machineSupportsContainers(ctx context.Context, pr Cont
 	}
 	if len(types) == 0 {
 		cfg.Logger.Infof(ctx, "uninstalling no supported containers on %q", mTag)
-		return nil, dependency.ErrUninstall
+		return nil, internalerors.Errorf("no supported container types on %s", mTag).Add(ErrNotContainerHost)
 	}
 
 	cfg.Logger.Debugf(ctx, "%s supported containers types set as %q", mTag, types)
@@ -187,7 +201,7 @@ func (cfg ManifoldConfig) machineSupportsContainers(ctx context.Context, pr Cont
 	}
 	if !typeSet.Contains(string(cfg.ContainerType)) {
 		cfg.Logger.Infof(ctx, "%s does not support %s container", mTag, string(cfg.ContainerType))
-		return nil, dependency.ErrUninstall
+		return nil, internalerors.Errorf("%s does not support %s containers", mTag, cfg.ContainerType).Add(ErrNotContainerHost)
 	}
 	return machine, nil
 }

--- a/internal/worker/containerprovisioner/manifold.go
+++ b/internal/worker/containerprovisioner/manifold.go
@@ -153,6 +153,12 @@ func (s *containerShim) Machines(ctx context.Context, tags ...names.MachineTag) 
 }
 
 func (cfg ManifoldConfig) machineSupportsContainers(ctx context.Context, pr ContainerMachineGetter, mTag names.MachineTag) (ContainerMachine, error) {
+	// Container machines cannot provision further containers.
+	if names.IsContainerMachine(mTag.Id()) {
+		cfg.Logger.Infof(ctx, "uninstalling container provisioner: machine %q is itself a container", mTag)
+		return nil, dependency.ErrUninstall
+	}
+
 	result, err := pr.Machines(ctx, mTag)
 	if err != nil {
 		return nil, errors.Annotatef(err, "loading machine %s from state", mTag)

--- a/internal/worker/containerprovisioner/manifold.go
+++ b/internal/worker/containerprovisioner/manifold.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	internalerors "github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/rpc/params"
 )
 
 // ErrNotContainerHost is returned by machineSupportsContainers when the
@@ -139,7 +140,7 @@ type ContainerMachineGetter interface {
 
 type ContainerMachineResult struct {
 	Machine ContainerMachine
-	Err     error
+	Err     *params.Error
 }
 
 type containerShim struct {

--- a/internal/worker/containerprovisioner/manifold_test.go
+++ b/internal/worker/containerprovisioner/manifold_test.go
@@ -90,7 +90,7 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifoldContainerMachi
 		ContainerType: instance.LXD,
 	}
 	_, err := containerprovisioner.MachineSupportsContainers(c, cfg, s.getter, tag)
-	c.Assert(err, tc.ErrorMatches, "resource permanently unavailable")
+	c.Assert(err, tc.ErrorIs, containerprovisioner.ErrNotContainerHost)
 }
 
 func (s *containerManifoldSuite) TestContainerProvisioningManifold(c *tc.C) {
@@ -145,7 +145,7 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifoldNoContainerSup
 		ContainerType: instance.LXD,
 	}
 	_, err := containerprovisioner.MachineSupportsContainers(c, cfg, s.getter, tag)
-	c.Assert(err, tc.ErrorMatches, "resource permanently unavailable")
+	c.Assert(err, tc.ErrorIs, containerprovisioner.ErrNotContainerHost)
 }
 
 func (s *containerManifoldSuite) TestContainerProvisioningManifoldMachineDead(c *tc.C) {
@@ -162,7 +162,52 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifoldMachineDead(c 
 		ContainerType: instance.LXD,
 	}
 	_, err := containerprovisioner.MachineSupportsContainers(c, cfg, s.getter, tag)
-	c.Assert(err, tc.ErrorMatches, "resource permanently unavailable")
+	c.Assert(err, tc.ErrorIs, containerprovisioner.ErrNotContainerHost)
+}
+
+func (s *containerManifoldSuite) TestContainerProvisioningManifoldMachineNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	tag := names.NewMachineTag("42")
+	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(nil, errors.NotFoundf("machine %s", tag))
+	cfg := containerprovisioner.ManifoldConfig{
+		Logger:        loggertesting.WrapCheckLog(c),
+		ContainerType: instance.LXD,
+	}
+	_, err := containerprovisioner.MachineSupportsContainers(c, cfg, s.getter, tag)
+	c.Assert(err, tc.ErrorIs, errors.NotFound)
+}
+
+func (s *containerManifoldSuite) TestContainerProvisioningManifoldMachinesEmptyResult(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	tag := names.NewMachineTag("42")
+	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return([]containerprovisioner.ContainerMachineResult{}, nil)
+	cfg := containerprovisioner.ManifoldConfig{
+		Logger:        loggertesting.WrapCheckLog(c),
+		ContainerType: instance.LXD,
+	}
+	_, err := containerprovisioner.MachineSupportsContainers(c, cfg, s.getter, tag)
+	c.Assert(err, tc.ErrorMatches, "loading machine .* from state: no results")
+}
+
+func (s *containerManifoldSuite) TestContainerProvisioningManifoldContainerTypeNotSupported(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	tag := names.NewMachineTag("42")
+	retval := []containerprovisioner.ContainerMachineResult{
+		{Machine: s.machine},
+	}
+	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(retval, nil)
+	// Machine supports NONE only, not LXD.
+	s.machine.EXPECT().SupportedContainers(gomock.Any()).Return([]instance.ContainerType{instance.NONE}, true, nil)
+	s.machine.EXPECT().Life().Return(life.Alive)
+	cfg := containerprovisioner.ManifoldConfig{
+		Logger:        loggertesting.WrapCheckLog(c),
+		ContainerType: instance.LXD,
+	}
+	_, err := containerprovisioner.MachineSupportsContainers(c, cfg, s.getter, tag)
+	c.Assert(err, tc.ErrorIs, containerprovisioner.ErrNotContainerHost)
 }
 
 func (s *containerManifoldSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/internal/worker/containerprovisioner/manifold_test.go
+++ b/internal/worker/containerprovisioner/manifold_test.go
@@ -80,6 +80,19 @@ func (s *containerManifoldSuite) TestConfigValidateSuccess(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *containerManifoldSuite) TestContainerProvisioningManifoldContainerMachine(c *tc.C) {
+	// A container machine (e.g. 0/lxd/0) should never provision further
+	// containers. The worker must uninstall itself immediately without
+	// making any API calls.
+	tag := names.NewMachineTag("0/lxd/0")
+	cfg := containerprovisioner.ManifoldConfig{
+		Logger:        loggertesting.WrapCheckLog(c),
+		ContainerType: instance.LXD,
+	}
+	_, err := containerprovisioner.MachineSupportsContainers(c, cfg, s.getter, tag)
+	c.Assert(err, tc.ErrorMatches, "resource permanently unavailable")
+}
+
 func (s *containerManifoldSuite) TestContainerProvisioningManifold(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/internal/worker/containerprovisioner/manifold_test.go
+++ b/internal/worker/containerprovisioner/manifold_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/core/life"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/worker/containerprovisioner"
+	"github.com/juju/juju/rpc/params"
 )
 
 type containerManifoldSuite struct {
@@ -99,6 +100,26 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifold(c *tc.C) {
 	tag := names.NewMachineTag("42")
 	retval := []containerprovisioner.ContainerMachineResult{
 		{Machine: s.machine},
+	}
+	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(retval, nil)
+	s.machine.EXPECT().SupportedContainers(gomock.Any()).Return([]instance.ContainerType{instance.LXD}, true, nil)
+	s.machine.EXPECT().Life().Return(life.Alive)
+	cfg := containerprovisioner.ManifoldConfig{
+		Logger:        loggertesting.WrapCheckLog(c),
+		ContainerType: instance.LXD,
+	}
+	m, err := containerprovisioner.MachineSupportsContainers(c, cfg, s.getter, tag)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(m, tc.NotNil)
+}
+
+func (s *containerManifoldSuite) TestContainerProvisioningManifoldIgnoresTypedNilError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	tag := names.NewMachineTag("42")
+	var machineErr *params.Error
+	retval := []containerprovisioner.ContainerMachineResult{
+		{Machine: s.machine, Err: machineErr},
 	}
 	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(retval, nil)
 	s.machine.EXPECT().SupportedContainers(gomock.Any()).Return([]instance.ContainerType{instance.LXD}, true, nil)


### PR DESCRIPTION
On container machines (e.g. `0/lxd/0`), the `lxd-container-provisioner`
manifold called `WatchMachineContainerLife` with its own tag, which the
server rejects. Because that error is not `dependency.ErrUninstall`, the
dependency engine kept restarting it in a tight loop. 

Fixed by checking `names.IsContainerMachine` at the top of 
`machineSupportsContainers` and returning `ErrUninstall` immediately, so 
the manifold stops permanently without making any API calls.

## QA steps

Bootstrap, add a machine and a container on top of that machine, finally deploy ubuntu `--to` it:
```
$ juju bootstrap lxd c
$ juju add-model m
$ juju add-machine
$ juju add-machine lxd:0
$ juju deploy ubuntu --to 0
```
Check that there are no looping error logs in the container machine:
```
$ tail -f /var/log/juju/machine-0-lxd-0.log
```

_Note: another issue has been discovered when deploying directly without creating host and container previously, this is going to be addressed separately._

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22056.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9473](https://warthogs.atlassian.net/browse/JUJU-9473)


[JUJU-9473]: https://warthogs.atlassian.net/browse/JUJU-9473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ