### PR TITLE
fix(deployer): gate deployer on controlleragentconfig socket readiness

### DIFF
--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -358,9 +358,10 @@ type MachineAgent struct {
 	preUpgradeSteps PreUpgradeStepsFunc
 	upgradeSteps    UpgradeStepsFunc
 
-	bootstrapLock    gate.Lock
-	upgradeDBLock    gate.Lock
-	upgradeStepsLock gate.Lock
+	bootstrapLock                  gate.Lock
+	upgradeDBLock                  gate.Lock
+	upgradeStepsLock               gate.Lock
+	controllerAgentConfigReadyLock gate.Lock
 
 	isCaasAgent bool
 	cmdRunner   CommandRunner
@@ -490,6 +491,10 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 	a.bootstrapLock = gate.NewLock()
 	a.upgradeDBLock = internalupgrade.NewLock(agentConfig, jujuversion.Current)
 	a.upgradeStepsLock = internalupgrade.NewLock(agentConfig, jujuversion.Current)
+	a.controllerAgentConfigReadyLock = gate.NewLock()
+	if _, isController := agentConfig.ControllerAgentInfo(); !isController {
+		a.controllerAgentConfigReadyLock.Unlock()
+	}
 
 	createEngine := a.makeEngineCreator(agentName, agentConfig.UpgradedToVersion(), logSink)
 	if err := a.createJujudSymlinks(agentConfig.DataDir()); err != nil {
@@ -551,6 +556,7 @@ func (a *MachineAgent) makeEngineCreator(
 			UpgradeDBLock:                     a.upgradeDBLock,
 			UpgradeStepsLock:                  a.upgradeStepsLock,
 			UpgradeCheckLock:                  a.initialUpgradeCheckComplete,
+			ControllerAgentConfigReadyLock:    a.controllerAgentConfigReadyLock,
 			NewDBWorkerFunc:                   a.newDBWorkerFunc,
 			PreUpgradeSteps:                   a.preUpgradeSteps,
 			UpgradeSteps:                      a.upgradeSteps,

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -1128,9 +1128,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// controlleragentconfig socket is ready (controllerAgentConfigReadyFlag)
 		// so the controller charm's install hook can reach the socket. On
 		// non-controller machines that flag is pre-unlocked.
-		deployerName: engine.Housing{
-			Flags: []string{controllerAgentConfigReadyFlagName},
-		}.Decorate(ifFullyUpgraded(deployer.Manifold(deployer.ManifoldConfig{
+		deployerName: ifControllerAgentConfigReady(ifFullyUpgraded(deployer.Manifold(deployer.ManifoldConfig{
 			AgentName:      agentName,
 			APICallerName:  apiCallerName,
 			FlightRecorder: config.FlightRecorder,
@@ -1363,6 +1361,17 @@ var ifCredentialValid = engine.Housing{
 var ifDatabaseUpgradeComplete = engine.Housing{
 	Flags: []string{
 		upgradeDatabaseFlagName,
+	},
+}.Decorate
+
+// ifControllerAgentConfigReady gates against the controlleragentconfig worker
+// having started its socket listener. On controller machines this prevents the
+// deployer from starting before configchange.socket is on disk. On
+// non-controller machines the underlying gate lock is pre-unlocked by the
+// caller so this is a no-op.
+var ifControllerAgentConfigReady = engine.Housing{
+	Flags: []string{
+		controllerAgentConfigReadyFlagName,
 	},
 }.Decorate
 

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -1128,7 +1128,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// controlleragentconfig socket is ready (controllerAgentConfigReadyFlag)
 		// so the controller charm's install hook can reach the socket. On
 		// non-controller machines that flag is pre-unlocked.
-		deployerName: ifControllerAgentConfigReady(ifFullyUpgraded(deployer.Manifold(deployer.ManifoldConfig{
+		deployerName: ifControllerAgentConfigNeededAndReady(ifFullyUpgraded(deployer.Manifold(deployer.ManifoldConfig{
 			AgentName:      agentName,
 			APICallerName:  apiCallerName,
 			FlightRecorder: config.FlightRecorder,
@@ -1364,12 +1364,18 @@ var ifDatabaseUpgradeComplete = engine.Housing{
 	},
 }.Decorate
 
-// ifControllerAgentConfigReady gates against the controlleragentconfig worker
-// having started its socket listener. On controller machines this prevents the
-// deployer from starting before configchange.socket is on disk. On
-// non-controller machines the underlying gate lock is pre-unlocked by the
-// caller so this is a no-op.
-var ifControllerAgentConfigReady = engine.Housing{
+// ifControllerAgentConfigNeededAndReady gates a manifold on two conditions:
+// "needed"  — the machine is a controller, so configchange.socket must exist
+//
+//	before the gated worker starts (e.g. the controller charm's
+//	install hook connects to it); on non-controller machines the gate
+//	lock is pre-unlocked by the caller, making this a no-op there.
+//
+// "ready"   — the controlleragentconfig worker has started its socket listener,
+//
+//	meaning configchange.socket is on disk (created synchronously
+//	inside NewWorker before the manifold reports as running).
+var ifControllerAgentConfigNeededAndReady = engine.Housing{
 	Flags: []string{
 		controllerAgentConfigReadyFlagName,
 	},

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -170,6 +170,13 @@ type ManifoldsConfig struct {
 	// upgrader worker completes it's first check.
 	UpgradeCheckLock gate.Lock
 
+	// ControllerAgentConfigReadyLock is passed to the controller agent
+	// config ready gate to coordinate the deployer with the
+	// controlleragentconfig worker. On controller machines the deployer
+	// must not start until the configchange.socket exists; on
+	// non-controller machines the caller pre-unlocks this lock.
+	ControllerAgentConfigReadyLock gate.Lock
+
 	// NewDBWorkerFunc returns a tracked db worker.
 	NewDBWorkerFunc dbaccessor.NewDBWorkerFunc
 
@@ -323,6 +330,16 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker: gate.NewFlagWorker,
 		}),
 
+		// controllerAgentConfigReadyGateName/FlagName coordinate the deployer
+		// with the controlleragentconfig worker. The deployer must not start
+		// on controller machines until the configchange.socket is available.
+		// On non-controller machines the lock is pre-unlocked by the caller.
+		controllerAgentConfigReadyGateName: gate.ManifoldEx(config.ControllerAgentConfigReadyLock),
+		controllerAgentConfigReadyFlagName: gate.FlagManifold(gate.FlagManifoldConfig{
+			GateName:  controllerAgentConfigReadyGateName,
+			NewWorker: gate.NewFlagWorker,
+		}),
+
 		// The termination worker returns ErrTerminateAgent if a
 		// termination signal is received by the process it's running
 		// in. It has no inputs and its only output is the error it
@@ -348,6 +365,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:            internallogger.GetLogger("juju.worker.controlleragentconfig"),
 			NewSocketListener: controlleragentconfig.NewSocketListener,
 			SocketName:        path.Join(agentConfig.DataDir(), "configchange.socket"),
+			ReadyUnlocker:     config.ControllerAgentConfigReadyLock,
 		})),
 
 		// The stateconfigwatcher manifold watches the machine agent's
@@ -1106,8 +1124,13 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The deployer worker is primarily for deploying and recalling unit
 		// agents, according to changes in a set of state units; and for the
 		// final removal of its agents' units from state when they are no
-		// longer needed.
-		deployerName: ifFullyUpgraded(deployer.Manifold(deployer.ManifoldConfig{
+		// longer needed. On controller machines it must also wait until the
+		// controlleragentconfig socket is ready (controllerAgentConfigReadyFlag)
+		// so the controller charm's install hook can reach the socket. On
+		// non-controller machines that flag is pre-unlocked.
+		deployerName: engine.Housing{
+			Flags: []string{controllerAgentConfigReadyFlagName},
+		}.Decorate(ifFullyUpgraded(deployer.Manifold(deployer.ManifoldConfig{
 			AgentName:      agentName,
 			APICallerName:  apiCallerName,
 			FlightRecorder: config.FlightRecorder,
@@ -1117,7 +1140,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			UnitEngineConfig: config.UnitEngineConfig,
 			SetupLogging:     config.SetupLogging,
 			NewDeployContext: config.NewDeployContext,
-		})),
+		}))),
 
 		// The reboot manifold manages a worker which will reboot the
 		// machine when requested. It needs an API connection and
@@ -1374,64 +1397,66 @@ const (
 	migrationInactiveFlagName = "migration-inactive-flag"
 	migrationMinionName       = "migration-minion"
 
-	apiAddressSetterName          = "api-address-setter"
-	apiAddressUpdaterName         = "api-address-updater"
-	apiServerName                 = "api-server"
-	apiRemoteCallerName           = "api-remote-caller"
-	apiRemoteRelationCallerName   = "api-remote-relation-caller"
-	auditConfigUpdaterName        = "audit-config-updater"
-	authenticationWorkerName      = "ssh-authkeys-updater"
-	brokerTrackerName             = "broker-tracker"
-	certificateUpdaterName        = "certificate-updater"
-	certificateWatcherName        = "certificate-watcher"
-	changeStreamName              = "change-stream"
-	changeStreamPrunerName        = "change-stream-pruner"
-	controllerAgentConfigName     = "controller-agent-config"
-	controllerPresenceName        = "controller-presence"
-	controlSocketName             = "control-socket"
-	dbAccessorName                = "db-accessor"
-	deployerName                  = "deployer"
-	diskManagerName               = "disk-manager"
-	domainServicesName            = "domain-services"
-	externalControllerUpdaterName = "external-controller-updater"
-	fileNotifyWatcherName         = "file-notify-watcher"
-	hostKeyReporterName           = "host-key-reporter"
-	httpClientName                = "http-client"
-	httpServerArgsName            = "http-server-args"
-	httpServerName                = "http-server"
-	identityFileWriterName        = "ssh-identity-writer"
-	isControllerFlagName          = "is-controller-flag"
-	isNotControllerFlagName       = "is-not-controller-flag"
-	isPrimaryControllerFlagName   = "is-primary-controller-flag"
-	jwtParserName                 = "jwt-parser"
-	leaseExpiryName               = "lease-expiry"
-	leaseManagerName              = "lease-manager"
-	loggingConfigUpdaterName      = "logging-config-updater"
-	logSinkName                   = "log-sink"
-	lxdContainerProvisioner       = "lxd-container-provisioner"
-	machineActionName             = "machine-action-runner"
-	machinerName                  = "machiner"
-	modelWorkerManagerName        = "model-worker-manager"
-	objectStoreName               = "object-store"
-	objectStoreS3CallerName       = "object-store-s3-caller"
-	objectStoreServicesName       = "object-store-services"
-	objectStoreFortressName       = "object-store-fortress"
-	objectStoreFacadeName         = "object-store-facade"
-	objectStoreDrainerName        = "object-store-drainer"
-	providerDomainServicesName    = "provider-services"
-	providerTrackerName           = "provider-tracker"
-	proxyConfigUpdater            = "proxy-config-updater"
-	queryLoggerName               = "query-logger"
-	rebootName                    = "reboot-executor"
-	secretBackendRotateName       = "secret-backend-rotate"
-	sshServerName                 = "ssh-server"
-	machineConverterName          = "machine-converter"
-	storageProvisionerName        = "storage-provisioner"
-	storageRegistryName           = "storage-registry"
-	toolsVersionCheckerName       = "tools-version-checker"
-	traceName                     = "trace"
-	validCredentialFlagName       = "valid-credential-flag"
-	undertakerName                = "undertaker"
-	machineSetupName              = "machine-setup"
-	watcherRegistryName           = "watcher-registry"
+	apiAddressSetterName               = "api-address-setter"
+	apiAddressUpdaterName              = "api-address-updater"
+	apiServerName                      = "api-server"
+	apiRemoteCallerName                = "api-remote-caller"
+	apiRemoteRelationCallerName        = "api-remote-relation-caller"
+	auditConfigUpdaterName             = "audit-config-updater"
+	authenticationWorkerName           = "ssh-authkeys-updater"
+	brokerTrackerName                  = "broker-tracker"
+	certificateUpdaterName             = "certificate-updater"
+	certificateWatcherName             = "certificate-watcher"
+	changeStreamName                   = "change-stream"
+	changeStreamPrunerName             = "change-stream-pruner"
+	controllerAgentConfigName          = "controller-agent-config"
+	controllerAgentConfigReadyGateName = "controller-agent-config-ready-gate"
+	controllerAgentConfigReadyFlagName = "controller-agent-config-ready-flag"
+	controllerPresenceName             = "controller-presence"
+	controlSocketName                  = "control-socket"
+	dbAccessorName                     = "db-accessor"
+	deployerName                       = "deployer"
+	diskManagerName                    = "disk-manager"
+	domainServicesName                 = "domain-services"
+	externalControllerUpdaterName      = "external-controller-updater"
+	fileNotifyWatcherName              = "file-notify-watcher"
+	hostKeyReporterName                = "host-key-reporter"
+	httpClientName                     = "http-client"
+	httpServerArgsName                 = "http-server-args"
+	httpServerName                     = "http-server"
+	identityFileWriterName             = "ssh-identity-writer"
+	isControllerFlagName               = "is-controller-flag"
+	isNotControllerFlagName            = "is-not-controller-flag"
+	isPrimaryControllerFlagName        = "is-primary-controller-flag"
+	jwtParserName                      = "jwt-parser"
+	leaseExpiryName                    = "lease-expiry"
+	leaseManagerName                   = "lease-manager"
+	loggingConfigUpdaterName           = "logging-config-updater"
+	logSinkName                        = "log-sink"
+	lxdContainerProvisioner            = "lxd-container-provisioner"
+	machineActionName                  = "machine-action-runner"
+	machinerName                       = "machiner"
+	modelWorkerManagerName             = "model-worker-manager"
+	objectStoreName                    = "object-store"
+	objectStoreS3CallerName            = "object-store-s3-caller"
+	objectStoreServicesName            = "object-store-services"
+	objectStoreFortressName            = "object-store-fortress"
+	objectStoreFacadeName              = "object-store-facade"
+	objectStoreDrainerName             = "object-store-drainer"
+	providerDomainServicesName         = "provider-services"
+	providerTrackerName                = "provider-tracker"
+	proxyConfigUpdater                 = "proxy-config-updater"
+	queryLoggerName                    = "query-logger"
+	rebootName                         = "reboot-executor"
+	secretBackendRotateName            = "secret-backend-rotate"
+	sshServerName                      = "ssh-server"
+	machineConverterName               = "machine-converter"
+	storageProvisionerName             = "storage-provisioner"
+	storageRegistryName                = "storage-registry"
+	toolsVersionCheckerName            = "tools-version-checker"
+	traceName                          = "trace"
+	validCredentialFlagName            = "valid-credential-flag"
+	undertakerName                     = "undertaker"
+	machineSetupName                   = "machine-setup"
+	watcherRegistryName                = "watcher-registry"
 )

--- a/cmd/jujud-controller/agent/machine/manifolds_test.go
+++ b/cmd/jujud-controller/agent/machine/manifolds_test.go
@@ -85,6 +85,8 @@ func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *tc.C) {
 			"clock",
 			"control-socket",
 			"controller-agent-config",
+			"controller-agent-config-ready-flag",
+			"controller-agent-config-ready-gate",
 			"controller-presence",
 			"db-accessor",
 			"deployer",
@@ -178,6 +180,8 @@ func (s *ManifoldsSuite) TestManifoldNamesCAAS(c *tc.C) {
 			"clock",
 			"control-socket",
 			"controller-agent-config",
+			"controller-agent-config-ready-flag",
+			"controller-agent-config-ready-gate",
 			"controller-presence",
 			"db-accessor",
 			"domain-services",
@@ -274,6 +278,8 @@ func (s *ManifoldsSuite) TestMigrationGuardsUsed(c *tc.C) {
 		"clock",
 		"control-socket",
 		"controller-agent-config",
+		"controller-agent-config-ready-flag",
+		"controller-agent-config-ready-gate",
 		"controller-presence",
 		"db-accessor",
 		"deployer",
@@ -893,6 +899,12 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"state-config-watcher",
 	},
 
+	"controller-agent-config-ready-gate": {},
+
+	"controller-agent-config-ready-flag": {
+		"controller-agent-config-ready-gate",
+	},
+
 	"controller-presence": {
 		"agent",
 		"api-remote-caller",
@@ -933,6 +945,8 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-caller",
 		"api-config-watcher",
+		"controller-agent-config-ready-flag",
+		"controller-agent-config-ready-gate",
 		"upgrade-check-flag",
 		"upgrade-check-gate",
 		"upgrade-steps-flag",
@@ -2008,6 +2022,12 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"state-config-watcher",
 	},
 
+	"controller-agent-config-ready-gate": {},
+
+	"controller-agent-config-ready-flag": {
+		"controller-agent-config-ready-gate",
+	},
+
 	"controller-presence": {
 		"agent",
 		"api-remote-caller",
@@ -2697,6 +2717,10 @@ func (mc *mockConfig) Controller() names.ControllerTag {
 }
 
 func (mc *mockConfig) StateServingInfo() (controller.ControllerAgentInfo, bool) {
+	return mc.ssi, mc.ssiSet
+}
+
+func (mc *mockConfig) ControllerAgentInfo() (controller.ControllerAgentInfo, bool) {
 	return mc.ssi, mc.ssiSet
 }
 

--- a/internal/provider/unmanaged/provider_test.go
+++ b/internal/provider/unmanaged/provider_test.go
@@ -224,6 +224,23 @@ func (s *providerSuite) TestSchema(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestProviderSatisfiesModelConfigProvider ensures that UnmanagedProvider
+// implements the combined ModelConfigProvider + ProviderSchema interface.
+// This is a regression test: Schema() was missing prior to its introduction,
+// breaking callers that rely on the ProviderSchema interface being satisfied.
+func (s *providerSuite) TestProviderSatisfiesModelConfigProvider(c *tc.C) {
+	p, err := environs.Provider("unmanaged")
+	c.Assert(err, tc.ErrorIsNil)
+
+	mcp, ok := p.(environs.ModelConfigProvider)
+	c.Assert(ok, tc.IsTrue, tc.Commentf("UnmanagedProvider must implement environs.ModelConfigProvider"))
+	c.Assert(mcp.ConfigSchema(), tc.NotNil)
+
+	ps, ok := p.(environs.ProviderSchema)
+	c.Assert(ok, tc.IsTrue, tc.Commentf("UnmanagedProvider must implement environs.ProviderSchema"))
+	c.Assert(ps.Schema(), tc.NotNil)
+}
+
 func (s *providerSuite) TestPingEndpointWithUser(c *tc.C) {
 	endpoint := "user@IP"
 	called := false

--- a/internal/worker/controlleragentconfig/manifold.go
+++ b/internal/worker/controlleragentconfig/manifold.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/socketlistener"
+	"github.com/juju/juju/internal/worker/gate"
 )
 
 // SocketListener describes a worker that listens on a unix socket.
@@ -36,6 +37,10 @@ type ManifoldConfig struct {
 	SocketName string
 	// NewSocketListener is the function that creates a new socket listener.
 	NewSocketListener func(socketlistener.Config) (SocketListener, error)
+	// ReadyUnlocker is unlocked once the socket listener is successfully
+	// started, signalling to dependents (e.g. the deployer) that the socket
+	// is available.
+	ReadyUnlocker gate.Unlocker
 }
 
 // Validate validates the manifold configuration.
@@ -54,6 +59,9 @@ func (cfg ManifoldConfig) Validate() error {
 	}
 	if cfg.NewSocketListener == nil {
 		return errors.NotValidf("nil NewSocketListener func")
+	}
+	if cfg.ReadyUnlocker == nil {
+		return errors.NotValidf("nil ReadyUnlocker")
 	}
 	return nil
 }
@@ -85,6 +93,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
+
+			// Socket listener started successfully; the socket file now exists.
+			// Unblock any manifolds waiting for it (e.g. the deployer).
+			config.ReadyUnlocker.Unlock()
 
 			return w, nil
 		},

--- a/internal/worker/controlleragentconfig/manifold_test.go
+++ b/internal/worker/controlleragentconfig/manifold_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/worker/v5/workertest"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/internal/worker/gate"
 )
 
 type manifoldSuite struct {
@@ -63,6 +64,10 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	cfg = s.getConfig()
 	cfg.SocketName = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.ReadyUnlocker = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 }
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {
@@ -72,6 +77,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		Clock:             clock.WallClock,
 		NewSocketListener: NewSocketListener,
 		SocketName:        filepath.Join(s.socketDir, "test.socket"),
+		ReadyUnlocker:     gate.NewLock(),
 	}
 }
 
@@ -92,6 +98,24 @@ func (s *manifoldSuite) TestStart(c *tc.C) {
 	w, err := Manifold(s.getConfig()).Start(c.Context(), s.newContext())
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
+}
+
+// TestStartUnlocksReadyGate verifies that a successful Start call unlocks
+// the ReadyUnlocker, signalling to dependents that the socket is available.
+func (s *manifoldSuite) TestStartUnlocksReadyGate(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	lock := gate.NewLock()
+	cfg := s.getConfig()
+	cfg.ReadyUnlocker = lock
+
+	c.Assert(lock.IsUnlocked(), tc.IsFalse)
+
+	w, err := Manifold(cfg).Start(c.Context(), s.newContext())
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	c.Check(lock.IsUnlocked(), tc.IsTrue)
 }
 
 func (s *manifoldSuite) TestOutput(c *tc.C) {

--- a/internal/worker/deployer/deployer.go
+++ b/internal/worker/deployer/deployer.go
@@ -60,8 +60,10 @@ type Context interface {
 
 	// DeployUnit causes the agent for the specified unit to be started and run
 	// continuously until further notice without further intervention. It will
-	// return an error if the agent is already deployed.
-	DeployUnit(unitName, initialPassword string) error
+	// return an error if the agent is already deployed. The provided context
+	// can be used to cancel a pending deployment (e.g. on machine agent
+	// shutdown).
+	DeployUnit(ctx context.Context, unitName, initialPassword string) error
 
 	// RecallUnit causes the agent for the specified unit to be stopped, and
 	// the agent's data to be destroyed. It will return an error if the agent
@@ -203,7 +205,7 @@ func (d *Deployer) deploy(ctx context.Context, unit Unit) error {
 	if err := unit.SetPassword(ctx, initialPassword); err != nil {
 		return fmt.Errorf("cannot set password for unit %q: %v", unitName, err)
 	}
-	if err := d.ctx.DeployUnit(unitName, initialPassword); err != nil {
+	if err := d.ctx.DeployUnit(ctx, unitName, initialPassword); err != nil {
 		return err
 	}
 	d.deployed.Add(unitName)

--- a/internal/worker/deployer/deployer_test.go
+++ b/internal/worker/deployer/deployer_test.go
@@ -4,6 +4,7 @@
 package deployer_test
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"sync"
@@ -262,7 +263,7 @@ func (c *fakeContext) Wait() error {
 	return nil
 }
 
-func (c *fakeContext) DeployUnit(unitName, initialPassword string) error {
+func (c *fakeContext) DeployUnit(ctx context.Context, unitName, initialPassword string) error {
 	c.deployedMu.Lock()
 	defer c.deployedMu.Unlock()
 

--- a/internal/worker/deployer/nested.go
+++ b/internal/worker/deployer/nested.go
@@ -229,11 +229,10 @@ func (c *nestedContext) Report(ctx context.Context) map[string]any {
 // The unit's agent.conf is still being used by the unit workers, so that
 // needs to be created, along with a link to the tools directory for the
 // unit.
-func (c *nestedContext) DeployUnit(unitName, initialPassword string) error {
-	ctx := context.TODO()
+func (c *nestedContext) DeployUnit(ctx context.Context, unitName, initialPassword string) error {
+	tag := names.NewUnitTag(unitName)
 
 	// Create unit agent config file.
-	tag := names.NewUnitTag(unitName)
 	_, err := c.createUnitAgentConfig(ctx, tag, initialPassword)
 	if err != nil {
 		// Any error here is indicative of a disk issue, potentially out of

--- a/internal/worker/deployer/nested_test.go
+++ b/internal/worker/deployer/nested_test.go
@@ -160,7 +160,7 @@ func (s *NestedContextSuite) TestContextStops(c *tc.C) {
 func (s *NestedContextSuite) TestDeployUnit(c *tc.C) {
 	ctx := s.newContext(c)
 	unitName := "something/0"
-	err := ctx.DeployUnit(unitName, "password")
+	err := ctx.DeployUnit(c.Context(), unitName, "password")
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Wait for unit to start.
@@ -181,7 +181,7 @@ func (s *NestedContextSuite) TestRecallUnit(c *tc.C) {
 	tag := names.NewUnitTag(unitName)
 	s.config.RebootMonitorStatePurger = &fakeRebootMonitor{c: c, tag: tag}
 	ctx := s.newContext(c)
-	err := ctx.DeployUnit(unitName, "password")
+	err := ctx.DeployUnit(c.Context(), unitName, "password")
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Wait for unit to start.
@@ -232,7 +232,7 @@ func waitForFile(filePath string) error {
 func (s *NestedContextSuite) deployThreeUnits(c *tc.C, ctx deployer.Context) {
 	// Units are conveniently in alphabetical order.
 	for _, unitName := range []string{"first/0", "second/0", "third/0"} {
-		err := ctx.DeployUnit(unitName, "password")
+		err := ctx.DeployUnit(c.Context(), unitName, "password")
 		c.Assert(err, tc.ErrorIsNil)
 		// Wait for unit to start.
 		s.workers.waitForStart(c, unitName)


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

On machines promoted to controller, the deployer (gated on `ifFullyUpgraded`) could start before `controlleragentconfig` (gated on `ifController`) had created `configchange.socket`. The controller charm's install hook calls that socket on startup; if absent, the hook fails with `FileNotFoundError` and the unit enters an error state.

**Fix:** Gate the deployer on a `controllerAgentConfigNeededAndReady` flag manifold. The flag is pre-unlocked on non-controller machines (so the deployer starts without delay), and unlocked by `controlleragentconfig` after `NewWorker` returns (socket exists on disk). No polling, no business logic change — pure dependency graph.

### Details

- Add a `controllerAgentConfigReadyLock` (gate.Lock) created in `commonManifolds()`. On non-controller machines it is pre-unlocked immediately (`ControllerAgentInfo` returns false), so the deployer starts without delay. On controller machines it starts locked.
- Wire a `controllerAgentConfigReadyGate` and `controllerAgentConfigReadyFlag` into every machine agent.
- `controlleragentconfig.ManifoldConfig` gains a `ReadyUnlocker` field. The `Start` func calls `ReadyUnlocker.Unlock()` immediately after `NewWorker` returns.
- The deployer manifold is wrapped with an additional `engine.Housing` that blocks on the flag.

> **Note:** Split from #22429. The main Schema() fix and instancepoller fly-by are in #22514.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~Integration tests~
- ~doc.go added or updated in changed packages~

## QA steps

Run the unmanaged CI test suite:

```sh
cd tests && ./main.sh unmanaged
```

Expected: bootstrap completes, controller charm installs successfully without `FileNotFoundError`, all units reach active/idle.

## Documentation changes

None.

## Links

**Jira card:** [JUJU-9797](https://warthogs.atlassian.net/browse/JUJU-9797)
**Previous PR:** #22429 (split into #22514 and this PR)

[JUJU-9797]: https://warthogs.atlassian.net/browse/JUJU-9797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ