### PR TITLE
fix: transaction retry issues

### DIFF
--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -484,6 +484,11 @@ func (st *State) AddIAASUnits(
 		machineNames []coremachine.Name
 	)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var (
+			txnUnitNames    []coreunit.Name
+			txnMachineNames []coremachine.Name
+		)
+
 		if err := st.checkApplicationAlive(ctx, tx, appUUID.String()); err != nil {
 			return errors.Capture(err)
 		}
@@ -498,9 +503,12 @@ func (st *State) AddIAASUnits(
 			if err != nil {
 				return errors.Errorf("inserting unit %d: %w ", i, err)
 			}
-			machineNames = append(machineNames, mNames...)
-			unitNames = append(unitNames, uName)
+			txnMachineNames = append(txnMachineNames, mNames...)
+			txnUnitNames = append(txnUnitNames, uName)
 		}
+
+		unitNames = txnUnitNames
+		machineNames = txnMachineNames
 		return nil
 	})
 	return unitNames, machineNames, errors.Capture(err)
@@ -526,6 +534,8 @@ func (st *State) AddCAASUnits(
 
 	var unitNames []coreunit.Name
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var txnUnitNames []coreunit.Name
+
 		charmUUID, err := st.getCharmIDByApplicationUUID(ctx, tx, appUUID.String())
 		if err != nil {
 			return errors.Errorf("getting application %q charm uuid: %w", appUUID, err)
@@ -537,8 +547,10 @@ func (st *State) AddCAASUnits(
 				return errors.Errorf("inserting unit %q: %w ", unitName, err)
 			}
 
-			unitNames = append(unitNames, coreunit.Name(unitName))
+			txnUnitNames = append(txnUnitNames, coreunit.Name(unitName))
 		}
+
+		unitNames = txnUnitNames
 		return nil
 	})
 	return unitNames, errors.Capture(err)

--- a/domain/model/state/controller/state.go
+++ b/domain/model/state/controller/state.go
@@ -1037,13 +1037,16 @@ func (s *State) GetModelTypes(ctx context.Context) ([]coremodel.ModelType, error
 			return errors.Capture(err)
 		}
 
+		txnRval := make([]coremodel.ModelType, 0, len(result))
 		for _, r := range result {
 			mt := coremodel.ModelType(r.Type)
 			if !mt.IsValid() {
 				return errors.Errorf("invalid model type %q", r.Type)
 			}
-			rval = append(rval, mt)
+			txnRval = append(txnRval, mt)
 		}
+
+		rval = txnRval
 		return nil
 	})
 }
@@ -1073,14 +1076,17 @@ ORDER BY name`, dbModel{})
 			return errors.Capture(err)
 		}
 
+		txnRval := make([]coremodel.Model, 0, len(result))
 		for _, r := range result {
 			model, err := r.toCoreModel()
 			if err != nil {
 				return errors.Capture(err)
 			}
 
-			rval = append(rval, model)
+			txnRval = append(txnRval, model)
 		}
+
+		rval = txnRval
 
 		return nil
 	})
@@ -1253,14 +1259,17 @@ WHERE  uuid IN (SELECT grant_on
 			return errors.Capture(err)
 		}
 
+		txnRval := make([]coremodel.Model, 0, len(result))
 		for _, r := range result {
 			mod, err := r.toCoreModel()
 			if err != nil {
 				return errors.Capture(err)
 			}
 
-			rval = append(rval, mod)
+			txnRval = append(txnRval, mod)
 		}
+
+		rval = txnRval
 
 		return nil
 	})

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -397,6 +397,8 @@ WHERE  subnet_cidr = $M.cidr`
 
 	var resultSubnets subnetRows
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var txnResultSubnets subnetRows
+
 		for _, cidr := range cidrs {
 			var rows subnetRows
 			if err := tx.Query(ctx, s, sqlair.M{"cidr": cidr}).GetAll(&rows); err != nil {
@@ -405,8 +407,10 @@ WHERE  subnet_cidr = $M.cidr`
 				}
 				return errors.Errorf("retrieving subnets by CIDR %v: %w", cidr, err)
 			}
-			resultSubnets = append(resultSubnets, rows...)
+			txnResultSubnets = append(txnResultSubnets, rows...)
 		}
+
+		resultSubnets = txnResultSubnets
 		return nil
 	}); err != nil {
 		return nil, errors.Capture(err)

--- a/domain/relation/state/migration.go
+++ b/domain/relation/state/migration.go
@@ -186,6 +186,8 @@ FROM   relation r
 	var exportRelations []domainrelation.ExportRelation
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var rels []getRelation
+		var txnExportRelations []domainrelation.ExportRelation
+
 		err = tx.Query(ctx, stmt).GetAll(&rels)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil
@@ -243,8 +245,10 @@ FROM   relation r
 
 				exportRelation.Endpoints = append(exportRelation.Endpoints, exportEndpoint)
 			}
-			exportRelations = append(exportRelations, exportRelation)
+			txnExportRelations = append(txnExportRelations, exportRelation)
 		}
+
+		exportRelations = txnExportRelations
 
 		return nil
 	})

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -889,6 +889,8 @@ func (st *State) GetRelationsStatusForUnit(
 	var relationUnitStatuses []domainrelation.RelationUnitStatusResult
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var statuses []relationUnitStatus
+		var txnRelationUnitStatuses []domainrelation.RelationUnitStatusResult
+
 		err := tx.Query(ctx, stmt, uuid).GetAll(&statuses)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Capture(err)
@@ -900,12 +902,14 @@ func (st *State) GetRelationsStatusForUnit(
 				return errors.Errorf("getting endpoints of relation %q: %w", status.RelationUUID, err)
 			}
 
-			relationUnitStatuses = append(relationUnitStatuses, domainrelation.RelationUnitStatusResult{
+			txnRelationUnitStatuses = append(txnRelationUnitStatuses, domainrelation.RelationUnitStatusResult{
 				Endpoints: endpoints,
 				InScope:   status.InScope,
 				Suspended: status.Suspended,
 			})
 		}
+
+		relationUnitStatuses = txnRelationUnitStatuses
 
 		return nil
 	})

--- a/domain/removal/state/model/secret.go
+++ b/domain/removal/state/model/secret.go
@@ -369,8 +369,9 @@ WHERE     sm.auto_prune = true AND sro.obsolete = true`
 	var deletedRevisionIDs []string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var (
-			dbSecrets    secretIDList
-			dbsecretRevs secretExternalRevisions
+			dbSecrets             secretIDList
+			dbsecretRevs          secretExternalRevisions
+			txnDeletedRevisionIDs []string
 		)
 		err = tx.Query(ctx, stmt).GetAll(&dbSecrets, &dbsecretRevs)
 		if errors.Is(err, sqlair.ErrNoRows) {
@@ -393,8 +394,9 @@ WHERE     sm.auto_prune = true AND sro.obsolete = true`
 			if err != nil {
 				return errors.Capture(err)
 			}
-			deletedRevisionIDs = append(deletedRevisionIDs, deleted...)
+			txnDeletedRevisionIDs = append(txnDeletedRevisionIDs, deleted...)
 		}
+		deletedRevisionIDs = txnDeletedRevisionIDs
 		return nil
 	})
 	if err != nil {

--- a/domain/removal/state/model/state.go
+++ b/domain/removal/state/model/state.go
@@ -146,11 +146,12 @@ func (st *State) initialEntityRemovalQuery() eventsource.NamespaceQuery {
 			return nil, errors.Errorf("preparing select machines query: %w", err)
 		}
 
-		var (
-			units, apps, relations, machines []entityUUID
-			entities                         []string
-		)
+		var entities []string
 		err = runner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+			var (
+				units, apps, relations, machines []entityUUID
+				txnEntities                      []string
+			)
 			if err := tx.Query(ctx, selectUnits).GetAll(&units); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 				return errors.Errorf("selecting units: %w", err)
 			}
@@ -165,17 +166,19 @@ func (st *State) initialEntityRemovalQuery() eventsource.NamespaceQuery {
 			}
 
 			for _, u := range units {
-				entities = append(entities, "unit:"+u.UUID)
+				txnEntities = append(txnEntities, "unit:"+u.UUID)
 			}
 			for _, a := range apps {
-				entities = append(entities, "application:"+a.UUID)
+				txnEntities = append(txnEntities, "application:"+a.UUID)
 			}
 			for _, r := range relations {
-				entities = append(entities, "relation:"+r.UUID)
+				txnEntities = append(txnEntities, "relation:"+r.UUID)
 			}
 			for _, m := range machines {
-				entities = append(entities, "machine:"+m.UUID)
+				txnEntities = append(txnEntities, "machine:"+m.UUID)
 			}
+
+			entities = txnEntities
 			return nil
 		})
 		if err != nil {

--- a/domain/resource/state/resource.go
+++ b/domain/resource/state/resource.go
@@ -370,6 +370,11 @@ WHERE application_uuid = $resourceIdentity.application_uuid`
 		available []coreresource.Resource
 	)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) (err error) {
+		var (
+			txnPotential []charmresource.Resource
+			txnAvailable []coreresource.Resource
+		)
+
 		// Resources found linked to the application.
 		var resources []resourceView
 
@@ -396,7 +401,7 @@ WHERE application_uuid = $resourceIdentity.application_uuid`
 					return errors.Capture(err)
 				}
 				// Add potential resource.
-				potential = append(potential, charmRes)
+				txnPotential = append(txnPotential, charmRes)
 				continue
 			}
 
@@ -405,8 +410,11 @@ WHERE application_uuid = $resourceIdentity.application_uuid`
 				return errors.Capture(err)
 			}
 			// Add available resource.
-			available = append(available, r)
+			txnAvailable = append(txnAvailable, r)
 		}
+
+		potential = txnPotential
+		available = txnAvailable
 		return nil
 	})
 	return potential, available, errors.Capture(err)
@@ -448,6 +456,8 @@ func (st *State) listUnitResources(
 
 	var unitResources []coreresource.UnitResources
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) (err error) {
+		var txnUnitResources []coreresource.UnitResources
+
 		// Units linked to the application.
 		var units []unitUUIDAndName
 
@@ -476,11 +486,13 @@ func (st *State) listUnitResources(
 				}
 				resources = append(resources, r)
 			}
-			unitResources = append(unitResources, coreresource.UnitResources{
+			txnUnitResources = append(txnUnitResources, coreresource.UnitResources{
 				Name:      coreunit.Name(unit.Name),
 				Resources: resources,
 			})
 		}
+
+		unitResources = txnUnitResources
 		return nil
 	})
 


### PR DESCRIPTION
Whilst looking at and reviewing another PR it was observed that there is a gotcha when a transaction retries. If we're appending to a slice and it retries, then it's possible to end up with a lot more entities in the slice that expected. The solution is always us a variable inside of the transaction and only assign it to the outer scope once it's safe to do so.

I did have a thought of re-running all Txn to ensure that they're idempotent, but it becomes very tricky with writes i.e. you would have to start the first transaction and fail it (the tricky part) and then allow it to replay. Not only is that difficult to do, it will also make all our state tests slower.

## QA steps

The tests should pass.
