### PR TITLE
fix: do not drop root disk constraints when custom networking

### DIFF
--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -6,6 +6,7 @@ package lxd
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/juju/collections/set"
@@ -234,7 +235,10 @@ func (env *environ) getContainerSpec(
 			return cSpec, errors.Trace(err)
 		}
 
-		cSpec.Devices = nics
+		if cSpec.Devices == nil {
+			cSpec.Devices = make(map[string]map[string]string)
+		}
+		maps.Copy(cSpec.Devices, nics)
 	}
 
 	userData, err := providerinit.ComposeUserData(args.InstanceConfig, cloudCfg, lxdRenderer{})

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -597,6 +597,67 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *tc.C) {
 	c.Assert(*res.Hardware.RootDiskSource, tc.Equals, "test-storage-pool")
 }
 
+func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndCustomNICs(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	svr := lxd.NewMockServer(ctrl)
+	invalidator := lxd.NewMockCredentialInvalidator(ctrl)
+
+	nics := map[string]map[string]string{
+		"eno9": {
+			"name":    "eno9",
+			"mtu":     "9000",
+			"nictype": "bridged",
+			"parent":  "lxdbr0",
+			"hwaddr":  "00:00:00:00:00",
+		},
+	}
+
+	check := func(spec containerlxd.ContainerSpec) bool {
+		if spec.Config[containerlxd.NetworkConfigKey] != cloudinit.CloudInitNetworkConfigDisabled {
+			return false
+		}
+		if !reflect.DeepEqual(spec.Devices["eno9"], nics["eno9"]) {
+			return false
+		}
+		if !reflect.DeepEqual(spec.Devices["root"], map[string]string{
+			"type": "disk",
+			"pool": "test-storage-pool",
+			"path": "/",
+		}) {
+			return false
+		}
+		return true
+	}
+
+	exp := svr.EXPECT()
+	gomock.InOrder(
+		exp.HostArch().Return(arch.AMD64),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
+		exp.GetNICsFromProfile("default").Return(nics, nil),
+		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
+			Instance: api.Instance{Location: "node01"},
+		}, nil),
+		exp.HostArch().Return(arch.AMD64),
+	)
+
+	args := s.GetStartInstanceArgs(c)
+	rootDiskSource := "test-storage-pool"
+	args.Constraints = constraints.Value{
+		RootDiskSource: &rootDiskSource,
+	}
+
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{}, invalidator)
+	res, err := env.StartInstance(c.Context(), args)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res, tc.NotNil)
+	c.Assert(*res.Hardware.AvailabilityZone, tc.DeepEquals, "node01")
+	c.Assert(res.Hardware.RootDiskSource, tc.NotNil)
+	c.Assert(*res.Hardware.RootDiskSource, tc.Equals, "test-storage-pool")
+}
+
 func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndVirtType(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. Run the unit test in main branch and it will fail
2. Run the unit test again with the fix and it will succeed
 
<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 4. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 5. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    6. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    7. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

N/A

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22048.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9456](https://warthogs.atlassian.net/browse/JUJU-9456)


[JUJU-9456]: https://warthogs.atlassian.net/browse/JUJU-9456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ