### PR TITLE
feat: migrate change-stream manifold off agent dependency

### DIFF
--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -544,6 +544,7 @@ func (a *MachineAgent) makeEngineCreator(
 		manifoldsCfg := machine.ManifoldsConfig{
 			PreviousAgentVersion:              previousAgentVersion,
 			AgentName:                         agentName,
+			ControllerID:                      agentConfig.Tag().Id(),
 			Agent:                             agent.APIHostPortsSetter{Agent: a},
 			RootDir:                           a.rootDir,
 			AgentConfigChanged:                a.configChangedVal,

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -652,7 +652,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		changeStreamName: changestream.Manifold(changestream.ManifoldConfig{
-			AgentName:            agentName,
+			ControllerID:         config.ControllerID,
 			DBAccessor:           dbAccessorName,
 			FileNotifyWatcher:    fileNotifyWatcherName,
 			Clock:                config.Clock,

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -137,6 +137,12 @@ type ManifoldsConfig struct {
 	// making the worker get it from the agent worker itself.
 	AgentName string
 
+	// ControllerID is the numeric ID of the controller (e.g. "0" for
+	// controller-0). It is passed directly to controller-only manifolds
+	// that now take direct identity values instead of looking them up
+	// through the agent manifold.
+	ControllerID string
+
 	// Agent contains the agent that will be wrapped and made available to
 	// its dependencies via a dependency.Engine.
 	Agent coreagent.Agent

--- a/cmd/jujuagentd/agent/machine/manifolds_test.go
+++ b/cmd/jujuagentd/agent/machine/manifolds_test.go
@@ -460,6 +460,23 @@ func (*ManifoldsSuite) TestProviderTrackerDoesNotUseDomainServices(c *tc.C) {
 	c.Check(dependencies.Contains("domain-services"), tc.IsFalse)
 }
 
+func (*ManifoldsSuite) TestChangeStreamDirectInputs(c *tc.C) {
+	// change-stream no longer depends on the agent manifold directly.
+	// It receives the controller ID as a static config value, so only
+	// db-accessor and file-notify-watcher appear in its direct Inputs.
+	manifolds := machine.IAASManifolds(machine.ManifoldsConfig{
+		Agent:           &mockAgent{},
+		PreUpgradeSteps: preUpgradeSteps,
+	})
+	manifold, ok := manifolds["change-stream"]
+	c.Assert(ok, tc.IsTrue)
+	c.Check(manifold.Inputs, tc.SameContents, []string{
+		"db-accessor",
+		"file-notify-watcher",
+	})
+	checkNotContains(c, manifold.Inputs, "agent")
+}
+
 func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *tc.C) {
 	ag := &mockAgent{
 		conf: mockConfig{

--- a/cmd/jujud/agent/controller.go
+++ b/cmd/jujud/agent/controller.go
@@ -403,6 +403,7 @@ func (a *ControllerAgent) makeEngineCreator(
 		manifoldsCfg := agentcontroller.ManifoldsConfig{
 			PreviousAgentVersion:              previousAgentVersion,
 			AgentName:                         agentName,
+			ControllerID:                      a.agentTag.Id(),
 			Agent:                             agent.APIHostPortsSetter{Agent: a},
 			RootDir:                           a.rootDir,
 			AgentConfigChanged:                a.configChangedVal,

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -112,6 +112,12 @@ type ManifoldsConfig struct {
 	// itself.
 	AgentName string
 
+	// ControllerID is the numeric ID of the controller (e.g. "0" for
+	// controller-0). It is passed directly to manifolds that require
+	// the controller's identity without needing the agent manifold for
+	// the lookup.
+	ControllerID string
+
 	// Agent contains the agent that will be wrapped and made available
 	// to its dependencies via a dependency.Engine.
 	Agent coreagent.Agent

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -573,7 +573,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 
 		changeStreamName: changestream.Manifold(changestream.ManifoldConfig{
-			AgentName:            agentName,
+			ControllerID:         config.ControllerID,
 			DBAccessor:           dbAccessorName,
 			FileNotifyWatcher:    fileNotifyWatcherName,
 			Clock:                config.Clock,
@@ -667,7 +667,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			GetControllerService:            objectstoredrainer.GetControllerService,
 			GeObjectStoreServices:           objectstoredrainer.GeObjectStoreServicesGetter,
 			GetControllerObjectStoreService: objectstoredrainer.GetControllerObjectStoreService,
-			GetGuardService:                 objectstoredrainer.GetGuardService,
+			GetDrainingService:              objectstoredrainer.GetDrainingService,
 			GetControllerConfigService:      objectstoredrainer.GetControllerConfigService,
 			NewHashFileSystemAccessor:       objectstoredrainer.NewHashFileStoreAccessor,
 			NewDrainerWorker:                objectstoredrainer.NewDrainWorker,

--- a/cmd/jujud/agent/controller/manifolds_test.go
+++ b/cmd/jujud/agent/controller/manifolds_test.go
@@ -320,6 +320,30 @@ func (*ManifoldsSuite) TestUpgradeGates(c *tc.C) {
 	checkContains(c, manifolds["upgrade-check-gate"].Inputs, "controller-upgrade-flag")
 }
 
+func (*ManifoldsSuite) TestChangeStreamDirectInputs(c *tc.C) {
+	// change-stream no longer depends on the agent manifold directly.
+	// It receives the controller ID as a static config value, so only
+	// db-accessor and file-notify-watcher appear in its direct Inputs.
+	for _, manifolds := range []dependency.Manifolds{
+		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["change-stream"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{
+			"db-accessor",
+			"file-notify-watcher",
+		})
+		checkNotContains(c, manifold.Inputs, "agent")
+	}
+}
+
 func (*ManifoldsSuite) TestOutOfScopeWorkersUseControllerUpgradeGate(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{

--- a/internal/worker/changestream/manifold.go
+++ b/internal/worker/changestream/manifold.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
@@ -30,7 +29,10 @@ type WatchableDBFn = func(string, coredatabase.TxnRunner, FileNotifier, clock.Cl
 // ManifoldConfig defines the names of the manifolds on which a Manifold will
 // depend.
 type ManifoldConfig struct {
-	AgentName         string
+	// ControllerID is the numeric ID of the controller (e.g. "0" for
+	// controller-0). The manifold uses this value directly as
+	// WorkerConfig.AgentTag.
+	ControllerID      string
 	DBAccessor        string
 	FileNotifyWatcher string
 
@@ -42,8 +44,8 @@ type ManifoldConfig struct {
 }
 
 func (cfg ManifoldConfig) Validate() error {
-	if cfg.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
+	if cfg.ControllerID == "" {
+		return errors.NotValidf("empty ControllerID")
 	}
 	if cfg.DBAccessor == "" {
 		return errors.NotValidf("empty DBAccessorName")
@@ -74,7 +76,6 @@ func (cfg ManifoldConfig) Validate() error {
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
 			config.DBAccessor,
 			config.FileNotifyWatcher,
 		},
@@ -83,13 +84,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err := config.Validate(); err != nil {
 				return nil, errors.Trace(err)
 			}
-
-			var agent agent.Agent
-			if err := getter.Get(config.AgentName, &agent); err != nil {
-				return nil, errors.Trace(err)
-			}
-
-			agentConfig := agent.CurrentConfig()
 
 			var dbGetter DBGetter
 			if err := getter.Get(config.DBAccessor, &dbGetter); err != nil {
@@ -108,7 +102,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			cfg := WorkerConfig{
-				AgentTag:          agentConfig.Tag().Id(),
+				AgentTag:          config.ControllerID,
 				DBGetter:          dbGetter,
 				FileNotifyWatcher: fileNotifyWatcher,
 				Clock:             config.Clock,

--- a/internal/worker/changestream/manifold_test.go
+++ b/internal/worker/changestream/manifold_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
+	dependencytesting "github.com/juju/worker/v5/dependency/testing"
+	"github.com/juju/worker/v5/workertest"
 	"go.uber.org/goleak"
+	gomock "go.uber.org/mock/gomock"
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
@@ -39,7 +42,7 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig(c)
-	cfg.AgentName = ""
+	cfg.ControllerID = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig(c)
@@ -59,9 +62,45 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 }
 
+func (s *manifoldSuite) TestManifoldInputs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cfg := s.getConfig(c)
+	inputs := Manifold(cfg).Inputs
+	c.Check(inputs, tc.SameContents, []string{
+		cfg.DBAccessor,
+		cfg.FileNotifyWatcher,
+	})
+	// The agent manifold is no longer a direct input.
+	for _, input := range inputs {
+		c.Check(input, tc.Not(tc.Equals), "agent")
+	}
+}
+
+func (s *manifoldSuite) TestManifoldStart(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectClock()
+	s.prometheusRegisterer.EXPECT().Register(gomock.Any()).Return(nil)
+	s.prometheusRegisterer.EXPECT().Unregister(gomock.Any()).Return(true)
+
+	cfg := s.getConfig(c)
+	// The getter only exposes the two direct inputs; any request for
+	// the "agent" manifold would result in a missing-resource error,
+	// which would bubble up and fail the assertion below.
+	getter := dependencytesting.StubGetter(map[string]any{
+		cfg.DBAccessor:        s.dbGetter,
+		cfg.FileNotifyWatcher: s.fileNotifyWatcher,
+	})
+
+	w, err := Manifold(cfg).Start(c.Context(), getter)
+	c.Assert(err, tc.ErrorIsNil)
+	workertest.CleanKill(c, w)
+}
+
 func (s *manifoldSuite) getConfig(c *tc.C) ManifoldConfig {
 	return ManifoldConfig{
-		AgentName:            "agent",
+		ControllerID:         "0",
 		DBAccessor:           "dbaccessor",
 		FileNotifyWatcher:    "filenotifywatcher",
 		Clock:                s.clock,


### PR DESCRIPTION
The `changestream` worker manifold previously resolved the controller ID at startup by depending on the `agent` manifold and calling `agent.CurrentConfig().Tag().Id()`. This PR replaces that indirect dependency with a direct `ControllerID string` field on `ManifoldConfig`, removing the `agent` manifold from the change-stream manifold's input set entirely.

### Changes

- `ManifoldConfig` now takes a plain `ControllerID string` instead of resolving the ID via the `agent` manifold at startup.
- Both controller and machine-agent wiring updated to populate and pass `ControllerID` directly.
- Tests updated to assert the new direct inputs and cover the `ControllerID` validation and start paths.

### Motivation

Removing the `agent` manifold as a direct dependency is a prerequisite for the standalone controller work (JUJU-9694). When the controller runs as a standalone process, the `agent` manifold may not be present on the dependency engine, so workers that need only the controller ID should receive it as a plain value rather than fetching it via the agent.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
```sh
❯ juju bootstrap lxd src --build-agent
❯ juju add-model m
❯ juju add-machine -n 1
```

Make sure controller agent and machine agent is working fine:

```sh
❯ jst
Model  Controller  Cloud/Region  Version      Timestamp
m      src         lxd/default   4.1-beta2.1  12:58:44+02:00

Machine  State    Address       Inst id        Base          AZ      Message
0        started  10.159.202.9  juju-c3661b-0  ubuntu@24.04  tuxedo  Running

❯ juju ssh -m controller 0 -- ps -ef | grep juju
root        2014       1  0 10:56 ?        00:00:00 bash /etc/systemd/system/jujuagentd-machine-0-exec-start.sh
root        2018    2014  0 10:56 ?        00:00:03 /var/lib/juju/tools/machine-0/jujuagentd machine --data-dir /var/lib/juju --machine-id 0 --debu
Connection to 10.159.202.88 closed.

❯ juju add-ssh-key -m m "$(cat $JUJU_DATA/ssh/juju_id_rsa.pub)"
❯ juju ssh 0 -- ps -ef | grep juju
root        1758       1  0 10:57 ?        00:00:00 bash /etc/systemd/system/jujuagentd-machine-0-exec-start.sh
root        1762    1758  0 10:57 ?        00:00:00 /var/lib/juju/tools/machine-0/jujuagentd machine --data-dir /var/lib/juju --machine-id 0 --debu
Connection to 10.159.202.9 closed.
```

## Documentation changes


## Links

**Jira card:** [JUJU-9717](https://warthogs.atlassian.net/browse/JUJU-9717)


[JUJU-9717]: https://warthogs.atlassian.net/browse/JUJU-9717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ