### PR TITLE
feat: consistently show offer connections

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -437,13 +437,6 @@ func (api *OffersAPI) applicationOffersFromModel(
 		})
 	}
 
-	// If the required access level is *only* read, then return the results at
-	// this point without populating the offer connections. Offer connections
-	// are only relevant to users with admin access.
-	if requiredAccess == permission.ReadAccess {
-		return results, nil
-	}
-
 	// If the user is not a model admin or there are no results,
 	// return the results without populating the offer connections.
 	if !isModelAdmin || len(results) == 0 {

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -1001,6 +1001,7 @@ func (s *offerSuite) TestFindApplicationOffers(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	filters := params.OfferFilters{
 		Filters: []params.OfferFilter{
@@ -1108,6 +1109,7 @@ func (s *offerSuite) TestFindApplicationOffersAllOffers(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), []crossmodelrelationservice.OfferFilter{{}}).Return(offerDetails, nil)
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	filters := params.OfferFilters{Filters: []params.OfferFilter{{}}}
 
@@ -1521,6 +1523,7 @@ func (s *offerSuite) TestApplicationOffers(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 	args := params.OfferURLs{
 		OfferURLs: []string{"fred@external/test-model.hosted-db2", "fred@external/test-model.testing"},
 	}
@@ -1614,6 +1617,7 @@ func (s *offerSuite) TestApplicationOffersMixSuccessAndFail(c *tc.C) {
 		},
 	}
 	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), gomock.Any()).Return(nil, nil)
 	args := params.OfferURLs{
 		OfferURLs: []string{"fred@external/test-model.hosted-db2:endpoint", "fred@external/test-model.testing"},
 	}
@@ -1683,6 +1687,87 @@ func (s *offerSuite) TestApplicationOffersNotFound(c *tc.C) {
 	c.Check(obtainedOffers.Results[0].Error, tc.DeepEquals, &params.Error{
 		Message: `application offer "fred@external/test-model.testing"`,
 		Code:    params.CodeNotFound,
+	})
+}
+
+// TestApplicationOffersWithConnections tests that connections are populated
+// for admin users when querying a single offer by URL.
+func (s *offerSuite) TestApplicationOffersWithConnections(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	offerAPI := s.offerAPI(c)
+	adminTag := s.setupAuthUser("admin")
+	s.expectEntityHasPermission(adminTag, permission.SuperuserAccess)
+	adminUser := user.User{DisplayName: "fred smith"}
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), user.NameFromTag(adminTag)).Return(adminUser, nil)
+
+	modelName := "prod"
+	modelOwnerTag := names.NewUserTag("fred@external")
+
+	foundModel := model.Model{
+		Name:      modelName,
+		Qualifier: model.Qualifier(modelOwnerTag.Id()),
+		UUID:      tc.Must0(c, model.NewUUID),
+	}
+	s.modelService.EXPECT().GetModelByNameAndQualifier(gomock.Any(), modelName, foundModel.Qualifier).Return(foundModel, nil)
+
+	offerUUID := uuid.MustNewUUID().String()
+	consumerModelUUID := uuid.MustNewUUID().String()
+
+	charmLocator := charm.CharmLocator{
+		Name:         "app",
+		Revision:     42,
+		Source:       charm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}
+	offerDetails := []*crossmodelrelation.OfferDetail{
+		{
+			OfferUUID:              offerUUID,
+			OfferName:              "hosted-db2",
+			ApplicationName:        "test-app",
+			ApplicationDescription: "testing application",
+			CharmLocator:           charmLocator,
+			Endpoints: []crossmodelrelation.OfferEndpoint{
+				{Name: "db"},
+			},
+			OfferUsers: []crossmodelrelation.OfferUser{{Name: "admin", Access: permission.AdminAccess}},
+		},
+	}
+	domainFilters := []crossmodelrelationservice.OfferFilter{{OfferName: "hosted-db2"}}
+	s.crossModelRelationService.EXPECT().GetOffers(gomock.Any(), domainFilters).Return(offerDetails, nil)
+
+	connections := []crossmodelrelation.OfferConnectionDetail{
+		{
+			OfferUUID:       offerUUID,
+			SourceModelUUID: consumerModelUUID,
+			RelationID:      42,
+			Username:        "consumer-user",
+			Endpoint:        "db",
+			Status:          "joined",
+			IngressSubnets:  []string{"10.0.0.0/24"},
+		},
+	}
+	s.crossModelRelationService.EXPECT().GetOfferConnections(gomock.Any(), []string{offerUUID}).Return(connections, nil)
+
+	args := params.OfferURLs{
+		OfferURLs: []string{"fred@external/prod.hosted-db2"},
+	}
+
+	obtained, err := offerAPI.ApplicationOffers(c.Context(), args)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained.Results, tc.HasLen, 1)
+	c.Assert(obtained.Results[0].Result, tc.NotNil)
+	c.Assert(obtained.Results[0].Result.Connections, tc.HasLen, 1)
+	c.Check(obtained.Results[0].Result.Connections[0], tc.DeepEquals, params.OfferConnection{
+		SourceModelTag: names.NewModelTag(consumerModelUUID).String(),
+		RelationId:     42,
+		Username:       "consumer-user",
+		Endpoint:       "db",
+		Status: params.EntityStatus{
+			Status: status.Status("joined"),
+		},
+		IngressSubnets: []string{"10.0.0.0/24"},
 	})
 }
 


### PR DESCRIPTION
This change is in response to a failing test in the Terraform provider raised in https://github.com/juju/juju/issues/22238 which can be summarised as "An API call to ApplicationOffer does not return offer connections".

In `apiserver/facades/client/applicationoffers/applicationoffers.go`, the single-offer lookup path used by client.ApplicationOffer (see `api/client/applicationoffers/client.go`) was calling the same logic that can return offer connections, but it returned early whenever the request was treated as read-only. That meant an admin caller could fetch an offer and get an empty `Connections` list even though the offer still had active or lingering connections. I've changed that path so verified model admins still get [Connections](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) populated for ApplicationOffers, not just for ListApplicationOffers.

This fixes https://github.com/juju/juju/issues/22238.

Although this fixed the issue, when using an agent to investigate this it additionally pointed out that,
> In `domain/crossmodelrelation/state/model/offer.go`, GetOfferConnections was more restrictive than removal. Removal blocks on the presence of rows in offer_connection, but the query used to populate API connections required successful inner joins through relation, relation status, and remote-consumer metadata. During relation teardown, that extra metadata can disappear before the offer_connection row is removed, so the client sees zero connections while removal still refuses to delete the offer. I changed the query to use offer_connection as the source of truth and left-join the descriptive metadata, so the API continues to report a blocking connection until the same row removal will allow deletion.

The changes that accompany the above are a bit more involved and I can't verify their correctness so I have not included them, though they might offer more correct behavior.  See https://github.com/juju/juju/compare/main...kian99:juju:fix-offer-test?expand=1

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Unfortunately the `juju show-offer` command shows a limited view of what the controller returns. I.e. even with `juju show-offer --format yaml` we only print,
```go
type ShowOfferedApplication struct {
	// Description is the user entered description.
	Description string `yaml:"description,omitempty" json:"description,omitempty"`

	// Access is the level of access the user has on the offer.
	Access string `yaml:"access" json:"access"`

	// Endpoints list of offered application endpoints.
	Endpoints map[string]RemoteEndpoint `yaml:"endpoints" json:"endpoints"`

	// Users are the users who can access the offer.
	Users map[string]OfferUser `yaml:"users,omitempty" json:"users,omitempty"`
}
```
As opposed to the details an offer contains,
```go
type ApplicationOfferDetails struct {
	// OfferName is the name of the offer
	OfferName string

	// ApplicationName is the application name to which the offer pertains.
	ApplicationName string

	// ApplicationDescription is the application description.
	ApplicationDescription string

	// OfferURL is the URL where the offer can be located.
	OfferURL string

	// CharmURL is the URL of the charm for the remote application.
	CharmURL string

	// Endpoints are the charm endpoints supported by the application.
	// TODO(wallyworld) - do not use charm.Relation here
	Endpoints []charm.Relation

	// Connects are the connections to the offer.
	Connections []OfferConnection

	// Users are the users able to access the offer.
	Users []OfferUserDetails

	// OfferUUID is the UUID of the offer.
	OfferUUID string
}
```

One needs to run the CLI with a debugger or add a log line to dump the API response.
The steps to verify are,
- make install
- juju bootstrap localhost test-offer-fix
- juju add-model source
- juju deploy juju-qa-dummy-source
- juju offer dummy-source:sink
- juju add-model sink
- juju deploy juju-qa-dummy-sink
- juju relate dummy-sink admin/source.dummy-source
- juju switch source
- watch juju status # Wait for 1/1 connections
- juju show-offer dummy-source


## Links

**Issue:** Fixes #22238 

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9844](https://warthogs.atlassian.net/browse/JUJU-9844)


[JUJU-9844]: https://warthogs.atlassian.net/browse/JUJU-9844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ