### PR TITLE
fix(unitstate): prevent panic when charm state is empty at commit time

### DIFF
--- a/domain/unitstate/state/state.go
+++ b/domain/unitstate/state/state.go
@@ -243,20 +243,21 @@ func (st *State) setUnitStateCharm(ctx context.Context, tx *sqlair.TX, id entity
 		return errors.Errorf("preparing charm state delete query: %w", err)
 	}
 
-	keyVals := makeUnitCharmStateKeyVals(id, state)
-
-	q = "INSERT INTO unit_state_charm(*) VALUES ($unitCharmStateKeyVal.*)"
-	iStmt, err := st.Prepare(q, keyVals[0])
-	if err != nil {
-		return errors.Errorf("preparing charm state insert query: %w", err)
-	}
-
 	if err := tx.Query(ctx, dStmt, id).Run(); err != nil {
 		return errors.Errorf("deleting unit charm state: %w", err)
 	}
 
-	if err := tx.Query(ctx, iStmt, keyVals).Run(); err != nil {
-		return errors.Errorf("setting unit charm state: %w", err)
+	keyVals := makeUnitCharmStateKeyVals(id, state)
+	if len(keyVals) != 0 {
+		q = "INSERT INTO unit_state_charm(*) VALUES ($unitCharmStateKeyVal.*)"
+		iStmt, err := st.Prepare(q, keyVals[0])
+		if err != nil {
+			return errors.Errorf("preparing charm state insert query: %w", err)
+		}
+
+		if err := tx.Query(ctx, iStmt, keyVals).Run(); err != nil {
+			return errors.Errorf("setting unit charm state: %w", err)
+		}
 	}
 	return nil
 }

--- a/domain/unitstate/state/state_test.go
+++ b/domain/unitstate/state/state_test.go
@@ -189,6 +189,36 @@ func (s *stateSuite) TestUpdateUnitStateCharm(c *tc.C) {
 	c.Check(gotState, tc.DeepEquals, expState)
 }
 
+func (s *stateSuite) TestUpdateUnitStateCharmEmptyMap(c *tc.C) {
+	ctx := c.Context()
+
+	// Set some initial state. This should be deleted when we set empty state.
+	s.addUnitStateCharm(c, "one-key", "one-val")
+
+	err := s.TxnRunner().Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return s.state.setUnitStateCharm(ctx, tx, entityUUID{UUID: s.unitUUID}, map[string]string{})
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	var rowCount int
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		q := "SELECT key, value FROM unit_state_charm WHERE unit_uuid = ?"
+		rows, err := tx.QueryContext(ctx, q, s.unitUUID)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = rows.Close() }()
+
+		for rows.Next() {
+			rowCount++
+		}
+		return rows.Err()
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(rowCount, tc.DeepEquals, 0)
+}
+
 func (s *stateSuite) TestUpdateUnitStateRelation(c *tc.C) {
 	ctx := c.Context()
 


### PR DESCRIPTION
## Description

`state-delete` panics the uniter when the persisted unit state would have zero entries after the hook commits. The `setUnitStateCharm` function unconditionally accessed `keyVals[0]` to prepare an INSERT statement, but when the state map is empty `makeUnitCharmStateKeyVals` returns an empty slice, causing an index-out-of-range panic.

## Fix

Guard the INSERT with a `len(keyVals) != 0` check, matching the existing pattern in `setUnitStateRelation` which already handles empty maps correctly. The DELETE is always executed first to clear stale state.

## Testing

Added `TestUpdateUnitStateCharmEmptyMap` which:
1. Sets initial charm state
2. Calls `setUnitStateCharm` with an empty map
3. Verifies no panic and zero rows remain

All `domain/unitstate/...` tests pass with `-race`.

## QA

```bash
juju deploy ubuntu --base ubuntu@24.04
juju wait-for application ubuntu
juju exec --unit ubuntu/0 -- 'state-delete anything && echo HOOK-DONE'
# Should print HOOK-DONE with no panic in uniter logs
```

Fixes https://github.com/juju/juju/issues/22523
JIRA: [JUJU-9902](https://warthogs.atlassian.net/browse/JUJU-9902)

[JUJU-9902]: https://warthogs.atlassian.net/browse/JUJU-9902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ