### PR TITLE
fix: pass new secret ID to K8s backend on user secret create

### DIFF
--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -96,7 +96,21 @@ func (s *SecretService) getBackend(cfg *provider.ModelBackendConfig) (provider.S
 	return p.NewBackend(cfg)
 }
 
-func (s *SecretService) getBackendForUserSecrets(ctx context.Context, accessor domainsecret.SecretAccessor) (provider.SecretsBackend, string, error) {
+// getBackendForUserSecrets returns a secrets backend client restricted to the
+// secrets the given accessor is allowed to manage.
+//
+// newSecretIDs must be provided when the caller is about to create a secret
+// whose URI has not yet been persisted to state. The K8s backend cannot
+// restrict the "create" verb by resource name, so it pre-creates an empty
+// placeholder and grants the restricted service account "patch" access to it
+// by name. Without the new secret ID in the owned list, policyRulesForSecretAccess
+// omits the secrets rule entirely (the "if len(owned) > 0" guard is intentional
+// to avoid granting access to all secrets), and SaveContent will be forbidden.
+func (s *SecretService) getBackendForUserSecrets(
+	ctx context.Context,
+	accessor domainsecret.SecretAccessor,
+	newSecretIDs ...string,
+) (provider.SecretsBackend, string, error) {
 	modelUUID, err := s.secretState.GetModelUUID(ctx)
 	if err != nil {
 		return nil, "", errors.Errorf("getting model UUID: %w", err)
@@ -125,6 +139,10 @@ func (s *SecretService) getBackendForUserSecrets(ctx context.Context, accessor d
 	for _, r := range revInfo {
 		ownedRevisions.Add(r.URI, r.RevisionID)
 		owned.Add(r.URI.ID)
+	}
+	// Include any secrets being created in this call (not yet in state).
+	for _, id := range newSecretIDs {
+		owned.Add(id)
 	}
 	s.logger.Debugf(ctx, "secrets for %s:\nowned: %v", accessor, ownedRevisions)
 
@@ -246,7 +264,7 @@ func (s *SecretService) CreateUserSecret(ctx context.Context, uri *secrets.URI, 
 	p.Data = make(map[string]string)
 	maps.Copy(p.Data, params.Data)
 
-	backend, backendID, err := s.getBackendForUserSecrets(ctx, params.Accessor)
+	backend, backendID, err := s.getBackendForUserSecrets(ctx, params.Accessor, uri.ID)
 	if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -115,6 +116,10 @@ func (s *serviceSuite) TestCreateUserSecretFailedLabelExistsWithCleanup(c *tc.C)
 func (s *serviceSuite) assertCreateUserSecret(c *tc.C, isInternal, finalStepFailed, labelExists bool) {
 	defer s.setupMocks(c).Finish()
 
+	// Create the URI for the new secret upfront so we can include it in the
+	// expected owned list for RestrictedConfig.
+	uri := coresecrets.NewURI()
+
 	params := domainsecret.UpsertSecretParams{
 		Description: new("a secret"),
 		Label:       new("my secret"),
@@ -172,7 +177,10 @@ func (s *serviceSuite) assertCreateUserSecret(c *tc.C, isInternal, finalStepFail
 	)
 	s.secretsBackendProvider.EXPECT().IssuesTokens().Return(false)
 	issuedTokenUUID := ""
-	owned := []string{existingOwnedURI.ID}
+	// The owned list includes both the existing secret and the new one being
+	// created, sorted lexicographically (as returned by set.SortedValues()).
+	owned := []string{existingOwnedURI.ID, uri.ID}
+	slices.Sort(owned)
 	ownedRevisions := provider.SecretRevisions{}
 	ownedRevisions.Add(existingOwnedURI, "rev-id")
 	s.secretsBackendProvider.EXPECT().RestrictedConfig(
@@ -202,7 +210,6 @@ func (s *serviceSuite) assertCreateUserSecret(c *tc.C, isInternal, finalStepFail
 	)
 
 	s.state.EXPECT().GetModelUUID(gomock.Any()).Return(s.modelID, nil).AnyTimes()
-	uri := coresecrets.NewURI()
 	rollbackCalled := false
 	s.secretBackendState.EXPECT().AddSecretBackendReference(gomock.Any(), params.ValueRef, s.modelID, s.fakeUUID.String(), uri.ID).Return(
 		func() error {
@@ -258,6 +265,122 @@ func (s *serviceSuite) assertCreateUserSecret(c *tc.C, isInternal, finalStepFail
 	} else {
 		c.Assert(err, tc.ErrorIsNil)
 	}
+}
+
+// TestCreateUserSecretNoExistingSecrets is a regression test for
+// https://github.com/juju/juju/issues/22485 - when creating the very first
+// secret for a model (no existing secrets), the K8s backend must still receive
+// the new secret's ID in the owned list so it can pre-create the placeholder
+// and grant the restricted service account "patch" permission on it.
+func (s *serviceSuite) TestCreateUserSecretNoExistingSecrets(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uri := coresecrets.NewURI()
+
+	params := domainsecret.UpsertSecretParams{
+		Description: new("a secret"),
+		Label:       new("my secret"),
+		AutoPrune:   new(true),
+		Checksum:    "checksum-1234",
+		RevisionID:  new(s.fakeUUID.String()),
+		CreateTime:  s.clock.Now(),
+		UpdateTime:  s.clock.Now(),
+		ValueRef: &coresecrets.ValueRef{
+			BackendID:  "backend-id",
+			RevisionID: "rev-id",
+		},
+	}
+
+	s.secretBackendState.EXPECT().GetActiveModelSecretBackend(gomock.Any(), s.modelID).Return(
+		"backend-id",
+		&provider.ModelBackendConfig{
+			ControllerUUID: coretesting.ControllerTag.Id(),
+			ModelUUID:      s.modelID.String(),
+			ModelName:      "some-model",
+			BackendConfig: provider.BackendConfig{
+				BackendType: "active-type",
+				Config:      map[string]any{"foo": "active-type"},
+			},
+		}, nil,
+	)
+
+	mBackendConfig := &provider.ModelBackendConfig{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      s.modelID.String(),
+		ModelName:      "some-model",
+		BackendConfig: provider.BackendConfig{
+			BackendType: "active-type",
+			Config:      map[string]any{"foo": "active-type"},
+		},
+	}
+	s.secretsBackendProvider.EXPECT().Initialise(mBackendConfig).Return(nil)
+
+	// No existing secrets - ListGrantedSecretsForBackend returns empty.
+	s.state.EXPECT().ListGrantedSecretsForBackend(gomock.Any(), "backend-id", []domainsecret.AccessParams{
+		{
+			SubjectID:     s.modelID.String(),
+			SubjectTypeID: domainsecret.SubjectModel,
+		},
+	}, []domainsecret.Role{domainsecret.RoleManage}).Return(
+		[]*coresecrets.SecretRevisionRef{}, nil,
+	)
+	s.secretsBackendProvider.EXPECT().IssuesTokens().Return(false)
+
+	// The key assertion: even with no existing secrets, the new secret's ID
+	// must appear in the owned list passed to RestrictedConfig.
+	issuedTokenUUID := ""
+	owned := []string{uri.ID}
+	ownedRevisions := provider.SecretRevisions{}
+	s.secretsBackendProvider.EXPECT().RestrictedConfig(
+		gomock.Any(),
+		mBackendConfig,
+		true, false,
+		issuedTokenUUID,
+		coresecrets.Accessor{
+			Kind: coresecrets.ModelAccessor,
+			ID:   s.modelID.String(),
+		},
+		owned, ownedRevisions, provider.SecretRevisions{},
+	).Return(
+		&mBackendConfig.BackendConfig, nil,
+	)
+	s.secretsBackendProvider.EXPECT().NewBackend(
+		&provider.ModelBackendConfig{
+			ControllerUUID: coretesting.ControllerTag.Id(),
+			ModelUUID:      s.modelID.String(),
+			ModelName:      "some-model",
+			BackendConfig:  mBackendConfig.BackendConfig,
+		},
+	).DoAndReturn(
+		func(cfg *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+			return s.secretsBackend, nil
+		},
+	)
+
+	s.state.EXPECT().GetModelUUID(gomock.Any()).Return(s.modelID, nil).AnyTimes()
+	s.secretBackendState.EXPECT().AddSecretBackendReference(gomock.Any(), params.ValueRef, s.modelID, s.fakeUUID.String(), uri.ID).Return(
+		func() error { return nil }, nil,
+	)
+	s.secretsBackend.EXPECT().SaveContent(gomock.Any(), uri, 1, coresecrets.NewSecretValue(map[string]string{"foo": "bar"})).
+		Return("rev-id", nil)
+	s.state.EXPECT().CreateUserSecret(c.Context(), 1, uri, gomock.AssignableToTypeOf(params)).
+		Return(nil)
+
+	err := s.service.CreateUserSecret(c.Context(), uri, CreateUserSecretParams{
+		UpdateUserSecretParams: UpdateUserSecretParams{
+			Accessor: domainsecret.SecretAccessor{
+				Kind: domainsecret.ModelAccessor,
+				ID:   s.modelID.String(),
+			},
+			Description: new("a secret"),
+			Label:       new("my secret"),
+			Data:        map[string]string{"foo": "bar"},
+			AutoPrune:   new(true),
+			Checksum:    "checksum-1234",
+		},
+		Version: 1,
+	})
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *serviceSuite) TestUpdateUserSecretInternal(c *tc.C) {


### PR DESCRIPTION
## Problem

When a user creates their very first secret on a MicroK8s model with RBAC
enabled, `juju add-secret` fails with a RBAC forbidden error.

Root cause: `getBackendForUserSecrets` calls
`ListGrantedSecretsForBackend` to build the list of secrets the model
accessor owns. For a brand-new secret this list is empty, because the
secret has not been persisted to state yet. An empty `owned` slice causes
`policyRulesForSecretAccess` to skip adding the `secrets` rule entirely
(the `if len(owned) > 0` guard is intentional — without it the SA would
gain access to *all* secrets). The resulting restricted ServiceAccount only
has `namespaces get/list`, so the subsequent `SaveContent` call is
forbidden.

The K8s backend cannot restrict the `create` verb by resource name, so it
pre-creates an empty placeholder Secret and grants the restricted SA `patch`
access to it by name. The new secret's ID must be present in the owned list
*before* `RestrictedConfig` is called for this pre-creation to happen.

## Fix

Add a variadic `newSecretIDs ...string` parameter to
`getBackendForUserSecrets`. IDs passed here are inserted into the `owned`
set before `RestrictedConfig` is called. `CreateUserSecret` now passes
`uri.ID` at the call site; all other callers are unaffected.

## Testing

- Updated `assertCreateUserSecret` to include the new secret's URI ID in
  the expected `owned` slice.
- Added `TestCreateUserSecretNoExistingSecrets` regression test: verifies
  that when `ListGrantedSecretsForBackend` returns empty (no existing
  secrets), the new secret ID still appears in the `owned` list passed to
  `RestrictedConfig`.

## QA Steps

1. Bootstrap a MicroK8s controller with RBAC enabled:
   ```
   microk8s enable rbac
   juju bootstrap microk8s mk8s
   juju add-model test-secrets
   ```
2. Add a secret (previously failing with RBAC forbidden):
   ```
   juju add-secret my-secret token=s3cr3t
   ```
3. Verify the secret is created successfully and a subsequent
   `juju secrets` lists it.
4. Add a second secret and verify it also succeeds (existing-secrets path).

## Followup

Two follow-up issues were identified during this fix and should be filed
once this PR is merged. Context and reproduction steps are in the attached
file: **[followup-gh22485.md](https://gist.github.com/gfouillet/25add1cac847924b2c9ef411257b4cb0)**

- **Issue A** — `issuedTokenUUID` is never persisted to state, so
  `CleanupIssuedTokens` is never called and K8s ServiceAccounts/Roles/
  RoleBindings accumulate in the namespace indefinitely.
- **Issue B** — if `CreateUserSecret` fails after the backend call, the
  pre-created K8s placeholder Secret is never cleaned up.

## Links

**Issue:** Fixes #22485

**Jira card:** [JUJU-9859](https://warthogs.atlassian.net/browse/JUJU-9859)

[JUJU-9859]: https://warthogs.atlassian.net/browse/JUJU-9859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ