### PR TITLE
feat: tla+ spec for object store state machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ dqlite-deps.tar.bz2
 .direnv/
 .codex
 .workshop.lock
+*.bin
+.cache

--- a/core/objectstore/phase.go
+++ b/core/objectstore/phase.go
@@ -9,6 +9,10 @@ const (
 	// ErrTerminalPhase is the error returned when the object store is already
 	// in a terminal phase.
 	ErrTerminalPhase = errors.ConstError("object store is already in a terminal phase")
+
+	// ErrInvalidTransition is the error returned when the transition from the
+	// current phase to the new phase is not allowed.
+	ErrInvalidTransition = errors.ConstError("invalid transition from current phase to new phase")
 )
 
 // Phase is the type to identify the phase of the object store.
@@ -84,7 +88,7 @@ func (p Phase) TransitionTo(newPhase Phase) (Phase, error) {
 			return p, ErrTerminalPhase
 		}
 	}
-	return "", errors.Errorf("invalid transition from %q to %q", p, newPhase)
+	return "", errors.Errorf("invalid transition from %q to %q", p, newPhase).Add(ErrInvalidTransition)
 }
 
 // IsValid returns true if the phase is a valid phase.

--- a/core/objectstore/phase_tla_test.go
+++ b/core/objectstore/phase_tla_test.go
@@ -1,0 +1,335 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package objectstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/juju/tc"
+)
+
+var tlaQuotedStringRe = regexp.MustCompile(`"([^"]+)"`)
+
+func (s *phaseSuite) TestTLASpecMatchesGo(c *tc.C) {
+	specPath := filepath.Join("tla", "ObjectStoreTransitionPhases.tla")
+	specBytes, err := os.ReadFile(specPath)
+	c.Assert(err, tc.ErrorIsNil)
+	spec := string(specBytes)
+
+	tlaPhases, err := parseTLANamedSet(spec, "Phases")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(tlaPhases, tc.DeepEquals, allPhaseNames())
+
+	initialPhase, err := parseTLANamedString(spec, "InitialPhase")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(initialPhase, tc.Equals, PhaseUnknown.String())
+
+	tlaTransitions, err := parseTLATransitions(spec)
+	c.Assert(err, tc.ErrorIsNil)
+	goTransitions, err := goTransitionNames()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(tlaTransitions, tc.DeepEquals, goTransitions)
+
+	c.Check(
+		terminalPhasesFromTransitions(tlaPhases, tlaTransitions),
+		tc.DeepEquals,
+		goTerminalPhaseNames(),
+	)
+
+	tlaNotStarted, err := parseTLANamedSet(spec, "NotStartedPhases")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(tlaNotStarted, tc.DeepEquals, goNotStartedPhaseNames())
+
+	tlaDraining, err := parseTLANamedSet(spec, "DrainingPhases")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(tlaDraining, tc.DeepEquals, goDrainingPhaseNames())
+
+	maxTransitions, err := parseTLANamedInt(spec, "MaxTransitions")
+	c.Assert(err, tc.ErrorIsNil)
+	longestPath, err := longestTransitionPath(PhaseUnknown.String(), goTransitions)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(maxTransitions, tc.Equals, longestPath)
+}
+
+func (s *phaseSuite) TestTLAConfigMatchesExpectedChecks(c *tc.C) {
+	cfgPath := filepath.Join("tla", "ObjectStoreTransitionPhases.cfg")
+	cfgBytes, err := os.ReadFile(cfgPath)
+	c.Assert(err, tc.ErrorIsNil)
+
+	cfg, err := parseTLAConfig(string(cfgBytes))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cfg.specification, tc.Equals, "Spec")
+	c.Check(cfg.invariants, tc.DeepEquals, []string{
+		"TypeInvariant",
+		"StepBoundInvariant",
+	})
+	c.Check(cfg.properties, tc.DeepEquals, []string{
+		"TransitionSafety",
+		"EventuallyTerminal",
+	})
+}
+
+func parseTLANamedSet(spec, name string) ([]string, error) {
+	pattern := regexp.MustCompile(
+		fmt.Sprintf(`(?ms)\b%s\s*==\s*\{([^}]*)\}`, regexp.QuoteMeta(name)),
+	)
+	matches := pattern.FindStringSubmatch(spec)
+	if len(matches) != 2 {
+		return nil, fmt.Errorf("%s set definition not found", name)
+	}
+	return sortedUniqueStrings(parseQuotedStrings(matches[1])), nil
+}
+
+func parseTLANamedString(spec, name string) (string, error) {
+	pattern := regexp.MustCompile(
+		fmt.Sprintf(`(?m)\b%s\s*==\s*"([^"]+)"`, regexp.QuoteMeta(name)),
+	)
+	matches := pattern.FindStringSubmatch(spec)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("%s string definition not found", name)
+	}
+	return matches[1], nil
+}
+
+func parseTLANamedInt(spec, name string) (int, error) {
+	pattern := regexp.MustCompile(
+		fmt.Sprintf(`(?m)\b%s\s*==\s*(\d+)`, regexp.QuoteMeta(name)),
+	)
+	matches := pattern.FindStringSubmatch(spec)
+	if len(matches) != 2 {
+		return 0, fmt.Errorf("%s integer definition not found", name)
+	}
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("parsing %s: %w", name, err)
+	}
+	return value, nil
+}
+
+func parseTLATransitions(spec string) (map[string][]string, error) {
+	const transitionPattern = `(?m)p\s*=\s*"([^"]+)"\s*->\s*\{([^}]*)\}`
+	matches := regexp.MustCompile(transitionPattern).FindAllStringSubmatch(spec, -1)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("transition definitions not found")
+	}
+
+	transitions := make(map[string][]string, len(matches))
+	for _, match := range matches {
+		source := match[1]
+		if _, exists := transitions[source]; exists {
+			return nil, fmt.Errorf("duplicate transition definition for %q", source)
+		}
+		transitions[source] = sortedUniqueStrings(parseQuotedStrings(match[2]))
+	}
+	return transitions, nil
+}
+
+func parseQuotedStrings(value string) []string {
+	matches := tlaQuotedStringRe.FindAllStringSubmatch(value, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	result := make([]string, 0, len(matches))
+	for _, match := range matches {
+		result = append(result, match[1])
+	}
+	return result
+}
+
+func parseTLAConfig(cfgText string) (tlaConfig, error) {
+	cfg := tlaConfig{}
+	section := ""
+
+	for _, raw := range strings.Split(cfgText, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, `\*`) {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, "SPECIFICATION "):
+			fields := strings.Fields(line)
+			if len(fields) != 2 {
+				return tlaConfig{}, fmt.Errorf("invalid specification line %q", line)
+			}
+			cfg.specification = fields[1]
+			section = ""
+		case line == "INVARIANTS":
+			section = "invariants"
+		case line == "PROPERTIES":
+			section = "properties"
+		default:
+			switch section {
+			case "invariants":
+				cfg.invariants = append(cfg.invariants, line)
+			case "properties":
+				cfg.properties = append(cfg.properties, line)
+			default:
+				return tlaConfig{}, fmt.Errorf("unexpected config line %q", line)
+			}
+		}
+	}
+
+	if cfg.specification == "" {
+		return tlaConfig{}, fmt.Errorf("missing specification")
+	}
+	return cfg, nil
+}
+
+func goTransitionNames() (map[string][]string, error) {
+	transitions := make(map[string][]string)
+	phases := allPhases()
+
+	for _, source := range phases {
+		var allowed []string
+		for _, target := range phases {
+			newPhase, err := source.TransitionTo(target)
+			switch {
+			case err == nil:
+				candidate := newPhase.String()
+				if candidate == "" {
+					candidate = target.String()
+				}
+				allowed = append(allowed, candidate)
+			case errors.Is(err, ErrInvalidTransition), errors.Is(err, ErrTerminalPhase):
+				continue
+			default:
+				return nil, err
+			}
+		}
+		if len(allowed) == 0 {
+			continue
+		}
+		transitions[source.String()] = sortedUniqueStrings(allowed)
+	}
+	return transitions, nil
+}
+
+func terminalPhasesFromTransitions(phases []string, transitions map[string][]string) []string {
+	var terminals []string
+	for _, phase := range phases {
+		if len(transitions[phase]) == 0 {
+			terminals = append(terminals, phase)
+		}
+	}
+	return sortedUniqueStrings(terminals)
+}
+
+func goTerminalPhaseNames() []string {
+	var phases []string
+	for _, phase := range allPhases() {
+		if phase.IsTerminal() {
+			phases = append(phases, phase.String())
+		}
+	}
+	return sortedUniqueStrings(phases)
+}
+
+func goNotStartedPhaseNames() []string {
+	var phases []string
+	for _, phase := range allPhases() {
+		if phase.IsNotStarted() {
+			phases = append(phases, phase.String())
+		}
+	}
+	return sortedUniqueStrings(phases)
+}
+
+func goDrainingPhaseNames() []string {
+	var phases []string
+	for _, phase := range allPhases() {
+		if phase.IsDraining() {
+			phases = append(phases, phase.String())
+		}
+	}
+	return sortedUniqueStrings(phases)
+}
+
+func allPhases() []Phase {
+	return []Phase{
+		PhaseUnknown,
+		PhaseDraining,
+		PhaseError,
+		PhaseCompleted,
+	}
+}
+
+func allPhaseNames() []string {
+	names := make([]string, 0, len(allPhases()))
+	for _, phase := range allPhases() {
+		names = append(names, phase.String())
+	}
+	return sortedUniqueStrings(names)
+}
+
+func longestTransitionPath(start string, transitions map[string][]string) (int, error) {
+	memo := make(map[string]int)
+	visiting := make(map[string]struct{})
+
+	var dfs func(string) (int, error)
+	dfs = func(phase string) (int, error) {
+		if depth, exists := memo[phase]; exists {
+			return depth, nil
+		}
+		if _, exists := visiting[phase]; exists {
+			return 0, fmt.Errorf("cycle detected at phase %q", phase)
+		}
+		visiting[phase] = struct{}{}
+		defer delete(visiting, phase)
+
+		targets := transitions[phase]
+		if len(targets) == 0 {
+			return 0, nil
+		}
+
+		maxDepth := 0
+		for _, target := range targets {
+			depth, err := dfs(target)
+			if err != nil {
+				return 0, err
+			}
+			depth++
+			if depth > maxDepth {
+				maxDepth = depth
+			}
+		}
+
+		memo[phase] = maxDepth
+		return maxDepth, nil
+	}
+
+	return dfs(start)
+}
+
+func sortedUniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	unique := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		unique[value] = struct{}{}
+	}
+
+	result := make([]string, 0, len(unique))
+	for value := range unique {
+		result = append(result, value)
+	}
+	slices.Sort(result)
+	return result
+}
+
+type tlaConfig struct {
+	specification string
+	invariants    []string
+	properties    []string
+}

--- a/core/objectstore/phase_tla_test.go
+++ b/core/objectstore/phase_tla_test.go
@@ -149,7 +149,7 @@ func parseTLAConfig(cfgText string) (tlaConfig, error) {
 	cfg := tlaConfig{}
 	section := ""
 
-	for _, raw := range strings.Split(cfgText, "\n") {
+	for raw := range strings.SplitSeq(cfgText, "\n") {
 		line := strings.TrimSpace(raw)
 		if line == "" || strings.HasPrefix(line, `\*`) {
 			continue

--- a/core/objectstore/tla/ObjectStoreTransitionPhases.cfg
+++ b/core/objectstore/tla/ObjectStoreTransitionPhases.cfg
@@ -1,0 +1,9 @@
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeInvariant
+    StepBoundInvariant
+
+PROPERTIES
+    TransitionSafety
+    EventuallyTerminal

--- a/core/objectstore/tla/ObjectStoreTransitionPhases.tla
+++ b/core/objectstore/tla/ObjectStoreTransitionPhases.tla
@@ -1,0 +1,84 @@
+---- MODULE ObjectStoreTransitionPhases ----
+\* Copyright 2026 Canonical Ltd.
+\* Licensed under the AGPLv3, see LICENCE file for details.
+
+EXTENDS Naturals
+
+\* Model of core/objectstore/phase.go transition behaviour.
+Phases == {"unknown", "draining", "error", "completed"}
+
+InitialPhase == "unknown"
+
+\* Transition relation matching TransitionTo in phase.go.
+AllowedNext ==
+    [p \in Phases |->
+        CASE p = "unknown" -> {"draining"}
+            [] p = "draining" -> {"error", "completed"}
+            [] OTHER -> {}
+    ]
+
+CanTransition(from, to) == to \in AllowedNext[from]
+
+TerminalPhases == {p \in Phases : AllowedNext[p] = {}}
+
+NotStartedPhases == {"unknown"}
+
+DrainingPhases == {"draining"}
+
+\* Longest valid path from InitialPhase has 2 transitions.
+MaxTransitions == 2
+
+VARIABLES phase, steps
+
+vars == <<phase, steps>>
+
+Init ==
+    /\ phase = InitialPhase
+    /\ steps = 0
+
+Advance ==
+    /\ phase \notin TerminalPhases
+    /\ \E next \in AllowedNext[phase]:
+        /\ phase' = next
+        /\ steps' = steps + 1
+
+StayTerminal ==
+    /\ phase \in TerminalPhases
+    /\ UNCHANGED vars
+
+Next == Advance \/ StayTerminal
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(Advance)
+
+TypeInvariant ==
+    /\ phase \in Phases
+    /\ steps \in Nat
+
+ASSUME TerminalPhasesMatchGo ==
+    TerminalPhases = {"error", "completed"}
+
+ASSUME NotStartedPhasesMatchGo ==
+    NotStartedPhases = {"unknown"}
+
+ASSUME DrainingPhasesMatchGo ==
+    DrainingPhases = {"draining"}
+
+ASSUME AllowedTransitionsMatchGo ==
+    /\ AllowedNext["unknown"] = {"draining"}
+    /\ AllowedNext["draining"] = {"error", "completed"}
+    /\ AllowedNext["error"] = {}
+    /\ AllowedNext["completed"] = {}
+
+StepBoundInvariant == steps <= MaxTransitions
+
+TransitionAction ==
+    (phase' = phase) \/ CanTransition(phase, phase')
+
+TransitionSafety == [][TransitionAction]_vars
+
+EventuallyTerminal == <> (phase \in TerminalPhases)
+
+=============================================================================

--- a/internal/worker/lease/manager_cross_test.go
+++ b/internal/worker/lease/manager_cross_test.go
@@ -107,7 +107,10 @@ func (s *CrossSuite) testWaits(c *tc.C, lease1, lease2 corelease.Key) {
 		b1.assertBlocked(c)
 		b2.assertBlocked(c)
 
-		clock.Advance(2 * time.Second)
+		// Simulate the lease store observing the first lease expiry before
+		// the manager processes its scheduled expiry check.
+		delete(fix.leases, lease1)
+		c.Assert(clock.WaitAdvance(2*time.Second, testhelpers.ShortWait, 1), tc.ErrorIsNil)
 
 		err := b1.assertUnblocked(c)
 		c.Assert(err, tc.ErrorIsNil)

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -79,6 +79,7 @@ TEST_NAMES="actions \
             static_analysis \
             storage \
             storage_k8s \
+            tla \
             unmanaged \
             upgrade \
             user"

--- a/tests/suites/tla/task.sh
+++ b/tests/suites/tla/task.sh
@@ -1,0 +1,135 @@
+tla_tools_sha256() {
+	local version
+	version=${1}
+
+	case "${version}" in
+	v1.8.0) echo "71546dff3897a01b0ee4fa64135d9f5e9384d2b7e47b3cc20a16b655b0eb4f86" ;;
+	*)
+		echo "No known sha256 for tla2tools ${version}; set TLA_TOOLS_SHA256" >&2
+		return 1
+		;;
+	esac
+}
+
+verify_tla_tools_sha256() {
+	local file expected_sha got_sha
+
+	file=${1}
+	expected_sha=${2}
+	got_sha=$(sha256sum "${file}" | awk '{print $1}')
+
+	if [ "${got_sha}" != "${expected_sha}" ]; then
+		echo "sha256sum mismatch (${got_sha}, expected ${expected_sha})"
+		return 1
+	fi
+}
+
+download_tla_tools() {
+	local url output version
+
+	url=${1}
+	output=${2}
+	version=${3}
+
+	mkdir -p "$(dirname "${output}")"
+	echo "Downloading TLA+ tools (${version})"
+	curl --fail --location --silent --show-error \
+		"${url}" \
+		--output "${output}"
+}
+
+run_prepare_tla_tools() {
+	local project_dir tla_tools_version tla_tools_dir tla_tools_jar tla_tools_url
+	local expected_tla_tools_sha256
+
+	project_dir=$(pwd)
+
+	tla_tools_version="${TLA_TOOLS_VERSION:-v1.8.0}"
+	tla_tools_dir="${project_dir}/.cache/tla2tools/${tla_tools_version}"
+	tla_tools_jar="${TLC_JAR:-${tla_tools_dir}/tla2tools.jar}"
+	tla_tools_url="https://github.com/tlaplus/tlaplus/releases/download/${tla_tools_version}/tla2tools.jar"
+	expected_tla_tools_sha256="${TLA_TOOLS_SHA256:-$(tla_tools_sha256 "${tla_tools_version}")}"
+
+	if [ ! -f "${tla_tools_jar}" ]; then
+		download_tla_tools "${tla_tools_url}" "${tla_tools_jar}" "${tla_tools_version}"
+	fi
+
+	if ! verify_tla_tools_sha256 "${tla_tools_jar}" "${expected_tla_tools_sha256}"; then
+		rm -f "${tla_tools_jar}"
+		download_tla_tools "${tla_tools_url}" "${tla_tools_jar}" "${tla_tools_version}"
+		verify_tla_tools_sha256 "${tla_tools_jar}" "${expected_tla_tools_sha256}" || exit 1
+	fi
+}
+
+run_tla_model() {
+	local spec_path cfg_path
+	local project_dir spec_file cfg_file
+	local tla_tools_version tla_tools_dir tla_tools_jar
+	local work_dir
+
+	spec_path=${1}
+	cfg_path=${2}
+
+	project_dir=$(pwd)
+	spec_file="${project_dir}/${spec_path}"
+	cfg_file="${project_dir}/${cfg_path}"
+
+	tla_tools_version="${TLA_TOOLS_VERSION:-v1.8.0}"
+	tla_tools_dir="${project_dir}/.cache/tla2tools/${tla_tools_version}"
+	tla_tools_jar="${TLC_JAR:-${tla_tools_dir}/tla2tools.jar}"
+
+	if [ ! -f "${tla_tools_jar}" ]; then
+		echo "tla2tools.jar not found; run run_prepare_tla_tools first" >&2
+		exit 1
+	fi
+
+	if [ ! -f "${spec_file}" ]; then
+		echo "TLA spec not found: ${spec_file}" >&2
+		exit 1
+	fi
+
+	if [ ! -f "${cfg_file}" ]; then
+		echo "TLA config not found: ${cfg_file}" >&2
+		exit 1
+	fi
+
+	work_dir=$(mktemp -d "${TEST_DIR}/tla.XXX")
+	# shellcheck disable=SC2064
+	trap "rm -rf '${work_dir}'" RETURN
+
+	cp "${spec_file}" "${cfg_file}" "${work_dir}/"
+
+	(
+		cd "${work_dir}" || exit
+		java -XX:+UseParallelGC -cp "${tla_tools_jar}" tlc2.TLC \
+			-cleanup \
+			-workers auto \
+			-config "$(basename "${cfg_file}")" \
+			"$(basename "${spec_file}")"
+	)
+}
+
+run_objectstore_transition_phases() {
+	run_tla_model \
+		"core/objectstore/tla/ObjectStoreTransitionPhases.tla" \
+		"core/objectstore/tla/ObjectStoreTransitionPhases.cfg"
+}
+
+test_tla() {
+	if [ "$(skip 'test_tla')" ]; then
+		echo "==> TEST SKIPPED: tla checks"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		echo "==> Checking for dependencies"
+		check_dependencies java curl sha256sum
+
+		run "run_prepare_tla_tools"
+		run "run_objectstore_transition_phases"
+	)
+}


### PR DESCRIPTION
This backfills TLA+ specs for the state machines in both migration and objectstore phases to ensure correctness. This ensures that all transitions are safe and all are terminal.

We have a lots of state machines, we should ensure that they're terminal and are safe. We'll start to add this sort of tla+ spec to each one.

In an reality we should be creating TLA+ specs from agent specs in some scenarios, or to verify the corretness of workers. Now that we can ask for help with this skill, it becomes more approachable and easier to align and implement.

## QA steps

It expects to java to be on `$PATH`.

```sh
$ cd tests && ./main.sh tla
```
