### PR TITLE
fix(snap): host bash_completion install and lxd snap

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,9 +1,4 @@
 #!/bin/bash
 
-# Make sure we have lxd installed to use
-if [ "$(which lxd)" = "" ]; then
-    snap install lxd || true
-fi
-
 # copy bash completions to host system
 cp -a $SNAP/bash_completions/* /usr/share/bash-completion/completions/. || true

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# copy bash completions to host system
-cp -a $SNAP/bash_completions/* /usr/share/bash-completion/completions/. || true


### PR DESCRIPTION
## Checklist

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## changes

- bash_completions are no longer present at `$SNAP/bash_completions`, remove obsolete call
- fix juju snap snap `configure` hook automatically installing lxd (which clashes with a non-snap lxd install where `lxd` is in `$PATH` but on the host)