### PR TITLE
fix: ensure external controller addresses are always migrated

### DIFF
--- a/apiserver/facades/controller/crosscontroller/register.go
+++ b/apiserver/facades/controller/crosscontroller/register.go
@@ -4,12 +4,14 @@
 package crosscontroller
 
 import (
+	"net"
 	"reflect"
 
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/network"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -26,7 +28,7 @@ func newStateCrossControllerAPI(ctx facade.Context) (*CrossControllerAPI, error)
 	return NewCrossControllerAPI(
 		ctx.Resources(),
 		func() ([]string, string, error) {
-			return common.StateControllerInfo(st)
+			return controllerInfo(st)
 		},
 		func() (string, error) {
 			config, err := st.ControllerConfig()
@@ -37,4 +39,44 @@ func newStateCrossControllerAPI(ctx facade.Context) (*CrossControllerAPI, error)
 		},
 		st.WatchAPIHostPortsForClients,
 	)
+}
+
+// controllerInfoGetter indirects state for retrieving information
+// required for cross-controller communication.
+type controllerInfoGetter interface {
+	APIHostPortsForClients() ([]network.SpaceHostPorts, error)
+	ControllerConfig() (controller.Config, error)
+}
+
+// controllerInfo retrieves information required to communicate
+// with this controller - API addresses and the CA cert.
+func controllerInfo(st controllerInfoGetter) ([]string, string, error) {
+	apiHostPorts, err := st.APIHostPortsForClients()
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+
+	var addrs []string
+	for _, hostPorts := range apiHostPorts {
+		ordered := hostPorts.HostPorts().FilterUnusable().PrioritizedForScope(network.ScopeMatchPublic)
+		for _, addr := range ordered {
+			if addr == "" {
+				continue
+			}
+			host, _, err := net.SplitHostPort(addr)
+			if err == nil {
+				if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+					continue
+				}
+			}
+		}
+	}
+
+	controllerConfig, err := st.ControllerConfig()
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+
+	caCert, _ := controllerConfig.CACert()
+	return addrs, caCert, nil
 }

--- a/apiserver/facades/controller/crosscontroller/register.go
+++ b/apiserver/facades/controller/crosscontroller/register.go
@@ -63,12 +63,15 @@ func controllerInfo(st controllerInfoGetter) ([]string, string, error) {
 			if addr == "" {
 				continue
 			}
+			// Addresses can be recorded without a scope.
+			// Ensure no loopback addresses are included.
 			host, _, err := net.SplitHostPort(addr)
 			if err == nil {
 				if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
 					continue
 				}
 			}
+			addrs = append(addrs, addr)
 		}
 	}
 

--- a/apiserver/facades/controller/crosscontroller/register.go
+++ b/apiserver/facades/controller/crosscontroller/register.go
@@ -67,6 +67,9 @@ func controllerInfo(st controllerInfoGetter) ([]string, string, error) {
 			// Ensure no loopback addresses are included.
 			host, _, err := net.SplitHostPort(addr)
 			if err == nil {
+				if host == "localhost" {
+					continue
+				}
 				if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
 					continue
 				}

--- a/go.mod
+++ b/go.mod
@@ -220,7 +220,7 @@ require (
 	github.com/microsoft/kiota-serialization-multipart-go v1.0.0 // indirect
 	github.com/microsoft/kiota-serialization-text-go v1.0.0 // indirect
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.0.0 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect

--- a/go.sum
+++ b/go.sum
@@ -750,8 +750,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
 github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1513,6 +1513,8 @@ func (s externalControllerShim) LocalControllerInfo(modelUUIDs []string) (migrat
 			if addr == "" {
 				continue
 			}
+			// Addresses can be recorded without a scope.
+			// Ensure no loopback addresses are included.
 			host, _, err := net.SplitHostPort(addr)
 			if err == nil {
 				if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -1448,46 +1449,33 @@ type externalControllerShim struct {
 	st *State
 }
 
-// externalControllerInfoShim is used to align to an interface with in the
-// migrations package.
-type externalControllerInfoShim struct {
-	info externalControllerDoc
+// externalControllerInfo implements MigrationExternalController for use
+// during migration export.
+type externalControllerInfo struct {
+	id     string
+	alias  string
+	addrs  []string
+	caCert string
+	models []string
 }
 
-// ID holds the controller ID from the external controller
-func (e externalControllerInfoShim) ID() string {
-	return e.info.Id
-}
-
-// Alias holds an alias (human friendly) name for the controller.
-func (e externalControllerInfoShim) Alias() string {
-	return e.info.Alias
-}
-
-// Addrs holds the host:port values for the external
-// controller's API server.
-func (e externalControllerInfoShim) Addrs() []string {
-	return e.info.Addrs
-}
-
-// CACert holds the certificate to validate the external
-// controller's target API server's TLS certificate.
-func (e externalControllerInfoShim) CACert() string {
-	return e.info.CACert
-}
-
-// Models holds model UUIDs hosted on this controller.
-func (e externalControllerInfoShim) Models() []string {
-	return e.info.Models
-}
+func (e externalControllerInfo) ID() string       { return e.id }
+func (e externalControllerInfo) Alias() string    { return e.alias }
+func (e externalControllerInfo) Addrs() []string  { return e.addrs }
+func (e externalControllerInfo) CACert() string   { return e.caCert }
+func (e externalControllerInfo) Models() []string { return e.models }
 
 func (s externalControllerShim) ControllerForModel(uuid string) (migrations.MigrationExternalController, error) {
 	entity, err := s.st.ExternalControllerForModel(uuid)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return externalControllerInfoShim{
-		info: entity.doc,
+	return externalControllerInfo{
+		id:     entity.doc.Id,
+		alias:  entity.doc.Alias,
+		addrs:  entity.doc.Addrs,
+		caCert: entity.doc.CACert,
+		models: entity.doc.Models,
 	}, nil
 }
 
@@ -1502,6 +1490,54 @@ func (s externalControllerShim) AllRemoteApplications() ([]migrations.MigrationR
 		result[k] = remoteApplicationShim{RemoteApplication: v}
 	}
 	return result, nil
+}
+
+// ModelExists returns true if the model with the given UUID is hosted on
+// this controller.
+func (s externalControllerShim) ModelExists(uuid string) (bool, error) {
+	return s.st.ModelExists(uuid)
+}
+
+// LocalControllerInfo returns a MigrationExternalController representing the
+// current controller. The provided modelUUIDs are set as the hosted models.
+func (s externalControllerShim) LocalControllerInfo(modelUUIDs []string) (migrations.MigrationExternalController, error) {
+	apiHostPorts, err := s.st.APIHostPortsForClients()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var addrs []string
+	for _, hostPorts := range apiHostPorts {
+		ordered := hostPorts.HostPorts().FilterUnusable().PrioritizedForScope(network.ScopeMatchPublic)
+		for _, addr := range ordered {
+			if addr == "" {
+				continue
+			}
+			host, _, err := net.SplitHostPort(addr)
+			if err == nil {
+				if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+					continue
+				}
+			}
+			addrs = append(addrs, addr)
+		}
+	}
+
+	controllerConfig, err := s.st.ControllerConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	caCert, _ := controllerConfig.CACert()
+	alias := controllerConfig.ControllerName()
+
+	return externalControllerInfo{
+		id:     s.st.ControllerUUID(),
+		alias:  alias,
+		addrs:  addrs,
+		caCert: caCert,
+		models: modelUUIDs,
+	}, nil
 }
 
 func (e *exporter) externalControllers() error {

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -1517,6 +1517,9 @@ func (s externalControllerShim) LocalControllerInfo(modelUUIDs []string) (migrat
 			// Ensure no loopback addresses are included.
 			host, _, err := net.SplitHostPort(addr)
 			if err == nil {
+				if host == "localhost" {
+					continue
+				}
 				if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
 					continue
 				}

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -951,6 +951,62 @@ func (s *MigrationExportSuite) TestExternalControllers(c *gc.C) {
 	c.Assert(ctrl.Models(), gc.DeepEquals, []string{s.Model.UUID(), "af5a9137-934c-4b0c-8317-643b69cf4971"})
 }
 
+func (s *MigrationExportSuite) TestExternalControllersLocalController(c *gc.C) {
+	// Create a second model on this controller that will be the source of the
+	// remote application's offer.
+	otherState := s.Factory.MakeModel(c, nil)
+	defer func() { _ = otherState.Close() }()
+	otherModel, err := otherState.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.State.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "gravy-rainbow",
+		URL:         "me/model.rainbow",
+		SourceModel: otherModel.ModelTag(),
+		Token:       "charisma",
+		OfferUUID:   "offer-uuid",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// No external controller record is saved for the other model - this
+	// simulates the case where the offer's source model is on this controller.
+
+	// Set API host ports so the local controller has addresses to export.
+	err = s.State.SetAPIHostPorts([]network.SpaceHostPorts{{
+		{SpaceAddress: network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)), NetPort: 17070},
+		{SpaceAddress: network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopePublic)), NetPort: 17070},
+		// This one is filtered out.
+		{SpaceAddress: network.NewSpaceAddress("127.0.0.1"), NetPort: 17070},
+	}})
+	c.Assert(err, jc.ErrorIsNil)
+
+	model, err := s.State.ExportPartial(state.ExportConfig{
+		SkipActions:              true,
+		SkipAnnotations:          true,
+		SkipCloudImageMetadata:   true,
+		SkipCredentials:          true,
+		SkipIPAddresses:          true,
+		SkipSettings:             true,
+		SkipSSHHostKeys:          true,
+		SkipStatusHistory:        true,
+		SkipLinkLayerDevices:     true,
+		SkipUnitAgentBinaries:    true,
+		SkipMachineAgentBinaries: true,
+		SkipRelationData:         true,
+		SkipInstanceData:         true,
+		SkipApplicationOffers:    true,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ctrls := model.ExternalControllers()
+	c.Assert(ctrls, gc.HasLen, 1)
+
+	ctrl := ctrls[0]
+	c.Check(ctrl.ID(), gc.Equals, names.NewControllerTag(s.State.ControllerUUID()))
+	c.Check(ctrl.Addrs(), jc.SameContents, []string{"1.2.3.4:17070", "10.0.0.1:17070"})
+	c.Check(ctrl.Models(), jc.SameContents, []string{otherModel.UUID()})
+}
+
 func (s *MigrationExportSuite) TestUnits(c *gc.C) {
 	s.assertMigrateUnits(c, s.State)
 }

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -975,8 +975,9 @@ func (s *MigrationExportSuite) TestExternalControllersLocalController(c *gc.C) {
 	err = s.State.SetAPIHostPorts([]network.SpaceHostPorts{{
 		{SpaceAddress: network.NewSpaceAddress("10.0.0.1", network.WithScope(network.ScopeCloudLocal)), NetPort: 17070},
 		{SpaceAddress: network.NewSpaceAddress("1.2.3.4", network.WithScope(network.ScopePublic)), NetPort: 17070},
-		// This one is filtered out.
+		// These ones are filtered out.
 		{SpaceAddress: network.NewSpaceAddress("127.0.0.1"), NetPort: 17070},
+		{SpaceAddress: network.NewSpaceAddress("localhost")},
 	}})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/state/migrations/externalcontroller_mock_test.go
+++ b/state/migrations/externalcontroller_mock_test.go
@@ -157,6 +157,36 @@ func (mr *MockExternalControllerSourceMockRecorder) ControllerForModel(arg0 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerForModel", reflect.TypeOf((*MockExternalControllerSource)(nil).ControllerForModel), arg0)
 }
 
+// LocalControllerInfo mocks base method.
+func (m *MockExternalControllerSource) LocalControllerInfo(arg0 []string) (MigrationExternalController, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LocalControllerInfo", arg0)
+	ret0, _ := ret[0].(MigrationExternalController)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LocalControllerInfo indicates an expected call of LocalControllerInfo.
+func (mr *MockExternalControllerSourceMockRecorder) LocalControllerInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalControllerInfo", reflect.TypeOf((*MockExternalControllerSource)(nil).LocalControllerInfo), arg0)
+}
+
+// ModelExists mocks base method.
+func (m *MockExternalControllerSource) ModelExists(arg0 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModelExists", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModelExists indicates an expected call of ModelExists.
+func (mr *MockExternalControllerSourceMockRecorder) ModelExists(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelExists", reflect.TypeOf((*MockExternalControllerSource)(nil).ModelExists), arg0)
+}
+
 // MockExternalControllerModel is a mock of ExternalControllerModel interface.
 type MockExternalControllerModel struct {
 	ctrl     *gomock.Controller

--- a/state/migrations/externalcontrollers.go
+++ b/state/migrations/externalcontrollers.go
@@ -6,8 +6,11 @@ package migrations
 import (
 	"github.com/juju/description/v3"
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v4"
 )
+
+var logger = loggo.GetLogger("juju.state.migrations.externalcontrollers")
 
 // MigrationExternalController represents a state.ExternalController
 // Point of use interface to enable better encapsulation.
@@ -91,7 +94,7 @@ func (m ExportExternalControllers) Execute(src ExternalControllerSource, dst Ext
 	for modelUUID := range sourceModelUUIDs {
 		externalController, err := src.ControllerForModel(modelUUID)
 		if err != nil {
-			if !errors.IsNotFound(err) {
+			if !errors.Is(err, errors.NotFound) {
 				return errors.Trace(err)
 			}
 			// No external controller record found. Check if the model
@@ -103,12 +106,13 @@ func (m ExportExternalControllers) Execute(src ExternalControllerSource, dst Ext
 			if existsErr != nil {
 				return errors.Trace(existsErr)
 			}
-			if !exists {
-				return errors.Annotatef(err,
-					"cannot find external controller for model %q "+
-						"and model is not on this controller", modelUUID)
+			if exists {
+				localModelUUIDs = append(localModelUUIDs, modelUUID)
+			} else {
+				logger.Warningf(
+					"cannot find external controller for model %q and model is not on this controller",
+					modelUUID)
 			}
-			localModelUUIDs = append(localModelUUIDs, modelUUID)
 			continue
 		}
 		controllers[externalController.ID()] = externalController

--- a/state/migrations/externalcontrollers.go
+++ b/state/migrations/externalcontrollers.go
@@ -34,6 +34,18 @@ type MigrationExternalController interface {
 // external controllers.
 type AllExternalControllerSource interface {
 	ControllerForModel(string) (MigrationExternalController, error)
+
+	// ModelExists returns true if the model with the given UUID is
+	// hosted on this controller.
+	ModelExists(string) (bool, error)
+
+	// LocalControllerInfo returns a MigrationExternalController
+	// representing the current controller, with the given model UUIDs
+	// as its hosted models. This is used during export to include the
+	// local controller as an external controller record so that after
+	// migration, the target controller knows how to reach back to the
+	// source controller for consumed offers that were local.
+	LocalControllerInfo(modelUUIDs []string) (MigrationExternalController, error)
 }
 
 // ExternalControllerSource composes all the interfaces to create a external
@@ -58,7 +70,7 @@ type ExportExternalControllers struct{}
 // This doesn't conform to an interface because go doesn't have generics, but
 // when this does arrive this would be an excellent place to use them.
 func (m ExportExternalControllers) Execute(src ExternalControllerSource, dst ExternalControllerModel) error {
-	// If there are not remote applications, then no external controllers will
+	// If there are no remote applications, then no external controllers will
 	// be exported. We should understand if that's ever going to be an issue?
 	remoteApplications, err := src.AllRemoteApplications()
 	if err != nil {
@@ -75,23 +87,43 @@ func (m ExportExternalControllers) Execute(src ExternalControllerSource, dst Ext
 	}
 
 	controllers := make(map[string]MigrationExternalController)
+	var localModelUUIDs []string
 	for modelUUID := range sourceModelUUIDs {
 		externalController, err := src.ControllerForModel(modelUUID)
 		if err != nil {
-			// This can occur when attempting to export a remote application
-			// where there is a external controller, yet the controller doesn't
-			// exist.
-			// This generally only happens whilst keeping backwards
-			// compatibility, whilst remote applications aren't exported or
-			// imported correctly.
-			// TODO (stickupkid): This should be removed when we support CMR
-			// migrations without a feature flag.
-			if errors.IsNotFound(err) {
-				continue
+			if !errors.IsNotFound(err) {
+				return errors.Trace(err)
 			}
-			return errors.Trace(err)
+			// No external controller record found. Check if the model
+			// is hosted on this controller. If so, we need to include
+			// the local controller as an external controller in the
+			// export, because after migration the consumed offers that
+			// were local will be on an external controller.
+			exists, existsErr := src.ModelExists(modelUUID)
+			if existsErr != nil {
+				return errors.Trace(existsErr)
+			}
+			if !exists {
+				return errors.Annotatef(err,
+					"cannot find external controller for model %q "+
+						"and model is not on this controller", modelUUID)
+			}
+			localModelUUIDs = append(localModelUUIDs, modelUUID)
+			continue
 		}
 		controllers[externalController.ID()] = externalController
+	}
+
+	// If any remote applications reference models on this controller,
+	// include the local controller info as an external controller so
+	// the target controller can reach back after migration.
+	if len(localModelUUIDs) > 0 {
+		localCtrl, err := src.LocalControllerInfo(localModelUUIDs)
+		if err != nil {
+			return errors.Annotate(err,
+				"getting local controller info for export")
+		}
+		controllers[localCtrl.ID()] = localCtrl
 	}
 
 	for _, controller := range controllers {

--- a/state/migrations/externalcontrollers_test.go
+++ b/state/migrations/externalcontrollers_test.go
@@ -137,7 +137,47 @@ func (s *ExternalControllersExportSuite) TestExportExternalControllerRequestsExt
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ExternalControllersExportSuite) TestExportExternalControllerWithNoControllerNotFound(c *gc.C) {
+func (s *ExternalControllersExportSuite) TestExportExternalControllerWithNoControllerNotFoundModelIsLocal(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	entities := []MigrationRemoteApplication{
+		s.migrationRemoteApplication(ctrl, func(expect *MockMigrationRemoteApplicationMockRecorder) {
+			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
+		}),
+	}
+
+	localCtrl := s.migrationExternalController(ctrl, func(expect *MockMigrationExternalControllerMockRecorder) {
+		expect.ID().Return("local-ctrl-uuid").Times(2)
+		expect.Addrs().Return([]string{"10.0.0.1:17070"})
+		expect.Alias().Return("my-controller")
+		expect.CACert().Return("local-ca-cert")
+		expect.Models().Return([]string{"uuid-2"})
+	})
+
+	externalController := NewMockExternalController(ctrl)
+
+	source := NewMockExternalControllerSource(ctrl)
+	source.EXPECT().AllRemoteApplications().Return(entities, nil)
+	source.EXPECT().ControllerForModel("uuid-2").Return(nil, errors.NotFoundf("not found"))
+	source.EXPECT().ModelExists("uuid-2").Return(true, nil)
+	source.EXPECT().LocalControllerInfo([]string{"uuid-2"}).Return(localCtrl, nil)
+
+	model := NewMockExternalControllerModel(ctrl)
+	model.EXPECT().AddExternalController(description.ExternalControllerArgs{
+		Tag:    names.NewControllerTag("local-ctrl-uuid"),
+		Addrs:  []string{"10.0.0.1:17070"},
+		Alias:  "my-controller",
+		CACert: "local-ca-cert",
+		Models: []string{"uuid-2"},
+	}).Return(externalController)
+
+	migration := ExportExternalControllers{}
+	err := migration.Execute(source, model)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ExternalControllersExportSuite) TestExportExternalControllerWithNoControllerNotFoundModelNotLocal(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -150,8 +190,114 @@ func (s *ExternalControllersExportSuite) TestExportExternalControllerWithNoContr
 	source := NewMockExternalControllerSource(ctrl)
 	source.EXPECT().AllRemoteApplications().Return(entities, nil)
 	source.EXPECT().ControllerForModel("uuid-2").Return(nil, errors.NotFoundf("not found"))
+	source.EXPECT().ModelExists("uuid-2").Return(false, nil)
 
 	model := NewMockExternalControllerModel(ctrl)
+
+	migration := ExportExternalControllers{}
+	err := migration.Execute(source, model)
+	c.Assert(err, gc.ErrorMatches,
+		`cannot find external controller for model "uuid-2" and model is not on this controller: not found not found`)
+}
+
+func (s *ExternalControllersExportSuite) TestExportExternalControllerMultipleLocalModels(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	entities := []MigrationRemoteApplication{
+		s.migrationRemoteApplication(ctrl, func(expect *MockMigrationRemoteApplicationMockRecorder) {
+			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
+		}),
+		s.migrationRemoteApplication(ctrl, func(expect *MockMigrationRemoteApplicationMockRecorder) {
+			expect.SourceModel().Return(names.NewModelTag("uuid-3"))
+		}),
+	}
+
+	localCtrl := s.migrationExternalController(ctrl, func(expect *MockMigrationExternalControllerMockRecorder) {
+		expect.ID().Return("local-ctrl-uuid").Times(2)
+		expect.Addrs().Return([]string{"10.0.0.1:17070"})
+		expect.Alias().Return("my-controller")
+		expect.CACert().Return("local-ca-cert")
+		expect.Models().Return([]string{"uuid-2", "uuid-3"})
+	})
+
+	externalController := NewMockExternalController(ctrl)
+
+	source := NewMockExternalControllerSource(ctrl)
+	source.EXPECT().AllRemoteApplications().Return(entities, nil)
+	source.EXPECT().ControllerForModel("uuid-2").Return(nil, errors.NotFoundf("not found"))
+	source.EXPECT().ModelExists("uuid-2").Return(true, nil)
+	source.EXPECT().ControllerForModel("uuid-3").Return(nil, errors.NotFoundf("not found"))
+	source.EXPECT().ModelExists("uuid-3").Return(true, nil)
+	source.EXPECT().LocalControllerInfo(gomock.Any()).Return(localCtrl, nil)
+
+	model := NewMockExternalControllerModel(ctrl)
+	model.EXPECT().AddExternalController(description.ExternalControllerArgs{
+		Tag:    names.NewControllerTag("local-ctrl-uuid"),
+		Addrs:  []string{"10.0.0.1:17070"},
+		Alias:  "my-controller",
+		CACert: "local-ca-cert",
+		Models: []string{"uuid-2", "uuid-3"},
+	}).Return(externalController)
+
+	migration := ExportExternalControllers{}
+	err := migration.Execute(source, model)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *ExternalControllersExportSuite) TestExportExternalControllerMixOfLocalAndExternal(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	entities := []MigrationRemoteApplication{
+		s.migrationRemoteApplication(ctrl, func(expect *MockMigrationRemoteApplicationMockRecorder) {
+			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
+		}),
+		s.migrationRemoteApplication(ctrl, func(expect *MockMigrationRemoteApplicationMockRecorder) {
+			expect.SourceModel().Return(names.NewModelTag("uuid-3"))
+		}),
+	}
+
+	extCtrlModel := s.migrationExternalController(ctrl, func(expect *MockMigrationExternalControllerMockRecorder) {
+		expect.ID().Return("f47ac10b-58cc-4372-a567-0e02b2c3d479").Times(2)
+		expect.Addrs().Return([]string{"10.0.0.1/24"})
+		expect.Alias().Return("magic")
+		expect.CACert().Return("magic-ca-cert")
+		expect.Models().Return([]string{"uuid-2"})
+	})
+
+	localCtrl := s.migrationExternalController(ctrl, func(expect *MockMigrationExternalControllerMockRecorder) {
+		expect.ID().Return("local-ctrl-uuid").Times(2)
+		expect.Addrs().Return([]string{"10.0.0.2:17070"})
+		expect.Alias().Return("my-controller")
+		expect.CACert().Return("local-ca-cert")
+		expect.Models().Return([]string{"uuid-3"})
+	})
+
+	externalController := NewMockExternalController(ctrl)
+
+	source := NewMockExternalControllerSource(ctrl)
+	source.EXPECT().AllRemoteApplications().Return(entities, nil)
+	source.EXPECT().ControllerForModel("uuid-2").Return(extCtrlModel, nil)
+	source.EXPECT().ControllerForModel("uuid-3").Return(nil, errors.NotFoundf("not found"))
+	source.EXPECT().ModelExists("uuid-3").Return(true, nil)
+	source.EXPECT().LocalControllerInfo([]string{"uuid-3"}).Return(localCtrl, nil)
+
+	model := NewMockExternalControllerModel(ctrl)
+	model.EXPECT().AddExternalController(description.ExternalControllerArgs{
+		Tag:    names.NewControllerTag("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+		Addrs:  []string{"10.0.0.1/24"},
+		Alias:  "magic",
+		CACert: "magic-ca-cert",
+		Models: []string{"uuid-2"},
+	}).Return(externalController)
+	model.EXPECT().AddExternalController(description.ExternalControllerArgs{
+		Tag:    names.NewControllerTag("local-ctrl-uuid"),
+		Addrs:  []string{"10.0.0.2:17070"},
+		Alias:  "my-controller",
+		CACert: "local-ca-cert",
+		Models: []string{"uuid-3"},
+	}).Return(externalController)
 
 	migration := ExportExternalControllers{}
 	err := migration.Execute(source, model)

--- a/state/migrations/externalcontrollers_test.go
+++ b/state/migrations/externalcontrollers_test.go
@@ -177,29 +177,6 @@ func (s *ExternalControllersExportSuite) TestExportExternalControllerWithNoContr
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *ExternalControllersExportSuite) TestExportExternalControllerWithNoControllerNotFoundModelNotLocal(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	entities := []MigrationRemoteApplication{
-		s.migrationRemoteApplication(ctrl, func(expect *MockMigrationRemoteApplicationMockRecorder) {
-			expect.SourceModel().Return(names.NewModelTag("uuid-2"))
-		}),
-	}
-
-	source := NewMockExternalControllerSource(ctrl)
-	source.EXPECT().AllRemoteApplications().Return(entities, nil)
-	source.EXPECT().ControllerForModel("uuid-2").Return(nil, errors.NotFoundf("not found"))
-	source.EXPECT().ModelExists("uuid-2").Return(false, nil)
-
-	model := NewMockExternalControllerModel(ctrl)
-
-	migration := ExportExternalControllers{}
-	err := migration.Execute(source, model)
-	c.Assert(err, gc.ErrorMatches,
-		`cannot find external controller for model "uuid-2" and model is not on this controller: not found not found`)
-}
-
 func (s *ExternalControllersExportSuite) TestExportExternalControllerMultipleLocalModels(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
When migrating a model with consumed offers, if the offers are in a model on the same controller, then no external controller record is migrated. But this breaks the model when it lands on the target controller since then the offers do become hosted on an external controller.

This PR ensures that external controller info is generated for locally consumed offers.

As a drive by, the 3.6 approach to generating external controller info is back ported to the crosscontroller facade.

## QA steps

juju bootstrap lxd c1
juju add-model src
juju deploy postgresql
juju offer postgresql:db
juju add-model cons
juju consume src.postgresql

juju bootstrap lxd c2
juju switch c1
juju migrate cons c2
juju switch c2:admin/cons
juju status

open a mongo console on c2
db.externalControllers.find().pretty()

## Links

**Issue:** Fixes #22517.

**Jira card:** [JUJU-9891](https://warthogs.atlassian.net/browse/JUJU-9891)

[JUJU-9891]: https://warthogs.atlassian.net/browse/JUJU-9891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ