### PR TITLE
fix(apiclient proxy): fix apiclient http transport proxy

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -170,6 +170,7 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 	// all the way down to a single connection.
 	httpsTransport.MaxIdleConns = 1
 	httpsTransport.IdleConnTimeout = 90 * time.Second
+	httpsTransport.Proxy = proxyForRequest
 
 	// Technically, when there's no CACert, we don't need this
 	// machinery because we could just use http.DefaultTransport

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -160,17 +160,7 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		bakeryClient.Client = &httpc
 	}
 
-	httpsTransport := jujuhttp.NewHTTPTLSTransport(jujuhttp.TransportConfig{
-		TLSConfig: dialResult.tlsConfig,
-	})
-	// http.DefaultTransport uses 100 idle connections and 90s timeout.
-	// Old versions of juju/http were not setting this at all, which meant
-	// that we were not cleaning up idle connections. Since we are creating
-	// a new httpsTransport for each api.Open, we can set the MaxIdleConns
-	// all the way down to a single connection.
-	httpsTransport.MaxIdleConns = 1
-	httpsTransport.IdleConnTimeout = 90 * time.Second
-	httpsTransport.Proxy = proxyForRequest
+	httpsTransport := newPrimaryHTTPTransport(dialResult.tlsConfig)
 
 	// Technically, when there's no CACert, we don't need this
 	// machinery because we could just use http.DefaultTransport
@@ -245,6 +235,21 @@ func Open(info *Info, opts DialOpts) (Connection, error) {
 		broken:      st.broken,
 	}).run()
 	return st, nil
+}
+
+func newPrimaryHTTPTransport(tlsConfig *tls.Config) *http.Transport {
+	httpsTransport := jujuhttp.NewHTTPTLSTransport(jujuhttp.TransportConfig{
+		TLSConfig: tlsConfig,
+	})
+	// http.DefaultTransport uses 100 idle connections and 90s timeout.
+	// Old versions of juju/http were not setting this at all, which meant
+	// that we were not cleaning up idle connections. Since we are creating
+	// a new httpsTransport for each api.Open, we can set the MaxIdleConns
+	// all the way down to a single connection.
+	httpsTransport.MaxIdleConns = 1
+	httpsTransport.IdleConnTimeout = 90 * time.Second
+	httpsTransport.Proxy = proxyForRequest
+	return httpsTransport
 }
 
 // CookieURLFromHost creates a url.URL from a given host.

--- a/api/apiclient_whitebox_test.go
+++ b/api/apiclient_whitebox_test.go
@@ -138,3 +138,26 @@ func (s *apiclientWhiteboxSuite) TestProxyForRequestNormalizesWebsocketSchemes(c
 
 	c.Assert(proxy.DefaultConfig.Set(proxyutils.Settings{}), jc.ErrorIsNil)
 }
+
+func (s *apiclientWhiteboxSuite) TestNewPrimaryHTTPTransportUsesProxyConfig(c *gc.C) {
+	err := proxy.DefaultConfig.Set(proxyutils.Settings{
+		Https: "https://proxy.example:8443",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer func() {
+		c.Assert(proxy.DefaultConfig.Set(proxyutils.Settings{}), jc.ErrorIsNil)
+	}()
+
+	transport := newPrimaryHTTPTransport(nil)
+	c.Assert(transport.Proxy, gc.NotNil)
+	c.Assert(transport.MaxIdleConns, gc.Equals, 1)
+	c.Assert(transport.IdleConnTimeout, gc.Equals, 90*time.Second)
+
+	req, err := http.NewRequest(http.MethodGet, "https://controller.example:17070/model/uuid", nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	proxyURL, err := transport.Proxy(req)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(proxyURL, gc.NotNil)
+	c.Assert(proxyURL.String(), gc.Equals, "https://proxy.example:8443")
+}


### PR DESCRIPTION
# Description

After a user reported the `juju attach-resource` was not working in the bastion I figured we had some missing proxy env handling in the http part of the client, and indeed the primary http transport wasn't honoring the proxy config

# QA

The qa is a bit convoluted but i wanted to make extra sure the fix is actually correct.

Setup a simple proxy.
docker-compose.yaml
```
version: '3.8'

services:
  tinyproxy:
    image: vimagick/tinyproxy
    ports:
      - "8888:8888"
    volumes:
      - ./data:/etc/tinyproxy
    restart: unless-stopped
```
`data/tinyproxy.conf'
```
Port 8888
Listen 0.0.0.0
Timeout 600
Allow 0.0.0.0/0
```

`docker compose up`

Then:
`juju bootstrap test`
`juju deploy juju-qa-test`

Setup your machine to refuse connection not passing through the proxy by running this `./script <up>`
> this script is ai generated, do your own blocking of connection as you like.
```
#!/usr/bin/env bash
set -euo pipefail

# Config via env vars:
# CONTROLLER_IPV4=10.165.178.207
# CONTROLLER_IPV6=fd42:9398:9c5b:f44:216:3eff:fe98:c691
# CONTROLLER_PORT=17070
# TARGET_UID=1000
CONTROLLER_IPV4="${CONTROLLER_IPV4:-10.165.178.207}"
CONTROLLER_IPV6="${CONTROLLER_IPV6:-fd42:9398:9c5b:f44:216:3eff:fe98:c691}"
CONTROLLER_PORT="${CONTROLLER_PORT:-17070}"
TARGET_UID="${TARGET_UID:-$(id -u)}"

ACTION="${1:-}"

usage() {
  echo "Usage: $0 {up|down|status}"
  exit 1
}

has_rule() {
  local bin="$1" ip="$2"
  sudo "$bin" -C OUTPUT -p tcp -d "$ip" --dport "$CONTROLLER_PORT" -m owner --uid-owner "$TARGET_UID" -j REJECT >/dev/null 2>&1
}

add_rule() {
  local bin="$1" ip="$2"
  if has_rule "$bin" "$ip"; then
    echo "[skip] $bin rule already present for $ip:$CONTROLLER_PORT uid=$TARGET_UID"
  else
    sudo "$bin" -I OUTPUT 1 -p tcp -d "$ip" --dport "$CONTROLLER_PORT" -m owner --uid-owner "$TARGET_UID" -j REJECT
    echo "[add ] $bin blocked $ip:$CONTROLLER_PORT for uid=$TARGET_UID"
  fi
}

del_rule() {
  local bin="$1" ip="$2"
  if has_rule "$bin" "$ip"; then
    sudo "$bin" -D OUTPUT -p tcp -d "$ip" --dport "$CONTROLLER_PORT" -m owner --uid-owner "$TARGET_UID" -j REJECT
    echo "[del ] $bin unblocked $ip:$CONTROLLER_PORT for uid=$TARGET_UID"
  else
    echo "[skip] $bin no rule for $ip:$CONTROLLER_PORT uid=$TARGET_UID"
  fi
}

show_status() {
  echo "Target UID: $TARGET_UID"
  echo "Controller port: $CONTROLLER_PORT"
  if [[ -n "$CONTROLLER_IPV4" ]]; then
    if has_rule iptables "$CONTROLLER_IPV4"; then
      echo "IPv4: BLOCKED $CONTROLLER_IPV4:$CONTROLLER_PORT"
    else
      echo "IPv4: OPEN    $CONTROLLER_IPV4:$CONTROLLER_PORT"
    fi
  fi
  if [[ -n "$CONTROLLER_IPV6" ]]; then
    if has_rule ip6tables "$CONTROLLER_IPV6"; then
      echo "IPv6: BLOCKED [$CONTROLLER_IPV6]:$CONTROLLER_PORT"
    else
      echo "IPv6: OPEN    [$CONTROLLER_IPV6]:$CONTROLLER_PORT"
    fi
  fi
}

case "$ACTION" in
  up)
    [[ -n "$CONTROLLER_IPV4" ]] && add_rule iptables "$CONTROLLER_IPV4"
    [[ -n "$CONTROLLER_IPV6" ]] && add_rule ip6tables "$CONTROLLER_IPV6"
    show_status
    ;;
  down)
    [[ -n "$CONTROLLER_IPV4" ]] && del_rule iptables "$CONTROLLER_IPV4"
    [[ -n "$CONTROLLER_IPV6" ]] && del_rule ip6tables "$CONTROLLER_IPV6"
    show_status
    ;;
  status)
    show_status
    ;;
  *)
    usage
    ;;
esac
```

`juju status` should hang, but this should work
```
HTTP_PROXY="http://127.0.0.1:8888" \
HTTPS_PROXY="http://127.0.0.1:8888" \
juju status
```

this command should fail with:
```
HTTP_PROXY="http://127.0.0.1:8888" \
HTTPS_PROXY="http://127.0.0.1:8888" \
NO_PROXY="" \
no_proxy="" \
/snap/bin/juju --debug attach-resource juju-qa-test foo-file="/home/duttos/jaas/juju-3.6/tests/suites/resources/foo-file.txt"
```
```
ERROR failed to upload resource "foo-file": Put "https://10.165.178.207:17070/model/07d667bc-486a-4a77-8f6c-7398e51829c8/applications/juju-qa-test/resources/foo-file": dial tcp 10.165.178.207:17070: connect: connection refused
```

and juju with the patch should work
```
HTTP_PROXY="http://127.0.0.1:8888" \
HTTPS_PROXY="http://127.0.0.1:8888" \
NO_PROXY="" \
no_proxy="" \
juju --debug attach-resource juju-qa-test foo-file="/home/duttos/jaas/juju-3.6/tests/suites/resources/foo-file.txt"
```