### PR TITLE
fix: harden microk8s controller port-forward bootstrap

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -564,7 +564,7 @@ func parseURLWithOptionalScheme(addr string) (*url.URL, bool) {
 // connection wins.
 //
 // It also returns the TLS configuration that it has derived from the Info.
-func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, error) {
+func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (dialInfo *dialResult, err error) {
 	if len(info.Addrs) == 0 {
 		return nil, errors.New("no API addresses to connect to")
 	}
@@ -587,6 +587,12 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 		if err := info.Proxier.Start(ctx); err != nil {
 			return nil, errors.Annotate(err, "starting proxy for api connection")
 		}
+		defer func() {
+			if err != nil {
+				err = stopStartedProxier(info.Proxier, err)
+			}
+		}()
+
 		logger.Debugf(ctx, "starting proxier for connection")
 
 		switch p := info.Proxier.(type) {
@@ -600,10 +606,9 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 				// in the future, we should not implement a local listening
 				// proxier, instead we should implement a Dialer that can be
 				// passed down that proxies the connection in process.
-				Host: net.JoinHostPort("127.0.0.1", p.Port()),
+				Host: net.JoinHostPort(p.Host(), p.Port()),
 			}}
 		default:
-			info.Proxier.Stop()
 			return nil, errors.New("unknown proxier provided")
 		}
 	}
@@ -658,17 +663,17 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 	}
 
 	if opts.VerifyCA != nil {
-		err := verifyCAMulti(ctx, addrs, &opts)
-		if errors.Is(err, context.Canceled) {
+		verifyErr := verifyCAMulti(ctx, addrs, &opts)
+		if errors.Is(verifyErr, context.Canceled) {
 			errorDone()
 			return nil, errors.Trace(context.Cause(ctx))
-		} else if err != nil {
+		} else if verifyErr != nil {
 			errorDone()
-			return nil, errors.Trace(err)
+			return nil, errors.Trace(verifyErr)
 		}
 	}
 
-	dialInfo, err := dialWebsocketMulti(ctx, addrs, path, opts)
+	dialInfo, err = dialWebsocketMulti(ctx, addrs, path, opts)
 	if errors.Is(err, context.Canceled) ||
 		errors.Is(err, parallel.ErrStopped) {
 		errorDone()
@@ -680,6 +685,26 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 	logger.Infof(ctx, "connection established to %q", dialInfo.dialAddr.String())
 	dialInfo.proxier = info.Proxier
 	return dialInfo, nil
+}
+
+func stopStartedProxier(proxier Proxier, err error) error {
+	if proxier == nil {
+		return err
+	}
+	reporter, ok := proxier.(ProxierErrorReporter)
+	if !ok {
+		proxier.Stop()
+		return err
+	}
+	proxyErr := reporter.ProxyError()
+	proxier.Stop()
+	if proxyErr == nil {
+		proxyErr = reporter.ProxyError()
+	}
+	if err != nil && proxyErr != nil {
+		return internalerrors.Errorf("%w; proxy error: %v", err, proxyErr)
+	}
+	return err
 }
 
 // gorillaDialWebsocket makes a websocket connection using the

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/juju/juju/core/network"
 	jujuversion "github.com/juju/juju/core/version"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	proxytest "github.com/juju/juju/internal/proxy/testing"
 	"github.com/juju/juju/internal/testhelpers"
 	jtesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc"
@@ -795,6 +796,45 @@ func (s *apiclientSuite) testOpenDialError(c *tc.C, t dialTest) {
 	case <-time.After(jtesting.LongWait):
 		c.Fatalf("timed out waiting for API open")
 	}
+}
+
+func (s *apiclientSuite) TestDialAPIStopsProxierOnDialFailure(c *tc.C) {
+	var stopped int32
+	proxier := proxytest.NewMockTunnelProxier()
+	proxier.HostFn = func() string { return "127.0.0.1" }
+	proxier.PortFn = func() string { return "33419" }
+	proxier.StopFn = func() { atomic.AddInt32(&stopped, 1) }
+	proxier.ProxyErrorFn = func() error { return errors.New("lost connection to pod") }
+
+	info := s.APIInfo()
+	info.Proxier = proxier
+	info.Addrs = []string{"10.152.183.79:17070"}
+
+	var dialed string
+	_, _, err := api.DialAPI(c, info, api.DialOpts{
+		RetryDelay: 0,
+		DialWebsocket: func(ctx context.Context, urlStr string, tlsConfig *tls.Config, ipAddr string) (jsoncodec.JSONConn, error) {
+			dialed = urlStr
+			return nil, errors.New("websocket refused")
+		},
+	})
+	c.Assert(err, tc.ErrorMatches, "unable to connect to API: websocket refused; proxy error: lost connection to pod")
+	c.Check(dialed, tc.Matches, `wss://127\.0\.0\.1:33419/model/.*/api`)
+	c.Check(atomic.LoadInt32(&stopped), tc.Equals, int32(1))
+}
+
+func (s *apiclientSuite) TestDialAPIStopsUnknownProxierOnce(c *tc.C) {
+	var stopped int32
+	proxier := &proxytest.MockProxier{
+		StopFn: func() { atomic.AddInt32(&stopped, 1) },
+	}
+
+	info := s.APIInfo()
+	info.Proxier = proxier
+
+	_, _, err := api.DialAPI(c, info, api.DialOpts{})
+	c.Assert(err, tc.ErrorMatches, "unknown proxier provided")
+	c.Check(atomic.LoadInt32(&stopped), tc.Equals, int32(1))
 }
 
 func (s *apiclientSuite) TestOpenWithNoCACert(c *tc.C) {

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -46,3 +46,11 @@ type TunnelProxier interface {
 	// Port returns the host port to connect to for tunneling connections.
 	Port() string
 }
+
+// ProxierErrorReporter describes a proxier that can report asynchronous proxy
+// errors observed after Start has returned successfully.
+type ProxierErrorReporter interface {
+	// ProxyError returns the asynchronous proxy error, if one has been
+	// observed. It returns nil when the proxier has no error to report.
+	ProxyError() error
+}

--- a/caas/kubernetes/tunnel.go
+++ b/caas/kubernetes/tunnel.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"net"
 	"net/http"
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/juju/errors"
@@ -17,6 +18,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -33,14 +35,32 @@ const (
 	ForwardPortTimeout time.Duration = time.Minute * 10
 )
 
+type portForwarder interface {
+	ForwardPorts() error
+	GetPorts() ([]portforward.ForwardedPort, error)
+}
+
+var newPortForwarder = func(
+	dialer httpstream.Dialer,
+	addresses []string,
+	ports []string,
+	stopChan <-chan struct{},
+	readyChan chan struct{},
+	out, errOut io.Writer,
+) (portForwarder, error) {
+	return portforward.NewOnAddresses(dialer, addresses, ports, stopChan, readyChan, out, errOut)
+}
+
 // Tunnel represents an ssh like tunnel to a Kubernetes Pod or Service
 type Tunnel struct {
 	client     rest.Interface
 	config     *rest.Config
 	Kind       TunnelKind
+	errChan    chan error
 	LocalPort  string
 	Namespace  string
 	Out        io.Writer
+	closeOnce  sync.Once
 	readyChan  chan struct{}
 	RemotePort string
 	stopChan   chan struct{}
@@ -56,10 +76,22 @@ const (
 
 // Close disconnects a tunnel connection
 func (t *Tunnel) Close() {
-	select {
-	case <-t.stopChan:
-	default:
+	t.closeOnce.Do(func() {
 		close(t.stopChan)
+	})
+}
+
+// ForwardError returns a port-forwarding error observed after the tunnel was
+// reported as ready.
+func (t *Tunnel) ForwardError() error {
+	if t.errChan == nil {
+		return nil
+	}
+	select {
+	case err := <-t.errChan:
+		return err
+	default:
+		return nil
 	}
 }
 
@@ -94,6 +126,9 @@ func (t *Tunnel) findSuitablePodForService(ctx context.Context) (*corev1.Pod, er
 	return &pods.Items[rand.Intn(podCount-1)], nil
 }
 
+// ForwardPort starts forwarding RemotePort to an assigned IPv4 localhost port.
+// A Tunnel is single-use for forwarding; call ForwardPort at most once, then
+// Close to stop the forwarding session.
 func (t *Tunnel) ForwardPort(ctx context.Context) error {
 	if !t.IsValidTunnelKind() {
 		return fmt.Errorf("invalid tunnel kind %s", t.Kind)
@@ -129,48 +164,49 @@ func (t *Tunnel) ForwardPort(ctx context.Context) error {
 	}
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, u)
 
-	local, err := getAvailablePort()
-	if err != nil {
-		return fmt.Errorf("could not find an available port: %w", err)
-	}
-	t.LocalPort = local
+	return t.forwardPort(ctx, dialer)
+}
 
-	ports := []string{fmt.Sprintf("%s:%s", t.LocalPort, t.RemotePort)}
-
-	pf, err := portforward.New(dialer, ports, t.stopChan, t.readyChan, t.Out, t.Out)
+func (t *Tunnel) forwardPort(ctx context.Context, dialer httpstream.Dialer) error {
+	ports := []string{fmt.Sprintf("0:%s", t.RemotePort)}
+	pf, err := newPortForwarder(
+		dialer,
+		[]string{"127.0.0.1"},
+		ports,
+		t.stopChan,
+		t.readyChan,
+		t.Out,
+		t.Out,
+	)
 	if err != nil {
 		return err
 	}
 
-	errChan := make(chan error, 1)
+	t.errChan = make(chan error, 1)
 	go func() {
-		errChan <- pf.ForwardPorts()
+		t.errChan <- pf.ForwardPorts()
 	}()
 
 	select {
 	case <-ctx.Done():
-		close(t.stopChan)
+		t.Close()
 		return ctx.Err()
-	case err = <-errChan:
-		close(t.stopChan)
+	case err = <-t.errChan:
+		t.Close()
 		return fmt.Errorf("forwarding ports: %v", err)
-	case <-pf.Ready:
+	case <-t.readyChan:
+		forwardedPorts, err := pf.GetPorts()
+		if err != nil {
+			t.Close()
+			return fmt.Errorf("getting forwarded ports: %w", err)
+		}
+		if len(forwardedPorts) == 0 {
+			t.Close()
+			return errors.New("no forwarded ports")
+		}
+		t.LocalPort = strconv.Itoa(int(forwardedPorts[0].Local))
 		return nil
 	}
-}
-
-func getAvailablePort() (string, error) {
-	l, err := net.Listen("tcp", ":0")
-	if err != nil {
-		return "", err
-	}
-	defer l.Close()
-
-	_, p, err := net.SplitHostPort(l.Addr().String())
-	if err != nil {
-		return "", err
-	}
-	return p, err
 }
 
 // IsValidTunnelKind tests that the tunnel kind supplied to this tunnel is valid
@@ -189,7 +225,8 @@ func NewTunnelForConfig(
 	kind TunnelKind,
 	namespace,
 	target,
-	remotePort string) (*Tunnel, error) {
+	remotePort string,
+) (*Tunnel, error) {
 
 	config := *c
 	gv := corev1.SchemeGroupVersion

--- a/caas/kubernetes/tunnel_test.go
+++ b/caas/kubernetes/tunnel_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package kubernetes
+
+import (
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/juju/errors"
+	"github.com/juju/tc"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/tools/portforward"
+
+	"github.com/juju/juju/internal/testhelpers"
+)
+
+type tunnelSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestTunnelSuite(t *testing.T) {
+	tc.Run(t, &tunnelSuite{})
+}
+
+func (s *tunnelSuite) TestCloseIsConcurrentSafe(c *tc.C) {
+	tunnel := newTestTunnel()
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() {
+			tunnel.Close()
+		})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for concurrent closes")
+	}
+	select {
+	case <-tunnel.stopChan:
+	default:
+		c.Fatalf("stop channel was not closed")
+	}
+}
+
+func (s *tunnelSuite) TestForwardPortBindsIPv4LocalhostAndUsesAssignedPort(c *tc.C) {
+	var gotAddresses []string
+	var gotPorts []string
+	done := make(chan struct{})
+	forwarder := &fakePortForwarder{
+		done:        done,
+		signalReady: true,
+		waitForStop: true,
+		forwardedPorts: []portforward.ForwardedPort{{
+			Local:  33419,
+			Remote: 17070,
+		}},
+	}
+	s.PatchValue(&newPortForwarder, func(
+		_ httpstream.Dialer,
+		addresses []string,
+		ports []string,
+		stopChan <-chan struct{},
+		readyChan chan struct{},
+		_, _ io.Writer,
+	) (portForwarder, error) {
+		gotAddresses = append([]string(nil), addresses...)
+		gotPorts = append([]string(nil), ports...)
+		forwarder.stopChan = stopChan
+		forwarder.readyChan = readyChan
+		return forwarder, nil
+	})
+
+	tunnel := newTestTunnel()
+	err := tunnel.forwardPort(c.Context(), nil)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotAddresses, tc.DeepEquals, []string{"127.0.0.1"})
+	c.Check(gotPorts, tc.DeepEquals, []string{"0:17070"})
+	c.Check(tunnel.LocalPort, tc.Equals, "33419")
+
+	tunnel.Close()
+	assertDone(c, done)
+}
+
+func (s *tunnelSuite) TestForwardPortReportsFailureBeforeReady(c *tc.C) {
+	done := make(chan struct{})
+	forwarder := &fakePortForwarder{
+		done:       done,
+		forwardErr: errors.New("lost connection to pod"),
+	}
+	s.PatchValue(&newPortForwarder, func(
+		_ httpstream.Dialer,
+		_ []string,
+		_ []string,
+		stopChan <-chan struct{},
+		readyChan chan struct{},
+		_, _ io.Writer,
+	) (portForwarder, error) {
+		forwarder.stopChan = stopChan
+		forwarder.readyChan = readyChan
+		return forwarder, nil
+	})
+
+	tunnel := newTestTunnel()
+	err := tunnel.forwardPort(c.Context(), nil)
+	c.Assert(err, tc.ErrorMatches, "forwarding ports: lost connection to pod")
+	assertDone(c, done)
+}
+
+func (s *tunnelSuite) TestForwardPortStopsWhenAssignedPortCannotBeRead(c *tc.C) {
+	done := make(chan struct{})
+	forwarder := &fakePortForwarder{
+		done:        done,
+		signalReady: true,
+		waitForStop: true,
+		getPortsErr: errors.New("ports unavailable"),
+	}
+	s.PatchValue(&newPortForwarder, func(
+		_ httpstream.Dialer,
+		_ []string,
+		_ []string,
+		stopChan <-chan struct{},
+		readyChan chan struct{},
+		_, _ io.Writer,
+	) (portForwarder, error) {
+		forwarder.stopChan = stopChan
+		forwarder.readyChan = readyChan
+		return forwarder, nil
+	})
+
+	tunnel := newTestTunnel()
+	err := tunnel.forwardPort(c.Context(), nil)
+	c.Assert(err, tc.ErrorMatches, "getting forwarded ports: ports unavailable")
+	assertDone(c, done)
+}
+
+func (s *tunnelSuite) TestForwardPortReportsPostReadyFailure(c *tc.C) {
+	done := make(chan struct{})
+	release := make(chan struct{})
+	forwarder := &fakePortForwarder{
+		done:        done,
+		release:     release,
+		signalReady: true,
+		forwardErr:  errors.New("lost connection to pod"),
+		forwardedPorts: []portforward.ForwardedPort{{
+			Local:  33419,
+			Remote: 17070,
+		}},
+	}
+	s.PatchValue(&newPortForwarder, func(
+		_ httpstream.Dialer,
+		_ []string,
+		_ []string,
+		stopChan <-chan struct{},
+		readyChan chan struct{},
+		_, _ io.Writer,
+	) (portForwarder, error) {
+		forwarder.stopChan = stopChan
+		forwarder.readyChan = readyChan
+		return forwarder, nil
+	})
+
+	tunnel := newTestTunnel()
+	err := tunnel.forwardPort(c.Context(), nil)
+	c.Assert(err, tc.ErrorIsNil)
+
+	close(release)
+	assertDone(c, done)
+	c.Check(tunnel.ForwardError(), tc.ErrorMatches, "lost connection to pod")
+}
+
+type fakePortForwarder struct {
+	done           chan struct{}
+	forwardErr     error
+	forwardedPorts []portforward.ForwardedPort
+	getPortsErr    error
+	readyChan      chan struct{}
+	release        chan struct{}
+	signalReady    bool
+	stopChan       <-chan struct{}
+	waitForStop    bool
+}
+
+func (f *fakePortForwarder) ForwardPorts() error {
+	if f.done != nil {
+		defer close(f.done)
+	}
+	if f.signalReady {
+		close(f.readyChan)
+	}
+	if f.release != nil {
+		select {
+		case <-f.release:
+		case <-f.stopChan:
+			return nil
+		}
+	}
+	if f.waitForStop {
+		<-f.stopChan
+	}
+	return f.forwardErr
+}
+
+func (f *fakePortForwarder) GetPorts() ([]portforward.ForwardedPort, error) {
+	if f.getPortsErr != nil {
+		return nil, f.getPortsErr
+	}
+	return f.forwardedPorts, nil
+}
+
+func newTestTunnel() *Tunnel {
+	return &Tunnel{
+		Out:        io.Discard,
+		readyChan:  make(chan struct{}),
+		RemotePort: "17070",
+		stopChan:   make(chan struct{}),
+	}
+}
+
+func assertDone(c *tc.C, done <-chan struct{}) {
+	select {
+	case <-done:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for forwarding goroutine")
+	}
+}

--- a/internal/provider/kubernetes/proxy/proxier.go
+++ b/internal/provider/kubernetes/proxy/proxier.go
@@ -36,7 +36,7 @@ const (
 )
 
 func (p *Proxier) Host() string {
-	return "localhost"
+	return "127.0.0.1"
 }
 
 func NewProxier(config ProxierConfig) *Proxier {
@@ -98,6 +98,15 @@ func (p *Proxier) MarshalYAML() (any, error) {
 
 func (p *Proxier) Port() string {
 	return p.tunnel.LocalPort
+}
+
+// ProxyError reports asynchronous port-forwarding errors observed after the
+// tunnel was reported as ready.
+func (p *Proxier) ProxyError() error {
+	if p.tunnel == nil {
+		return nil
+	}
+	return p.tunnel.ForwardError()
 }
 
 func (p *Proxier) Start(ctx context.Context) (err error) {

--- a/internal/proxy/testing/proxy.go
+++ b/internal/proxy/testing/proxy.go
@@ -17,6 +17,9 @@ type MockProxier struct {
 
 	// See Proxier interface
 	TypeFn func() string
+
+	// See api.ProxierErrorReporter interface
+	ProxyErrorFn func() error
 }
 
 type MockTunnelProxier struct {
@@ -64,6 +67,13 @@ func (mp *MockProxier) Type() string {
 		return "mock-proxier"
 	}
 	return mp.TypeFn()
+}
+
+func (mp *MockProxier) ProxyError() error {
+	if mp.ProxyErrorFn == nil {
+		return nil
+	}
+	return mp.ProxyErrorFn()
 }
 
 func (mtp *MockTunnelProxier) Host() string {


### PR DESCRIPTION
Root cause: the microk8s bootstrap path used a localhost port-forward proxy that reported ready once listeners were created, but Juju then dialed 127.0.0.1 directly. That made the bootstrap retry loop sensitive to a race where the proxy could die after Ready and before the first API websocket dial, which surfaced as a connection-refused error on an ephemeral local port.

Resolve this by making the tunnel bind deterministically on 127.0.0.1, letting client-go allocate the local port atomically, reading the assigned port back from the port-forwarder, and retaining post-ready proxy errors so failed dials can report the underlying proxy loss instead of a misleading localhost refusal.

Design decisions: keep the fix local to the existing tunnel/proxier path rather than introducing a new dialer abstraction, because the current API already models tunnel proxies as start/stop lifecycle objects. Also stop the proxier on failed dial attempts so the local listener does not leak past a failed bootstrap attempt. Added targeted tests for port assignment, failure propagation, and proxy cleanup.

## QA steps

Unfortunately this change will not propagate sufficiently to fix the github action until it is released via snap to 4.0/stable.

It is also very difficult to reproduce this error outside of a github action.  It results from a combination of the confined environment, and resource contention

So it is very difficult to verify this resolves the bug.

To QA, verify we can bootstrap to microk8s and/or minikube. I did both
