### PR TITLE
fix: do not drop root disk constraints when custom networking

### DIFF
--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -5,6 +5,7 @@ package lxd
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/canonical/lxd/shared/api"
@@ -236,7 +237,10 @@ func (env *environ) getContainerSpec(
 			return cSpec, errors.Trace(err)
 		}
 
-		cSpec.Devices = nics
+		if cSpec.Devices == nil {
+			cSpec.Devices = make(map[string]map[string]string)
+		}
+		maps.Copy(cSpec.Devices, nics)
 	}
 
 	userData, err := providerinit.ComposeUserData(args.InstanceConfig, cloudCfg, lxdRenderer{})

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -611,14 +611,11 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndCustomNICs(c *gc
 		if !reflect.DeepEqual(spec.Devices["eno9"], nics["eno9"]) {
 			return false
 		}
-		if !reflect.DeepEqual(spec.Devices["root"], map[string]string{
+		return reflect.DeepEqual(spec.Devices["root"], map[string]string{
 			"type": "disk",
 			"pool": "test-storage-pool",
 			"path": "/",
-		}) {
-			return false
-		}
-		return true
+		})
 	}
 
 	exp := svr.EXPECT()

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -588,6 +588,66 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 	c.Assert(*res.Hardware.RootDiskSource, gc.Equals, "test-storage-pool")
 }
 
+func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndCustomNICs(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	svr := lxd.NewMockServer(ctrl)
+
+	nics := map[string]map[string]string{
+		"eno9": {
+			"name":    "eno9",
+			"mtu":     "9000",
+			"nictype": "bridged",
+			"parent":  "lxdbr0",
+			"hwaddr":  "00:00:00:00:00",
+		},
+	}
+
+	check := func(spec containerlxd.ContainerSpec) bool {
+		if spec.Config[containerlxd.NetworkConfigKey] != cloudinit.CloudInitNetworkConfigDisabled {
+			return false
+		}
+		if !reflect.DeepEqual(spec.Devices["eno9"], nics["eno9"]) {
+			return false
+		}
+		if !reflect.DeepEqual(spec.Devices["root"], map[string]string{
+			"type": "disk",
+			"pool": "test-storage-pool",
+			"path": "/",
+		}) {
+			return false
+		}
+		return true
+	}
+
+	exp := svr.EXPECT()
+	gomock.InOrder(
+		exp.HostArch().Return(arch.AMD64),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, api.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
+		exp.GetNICsFromProfile("default").Return(nics, nil),
+		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
+			Instance: api.Instance{Location: "node01"},
+		}, nil),
+		exp.HostArch().Return(arch.AMD64),
+	)
+
+	args := s.GetStartInstanceArgs(c)
+	rootDiskSource := "test-storage-pool"
+	args.Constraints = constraints.Value{
+		RootDiskSource: &rootDiskSource,
+	}
+
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
+	res, err := env.StartInstance(s.callCtx, args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+	c.Assert(*res.Hardware.AvailabilityZone, jc.DeepEquals, "node01")
+	c.Assert(res.Hardware.RootDiskSource, gc.NotNil)
+	c.Assert(*res.Hardware.RootDiskSource, gc.Equals, "test-storage-pool")
+}
+
 func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndVirtType(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

This was needed to handle a corner case in LXD provisioning where, if the default profile did not include an eth0 device and Juju had to build custom networking, the code unintentionally dropped root disk settings from user-specified constraints.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### bootstrap with the local code
```bash
GOOS=linux GOARCH=amd64 make juju jujud
export PATH="$(go env GOPATH)/bin:$PATH"
which juju
/home/ubuntu/go/bin/juju

juju bootstrap lxd qa-controller --build-agent --bootstrap-base=ubuntu@24.04
Creating Juju controller "qa-controller" on lxd/localhost
Building local Juju agent binary version 3.6.24 for amd64
To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
Launching controller instance(s) on localhost/localhost...
 - juju-d51710-0 (arch=amd64)                   
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.87.41.219:22
Attempting to connect to [fd42:e301:f197:9ceb:216:3eff:fef9:3c67]:22
Connected to 10.87.41.219
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.87.41.219 to verify accessibility...

Bootstrap complete, controller "qa-controller" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.
```

### create reproducer LXD project

```bash
lxc project create reproducer
lxc profile show default --project reproducer
name: default
description: Default LXD profile for project reproducer
config: {}
devices:
  enp5s0:
    name: enp5s0
    network: lxdbr0
    type: nic
  root:
    path: /
    pool: default
    size: 14GB
    type: disk
project: reproducer
``` 

### Add juju machine with disk constraints

```bash
juju add-model reproducer --config project=reproducer
Added 'reproducer' model on localhost/localhost with credential 'localhost' for user 'admin'
juju add-machine --base 'ubuntu@24.04' --constraints='cores=2 mem=2G root-disk=18G root-disk-source=default'
created machine 1
juju status
Model       Controller     Cloud/Region         Version   SLA          Timestamp
reproducer  qa-controller  localhost/localhost  3.6.24.1  unsupported  10:16:02Z

Machine  State    Address                                 Inst id        Base          AZ         Message
1        started  fd42:e301:f197:9ceb:216:3eff:fe8f:d03e  juju-37ee48-1  ubuntu@24.04  juju-test  Running
```

### Verify that the lxd config of the machine contains both nic custom parts (not `eth0`) and storage device override

```bash
lxc config show juju-37ee48-1 --project reproducer
architecture: x86_64
config:
  image.architecture: amd64
...
...
  user.network-config: |
    config: "disabled"
  user.user-data: |
    #cloud-config
    bootcmd:
    - install -D -m 600 /dev/null '/etc/netplan/99-juju.yaml'
    - |-
      echo 'network:
        version: 2
        ethernets:
          enp5s0:
            dhcp4: true
            dhcp4-overrides:
              route-metric: 100
...
...
devices:
  enp5s0:
    hwaddr: 00:16:3e:8f:d0:3e
    name: enp5s0
    network: lxdbr0
    type: nic
  root:
    path: /
    pool: default
    size: 18432MiB
    type: disk
ephemeral: false
profiles:
- default
- juju-reproducer-fc2375
stateful: false
description: ""
```

### Verify no errors in the models:

**NOTE:** The machine 0 was an attempt with wrong input by me - it's irrelevant
```bash
juju debug-log -m reproducer --replay | grep ERROR
controller-0: 10:10:26 ERROR juju.worker.provisioner cannot start instance for machine "0": Failed creating instance record: Failed initialising instance: Failed loading storage pool: Storage pool not found
controller-0: 10:10:26 ERROR juju.worker.provisioner failed to remove dead machine "0"
machine-1: 10:12:16 ERROR juju.worker.dependency "kvm-container-provisioner" manifold worker returned unexpected error: container types not yet available
machine-1: 10:12:16 ERROR juju.worker.dependency "lxd-container-provisioner" manifold worker returned unexpected error: container types not yet available
```
```
juju debug-log -m controller --replay | grep ERROR
machine-0: 10:05:47 ERROR juju.mongo could not set the value of "/sys/kernel/mm/transparent_hugepage/enabled" to "never" because of: open /sys/kernel/mm/transparent_hugepage/enabled: permission denied
machine-0: 10:05:47 ERROR juju.mongo could not set the value of "/sys/kernel/mm/transparent_hugepage/defrag" to "never" because of: open /sys/kernel/mm/transparent_hugepage/defrag: permission denied
machine-0: 10:05:47 ERROR juju.mongo could not set the value of "/proc/sys/net/core/netdev_max_backlog" to "1000" because of: "/proc/sys/net/core/netdev_max_backlog" does not exist, will not set "1000"
machine-0: 10:05:47 ERROR juju.worker.dependency "api-caller" manifold worker returned unexpected error: [413858] "machine-0" cannot open api: unable to connect to API: dial tcp 127.0.0.1:17070: connect: connection refused
machine-0: 10:05:51 ERROR juju.worker.peergrouper cannot write API server addresses: no API servers specified
machine-0: 10:05:51 ERROR juju.worker.dependency "kvm-container-provisioner" manifold worker returned unexpected error: container types not yet available
machine-0: 10:05:51 ERROR juju.worker.dependency "lxd-container-provisioner" manifold worker returned unexpected error: container types not yet available
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.worker.logger connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.worker.dependency "kvm-container-provisioner" manifold worker returned unexpected error: container types not yet available
machine-0: 10:05:51 ERROR juju.worker.dependency "lxd-container-provisioner" manifold worker returned unexpected error: container types not yet available
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down
machine-0: 10:05:51 ERROR juju.api.watcher error trying to stop watcher: connection is shutdown before send: connection is shut down

```
<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 4. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 5. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    6. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    7. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

N/A

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22048.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9456](https://warthogs.atlassian.net/browse/JUJU-9456)


[JUJU-9456]: https://warthogs.atlassian.net/browse/JUJU-9456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ