### PR TITLE
fix: wait for workerpool to become idle

### DIFF
--- a/core/workerpool/workerpool.go
+++ b/core/workerpool/workerpool.go
@@ -109,7 +109,10 @@ func (wp *WorkerPool) Done() <-chan struct{} {
 	return wp.shutdownTriggerCh
 }
 
-// Idle returns true when the queue is empty and the workers are not working.
+// Idle waits until the queue is empty and the workers are not working.
+//
+// It returns false if the pool starts shutting down or the context is done
+// before the pool becomes idle.
 func (wp *WorkerPool) Idle(ctx context.Context) bool {
 	respChan := make(chan int, len(wp.idleChans))
 	for {
@@ -137,13 +140,9 @@ func (wp *WorkerPool) Idle(ctx context.Context) bool {
 			// All workers are idle and don't see any queued tasks.
 			return true
 		}
-		if numEmpty != 0 {
-			// Some of the workers disagreed about the number of queued tasks,
-			// try again until we get consensus.
-			continue
-		}
-		// All workers see queued tasks, so we cannot be idle.
-		return false
+
+		// Either some or all workers still see queued tasks. Keep waiting until
+		// everyone agrees that the pool is idle, or the caller gives up.
 	}
 }
 

--- a/core/workerpool/workerpool_test.go
+++ b/core/workerpool/workerpool_test.go
@@ -62,6 +62,53 @@ func (s *ProvisionerWorkerPoolSuite) TestIdle(c *tc.C) {
 	}
 }
 
+func (s *ProvisionerWorkerPoolSuite) TestIdleWaitsForWorkers(c *tc.C) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	idleResult := make(chan bool, 1)
+	wp := NewWorkerPool(loggertesting.WrapCheckLog(c), 1)
+
+	select {
+	case wp.Queue() <- Task{
+		Type: "alien invasion",
+		Process: func() error {
+			close(started)
+			<-release
+			return nil
+		},
+	}:
+	case <-c.Context().Done():
+		c.Fatal("test context cancelled while enqueueing task")
+	}
+
+	select {
+	case <-started:
+	case <-c.Context().Done():
+		c.Fatal("test context cancelled while waiting for task to start")
+	}
+
+	go func() {
+		idleResult <- wp.Idle(c.Context())
+	}()
+
+	select {
+	case result := <-idleResult:
+		c.Fatalf("Idle returned early with %v", result)
+	default:
+	}
+
+	close(release)
+
+	select {
+	case result := <-idleResult:
+		c.Check(result, tc.IsTrue)
+	case <-c.Context().Done():
+		c.Fatal("test context cancelled while waiting for Idle")
+	}
+
+	c.Assert(wp.Close(), tc.ErrorIsNil)
+}
+
 func (s *ProvisionerWorkerPoolSuite) TestProcessMoreTasksThanWorkers(c *tc.C) {
 	doneCh := make(chan struct{}, 10)
 	wp := NewWorkerPool(loggertesting.WrapCheckLog(c), 5)

--- a/core/workerpool/workerpool_test.go
+++ b/core/workerpool/workerpool_test.go
@@ -4,6 +4,7 @@
 package workerpool
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"sync"
@@ -66,6 +67,10 @@ func (s *ProvisionerWorkerPoolSuite) TestIdleWaitsForWorkers(c *tc.C) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	idleResult := make(chan bool, 1)
+	idleCtx := &idleEnteredContext{
+		Context: c.Context(),
+		entered: make(chan struct{}),
+	}
 	wp := NewWorkerPool(loggertesting.WrapCheckLog(c), 1)
 
 	select {
@@ -88,8 +93,14 @@ func (s *ProvisionerWorkerPoolSuite) TestIdleWaitsForWorkers(c *tc.C) {
 	}
 
 	go func() {
-		idleResult <- wp.Idle(c.Context())
+		idleResult <- wp.Idle(idleCtx)
 	}()
+
+	select {
+	case <-idleCtx.entered:
+	case <-c.Context().Done():
+		c.Fatal("test context cancelled while waiting for Idle to start")
+	}
 
 	select {
 	case result := <-idleResult:
@@ -107,6 +118,19 @@ func (s *ProvisionerWorkerPoolSuite) TestIdleWaitsForWorkers(c *tc.C) {
 	}
 
 	c.Assert(wp.Close(), tc.ErrorIsNil)
+}
+
+type idleEnteredContext struct {
+	context.Context
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (c *idleEnteredContext) Done() <-chan struct{} {
+	c.once.Do(func() {
+		close(c.entered)
+	})
+	return c.Context.Done()
 }
 
 func (s *ProvisionerWorkerPoolSuite) TestProcessMoreTasksThanWorkers(c *tc.C) {


### PR DESCRIPTION
Fix for flaky test #22396

Cause: WorkerPool.Idle behaved like a one-shot snapshot in one path, but both the test and production caller use it as a bounded wait.

What was happening:
- TestIdle queues work, then immediately calls wp.Idle(c.Context()).
- Idle only retried when workers disagreed about queue state.
- If all workers consistently observed queued work during that sampling round, Idle returned false immediately instead of waiting for the pool to drain.
- That timing is rare, so the failure was flaky.

Fix:
- Changed core/workerpool/workerpool.go so Idle keeps waiting until:
- all workers report no queued work, then returns true
- or shutdown/context cancellation happens, then returns false
- Added a regression test in core/workerpool/workerpool_test.go that verifies Idle does not return early while a worker is still busy.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju bootstrap lxd src
juju add-model workerpool-test
juju add-machine
juju add-machine
juju add-machine
juju model-config num-provision-workers=4
juju status
juju remove-machine 1 --force --no-wait
```

## Documentation changes


## Links

**Issue:** Fixes #22396

**Jira card:** [JUJU-9843](https://warthogs.atlassian.net/browse/JUJU-9843)


[JUJU-9843]: https://warthogs.atlassian.net/browse/JUJU-9843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ