### PR TITLE
feat: migrate db-accessor manifold off agent dependency

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -260,9 +260,16 @@ func (b *AgentBootstrap) Initialize(ctx context.Context) (resultErr error) {
 	// dqlite for k8s.
 	isLoopbackPreferred := isCAAS
 
+	agentInfo, _ := b.agentConfig.ControllerAgentInfo()
+	nodeManagerCfg := database.NodeManagerConfig{
+		DataDir:              b.agentConfig.DataDir(),
+		CACert:               b.agentConfig.CACert(),
+		ControllerCert:       agentInfo.Cert,
+		ControllerPrivateKey: agentInfo.PrivateKey,
+	}
 	if err := b.bootstrapDqlite(
 		ctx,
-		database.NewNodeManager(b.agentConfig, isLoopbackPreferred, b.logger, coredatabase.NoopSlowQueryLogger{}),
+		database.NewNodeManager(nodeManagerCfg, isLoopbackPreferred, b.logger, coredatabase.NoopSlowQueryLogger{}),
 		controllerModelUUID,
 		b.logger,
 		databaseBootstrapOptions...,

--- a/cmd/jujuagentd/agent/agenttest/agent.go
+++ b/cmd/jujuagentd/agent/agenttest/agent.go
@@ -142,9 +142,16 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *tc.C, tag names.Tag, password str
 	conf := s.WriteStateAgentConfig(c, tag, password, vers, names.NewModelTag(s.ControllerModelUUID()), apiPort)
 	s.primeAPIHostPorts(c)
 
+	agentInfo, _ := conf.ControllerAgentInfo()
+	nodeManagerCfg := database.NodeManagerConfig{
+		DataDir:              conf.DataDir(),
+		CACert:               conf.CACert(),
+		ControllerCert:       agentInfo.Cert,
+		ControllerPrivateKey: agentInfo.PrivateKey,
+	}
 	err = database.BootstrapDqlite(
 		c.Context(),
-		database.NewNodeManager(conf, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{}),
+		database.NewNodeManager(nodeManagerCfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{}),
 		tc.Must0(c, coremodel.NewUUID),
 		loggertesting.WrapCheckLog(c),
 	)

--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -54,6 +54,7 @@ import (
 	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/container/broker"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	internaldependency "github.com/juju/juju/internal/dependency"
 	"github.com/juju/juju/internal/flightrecorder"
 	internallogger "github.com/juju/juju/internal/logger"
@@ -542,9 +543,12 @@ func (a *MachineAgent) makeEngineCreator(
 		flightRecorder := workerflightrecorder.New(flightrecorder.NewRecorder(clock), "", internallogger.GetLogger("juju.flightrecorder"))
 
 		manifoldsCfg := machine.ManifoldsConfig{
-			PreviousAgentVersion:              previousAgentVersion,
-			AgentName:                         agentName,
-			ControllerID:                      agentConfig.Tag().Id(),
+			PreviousAgentVersion: previousAgentVersion,
+			AgentName:            agentName,
+			ControllerID:         agentConfig.Tag().Id(),
+			ControllerRuntimeConfigPath: controllerruntimeconfig.ConfigPath(
+				filepath.Join(agentConfig.DataDir(), "agents", "controller-"+agentConfig.Tag().Id()),
+			),
 			Agent:                             agent.APIHostPortsSetter{Agent: a},
 			RootDir:                           a.rootDir,
 			AgentConfigChanged:                a.configChangedVal,

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -143,6 +143,13 @@ type ManifoldsConfig struct {
 	// through the agent manifold.
 	ControllerID string
 
+	// ControllerRuntimeConfigPath is the absolute path to the
+	// controller runtime config file (runtime.conf) written at
+	// bootstrap. It is passed to the db-accessor manifold so that the
+	// worker can read its own connection parameters without going
+	// through the legacy agent.Config.
+	ControllerRuntimeConfigPath string
+
 	// Agent contains the agent that will be wrapped and made available to
 	// its dependencies via a dependency.Engine.
 	Agent coreagent.Agent
@@ -952,8 +959,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 // IAASManifolds returns a set of co-configured manifolds covering the
 // various responsibilities of a IAAS machine agent.
 func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
-	agentConfig := config.Agent.CurrentConfig()
-
 	manifolds := dependency.Manifolds{
 		// Bootstrap worker is responsible for setting up the initial machine.
 		bootstrapName: ifDatabaseUpgradeComplete(bootstrap.Manifold(bootstrap.ManifoldConfig{
@@ -1027,17 +1032,15 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// DBAccessor is a manifold that provides a DBAccessor worker
 		// that can be used to access the database.
 		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			AgentName:                 agentName,
-			QueryLoggerName:           queryLoggerName,
-			ControllerAgentConfigName: controllerAgentConfigName,
-			Clock:                     config.Clock,
-			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-			LogDir:                    agentConfig.LogDir(),
-			PrometheusRegisterer:      config.PrometheusRegisterer,
-			NewApp:                    dbaccessor.NewApp,
-			NewDBWorker:               config.NewDBWorkerFunc,
-			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
-			NewNodeManager:            dbaccessor.IAASNodeManager,
+			QueryLoggerName:             queryLoggerName,
+			ControllerAgentConfigName:   controllerAgentConfigName,
+			ControllerRuntimeConfigPath: config.ControllerRuntimeConfigPath,
+			Logger:                      internallogger.GetLogger("juju.worker.dbaccessor"),
+			PrometheusRegisterer:        config.PrometheusRegisterer,
+			NewApp:                      dbaccessor.NewApp,
+			NewDBWorker:                 config.NewDBWorkerFunc,
+			NewMetricsCollector:         dbaccessor.NewMetricsCollector,
+			NewNodeManager:              dbaccessor.IAASNodeManager,
 		})),
 
 		// The diskmanager worker periodically lists block devices on the
@@ -1187,8 +1190,6 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 // CAASManifolds returns a set of co-configured manifolds covering the
 // various responsibilities of a CAAS machine agent.
 func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
-	agentConfig := config.Agent.CurrentConfig()
-
 	return mergeManifolds(config, dependency.Manifolds{
 		// Bootstrap worker is responsible for setting up the initial machine.
 		bootstrapName: ifDatabaseUpgradeComplete(bootstrap.Manifold(bootstrap.ManifoldConfig{
@@ -1263,17 +1264,15 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// DBAccessor is a manifold that provides a DBAccessor worker
 		// that can be used to access the database.
 		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			AgentName:                 agentName,
-			QueryLoggerName:           queryLoggerName,
-			ControllerAgentConfigName: controllerAgentConfigName,
-			Clock:                     config.Clock,
-			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-			LogDir:                    agentConfig.LogDir(),
-			PrometheusRegisterer:      config.PrometheusRegisterer,
-			NewApp:                    dbaccessor.NewApp,
-			NewDBWorker:               config.NewDBWorkerFunc,
-			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
-			NewNodeManager:            dbaccessor.CAASNodeManager,
+			QueryLoggerName:             queryLoggerName,
+			ControllerAgentConfigName:   controllerAgentConfigName,
+			ControllerRuntimeConfigPath: config.ControllerRuntimeConfigPath,
+			Logger:                      internallogger.GetLogger("juju.worker.dbaccessor"),
+			PrometheusRegisterer:        config.PrometheusRegisterer,
+			NewApp:                      dbaccessor.NewApp,
+			NewDBWorker:                 config.NewDBWorkerFunc,
+			NewMetricsCollector:         dbaccessor.NewMetricsCollector,
+			NewNodeManager:              dbaccessor.CAASNodeManager,
 		})),
 	})
 }

--- a/cmd/jujuagentd/agent/safemode.go
+++ b/cmd/jujuagentd/agent/safemode.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/clock"
@@ -30,6 +31,7 @@ import (
 	"github.com/juju/juju/cmd/jujuagentd/reboot"
 	cmdutil "github.com/juju/juju/cmd/jujuagentd/util"
 	"github.com/juju/juju/core/semversion"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	internaldependency "github.com/juju/juju/internal/dependency"
 	internallogger "github.com/juju/juju/internal/logger"
 	k8sconstants "github.com/juju/juju/internal/provider/kubernetes/constants"
@@ -308,12 +310,16 @@ func (a *SafeModeMachineAgent) makeEngineCreator(
 			return nil, err
 		}
 
+		agentConfig := a.CurrentConfig()
 		manifoldsCfg := safemode.ManifoldsConfig{
 			Agent:              agent.APIHostPortsSetter{Agent: a},
 			AgentConfigChanged: a.configChangedVal,
 			NewDBWorkerFunc:    a.newDBWorkerFunc,
-			Clock:              clock.WallClock,
-			IsCaasConfig:       a.isCaasAgent,
+			ControllerRuntimeConfigPath: controllerruntimeconfig.ConfigPath(
+				filepath.Join(agentConfig.DataDir(), "agents", "controller-"+a.Tag().Id()),
+			),
+			Clock:        clock.WallClock,
+			IsCaasConfig: a.isCaasAgent,
 		}
 
 		var manifolds dependency.Manifolds

--- a/cmd/jujuagentd/agent/safemode/manifolds.go
+++ b/cmd/jujuagentd/agent/safemode/manifolds.go
@@ -37,6 +37,13 @@ type ManifoldsConfig struct {
 	// NewDBWorkerFunc returns a tracked db worker.
 	NewDBWorkerFunc dbaccessor.NewDBWorkerFunc
 
+	// ControllerRuntimeConfigPath is the absolute path to the
+	// controller runtime config file (runtime.conf) written at
+	// bootstrap. It is passed to the db-accessor manifold so that the
+	// worker can read its own connection parameters without going
+	// through the legacy agent.Config.
+	ControllerRuntimeConfigPath string
+
 	// Clock supplies timekeeping services to various workers.
 	Clock clock.Clock
 
@@ -102,21 +109,17 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 // IAASManifolds returns a set of co-configured manifolds covering the
 // various responsibilities of a IAAS machine agent.
 func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
-	agentConfig := config.Agent.CurrentConfig()
-
 	return mergeManifolds(config, dependency.Manifolds{
 		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			AgentName:                 agentName,
-			QueryLoggerName:           queryLoggerName,
-			ControllerAgentConfigName: controllerAgentConfigName,
-			Clock:                     config.Clock,
-			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-			LogDir:                    agentConfig.LogDir(),
-			PrometheusRegisterer:      noopPrometheusRegisterer{},
-			NewApp:                    dbaccessor.NewApp,
-			NewDBWorker:               config.NewDBWorkerFunc,
-			NewNodeManager:            dbaccessor.IAASNodeManager,
-			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
+			QueryLoggerName:             queryLoggerName,
+			ControllerAgentConfigName:   controllerAgentConfigName,
+			ControllerRuntimeConfigPath: config.ControllerRuntimeConfigPath,
+			Logger:                      internallogger.GetLogger("juju.worker.dbaccessor"),
+			PrometheusRegisterer:        noopPrometheusRegisterer{},
+			NewApp:                      dbaccessor.NewApp,
+			NewDBWorker:                 config.NewDBWorkerFunc,
+			NewNodeManager:              dbaccessor.IAASNodeManager,
+			NewMetricsCollector:         dbaccessor.NewMetricsCollector,
 		})),
 	})
 }
@@ -124,21 +127,17 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 // CAASManifolds returns a set of co-configured manifolds covering the
 // various responsibilities of a CAAS machine agent.
 func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
-	agentConfig := config.Agent.CurrentConfig()
-
 	return mergeManifolds(config, dependency.Manifolds{
 		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			AgentName:                 agentName,
-			QueryLoggerName:           queryLoggerName,
-			ControllerAgentConfigName: controllerAgentConfigName,
-			Clock:                     config.Clock,
-			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-			LogDir:                    agentConfig.LogDir(),
-			PrometheusRegisterer:      noopPrometheusRegisterer{},
-			NewApp:                    dbaccessor.NewApp,
-			NewDBWorker:               config.NewDBWorkerFunc,
-			NewNodeManager:            dbaccessor.CAASNodeManager,
-			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
+			QueryLoggerName:             queryLoggerName,
+			ControllerAgentConfigName:   controllerAgentConfigName,
+			ControllerRuntimeConfigPath: config.ControllerRuntimeConfigPath,
+			Logger:                      internallogger.GetLogger("juju.worker.dbaccessor"),
+			PrometheusRegisterer:        noopPrometheusRegisterer{},
+			NewApp:                      dbaccessor.NewApp,
+			NewDBWorker:                 config.NewDBWorkerFunc,
+			NewNodeManager:              dbaccessor.CAASNodeManager,
+			NewMetricsCollector:         dbaccessor.NewMetricsCollector,
 		})),
 	})
 }

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -142,9 +142,16 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *tc.C, tag names.Tag, password str
 	conf := s.WriteStateAgentConfig(c, tag, password, vers, names.NewModelTag(s.ControllerModelUUID()), apiPort)
 	s.primeAPIHostPorts(c)
 
+	agentInfo, _ := conf.ControllerAgentInfo()
+	nodeManagerCfg := database.NodeManagerConfig{
+		DataDir:              conf.DataDir(),
+		CACert:               conf.CACert(),
+		ControllerCert:       agentInfo.Cert,
+		ControllerPrivateKey: agentInfo.PrivateKey,
+	}
 	err = database.BootstrapDqlite(
 		c.Context(),
-		database.NewNodeManager(conf, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{}),
+		database.NewNodeManager(nodeManagerCfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{}),
 		tc.Must0(c, coremodel.NewUUID),
 		loggertesting.WrapCheckLog(c),
 	)

--- a/cmd/jujud/agent/controller.go
+++ b/cmd/jujud/agent/controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/juju/clock"
@@ -37,6 +38,7 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/semversion"
 	jujuversion "github.com/juju/juju/core/version"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	internaldependency "github.com/juju/juju/internal/dependency"
 	"github.com/juju/juju/internal/flightrecorder"
 	internallogger "github.com/juju/juju/internal/logger"
@@ -401,9 +403,12 @@ func (a *ControllerAgent) makeEngineCreator(
 		)
 
 		manifoldsCfg := agentcontroller.ManifoldsConfig{
-			PreviousAgentVersion:              previousAgentVersion,
-			AgentName:                         agentName,
-			ControllerID:                      a.agentTag.Id(),
+			PreviousAgentVersion: previousAgentVersion,
+			AgentName:            agentName,
+			ControllerID:         a.agentTag.Id(),
+			ControllerRuntimeConfigPath: controllerruntimeconfig.ConfigPath(
+				filepath.Join(agentConfig.DataDir(), "agents", "controller-"+a.agentTag.Id()),
+			),
 			Agent:                             agent.APIHostPortsSetter{Agent: a},
 			RootDir:                           a.rootDir,
 			AgentConfigChanged:                a.configChangedVal,

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -118,6 +118,13 @@ type ManifoldsConfig struct {
 	// the lookup.
 	ControllerID string
 
+	// ControllerRuntimeConfigPath is the absolute path to the
+	// controller runtime config file (runtime.conf) written at
+	// bootstrap. It is passed to the db-accessor manifold so that the
+	// worker can read its own connection parameters without going
+	// through the legacy agent.Config.
+	ControllerRuntimeConfigPath string
+
 	// Agent contains the agent that will be wrapped and made available
 	// to its dependencies via a dependency.Engine.
 	Agent coreagent.Agent
@@ -1017,34 +1024,30 @@ func NewCAASAgentConfigUpdaterManifoldConfig() agentconfigupdater.ManifoldConfig
 // NewIAASDBAccessorManifoldConfig returns the IAAS-specific db-accessor config.
 func NewIAASDBAccessorManifoldConfig(config ManifoldsConfig) dbaccessor.ManifoldConfig {
 	return dbaccessor.ManifoldConfig{
-		AgentName:                 agentName,
-		QueryLoggerName:           queryLoggerName,
-		ControllerAgentConfigName: controllerAgentConfigName,
-		Clock:                     config.Clock,
-		Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-		LogDir:                    config.Agent.CurrentConfig().LogDir(),
-		PrometheusRegisterer:      config.PrometheusRegisterer,
-		NewApp:                    dbaccessor.NewApp,
-		NewDBWorker:               config.NewDBWorkerFunc,
-		NewMetricsCollector:       dbaccessor.NewMetricsCollector,
-		NewNodeManager:            dbaccessor.IAASNodeManager,
+		QueryLoggerName:             queryLoggerName,
+		ControllerAgentConfigName:   controllerAgentConfigName,
+		ControllerRuntimeConfigPath: config.ControllerRuntimeConfigPath,
+		Logger:                      internallogger.GetLogger("juju.worker.dbaccessor"),
+		PrometheusRegisterer:        config.PrometheusRegisterer,
+		NewApp:                      dbaccessor.NewApp,
+		NewDBWorker:                 config.NewDBWorkerFunc,
+		NewMetricsCollector:         dbaccessor.NewMetricsCollector,
+		NewNodeManager:              dbaccessor.IAASNodeManager,
 	}
 }
 
 // NewCAASDBAccessorManifoldConfig returns the CAAS-specific db-accessor config.
 func NewCAASDBAccessorManifoldConfig(config ManifoldsConfig) dbaccessor.ManifoldConfig {
 	return dbaccessor.ManifoldConfig{
-		AgentName:                 agentName,
-		QueryLoggerName:           queryLoggerName,
-		ControllerAgentConfigName: controllerAgentConfigName,
-		Clock:                     config.Clock,
-		Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-		LogDir:                    config.Agent.CurrentConfig().LogDir(),
-		PrometheusRegisterer:      config.PrometheusRegisterer,
-		NewApp:                    dbaccessor.NewApp,
-		NewDBWorker:               config.NewDBWorkerFunc,
-		NewMetricsCollector:       dbaccessor.NewMetricsCollector,
-		NewNodeManager:            dbaccessor.CAASNodeManager,
+		QueryLoggerName:             queryLoggerName,
+		ControllerAgentConfigName:   controllerAgentConfigName,
+		ControllerRuntimeConfigPath: config.ControllerRuntimeConfigPath,
+		Logger:                      internallogger.GetLogger("juju.worker.dbaccessor"),
+		PrometheusRegisterer:        config.PrometheusRegisterer,
+		NewApp:                      dbaccessor.NewApp,
+		NewDBWorker:                 config.NewDBWorkerFunc,
+		NewMetricsCollector:         dbaccessor.NewMetricsCollector,
+		NewNodeManager:              dbaccessor.CAASNodeManager,
 	}
 }
 

--- a/cmd/jujud/agent/safemode.go
+++ b/cmd/jujud/agent/safemode.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/juju/clock"
@@ -29,6 +30,7 @@ import (
 	"github.com/juju/juju/cmd/jujud/agent/safemode"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
 	"github.com/juju/juju/core/semversion"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	internaldependency "github.com/juju/juju/internal/dependency"
 	internallogger "github.com/juju/juju/internal/logger"
 	k8sconstants "github.com/juju/juju/internal/provider/kubernetes/constants"
@@ -305,7 +307,10 @@ func (a *SafeModeControllerAgent) makeEngineCreator(
 			Agent:              agent.APIHostPortsSetter{Agent: a},
 			AgentConfigChanged: a.configChangedVal,
 			NewDBWorkerFunc:    a.newDBWorkerFunc,
-			Clock:              clock.WallClock,
+			ControllerRuntimeConfigPath: controllerruntimeconfig.ConfigPath(
+				filepath.Join(a.CurrentConfig().DataDir(), "agents", "controller-"+a.Tag().Id()),
+			),
+			Clock: clock.WallClock,
 		}
 
 		var manifolds dependency.Manifolds

--- a/cmd/jujud/agent/safemode/manifolds.go
+++ b/cmd/jujud/agent/safemode/manifolds.go
@@ -34,6 +34,13 @@ type ManifoldsConfig struct {
 	// NewDBWorkerFunc returns a tracked db worker.
 	NewDBWorkerFunc dbaccessor.NewDBWorkerFunc
 
+	// ControllerRuntimeConfigPath is the absolute path to the
+	// controller runtime config file (runtime.conf) written at
+	// bootstrap. It is passed to the db-accessor manifold so that the
+	// worker can read its own connection parameters without going
+	// through the legacy agent.Config.
+	ControllerRuntimeConfigPath string
+
 	// Clock supplies timekeeping services to various workers.
 	Clock clock.Clock
 }
@@ -81,42 +88,34 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 // IAASManifolds returns manifolds for an IAAS controller safe-mode engine.
 func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
-	agentConfig := config.Agent.CurrentConfig()
-
 	return mergeManifolds(config, dependency.Manifolds{
 		dbAccessorName: dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			AgentName:                 agentName,
-			QueryLoggerName:           queryLoggerName,
-			ControllerAgentConfigName: controllerAgentConfigName,
-			Clock:                     config.Clock,
-			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-			LogDir:                    agentConfig.LogDir(),
-			PrometheusRegisterer:      noopPrometheusRegisterer{},
-			NewApp:                    dbaccessor.NewApp,
-			NewDBWorker:               config.NewDBWorkerFunc,
-			NewNodeManager:            dbaccessor.IAASNodeManager,
-			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
+			QueryLoggerName:             queryLoggerName,
+			ControllerAgentConfigName:   controllerAgentConfigName,
+			ControllerRuntimeConfigPath: config.ControllerRuntimeConfigPath,
+			Logger:                      internallogger.GetLogger("juju.worker.dbaccessor"),
+			PrometheusRegisterer:        noopPrometheusRegisterer{},
+			NewApp:                      dbaccessor.NewApp,
+			NewDBWorker:                 config.NewDBWorkerFunc,
+			NewNodeManager:              dbaccessor.IAASNodeManager,
+			NewMetricsCollector:         dbaccessor.NewMetricsCollector,
 		}),
 	})
 }
 
 // CAASManifolds returns manifolds for a CAAS controller safe-mode engine.
 func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
-	agentConfig := config.Agent.CurrentConfig()
-
 	return mergeManifolds(config, dependency.Manifolds{
 		dbAccessorName: dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			AgentName:                 agentName,
-			QueryLoggerName:           queryLoggerName,
-			ControllerAgentConfigName: controllerAgentConfigName,
-			Clock:                     config.Clock,
-			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-			LogDir:                    agentConfig.LogDir(),
-			PrometheusRegisterer:      noopPrometheusRegisterer{},
-			NewApp:                    dbaccessor.NewApp,
-			NewDBWorker:               config.NewDBWorkerFunc,
-			NewNodeManager:            dbaccessor.CAASNodeManager,
-			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
+			QueryLoggerName:             queryLoggerName,
+			ControllerAgentConfigName:   controllerAgentConfigName,
+			ControllerRuntimeConfigPath: config.ControllerRuntimeConfigPath,
+			Logger:                      internallogger.GetLogger("juju.worker.dbaccessor"),
+			PrometheusRegisterer:        noopPrometheusRegisterer{},
+			NewApp:                      dbaccessor.NewApp,
+			NewDBWorker:                 config.NewDBWorkerFunc,
+			NewNodeManager:              dbaccessor.CAASNodeManager,
+			NewMetricsCollector:         dbaccessor.NewMetricsCollector,
 		}),
 	})
 }

--- a/internal/cloudconfig/userdatacfg.go
+++ b/internal/cloudconfig/userdatacfg.go
@@ -27,6 +27,7 @@ import (
 	"github.com/juju/juju/environs/simplestreams"
 	"github.com/juju/juju/internal/cloudconfig/cloudinit"
 	"github.com/juju/juju/internal/cloudconfig/instancecfg"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	"github.com/juju/juju/internal/featureflag"
 	internallogger "github.com/juju/juju/internal/logger"
 	jujunames "github.com/juju/juju/juju/names"
@@ -491,6 +492,30 @@ func (w *userdataConfig) configureBootstrap() error {
 		return errors.Annotate(err, "marshalling bootstrap params")
 	}
 	w.conf.AddRunTextFile(bootstrapParamsFile, string(bootstrapParams), 0600)
+
+	// Write the controller runtime config before the bootstrap agent runs.
+	// This provides Dqlite startup values for the controller process without
+	// requiring access to machine-agent config.
+	controllerAgentDir := path.Join(
+		w.icfg.DataDir, "agents", "controller-"+agent.BootstrapControllerId,
+	)
+	runtimeCfg := controllerruntimeconfig.ControllerRuntimeConfig{
+		ControllerID:          agent.BootstrapControllerId,
+		DataDir:               w.icfg.DataDir,
+		LogDir:                w.icfg.LogDir,
+		QueryTracingEnabled:   w.icfg.ControllerConfig.QueryTracingEnabled(),
+		QueryTracingThreshold: w.icfg.ControllerConfig.QueryTracingThreshold(),
+		DqliteBusyTimeout:     w.icfg.ControllerConfig.DqliteBusyTimeout(),
+		CACert:                w.icfg.APIInfo.CACert,
+		ControllerCert:        w.icfg.Bootstrap.ControllerAgentInfo.Cert,
+		ControllerPrivateKey:  w.icfg.Bootstrap.ControllerAgentInfo.PrivateKey,
+	}
+	runtimeCfgContent, err := controllerruntimeconfig.RenderControllerRuntimeConfig(runtimeCfg)
+	if err != nil {
+		return errors.Annotate(err, "rendering controller runtime config")
+	}
+	runtimeCfgPath := controllerruntimeconfig.ConfigPath(controllerAgentDir)
+	w.conf.AddRunTextFile(runtimeCfgPath, string(runtimeCfgContent), 0600)
 
 	loggingOption := "--show-log"
 	if loggo.GetLogger("").LogLevel() == loggo.DEBUG {

--- a/internal/cloudconfig/userdatacfg_test.go
+++ b/internal/cloudconfig/userdatacfg_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/juju/juju/internal/cloudconfig"
 	"github.com/juju/juju/internal/cloudconfig/cloudinit"
 	"github.com/juju/juju/internal/cloudconfig/instancecfg"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	"github.com/juju/juju/internal/featureflag"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/tools"
@@ -930,6 +931,53 @@ func (s *cloudinitSuite) TestCloudInitConfigureBootstrapFeatureFlags(c *tc.C) {
 	scripts := s.bootstrapConfigScripts(c)
 	expected := "JUJU_DEV_FEATURE_FLAGS=foo,special .*/jujuagentd bootstrap-state .*"
 	assertScriptMatch(c, scripts, expected, false)
+}
+
+// TestCloudInitConfigureBootstrapWritesRuntimeConfig verifies that IAAS
+// bootstrap cloud-init adds a write step for the controller runtime config
+// (runtime.conf) at the expected path with restricted permissions.
+func (*cloudinitSuite) TestCloudInitConfigureBootstrapWritesRuntimeConfig(c *tc.C) {
+	envConfig := minimalModelConfig(c)
+	instConfig := makeBootstrapConfig(jammy, 0).maybeSetModelConfig(envConfig)
+	rendered := instConfig.render()
+	cloudcfg, err := cloudinit.New(rendered.Base.OS)
+	c.Assert(err, tc.ErrorIsNil)
+	udata, err := cloudconfig.NewUserdataConfig(&rendered, cloudcfg)
+	c.Assert(err, tc.ErrorIsNil)
+	err = udata.Configure()
+	c.Assert(err, tc.ErrorIsNil)
+	data, err := cloudcfg.RenderYAML()
+	c.Assert(err, tc.ErrorIsNil)
+	configKeyValues := make(map[any]any)
+	err = goyaml.Unmarshal(data, &configKeyValues)
+	c.Assert(err, tc.ErrorIsNil)
+	scripts := getScripts(configKeyValues)
+
+	controllerAgentDir := path.Join(
+		jujuDataDir("ubuntu"),
+		"agents",
+		"controller-"+agent.BootstrapControllerId,
+	)
+	expectedPath := controllerruntimeconfig.ConfigPath(controllerAgentDir)
+
+	// AddRunTextFile emits an install step followed by an echo step.
+	// Verify that both reference the expected runtime.conf path and that
+	// the install step uses owner-only permissions (0600).
+	var installScript, echoScript string
+	for _, s := range scripts {
+		if strings.Contains(s, expectedPath) {
+			if strings.HasPrefix(s, "install ") {
+				installScript = s
+			} else if strings.Contains(s, "echo") {
+				echoScript = s
+			}
+		}
+	}
+	c.Assert(installScript, tc.Not(tc.Equals), "",
+		tc.Commentf("expected install step for %s in runcmd scripts", expectedPath))
+	c.Assert(echoScript, tc.Not(tc.Equals), "",
+		tc.Commentf("expected echo step for %s in runcmd scripts", expectedPath))
+	c.Check(installScript, tc.Matches, `install -D -m 600 /dev/null '`+regexp.QuoteMeta(expectedPath)+`'`)
 }
 
 func (*cloudinitSuite) TestCloudInitConfigureUsesGivenConfig(c *tc.C) {

--- a/internal/controllerruntimeconfig/config.go
+++ b/internal/controllerruntimeconfig/config.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerruntimeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/names/v6"
+	"github.com/juju/utils/v4"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	// Filename is the name of the controller runtime configuration file
+	// within the controller agent directory.
+	Filename = "runtime.conf"
+)
+
+// ConfigPath returns the path to the controller runtime configuration
+// file in the given controller agent directory.
+func ConfigPath(controllerAgentDir string) string {
+	return filepath.Join(controllerAgentDir, Filename)
+}
+
+// ControllerRuntimeConfig holds the static local startup values required
+// by the controller process and Dqlite before the database is available.
+//
+// The file contains TLS private key material and must be written with
+// owner-only permissions (0600). Values in this struct must never be
+// logged verbatim.
+type ControllerRuntimeConfig struct {
+	// ControllerID is the numeric controller agent ID, e.g. "0".
+	ControllerID string `yaml:"controller-id"`
+
+	// DataDir is the Dqlite data directory root.
+	DataDir string `yaml:"data-dir"`
+
+	// LogDir is the controller process log directory.
+	LogDir string `yaml:"log-dir"`
+
+	// DqlitePort is the Dqlite application bind/listen port. A value of
+	// zero means the controller uses the compiled-in default port.
+	DqlitePort int `yaml:"dqlite-port,omitempty"`
+
+	// QueryTracingEnabled controls whether Dqlite query tracing is on.
+	QueryTracingEnabled bool `yaml:"query-tracing-enabled"`
+
+	// QueryTracingThreshold is the slow-query threshold for Dqlite. A
+	// value of zero means all traced queries are logged.
+	QueryTracingThreshold time.Duration `yaml:"query-tracing-threshold"`
+
+	// DqliteBusyTimeout is the SQLite busy timeout for Dqlite.
+	DqliteBusyTimeout time.Duration `yaml:"dqlite-busy-timeout"`
+
+	// CACert is the TLS CA certificate PEM block used for Dqlite.
+	CACert string `yaml:"ca-cert"`
+
+	// ControllerCert is the Dqlite node TLS certificate PEM block.
+	ControllerCert string `yaml:"controller-cert"`
+
+	// ControllerPrivateKey is the Dqlite node TLS private key PEM block.
+	// This field is sensitive and must not be logged.
+	ControllerPrivateKey string `yaml:"controller-private-key"`
+}
+
+// Validate returns an error if any required field is missing or invalid.
+func (cfg ControllerRuntimeConfig) Validate() error {
+	if !names.IsValidControllerAgent(cfg.ControllerID) {
+		return errors.NotValidf("controller ID %q", cfg.ControllerID)
+	}
+	if cfg.DataDir == "" {
+		return errors.NotValidf("empty data-dir")
+	}
+	if cfg.LogDir == "" {
+		return errors.NotValidf("empty log-dir")
+	}
+	if cfg.DqlitePort != 0 && (cfg.DqlitePort < 1 || cfg.DqlitePort > 65535) {
+		return errors.NotValidf("dqlite port %d", cfg.DqlitePort)
+	}
+	if cfg.QueryTracingThreshold < 0 {
+		return errors.NotValidf("negative query-tracing-threshold")
+	}
+	if cfg.DqliteBusyTimeout < 0 {
+		return errors.NotValidf("negative dqlite-busy-timeout")
+	}
+	if cfg.CACert == "" {
+		return errors.NotValidf("empty ca-cert")
+	}
+	if cfg.ControllerCert == "" {
+		return errors.NotValidf("empty controller-cert")
+	}
+	if cfg.ControllerPrivateKey == "" {
+		return errors.NotValidf("empty controller-private-key")
+	}
+	return nil
+}
+
+// ReadControllerRuntimeConfig reads and validates the controller runtime
+// configuration from the file at path. It returns an annotated error if
+// the file is missing, malformed, or fails validation.
+func ReadControllerRuntimeConfig(path string) (ControllerRuntimeConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ControllerRuntimeConfig{}, errors.Annotatef(err,
+			"reading controller runtime config %q", path)
+	}
+	var cfg ControllerRuntimeConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return ControllerRuntimeConfig{}, errors.Annotatef(err,
+			"parsing controller runtime config %q", path)
+	}
+	if err := cfg.Validate(); err != nil {
+		return ControllerRuntimeConfig{}, errors.Annotatef(err,
+			"validating controller runtime config %q", path)
+	}
+	return cfg, nil
+}
+
+// WriteControllerRuntimeConfig validates cfg and atomically writes it to
+// the file at path with 0600 permissions. Parent directories are created
+// if they do not exist.
+func WriteControllerRuntimeConfig(path string, cfg ControllerRuntimeConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return errors.Annotate(err, "invalid controller runtime config")
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return errors.Annotate(err, "marshalling controller runtime config")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return errors.Annotatef(err,
+			"creating parent directory for controller runtime config %q", path)
+	}
+	if err := utils.AtomicWriteFile(path, data, 0600); err != nil {
+		return errors.Annotatef(err,
+			"writing controller runtime config %q", path)
+	}
+	return nil
+}
+
+// RenderControllerRuntimeConfig validates cfg and marshals it to YAML.
+// It is provided for callers that need the raw YAML content, for example
+// cloud-init script generation and Kubernetes ConfigMap assembly.
+func RenderControllerRuntimeConfig(cfg ControllerRuntimeConfig) ([]byte, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Annotate(err, "invalid controller runtime config")
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, errors.Annotate(err, "marshalling controller runtime config")
+	}
+	return data, nil
+}

--- a/internal/controllerruntimeconfig/config_test.go
+++ b/internal/controllerruntimeconfig/config_test.go
@@ -1,0 +1,296 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controllerruntimeconfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/juju/tc"
+	"go.uber.org/goleak"
+
+	"github.com/juju/juju/internal/controllerruntimeconfig"
+	"github.com/juju/juju/internal/testhelpers"
+)
+
+type configSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestConfigSuite(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	tc.Run(t, &configSuite{})
+}
+
+func validConfig() controllerruntimeconfig.ControllerRuntimeConfig {
+	return controllerruntimeconfig.ControllerRuntimeConfig{
+		ControllerID:          "0",
+		DataDir:               "/var/lib/juju",
+		LogDir:                "/var/log/juju",
+		QueryTracingEnabled:   true,
+		QueryTracingThreshold: time.Second,
+		DqliteBusyTimeout:     2 * time.Second,
+		CACert:                "ca-cert-pem",
+		ControllerCert:        "controller-cert-pem",
+		ControllerPrivateKey:  "controller-private-key-pem",
+	}
+}
+
+// TestValidate_ValidConfig ensures a correctly populated config passes
+// validation.
+func (s *configSuite) TestValidate_ValidConfig(c *tc.C) {
+	cfg := validConfig()
+	c.Assert(cfg.Validate(), tc.ErrorIsNil)
+}
+
+// TestValidate_ZeroDqlitePortIsValid ensures DqlitePort == 0 (use default)
+// is accepted.
+func (s *configSuite) TestValidate_ZeroDqlitePortIsValid(c *tc.C) {
+	cfg := validConfig()
+	cfg.DqlitePort = 0
+	c.Assert(cfg.Validate(), tc.ErrorIsNil)
+}
+
+// TestValidate_NonZeroDqlitePortIsValid ensures a valid non-zero Dqlite port
+// is accepted.
+func (s *configSuite) TestValidate_NonZeroDqlitePortIsValid(c *tc.C) {
+	cfg := validConfig()
+	cfg.DqlitePort = 17666
+	c.Assert(cfg.Validate(), tc.ErrorIsNil)
+}
+
+// TestValidate_InvalidControllerID ensures a non-numeric controller ID is
+// rejected.
+func (s *configSuite) TestValidate_InvalidControllerID(c *tc.C) {
+	cfg := validConfig()
+	cfg.ControllerID = "not-numeric"
+	c.Check(cfg.Validate(), tc.ErrorMatches, `controller ID "not-numeric" not valid`)
+}
+
+// TestValidate_EmptyControllerID ensures an empty controller ID is rejected.
+func (s *configSuite) TestValidate_EmptyControllerID(c *tc.C) {
+	cfg := validConfig()
+	cfg.ControllerID = ""
+	c.Check(cfg.Validate(), tc.ErrorMatches, `controller ID "" not valid`)
+}
+
+// TestValidate_EmptyDataDir ensures an empty data dir is rejected.
+func (s *configSuite) TestValidate_EmptyDataDir(c *tc.C) {
+	cfg := validConfig()
+	cfg.DataDir = ""
+	c.Check(cfg.Validate(), tc.ErrorMatches, `empty data-dir not valid`)
+}
+
+// TestValidate_EmptyLogDir ensures an empty log dir is rejected.
+func (s *configSuite) TestValidate_EmptyLogDir(c *tc.C) {
+	cfg := validConfig()
+	cfg.LogDir = ""
+	c.Check(cfg.Validate(), tc.ErrorMatches, `empty log-dir not valid`)
+}
+
+// TestValidate_InvalidDqlitePort ensures an out-of-range Dqlite port is
+// rejected.
+func (s *configSuite) TestValidate_InvalidDqlitePort(c *tc.C) {
+	cfg := validConfig()
+	cfg.DqlitePort = 99999
+	c.Check(cfg.Validate(), tc.ErrorMatches, `dqlite port 99999 not valid`)
+}
+
+// TestValidate_NegativeQueryTracingThreshold ensures a negative threshold is
+// rejected.
+func (s *configSuite) TestValidate_NegativeQueryTracingThreshold(c *tc.C) {
+	cfg := validConfig()
+	cfg.QueryTracingThreshold = -time.Second
+	c.Check(cfg.Validate(), tc.ErrorMatches, `negative query-tracing-threshold not valid`)
+}
+
+// TestValidate_ZeroQueryTracingThresholdIsValid ensures 0 threshold (log all)
+// is accepted.
+func (s *configSuite) TestValidate_ZeroQueryTracingThresholdIsValid(c *tc.C) {
+	cfg := validConfig()
+	cfg.QueryTracingThreshold = 0
+	c.Assert(cfg.Validate(), tc.ErrorIsNil)
+}
+
+// TestValidate_NegativeDqliteBusyTimeout ensures a negative busy timeout is
+// rejected.
+func (s *configSuite) TestValidate_NegativeDqliteBusyTimeout(c *tc.C) {
+	cfg := validConfig()
+	cfg.DqliteBusyTimeout = -time.Second
+	c.Check(cfg.Validate(), tc.ErrorMatches, `negative dqlite-busy-timeout not valid`)
+}
+
+// TestValidate_EmptyCACert ensures an empty CA cert is rejected.
+func (s *configSuite) TestValidate_EmptyCACert(c *tc.C) {
+	cfg := validConfig()
+	cfg.CACert = ""
+	c.Check(cfg.Validate(), tc.ErrorMatches, `empty ca-cert not valid`)
+}
+
+// TestValidate_EmptyControllerCert ensures an empty controller cert is
+// rejected.
+func (s *configSuite) TestValidate_EmptyControllerCert(c *tc.C) {
+	cfg := validConfig()
+	cfg.ControllerCert = ""
+	c.Check(cfg.Validate(), tc.ErrorMatches, `empty controller-cert not valid`)
+}
+
+// TestValidate_EmptyControllerPrivateKey ensures an empty private key is
+// rejected.
+func (s *configSuite) TestValidate_EmptyControllerPrivateKey(c *tc.C) {
+	cfg := validConfig()
+	cfg.ControllerPrivateKey = ""
+	c.Check(cfg.Validate(), tc.ErrorMatches, `empty controller-private-key not valid`)
+}
+
+// TestWriteAndReadRoundTrip ensures the write/read cycle preserves all fields.
+func (s *configSuite) TestWriteAndReadRoundTrip(c *tc.C) {
+	dir := c.MkDir()
+	path := filepath.Join(dir, controllerruntimeconfig.Filename)
+	cfg := validConfig()
+	cfg.DqlitePort = 17666
+
+	err := controllerruntimeconfig.WriteControllerRuntimeConfig(path, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	got, err := controllerruntimeconfig.ReadControllerRuntimeConfig(path)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, cfg)
+}
+
+// TestWriteAndReadRoundTrip_AllNodeManagerFields confirms that all fields
+// required for NodeManager are preserved after a round-trip.
+func (s *configSuite) TestWriteAndReadRoundTrip_AllNodeManagerFields(c *tc.C) {
+	dir := c.MkDir()
+	path := filepath.Join(dir, controllerruntimeconfig.Filename)
+	cfg := controllerruntimeconfig.ControllerRuntimeConfig{
+		ControllerID:          "0",
+		DataDir:               "/var/lib/juju",
+		LogDir:                "/var/log/juju",
+		DqlitePort:            0, // default
+		QueryTracingEnabled:   true,
+		QueryTracingThreshold: 500 * time.Millisecond,
+		DqliteBusyTimeout:     3 * time.Second,
+		CACert:                "ca-cert-pem-data",
+		ControllerCert:        "controller-cert-pem-data",
+		ControllerPrivateKey:  "controller-private-key-pem-data",
+	}
+
+	err := controllerruntimeconfig.WriteControllerRuntimeConfig(path, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	got, err := controllerruntimeconfig.ReadControllerRuntimeConfig(path)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got.ControllerID, tc.Equals, cfg.ControllerID)
+	c.Check(got.DataDir, tc.Equals, cfg.DataDir)
+	c.Check(got.LogDir, tc.Equals, cfg.LogDir)
+	c.Check(got.CACert, tc.Equals, cfg.CACert)
+	c.Check(got.ControllerCert, tc.Equals, cfg.ControllerCert)
+	c.Check(got.ControllerPrivateKey, tc.Equals, cfg.ControllerPrivateKey)
+	c.Check(got.DqliteBusyTimeout, tc.Equals, cfg.DqliteBusyTimeout)
+	c.Check(got.DqlitePort, tc.Equals, cfg.DqlitePort)
+	c.Check(got.QueryTracingEnabled, tc.Equals, cfg.QueryTracingEnabled)
+	c.Check(got.QueryTracingThreshold, tc.Equals, cfg.QueryTracingThreshold)
+}
+
+// TestWrite_CreatesParentDirectory ensures WriteControllerRuntimeConfig
+// creates the parent directory if it does not exist.
+func (s *configSuite) TestWrite_CreatesParentDirectory(c *tc.C) {
+	dir := c.MkDir()
+	path := filepath.Join(dir, "agents", "controller-0",
+		controllerruntimeconfig.Filename)
+	cfg := validConfig()
+
+	err := controllerruntimeconfig.WriteControllerRuntimeConfig(path, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = os.Stat(path)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestWrite_Permissions ensures the written file has 0600 permissions.
+func (s *configSuite) TestWrite_Permissions(c *tc.C) {
+	dir := c.MkDir()
+	path := filepath.Join(dir,
+		controllerruntimeconfig.Filename)
+	cfg := validConfig()
+
+	err := controllerruntimeconfig.WriteControllerRuntimeConfig(path, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	info, err := os.Stat(path)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.Mode().Perm(), tc.Equals, os.FileMode(0600))
+}
+
+// TestRead_MissingFile ensures ReadControllerRuntimeConfig returns an
+// annotated error when the file does not exist.
+func (s *configSuite) TestRead_MissingFile(c *tc.C) {
+	_, err := controllerruntimeconfig.ReadControllerRuntimeConfig(
+		"/nonexistent/path/runtime.conf")
+	c.Assert(err, tc.ErrorMatches,
+		`reading controller runtime config "/nonexistent/path/runtime.conf":.*`)
+}
+
+// TestRead_MalformedFile ensures ReadControllerRuntimeConfig returns an
+// annotated parse error for malformed YAML.
+func (s *configSuite) TestRead_MalformedFile(c *tc.C) {
+	dir := c.MkDir()
+	path := filepath.Join(dir, controllerruntimeconfig.Filename)
+	err := os.WriteFile(path, []byte(":\tinvalid: yaml: content"), 0600)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = controllerruntimeconfig.ReadControllerRuntimeConfig(path)
+	c.Assert(err, tc.ErrorMatches, `parsing controller runtime config.*`)
+}
+
+// TestRead_MissingRequiredField ensures ReadControllerRuntimeConfig returns a
+// validation error naming the missing field.
+func (s *configSuite) TestRead_MissingRequiredField(c *tc.C) {
+	dir := c.MkDir()
+	path := filepath.Join(dir, controllerruntimeconfig.Filename)
+	// Write config without the required ca-cert field.
+	content := `
+controller-id: "0"
+data-dir: /var/lib/juju
+log-dir: /var/log/juju
+controller-cert: cert-pem
+controller-private-key: key-pem
+`[1:]
+	err := os.WriteFile(path, []byte(content), 0600)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = controllerruntimeconfig.ReadControllerRuntimeConfig(path)
+	c.Assert(err, tc.ErrorMatches, `validating controller runtime config.*ca-cert.*`)
+}
+
+// TestConfigPath ensures the path helper returns the expected path.
+func (s *configSuite) TestConfigPath(c *tc.C) {
+	got := controllerruntimeconfig.ConfigPath(
+		"/var/lib/juju/agents/controller-0")
+	c.Check(got, tc.Equals,
+		"/var/lib/juju/agents/controller-0/runtime.conf")
+}
+
+// TestRenderControllerRuntimeConfig ensures RenderControllerRuntimeConfig
+// returns valid YAML that round-trips correctly.
+func (s *configSuite) TestRenderControllerRuntimeConfig(c *tc.C) {
+	cfg := validConfig()
+
+	data, err := controllerruntimeconfig.RenderControllerRuntimeConfig(cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(data, tc.Not(tc.HasLen), 0)
+
+	// Write to a temp file and read back to confirm round-trip.
+	dir := c.MkDir()
+	path := filepath.Join(dir, controllerruntimeconfig.Filename)
+	err = os.WriteFile(path, data, 0600)
+	c.Assert(err, tc.ErrorIsNil)
+
+	got, err := controllerruntimeconfig.ReadControllerRuntimeConfig(path)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, cfg)
+}

--- a/internal/controllerruntimeconfig/doc.go
+++ b/internal/controllerruntimeconfig/doc.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package controllerruntimeconfig manages the controller runtime configuration
+// file written at bootstrap time.
+//
+// Controller runtime configuration is a local YAML file
+// (<controller-agent-dir>/runtime.conf) that holds the static startup values
+// required by the controller process and Dqlite before the domain database is
+// available. Its fields include the controller ID, data and log directories,
+// Dqlite port and tuning settings, the TLS CA certificate, and the controller
+// TLS certificate and private key.
+//
+// The file is distinct from the machine-agent config file (agent.conf) and
+// from the charm-written cluster config (controller.conf). It is written once
+// at bootstrap with owner-only permissions (0600) because it contains TLS
+// private key material.
+//
+// See github.com/juju/juju/internal/cloudconfig for the IAAS bootstrap path
+// that writes this file. See
+// github.com/juju/juju/internal/provider/kubernetes for the CAAS bootstrap
+// path that projects it into the controller pod via a ConfigMap volume.
+package controllerruntimeconfig

--- a/internal/database/node.go
+++ b/internal/database/node.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v3"
 
-	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	corenetwork "github.com/juju/juju/core/network"
@@ -39,11 +38,48 @@ const (
 	dqliteClusterFileName = "cluster.yaml"
 )
 
+// NodeManagerConfig holds the static startup values required by NodeManager
+// to configure and operate a Dqlite node. All values are set once at
+// construction and treated as immutable thereafter.
+type NodeManagerConfig struct {
+	// DataDir is the root data directory of the controller agent. Dqlite
+	// stores its data under <DataDir>/dqlite.
+	DataDir string
+
+	// DqlitePort is the TCP port Dqlite listens on. Zero means use the
+	// compiled-in default (17666).
+	DqlitePort int
+
+	// QueryTracingEnabled enables per-query tracing in Dqlite, routing
+	// log output through the slow-query logger.
+	QueryTracingEnabled bool
+
+	// QueryTracingThreshold is the minimum query duration that triggers
+	// a slow-query log entry. Only relevant when QueryTracingEnabled is true.
+	QueryTracingThreshold time.Duration
+
+	// DqliteBusyTimeout is the duration Dqlite waits when a table is
+	// locked before returning SQLITE_BUSY. Zero disables the timeout.
+	DqliteBusyTimeout time.Duration
+
+	// CACert is the PEM-encoded CA certificate used to verify Dqlite
+	// peer TLS connections.
+	CACert string
+
+	// ControllerCert is the PEM-encoded controller TLS certificate
+	// presented to Dqlite peers.
+	ControllerCert string
+
+	// ControllerPrivateKey is the PEM-encoded private key corresponding
+	// to ControllerCert.
+	ControllerPrivateKey string
+}
+
 // NodeManager is responsible for interrogating a single Dqlite node,
 // and emitting configuration for starting its Dqlite `App` based on
 // operational requirements and controller agent config.
 type NodeManager struct {
-	cfg                 agent.Config
+	cfg                 NodeManagerConfig
 	port                int
 	isLoopbackPreferred bool
 	logger              logger.Logger
@@ -53,7 +89,7 @@ type NodeManager struct {
 }
 
 // NewNodeManager returns a new NodeManager reference
-// based on the input agent configuration.
+// based on the input controller runtime configuration.
 //
 // If isLoopbackPreferred is true, we bind Dqlite to 127.0.0.1 and eschew TLS
 // termination. This is useful primarily in unit testing and a temporary
@@ -62,7 +98,7 @@ type NodeManager struct {
 // If it is false, we attempt to identify a unique local-cloud address.
 // If we find one, we use it as the bind address. Otherwise, we fall back
 // to the loopback binding.
-func NewNodeManager(cfg agent.Config, isLoopbackPreferred bool, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) *NodeManager {
+func NewNodeManager(cfg NodeManagerConfig, isLoopbackPreferred bool, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) *NodeManager {
 	m := &NodeManager{
 		cfg:                 cfg,
 		port:                dqlitePort,
@@ -70,10 +106,8 @@ func NewNodeManager(cfg agent.Config, isLoopbackPreferred bool, logger logger.Lo
 		logger:              logger,
 		slowQueryLogger:     slowQueryLogger,
 	}
-	if cfg != nil {
-		if port, ok := cfg.DqlitePort(); ok {
-			m.port = port
-		}
+	if cfg.DqlitePort != 0 {
+		m.port = cfg.DqlitePort
 	}
 	return m
 }
@@ -137,7 +171,7 @@ func (m *NodeManager) IsExistingNode() (bool, error) {
 // a path determined by the agent config, then returns that path.
 func (m *NodeManager) EnsureDataDir() (string, error) {
 	if m.dataDir == "" {
-		dir := filepath.Join(m.cfg.DataDir(), dqliteDataDir)
+		dir := filepath.Join(m.cfg.DataDir, dqliteDataDir)
 		if err := os.MkdirAll(dir, 0700); err != nil {
 			return "", errors.Annotatef(err, "creating directory for Dqlite data")
 		}
@@ -215,8 +249,8 @@ func (m *NodeManager) SetNodeInfo(server dqlite.NodeInfo) error {
 // WithLogFuncOption returns a Dqlite application Option that will proxy Dqlite
 // log output via this factory's logger where the level is recognised.
 func (m *NodeManager) WithLogFuncOption() app.Option {
-	if m.cfg.QueryTracingEnabled() {
-		return app.WithLogFunc(m.slowQueryLogFunc(m.cfg.QueryTracingThreshold()))
+	if m.cfg.QueryTracingEnabled {
+		return app.WithLogFunc(m.slowQueryLogFunc(m.cfg.QueryTracingThreshold))
 	}
 	return app.WithLogFunc(m.appLogFunc)
 }
@@ -224,7 +258,7 @@ func (m *NodeManager) WithLogFuncOption() app.Option {
 // WithTracingOption returns a Dqlite application Option that will enable
 // tracing of Dqlite queries.
 func (m *NodeManager) WithTracingOption() app.Option {
-	if m.cfg.QueryTracingEnabled() {
+	if m.cfg.QueryTracingEnabled {
 		return app.WithTracing(client.LogWarn)
 	}
 	return app.WithTracing(client.LogNone)
@@ -233,8 +267,7 @@ func (m *NodeManager) WithTracingOption() app.Option {
 // WithBusyTimeoutOption returns a Dqlite application Option that sets
 // the busy timeout based on the agent configuration.
 func (m *NodeManager) WithBusyTimeoutOption() app.Option {
-	timeout := m.cfg.DqliteBusyTimeout()
-	return app.WithBusyTimeout(max(timeout, 0))
+	return app.WithBusyTimeout(max(m.cfg.DqliteBusyTimeout, 0))
 }
 
 // WithPreferredCloudLocalAddressOption uses the input network config source to
@@ -296,13 +329,12 @@ func (m *NodeManager) WithAddressOption(ip string) app.Option {
 // WithTLSOption returns a Dqlite application Option for TLS encryption
 // of traffic between clients and clustered application nodes.
 func (m *NodeManager) WithTLSOption() (app.Option, error) {
-	stateInfo, ok := m.cfg.ControllerAgentInfo()
-	if !ok {
+	if m.cfg.ControllerCert == "" {
 		return nil, errors.NotSupportedf("Dqlite node initialisation on non-controller machine/container")
 	}
 
 	listen, dial, err := dqliteTLSConfig(
-		m.cfg.CACert(), stateInfo.Cert, stateInfo.PrivateKey,
+		m.cfg.CACert, m.cfg.ControllerCert, m.cfg.ControllerPrivateKey,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -376,18 +408,17 @@ func (m *NodeManager) TLSDialer(ctx context.Context) (client.DialFunc, error) {
 		return client.DefaultDialFunc, nil
 	}
 
-	stateInfo, ok := m.cfg.ControllerAgentInfo()
-	if !ok {
+	if m.cfg.ControllerCert == "" {
 		return nil, errors.NotSupportedf("Dqlite node initialisation on non-controller machine/container")
 	}
 
-	cert, err := tls.X509KeyPair([]byte(stateInfo.Cert), []byte(stateInfo.PrivateKey))
+	cert, err := tls.X509KeyPair([]byte(m.cfg.ControllerCert), []byte(m.cfg.ControllerPrivateKey))
 	if err != nil {
 		return nil, errors.Annotate(err, "parsing controller certificate")
 	}
 
 	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM([]byte(stateInfo.Cert)) {
+	if !pool.AppendCertsFromPEM([]byte(m.cfg.ControllerCert)) {
 		return nil, errors.New("failed to append controller cert to pool")
 	}
 

--- a/internal/database/node_test.go
+++ b/internal/database/node_test.go
@@ -22,8 +22,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"gopkg.in/yaml.v3"
 
-	"github.com/juju/juju/agent"
-	"github.com/juju/juju/controller"
 	coredatabase "github.com/juju/juju/core/database"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/internal/database/app"
@@ -54,11 +52,11 @@ func (s *nodeManagerSuite) SetUpTest(c *tc.C) {
 func (s *nodeManagerSuite) TestEnsureDataDirSuccess(c *tc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
-	cfg := fakeAgentConfig{dataDir: "/tmp/" + subDir}
+	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
 	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	expected := fmt.Sprintf("/tmp/%s/%s", subDir, dqliteDataDir)
-	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir()) })
+	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
 	// Call twice to check both the creation and extant scenarios.
 	dir, err := m.EnsureDataDir()
@@ -79,8 +77,8 @@ func (s *nodeManagerSuite) TestEnsureDataDirSuccess(c *tc.C) {
 func (s *nodeManagerSuite) TestIsLoopbackPreferred(c *tc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
-	cfg := fakeAgentConfig{dataDir: "/tmp/" + subDir}
-	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir()) })
+	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
+	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
 	// Check to see if the loopback address is preferred.
 	// This is only set during the construction, so we need to create multiple
@@ -100,8 +98,8 @@ func (s *nodeManagerSuite) TestIsLoopbackPreferred(c *tc.C) {
 func (s *nodeManagerSuite) TestIsExistingNode(c *tc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
-	cfg := fakeAgentConfig{dataDir: "/tmp/" + subDir}
-	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir()) })
+	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
+	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
 	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
@@ -126,8 +124,8 @@ func (s *nodeManagerSuite) TestIsExistingNode(c *tc.C) {
 func (s *nodeManagerSuite) TestIsBootstrappedNode(c *tc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
-	cfg := fakeAgentConfig{dataDir: "/tmp/" + subDir}
-	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir()) })
+	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
+	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
 	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	ctx := c.Context()
@@ -191,8 +189,8 @@ func (s *nodeManagerSuite) TestIsBootstrappedNode(c *tc.C) {
 func (s *nodeManagerSuite) TestSetClusterServersSuccess(c *tc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
-	cfg := fakeAgentConfig{dataDir: "/tmp/" + subDir}
-	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir()) })
+	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
+	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
 	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	ctx := c.Context()
@@ -236,8 +234,8 @@ func (s *nodeManagerSuite) TestSetClusterServersSuccess(c *tc.C) {
 func (s *nodeManagerSuite) TestSetGetNodeInfoSuccess(c *tc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
-	cfg := fakeAgentConfig{dataDir: "/tmp/" + subDir}
-	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir()) })
+	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
+	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
 	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	dataDir, err := m.EnsureDataDir()
@@ -274,8 +272,8 @@ Role: 0
 func (s *nodeManagerSuite) TestSetClusterToLocalNodeSuccess(c *tc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
-	cfg := fakeAgentConfig{dataDir: "/tmp/" + subDir}
-	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir()) })
+	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
+	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
 	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	ctx := c.Context()
@@ -310,8 +308,7 @@ func (s *nodeManagerSuite) TestSetClusterToLocalNodeSuccess(c *tc.C) {
 }
 
 func (s *nodeManagerSuite) TestWithAddressOptionIPv4Success(c *tc.C) {
-	m := NewNodeManager(nil, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
-	m.port = dqlitetesting.FindTCPPort(c)
+	m := NewNodeManager(NodeManagerConfig{DqlitePort: dqlitetesting.FindTCPPort(c)}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("127.0.0.1"))
 	c.Assert(err, tc.ErrorIsNil)
@@ -321,8 +318,7 @@ func (s *nodeManagerSuite) TestWithAddressOptionIPv4Success(c *tc.C) {
 }
 
 func (s *nodeManagerSuite) TestWithAddressOptionIPv6Success(c *tc.C) {
-	m := NewNodeManager(nil, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
-	m.port = dqlitetesting.FindTCPPort(c)
+	m := NewNodeManager(NodeManagerConfig{DqlitePort: dqlitetesting.FindTCPPort(c)}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("::1"))
 	c.Assert(err, tc.ErrorIsNil)
@@ -332,7 +328,7 @@ func (s *nodeManagerSuite) TestWithAddressOptionIPv6Success(c *tc.C) {
 }
 
 func (s *nodeManagerSuite) TestWithTLSOptionSuccess(c *tc.C) {
-	cfg := fakeAgentConfig{}
+	cfg := tlsNodeManagerConfig()
 	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	withTLS, err := m.WithTLSOption()
@@ -362,7 +358,7 @@ func (s *nodeManagerSuite) TestDqliteTLSConfigSuccess(c *tc.C) {
 }
 
 func (s *nodeManagerSuite) TestWithTLSOptionRejectsClientWithoutCertificate(c *tc.C) {
-	cfg := fakeAgentConfig{}
+	cfg := tlsNodeManagerConfig()
 	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	m.port = dqlitetesting.FindTCPPort(c)
 
@@ -404,7 +400,7 @@ func (s *nodeManagerSuite) TestWithTLSOptionRejectsClientWithoutCertificate(c *t
 }
 
 func (s *nodeManagerSuite) TestWithTLSOptionJoinClusterSuccess(c *tc.C) {
-	cfg := fakeAgentConfig{}
+	cfg := tlsNodeManagerConfig()
 
 	m0 := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	m0.port = dqlitetesting.FindTCPPort(c)
@@ -447,8 +443,7 @@ func (s *nodeManagerSuite) TestWithTLSOptionJoinClusterSuccess(c *tc.C) {
 }
 
 func (s *nodeManagerSuite) TestWithClusterOptionIPv4Success(c *tc.C) {
-	cfg := fakeAgentConfig{}
-	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithClusterOption([]string{"10.6.6.6"}))
 	c.Assert(err, tc.ErrorIsNil)
@@ -458,8 +453,7 @@ func (s *nodeManagerSuite) TestWithClusterOptionIPv4Success(c *tc.C) {
 }
 
 func (s *nodeManagerSuite) TestWithClusterOptionIPv6Success(c *tc.C) {
-	cfg := fakeAgentConfig{}
-	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithClusterOption([]string{"::1"}))
 	c.Assert(err, tc.ErrorIsNil)
@@ -476,7 +470,7 @@ func (s *nodeManagerSuite) TestWithPreferredCloudLocalAddressOptionNoAddrFallbac
 	src := NewMockConfigSource(ctrl)
 	src.EXPECT().Interfaces().Return(nil, nil)
 
-	m := NewNodeManager(nil, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	m.port = dqlitetesting.FindTCPPort(c)
 
 	opt, err := m.WithPreferredCloudLocalAddressOption(src)
@@ -519,7 +513,7 @@ func (s *nodeManagerSuite) TestWithPreferredCloudLocalAddressOptionSingleAddrSuc
 	src := NewMockConfigSource(ctrl)
 	src.EXPECT().Interfaces().Return([]corenetwork.ConfigSourceNIC{loopback, lxdbr0, eth0}, nil)
 
-	m := NewNodeManager(nil, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	m.port = dqlitetesting.FindTCPPort(c)
 
 	opt, err := m.WithPreferredCloudLocalAddressOption(src)
@@ -539,40 +533,55 @@ func (s *nodeManagerSuite) TestWithPreferredCloudLocalAddressOptionSingleAddrSuc
 	}
 }
 
-type fakeAgentConfig struct {
-	agent.Config
-
-	dataDir  string
-	apiAddrs []string
+// tlsNodeManagerConfig returns a NodeManagerConfig populated with the test
+// CA, server certificate, and private key used across TLS-related tests.
+func tlsNodeManagerConfig() NodeManagerConfig {
+	return NodeManagerConfig{
+		CACert:               jujutesting.CACert,
+		ControllerCert:       jujutesting.ServerCert,
+		ControllerPrivateKey: jujutesting.ServerKey,
+	}
 }
 
-// DataDir implements agent.Config.
-func (cfg fakeAgentConfig) DataDir() string {
-	return cfg.dataDir
+func (s *nodeManagerSuite) TestNodeManagerConfigDqlitePort(c *tc.C) {
+	port := dqlitetesting.FindTCPPort(c)
+	m := NewNodeManager(NodeManagerConfig{DqlitePort: port}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+
+	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("127.0.0.1"))
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() {
+		err := dqliteApp.Close()
+		c.Assert(err, tc.ErrorIsNil)
+	}()
+
+	host, portStr, err := net.SplitHostPort(dqliteApp.Address())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(host, tc.Equals, "127.0.0.1")
+	c.Check(portStr, tc.Equals, strconv.Itoa(port))
 }
 
-// CACert implements agent.Config.
-func (cfg fakeAgentConfig) CACert() string {
-	return jujutesting.CACert
+func (s *nodeManagerSuite) TestWithTracingOptionQueryTracingEnabled(c *tc.C) {
+	port := dqlitetesting.FindTCPPort(c)
+	m := NewNodeManager(NodeManagerConfig{QueryTracingEnabled: true}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m.port = port
+
+	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("127.0.0.1"), m.WithTracingOption(), m.WithLogFuncOption())
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = dqliteApp.Close()
+	c.Assert(err, tc.ErrorIsNil)
 }
 
-// ControllerAgentInfo implements agent.AgentConfig.
-func (cfg fakeAgentConfig) ControllerAgentInfo() (controller.ControllerAgentInfo, bool) {
-	return controller.ControllerAgentInfo{
-		CAPrivateKey: jujutesting.CAKey,
-		Cert:         jujutesting.ServerCert,
-		PrivateKey:   jujutesting.ServerKey,
-	}, true
-}
+func (s *nodeManagerSuite) TestWithBusyTimeoutOption(c *tc.C) {
+	port := dqlitetesting.FindTCPPort(c)
+	m := NewNodeManager(NodeManagerConfig{DqliteBusyTimeout: 5 * time.Second}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m.port = port
 
-// APIAddresses implements agent.Config.
-func (cfg fakeAgentConfig) APIAddresses() ([]string, error) {
-	return cfg.apiAddrs, nil
-}
+	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("127.0.0.1"), m.WithBusyTimeoutOption())
+	c.Assert(err, tc.ErrorIsNil)
 
-// DqlitePort implements agent.Config.
-func (cfg fakeAgentConfig) DqlitePort() (int, bool) {
-	return 0, false
+	err = dqliteApp.Close()
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func firstCertificateDNSName(c *tc.C, certPEM string) string {

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -41,6 +41,7 @@ import (
 	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/cloudconfig"
 	"github.com/juju/juju/internal/cloudconfig/podcfg"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/docker/registry"
 	"github.com/juju/juju/internal/featureflag"
@@ -716,12 +717,32 @@ func (c *controllerStack) ensureControllerConfigmapAgentConf(ctx context.Context
 	}
 	logger.Tracef(context.TODO(), "controller unit agentConfig file content: \n%s", string(unitAgentConfigFileContent))
 
+	// Build and render the controller runtime config for the CAAS controller
+	// pod. This file provides Dqlite startup values before the database is
+	// available, without requiring access to machine-agent config.
+	runtimeCfg := controllerruntimeconfig.ControllerRuntimeConfig{
+		ControllerID:          c.pcfg.ControllerId,
+		DataDir:               c.pcfg.DataDir,
+		LogDir:                c.pcfg.LogDir,
+		QueryTracingEnabled:   c.pcfg.Controller.QueryTracingEnabled(),
+		QueryTracingThreshold: c.pcfg.Controller.QueryTracingThreshold(),
+		DqliteBusyTimeout:     c.pcfg.Controller.DqliteBusyTimeout(),
+		CACert:                c.pcfg.APIInfo.CACert,
+		ControllerCert:        c.pcfg.Bootstrap.ControllerAgentInfo.Cert,
+		ControllerPrivateKey:  c.pcfg.Bootstrap.ControllerAgentInfo.PrivateKey,
+	}
+	runtimeCfgContent, err := controllerruntimeconfig.RenderControllerRuntimeConfig(runtimeCfg)
+	if err != nil {
+		return errors.Annotate(err, "rendering controller runtime config")
+	}
+
 	cm, err := c.getControllerConfigMap(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	cm.Data[constants.ControllerAgentConfigFilename] = string(agentConfigFileContent)
 	cm.Data[constants.ControllerUnitAgentConfigFilename] = string(unitAgentConfigFileContent)
+	cm.Data[controllerruntimeconfig.Filename] = string(runtimeCfgContent)
 
 	logger.Tracef(context.TODO(), "ensuring agent.conf configmap: \n%+v", cm)
 	cleanUp, err := c.broker.ensureConfigMap(ctx, cm)
@@ -1059,6 +1080,9 @@ func (c *controllerStack) buildStorageSpecForController(ctx context.Context, sta
 					}, {
 						Key:  constants.ControllerUnitAgentConfigFilename,
 						Path: constants.ControllerUnitAgentConfigFilename,
+					}, {
+						Key:  controllerruntimeconfig.Filename,
+						Path: controllerruntimeconfig.Filename,
 					},
 				},
 			},
@@ -1205,6 +1229,20 @@ func (c *controllerStack) controllerContainers(setupCmd, machineCmd, controllerI
 				MountPath: c.pathJoin(c.pcfg.DataDir, cloudconfig.FileNameBootstrapParams),
 				SubPath:   cloudconfig.FileNameBootstrapParams,
 				ReadOnly:  true,
+			},
+			{
+				// Mount the controller runtime config at the expected path
+				// so the controller process can read Dqlite startup values
+				// before the database is available.
+				Name: c.resourceNameVolAgentConf,
+				MountPath: c.pathJoin(
+					c.pcfg.DataDir,
+					"agents",
+					"controller-"+c.pcfg.ControllerId,
+					controllerruntimeconfig.Filename,
+				),
+				SubPath:  controllerruntimeconfig.Filename,
+				ReadOnly: true,
 			},
 			{
 				Name:      constants.CharmVolumeName,

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	envtesting "github.com/juju/juju/environs/testing"
 	"github.com/juju/juju/internal/cloudconfig/podcfg"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/featureflag"
 	"github.com/juju/juju/internal/provider/kubernetes"
@@ -450,9 +451,10 @@ func (s *bootstrapSuite) TestBootstrap(c *tc.C) {
 			Annotations: map[string]string{"controller.juju.is/id": coretesting.ControllerTag.Id()},
 		},
 		Data: map[string]string{
-			"bootstrap-params":           string(bootstrapParamsContent),
-			"controller-agent.conf":      controllerStacker.GetControllerAgentConfigContent(c),
-			"controller-unit-agent.conf": controllerStacker.GetControllerUnitAgentConfigContent(c),
+			"bootstrap-params":               string(bootstrapParamsContent),
+			"controller-agent.conf":          controllerStacker.GetControllerAgentConfigContent(c),
+			"controller-unit-agent.conf":     controllerStacker.GetControllerUnitAgentConfigContent(c),
+			controllerruntimeconfig.Filename: controllerStacker.GetControllerRuntimeConfigContent(c),
 		},
 	}
 
@@ -539,6 +541,9 @@ func (s *bootstrapSuite) TestBootstrap(c *tc.C) {
 					}, {
 						Key:  "controller-unit-agent.conf",
 						Path: "controller-unit-agent.conf",
+					}, {
+						Key:  controllerruntimeconfig.Filename,
+						Path: controllerruntimeconfig.Filename,
 					},
 				},
 			},
@@ -731,6 +736,13 @@ exec /opt/pebble run --http :38811 --verbose
 					ReadOnly:  true,
 					MountPath: "/var/lib/juju/bootstrap-params",
 					SubPath:   "bootstrap-params",
+				},
+				{
+					Name:     "juju-controller-test-agent-conf",
+					ReadOnly: true,
+					MountPath: "/var/lib/juju/agents/controller-0/" +
+						controllerruntimeconfig.Filename,
+					SubPath: controllerruntimeconfig.Filename,
 				},
 				{
 					Name:      "charm-data",

--- a/internal/provider/kubernetes/export_test.go
+++ b/internal/provider/kubernetes/export_test.go
@@ -19,6 +19,7 @@ import (
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/cloudconfig/podcfg"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	"github.com/juju/juju/internal/storage"
 )
 
@@ -47,6 +48,7 @@ type ControllerStackerForTest interface {
 	controllerStacker
 	GetControllerAgentConfigContent(*tc.C) string
 	GetControllerUnitAgentConfigContent(*tc.C) string
+	GetControllerRuntimeConfigContent(*tc.C) string
 	GetControllerUnitAgentPassword() string
 	GetStorageSize() resource.Quantity
 	GetControllerSvcSpec(string, *podcfg.BootstrapConfig) (*controllerServiceSpec, error)
@@ -62,6 +64,23 @@ func (cs *controllerStack) GetControllerUnitAgentConfigContent(c *tc.C) string {
 	agentCfg, err := cs.unitAgentConfig.Render()
 	c.Assert(err, tc.ErrorIsNil)
 	return string(agentCfg)
+}
+
+func (cs *controllerStack) GetControllerRuntimeConfigContent(c *tc.C) string {
+	runtimeCfg := controllerruntimeconfig.ControllerRuntimeConfig{
+		ControllerID:          cs.pcfg.ControllerId,
+		DataDir:               cs.pcfg.DataDir,
+		LogDir:                cs.pcfg.LogDir,
+		QueryTracingEnabled:   cs.pcfg.Controller.QueryTracingEnabled(),
+		QueryTracingThreshold: cs.pcfg.Controller.QueryTracingThreshold(),
+		DqliteBusyTimeout:     cs.pcfg.Controller.DqliteBusyTimeout(),
+		CACert:                cs.pcfg.APIInfo.CACert,
+		ControllerCert:        cs.pcfg.Bootstrap.ControllerAgentInfo.Cert,
+		ControllerPrivateKey:  cs.pcfg.Bootstrap.ControllerAgentInfo.PrivateKey,
+	}
+	data, err := controllerruntimeconfig.RenderControllerRuntimeConfig(runtimeCfg)
+	c.Assert(err, tc.ErrorIsNil)
+	return string(data)
 }
 
 func (cs *controllerStack) GetControllerUnitAgentPassword() string {

--- a/internal/worker/dbaccessor/manifold.go
+++ b/internal/worker/dbaccessor/manifold.go
@@ -38,7 +38,6 @@ type ManifoldConfig struct {
 	ControllerAgentConfigName   string
 	ControllerRuntimeConfigPath string
 	Logger                      logger.Logger
-	LogDir                      string
 	PrometheusRegisterer        prometheus.Registerer
 	NewApp                      func(string, ...app.Option) (DBApp, error)
 	NewDBWorker                 NewDBWorkerFunc
@@ -58,9 +57,6 @@ func (cfg ManifoldConfig) Validate() error {
 	}
 	if cfg.Logger == nil {
 		return errors.NotValidf("nil Logger")
-	}
-	if cfg.LogDir == "" {
-		return errors.NotValidf("empty LogDir")
 	}
 	if cfg.PrometheusRegisterer == nil {
 		return errors.NotValidf("nil PrometheusRegisterer")

--- a/internal/worker/dbaccessor/manifold.go
+++ b/internal/worker/dbaccessor/manifold.go
@@ -13,9 +13,9 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/database/app"
 	"github.com/juju/juju/internal/database/dqlite"
@@ -26,38 +26,35 @@ import (
 // NewDBWorkerFunc creates a tracked db worker.
 type NewDBWorkerFunc func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
 
-// NewNodeManagerFunc creates a NodeManager
-type NewNodeManagerFunc func(agent.Config, logger.Logger, coredatabase.SlowQueryLogger) NodeManager
+// NewNodeManagerFunc creates a NodeManager from an explicit controller
+// runtime config value object.
+type NewNodeManagerFunc func(database.NodeManagerConfig, logger.Logger, coredatabase.SlowQueryLogger) NodeManager
 
 // ManifoldConfig contains:
 // - The names of other manifolds on which the DB accessor depends.
 // - Other dependencies from ManifoldsConfig required by the worker.
 type ManifoldConfig struct {
-	AgentName                 string
-	QueryLoggerName           string
-	ControllerAgentConfigName string
-	Clock                     clock.Clock
-	Logger                    logger.Logger
-	LogDir                    string
-	PrometheusRegisterer      prometheus.Registerer
-	NewApp                    func(string, ...app.Option) (DBApp, error)
-	NewDBWorker               NewDBWorkerFunc
-	NewNodeManager            NewNodeManagerFunc
-	NewMetricsCollector       func() *Collector
+	QueryLoggerName             string
+	ControllerAgentConfigName   string
+	ControllerRuntimeConfigPath string
+	Logger                      logger.Logger
+	LogDir                      string
+	PrometheusRegisterer        prometheus.Registerer
+	NewApp                      func(string, ...app.Option) (DBApp, error)
+	NewDBWorker                 NewDBWorkerFunc
+	NewNodeManager              NewNodeManagerFunc
+	NewMetricsCollector         func() *Collector
 }
 
 func (cfg ManifoldConfig) Validate() error {
-	if cfg.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
-	}
 	if cfg.QueryLoggerName == "" {
 		return errors.NotValidf("empty QueryLoggerName")
 	}
 	if cfg.ControllerAgentConfigName == "" {
 		return errors.NotValidf("empty ControllerAgentConfigName")
 	}
-	if cfg.Clock == nil {
-		return errors.NotValidf("nil Clock")
+	if cfg.ControllerRuntimeConfigPath == "" {
+		return errors.NotValidf("empty ControllerRuntimeConfigPath")
 	}
 	if cfg.Logger == nil {
 		return errors.NotValidf("nil Logger")
@@ -88,7 +85,6 @@ func (cfg ManifoldConfig) Validate() error {
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
 			config.QueryLoggerName,
 			config.ControllerAgentConfigName,
 		},
@@ -98,13 +94,13 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			var thisAgent agent.Agent
-			if err := getter.Get(config.AgentName, &thisAgent); err != nil {
-				return nil, err
+			runtimeCfg, err := controllerruntimeconfig.ReadControllerRuntimeConfig(config.ControllerRuntimeConfigPath)
+			if err != nil {
+				return nil, errors.Annotate(err, "reading controller runtime config")
 			}
-			agentConfig := thisAgent.CurrentConfig()
-			controllerID := agentConfig.Tag().Id()
-			configPath := path.Join(agentConfig.DataDir(), "agents", "controller-"+controllerID, "controller.conf")
+
+			controllerID := runtimeCfg.ControllerID
+			configPath := path.Join(runtimeCfg.DataDir, "agents", "controller-"+controllerID, "controller.conf")
 			controllerConf := controllerConfigReader{configPath: configPath}
 
 			var controllerConfigWatcher controlleragentconfig.ConfigWatcher
@@ -124,9 +120,20 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, err
 			}
 
+			nodeManagerCfg := database.NodeManagerConfig{
+				DataDir:               runtimeCfg.DataDir,
+				DqlitePort:            runtimeCfg.DqlitePort,
+				QueryTracingEnabled:   runtimeCfg.QueryTracingEnabled,
+				QueryTracingThreshold: runtimeCfg.QueryTracingThreshold,
+				DqliteBusyTimeout:     runtimeCfg.DqliteBusyTimeout,
+				CACert:                runtimeCfg.CACert,
+				ControllerCert:        runtimeCfg.ControllerCert,
+				ControllerPrivateKey:  runtimeCfg.ControllerPrivateKey,
+			}
+
 			cfg := WorkerConfig{
-				NodeManager:             config.NewNodeManager(agentConfig, config.Logger, slowQueryLogger),
-				Clock:                   config.Clock,
+				NodeManager:             config.NewNodeManager(nodeManagerCfg, config.Logger, slowQueryLogger),
+				Clock:                   clock.WallClock,
 				ControllerID:            controllerID,
 				MetricsCollector:        metricsCollector,
 				Logger:                  config.Logger,
@@ -181,13 +188,13 @@ func dbAccessorOutput(in worker.Worker, out any) error {
 
 // IAASNodeManager returns a NodeManager that is configured to use
 // the cloud-local TLS terminated address for Dqlite.
-func IAASNodeManager(cfg agent.Config, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
+func IAASNodeManager(cfg database.NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
 	return database.NewNodeManager(cfg, false, logger, slowQueryLogger)
 }
 
 // CAASNodeManager returns a NodeManager that is configured to use
 // the loopback address for Dqlite.
-func CAASNodeManager(cfg agent.Config, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
+func CAASNodeManager(cfg database.NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
 	return database.NewNodeManager(cfg, true, logger, slowQueryLogger)
 }
 

--- a/internal/worker/dbaccessor/manifold_test.go
+++ b/internal/worker/dbaccessor/manifold_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/goleak"
 
-	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/database/app"
 )
 
@@ -32,9 +32,6 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	cfg := s.getConfig()
 	c.Check(cfg.Validate(), tc.ErrorIsNil)
 
-	cfg.AgentName = ""
-	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
-
 	cfg = s.getConfig()
 	cfg.QueryLoggerName = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
@@ -44,7 +41,7 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
-	cfg.Clock = nil
+	cfg.ControllerRuntimeConfigPath = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
@@ -78,13 +75,12 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
-		AgentName:                 "agent",
-		QueryLoggerName:           "query-logger",
-		ControllerAgentConfigName: "controller-agent-config",
-		Clock:                     s.clock,
-		Logger:                    s.logger,
-		LogDir:                    "log-dir",
-		PrometheusRegisterer:      s.prometheusRegisterer,
+		QueryLoggerName:             "query-logger",
+		ControllerAgentConfigName:   "controller-agent-config",
+		ControllerRuntimeConfigPath: "/var/lib/juju/agents/controller-0/runtime.conf",
+		Logger:                      s.logger,
+		LogDir:                      "log-dir",
+		PrometheusRegisterer:        s.prometheusRegisterer,
 		NewApp: func(string, ...app.Option) (DBApp, error) {
 			return s.dbApp, nil
 		},
@@ -94,7 +90,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		NewMetricsCollector: func() *Collector {
 			return &Collector{}
 		},
-		NewNodeManager: func(agent.Config, logger.Logger, coredatabase.SlowQueryLogger) NodeManager {
+		NewNodeManager: func(database.NodeManagerConfig, logger.Logger, coredatabase.SlowQueryLogger) NodeManager {
 			return s.nodeManager
 		},
 	}

--- a/internal/worker/dbaccessor/manifold_test.go
+++ b/internal/worker/dbaccessor/manifold_test.go
@@ -49,10 +49,6 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
-	cfg.LogDir = ""
-	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
-
-	cfg = s.getConfig()
 	cfg.PrometheusRegisterer = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -79,7 +75,6 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		ControllerAgentConfigName:   "controller-agent-config",
 		ControllerRuntimeConfigPath: "/var/lib/juju/agents/controller-0/runtime.conf",
 		Logger:                      s.logger,
-		LogDir:                      "log-dir",
 		PrometheusRegisterer:        s.prometheusRegisterer,
 		NewApp: func(string, ...app.Option) (DBApp, error) {
 			return s.dbApp, nil

--- a/internal/worker/dbaccessor/worker_integration_test.go
+++ b/internal/worker/dbaccessor/worker_integration_test.go
@@ -11,16 +11,12 @@ import (
 	"github.com/canonical/sqlair"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
 	"go.uber.org/goleak"
 
-	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
-	"github.com/juju/juju/core/model"
-	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/domain/schema"
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/database/app"
@@ -28,7 +24,6 @@ import (
 	"github.com/juju/juju/internal/database/pragma"
 	databasetesting "github.com/juju/juju/internal/database/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
-	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/dbaccessor"
 )
 
@@ -59,24 +54,11 @@ func (s *integrationSuite) SetUpSuite(c *tc.C) {
 func (s *integrationSuite) SetUpTest(c *tc.C) {
 	s.DqliteSuite.SetUpTest(c)
 
-	params := agent.AgentConfigParams{
-		Tag:               names.NewMachineTag("0"),
-		UpgradedToVersion: jujuversion.Current,
-		Jobs:              []model.MachineJob{model.JobHostUnits},
-		Password:          "sekrit",
-		CACert:            "ca cert",
-		APIAddresses:      []string{"localhost:1235"},
-		Nonce:             "a nonce",
-		Model:             testing.ModelTag,
-		Controller:        testing.ControllerTag,
-	}
-	params.Paths.DataDir = s.RootPath()
-	params.Paths.LogDir = c.MkDir()
-	agentConfig, err := agent.NewAgentConfig(params)
-	c.Assert(err, tc.ErrorIsNil)
-
 	logger := loggertesting.WrapCheckLog(c)
-	nodeManager := database.NewNodeManager(agentConfig, false, logger, coredatabase.NoopSlowQueryLogger{})
+	nodeManager := database.NewNodeManager(
+		database.NodeManagerConfig{DataDir: s.RootPath()},
+		false, logger, coredatabase.NoopSlowQueryLogger{},
+	)
 
 	db, err := s.DBApp().Open(c.Context(), coredatabase.ControllerNS)
 	c.Assert(err, tc.ErrorIsNil)
@@ -102,7 +84,7 @@ func (s *integrationSuite) SetUpTest(c *tc.C) {
 		MetricsCollector:        dbaccessor.NewMetricsCollector(),
 		Clock:                   clock.WallClock,
 		Logger:                  logger,
-		ControllerID:            agentConfig.Tag().Id(),
+		ControllerID:            "0",
 		ControllerConfigWatcher: controllerConfigWatcher{},
 		ClusterConfig:           clusterConfig{},
 	})

--- a/internal/worker/dbreplaccessor/manifold.go
+++ b/internal/worker/dbreplaccessor/manifold.go
@@ -39,7 +39,7 @@ type ClusterIntrospector interface {
 type NewDBReplWorkerFunc func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error)
 
 // NewNodeManagerFunc creates a NodeManager
-type NewNodeManagerFunc func(agent.Config, logger.Logger, coredatabase.SlowQueryLogger) NodeManager
+type NewNodeManagerFunc func(database.NodeManagerConfig, logger.Logger, coredatabase.SlowQueryLogger) NodeManager
 
 // ManifoldConfig contains:
 // - The names of other manifolds on which the DB accessor depends.
@@ -94,8 +94,16 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 			agentConfig := thisAgent.CurrentConfig()
 
+			info, _ := agentConfig.ControllerAgentInfo()
+			nodeManagerCfg := database.NodeManagerConfig{
+				DataDir:              agentConfig.DataDir(),
+				CACert:               agentConfig.CACert(),
+				ControllerCert:       info.Cert,
+				ControllerPrivateKey: info.PrivateKey,
+			}
+
 			cfg := WorkerConfig{
-				NodeManager:     config.NewNodeManager(agentConfig, config.Logger, coredatabase.NoopSlowQueryLogger{}),
+				NodeManager:     config.NewNodeManager(nodeManagerCfg, config.Logger, coredatabase.NoopSlowQueryLogger{}),
 				Clock:           config.Clock,
 				Logger:          config.Logger,
 				NewApp:          config.NewApp,
@@ -131,12 +139,12 @@ func dbAccessorOutput(in worker.Worker, out any) error {
 
 // IAASNodeManager returns a NodeManager that is configured to use
 // the cloud-local TLS terminated address for Dqlite.
-func IAASNodeManager(cfg agent.Config, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
+func IAASNodeManager(cfg database.NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
 	return database.NewNodeManager(cfg, false, logger, slowQueryLogger)
 }
 
 // CAASNodeManager returns a NodeManager that is configured to use
 // the loopback address for Dqlite.
-func CAASNodeManager(cfg agent.Config, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
+func CAASNodeManager(cfg database.NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
 	return database.NewNodeManager(cfg, true, logger, slowQueryLogger)
 }

--- a/internal/worker/dbreplaccessor/manifold_test.go
+++ b/internal/worker/dbreplaccessor/manifold_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/juju/tc"
 	"go.uber.org/goleak"
 
-	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/internal/database"
 )
 
 type manifoldSuite struct {
@@ -66,7 +66,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		NewDBReplWorker: func(context.Context, DBApp, string, ...TrackedDBWorkerOption) (TrackedDB, error) {
 			return nil, nil
 		},
-		NewNodeManager: func(agent.Config, logger.Logger, coredatabase.SlowQueryLogger) NodeManager {
+		NewNodeManager: func(database.NodeManagerConfig, logger.Logger, coredatabase.SlowQueryLogger) NodeManager {
 			return s.nodeManager
 		},
 	}

--- a/internal/worker/introspection/script.go
+++ b/internal/worker/introspection/script.go
@@ -172,9 +172,9 @@ juju_db_repl () {
   local flag="--${type}-id=${id}"
 
   if [ -x "$(which sudo)" ]; then
-    sudo /var/lib/juju/tools/$agent/jujud db-repl ${flag}
+    sudo /var/lib/juju/tools/$agent/jujuagentd db-repl ${flag}
   else
-    /var/lib/juju/tools/$agent/jujud db-repl ${flag}
+    /var/lib/juju/tools/$agent/jujuagentd db-repl ${flag}
   fi
 }
 


### PR DESCRIPTION
### Problem

`dbaccessor.Manifold()` fetched the `agent` manifold and passed the full
`agent.Config` to `internal/database.NewNodeManager`, creating a hard
dependency between the controller's Dqlite startup path and the machine-agent
config surface.

### Solution

Introduce a controller-owned `runtime.conf` written during bootstrap.
`db-accessor` reads it before Dqlite starts and no longer touches
`agent.Config`.

### Changes

- Added `internal/controllerruntimeconfig` package with
`ControllerRuntimeConfig` struct, YAML round-trip helpers, and `ConfigPath`;
updated IAAS and CAAS bootstrap to write the file (`0600`) before the
controller agent starts.
- Replaced `agent.Config` in `internal/database.NewNodeManager` with an
explicit `NodeManagerConfig` value struct; `internal/database` no longer
imports `github.com/juju/juju/agent`.
- Removed `AgentName`, `Clock`, and `LogDir` from `dbaccessor.ManifoldConfig`;
added `ControllerRuntimeConfigPath`; `Manifold().Inputs` no longer lists
`agent` or `clock`.
- Wired `ControllerRuntimeConfigPath` into all four manifold packages
(`controller`, `safemode` ×2, `machine`); each entry-point computes the path
from `agentConfig.DataDir()`.
- Audited all call sites, fixed two `agenttest` helpers still passing
`agent.Config` to `NewNodeManager`, and added an IAAS bootstrap test for
`runtime.conf` write coverage.

### Not changed

`agent.conf` still carries the Dqlite fields — `agentconfigupdater`,
`dbreplaccessor`, `apiservercertwatcher`, `machineconverter`, and the
`bootstrap` worker still read them. Removing those fields is deferred to Stage
5.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ juju bootstrap lxd src --build-agent
❯ juju add-model m
❯ juju add-machine -n 1

❯ jst
Model  Controller       Cloud/Region  Version      Timestamp
m      test-controller  lxd/default   4.1-beta2.2  18:42:44+02:00

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.200  juju-989c71-0  ubuntu@24.04  tuxedo  Running

❯ jst -m controller
Model       Controller       Cloud/Region  Version      Timestamp
controller  test-controller  lxd/default   4.1-beta2.2  18:42:47+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.159.202.209  17022,17070/tcp

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.209  juju-4a772a-0  ubuntu@24.04  tuxedo  Running

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer

❯ juju ssh -m controller 0 -- ps -ef | grep juju
root        2680       1  0 16:06 ?        00:00:00 bash /etc/systemd/system/jujuagentd-machine-0-exec-start.sh
root        2684    2680  0 16:06 ?        00:00:09 /var/lib/juju/tools/machine-0/jujuagentd machine --data-dir /var/lib/juju --machine-id 0 --debu


❯ juju ssh -m controller 0 -- sudo cat /var/lib/juju/agents/controller-0/runtime.conf | yq 'keys'
Connection to 10.159.202.209 closed.
- controller-id
- data-dir
- log-dir
- query-tracing-enabled
- query-tracing-threshold
- dqlite-busy-timeout
- ca-cert
- controller-cert
- controller-private-key

```


## Documentation changes


## Links

**Jira card:** [JUJU-9708](https://warthogs.atlassian.net/browse/JUJU-9708)


[JUJU-9708]: https://warthogs.atlassian.net/browse/JUJU-9708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ