### PR TITLE
fix: properly handle legacy k8s modeloperator labels

### DIFF
--- a/internal/provider/kubernetes/constants/constants.go
+++ b/internal/provider/kubernetes/constants/constants.go
@@ -88,6 +88,16 @@ const (
 	CharmMemLimitMi = "1024Mi"
 )
 
+const (
+	// ModelOperatorTargetValue is the value of the operator target for
+	// model operators.
+	ModelOperatorTargetValue = "model"
+
+	// ModelOperatorName is the model operator stack name used for deployment,
+	// service, RBAC resources.
+	ModelOperatorName = "modeloperator"
+)
+
 // DefaultPropagationPolicy returns the default propagation policy.
 func DefaultPropagationPolicy() *metav1.DeletionPropagation {
 	v := metav1.DeletePropagationForeground

--- a/internal/provider/kubernetes/modeloperator.go
+++ b/internal/provider/kubernetes/modeloperator.go
@@ -19,7 +19,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
@@ -113,14 +112,9 @@ const (
 	EnvModelAgentCAASServiceName      = "SERVICE_NAME"
 	EnvModelAgentCAASServiceNamespace = "SERVICE_NAMESPACE"
 	EnvModelAgentHTTPPort             = "HTTP_PORT"
-
-	OperatorModelTarget = "model"
 )
 
 var (
-	// modelOperatorName is the model operator stack name used for deployment, service, RBAC resources.
-	modelOperatorName = "modeloperator"
-
 	// ExecRBACResourceName is the model's exec RBAC resource name.
 	ExecRBACResourceName = "model-exec"
 )
@@ -217,10 +211,8 @@ func ensureModelOperator(
 ) (err error) {
 
 	ctx := context.TODO()
-	operatorName := modelOperatorName
-	modelTag := names.NewModelTag(modelUUID)
 
-	selectorLabels := modelOperatorLabels(operatorName, broker.LabelVersion())
+	selectorLabels := utils.LabelsForModelOperator(broker.LabelVersion())
 	labels := selectorLabels
 	if broker.LabelVersion() != constants.LegacyLabelVersion {
 		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
@@ -232,6 +224,9 @@ func ensureModelOperator(
 			utils.RunCleanUps(cleanUpFuncs)
 		}
 	}()
+
+	operatorName := constants.ModelOperatorName
+	modelTag := names.NewModelTag(modelUUID)
 
 	configMap := modelOperatorConfigMap(
 		broker.Namespace(),
@@ -254,7 +249,7 @@ func ensureModelOperator(
 				},
 				Items: []core.KeyToPath{
 					{
-						Key:  modelOperatorConfigMapAgentConfKey(modelOperatorName),
+						Key:  modelOperatorConfigMapAgentConfKey(constants.ModelOperatorName),
 						Path: constants.TemplateFileNameAgentConf,
 					},
 				},
@@ -368,7 +363,7 @@ func (k *kubernetesClient) ModelOperator() (*caas.ModelOperatorConfig, error) {
 	if k.namespace == "" {
 		return nil, errNoNamespace
 	}
-	operatorName := modelOperatorName
+	operatorName := constants.ModelOperatorName
 	exists, err := k.ModelOperatorExists()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -507,7 +502,7 @@ func modelOperatorDeployment(
 // ModelOperatorExists indicates if the model operator for the given broker
 // exists
 func (k *kubernetesClient) ModelOperatorExists() (bool, error) {
-	operatorName := modelOperatorName
+	operatorName := constants.ModelOperatorName
 	exists, err := k.modelOperatorDeploymentExists(operatorName)
 	if err != nil {
 		return false, errors.Trace(err)
@@ -529,13 +524,6 @@ func (k *kubernetesClient) modelOperatorDeploymentExists(operatorName string) (b
 		return false, errors.Trace(err)
 	}
 	return true, nil
-}
-
-func modelOperatorLabels(operatorName string, labelVersion constants.LabelVersion) labels.Set {
-	if labelVersion == constants.LegacyLabelVersion {
-		return utils.LabelForKeyValue(constants.LegacyLabelModelOperator, operatorName)
-	}
-	return utils.LabelsForOperator(operatorName, OperatorModelTarget, labelVersion)
 }
 
 func modelOperatorService(
@@ -789,19 +777,19 @@ func modelOperatorConfigMapAgentConfKey(operatorName string) string {
 // - [errors.NotFound]: When the deployment is missing or no containers can be found.
 func (k *kubernetesClient) GetModelOperatorDeploymentImage() (string, error) {
 	api := k.client().AppsV1().Deployments(k.namespace)
-	res, err := api.Get(context.Background(), modelOperatorName, metav1.GetOptions{})
+	res, err := api.Get(context.Background(), constants.ModelOperatorName, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
-		return "", errors.NewNotFound(err, fmt.Sprintf("k8s %q deployment not found", modelOperatorName))
+		return "", errors.NewNotFound(err, fmt.Sprintf("k8s %q deployment not found", constants.ModelOperatorName))
 	} else if err != nil {
 		return "", errors.Trace(err)
 	}
 
 	containers := res.Spec.Template.Spec.Containers
 	if len(containers) == 0 {
-		return "", errors.NotFoundf("no containers found in model operator deployment %q", modelOperatorName)
+		return "", errors.NotFoundf("no containers found in model operator deployment %q", constants.ModelOperatorName)
 	}
 
 	image := containers[0].Image
-	logger.Tracef("model operator %q deployment image: %s", modelOperatorName, image)
+	logger.Tracef("model operator %q deployment image: %s", constants.ModelOperatorName, image)
 	return image, nil
 }

--- a/internal/provider/kubernetes/modeloperator_test.go
+++ b/internal/provider/kubernetes/modeloperator_test.go
@@ -121,17 +121,17 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 		c.Fatalf("timed out waiting for ensureModelOperator return")
 	}
 
-	cm, err := m.client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	cm, err := m.client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), constants.ModelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cm.Name, gc.Equals, modelOperatorName)
+	c.Assert(cm.Name, gc.Equals, constants.ModelOperatorName)
 	c.Assert(cm.Namespace, gc.Equals, namespace)
-	conf, ok := cm.Data[modelOperatorConfigMapAgentConfKey(modelOperatorName)]
+	conf, ok := cm.Data[modelOperatorConfigMapAgentConfKey(constants.ModelOperatorName)]
 	c.Assert(ok, gc.Equals, true)
 	c.Assert(conf, jc.DeepEquals, string(config.AgentConf))
 
-	d, err := m.client.AppsV1().Deployments(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	d, err := m.client.AppsV1().Deployments(namespace).Get(context.TODO(), constants.ModelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(d.Name, gc.Equals, modelOperatorName)
+	c.Assert(d.Name, gc.Equals, constants.ModelOperatorName)
 	c.Assert(d.Namespace, gc.Equals, namespace)
 	c.Assert(d.Spec.Template.Spec.Containers[0].Image, gc.Equals, config.ImageDetails.RegistryPath)
 	c.Assert(d.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort, gc.Equals, config.Port)
@@ -140,9 +140,9 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 		c.Assert(d.Spec.Template.Spec.ImagePullSecrets[0].Name, gc.Equals, constants.CAASImageRepoSecretName)
 	}
 
-	r, err := m.client.RbacV1().Roles(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	r, err := m.client.RbacV1().Roles(namespace).Get(context.TODO(), constants.ModelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(r.Name, gc.Equals, modelOperatorName)
+	c.Assert(r.Name, gc.Equals, constants.ModelOperatorName)
 	c.Assert(r.Namespace, gc.Equals, namespace)
 	c.Assert(r.Rules[0].APIGroups, jc.DeepEquals, []string{""})
 	c.Assert(r.Rules[0].Resources, jc.DeepEquals, []string{"serviceaccounts"})
@@ -152,24 +152,24 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 		"watch",
 	})
 
-	rb, err := m.client.RbacV1().RoleBindings(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	rb, err := m.client.RbacV1().RoleBindings(namespace).Get(context.TODO(), constants.ModelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(rb.Name, gc.Equals, modelOperatorName)
+	c.Assert(rb.Name, gc.Equals, constants.ModelOperatorName)
 	c.Assert(rb.Namespace, gc.Equals, namespace)
 	c.Assert(rb.RoleRef.APIGroup, gc.Equals, "rbac.authorization.k8s.io")
 	c.Assert(rb.RoleRef.Kind, gc.Equals, "Role")
-	c.Assert(rb.RoleRef.Name, gc.Equals, modelOperatorName)
+	c.Assert(rb.RoleRef.Name, gc.Equals, constants.ModelOperatorName)
 
-	sa, err := m.client.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	sa, err := m.client.CoreV1().ServiceAccounts(namespace).Get(context.TODO(), constants.ModelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	trueVar := true
-	c.Assert(sa.Name, gc.Equals, modelOperatorName)
+	c.Assert(sa.Name, gc.Equals, constants.ModelOperatorName)
 	c.Assert(sa.Namespace, gc.Equals, namespace)
 	c.Assert(sa.AutomountServiceAccountToken, jc.DeepEquals, &trueVar)
 
-	s, err := m.client.CoreV1().Services(namespace).Get(context.TODO(), modelOperatorName, meta.GetOptions{})
+	s, err := m.client.CoreV1().Services(namespace).Get(context.TODO(), constants.ModelOperatorName, meta.GetOptions{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.Name, gc.Equals, modelOperatorName)
+	c.Assert(s.Name, gc.Equals, constants.ModelOperatorName)
 	c.Assert(s.Namespace, gc.Equals, namespace)
 	c.Assert(s.Spec.Ports[0].Port, gc.Equals, config.Port)
 

--- a/internal/provider/kubernetes/modeloperator_upgrade.go
+++ b/internal/provider/kubernetes/modeloperator_upgrade.go
@@ -60,5 +60,5 @@ func (k *kubernetesClient) upgradeModelOperator(agentTag names.Tag, vers version
 		namespaceFn:    k.Namespace,
 		labelVersionFn: k.LabelVersion,
 	}
-	return modelOperatorUpgrade(modelOperatorName, vers, broker)
+	return modelOperatorUpgrade(constants.ModelOperatorName, vers, broker)
 }

--- a/internal/provider/kubernetes/modeloperator_upgrade_test.go
+++ b/internal/provider/kubernetes/modeloperator_upgrade_test.go
@@ -52,7 +52,7 @@ func (s *modelUpgraderSuite) SetUpTest(c *gc.C) {
 
 func (s *modelUpgraderSuite) TestModelOperatorUpgrade(c *gc.C) {
 	var (
-		operatorName = modelOperatorName
+		operatorName = constants.ModelOperatorName
 		oldImagePath = fmt.Sprintf("%s/%s:9.9.8", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
 		newImagePath = fmt.Sprintf("%s/%s:9.9.9", podcfg.JujudOCINamespace, podcfg.JujudOCIName)
 	)

--- a/internal/provider/kubernetes/package_test.go
+++ b/internal/provider/kubernetes/package_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
+	core "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
@@ -16,4 +17,12 @@ func TestAll(t *testing.T) {
 
 func (k *kubernetesClient) EnsureRoleBinding(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, []func(), error) {
 	return k.ensureRoleBinding(rb)
+}
+
+func (k *kubernetesClient) EnsureServiceAccount(sa *core.ServiceAccount) (*core.ServiceAccount, []func(), error) {
+	return k.ensureServiceAccount(sa)
+}
+
+func (k *kubernetesClient) EnsureRole(role *rbacv1.Role) (*rbacv1.Role, []func(), error) {
+	return k.ensureRole(role)
 }

--- a/internal/provider/kubernetes/rbac.go
+++ b/internal/provider/kubernetes/rbac.go
@@ -240,8 +240,8 @@ func (k *kubernetesClient) ensureServiceAccount(sa *core.ServiceAccount) (out *c
 
 	var existingLabelVersion constants.LabelVersion
 	switch name := sa.GetName(); name {
-	case ExecRBACResourceName, modelOperatorName:
-		existingLabelVersion, err = utils.MatchOperatorMetaLabelVersion(existing.ObjectMeta, modelOperatorName, OperatorModelTarget)
+	case ExecRBACResourceName, constants.ModelOperatorName:
+		existingLabelVersion, err = utils.MatchModelOperatorMetaLabelVersion(existing.ObjectMeta)
 	default:
 		if isOperatorName(name) {
 			existingLabelVersion, err = utils.MatchOperatorMetaLabelVersion(existing.ObjectMeta, appNameFromOperator(name), OperatorAppTarget)
@@ -340,8 +340,8 @@ func (k *kubernetesClient) ensureRole(role *rbacv1.Role) (out *rbacv1.Role, clea
 
 	var existingLabelVersion constants.LabelVersion
 	switch name := role.GetName(); name {
-	case ExecRBACResourceName, modelOperatorName:
-		existingLabelVersion, err = utils.MatchOperatorMetaLabelVersion(existing.ObjectMeta, modelOperatorName, OperatorModelTarget)
+	case ExecRBACResourceName, constants.ModelOperatorName:
+		existingLabelVersion, err = utils.MatchModelOperatorMetaLabelVersion(existing.ObjectMeta)
 	default:
 		if isOperatorName(name) {
 			existingLabelVersion, err = utils.MatchOperatorMetaLabelVersion(existing.ObjectMeta, appNameFromOperator(name), OperatorAppTarget)

--- a/internal/provider/kubernetes/rbac_test.go
+++ b/internal/provider/kubernetes/rbac_test.go
@@ -7,9 +7,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
+	core "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	k8sconstants "github.com/juju/juju/internal/provider/kubernetes/constants"
 	"github.com/juju/juju/testing"
 )
 
@@ -141,4 +143,305 @@ func (s *rbacSuite) TestEnsureRoleBinding(c *gc.C) {
 
 	_, _, err = s.broker.EnsureRoleBinding(&rb2)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *rbacSuite) TestEnsureServiceAccountModelOperatorV2Labels(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	// Labels that MatchModelOperatorMetaLabelVersion expects for v2:
+	// LabelsForModelOperator(LabelVersion2) merged with LabelsJuju.
+	v2Labels := map[string]string{
+		k8sconstants.LabelJujuOperatorName:     k8sconstants.ModelOperatorName,
+		k8sconstants.LabelJujuOperatorTarget:   k8sconstants.ModelOperatorTargetValue,
+		k8sconstants.LabelKubernetesAppManaged: "juju",
+	}
+
+	sa := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    v2Labels,
+		},
+	}
+
+	existingSA := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    v2Labels,
+		},
+	}
+
+	gomock.InOrder(
+		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), sa, v1.CreateOptions{}).
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockServiceAccounts.EXPECT().Get(gomock.Any(), k8sconstants.ModelOperatorName, v1.GetOptions{}).
+			Return(existingSA, nil),
+		s.mockServiceAccounts.EXPECT().Update(gomock.Any(), sa, v1.UpdateOptions{}).
+			Return(sa, nil),
+	)
+
+	out, _, err := s.broker.EnsureServiceAccount(sa)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(out.GetName(), gc.Equals, k8sconstants.ModelOperatorName)
+}
+
+func (s *rbacSuite) TestEnsureServiceAccountModelOperatorLegacyLabels(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	// Legacy labels: only LegacyLabelModelOperator.
+	legacyLabels := map[string]string{
+		k8sconstants.LegacyLabelModelOperator: k8sconstants.ModelOperatorName,
+	}
+
+	sa := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    legacyLabels,
+		},
+	}
+
+	existingSA := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    legacyLabels,
+		},
+	}
+
+	gomock.InOrder(
+		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), sa, v1.CreateOptions{}).
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockServiceAccounts.EXPECT().Get(gomock.Any(), k8sconstants.ModelOperatorName, v1.GetOptions{}).
+			Return(existingSA, nil),
+		s.mockServiceAccounts.EXPECT().Update(gomock.Any(), sa, v1.UpdateOptions{}).
+			Return(sa, nil),
+	)
+
+	out, _, err := s.broker.EnsureServiceAccount(sa)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(out.GetName(), gc.Equals, k8sconstants.ModelOperatorName)
+}
+
+func (s *rbacSuite) TestEnsureServiceAccountModelOperatorUnexpectedLabels(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	sa := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    map[string]string{"random": "label"},
+		},
+	}
+
+	existingSA := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    map[string]string{"random": "label"},
+		},
+	}
+
+	gomock.InOrder(
+		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), sa, v1.CreateOptions{}).
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockServiceAccounts.EXPECT().Get(gomock.Any(), k8sconstants.ModelOperatorName, v1.GetOptions{}).
+			Return(existingSA, nil),
+	)
+
+	_, _, err := s.broker.EnsureServiceAccount(sa)
+	c.Assert(err, gc.ErrorMatches, `.*unexpected operator labels.*`)
+}
+
+func (s *rbacSuite) TestEnsureServiceAccountExecRBACV2Labels(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	v2Labels := map[string]string{
+		k8sconstants.LabelJujuOperatorName:     k8sconstants.ModelOperatorName,
+		k8sconstants.LabelJujuOperatorTarget:   k8sconstants.ModelOperatorTargetValue,
+		k8sconstants.LabelKubernetesAppManaged: "juju",
+	}
+
+	sa := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "model-exec",
+			Namespace: "test",
+			Labels:    v2Labels,
+		},
+	}
+
+	existingSA := &core.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "model-exec",
+			Namespace: "test",
+			Labels:    v2Labels,
+		},
+	}
+
+	gomock.InOrder(
+		s.mockServiceAccounts.EXPECT().Create(gomock.Any(), sa, v1.CreateOptions{}).
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockServiceAccounts.EXPECT().Get(gomock.Any(), "model-exec", v1.GetOptions{}).
+			Return(existingSA, nil),
+		s.mockServiceAccounts.EXPECT().Update(gomock.Any(), sa, v1.UpdateOptions{}).
+			Return(sa, nil),
+	)
+
+	out, _, err := s.broker.EnsureServiceAccount(sa)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(out.GetName(), gc.Equals, "model-exec")
+}
+
+func (s *rbacSuite) TestEnsureRoleModelOperatorV2Labels(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	v2Labels := map[string]string{
+		k8sconstants.LabelJujuOperatorName:     k8sconstants.ModelOperatorName,
+		k8sconstants.LabelJujuOperatorTarget:   k8sconstants.ModelOperatorTargetValue,
+		k8sconstants.LabelKubernetesAppManaged: "juju",
+	}
+
+	role := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    v2Labels,
+		},
+	}
+
+	existingRole := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    v2Labels,
+		},
+	}
+
+	gomock.InOrder(
+		s.mockRoles.EXPECT().Create(gomock.Any(), role, v1.CreateOptions{}).
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockRoles.EXPECT().Get(gomock.Any(), k8sconstants.ModelOperatorName, v1.GetOptions{}).
+			Return(existingRole, nil),
+		s.mockRoles.EXPECT().Update(gomock.Any(), role, v1.UpdateOptions{}).
+			Return(role, nil),
+	)
+
+	out, _, err := s.broker.EnsureRole(role)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(out.GetName(), gc.Equals, k8sconstants.ModelOperatorName)
+}
+
+func (s *rbacSuite) TestEnsureRoleModelOperatorLegacyLabels(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	legacyLabels := map[string]string{
+		k8sconstants.LegacyLabelModelOperator: k8sconstants.ModelOperatorName,
+	}
+
+	role := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    legacyLabels,
+		},
+	}
+
+	existingRole := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    legacyLabels,
+		},
+	}
+
+	gomock.InOrder(
+		s.mockRoles.EXPECT().Create(gomock.Any(), role, v1.CreateOptions{}).
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockRoles.EXPECT().Get(gomock.Any(), k8sconstants.ModelOperatorName, v1.GetOptions{}).
+			Return(existingRole, nil),
+		s.mockRoles.EXPECT().Update(gomock.Any(), role, v1.UpdateOptions{}).
+			Return(role, nil),
+	)
+
+	out, _, err := s.broker.EnsureRole(role)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(out.GetName(), gc.Equals, k8sconstants.ModelOperatorName)
+}
+
+func (s *rbacSuite) TestEnsureRoleModelOperatorUnexpectedLabels(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	role := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    map[string]string{"random": "label"},
+		},
+	}
+
+	existingRole := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      k8sconstants.ModelOperatorName,
+			Namespace: "test",
+			Labels:    map[string]string{"random": "label"},
+		},
+	}
+
+	gomock.InOrder(
+		s.mockRoles.EXPECT().Create(gomock.Any(), role, v1.CreateOptions{}).
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockRoles.EXPECT().Get(gomock.Any(), k8sconstants.ModelOperatorName, v1.GetOptions{}).
+			Return(existingRole, nil),
+	)
+
+	_, _, err := s.broker.EnsureRole(role)
+	c.Assert(err, gc.ErrorMatches, `.*unexpected operator labels.*`)
+}
+
+func (s *rbacSuite) TestEnsureRoleExecRBACV2Labels(c *gc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	v2Labels := map[string]string{
+		k8sconstants.LabelJujuOperatorName:     k8sconstants.ModelOperatorName,
+		k8sconstants.LabelJujuOperatorTarget:   k8sconstants.ModelOperatorTargetValue,
+		k8sconstants.LabelKubernetesAppManaged: "juju",
+	}
+
+	role := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "model-exec",
+			Namespace: "test",
+			Labels:    v2Labels,
+		},
+	}
+
+	existingRole := &rbacv1.Role{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "model-exec",
+			Namespace: "test",
+			Labels:    v2Labels,
+		},
+	}
+
+	gomock.InOrder(
+		s.mockRoles.EXPECT().Create(gomock.Any(), role, v1.CreateOptions{}).
+			Return(nil, s.k8sAlreadyExistsError()),
+		s.mockRoles.EXPECT().Get(gomock.Any(), "model-exec", v1.GetOptions{}).
+			Return(existingRole, nil),
+		s.mockRoles.EXPECT().Update(gomock.Any(), role, v1.UpdateOptions{}).
+			Return(role, nil),
+	)
+
+	out, _, err := s.broker.EnsureRole(role)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(out.GetName(), gc.Equals, "model-exec")
 }

--- a/internal/provider/kubernetes/utils/labels.go
+++ b/internal/provider/kubernetes/utils/labels.go
@@ -97,6 +97,21 @@ func MatchOperatorMetaLabelVersion(meta meta.ObjectMeta, operatorName, target st
 	return -1, ErrUnexpectedOperatorLabels
 }
 
+// MatchModelOperatorMetaLabelVersion checks to see if the provided resource is running on an older
+// model operator / role labeling scheme or a newer one and returns the detected label version.
+func MatchModelOperatorMetaLabelVersion(meta meta.ObjectMeta) (constants.LabelVersion, error) {
+	for i := constants.LastLabelVersion; i >= constants.FirstLabelVersion; i-- {
+		want := LabelsForModelOperator(i)
+		if i != constants.LegacyLabelVersion {
+			want = labels.Merge(want, LabelsJuju)
+		}
+		if HasLabels(meta.Labels, want) {
+			return i, nil
+		}
+	}
+	return -1, ErrUnexpectedOperatorLabels
+}
+
 // MatchApplicationMetaLabelVersion checks to see if the provided resource is running on an older
 // application labeling scheme or a newer one and returns the detected label version.
 func MatchApplicationMetaLabelVersion(meta meta.ObjectMeta, appName string) (constants.LabelVersion, error) {
@@ -217,6 +232,20 @@ func LabelsForOperator(name, target string, labelVersion constants.LabelVersion)
 	return map[string]string{
 		constants.LabelJujuOperatorName:   name,
 		constants.LabelJujuOperatorTarget: target,
+	}
+}
+
+// LabelsForModelOperator returns the labels that should be placed on a juju
+// model operator.
+func LabelsForModelOperator(labelVersion constants.LabelVersion) labels.Set {
+	if labelVersion == constants.LegacyLabelVersion {
+		return map[string]string{
+			constants.LegacyLabelModelOperator: constants.ModelOperatorName,
+		}
+	}
+	return map[string]string{
+		constants.LabelJujuOperatorName:   constants.ModelOperatorName,
+		constants.LabelJujuOperatorTarget: constants.ModelOperatorTargetValue,
 	}
 }
 


### PR DESCRIPTION
It seems really old k8s deployments have modeloperator artefacts - service account and role - which use legacy labels:

```
{
  juju-modeloperator: modeloperator
}
```

As seen on Prodstack6

```
2026-05-28 00:35:01 ERROR juju.worker.dependency engine.go:695 "caas-model-operator" manifold worker returned unexpected error: failed to update model operator: deploying model operator: ensuring service account: ensuring ServiceAccount "modeloperator" with labels map[juju-modeloperator:modeloperator] : unexpected operator labels
```

The model operator worker is bouncing because the detection of these legacy labels is broken - operator labels are being confused with model operator labels.

This PR adds bespoke handling for model operator labels, with the correct legacy labels in play.

## QA steps

Regression test
```
juju bootstrap microk8s
juju add-model foo
juju deploy snappass-test
```
Check logs for errors

Replace labels with legacy ones
```
kubectl -n foo label serviceaccount modeloperator juju-modeloperator=modeloperator --overwrite
serviceaccount/modeloperator labeled
kubectl -n foo label serviceaccount modeloperator app.kubernetes.io/managed-by-               
kubectl -n foo label serviceaccount modeloperator operator.juju.is/name-       
kubectl -n foo label serviceaccount modeloperator operator.juju.is/target-

kubectl -n foo get -o yaml sa/modeloperator                                             
apiVersion: v1
automountServiceAccountToken: true
kind: ServiceAccount
metadata:
  creationTimestamp: "2026-05-28T03:00:14Z"
  labels:
    juju-modeloperator: modeloperator
  name: modeloperator
  namespace: foo
  resourceVersion: "1574"
  uid: 458d730a-fbc8-432f-826c-01d69cb2dd01
```

Restart the controller pod.
Check logs for errors.
```
kubectl -n foo get -o yaml sa/modeloperator                               
apiVersion: v1
automountServiceAccountToken: true
kind: ServiceAccount
metadata:
  creationTimestamp: "2026-05-28T03:00:14Z"
  labels:
    app.kubernetes.io/managed-by: juju
    operator.juju.is/name: modeloperator
    operator.juju.is/target: model
  name: modeloperator
  namespace: foo
  resourceVersion: "1895"
  uid: 458d730a-fbc8-432f-826c-01d69cb2dd01
```

## Links

**Issue:** Fixes #22509.

**Jira card:** [JUJU-9883](https://warthogs.atlassian.net/browse/JUJU-9883)


[JUJU-9883]: https://warthogs.atlassian.net/browse/JUJU-9883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ