### PR TITLE
fix(deps): bump Go 1.26.4 to resolve govulncheck failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/compute v1.44.0

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -149,13 +149,6 @@ run_govulncheck() {
 		#
 		# https://pkg.go.dev/vuln/GO-2025-4121
 		"GO-2025-4121"
-		# The vulnerabilities below are fixed in the version of
-		# golang.org/x/crypto we now use but the govuln db
-		# seems out of date at the time of writing.
-		# https://pkg.go.dev/vuln/GO-2025-4134
-		# https://pkg.go.dev/vuln/GO-2025-4135
-		"GO-2025-4134"
-		"GO-2025-4135"
 		# LXD daemon vulnerability not client
 		# https://pkg.go.dev/vuln/GO-2026-4595
 		"GO-2026-4595"


### PR DESCRIPTION
## Why this change is needed

CI govulncheck is reporting three standard library vulnerabilities that are fixed in Go 1.26.4:

| ID | CVE | Package | Issue |
|---|---|---|---|
| GO-2026-5037 | CVE-2026-27145 | `crypto/x509` | Quadratic CPU in VerifyHostname with large DNS SAN |
| GO-2026-5038 | CVE-2026-42504 | `mime` | Excessive CPU decoding malicious MIME headers |
| GO-2026-5039 | CVE-2026-42507 | `net/textproto` | Error injection via input in error messages |

Additionally, two stale ignore entries (`GO-2025-4134`, `GO-2025-4135`) are removed from the govulncheck ignore list — these `golang.org/x/crypto/ssh` vulnerabilities are already fixed in the current version (v0.52.0 > v0.45.0).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you are testing~
- ~[ ] Integration tests, with comments saying what you are testing~
- ~[ ] doc.go added or updated in changed packages~

## QA steps

1. Run `govulncheck ./...` and verify GO-2026-5037, GO-2026-5038, GO-2026-5039 no longer appear.
2. Verify GO-2025-4134 and GO-2025-4135 also do not appear (already fixed in golang.org/x/crypto v0.52.0).
3. Run `go mod tidy` and confirm no drift.

## Documentation changes

None — internal dependency bump only.

## Links

**Jira card:** N/A