### PR TITLE
fix: include trailing / in oci repo paths when needed

### DIFF
--- a/docker/registry/internal/acr_test.go
+++ b/docker/registry/internal/acr_test.go
@@ -5,6 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -54,9 +55,9 @@ func (s *azureContainerRegistrySuite) getRegistry(c *gc.C) (*internal.AzureConta
 			// registry.Ping() 1st try failed - bearer token was missing.
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2`)
+					c.Check(req.Header, jc.DeepEquals, http.Header{})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/`)
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusUnauthorized,
@@ -72,9 +73,9 @@ func (s *azureContainerRegistrySuite) getRegistry(c *gc.C) (*internal.AzureConta
 			// Refresh OAuth Token
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/oauth2/token?scope=repository%3Ajujud-operator%3Ametadata_read&service=jujuqa.azurecr.io`)
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/oauth2/token?scope=repository%3Ajujud-operator%3Ametadata_read&service=jujuqa.azurecr.io`)
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusOK,
@@ -85,10 +86,10 @@ func (s *azureContainerRegistrySuite) getRegistry(c *gc.C) (*internal.AzureConta
 			// registry.Ping()
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2`)
-					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/`)
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 				},
 			),
 		)
@@ -133,9 +134,9 @@ func (s *azureContainerRegistrySuite) TestTagsV2(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -150,9 +151,9 @@ func (s *azureContainerRegistrySuite) TestTagsV2(c *gc.C) {
 		// Refresh OAuth Token
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/oauth2/token?scope=repository%3Ajujud-operator%3Ametadata_read&service=jujuqa.azurecr.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/oauth2/token?scope=repository%3Ajujud-operator%3Ametadata_read&service=jujuqa.azurecr.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -162,9 +163,9 @@ func (s *azureContainerRegistrySuite) TestTagsV2(c *gc.C) {
 		),
 
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -193,9 +194,9 @@ func (s *azureContainerRegistrySuite) TestTagsErrorResponseV2(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -210,9 +211,9 @@ func (s *azureContainerRegistrySuite) TestTagsErrorResponseV2(c *gc.C) {
 		// Refresh OAuth Token
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/oauth2/token?scope=repository%3Ajujud-operator%3Ametadata_read&service=jujuqa.azurecr.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/oauth2/token?scope=repository%3Ajujud-operator%3Ametadata_read&service=jujuqa.azurecr.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -221,9 +222,9 @@ func (s *azureContainerRegistrySuite) TestTagsErrorResponseV2(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,
@@ -244,9 +245,9 @@ func (s *azureContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C, 
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/manifests/2.9.10`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/manifests/2.9.10`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -261,9 +262,9 @@ func (s *azureContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C, 
 		// Refresh OAuth Token
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/oauth2/token?scope=repository%3Ajujud-operator%3Ametadata_read&service=jujuqa.azurecr.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/oauth2/token?scope=repository%3Ajujud-operator%3Ametadata_read&service=jujuqa.azurecr.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -272,9 +273,9 @@ func (s *azureContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C, 
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/manifests/2.9.10`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/v2/jujud-operator/manifests/2.9.10`)
 			resps := &http.Response{
 				Header: http.Header{
 					http.CanonicalHeaderKey("Content-Type"): []string{contentType},
@@ -327,9 +328,9 @@ func (s *azureContainerRegistrySuite) TestGetBlobs(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals,
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals,
 				`https://jujuqa.azurecr.io/v2/jujud-operator/blobs/sha256:f0609d8a844f7271411c1a9c5d7a898fd9f9c5a4844e3bc7db6d725b54671ac1`,
 			)
 			return &http.Response{
@@ -346,9 +347,9 @@ func (s *azureContainerRegistrySuite) TestGetBlobs(c *gc.C) {
 		// Refresh OAuth Token
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/oauth2/token?scope=repository%3Ajujud-operator%3Ametadata_read&service=jujuqa.azurecr.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://jujuqa.azurecr.io/oauth2/token?scope=repository%3Ajujud-operator%3Ametadata_read&service=jujuqa.azurecr.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -357,9 +358,9 @@ func (s *azureContainerRegistrySuite) TestGetBlobs(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals,
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals,
 				`https://jujuqa.azurecr.io/v2/jujud-operator/blobs/sha256:f0609d8a844f7271411c1a9c5d7a898fd9f9c5a4844e3bc7db6d725b54671ac1`,
 			)
 			resps := &http.Response{

--- a/docker/registry/internal/base_client.go
+++ b/docker/registry/internal/base_client.go
@@ -182,7 +182,11 @@ func commonURLGetter(version APIVersion, url url.URL, pathTemplate string, args 
 	ver := version.String()
 	pathSuffix := fmt.Sprintf(pathTemplate, args...)
 	// Ensure we don't double up the version in the final URL.
-	pathSuffix = strings.TrimLeft(pathSuffix, ver+"/")
+	pathSuffix = strings.TrimPrefix(pathSuffix, "/"+ver+"/")
+	pathSuffix = strings.TrimPrefix(pathSuffix, ver+"/")
+	if pathSuffix == "/"+ver || pathSuffix == ver {
+		pathSuffix = ""
+	}
 
 	if !strings.HasSuffix(strings.TrimRight(url.Path, "/"), ver) {
 		url.Path = path.Join(url.Path, ver)
@@ -190,7 +194,11 @@ func commonURLGetter(version APIVersion, url url.URL, pathTemplate string, args 
 	if url.Scheme == "" {
 		url.Scheme = "https"
 	}
-	url.Path = path.Join(url.Path, pathSuffix)
+	if pathSuffix == "/" {
+		url.Path = url.Path + pathSuffix
+	} else {
+		url.Path = path.Join(url.Path, pathSuffix)
+	}
 	return url.String()
 }
 
@@ -243,13 +251,25 @@ func (c *baseClient) getPaginatedJSON(reqURL string, response interface{}) (stri
 		return "", err
 	}
 	logger.Tracef("paginatedJSON link %q", link)
+	nextURL, err := pageLinkURL(resp, link)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return nextURL, nil
+}
+
+func pageLinkURL(resp *http.Response, link string) (string, error) {
 	linkURL, err := url.Parse(link)
 	if err != nil {
 		return "", errors.Annotatef(err, "invalid link URL %q", link)
 	}
-	nextURL := c.url("%s", linkURL.Path)
-	nextURL += "?" + linkURL.RawQuery
-	return nextURL, nil
+	if linkURL.Scheme != "" {
+		return linkURL.String(), nil
+	}
+	if resp.Request == nil || resp.Request.URL == nil {
+		return "", errors.NotValidf("pagination response request URL")
+	}
+	return resp.Request.URL.ResolveReference(linkURL).String(), nil
 }
 
 var (

--- a/docker/registry/internal/base_client_internal_test.go
+++ b/docker/registry/internal/base_client_internal_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package internal
+
+import (
+	"net/url"
+
+	gc "gopkg.in/check.v1"
+)
+
+type commonURLGetterSuite struct{}
+
+var _ = gc.Suite(&commonURLGetterSuite{})
+
+func (s *commonURLGetterSuite) TestRootPathKeepsTrailingSlash(c *gc.C) {
+	baseURL := url.URL{Scheme: "https", Host: "ghcr.io"}
+	got := commonURLGetter(APIVersionV2, baseURL, "/")
+	c.Assert(got, gc.Equals, "https://ghcr.io/v2/")
+}
+
+func (s *commonURLGetterSuite) TestPathWithLeadingVersionPrefix(c *gc.C) {
+	baseURL := url.URL{Scheme: "https", Host: "ghcr.io"}
+
+	got := commonURLGetter(
+		APIVersionV2,
+		baseURL,
+		"/v2/jujuqa/jujud-operator/tags/list",
+	)
+	c.Assert(got, gc.Equals, "https://ghcr.io/v2/jujuqa/jujud-operator/tags/list")
+}
+
+func (s *commonURLGetterSuite) TestPathWithVersionPrefixNoLeadingSlash(c *gc.C) {
+	baseURL := url.URL{Scheme: "https", Host: "ghcr.io"}
+
+	got := commonURLGetter(
+		APIVersionV2,
+		baseURL,
+		"v2/jujuqa/jujud-operator/tags/list",
+	)
+	c.Assert(got, gc.Equals, "https://ghcr.io/v2/jujuqa/jujud-operator/tags/list")
+}

--- a/docker/registry/internal/base_client_test.go
+++ b/docker/registry/internal/base_client_test.go
@@ -5,6 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -53,9 +54,9 @@ func (s *baseSuite) getRegistry(c *gc.C) (*internal.BaseClient, *gomock.Controll
 		// registry.Ping() 1st try failed - bearer token was missing.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://example.com/v2/`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -72,10 +73,10 @@ func (s *baseSuite) getRegistry(c *gc.C) (*internal.BaseClient, *gomock.Controll
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
 				if s.isPrivate {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + authToken}})
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + authToken}})
 				}
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -86,10 +87,10 @@ func (s *baseSuite) getRegistry(c *gc.C) (*internal.BaseClient, *gomock.Controll
 		// registry.Ping()
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2`)
-				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://example.com/v2/`)
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
 	)

--- a/docker/registry/internal/base_manifests_test.go
+++ b/docker/registry/internal/base_manifests_test.go
@@ -25,9 +25,9 @@ func (s *baseSuite) assertGetManifestsSchemaVersion1(c *gc.C, responseData, cont
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/manifests/2.9.10`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/manifests/2.9.10`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -42,9 +42,9 @@ func (s *baseSuite) assertGetManifestsSchemaVersion1(c *gc.C, responseData, cont
 		// Refresh OAuth Token.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.getAuthToken("username", "pwd")}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.getAuthToken("username", "pwd")}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -53,9 +53,9 @@ func (s *baseSuite) assertGetManifestsSchemaVersion1(c *gc.C, responseData, cont
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/manifests/2.9.10`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/manifests/2.9.10`)
 			resps := &http.Response{
 				Header: http.Header{
 					http.CanonicalHeaderKey("Content-Type"): []string{contentType},
@@ -137,9 +137,9 @@ func (s *baseSuite) TestGetBlobs(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals,
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals,
 				`https://example.com/v2/jujuqa/jujud-operator/blobs/sha256:f0609d8a844f7271411c1a9c5d7a898fd9f9c5a4844e3bc7db6d725b54671ac1`,
 			)
 			return &http.Response{
@@ -156,9 +156,9 @@ func (s *baseSuite) TestGetBlobs(c *gc.C) {
 		// Refresh OAuth Token.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.getAuthToken("username", "pwd")}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.getAuthToken("username", "pwd")}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -167,9 +167,9 @@ func (s *baseSuite) TestGetBlobs(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals,
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals,
 				`https://example.com/v2/jujuqa/jujud-operator/blobs/sha256:f0609d8a844f7271411c1a9c5d7a898fd9f9c5a4844e3bc7db6d725b54671ac1`,
 			)
 			resps := &http.Response{

--- a/docker/registry/internal/base_tags_test.go
+++ b/docker/registry/internal/base_tags_test.go
@@ -29,9 +29,9 @@ func (s *baseSuite) TestTagsPublicRegistry(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -46,9 +46,9 @@ func (s *baseSuite) TestTagsPublicRegistry(c *gc.C) {
 		// Refresh OAuth Token without credential.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -57,9 +57,9 @@ func (s *baseSuite) TestTagsPublicRegistry(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -89,9 +89,9 @@ func (s *baseSuite) TestTagsPrivateRegistry(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -106,9 +106,9 @@ func (s *baseSuite) TestTagsPrivateRegistry(c *gc.C) {
 		// Refresh OAuth Token.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.getAuthToken("username", "pwd")}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.getAuthToken("username", "pwd")}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -117,9 +117,9 @@ func (s *baseSuite) TestTagsPrivateRegistry(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -148,9 +148,9 @@ func (s *baseSuite) TestTagsErrorResponse(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -165,9 +165,9 @@ func (s *baseSuite) TestTagsErrorResponse(c *gc.C) {
 		// Refresh OAuth Token
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.getAuthToken("username", "pwd")}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.getAuthToken("username", "pwd")}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -176,9 +176,9 @@ func (s *baseSuite) TestTagsErrorResponse(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://example.com/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,

--- a/docker/registry/internal/dockerhub_test.go
+++ b/docker/registry/internal/dockerhub_test.go
@@ -5,6 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -52,9 +53,9 @@ func (s *dockerhubSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Contro
 		// registry.Ping() 1st try failed - bearer token was missing.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://index.docker.io/v2`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://index.docker.io/v2/`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -71,10 +72,10 @@ func (s *dockerhubSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Contro
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
 				if s.isPrivate {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
 				}
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.docker.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.docker.io`)
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://auth.docker.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.docker.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -85,10 +86,10 @@ func (s *dockerhubSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Contro
 		// registry.Ping()
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://index.docker.io/v2`)
-				return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://index.docker.io/v2/`)
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
 	)
@@ -127,9 +128,9 @@ func (s *dockerhubSuite) TestTagsPublicRegistry(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -144,9 +145,9 @@ func (s *dockerhubSuite) TestTagsPublicRegistry(c *gc.C) {
 		// Refresh OAuth Token without credential.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.docker.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.docker.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://auth.docker.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.docker.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -156,9 +157,9 @@ func (s *dockerhubSuite) TestTagsPublicRegistry(c *gc.C) {
 		),
 
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -188,9 +189,9 @@ func (s *dockerhubSuite) TestTagsPrivateRegistry(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -205,9 +206,9 @@ func (s *dockerhubSuite) TestTagsPrivateRegistry(c *gc.C) {
 		// Refresh OAuth Token.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.docker.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.docker.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://auth.docker.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.docker.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -217,9 +218,9 @@ func (s *dockerhubSuite) TestTagsPrivateRegistry(c *gc.C) {
 		),
 
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -248,9 +249,9 @@ func (s *dockerhubSuite) TestTagsErrorResponse(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -265,9 +266,9 @@ func (s *dockerhubSuite) TestTagsErrorResponse(c *gc.C) {
 		// Refresh OAuth Token
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.docker.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.docker.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://auth.docker.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.docker.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -276,9 +277,9 @@ func (s *dockerhubSuite) TestTagsErrorResponse(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://index.docker.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,

--- a/docker/registry/internal/gcr.go
+++ b/docker/registry/internal/gcr.go
@@ -97,10 +97,6 @@ func (c googleContainerRegistry) Ping() error {
 		return nil
 	}
 	url := c.url("/")
-	if !strings.HasSuffix(url, "/") {
-		// gcr v2 root endpoint requires the trailing slash(otherwise 404 returns).
-		url += "/"
-	}
 	logger.Debugf("gcr ping %q", url)
 	resp, err := c.client.Get(url)
 	if resp != nil {

--- a/docker/registry/internal/gcr_test.go
+++ b/docker/registry/internal/gcr_test.go
@@ -53,9 +53,9 @@ func (s *googleContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, 
 			// registry.Ping() 1st try failed - bearer token was missing.
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://gcr.io/v2/`)
+					c.Check(req.Header, jc.DeepEquals, http.Header{})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://gcr.io/v2/`)
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusUnauthorized,
@@ -71,9 +71,9 @@ func (s *googleContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, 
 			// Refresh OAuth Token
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://gcr.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=gcr.io`)
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://gcr.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=gcr.io`)
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusOK,
@@ -84,9 +84,9 @@ func (s *googleContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, 
 			// registry.Ping()
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://gcr.io/v2/`)
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://gcr.io/v2/`)
 					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
 				},
 			),
@@ -132,9 +132,9 @@ func (s *googleContainerRegistrySuite) TestTags(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://gcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://gcr.io/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -149,9 +149,9 @@ func (s *googleContainerRegistrySuite) TestTags(c *gc.C) {
 		// Refresh OAuth Token
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://gcr.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=gcr.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://gcr.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=gcr.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -160,9 +160,9 @@ func (s *googleContainerRegistrySuite) TestTags(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://gcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://gcr.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -191,9 +191,9 @@ func (s *googleContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://gcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://gcr.io/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -208,9 +208,9 @@ func (s *googleContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 		// Refresh OAuth Token
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://gcr.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=gcr.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://gcr.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=gcr.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -219,9 +219,9 @@ func (s *googleContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://gcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://gcr.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,

--- a/docker/registry/internal/github.go
+++ b/docker/registry/internal/github.go
@@ -78,10 +78,6 @@ func (c githubContainerRegistry) Ping() error {
 		return nil
 	}
 	url := c.url("/")
-	if !strings.HasSuffix(url, "/") {
-		// github v2 root endpoint requires the trailing slash(otherwise 404 returns).
-		url += "/"
-	}
 	logger.Debugf("github ping %q", url)
 	resp, err := c.client.Get(url)
 	if resp != nil {

--- a/docker/registry/internal/github_test.go
+++ b/docker/registry/internal/github_test.go
@@ -5,6 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -60,9 +61,9 @@ func (s *githubSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Controlle
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
 					authToken := base64.StdEncoding.EncodeToString([]byte("pwd"))
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + authToken}})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://ghcr.io/v2/`)
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + authToken}})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/`)
 					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
 				},
 			),
@@ -154,9 +155,9 @@ func (s *githubSuite) TestTagsPublicRegistry(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -171,9 +172,9 @@ func (s *githubSuite) TestTagsPublicRegistry(c *gc.C) {
 		// Refresh OAuth Token without credential.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://ghcr.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=ghcr.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=ghcr.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -182,9 +183,9 @@ func (s *githubSuite) TestTagsPublicRegistry(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				Header:     http.Header{http.CanonicalHeaderKey("Link"): []string{`/v2/juju/jujud-operator/tags/list?last=2.9.10.2&n=0; rel="next"`}},
@@ -194,8 +195,8 @@ func (s *githubSuite) TestTagsPublicRegistry(c *gc.C) {
 			return resps, nil
 		}),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://ghcr.io/v2/juju/jujud-operator/tags/list?last=2.9.10.2&n=0`)
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/juju/jujud-operator/tags/list?last=2.9.10.2&n=0`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -213,6 +214,141 @@ func (s *githubSuite) TestTagsPublicRegistry(c *gc.C) {
 	})
 }
 
+func (s *githubSuite) TestTagsPublicRegistryWithAbsolutePaginationLink(c *gc.C) {
+	// Use anonymous login for public repository.
+	s.isPrivate = false
+	reg, ctrl := s.getRegistry(c)
+	defer ctrl.Finish()
+
+	data := `
+{"name":"jujuqa/jujud-operator","tags":["2.9.10.1","2.9.10.2"]}
+`[1:]
+	data2 := `
+{"name":"jujuqa/jujud-operator","tags":["2.9.10"]}
+`[1:]
+
+	gomock.InOrder(
+		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			return &http.Response{
+				Request:    req,
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(nil),
+				Header: http.Header{
+					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+						`Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:jujuqa/jujud-operator:pull"`,
+					},
+				},
+			}, nil
+		}),
+		// Refresh OAuth Token without credential.
+		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=ghcr.io`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+				}, nil
+			},
+		),
+		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			resps := &http.Response{
+				Request: req,
+				Header: http.Header{http.CanonicalHeaderKey("Link"): []string{
+					`<https://ghcr.io/v2/juju/jujud-operator/tags/list?last=2.9.10.2&n=0>; rel="next"`,
+				}},
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(data)),
+			}
+			return resps, nil
+		}),
+		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/juju/jujud-operator/tags/list?last=2.9.10.2&n=0`)
+			resps := &http.Response{
+				Request:    req,
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(data2)),
+			}
+			return resps, nil
+		}),
+	)
+	vers, err := reg.Tags("jujud-operator")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vers, jc.DeepEquals, tools.Versions{
+		image.NewImageInfo(version.MustParse("2.9.10.1")),
+		image.NewImageInfo(version.MustParse("2.9.10.2")),
+		image.NewImageInfo(version.MustParse("2.9.10")),
+	})
+}
+
+func (s *githubSuite) TestTagsPublicRegistryWithInvalidPaginationLink(c *gc.C) {
+	// Use anonymous login for public repository.
+	s.isPrivate = false
+	reg, ctrl := s.getRegistry(c)
+	defer ctrl.Finish()
+
+	data := `
+{"name":"jujuqa/jujud-operator","tags":["2.9.10.1","2.9.10.2"]}
+`[1:]
+
+	gomock.InOrder(
+		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			return &http.Response{
+				Request:    req,
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(nil),
+				Header: http.Header{
+					http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+						`Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:jujuqa/jujud-operator:pull"`,
+					},
+				},
+			}, nil
+		}),
+		// Refresh OAuth Token without credential.
+		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=ghcr.io`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"token": "jwt-token", "access_token": "jwt-token","expires_in": 300}`)),
+				}, nil
+			},
+		),
+		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			resps := &http.Response{
+				Request: req,
+				Header: http.Header{http.CanonicalHeaderKey("Link"): []string{
+					`<https://[::1>; rel="next"`,
+				}},
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(data)),
+			}
+			return resps, nil
+		}),
+	)
+
+	_, err := reg.Tags("jujud-operator")
+	c.Assert(err, gc.ErrorMatches, `.*invalid link URL "https://\[::1".*`)
+}
+
 func (s *githubSuite) TestTagsPrivateRegistry(c *gc.C) {
 	// Use v2 for private repository.
 	s.isPrivate = true
@@ -226,9 +362,9 @@ func (s *githubSuite) TestTagsPrivateRegistry(c *gc.C) {
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
 			authToken := base64.StdEncoding.EncodeToString([]byte("pwd"))
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + authToken}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + authToken}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -258,9 +394,9 @@ func (s *githubSuite) TestTagsErrorResponse(c *gc.C) {
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
 			authToken := base64.StdEncoding.EncodeToString([]byte("pwd"))
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + authToken}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + authToken}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://ghcr.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,

--- a/docker/registry/internal/gitlab_test.go
+++ b/docker/registry/internal/gitlab_test.go
@@ -5,6 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -53,9 +54,9 @@ func (s *gitlabSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Controlle
 			// registry.Ping() 1st try failed - bearer token was missing.
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2`)
+					c.Check(req.Header, jc.DeepEquals, http.Header{})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/`)
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusUnauthorized,
@@ -71,9 +72,9 @@ func (s *gitlabSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Controlle
 			// Refresh OAuth Token
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://gitlab.com/jwt/auth?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=container_registry`)
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://gitlab.com/jwt/auth?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=container_registry`)
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusOK,
@@ -84,10 +85,10 @@ func (s *gitlabSuite) getRegistry(c *gc.C) (registry.Registry, *gomock.Controlle
 			// registry.Ping()
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2`)
-					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `jwt-token`}})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/`)
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 				},
 			),
 		)
@@ -128,9 +129,9 @@ func (s *gitlabSuite) TestTagsPublicRegistry(c *gc.C) {
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -146,9 +147,9 @@ func (s *gitlabSuite) TestTagsPublicRegistry(c *gc.C) {
 		// Refresh OAuth Token without credential.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://gitlab.com/jwt/auth?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=container_registry`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://gitlab.com/jwt/auth?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=container_registry`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -157,9 +158,9 @@ func (s *gitlabSuite) TestTagsPublicRegistry(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -190,9 +191,9 @@ func (s *gitlabSuite) TestTagsPrivateRegistry(c *gc.C) {
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -208,9 +209,9 @@ func (s *gitlabSuite) TestTagsPrivateRegistry(c *gc.C) {
 		// Refresh OAuth Token.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://gitlab.com/jwt/auth?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=container_registry`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://gitlab.com/jwt/auth?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=container_registry`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -219,9 +220,9 @@ func (s *gitlabSuite) TestTagsPrivateRegistry(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -250,9 +251,9 @@ func (s *gitlabSuite) TestTagsErrorResponse(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -267,9 +268,9 @@ func (s *gitlabSuite) TestTagsErrorResponse(c *gc.C) {
 		// Refresh OAuth Token.
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://gitlab.com/jwt/auth?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=container_registry`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://gitlab.com/jwt/auth?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=container_registry`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -279,9 +280,9 @@ func (s *gitlabSuite) TestTagsErrorResponse(c *gc.C) {
 		),
 
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://registry.gitlab.com/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,

--- a/docker/registry/internal/quay_test.go
+++ b/docker/registry/internal/quay_test.go
@@ -5,6 +5,7 @@ package internal_test
 
 import (
 	"encoding/base64"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -53,9 +54,9 @@ func (s *quayContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, *g
 			// registry.Ping() 1st try failed - bearer token was missing.
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2`)
+					c.Check(req.Header, jc.DeepEquals, http.Header{})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://quay.io/v2/`)
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusUnauthorized,
@@ -71,9 +72,9 @@ func (s *quayContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, *g
 			// Refresh OAuth Token
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=quay.io`)
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://quay.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=quay.io`)
 					return &http.Response{
 						Request:    req,
 						StatusCode: http.StatusOK,
@@ -84,10 +85,10 @@ func (s *quayContainerRegistrySuite) getRegistry(c *gc.C) (registry.Registry, *g
 			// registry.Ping()
 			s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 				func(req *http.Request) (*http.Response, error) {
-					c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-					c.Assert(req.Method, gc.Equals, `GET`)
-					c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2`)
-					return &http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(nil)}, nil
+					c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+					c.Check(req.Method, gc.Equals, `GET`)
+					c.Check(req.URL.String(), gc.Equals, `https://quay.io/v2/`)
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 				},
 			),
 		)
@@ -120,9 +121,9 @@ func (s *quayContainerRegistrySuite) TestTagsPublic(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -152,9 +153,9 @@ func (s *quayContainerRegistrySuite) TestTagsPrivate(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -169,9 +170,9 @@ func (s *quayContainerRegistrySuite) TestTagsPrivate(c *gc.C) {
 		// Refresh OAuth Token
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=quay.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://quay.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=quay.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -180,9 +181,9 @@ func (s *quayContainerRegistrySuite) TestTagsPrivate(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -211,9 +212,9 @@ func (s *quayContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 
 	gomock.InOrder(
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusUnauthorized,
@@ -228,9 +229,9 @@ func (s *quayContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 		// Refresh OAuth Token
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
-				c.Assert(req.Method, gc.Equals, `GET`)
-				c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=quay.io`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + s.authToken}})
+				c.Check(req.Method, gc.Equals, `GET`)
+				c.Check(req.URL.String(), gc.Equals, `https://quay.io/v2/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=quay.io`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -239,9 +240,9 @@ func (s *quayContainerRegistrySuite) TestTagsErrorResponse(c *gc.C) {
 			},
 		),
 		s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
-			c.Assert(req.Method, gc.Equals, `GET`)
-			c.Assert(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer jwt-token"}})
+			c.Check(req.Method, gc.Equals, `GET`)
+			c.Check(req.URL.String(), gc.Equals, `https://quay.io/v2/jujuqa/jujud-operator/tags/list`)
 			resps := &http.Response{
 				Request:    req,
 				StatusCode: http.StatusForbidden,

--- a/docker/registry/internal/transports_test.go
+++ b/docker/registry/internal/transports_test.go
@@ -58,7 +58,7 @@ func (s *transportSuite) TestBasicTransport(c *gc.C) {
 	// username + password.
 	mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 		func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + base64.StdEncoding.EncodeToString([]byte("username:pwd"))}})
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + base64.StdEncoding.EncodeToString([]byte("username:pwd"))}})
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -76,7 +76,7 @@ func (s *transportSuite) TestBasicTransport(c *gc.C) {
 	// auth token.
 	mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 		func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+			c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -94,7 +94,7 @@ func (s *transportSuite) TestBasicTransport(c *gc.C) {
 	// no credentials.
 	mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 		func(req *http.Request) (*http.Response, error) {
-			c.Assert(req.Header, jc.DeepEquals, http.Header{})
+			c.Check(req.Header, jc.DeepEquals, http.Header{})
 			return &http.Response{
 				Request:    req,
 				StatusCode: http.StatusOK,
@@ -121,8 +121,8 @@ func (s *transportSuite) TestTokenTransportOAuthTokenProvided(c *gc.C) {
 	gomock.InOrder(
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
@@ -147,8 +147,8 @@ func (s *transportSuite) TestTokenTransportTokenRefresh(c *gc.C) {
 		// 1st try failed - bearer token was missing.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -164,8 +164,8 @@ func (s *transportSuite) TestTokenTransportTokenRefresh(c *gc.C) {
 		// Refresh OAuth Token.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -176,8 +176,8 @@ func (s *transportSuite) TestTokenTransportTokenRefresh(c *gc.C) {
 		// retry.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
@@ -201,8 +201,8 @@ func (s *transportSuite) TestTokenTransportTokenRefreshFailedRealmMissing(c *gc.
 	gomock.InOrder(
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -235,8 +235,8 @@ func (s *transportSuite) TestTokenTransportTokenRefreshFailedServiceMissing(c *g
 	gomock.InOrder(
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -284,8 +284,8 @@ func (s *transportSuite) TestChallengeTransportTokenRefresh(c *gc.C) {
 		// 1st try failed - bearer token was missing.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -301,8 +301,8 @@ func (s *transportSuite) TestChallengeTransportTokenRefresh(c *gc.C) {
 		// Refresh OAuth Token.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -313,8 +313,8 @@ func (s *transportSuite) TestChallengeTransportTokenRefresh(c *gc.C) {
 		// retry.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
@@ -339,8 +339,8 @@ func (s *transportSuite) TestChallengeTransportBasic(c *gc.C) {
 		// 1st try failed - bearer token was missing.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -356,8 +356,8 @@ func (s *transportSuite) TestChallengeTransportBasic(c *gc.C) {
 		// retry.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
@@ -382,8 +382,8 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 		// 1st try failed - bearer token was missing.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -400,16 +400,16 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 		// retry.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(nil)}, nil
 			},
 		),
 		// Refresh OAuth Token.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -420,8 +420,8 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 		// retry.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
@@ -429,8 +429,8 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 		// re-use last successful
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -447,8 +447,8 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 		// Refresh OAuth Token.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -459,8 +459,8 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 		// retry.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),
@@ -468,8 +468,8 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 		// re-use last successful
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -486,8 +486,8 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 		// Refresh OAuth Token.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusOK,
@@ -498,8 +498,8 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 		// still bad
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{
 					Request:    req,
 					StatusCode: http.StatusUnauthorized,
@@ -516,8 +516,8 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 		// retry with basic again.
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
 			func(req *http.Request) (*http.Response, error) {
-				c.Assert(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
-				c.Assert(req.URL.String(), gc.Equals, `https://example.com`)
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Basic " + `dXNlcm5hbWU6cHdkMQ==`}})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
 			},
 		),

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0


### PR DESCRIPTION
There's 2 issues:

1. According to the spec
https://github.com/opencontainers/distribution-spec/blob/main/spec.md#api
we always need a trailing "/" on "v2" URLs.
This was being done for select repos, not all.

2. The Link URLs in the response headers, used for pagination, were only supported for relative URLs.
This adds support for absolute URLs as well.

## QA steps

Regression test:

Compile this branch with version 2.9.58

make microk8s-operator-update
juju bootstrap microk8s
juju upgrade-controller


## Links

**Issue:** Fixes #22540.
