### PR TITLE
fix: presence status reporting for container placement

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -177,6 +177,7 @@ var modelPostPatchFilesByVersion = []struct {
 	version: semversion.MustParse("4.0.12"),
 	files: []string{
 		"0058-charm-secret-removal.PATCH.sql",
+		"0059-machine-status.PATCH.sql",
 	},
 }}
 

--- a/domain/schema/model/sql/0059-machine-status.PATCH.sql
+++ b/domain/schema/model/sql/0059-machine-status.PATCH.sql
@@ -1,0 +1,22 @@
+DROP VIEW v_machine_status;
+
+CREATE VIEW v_machine_status AS
+WITH machine_presence AS (
+    SELECT machine_uuid
+    FROM machine_agent_presence
+    UNION
+    SELECT mp.parent_uuid AS machine_uuid
+    FROM machine_parent AS mp
+    JOIN machine_agent_presence AS map ON mp.machine_uuid = map.machine_uuid
+)
+
+SELECT
+    ms.machine_uuid,
+    ms.message,
+    ms.data,
+    ms.updated_at,
+    msv.status,
+    mp.machine_uuid IS NOT NULL AS present
+FROM machine_status AS ms
+JOIN machine_status_value AS msv ON ms.status_id = msv.id
+LEFT JOIN machine_presence AS mp ON ms.machine_uuid = mp.machine_uuid;

--- a/domain/status/state/model/modelstate_test.go
+++ b/domain/status/state/model/modelstate_test.go
@@ -791,6 +791,38 @@ func (s *modelStateSuite) TestGetMachineAgentStatusPresent(c *tc.C) {
 	assertStatusInfoEqual(c, gotStatus.StatusInfo, status)
 }
 
+func (s *modelStateSuite) TestGetMachineAgentStatusPresentViaChildMachine(c *tc.C) {
+	_, parentName, _, childName := s.createContainerMachine(c)
+
+	status := status.StatusInfo[status.MachineStatusType]{
+		Status:  status.MachineStatusStarted,
+		Message: "it's starting",
+		Data:    []byte(`{"foo": "bar"}`),
+		Since:   new(time.Now()),
+	}
+
+	err := s.state.SetMachineStatus(c.Context(), parentName.String(), status)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.state.SetMachinePresence(c.Context(), childName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	gotStatus, err := s.state.GetMachineStatus(c.Context(), parentName.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(gotStatus.Present, tc.IsTrue)
+	assertStatusInfoEqual(c, gotStatus.StatusInfo, status)
+
+	err = s.state.DeleteMachinePresence(c.Context(), childName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	gotStatus, err = s.state.GetMachineStatus(c.Context(), parentName.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(gotStatus.Present, tc.IsFalse)
+	assertStatusInfoEqual(c, gotStatus.StatusInfo, status)
+}
+
 func (s *modelStateSuite) TestGetUnitWorkloadStatusUnitNotFound(c *tc.C) {
 	_, err := s.state.GetUnitWorkloadStatus(c.Context(), "missing-uuid")
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
@@ -2939,6 +2971,33 @@ func (s *modelStateSuite) createMachine(c *tc.C) (coremachine.UUID, coremachine.
 	c.Assert(err, tc.ErrorIsNil)
 
 	return mUUID, name
+}
+
+func (s *modelStateSuite) createContainerMachine(c *tc.C) (coremachine.UUID, coremachine.Name, coremachine.UUID, coremachine.Name) {
+	machineState := machinestate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	_, machineNames, err := machineState.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Directive: deployment.Placement{
+			Type:      deployment.PlacementTypeContainer,
+			Container: deployment.ContainerTypeLXD,
+		},
+		Platform: deployment.Platform{
+			OSType:       deployment.Ubuntu,
+			Architecture: architecture.AMD64,
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(machineNames, tc.HasLen, 2)
+
+	parentName := machineNames[0]
+	parentUUID, err := machineState.GetMachineUUID(c.Context(), parentName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	childName := machineNames[1]
+	childUUID, err := machineState.GetMachineUUID(c.Context(), childName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return parentUUID, parentName, childUUID, childName
 }
 
 func (s *modelStateSuite) assertUnitStatus(c *tc.C, statusType, unitUUID coreunit.UUID, statusID int, message string, since *time.Time, data []byte) {


### PR DESCRIPTION
Fix machine status reporting for container placements where the parent host machine is incorrectly shown as down while its child container machine is running and connected.

The machine status view now computes machine presence from both direct machine-agent presence and child- machine presence via machine_parent, so a parent host with an active container machine is considered present for status display.

  #### Why This Is View-Only

  The live debugging showed the unit and container eventually start correctly; the remaining bug is that
  juju status reports the parent machine as down. The existing service behavior intentionally maps
  “started but not present” to down, so the correct narrow fix is to make v_machine_status.present reflect
  the container placement topology instead of changing presence lifecycle semantics or agent startup
  behavior.


## QA steps
Bootstrap on lxd (or aws) and then deploy with placement to a container without previously manually adding a machine:

```
$ juju bootstrap lxd c
$ juju add-model m
$ juju deploy ubuntu --to lxd
```
After a while the status should look like this:
```
$ juju status
Model  Controller  Cloud/Region         Version   Timestamp
m      c           localhost/localhost  4.0.12.1  13:20:48+02:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  24.04    active      1  ubuntu  latest/stable   26  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0/lxd/0  10.134.1.232           

Machine  State    Address       Inst id              Base          AZ                                Message
0        started  10.134.1.35   juju-18e9b6-0        ubuntu@24.04  nvinuesa-ThinkPad-P16s-Gen-4-AMD  Running
0/lxd/0  started  10.134.1.232  juju-18e9b6-0-lxd-0  ubuntu@24.04  nvinuesa-ThinkPad-P16s-Gen-4-AMD  Container started
```


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22057.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9477](https://warthogs.atlassian.net/browse/JUJU-9477)


[JUJU-9477]: https://warthogs.atlassian.net/browse/JUJU-9477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ