### PR TITLE
feat(modelmigration): implement model migration domain watchers

### DIFF
--- a/apiserver/facades/agent/migrationminion/migrationminion.go
+++ b/apiserver/facades/agent/migrationminion/migrationminion.go
@@ -49,7 +49,7 @@ func NewAPI(
 // from the watcher.
 func (api *API) Watch(ctx context.Context) (params.NotifyWatchResult, error) {
 	var res params.NotifyWatchResult
-	w, err := api.modelMigrationService.WatchForMigration(ctx)
+	w, err := api.modelMigrationService.WatchMigrationPhase(ctx)
 	if err != nil {
 		res.Error = apiservererrors.ServerError(err)
 		return res, nil

--- a/apiserver/facades/agent/migrationminion/migrationminion_test.go
+++ b/apiserver/facades/agent/migrationminion/migrationminion_test.go
@@ -86,7 +86,7 @@ func (s *Suite) TestWatch(c *tc.C) {
 	w := watchertest.NewMockNotifyWatcher(ch)
 	defer workertest.CleanKill(c, w)
 
-	s.modelMigrationService.EXPECT().WatchForMigration(gomock.Any()).Return(w, nil)
+	s.modelMigrationService.EXPECT().WatchMigrationPhase(gomock.Any()).Return(w, nil)
 	s.watcherRegistry.EXPECT().Register(gomock.Any(), gomock.Any()).Return("123", nil)
 	api := s.mustMakeAPI(c)
 	result, err := api.Watch(c.Context())

--- a/apiserver/facades/agent/migrationminion/mocks_test.go
+++ b/apiserver/facades/agent/migrationminion/mocks_test.go
@@ -120,41 +120,41 @@ func (c *MockModelMigrationServiceReportMinionCall) DoAndReturn(f func(context.C
 	return c
 }
 
-// WatchForMigration mocks base method.
-func (m *MockModelMigrationService) WatchForMigration(arg0 context.Context) (watcher.Watcher[struct{}], error) {
+// WatchMigrationPhase mocks base method.
+func (m *MockModelMigrationService) WatchMigrationPhase(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchForMigration", arg0)
+	ret := m.ctrl.Call(m, "WatchMigrationPhase", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchForMigration indicates an expected call of WatchForMigration.
-func (mr *MockModelMigrationServiceMockRecorder) WatchForMigration(arg0 any) *MockModelMigrationServiceWatchForMigrationCall {
+// WatchMigrationPhase indicates an expected call of WatchMigrationPhase.
+func (mr *MockModelMigrationServiceMockRecorder) WatchMigrationPhase(arg0 any) *MockModelMigrationServiceWatchMigrationPhaseCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchForMigration", reflect.TypeOf((*MockModelMigrationService)(nil).WatchForMigration), arg0)
-	return &MockModelMigrationServiceWatchForMigrationCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchMigrationPhase", reflect.TypeOf((*MockModelMigrationService)(nil).WatchMigrationPhase), arg0)
+	return &MockModelMigrationServiceWatchMigrationPhaseCall{Call: call}
 }
 
-// MockModelMigrationServiceWatchForMigrationCall wrap *gomock.Call
-type MockModelMigrationServiceWatchForMigrationCall struct {
+// MockModelMigrationServiceWatchMigrationPhaseCall wrap *gomock.Call
+type MockModelMigrationServiceWatchMigrationPhaseCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelMigrationServiceWatchForMigrationCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *MockModelMigrationServiceWatchForMigrationCall {
+func (c *MockModelMigrationServiceWatchMigrationPhaseCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *MockModelMigrationServiceWatchMigrationPhaseCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelMigrationServiceWatchForMigrationCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockModelMigrationServiceWatchForMigrationCall {
+func (c *MockModelMigrationServiceWatchMigrationPhaseCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockModelMigrationServiceWatchMigrationPhaseCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelMigrationServiceWatchForMigrationCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockModelMigrationServiceWatchForMigrationCall {
+func (c *MockModelMigrationServiceWatchMigrationPhaseCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockModelMigrationServiceWatchMigrationPhaseCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/migrationminion/service.go
+++ b/apiserver/facades/agent/migrationminion/service.go
@@ -18,9 +18,9 @@ import (
 type ModelMigrationService interface {
 	// Migration returns status about migration of this model.
 	Migration(ctx context.Context) (modelmigration.Migration, error)
-	// WatchForMigration returns a notification watcher that fires when this model
-	// undergoes migration.
-	WatchForMigration(ctx context.Context) (watcher.NotifyWatcher, error)
+	// WatchMigrationPhase returns a notification watcher that fires on each
+	// migration phase transition for this model.
+	WatchMigrationPhase(ctx context.Context) (watcher.NotifyWatcher, error)
 	// ReportMinion accepts a phase report from a migration minion agent.
 	ReportMinion(ctx context.Context, entityKey string, phase migration.Phase, success bool) error
 }

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -115,6 +115,10 @@ type ControllerState interface {
 	// model, or [modelmigrationerrors.ErrMigrationNotFound] if none exists.
 	GetActiveExport(ctx context.Context, modelUUID string) (modelmigrationinternal.Migration, error)
 
+	// GetActiveExportUUID returns the UUID of the active export migration for
+	// the model, or [modelmigrationerrors.ErrMigrationNotFound] if none exists.
+	GetActiveExportUUID(ctx context.Context, modelUUID string) (string, error)
+
 	// GetMigrationMode derives the migration mode for the model.
 	GetMigrationMode(ctx context.Context, modelUUID string) (modelmigration.MigrationMode, error)
 
@@ -488,7 +492,7 @@ func (s *Service) WatchMinionReports(ctx context.Context) (watcher.NotifyWatcher
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	mig, err := s.controllerState.GetActiveExport(ctx, s.modelUUID)
+	migUUID, err := s.controllerState.GetActiveExportUUID(ctx, s.modelUUID)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -499,7 +503,7 @@ func (s *Service) WatchMinionReports(ctx context.Context) (watcher.NotifyWatcher
 		eventsource.PredicateFilter(
 			s.controllerState.NamespaceForWatchMinionSync(),
 			changestream.All,
-			eventsource.EqualsPredicate(mig.UUID),
+			eventsource.EqualsPredicate(migUUID),
 		),
 	)
 }

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -94,6 +94,18 @@ type ControllerState interface {
 	// completed or been aborted.
 	DeleteModelImportingStatus(ctx context.Context, modelUUID string) error
 
+	// NamespaceForWatchExport returns the changestream namespace for export
+	// migration start/end changes keyed by model UUID.
+	NamespaceForWatchExport() string
+
+	// NamespaceForWatchPhase returns the changestream namespace for export
+	// migration phase transitions keyed by model UUID.
+	NamespaceForWatchPhase() string
+
+	// NamespaceForWatchMinionSync returns the changestream namespace for minion
+	// sync report changes keyed by migration UUID.
+	NamespaceForWatchMinionSync() string
+
 	// InsertExport records a new export migration attempt for a model,
 	// returning [modelmigrationerrors.ErrMigrationAlreadyActive] if the model already
 	// has an active export.
@@ -144,11 +156,6 @@ type ModelState interface {
 	// table in the model database, indicating that the model import has
 	// completed or been aborted.
 	DeleteModelImportingStatus(ctx context.Context) error
-
-	// GetNamespaceModelMigrating returns the name of the model_migrating
-	// changestream namespace. A change in this namespace indicates that this
-	// model has started or stopped undergoing a migration.
-	GetNamespaceModelMigrating() string
 
 	// GetMigrationAgents returns all agents that must report migration
 	// minion progress for this model.
@@ -402,29 +409,40 @@ func unmarshalMacaroons(data string) ([]macaroon.Slice, error) {
 }
 
 // WatchForMigration returns a notification watcher that fires when this model
-// undergoes migration.
+// starts or stops undergoing migration. Intermediate phase transitions are
+// reported by WatchMigrationPhase.
 func (s *Service) WatchForMigration(ctx context.Context) (watcher.NotifyWatcher, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
+	return s.watchControllerNamespace(
+		ctx, "watch for model migration", s.controllerState.NamespaceForWatchExport(),
+	)
+}
+
+// WatchMigrationPhase returns a notification watcher that fires on each of this
+// model's migration phase transitions.
+func (s *Service) WatchMigrationPhase(ctx context.Context) (watcher.NotifyWatcher, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	return s.watchControllerNamespace(
+		ctx, "watch for migration phase change", s.controllerState.NamespaceForWatchPhase(),
+	)
+}
+
+func (s *Service) watchControllerNamespace(
+	ctx context.Context, summary, namespace string,
+) (watcher.NotifyWatcher, error) {
 	return s.watcherFactory.NewNotifyWatcher(
 		ctx,
-		"watch for model migration",
+		summary,
 		eventsource.PredicateFilter(
-			s.modelState.GetNamespaceModelMigrating(),
+			namespace,
 			changestream.All,
 			eventsource.EqualsPredicate(s.modelUUID),
 		),
 	)
-}
-
-// WatchMigrationPhase returns a notification watcher that fires when this
-// model's migration phase changes.
-func (s *Service) WatchMigrationPhase(ctx context.Context) (watcher.NotifyWatcher, error) {
-	_, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-	// TODO(modelmigration): implement migration watcher.
-	return watcher.TODO[struct{}](), nil
 }
 
 // ReportMinion accepts a phase report from a migration minion agent.
@@ -465,12 +483,25 @@ func (s *Service) SetMigrationStatusMessage(ctx context.Context, message string)
 }
 
 // WatchMinionReports returns a notification watcher that fires when any minion
-// reports a update to their phase.
+// reports an update to their phase for this model's active migration.
 func (s *Service) WatchMinionReports(ctx context.Context) (watcher.NotifyWatcher, error) {
-	_, span := trace.Start(ctx, trace.NameFromFunc())
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
-	// TODO(modelmigration): implement watching minion reports.
-	return watcher.TODO[struct{}](), nil
+
+	mig, err := s.controllerState.GetActiveExport(ctx, s.modelUUID)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	return s.watcherFactory.NewNotifyWatcher(
+		ctx,
+		"watch for migration minion reports",
+		eventsource.PredicateFilter(
+			s.controllerState.NamespaceForWatchMinionSync(),
+			changestream.All,
+			eventsource.EqualsPredicate(mig.UUID),
+		),
+	)
 }
 
 // MinionReports returns phase information about minions in this model for the

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -286,6 +286,45 @@ func (c *MockControllerStateGetActiveExportCall) DoAndReturn(f func(context.Cont
 	return c
 }
 
+// GetActiveExportUUID mocks base method.
+func (m *MockControllerState) GetActiveExportUUID(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActiveExportUUID", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetActiveExportUUID indicates an expected call of GetActiveExportUUID.
+func (mr *MockControllerStateMockRecorder) GetActiveExportUUID(arg0, arg1 any) *MockControllerStateGetActiveExportUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveExportUUID", reflect.TypeOf((*MockControllerState)(nil).GetActiveExportUUID), arg0, arg1)
+	return &MockControllerStateGetActiveExportUUIDCall{Call: call}
+}
+
+// MockControllerStateGetActiveExportUUIDCall wrap *gomock.Call
+type MockControllerStateGetActiveExportUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockControllerStateGetActiveExportUUIDCall) Return(arg0 string, arg1 error) *MockControllerStateGetActiveExportUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockControllerStateGetActiveExportUUIDCall) Do(f func(context.Context, string) (string, error)) *MockControllerStateGetActiveExportUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockControllerStateGetActiveExportUUIDCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockControllerStateGetActiveExportUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetControllerTargetVersion mocks base method.
 func (m *MockControllerState) GetControllerTargetVersion(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -440,6 +440,120 @@ func (c *MockControllerStateInsertMinionReportCall) DoAndReturn(f func(context.C
 	return c
 }
 
+// NamespaceForWatchExport mocks base method.
+func (m *MockControllerState) NamespaceForWatchExport() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NamespaceForWatchExport")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// NamespaceForWatchExport indicates an expected call of NamespaceForWatchExport.
+func (mr *MockControllerStateMockRecorder) NamespaceForWatchExport() *MockControllerStateNamespaceForWatchExportCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceForWatchExport", reflect.TypeOf((*MockControllerState)(nil).NamespaceForWatchExport))
+	return &MockControllerStateNamespaceForWatchExportCall{Call: call}
+}
+
+// MockControllerStateNamespaceForWatchExportCall wrap *gomock.Call
+type MockControllerStateNamespaceForWatchExportCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockControllerStateNamespaceForWatchExportCall) Return(arg0 string) *MockControllerStateNamespaceForWatchExportCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockControllerStateNamespaceForWatchExportCall) Do(f func() string) *MockControllerStateNamespaceForWatchExportCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockControllerStateNamespaceForWatchExportCall) DoAndReturn(f func() string) *MockControllerStateNamespaceForWatchExportCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// NamespaceForWatchMinionSync mocks base method.
+func (m *MockControllerState) NamespaceForWatchMinionSync() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NamespaceForWatchMinionSync")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// NamespaceForWatchMinionSync indicates an expected call of NamespaceForWatchMinionSync.
+func (mr *MockControllerStateMockRecorder) NamespaceForWatchMinionSync() *MockControllerStateNamespaceForWatchMinionSyncCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceForWatchMinionSync", reflect.TypeOf((*MockControllerState)(nil).NamespaceForWatchMinionSync))
+	return &MockControllerStateNamespaceForWatchMinionSyncCall{Call: call}
+}
+
+// MockControllerStateNamespaceForWatchMinionSyncCall wrap *gomock.Call
+type MockControllerStateNamespaceForWatchMinionSyncCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockControllerStateNamespaceForWatchMinionSyncCall) Return(arg0 string) *MockControllerStateNamespaceForWatchMinionSyncCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockControllerStateNamespaceForWatchMinionSyncCall) Do(f func() string) *MockControllerStateNamespaceForWatchMinionSyncCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockControllerStateNamespaceForWatchMinionSyncCall) DoAndReturn(f func() string) *MockControllerStateNamespaceForWatchMinionSyncCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// NamespaceForWatchPhase mocks base method.
+func (m *MockControllerState) NamespaceForWatchPhase() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NamespaceForWatchPhase")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// NamespaceForWatchPhase indicates an expected call of NamespaceForWatchPhase.
+func (mr *MockControllerStateMockRecorder) NamespaceForWatchPhase() *MockControllerStateNamespaceForWatchPhaseCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceForWatchPhase", reflect.TypeOf((*MockControllerState)(nil).NamespaceForWatchPhase))
+	return &MockControllerStateNamespaceForWatchPhaseCall{Call: call}
+}
+
+// MockControllerStateNamespaceForWatchPhaseCall wrap *gomock.Call
+type MockControllerStateNamespaceForWatchPhaseCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockControllerStateNamespaceForWatchPhaseCall) Return(arg0 string) *MockControllerStateNamespaceForWatchPhaseCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockControllerStateNamespaceForWatchPhaseCall) Do(f func() string) *MockControllerStateNamespaceForWatchPhaseCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockControllerStateNamespaceForWatchPhaseCall) DoAndReturn(f func() string) *MockControllerStateNamespaceForWatchPhaseCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetPhase mocks base method.
 func (m *MockControllerState) SetPhase(arg0 context.Context, arg1 string, arg2 migration.Phase) error {
 	m.ctrl.T.Helper()
@@ -729,44 +843,6 @@ func (c *MockModelStateGetModelTargetAgentVersionCall) Do(f func(context.Context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelStateGetModelTargetAgentVersionCall) DoAndReturn(f func(context.Context) (string, error)) *MockModelStateGetModelTargetAgentVersionCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetNamespaceModelMigrating mocks base method.
-func (m *MockModelState) GetNamespaceModelMigrating() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNamespaceModelMigrating")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetNamespaceModelMigrating indicates an expected call of GetNamespaceModelMigrating.
-func (mr *MockModelStateMockRecorder) GetNamespaceModelMigrating() *MockModelStateGetNamespaceModelMigratingCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespaceModelMigrating", reflect.TypeOf((*MockModelState)(nil).GetNamespaceModelMigrating))
-	return &MockModelStateGetNamespaceModelMigratingCall{Call: call}
-}
-
-// MockModelStateGetNamespaceModelMigratingCall wrap *gomock.Call
-type MockModelStateGetNamespaceModelMigratingCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockModelStateGetNamespaceModelMigratingCall) Return(arg0 string) *MockModelStateGetNamespaceModelMigratingCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockModelStateGetNamespaceModelMigratingCall) Do(f func() string) *MockModelStateGetNamespaceModelMigratingCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateGetNamespaceModelMigratingCall) DoAndReturn(f func() string) *MockModelStateGetNamespaceModelMigratingCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -396,8 +396,7 @@ func (s *serviceSuite) TestWatchMinionReports(c *tc.C) {
 	migUUID := tc.Must(c, uuid.NewUUID).String()
 	ch := make(chan struct{}, 1)
 	gomock.InOrder(
-		s.controllerState.EXPECT().GetActiveExport(gomock.Any(), s.modelUUID).Return(
-			modelmigrationinternal.Migration{UUID: migUUID}, nil),
+		s.controllerState.EXPECT().GetActiveExportUUID(gomock.Any(), s.modelUUID).Return(migUUID, nil),
 		s.controllerState.EXPECT().NamespaceForWatchMinionSync().Return("model_migration_export_minion_sync"),
 		s.watcherFactory.EXPECT().NewNotifyWatcher(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ context.Context, _ string, fo eventsource.FilterOption, _ ...eventsource.FilterOption) (watcher.Watcher[struct{}], error) {

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -282,8 +282,8 @@ func (s *serviceSuite) TestActivateImportModelFails(c *tc.C) {
 }
 
 // TestWatchForMigration asserts that WatchForMigration asks the watcher
-// factory for a notify watcher filtering on the model_migrating namespace
-// scoped to this service's model UUID.
+// factory for a notify watcher filtering on the controller-side export
+// namespace scoped to this service's model UUID.
 func (s *serviceSuite) TestWatchForMigration(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -297,7 +297,7 @@ func (s *serviceSuite) TestWatchForMigration(c *tc.C) {
 
 	otherUUID := tc.Must(c, uuid.NewUUID).String()
 	ch := make(chan struct{}, 1)
-	s.modelState.EXPECT().GetNamespaceModelMigrating().Return("model_migrating")
+	s.controllerState.EXPECT().NamespaceForWatchExport().Return("model_migration_export")
 	s.watcherFactory.EXPECT().NewNotifyWatcher(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, fo eventsource.FilterOption, _ ...eventsource.FilterOption) (watcher.Watcher[struct{}], error) {
 			namespace = fo.Namespace()
@@ -325,7 +325,7 @@ func (s *serviceSuite) TestWatchForMigration(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
-	c.Check(namespace, tc.Equals, "model_migrating")
+	c.Check(namespace, tc.Equals, "model_migration_export")
 	c.Check(changeMask, tc.Equals, changestream.All)
 	c.Check(predicateCalled, tc.IsTrue)
 	c.Check(matchesUUID, tc.IsTrue)
@@ -337,7 +337,7 @@ func (s *serviceSuite) TestWatchForMigration(c *tc.C) {
 func (s *serviceSuite) TestWatchForMigrationError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelState.EXPECT().GetNamespaceModelMigrating().Return("model_migrating")
+	s.controllerState.EXPECT().NamespaceForWatchExport().Return("model_migration_export")
 	s.watcherFactory.EXPECT().NewNotifyWatcher(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		nil, errors.Errorf("boom"),
 	)
@@ -352,6 +352,72 @@ func (s *serviceSuite) TestWatchForMigrationError(c *tc.C) {
 	)
 	_, err := svc.WatchForMigration(c.Context())
 	c.Assert(err, tc.ErrorMatches, ".*boom")
+}
+
+// TestWatchMigrationPhase asserts the phase watcher filters the controller-side
+// phase namespace by this model's UUID.
+func (s *serviceSuite) TestWatchMigrationPhase(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	var (
+		namespace   string
+		matchesUUID bool
+	)
+	ch := make(chan struct{}, 1)
+	s.controllerState.EXPECT().NamespaceForWatchPhase().Return("model_migration_export_phase")
+	s.watcherFactory.EXPECT().NewNotifyWatcher(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, fo eventsource.FilterOption, _ ...eventsource.FilterOption) (watcher.Watcher[struct{}], error) {
+			namespace = fo.Namespace()
+			if pred := fo.ChangePredicate(); pred != nil {
+				matchesUUID = pred(s.modelUUID)
+			}
+			return watchertest.NewMockNotifyWatcher(ch), nil
+		},
+	)
+
+	w, err := s.service().WatchMigrationPhase(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	c.Check(namespace, tc.Equals, "model_migration_export_phase")
+	c.Check(matchesUUID, tc.IsTrue)
+}
+
+// TestWatchMinionReports asserts the minion watcher resolves the active
+// migration and filters the minion-sync namespace by its UUID.
+func (s *serviceSuite) TestWatchMinionReports(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	var (
+		namespace      string
+		matchesMigID   bool
+		matchesModelID bool
+	)
+	migUUID := tc.Must(c, uuid.NewUUID).String()
+	ch := make(chan struct{}, 1)
+	gomock.InOrder(
+		s.controllerState.EXPECT().GetActiveExport(gomock.Any(), s.modelUUID).Return(
+			modelmigrationinternal.Migration{UUID: migUUID}, nil),
+		s.controllerState.EXPECT().NamespaceForWatchMinionSync().Return("model_migration_export_minion_sync"),
+		s.watcherFactory.EXPECT().NewNotifyWatcher(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ string, fo eventsource.FilterOption, _ ...eventsource.FilterOption) (watcher.Watcher[struct{}], error) {
+				namespace = fo.Namespace()
+				if pred := fo.ChangePredicate(); pred != nil {
+					matchesMigID = pred(migUUID)
+					matchesModelID = pred(s.modelUUID)
+				}
+				return watchertest.NewMockNotifyWatcher(ch), nil
+			},
+		),
+	)
+
+	w, err := s.service().WatchMinionReports(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	c.Check(namespace, tc.Equals, "model_migration_export_minion_sync")
+	c.Check(matchesMigID, tc.IsTrue)
+	c.Check(matchesModelID, tc.IsFalse)
 }
 
 // service constructs a Service backed by the suite mocks.

--- a/domain/modelmigration/state/controller/state.go
+++ b/domain/modelmigration/state/controller/state.go
@@ -93,6 +93,24 @@ FROM   controller
 	return versionValue.TargetVersion, nil
 }
 
+// NamespaceForWatchExport returns the changestream namespace that fires when an
+// export migration starts or changes active/terminal state.
+func (s *State) NamespaceForWatchExport() string {
+	return "model_migration_export"
+}
+
+// NamespaceForWatchPhase returns the changestream namespace that fires on each
+// export migration phase transition, keyed by model UUID.
+func (s *State) NamespaceForWatchPhase() string {
+	return "model_migration_export_phase"
+}
+
+// NamespaceForWatchMinionSync returns the changestream namespace that fires
+// when a minion sync report changes, keyed by migration UUID.
+func (s *State) NamespaceForWatchMinionSync() string {
+	return "model_migration_export_minion_sync"
+}
+
 // InsertExport records a new export migration attempt for a model. It ensures
 // the target external_controller row exists, inserts the
 // model_migration_export row in the QUIESCE phase with its companion
@@ -136,6 +154,7 @@ func (s *State) InsertExport(ctx context.Context, spec modelmigrationinternal.Mi
 	}
 	phaseEntry := migrationPhaseEntry{
 		MigrationUUID: spec.MigrationUUID,
+		ModelUUID:     spec.ModelUUID,
 		PhaseID:       quiesceID,
 		ChangedAt:     now,
 	}
@@ -491,7 +510,7 @@ func (s *State) SetPhase(ctx context.Context, migrationUUID string, newPhase mig
 	}
 	migUUID := entityUUID{UUID: migrationUUID}
 	selectPhaseStmt, err := s.Prepare(`
-SELECT &currentPhase.current_phase_id
+SELECT &currentPhase.*
 FROM   model_migration_export
 WHERE  uuid = $entityUUID.uuid
 AND    current_phase_id NOT IN (
@@ -515,14 +534,9 @@ AND    current_phase_id = $phaseUpdate.expected_phase_id
 	}
 
 	now := s.clock.Now().UTC()
-	phaseEntry := migrationPhaseEntry{
-		MigrationUUID: migrationUUID,
-		PhaseID:       newPhaseID,
-		ChangedAt:     now,
-	}
 	insertPhaseStmt, err := s.Prepare(`
 INSERT INTO model_migration_export_phase (*) VALUES ($migrationPhaseEntry.*)
-`, phaseEntry)
+`, migrationPhaseEntry{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -574,6 +588,12 @@ INSERT INTO model_migration_export_phase (*) VALUES ($migrationPhaseEntry.*)
 			)
 		}
 
+		phaseEntry := migrationPhaseEntry{
+			MigrationUUID: migrationUUID,
+			ModelUUID:     cur.ModelUUID,
+			PhaseID:       newPhaseID,
+			ChangedAt:     now,
+		}
 		if err := tx.Query(ctx, insertPhaseStmt, phaseEntry).Run(); err != nil {
 			return errors.Errorf("recording phase history for migration %q: %w", migrationUUID, err)
 		}
@@ -796,6 +816,18 @@ func (s *State) MarkExportEnded(ctx context.Context, migrationUUID string, termi
 		PhaseID:   phaseID,
 		UpdatedAt: now,
 	}
+	selectExportStmt, err := s.Prepare(`
+SELECT &currentPhase.*
+FROM   model_migration_export
+WHERE  uuid = $endExport.uuid
+AND    current_phase_id NOT IN (
+       $terminalPhaseIDArgs.reap_failed_id,
+       $terminalPhaseIDArgs.done_id,
+       $terminalPhaseIDArgs.abort_done_id)
+`, end, terminalIDs, currentPhase{})
+	if err != nil {
+		return errors.Capture(err)
+	}
 	updateStmt, err := s.Prepare(`
 UPDATE model_migration_export
 SET    current_phase_id = $endExport.current_phase_id,
@@ -810,19 +842,22 @@ AND    current_phase_id NOT IN (
 		return errors.Capture(err)
 	}
 
-	phaseEntry := migrationPhaseEntry{
-		MigrationUUID: migrationUUID,
-		PhaseID:       phaseID,
-		ChangedAt:     now,
-	}
 	insertPhaseStmt, err := s.Prepare(`
 INSERT INTO model_migration_export_phase (*) VALUES ($migrationPhaseEntry.*)
-`, phaseEntry)
+`, migrationPhaseEntry{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var cur currentPhase
+		if err := tx.Query(ctx, selectExportStmt, end, terminalIDs).Get(&cur); err != nil {
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return errors.Errorf("no active migration %q: %w", migrationUUID, modelmigrationerrors.ErrMigrationNotFound)
+			}
+			return errors.Errorf("reading export migration %q: %w", migrationUUID, err)
+		}
+
 		var outcome sqlair.Outcome
 		if err := tx.Query(ctx, updateStmt, end, terminalIDs).Get(&outcome); err != nil {
 			return errors.Errorf("ending migration %q: %w", migrationUUID, err)
@@ -833,6 +868,12 @@ INSERT INTO model_migration_export_phase (*) VALUES ($migrationPhaseEntry.*)
 		}
 		if affected == 0 {
 			return errors.Errorf("no active migration %q: %w", migrationUUID, modelmigrationerrors.ErrMigrationNotFound)
+		}
+		phaseEntry := migrationPhaseEntry{
+			MigrationUUID: migrationUUID,
+			ModelUUID:     cur.ModelUUID,
+			PhaseID:       phaseID,
+			ChangedAt:     now,
 		}
 		if err := tx.Query(ctx, insertPhaseStmt, phaseEntry).Run(); err != nil {
 			return errors.Errorf("recording terminal phase for migration %q: %w", migrationUUID, err)

--- a/domain/modelmigration/state/controller/state.go
+++ b/domain/modelmigration/state/controller/state.go
@@ -111,6 +111,53 @@ func (s *State) NamespaceForWatchMinionSync() string {
 	return "model_migration_export_minion_sync"
 }
 
+// GetActiveExportUUID returns the UUID of the active export migration for the
+// given model. If no active export exists [modelmigrationerrors.ErrMigrationNotFound]
+// is returned.
+func (s *State) GetActiveExportUUID(ctx context.Context, modelUUID string) (string, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	mUUID := modelUUIDArg{ModelUUID: modelUUID}
+	terminalIDs, err := terminalPhaseIDs()
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	stmt, err := s.Prepare(`
+SELECT &entityUUID.uuid
+FROM   model_migration_export
+WHERE  model_uuid = $modelUUIDArg.model_uuid
+AND    current_phase_id NOT IN (
+       $terminalPhaseIDArgs.reap_failed_id,
+       $terminalPhaseIDArgs.done_id,
+       $terminalPhaseIDArgs.abort_done_id)
+`, mUUID, terminalIDs, entityUUID{})
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	var result entityUUID
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = entityUUID{}
+
+		err := tx.Query(ctx, stmt, mUUID, terminalIDs).Get(&result)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("no active migration for model %q: %w", modelUUID, modelmigrationerrors.ErrMigrationNotFound)
+		} else if err != nil {
+			return errors.Errorf("querying active export for model %q: %w", modelUUID, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	return result.UUID, nil
+}
+
 // InsertExport records a new export migration attempt for a model. It ensures
 // the target external_controller row exists, inserts the
 // model_migration_export row in the QUIESCE phase with its companion

--- a/domain/modelmigration/state/controller/state_test.go
+++ b/domain/modelmigration/state/controller/state_test.go
@@ -422,6 +422,45 @@ func (s *stateSuite) TestInsertExportAfterEnded(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestGetActiveExportUUID returns the UUID of the active export migration for
+// the model.
+func (s *stateSuite) TestGetActiveExportUUID(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	spec := s.newMigrationSpec()
+	err := st.InsertExport(c.Context(), spec)
+	c.Assert(err, tc.ErrorIsNil)
+
+	got, err := st.GetActiveExportUUID(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.Equals, spec.MigrationUUID)
+}
+
+// TestGetActiveExportUUIDNotFound asserts ErrMigrationNotFound is returned when
+// the model has no export migration.
+func (s *stateSuite) TestGetActiveExportUUIDNotFound(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	_, err := st.GetActiveExportUUID(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrMigrationNotFound)
+}
+
+// TestGetActiveExportUUIDIgnoresTerminalExport asserts a terminal export is no
+// longer considered active.
+func (s *stateSuite) TestGetActiveExportUUIDIgnoresTerminalExport(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	spec := s.newMigrationSpec()
+	err := st.InsertExport(c.Context(), spec)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.MarkExportEnded(c.Context(), spec.MigrationUUID, migration.ABORTDONE)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = st.GetActiveExportUUID(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrMigrationNotFound)
+}
+
 func (s *stateSuite) TestInsertExportUpdatesExternalController(c *tc.C) {
 	db := s.DB()
 	st := New(s.TxnRunnerFactory(), clock.WallClock)

--- a/domain/modelmigration/state/controller/state_test.go
+++ b/domain/modelmigration/state/controller/state_test.go
@@ -162,9 +162,10 @@ func (s *stateSuite) TestDeleteModelImportingStatusSuccess(c *tc.C) {
 
 	// Insert a model_migration_import entry.
 	migratingUUID := uuid.MustNewUUID().String()
+	sourceMigrationUUID := uuid.MustNewUUID().String()
 	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, 'source-migration-uuid')",
-		migratingUUID, s.modelUUID)
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		migratingUUID, s.modelUUID, sourceMigrationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Verify the entry exists.
@@ -221,9 +222,10 @@ func (s *stateSuite) TestDeleteModelImportingStatusVerifyCorrectEntry(c *tc.C) {
 
 	// Insert a model_migration_import entry with a specific UUID.
 	migratingUUID := uuid.MustNewUUID().String()
+	sourceMigrationUUID := uuid.MustNewUUID().String()
 	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, 'source-migration-uuid')",
-		migratingUUID, s.modelUUID)
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		migratingUUID, s.modelUUID, sourceMigrationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Verify we can query the specific entry by its UUID.
@@ -256,9 +258,10 @@ func (s *stateSuite) TestDeleteModelImportingStatusWrongModelUUID(c *tc.C) {
 
 	// Insert a model_migration_import entry.
 	migratingUUID := uuid.MustNewUUID().String()
+	sourceMigrationUUID := uuid.MustNewUUID().String()
 	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, 'source-migration-uuid')",
-		migratingUUID, s.modelUUID)
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		migratingUUID, s.modelUUID, sourceMigrationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Try to clear with a different (non-existent) model UUID.
@@ -283,9 +286,10 @@ func (s *stateSuite) TestDeleteModelImportingStatusIdempotent(c *tc.C) {
 
 	// Insert a model_migration_import entry.
 	migratingUUID := uuid.MustNewUUID().String()
+	sourceMigrationUUID := uuid.MustNewUUID().String()
 	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, 'source-migration-uuid')",
-		migratingUUID, s.modelUUID)
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		migratingUUID, s.modelUUID, sourceMigrationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Clear the importing status multiple times.

--- a/domain/modelmigration/state/controller/types.go
+++ b/domain/modelmigration/state/controller/types.go
@@ -52,6 +52,7 @@ type migrationTargetAuth struct {
 // migrationPhaseEntry maps a model_migration_export_phase history row.
 type migrationPhaseEntry struct {
 	MigrationUUID string    `db:"migration_uuid"`
+	ModelUUID     string    `db:"model_uuid"`
 	PhaseID       int       `db:"phase_id"`
 	ChangedAt     time.Time `db:"changed_at"`
 }
@@ -85,7 +86,8 @@ type phaseIDArg struct {
 
 // currentPhase is the projection of the export's denormalised current phase.
 type currentPhase struct {
-	CurrentPhaseID int `db:"current_phase_id"`
+	CurrentPhaseID int    `db:"current_phase_id"`
+	ModelUUID      string `db:"model_uuid"`
 }
 
 // terminalPhaseIDArgs carries the persisted ids for terminal export phases.

--- a/domain/modelmigration/state/model/state.go
+++ b/domain/modelmigration/state/model/state.go
@@ -32,13 +32,6 @@ func New(modelFactory database.TxnRunnerFactory, modelUUID model.UUID) *State {
 	}
 }
 
-// GetNamespaceModelMigrating returns the name of the model_migrating
-// changestream namespace. A change in this namespace indicates that this
-// model has started or stopped undergoing a migration.
-func (s *State) GetNamespaceModelMigrating() string {
-	return "model_migrating"
-}
-
 // GetControllerUUID is responsible for returning the controller's unique id
 // from state.
 func (s *State) GetControllerUUID(

--- a/domain/modelmigration/watcher_test.go
+++ b/domain/modelmigration/watcher_test.go
@@ -116,6 +116,15 @@ func (s *exportWatcherSuite) TestWatchMigrationPhase(c *tc.C) {
 		w.AssertChange()
 	})
 
+	// A change on the export row itself (namespace 10019) must NOT fire the
+	// phase watcher (namespace 10020): the two surfaces are deliberately
+	// isolated, mirroring the converse assertion in TestWatchForMigration.
+	harness.AddTest(c, func(c *tc.C) {
+		s.endExport(c, migrationUUID)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertNoChange()
+	})
+
 	harness.Run(c, struct{}{})
 }
 

--- a/domain/modelmigration/watcher_test.go
+++ b/domain/modelmigration/watcher_test.go
@@ -8,66 +8,45 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/juju/clock"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/core/changestream"
-	"github.com/juju/juju/core/database"
-	coremodel "github.com/juju/juju/core/model"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/providertracker"
-	usertesting "github.com/juju/juju/core/user/testing"
-	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain"
-	domainagentbinary "github.com/juju/juju/domain/agentbinary"
-	"github.com/juju/juju/domain/model"
-	modelstate "github.com/juju/juju/domain/model/state/model"
 	"github.com/juju/juju/domain/modelmigration/service"
-	migrationstate "github.com/juju/juju/domain/modelmigration/state/model"
+	migrationstatecontroller "github.com/juju/juju/domain/modelmigration/state/controller"
 	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
 )
 
-type watcherSuite struct {
-	changestreamtesting.ModelSuite
+// exportWatcherSuite exercises the source-side export watchers end-to-end
+// against the controller database. The export rows are inserted directly with
+// SQL so this watcher suite does not depend on the (separate) source-side state
+// write methods.
+type exportWatcherSuite struct {
+	changestreamtesting.ControllerSuite
 
-	modelUUID coremodel.UUID
+	modelUUID string
 }
 
-func TestWatcherSuite(t *testing.T) {
-	tc.Run(t, &watcherSuite{})
+func TestExportWatcherSuite(t *testing.T) {
+	tc.Run(t, &exportWatcherSuite{})
 }
 
-func (s *watcherSuite) SetUpTest(c *tc.C) {
-	s.ModelSuite.SetUpTest(c)
-	s.modelUUID = coremodel.UUID(s.ModelUUID())
-
-	// Seed the model row so that model_migrating's FK to model is satisfied.
-	modelSt := modelstate.NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-	err := modelSt.Create(c.Context(), model.ModelDetailArgs{
-		UUID:               s.modelUUID,
-		AgentStream:        domainagentbinary.AgentStreamReleased,
-		AgentVersion:       jujuversion.Current,
-		LatestAgentVersion: jujuversion.Current,
-		ControllerUUID:     uuid.MustNewUUID(),
-		Name:               "test-model",
-		Qualifier:          "prod",
-		Type:               coremodel.IAAS,
-		Cloud:              "aws",
-		CloudType:          "ec2",
-		CloudRegion:        "us-east-1",
-		CredentialOwner:    usertesting.GenNewName(c, "myowner"),
-		CredentialName:     "mycredential",
-	})
-	c.Assert(err, tc.ErrorIsNil)
+func (s *exportWatcherSuite) SetUpTest(c *tc.C) {
+	s.ControllerSuite.SetUpTest(c)
+	s.modelUUID = uuid.MustNewUUID().String()
 }
 
-// TestWatchForMigration asserts that inserting or deleting a row in the
-// model_migrating table for this model fires the watcher. The service-level
-// predicate filtering (scope to this model's UUID) is covered in the service
-// unit tests.
-func (s *watcherSuite) TestWatchForMigration(c *tc.C) {
-	svc := s.setupService(c)
+// TestWatchForMigration asserts the existence watcher fires when an export
+// migration starts and ends, but NOT on intermediate phase transitions.
+func (s *exportWatcherSuite) TestWatchForMigration(c *tc.C) {
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "model_migration_export")
+	svc := s.setupService(c, factory)
 
 	s.AssertChangeStreamIdle(c)
 	w, err := svc.WatchForMigration(c.Context())
@@ -75,34 +54,29 @@ func (s *watcherSuite) TestWatchForMigration(c *tc.C) {
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, w))
 
-	// Initially there is nothing to report.
+	var migrationUUID string
+
 	harness.AddTest(c, func(c *tc.C) {}, func(w watchertest.WatcherC[struct{}]) {
 		w.AssertNoChange()
 	})
 
-	// Inserting a model_migrating row for this model fires the watcher.
-	migratingUUID := uuid.MustNewUUID().String()
+	// Recording the export (migration start) fires the watcher.
 	harness.AddTest(c, func(c *tc.C) {
-		err := s.ModelTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-			_, err := tx.ExecContext(ctx,
-				"INSERT INTO model_migrating (uuid, model_uuid) VALUES (?, ?)",
-				migratingUUID, s.modelUUID.String())
-			return err
-		})
-		c.Assert(err, tc.ErrorIsNil)
+		migrationUUID = s.insertExport(c)
 	}, func(w watchertest.WatcherC[struct{}]) {
 		w.AssertChange()
 	})
 
-	// Deleting the same row fires the watcher.
+	// An intermediate phase change must NOT fire the existence watcher.
 	harness.AddTest(c, func(c *tc.C) {
-		err := s.ModelTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-			_, err := tx.ExecContext(ctx,
-				"DELETE FROM model_migrating WHERE uuid = ?",
-				migratingUUID)
-			return err
-		})
-		c.Assert(err, tc.ErrorIsNil)
+		s.setExportPhase(c, migrationUUID, 2)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertNoChange()
+	})
+
+	// Ending the export by entering a terminal phase fires the watcher.
+	harness.AddTest(c, func(c *tc.C) {
+		s.endExport(c, migrationUUID)
 	}, func(w watchertest.WatcherC[struct{}]) {
 		w.AssertChange()
 	})
@@ -110,14 +84,138 @@ func (s *watcherSuite) TestWatchForMigration(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
-func (s *watcherSuite) setupService(c *tc.C) *service.Service {
-	modelDB := func(ctx context.Context) (database.TxnRunner, error) {
-		return s.ModelTxnRunner(), nil
+// TestWatchMigrationPhase asserts the phase watcher fires on each phase row
+// recorded for this model.
+func (s *exportWatcherSuite) TestWatchMigrationPhase(c *tc.C) {
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "model_migration_export_phase")
+	svc := s.setupService(c, factory)
+
+	migrationUUID := s.insertExport(c)
+
+	s.AssertChangeStreamIdle(c)
+	w, err := svc.WatchMigrationPhase(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, w))
+
+	harness.AddTest(c, func(c *tc.C) {}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertNoChange()
+	})
+
+	// Recording a phase fires the watcher.
+	harness.AddTest(c, func(c *tc.C) {
+		s.insertPhase(c, migrationUUID, 1)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	// A subsequent phase fires the watcher again.
+	harness.AddTest(c, func(c *tc.C) {
+		s.insertPhase(c, migrationUUID, 2)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	harness.Run(c, struct{}{})
+}
+
+// TestWatchMinionReports asserts the minion watcher fires when a minion report
+// is recorded for the model's active migration.
+func (s *exportWatcherSuite) TestWatchMinionReports(c *tc.C) {
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "model_migration_export_minion_sync")
+	svc := s.setupService(c, factory)
+
+	// The minion watcher resolves the active migration UUID, so the export must
+	// already exist.
+	migrationUUID := s.insertExport(c)
+
+	s.AssertChangeStreamIdle(c)
+	w, err := svc.WatchMinionReports(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, w))
+
+	harness.AddTest(c, func(c *tc.C) {}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertNoChange()
+	})
+
+	harness.AddTest(c, func(c *tc.C) {
+		s.insertMinionReport(c, migrationUUID, 1, "machine-0", true)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	harness.Run(c, struct{}{})
+}
+
+// insertMinionReport records a minion sync row directly.
+func (s *exportWatcherSuite) insertMinionReport(c *tc.C, migrationUUID string, phaseID int, entityKey string, success bool) {
+	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_export_minion_sync (migration_uuid, phase_id, entity_key, success, reported_at)
+VALUES (?, ?, ?, ?, DATETIME('now', 'utc'))`,
+			migrationUUID, phaseID, entityKey, success)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// insertExport inserts an active export row (and its target external controller)
+// directly, returning the migration UUID.
+func (s *exportWatcherSuite) insertExport(c *tc.C) string {
+	migrationUUID := uuid.MustNewUUID().String()
+	ctrlUUID := uuid.MustNewUUID().String()
+	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx,
+			"INSERT INTO external_controller (uuid, ca_cert) VALUES (?, 'ca-cert')", ctrlUUID); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_export
+    (uuid, model_uuid, target_controller_uuid, current_phase_id, updated_at, start_time)
+VALUES (?, ?, ?, 1, DATETIME('now', 'utc'), DATETIME('now', 'utc'))`,
+			migrationUUID, s.modelUUID, ctrlUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return migrationUUID
+}
+
+// setExportPhase updates the export's denormalised current phase only.
+func (s *exportWatcherSuite) setExportPhase(c *tc.C, migrationUUID string, phaseID int) {
+	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			"UPDATE model_migration_export SET current_phase_id = ?, updated_at = DATETIME('now', 'utc') WHERE uuid = ?",
+			phaseID, migrationUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// endExport marks the export as terminal.
+func (s *exportWatcherSuite) endExport(c *tc.C, migrationUUID string) {
+	s.setExportPhase(c, migrationUUID, 8)
+}
+
+// insertPhase records a phase-history row carrying the model-scoped key.
+func (s *exportWatcherSuite) insertPhase(c *tc.C, migrationUUID string, phaseID int) {
+	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_export_phase (migration_uuid, model_uuid, phase_id, changed_at)
+VALUES (?, ?, ?, DATETIME('now', 'utc'))`,
+			migrationUUID, s.modelUUID, phaseID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *exportWatcherSuite) controllerDBFactory() coredatabase.TxnRunnerFactory {
+	return func(ctx context.Context) (coredatabase.TxnRunner, error) {
+		return s.ControllerTxnRunner(), nil
 	}
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "modelmigration")
+}
 
-	modelState := migrationstate.New(modelDB, s.modelUUID)
-
+func (s *exportWatcherSuite) setupService(c *tc.C, factory domain.WatchableDBFactory) *service.Service {
 	noopInstanceGetter := func(context.Context) (service.InstanceProvider, error) {
 		return nil, nil
 	}
@@ -126,9 +224,9 @@ func (s *watcherSuite) setupService(c *tc.C) *service.Service {
 	}
 
 	return service.NewService(
+		migrationstatecontroller.New(s.controllerDBFactory(), clock.WallClock),
 		nil,
-		modelState,
-		s.modelUUID.String(),
+		s.modelUUID,
 		domain.NewWatcherFactory(factory, loggertesting.WrapCheckLog(c)),
 		providertracker.ProviderGetter[service.InstanceProvider](noopInstanceGetter),
 		providertracker.ProviderGetter[service.ResourceProvider](noopResourceGetter),

--- a/domain/schema/controller/sql/0031-model-migration.PATCH.sql
+++ b/domain/schema/controller/sql/0031-model-migration.PATCH.sql
@@ -285,8 +285,12 @@ ON model_migration_export_target_auth (external_controller_uuid);
 -- Time-ordered record of which phases an export migration has entered.
 -- Each phase is entered at most once per migration, so (migration_uuid,
 -- phase_id) is the natural key.
+--
+-- model_uuid is denormalised from the parent model_migration_export row so the
+-- changestream trigger can emit the model-scoped key watched for phase changes.
 CREATE TABLE model_migration_export_phase (
     migration_uuid TEXT NOT NULL,
+    model_uuid TEXT NOT NULL,
     phase_id INT NOT NULL,
     changed_at TIMESTAMP NOT NULL,
     PRIMARY KEY (migration_uuid, phase_id),
@@ -354,15 +358,26 @@ BEGIN
 END;
 
 -- update trigger for ModelMigrationExport
+--
+-- The export namespace is the model-scoped "is there an active migration?"
+-- surface. It deliberately ignores ordinary current_phase_id / updated_at
+-- changes so the migration master is not woken for every phase transition.
+-- Terminal phase changes still fire because they end the active migration.
 CREATE TRIGGER trg_log_model_migration_export_update
 AFTER UPDATE ON model_migration_export FOR EACH ROW
 WHEN
     NEW.uuid != OLD.uuid OR
     NEW.model_uuid != OLD.model_uuid OR
     NEW.target_controller_uuid != OLD.target_controller_uuid OR
-    NEW.current_phase_id != OLD.current_phase_id OR
-    NEW.updated_at != OLD.updated_at OR
-    NEW.start_time != OLD.start_time
+    NEW.start_time != OLD.start_time OR
+    (
+        OLD.current_phase_id NOT IN (7, 8, 10) AND
+        NEW.current_phase_id IN (7, 8, 10)
+    ) OR
+    (
+        OLD.current_phase_id IN (7, 8, 10) AND
+        NEW.current_phase_id NOT IN (7, 8, 10)
+    )
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, 10019, OLD.model_uuid, DATETIME('now', 'utc'));
@@ -377,14 +392,14 @@ BEGIN
 END;
 
 -- insert namespace for ModelMigrationExportPhase
-INSERT INTO change_log_namespace VALUES (10020, 'model_migration_export_phase', 'ModelMigrationExportPhase changes based on migration_uuid');
+INSERT INTO change_log_namespace VALUES (10020, 'model_migration_export_phase', 'ModelMigrationExportPhase changes based on model_uuid');
 
 -- insert trigger for ModelMigrationExportPhase
 CREATE TRIGGER trg_log_model_migration_export_phase_insert
 AFTER INSERT ON model_migration_export_phase FOR EACH ROW
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
-    VALUES (1, 10020, NEW.migration_uuid, DATETIME('now', 'utc'));
+    VALUES (1, 10020, NEW.model_uuid, DATETIME('now', 'utc'));
 END;
 
 -- update trigger for ModelMigrationExportPhase
@@ -392,11 +407,12 @@ CREATE TRIGGER trg_log_model_migration_export_phase_update
 AFTER UPDATE ON model_migration_export_phase FOR EACH ROW
 WHEN
     NEW.migration_uuid != OLD.migration_uuid OR
+    NEW.model_uuid != OLD.model_uuid OR
     NEW.phase_id != OLD.phase_id OR
     NEW.changed_at != OLD.changed_at
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
-    VALUES (2, 10020, OLD.migration_uuid, DATETIME('now', 'utc'));
+    VALUES (2, 10020, OLD.model_uuid, DATETIME('now', 'utc'));
 END;
 
 -- delete trigger for ModelMigrationExportPhase
@@ -404,7 +420,7 @@ CREATE TRIGGER trg_log_model_migration_export_phase_delete
 AFTER DELETE ON model_migration_export_phase FOR EACH ROW
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
-    VALUES (4, 10020, OLD.migration_uuid, DATETIME('now', 'utc'));
+    VALUES (4, 10020, OLD.model_uuid, DATETIME('now', 'utc'));
 END;
 
 -- insert namespace for ModelMigrationExportMinionSync

--- a/domain/services/model.go
+++ b/domain/services/model.go
@@ -422,7 +422,7 @@ func (s *ModelServices) ModelMigration() *modelmigrationservice.Service {
 		modelmigrationstatecontroller.New(changestream.NewTxnRunnerFactory(s.controllerDB), s.clock),
 		modelmigrationstatemodel.New(changestream.NewTxnRunnerFactory(s.modelDB), s.modelUUID),
 		s.modelUUID.String(),
-		s.modelWatcherFactory("modelmigration"),
+		s.controllerWatcherFactory("modelmigration"),
 		providertracker.ProviderRunner[modelmigrationservice.InstanceProvider](s.providerFactory, s.modelUUID.String()),
 		providertracker.ProviderRunner[modelmigrationservice.ResourceProvider](s.providerFactory, s.modelUUID.String()),
 	)


### PR DESCRIPTION
This PR implements the three source-side migration watchers and fixes a design issue where
`WatchForMigration` and `WatchMigrationPhase` were effectively identical — both watching the same table for
the same events. The fix restores the deliberate split that existed in 3.6 between the "did a migration
start/stop?" signal and the "what phase are we in now?" signal.

`WatchForMigration` is used by the migrationmaster worker to know when to start driving a migration. It
  should only fire when a migration starts or ends. However, the model_migration_export table's UPDATE
  trigger was also firing whenever the current phase changed (because current_phase_id and
  phase_changed_at are denormalized onto that row). This meant the master was being woken on every phase
  transition, which is unnecessary work.

  `WatchMigrationPhase` is used by the migration flag worker and needs to fire on every phase transition.
  Before this PR it was backed by the same table and trigger as `WatchForMigration`, making the two watchers
  indistinguishable.

  The minion facade was also using `WatchForMigration` when it should use `WatchMigrationPhase`, because the
  minion needs to react to each phase (QUIESCE, VALIDATION, etc.), not just to migration start/end.

Because of this, a small update on the DDL was needed:

  - The model_migration_export UPDATE trigger (namespace 10019) no longer fires when current_phase_id or
  phase_changed_at changes. It now only fires when the migration actually starts (INSERT trigger) or ends
  (UPDATE to end_time). The current_phase_id column is kept for cheap synchronous reads; only its trigger
  participation is removed.
  - model_migration_export_phase gains a model_uuid TEXT NOT NULL column. This is needed so the phase
  table's triggers (namespace 10020) can emit a model-scoped key, exactly like model_migrating does.
  Without this, a watcher filtering by model UUID would not be able to subscribe to this table.
  - The namespace 10020 INSERT/DELETE triggers are updated to emit NEW.model_uuid / OLD.model_uuid instead
  of the migration UUID, making the phase watcher model-scoped and consistent with the existence watcher.


## QA steps

Nothing wired yet, unit tests should pass though.

## Links



<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9897](https://warthogs.atlassian.net/browse/JUJU-9897)


[JUJU-9897]: https://warthogs.atlassian.net/browse/JUJU-9897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ