### PR TITLE
test: avoid introspection shutdown log race

### DIFF
--- a/agent/addons/addons.go
+++ b/agent/addons/addons.go
@@ -72,10 +72,8 @@ func StartIntrospection(cfg IntrospectionConfig) error {
 	}
 	go func() {
 		_ = cfg.Engine.Wait()
-		cfg.Logger.Debugf(context.TODO(), "engine stopped, stopping introspection")
 		w.Kill()
 		_ = w.Wait()
-		cfg.Logger.Debugf(context.TODO(), "introspection stopped")
 	}()
 
 	return nil


### PR DESCRIPTION
Fixed the flaky race in agent/addons/addons.go.

Cause:
- StartIntrospection starts a background goroutine tied to engine shutdown.
- That goroutine emitted two Debugf calls after cfg.Engine.Wait().
- In tests, cfg.Logger is often loggertesting.WrapCheckLog(c), which ultimately
logs through testing.T / tc.C.
- During test teardown, those async log calls can race with testing’s internal
teardown state, which matches the CI stack trace.

Change:
- Removed the two non-essential debug logs from the shutdown goroutine in
agent/addons/addons.go.
- The goroutine still waits for the engine, kills the introspection worker, and
waits for it to stop, so behavior is unchanged aside from dropping diagnostic
logging on that async path.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
```sh
go test -race -c ./internal/worker/deployer
go install golang.org/x/tools/cmd/stress@latest
stress ./deployer.test # This can reproduce the data race but might need to wait until ~10000 iterations.
```

## Documentation changes


## Links

**Issue:** Fixes #22331

**Jira card:** [JUJU-9811](https://warthogs.atlassian.net/browse/JUJU-9811)


[JUJU-9811]: https://warthogs.atlassian.net/browse/JUJU-9811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ