### PR TITLE
feat: add missing indexes and PKs

### DIFF
--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -210,11 +210,6 @@ const (
 	// wrong value.
 	CharmRelationRoleNotValid = errors.ConstError("charm relation role not valid")
 
-	// MultipleCharmHashes describes and error that occurs when a charm has
-	// multiple hash values. At the moment, we only support sha256 hash format,
-	// so if another is found, an error is returned.
-	MultipleCharmHashes = errors.ConstError("multiple charm hashes found")
-
 	// CharmAlreadyAvailable describes an error that occurs when a charm is
 	// already been made available. There is no need to download it again.
 	CharmAlreadyAvailable = errors.ConstError("charm already available")
@@ -248,6 +243,10 @@ const (
 	// CharmHashNotFound describes an error that occurs when the charm hash is
 	// not found.
 	CharmHashNotFound = errors.ConstError("charm hash not found")
+
+	// CharmHashAlreadyExists describes an error that occurs when setting the
+	// hash for a charm that already has one.
+	CharmHashAlreadyExists = errors.ConstError("charm hash already exists")
 
 	// CharmProvenanceNotValid describes an error that occurs when the
 	// charm download provenance is not valid.

--- a/domain/application/state/application_bench_test.go
+++ b/domain/application/state/application_bench_test.go
@@ -1,0 +1,494 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/clock"
+	_ "github.com/mattn/go-sqlite3"
+
+	coreapplication "github.com/juju/juju/core/application"
+	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/instance"
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/domain/application"
+	"github.com/juju/juju/domain/application/architecture"
+	"github.com/juju/juju/domain/application/charm"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/constraints"
+	"github.com/juju/juju/domain/deployment"
+	domainlife "github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/schema"
+	"github.com/juju/juju/internal/database/txn"
+	"github.com/juju/juju/internal/errors"
+	internallogger "github.com/juju/juju/internal/logger"
+	"github.com/juju/juju/internal/uuid"
+)
+
+func BenchmarkSetApplicationConstraints(b *testing.B) {
+	tests := []struct {
+		name string
+		fn   func(context.Context, *State, coreapplication.UUID, constraints.Constraints) error
+	}{{
+		name: "StateBasePrepareWarm",
+		fn:   setApplicationConstraintsWithStatePrepare,
+	}, {
+		name: "StaticMustPrepare",
+		fn: func(ctx context.Context, st *State, appID coreapplication.UUID, cons constraints.Constraints) error {
+			return st.SetApplicationConstraints(ctx, appID, cons)
+		},
+	}}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			ctx := b.Context()
+			st, appID := newApplicationBenchmarkState(b, ctx)
+			cons := benchmarkApplicationConstraints()
+			if err := test.fn(ctx, st, appID, cons); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				if err := test.fn(ctx, st, appID, cons); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func newApplicationBenchmarkState(
+	b *testing.B,
+	ctx context.Context,
+) (*State, coreapplication.UUID) {
+	b.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.ExecContext(ctx, "PRAGMA foreign_keys=ON"); err != nil {
+		b.Fatal(err)
+	}
+
+	runner := &benchmarkTxnRunner{
+		db:     sqlair.NewDB(db),
+		runner: txn.NewRetryingTxnRunner(),
+		dying:  make(chan struct{}),
+	}
+	changeSet, err := schema.ModelDDL().Ensure(ctx, runner)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if changeSet.Post != schema.ModelDDL().Len() {
+		b.Fatalf("unexpected schema version %d", changeSet.Post)
+	}
+
+	modelUUID, err := coremodel.NewUUID()
+	if err != nil {
+		b.Fatal(err)
+	}
+	factory := func(context.Context) (coredatabase.TxnRunner, error) {
+		return runner, nil
+	}
+	setupState := NewState(
+		factory,
+		modelUUID,
+		clock.WallClock,
+		internallogger.Noop(),
+	)
+
+	appID, _, err := setupState.CreateIAASApplication(
+		ctx,
+		"benchmark-app",
+		application.AddIAASApplicationArg{
+			BaseAddApplicationArg: application.BaseAddApplicationArg{
+				Platform: deployment.Platform{
+					Channel:      "22.04/stable",
+					OSType:       deployment.Ubuntu,
+					Architecture: architecture.AMD64,
+				},
+				Channel: &deployment.Channel{
+					Track: "latest",
+					Risk:  deployment.RiskStable,
+				},
+				Charm: charm.Charm{
+					Metadata: charm.Metadata{
+						Name: "benchmark-app",
+					},
+					Manifest: charm.Manifest{
+						Bases: []charm.Base{{
+							Name: "ubuntu",
+							Channel: charm.Channel{
+								Risk: charm.RiskStable,
+							},
+							Architectures: []string{"amd64"},
+						}},
+					},
+					Source:        charm.CharmHubSource,
+					ReferenceName: "benchmark-app",
+					Revision:      1,
+					Hash:          "benchmark-hash",
+					Architecture:  architecture.AMD64,
+				},
+				CharmDownloadInfo: &charm.DownloadInfo{
+					Provenance:         charm.ProvenanceDownload,
+					CharmhubIdentifier: "benchmark-charm",
+					DownloadURL:        "https://example.invalid/benchmark.charm",
+					DownloadSize:       42,
+				},
+			},
+		},
+		nil,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if err := addBenchmarkSpaces(ctx, runner, "space0", "space1"); err != nil {
+		b.Fatal(err)
+	}
+
+	return NewState(
+		factory,
+		modelUUID,
+		clock.WallClock,
+		internallogger.Noop(),
+	), appID
+}
+
+type benchmarkTxnRunner struct {
+	db     *sqlair.DB
+	runner *txn.RetryingTxnRunner
+	dying  chan struct{}
+}
+
+func (r *benchmarkTxnRunner) Txn(ctx context.Context, fn func(context.Context, *sqlair.TX) error) error {
+	return r.runner.Txn(ctx, r.db, fn)
+}
+
+func (r *benchmarkTxnRunner) StdTxn(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	return r.runner.StdTxn(ctx, r.db.PlainDB(), fn)
+}
+
+func (r *benchmarkTxnRunner) Dying() <-chan struct{} {
+	return r.dying
+}
+
+func addBenchmarkSpaces(ctx context.Context, runner *benchmarkTxnRunner, names ...string) error {
+	return runner.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		for i, name := range names {
+			if _, err := tx.ExecContext(
+				ctx,
+				"INSERT INTO space (uuid, name) VALUES (?, ?)",
+				fmt.Sprintf("benchmark-space-%d", i),
+				name,
+			); err != nil {
+				return errors.Capture(err)
+			}
+		}
+		return nil
+	})
+}
+
+func benchmarkApplicationConstraints() constraints.Constraints {
+	return constraints.Constraints{
+		Arch:             ptrTo("amd64"),
+		CpuCores:         ptrTo(uint64(2)),
+		CpuPower:         ptrTo(uint64(42)),
+		Mem:              ptrTo(uint64(8)),
+		RootDisk:         ptrTo(uint64(256)),
+		RootDiskSource:   ptrTo("root-disk-source"),
+		InstanceRole:     ptrTo("instance-role"),
+		InstanceType:     ptrTo("instance-type"),
+		Container:        ptrTo(instance.LXD),
+		VirtType:         ptrTo("virt-type"),
+		AllocatePublicIP: ptrTo(true),
+		ImageID:          ptrTo("image-id"),
+		Spaces: ptrTo([]constraints.SpaceConstraint{
+			{SpaceName: "space0", Exclude: false},
+			{SpaceName: "space1", Exclude: true},
+		}),
+		Tags:  ptrTo([]string{"tag0", "tag1"}),
+		Zones: ptrTo([]string{"zone0", "zone1"}),
+	}
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}
+
+func setApplicationConstraintsWithStatePrepare(
+	ctx context.Context,
+	st *State,
+	appID coreapplication.UUID,
+	cons constraints.Constraints,
+) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := checkApplicationNotDeadWithStatePrepare(ctx, st, tx, appID); err != nil {
+			return errors.Capture(err)
+		}
+
+		return st.setApplicationConstraintsWithStatePrepare(ctx, tx, appID.String(), cons)
+	})
+}
+
+func checkApplicationNotDeadWithStatePrepare(
+	ctx context.Context,
+	st *State,
+	tx *sqlair.TX,
+	appUUID coreapplication.UUID,
+) error {
+	return checkApplicationLifeWithStatePrepare(ctx, st, tx, appUUID, domainlife.Dying)
+}
+
+func checkApplicationLifeWithStatePrepare(
+	ctx context.Context,
+	st *State,
+	tx *sqlair.TX,
+	appUUID coreapplication.UUID,
+	allowed domainlife.Life,
+) error {
+	type life struct {
+		LifeID domainlife.Life `db:"life_id"`
+	}
+
+	ident := entityUUID{UUID: appUUID.String()}
+	query := `
+SELECT &life.*
+FROM application AS a
+JOIN charm AS c ON a.charm_uuid = c.uuid
+WHERE a.uuid = $entityUUID.uuid;
+`
+	stmt, err := st.Prepare(query, ident, life{})
+	if err != nil {
+		return errors.Errorf("preparing query for application %q: %w", ident.UUID, err)
+	}
+
+	var result life
+	err = tx.Query(ctx, stmt, ident).Get(&result)
+	if errors.Is(err, sql.ErrNoRows) {
+		return applicationerrors.ApplicationNotFound
+	} else if err != nil {
+		return errors.Errorf("checking application %q exists: %w", ident.UUID, err)
+	}
+
+	switch result.LifeID {
+	case domainlife.Dead:
+		if allowed < result.LifeID {
+			return applicationerrors.ApplicationIsDead
+		}
+	case domainlife.Dying:
+		if allowed < result.LifeID {
+			return applicationerrors.ApplicationNotAlive
+		}
+	default:
+		return nil
+	}
+	return nil
+}
+
+func (st *State) setApplicationConstraintsWithStatePrepare(
+	ctx context.Context,
+	tx *sqlair.TX,
+	appUUID string,
+	cons constraints.Constraints,
+) error {
+
+	cUUID, err := uuid.NewUUID()
+	if err != nil {
+		return errors.Capture(err)
+	}
+	cUUIDStr := cUUID.String()
+
+	selectConstraintUUIDQuery := `
+SELECT &constraintUUID.*
+FROM   application_constraint
+WHERE  application_uuid = $applicationUUID.application_uuid
+`
+	selectConstraintUUIDStmt, err := st.Prepare(selectConstraintUUIDQuery, constraintUUID{}, applicationUUID{})
+	if err != nil {
+		return errors.Errorf("preparing select application constraint uuid query: %w", err)
+	}
+
+	// Check that spaces provided as constraints do exist in the space table.
+	selectSpaceQuery := `SELECT &spaceUUID.uuid FROM space WHERE name = $spaceName.name`
+	selectSpaceStmt, err := st.Prepare(selectSpaceQuery, spaceUUID{}, spaceName{})
+	if err != nil {
+		return errors.Errorf("preparing select space query: %w", err)
+	}
+
+	// Cleanup all previous tags, spaces and zones from their join tables.
+	deleteConstraintTagsQuery := `DELETE FROM constraint_tag WHERE constraint_uuid = $constraintUUID.constraint_uuid`
+	deleteConstraintTagsStmt, err := st.Prepare(deleteConstraintTagsQuery, constraintUUID{})
+	if err != nil {
+		return errors.Errorf("preparing delete constraint tags query: %w", err)
+	}
+	deleteConstraintSpacesQuery := `DELETE FROM constraint_space WHERE constraint_uuid = $constraintUUID.constraint_uuid`
+	deleteConstraintSpacesStmt, err := st.Prepare(deleteConstraintSpacesQuery, constraintUUID{})
+	if err != nil {
+		return errors.Errorf("preparing delete constraint spaces query: %w", err)
+	}
+	deleteConstraintZonesQuery := `DELETE FROM constraint_zone WHERE constraint_uuid = $constraintUUID.constraint_uuid`
+	deleteConstraintZonesStmt, err := st.Prepare(deleteConstraintZonesQuery, constraintUUID{})
+	if err != nil {
+		return errors.Errorf("preparing delete constraint zones query: %w", err)
+	}
+
+	selectContainerTypeIDQuery := `SELECT &containerTypeID.id FROM container_type WHERE value = $containerTypeVal.value`
+	selectContainerTypeIDStmt, err := st.Prepare(selectContainerTypeIDQuery, containerTypeID{}, containerTypeVal{})
+	if err != nil {
+		return errors.Errorf("preparing select container type id query: %w", err)
+	}
+
+	insertConstraintsQuery := `
+INSERT INTO "constraint"(*)
+VALUES ($setConstraint.*)
+ON CONFLICT (uuid) DO UPDATE SET
+    arch = excluded.arch,
+    cpu_cores = excluded.cpu_cores,
+    cpu_power = excluded.cpu_power,
+    mem = excluded.mem,
+    root_disk= excluded.root_disk,
+    root_disk_source = excluded.root_disk_source,
+    instance_role = excluded.instance_role,
+    instance_type = excluded.instance_type,
+    container_type_id = excluded.container_type_id,
+    virt_type = excluded.virt_type,
+    allocate_public_ip = excluded.allocate_public_ip,
+    image_id = excluded.image_id
+`
+	insertConstraintsStmt, err := st.Prepare(insertConstraintsQuery, setConstraint{})
+	if err != nil {
+		return errors.Errorf("preparing insert constraints query: %w", err)
+	}
+
+	insertConstraintTagsQuery := `INSERT INTO constraint_tag(*) VALUES ($setConstraintTag.*)`
+	insertConstraintTagsStmt, err := st.Prepare(insertConstraintTagsQuery, setConstraintTag{})
+	if err != nil {
+		return errors.Errorf("preparing insert constraint tags query: %w", err)
+	}
+
+	insertConstraintSpacesQuery := `INSERT INTO constraint_space(*) VALUES ($setConstraintSpace.*)`
+	insertConstraintSpacesStmt, err := st.Prepare(insertConstraintSpacesQuery, setConstraintSpace{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	insertConstraintZonesQuery := `INSERT INTO constraint_zone(*) VALUES ($setConstraintZone.*)`
+	insertConstraintZonesStmt, err := st.Prepare(insertConstraintZonesQuery, setConstraintZone{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	insertAppConstraintsQuery := `
+INSERT INTO application_constraint(*)
+VALUES ($setApplicationConstraint.*)
+ON CONFLICT (application_uuid) DO NOTHING
+`
+	insertAppConstraintsStmt, err := st.Prepare(insertAppConstraintsQuery, setApplicationConstraint{})
+	if err != nil {
+		return errors.Errorf("preparing insert application constraints query: %w", err)
+	}
+
+	var containerTypeID containerTypeID
+	if cons.Container != nil {
+		err = tx.Query(ctx, selectContainerTypeIDStmt, containerTypeVal{Value: string(*cons.Container)}).Get(&containerTypeID)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			st.logger.Warningf(ctx, "cannot set constraints, container type %q does not exist", *cons.Container)
+			return applicationerrors.InvalidApplicationConstraints
+		}
+		if err != nil {
+			return errors.Capture(err)
+		}
+	}
+
+	// First check if the constraint already exists, in that case
+	// we need to update it, unsetting the nil values.
+	var retrievedConstraintUUID constraintUUID
+	err = tx.Query(ctx, selectConstraintUUIDStmt, applicationUUID{ApplicationUUID: appUUID}).Get(&retrievedConstraintUUID)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Capture(err)
+	} else if err == nil {
+		cUUIDStr = retrievedConstraintUUID.ConstraintUUID
+	}
+
+	// Cleanup tags, spaces and zones from their join tables.
+	if err := tx.Query(ctx, deleteConstraintTagsStmt, constraintUUID{ConstraintUUID: cUUIDStr}).Run(); err != nil {
+		return errors.Capture(err)
+	}
+	if err := tx.Query(ctx, deleteConstraintSpacesStmt, constraintUUID{ConstraintUUID: cUUIDStr}).Run(); err != nil {
+		return errors.Capture(err)
+	}
+	if err := tx.Query(ctx, deleteConstraintZonesStmt, constraintUUID{ConstraintUUID: cUUIDStr}).Run(); err != nil {
+		return errors.Capture(err)
+	}
+
+	constraints := encodeConstraints(cUUIDStr, cons, containerTypeID.ID)
+
+	if err := tx.Query(ctx, insertConstraintsStmt, constraints).Run(); err != nil {
+		return errors.Capture(err)
+	}
+
+	if cons.Tags != nil {
+		for _, tag := range *cons.Tags {
+			constraintTag := setConstraintTag{ConstraintUUID: cUUIDStr, Tag: tag}
+			if err := tx.Query(ctx, insertConstraintTagsStmt, constraintTag).Run(); err != nil {
+				return errors.Capture(err)
+			}
+		}
+	}
+
+	if cons.Spaces != nil {
+		for _, space := range *cons.Spaces {
+			// Make sure the space actually exists.
+			var spaceUUID spaceUUID
+			err := tx.Query(ctx, selectSpaceStmt, spaceName{Name: space.SpaceName}).Get(&spaceUUID)
+			if errors.Is(err, sqlair.ErrNoRows) {
+				st.logger.Warningf(ctx, "cannot set constraints, space %q does not exist", space)
+				return applicationerrors.InvalidApplicationConstraints
+			}
+			if err != nil {
+				return errors.Capture(err)
+			}
+
+			constraintSpace := setConstraintSpace{ConstraintUUID: cUUIDStr, Space: space.SpaceName, Exclude: space.Exclude}
+			if err := tx.Query(ctx, insertConstraintSpacesStmt, constraintSpace).Run(); err != nil {
+				return errors.Capture(err)
+			}
+		}
+	}
+
+	if cons.Zones != nil {
+		for _, zone := range *cons.Zones {
+			constraintZone := setConstraintZone{ConstraintUUID: cUUIDStr, Zone: zone}
+			if err := tx.Query(ctx, insertConstraintZonesStmt, constraintZone).Run(); err != nil {
+				return errors.Capture(err)
+			}
+		}
+	}
+
+	return errors.Capture(
+		tx.Query(ctx, insertAppConstraintsStmt, setApplicationConstraint{
+			ApplicationUUID: appUUID,
+			ConstraintUUID:  cUUIDStr,
+		}).Run(),
+	)
+}

--- a/domain/application/state/application_bench_test.go
+++ b/domain/application/state/application_bench_test.go
@@ -205,29 +205,25 @@ func addBenchmarkSpaces(ctx context.Context, runner *benchmarkTxnRunner, names .
 
 func benchmarkApplicationConstraints() constraints.Constraints {
 	return constraints.Constraints{
-		Arch:             ptrTo("amd64"),
-		CpuCores:         ptrTo(uint64(2)),
-		CpuPower:         ptrTo(uint64(42)),
-		Mem:              ptrTo(uint64(8)),
-		RootDisk:         ptrTo(uint64(256)),
-		RootDiskSource:   ptrTo("root-disk-source"),
-		InstanceRole:     ptrTo("instance-role"),
-		InstanceType:     ptrTo("instance-type"),
-		Container:        ptrTo(instance.LXD),
-		VirtType:         ptrTo("virt-type"),
-		AllocatePublicIP: ptrTo(true),
-		ImageID:          ptrTo("image-id"),
-		Spaces: ptrTo([]constraints.SpaceConstraint{
+		Arch:             new("amd64"),
+		CpuCores:         new(uint64(2)),
+		CpuPower:         new(uint64(42)),
+		Mem:              new(uint64(8)),
+		RootDisk:         new(uint64(256)),
+		RootDiskSource:   new("root-disk-source"),
+		InstanceRole:     new("instance-role"),
+		InstanceType:     new("instance-type"),
+		Container:        new(instance.LXD),
+		VirtType:         new("virt-type"),
+		AllocatePublicIP: new(true),
+		ImageID:          new("image-id"),
+		Spaces: new([]constraints.SpaceConstraint{
 			{SpaceName: "space0", Exclude: false},
 			{SpaceName: "space1", Exclude: true},
 		}),
-		Tags:  ptrTo([]string{"tag0", "tag1"}),
-		Zones: ptrTo([]string{"zone0", "zone1"}),
+		Tags:  new([]string{"tag0", "tag1"}),
+		Zones: new([]string{"zone0", "zone1"}),
 	}
-}
-
-func ptrTo[T any](v T) *T {
-	return &v
 }
 
 func setApplicationConstraintsWithStatePrepare(

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -2284,7 +2284,7 @@ func (s *applicationStateSuite) TestGetApplicationsForRevisionUpdater(c *tc.C) {
 	// Get the applications for the revision updater.
 	apps, err := s.state.GetApplicationsForRevisionUpdater(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(apps, tc.DeepEquals, []application.RevisionUpdaterApplication{{
+	c.Check(apps, tc.SameContents, []application.RevisionUpdaterApplication{{
 		Name: "foo",
 		CharmLocator: charm.CharmLocator{
 			Name:         "foo",

--- a/domain/application/state/charm.go
+++ b/domain/application/state/charm.go
@@ -310,7 +310,7 @@ func (s *State) GetCharmArchiveMetadata(ctx context.Context, id corecharm.ID) (a
 		return "", "", errors.Capture(err)
 	}
 
-	var archivePathAndHashes []charmArchivePathAndHash
+	var archivePathAndHash charmArchivePathAndHash
 	ident := entityUUID{UUID: id.String()}
 
 	query := `
@@ -326,7 +326,7 @@ WHERE charm.uuid = $entityUUID.uuid;
 	}
 
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		if err := tx.Query(ctx, stmt, ident).GetAll(&archivePathAndHashes); err != nil {
+		if err := tx.Query(ctx, stmt, ident).Get(&archivePathAndHash); err != nil {
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return applicationerrors.CharmNotFound
 			}
@@ -336,11 +336,8 @@ WHERE charm.uuid = $entityUUID.uuid;
 	}); err != nil {
 		return "", "", errors.Errorf("getting charm archive metadata: %w", err)
 	}
-	if len(archivePathAndHashes) > 1 {
-		return "", "", errors.Errorf("getting charm archive metadata: %w", applicationerrors.MultipleCharmHashes)
-	}
 
-	return archivePathAndHashes[0].ArchivePath, archivePathAndHashes[0].Hash, nil
+	return archivePathAndHash.ArchivePath, archivePathAndHash.Hash, nil
 }
 
 // GetCharmMetadata returns the metadata for the charm using the charm ID.

--- a/domain/application/state/charm_test.go
+++ b/domain/application/state/charm_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/utils/v4"
 
 	coreapplication "github.com/juju/juju/core/application"
-	corecharm "github.com/juju/juju/core/charm"
 	charmtesting "github.com/juju/juju/core/charm/testing"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/model"
@@ -2911,7 +2910,7 @@ func (s *charmStateSuite) TestGetCharmArchiveMetadata(c *tc.C) {
 	c.Check(hash, tc.DeepEquals, "hash")
 }
 
-func (s *charmStateSuite) TestGetCharmArchiveMetadataInsertAdditionalHashKind(c *tc.C) {
+func (s *charmStateSuite) TestCharmHashIsSingleRowPerCharm(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), s.modelUUID, clock.WallClock,
 		loggertesting.WrapCheckLog(c))
 
@@ -2929,13 +2928,10 @@ func (s *charmStateSuite) TestGetCharmArchiveMetadataInsertAdditionalHashKind(c 
 	}, nil, false)
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		return insertAdditionalHashKindForCharm(ctx, c, tx, id, "sha386", "hash386")
+	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		return st.addCharmHash(ctx, tx, id, "hash386")
 	})
-	c.Assert(err, tc.ErrorIsNil)
-
-	_, _, err = st.GetCharmArchiveMetadata(c.Context(), id)
-	c.Assert(err, tc.ErrorIs, applicationerrors.MultipleCharmHashes)
+	c.Assert(err, tc.ErrorIs, applicationerrors.CharmHashAlreadyExists)
 }
 
 func (s *charmStateSuite) TestGetCharmArchiveMetadataCharmNotFound(c *tc.C) {
@@ -3581,28 +3577,6 @@ func insertCharmManifest(ctx context.Context, c *tc.C, tx *sql.Tx, uuid string) 
 	}
 
 	return charm.Manifest{}, nil
-}
-
-func insertAdditionalHashKindForCharm(ctx context.Context, c *tc.C, tx *sql.Tx, charmId corecharm.ID, kind, hash string) error {
-	var kindId int
-	rows, err := tx.QueryContext(ctx, `SELECT id FROM hash_kind`)
-	c.Assert(err, tc.ErrorIsNil)
-	for rows.Next() {
-		var id int
-		err := rows.Scan(&id)
-		c.Assert(err, tc.ErrorIsNil)
-		kindId = max(kindId, id)
-	}
-	kindId++
-	defer func() { _ = rows.Close() }()
-
-	_, err = tx.ExecContext(ctx, `INSERT INTO hash_kind (id, name) VALUES (?, ?)`, kindId, kind)
-	c.Assert(err, tc.ErrorIsNil)
-
-	_, err = tx.ExecContext(ctx, `INSERT INTO charm_hash (charm_uuid, hash_kind_id, hash) VALUES (?, ?, ?)`, charmId, kindId, hash)
-	c.Assert(err, tc.ErrorIsNil)
-
-	return nil
 }
 
 func insertMinimalApplication(ctx context.Context, c *tc.C, tx *sql.Tx, uuid, charm_uuid string) error {

--- a/domain/application/state/state.go
+++ b/domain/application/state/state.go
@@ -613,7 +613,13 @@ func (s *State) addCharmHash(ctx context.Context, tx *sqlair.TX, id corecharm.ID
 		return errors.Errorf("preparing query: %w", err)
 	}
 
-	if err := tx.Query(ctx, hashStmt, setHash).Run(); err != nil {
+	if err := tx.Query(ctx, hashStmt, setHash).Run(); internaldatabase.IsErrConstraintPrimaryKey(err) ||
+		internaldatabase.IsErrConstraintUnique(err) {
+		return errors.Errorf(
+			"charm hash for charm %q already exists",
+			id,
+		).Add(applicationerrors.CharmHashAlreadyExists)
+	} else if err != nil {
 		return errors.Errorf("inserting charm hash: %w", err)
 	}
 

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"slices"
 	"sort"
 	"strings"
 
@@ -3140,28 +3139,31 @@ WHERE  ru.relation_endpoint_uuid = $relationEndpointUUID.uuid
 	return relUnits, nil
 }
 
-// checkCompatibleBases determines if the bases of two application endpoints
-// are compatible for a relation.
-// It compares the OS and channel of the base configurations for both endpoints.
-// Returns an error if no compatible bases are found or if fetching bases fails.
+// checkCompatibleBases determines if the base of two application endpoints is
+// compatible for a container-scoped relation.
 func (st *State) checkCompatibleBases(ctx context.Context, tx *sqlair.TX, ep1 Endpoint, ep2 Endpoint) error {
 	if ep1.Scope != charm.ScopeContainer && ep2.Scope != charm.ScopeContainer {
 		return nil
 	}
 
-	app1Bases, err := st.getBases(ctx, tx, ep1)
+	app1Base, ok, err := st.getBase(ctx, tx, ep1)
 	if err != nil {
-		return errors.Errorf("getting bases of application %q: %w", ep1.ApplicationName, err)
-	}
-	app2Bases, err := st.getBases(ctx, tx, ep2)
-	if err != nil {
-		return errors.Errorf("getting bases of application %q: %w", ep2.ApplicationName, err)
+		return errors.Errorf("getting base of application %q: %w", ep1.ApplicationName, err)
+	} else if !ok {
+		return errors.Errorf("no compatible bases found for application %q and %q", ep1.ApplicationName,
+			ep2.ApplicationName).Add(relationerrors.CompatibleEndpointsNotFound)
 	}
 
-	for _, base1 := range app1Bases {
-		if slices.ContainsFunc(app2Bases, base1.IsCompatible) {
-			return nil
-		}
+	app2Base, ok, err := st.getBase(ctx, tx, ep2)
+	if err != nil {
+		return errors.Errorf("getting base of application %q: %w", ep2.ApplicationName, err)
+	} else if !ok {
+		return errors.Errorf("no compatible bases found for application %q and %q", ep1.ApplicationName,
+			ep2.ApplicationName).Add(relationerrors.CompatibleEndpointsNotFound)
+	}
+
+	if app1Base.IsCompatible(app2Base) {
+		return nil
 	}
 
 	return errors.Errorf("no compatible bases found for application %q and %q", ep1.ApplicationName,
@@ -3471,9 +3473,9 @@ AND    ae.application_name = $endpointIdentifier.application_name
 	return corerelation.EndpointUUID(endpoint.UUID), nil
 }
 
-// getBases retrieves a list of OS and channel information for a specific
-// application, given an endpoint and transaction.
-func (st *State) getBases(ctx context.Context, tx *sqlair.TX, ep1 Endpoint) ([]corebase.Base, error) {
+// getBase retrieves OS and channel information for a specific application,
+// given an endpoint and transaction.
+func (st *State) getBase(ctx context.Context, tx *sqlair.TX, ep1 Endpoint) (corebase.Base, bool, error) {
 	stmt, err := st.Prepare(`
 SELECT 
     ap.channel AS &applicationPlatform.channel,
@@ -3482,27 +3484,26 @@ FROM application_platform ap
 JOIN os ON ap.os_id = os.id
 WHERE ap.application_uuid = $Endpoint.application_uuid`, ep1, applicationPlatform{})
 	if err != nil {
-		return nil, errors.Capture(err)
-	}
-	var appPlatforms []applicationPlatform
-	err = tx.Query(ctx, stmt, ep1).GetAll(&appPlatforms)
-	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return nil, errors.Errorf("getting application platforms for %q: %w", ep1, err)
+		return corebase.Base{}, false, errors.Capture(err)
 	}
 
-	var result []corebase.Base
-	for _, appPlatform := range appPlatforms {
-		channel, err := corebase.ParseChannel(appPlatform.Channel)
-		if err != nil {
-			return nil, errors.Errorf("parsing channel %q: %w", appPlatform.Channel, err)
-		}
-		result = append(result, corebase.Base{
-			OS:      appPlatform.OS,
-			Channel: channel,
-		})
+	var appPlatform applicationPlatform
+	err = tx.Query(ctx, stmt, ep1).Get(&appPlatform)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return corebase.Base{}, false, nil
+	} else if err != nil {
+		return corebase.Base{}, false, errors.Errorf("getting application platform for %q: %w", ep1, err)
 	}
 
-	return result, nil
+	channel, err := corebase.ParseChannel(appPlatform.Channel)
+	if err != nil {
+		return corebase.Base{}, false, errors.Errorf("parsing channel %q: %w", appPlatform.Channel, err)
+	}
+
+	return corebase.Base{
+		OS:      appPlatform.OS,
+		Channel: channel,
+	}, true, nil
 }
 
 func (st *State) getRelationDetails(ctx context.Context, tx *sqlair.TX, relationUUID string) (domainrelation.RelationDetailsResult, error) {

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -82,6 +82,7 @@ var controllerPostPatchFilesByVersion = []struct {
 	version: semversion.MustParse("4.0.12"),
 	files: []string{
 		"0031-model-migration.PATCH.sql",
+		"0032-view-indexes.PATCH.sql",
 	},
 }}
 

--- a/domain/schema/controller/sql/0032-view-indexes.PATCH.sql
+++ b/domain/schema/controller/sql/0032-view-indexes.PATCH.sql
@@ -1,0 +1,16 @@
+-- Patch 0032: Add indexes used by controller schema views.
+
+CREATE INDEX idx_agent_binary_store_object_store_uuid
+ON agent_binary_store (object_store_uuid);
+
+CREATE INDEX idx_object_store_metadata_path_metadata_uuid
+ON object_store_metadata_path (metadata_uuid);
+
+CREATE INDEX idx_permission_grant_to
+ON permission (grant_to);
+
+CREATE INDEX idx_permission_object_type_grant_on
+ON permission (object_type_id, grant_on);
+
+CREATE INDEX idx_user_name
+ON user (name);

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -178,6 +178,7 @@ var modelPostPatchFilesByVersion = []struct {
 	files: []string{
 		"0058-charm-secret-removal.PATCH.sql",
 		"0059-machine-status.PATCH.sql",
+		"0060-view-indexes.PATCH.sql",
 	},
 }}
 

--- a/domain/schema/model/sql/0060-view-indexes.PATCH.sql
+++ b/domain/schema/model/sql/0060-view-indexes.PATCH.sql
@@ -1,0 +1,173 @@
+-- Patch 0060: Add indexes used by model schema views.
+--
+-- Also makes application_platform and charm_hash single-row-per-application
+-- and single-row-per-charm tables respectively. The domain already treats
+-- application_uuid and charm_uuid as row identities for these tables.
+
+DROP VIEW v_application_charm_download_info;
+DROP VIEW v_application_origin;
+DROP VIEW v_application_platform_channel;
+DROP VIEW v_revision_updater_application;
+
+CREATE TABLE application_platform_new (
+    application_uuid TEXT NOT NULL PRIMARY KEY,
+    os_id TEXT NOT NULL,
+    channel TEXT,
+    architecture_id INT NOT NULL,
+    CONSTRAINT fk_application_platform_application
+    FOREIGN KEY (application_uuid)
+    REFERENCES application (uuid),
+    CONSTRAINT fk_application_platform_os
+    FOREIGN KEY (os_id)
+    REFERENCES os (id),
+    CONSTRAINT fk_application_platform_architecture
+    FOREIGN KEY (architecture_id)
+    REFERENCES architecture (id)
+);
+
+INSERT INTO application_platform_new (
+    application_uuid,
+    os_id,
+    channel,
+    architecture_id
+)
+SELECT
+    application_uuid,
+    os_id,
+    channel,
+    architecture_id
+FROM application_platform;
+
+DROP TABLE application_platform;
+ALTER TABLE application_platform_new RENAME TO application_platform;
+
+CREATE TABLE charm_hash_new (
+    charm_uuid TEXT NOT NULL PRIMARY KEY,
+    hash_kind_id INT NOT NULL DEFAULT 0,
+    hash TEXT NOT NULL,
+    CONSTRAINT fk_charm_hash_charm
+    FOREIGN KEY (charm_uuid)
+    REFERENCES charm (uuid),
+    CONSTRAINT fk_charm_hash_kind
+    FOREIGN KEY (hash_kind_id)
+    REFERENCES hash_kind (id)
+);
+
+INSERT INTO charm_hash_new (
+    charm_uuid,
+    hash_kind_id,
+    hash
+)
+SELECT
+    charm_uuid,
+    hash_kind_id,
+    hash
+FROM charm_hash;
+
+DROP TABLE charm_hash;
+ALTER TABLE charm_hash_new RENAME TO charm_hash;
+
+-- noqa: disable=all
+CREATE TRIGGER trg_charm_hash_immutable_update
+BEFORE UPDATE ON charm_hash
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(FAIL, 'charm_hash table is unmodifiable, only insertions and deletions are allowed');
+END;
+-- noqa: enable=all
+
+CREATE VIEW v_application_charm_download_info AS
+SELECT
+    a.uuid AS application_uuid,
+    c.uuid AS charm_uuid,
+    c.reference_name AS name,
+    c.available,
+    cs.id AS source_id,
+    cp.name AS provenance,
+    cdi.charmhub_identifier,
+    cdi.download_url,
+    cdi.download_size,
+    ch.hash
+FROM application AS a
+LEFT JOIN charm AS c ON a.charm_uuid = c.uuid
+LEFT JOIN charm_download_info AS cdi ON c.uuid = cdi.charm_uuid
+LEFT JOIN charm_provenance AS cp ON cdi.provenance_id = cp.id
+LEFT JOIN charm_source AS cs ON c.source_id = cs.id
+LEFT JOIN charm_hash AS ch ON c.uuid = ch.charm_uuid;
+
+CREATE VIEW v_application_platform_channel AS
+SELECT
+    ap.application_uuid,
+    os.name AS platform_os,
+    os.id AS platform_os_id,
+    ap.channel AS platform_channel,
+    a.name AS platform_architecture,
+    a.id AS platform_architecture_id,
+    ac.track AS channel_track,
+    ac.risk AS channel_risk,
+    ac.branch AS channel_branch
+FROM application_platform AS ap
+JOIN os ON ap.os_id = os.id
+JOIN architecture AS a ON ap.architecture_id = a.id
+LEFT JOIN application_channel AS ac ON ap.application_uuid = ac.application_uuid;
+
+CREATE VIEW v_revision_updater_application AS
+SELECT
+    a.uuid,
+    a.name,
+    c.reference_name,
+    c.revision,
+    c.architecture_id AS charm_architecture_id,
+    ac.track AS channel_track,
+    ac.risk AS channel_risk,
+    ac.branch AS channel_branch,
+    ap.os_id AS platform_os_id,
+    ap.channel AS platform_channel,
+    ap.architecture_id AS platform_architecture_id,
+    cdi.charmhub_identifier
+FROM application AS a
+LEFT JOIN charm AS c ON a.charm_uuid = c.uuid
+LEFT JOIN application_channel AS ac ON a.uuid = ac.application_uuid
+LEFT JOIN application_platform AS ap ON a.uuid = ap.application_uuid
+LEFT JOIN charm_download_info AS cdi ON c.uuid = cdi.charm_uuid
+WHERE a.life_id = 0 AND c.source_id = 1;
+
+CREATE VIEW v_application_origin AS
+SELECT
+    a.uuid,
+    c.reference_name,
+    c.source_id,
+    c.revision,
+    cdi.charmhub_identifier,
+    ch.hash
+FROM application AS a
+JOIN charm AS c ON a.charm_uuid = c.uuid
+LEFT JOIN charm_download_info AS cdi ON c.uuid = cdi.charm_uuid
+JOIN charm_hash AS ch ON c.uuid = ch.charm_uuid;
+
+CREATE INDEX idx_agent_binary_store_object_store_uuid
+ON agent_binary_store (object_store_uuid);
+
+CREATE INDEX idx_object_store_metadata_path_metadata_uuid
+ON object_store_metadata_path (metadata_uuid);
+
+CREATE INDEX idx_application_charm_uuid
+ON application (charm_uuid);
+
+CREATE INDEX idx_provider_link_layer_device_device_uuid
+ON provider_link_layer_device (device_uuid);
+
+CREATE INDEX idx_provider_ip_address_address_uuid
+ON provider_ip_address (address_uuid);
+
+CREATE INDEX idx_subnet_space_uuid
+ON subnet (space_uuid);
+
+CREATE INDEX idx_availability_zone_subnet_subnet_uuid
+ON availability_zone_subnet (subnet_uuid);
+
+CREATE INDEX idx_application_endpoint_charm_relation_uuid
+ON application_endpoint (charm_relation_uuid);
+
+CREATE INDEX idx_relation_endpoint_endpoint_uuid
+ON relation_endpoint (endpoint_uuid);


### PR DESCRIPTION
Adds missing indexes to tables based on view usage. Two tables needed primary keys added.

There was logic for comparing application bases to determine subordinate/primary compatibility. This has been changed to assume singular bases instead of the multiple previously allowed by the table definition.

The same applies to charm hashes. A charm can only have one hash, which is now enforced by primary key.

## QA steps

All existing state tests pass.