### PR TITLE
chore: remove object store drainer dependency on agent.conf

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/core/machinelock"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/semversion"
 	internallogger "github.com/juju/juju/internal/logger"
@@ -310,9 +309,6 @@ type Config interface {
 	// sampling. The lower the threshold, the more spans will be sampled.
 	OpenTelemetryTailSamplingThreshold() time.Duration
 
-	// ObjectStoreType returns the type of object store to use.
-	ObjectStoreType() objectstore.BackendType
-
 	// DqlitePort returns the port that should be used by Dqlite. This should
 	// only be set during testing.
 	DqlitePort() (int, bool)
@@ -385,9 +381,6 @@ type configSetterOnly interface {
 	// SetOpenTelemetryTailSamplingThreshold sets the threshold for tail-based
 	// sampling. The lower the threshold, the more spans will be sampled.
 	SetOpenTelemetryTailSamplingThreshold(time.Duration)
-
-	// SetObjectStoreType sets the type of object store to use.
-	SetObjectStoreType(objectstore.BackendType)
 }
 
 // LogFileName returns the filename for the Agent's log file.
@@ -470,7 +463,6 @@ type configInternal struct {
 	openTelemetryStackTraces           bool
 	openTelemetrySampleRatio           float64
 	openTelemetryTailSamplingThreshold time.Duration
-	objectStoreType                    objectstore.BackendType
 	dqlitePort                         int
 }
 
@@ -499,7 +491,6 @@ type AgentConfigParams struct {
 	OpenTelemetryStackTraces           bool
 	OpenTelemetrySampleRatio           float64
 	OpenTelemetryTailSamplingThreshold time.Duration
-	ObjectStoreType                    objectstore.BackendType
 	DqlitePort                         int
 }
 
@@ -571,7 +562,6 @@ func NewAgentConfig(configParams AgentConfigParams) (ConfigSetterWriter, error) 
 		openTelemetryStackTraces:           configParams.OpenTelemetryStackTraces,
 		openTelemetrySampleRatio:           configParams.OpenTelemetrySampleRatio,
 		openTelemetryTailSamplingThreshold: configParams.OpenTelemetryTailSamplingThreshold,
-		objectStoreType:                    configParams.ObjectStoreType,
 		dqlitePort:                         configParams.DqlitePort,
 	}
 	if len(configParams.APIAddresses) > 0 {
@@ -954,16 +944,6 @@ func (c *configInternal) OpenTelemetryTailSamplingThreshold() time.Duration {
 // SetOpenTelemetryTailSamplingThreshold implements configSetterOnly.
 func (c *configInternal) SetOpenTelemetryTailSamplingThreshold(v time.Duration) {
 	c.openTelemetryTailSamplingThreshold = v
-}
-
-// ObjectStoreType implements Config.
-func (c *configInternal) ObjectStoreType() objectstore.BackendType {
-	return c.objectStoreType
-}
-
-// SetObjectStoreType implements configSetterOnly.
-func (c *configInternal) SetObjectStoreType(v objectstore.BackendType) {
-	c.objectStoreType = v
 }
 
 var validAddr = regexp.MustCompile("^.+:[0-9]+$")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/semversion"
 	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/internal/testing"
@@ -708,16 +707,4 @@ func (*suite) TestSetOpenTelemetryTailSamplingThreshold(c *tc.C) {
 	conf.SetOpenTelemetryTailSamplingThreshold(time.Second)
 	queryTracingTailSamplingThreshold = conf.OpenTelemetryTailSamplingThreshold()
 	c.Assert(queryTracingTailSamplingThreshold, tc.Equals, time.Second, tc.Commentf("open telemetry tail sampling threshold setting not updated"))
-}
-
-func (*suite) TestSetObjectStoreType(c *tc.C) {
-	conf, err := agent.NewAgentConfig(attributeParams)
-	c.Assert(err, tc.ErrorIsNil)
-
-	objectStoreType := conf.ObjectStoreType()
-	c.Assert(objectStoreType, tc.Equals, attributeParams.ObjectStoreType)
-
-	conf.SetObjectStoreType("s3")
-	objectStoreType = conf.ObjectStoreType()
-	c.Assert(objectStoreType, tc.Equals, objectstore.S3Backend, tc.Commentf("object store type setting not updated"))
 }

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/semversion"
 )
 
@@ -70,8 +69,6 @@ type format_2_0Serialization struct {
 	OpenTelemetryStackTraces           bool          `yaml:"opentelemetrystacktraces,omitempty"`
 	OpenTelemetrySampleRatio           string        `yaml:"opentelemetrysampleratio,omitempty"`
 	OpenTelemetryTailSamplingThreshold time.Duration `yaml:"opentelemetrytailsamplingthreshold,omitempty"`
-
-	ObjectStoreType string `yaml:"objectstoretype,omitempty"`
 
 	DqlitePort int `yaml:"dqlite-port,omitempty"`
 }
@@ -162,13 +159,6 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 		}
 		config.openTelemetrySampleRatio = sampleRatio
 	}
-	if format.ObjectStoreType != "" {
-		objectStoreType, err := objectstore.ParseObjectStoreType(format.ObjectStoreType)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		config.objectStoreType = objectStoreType
-	}
 	return config, nil
 }
 
@@ -222,9 +212,6 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 	}
 	if config.openTelemetrySampleRatio != 0 {
 		format.OpenTelemetrySampleRatio = fmt.Sprintf("%.04f", config.openTelemetrySampleRatio)
-	}
-	if config.objectStoreType != "" {
-		format.ObjectStoreType = config.objectStoreType.String()
 	}
 	return goyaml.Marshal(format)
 }

--- a/agent/format-2.0_whitebox_test.go
+++ b/agent/format-2.0_whitebox_test.go
@@ -18,7 +18,6 @@ import (
 
 	agentconstants "github.com/juju/juju/agent/constants"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/internal/testing"
 )
@@ -113,22 +112,6 @@ func (*format_2_0Suite) TestOpenTelemetry(c *tc.C) {
 	c.Check(newConfig.OpenTelemetryStackTraces(), tc.IsTrue)
 	c.Check(newConfig.OpenTelemetrySampleRatio(), tc.Equals, 0.5)
 	c.Check(newConfig.OpenTelemetryTailSamplingThreshold(), tc.Equals, time.Second)
-}
-
-func (*format_2_0Suite) TestObjectStore(c *tc.C) {
-	config := newTestConfig(c)
-	// configFilePath is not serialized as it is the location of the file.
-	config.configFilePath = ""
-
-	config.SetObjectStoreType(objectstore.FileBackend)
-
-	data, err := format_2_0.marshal(config)
-	c.Assert(err, tc.ErrorIsNil)
-	newConfig, err := format_2_0.unmarshal(data)
-	c.Assert(err, tc.ErrorIsNil)
-
-	c.Check(newConfig, tc.DeepEquals, config)
-	c.Check(newConfig.ObjectStoreType(), tc.Equals, objectstore.FileBackend)
 }
 
 var agentConfig2_0Contents = `

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -105,8 +105,6 @@ func (s *AgentSuite) PrimeAgentVersion(c *tc.C, tag names.Tag, password string, 
 			OpenTelemetrySampleRatio:           controller.DefaultOpenTelemetrySampleRatio,
 			OpenTelemetryTailSamplingThreshold: controller.DefaultOpenTelemetryTailSamplingThreshold,
 
-			ObjectStoreType: controller.DefaultObjectStoreType,
-
 			DqlitePort: dqlitePort,
 		},
 	)
@@ -187,8 +185,6 @@ func (s *AgentSuite) WriteStateAgentConfig(
 			OpenTelemetryStackTraces:           controller.DefaultOpenTelemetryStackTraces,
 			OpenTelemetrySampleRatio:           controller.DefaultOpenTelemetrySampleRatio,
 			OpenTelemetryTailSamplingThreshold: controller.DefaultOpenTelemetryTailSamplingThreshold,
-
-			ObjectStoreType: controller.DefaultObjectStoreType,
 
 			DqlitePort: dqlitePort,
 		},

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/core/objectstore"
 	coreos "github.com/juju/juju/core/os"
 	coreuser "github.com/juju/juju/core/user"
 	jujuversion "github.com/juju/juju/core/version"
@@ -291,7 +290,6 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 		agentConfig.SetOpenTelemetryStackTraces(args.ControllerConfig.OpenTelemetryStackTraces())
 		agentConfig.SetOpenTelemetrySampleRatio(args.ControllerConfig.OpenTelemetrySampleRatio())
 		agentConfig.SetOpenTelemetryTailSamplingThreshold(args.ControllerConfig.OpenTelemetryTailSamplingThreshold())
-		agentConfig.SetObjectStoreType(objectstore.FileBackend)
 
 		return nil
 	}); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/compute v1.44.0

--- a/internal/cloudconfig/instancecfg/instancecfg.go
+++ b/internal/cloudconfig/instancecfg/instancecfg.go
@@ -32,7 +32,6 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/domain/deployment/charm"
@@ -521,7 +520,6 @@ func (cfg *InstanceConfig) AgentConfig(
 		configParams.OpenTelemetryStackTraces = cfg.ControllerConfig.OpenTelemetryStackTraces()
 		configParams.OpenTelemetrySampleRatio = cfg.ControllerConfig.OpenTelemetrySampleRatio()
 		configParams.OpenTelemetryTailSamplingThreshold = cfg.ControllerConfig.OpenTelemetryTailSamplingThreshold()
-		configParams.ObjectStoreType = objectstore.FileBackend
 	}
 	if cfg.Bootstrap == nil {
 		return agent.NewAgentConfig(configParams)

--- a/internal/cloudconfig/podcfg/podcfg.go
+++ b/internal/cloudconfig/podcfg/podcfg.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/environs/config"
@@ -115,7 +114,6 @@ func (cfg *ControllerPodConfig) AgentConfig(tag names.Tag) (agent.ConfigSetterWr
 		OpenTelemetryStackTraces:           cfg.Controller.OpenTelemetryStackTraces(),
 		OpenTelemetrySampleRatio:           cfg.Controller.OpenTelemetrySampleRatio(),
 		OpenTelemetryTailSamplingThreshold: cfg.Controller.OpenTelemetryTailSamplingThreshold(),
-		ObjectStoreType:                    objectstore.FileBackend,
 	}
 	return agent.NewStateMachineConfig(configParams, cfg.Bootstrap.ControllerAgentInfo)
 }

--- a/internal/objectstore/factory.go
+++ b/internal/objectstore/factory.go
@@ -249,15 +249,6 @@ func newFileObjectStore(ctx context.Context, namespace string, opts *options) (_
 	return newRemoteFileObjectStore(fileStore, blobRetriever)
 }
 
-// BackendTypeOrDefault returns the default backend type for the given object
-// store type or falls back to the default backend type.
-func BackendTypeOrDefault(objectStoreType objectstore.BackendType) objectstore.BackendType {
-	if s, err := objectstore.ParseObjectStoreType(objectStoreType.String()); err == nil {
-		return s
-	}
-	return DefaultBackendType()
-}
-
 // DefaultBackendType returns the default backend type for the given object
 // store type or falls back to the default backend type.
 func DefaultBackendType() objectstore.BackendType {

--- a/internal/upgrade/agent_mock_test.go
+++ b/internal/upgrade/agent_mock_test.go
@@ -17,7 +17,6 @@ import (
 	api "github.com/juju/juju/api"
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -792,44 +791,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/upgradesteps/agent_mock_test.go
+++ b/internal/upgradesteps/agent_mock_test.go
@@ -18,7 +18,6 @@ import (
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -793,44 +792,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2117,44 +2078,6 @@ func (c *MockConfigSetterNonceCall) DoAndReturn(f func() string) *MockConfigSett
 	return c
 }
 
-// ObjectStoreType mocks base method.
-func (m *MockConfigSetter) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) ObjectStoreType() *MockConfigSetterObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).ObjectStoreType))
-	return &MockConfigSetterObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // OldPassword mocks base method.
 func (m *MockConfigSetter) OldPassword() string {
 	m.ctrl.T.Helper()
@@ -2675,42 +2598,6 @@ func (c *MockConfigSetterSetLoggingConfigCall) Do(f func(string)) *MockConfigSet
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigSetterSetLoggingConfigCall) DoAndReturn(f func(string)) *MockConfigSetterSetLoggingConfigCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// SetObjectStoreType mocks base method.
-func (m *MockConfigSetter) SetObjectStoreType(arg0 objectstore.BackendType) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetObjectStoreType", arg0)
-}
-
-// SetObjectStoreType indicates an expected call of SetObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) SetObjectStoreType(arg0 any) *MockConfigSetterSetObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).SetObjectStoreType), arg0)
-	return &MockConfigSetterSetObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterSetObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterSetObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterSetObjectStoreTypeCall) Return() *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterSetObjectStoreTypeCall) Do(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterSetObjectStoreTypeCall) DoAndReturn(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/auditconfigupdater/agent_mock_test.go
+++ b/internal/worker/auditconfigupdater/agent_mock_test.go
@@ -17,7 +17,6 @@ import (
 	api "github.com/juju/juju/api"
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -792,44 +791,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/bootstrap/agent_mock_test.go
+++ b/internal/worker/bootstrap/agent_mock_test.go
@@ -17,7 +17,6 @@ import (
 	api "github.com/juju/juju/api"
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -792,44 +791,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/containerbroker/mocks/agent_mock.go
+++ b/internal/worker/containerbroker/mocks/agent_mock.go
@@ -17,7 +17,6 @@ import (
 	api "github.com/juju/juju/api"
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -792,44 +791,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/machineconverter/agent_mock_test.go
+++ b/internal/worker/machineconverter/agent_mock_test.go
@@ -18,7 +18,6 @@ import (
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -793,44 +792,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2117,44 +2078,6 @@ func (c *MockConfigSetterNonceCall) DoAndReturn(f func() string) *MockConfigSett
 	return c
 }
 
-// ObjectStoreType mocks base method.
-func (m *MockConfigSetter) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) ObjectStoreType() *MockConfigSetterObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).ObjectStoreType))
-	return &MockConfigSetterObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // OldPassword mocks base method.
 func (m *MockConfigSetter) OldPassword() string {
 	m.ctrl.T.Helper()
@@ -2675,42 +2598,6 @@ func (c *MockConfigSetterSetLoggingConfigCall) Do(f func(string)) *MockConfigSet
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigSetterSetLoggingConfigCall) DoAndReturn(f func(string)) *MockConfigSetterSetLoggingConfigCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// SetObjectStoreType mocks base method.
-func (m *MockConfigSetter) SetObjectStoreType(arg0 objectstore.BackendType) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetObjectStoreType", arg0)
-}
-
-// SetObjectStoreType indicates an expected call of SetObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) SetObjectStoreType(arg0 any) *MockConfigSetterSetObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).SetObjectStoreType), arg0)
-	return &MockConfigSetterSetObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterSetObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterSetObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterSetObjectStoreTypeCall) Return() *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterSetObjectStoreTypeCall) Do(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterSetObjectStoreTypeCall) DoAndReturn(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/objectstore/agent_mock_test.go
+++ b/internal/worker/objectstore/agent_mock_test.go
@@ -17,7 +17,6 @@ import (
 	api "github.com/juju/juju/api"
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -792,44 +791,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/objectstore/worker.go
+++ b/internal/worker/objectstore/worker.go
@@ -396,7 +396,7 @@ func (w *objectStoreWorker) initObjectStore(ctx context.Context, namespace strin
 
 		objectStore, err := w.cfg.NewObjectStoreWorker(
 			ctx,
-			internalobjectstore.BackendTypeOrDefault(backendInfo.Type),
+			backendInfo.Type,
 			namespace,
 			internalobjectstore.WithRootDir(w.cfg.RootDir),
 			internalobjectstore.WithRootBucket(w.cfg.RootBucket),

--- a/internal/worker/objectstore/worker_test.go
+++ b/internal/worker/objectstore/worker_test.go
@@ -40,7 +40,7 @@ type workerSuite struct {
 	modelClaimGetter           *MockModelClaimGetter
 	modelMetadataService       *MockMetadataService
 	modelServices              *MockModelServices
-	called                     int64
+	called                     atomic.Int64
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
@@ -112,7 +112,7 @@ func (s *workerSuite) TestGetObjectStoreIsCached(c *tc.C) {
 
 	workertest.CleanKill(c, w)
 
-	c.Assert(atomic.LoadInt64(&s.called), tc.Equals, int64(1))
+	c.Assert(s.called.Load(), tc.Equals, int64(1))
 }
 
 func (s *workerSuite) TestGetObjectStoreIsNotCachedForDifferentNamespaces(c *tc.C) {
@@ -134,7 +134,7 @@ func (s *workerSuite) TestGetObjectStoreIsNotCachedForDifferentNamespaces(c *tc.
 
 	workertest.CleanKill(c, w)
 
-	c.Assert(atomic.LoadInt64(&s.called), tc.Equals, int64(10))
+	c.Assert(s.called.Load(), tc.Equals, int64(10))
 }
 
 func (s *workerSuite) TestGetObjectStoreConcurrently(c *tc.C) {
@@ -162,7 +162,7 @@ func (s *workerSuite) TestGetObjectStoreConcurrently(c *tc.C) {
 	}
 
 	assertWait(c, wg.Wait)
-	c.Assert(atomic.LoadInt64(&s.called), tc.Equals, int64(10))
+	c.Assert(s.called.Load(), tc.Equals, int64(10))
 
 	workertest.CleanKill(c, w)
 }
@@ -194,7 +194,7 @@ func (s *workerSuite) TestFlushWorkersRemovesCachedWorkers(c *tc.C) {
 	// Create a worker by requesting an object store.
 	_, err := w.GetObjectStore(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(atomic.LoadInt64(&s.called), tc.Equals, int64(1))
+	c.Check(s.called.Load(), tc.Equals, int64(1))
 
 	// Flush should remove all workers.
 	err = w.FlushWorkers(c.Context())
@@ -204,7 +204,7 @@ func (s *workerSuite) TestFlushWorkersRemovesCachedWorkers(c *tc.C) {
 	// proving the cache was cleared.
 	_, err = w.GetObjectStore(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(atomic.LoadInt64(&s.called), tc.Equals, int64(2))
+	c.Check(s.called.Load(), tc.Equals, int64(2))
 
 	workertest.CleanKill(c, w)
 }
@@ -249,7 +249,7 @@ func (s *workerSuite) newWorker(c *tc.C) *objectStoreWorker {
 			if ns == "denied" {
 				return nil, database.ErrDBNotFound
 			}
-			atomic.AddInt64(&s.called, 1)
+			s.called.Add(1)
 			return newStubTrackedObjectStore(s.trackedObjectStore), nil
 		},
 		NewTrackerWorker: func(modelUUID model.UUID, modelService ModelService, objectStore TrackedObjectStore, tracer trace.Tracer, logger logger.Logger) (worker.Worker, error) {
@@ -275,7 +275,7 @@ func (s *workerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	// Ensure we buffer the channel, this is because we might miss the
 	// event if we're too quick at starting up.
 	s.states = make(chan string, 1)
-	atomic.StoreInt64(&s.called, 0)
+	s.called.Store(0)
 
 	ctrl := s.baseSuite.setupMocks(c)
 

--- a/internal/worker/objectstoredrainer/agent_mock_test.go
+++ b/internal/worker/objectstoredrainer/agent_mock_test.go
@@ -18,7 +18,6 @@ import (
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -793,44 +792,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2117,44 +2078,6 @@ func (c *MockConfigSetterNonceCall) DoAndReturn(f func() string) *MockConfigSett
 	return c
 }
 
-// ObjectStoreType mocks base method.
-func (m *MockConfigSetter) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) ObjectStoreType() *MockConfigSetterObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).ObjectStoreType))
-	return &MockConfigSetterObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // OldPassword mocks base method.
 func (m *MockConfigSetter) OldPassword() string {
 	m.ctrl.T.Helper()
@@ -2675,42 +2598,6 @@ func (c *MockConfigSetterSetLoggingConfigCall) Do(f func(string)) *MockConfigSet
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigSetterSetLoggingConfigCall) DoAndReturn(f func(string)) *MockConfigSetterSetLoggingConfigCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// SetObjectStoreType mocks base method.
-func (m *MockConfigSetter) SetObjectStoreType(arg0 objectstore.BackendType) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetObjectStoreType", arg0)
-}
-
-// SetObjectStoreType indicates an expected call of SetObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) SetObjectStoreType(arg0 any) *MockConfigSetterSetObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).SetObjectStoreType), arg0)
-	return &MockConfigSetterSetObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterSetObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterSetObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterSetObjectStoreTypeCall) Return() *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterSetObjectStoreTypeCall) Do(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterSetObjectStoreTypeCall) DoAndReturn(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/objectstoredrainer/manifold.go
+++ b/internal/worker/objectstoredrainer/manifold.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	coreobjectstore "github.com/juju/juju/core/objectstore"
-	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/worker/fortress"
@@ -60,9 +59,6 @@ type GetControllerConfigServiceFunc func(getter dependency.Getter, name string) 
 type ControllerConfigService interface {
 	// ControllerConfig returns the current controller configuration.
 	ControllerConfig(context.Context) (controller.Config, error)
-
-	// WatchControllerConfig watches the controller config for changes.
-	WatchControllerConfig(context.Context) (watcher.StringsWatcher, error)
 }
 
 // ManifoldConfig holds the dependencies and configuration for a

--- a/internal/worker/objectstoredrainer/manifold.go
+++ b/internal/worker/objectstoredrainer/manifold.go
@@ -18,10 +18,8 @@ import (
 	"github.com/juju/juju/core/model"
 	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/watcher"
-	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/internal/services"
-	internalworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/fortress"
 )
 
@@ -203,53 +201,13 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 	currentConfig := a.CurrentConfig()
 	dataDir := currentConfig.DataDir()
 
-	phase, err := drainingService.GetDrainingPhase(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var (
-		objectStoreTypeChanged                       bool
-		agentsObjectStoreType, configObjectStoreType coreobjectstore.BackendType
-	)
-	err = a.ChangeConfig(func(cfg agent.ConfigSetter) error {
-		agentsObjectStoreType = cfg.ObjectStoreType()
-		configObjectStoreType = coreobjectstore.FileBackend
-		objectStoreTypeChanged = agentsObjectStoreType != configObjectStoreType
-
-		// We've bounced whilst draining, so we need to ensure that we don't
-		// change the object store type if we're still draining.
-		if phase.IsDraining() && objectStoreTypeChanged {
-			objectStoreTypeChanged = false
-		}
-
-		if objectStoreTypeChanged {
-			config.Logger.Debugf(ctx, "setting object store type: %q => %q", agentsObjectStoreType, configObjectStoreType)
-			cfg.SetObjectStoreType(configObjectStoreType)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// If the object store type has changed whilst we're starting the worker,
-	// crash the agent and come back up clean.
-	if objectStoreTypeChanged {
-		config.Logger.Infof(ctx, "restarting agent for new object store type")
-		return nil, internalerrors.Errorf("object store type changed from %q to %q", agentsObjectStoreType, configObjectStoreType).
-			Add(internalworker.ErrRestartAgent)
-	}
-
 	worker, err := config.NewWorker(Config{
-		Agent:                        a,
 		Guard:                        fortress,
 		DrainingService:              drainingService,
 		ControllerService:            controllerService,
 		ControllerObjectStoreService: controllerObjectStoreSerivce,
 		ObjectStoreServicesGetter:    objectStoreServicesGetter,
 		ObjectStoreFlusher:           objectStoreFlusher,
-		ObjectStoreType:              configObjectStoreType,
 		NewHashFileSystemAccessor:    config.NewHashFileSystemAccessor,
 		NewDrainerWorker:             config.NewDrainerWorker,
 		SelectFileHash:               config.SelectFileHash,

--- a/internal/worker/objectstoredrainer/manifold_test.go
+++ b/internal/worker/objectstoredrainer/manifold_test.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/goleak"
 	gomock "go.uber.org/mock/gomock"
 
-	agent "github.com/juju/juju/agent"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
@@ -160,18 +159,11 @@ func (s *manifoldSuite) TestStart(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.agentConfig.EXPECT().DataDir().Return(c.MkDir())
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
 	s.agent.EXPECT().CurrentConfig().Return(s.agentConfig)
 
 	cfg := internaltesting.FakeControllerConfig()
 
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(cfg, nil)
-
-	s.guardService.EXPECT().GetDrainingPhase(gomock.Any()).Return(objectstore.PhaseUnknown, nil)
-
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 
 	w, err := Manifold(s.getConfig(c)).Start(c.Context(), s.newGetter())
 	c.Assert(err, tc.ErrorIsNil)
@@ -239,29 +231,22 @@ func (s *manifoldSuite) getConfigWithRealWorker(c *tc.C) ManifoldConfig {
 
 // setupManifoldStartExpectations sets up the common expectations for the
 // manifold start method (controller config, agent config, data dir).
-func (s *manifoldSuite) setupManifoldStartExpectations(c *tc.C, phase objectstore.Phase) {
+func (s *manifoldSuite) setupManifoldStartExpectations(c *tc.C) {
 	cfg := internaltesting.FakeControllerConfig()
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(cfg, nil)
 	s.agentConfig.EXPECT().DataDir().Return(c.MkDir())
 	s.agent.EXPECT().CurrentConfig().Return(s.agentConfig)
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
-	// GetDrainingPhase is called both by the manifold start (to decide on
-	// restart) and by the worker main loop (via the watcher).
-	s.guardService.EXPECT().GetDrainingPhase(gomock.Any()).Return(phase, nil)
 }
 
-// TestManifoldRecoverFromChangeConfigCrash exercises the full manifold start →
+// TestManifoldRecoverFromFlushWorkersCrash exercises the full manifold start →
 // worker crash → manifold restart → worker succeeds cycle when the crash occurs
-// during ChangeConfig in completeDraining.
-func (s *manifoldSuite) TestManifoldRecoverFromChangeConfigCrash(c *tc.C) {
+// during FlushWorkers in completeDraining.
+func (s *manifoldSuite) TestManifoldRecoverFromFlushWorkersCrash(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// --- First start: worker enters draining, ChangeConfig fails ---
+	// --- First start: worker enters draining, FlushWorkers fails ---
 
-	s.setupManifoldStartExpectations(c, objectstore.PhaseDraining)
+	s.setupManifoldStartExpectations(c)
 
 	draining1 := make(chan struct{})
 	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
@@ -273,93 +258,6 @@ func (s *manifoldSuite) TestManifoldRecoverFromChangeConfigCrash(c *tc.C) {
 	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	// ChangeConfig fails during completeDraining.
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).Return(errors.New("disk full"))
-
-	w1, err := Manifold(s.getConfigWithRealWorker(c)).Start(c.Context(), s.newGetter())
-	c.Assert(err, tc.ErrorIsNil)
-
-	select {
-	case draining1 <- struct{}{}:
-	case <-c.Context().Done():
-		c.Fatalf("timeout waiting for draining event")
-	}
-
-	err = workertest.CheckKilled(c, w1)
-	c.Assert(err, tc.ErrorMatches, ".*disk full.*")
-
-	// --- Second start: simulates dependency engine restart ---
-	// Phase is still Draining because the real crash would prevent PhaseError
-	// from being set. The manifold re-creates the worker.
-
-	s.setupManifoldStartExpectations(c, objectstore.PhaseDraining)
-
-	draining2 := make(chan struct{})
-	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
-		return watchertest.NewMockNotifyWatcher(draining2), nil
-	})
-	s.guardService.EXPECT().GetDrainingPhase(gomock.Any()).Return(objectstore.PhaseDraining, nil)
-	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
-	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
-
-	// This time all steps succeed.
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
-	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
-
-	done := make(chan struct{})
-	s.guardService.EXPECT().SetDrainingPhase(gomock.Any(), objectstore.PhaseCompleted).DoAndReturn(func(ctx context.Context, p objectstore.Phase) error {
-		defer close(done)
-		return nil
-	})
-
-	w2, err := Manifold(s.getConfigWithRealWorker(c)).Start(c.Context(), s.newGetter())
-	c.Assert(err, tc.ErrorIsNil)
-	defer workertest.DirtyKill(c, w2)
-
-	select {
-	case draining2 <- struct{}{}:
-	case <-c.Context().Done():
-		c.Fatalf("timeout waiting for draining event")
-	}
-
-	select {
-	case <-done:
-	case <-c.Context().Done():
-		c.Fatalf("timeout waiting for completion")
-	}
-
-	workertest.CleanKill(c, w2)
-}
-
-// TestManifoldRecoverFromFlushWorkersCrash exercises the full manifold start →
-// worker crash → manifold restart → worker succeeds cycle when the crash occurs
-// during FlushWorkers in completeDraining.
-func (s *manifoldSuite) TestManifoldRecoverFromFlushWorkersCrash(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	// --- First start: worker enters draining, FlushWorkers fails ---
-
-	s.setupManifoldStartExpectations(c, objectstore.PhaseDraining)
-
-	draining1 := make(chan struct{})
-	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
-		return watchertest.NewMockNotifyWatcher(draining1), nil
-	})
-	s.guardService.EXPECT().GetDrainingPhase(gomock.Any()).Return(objectstore.PhaseDraining, nil)
-	s.guardService.EXPECT().SetDrainingPhase(gomock.Any(), objectstore.PhaseError).Return(nil)
-	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
-	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
-
-	// ChangeConfig succeeds, FlushWorkers fails.
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(errors.New("flush timeout"))
 
 	w1, err := Manifold(s.getConfigWithRealWorker(c)).Start(c.Context(), s.newGetter())
@@ -374,9 +272,11 @@ func (s *manifoldSuite) TestManifoldRecoverFromFlushWorkersCrash(c *tc.C) {
 	err = workertest.CheckKilled(c, w1)
 	c.Assert(err, tc.ErrorMatches, ".*flush timeout.*")
 
-	// --- Second start: recovery succeeds ---
+	// --- Second start: simulates dependency engine restart ---
+	// The manifold re-creates the worker and the idempotent completion path
+	// succeeds on retry.
 
-	s.setupManifoldStartExpectations(c, objectstore.PhaseDraining)
+	s.setupManifoldStartExpectations(c)
 
 	draining2 := make(chan struct{})
 	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
@@ -386,11 +286,6 @@ func (s *manifoldSuite) TestManifoldRecoverFromFlushWorkersCrash(c *tc.C) {
 	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
 
 	done := make(chan struct{})
@@ -426,7 +321,7 @@ func (s *manifoldSuite) TestManifoldRecoverFromSetPhaseCrash(c *tc.C) {
 
 	// --- First start: all steps succeed except the final commit ---
 
-	s.setupManifoldStartExpectations(c, objectstore.PhaseDraining)
+	s.setupManifoldStartExpectations(c)
 
 	draining1 := make(chan struct{})
 	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
@@ -437,13 +332,8 @@ func (s *manifoldSuite) TestManifoldRecoverFromSetPhaseCrash(c *tc.C) {
 	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
-	// SetDrainingPhase(PhaseCompleted) fails — simulates crash before DB commit.
+	// SetDrainingPhase(PhaseCompleted) fails, simulating a crash before commit.
 	s.guardService.EXPECT().SetDrainingPhase(gomock.Any(), objectstore.PhaseCompleted).Return(errors.New("connection reset"))
 
 	w1, err := Manifold(s.getConfigWithRealWorker(c)).Start(c.Context(), s.newGetter())
@@ -458,10 +348,9 @@ func (s *manifoldSuite) TestManifoldRecoverFromSetPhaseCrash(c *tc.C) {
 	err = workertest.CheckKilled(c, w1)
 	c.Assert(err, tc.ErrorMatches, ".*connection reset.*")
 
-	// --- Second start: recovery succeeds —
-	// All idempotent steps are re-applied, final commit works.
+	// --- Second start: recovery succeeds ---
 
-	s.setupManifoldStartExpectations(c, objectstore.PhaseDraining)
+	s.setupManifoldStartExpectations(c)
 
 	draining2 := make(chan struct{})
 	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
@@ -471,11 +360,6 @@ func (s *manifoldSuite) TestManifoldRecoverFromSetPhaseCrash(c *tc.C) {
 	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
 
 	done := make(chan struct{})

--- a/internal/worker/objectstoredrainer/service_mock_test.go
+++ b/internal/worker/objectstoredrainer/service_mock_test.go
@@ -563,45 +563,6 @@ func (c *MockControllerConfigServiceControllerConfigCall) DoAndReturn(f func(con
 	return c
 }
 
-// WatchControllerConfig mocks base method.
-func (m *MockControllerConfigService) WatchControllerConfig(arg0 context.Context) (watcher.Watcher[[]string], error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchControllerConfig", arg0)
-	ret0, _ := ret[0].(watcher.Watcher[[]string])
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchControllerConfig indicates an expected call of WatchControllerConfig.
-func (mr *MockControllerConfigServiceMockRecorder) WatchControllerConfig(arg0 any) *MockControllerConfigServiceWatchControllerConfigCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchControllerConfig", reflect.TypeOf((*MockControllerConfigService)(nil).WatchControllerConfig), arg0)
-	return &MockControllerConfigServiceWatchControllerConfigCall{Call: call}
-}
-
-// MockControllerConfigServiceWatchControllerConfigCall wrap *gomock.Call
-type MockControllerConfigServiceWatchControllerConfigCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockControllerConfigServiceWatchControllerConfigCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockControllerConfigServiceWatchControllerConfigCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockControllerConfigServiceWatchControllerConfigCall) Do(f func(context.Context) (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchControllerConfigCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerConfigServiceWatchControllerConfigCall) DoAndReturn(f func(context.Context) (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchControllerConfigCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // MockHashFileSystemAccessor is a mock of HashFileSystemAccessor interface.
 type MockHashFileSystemAccessor struct {
 	ctrl     *gomock.Controller

--- a/internal/worker/objectstoredrainer/worker.go
+++ b/internal/worker/objectstoredrainer/worker.go
@@ -467,28 +467,27 @@ func (w *Worker) waitForDraining(ctx context.Context, signal <-chan drainResult,
 }
 
 // completeDraining flushes the object store workers and marks the draining
-// phase as completed so the guard can be unlocked.
-// The worker itself is run only on the singular primary controller.
+// phase as completed so the guard can be unlocked. The worker itself is run
+// only on the singular primary controller.
 //
 // The ordering is important for crash recovery:
 // 1. Flush workers (idempotent, re-applied on restart if missed)
 // 2. Set phase to completed (atomic commit point, marks old backend dead)
 //
-// SetDrainingPhase(PhaseCompleted) is deliberately last because it
-// atomically marks the old backend as dead in the database. If step 1
-// fail, the phase remains Draining, the old backend is still alive,
-// and the error path can set PhaseError. On retry or restart the
-// idempotent steps are simply re-applied.
+// SetDrainingPhase(PhaseCompleted) is deliberately last because it atomically
+// marks the old backend as dead in the database. If step 1 fails, the phase
+// remains Draining, the old backend is still alive, and the error path can set
+// PhaseError. On retry or restart the idempotent steps are simply re-applied.
 //
 // NOTE: The fortress guard ensures no new objectstore operations can begin
 // during draining (all callers go through the objectStoreFacade which uses
-// fortress.Guest.Visit). However, callers that obtained an io.ReadCloser
-// from a Get() call before lockdown may still be streaming data when
-// FlushWorkers kills the underlying objectstore child workers. This is a
-// known limitation — such readers will receive an IO error. The practical
-// risk is low because draining is a rare operational event and callers
-// handle read errors. Fixing this would require reference-counting active
-// readers, which is disproportionate to the risk.
+// fortress.Guest.Visit). However, callers that obtained an io.ReadCloser from
+// a Get() call before lockdown may still be streaming data when FlushWorkers
+// kills the underlying objectstore child workers. This is a known limitation —
+// such readers will receive an IO error. The practical risk is low because
+// draining is a rare operational event and callers handle read errors. Fixing
+// this would require reference-counting active readers, which is
+// disproportionate to the risk.
 func (w *Worker) completeDraining(ctx context.Context) error {
 	// Flush the object store workers to ensure that they are all stopped and
 	// removed. This is necessary to ensure that the object store is in a clean

--- a/internal/worker/objectstoredrainer/worker.go
+++ b/internal/worker/objectstoredrainer/worker.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/catacomb"
 
-	"github.com/juju/juju/agent"
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
@@ -95,14 +94,12 @@ type ControllerService interface {
 
 // Config holds the dependencies and configuration for a Worker.
 type Config struct {
-	Agent                        agent.Agent
 	Guard                        fortress.Guard
 	DrainingService              DrainingService
 	ControllerService            ControllerService
 	ControllerObjectStoreService objectstore.ObjectStoreMetadata
 	ObjectStoreServicesGetter    ObjectStoreServicesGetter
 	ObjectStoreFlusher           objectstore.ObjectStoreFlusher
-	ObjectStoreType              objectstore.BackendType
 	NewHashFileSystemAccessor    NewHashFileSystemAccessorFunc
 	NewDrainerWorker             NewDrainerWorkerFunc
 	S3Client                     objectstore.Client
@@ -116,9 +113,6 @@ type Config struct {
 // Validate returns an error if the config cannot be expected to
 // drive a functional Worker.
 func (config Config) Validate() error {
-	if config.Agent == nil {
-		return errors.Errorf("nil Agent").Add(coreerrors.NotValid)
-	}
 	if config.Guard == nil {
 		return errors.Errorf("nil Guard").Add(coreerrors.NotValid)
 	}
@@ -190,8 +184,6 @@ func NewWorker(config Config) (worker.Worker, error) {
 	w := &Worker{
 		runner: runner,
 
-		agent: config.Agent,
-
 		guard:           config.Guard,
 		drainingService: config.DrainingService,
 
@@ -200,7 +192,6 @@ func NewWorker(config Config) (worker.Worker, error) {
 
 		objectStoreServicesGetter: config.ObjectStoreServicesGetter,
 		objectStoreFlusher:        config.ObjectStoreFlusher,
-		objectStoreType:           config.ObjectStoreType,
 
 		newDrainWorker: config.NewDrainerWorker,
 		newFileSystem:  config.NewHashFileSystemAccessor,
@@ -236,8 +227,6 @@ type Worker struct {
 	catacomb catacomb.Catacomb
 	runner   *worker.Runner
 
-	agent agent.Agent
-
 	guard           fortress.Guard
 	drainingService DrainingService
 
@@ -246,7 +235,6 @@ type Worker struct {
 
 	objectStoreServicesGetter ObjectStoreServicesGetter
 	objectStoreFlusher        objectstore.ObjectStoreFlusher
-	objectStoreType           objectstore.BackendType
 
 	newFileSystem  NewHashFileSystemAccessorFunc
 	newDrainWorker NewDrainerWorkerFunc
@@ -478,20 +466,17 @@ func (w *Worker) waitForDraining(ctx context.Context, signal <-chan drainResult,
 	}
 }
 
-// completeDraining updates the agent configuration to indicate that the
-// object store type has changed and then flushes the object store workers.
-// It sets the draining phase to completed, which will cause the main loop
-// to unlock the guard and allow the object store to be used again.
+// completeDraining flushes the object store workers and marks the draining
+// phase as completed so the guard can be unlocked.
 // The worker itself is run only on the singular primary controller.
 //
 // The ordering is important for crash recovery:
-// 1. Update agent config (idempotent, re-applied on restart if missed)
-// 2. Flush workers (idempotent, re-applied on restart if missed)
-// 3. Set phase to completed (atomic commit point, marks old backend dead)
+// 1. Flush workers (idempotent, re-applied on restart if missed)
+// 2. Set phase to completed (atomic commit point, marks old backend dead)
 //
 // SetDrainingPhase(PhaseCompleted) is deliberately last because it
-// atomically marks the old backend as dead in the database. If steps 1
-// or 2 fail, the phase remains Draining, the old backend is still alive,
+// atomically marks the old backend as dead in the database. If step 1
+// fail, the phase remains Draining, the old backend is still alive,
 // and the error path can set PhaseError. On retry or restart the
 // idempotent steps are simply re-applied.
 //
@@ -505,18 +490,6 @@ func (w *Worker) waitForDraining(ctx context.Context, signal <-chan drainResult,
 // handle read errors. Fixing this would require reference-counting active
 // readers, which is disproportionate to the risk.
 func (w *Worker) completeDraining(ctx context.Context) error {
-	w.logger.Infof(ctx, "completing object store draining")
-
-	// Update the agent configuration to reflect the new object store type.
-	// This is idempotent — if it was already written, re-writing is harmless.
-	if err := w.agent.ChangeConfig(func(setter agent.ConfigSetter) error {
-		w.logger.Debugf(ctx, "setting object store type: %q => %q", setter.ObjectStoreType(), w.objectStoreType)
-		setter.SetObjectStoreType(w.objectStoreType)
-		return nil
-	}); err != nil {
-		return errors.Capture(err)
-	}
-
 	// Flush the object store workers to ensure that they are all stopped and
 	// removed. This is necessary to ensure that the object store is in a clean
 	// state before we start using it again. Safe to call while the DB still

--- a/internal/worker/objectstoredrainer/worker_test.go
+++ b/internal/worker/objectstoredrainer/worker_test.go
@@ -18,7 +18,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"gopkg.in/tomb.v2"
 
-	agent "github.com/juju/juju/agent"
 	"github.com/juju/juju/core/logger"
 	model "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
@@ -85,12 +84,6 @@ func (s *workerSuite) TestObjectStoreDrainingDraining(c *tc.C) {
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return([]string{"model-uuid1"}, nil)
 	s.objectStoreServicesGetter.EXPECT().ServicesForModel(model.UUID("model-uuid1")).Return(s.objectStoreService)
 	s.objectStoreService.EXPECT().ObjectStore().Return(s.objectStoreMetadata)
-
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
 
@@ -375,7 +368,7 @@ func (s *workerSuite) TestWaitForDrainingModelFailure(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `.*drain worker for model "model-uuid1" failed.*s3 upload failed.*`)
 }
 
-func (s *workerSuite) TestCompleteDrainingChangeConfigError(c *tc.C) {
+func (s *workerSuite) TestCompleteDrainingSetPhaseError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	draining := make(chan struct{})
@@ -389,9 +382,8 @@ func (s *workerSuite) TestCompleteDrainingChangeConfigError(c *tc.C) {
 	// GetModelNamespaces returns empty so completeDraining is called directly.
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	// ChangeConfig fails — SetDrainingPhase(PhaseCompleted) is never reached
-	// because it comes after ChangeConfig in the new ordering.
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).Return(errors.New("disk full"))
+	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
+	s.guardService.EXPECT().SetDrainingPhase(gomock.Any(), objectstore.PhaseCompleted).Return(errors.New("disk full"))
 
 	w := s.newWorker(c)
 	defer workertest.DirtyKill(c, w)
@@ -420,12 +412,6 @@ func (s *workerSuite) TestCompleteDrainingFlushWorkersError(c *tc.C) {
 
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
-
 	// FlushWorkers fails — SetDrainingPhase(PhaseCompleted) is never reached.
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(errors.New("flush failed"))
 
@@ -443,13 +429,13 @@ func (s *workerSuite) TestCompleteDrainingFlushWorkersError(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, ".*flush failed.*")
 }
 
-// TestRecoverFromCrashDuringChangeConfig verifies that if the worker crashes
-// (hard kill) during ChangeConfig, on restart the phase is still Draining and
-// the worker re-enters the draining flow and completes successfully.
-func (s *workerSuite) TestRecoverFromCrashDuringChangeConfig(c *tc.C) {
+// TestRecoverFromCrashDuringFlushWorkers verifies that if the worker crashes
+// during FlushWorkers, on restart the phase is still Draining and the worker
+// re-enters the draining flow and completes successfully.
+func (s *workerSuite) TestRecoverFromCrashDuringFlushWorkers(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// --- First worker: crashes during ChangeConfig ---
+	// --- First worker: crashes during FlushWorkers ---
 
 	draining1 := make(chan struct{})
 	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
@@ -460,8 +446,7 @@ func (s *workerSuite) TestRecoverFromCrashDuringChangeConfig(c *tc.C) {
 	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	// ChangeConfig fails (simulating a crash scenario where error path runs).
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).Return(errors.New("disk full"))
+	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(errors.New("flush timeout"))
 
 	w1 := s.newWorker(c)
 
@@ -472,7 +457,7 @@ func (s *workerSuite) TestRecoverFromCrashDuringChangeConfig(c *tc.C) {
 	}
 
 	err := workertest.CheckKilled(c, w1)
-	c.Assert(err, tc.ErrorMatches, ".*disk full.*")
+	c.Assert(err, tc.ErrorMatches, ".*flush timeout.*")
 
 	// --- Second worker: simulates restart, phase is still Draining ---
 
@@ -484,12 +469,6 @@ func (s *workerSuite) TestRecoverFromCrashDuringChangeConfig(c *tc.C) {
 	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	// This time ChangeConfig succeeds.
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
 
 	done := make(chan struct{})
@@ -520,91 +499,10 @@ func (s *workerSuite) TestRecoverFromCrashDuringChangeConfig(c *tc.C) {
 // during FlushWorkers, on restart the phase is still Draining and the worker
 // re-enters the draining flow and completes successfully. ChangeConfig is
 // idempotent so re-applying it on the second attempt is harmless.
-func (s *workerSuite) TestRecoverFromCrashDuringFlushWorkers(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	// --- First worker: crashes during FlushWorkers ---
-
-	draining1 := make(chan struct{})
-	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
-		return watchertest.NewMockNotifyWatcher(draining1), nil
-	})
-	s.guardService.EXPECT().GetDrainingPhase(gomock.Any()).Return(objectstore.PhaseDraining, nil)
-	s.guardService.EXPECT().SetDrainingPhase(gomock.Any(), objectstore.PhaseError).Return(nil)
-	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
-	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
-
-	// ChangeConfig succeeds but FlushWorkers fails.
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
-	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(errors.New("flush timeout"))
-
-	w1 := s.newWorker(c)
-
-	select {
-	case draining1 <- struct{}{}:
-	case <-c.Context().Done():
-		c.Fatalf("timeout waiting for draining event")
-	}
-
-	err := workertest.CheckKilled(c, w1)
-	c.Assert(err, tc.ErrorMatches, ".*flush timeout.*")
-
-	// --- Second worker: simulates restart, phase is still Draining ---
-
-	draining2 := make(chan struct{})
-	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
-		return watchertest.NewMockNotifyWatcher(draining2), nil
-	})
-	s.guardService.EXPECT().GetDrainingPhase(gomock.Any()).Return(objectstore.PhaseDraining, nil)
-	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
-	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
-
-	// Both ChangeConfig and FlushWorkers succeed on retry.
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
-	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
-
-	done := make(chan struct{})
-	s.guardService.EXPECT().SetDrainingPhase(gomock.Any(), objectstore.PhaseCompleted).DoAndReturn(func(ctx context.Context, p objectstore.Phase) error {
-		defer close(done)
-		return nil
-	})
-
-	w2 := s.newWorker(c)
-	defer workertest.DirtyKill(c, w2)
-
-	select {
-	case draining2 <- struct{}{}:
-	case <-c.Context().Done():
-		c.Fatalf("timeout waiting for draining event")
-	}
-
-	select {
-	case <-done:
-	case <-c.Context().Done():
-		c.Fatalf("timeout waiting for completion")
-	}
-
-	workertest.CleanKill(c, w2)
-}
-
-// TestRecoverFromCrashDuringSetDrainingPhaseCompleted verifies that if the
-// worker crashes after ChangeConfig and FlushWorkers succeed but before
-// SetDrainingPhase(PhaseCompleted) is persisted, on restart the phase is still
-// Draining and the worker can complete the transition. Both ChangeConfig and
-// FlushWorkers are idempotent so re-applying them is safe.
 func (s *workerSuite) TestRecoverFromCrashDuringSetDrainingPhaseCompleted(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// --- First worker: ChangeConfig and FlushWorkers succeed, but
-	// SetDrainingPhase(PhaseCompleted) fails (simulating crash before DB write) ---
+	// --- First worker: FlushWorkers succeeds, but completion commit fails ---
 
 	draining1 := make(chan struct{})
 	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
@@ -615,13 +513,7 @@ func (s *workerSuite) TestRecoverFromCrashDuringSetDrainingPhaseCompleted(c *tc.
 	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
-	// SetDrainingPhase(PhaseCompleted) fails — simulates crash/network error.
 	s.guardService.EXPECT().SetDrainingPhase(gomock.Any(), objectstore.PhaseCompleted).Return(errors.New("connection reset"))
 
 	w1 := s.newWorker(c)
@@ -645,12 +537,6 @@ func (s *workerSuite) TestRecoverFromCrashDuringSetDrainingPhaseCompleted(c *tc.
 	s.guard.EXPECT().Lockdown(gomock.Any()).Return(nil)
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	// All steps succeed on retry (idempotent).
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
 
 	done := make(chan struct{})
@@ -734,12 +620,6 @@ func (s *workerSuite) TestDrainingNoModelsCompletesDirectly(c *tc.C) {
 	// No models — completeDraining called directly after agent binaries.
 	s.controllerService.EXPECT().GetModelNamespaces(gomock.Any()).Return(nil, nil)
 
-	s.agentConfigSetter.EXPECT().ObjectStoreType().Return(objectstore.FileBackend)
-	s.agentConfigSetter.EXPECT().SetObjectStoreType(objectstore.FileBackend)
-	s.agent.EXPECT().ChangeConfig(gomock.Any()).DoAndReturn(func(fn agent.ConfigMutator) error {
-		return fn(s.agentConfigSetter)
-	})
-
 	s.objectStoreFlusher.EXPECT().FlushWorkers(gomock.Any()).Return(nil)
 
 	done := make(chan struct{})
@@ -813,14 +693,12 @@ func (s *workerSuite) newWorker(c *tc.C) worker.Worker {
 
 func (s *workerSuite) getConfig(c *tc.C) Config {
 	return Config{
-		Agent:                        s.agent,
 		Guard:                        s.guard,
 		DrainingService:              s.guardService,
 		ControllerService:            s.controllerService,
 		ObjectStoreServicesGetter:    s.objectStoreServicesGetter,
 		ControllerObjectStoreService: s.controllerObjectStoreMetadata,
 		ObjectStoreFlusher:           s.objectStoreFlusher,
-		ObjectStoreType:              objectstore.FileBackend,
 		S3Client:                     s.s3Client,
 		NewHashFileSystemAccessor: func(namespace, rootDir string, logger logger.Logger) HashFileSystemAccessor {
 			return s.hashFileSystemAccessor

--- a/internal/worker/objectstoredrainer/worker_test.go
+++ b/internal/worker/objectstoredrainer/worker_test.go
@@ -495,10 +495,10 @@ func (s *workerSuite) TestRecoverFromCrashDuringFlushWorkers(c *tc.C) {
 	workertest.CleanKill(c, w2)
 }
 
-// TestRecoverFromCrashDuringFlushWorkers verifies that if the worker crashes
-// during FlushWorkers, on restart the phase is still Draining and the worker
-// re-enters the draining flow and completes successfully. ChangeConfig is
-// idempotent so re-applying it on the second attempt is harmless.
+// TestRecoverFromCrashDuringSetDrainingPhaseCompleted verifies that if the
+// worker crashes after FlushWorkers succeeds but before the draining phase is
+// committed as Completed, on restart the phase is still Draining and the
+// worker re-enters the draining flow and completes successfully.
 func (s *workerSuite) TestRecoverFromCrashDuringSetDrainingPhaseCompleted(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/internal/worker/singular/agent_mock_test.go
+++ b/internal/worker/singular/agent_mock_test.go
@@ -17,7 +17,6 @@ import (
 	api "github.com/juju/juju/api"
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -792,44 +791,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/trace/agent_mock_test.go
+++ b/internal/worker/trace/agent_mock_test.go
@@ -17,7 +17,6 @@ import (
 	api "github.com/juju/juju/api"
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -792,44 +791,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/upgradedatabase/agent_mock_test.go
+++ b/internal/worker/upgradedatabase/agent_mock_test.go
@@ -18,7 +18,6 @@ import (
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -793,44 +792,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2117,44 +2078,6 @@ func (c *MockConfigSetterNonceCall) DoAndReturn(f func() string) *MockConfigSett
 	return c
 }
 
-// ObjectStoreType mocks base method.
-func (m *MockConfigSetter) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) ObjectStoreType() *MockConfigSetterObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).ObjectStoreType))
-	return &MockConfigSetterObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // OldPassword mocks base method.
 func (m *MockConfigSetter) OldPassword() string {
 	m.ctrl.T.Helper()
@@ -2675,42 +2598,6 @@ func (c *MockConfigSetterSetLoggingConfigCall) Do(f func(string)) *MockConfigSet
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigSetterSetLoggingConfigCall) DoAndReturn(f func(string)) *MockConfigSetterSetLoggingConfigCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// SetObjectStoreType mocks base method.
-func (m *MockConfigSetter) SetObjectStoreType(arg0 objectstore.BackendType) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetObjectStoreType", arg0)
-}
-
-// SetObjectStoreType indicates an expected call of SetObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) SetObjectStoreType(arg0 any) *MockConfigSetterSetObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).SetObjectStoreType), arg0)
-	return &MockConfigSetterSetObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterSetObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterSetObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterSetObjectStoreTypeCall) Return() *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterSetObjectStoreTypeCall) Do(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterSetObjectStoreTypeCall) DoAndReturn(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/upgradestepsagent/agent_mock_test.go
+++ b/internal/worker/upgradestepsagent/agent_mock_test.go
@@ -18,7 +18,6 @@ import (
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -793,44 +792,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2117,44 +2078,6 @@ func (c *MockConfigSetterNonceCall) DoAndReturn(f func() string) *MockConfigSett
 	return c
 }
 
-// ObjectStoreType mocks base method.
-func (m *MockConfigSetter) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) ObjectStoreType() *MockConfigSetterObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).ObjectStoreType))
-	return &MockConfigSetterObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // OldPassword mocks base method.
 func (m *MockConfigSetter) OldPassword() string {
 	m.ctrl.T.Helper()
@@ -2675,42 +2598,6 @@ func (c *MockConfigSetterSetLoggingConfigCall) Do(f func(string)) *MockConfigSet
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigSetterSetLoggingConfigCall) DoAndReturn(f func(string)) *MockConfigSetterSetLoggingConfigCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// SetObjectStoreType mocks base method.
-func (m *MockConfigSetter) SetObjectStoreType(arg0 objectstore.BackendType) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetObjectStoreType", arg0)
-}
-
-// SetObjectStoreType indicates an expected call of SetObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) SetObjectStoreType(arg0 any) *MockConfigSetterSetObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).SetObjectStoreType), arg0)
-	return &MockConfigSetterSetObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterSetObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterSetObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterSetObjectStoreTypeCall) Return() *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterSetObjectStoreTypeCall) Do(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterSetObjectStoreTypeCall) DoAndReturn(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/upgradestepscontroller/agent_mock_test.go
+++ b/internal/worker/upgradestepscontroller/agent_mock_test.go
@@ -18,7 +18,6 @@ import (
 	controller "github.com/juju/juju/controller"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
-	objectstore "github.com/juju/juju/core/objectstore"
 	semversion "github.com/juju/juju/core/semversion"
 	names "github.com/juju/names/v6"
 	shell "github.com/juju/utils/v4/shell"
@@ -793,44 +792,6 @@ func (c *MockConfigNonceCall) Do(f func() string) *MockConfigNonceCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigNonceCall) DoAndReturn(f func() string) *MockConfigNonceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ObjectStoreType mocks base method.
-func (m *MockConfig) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigMockRecorder) ObjectStoreType() *MockConfigObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfig)(nil).ObjectStoreType))
-	return &MockConfigObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigObjectStoreTypeCall wrap *gomock.Call
-type MockConfigObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2117,44 +2078,6 @@ func (c *MockConfigSetterNonceCall) DoAndReturn(f func() string) *MockConfigSett
 	return c
 }
 
-// ObjectStoreType mocks base method.
-func (m *MockConfigSetter) ObjectStoreType() objectstore.BackendType {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjectStoreType")
-	ret0, _ := ret[0].(objectstore.BackendType)
-	return ret0
-}
-
-// ObjectStoreType indicates an expected call of ObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) ObjectStoreType() *MockConfigSetterObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).ObjectStoreType))
-	return &MockConfigSetterObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterObjectStoreTypeCall) Return(arg0 objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterObjectStoreTypeCall) Do(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterObjectStoreTypeCall) DoAndReturn(f func() objectstore.BackendType) *MockConfigSetterObjectStoreTypeCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // OldPassword mocks base method.
 func (m *MockConfigSetter) OldPassword() string {
 	m.ctrl.T.Helper()
@@ -2675,42 +2598,6 @@ func (c *MockConfigSetterSetLoggingConfigCall) Do(f func(string)) *MockConfigSet
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigSetterSetLoggingConfigCall) DoAndReturn(f func(string)) *MockConfigSetterSetLoggingConfigCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// SetObjectStoreType mocks base method.
-func (m *MockConfigSetter) SetObjectStoreType(arg0 objectstore.BackendType) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetObjectStoreType", arg0)
-}
-
-// SetObjectStoreType indicates an expected call of SetObjectStoreType.
-func (mr *MockConfigSetterMockRecorder) SetObjectStoreType(arg0 any) *MockConfigSetterSetObjectStoreTypeCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetObjectStoreType", reflect.TypeOf((*MockConfigSetter)(nil).SetObjectStoreType), arg0)
-	return &MockConfigSetterSetObjectStoreTypeCall{Call: call}
-}
-
-// MockConfigSetterSetObjectStoreTypeCall wrap *gomock.Call
-type MockConfigSetterSetObjectStoreTypeCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockConfigSetterSetObjectStoreTypeCall) Return() *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockConfigSetterSetObjectStoreTypeCall) Do(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConfigSetterSetObjectStoreTypeCall) DoAndReturn(f func(objectstore.BackendType)) *MockConfigSetterSetObjectStoreTypeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -149,13 +149,6 @@ run_govulncheck() {
 		#
 		# https://pkg.go.dev/vuln/GO-2025-4121
 		"GO-2025-4121"
-		# The vulnerabilities below are fixed in the version of
-		# golang.org/x/crypto we now use but the govuln db
-		# seems out of date at the time of writing.
-		# https://pkg.go.dev/vuln/GO-2025-4134
-		# https://pkg.go.dev/vuln/GO-2025-4135
-		"GO-2025-4134"
-		"GO-2025-4135"
 		# LXD daemon vulnerability not client
 		# https://pkg.go.dev/vuln/GO-2026-4595
 		"GO-2026-4595"


### PR DESCRIPTION
This change removes the remaining object store drainer dependency on
`agent.conf`.

The object store backend and draining lifecycle are already DB-backed. This PR
finishes that cleanup by removing the leftover agent-config plumbing from the
drainer path, so `objectstoredrainer` no longer reads or mutates `agent.conf`
and no longer carries object-store-type state internally.

## Why

`agent.conf` was still carrying stale object store state that no longer matched
the real ownership model.

Object store backend selection and draining are controller-wide concerns.
Keeping residual backend-type state in agent config meant the drainer still had
to reconcile local config with DB-backed state, even though the database is the
authoritative source.

This change removes that split responsibility and leaves the drainer as a
consumer of existing DB-backed draining state.

## Previous behavior

Even after the object store transition flow moved to DB-backed services, the
drainer still had logic tied to `agent.conf`:

- the manifold read agent config during startup
- startup logic could reconcile object store type through agent config
- the worker still carried object-store-type state internally
- draining completion still updated `agent.conf`
- agent config still exposed and serialized `ObjectStoreType`

So while backend/draining state was already DB-driven, the drainer still had a
leftover config-state path.

## New behavior

The drainer now operates only on DB-backed draining state:

1. startup reads agent config only for normal agent runtime data such as
   `DataDir`
2. `objectstoredrainer` watches DB-backed draining state
3. when draining is active, it locks down, drains controller/model data,
   flushes object store workers, and marks draining completed
4. no object store backend state is read from or written to `agent.conf`

So the drainer is now a pure draining-phase consumer.

## Result

After this change:

- `agent.conf` is no longer involved in the drainer flow
- object store backend/draining state remains DB-owned
- `objectstoredrainer` has a narrower and cleaner responsibility
- the remaining object store migration path is easier to reason about

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Set up minio as S3 compatible store:

```sh
❯ mkdir -p ${HOME}/.local/minio/data
❯ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   --user $(id -u):$(id -g) \
   --name minio1 \
   -e "MINIO_ROOT_USER=ROOTUSER" \
   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
   -v ${HOME}/.local/minio/data:/data \
   quay.io/minio/minio server /data --console-address ":9001"1

❯ docker exec -it minio1 bash
❯ mc alias set foo http://localhost:9000 ROOTUSER CHANGEME123
❯ mc admin info foo
❯ mc admin accesskey create foo
# Note down the access keys
```

**Build controller charm**
Checkout the following juju/juju-controller#107 and then pack it for use.

```sh
❯ charmcraft pack
❯ mv juju-controller_ubuntu@24.04-amd64.charm <juju location>
```

**Bootstrap**

```sh
❯ juju bootstrap lxd src --bootstrap-base=ubuntu@24.04 --controller-charm-path=$GOBIN/juju-controller_ubuntu@24.04-amd64.charm --build-agent
❯ juju add-model foo
❯ juju deploy juju-qa-test
```

**Drain:** 

Add the s3-integrator so it can drive the draining:

```sh
❯ juju switch controller
❯ juju deploy s3-integrator
❯ juju integrate controller:s3-backend s3-integrator
❯ juju config s3-integrator endpoint=http://172.17.0.1:9000
❯ juju run s3-integrator/leader sync-s3-credentials access-key=<access key> secret-key=<secret key>
```

Check the logs:

```sh
❯ juju debug-log --replay -m controller | rg drain
machine-0: 16:53:48 DEBUG juju.worker.dependency "object-store-drainer" manifold worker started at 2026-06-02 14:53:48.17802061 +0000 UTC
machine-0: 16:53:48 INFO juju.worker.objectstoredrainer object store is not draining, unlocking guard
machine-0: 16:53:52 DEBUG juju.worker.dependency "user-secrets-drain-worker" manifold worker started at 2026-06-02 14:53:52.353946331 +0000 UTC
machine-0: 16:57:33 INFO juju.worker.objectstoredrainer object store is draining, locking guard
machine-0: 16:57:33 INFO juju.worker.objectstoredrainer draining controller agent binaries
machine-0: 16:57:33 INFO juju.worker.objectstoredrainer runner "objectstore-drainer" starting worker "controller"
machine-0: 16:57:33 WARNING juju.worker.objectstoredrainer drain attempt 1/10 for "controller" failed: no session available, retrying
machine-0: 16:58:04 INFO juju.worker.objectstoredrainer drain worker for controller agent binaries completed
machine-0: 16:58:04 INFO juju.worker.objectstoredrainer draining model "c31c1380-1be6-4ded-86b8-e3d7ec6954e1"
machine-0: 16:58:04 INFO juju.worker.objectstoredrainer draining model "d290d323-7b1e-4eda-8e8a-3a1fceb84499"
machine-0: 16:58:04 INFO juju.worker.objectstoredrainer runner "objectstore-drainer" starting worker "d290d323-7b1e-4eda-8e8a-3a1fceb84499"
machine-0: 16:58:04 INFO juju.worker.objectstoredrainer runner "objectstore-drainer" starting worker "c31c1380-1be6-4ded-86b8-e3d7ec6954e1"
machine-0: 16:58:04 INFO juju.worker.objectstoredrainer drain worker for model "c31c1380-1be6-4ded-86b8-e3d7ec6954e1" completed
machine-0: 16:58:04 INFO juju.worker.objectstoredrainer waiting for 1 more drain workers to complete
machine-0: 16:58:04 INFO juju.worker.objectstoredrainer drain worker for model "d290d323-7b1e-4eda-8e8a-3a1fceb84499" completed
machine-0: 16:58:04 INFO juju.worker.objectstoredrainer object store draining completed successfully
machine-0: 16:58:11 INFO juju.worker.objectstoredrainer object store is not draining, unlocking guard
```

Check the db:

```sh
❯ juju ssh -m controller 0
❯ juju_db_repl
repl (controller)> SELECT * FROM object_store_backend
uuid					life_id	type_id	updated_at				
653813f9-2896-5332-8cbe-629a337a56a3	2	0	2026-06-02 14:57:26.502027555 +0000 UTC
7cb2a3fa-c8ab-45a9-82b4-7f16789ae21d	0	1	2026-06-02 14:57:26.502027555 +0000 UTC

repl (controller)> SELECT * FROM object_store_drain_info
uuid					phase_type_id	from_backend_uuid			to_backend_uuid				
45a12f7f-c6ad-445b-8d94-a6907fa7a0c2	3		653813f9-2896-5332-8cbe-629a337a56a3	7cb2a3fa-c8ab-45a9-82b4-7f16789ae21d	
```


## Documentation changes

## Links

Relates to: #22380

**Jira card:** [JUJU-9721](https://warthogs.atlassian.net/browse/JUJU-9721)


[JUJU-9721]: https://warthogs.atlassian.net/browse/JUJU-9721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ