### PR TITLE
docs: extend secret lifecycle section to cover user-secret lifecycle

### DIFF
--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -418,6 +418,8 @@ Thereafter, any subsequent `secret-changed` hooks will be run with this label.
 
 All units observing the affected secret.
 
+For a {ref}`user secret <user-secret>`, `secret-changed` is the **only** secret hook an observer ever receives. It fires when the user updates the secret content with `juju update-secret`. The `juju grant-secret` command does **not** fire a hook; the secret only becomes observable after the user also configures the application with the secret URI (which triggers `config-changed`). User secrets have no rotate, expire, or remove lifecycle.
+
 ```{note}
 Upon receiving that event (or at any time after that) a consumer can choose to:
 

--- a/docs/reference/secret.md
+++ b/docs/reference/secret.md
@@ -214,7 +214,7 @@ Charms that create secrets should _always_ handle the `secret-remove` event. Tha
 
 A user secret has a simpler lifecycle than a charm secret:
 
-1. **Create**: A model admin creates the secret: `juju add-secret <name> <key>=<value>`
+1. **Create**: A model admin creates the secret: `juju add-secret <name> <key>=<value>`.
 2. **Grant**: The admin grants access to an application: `juju grant-secret <name> <app-name>` — this does **not** fire a hook on the observing charm.
 3. **Configure**: The admin sets the application's configuration option to the secret URI: `juju config <app-name> <option>=<secret-uri>` — this triggers a `config-changed` hook on the observing charm.
 4. **Update**: The admin updates the secret content: `juju update-secret <name> <key>=<new-value>` — this triggers `secret-changed` on all observing units.

--- a/docs/reference/secret.md
+++ b/docs/reference/secret.md
@@ -178,9 +178,7 @@ An entity that does not own the secret can only **view** it (call `secret-get`),
 
 ## Secret lifecycle
 
-```{important}
-This section currently covers only the lifecycle of a charm secret.
-```
+### Charm-secret lifecycle
 
 Charms can use relations to share secrets, such as API keys, a database's address, credentials and so on. Like a relation has a "provider" and a "requirer", so a secret has an "owner" and an "observer" -- though these need not coincide with the applications' roles in the relation.
 
@@ -211,4 +209,17 @@ Juju maintains a list of which observers are tracking each revision of each secr
 Charms that create secrets should _always_ handle the `secret-remove` event. That is because secret revisions, even if obsolete, remain until removed by the charm; if a charm does not remove them, they accumulate indefinitely.
 
 ```
+
+### User-secret lifecycle
+
+A user secret has a simpler lifecycle than a charm secret:
+
+1. **Create**: A model admin creates the secret: `juju add-secret <name> <key>=<value>`
+2. **Grant**: The admin grants access to an application: `juju grant-secret <name> <app-name>` — this does **not** fire a hook on the observing charm.
+3. **Configure**: The admin sets the application's configuration option to the secret URI: `juju config <app-name> <option>=<secret-uri>` — this triggers a `config-changed` hook on the observing charm.
+4. **Update**: The admin updates the secret content: `juju update-secret <name> <key>=<new-value>` — this triggers `secret-changed` on all observing units.
+
+The **only hook** a user-secret observer receives is `secret-changed`. There is no `secret-rotate`, `secret-expired`, or `secret-remove` lifecycle for user secrets.
+
+> See also: {ref}`hook-secret-changed`, {ref}`manage-secrets`
 

--- a/docs/reference/secret.md
+++ b/docs/reference/secret.md
@@ -212,7 +212,7 @@ Charms that create secrets should _always_ handle the `secret-remove` event. Tha
 
 ### User-secret lifecycle
 
-A user secret has a simpler lifecycle than a charm secret:
+A user secret's lifecycle consists of:
 
 1. **Create**: A model admin creates the secret: `juju add-secret <name> <key>=<value>`.
 2. **Grant**: The admin grants access to an application: `juju grant-secret <name> <app-name>` — this does **not** fire a hook on the observing charm.


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

The secret lifecycle docs currently only cover charm-owned secrets. This PR adds a small extension to include user secrets.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

-->

Build the docs, read the changed pages.

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

Doc-only change.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** #18892.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
