### PR TITLE
feat: allow removal of offers with connections without force flag

### DIFF
--- a/cmd/juju/crossmodel/remove.go
+++ b/cmd/juju/crossmodel/remove.go
@@ -6,6 +6,7 @@ package crossmodel
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/juju/errors"
@@ -19,6 +20,7 @@ import (
 	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/crossmodel"
+	coremodel "github.com/juju/juju/core/model"
 )
 
 // NewRemoveOfferCommand returns a command used to remove a specified offer.
@@ -36,15 +38,17 @@ type removeCommand struct {
 	offers      []string
 	offerSource string
 
-	assumeYes bool
-	force     bool
+	force    bool
+	noPrompt bool
 }
 
 const destroyOfferDoc = `
 Remove one or more application offers.
 
-If the ` + "`--force`" + ` option is specified, any existing relations to the
-offer will also be removed.
+If an offer has active connections, Juju will ask for confirmation before
+removing the offer and the relations to it unless --no-prompt is used.
+
+Use --force to request forced offer removal from the controller.
 
 Offers to remove are normally specified by their URL.
 It's also possible to specify just the offer name, in which case
@@ -53,7 +57,6 @@ the offer is considered to reside in the current model.
 
 const destroyOfferExamples = `
     juju remove-offer staging/mymodel.hosted-mysql
-    juju remove-offer staging/mymodel.hosted-mysql --force
     juju remove-offer hosted-mysql
 `
 
@@ -75,9 +78,8 @@ func (c *removeCommand) Info() *cmd.Info {
 // SetFlags implements Command.SetFlags.
 func (c *removeCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.ControllerCommandBase.SetFlags(f)
-	f.BoolVar(&c.force, "force", false, "Remove the offer as well as any relations to the offer")
-	f.BoolVar(&c.assumeYes, "y", false, "Do not prompt for confirmation")
-	f.BoolVar(&c.assumeYes, "yes", false, "")
+	f.BoolVar(&c.force, "force", false, "Force remove the offer")
+	f.BoolVar(&c.noPrompt, "no-prompt", false, "Do not prompt for confirmation")
 }
 
 // Init implements Command.Init.
@@ -93,6 +95,7 @@ func (c *removeCommand) Init(args []string) error {
 type RemoveAPI interface {
 	Close() error
 	DestroyOffers(ctx context.Context, force bool, offerURLs ...string) error
+	ListOffers(ctx context.Context, filters ...crossmodel.ApplicationOfferFilter) ([]*crossmodel.ApplicationOfferDetails, error)
 }
 
 // NewApplicationOffersAPI returns an application offers api.
@@ -106,7 +109,7 @@ func (c *removeCommand) NewApplicationOffersAPI(ctx context.Context, controllerN
 
 var removeOfferMsg = `
 WARNING! This command will remove offers: %v
-This includes all relations to those offers.
+Any existing relations to those offers will also be removed.
 `[1:]
 
 // Run implements Command.Run.
@@ -123,11 +126,13 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 	}
 
 	var invalidOffers []string
+	parsedOffers := make([]crossmodel.OfferURL, len(c.offers))
 	for i, urlStr := range c.offers {
 		url, err := c.parseOfferURL(controllerName, currentModel, urlStr)
 		if err != nil {
 			return errors.Trace(err)
 		}
+		parsedOffers[i] = url
 		c.offers[i] = url.String()
 		if c.offerSource == "" {
 			c.offerSource = url.Source
@@ -148,22 +153,87 @@ func (c *removeCommand) Run(ctx *cmd.Context) error {
 		c.offerSource = controllerName
 	}
 
-	if !c.assumeYes && c.force {
-		fmt.Fprintf(ctx.Stderr, removeOfferMsg, strings.Join(c.offers, ", "))
-
-		if err := jujucmd.UserConfirmYes(ctx); err != nil {
-			return errors.Annotate(err, "offer removal")
-		}
-	}
-
 	api, err := c.newAPIFunc(ctx, c.offerSource)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer api.Close()
 
+	err = c.resolveOfferRemoval(ctx, api, parsedOffers)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	err = api.DestroyOffers(ctx, c.force, c.offers...)
 	return block.ProcessBlockedError(err, block.BlockRemove)
+}
+
+func (c *removeCommand) resolveOfferRemoval(
+	ctx *cmd.Context,
+	api RemoveAPI,
+	offers []crossmodel.OfferURL,
+) error {
+	connectedOffers, err := c.connectedOffers(ctx, api, offers)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(connectedOffers) == 0 {
+		return nil
+	}
+
+	if err := c.confirmOfferRemoval(ctx, connectedOffers); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (c *removeCommand) confirmOfferRemoval(ctx *cmd.Context, offers []string) error {
+	if c.noPrompt {
+		return nil
+	}
+
+	fmt.Fprintf(ctx.Stderr, removeOfferMsg, strings.Join(offers, ", "))
+	if err := jujucmd.UserConfirmYes(ctx); err != nil {
+		return errors.Annotate(err, "offer removal")
+	}
+	return nil
+}
+
+func (c *removeCommand) connectedOffers(
+	ctx context.Context,
+	api RemoveAPI,
+	offers []crossmodel.OfferURL,
+) ([]string, error) {
+	filters := make([]crossmodel.ApplicationOfferFilter, len(offers))
+	userOffers := make(map[string]string, len(offers))
+	for i, offer := range offers {
+		localURL := offer.AsLocal().String()
+		filters[i] = crossmodel.ApplicationOfferFilter{
+			ModelQualifier: coremodel.Qualifier(offer.ModelQualifier),
+			ModelName:      offer.ModelName,
+			OfferName:      fmt.Sprintf("^%v$", regexp.QuoteMeta(offer.Name)),
+		}
+		userOffers[localURL] = c.offers[i]
+	}
+
+	listedOffers, err := api.ListOffers(ctx, filters...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	connected := make([]string, 0)
+	for _, offer := range listedOffers {
+		if len(offer.Connections) == 0 {
+			continue
+		}
+		userOffer, ok := userOffers[offer.OfferURL]
+		if !ok {
+			continue
+		}
+		connected = append(connected, userOffer)
+	}
+
+	return connected, nil
 }
 
 func (c *removeCommand) parseOfferURL(controllerName, currentModel, urlStr string) (crossmodel.OfferURL, error) {

--- a/cmd/juju/crossmodel/remove_test.go
+++ b/cmd/juju/crossmodel/remove_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/cmd/cmd"
 	"github.com/juju/juju/cmd/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/modelcmd"
+	corecrossmodel "github.com/juju/juju/core/crossmodel"
 )
 
 func newRemoveCommandForTest(store jujuclient.ClientStore, api RemoveAPI) cmd.Command {
@@ -69,24 +70,33 @@ func (s *removeSuite) TestRemoveInconsistentControllers(c *tc.C) {
 
 func (s *removeSuite) TestRemoveApiError(c *tc.C) {
 	s.mockAPI.msg = "fail"
-	_, err := s.runRemove(c, "prod/model.db2", "-y")
+	_, err := s.runRemove(c, "prod/model.db2", "--no-prompt")
 	c.Assert(err, tc.ErrorMatches, ".*fail.*")
 }
 
 func (s *removeSuite) TestRemove(c *tc.C) {
 	s.mockAPI.expectedURLs = []string{"prod/model.db2", "staging/model.db2"}
-	_, err := s.runRemove(c, "prod/model.db2", "staging/model.db2", "-y")
+	_, err := s.runRemove(c, "prod/model.db2", "staging/model.db2", "--no-prompt")
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *removeSuite) TestRemoveForce(c *tc.C) {
-	s.mockAPI.expectedURLs = []string{"prod/model.db2", "staging/model.db2"}
+func (s *removeSuite) TestRemoveWithForce(c *tc.C) {
+	s.mockAPI.expectedURLs = []string{"prod/model.db2"}
 	s.mockAPI.expectedForce = true
-	_, err := s.runRemove(c, "prod/model.db2", "staging/model.db2", "-y", "--force")
+
+	_, err := s.runRemove(c, "prod/model.db2", "--force", "--no-prompt")
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *removeSuite) TestRemoveForceMessage(c *tc.C) {
+func (s *removeSuite) TestRemoveWithConnectionsPrompts(c *tc.C) {
+	s.mockAPI.expectedURLs = []string{"prod/model.db2"}
+	s.mockAPI.offerDetails = []*corecrossmodel.ApplicationOfferDetails{{
+		OfferURL: "prod/model.db2",
+		Connections: []corecrossmodel.OfferConnection{{
+			RelationId: 1,
+		}},
+	}}
+
 	var stdin, stdout, stderr bytes.Buffer
 	ctx, err := cmd.DefaultContext()
 	c.Assert(err, tc.ErrorIsNil)
@@ -96,17 +106,31 @@ func (s *removeSuite) TestRemoveForceMessage(c *tc.C) {
 	stdin.WriteString("y")
 
 	com := newRemoveCommandForTest(s.store, s.mockAPI)
-	err = cmdtesting.InitCommand(com, []string{"prod/model.db2", "--force"})
+	err = cmdtesting.InitCommand(com, []string{"prod/model.db2"})
 	c.Assert(err, tc.ErrorIsNil)
-	com.Run(ctx)
+	err = com.Run(ctx)
+	c.Assert(err, tc.ErrorIsNil)
 
 	expected := `
 WARNING! This command will remove offers: prod/model.db2
-This includes all relations to those offers.
+Any existing relations to those offers will also be removed.
 
 Continue [y/N]? `[1:]
 
 	c.Assert(cmdtesting.Stderr(ctx), tc.Equals, expected)
+}
+
+func (s *removeSuite) TestRemoveWithConnectionsAndNoPrompt(c *tc.C) {
+	s.mockAPI.expectedURLs = []string{"prod/model.db2"}
+	s.mockAPI.offerDetails = []*corecrossmodel.ApplicationOfferDetails{{
+		OfferURL: "prod/model.db2",
+		Connections: []corecrossmodel.OfferConnection{{
+			RelationId: 1,
+		}},
+	}}
+
+	_, err := s.runRemove(c, "prod/model.db2", "--no-prompt")
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *removeSuite) TestRemoveNameOnly(c *tc.C) {
@@ -134,6 +158,7 @@ type mockRemoveAPI struct {
 	msg           string
 	expectedForce bool
 	expectedURLs  []string
+	offerDetails  []*corecrossmodel.ApplicationOfferDetails
 }
 
 func (s mockRemoveAPI) Close() error {
@@ -151,4 +176,8 @@ func (s mockRemoveAPI) DestroyOffers(ctx context.Context, force bool, offerURLs 
 		return errors.Errorf("mismatched URLs: %v != %v", s.expectedURLs, offerURLs)
 	}
 	return nil
+}
+
+func (s mockRemoveAPI) ListOffers(ctx context.Context, filters ...corecrossmodel.ApplicationOfferFilter) ([]*corecrossmodel.ApplicationOfferDetails, error) {
+	return s.offerDetails, nil
 }

--- a/docs/howto/manage-offers.md
+++ b/docs/howto/manage-offers.md
@@ -490,10 +490,13 @@ See more: {ref}`command-juju-suspend-relation`, {ref}`command-juju-resume-relati
 ## Remove an offer
 > Who: User with {ref}`offer admin access <user-access-offer-admin>`.
 
-An offer can be removed providing it hasn't been used in any relation. To override this behaviour the `--force` option is required, in which case the relation is also removed. This is how an offer is removed:
+An offer can be removed directly. If it has active integrations, the CLI asks for
+confirmation before removing the offer and those integrations, unless
+`--no-prompt` is used. Pass `--force` to forward a forced removal request to the
+controller.
 
 ```text
-juju remove-offer [--force] <offer-url>
+juju remove-offer <offer-url>
 ```
 
 Note that, if the offer resides in the current model, then the shorter offer name can be used instead of the longer URL.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/remove-offer.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/remove-offer.md
@@ -13,13 +13,12 @@ Removes one or more offers specified by their URL.
 | --- | --- | --- |
 | `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
 | `-c`, `--controller` |  | Controller to operate in |
-| `--force` | false | Remove the offer as well as any relations to the offer |
-| `-y`, `--yes` | false | Do not prompt for confirmation |
+| `--force` | false | Force remove the offer |
+| `--no-prompt` | false | Do not prompt for confirmation |
 
 ## Examples
 
     juju remove-offer staging/mymodel.hosted-mysql
-    juju remove-offer staging/mymodel.hosted-mysql --force
     juju remove-offer hosted-mysql
 
 
@@ -27,8 +26,10 @@ Removes one or more offers specified by their URL.
 
 Remove one or more application offers.
 
-If the `--force` option is specified, any existing relations to the
-offer will also be removed.
+If an offer has active connections, Juju will ask for confirmation before
+removing the offer and the relations to it unless --no-prompt is used.
+
+Use --force to request forced offer removal from the controller.
 
 Offers to remove are normally specified by their URL.
 It's also possible to specify just the offer name, in which case

--- a/domain/removal/service/offer.go
+++ b/domain/removal/service/offer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/juju/core/offer"
+	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/trace"
 	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
 	"github.com/juju/juju/internal/errors"
@@ -16,6 +17,14 @@ import (
 type OfferState interface {
 	// OfferExists returns true if an offer exists with the input offer UUID.
 	OfferExists(ctx context.Context, offerUUID string) (bool, error)
+
+	// GetOfferRelationUUIDs returns the remote relation UUIDs for any active
+	// connections to the offer.
+	GetOfferRelationUUIDs(ctx context.Context, offerUUID string) ([]string, error)
+
+	// HideOffer removes the endpoints for an offer so it can no longer be listed
+	// or consumed while existing remote relations finish tearing down.
+	HideOffer(ctx context.Context, offerUUID string) error
 
 	// DeleteOffer removes an offer from the database completely.
 	DeleteOffer(ctx context.Context, offerUUID string, force bool) error
@@ -27,11 +36,6 @@ type ControllerOfferState interface {
 }
 
 // RemoveOffer removes the offer from the model.
-//
-// NOTE: This method is different from the other removal methods, because offers
-// do not have life, and their removal only cascade removes synthetic entities
-// whose life does not matter either. This means we can simply attempt to remove
-// the offer directly in this call.
 func (s *Service) RemoveOffer(ctx context.Context, offerUUID offer.UUID, force bool) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -43,7 +47,27 @@ func (s *Service) RemoveOffer(ctx context.Context, offerUUID offer.UUID, force b
 		return errors.Errorf("offer %q does not exist", offerUUID).Add(crossmodelrelationerrors.OfferNotFound)
 	}
 
-	if err := s.modelState.DeleteOffer(ctx, offerUUID.String(), force); err != nil {
+	relationUUIDs, err := s.modelState.GetOfferRelationUUIDs(ctx, offerUUID.String())
+	if err != nil {
+		return errors.Errorf("getting relations for offer %q: %w", offerUUID, err)
+	}
+
+	if len(relationUUIDs) > 0 {
+		for _, relationUUID := range relationUUIDs {
+			relUUID, err := corerelation.ParseUUID(relationUUID)
+			if err != nil {
+				return errors.Errorf("parsing relation UUID %q for offer %q: %w", relationUUID, offerUUID, err)
+			}
+
+			if _, err := s.RemoveRelationWithRemoteConsumer(ctx, relUUID, force, 0); err != nil {
+				return errors.Errorf("removing relation %q for offer %q: %w", relUUID, offerUUID, err)
+			}
+		}
+
+		if err := s.modelState.HideOffer(ctx, offerUUID.String()); err != nil {
+			return errors.Errorf("hiding offer %q: %w", offerUUID, err)
+		}
+	} else if err := s.modelState.DeleteOffer(ctx, offerUUID.String(), force); err != nil {
 		return errors.Errorf("deleting offer %q: %w", offerUUID, err)
 	}
 

--- a/domain/removal/service/offer_test.go
+++ b/domain/removal/service/offer_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juju/tc"
+	"go.uber.org/mock/gomock"
+
+	"github.com/juju/juju/core/offer"
+	"github.com/juju/juju/core/relation"
+	"github.com/juju/juju/domain/removal/internal"
+)
+
+type removeOfferSuite struct {
+	baseSuite
+}
+
+func TestRemoveOfferSuite(t *testing.T) {
+	tc.Run(t, &removeOfferSuite{})
+}
+
+func (s *removeOfferSuite) TestRemoveOfferDeletesDisconnectedOffer(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	offerUUID := tc.Must(c, offer.NewUUID)
+
+	exp := s.modelState.EXPECT()
+	exp.OfferExists(gomock.Any(), offerUUID.String()).Return(true, nil)
+	exp.GetOfferRelationUUIDs(gomock.Any(), offerUUID.String()).Return(nil, nil)
+	exp.DeleteOffer(gomock.Any(), offerUUID.String(), false).Return(nil)
+	s.controllerState.EXPECT().DeleteOfferAccess(gomock.Any(), offerUUID.String()).Return(nil)
+
+	err := s.newService(c).RemoveOffer(c.Context(), offerUUID, false)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *removeOfferSuite) TestRemoveOfferSchedulesConnectedRelationsAndHidesOffer(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	offerUUID := tc.Must(c, offer.NewUUID)
+	relUUID0 := tc.Must(c, relation.NewUUID)
+	relUUID1 := tc.Must(c, relation.NewUUID)
+	when := time.Now()
+
+	s.clock.EXPECT().Now().Return(when).Times(2)
+
+	exp := s.modelState.EXPECT()
+	gomock.InOrder(
+		exp.OfferExists(gomock.Any(), offerUUID.String()).Return(true, nil),
+		exp.GetOfferRelationUUIDs(gomock.Any(), offerUUID.String()).Return([]string{relUUID0.String(), relUUID1.String()}, nil),
+		exp.RelationWithRemoteConsumerExists(gomock.Any(), relUUID0.String()).Return(true, nil),
+		exp.EnsureRelationWithRemoteConsumerNotAliveCascade(gomock.Any(), relUUID0.String()).Return(internal.CascadedRelationWithRemoteConsumerLives{}, nil),
+		exp.RelationWithRemoteConsumerScheduleRemoval(gomock.Any(), gomock.Any(), relUUID0.String(), false, when.UTC()).Return(nil),
+		exp.RelationWithRemoteConsumerExists(gomock.Any(), relUUID1.String()).Return(true, nil),
+		exp.EnsureRelationWithRemoteConsumerNotAliveCascade(gomock.Any(), relUUID1.String()).Return(internal.CascadedRelationWithRemoteConsumerLives{}, nil),
+		exp.RelationWithRemoteConsumerScheduleRemoval(gomock.Any(), gomock.Any(), relUUID1.String(), false, when.UTC()).Return(nil),
+		exp.HideOffer(gomock.Any(), offerUUID.String()).Return(nil),
+	)
+	s.controllerState.EXPECT().DeleteOfferAccess(gomock.Any(), offerUUID.String()).Return(nil)
+
+	err := s.newService(c).RemoveOffer(c.Context(), offerUUID, false)
+	c.Assert(err, tc.ErrorIsNil)
+}

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -2889,6 +2889,45 @@ func (c *MockModelDBStateGetModelTypeCall) DoAndReturn(f func(context.Context) (
 	return c
 }
 
+// GetOfferRelationUUIDs mocks base method.
+func (m *MockModelDBState) GetOfferRelationUUIDs(arg0 context.Context, arg1 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOfferRelationUUIDs", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOfferRelationUUIDs indicates an expected call of GetOfferRelationUUIDs.
+func (mr *MockModelDBStateMockRecorder) GetOfferRelationUUIDs(arg0, arg1 any) *MockModelDBStateGetOfferRelationUUIDsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOfferRelationUUIDs", reflect.TypeOf((*MockModelDBState)(nil).GetOfferRelationUUIDs), arg0, arg1)
+	return &MockModelDBStateGetOfferRelationUUIDsCall{Call: call}
+}
+
+// MockModelDBStateGetOfferRelationUUIDsCall wrap *gomock.Call
+type MockModelDBStateGetOfferRelationUUIDsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateGetOfferRelationUUIDsCall) Return(arg0 []string, arg1 error) *MockModelDBStateGetOfferRelationUUIDsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateGetOfferRelationUUIDsCall) Do(f func(context.Context, string) ([]string, error)) *MockModelDBStateGetOfferRelationUUIDsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateGetOfferRelationUUIDsCall) DoAndReturn(f func(context.Context, string) ([]string, error)) *MockModelDBStateGetOfferRelationUUIDsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRelationLife mocks base method.
 func (m *MockModelDBState) GetRelationLife(arg0 context.Context, arg1 string) (life.Life, error) {
 	m.ctrl.T.Helper()
@@ -3392,6 +3431,44 @@ func (c *MockModelDBStateGetVolumeStatusCall) Do(f func(context.Context, string)
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelDBStateGetVolumeStatusCall) DoAndReturn(f func(context.Context, string) (int, error)) *MockModelDBStateGetVolumeStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// HideOffer mocks base method.
+func (m *MockModelDBState) HideOffer(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HideOffer", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HideOffer indicates an expected call of HideOffer.
+func (mr *MockModelDBStateMockRecorder) HideOffer(arg0, arg1 any) *MockModelDBStateHideOfferCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HideOffer", reflect.TypeOf((*MockModelDBState)(nil).HideOffer), arg0, arg1)
+	return &MockModelDBStateHideOfferCall{Call: call}
+}
+
+// MockModelDBStateHideOfferCall wrap *gomock.Call
+type MockModelDBStateHideOfferCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDBStateHideOfferCall) Return(arg0 error) *MockModelDBStateHideOfferCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDBStateHideOfferCall) Do(f func(context.Context, string) error) *MockModelDBStateHideOfferCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDBStateHideOfferCall) DoAndReturn(f func(context.Context, string) error) *MockModelDBStateHideOfferCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/state/model/application.go
+++ b/domain/removal/state/model/application.go
@@ -449,9 +449,9 @@ WHERE  uuid = $entityUUID.uuid;`, applicationUUID)
 		}
 
 		for _, offer := range offers {
-			// We don't need to worry about whether the offer has connections here.
-			// Either we are using force, meaning we don't care, or we are not forcing,
-			// meaning we checked there are no connections before setting to dying.
+			// Offer deletion handles any connected remote-consumer relation cleanup
+			// directly, so application removal does not need a separate connection
+			// pre-check here.
 			if err := st.deleteOffer(ctx, tx, offer, force); err != nil {
 				return errors.Errorf("deleting offer %q: %w", offer.UUID, err)
 			}

--- a/domain/removal/state/model/offer.go
+++ b/domain/removal/state/model/offer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/canonical/sqlair"
 
-	removalerrors "github.com/juju/juju/domain/removal/errors"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -60,15 +59,6 @@ func (st *State) DeleteOffer(ctx context.Context, oUUID string, force bool) erro
 }
 
 func (st *State) deleteOffer(ctx context.Context, tx *sqlair.TX, offerUUID entityUUID, force bool) error {
-	checkConnsStmt, err := st.Prepare(`
-SELECT COUNT(*) AS &count.count
-FROM offer_connection 
-WHERE offer_uuid = $entityUUID.uuid
-`, count{}, offerUUID)
-	if err != nil {
-		return errors.Errorf("preparing offer connection count query: %w", err)
-	}
-
 	getSynthRelationsStmt, err := st.Prepare(`
 SELECT remote_relation_uuid AS &entityUUID.uuid
 FROM   offer_connection
@@ -94,38 +84,21 @@ WHERE uuid = $entityUUID.uuid
 		return errors.Errorf("preparing delete offer query: %w", err)
 	}
 
-	// If we aren't forcing, check for existing connections.
-	if !force {
-		var count count
-		if err := tx.Query(ctx, checkConnsStmt, offerUUID).Get(&count); err != nil {
-			return errors.Errorf("checking offer connections: %w", err)
-		} else if count.Count > 0 {
-			return errors.Errorf("cannot delete offer %q, it has %d connections", offerUUID, count.Count).
-				Add(removalerrors.OfferHasRelations).
-				Add(removalerrors.ForceRequired)
-		}
+	var synthRelationUUIDs []entityUUID
+	err = tx.Query(ctx, getSynthRelationsStmt, offerUUID).GetAll(&synthRelationUUIDs)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Errorf("getting synthetic relation UUIDs: %w", err)
 	}
 
-	// If we aren't force removing, we know we don't have any connections
-	// so we don't need to run the queries deleting the connections and
-	// remote apps/relations
-	if force {
-		var synthRelationUUIDs []entityUUID
-		err = tx.Query(ctx, getSynthRelationsStmt, offerUUID).GetAll(&synthRelationUUIDs)
-		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("getting synthetic relation UUIDs: %w", err)
+	for _, synthRelationUUID := range synthRelationUUIDs {
+		err = st.deleteRelationUnitsForRelation(ctx, tx, synthRelationUUID)
+		if err != nil {
+			return errors.Errorf("deleting relation units for relation %q: %w", synthRelationUUID, err)
 		}
 
-		for _, synthRelationUUID := range synthRelationUUIDs {
-			err = st.deleteRelationUnitsForRelation(ctx, tx, synthRelationUUID)
-			if err != nil {
-				return errors.Errorf("deleting relation units for relation %q: %w", synthRelationUUID, err)
-			}
-
-			err = st.deleteRelationWithRemoteConsumer(ctx, tx, synthRelationUUID)
-			if err != nil {
-				return errors.Errorf("deleting synthetic relations with remote consumers: %w", err)
-			}
+		err = st.deleteRelationWithRemoteConsumer(ctx, tx, synthRelationUUID)
+		if err != nil {
+			return errors.Errorf("deleting synthetic relations with remote consumers: %w", err)
 		}
 	}
 

--- a/domain/removal/state/model/offer.go
+++ b/domain/removal/state/model/offer.go
@@ -43,6 +43,50 @@ WHERE  uuid = $entityUUID.uuid`, offerUUID)
 	return offerExists, errors.Capture(err)
 }
 
+// GetOfferRelationUUIDs returns the synthetic relation UUIDs for any remote
+// consumers connected to the offer.
+func (st *State) GetOfferRelationUUIDs(ctx context.Context, oUUID string) ([]string, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	offerUUID := entityUUID{UUID: oUUID}
+	var synthRelationUUIDs []entityUUID
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		relationUUIDs, err := st.getOfferRelationUUIDs(ctx, tx, offerUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		synthRelationUUIDs = relationUUIDs
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	result := make([]string, len(synthRelationUUIDs))
+	for i, relationUUID := range synthRelationUUIDs {
+		result[i] = relationUUID.UUID
+	}
+	return result, nil
+}
+
+// HideOffer removes the offer endpoints so the offer can no longer be listed or
+// consumed while existing remote relations finish removal.
+func (st *State) HideOffer(ctx context.Context, oUUID string) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	offerUUID := entityUUID{UUID: oUUID}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return st.hideOffer(ctx, tx, offerUUID)
+	})
+	return errors.Capture(err)
+}
+
 // DeleteOffer removes an offer from the database completely.
 func (st *State) DeleteOffer(ctx context.Context, oUUID string, force bool) error {
 	db, err := st.DB(ctx)
@@ -58,16 +102,25 @@ func (st *State) DeleteOffer(ctx context.Context, oUUID string, force bool) erro
 	return errors.Capture(err)
 }
 
-func (st *State) deleteOffer(ctx context.Context, tx *sqlair.TX, offerUUID entityUUID, force bool) error {
+func (st *State) getOfferRelationUUIDs(ctx context.Context, tx *sqlair.TX, offerUUID entityUUID) ([]entityUUID, error) {
 	getSynthRelationsStmt, err := st.Prepare(`
 SELECT remote_relation_uuid AS &entityUUID.uuid
 FROM   offer_connection
 WHERE  offer_uuid = $entityUUID.uuid
 `, entityUUID{})
 	if err != nil {
-		return errors.Errorf("preparing synthetic relations query: %w", err)
+		return nil, errors.Errorf("preparing synthetic relations query: %w", err)
 	}
 
+	var synthRelationUUIDs []entityUUID
+	err = tx.Query(ctx, getSynthRelationsStmt, offerUUID).GetAll(&synthRelationUUIDs)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return nil, errors.Errorf("getting synthetic relation UUIDs: %w", err)
+	}
+	return synthRelationUUIDs, nil
+}
+
+func (st *State) hideOffer(ctx context.Context, tx *sqlair.TX, offerUUID entityUUID) error {
 	deleteOfferEndpointsStmt, err := st.Prepare(`
 DELETE FROM offer_endpoint
 WHERE offer_uuid = $entityUUID.uuid
@@ -76,6 +129,14 @@ WHERE offer_uuid = $entityUUID.uuid
 		return errors.Errorf("preparing delete offer endpoints query: %w", err)
 	}
 
+	if err := tx.Query(ctx, deleteOfferEndpointsStmt, offerUUID).Run(); err != nil {
+		return errors.Errorf("deleting offer endpoints: %w", err)
+	}
+
+	return nil
+}
+
+func (st *State) deleteOffer(ctx context.Context, tx *sqlair.TX, offerUUID entityUUID, force bool) error {
 	deleteOfferStmt, err := st.Prepare(`
 DELETE FROM offer 
 WHERE uuid = $entityUUID.uuid
@@ -84,10 +145,9 @@ WHERE uuid = $entityUUID.uuid
 		return errors.Errorf("preparing delete offer query: %w", err)
 	}
 
-	var synthRelationUUIDs []entityUUID
-	err = tx.Query(ctx, getSynthRelationsStmt, offerUUID).GetAll(&synthRelationUUIDs)
-	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return errors.Errorf("getting synthetic relation UUIDs: %w", err)
+	synthRelationUUIDs, err := st.getOfferRelationUUIDs(ctx, tx, offerUUID)
+	if err != nil {
+		return errors.Capture(err)
 	}
 
 	for _, synthRelationUUID := range synthRelationUUIDs {
@@ -102,8 +162,8 @@ WHERE uuid = $entityUUID.uuid
 		}
 	}
 
-	if err := tx.Query(ctx, deleteOfferEndpointsStmt, offerUUID).Run(); err != nil {
-		return errors.Errorf("deleting offer endpoints: %w", err)
+	if err := st.hideOffer(ctx, tx, offerUUID); err != nil {
+		return errors.Capture(err)
 	}
 
 	if err := tx.Query(ctx, deleteOfferStmt, offerUUID).Run(); err != nil {

--- a/domain/removal/state/model/offer.go
+++ b/domain/removal/state/model/offer.go
@@ -73,7 +73,8 @@ func (st *State) GetOfferRelationUUIDs(ctx context.Context, oUUID string) ([]str
 }
 
 // HideOffer removes the offer endpoints so the offer can no longer be listed or
-// consumed while existing remote relations finish removal.
+// consumed while existing remote relations finish removal. If there are no
+// remaining connections, the offer row is removed as well.
 func (st *State) HideOffer(ctx context.Context, oUUID string) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -131,6 +132,36 @@ WHERE offer_uuid = $entityUUID.uuid
 
 	if err := tx.Query(ctx, deleteOfferEndpointsStmt, offerUUID).Run(); err != nil {
 		return errors.Errorf("deleting offer endpoints: %w", err)
+	}
+
+	if err := st.deleteHiddenOffer(ctx, tx, offerUUID); err != nil {
+		return errors.Capture(err)
+	}
+
+	return nil
+}
+
+func (st *State) deleteHiddenOffer(ctx context.Context, tx *sqlair.TX, offerUUID entityUUID) error {
+	deleteHiddenOfferStmt, err := st.Prepare(`
+DELETE FROM offer
+WHERE  uuid = $entityUUID.uuid
+AND    NOT EXISTS (
+	SELECT 1
+	FROM   offer_endpoint
+	WHERE  offer_uuid = $entityUUID.uuid
+)
+AND    NOT EXISTS (
+	SELECT 1
+	FROM   offer_connection
+	WHERE  offer_uuid = $entityUUID.uuid
+)
+`, entityUUID{})
+	if err != nil {
+		return errors.Errorf("preparing hidden offer deletion: %w", err)
+	}
+
+	if err := tx.Query(ctx, deleteHiddenOfferStmt, offerUUID).Run(); err != nil {
+		return errors.Errorf("deleting hidden offer: %w", err)
 	}
 
 	return nil

--- a/domain/removal/state/model/offer_test.go
+++ b/domain/removal/state/model/offer_test.go
@@ -65,6 +65,54 @@ func (s *offerSuite) TestDeleteOfferSuperfluousForce(c *tc.C) {
 	c.Check(exists, tc.Equals, false)
 }
 
+func (s *offerSuite) TestGetOfferRelationUUIDs(c *tc.C) {
+	relUUID, _, offerUUID := s.createRelationWithRemoteConsumer(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	relationUUIDs, err := st.GetOfferRelationUUIDs(c.Context(), offerUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(relationUUIDs, tc.DeepEquals, []string{relUUID.String()})
+}
+
+func (s *offerSuite) TestHideOfferWithRelations(c *tc.C) {
+	_, _, offerUUID := s.createRelationWithRemoteConsumer(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := st.HideOffer(c.Context(), offerUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	exists, err := st.OfferExists(c.Context(), offerUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, true)
+
+	var (
+		offerEndpointCount int
+		relCount           int
+		remoteAppCount     int
+	)
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM offer_endpoint WHERE offer_uuid = ?", offerUUID.String()).Scan(&offerEndpointCount)
+		if err != nil {
+			return err
+		}
+		err = tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM relation").Scan(&relCount)
+		if err != nil {
+			return err
+		}
+		err = tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM application_remote_consumer").Scan(&remoteAppCount)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(offerEndpointCount, tc.Equals, 0)
+	c.Check(relCount, tc.Equals, 1)
+	c.Check(remoteAppCount, tc.Equals, 1)
+}
+
 func (s *offerSuite) TestDeleteOfferWithRelations(c *tc.C) {
 	_, _, offerUUID := s.createRelationWithRemoteConsumer(c)
 

--- a/domain/removal/state/model/offer_test.go
+++ b/domain/removal/state/model/offer_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/juju/tc"
 
-	removalerrors "github.com/juju/juju/domain/removal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -66,14 +65,36 @@ func (s *offerSuite) TestDeleteOfferSuperfluousForce(c *tc.C) {
 	c.Check(exists, tc.Equals, false)
 }
 
-func (s *offerSuite) TestDeleteOfferFailsWithRelations(c *tc.C) {
+func (s *offerSuite) TestDeleteOfferWithRelations(c *tc.C) {
 	_, _, offerUUID := s.createRelationWithRemoteConsumer(c)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	err := st.DeleteOffer(c.Context(), offerUUID.String(), false)
-	c.Check(err, tc.ErrorIs, removalerrors.OfferHasRelations)
-	c.Check(err, tc.ErrorIs, removalerrors.ForceRequired)
+	c.Assert(err, tc.ErrorIsNil)
+
+	exists, err := st.OfferExists(c.Context(), offerUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
+
+	var (
+		relCount       int
+		remoteAppCount int
+	)
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM relation").Scan(&relCount)
+		if err != nil {
+			return err
+		}
+		err = tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM application_remote_consumer").Scan(&remoteAppCount)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(relCount, tc.Equals, 0)
+	c.Check(remoteAppCount, tc.Equals, 0)
 }
 
 func (s *offerSuite) TestDeleteOfferForceWithRelations(c *tc.C) {

--- a/domain/removal/state/model/offer_test.go
+++ b/domain/removal/state/model/offer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/tc"
 
+	"github.com/juju/juju/domain/life"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -111,6 +112,27 @@ func (s *offerSuite) TestHideOfferWithRelations(c *tc.C) {
 	c.Check(offerEndpointCount, tc.Equals, 0)
 	c.Check(relCount, tc.Equals, 1)
 	c.Check(remoteAppCount, tc.Equals, 1)
+}
+
+func (s *offerSuite) TestHideOfferDeletesOfferAfterRelationsRemoved(c *tc.C) {
+	relUUID, _, offerUUID := s.createRelationWithRemoteConsumer(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	s.advanceRelationLife(c, relUUID, life.Dying)
+
+	err := st.DeleteRelationUnits(c.Context(), relUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.DeleteRelationWithRemoteConsumer(c.Context(), relUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.HideOffer(c.Context(), offerUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	exists, err := st.OfferExists(c.Context(), offerUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.Equals, false)
 }
 
 func (s *offerSuite) TestDeleteOfferWithRelations(c *tc.C) {

--- a/domain/removal/state/model/relationwithremoteconsumer.go
+++ b/domain/removal/state/model/relationwithremoteconsumer.go
@@ -205,6 +205,15 @@ AND    cs.name = 'cmr'`, remoteRelationUUID)
 		return errors.Errorf("preparing remote relation application UUID query: %w", err)
 	}
 
+	getOfferUUIDStmt, err := st.Prepare(`
+SELECT offer_uuid AS &entityUUID.uuid
+FROM   offer_connection
+WHERE  remote_relation_uuid = $entityUUID.uuid
+`, remoteRelationUUID)
+	if err != nil {
+		return errors.Errorf("preparing remote relation offer UUID query: %w", err)
+	}
+
 	deleteRelationNetworkIngressStmt, err := st.Prepare(`
 DELETE FROM relation_network_ingress
 WHERE  relation_uuid = $entityUUID.uuid`, remoteRelationUUID)
@@ -228,10 +237,34 @@ WHERE remote_relation_uuid = $entityUUID.uuid
 		return errors.Errorf("preparing offer connection deletion: %w", err)
 	}
 
+	deleteHiddenOfferStmt, err := st.Prepare(`
+DELETE FROM offer
+WHERE  uuid = $entityUUID.uuid
+AND    NOT EXISTS (
+	SELECT 1
+	FROM   offer_endpoint
+	WHERE  offer_uuid = $entityUUID.uuid
+)
+AND    NOT EXISTS (
+	SELECT 1
+	FROM   offer_connection
+	WHERE  offer_uuid = $entityUUID.uuid
+)
+`, entityUUID{})
+	if err != nil {
+		return errors.Errorf("preparing hidden offer deletion: %w", err)
+	}
+
 	var synthAppUUID entityUUID
 	err = tx.Query(ctx, getSyntheticAppUUIDStmt, remoteRelationUUID).Get(&synthAppUUID)
 	if err != nil {
 		return errors.Errorf("getting application UUID: %w", err)
+	}
+
+	var offerUUID entityUUID
+	err = tx.Query(ctx, getOfferUUIDStmt, remoteRelationUUID).Get(&offerUUID)
+	if err != nil {
+		return errors.Errorf("getting offer UUID: %w", err)
 	}
 
 	err = tx.Query(ctx, deleteRelationNetworkIngressStmt, remoteRelationUUID).Run()
@@ -247,6 +280,11 @@ WHERE remote_relation_uuid = $entityUUID.uuid
 	err = tx.Query(ctx, deleteOfferConnectionStmt, remoteRelationUUID).Run()
 	if err != nil {
 		return errors.Errorf("running offer connection deletion: %w", err)
+	}
+
+	err = tx.Query(ctx, deleteHiddenOfferStmt, offerUUID).Run()
+	if err != nil {
+		return errors.Errorf("deleting hidden offer: %w", err)
 	}
 
 	err = st.deleteRelation(ctx, tx, remoteRelationUUID)

--- a/domain/removal/state/model/relationwithremoteconsumer.go
+++ b/domain/removal/state/model/relationwithremoteconsumer.go
@@ -237,24 +237,6 @@ WHERE remote_relation_uuid = $entityUUID.uuid
 		return errors.Errorf("preparing offer connection deletion: %w", err)
 	}
 
-	deleteHiddenOfferStmt, err := st.Prepare(`
-DELETE FROM offer
-WHERE  uuid = $entityUUID.uuid
-AND    NOT EXISTS (
-	SELECT 1
-	FROM   offer_endpoint
-	WHERE  offer_uuid = $entityUUID.uuid
-)
-AND    NOT EXISTS (
-	SELECT 1
-	FROM   offer_connection
-	WHERE  offer_uuid = $entityUUID.uuid
-)
-`, entityUUID{})
-	if err != nil {
-		return errors.Errorf("preparing hidden offer deletion: %w", err)
-	}
-
 	var synthAppUUID entityUUID
 	err = tx.Query(ctx, getSyntheticAppUUIDStmt, remoteRelationUUID).Get(&synthAppUUID)
 	if err != nil {
@@ -282,9 +264,9 @@ AND    NOT EXISTS (
 		return errors.Errorf("running offer connection deletion: %w", err)
 	}
 
-	err = tx.Query(ctx, deleteHiddenOfferStmt, offerUUID).Run()
+	err = st.deleteHiddenOffer(ctx, tx, offerUUID)
 	if err != nil {
-		return errors.Errorf("deleting hidden offer: %w", err)
+		return errors.Capture(err)
 	}
 
 	err = st.deleteRelation(ctx, tx, remoteRelationUUID)

--- a/domain/removal/state/model/relationwithremoteconsumer_test.go
+++ b/domain/removal/state/model/relationwithremoteconsumer_test.go
@@ -208,3 +208,26 @@ func (s *relationWithRemoteConsumer) TestDeleteRelationWithRemoteConsumerUnits(c
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(count, tc.Equals, 0)
 }
+
+func (s *relationWithRemoteConsumer) TestDeleteRelationWithRemoteConsumerDeletesHiddenOffer(c *tc.C) {
+	relUUID, _, offerUUID := s.createRelationWithRemoteConsumer(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := st.HideOffer(c.Context(), offerUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.advanceRelationLife(c, relUUID, life.Dying)
+
+	err = st.DeleteRelationUnits(c.Context(), relUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.DeleteRelationWithRemoteConsumer(c.Context(), relUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	row := s.DB().QueryRow("SELECT COUNT(*) FROM offer WHERE uuid = ?", offerUUID.String())
+	var count int
+	err = row.Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+}

--- a/internal/worker/remoterelationconsumer/localconsumerworker.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker.go
@@ -224,7 +224,7 @@ func (w *localConsumerWorker) Kill() {
 // Wait is defined on worker.Worker
 func (w *localConsumerWorker) Wait() error {
 	err := w.catacomb.Wait()
-	if err != nil {
+	if err != nil && !errors.Is(err, RemoteApplicationOffererDeadErr) {
 		w.logger.Errorf(context.Background(), "error in remote application worker for %v: %v", w.applicationName, err)
 	}
 	return err
@@ -473,7 +473,10 @@ func (w *localConsumerWorker) watchRemoteOfferStatus(ctx context.Context) (watch
 		BakeryVersion: defaultBakeryVersion,
 	})
 	if isNotFound(err) {
-		return nil, w.remoteOfferRemoved(ctx)
+		if err := w.remoteOfferRemoved(ctx); err != nil {
+			return nil, err
+		}
+		return nil, RemoteApplicationOffererDeadErr
 	} else if err != nil {
 		if statusErr := w.setApplicationOffererStatusMacaroonError(ctx, err); statusErr != nil {
 			w.logger.Errorf(ctx, "failed updating remote application %v status from remote model %v: %v", w.applicationName, w.offererModelUUID, statusErr)

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -292,6 +292,54 @@ func (s *localConsumerWorkerSuite) TestStartWatchOfferStatusFailed(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `watching status for offer: not valid`)
 }
 
+func (s *localConsumerWorkerSuite) TestStartWatchOfferStatusNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	done := make(chan struct{})
+
+	s.crossModelService.EXPECT().
+		WatchRelationsLifeSuspendedStatusForApplication(gomock.Any(), s.applicationUUID).
+		DoAndReturn(func(ctx context.Context, i application.UUID) (watcher.StringsWatcher, error) {
+			ch := make(chan []string)
+			return watchertest.NewMockStringsWatcher(ch), nil
+		})
+
+	s.remoteRelationClientGetter.EXPECT().
+		GetRemoteRelationClient(gomock.Any(), s.offererModelUUID).
+		Return(s.remoteModelRelationClient, nil)
+
+	s.remoteModelRelationClient.EXPECT().
+		WatchOfferStatus(gomock.Any(), params.OfferArg{
+			OfferUUID:     s.offerUUID,
+			Macaroons:     macaroon.Slice{s.macaroon},
+			BakeryVersion: bakery.LatestVersion,
+		}).
+		DoAndReturn(func(ctx context.Context, oa params.OfferArg) (watcher.OfferStatusWatcher, error) {
+			defer close(done)
+			return nil, params.Error{Code: params.CodeNotFound, Message: "offer not found"}
+		})
+
+	s.crossModelService.EXPECT().
+		SetRemoteApplicationOffererStatus(gomock.Any(), s.applicationName, status.StatusInfo{
+			Status:  status.Terminated,
+			Message: "offer has been removed",
+		}).
+		Return(nil)
+
+	w, err := NewLocalConsumerWorker(s.newLocalConsumerWorkerConfig(c))
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for WatchOfferStatus to be called")
+	}
+
+	err = workertest.CheckKilled(c, w)
+	c.Assert(err, tc.ErrorIs, RemoteApplicationOffererDeadErr)
+}
+
 func (s *localConsumerWorkerSuite) TestWatchApplicationStatusChanged(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 


### PR DESCRIPTION
This change is in response to the issue ["Consumed offer prevents relation teardown"](https://github.com/juju/juju/issues/21766)  which was resolved when we allowed application/model removal to proceed even when an offer had >0 connections.

This change allows the same thing for offer removal without the need for the force flag. I.e. an offer with >0 connections can be removed.

The first 3 commits in the PR follow the 3 steps I took when constructing this change. The 4th is in response to review.
1. Tweak the CLI to prompt for offer removal when connections are > 0. Refactor the `-y` flag to `--no-prompt`. On the server side, remove the use of the force flag in the state logic, effectively always doing what force did. On the CLI side, the force flag, if used, just sets the corresponding field on the API request.
2. Gracefully handle offer removal by ensuring remote-relations go through a cleanup lifecycle.
3. Fix an issue in the `localconsumerworker`, where after running `juju remove-saas` on a terminated saas, we'd encounter the error "ERROR juju.worker.remoterelationconsumer logger-tags:cmr error in remote application worker for dummy-source: panic resulted in: runtime error: invalid memory address or nil pointer dereference".

## Checklist
- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
```bash
make install
juju bootstrap localhost test-4-local
juju add-model source
juju deploy juju-qa-dummy-source
juju offer dummy-source:sink
juju config dummy-source token=abc
juju add-model sink
juju deploy juju-qa-dummy-sink
juju relate dummy-sink admin/src.dummy-source
watch juju status
# Wait for apps to become active
juju switch source
juju remove-offer dummy-source
juju switch sink
watch juju status --relations
# Wait for relation removal and for saas to enter terminated state
juju remove-saas
# Now we will recreate the offer and ensure consuming it again works
juju switch source
juju config dummy-source token=def
juju offer dummy-source
juju switch sink
juju relate dummy-sink admin/src.dummy-source
watch juju status
# Watch for message to indicate the token has changed to def
```

## Documentation changes

Updated docs where necessary.

## Links
