### PR TITLE
Fix snap hook configure 4.0

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,9 +1,4 @@
 #!/bin/bash
 
-# Make sure we have lxd installed to use
-if [ "$(which lxd)" = "" ]; then
-    snap install lxd || true
-fi
-
 # copy bash completions to host system
 cp -a $SNAP/bash_completions/* /usr/share/bash-completion/completions/. || true

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# copy bash completions to host system
-cp -a $SNAP/bash_completions/* /usr/share/bash-completion/completions/. || true


### PR DESCRIPTION
the bash-completions are no longer present and thus the copy is obsolete. and juju can run without lxd.

like #22472 but for 4.0