### PR TITLE
fix(credential): validate auth type against cloud on CheckCredentialModels

### DIFF
--- a/domain/credential/service/service.go
+++ b/domain/credential/service/service.go
@@ -42,6 +42,11 @@ type WatcherFactory interface {
 type State interface {
 	ProviderState
 
+	// CloudSupportedAuthTypes returns the auth types supported by the named
+	// cloud. It is used to validate a credential's auth type without needing
+	// to inject the cloud service.
+	CloudSupportedAuthTypes(ctx context.Context, cloudName string) (cloud.AuthTypes, error)
+
 	// GetModelCredentialStatus returns the credential key that is in use by the
 	// model and also if the credential is considered valid or not.
 	// The following errors can be expected:
@@ -316,6 +321,22 @@ func (s *Service) CheckAndUpdateCredential(ctx context.Context, key corecredenti
 }
 
 func (s *Service) validateCredential(ctx context.Context, key corecredential.Key, cred cloud.Credential) ([]CheckCredentialModelResult, bool, error) {
+	// Validate the credential's auth type against the cloud once, before
+	// listing models. Auth-type compatibility is a cloud-level constraint; there
+	// is no need to query models at all if the credential is already invalid.
+	supportedAuthTypes, err := s.st.CloudSupportedAuthTypes(ctx, key.Cloud)
+	if err != nil {
+		return nil, false, errors.Errorf(
+			"getting supported auth types for cloud %q: %w", key.Cloud, err,
+		)
+	}
+	if !supportedAuthTypes.Contains(cred.AuthType()) {
+		return nil, false, errors.Errorf(
+			"validating credential %q for cloud %q: supported auth-types %q, %q %w",
+			key.Name, key.Cloud, supportedAuthTypes, cred.AuthType(), coreerrors.NotSupported,
+		)
+	}
+
 	models, err := s.modelsUsingCredential(ctx, key)
 	if err != nil && !errors.Is(err, credentialerrors.NotFound) {
 		return nil, false, errors.Capture(err)
@@ -373,7 +394,8 @@ func (s *Service) CheckAndRevokeCredential(ctx context.Context, key corecredenti
 		if force {
 			opMessage = "will be deleted but"
 		}
-		s.logger.Debugf(ctx, "credential %v %v it is used by model%v",
+		s.logger.Debugf(
+			ctx, "credential %v %v it is used by model%v",
 			key,
 			opMessage,
 			modelsPretty(models),
@@ -458,7 +480,8 @@ func modelsPretty(in map[coremodel.UUID]string) string {
 		firstLine = " "
 	}
 
-	return fmt.Sprintf("%v%v%v",
+	return fmt.Sprintf(
+		"%v%v%v",
 		plural(len(in)),
 		firstLine,
 		strings.Join(uuids, "\n- "),

--- a/domain/credential/service/service_test.go
+++ b/domain/credential/service/service_test.go
@@ -237,20 +237,21 @@ func (s *serviceSuite) TestWatchCredentialInvalidID(c *tc.C) {
 func (s *serviceSuite) TestCheckAndUpdateCredentialsNoModelsFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	cred := credential.CloudCredentialInfo{}
 	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: usertesting.GenNewName(c, "bob"),
 		Name:  "foobar",
 	}
 
+	s.state.EXPECT().CloudSupportedAuthTypes(gomock.Any(), "cirrus").Return(
+		cloud.AuthTypes{cloud.EmptyAuthType}, nil,
+	)
 	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, coreerrors.NotFound)
-
-	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, cred)
+	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, gomock.Any())
 
 	service := s.service(c)
 
-	results, err := service.CheckAndUpdateCredential(c.Context(), key, cloud.Credential{}, false)
+	results, err := service.CheckAndUpdateCredential(c.Context(), key, cloud.NewCredential(cloud.EmptyAuthType, nil), false)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.HasLen, 0)
 }
@@ -266,18 +267,20 @@ func (s *serviceSuite) TestCheckAndUpdateCredentialInvalidKey(c *tc.C) {
 func (s *serviceSuite) TestCheckAndUpdateCredentialModelsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	cred := cloud.Credential{}
 	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: usertesting.GenNewName(c, "bob"),
 		Name:  "foobar",
 	}
 
+	s.state.EXPECT().CloudSupportedAuthTypes(gomock.Any(), "cirrus").Return(
+		cloud.AuthTypes{cloud.EmptyAuthType}, nil,
+	)
 	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, errors.New("cannot get models"))
 
 	service := s.service(c)
 
-	results, err := service.CheckAndUpdateCredential(c.Context(), key, cred, false)
+	results, err := service.CheckAndUpdateCredential(c.Context(), key, cloud.NewCredential(cloud.EmptyAuthType, nil), false)
 	c.Assert(err, tc.ErrorMatches, "cannot get models")
 	c.Assert(results, tc.HasLen, 0)
 }
@@ -285,7 +288,7 @@ func (s *serviceSuite) TestCheckAndUpdateCredentialModelsError(c *tc.C) {
 func (s *serviceSuite) TestCheckAndUpdateCredential(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	cred := cloud.Credential{}
+	cred := cloud.NewCredential(cloud.EmptyAuthType, nil)
 	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: usertesting.GenNewName(c, "bob"),
@@ -295,8 +298,10 @@ func (s *serviceSuite) TestCheckAndUpdateCredential(c *tc.C) {
 	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 	}, nil)
-
-	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, credential.CloudCredentialInfo{})
+	s.state.EXPECT().CloudSupportedAuthTypes(gomock.Any(), "cirrus").Return(
+		cloud.AuthTypes{cloud.EmptyAuthType}, nil,
+	)
+	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, gomock.Any())
 
 	service := s.service(c)
 
@@ -312,21 +317,22 @@ func (s *serviceSuite) TestCheckAndUpdateCredential(c *tc.C) {
 func (s *serviceSuite) TestCheckAndUpdateNewCredential(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	cred := cloud.Credential{}
 	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: usertesting.GenNewName(c, "bob"),
 		Name:  "foobar",
 	}
 
+	s.state.EXPECT().CloudSupportedAuthTypes(gomock.Any(), "cirrus").Return(
+		cloud.AuthTypes{cloud.EmptyAuthType}, nil,
+	)
 	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, credentialerrors.NotFound)
-
-	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, credential.CloudCredentialInfo{})
+	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, gomock.Any())
 
 	service := s.service(c)
 
 	results, err := service.CheckAndUpdateCredential(
-		c.Context(), key, cred, false)
+		c.Context(), key, cloud.NewCredential(cloud.EmptyAuthType, nil), false)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.HasLen, 0)
 }
@@ -584,18 +590,20 @@ func (s *serviceSuite) TestCheckCredentialModelsInvalidKey(c *tc.C) {
 func (s *serviceSuite) TestCheckCredentialModelsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	cred := cloud.Credential{}
 	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: usertesting.GenNewName(c, "bob"),
 		Name:  "foobar",
 	}
 
+	s.state.EXPECT().CloudSupportedAuthTypes(gomock.Any(), "cirrus").Return(
+		cloud.AuthTypes{cloud.EmptyAuthType}, nil,
+	)
 	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, errors.New("cannot get models"))
 
 	service := s.service(c)
 
-	results, err := service.CheckCredentialModels(c.Context(), key, cred)
+	results, err := service.CheckCredentialModels(c.Context(), key, cloud.NewCredential(cloud.EmptyAuthType, nil))
 	c.Assert(err, tc.ErrorMatches, "cannot get models")
 	c.Assert(results, tc.HasLen, 0)
 }
@@ -603,7 +611,7 @@ func (s *serviceSuite) TestCheckCredentialModelsError(c *tc.C) {
 func (s *serviceSuite) TestCheckCredentialModels(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	cred := cloud.Credential{}
+	cred := cloud.NewCredential(cloud.EmptyAuthType, nil)
 	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: usertesting.GenNewName(c, "bob"),
@@ -613,6 +621,9 @@ func (s *serviceSuite) TestCheckCredentialModels(c *tc.C) {
 	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
 		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
 	}, nil)
+	s.state.EXPECT().CloudSupportedAuthTypes(gomock.Any(), "cirrus").Return(
+		cloud.AuthTypes{cloud.EmptyAuthType}, nil,
+	)
 
 	service := s.service(c)
 
@@ -626,18 +637,90 @@ func (s *serviceSuite) TestCheckCredentialModels(c *tc.C) {
 func (s *serviceSuite) TestCheckCredentialModelsNewCredential(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	cred := cloud.Credential{}
 	key := corecredential.Key{
 		Cloud: "cirrus",
 		Owner: usertesting.GenNewName(c, "bob"),
 		Name:  "foobar",
 	}
 
+	s.state.EXPECT().CloudSupportedAuthTypes(gomock.Any(), "cirrus").Return(
+		cloud.AuthTypes{cloud.EmptyAuthType}, nil,
+	)
 	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, credentialerrors.NotFound)
 
 	service := s.service(c)
 
-	results, err := service.CheckCredentialModels(c.Context(), key, cred)
+	results, err := service.CheckCredentialModels(c.Context(), key, cloud.NewCredential(cloud.EmptyAuthType, nil))
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.HasLen, 0)
+}
+
+// TestCheckAndUpdateCredentialUnsupportedAuthType checks that when the
+// credential uses an auth type not supported by the cloud, validation fails
+// and the credential is not updated.
+func (s *serviceSuite) TestCheckAndUpdateCredentialUnsupportedAuthType(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	key := corecredential.Key{
+		Cloud: "cirrus",
+		Owner: usertesting.GenNewName(c, "bob"),
+		Name:  "foobar",
+	}
+	cred := cloud.NewCredential(cloud.AuthType("badauthtype"), nil)
+
+	s.state.EXPECT().CloudSupportedAuthTypes(gomock.Any(), "cirrus").Return(
+		cloud.AuthTypes{cloud.UserPassAuthType}, nil,
+	)
+
+	results, err := s.service(c).CheckAndUpdateCredential(c.Context(), key, cred, false)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
+	c.Assert(results, tc.IsNil)
+}
+
+// TestCheckAndUpdateCredentialValidAuthType checks that when the credential
+// uses a supported auth type, validation succeeds.
+func (s *serviceSuite) TestCheckAndUpdateCredentialValidAuthType(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	key := corecredential.Key{
+		Cloud: "cirrus",
+		Owner: usertesting.GenNewName(c, "bob"),
+		Name:  "foobar",
+	}
+	cred := cloud.NewCredential(cloud.UserPassAuthType, nil)
+
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(map[coremodel.UUID]string{
+		coremodel.UUID(jujutesting.ModelTag.Id()): "mymodel",
+	}, nil)
+	s.state.EXPECT().CloudSupportedAuthTypes(gomock.Any(), "cirrus").Return(
+		cloud.AuthTypes{cloud.UserPassAuthType}, nil,
+	)
+	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, gomock.Any())
+
+	results, err := s.service(c).CheckAndUpdateCredential(c.Context(), key, cred, false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results, tc.HasLen, 1)
+	c.Assert(results[0].Errors, tc.HasLen, 0)
+}
+
+// TestCheckCredentialModelsUnsupportedAuthType checks that when the credential
+// uses an auth type not supported by the cloud, CheckCredentialModels returns
+// a top-level error without querying models.
+func (s *serviceSuite) TestCheckCredentialModelsUnsupportedAuthType(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	key := corecredential.Key{
+		Cloud: "cirrus",
+		Owner: usertesting.GenNewName(c, "bob"),
+		Name:  "foobar",
+	}
+	cred := cloud.NewCredential(cloud.AuthType("badauthtype"), nil)
+
+	s.state.EXPECT().CloudSupportedAuthTypes(gomock.Any(), "cirrus").Return(
+		cloud.AuthTypes{cloud.UserPassAuthType}, nil,
+	)
+
+	results, err := s.service(c).CheckCredentialModels(c.Context(), key, cred)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
+	c.Assert(results, tc.IsNil)
 }

--- a/domain/credential/service/state_mock_test.go
+++ b/domain/credential/service/state_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	cloud "github.com/juju/juju/cloud"
 	credential "github.com/juju/juju/core/credential"
 	instance "github.com/juju/juju/core/instance"
 	machine "github.com/juju/juju/core/machine"
@@ -161,6 +162,45 @@ func (c *MockStateCloudCredentialsForOwnerCall) Do(f func(context.Context, user.
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateCloudCredentialsForOwnerCall) DoAndReturn(f func(context.Context, user.Name, string) (map[string]credential0.CloudCredentialResult, error)) *MockStateCloudCredentialsForOwnerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// CloudSupportedAuthTypes mocks base method.
+func (m *MockState) CloudSupportedAuthTypes(arg0 context.Context, arg1 string) (cloud.AuthTypes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloudSupportedAuthTypes", arg0, arg1)
+	ret0, _ := ret[0].(cloud.AuthTypes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CloudSupportedAuthTypes indicates an expected call of CloudSupportedAuthTypes.
+func (mr *MockStateMockRecorder) CloudSupportedAuthTypes(arg0, arg1 any) *MockStateCloudSupportedAuthTypesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSupportedAuthTypes", reflect.TypeOf((*MockState)(nil).CloudSupportedAuthTypes), arg0, arg1)
+	return &MockStateCloudSupportedAuthTypesCall{Call: call}
+}
+
+// MockStateCloudSupportedAuthTypesCall wrap *gomock.Call
+type MockStateCloudSupportedAuthTypesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateCloudSupportedAuthTypesCall) Return(arg0 cloud.AuthTypes, arg1 error) *MockStateCloudSupportedAuthTypesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateCloudSupportedAuthTypesCall) Do(f func(context.Context, string) (cloud.AuthTypes, error)) *MockStateCloudSupportedAuthTypesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateCloudSupportedAuthTypesCall) DoAndReturn(f func(context.Context, string) (cloud.AuthTypes, error)) *MockStateCloudSupportedAuthTypesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/credential/state/state.go
+++ b/domain/credential/state/state.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/canonical/sqlair"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
 	corecredential "github.com/juju/juju/core/credential"
 	coredatabase "github.com/juju/juju/core/database"
@@ -373,6 +374,32 @@ func dbCredentialFromCredential(ctx context.Context, tx *sqlair.TX, credentialUU
 
 	}
 	return cred, nil
+}
+
+// CloudSupportedAuthTypes returns the auth types supported by the named cloud.
+// It is used by the credential service to validate a credential's auth type
+// without needing to inject the cloud service.
+func (st *State) CloudSupportedAuthTypes(ctx context.Context, cloudName string) (cloud.AuthTypes, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var result authTypes
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		result, err = validAuthTypesForCloud(ctx, tx, cloudName)
+		return errors.Capture(err)
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	authTypeNames := make(cloud.AuthTypes, len(result))
+	for i, at := range result {
+		authTypeNames[i] = cloud.AuthType(at.Type)
+	}
+	return authTypeNames, nil
 }
 
 func validAuthTypesForCloud(ctx context.Context, tx *sqlair.TX, cloudName string) (authTypes, error) {

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"regexp"
+	"slices"
 	stdtesting "testing"
 
 	"github.com/juju/clock"
@@ -834,4 +835,32 @@ SELECT ?, ?, ?, 0, 0, true,
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(valid, tc.IsFalse)
 	c.Check(credKey, tc.Equals, key)
+}
+
+// TestCloudSupportedAuthTypes verifies that CloudSupportedAuthTypes returns
+// all auth types registered for an existing cloud.
+func (s *credentialSuite) TestCloudSupportedAuthTypes(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	// "stratus" is seeded in SetUpTest with AccessKeyAuthType and
+	// UserPassAuthType.
+	authTypes, err := st.CloudSupportedAuthTypes(c.Context(), "stratus")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(authTypes, tc.HasLen, 2)
+
+	// Sort before comparing since the SQL query has no ORDER BY.
+	slices.Sort(authTypes)
+	c.Check(authTypes, tc.DeepEquals, cloud.AuthTypes{
+		cloud.AccessKeyAuthType,
+		cloud.UserPassAuthType,
+	})
+}
+
+// TestCloudSupportedAuthTypesUnknownCloud verifies that CloudSupportedAuthTypes
+// returns an error when the named cloud does not exist.
+func (s *credentialSuite) TestCloudSupportedAuthTypesUnknownCloud(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	_, err := st.CloudSupportedAuthTypes(c.Context(), "no-such-cloud")
+	c.Assert(err, tc.Not(tc.ErrorIsNil))
 }


### PR DESCRIPTION
`validateModelCredential` in `domain/credential/service` was a `TODO` stub returning nil, meaning `CheckCredentialModels` performed no per-model validation. JIMM relies on this endpoint returning model-level errors to decide whether to store a credential in its own database; with validation absent, credentials with unsupported auth types were silently accepted.

**Behavior before the fix**
`CheckCredentialsModels` performed no auth-type validation.
`validateModelCredential` was (and still is) a stub that always returns
nil — this was also the case in Juju 3.6, so per-model auth-type errors
were never returned by either version. With an unsupported auth type the
call returned a result with no errors: no credential-level error, no per-model
errors. JIMM treated this as success and stored the bad credential.

**Behavior after the fix**

`validateCredential` now checks the credential's auth type against the
cloud before listing models. An unsupported auth type returns a
credential-level error (`params.UpdateCredentialResult.Error`) with code
"not supported". The model list is never queried. JIMM inspects
Result.Error and rejects the update.

This is not a change to per-model validation semantics — model-level
validation remains a stub and is out of scope. The fix only adds the
missing cloud-level auth-type gate.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This fix cannot be tested using the Juju CLI because juju update-credential
rejects unsupported auth types client-side inside the LXD provider's
FinalizeCredential before the request ever reaches the controller. JIMM, by
contrast, calls the CheckCredentialsModels API endpoint directly, bypassing
client-side provider validation entirely, which is why it was silently
accepting credentials with invalid auth types.

I have tested this using a small go application:

<details>

<summary>Source code for test app: `cmd/check-cred-models/main.go`</summary>

```go
// check-cred-models reproduces the JIMM validation scenario:
// it creates a model backed by a named credential, then calls
// CheckCredentialsModels with an unsupported auth type and checks
// the result.
package main

import (
	"context"
	"encoding/json"
	"fmt"
	"os"
	"time"

	"github.com/juju/names/v6"

	cloudapi "github.com/juju/juju/api/client/cloud"
	"github.com/juju/juju/api/client/modelmanager"
	"github.com/juju/juju/api/connector"
	"github.com/juju/juju/api/jujuclient"
	"github.com/juju/juju/rpc/params"
)

const testModelName = "check-cred-models-test"

func main() {
	if len(os.Args) < 3 {
		fmt.Fprintln(os.Stderr, "usage: check-cred-models <controller> <cloud>")
		fmt.Fprintln(os.Stderr, "  e.g: check-cred-models test-controller lxd")
		fmt.Fprintln(os.Stderr, "")
		fmt.Fprintln(os.Stderr, "The current user and first available credential are auto-discovered.")
		os.Exit(1)
	}
	controllerName, cloudName := os.Args[1], os.Args[2]

	// Discover the logged-in user for this controller.
	store := jujuclient.NewFileClientStore()
	account, err := store.AccountDetails(controllerName)
	if err != nil {
		fatalf("get account details: %v", err)
	}
	userTag := names.NewUserTag(account.User)
	fmt.Printf("==> user: %s\n", userTag.Id())

	conn, err := connector.NewClientStore(connector.ClientStoreConfig{
		ControllerName: controllerName,
		ClientStore:    store,
	})
	if err != nil {
		fatalf("connector: %v", err)
	}

	apiConn, err := conn.Connect(context.Background())
	if err != nil {
		fatalf("open: %v", err)
	}
	defer apiConn.Close()

	cloudClient := cloudapi.NewClient(apiConn)

	// Discover the first credential for this user on the cloud.
	credTags, err := cloudClient.UserCredentials(context.Background(), userTag, names.NewCloudTag(cloudName))
	if err != nil {
		fatalf("list credentials: %v", err)
	}
	if len(credTags) == 0 {
		fatalf("no credentials found for user %s on cloud %s", userTag.Id(), cloudName)
	}
	credTag := credTags[0]
	fmt.Printf("==> using credential: %s\n\n", credTag.Id())

	// Step 1: create a temporary model backed by the credential so that
	// ModelsUsingCloudCredential would return it — faithfully reproducing
	// the JIMM scenario where credentials are already in use by models.
	fmt.Printf("==> creating temporary model %q on %s\n", testModelName, cloudName)
	mmClient := modelmanager.NewClient(apiConn)
	modelInfo, err := mmClient.CreateModel(
		context.Background(),
		testModelName,
		userTag,
		cloudName,
		"", // default region
		credTag,
		nil,
	)
	if err != nil {
		fatalf("create model: %v", err)
	}
	modelTag := names.NewModelTag(modelInfo.UUID)
	fmt.Printf("    model UUID: %s\n\n", modelInfo.UUID)

	// Always clean up the temporary model.
	defer func() {
		fmt.Printf("\n==> destroying temporary model %s\n", modelInfo.UUID)
		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
		defer cancel()
		t := true
		if err := mmClient.DestroyModel(ctx, modelTag, &t, &t, nil, nil); err != nil {
			fmt.Fprintf(os.Stderr, "WARNING: could not destroy model: %v\n", err)
		}
	}()

	// Step 2: call CheckCredentialsModels with an unsupported auth type.
	//
	// Without the fix: returns an empty result — no credential-level error,
	// no per-model errors. JIMM accepts the bad credential.
	//
	// With the fix: returns a credential-level error (r.Error != nil, code
	// "not supported") before models are even listed. JIMM rejects the update.
	fmt.Printf("==> calling CheckCredentialsModels with auth-type \"badauthtype\"\n\n")
	results, err := cloudClient.CheckCredentialsModels(context.Background(), params.TaggedCredentials{
		Credentials: []params.TaggedCredential{{
			Tag: credTag.String(),
			Credential: params.CloudCredential{
				AuthType: "badauthtype",
				Attributes: map[string]string{
					"bad-attr": "bad-value",
				},
			},
		}},
	})
	if err != nil {
		fatalf("RPC: %v", err)
	}

	out, _ := json.MarshalIndent(results, "", "  ")
	fmt.Println(string(out))
	fmt.Println()

	// With the fix, the unsupported auth type is caught at the cloud level and
	// returned as a credential-level error (result.Error != nil). There are no
	// per-model errors because model listing is skipped entirely.
	credentialError := false
	for _, r := range results {
		if r.Error != nil {
			credentialError = true
		}
	}
	if credentialError {
		fmt.Println("RESULT: credential-level error returned — fix is working.")
	} else {
		fmt.Println("RESULT: no credential-level error — fix absent or not triggered.")
	}
}

func fatalf(f string, args ...any) {
	fmt.Fprintf(os.Stderr, f+"\n", args...)
	os.Exit(1)
}
``` 

</details>

Test setup:

```sh
juju bootstrap lxd test-controller

juju add-model test-model

# Verify the credential is certificate-based
juju show-credential lxd lxd

# Create a YAML with an unsupported auth-type
cat > /tmp/bad-cred.yaml << 'EOF'
credentials:
  lxd:
    new:
      auth-type: userpass
      username: fakeuser
      password: fakepass
EOF
```

Running the test on this branch with the fix:

```sh
❯ go run cmd/check-cred-models/main.go test-controller lxd
==> user: admin
==> using credential: lxd/admin/lxd

==> creating temporary model "check-cred-models-test" on lxd
    model UUID: 3416c843-fa72-482f-8bbf-3135dde9d887

==> calling CheckCredentialsModels with auth-type "badauthtype"

[
  {
    "tag": "cloudcred-lxd_admin_lxd",
    "error": {
      "message": "validating credential \"lxd\" for cloud \"lxd\": supported auth-types [\"certificate\"], \"badauthtype\" not supported",
      "code": "not supported"
    }
  }
]

RESULT: credential-level error returned — fix is working.

==> destroying temporary model 3416c843-fa72-482f-8bbf-3135dde9d887
```


Running the test on `4.0` without the fix:

```sh
❯ go run cmd/check-cred-models/main.go test-controller lxd
==> user: admin
==> using credential: lxd/admin/lxd

==> creating temporary model "check-cred-models-test" on lxd
    model UUID: 746b4858-629d-4f35-8216-51758d553327

==> calling CheckCredentialsModels with auth-type "badauthtype"

[
  {
    "tag": "cloudcred-lxd_admin_lxd",
    "models": [
      {
        "uuid": "746b4858-629d-4f35-8216-51758d553327",
        "name": "check-cred-models-test"
      },
      {
        "uuid": "76e9fc27-8854-48db-8059-fd0369a46981",
        "name": "controller"
      },
      {
        "uuid": "ffc12d2b-b67b-42d2-8b37-eeddc65ae9f4",
        "name": "test-model"
      }
    ]
  }
]

RESULT: models listed but no per-model errors — credential accepted without validation (fix absent or not triggered).

==> destroying temporary model 746b4858-629d-4f35-8216-51758d553327
```


## Documentation changes


## Links

**Issue:** Fixes #22273

**Jira card:** [JUJU-9693](https://warthogs.atlassian.net/browse/JUJU-9693)


[JUJU-9693]: https://warthogs.atlassian.net/browse/JUJU-9693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ