### PR TITLE
fix(crossmodelrelation): assert change stream idle before watcher creation

### DIFF
--- a/domain/crossmodelrelation/watcher_test.go
+++ b/domain/crossmodelrelation/watcher_test.go
@@ -59,6 +59,8 @@ func (s *watcherSuite) TestWatchRemoteApplicationOfferers(c *tc.C) {
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, s.modelUUID)
 
 	svc, _ := s.setupService(c, factory)
+
+	s.modelIdler.AssertChangeStreamIdle(c)
 	watcher, err := svc.WatchRemoteApplicationOfferers(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -123,6 +125,7 @@ func (s *watcherSuite) TestWatchRemoteApplicationConsumers(c *tc.C) {
 
 	s.createLocalOfferForConsumer(c, db, offerUUID)
 
+	s.modelIdler.AssertChangeStreamIdle(c)
 	watcher, err := svc.WatchRemoteApplicationConsumers(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -480,6 +483,7 @@ func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *tc.C) {
 	uri2.SourceUUID = s.modelUUID
 	realApplicationUUID, syntheticApplicationUUID := s.setupRemoteApplicationConsumer(c, db)
 
+	s.modelIdler.AssertChangeStreamIdle(c)
 	w, err := svc.WatchRemoteConsumedSecretsChanges(ctx, application.UUID(realApplicationUUID))
 	c.Assert(err, tc.IsNil)
 	c.Assert(w, tc.NotNil)


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

Three `crossmodelrelation` watcher tests were flaky under `-race` in CI
(build #36785). They subscribed to the change stream before
`PrimeChangeStream` entries had been fully processed, causing
`AssertChangeStreamIdle` within the test harness to time out.

This adds `s.modelIdler.AssertChangeStreamIdle(c)` before watcher creation
in the three affected tests, matching the pattern already used by
non-flaky tests like `TestWatchConsumerRelations` and
`TestWatchRelationIngressNetworks`.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you are testing
- ~Integration tests~
- ~doc.go~

## QA steps

```sh
cd domain/crossmodelrelation
go test -c -race
timeout 121 stress -timeout 120s ./crossmodelrelation.test \
  -test.run "TestWatchRemoteApplicationOfferers|TestWatchRemoteApplicationConsumers|TestWatchRemoteConsumedSecretsChanges"
```

Expected: 0 failures across thousands of runs (verified locally: 2736
runs, 0 failures over 2 minutes with race detector).

## Documentation changes

None — test-only change.

## Links

**Issue:** Fixes CI flakiness in `github-make-check-juju` build #36785.
