### PR TITLE
feat(cli): provide a clearer error message when deploying or using resources outside of confinement

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -82,6 +82,10 @@ func minimalModelConfig() map[string]any {
 
 func (s *DeploySuiteBase) SetUpTest(c *tc.C) {
 	s.FakeHomeSuite.SetUpTest(c)
+	// The snap confinement hint keys off $SNAP, which snapd sets for every
+	// process started by a snap-installed Go toolchain. Clear it so that the
+	// error messages asserted here do not depend on how the tests were run.
+	c.Setenv("SNAP", "")
 	s.fakeAPI = vanillaFakeModelAPI(minimalModelConfig())
 	s.fakeAPI.deployerFactoryFunc = deployer.NewDeployerFactory
 }

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -244,7 +244,8 @@ func (d *factory) localCharmDeployer(ctx context.Context, getter ModelConfigGett
 	} else if errors.Cause(err) == zip.ErrFormat {
 		return nil, errors.Errorf("invalid charm or bundle provided at %q", d.charmOrBundle)
 	} else if errors.Is(err, errors.NotFound) {
-		return nil, errors.Wrap(err, errors.NotFoundf("charm or bundle at %q", d.charmOrBundle))
+		hint := utils.SnapConfinementHintFromEnv(d.charmOrBundle)
+		return nil, errors.Errorf("charm or bundle at %q not found%s", d.charmOrBundle, hint)
 	} else if errors.Is(err, os.ErrNotExist) {
 		logger.Debugf(context.TODO(), "cannot interpret as local charm: %v", err)
 		return nil, nil
@@ -348,7 +349,8 @@ func (d *factory) checkPath() error {
 	}
 	// Check in case we do have a valid path, but it doesn't exist
 	if fileStatErr != nil && charm.IsValidLocalCharmOrBundlePath(d.charmOrBundle) && os.IsNotExist(errors.Cause(fileStatErr)) {
-		return errors.Errorf("no charm was found at %q", d.charmOrBundle)
+		hint := utils.SnapConfinementHintFromEnv(d.charmOrBundle)
+		return errors.Errorf("no charm was found at %q%s", d.charmOrBundle, hint)
 	}
 	return nil
 }

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -244,8 +244,10 @@ func (d *factory) localCharmDeployer(ctx context.Context, getter ModelConfigGett
 	} else if errors.Cause(err) == zip.ErrFormat {
 		return nil, errors.Errorf("invalid charm or bundle provided at %q", d.charmOrBundle)
 	} else if errors.Is(err, errors.NotFound) {
-		hint := utils.SnapConfinementHintFromEnv(d.charmOrBundle)
-		return nil, errors.Errorf("charm or bundle at %q not found%s", d.charmOrBundle, hint)
+		return nil, utils.AnnotateWithSnapHint(
+			errors.Wrap(err, errors.NotFoundf("charm or bundle at %q", d.charmOrBundle)),
+			d.charmOrBundle,
+		)
 	} else if errors.Is(err, os.ErrNotExist) {
 		logger.Debugf(context.TODO(), "cannot interpret as local charm: %v", err)
 		return nil, nil

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -351,8 +351,10 @@ func (d *factory) checkPath() error {
 	}
 	// Check in case we do have a valid path, but it doesn't exist
 	if fileStatErr != nil && charm.IsValidLocalCharmOrBundlePath(d.charmOrBundle) && os.IsNotExist(errors.Cause(fileStatErr)) {
-		hint := utils.SnapConfinementHintFromEnv(d.charmOrBundle)
-		return errors.Errorf("no charm was found at %q%s", d.charmOrBundle, hint)
+		return utils.AnnotateWithSnapHint(
+			errors.Wrap(fileStatErr, errors.Errorf("no charm was found at %q", d.charmOrBundle)),
+			d.charmOrBundle,
+		)
 	}
 	return nil
 }

--- a/cmd/juju/application/deployer/resource.go
+++ b/cmd/juju/application/deployer/resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/client/application"
 	"github.com/juju/juju/api/client/resources"
+	"github.com/juju/juju/cmd/juju/application/utils"
 	resourcecmd "github.com/juju/juju/cmd/juju/resource"
 	"github.com/juju/juju/cmd/modelcmd"
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
@@ -124,6 +125,9 @@ func UploadExistingPendingResources(
 
 		r, openResErr := resourcecmd.OpenResource(pendingResUpload.Filename, t, filesystem.Open)
 		if openResErr != nil {
+			if t == charmresource.TypeFile {
+				openResErr = utils.AnnotateWithSnapHint(openResErr, pendingResUpload.Filename)
+			}
 			return errors.Annotatef(openResErr, "unable to open resource %v", pendingResUpload.Name)
 		}
 

--- a/cmd/juju/application/refresher/refresher.go
+++ b/cmd/juju/application/refresher/refresher.go
@@ -189,7 +189,8 @@ func (d *localCharmRefresher) Refresh(ctx context.Context) (*CharmID, error) {
 		}, nil
 	}
 	if errors.Is(err, errors.NotFound) {
-		return nil, errors.Errorf("no charm found at %q", d.charmRef)
+		return nil, utils.AnnotateWithSnapHint(
+			errors.Errorf("no charm found at %q", d.charmRef), d.charmRef)
 	}
 	// If we get a "not exists" or invalid path error then we attempt to interpret
 	// the supplied charm reference as a URL below, otherwise we return the error.

--- a/cmd/juju/application/utils/snap_hint.go
+++ b/cmd/juju/application/utils/snap_hint.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SnapConfinementHint returns a hint message when running as a snap and path
+// is outside the snap's reachable directories (HOME / SNAP_REAL_HOME).
+// Returns "" if not running as a snap, if the path is under a reachable root,
+// or if path does not look like a filesystem path (no '/' separator).
+//
+// snapEnv is $SNAP, snapRealHome is $SNAP_REAL_HOME, homeDir is $HOME.
+func SnapConfinementHint(path, snapEnv, snapRealHome, homeDir string) string {
+	if snapEnv == "" {
+		return ""
+	}
+	// Only trigger for path-like arguments (contains a directory separator).
+	if !strings.Contains(path, "/") {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = path
+	}
+	if isUnderRoot(abs, homeDir) || isUnderRoot(abs, snapRealHome) {
+		return ""
+	}
+	return fmt.Sprintf(
+		"\n\nThe Juju snap is strictly confined and cannot access files outside your home\n"+
+			"directory. Move the file into your home directory and try again, for example:\n\n"+
+			"    cp %s ~/", path)
+}
+
+// SnapConfinementHintFromEnv calls SnapConfinementHint using the process environment.
+func SnapConfinementHintFromEnv(path string) string {
+	return SnapConfinementHint(path, os.Getenv("SNAP"), os.Getenv("SNAP_REAL_HOME"), os.Getenv("HOME"))
+}
+
+// isUnderRoot reports whether path is under root (root followed by a path separator).
+func isUnderRoot(path, root string) bool {
+	if root == "" {
+		return false
+	}
+	return strings.HasPrefix(path, root+string(filepath.Separator))
+}

--- a/cmd/juju/application/utils/snap_hint.go
+++ b/cmd/juju/application/utils/snap_hint.go
@@ -11,12 +11,14 @@ import (
 )
 
 // SnapConfinementHint returns a hint message when running as a snap and path
-// is outside the snap's reachable directories (HOME / SNAP_REAL_HOME).
+// is outside the snap's reachable directories (HOME / SNAP_REAL_HOME /
+// SNAP_USER_DATA / SNAP_USER_COMMON).
 // Returns "" if not running as a snap, if the path is under a reachable root,
 // or if path does not look like a filesystem path (no '/' separator).
 //
-// snapEnv is $SNAP, snapRealHome is $SNAP_REAL_HOME, homeDir is $HOME.
-func SnapConfinementHint(path, snapEnv, snapRealHome, homeDir string) string {
+// snapEnv is $SNAP, snapRealHome is $SNAP_REAL_HOME, homeDir is $HOME,
+// snapUserData is $SNAP_USER_DATA, snapUserCommon is $SNAP_USER_COMMON.
+func SnapConfinementHint(path, snapEnv, snapRealHome, homeDir, snapUserData, snapUserCommon string) string {
 	if snapEnv == "" {
 		return ""
 	}
@@ -28,7 +30,8 @@ func SnapConfinementHint(path, snapEnv, snapRealHome, homeDir string) string {
 	if err != nil {
 		abs = path
 	}
-	if isUnderRoot(abs, homeDir) || isUnderRoot(abs, snapRealHome) {
+	if isUnderRoot(abs, homeDir) || isUnderRoot(abs, snapRealHome) ||
+		isUnderRoot(abs, snapUserData) || isUnderRoot(abs, snapUserCommon) {
 		return ""
 	}
 	return fmt.Sprintf(
@@ -39,7 +42,14 @@ func SnapConfinementHint(path, snapEnv, snapRealHome, homeDir string) string {
 
 // SnapConfinementHintFromEnv calls SnapConfinementHint using the process environment.
 func SnapConfinementHintFromEnv(path string) string {
-	return SnapConfinementHint(path, os.Getenv("SNAP"), os.Getenv("SNAP_REAL_HOME"), os.Getenv("HOME"))
+	return SnapConfinementHint(
+		path,
+		os.Getenv("SNAP"),
+		os.Getenv("SNAP_REAL_HOME"),
+		os.Getenv("HOME"),
+		os.Getenv("SNAP_USER_DATA"),
+		os.Getenv("SNAP_USER_COMMON"),
+	)
 }
 
 // isUnderRoot reports whether path is under root (root followed by a path separator).

--- a/cmd/juju/application/utils/snap_hint.go
+++ b/cmd/juju/application/utils/snap_hint.go
@@ -8,54 +8,140 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/juju/errors"
 )
+
+// SnapEnv holds the snap environment variables that determine which paths the
+// Juju snap is able to reach.
+type SnapEnv struct {
+	// Snap is $SNAP, empty when not running as a snap.
+	Snap string
+	// RealHome is $SNAP_REAL_HOME.
+	RealHome string
+	// Home is $HOME.
+	Home string
+	// UserData is $SNAP_USER_DATA.
+	UserData string
+	// UserCommon is $SNAP_USER_COMMON.
+	UserCommon string
+}
 
 // SnapConfinementHint returns a hint message when running as a snap and path
 // is outside the snap's reachable directories (HOME / SNAP_REAL_HOME /
 // SNAP_USER_DATA / SNAP_USER_COMMON).
 // Returns "" if not running as a snap, if the path is under a reachable root,
 // or if path does not look like a filesystem path (no '/' separator).
-//
-// snapEnv is $SNAP, snapRealHome is $SNAP_REAL_HOME, homeDir is $HOME,
-// snapUserData is $SNAP_USER_DATA, snapUserCommon is $SNAP_USER_COMMON.
-func SnapConfinementHint(path, snapEnv, snapRealHome, homeDir, snapUserData, snapUserCommon string) string {
-	if snapEnv == "" {
+func SnapConfinementHint(path string, env SnapEnv) string {
+	if env.Snap == "" {
 		return ""
 	}
 	// Only trigger for path-like arguments (contains a directory separator).
 	if !strings.Contains(path, "/") {
 		return ""
 	}
+	// A leading ~ is normally expanded by the shell before Juju sees the
+	// argument. If it survives, the path is under the user's real home, which
+	// the snap can reach, so a confinement hint would be wrong (and the
+	// suggested cp would be a self-copy).
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		return ""
+	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		abs = path
 	}
-	if isUnderRoot(abs, homeDir) || isUnderRoot(abs, snapRealHome) ||
-		isUnderRoot(abs, snapUserData) || isUnderRoot(abs, snapUserCommon) {
+	if isUnderRoot(abs, env.Home) || isUnderRoot(abs, env.RealHome) ||
+		isUnderRoot(abs, env.UserData) || isUnderRoot(abs, env.UserCommon) {
 		return ""
 	}
 	return fmt.Sprintf(
 		"\n\nThe Juju snap is strictly confined and cannot access files outside your home\n"+
 			"directory. Move the file into your home directory and try again, for example:\n\n"+
-			"    cp %s ~/", path)
+			"    cp %s ~/", shellQuote(path))
 }
 
-// SnapConfinementHintFromEnv calls SnapConfinementHint using the process environment.
+// shellQuote returns path quoted for safe use in a POSIX shell command. A path
+// made only of characters the shell does not treat specially is returned
+// unchanged, so the common suggestion stays readable; anything else is
+// single-quoted. An embedded single quote is spliced in using the standard
+// POSIX idiom of closing the quoting, escaping the quote, and reopening:
+//
+//	'\''
+//
+// Single quotes are used rather than double quotes because they also suppress
+// $, backtick and backslash interpretation.
+func shellQuote(path string) string {
+	const safe = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+		"0123456789@%+=:,./-_"
+	if path == "" {
+		return "''"
+	}
+	if strings.ContainsFunc(path, func(r rune) bool {
+		return !strings.ContainsRune(safe, r)
+	}) {
+		return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+	}
+	return path
+}
+
+// SnapConfinementHintFromEnv calls SnapConfinementHint using the process
+// environment.
 func SnapConfinementHintFromEnv(path string) string {
-	return SnapConfinementHint(
-		path,
-		os.Getenv("SNAP"),
-		os.Getenv("SNAP_REAL_HOME"),
-		os.Getenv("HOME"),
-		os.Getenv("SNAP_USER_DATA"),
-		os.Getenv("SNAP_USER_COMMON"),
-	)
+	return SnapConfinementHint(path, SnapEnv{
+		Snap:       os.Getenv("SNAP"),
+		RealHome:   os.Getenv("SNAP_REAL_HOME"),
+		Home:       os.Getenv("HOME"),
+		UserData:   os.Getenv("SNAP_USER_DATA"),
+		UserCommon: os.Getenv("SNAP_USER_COMMON"),
+	})
 }
 
-// isUnderRoot reports whether path is under root (root followed by a path separator).
+// isUnderRoot reports whether path is under root (root followed by a path
+// separator).
 func isUnderRoot(path, root string) bool {
 	if root == "" {
 		return false
 	}
 	return strings.HasPrefix(path, root+string(filepath.Separator))
+}
+
+// snapHintError appends a snap confinement hint to the message of the error it
+// wraps. The hint is a suffix rather than a juju/errors annotation (which is a
+// prefix) so that the underlying failure is still the first thing the user
+// reads. Cause and Unwrap delegate to the wrapped error, so appending the hint
+// does not change how callers classify the error.
+type snapHintError struct {
+	underlying error
+	hint       string
+}
+
+// Error implements error.
+func (e *snapHintError) Error() string {
+	return e.underlying.Error() + e.hint
+}
+
+// Cause implements the causer interface used by errors.Cause.
+func (e *snapHintError) Cause() error {
+	return errors.Cause(e.underlying)
+}
+
+// Unwrap implements the interface used by errors.Is and errors.As.
+func (e *snapHintError) Unwrap() error {
+	return e.underlying
+}
+
+// AnnotateWithSnapHint returns err with a snap confinement hint appended to its
+// message, when running as a snap and path is outside the directories the snap
+// can reach. If no hint applies, err is returned unchanged. The error's cause
+// and wrap chain are preserved either way.
+func AnnotateWithSnapHint(err error, path string) error {
+	if err == nil {
+		return nil
+	}
+	hint := SnapConfinementHintFromEnv(path)
+	if hint == "" {
+		return err
+	}
+	return &snapHintError{underlying: err, hint: hint}
 }

--- a/cmd/juju/application/utils/snap_hint_test.go
+++ b/cmd/juju/application/utils/snap_hint_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"strings"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/cmd/juju/application/utils"
+)
+
+type snapHintSuite struct{}
+
+var _ = gc.Suite(&snapHintSuite{})
+
+func (s *snapHintSuite) TestSnapConfinementHint(c *gc.C) {
+	const (
+		snapEnv      = "/snap/juju/current"
+		snapRealHome = "/home/user"
+		homeDir      = "/home/user"
+	)
+
+	tests := []struct {
+		desc     string
+		path     string
+		snapEnv  string
+		wantHint bool
+	}{
+		{
+			// (a) path under HOME, snap set - genuine not-found, no hint
+			desc:     "path under HOME snap set",
+			path:     homeDir + "/charms/foo.charm",
+			snapEnv:  snapEnv,
+			wantHint: false,
+		},
+		{
+			// (b) path under /tmp, snap set - confinement hint
+			desc:     "path under /tmp snap set",
+			path:     "/tmp/foo.charm",
+			snapEnv:  snapEnv,
+			wantHint: true,
+		},
+		{
+			// (c) path under /tmp, snap NOT set - no hint
+			desc:     "path under /tmp snap not set",
+			path:     "/tmp/foo.charm",
+			snapEnv:  "",
+			wantHint: false,
+		},
+		{
+			// (d) charmhub-style name (no '/') - no hint
+			desc:     "charmhub name no slash",
+			path:     "mysql",
+			snapEnv:  snapEnv,
+			wantHint: false,
+		},
+		{
+			// (e) path under /mnt, snap set - confinement hint
+			desc:     "path under /mnt snap set",
+			path:     "/mnt/usb/foo.charm",
+			snapEnv:  snapEnv,
+			wantHint: true,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Logf("case: %s", tt.desc)
+		hint := utils.SnapConfinementHint(tt.path, tt.snapEnv, snapRealHome, homeDir)
+		if tt.wantHint {
+			c.Check(hint, gc.Not(gc.Equals), "",
+				gc.Commentf("expected hint for path %q", tt.path))
+			c.Check(strings.Contains(hint, tt.path), gc.Equals, true,
+				gc.Commentf("hint should contain the path %q", tt.path))
+		} else {
+			c.Check(hint, gc.Equals, "",
+				gc.Commentf("expected no hint for path %q", tt.path))
+		}
+	}
+}

--- a/cmd/juju/application/utils/snap_hint_test.go
+++ b/cmd/juju/application/utils/snap_hint_test.go
@@ -5,28 +5,35 @@ package utils_test
 
 import (
 	"strings"
+	"testing"
 
-	gc "gopkg.in/check.v1"
+	"github.com/juju/tc"
 
 	"github.com/juju/juju/cmd/juju/application/utils"
 )
 
 type snapHintSuite struct{}
 
-var _ = gc.Suite(&snapHintSuite{})
+func TestSnapConfinementHintSuite(t *testing.T) {
+	tc.Run(t, &snapHintSuite{})
+}
 
-func (s *snapHintSuite) TestSnapConfinementHint(c *gc.C) {
+func (s *snapHintSuite) TestSnapConfinementHint(c *tc.C) {
 	const (
-		snapEnv      = "/snap/juju/current"
-		snapRealHome = "/home/user"
-		homeDir      = "/home/user"
+		snapEnv        = "/snap/juju/current"
+		snapRealHome   = "/home/user"
+		homeDir        = "/home/user"
+		snapUserData   = "/home/user/snap/juju/current"
+		snapUserCommon = "/home/user/snap/juju/common"
 	)
 
 	tests := []struct {
-		desc     string
-		path     string
-		snapEnv  string
-		wantHint bool
+		desc           string
+		path           string
+		snapEnv        string
+		snapUserData   string
+		snapUserCommon string
+		wantHint       bool
 	}{
 		{
 			// (a) path under HOME, snap set - genuine not-found, no hint
@@ -63,19 +70,35 @@ func (s *snapHintSuite) TestSnapConfinementHint(c *gc.C) {
 			snapEnv:  snapEnv,
 			wantHint: true,
 		},
+		{
+			// (f) path under $SNAP_USER_DATA, snap set - no hint
+			desc:         "path under SNAP_USER_DATA snap set",
+			path:         snapUserData + "/foo.charm",
+			snapEnv:      snapEnv,
+			snapUserData: snapUserData,
+			wantHint:     false,
+		},
+		{
+			// (g) path under $SNAP_USER_COMMON, snap set - no hint
+			desc:           "path under SNAP_USER_COMMON snap set",
+			path:           snapUserCommon + "/foo.charm",
+			snapEnv:        snapEnv,
+			snapUserCommon: snapUserCommon,
+			wantHint:       false,
+		},
 	}
 
 	for _, tt := range tests {
 		c.Logf("case: %s", tt.desc)
-		hint := utils.SnapConfinementHint(tt.path, tt.snapEnv, snapRealHome, homeDir)
+		hint := utils.SnapConfinementHint(tt.path, tt.snapEnv, snapRealHome, homeDir, tt.snapUserData, tt.snapUserCommon)
 		if tt.wantHint {
-			c.Check(hint, gc.Not(gc.Equals), "",
-				gc.Commentf("expected hint for path %q", tt.path))
-			c.Check(strings.Contains(hint, tt.path), gc.Equals, true,
-				gc.Commentf("hint should contain the path %q", tt.path))
+			c.Check(hint, tc.Not(tc.Equals), "",
+				tc.Commentf("expected hint for path %q", tt.path))
+			c.Check(strings.Contains(hint, tt.path), tc.Equals, true,
+				tc.Commentf("hint should contain the path %q", tt.path))
 		} else {
-			c.Check(hint, gc.Equals, "",
-				gc.Commentf("expected no hint for path %q", tt.path))
+			c.Check(hint, tc.Equals, "",
+				tc.Commentf("expected no hint for path %q", tt.path))
 		}
 	}
 }

--- a/cmd/juju/application/utils/snap_hint_test.go
+++ b/cmd/juju/application/utils/snap_hint_test.go
@@ -4,9 +4,11 @@
 package utils_test
 
 import (
-	"strings"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/juju/errors"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/cmd/juju/application/utils"
@@ -21,84 +23,246 @@ func TestSnapConfinementHintSuite(t *testing.T) {
 func (s *snapHintSuite) TestSnapConfinementHint(c *tc.C) {
 	const (
 		snapEnv        = "/snap/juju/current"
-		snapRealHome   = "/home/user"
 		homeDir        = "/home/user"
 		snapUserData   = "/home/user/snap/juju/current"
 		snapUserCommon = "/home/user/snap/juju/common"
 	)
 
+	// Each case spells out the whole environment rather than relying on shared
+	// defaults, so that cases which deliberately leave a root unset (e.g. HOME
+	// unset, or every root unset) are readable at a glance.
 	tests := []struct {
-		desc           string
-		path           string
-		snapEnv        string
-		snapUserData   string
-		snapUserCommon string
-		wantHint       bool
+		desc     string
+		path     string
+		env      utils.SnapEnv
+		wantHint bool
 	}{
 		{
 			// (a) path under HOME, snap set - genuine not-found, no hint
 			desc:     "path under HOME snap set",
 			path:     homeDir + "/charms/foo.charm",
-			snapEnv:  snapEnv,
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir, Home: homeDir},
 			wantHint: false,
 		},
 		{
 			// (b) path under /tmp, snap set - confinement hint
 			desc:     "path under /tmp snap set",
 			path:     "/tmp/foo.charm",
-			snapEnv:  snapEnv,
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir, Home: homeDir},
 			wantHint: true,
 		},
 		{
 			// (c) path under /tmp, snap NOT set - no hint
 			desc:     "path under /tmp snap not set",
 			path:     "/tmp/foo.charm",
-			snapEnv:  "",
+			env:      utils.SnapEnv{RealHome: homeDir, Home: homeDir},
 			wantHint: false,
 		},
 		{
 			// (d) charmhub-style name (no '/') - no hint
 			desc:     "charmhub name no slash",
 			path:     "mysql",
-			snapEnv:  snapEnv,
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir, Home: homeDir},
 			wantHint: false,
 		},
 		{
 			// (e) path under /mnt, snap set - confinement hint
 			desc:     "path under /mnt snap set",
 			path:     "/mnt/usb/foo.charm",
-			snapEnv:  snapEnv,
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir, Home: homeDir},
 			wantHint: true,
 		},
 		{
-			// (f) path under $SNAP_USER_DATA, snap set - no hint
-			desc:         "path under SNAP_USER_DATA snap set",
-			path:         snapUserData + "/foo.charm",
-			snapEnv:      snapEnv,
-			snapUserData: snapUserData,
-			wantHint:     false,
+			// (f) tilde path, snap set - the shell would have expanded this to
+			// the real home, so no hint
+			desc:     "tilde path snap set",
+			path:     "~/foo.charm",
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir, Home: homeDir},
+			wantHint: false,
 		},
 		{
-			// (g) path under $SNAP_USER_COMMON, snap set - no hint
-			desc:           "path under SNAP_USER_COMMON snap set",
-			path:           snapUserCommon + "/foo.charm",
-			snapEnv:        snapEnv,
-			snapUserCommon: snapUserCommon,
-			wantHint:       false,
+			// (g) bare tilde, snap set - no hint (and no '/' either)
+			desc:     "bare tilde snap set",
+			path:     "~",
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir, Home: homeDir},
+			wantHint: false,
+		},
+		{
+			// (h) path under $SNAP_USER_DATA, snap set - no hint
+			desc:     "path under SNAP_USER_DATA snap set",
+			path:     snapUserData + "/foo.charm",
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir, Home: homeDir, UserData: snapUserData},
+			wantHint: false,
+		},
+		{
+			// (i) path under $SNAP_USER_COMMON, snap set - no hint
+			desc:     "path under SNAP_USER_COMMON snap set",
+			path:     snapUserCommon + "/foo.charm",
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir, Home: homeDir, UserCommon: snapUserCommon},
+			wantHint: false,
+		},
+		{
+			// (j) $SNAP_REAL_HOME allowlists on its own, with HOME unset
+			desc:     "path under SNAP_REAL_HOME with HOME unset",
+			path:     homeDir + "/charms/foo.charm",
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir},
+			wantHint: false,
+		},
+		{
+			// (k) path equal to a root, rather than under it. A root is only
+			// reachable via a separator, so this is treated as unreachable.
+			desc:     "path equal to HOME",
+			path:     homeDir,
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir, Home: homeDir},
+			wantHint: true,
+		},
+		{
+			// (l) every root unset - nothing is reachable, so the hint fires
+			desc:     "all roots unset",
+			path:     "/tmp/foo.charm",
+			env:      utils.SnapEnv{Snap: snapEnv},
+			wantHint: true,
+		},
+		{
+			// (m) trailing separator - cleaned before the root comparison, so
+			// it behaves the same as (b)
+			desc:     "unreachable path with trailing separator",
+			path:     "/tmp/foo.charm/",
+			env:      utils.SnapEnv{Snap: snapEnv, RealHome: homeDir, Home: homeDir},
+			wantHint: true,
 		},
 	}
 
 	for _, tt := range tests {
 		c.Logf("case: %s", tt.desc)
-		hint := utils.SnapConfinementHint(tt.path, tt.snapEnv, snapRealHome, homeDir, tt.snapUserData, tt.snapUserCommon)
+		hint := utils.SnapConfinementHint(tt.path, tt.env)
 		if tt.wantHint {
 			c.Check(hint, tc.Not(tc.Equals), "",
 				tc.Commentf("expected hint for path %q", tt.path))
-			c.Check(strings.Contains(hint, tt.path), tc.Equals, true,
+			c.Check(hint, tc.Contains, tt.path,
 				tc.Commentf("hint should contain the path %q", tt.path))
 		} else {
 			c.Check(hint, tc.Equals, "",
 				tc.Commentf("expected no hint for path %q", tt.path))
 		}
 	}
+}
+
+// TestSnapConfinementHintRelativePaths checks that a relative path is resolved
+// against the working directory before being compared with the snap's
+// reachable roots, so that "./foo.charm" is judged by where the user actually
+// is rather than by the literal string.
+func (s *snapHintSuite) TestSnapConfinementHintRelativePaths(c *tc.C) {
+	home := c.MkDir()
+	sub := filepath.Join(home, "charms")
+	c.Assert(os.Mkdir(sub, 0700), tc.ErrorIsNil)
+
+	// From a directory under HOME, "./foo.charm" resolves to a reachable path.
+	c.Chdir(sub)
+	env := utils.SnapEnv{Snap: "/snap/juju/current", Home: home}
+	c.Check(utils.SnapConfinementHint("./foo.charm", env), tc.Equals, "")
+
+	// "../foo.charm" from that same directory is still under HOME.
+	c.Check(utils.SnapConfinementHint("../foo.charm", env), tc.Equals, "")
+
+	// From the same directory, but with HOME elsewhere, the relative path is
+	// unreachable and the hint fires.
+	elsewhere := utils.SnapEnv{Snap: "/snap/juju/current", Home: c.MkDir()}
+	c.Check(utils.SnapConfinementHint("./foo.charm", elsewhere), tc.Not(tc.Equals), "")
+}
+
+// TestSnapConfinementHintMessage locks down the exact wording of the hint, so
+// that a stray whitespace or wording change is caught here rather than in a
+// user's terminal.
+func (s *snapHintSuite) TestSnapConfinementHintMessage(c *tc.C) {
+	hint := utils.SnapConfinementHint("/tmp/foo.charm", utils.SnapEnv{
+		Snap: "/snap/juju/current",
+		Home: "/home/user",
+	})
+	c.Check(hint, tc.Equals, `
+
+The Juju snap is strictly confined and cannot access files outside your home
+directory. Move the file into your home directory and try again, for example:
+
+    cp /tmp/foo.charm ~/`)
+}
+
+// TestSnapConfinementHintQuotesPaths checks that the suggested cp command is
+// safe to paste into a shell: a plain path is left unquoted for readability,
+// while a path containing whitespace, shell metacharacters or a single quote is
+// quoted so the shell treats it as one literal word.
+func (s *snapHintSuite) TestSnapConfinementHintQuotesPaths(c *tc.C) {
+	tests := []struct {
+		desc string
+		path string
+		want string
+	}{{
+		desc: "plain path left unquoted",
+		path: "/tmp/foo.charm",
+		want: "    cp /tmp/foo.charm ~/",
+	}, {
+		desc: "path with a space is quoted",
+		path: "/tmp/my charm.charm",
+		want: "    cp '/tmp/my charm.charm' ~/",
+	}, {
+		desc: "shell metacharacters are not expanded",
+		path: "/tmp/a$b`c.charm",
+		want: "    cp '/tmp/a$b`c.charm' ~/",
+	}, {
+		desc: "embedded single quote is escaped",
+		path: "/tmp/it's.charm",
+		want: `    cp '/tmp/it'\''s.charm' ~/`,
+	}}
+
+	for _, tt := range tests {
+		c.Logf("case: %s", tt.desc)
+		hint := utils.SnapConfinementHint(tt.path, utils.SnapEnv{
+			Snap:     "/snap/juju/current",
+			RealHome: "/home/user",
+			Home:     "/home/user",
+		})
+		c.Check(hint, tc.HasSuffix, tt.want)
+	}
+}
+
+// TestAnnotateWithSnapHintAppendsHint checks that the hint is appended after
+// the original message (rather than prefixed, as a juju/errors annotation
+// would be) and that the error's cause and wrap chain survive, so callers can
+// still classify the failure.
+func (s *snapHintSuite) TestAnnotateWithSnapHintAppendsHint(c *tc.C) {
+	c.Setenv("SNAP", "/snap/juju/current")
+	c.Setenv("HOME", "/home/user")
+	c.Setenv("SNAP_REAL_HOME", "")
+	c.Setenv("SNAP_USER_DATA", "")
+	c.Setenv("SNAP_USER_COMMON", "")
+
+	cause := errors.Annotatef(os.ErrNotExist, "file for resource %q", "foo")
+	err := utils.AnnotateWithSnapHint(cause, "/tmp/foo.charm")
+
+	c.Check(err.Error(), tc.Equals, `file for resource "foo": file does not exist
+
+The Juju snap is strictly confined and cannot access files outside your home
+directory. Move the file into your home directory and try again, for example:
+
+    cp /tmp/foo.charm ~/`)
+	c.Check(err.Error(), tc.HasPrefix, cause.Error(),
+		tc.Commentf("hint should be appended, not prefixed"))
+	c.Check(os.IsNotExist(errors.Cause(err)), tc.Equals, true)
+	c.Check(errors.Is(err, os.ErrNotExist), tc.Equals, true)
+}
+
+// TestAnnotateWithSnapHintNoHint checks that when no hint applies the error is
+// returned untouched, so no call site pays for the check.
+func (s *snapHintSuite) TestAnnotateWithSnapHintNoHint(c *tc.C) {
+	c.Setenv("SNAP", "")
+
+	cause := errors.Annotatef(os.ErrNotExist, "file for resource %q", "foo")
+	c.Check(utils.AnnotateWithSnapHint(cause, "/tmp/foo.charm"), tc.Equals, cause)
+}
+
+// TestAnnotateWithSnapHintNilError checks the nil-in, nil-out contract shared
+// by the juju/errors annotate helpers.
+func (s *snapHintSuite) TestAnnotateWithSnapHintNilError(c *tc.C) {
+	c.Setenv("SNAP", "/snap/juju/current")
+	c.Check(utils.AnnotateWithSnapHint(nil, "/tmp/foo.charm"), tc.IsNil)
 }

--- a/cmd/juju/resource/deploy.go
+++ b/cmd/juju/resource/deploy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 
 	apiresources "github.com/juju/juju/api/client/resources"
+	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/modelcmd"
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
 )
@@ -117,6 +118,9 @@ func (d deployUploader) upload(ctx context.Context, resourceValues map[string]st
 	for name, resValue := range resourceValues {
 		r, err := OpenResource(resValue, d.resources[name].Type, d.filesystem.Open)
 		if err != nil {
+			if d.resources[name].Type == charmresource.TypeFile {
+				err = utils.AnnotateWithSnapHint(err, resValue)
+			}
 			return nil, errors.Annotatef(err, "resource %q", name)
 		}
 		id, err := d.uploadPendingResource(ctx, name, resValue, r)

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -14,6 +14,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/cmd"
 	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/modelcmd"
 	coreresources "github.com/juju/juju/core/resource"
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
@@ -179,6 +180,11 @@ func (c *UploadCommand) Run(ctx *cmd.Context) error {
 func (c *UploadCommand) upload(ctx context.Context, rf resourceValue, client UploadClient) error {
 	f, err := OpenResource(rf.value, rf.resourceType, c.Filesystem().Open)
 	if err != nil {
+		if rf.resourceType == charmresource.TypeFile {
+			if hint := utils.SnapConfinementHintFromEnv(rf.value); hint != "" {
+				return errors.Errorf("%s%s", err.Error(), hint)
+			}
+		}
 		return errors.Trace(err)
 	}
 	defer f.Close()

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -13,8 +13,8 @@ import (
 	"github.com/juju/juju/api/client/resources"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/cmd"
-	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/juju/application/utils"
+	"github.com/juju/juju/cmd/juju/block"
 	"github.com/juju/juju/cmd/modelcmd"
 	coreresources "github.com/juju/juju/core/resource"
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
@@ -181,9 +181,7 @@ func (c *UploadCommand) upload(ctx context.Context, rf resourceValue, client Upl
 	f, err := OpenResource(rf.value, rf.resourceType, c.Filesystem().Open)
 	if err != nil {
 		if rf.resourceType == charmresource.TypeFile {
-			if hint := utils.SnapConfinementHintFromEnv(rf.value); hint != "" {
-				return errors.Errorf("%s%s", err.Error(), hint)
-			}
+			err = utils.AnnotateWithSnapHint(err, rf.value)
 		}
 		return errors.Trace(err)
 	}

--- a/cmd/juju/resource/validation.go
+++ b/cmd/juju/resource/validation.go
@@ -71,6 +71,12 @@ func ValidateResourceDetails(res map[string]string, resMeta map[string]charmreso
 		switch resMeta[name].Type {
 		case charmresource.TypeFile:
 			err = utils.CheckFile(name, value, fs)
+			if err != nil {
+				if hint := utils.SnapConfinementHintFromEnv(value); hint != "" {
+					return errors.Errorf("%s%s", err.Error(), hint)
+				}
+				return err
+			}
 		case charmresource.TypeContainerImage:
 			var dockerDetails docker.DockerImageDetails
 			dockerDetails, err = getDockerDetailsData(value, fs.Open)

--- a/cmd/juju/resource/validation.go
+++ b/cmd/juju/resource/validation.go
@@ -72,6 +72,12 @@ func ValidateResourceDetails(res map[string]string, resMeta map[string]charmreso
 		switch resMeta[name].Type {
 		case charmresource.TypeFile:
 			err = utils.CheckFile(name, value, fs)
+			if err != nil {
+				if hint := utils.SnapConfinementHintFromEnv(value); hint != "" {
+					return errors.Errorf("%s%s", err.Error(), hint)
+				}
+				return err
+			}
 		case charmresource.TypeContainerImage:
 			_, err := getDockerDetailsData(value, fs.Open)
 			if err != nil {

--- a/cmd/juju/resource/validation.go
+++ b/cmd/juju/resource/validation.go
@@ -73,10 +73,7 @@ func ValidateResourceDetails(res map[string]string, resMeta map[string]charmreso
 		case charmresource.TypeFile:
 			err = utils.CheckFile(name, value, fs)
 			if err != nil {
-				if hint := utils.SnapConfinementHintFromEnv(value); hint != "" {
-					return errors.Errorf("%s%s", err.Error(), hint)
-				}
-				return err
+				return utils.AnnotateWithSnapHint(err, value)
 			}
 		case charmresource.TypeContainerImage:
 			_, err := getDockerDetailsData(value, fs.Open)


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

When a user attempts to deploy a local charm or resource using the strictly confined snap, and the charm or resource is outside of the filesystem areas the snap has permission to access (`/tmp/` is common for beginners) Juju tells the user that the file does not exist. This is confusing, since the file *does* exist, it is just not visible to Juju. This PR changes the error message in that case to be clearer about what is (probably) happening, and suggests a solution.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

I haven't added integration tests. I wasn't sure if that was appropriate for a change like this. Let me know if they should be, and I can do that.

## QA steps

<!--

Describe steps to verify that the change works.

-->

1. Build the snap.
2. Bootstrap a model.
3. Create or download a charm, in `/tmp/`.
4. Run `juju deploy /tmp/path-to-charm/mycharm.charm` 
5. Observe that the error message is clearer than with current 4.0 Juju

Repeat with using a resource outside of confinement. Verify that deploying and using resources within the confined area does still work.

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

No documentation changes, this is essentially a documentation improvement.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** originally on [LP](https://bugs.launchpad.net/bugs/2078312), not migrated to GitHub as far as I know.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
