### PR TITLE
docs: correct integrate command in tutorial

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -450,11 +450,13 @@ Deployed "self-signed-certificates" from charm-hub charm "self-signed-certificat
 
 ```
 
+Since `postgresql-k8s` and `self-signed-certificates` could be integrated over either the `tls-certificates` interface or the `certificate_transfer` interface, we'll need to specify the endpoints explicitly when integrating:
+
 ```{terminal}
 :copy:
 :user: ubuntu
 :host: my-juju-vm
-juju integrate self-signed-certificates postgresql-k8s
+juju integrate postgresql-k8s:certificates self-signed-certificates:certificates
 
 ```
 


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->
This PR should be merged into both `3.6` and `main`.

The `juju integrate` command in the tutorial will fail with an error because multiple interfaces are supported between the two charms.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] ~Code style: imports ordered, good names, simple structure, etc~
- [x] ~Comments saying why design decisions were made~
- [x] ~Go unit tests, with comments saying what you're testing~
- [x] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Docs should build. Tutorial steps should work as documented.

```bash
ubuntu@my-juju-vm:~$ juju integrate self-signed-certificates postgresql-k8s
ERROR ambiguous relation: "self-signed-certificates postgresql-k8s" could refer
to "postgresql-k8s:certificates self-signed-certificates:certificates";
"postgresql-k8s:receive-ca-cert self-signed-certificates:send-ca-cert"
ubuntu@my-juju-vm:~$ juju integrate postgresql-k8s:certificates
self-signed-certificates:certificates
```

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

This PR updates the tutorial to provide the unambiguous `juju integrate` command and explain why it's needed.
<!-- How it affects user workflow (CLI or API). -->

## Links

Thanks to @marqode for reporting this issue and identifying the fix.
