### PR TITLE
chore: bump go version to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/compute v1.44.0


### PR DESCRIPTION
Fixes 3 govuln checks related to golang's std library.
