### PR TITLE
chore: remove object store drainer dependency on agent.conf

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/semversion"
 	internallogger "github.com/juju/juju/internal/logger"
@@ -310,9 +309,6 @@ type Config interface {
 	// sampling. The lower the threshold, the more spans will be sampled.
 	OpenTelemetryTailSamplingThreshold() time.Duration
 
-	// ObjectStoreType returns the type of object store to use.
-	ObjectStoreType() objectstore.BackendType
-
 	// DqlitePort returns the port that should be used by Dqlite. This should
 	// only be set during testing.
 	DqlitePort() (int, bool)
@@ -385,9 +381,6 @@ type configSetterOnly interface {
 	// SetOpenTelemetryTailSamplingThreshold sets the threshold for tail-based
 	// sampling. The lower the threshold, the more spans will be sampled.
 	SetOpenTelemetryTailSamplingThreshold(time.Duration)
-
-	// SetObjectStoreType sets the type of object store to use.
-	SetObjectStoreType(objectstore.BackendType)
 }
 
 // LogFileName returns the filename for the Agent's log file.
@@ -470,7 +463,6 @@ type configInternal struct {
 	openTelemetryStackTraces           bool
 	openTelemetrySampleRatio           float64
 	openTelemetryTailSamplingThreshold time.Duration
-	objectStoreType                    objectstore.BackendType
 	dqlitePort                         int
 }
 
@@ -499,7 +491,6 @@ type AgentConfigParams struct {
 	OpenTelemetryStackTraces           bool
 	OpenTelemetrySampleRatio           float64
 	OpenTelemetryTailSamplingThreshold time.Duration
-	ObjectStoreType                    objectstore.BackendType
 	DqlitePort                         int
 }
 
@@ -571,7 +562,6 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		openTelemetryStackTraces:           configParams.OpenTelemetryStackTraces,
 		openTelemetrySampleRatio:           configParams.OpenTelemetrySampleRatio,
 		openTelemetryTailSamplingThreshold: configParams.OpenTelemetryTailSamplingThreshold,
-		objectStoreType:                    configParams.ObjectStoreType,
 		dqlitePort:                         configParams.DqlitePort,
 	}
 	if len(configParams.APIAddresses) > 0 {
@@ -954,16 +944,6 @@ func (c *configInternal) OpenTelemetryTailSamplingThreshold() time.Duration {
 // SetOpenTelemetryTailSamplingThreshold implements configSetterOnly.
 func (c *configInternal) SetOpenTelemetryTailSamplingThreshold(v time.Duration) {
 	c.openTelemetryTailSamplingThreshold = v
-}
-
-// ObjectStoreType implements Config.
-func (c *configInternal) ObjectStoreType() objectstore.BackendType {
-	return c.objectStoreType
-}
-
-// SetObjectStoreType implements configSetterOnly.
-func (c *configInternal) SetObjectStoreType(v objectstore.BackendType) {
-	c.objectStoreType = v
 }
 
 var validAddr = regexp.MustCompile("^.+:[0-9]+$")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/semversion"
 	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/internal/testing"
@@ -708,16 +707,4 @@ func (*suite) TestSetOpenTelemetryTailSamplingThreshold(c *tc.C) {
 	conf.SetOpenTelemetryTailSamplingThreshold(time.Second)
 	queryTracingTailSamplingThreshold = conf.OpenTelemetryTailSamplingThreshold()
 	c.Assert(queryTracingTailSamplingThreshold, tc.Equals, time.Second, tc.Commentf("open telemetry tail sampling threshold setting not updated"))
-}
-
-func (*suite) TestSetObjectStoreType(c *tc.C) {
-	conf, err := agent.NewAgentConfig(attributeParams)
-	c.Assert(err, tc.ErrorIsNil)
-
-	objectStoreType := conf.ObjectStoreType()
-	c.Assert(objectStoreType, tc.Equals, attributeParams.ObjectStoreType)
-
-	conf.SetObjectStoreType("s3")
-	objectStoreType = conf.ObjectStoreType()
-	c.Assert(objectStoreType, tc.Equals, objectstore.S3Backend, tc.Commentf("object store type setting not updated"))
 }

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/semversion"
 )
 
@@ -70,8 +69,6 @@ type format_2_0Serialization struct {
 	OpenTelemetryStackTraces           bool          `yaml:"opentelemetrystacktraces,omitempty"`
 	OpenTelemetrySampleRatio           string        `yaml:"opentelemetrysampleratio,omitempty"`
 	OpenTelemetryTailSamplingThreshold time.Duration `yaml:"opentelemetrytailsamplingthreshold,omitempty"`
-
-	ObjectStoreType string `yaml:"objectstoretype,omitempty"`
 
 	DqlitePort int `yaml:"dqlite-port,omitempty"`
 }
@@ -162,13 +159,6 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 		}
 		config.openTelemetrySampleRatio = sampleRatio
 	}
-	if format.ObjectStoreType != "" {
-		objectStoreType, err := objectstore.ParseObjectStoreType(format.ObjectStoreType)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		config.objectStoreType = objectStoreType
-	}
 	return config, nil
 }
 
@@ -222,9 +212,6 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 	}
 	if config.openTelemetrySampleRatio != 0 {
 		format.OpenTelemetrySampleRatio = fmt.Sprintf("%.04f", config.openTelemetrySampleRatio)
-	}
-	if config.objectStoreType != "" {
-		format.ObjectStoreType = config.objectStoreType.String()
 	}
 	return goyaml.Marshal(format)
 }

--- a/agent/format-2.0_whitebox_test.go
+++ b/agent/format-2.0_whitebox_test.go
@@ -18,7 +18,6 @@ import (
 
 	agentconstants "github.com/juju/juju/agent/constants"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/internal/testing"
 )
@@ -113,22 +112,6 @@ func (*format_2_0Suite) TestOpenTelemetry(c *tc.C) {
 	c.Check(newConfig.OpenTelemetryStackTraces(), tc.IsTrue)
 	c.Check(newConfig.OpenTelemetrySampleRatio(), tc.Equals, 0.5)
 	c.Check(newConfig.OpenTelemetryTailSamplingThreshold(), tc.Equals, time.Second)
-}
-
-func (*format_2_0Suite) TestObjectStore(c *tc.C) {
-	config := newTestConfig(c)
-	// configFilePath is not serialized as it is the location of the file.
-	config.configFilePath = ""
-
-	config.SetObjectStoreType(objectstore.FileBackend)
-
-	data, err := format_2_0.marshal(config)
-	c.Assert(err, tc.ErrorIsNil)
-	newConfig, err := format_2_0.unmarshal(data)
-	c.Assert(err, tc.ErrorIsNil)
-
-	c.Check(newConfig, tc.DeepEquals, config)
-	c.Check(newConfig.ObjectStoreType(), tc.Equals, objectstore.FileBackend)
 }
 
 var agentConfig2_0Contents = `

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -105,8 +105,6 @@ func (s *AgentSuite) PrimeAgentVersion(c *tc.C, tag names.Tag, password string, 
 			OpenTelemetrySampleRatio:           controller.DefaultOpenTelemetrySampleRatio,
 			OpenTelemetryTailSamplingThreshold: controller.DefaultOpenTelemetryTailSamplingThreshold,
 
-			ObjectStoreType: controller.DefaultObjectStoreType,
-
 			DqlitePort: dqlitePort,
 		},
 	)
@@ -187,8 +185,6 @@ func (s *AgentSuite) WriteStateAgentConfig(
 			OpenTelemetryStackTraces:           controller.DefaultOpenTelemetryStackTraces,
 			OpenTelemetrySampleRatio:           controller.DefaultOpenTelemetrySampleRatio,
 			OpenTelemetryTailSamplingThreshold: controller.DefaultOpenTelemetryTailSamplingThreshold,
-
-			ObjectStoreType: controller.DefaultObjectStoreType,
 
 			DqlitePort: dqlitePort,
 		},

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/core/objectstore"
 	coreos "github.com/juju/juju/core/os"
 	coreuser "github.com/juju/juju/core/user"
 	jujuversion "github.com/juju/juju/core/version"
@@ -291,7 +290,6 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 		agentConfig.SetOpenTelemetryStackTraces(args.ControllerConfig.OpenTelemetryStackTraces())
 		agentConfig.SetOpenTelemetrySampleRatio(args.ControllerConfig.OpenTelemetrySampleRatio())
 		agentConfig.SetOpenTelemetryTailSamplingThreshold(args.ControllerConfig.OpenTelemetryTailSamplingThreshold())
-		agentConfig.SetObjectStoreType(objectstore.FileBackend)
 
 		return nil
 	}); err != nil {

--- a/domain/objectstore/service/service.go
+++ b/domain/objectstore/service/service.go
@@ -99,6 +99,9 @@ type DrainingState interface {
 	// object store is set to use S3 as the backend.
 	TransitionBackendToS3(ctx context.Context, uuid string, credential domainobjectstore.S3Credentials) error
 
+	// GetActiveObjectStoreBackend returns the active object store backend.
+	GetActiveObjectStoreBackend(ctx context.Context) (domainobjectstore.BackendInfo, error)
+
 	// InitialWatchBackendTable returns the table for the object store backend.
 	InitialWatchBackendTable() (string, string)
 
@@ -528,11 +531,30 @@ func (s BackendInfo) S3Credentials() (domainobjectstore.S3Credentials, bool) {
 // GetActiveObjectStoreBackend returns the active object store backend
 // information.
 func (s *WatchableDrainingService) GetActiveObjectStoreBackend(ctx context.Context) (BackendInfo, error) {
-	_, span := trace.Start(ctx, trace.NameFromFunc())
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
+	info, err := s.st.GetActiveObjectStoreBackend(ctx)
+	if err != nil {
+		return BackendInfo{}, errors.Errorf("getting active object store backend: %w", err)
+	}
+
+	backendUUID, err := objectstore.ParseUUID(info.UUID)
+	if err != nil {
+		return BackendInfo{}, errors.Errorf("parsing backend uuid: %w", err)
+	}
+
+	backendType, err := objectstore.ParseObjectStoreType(info.ObjectStoreType)
+	if err != nil {
+		return BackendInfo{}, errors.Errorf("parsing backend type: %w", err)
+	}
+
 	return BackendInfo{
-		Type: objectstore.FileBackend,
+		UUID:      backendUUID,
+		Type:      backendType,
+		Endpoint:  info.Endpoint,
+		AccessKey: info.AccessKey,
+		SecretKey: info.SecretKey,
 	}, nil
 }
 
@@ -540,12 +562,21 @@ func (s *WatchableDrainingService) GetActiveObjectStoreBackend(ctx context.Conte
 // credentials. This is used to update the object store information when the
 // object store is set to use S3 as the backend.
 func (s *WatchableDrainingService) TransitionBackendToS3(ctx context.Context, credential domainobjectstore.S3Credentials) error {
-	_, span := trace.Start(ctx, trace.NameFromFunc())
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
 	// Validate the credentials before transitioning the backend to S3.
 	if err := credential.Validate(); err != nil {
 		return errors.Errorf("validating S3 credentials: %w", err)
+	}
+
+	active, err := s.GetActiveObjectStoreBackend(ctx)
+	if err == nil {
+		if activeCreds, ok := active.S3Credentials(); ok && activeCreds == credential {
+			return nil
+		}
+	} else if !errors.Is(err, objectstoreerrors.ErrBackendNotFound) {
+		return errors.Errorf("getting active object store backend: %w", err)
 	}
 
 	uuid, err := objectstore.NewUUID()

--- a/domain/objectstore/service/service_test.go
+++ b/domain/objectstore/service/service_test.go
@@ -548,13 +548,27 @@ func (s *drainingServiceSuite) TestRemoveMetadata(c *tc.C) {
 func (s *drainingServiceSuite) TestGetActiveObjectStoreBackend(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	endpoint := "https://s3.example.com"
+	accessKey := "access-key"
+	secretKey := "secret-key"
+	s.state.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(domainobjectstore.BackendInfo{
+		UUID:            tc.Must(c, objectstore.NewUUID).String(),
+		ObjectStoreType: objectstore.S3Backend.String(),
+		Endpoint:        &endpoint,
+		AccessKey:       &accessKey,
+		SecretKey:       &secretKey,
+	}, nil)
+
 	info, err := NewWatchableDrainingService(s.state, s.watcherFactory).GetActiveObjectStoreBackend(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(info.Type, tc.Equals, objectstore.FileBackend)
-	c.Check(info.UUID, tc.Equals, objectstore.UUID(""))
-	c.Check(info.Endpoint, tc.IsNil)
-	c.Check(info.AccessKey, tc.IsNil)
-	c.Check(info.SecretKey, tc.IsNil)
+	c.Check(info.Type, tc.Equals, objectstore.S3Backend)
+	c.Check(info.UUID, tc.Not(tc.Equals), objectstore.UUID(""))
+	c.Assert(info.Endpoint, tc.NotNil)
+	c.Check(*info.Endpoint, tc.Equals, endpoint)
+	c.Assert(info.AccessKey, tc.NotNil)
+	c.Check(*info.AccessKey, tc.Equals, accessKey)
+	c.Assert(info.SecretKey, tc.NotNil)
+	c.Check(*info.SecretKey, tc.Equals, secretKey)
 }
 
 func (s *drainingServiceSuite) TestBackendInfoS3CredentialsNonS3(c *tc.C) {
@@ -603,7 +617,48 @@ func (s *drainingServiceSuite) TestTransitionBackendToS3Success(c *tc.C) {
 		SecretKey: "secret-key",
 	}
 
+	s.state.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(domainobjectstore.BackendInfo{}, objectstoreerrors.ErrBackendNotFound)
 	s.state.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any(), creds).Return(nil)
+
+	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), creds)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *drainingServiceSuite) TestTransitionBackendToS3DoesNotStartDrainingSeparately(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	}
+
+	s.state.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(domainobjectstore.BackendInfo{}, objectstoreerrors.ErrBackendNotFound)
+	s.state.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any(), creds).Return(nil)
+
+	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), creds)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *drainingServiceSuite) TestTransitionBackendToS3NoopWhenCredentialsAlreadyActive(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	endpoint := "https://s3.example.com"
+	accessKey := "access-key"
+	secretKey := "secret-key"
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:  endpoint,
+		AccessKey: accessKey,
+		SecretKey: secretKey,
+	}
+
+	s.state.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(domainobjectstore.BackendInfo{
+		UUID:            tc.Must(c, objectstore.NewUUID).String(),
+		ObjectStoreType: objectstore.S3Backend.String(),
+		Endpoint:        &endpoint,
+		AccessKey:       &accessKey,
+		SecretKey:       &secretKey,
+	}, nil)
 
 	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), creds)
 	c.Assert(err, tc.ErrorIsNil)
@@ -618,6 +673,7 @@ func (s *drainingServiceSuite) TestTransitionBackendToS3StateError(c *tc.C) {
 		SecretKey: "secret-key",
 	}
 
+	s.state.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(domainobjectstore.BackendInfo{}, objectstoreerrors.ErrBackendNotFound)
 	s.state.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any(), creds).Return(errors.New("boom"))
 
 	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), creds)

--- a/domain/objectstore/service/state_mock_test.go
+++ b/domain/objectstore/service/state_mock_test.go
@@ -687,6 +687,45 @@ func (c *MockDrainingStateGetMetadataBySHA256PrefixCall) DoAndReturn(f func(cont
 	return c
 }
 
+// GetActiveObjectStoreBackend mocks base method.
+func (m *MockDrainingState) GetActiveObjectStoreBackend(arg0 context.Context) (objectstore0.BackendInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActiveObjectStoreBackend", arg0)
+	ret0, _ := ret[0].(objectstore0.BackendInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetActiveObjectStoreBackend indicates an expected call of GetActiveObjectStoreBackend.
+func (mr *MockDrainingStateMockRecorder) GetActiveObjectStoreBackend(arg0 any) *MockDrainingStateGetActiveObjectStoreBackendCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveObjectStoreBackend", reflect.TypeOf((*MockDrainingState)(nil).GetActiveObjectStoreBackend), arg0)
+	return &MockDrainingStateGetActiveObjectStoreBackendCall{Call: call}
+}
+
+// MockDrainingStateGetActiveObjectStoreBackendCall wrap *gomock.Call
+type MockDrainingStateGetActiveObjectStoreBackendCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDrainingStateGetActiveObjectStoreBackendCall) Return(arg0 objectstore0.BackendInfo, arg1 error) *MockDrainingStateGetActiveObjectStoreBackendCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDrainingStateGetActiveObjectStoreBackendCall) Do(f func(context.Context) (objectstore0.BackendInfo, error)) *MockDrainingStateGetActiveObjectStoreBackendCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDrainingStateGetActiveObjectStoreBackendCall) DoAndReturn(f func(context.Context) (objectstore0.BackendInfo, error)) *MockDrainingStateGetActiveObjectStoreBackendCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // InitialWatchBackendTable mocks base method.
 func (m *MockDrainingState) InitialWatchBackendTable() (string, string) {
 	m.ctrl.T.Helper()

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -851,6 +851,15 @@ func (s *State) TransitionBackendToS3(ctx context.Context, uuid string, credenti
 		return errors.Capture(err)
 	}
 
+	phaseUUID, err := coreobjectstore.NewUUID()
+	if err != nil {
+		return errors.Errorf("creating draining uuid: %w", err)
+	}
+	phaseTypeID, err := encodePhaseTypeID(coreobjectstore.PhaseDraining)
+	if err != nil {
+		return errors.Errorf("encoding draining phase id: %w", err)
+	}
+
 	type s3Credentials struct {
 		UUID      string `db:"object_store_backend_uuid"`
 		Endpoint  string `db:"endpoint"`
@@ -903,6 +912,14 @@ VALUES ($newBackend.uuid, 0, 1, $newBackend.updated_at)`, backend)
 		return errors.Errorf("preparing insert object store backend statement: %w", err)
 	}
 
+	fromBackendStmt, err := s.Prepare(`
+SELECT b.uuid AS &backendUUID.uuid
+FROM object_store_backend AS b
+WHERE b.life_id = 1`, backendUUID{})
+	if err != nil {
+		return errors.Errorf("preparing active object store backend statement: %w", err)
+	}
+
 	s3InsertStmt, err := s.Prepare(`
 INSERT INTO object_store_backend_s3_credential (
     object_store_backend_uuid, 
@@ -915,6 +932,15 @@ VALUES ($s3Credentials.*)
 	if err != nil {
 		return errors.Errorf("preparing insert object store information statement: %w", err)
 	}
+
+	insertDrainingStmt, err := s.Prepare(`
+INSERT INTO object_store_drain_info (uuid, phase_type_id, from_backend_uuid, to_backend_uuid)
+VALUES ($dbSetPhaseInfo.*)
+`, dbSetPhaseInfo{})
+	if err != nil {
+		return errors.Errorf("preparing insert draining phase statement: %w", err)
+	}
+
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// Ensure that we're not currently in a draining phase, as we don't want
 		// to update the backend information while we're in the middle of a
@@ -938,6 +964,13 @@ VALUES ($s3Credentials.*)
 			return errors.Errorf("no object store backend active")
 		}
 
+		var fromBackend backendUUID
+		if err := tx.Query(ctx, fromBackendStmt).Get(&fromBackend); errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("migrating from: %w", objectstoreerrors.ErrBackendNotFound)
+		} else if err != nil {
+			return errors.Errorf("selecting draining source backend: %w", err)
+		}
+
 		// Now activate the new backend by inserting the new backend
 		// information, and the credentials for the S3 backend.
 		if err := tx.Query(ctx, insertBackendInfoStmt, backend).Get(&outcome); database.IsErrConstraintPrimaryKey(err) {
@@ -953,6 +986,15 @@ VALUES ($s3Credentials.*)
 
 		if err := tx.Query(ctx, s3InsertStmt, s3Creds).Run(); err != nil {
 			return errors.Errorf("inserting object store information: %w", err)
+		}
+
+		if err := tx.Query(ctx, insertDrainingStmt, dbSetPhaseInfo{
+			UUID:            phaseUUID.String(),
+			PhaseTypeID:     phaseTypeID,
+			FromBackendUUID: fromBackend.UUID,
+			ToBackendUUID:   uuid,
+		}).Run(); err != nil {
+			return errors.Errorf("inserting draining phase: %w", err)
 		}
 		return nil
 	})

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -694,13 +694,9 @@ func (s *stateSuite) TestGetActiveDrainingInfo(c *tc.C) {
 	err = st.TransitionBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.StartDraining(c.Context(), "foo")
-	c.Assert(err, tc.ErrorIsNil)
-
 	info, err := st.GetActiveDrainingInfo(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(info.Phase, tc.Equals, string(coreobjectstore.PhaseDraining))
-	c.Check(info.UUID, tc.Equals, "foo")
 	c.Check(info.ActiveBackendUUID, tc.Equals, backendUUID)
 
 	var fromBackendUUID string
@@ -728,14 +724,11 @@ func (s *stateSuite) TestSetDrainingPhase(c *tc.C) {
 	err := st.TransitionBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.StartDraining(c.Context(), "foo")
-	c.Assert(err, tc.ErrorIsNil)
-
 	info, err := st.GetActiveDrainingInfo(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(info.Phase, tc.Equals, string(coreobjectstore.PhaseDraining))
 
-	err = st.SetDrainingPhase(c.Context(), "foo", coreobjectstore.PhaseCompleted)
+	err = st.SetDrainingPhase(c.Context(), info.UUID, coreobjectstore.PhaseCompleted)
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = st.GetActiveDrainingInfo(c.Context())
@@ -777,9 +770,6 @@ func (s *stateSuite) TestStartDraining(c *tc.C) {
 	err := st.TransitionBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.StartDraining(c.Context(), "foo")
-	c.Assert(err, tc.ErrorIsNil)
-
 	err = st.StartDraining(c.Context(), "bar")
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrDrainingAlreadyInProgress)
 }
@@ -797,10 +787,10 @@ func (s *stateSuite) TestStartDrainingAndSetDrainingPhase(c *tc.C) {
 	err := st.TransitionBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.StartDraining(c.Context(), "foo")
+	info, err := st.GetActiveDrainingInfo(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.SetDrainingPhase(c.Context(), "foo", coreobjectstore.PhaseCompleted)
+	err = st.SetDrainingPhase(c.Context(), info.UUID, coreobjectstore.PhaseCompleted)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -816,9 +806,12 @@ func (s *stateSuite) TestTransitionBackendToS3CalledTwice(c *tc.C) {
 
 	err := st.TransitionBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
-
-	// Force the old backend to be marked as dead.
-	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
+	info, err := st.GetActiveDrainingInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.SetDrainingPhase(c.Context(), info.UUID, coreobjectstore.PhaseCompleted)
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.MarkObjectStoreBackendAsDrained(c.Context(), defaultFileBackendUUID)
+	c.Assert(err, tc.ErrorIsNil)
 
 	err = st.TransitionBackendToS3(c.Context(), backendUUID, creds)
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrBackendAlreadyExists)
@@ -839,14 +832,14 @@ func (s *stateSuite) TestTransitionBackendToS3MultipleTimes(c *tc.C) {
 
 	err := st.TransitionBackendToS3(c.Context(), backendUUID0, creds)
 	c.Assert(err, tc.ErrorIsNil)
-
-	// Force the file backend to be marked as dead.
-	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
-
-	err = st.TransitionBackendToS3(c.Context(), backendUUID1, creds)
+	info, err := st.GetActiveDrainingInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.SetDrainingPhase(c.Context(), info.UUID, coreobjectstore.PhaseCompleted)
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.MarkObjectStoreBackendAsDrained(c.Context(), defaultFileBackendUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.StartDraining(c.Context(), "foo")
+	err = st.TransitionBackendToS3(c.Context(), backendUUID1, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Force the first backend to be marked as dead.
@@ -855,7 +848,11 @@ func (s *stateSuite) TestTransitionBackendToS3MultipleTimes(c *tc.C) {
 	err = st.TransitionBackendToS3(c.Context(), backendUUID2, creds)
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrDrainingAlreadyInProgress)
 
-	err = st.SetDrainingPhase(c.Context(), "foo", coreobjectstore.PhaseCompleted)
+	info, err = st.GetActiveDrainingInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.SetDrainingPhase(c.Context(), info.UUID, coreobjectstore.PhaseCompleted)
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.MarkObjectStoreBackendAsDrained(c.Context(), backendUUID0)
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = st.TransitionBackendToS3(c.Context(), backendUUID2, creds)
@@ -877,24 +874,22 @@ func (s *stateSuite) TestTransitionBackendToS3WithActiveDrainingBackend(c *tc.C)
 	// This backend is ignored, as the draining phase is not active.
 	err := st.TransitionBackendToS3(c.Context(), backendUUID0, creds)
 	c.Assert(err, tc.ErrorIsNil)
-
-	// Force the file backend to be marked as dead.
-	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
+	info, err := st.GetActiveDrainingInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.SetDrainingPhase(c.Context(), info.UUID, coreobjectstore.PhaseCompleted)
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.MarkObjectStoreBackendAsDrained(c.Context(), defaultFileBackendUUID)
+	c.Assert(err, tc.ErrorIsNil)
 
 	err = st.TransitionBackendToS3(c.Context(), backendUUID1, creds)
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.StartDraining(c.Context(), "foo")
+	info, err = st.GetActiveDrainingInfo(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-
-	info, err := st.GetActiveDrainingInfo(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(info, tc.DeepEquals, domainobjectstore.DrainingInfo{
-		Phase:             string(coreobjectstore.PhaseDraining),
-		UUID:              "foo",
-		FromBackendUUID:   new(backendUUID0),
-		ActiveBackendUUID: backendUUID1,
-	})
+	c.Check(info.Phase, tc.Equals, string(coreobjectstore.PhaseDraining))
+	c.Assert(info.FromBackendUUID, tc.NotNil)
+	c.Check(*info.FromBackendUUID, tc.Equals, backendUUID0)
+	c.Check(info.ActiveBackendUUID, tc.Equals, backendUUID1)
 }
 
 func (s *stateSuite) TestTransitionBackendToS3NoActiveBackend(c *tc.C) {
@@ -965,6 +960,13 @@ WHERE object_store_backend_uuid = ?`, backendUUID)
 	c.Check(endpoint, tc.Equals, creds.Endpoint)
 	c.Check(accessKey, tc.Equals, creds.AccessKey)
 	c.Check(secretKey, tc.Equals, creds.SecretKey)
+
+	info, err := st.GetActiveDrainingInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.Phase, tc.Equals, string(coreobjectstore.PhaseDraining))
+	c.Assert(info.FromBackendUUID, tc.NotNil)
+	c.Check(*info.FromBackendUUID, tc.Equals, defaultFileBackendUUID)
+	c.Check(info.ActiveBackendUUID, tc.Equals, backendUUID)
 }
 
 func (s *stateSuite) TestMarkObjectStoreBackendAsDrained(c *tc.C) {
@@ -983,9 +985,14 @@ func (s *stateSuite) TestMarkObjectStoreBackendAsDrained(c *tc.C) {
 	// dying.
 	err := st.TransitionBackendToS3(c.Context(), drainingUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
+	info, err := st.GetActiveDrainingInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.SetDrainingPhase(c.Context(), info.UUID, coreobjectstore.PhaseCompleted)
+	c.Assert(err, tc.ErrorIsNil)
 
-	// Force the old backend to be marked as dead.
-	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
+	// Mark the old backend as drained before starting the next transition.
+	err = st.MarkObjectStoreBackendAsDrained(c.Context(), defaultFileBackendUUID)
+	c.Assert(err, tc.ErrorIsNil)
 
 	// Second call marks the first S3 backend as dying and activates a new one.
 	err = st.TransitionBackendToS3(c.Context(), activeUUID, creds)
@@ -1042,9 +1049,14 @@ func (s *stateSuite) TestMarkObjectStoreBackendAsDrainedReentrant(c *tc.C) {
 	// First promotion marks the default file backend as dying.
 	err := st.TransitionBackendToS3(c.Context(), drainingUUID, creds)
 	c.Assert(err, tc.ErrorIsNil)
+	info, err := st.GetActiveDrainingInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.SetDrainingPhase(c.Context(), info.UUID, coreobjectstore.PhaseCompleted)
+	c.Assert(err, tc.ErrorIsNil)
 
-	// Force the old backend to be marked as dead.
-	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
+	// Mark the old backend as drained before starting the next transition.
+	err = st.MarkObjectStoreBackendAsDrained(c.Context(), defaultFileBackendUUID)
+	c.Assert(err, tc.ErrorIsNil)
 
 	// Second promotion marks the first S3 backend as dying and activates a new
 	// one.

--- a/internal/cloudconfig/instancecfg/instancecfg.go
+++ b/internal/cloudconfig/instancecfg/instancecfg.go
@@ -32,7 +32,6 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/domain/deployment/charm"
@@ -521,7 +520,6 @@ func (cfg *InstanceConfig) AgentConfig(
 		configParams.OpenTelemetryStackTraces = cfg.ControllerConfig.OpenTelemetryStackTraces()
 		configParams.OpenTelemetrySampleRatio = cfg.ControllerConfig.OpenTelemetrySampleRatio()
 		configParams.OpenTelemetryTailSamplingThreshold = cfg.ControllerConfig.OpenTelemetryTailSamplingThreshold()
-		configParams.ObjectStoreType = objectstore.FileBackend
 	}
 	if cfg.Bootstrap == nil {
 		return agent.NewAgentConfig(configParams)

--- a/internal/cloudconfig/podcfg/podcfg.go
+++ b/internal/cloudconfig/podcfg/podcfg.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/environs/config"
@@ -115,7 +114,6 @@ func (cfg *ControllerPodConfig) AgentConfig(tag names.Tag) (agent.ConfigSetterWr
 		OpenTelemetryStackTraces:           cfg.Controller.OpenTelemetryStackTraces(),
 		OpenTelemetrySampleRatio:           cfg.Controller.OpenTelemetrySampleRatio(),
 		OpenTelemetryTailSamplingThreshold: cfg.Controller.OpenTelemetryTailSamplingThreshold(),
-		ObjectStoreType:                    objectstore.FileBackend,
 	}
 	return agent.NewStateMachineConfig(configParams, cfg.Bootstrap.ControllerAgentInfo)
 }

--- a/internal/objectstore/factory.go
+++ b/internal/objectstore/factory.go
@@ -249,15 +249,6 @@ func newFileObjectStore(ctx context.Context, namespace string, opts *options) (_
 	return newRemoteFileObjectStore(fileStore, blobRetriever)
 }
 
-// BackendTypeOrDefault returns the default backend type for the given object
-// store type or falls back to the default backend type.
-func BackendTypeOrDefault(objectStoreType objectstore.BackendType) objectstore.BackendType {
-	if s, err := objectstore.ParseObjectStoreType(objectStoreType.String()); err == nil {
-		return s
-	}
-	return DefaultBackendType()
-}
-
 // DefaultBackendType returns the default backend type for the given object
 // store type or falls back to the default backend type.
 func DefaultBackendType() objectstore.BackendType {

--- a/internal/worker/objectstore/worker.go
+++ b/internal/worker/objectstore/worker.go
@@ -396,7 +396,7 @@ func (w *objectStoreWorker) initObjectStore(ctx context.Context, namespace strin
 
 		objectStore, err := w.cfg.NewObjectStoreWorker(
 			ctx,
-			internalobjectstore.BackendTypeOrDefault(backendInfo.Type),
+			backendInfo.Type,
 			namespace,
 			internalobjectstore.WithRootDir(w.cfg.RootDir),
 			internalobjectstore.WithRootBucket(w.cfg.RootBucket),

--- a/internal/worker/objectstore/worker_test.go
+++ b/internal/worker/objectstore/worker_test.go
@@ -40,7 +40,7 @@ type workerSuite struct {
 	modelClaimGetter           *MockModelClaimGetter
 	modelMetadataService       *MockMetadataService
 	modelServices              *MockModelServices
-	called                     int64
+	called                     atomic.Int64
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
@@ -112,7 +112,7 @@ func (s *workerSuite) TestGetObjectStoreIsCached(c *tc.C) {
 
 	workertest.CleanKill(c, w)
 
-	c.Assert(atomic.LoadInt64(&s.called), tc.Equals, int64(1))
+	c.Assert(s.called.Load(), tc.Equals, int64(1))
 }
 
 func (s *workerSuite) TestGetObjectStoreIsNotCachedForDifferentNamespaces(c *tc.C) {
@@ -134,7 +134,7 @@ func (s *workerSuite) TestGetObjectStoreIsNotCachedForDifferentNamespaces(c *tc.
 
 	workertest.CleanKill(c, w)
 
-	c.Assert(atomic.LoadInt64(&s.called), tc.Equals, int64(10))
+	c.Assert(s.called.Load(), tc.Equals, int64(10))
 }
 
 func (s *workerSuite) TestGetObjectStoreConcurrently(c *tc.C) {
@@ -162,7 +162,7 @@ func (s *workerSuite) TestGetObjectStoreConcurrently(c *tc.C) {
 	}
 
 	assertWait(c, wg.Wait)
-	c.Assert(atomic.LoadInt64(&s.called), tc.Equals, int64(10))
+	c.Assert(s.called.Load(), tc.Equals, int64(10))
 
 	workertest.CleanKill(c, w)
 }
@@ -194,7 +194,7 @@ func (s *workerSuite) TestFlushWorkersRemovesCachedWorkers(c *tc.C) {
 	// Create a worker by requesting an object store.
 	_, err := w.GetObjectStore(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(atomic.LoadInt64(&s.called), tc.Equals, int64(1))
+	c.Check(s.called.Load(), tc.Equals, int64(1))
 
 	// Flush should remove all workers.
 	err = w.FlushWorkers(c.Context())
@@ -204,7 +204,7 @@ func (s *workerSuite) TestFlushWorkersRemovesCachedWorkers(c *tc.C) {
 	// proving the cache was cleared.
 	_, err = w.GetObjectStore(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(atomic.LoadInt64(&s.called), tc.Equals, int64(2))
+	c.Check(s.called.Load(), tc.Equals, int64(2))
 
 	workertest.CleanKill(c, w)
 }
@@ -249,7 +249,7 @@ func (s *workerSuite) newWorker(c *tc.C) *objectStoreWorker {
 			if ns == "denied" {
 				return nil, database.ErrDBNotFound
 			}
-			atomic.AddInt64(&s.called, 1)
+			s.called.Add(1)
 			return newStubTrackedObjectStore(s.trackedObjectStore), nil
 		},
 		NewTrackerWorker: func(modelUUID model.UUID, modelService ModelService, objectStore TrackedObjectStore, tracer trace.Tracer, logger logger.Logger) (worker.Worker, error) {
@@ -275,7 +275,7 @@ func (s *workerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	// Ensure we buffer the channel, this is because we might miss the
 	// event if we're too quick at starting up.
 	s.states = make(chan string, 1)
-	atomic.StoreInt64(&s.called, 0)
+	s.called.Store(0)
 
 	ctrl := s.baseSuite.setupMocks(c)
 

--- a/internal/worker/objectstoredrainer/manifold.go
+++ b/internal/worker/objectstoredrainer/manifold.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	coreobjectstore "github.com/juju/juju/core/objectstore"
-	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/worker/fortress"
@@ -60,9 +59,6 @@ type GetControllerConfigServiceFunc func(getter dependency.Getter, name string) 
 type ControllerConfigService interface {
 	// ControllerConfig returns the current controller configuration.
 	ControllerConfig(context.Context) (controller.Config, error)
-
-	// WatchControllerConfig watches the controller config for changes.
-	WatchControllerConfig(context.Context) (watcher.StringsWatcher, error)
 }
 
 // ManifoldConfig holds the dependencies and configuration for a

--- a/internal/worker/objectstoredrainer/manifold.go
+++ b/internal/worker/objectstoredrainer/manifold.go
@@ -18,10 +18,8 @@ import (
 	"github.com/juju/juju/core/model"
 	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/watcher"
-	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/internal/services"
-	internalworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/fortress"
 )
 
@@ -203,54 +201,13 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 	currentConfig := a.CurrentConfig()
 	dataDir := currentConfig.DataDir()
 
-	phase, err := guardService.GetDrainingPhase(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var (
-		objectStoreTypeChanged                       bool
-		agentsObjectStoreType, configObjectStoreType coreobjectstore.BackendType
-	)
-	err = a.ChangeConfig(func(cfg agent.ConfigSetter) error {
-		agentsObjectStoreType = cfg.ObjectStoreType()
-		configObjectStoreType = coreobjectstore.FileBackend
-		objectStoreTypeChanged = agentsObjectStoreType != configObjectStoreType
-
-		// We've bounced whilst draining, so we need to ensure that we don't
-		// change the object store type if we're still draining.
-		if phase.IsDraining() && objectStoreTypeChanged {
-			objectStoreTypeChanged = false
-		}
-
-		if objectStoreTypeChanged {
-			config.Logger.Debugf(ctx, "setting object store type: %q => %q", agentsObjectStoreType, configObjectStoreType)
-			cfg.SetObjectStoreType(configObjectStoreType)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// If the object store type has changed whilst we're starting the worker,
-	// crash the agent and come back up clean.
-	if objectStoreTypeChanged {
-		config.Logger.Infof(ctx, "restarting agent for new object store type")
-		return nil, internalerrors.Errorf("object store type changed from %q to %q", agentsObjectStoreType, configObjectStoreType).
-			Add(internalworker.ErrRestartAgent)
-	}
-
 	worker, err := config.NewWorker(Config{
-		Agent:                        a,
 		Guard:                        fortress,
 		GuardService:                 guardService,
 		ControllerService:            controllerService,
-		ControllerConfigService:      controllerConfigService,
 		ControllerObjectStoreService: controllerObjectStoreSerivce,
 		ObjectStoreServicesGetter:    objectStoreServicesGetter,
 		ObjectStoreFlusher:           objectStoreFlusher,
-		ObjectStoreType:              configObjectStoreType,
 		NewHashFileSystemAccessor:    config.NewHashFileSystemAccessor,
 		NewDrainerWorker:             config.NewDrainerWorker,
 		SelectFileHash:               config.SelectFileHash,

--- a/internal/worker/objectstoredrainer/manifold_test.go
+++ b/internal/worker/objectstoredrainer/manifold_test.go
@@ -16,7 +16,6 @@ import (
 	"go.uber.org/goleak"
 	gomock "go.uber.org/mock/gomock"
 
-	agent "github.com/juju/juju/agent"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
@@ -157,18 +156,11 @@ func (s *manifoldSuite) TestStart(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.agentConfig.EXPECT().DataDir().Return(c.MkDir())
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
 	s.agent.EXPECT().CurrentConfig().Return(s.agentConfig)
 
 	cfg := internaltesting.FakeControllerConfig()
 
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(cfg, nil)
-
-	s.guardService.EXPECT().GetDrainingPhase(gomock.Any()).Return(objectstore.PhaseUnknown, nil)
-
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 
 	w, err := Manifold(s.getConfig(c)).Start(c.Context(), s.newGetter())
 	c.Assert(err, tc.ErrorIsNil)

--- a/internal/worker/objectstoredrainer/worker.go
+++ b/internal/worker/objectstoredrainer/worker.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/catacomb"
 
-	"github.com/juju/juju/agent"
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
@@ -80,14 +79,12 @@ type ControllerService interface {
 
 // Config holds the dependencies and configuration for a Worker.
 type Config struct {
-	Agent                        agent.Agent
 	Guard                        fortress.Guard
 	GuardService                 GuardService
 	ControllerService            ControllerService
 	ControllerObjectStoreService objectstore.ObjectStoreMetadata
 	ObjectStoreServicesGetter    ObjectStoreServicesGetter
 	ObjectStoreFlusher           objectstore.ObjectStoreFlusher
-	ObjectStoreType              objectstore.BackendType
 	NewHashFileSystemAccessor    NewHashFileSystemAccessorFunc
 	NewDrainerWorker             NewDrainerWorkerFunc
 	S3Client                     objectstore.Client
@@ -101,9 +98,6 @@ type Config struct {
 // Validate returns an error if the config cannot be expected to
 // drive a functional Worker.
 func (config Config) Validate() error {
-	if config.Agent == nil {
-		return errors.Errorf("nil Agent").Add(coreerrors.NotValid)
-	}
 	if config.Guard == nil {
 		return errors.Errorf("nil Guard").Add(coreerrors.NotValid)
 	}
@@ -175,8 +169,6 @@ func NewWorker(config Config) (worker.Worker, error) {
 	w := &Worker{
 		runner: runner,
 
-		agent: config.Agent,
-
 		guard:        config.Guard,
 		guardService: config.GuardService,
 
@@ -185,7 +177,6 @@ func NewWorker(config Config) (worker.Worker, error) {
 
 		objectStoreServicesGetter: config.ObjectStoreServicesGetter,
 		objectStoreFlusher:        config.ObjectStoreFlusher,
-		objectStoreType:           config.ObjectStoreType,
 
 		newDrainWorker: config.NewDrainerWorker,
 		newFileSystem:  config.NewHashFileSystemAccessor,
@@ -220,8 +211,6 @@ type Worker struct {
 	catacomb catacomb.Catacomb
 	runner   *worker.Runner
 
-	agent agent.Agent
-
 	guard        fortress.Guard
 	guardService GuardService
 
@@ -230,7 +219,6 @@ type Worker struct {
 
 	objectStoreServicesGetter ObjectStoreServicesGetter
 	objectStoreFlusher        objectstore.ObjectStoreFlusher
-	objectStoreType           objectstore.BackendType
 
 	newFileSystem  NewHashFileSystemAccessorFunc
 	newDrainWorker NewDrainerWorkerFunc
@@ -347,37 +335,6 @@ func (w *Worker) loop() error {
 	}
 }
 
-// HandleConfigChange starts the whole draining process if the object store
-// type has changed.
-func (w *Worker) handleConfigChange(ctx context.Context) error {
-	phase, err := w.guardService.GetDrainingPhase(ctx)
-	if err != nil {
-		return errors.Capture(err)
-	}
-
-	objectStoreType := objectstore.FileBackend
-	objectStoreTypeChanged := objectStoreType != w.objectStoreType
-
-	if !objectStoreTypeChanged {
-		w.logger.Debugf(ctx, "object store type has not changed: %q", w.objectStoreType)
-		return nil
-	} else if phase.IsDraining() {
-		w.logger.Infof(ctx, "object store is already draining, no action taken")
-		return nil
-	}
-
-	w.logger.Debugf(ctx, "object store type changed: %q => %q", w.objectStoreType, objectStoreType)
-
-	w.objectStoreType = objectStoreType
-
-	// Force the draining process to move into the draining phase.
-	if err := w.guardService.SetDrainingPhase(ctx, objectstore.PhaseDraining); err != nil {
-		return errors.Capture(err)
-	}
-
-	return nil
-}
-
 func (w *Worker) drainAgentBinaries(ctx context.Context) error {
 	w.logger.Infof(ctx, "draining controller agent binaries")
 	signal := make(chan string, 1)
@@ -466,26 +423,9 @@ func (w *Worker) waitForDraining(ctx context.Context, signal <-chan string, name
 	}
 }
 
-// completeDraining updates the agent configuration to indicate that the
-// object store type has changed and then flushes the object store workers.
-// It sets the draining phase to completed, which will cause the main loop
-// to unlock the guard and allow the object store to be used again.
+// completeDraining flushes the object store workers and marks the draining
+// phase as completed so the guard can be unlocked.
 func (w *Worker) completeDraining(ctx context.Context) error {
-	// If we're in a completed state (PhaseCompleted), we can safely update the
-	// agent configuration and then force the object store to pick up the
-	// new configuration.
-	w.logger.Infof(ctx, "object store is in a completed state, updating agent configuration")
-	if err := w.agent.ChangeConfig(func(setter agent.ConfigSetter) error {
-		w.logger.Debugf(ctx, "setting object store type: %q => %q", setter.ObjectStoreType(), w.objectStoreType)
-		setter.SetObjectStoreType(w.objectStoreType)
-		return nil
-	}); err != nil {
-		return errors.Capture(err)
-	}
-
-	// Flush the object store workers to ensure that they are all stopped and
-	// removed. This is necessary to ensure that the object store is in a clean
-	// state before we start using it again.
 	if err := w.objectStoreFlusher.FlushWorkers(ctx); err != nil {
 		return errors.Capture(err)
 	}

--- a/internal/worker/objectstoredrainer/worker.go
+++ b/internal/worker/objectstoredrainer/worker.go
@@ -84,7 +84,6 @@ type Config struct {
 	Guard                        fortress.Guard
 	GuardService                 GuardService
 	ControllerService            ControllerService
-	ControllerConfigService      ControllerConfigService
 	ControllerObjectStoreService objectstore.ObjectStoreMetadata
 	ObjectStoreServicesGetter    ObjectStoreServicesGetter
 	ObjectStoreFlusher           objectstore.ObjectStoreFlusher
@@ -113,9 +112,6 @@ func (config Config) Validate() error {
 	}
 	if config.ControllerService == nil {
 		return errors.Errorf("nil ControllerService").Add(coreerrors.NotValid)
-	}
-	if config.ControllerConfigService == nil {
-		return errors.Errorf("nil ControllerConfigService").Add(coreerrors.NotValid)
 	}
 	if config.ControllerObjectStoreService == nil {
 		return errors.Errorf("nil controllerObjectStoreService").Add(coreerrors.NotValid)
@@ -185,7 +181,6 @@ func NewWorker(config Config) (worker.Worker, error) {
 		guardService: config.GuardService,
 
 		controllerService:            config.ControllerService,
-		controllerConfigService:      config.ControllerConfigService,
 		controllerObjectStoreService: config.ControllerObjectStoreService,
 
 		objectStoreServicesGetter: config.ObjectStoreServicesGetter,
@@ -231,7 +226,6 @@ type Worker struct {
 	guardService GuardService
 
 	controllerService            ControllerService
-	controllerConfigService      ControllerConfigService
 	controllerObjectStoreService objectstore.ObjectStoreMetadata
 
 	objectStoreServicesGetter ObjectStoreServicesGetter
@@ -271,15 +265,6 @@ func (w *Worker) Report(ctx context.Context) map[string]any {
 func (w *Worker) loop() error {
 	ctx := w.catacomb.Context(context.Background())
 
-	cfgWatcher, err := w.controllerConfigService.WatchControllerConfig(ctx)
-	if err != nil {
-		return errors.Capture(err)
-	}
-
-	if err := w.catacomb.Add(cfgWatcher); err != nil {
-		return errors.Capture(err)
-	}
-
 	drainingWatcher, err := w.guardService.WatchDraining(ctx)
 	if err != nil {
 		return errors.Capture(err)
@@ -292,11 +277,6 @@ func (w *Worker) loop() error {
 		select {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
-
-		case <-cfgWatcher.Changes():
-			if err := w.handleConfigChange(ctx); err != nil {
-				return errors.Capture(err)
-			}
 
 		case <-drainingWatcher.Changes():
 			phase, err := w.guardService.GetDrainingPhase(ctx)
@@ -370,11 +350,6 @@ func (w *Worker) loop() error {
 // HandleConfigChange starts the whole draining process if the object store
 // type has changed.
 func (w *Worker) handleConfigChange(ctx context.Context) error {
-	_, err := w.controllerConfigService.ControllerConfig(ctx)
-	if err != nil {
-		return errors.Capture(err)
-	}
-
 	phase, err := w.guardService.GetDrainingPhase(ctx)
 	if err != nil {
 		return errors.Capture(err)

--- a/internal/worker/objectstoredrainer/worker_test.go
+++ b/internal/worker/objectstoredrainer/worker_test.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"gopkg.in/tomb.v2"
 
-	agent "github.com/juju/juju/agent"
 	"github.com/juju/juju/core/logger"
 	model "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
@@ -40,10 +39,6 @@ func TestWorkerSuite(t *stdtesting.T) {
 
 func (s *workerSuite) TestObjectStoreDrainingNotDraining(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-
-	s.controllerConfigService.EXPECT().WatchControllerConfig(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[[]string], error) {
-		return watchertest.NewMockStringsWatcher(make(chan []string)), nil
-	})
 
 	draining := make(chan struct{})
 	watcher := watchertest.NewMockNotifyWatcher(draining)
@@ -77,10 +72,6 @@ func (s *workerSuite) TestObjectStoreDrainingNotDraining(c *tc.C) {
 func (s *workerSuite) TestObjectStoreDrainingDraining(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.controllerConfigService.EXPECT().WatchControllerConfig(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[[]string], error) {
-		return watchertest.NewMockStringsWatcher(make(chan []string)), nil
-	})
-
 	draining := make(chan struct{})
 	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
 		return watchertest.NewMockNotifyWatcher(draining), nil
@@ -92,12 +83,6 @@ func (s *workerSuite) TestObjectStoreDrainingDraining(c *tc.C) {
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return([]string{"model-uuid1"}, nil)
 	s.objectStoreServicesGetter.EXPECT().ServicesForModel(model.UUID("model-uuid1")).Return(s.objectStoreService)
 	s.objectStoreService.EXPECT().ObjectStore().Return(s.objectStoreMetadata)
-
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
 
@@ -127,10 +112,6 @@ func (s *workerSuite) TestObjectStoreDrainingDraining(c *tc.C) {
 
 func (s *workerSuite) TestObjectStoreDrainingNamespaceError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-
-	s.controllerConfigService.EXPECT().WatchControllerConfig(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[[]string], error) {
-		return watchertest.NewMockStringsWatcher(make(chan []string)), nil
-	})
 
 	ch := make(chan struct{})
 	watcher := watchertest.NewMockNotifyWatcher(ch)
@@ -174,14 +155,12 @@ func (s *workerSuite) newWorker(c *tc.C) worker.Worker {
 
 func (s *workerSuite) getConfig(c *tc.C) Config {
 	return Config{
-		Agent:                        s.agent,
 		Guard:                        s.guard,
 		GuardService:                 s.guardService,
 		ControllerService:            s.controllerService,
 		ObjectStoreServicesGetter:    s.objectStoreServicesGetter,
 		ControllerObjectStoreService: s.controllerObjectStoreMetadata,
 		ObjectStoreFlusher:           s.objectStoreFlusher,
-		ObjectStoreType:              objectstore.FileBackend,
 		S3Client:                     s.s3Client,
 		NewHashFileSystemAccessor: func(namespace, rootDir string, logger logger.Logger) HashFileSystemAccessor {
 			return s.hashFileSystemAccessor

--- a/internal/worker/objectstoredrainer/worker_test.go
+++ b/internal/worker/objectstoredrainer/worker_test.go
@@ -178,7 +178,6 @@ func (s *workerSuite) getConfig(c *tc.C) Config {
 		Guard:                        s.guard,
 		GuardService:                 s.guardService,
 		ControllerService:            s.controllerService,
-		ControllerConfigService:      s.controllerConfigService,
 		ObjectStoreServicesGetter:    s.objectStoreServicesGetter,
 		ControllerObjectStoreService: s.controllerObjectStoreMetadata,
 		ObjectStoreFlusher:           s.objectStoreFlusher,


### PR DESCRIPTION
This change removes the object store drainer's dependency on `agent.conf` as the source of truth for object store backend transitions.

Before this change, the drainer partly relied on agent config state to determine or persist object store backend changes. Now the database owns both:

- active object store backend state
- draining lifecycle state

The drainer no longer reads or mutates `agent.conf`. It only reacts to the draining phase stored in the database.

## Why

`agent.conf` was the wrong place to coordinate object store backend migration.

Backend transitions and draining are controller-wide state, not local agent state. Keeping part of that workflow in `agent.conf` created split ownership:

- backend/draining state in the database
- backend type persisted in agent config
- worker startup/update logic trying to reconcile the two

This change makes the database the single source of truth for the full transition.

## Previous behavior

The object store drainer previously had logic tied to `agent.conf`:

- the manifold read the current agent config
- startup logic compared object store type and could update `agent.conf`
- the worker carried object store type state internally
- draining completion updated `agent.conf` with the new object store type
- older flow also used controller-config/agent-config driven change detection to kick off draining behavior

In practice, the drainer was not just consuming drain state. It also participated in backend-type reconciliation through agent config mutation.

## New behavior

The flow is now fully DB-driven:

1. a backend transition to S3 is requested through the object store domain service
2. `TransitionBackendToS3` updates backend state in the database
3. that same transition also creates the draining record in the database
4. backend watchers react to backend-table changes as needed
5. `objectstoredrainer` reacts only to `WatchDraining`
6. when draining finishes, the drainer flushes object store workers and marks the draining phase completed
7. no agent config mutation happens at any point

So the drainer is now a pure draining-phase consumer.

## What changed

### `objectstoredrainer`
- removed agent dependency from the worker config
- removed internal object-store-type tracking from the worker
- removed remaining config-change handling logic
- removed completion-time mutation of `agent.conf`
- kept the worker focused on:
  - watching draining state
  - locking down during drain
  - draining controller/model data
  - completing the drain in DB state

### Object store domain/state
- `TransitionBackendToS3` now initiates draining as part of the database transition
- backend transition and drain start are now coordinated at the DB layer

### Agent config
- removed `ObjectStoreType` from `format-2.0.go`
- removed `ObjectStoreType` from agent config API/storage
- removed remaining call sites that populated or relied on that field

## Result

After this change:

- `agent.conf` is no longer involved in object store backend migration
- the database is the single source of truth for both backend and draining state
- `objectstoredrainer` has a narrower and cleaner responsibility
- backend transition semantics are easier to reason about and test


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Set up minio as S3 compatible store:

```sh
mkdir -p ${HOME}/.local/minio/data
docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   --user $(id -u):$(id -g) \
   --name minio1 \
   -e "MINIO_ROOT_USER=ROOTUSER" \
   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
   -v ${HOME}/.local/minio/data:/data \
   quay.io/minio/minio server /data --console-address ":9001"1

❯ docker exec -it minio1 bash
❯ mc alias set foo http://localhost:9000 ROOTUSER CHANGEME123
❯ mc admin info foo
❯ mc admin accesskey create foo
# Note down the access keys
```


**Build controller charm**
Checkout the following juju/juju-controller#107 and then pack it for use.

```sh
❯ charmcraft pack
❯ mv juju-controller_ubuntu@24.04-amd64.charm <juju location>
```

**Bootstrap**

```sh
❯ juju bootstrap lxd src --bootstrap-base=ubuntu@24.04 --controller-charm-path=$GOBIN/juju-controller_ubuntu@24.04-amd64.charm --build-agent
```

Add another model so we can test that:

```sh
❯ juju add-model foo
❯ juju deploy juju-qa-test
```

**Drain:** 

Add the s3-integrator so it can drive the draining:

```sh
❯ juju switch controller
❯ juju deploy s3-integrator
❯ juju integrate controller:s3-backend s3-integrator
❯ juju config s3-integrator endpoint=http://172.17.0.1:9000
❯ juju run s3-integrator/leader sync-s3-credentials access-key=<access key> secret-key=<secret key>
```

Check the logs:

```sh
❯ juju debug-log --replay -m controller | rg drain
machine-0: 15:15:56 DEBUG juju.worker.dependency "object-store-drainer" manifold worker started at 2026-06-02 13:15:56.95926704 +0000 UTC
machine-0: 15:15:56 INFO juju.worker.objectstoredrainer object store is not draining, unlocking guard
machine-0: 15:28:02 INFO juju.worker.objectstoredrainer object store is draining, locking guard
machine-0: 15:28:02 INFO juju.worker.objectstoredrainer draining controller agent binaries
machine-0: 15:28:02 INFO juju.worker.objectstoredrainer runner "objectstore-drainer" starting worker "controller"
machine-0: 15:28:02 INFO juju.worker.objectstoredrainer runner "objectstore-drainer" waiting 10s before starting worker "controller"
machine-0: 15:28:12 INFO juju.worker.objectstoredrainer runner "objectstore-drainer" starting worker "controller"
machine-0: 15:28:12 INFO juju.worker.objectstoredrainer drain worker for controller agent binaries completed
machine-0: 15:28:12 INFO juju.worker.objectstoredrainer draining model "2a1d1d9b-17a3-401a-871c-32fcceb3a13d"
machine-0: 15:28:12 INFO juju.worker.objectstoredrainer draining model "ffe0125e-7229-4634-8c87-4e999b912da8"
machine-0: 15:28:12 INFO juju.worker.objectstoredrainer runner "objectstore-drainer" starting worker "2a1d1d9b-17a3-401a-871c-32fcceb3a13d"
machine-0: 15:28:12 INFO juju.worker.objectstoredrainer runner "objectstore-drainer" starting worker "ffe0125e-7229-4634-8c87-4e999b912da8"
machine-0: 15:28:13 INFO juju.worker.objectstoredrainer drain worker for model "ffe0125e-7229-4634-8c87-4e999b912da8" completed
machine-0: 15:28:13 INFO juju.worker.objectstoredrainer waiting for 1 more drain workers to complete
machine-0: 15:28:13 INFO juju.worker.objectstoredrainer drain worker for model "2a1d1d9b-17a3-401a-871c-32fcceb3a13d" completed
machine-0: 15:28:13 INFO juju.worker.objectstoredrainer object store draining completed successfully
machine-0: 15:28:16 INFO juju.worker.objectstoredrainer object store is not draining, unlocking guard

```


Check the db:

```sh
❯ juju ssh -m controller 0
❯ juju_db_repl
repl (controller)> SELECT * FROM object_store_backend
uuid					life_id	type_id	updated_at				
653813f9-2896-5332-8cbe-629a337a56a3	1	0	2026-06-02 13:27:59.074177997 +0000 UTC
638653da-a875-4534-8f4d-c624fee4ec5e	0	1	2026-06-02 13:27:59.074177997 +0000 UTC

repl (controller)> SELECT * FROM object_store_drain_info
uuid					phase_type_id	from_backend_uuid			to_backend_uuid				
303f266f-3244-4459-82a7-d4b1a6986a6f	3		653813f9-2896-5332-8cbe-629a337a56a3	638653da-a875-4534-8f4d-c624fee4ec5e	

```

## Documentation changes


## Links

Relates to: #22380

**Jira card:** [JUJU-9721](https://warthogs.atlassian.net/browse/JUJU-9721)


[JUJU-9721]: https://warthogs.atlassian.net/browse/JUJU-9721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ