### PR TITLE
fix: handle slow upload of k8s oci image metadata

### DIFF
--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"time"
 
 	charmresource "github.com/juju/charm/v12/resource"
 	"github.com/juju/errors"
@@ -20,6 +21,7 @@ import (
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
+	"github.com/juju/juju/wrench"
 )
 
 // ResourcesBackend is the functionality of Juju's state needed for the resources API.
@@ -141,6 +143,11 @@ func (h *ResourcesUploadHandler) upload(backend ResourcesBackend, req *http.Requ
 	uploaded, err := h.readResource(backend, req)
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+
+	if wrench.IsActive("resources", "upload-delay") {
+		logger.Warningf("delaying resource upload due to wrench resources/upload-delay")
+		time.Sleep(30 * time.Second)
 	}
 
 	// UpdatePendingResource does the same as SetResource (just calls setResource) except SetResouce just blanks PendingID.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.25.10
+go 1.25.11
 
 require (
 	cloud.google.com/go/compute v1.44.0

--- a/resource/opener.go
+++ b/resource/opener.go
@@ -200,6 +200,17 @@ func (ro ResourceOpener) getResource(resName string, done func()) (_ resources.R
 		return res, reader, nil
 	}
 
+	// If the resource is being uploaded from the client, it may not be there
+	// yet so we need to force a retry.
+	if res.Origin == charmresource.OriginUpload {
+		if res.Revision == -1 {
+			logger.Debugf("resource %q is being uploaded but is not yet available", res.Name)
+			return resources.Resource{}, nil, errors.NewNotProvisioned(
+				nil, fmt.Sprintf("resource %q data not uploaded yet", res.Name))
+		}
+		return resources.Resource{}, nil, errors.NotFoundf("resource %q", res.Name)
+	}
+
 	// Otherwise, just the info was found in the cache. So we read the
 	// data from charmhub through a new resourceClient and set the data
 	// for the resource in the cache.

--- a/resource/opener_test.go
+++ b/resource/opener_test.go
@@ -234,6 +234,68 @@ func (s *OpenerSuite) TestGetResourceErrorReleasesLock(c *gc.C) {
 	c.Check(opened.ReadCloser, gc.IsNil)
 }
 
+func (s *OpenerSuite) TestOpenPendingUploadedResourceNotAvailableYet(c *gc.C) {
+	defer s.setupMocks(c, true).Finish()
+	res := resources.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name: "workload-image",
+				Type: charmresource.TypeContainerImage,
+			},
+			Origin:   charmresource.OriginUpload,
+			Revision: -1,
+		},
+		ApplicationID: "postgresql",
+	}
+	s.resources.EXPECT().OpenResourceForUniter("postgresql/0", "workload-image").Return(resources.Resource{}, nil, errors.NotFoundf("workload-image"))
+	s.resources.EXPECT().GetResource("postgresql", "workload-image").Return(res, nil)
+
+	opened, err := s.newOpener(0).OpenResource("workload-image")
+	c.Check(err, jc.ErrorIs, errors.NotProvisioned)
+	c.Check(opened, gc.NotNil)
+	c.Check(opened.ReadCloser, gc.IsNil)
+}
+
+func (s *OpenerSuite) TestOpenUploadedResourceDataMissing(c *gc.C) {
+	defer s.setupMocks(c, true).Finish()
+	res := resources.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name: "workload-image",
+				Type: charmresource.TypeContainerImage,
+			},
+			Origin:   charmresource.OriginUpload,
+			Revision: 666,
+		},
+		ApplicationID: "postgresql",
+	}
+	s.resources.EXPECT().OpenResourceForUniter("postgresql/0", "workload-image").Return(resources.Resource{}, nil, errors.NotFoundf("workload-image"))
+	s.resources.EXPECT().GetResource("postgresql", "workload-image").Return(res, nil)
+
+	_, err := s.newOpener(0).OpenResource("workload-image")
+	c.Check(err, jc.ErrorIs, errors.NotFound)
+}
+
+func (s *OpenerSuite) TestOpenUploadedResourceCacheError(c *gc.C) {
+	defer s.setupMocks(c, true).Finish()
+	res := resources.Resource{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name: "workload-image",
+				Type: charmresource.TypeContainerImage,
+			},
+			Origin:   charmresource.OriginUpload,
+			Revision: 666,
+		},
+		ApplicationID: "postgresql",
+	}
+	s.resources.EXPECT().OpenResourceForUniter("postgresql/0", "workload-image").Return(resources.Resource{}, nil, errors.NotFoundf("workload-image"))
+	s.resources.EXPECT().GetResource("postgresql", "workload-image").Return(res, errors.New("boom"))
+
+	_, err := s.newOpener(0).OpenResource("workload-image")
+	c.Check(err, gc.ErrorMatches, "boom")
+}
+
 func (s *OpenerSuite) newOpener(maxRequests int) *resource.ResourceOpener {
 	tag, _ := names.ParseUnitTag("postgresql/0")
 	var limiter resource.ResourceDownloadLock = resource.NewResourceDownloadLimiter(maxRequests, 0)

--- a/tests/suites/resources/attach.sh
+++ b/tests/suites/resources/attach.sh
@@ -1,0 +1,63 @@
+run_resource_attach() {
+	echo
+	name="resource-attach"
+
+	file="${TEST_DIR}/test-${name}.log"
+
+	ensure "test-${name}" "${file}"
+
+	juju deploy juju-qa-test
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+	#before_rev=$(get_resource_revision "juju-qa-test" "foo-file")
+	juju attach-resource juju-qa-test foo-file="./tests/suites/resources/foo-file.txt"
+
+	juju config juju-qa-test foo-file=true
+	# wait for config-changed, the charm will update the status
+	# to include the contents of foo-file.txt
+	wait_for "resource line one: did the resource attach?" "$(workload_status juju-qa-test 0).message"
+
+	destroy_model "test-${name}"
+}
+
+run_resource_attach_large() {
+	echo
+	name="resource-attach-large"
+
+	file="${TEST_DIR}/test-${name}.log"
+
+	ensure "test-${name}" "${file}"
+
+	juju deploy juju-qa-test
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
+
+	# .txt suffix required for attach.
+	FILE=$(mktemp /tmp/resource-XXXXX.txt)
+	# Use urandom to add alpha numeric characters with new lines added to the file
+	dd if=/dev/urandom bs=1048576 count=100 2>/dev/null | base64 >"${FILE}"
+	line=$(head -n 1 "${FILE}")
+	juju attach-resource juju-qa-test foo-file="${FILE}"
+
+	juju config juju-qa-test foo-file=true
+	# wait for config-changed, the charm will update the status
+	# to include the contents of foo-file.txt
+	wait_for "resource line one: ${line}" "$(workload_status juju-qa-test 0).message"
+
+	rm "${FILE}"
+	destroy_model "test-${name}"
+}
+
+test_attach_resources() {
+	if [ "$(skip 'test_attach_resources')" ]; then
+		echo "==> TEST SKIPPED: Resource attach"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_resource_attach"
+		run "run_resource_attach_large"
+	)
+}

--- a/tests/suites/resources/basic.sh
+++ b/tests/suites/resources/basic.sh
@@ -34,53 +34,6 @@ run_deploy_local_resource() {
 	destroy_model "test-${name}"
 }
 
-run_resource_attach() {
-	echo
-	name="resource-attach"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
-	juju deploy juju-qa-test
-	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
-	juju attach-resource juju-qa-test foo-file="./tests/suites/resources/foo-file.txt"
-
-	juju config juju-qa-test foo-file=true
-	# wait for config-changed, the charm will update the status
-	# to include the contents of foo-file.txt
-	wait_for "resource line one: did the resource attach?" "$(workload_status juju-qa-test 0).message"
-
-	destroy_model "test-${name}"
-}
-
-run_resource_attach_large() {
-	echo
-	name="resource-attach-large"
-
-	file="${TEST_DIR}/test-${name}.log"
-
-	ensure "test-${name}" "${file}"
-
-	juju deploy juju-qa-test
-	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
-
-	# .txt suffix required for attach.
-	FILE=$(mktemp /tmp/resource-XXXXX.txt)
-	# Use urandom to add alpha numeric characters with new lines added to the file
-	dd if=/dev/urandom bs=1048576 count=100 2>/dev/null | base64 >"${FILE}"
-	line=$(head -n 1 "${FILE}")
-	juju attach-resource juju-qa-test foo-file="${FILE}"
-
-	juju config juju-qa-test foo-file=true
-	# wait for config-changed, the charm will update the status
-	# to include the contents of foo-file.txt
-	wait_for "resource line one: ${line}" "$(workload_status juju-qa-test 0).message"
-
-	rm "${FILE}"
-	destroy_model "test-${name}"
-}
-
 test_basic_resources() {
 	if [ "$(skip 'test_basic_resources')" ]; then
 		echo "==> TEST SKIPPED: Resource basics"
@@ -94,9 +47,5 @@ test_basic_resources() {
 
 		run "run_deploy_local_resource"
 		run "run_deploy_repo_resource"
-
-		# these belong in a new file when there is time to update the CI jobs.
-		run "run_resource_attach"
-		run "run_resource_attach_large"
 	)
 }

--- a/tests/suites/resources/container.sh
+++ b/tests/suites/resources/container.sh
@@ -55,6 +55,42 @@ run_container_attach_resource() {
 	destroy_model "test-${name}"
 }
 
+add_wrench_resource_upload_delay() {
+	juju ssh -m controller controller/0 \
+		'mkdir -p /var/lib/juju/wrench && echo "upload-delay" > /var/lib/juju/wrench/resources'
+	juju ssh -m controller controller/0 \
+		'test -f /var/lib/juju/wrench/resources && grep -x "upload-delay" /var/lib/juju/wrench/resources >/dev/null'
+}
+
+cleanup_wrench_resource_upload_delay() {
+	juju ssh -m controller controller/0 \
+		'mkdir -p /var/lib/juju/wrench && : > /var/lib/juju/wrench/resources' >/dev/null 2>&1 || true
+}
+
+run_container_deploy_resource_slow_upload() {
+	echo
+	name="container-resource-k8s-metadata"
+
+	file="${TEST_DIR}/test-${name}.log"
+
+	ensure "test-${name}" "${file}"
+	add_clean_func "cleanup_wrench_resource_upload_delay"
+	add_wrench_resource_upload_delay
+
+	metadata_file="${TEST_DIR}/snappass-metadata.json"
+	cat >"${metadata_file}" <<EOF
+{
+  "ImageName": "samueldg/snappass:latest"
+}
+EOF
+
+	juju deploy snappass-test --resource snappass-image="${metadata_file}"
+	wait_for "active" '.applications["snappass-test"]["application-status"].current'
+	wait_for "active" '.applications["snappass-test"].units["snappass-test/0"]["workload-status"].current'
+
+	destroy_model "test-${name}"
+}
+
 test_container_resources() {
 	if [ "$(skip 'test_container_resources')" ]; then
 		echo "==> TEST SKIPPED: Container resources"
@@ -67,5 +103,6 @@ test_container_resources() {
 		cd .. || exit
 
 		run "run_container_attach_resource"
+		run "run_container_deploy_resource_slow_upload"
 	)
 }

--- a/tests/suites/resources/task.sh
+++ b/tests/suites/resources/task.sh
@@ -14,14 +14,14 @@ test_resources() {
 	bootstrap "test-resources" "${file}"
 
 	test_basic_resources
-	test_upgrade_resources
 
 	case "${BOOTSTRAP_PROVIDER:-}" in
 	"k8s")
 		test_container_resources
 		;;
 	*)
-		echo "==> TEST SKIPPED: test_container_resources - tests for k8s only"
+		test_attach_resources
+		test_upgrade_resources
 		;;
 	esac
 


### PR DESCRIPTION
When deploying a k8s charm, it's possible to use a local metadata json file to specify a private oci repo to get images from.
The juju cli client uploads this metadata file as part of the deploy. For slow uploads, the caas application provisioner can attempt to read the metadata and it's still marked as pending, so it falls back to using charmhub which is wrong since the resource doesn't come from charmhub.

This PR handles the missing file by returning a not provisioned error. This bubbles up to the provisioner worker and causes a retry.

The issue was reproduced with a wrench. The added ci test uses the wrench to validate the fix.

Also a go vuln fix - update go version.

## QA steps

A wrench is added to simulate slow uploads.

An existing TODO is fixed - attach tests are broken out.
The test charm is not specifically for k8s so only relevant tests are run for iaas and caas substrates.

`./main.sh -v -p k8s resources`

## Links


**Issue:** Fixes #22552.

