### PR TITLE
feat(static-analysis): add check to guard against dodgy txn retries

### DIFF
--- a/core/watcher/eventsource/namespace.go
+++ b/core/watcher/eventsource/namespace.go
@@ -188,6 +188,8 @@ func InitialNamespaceChanges(selectAll string, args ...any) NamespaceQuery {
 
 		var keys []string
 		err := runner.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			keys = nil
+
 			rows, err := tx.QueryContext(ctx, selectAll, args...)
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {

--- a/domain/access/state/types.go
+++ b/domain/access/state/types.go
@@ -247,3 +247,25 @@ type nameAndUUID struct {
 	Name string `db:"name"`
 	UUID string `db:"uuid"`
 }
+
+// userNameAndDisabled is used to pass a user's name and disabled
+// status as arguments to SQL.
+type userNameAndDisabled struct {
+	Name     string `db:"name"`
+	Disabled bool   `db:"disabled"`
+}
+
+// userNameAndPassword is used to pass a user's name and password
+// details as arguments to SQL.
+type userNameAndPassword struct {
+	Name         string `db:"name"`
+	PasswordHash string `db:"password_hash"`
+	PasswordSalt []byte `db:"password_salt"`
+}
+
+// userNameAndActivationKey is used to pass a user's name and
+// activation key as arguments to SQL.
+type userNameAndActivationKey struct {
+	Name          string `db:"name"`
+	ActivationKey []byte `db:"activation_key"`
+}

--- a/domain/access/state/user.go
+++ b/domain/access/state/user.go
@@ -276,15 +276,15 @@ SELECT (u.uuid,
 FROM   v_user_auth u
        LEFT JOIN v_user_last_login ull ON u.uuid = ull.user_uuid
        LEFT JOIN user AS creator ON u.created_by_uuid = creator.uuid
-WHERE  u.uuid = $M.uuid`
+WHERE  u.uuid = $userUUID.uuid`
 
-		selectGetUserStmt, err := st.Prepare(getUserQuery, dbUser{}, sqlair.M{})
+		selectGetUserStmt, err := st.Prepare(getUserQuery, dbUser{}, userUUID{})
 		if err != nil {
 			return errors.Errorf("preparing select getUser query: %w", err)
 		}
 
 		var result dbUser
-		err = tx.Query(ctx, selectGetUserStmt, sqlair.M{"uuid": uuid.String()}).Get(&result)
+		err = tx.Query(ctx, selectGetUserStmt, userUUID{UUID: uuid.String()}).Get(&result)
 		if errors.Is(err, sql.ErrNoRows) {
 			return errors.Errorf("%q: %w", uuid, accesserrors.UserNotFound)
 		} else if err != nil {
@@ -513,41 +513,39 @@ func (st *UserState) RemoveUser(ctx context.Context, name user.Name) error {
 		return errors.Capture(err)
 	}
 
-	m := make(sqlair.M, 1)
-
 	deleteModelAuthorizedKeysStmt, err := st.Prepare(`
 DELETE FROM model_authorized_keys
 WHERE user_public_ssh_key_id IN (SELECT id
 								 FROM user_public_ssh_key as upsk
-								 WHERE upsk.user_uuid = $M.uuid)
-	`, m)
+								 WHERE upsk.user_uuid = $userUUID.uuid)
+	`, userUUID{})
 	if err != nil {
 		return errors.Errorf("preparing delete model authorized keys query for user: %w", err)
 	}
 
 	deleteUserPublicSSHKeysStmt, err := st.Prepare(
-		"DELETE FROM user_public_ssh_key WHERE user_uuid = $M.uuid", m,
+		"DELETE FROM user_public_ssh_key WHERE user_uuid = $userUUID.uuid", userUUID{},
 	)
 	if err != nil {
 		return errors.Errorf("preparing delete user public ssh keys: %w", err)
 	}
 
-	deletePassStmt, err := st.Prepare("DELETE FROM user_password WHERE user_uuid = $M.uuid", m)
+	deletePassStmt, err := st.Prepare("DELETE FROM user_password WHERE user_uuid = $userUUID.uuid", userUUID{})
 	if err != nil {
 		return errors.Errorf("preparing password deletion query: %w", err)
 	}
 
-	deleteKeyStmt, err := st.Prepare("DELETE FROM user_activation_key WHERE user_uuid = $M.uuid", m)
+	deleteKeyStmt, err := st.Prepare("DELETE FROM user_activation_key WHERE user_uuid = $userUUID.uuid", userUUID{})
 	if err != nil {
 		return errors.Errorf("preparing activation key deletion query: %w", err)
 	}
 
-	deletePermStmt, err := st.Prepare("DELETE FROM permission WHERE grant_to = $M.uuid", m)
+	deletePermStmt, err := st.Prepare("DELETE FROM permission WHERE grant_to = $userUUID.uuid", userUUID{})
 	if err != nil {
 		return errors.Errorf("preparing permission deletion query: %w", err)
 	}
 
-	setRemovedStmt, err := st.Prepare("UPDATE user SET removed = true WHERE uuid = $M.uuid", m)
+	setRemovedStmt, err := st.Prepare("UPDATE user SET removed = true WHERE uuid = $userUUID.uuid", userUUID{})
 	if err != nil {
 		return errors.Errorf("preparing password deletion query: %w", err)
 	}
@@ -562,29 +560,29 @@ WHERE user_public_ssh_key_id IN (SELECT id
 			return errors.Capture(err)
 		}
 
-		m["uuid"] = uuid
+		uuidArgs := userUUID{UUID: uuid.String()}
 
-		if err := tx.Query(ctx, deleteModelAuthorizedKeysStmt, m).Run(); err != nil {
+		if err := tx.Query(ctx, deleteModelAuthorizedKeysStmt, uuidArgs).Run(); err != nil {
 			return errors.Errorf("deleting model authorized keys for %q: %w", name, err)
 		}
 
-		if err := tx.Query(ctx, deleteUserPublicSSHKeysStmt, m).Run(); err != nil {
+		if err := tx.Query(ctx, deleteUserPublicSSHKeysStmt, uuidArgs).Run(); err != nil {
 			return errors.Errorf("deleting user publish ssh keys for %q: %w", name, err)
 		}
 
-		if err := tx.Query(ctx, deletePassStmt, m).Run(); err != nil {
+		if err := tx.Query(ctx, deletePassStmt, uuidArgs).Run(); err != nil {
 			return errors.Errorf("deleting password for %q: %w", name, err)
 		}
 
-		if err := tx.Query(ctx, deleteKeyStmt, m).Run(); err != nil {
+		if err := tx.Query(ctx, deleteKeyStmt, uuidArgs).Run(); err != nil {
 			return errors.Errorf("deleting key for %q: %w", name, err)
 		}
 
-		if err := tx.Query(ctx, deletePermStmt, m).Run(); err != nil {
+		if err := tx.Query(ctx, deletePermStmt, uuidArgs).Run(); err != nil {
 			return errors.Errorf("deleting permission for %q: %w", name, err)
 		}
 
-		if err := tx.Query(ctx, setRemovedStmt, m).Run(); err != nil {
+		if err := tx.Query(ctx, setRemovedStmt, uuidArgs).Run(); err != nil {
 			return errors.Errorf("marking %q removed: %w", name, err)
 		}
 
@@ -610,9 +608,7 @@ func (st *UserState) SetActivationKey(ctx context.Context, name user.Name, activ
 		return errors.Capture(err)
 	}
 
-	m := make(sqlair.M, 1)
-
-	deletePassStmt, err := st.Prepare("DELETE FROM user_password WHERE user_uuid = $M.uuid", m)
+	deletePassStmt, err := st.Prepare("DELETE FROM user_password WHERE user_uuid = $userUUID.uuid", userUUID{})
 	if err != nil {
 		return errors.Errorf("preparing password deletion query: %w", err)
 	}
@@ -623,7 +619,7 @@ func (st *UserState) SetActivationKey(ctx context.Context, name user.Name, activ
 			return errors.Capture(err)
 		}
 
-		if err := tx.Query(ctx, deletePassStmt, sqlair.M{"uuid": uuid}).Run(); err != nil {
+		if err := tx.Query(ctx, deletePassStmt, userUUID{UUID: uuid.String()}).Run(); err != nil {
 			return errors.Errorf("deleting password for %q: %w", name, err)
 		}
 
@@ -645,11 +641,9 @@ func (st *UserState) GetActivationKey(ctx context.Context, name user.Name) ([]by
 		return nil, errors.Capture(err)
 	}
 
-	m := make(sqlair.M, 1)
-
 	selectKeyStmt, err := st.Prepare(`
-SELECT (*) AS (&dbActivationKey.*) FROM user_activation_key WHERE user_uuid = $M.uuid
-`, m, dbActivationKey{})
+SELECT (*) AS (&dbActivationKey.*) FROM user_activation_key WHERE user_uuid = $userUUID.uuid
+`, userUUID{}, dbActivationKey{})
 	if err != nil {
 		return nil, errors.Errorf("preparing activation get query: %w", err)
 	}
@@ -661,7 +655,7 @@ SELECT (*) AS (&dbActivationKey.*) FROM user_activation_key WHERE user_uuid = $M
 			return errors.Capture(err)
 		}
 
-		if err := tx.Query(ctx, selectKeyStmt, sqlair.M{"uuid": uuid}).Get(&key); err != nil {
+		if err := tx.Query(ctx, selectKeyStmt, userUUID{UUID: uuid.String()}).Get(&key); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return errors.Errorf("activation key for %q: %w", name, accesserrors.ActivationKeyNotFound)
 			}
@@ -692,9 +686,7 @@ func (st *UserState) SetPasswordHash(ctx context.Context, name user.Name, passwo
 		return errors.Capture(err)
 	}
 
-	m := make(sqlair.M, 1)
-
-	deleteKeyStmt, err := st.Prepare("DELETE FROM user_activation_key WHERE user_uuid = $M.uuid", m)
+	deleteKeyStmt, err := st.Prepare("DELETE FROM user_activation_key WHERE user_uuid = $userUUID.uuid", userUUID{})
 	if err != nil {
 		return errors.Errorf("preparing password deletion query: %w", err)
 	}
@@ -704,9 +696,9 @@ func (st *UserState) SetPasswordHash(ctx context.Context, name user.Name, passwo
 		if err != nil {
 			return errors.Capture(err)
 		}
-		m["uuid"] = uuid
+		uuidArgs := userUUID{UUID: uuid.String()}
 
-		if err := tx.Query(ctx, deleteKeyStmt, m).Run(); err != nil {
+		if err := tx.Query(ctx, deleteKeyStmt, uuidArgs).Run(); err != nil {
 			return errors.Errorf("deleting key for %q: %w", name, err)
 		}
 
@@ -728,15 +720,13 @@ func (st *UserState) EnableUserAuthentication(ctx context.Context, name user.Nam
 		return errors.Capture(err)
 	}
 
-	m := make(sqlair.M, 1)
-
 	q := `
 INSERT INTO user_authentication (user_uuid, disabled)
-VALUES ($M.uuid, false)
+VALUES ($userUUID.uuid, false)
 ON CONFLICT(user_uuid) DO
 UPDATE SET disabled = false`
 
-	enableUserStmt, err := st.Prepare(q, m)
+	enableUserStmt, err := st.Prepare(q, userUUID{})
 	if err != nil {
 		return errors.Errorf("preparing enable user query: %w", err)
 	}
@@ -746,9 +736,9 @@ UPDATE SET disabled = false`
 		if err != nil {
 			return errors.Capture(err)
 		}
-		m["uuid"] = uuid
+		uuidArgs := userUUID{UUID: uuid.String()}
 
-		if err := tx.Query(ctx, enableUserStmt, m).Run(); err != nil {
+		if err := tx.Query(ctx, enableUserStmt, uuidArgs).Run(); err != nil {
 			return errors.Errorf("enabling user %q: %w", name, err)
 		}
 
@@ -769,15 +759,13 @@ func (st *UserState) DisableUserAuthentication(ctx context.Context, name user.Na
 		return errors.Capture(err)
 	}
 
-	m := make(sqlair.M, 1)
-
 	q := `
 INSERT INTO user_authentication (user_uuid, disabled)
-VALUES ($M.uuid, true)
+VALUES ($userUUID.uuid, true)
 ON CONFLICT(user_uuid) DO
 UPDATE SET disabled = true`
 
-	disableUserStmt, err := st.Prepare(q, m)
+	disableUserStmt, err := st.Prepare(q, userUUID{})
 	if err != nil {
 		return errors.Errorf("preparing disable user query: %w", err)
 	}
@@ -787,13 +775,13 @@ UPDATE SET disabled = true`
 		if err != nil {
 			return errors.Capture(err)
 		}
-		m["uuid"] = uuid
+		uuidArgs := userUUID{UUID: uuid.String()}
 
 		if err := st.checkPotentiallyOrhpanedModels(ctx, tx, uuid.String()); err != nil {
 			return errors.Capture(err)
 		}
 
-		if err := tx.Query(ctx, disableUserStmt, m).Run(); err != nil {
+		if err := tx.Query(ctx, disableUserStmt, uuidArgs).Run(); err != nil {
 			return errors.Errorf("disabling user %q: %w", name, err)
 		}
 
@@ -1055,20 +1043,20 @@ func ensureUserAuthentication(
 ) error {
 	defineUserAuthenticationQuery := `
 INSERT INTO user_authentication (user_uuid, disabled)
-    SELECT uuid, $M.disabled
+    SELECT uuid, $userNameAndDisabled.disabled
     FROM   user
-    WHERE  name = $M.name AND removed = false
+    WHERE  name = $userNameAndDisabled.name AND removed = false
 ON CONFLICT(user_uuid) DO
 UPDATE SET user_uuid = excluded.user_uuid
 WHERE      disabled = false`
 
-	insertDefineUserAuthenticationStmt, err := sqlair.Prepare(defineUserAuthenticationQuery, sqlair.M{})
+	insertDefineUserAuthenticationStmt, err := sqlair.Prepare(defineUserAuthenticationQuery, userNameAndDisabled{})
 	if err != nil {
 		return errors.Errorf("preparing insert defineUserAuthentication query: %w", err)
 	}
 
 	var outcome sqlair.Outcome
-	err = tx.Query(ctx, insertDefineUserAuthenticationStmt, sqlair.M{"name": name.Name(), "disabled": false}).Get(&outcome)
+	err = tx.Query(ctx, insertDefineUserAuthenticationStmt, userNameAndDisabled{Name: name.Name(), Disabled: false}).Get(&outcome)
 	if internaldatabase.IsErrConstraintForeignKey(err) {
 		return errors.Errorf("%q: %w", name, accesserrors.UserNotFound)
 	} else if err != nil {
@@ -1099,21 +1087,21 @@ func setPasswordHash(ctx context.Context, tx *sqlair.TX, name user.Name, passwor
 
 	setPasswordHashQuery := `
 INSERT INTO user_password (user_uuid, password_hash, password_salt)
-    SELECT uuid, $M.password_hash, $M.password_salt
+    SELECT uuid, $userNameAndPassword.password_hash, $userNameAndPassword.password_salt
     FROM   user
-    WHERE  name = $M.name
+    WHERE  name = $userNameAndPassword.name
     AND    removed = false
 ON CONFLICT(user_uuid) DO UPDATE SET password_hash = excluded.password_hash, password_salt = excluded.password_salt`
 
-	insertSetPasswordHashStmt, err := sqlair.Prepare(setPasswordHashQuery, sqlair.M{})
+	insertSetPasswordHashStmt, err := sqlair.Prepare(setPasswordHashQuery, userNameAndPassword{})
 	if err != nil {
 		return errors.Errorf("preparing insert setPasswordHash query: %w", err)
 	}
 
-	err = tx.Query(ctx, insertSetPasswordHashStmt, sqlair.M{
-		"name":          name.Name(),
-		"password_hash": passwordHash,
-		"password_salt": salt},
+	err = tx.Query(ctx, insertSetPasswordHashStmt, userNameAndPassword{
+		Name:         name.Name(),
+		PasswordHash: passwordHash,
+		PasswordSalt: salt},
 	).Run()
 	if err != nil {
 		return errors.Errorf("setting password hash for user %q: %w", name, err)
@@ -1134,18 +1122,18 @@ func setActivationKey(ctx context.Context, tx *sqlair.TX, name user.Name, activa
 
 	setActivationKeyQuery := `
 INSERT INTO user_activation_key (user_uuid, activation_key)
-    SELECT uuid, $M.activation_key
+    SELECT uuid, $userNameAndActivationKey.activation_key
     FROM   user
-    WHERE  name = $M.name
+    WHERE  name = $userNameAndActivationKey.name
     AND    removed = false
 ON CONFLICT(user_uuid) DO UPDATE SET activation_key = excluded.activation_key`
 
-	insertSetActivationKeyStmt, err := sqlair.Prepare(setActivationKeyQuery, sqlair.M{})
+	insertSetActivationKeyStmt, err := sqlair.Prepare(setActivationKeyQuery, userNameAndActivationKey{})
 	if err != nil {
 		return errors.Errorf("preparing insert setActivationKey query: %w", err)
 	}
 
-	err = tx.Query(ctx, insertSetActivationKeyStmt, sqlair.M{"name": name.Name(), "activation_key": activationKey}).Run()
+	err = tx.Query(ctx, insertSetActivationKeyStmt, userNameAndActivationKey{Name: name.Name(), ActivationKey: activationKey}).Run()
 	if err != nil {
 		return errors.Errorf("setting activation key for user %q: %w", name, err)
 	}

--- a/domain/agentbinary/state/controller/state.go
+++ b/domain/agentbinary/state/controller/state.go
@@ -136,10 +136,6 @@ func (s *ControllerState) RegisterAgentBinary(ctx context.Context, arg agentbina
 	}
 
 	archVal := architectureRecord{Name: arg.Arch}
-	agentBinary := agentBinaryRecord{
-		Version:         arg.Version,
-		ObjectStoreUUID: arg.ObjectStoreUUID.String(),
-	}
 
 	archStmt, err := s.Prepare(`
 SELECT &architectureRecord.*
@@ -153,7 +149,7 @@ WHERE  name = $architectureRecord.name
 	insertStmt, err := s.Prepare(`
 INSERT INTO agent_binary_store (*)
 VALUES ($agentBinaryRecord.*)
-`, agentBinary)
+`, agentBinaryRecord{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -182,7 +178,11 @@ VALUES ($agentBinaryRecord.*)
 			return errors.Capture(err)
 		}
 
-		agentBinary.ArchitectureID = archVal.ID
+		agentBinary := agentBinaryRecord{
+			Version:         arg.Version,
+			ObjectStoreUUID: arg.ObjectStoreUUID.String(),
+			ArchitectureID:  archVal.ID,
+		}
 		err = tx.Query(ctx, insertStmt, agentBinary).Run()
 		if jujudb.IsErrConstraintPrimaryKey(err) {
 			// There must be an agent version for this version and arch already.
@@ -195,10 +195,6 @@ VALUES ($agentBinaryRecord.*)
 			existingAgentBinary, err := s.getAgentBinary(
 				ctx, tx, agentBinary.Version, agentBinary.ArchitectureID,
 			)
-			if errors.Is(err, coreerrors.NotFound) {
-				// This should never happen.
-				return errors.Capture(err)
-			}
 			if err != nil {
 				return errors.Capture(err)
 			}

--- a/domain/agentbinary/state/model/state.go
+++ b/domain/agentbinary/state/model/state.go
@@ -136,10 +136,6 @@ func (s *ModelState) RegisterAgentBinary(ctx context.Context, arg agentbinary.Re
 	}
 
 	archVal := architectureRecord{Name: arg.Arch}
-	agentBinary := agentBinaryRecord{
-		Version:         arg.Version,
-		ObjectStoreUUID: arg.ObjectStoreUUID.String(),
-	}
 
 	archStmt, err := s.Prepare(`
 SELECT &architectureRecord.*
@@ -153,7 +149,7 @@ WHERE  name = $architectureRecord.name
 	insertStmt, err := s.Prepare(`
 INSERT INTO agent_binary_store (*)
 VALUES ($agentBinaryRecord.*)
-`, agentBinary)
+`, agentBinaryRecord{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -182,7 +178,11 @@ VALUES ($agentBinaryRecord.*)
 			return errors.Capture(err)
 		}
 
-		agentBinary.ArchitectureID = archVal.ID
+		agentBinary := agentBinaryRecord{
+			Version:         arg.Version,
+			ObjectStoreUUID: arg.ObjectStoreUUID.String(),
+			ArchitectureID:  archVal.ID,
+		}
 		err = tx.Query(ctx, insertStmt, agentBinary).Run()
 		if jujudb.IsErrConstraintPrimaryKey(err) {
 			// There must be an agent version for this version and arch already.
@@ -196,7 +196,6 @@ VALUES ($agentBinaryRecord.*)
 				ctx, tx, agentBinary.Version, agentBinary.ArchitectureID,
 			)
 			if errors.Is(err, coreerrors.NotFound) {
-				// This should never happen.
 				return errors.Capture(err)
 			}
 			if err != nil {

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -952,11 +952,6 @@ func (st *State) SetApplicationScalingState(ctx context.Context, appName string,
 		return errors.Capture(err)
 	}
 
-	scaleDetails := applicationScale{
-		Scaling:     scaling,
-		ScaleTarget: targetScale,
-	}
-
 	upsertApplicationScale := `
 UPDATE application_scale
 SET    scale = $applicationScale.scale,
@@ -965,7 +960,7 @@ SET    scale = $applicationScale.scale,
 WHERE  application_uuid = $applicationScale.application_uuid
 `
 
-	upsertStmt, err := st.Prepare(upsertApplicationScale, scaleDetails)
+	upsertStmt, err := st.Prepare(upsertApplicationScale, applicationScale{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -976,13 +971,13 @@ WHERE  application_uuid = $applicationScale.application_uuid
 		} else if appDetails.IsApplicationSynthetic {
 			return errors.Errorf("cannot set scaling state for synthetic application %q", appName)
 		}
-		scaleDetails.ApplicationID = appDetails.UUID
 
 		currentScaleState, err := st.getApplicationScaleState(ctx, tx, appDetails.UUID)
 		if err != nil {
 			return errors.Capture(err)
 		}
 
+		var scale int
 		if scaling {
 			switch appDetails.LifeID {
 			case life.Alive:
@@ -991,17 +986,23 @@ WHERE  application_uuid = $applicationScale.application_uuid
 					return applicationerrors.ScalingStateInconsistent
 				}
 				// Make sure to leave the scale value unchanged.
-				scaleDetails.Scale = currentScaleState.Scale
+				scale = currentScaleState.Scale
 			case life.Dying, life.Dead:
 				// force scale to the scale target when dying/dead.
-				scaleDetails.Scale = targetScale
+				scale = targetScale
 			}
 		} else {
 			// Make sure to leave the scale value unchanged.
-			scaleDetails.Scale = currentScaleState.Scale
+			scale = currentScaleState.Scale
 		}
 
-		return tx.Query(ctx, upsertStmt, scaleDetails).Run()
+		scaleDetailsToUpdate := applicationScale{
+			ApplicationID: appDetails.UUID,
+			Scaling:       scaling,
+			Scale:         scale,
+			ScaleTarget:   targetScale,
+		}
+		return tx.Query(ctx, upsertStmt, scaleDetailsToUpdate).Run()
 	})
 	return errors.Capture(err)
 }
@@ -1015,16 +1016,12 @@ func (st *State) UpsertK8sService(ctx context.Context, applicationName, provider
 		return errors.Capture(err)
 	}
 
-	serviceInfo := k8sService{
-		ProviderID: providerID,
-	}
-
 	// Query any existing records for application and provider id.
 	queryExistingStmt, err := st.Prepare(`
 SELECT &k8sService.* 
 FROM   k8s_service
 WHERE  application_uuid = $k8sService.application_uuid
-AND    provider_id = $k8sService.provider_id`, serviceInfo)
+AND    provider_id = $k8sService.provider_id`, k8sService{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -1036,29 +1033,32 @@ AND    provider_id = $k8sService.provider_id`, serviceInfo)
 		} else if appDetails.IsApplicationSynthetic {
 			return errors.Errorf("cannot upsert cloud service for synthetic application %q", applicationName)
 		}
-		serviceInfo.ApplicationUUID = appDetails.UUID
 
 		// First see if the cloud service for the app and provider id already exists.
 		// If so, it's a no-op.
-		err = tx.Query(ctx, queryExistingStmt, serviceInfo).Get(&serviceInfo)
+		serviceInfoToUpsert := k8sService{
+			ProviderID:      providerID,
+			ApplicationUUID: appDetails.UUID,
+		}
+		err = tx.Query(ctx, queryExistingStmt, serviceInfoToUpsert).Get(&serviceInfoToUpsert)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf(
 				"querying cloud service for application %q and provider id %q: %w", applicationName, providerID, err)
 		} else if errors.Is(err, sqlair.ErrNoRows) {
 			// Nothing already exists so create a new net node and the cloud
 			// service.
-			netNodeUUID, k8sServiceUUID, err := st.createK8sService(ctx, tx, serviceInfo)
+			netNodeUUID, k8sServiceUUID, err := st.createK8sService(ctx, tx, serviceInfoToUpsert)
 			if err != nil {
 				return errors.Errorf("creating k8s service for application %q: %w", applicationName, err)
 			}
-			serviceInfo.NetNodeUUID = netNodeUUID.String()
-			serviceInfo.UUID = k8sServiceUUID.String()
+			serviceInfoToUpsert.NetNodeUUID = netNodeUUID.String()
+			serviceInfoToUpsert.UUID = k8sServiceUUID.String()
 		}
 
 		if len(sAddrs) > 0 {
 			// If we have addresses to insert, then first create the link layer
 			// device (if needed) and then insert the addresses.
-			if err := st.upsertK8sServiceAddresses(ctx, tx, serviceInfo, applicationName, sAddrs); err != nil {
+			if err := st.upsertK8sServiceAddresses(ctx, tx, serviceInfoToUpsert, applicationName, sAddrs); err != nil {
 				return errors.Capture(err)
 			}
 		}

--- a/domain/application/state/application_endpoint_test.go
+++ b/domain/application/state/application_endpoint_test.go
@@ -1218,6 +1218,8 @@ func nilEmpty(s *string) string {
 func (s *applicationEndpointStateSuite) fetchApplicationEndpoints(c *tc.C) []applicationEndpoint {
 	var endpoints []applicationEndpoint
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		endpoints = nil
+
 		rows, err := tx.Query(`
 SELECT ae.charm_relation_uuid, s.name
 FROM application_endpoint ae
@@ -1253,6 +1255,8 @@ type appEndpointSpace struct {
 func (s *applicationEndpointStateSuite) fetchApplicationEndpointAndSpaceUUID(c *tc.C, appID string) []appEndpointSpace {
 	var endpoints []appEndpointSpace
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		endpoints = nil
+
 		rows, err := tx.Query(`
 SELECT cr.name, s.name
 FROM application_endpoint AS ae
@@ -1284,6 +1288,8 @@ ORDER BY s.name`, appID)
 func (s *applicationEndpointStateSuite) fetchApplicationExtraEndpointAndSpaceUUID(c *tc.C, appID string) []appEndpointSpace {
 	var endpoints []appEndpointSpace
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		endpoints = nil
+
 		rows, err := tx.Query(`
 SELECT cr.name, s.name
 FROM application_extra_endpoint AS ae
@@ -1315,6 +1321,8 @@ ORDER BY s.name`, appID)
 func (s *applicationEndpointStateSuite) fetchApplicationExtraEndpoints(c *tc.C) []applicationEndpoint {
 	var endpoints []applicationEndpoint
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		endpoints = nil
+
 		rows, err := tx.Query(`
 SELECT ae.charm_extra_binding_uuid, s.name
 FROM application_extra_endpoint ae

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -588,6 +588,8 @@ WHERE name=?`, "666").Scan(&appUUID, &charmUUID)
 		foundAppPotentialResources []application.AddApplicationResourceArg
 	)
 	assertTxn("Fetch charm resources", func(ctx context.Context, tx *sql.Tx) error {
+		foundCharmResources = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT cr.name, crk.name as kind, path, description
 FROM charm_resource cr
@@ -607,6 +609,8 @@ WHERE charm_uuid=?`, charmUUID)
 		return nil
 	})
 	assertTxn("Fetch application available resources", func(ctx context.Context, tx *sql.Tx) error {
+		foundAppAvailableResources = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT vr.name, revision, origin_type
 FROM v_application_resource vr
@@ -631,6 +635,8 @@ AND state = 'available'`, appUUID)
 	})
 
 	assertTxn("Fetch application potential resources", func(ctx context.Context, tx *sql.Tx) error {
+		foundAppPotentialResources = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT vr.name, revision, origin_type
 FROM v_application_resource vr
@@ -734,6 +740,8 @@ WHERE name=?`, appName).Scan(&appUUID, &charmUUID)
 		foundAppPotentialResources []resource.AddResourceDetails
 	)
 	assertTxn("Fetch charm resources", func(ctx context.Context, tx *sql.Tx) error {
+		foundCharmResources = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT cr.name, crk.name as kind, path, description
 FROM charm_resource cr
@@ -753,6 +761,8 @@ WHERE charm_uuid=?`, charmUUID)
 		return nil
 	})
 	assertTxn("Fetch application available resources", func(ctx context.Context, tx *sql.Tx) error {
+		foundAppAvailableResources = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT vr.name, revision
 FROM v_application_resource vr
@@ -774,6 +784,8 @@ AND state = 'available'`, appUUID)
 	})
 
 	assertTxn("Fetch application potential resources", func(ctx context.Context, tx *sql.Tx) error {
+		foundAppPotentialResources = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT vr.name, revision
 FROM v_application_resource vr
@@ -843,7 +855,6 @@ VALUES (?, ?, ?, ?, ?, ?, ?)
 `
 			_, err := tx.ExecContext(ctx, insertStmt,
 				res.UUID, charmUUID, res.Name, res.Revision, 1, 0, res.CreatedAt)
-			c.Assert(err, tc.IsNil)
 			if err != nil {
 				return err
 			}
@@ -853,7 +864,6 @@ INSERT INTO pending_application_resource (application_name, resource_uuid)
 VALUES (?, ?)
 `
 			_, err = tx.ExecContext(ctx, linkStmt, appName, res.UUID)
-			c.Assert(err, tc.IsNil)
 			if err != nil {
 				return err
 			}
@@ -1171,6 +1181,8 @@ func (s *applicationStateSuite) TestUpsertK8sServiceAnother(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	var providerIds []string
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		providerIds = nil
+
 		rows, err := tx.QueryContext(ctx, "SELECT provider_id FROM k8s_service WHERE application_uuid = ?", appUUID)
 		if err != nil {
 			return err
@@ -1244,6 +1256,8 @@ func (s *applicationStateSuite) TestUpsertK8sServiceUpdateExistingEmptyAddresses
 	checkAddresses := func(c *tc.C, expectedAddresses ...string) {
 		var resultAddresses []string
 		err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			resultAddresses = nil
+
 			rows, err := tx.QueryContext(ctx, `
 SELECT address_value
 FROM ip_address
@@ -1305,6 +1319,8 @@ func (s *applicationStateSuite) TestUpsertK8sServiceUpdateExistingWithAddresses(
 	checkAddresses := func(c *tc.C, expectedAddresses ...string) {
 		var resultAddresses []string
 		err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			resultAddresses = nil
+
 			rows, err := tx.QueryContext(ctx, `
 SELECT address_value
 FROM ip_address
@@ -3297,6 +3313,10 @@ func (s *applicationStateSuite) TestSetConstraintFull(c *tc.C) {
 		allocatePublicIP                                                    bool
 	)
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		constraintSpaces = nil
+		constraintTags = nil
+		constraintZones = nil
+
 		err := tx.QueryRowContext(ctx, "SELECT application_uuid, constraint_uuid FROM application_constraint WHERE application_uuid=?", id).Scan(&applicationUUID, &constraintUUID)
 		if err != nil {
 			return err
@@ -4219,6 +4239,8 @@ func (s *baseSuite) assertPeerRelation(c *tc.C, appName string, peerRelationInpu
 
 	var peerRelations []peerRelation
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		peerRelations = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT cr.name, r.relation_id, rst.name
 FROM charm_relation cr

--- a/domain/application/state/charm.go
+++ b/domain/application/state/charm.go
@@ -652,6 +652,7 @@ WHERE c.uuid = $entityUUID.uuid;
 			return errors.Capture(err)
 		}
 
+		revision := ch.Revision
 		// If the charm requires sequencing, get the next revision from
 		// the reference name.
 		if requiresSequencing {
@@ -660,10 +661,12 @@ WHERE c.uuid = $entityUUID.uuid;
 			if err != nil {
 				return errors.Errorf("getting next charm revision: %w", err)
 			}
-			ch.Revision = int(rev)
+			revision = int(rev)
 		}
 
-		if err := s.addCharm(ctx, tx, id, ch, downloadInfo); err != nil {
+		charmToAdd := ch
+		charmToAdd.Revision = revision
+		if err := s.addCharm(ctx, tx, id, charmToAdd, downloadInfo); err != nil {
 			return errors.Capture(err)
 		}
 
@@ -900,8 +903,8 @@ WHERE model_uuid = $modelMigrating.model_uuid
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// Query the model_migrating table to check if this model has an entry.
-		migrationCheck.ModelUUID = s.modelUUID.String()
-		err = tx.Query(ctx, migrationStmt, migrationCheck).Get(&count)
+		migrationCheckArgs := modelMigrating{ModelUUID: s.modelUUID.String()}
+		err = tx.Query(ctx, migrationStmt, migrationCheckArgs).Get(&count)
 		if err != nil {
 			return errors.Errorf("checking if model is importing: %w", err)
 		}

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -35,29 +35,9 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 	if err != nil {
 		return errors.Capture(err)
 	}
-	charmIDStr := charmID.String()
-
-	appDetails := setApplicationDetails{
-		UUID:      args.ApplicationUUID,
-		Name:      name,
-		CharmUUID: charmIDStr,
-		LifeID:    life.Alive,
-
-		// The space is defaulted to Alpha, which is guaranteed to exist.
-		// However, if there is a default space defined in endpoint bindings
-		// (through a binding with an empty endpoint or by default-space model
-		// config), the application space will be updated later in the
-		// transaction, during the insertion of application_endpoints.
-		// The space defined here will be used as the default space when creating a
-		// relation where application_endpoint doesn't have a defined space.
-		// There is no need to set the space to the default space defined during
-		// migration import, because an application always has a default space
-		// which is passed through endpoint bindings in migration.
-		SpaceUUID: network.AlphaSpaceId.String(),
-	}
 
 	createApplication := `INSERT INTO application (*) VALUES ($setApplicationDetails.*)`
-	createApplicationStmt, err := st.Prepare(createApplication, appDetails)
+	createApplicationStmt, err := st.Prepare(createApplication, setApplicationDetails{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -113,6 +93,7 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 			return errors.Errorf("checking if application %q exists: %w", name, err)
 		}
 
+		charmUUID := charmID.String()
 		shouldInsertCharm := true
 
 		// Check if the charm already exists.
@@ -122,7 +103,7 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 		} else if errors.Is(err, applicationerrors.CharmAlreadyExists) {
 			// We already have an existing charm, in this case we just want
 			// to point the application to the existing charm.
-			appDetails.CharmUUID = existingCharmID
+			charmUUID = existingCharmID
 
 			shouldInsertCharm = false
 		}
@@ -142,8 +123,27 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 			}
 		}
 
+		applicationDetails := setApplicationDetails{
+			UUID:      args.ApplicationUUID,
+			Name:      name,
+			CharmUUID: charmUUID,
+			LifeID:    life.Alive,
+
+			// The space is defaulted to Alpha, which is guaranteed to exist.
+			// However, if there is a default space defined in endpoint bindings
+			// (through a binding with an empty endpoint or by default-space model
+			// config), the application space will be updated later in the
+			// transaction, during the insertion of application_endpoints.
+			// The space defined here will be used as the default space when creating a
+			// relation where application_endpoint doesn't have a defined space.
+			// There is no need to set the space to the default space defined during
+			// migration import, because an application always has a default space
+			// which is passed through endpoint bindings in migration.
+			SpaceUUID: network.AlphaSpaceId.String(),
+		}
+
 		// If the application doesn't exist, create it.
-		if err := tx.Query(ctx, createApplicationStmt, appDetails).Run(); err != nil {
+		if err := tx.Query(ctx, createApplicationStmt, applicationDetails).Run(); err != nil {
 			return errors.Errorf("inserting row for application %q: %w", name, err)
 		}
 		if err := tx.Query(ctx, createPlatformStmt, platformInfo).Run(); err != nil {
@@ -155,8 +155,8 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 		if err := st.createApplicationResources(
 			ctx, tx,
 			insertResourcesArgs{
-				appID:        appDetails.UUID,
-				charmUUID:    appDetails.CharmUUID,
+				appID:        applicationDetails.UUID,
+				charmUUID:    applicationDetails.CharmUUID,
 				charmSource:  args.Charm.Source,
 				appResources: args.Resources,
 			},
@@ -164,20 +164,20 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 		); err != nil {
 			return errors.Errorf("inserting or resolving resources for application %q: %w", name, err)
 		}
-		if err := st.insertApplicationConfig(ctx, tx, appDetails.UUID, args.Config); err != nil {
+		if err := st.insertApplicationConfig(ctx, tx, applicationDetails.UUID, args.Config); err != nil {
 			return errors.Errorf("inserting config for application %q: %w", name, err)
 		}
-		if err := st.insertApplicationSettings(ctx, tx, appDetails.UUID, args.Settings); err != nil {
+		if err := st.insertApplicationSettings(ctx, tx, applicationDetails.UUID, args.Settings); err != nil {
 			return errors.Errorf("inserting settings for application %q: %w", name, err)
 		}
 		if err := st.updateConfigHash(ctx, tx, entityUUID{UUID: args.ApplicationUUID}); err != nil {
 			return errors.Errorf("refreshing config hash for application %q: %w", name, err)
 		}
-		if err := st.updateDefaultSpace(ctx, tx, appDetails.UUID, args.EndpointBindings); err != nil {
+		if err := st.updateDefaultSpace(ctx, tx, applicationDetails.UUID, args.EndpointBindings); err != nil {
 			return errors.Errorf("updating default space: %w", err)
 		}
 		if err := st.insertApplicationEndpointBindings(ctx, tx, insertApplicationEndpointsParams{
-			appID:    appDetails.UUID,
+			appID:    applicationDetails.UUID,
 			bindings: args.EndpointBindings,
 		}); err != nil {
 			return errors.Errorf("inserting exposed endpoints for application %q: %w", name, err)

--- a/domain/application/state/package_test.go
+++ b/domain/application/state/package_test.go
@@ -914,6 +914,8 @@ func (s *baseSuite) createMigratingApplication(c *tc.C, name string) (coreapplic
 func (s *baseSuite) getApplicationUnits(c *tc.C, appUUID coreapplication.UUID) []coreunit.UUID {
 	var dbVals []string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		dbVals = nil
+
 		rows, err := tx.QueryContext(ctx, "SELECT uuid FROM unit WHERE application_uuid = ?", appUUID.String())
 		if err != nil {
 			return err

--- a/domain/application/state/storage_test.go
+++ b/domain/application/state/storage_test.go
@@ -240,6 +240,8 @@ WHERE name=?`, "666").Scan(&charmUUID)
 	)
 
 	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		foundCharmStorage = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT cs.name, csk.kind
 FROM charm_storage cs
@@ -261,6 +263,8 @@ WHERE charm_uuid=?`, charmUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		foundAppStorage = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT storage_name, storage_pool_uuid, size_mib, count
 FROM   application_storage_directive

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -108,6 +108,8 @@ WHERE u.name=?`,
 func (s *unitStateSuite) assertContainerPortValues(c *tc.C, unitName string, ports []string) {
 	var gotPorts []string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		gotPorts = nil
+
 		rows, err := tx.QueryContext(ctx, `
 
 SELECT ccp.port
@@ -319,6 +321,8 @@ func (s *unitStateSuite) assertCAASUnit(c *tc.C, name, passwordHash, addressValu
 	)
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		gotPorts = nil
+
 		err := tx.QueryRowContext(ctx, "SELECT password_hash FROM unit WHERE name = ?", name).Scan(&gotPasswordHash)
 		if err != nil {
 			return errors.Errorf("failed to get password hash: %v", err)
@@ -2728,6 +2732,8 @@ func (s *unitStateSuite) getUnitStorageDirectivesForCharm(
 ) []unitStorageDirectiveValue {
 	var directives []unitStorageDirectiveValue
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		directives = nil
+
 		rows, err := tx.QueryContext(
 			ctx,
 			`SELECT storage_name, storage_pool_uuid, size_mib, count

--- a/domain/changestream/state/state_test.go
+++ b/domain/changestream/state/state_test.go
@@ -302,7 +302,9 @@ VALUES ($M.ctrl_id, $M.node_id, $M.addr)
 				"node_id": i,
 				"addr":    fmt.Sprintf("127.0.1.%d", i+2),
 			}).Run()
-			c.Assert(err, tc.ErrorIsNil)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -324,7 +326,9 @@ ON CONFLICT (controller_id) DO UPDATE SET lower_bound = $M.lower_bound, updated_
 				"lower_bound": watermark.LowerBound,
 				"updated_at":  watermark.UpdatedAt,
 			}).Run()
-			c.Assert(err, tc.ErrorIsNil)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -344,7 +348,9 @@ VALUES ($M.id, 4, 10002, 0, $M.created_at);
 				"id":         i + 1000,
 				"created_at": now,
 			}).Run()
-			c.Assert(err, tc.ErrorIsNil)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/domain/cloudimagemetadata/bootstrap/bootstrap_test.go
+++ b/domain/cloudimagemetadata/bootstrap/bootstrap_test.go
@@ -129,7 +129,9 @@ func (s *bootstrapSuite) TestInitCustomImageMetadataWithNil(c *tc.C) {
 // It is used in test to keep save and find tests independent of each other
 func (s *bootstrapSuite) retrieveMetadataFromDB(c *tc.C) ([]cloudimagemetadata.Metadata, error) {
 	var metadata []cloudimagemetadata.Metadata
-	return metadata, s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		metadata = nil
+
 		rows, err := tx.Query(`
 SELECT 
 source,
@@ -166,4 +168,5 @@ image_id
 		}
 		return errors.Capture(rows.Err())
 	})
+	return metadata, err
 }

--- a/domain/cloudimagemetadata/state/helpers_test.go
+++ b/domain/cloudimagemetadata/state/helpers_test.go
@@ -20,7 +20,9 @@ import (
 // It is used in test to keep save and find tests independent of each other
 func (s *stateSuite) retrieveMetadataFromDB(c *tc.C) ([]cloudimagemetadata.Metadata, error) {
 	var metadata []cloudimagemetadata.Metadata
-	return metadata, s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		metadata = nil
+
 		rows, err := tx.Query(`
 SELECT 
     created_at,
@@ -62,6 +64,7 @@ JOIN architecture arch on cloud_image_metadata.architecture_id = arch.id
 		}
 		return errors.Capture(err)
 	})
+	return metadata, err
 }
 
 // runQuery executes the provided SQL query string using the current state's database connection.

--- a/domain/controllerconfig/state/state.go
+++ b/domain/controllerconfig/state/state.go
@@ -41,6 +41,8 @@ func (st *State) ControllerConfig(ctx context.Context) (map[string]string, error
 
 	result := make(map[string]string)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = map[string]string{}
+
 		var keyValues []KeyValue
 		if err := tx.Query(ctx, stmt).GetAll(&keyValues); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {

--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -90,8 +90,8 @@ WHERE       controller_id = $dbControllerNode.controller_id`, controllerNode)
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		for _, cID := range delete {
-			controllerNode.ControllerID = cID
-			if err := tx.Query(ctx, deleteStmt, controllerNode).Run(); err != nil {
+			controllerNodeToDelete := dbControllerNode{ControllerID: cID}
+			if err := tx.Query(ctx, deleteStmt, controllerNodeToDelete).Run(); err != nil {
 				return errors.Errorf("deleting controller node %q: %w", cID, err)
 			}
 		}
@@ -155,25 +155,18 @@ func (st *State) SetRunningAgentBinaryVersion(
 		return errors.Capture(err)
 	}
 
-	arch := architecture{Name: version.Arch}
-
 	selectArchIdStmt, err := st.Prepare(`
 SELECT id AS &architecture.id FROM architecture WHERE name = $architecture.name
-`, arch)
+`, architecture{})
 	if err != nil {
 		return errors.Capture(err)
-	}
-
-	controllerNodeAgentVer := controllerNodeAgentVersion{
-		ControllerID: controllerID,
-		Version:      version.Number.String(),
 	}
 
 	selectControllerNodeStmt, err := st.Prepare(`
 SELECT controller_id AS &controllerNodeAgentVersion.*
 FROM controller_node
 WHERE controller_id = $controllerNodeAgentVersion.controller_id
-	`, controllerNodeAgentVer)
+	`, controllerNodeAgentVersion{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -184,15 +177,15 @@ WHERE controller_id = $controllerNodeAgentVersion.controller_id
 INSERT INTO controller_node_agent_version (*) VALUES ($controllerNodeAgentVersion.*)
 ON CONFLICT (controller_id) DO
 UPDATE SET version = excluded.version
-`, controllerNodeAgentVer)
+`, controllerNodeAgentVersion{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-
 		// Ensure controller id exists in controller node before upserting controller node agent version.
-		err = tx.Query(ctx, selectControllerNodeStmt, controllerNodeAgentVer).Get(&controllerNodeAgentVer)
+		controllerNode := controllerNodeAgentVersion{ControllerID: controllerID}
+		err := tx.Query(ctx, selectControllerNodeStmt, controllerNode).Get(&controllerNode)
 
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf(
@@ -205,6 +198,7 @@ UPDATE SET version = excluded.version
 			)
 		}
 
+		arch := architecture{Name: version.Arch}
 		err = tx.Query(ctx, selectArchIdStmt, arch).Get(&arch)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf(
@@ -216,8 +210,12 @@ UPDATE SET version = excluded.version
 			)
 		}
 
-		controllerNodeAgentVer.ArchitectureID = arch.ID
-		return tx.Query(ctx, upsertControllerNodeAgentVerStmt, controllerNodeAgentVer).Run()
+		controllerNodeAgentVersionToSet := controllerNodeAgentVersion{
+			ControllerID:   controllerID,
+			Version:        version.Number.String(),
+			ArchitectureID: arch.ID,
+		}
+		return tx.Query(ctx, upsertControllerNodeAgentVerStmt, controllerNodeAgentVersionToSet).Run()
 	})
 
 	if err != nil {

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -751,6 +751,10 @@ func (s *stateSuite) checkControllerAPIAddress(c *tc.C, controllerID string, add
 		isAgent                       []bool
 	)
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		resultAddresses = nil
+		resultScopes = nil
+		isAgent = nil
+
 		rows, err := tx.QueryContext(ctx, "SELECT address, is_agent, scope FROM controller_api_address WHERE controller_id = ?", controllerID)
 		if err != nil {
 			return err

--- a/domain/crossmodelrelation/state/controller/offer.go
+++ b/domain/crossmodelrelation/state/controller/offer.go
@@ -44,12 +44,6 @@ func (st *State) CreateOfferAccess(
 		AccessType: corepermission.AdminAccess.String(),
 		ObjectType: corepermission.Offer.String(),
 	}
-	everyonePermission := permission{
-		UUID:       everyonePermissionUUID.String(),
-		GrantOn:    offerUUID.String(),
-		AccessType: corepermission.ReadAccess.String(),
-		ObjectType: corepermission.Offer.String(),
-	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		everyoneExternalUUID, err := st.getUserUUIDByName(ctx, tx, corepermission.EveryoneUserName)
@@ -66,7 +60,13 @@ func (st *State) CreateOfferAccess(
 		}
 
 		// Insert the everyone permission.
-		everyonePermission.GrantTo = everyoneExternalUUID
+		everyonePermission := permission{
+			UUID:       everyonePermissionUUID.String(),
+			GrantOn:    offerUUID.String(),
+			AccessType: corepermission.ReadAccess.String(),
+			ObjectType: corepermission.Offer.String(),
+			GrantTo:    everyoneExternalUUID,
+		}
 		if err := insertPermission(ctx, tx, everyonePermission); err != nil {
 			return errors.Errorf("inserting everyone permission: %w", err)
 		}

--- a/domain/crossmodelrelation/state/model/import_test.go
+++ b/domain/crossmodelrelation/state/model/import_test.go
@@ -286,6 +286,8 @@ func (s *importRemoteApplicationOfferersSuite) TestImportRemoteApplicationOffere
 	// Verify synthetic units were created
 	var unitNames []string
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		unitNames = nil
+
 		rows, err := tx.QueryContext(ctx, `
 			SELECT u.name
 			FROM unit u

--- a/domain/crossmodelrelation/state/model/package_test.go
+++ b/domain/crossmodelrelation/state/model/package_test.go
@@ -244,6 +244,8 @@ func (s *baseSuite) assertUnitNames(c *tc.C, applicationUUID coreapplication.UUI
 
 	var names []string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		names = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT name
 FROM unit
@@ -462,8 +464,11 @@ func (s *baseSuite) assertRelationEndpoints(c *tc.C, relationUUID, app1UUID, app
 	c.Helper()
 
 	appUUIDs := set.NewStrings(app1UUID, app2UUID)
+	var foundAppUUIDs []string
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		foundAppUUIDs = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT ae.application_uuid
 FROM   relation_endpoint AS re
@@ -481,13 +486,16 @@ WHERE  relation_uuid = ?
 			if err := rows.Scan(&appUUID); err != nil {
 				return err
 			}
-			if c.Check(appUUIDs.Contains(appUUID), tc.Equals, true) {
-				appUUIDs.Remove(appUUID)
-			}
+			foundAppUUIDs = append(foundAppUUIDs, appUUID)
 		}
 		return nil
 	})
 	c.Assert(err, tc.ErrorIsNil)
+	for _, appUUID := range foundAppUUIDs {
+		if c.Check(appUUIDs.Contains(appUUID), tc.IsTrue) {
+			appUUIDs.Remove(appUUID)
+		}
+	}
 	c.Check(appUUIDs.IsEmpty(), tc.Equals, true, tc.Commentf("relation_endpoint with app %q, not found", appUUIDs.SortedValues()))
 }
 
@@ -523,6 +531,9 @@ func (s *baseSuite) assertCharmMetadata(c *tc.C, appUUID, charmUUID string, expe
 		gotRequires = make(map[string]appcharm.Relation)
 	)
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		gotProvides = map[string]appcharm.Relation{}
+		gotRequires = map[string]appcharm.Relation{}
+
 		err := tx.QueryRowContext(ctx, `
 SELECT ch.reference_name, cs.name, cm.name
 FROM application
@@ -617,6 +628,8 @@ func (s *baseSuite) fetchApplicationEndpoints(c *tc.C, appID string) []applicati
 
 	var endpoints []applicationEndpoint
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		endpoints = nil
+
 		rows, err := tx.Query(`
 SELECT ae.charm_relation_uuid, s.name, cr.name AS charm_relation_name
 FROM application_endpoint ae

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -240,22 +240,22 @@ WHERE  availability_zone.name = $availabilityZoneName.name
 		disName = sql.Null[string]{V: v, Valid: true}
 	}
 
-	instanceData := instanceData{
-		MachineUUID: mUUID,
-		InstanceID:  instID,
-		DisplayName: disName,
-	}
-	if hardwareCharacteristics != nil {
-		instanceData.Arch = hardwareCharacteristics.Arch
-		instanceData.Mem = hardwareCharacteristics.Mem
-		instanceData.RootDisk = hardwareCharacteristics.RootDisk
-		instanceData.RootDiskSource = hardwareCharacteristics.RootDiskSource
-		instanceData.CPUCores = hardwareCharacteristics.CpuCores
-		instanceData.CPUPower = hardwareCharacteristics.CpuPower
-		instanceData.VirtType = hardwareCharacteristics.VirtType
-	}
-
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		instanceData := instanceData{
+			MachineUUID: mUUID,
+			InstanceID:  instID,
+			DisplayName: disName,
+		}
+		if hardwareCharacteristics != nil {
+			instanceData.Arch = hardwareCharacteristics.Arch
+			instanceData.Mem = hardwareCharacteristics.Mem
+			instanceData.RootDisk = hardwareCharacteristics.RootDisk
+			instanceData.RootDiskSource = hardwareCharacteristics.RootDiskSource
+			instanceData.CPUCores = hardwareCharacteristics.CpuCores
+			instanceData.CPUPower = hardwareCharacteristics.CpuPower
+			instanceData.VirtType = hardwareCharacteristics.VirtType
+		}
+
 		// If the machine is not
 		_, err := st.getInstanceID(ctx, tx, mUUID)
 		if err != nil && !errors.Is(err, machineerrors.NotProvisioned) {

--- a/domain/machine/state/placement_test.go
+++ b/domain/machine/state/placement_test.go
@@ -199,6 +199,8 @@ func (s *placementSuite) TestPlaceNetNodeMachinesUnsetMultipleTimes(c *tc.C) {
 	total := 10
 	netNodes := make([]string, 0, total)
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		netNodes = nil
+
 		for range total {
 			netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 			_, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
@@ -238,7 +240,10 @@ func (s *placementSuite) TestPlaceNetNodeMachinesUnsetMultipleTimesWithGaps(c *t
 
 	netNodes := make([]string, 0, stepTotal*2)
 	createMachines := func() {
+		var createdNetNodes []string
 		err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+			createdNetNodes = nil
+
 			for range stepTotal {
 				netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 				_, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
@@ -251,11 +256,12 @@ func (s *placementSuite) TestPlaceNetNodeMachinesUnsetMultipleTimesWithGaps(c *t
 				if err != nil {
 					return err
 				}
-				netNodes = append(netNodes, netNodeUUID.String())
+				createdNetNodes = append(createdNetNodes, netNodeUUID.String())
 			}
 			return nil
 		})
 		c.Assert(err, tc.ErrorIsNil)
+		netNodes = append(netNodes, createdNetNodes...)
 	}
 	deleteLastMachine := func() {
 		err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
@@ -476,6 +482,8 @@ func (s *placementSuite) TestPlaceNetNodeMachinesContainerMultipleTimes(c *tc.C)
 
 	netNodes := make([]string, 0, total)
 	err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		netNodes = nil
+
 		for range total {
 			netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 			_, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
@@ -519,7 +527,10 @@ func (s *placementSuite) TestPlaceNetNodeMachinesContainerMultipleTimesWithGaps(
 
 	netNodes := make([]string, 0, stepTotal*2)
 	createMachines := func() {
+		var createdNetNodes []string
 		err := s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+			createdNetNodes = nil
+
 			for range stepTotal {
 				netNodeUUID := tc.Must(c, domainnetwork.NewNetNodeUUID)
 				_, err := PlaceMachine(ctx, tx, s.st, clock.WallClock, domainmachine.PlaceMachineArgs{
@@ -533,11 +544,12 @@ func (s *placementSuite) TestPlaceNetNodeMachinesContainerMultipleTimesWithGaps(
 				if err != nil {
 					return err
 				}
-				netNodes = append(netNodes, netNodeUUID.String())
+				createdNetNodes = append(createdNetNodes, netNodeUUID.String())
 			}
 			return nil
 		})
 		c.Assert(err, tc.ErrorIsNil)
+		netNodes = append(netNodes, createdNetNodes...)
 	}
 	deleteLastMachine := func() {
 		// Delete the parent and the child.
@@ -895,6 +907,8 @@ WHERE m.name = ?
 func (s *placementSuite) checkContainerTypeForMachine(c *tc.C, name machine.Name, expected ...string) {
 	var containerTypes []string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		containerTypes = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT ct.value
 FROM machine AS m

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -180,11 +180,10 @@ func (st *State) SetRunningAgentBinaryVersion(
 		ID   int    `db:"id"`
 		Name string `db:"name"`
 	}
-	archMap := ArchitectureMap{Name: version.Arch}
 
 	archMapStmt, err := st.Prepare(`
 SELECT id AS &ArchitectureMap.id FROM architecture WHERE name = $ArchitectureMap.name
-`, archMap)
+`, ArchitectureMap{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -194,16 +193,12 @@ SELECT id AS &ArchitectureMap.id FROM architecture WHERE name = $ArchitectureMap
 		Version        string `db:"version"`
 		ArchitectureID int    `db:"architecture_id"`
 	}
-	machineAgentVersion := MachineAgentVersion{
-		MachineUUID: machineUUID,
-		Version:     version.Number.String(),
-	}
 
 	upsertRunningVersionStmt, err := st.Prepare(`
 INSERT INTO machine_agent_version (*) VALUES ($MachineAgentVersion.*)
 ON CONFLICT (machine_uuid) DO
 UPDATE SET version = excluded.version, architecture_id = excluded.architecture_id
-`, machineAgentVersion)
+`, MachineAgentVersion{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -214,6 +209,7 @@ UPDATE SET version = excluded.version, architecture_id = excluded.architecture_i
 			return errors.Capture(err)
 		}
 
+		archMap := ArchitectureMap{Name: version.Arch}
 		err = tx.Query(ctx, archMapStmt, archMap).Get(&archMap)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf(
@@ -225,8 +221,12 @@ UPDATE SET version = excluded.version, architecture_id = excluded.architecture_i
 			)
 		}
 
-		machineAgentVersion.ArchitectureID = archMap.ID
-		return tx.Query(ctx, upsertRunningVersionStmt, machineAgentVersion).Run()
+		machineAgentVersionToSet := MachineAgentVersion{
+			MachineUUID:    machineUUID,
+			Version:        version.Number.String(),
+			ArchitectureID: archMap.ID,
+		}
+		return tx.Query(ctx, upsertRunningVersionStmt, machineAgentVersionToSet).Run()
 	})
 
 	if err != nil {

--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -885,6 +885,8 @@ WHERE uuid IN (
 func (s *watcherSuite) getAppUnitAndMachineUUIDs(c *tc.C, appUUID string) (units []string, machines []string) {
 	result := make(map[string]string)
 	err := s.ModelTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = map[string]string{}
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT u.uuid, m.uuid
 FROM unit AS u

--- a/domain/model/bootstrap/bootstrap.go
+++ b/domain/model/bootstrap/bootstrap.go
@@ -61,7 +61,7 @@ func CreateGlobalModelRecord(
 	modelID coremodel.UUID,
 	args model.GlobalModelCreationArgs,
 ) internaldatabase.BootstrapOpt {
-	return func(ctx context.Context, controller, model database.TxnRunner) error {
+	return func(ctx context.Context, controller, modelDB database.TxnRunner) error {
 		if err := args.Validate(); err != nil {
 			return errors.Errorf("cannot create model when validating args: %w", err)
 		}
@@ -83,12 +83,13 @@ func CreateGlobalModelRecord(
 				return errors.Errorf("determining cloud type for model %q: %w", args.Name, err)
 			}
 
-			if args.SecretBackend == "" {
+			secretBackend := args.SecretBackend
+			if secretBackend == "" {
 				switch modelType {
 				case coremodel.CAAS:
-					args.SecretBackend = kubernetessecrets.BackendName
+					secretBackend = kubernetessecrets.BackendName
 				case coremodel.IAAS:
-					args.SecretBackend = jujusecrets.BackendName
+					secretBackend = jujusecrets.BackendName
 				default:
 					return errors.Errorf(
 						"%w for model type %q when creating model with name %q",
@@ -118,12 +119,14 @@ func CreateGlobalModelRecord(
 				}
 			}
 
-			if err := statecontroller.Create(ctx, preparer{}, tx, modelID, modelType, args); err != nil {
-				return errors.Errorf("create bootstrap model %s/%s with uuid %q: %w", args.Qualifier, args.Name, modelID, err)
+			creationArgs := args
+			creationArgs.SecretBackend = secretBackend
+			if err := statecontroller.Create(ctx, preparer{}, tx, modelID, modelType, creationArgs); err != nil {
+				return errors.Errorf("create bootstrap model %s/%s with uuid %q: %w", creationArgs.Qualifier, creationArgs.Name, modelID, err)
 			}
 
 			if err := activator(ctx, preparer{}, tx, modelID); err != nil {
-				return errors.Errorf("activating bootstrap model %s/%s with uuid %q: %w", args.Qualifier, args.Name, modelID, err)
+				return errors.Errorf("activating bootstrap model %s/%s with uuid %q: %w", creationArgs.Qualifier, creationArgs.Name, modelID, err)
 			}
 			return nil
 		})

--- a/domain/modelagent/state/model/state.go
+++ b/domain/modelagent/state/model/state.go
@@ -1139,25 +1139,18 @@ func (st *State) SetMachineRunningAgentBinaryVersion(
 		return errors.Capture(err)
 	}
 
-	archMap := architectureMap{Name: version.Arch}
-
 	archMapStmt, err := st.Prepare(`
 SELECT id AS &architectureMap.id FROM architecture WHERE name = $architectureMap.name
-`, archMap)
+`, architectureMap{})
 	if err != nil {
 		return errors.Capture(err)
-	}
-
-	machineAgentVersion := machineAgentVersion{
-		MachineUUID: machineUUID,
-		Version:     version.Number.String(),
 	}
 
 	upsertRunningVersionStmt, err := st.Prepare(`
 INSERT INTO machine_agent_version (*) VALUES ($machineAgentVersion.*)
 ON CONFLICT (machine_uuid) DO
 UPDATE SET version = excluded.version, architecture_id = excluded.architecture_id
-`, machineAgentVersion)
+`, machineAgentVersion{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -1168,6 +1161,7 @@ UPDATE SET version = excluded.version, architecture_id = excluded.architecture_i
 			return errors.Capture(err)
 		}
 
+		archMap := architectureMap{Name: version.Arch}
 		err = tx.Query(ctx, archMapStmt, archMap).Get(&archMap)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf(
@@ -1179,8 +1173,12 @@ UPDATE SET version = excluded.version, architecture_id = excluded.architecture_i
 			)
 		}
 
-		machineAgentVersion.ArchitectureID = archMap.ID
-		return tx.Query(ctx, upsertRunningVersionStmt, machineAgentVersion).Run()
+		machineAgentVersionToSet := machineAgentVersion{
+			MachineUUID:    machineUUID,
+			Version:        version.Number.String(),
+			ArchitectureID: archMap.ID,
+		}
+		return tx.Query(ctx, upsertRunningVersionStmt, machineAgentVersionToSet).Run()
 	})
 
 	if err != nil {
@@ -1480,18 +1478,11 @@ func (st *State) SetUnitRunningAgentBinaryVersion(
 		return errors.Capture(err)
 	}
 
-	archMap := architectureMap{Name: version.Arch}
-
 	archMapStmt, err := st.Prepare(`
 SELECT id AS &architectureMap.id FROM architecture WHERE name = $architectureMap.name
-`, archMap)
+`, architectureMap{})
 	if err != nil {
 		return errors.Capture(err)
-	}
-
-	unitAgentVersion := unitAgentVersion{
-		UnitUUID: uuid.String(),
-		Version:  version.Number.String(),
 	}
 
 	upsertRunningVersionStmt, err := st.Prepare(`
@@ -1500,13 +1491,12 @@ VALUES ($unitAgentVersion.*)
 ON CONFLICT (unit_uuid) DO
 UPDATE SET version = excluded.version,
            architecture_id = excluded.architecture_id
-`, unitAgentVersion)
+`, unitAgentVersion{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-
 		// Check if unit exists and is not dead.
 		err := st.checkUnitNotDead(ctx, tx, uuid)
 		if err != nil {
@@ -1516,6 +1506,7 @@ UPDATE SET version = excluded.version,
 		}
 
 		// Look up architecture ID.
+		archMap := architectureMap{Name: version.Arch}
 		err = tx.Query(ctx, archMapStmt, archMap).Get(&archMap)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf(
@@ -1527,8 +1518,12 @@ UPDATE SET version = excluded.version,
 			)
 		}
 
-		unitAgentVersion.ArchitectureID = archMap.ID
-		return tx.Query(ctx, upsertRunningVersionStmt, unitAgentVersion).Run()
+		unitAgentVersionToSet := unitAgentVersion{
+			UnitUUID:       uuid.String(),
+			Version:        version.Number.String(),
+			ArchitectureID: archMap.ID,
+		}
+		return tx.Query(ctx, upsertRunningVersionStmt, unitAgentVersionToSet).Run()
 	})
 
 	if err != nil {

--- a/domain/modelconfig/state/state.go
+++ b/domain/modelconfig/state/state.go
@@ -134,7 +134,9 @@ func (st *State) ModelConfig(ctx context.Context) (map[string]string, error) {
 		return config, errors.Capture(err)
 	}
 
-	return config, db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		config = map[string]string{}
+
 		var result []dbKeyValue
 		if err := tx.Query(ctx, stmt).GetAll(&result); err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return errors.Capture(err)
@@ -145,6 +147,7 @@ func (st *State) ModelConfig(ctx context.Context) (map[string]string, error) {
 		}
 		return nil
 	})
+	return config, err
 }
 
 // SetModelConfig is responsible for overwriting the currently set model config

--- a/domain/modeldefaults/state/state.go
+++ b/domain/modeldefaults/state/state.go
@@ -149,6 +149,8 @@ WHERE m.uuid = $modelUUID.uuid
 
 	result := map[string]string{}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = map[string]string{}
+
 		err := tx.Query(ctx, modelExistsStmt, model).Get(&model)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf(

--- a/domain/network/state/cloudservice_import_test.go
+++ b/domain/network/state/cloudservice_import_test.go
@@ -63,6 +63,8 @@ func (s *k8sServiceImportSuite) TestCreateK8sServices(c *tc.C) {
 	}
 	var k8sServices []k8sService
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		k8sServices = nil
+
 		rows, err := tx.QueryContext(ctx, `SELECT uuid, net_node_uuid, application_uuid, provider_id FROM k8s_service`)
 		if err != nil {
 			return errors.Errorf("querying net nodes: %w", err)
@@ -97,6 +99,8 @@ func (s *k8sServiceImportSuite) TestCreateK8sServices(c *tc.C) {
 func (s *k8sServiceImportSuite) fetchNetNodeUUIDs(c *tc.C) []string {
 	var nodes []string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		nodes = nil
+
 		rows, err := tx.QueryContext(ctx, `SELECT uuid FROM net_node`)
 		if err != nil {
 			return errors.Errorf("querying net nodes: %w", err)

--- a/domain/network/state/linklayer_merge_test.go
+++ b/domain/network/state/linklayer_merge_test.go
@@ -1524,6 +1524,8 @@ WHERE lld.net_node_uuid = ?
 `
 	err := s.TxnRunner().StdTxn(c.Context(),
 		func(ctx context.Context, tx *sql.Tx) error {
+			result = nil
+
 			rows, err := tx.QueryContext(ctx, query, netNodeUUID)
 			if err != nil {
 				return err
@@ -1563,6 +1565,8 @@ WHERE ia.net_node_uuid = ?
 `
 	err := s.TxnRunner().StdTxn(c.Context(),
 		func(ctx context.Context, tx *sql.Tx) error {
+			result = nil
+
 			rows, err := tx.QueryContext(ctx, query, netNodeUUID)
 			if err != nil {
 				return err

--- a/domain/network/state/movesubnets_test.go
+++ b/domain/network/state/movesubnets_test.go
@@ -820,6 +820,8 @@ func (s *spaceMachineSuite) fetchSubnetSpace(c *tc.C) []subnetSpace {
 	// Verify the subnets were actually moved in the database
 	var result []subnetSpace
 	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		result = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT subnet.uuid, space.name
 FROM subnet
@@ -833,7 +835,9 @@ JOIN space ON space.uuid = subnet.space_uuid
 			var uuid string
 			var space string
 			err := rows.Scan(&uuid, &space)
-			c.Assert(err, tc.IsNil)
+			if err != nil {
+				return err
+			}
 			result = append(result, subnetSpace{
 				UUID:  uuid,
 				Space: space,

--- a/domain/network/state/package_test.go
+++ b/domain/network/state/package_test.go
@@ -233,6 +233,8 @@ func (s *linkLayerBaseSuite) checkRowCount(c *tc.C, table string, expected int) 
 func (s *linkLayerBaseSuite) selectDistinctValues(c *tc.C, field, table string) []string {
 	var obtained []string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		obtained = nil
+
 		query := fmt.Sprintf(`SELECT DISTINCT %q FROM %q`, field, table)
 		rows, err := tx.QueryContext(ctx, query)
 		if err != nil {

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -469,6 +469,8 @@ func (s *stateSuite) TestAddControllerIDHint(c *tc.C) {
 
 	var nodes []string
 	err = runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		nodes = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT p.node_id
 FROM object_store_placement AS p

--- a/domain/operation/state/package_test.go
+++ b/domain/operation/state/package_test.go
@@ -75,6 +75,8 @@ func (s *baseSuite) query(c *tc.C, query string, args ...any) {
 func (s *baseSuite) queryRows(c *tc.C, query string, args ...any) []map[string]any {
 	var results []map[string]any
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		results = nil
+
 		rows, err := tx.QueryContext(ctx, query, args...)
 		if err != nil {
 			return err
@@ -136,6 +138,8 @@ func (s *baseSuite) getRowCountByField(c *tc.C, field, value, table string) int 
 func (s *baseSuite) selectDistinctValues(c *tc.C, field, table string) []string {
 	var obtained []string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		obtained = nil
+
 		query := fmt.Sprintf("SELECT DISTINCT %q FROM %q", field, table)
 		rows, err := tx.QueryContext(ctx, query)
 		if err != nil {

--- a/domain/operation/state/start.go
+++ b/domain/operation/state/start.go
@@ -115,6 +115,8 @@ func (st *State) AddActionOperation(ctx context.Context,
 
 	var result operation.RunResult
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = operation.RunResult{}
+
 		var err error
 
 		// Generate the operation ID.

--- a/domain/operation/watcher_test.go
+++ b/domain/operation/watcher_test.go
@@ -361,6 +361,8 @@ func (s *watcherSuite) addOperationTaskLogs(c *tc.C, taskUUID string, contents [
 	results := make([]string, 0, len(contents))
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		results = nil
+
 		for _, content := range contents {
 			date := time.Now().UTC()
 

--- a/domain/port/state/watcher_test.go
+++ b/domain/port/state/watcher_test.go
@@ -124,6 +124,8 @@ func (s *watcherSuite) TestInitialWatchOpenedPortsStatement(c *tc.C) {
 func (s *watcherSuite) assertUnits(c *tc.C, stmt string, expected []coreunit.UUID) {
 	var unitUUIDs []string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		unitUUIDs = nil
+
 		rows, err := tx.QueryContext(ctx, stmt)
 		if err != nil {
 			return err

--- a/domain/relation/state/package_test.go
+++ b/domain/relation/state/package_test.go
@@ -392,6 +392,8 @@ WHERE  r.relation_id = ?
 func (s *baseRelationSuite) getRelationApplicationSettings(c *tc.C, relationEndpointUUID string) map[string]string {
 	settings := map[string]string{}
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		settings = map[string]string{}
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT key, value
 FROM relation_application_setting 
@@ -465,6 +467,8 @@ AND    ru.unit_uuid = ?
 func (s *baseRelationSuite) getRelationUnitSettings(c *tc.C, relationUnitUUID corerelation.UnitUUID) map[string]string {
 	settings := map[string]string{}
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		settings = map[string]string{}
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT key, value
 FROM relation_unit_setting 

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -4685,6 +4685,8 @@ VALUES (?,?)
 func (s *addRelationSuite) fetchAllRelationStatusesOrderByRelationIDs(c *tc.C) []corestatus.Status {
 	var statuses []corestatus.Status
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		statuses = nil
+
 		query := `
 SELECT rst.name
 FROM relation r 
@@ -4719,6 +4721,8 @@ ORDER BY r.relation_id
 func (s *addRelationSuite) fetchAllEndpointUUIDsByRelationIDs(c *tc.C) map[int][]corerelation.EndpointUUID {
 	epUUIDsByRelID := make(map[int][]corerelation.EndpointUUID)
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		epUUIDsByRelID = map[int][]corerelation.EndpointUUID{}
+
 		query := `
 SELECT re.endpoint_uuid, r.relation_id
 FROM relation_endpoint re 
@@ -4749,6 +4753,8 @@ JOIN relation r  ON re.relation_uuid = r.uuid
 func (s *addRelationSuite) fetchRelationNetworkEgress(c *tc.C) [][]string {
 	var result [][]string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = nil
+
 		query := `
 SELECT r.relation_id, rne.cidr
 FROM relation_network_egress rne

--- a/domain/removal/state/model/application.go
+++ b/domain/removal/state/model/application.go
@@ -139,6 +139,8 @@ AND    life_id < 2`, applicationUUID)
 	}
 
 	if err := errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		res = internal.CascadedApplicationLives{}
+
 		if err := tx.Query(ctx, updateApplicationStmt, applicationUUID).Run(); err != nil {
 			return errors.Errorf("advancing application life: %w", err)
 		}

--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -130,6 +130,8 @@ AND    u.life_id < 2;`, machineUUID, uuids{})
 	}
 
 	if err := errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		cascaded = internal.CascadedMachineLives{}
+
 		// Remove any container machines that are on the same parent machine
 		// as the input machine.
 		var machineUUIDs []entityUUID

--- a/domain/removal/state/model/remoteapplicationofferer.go
+++ b/domain/removal/state/model/remoteapplicationofferer.go
@@ -135,6 +135,8 @@ AND    life_id = 0`, uuids{})
 	}
 
 	if err := errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		res = internal.CascadedRemoteApplicationOffererLives{}
+
 		if err := tx.Query(ctx, updateRemoteAppOffererStmt, remoteAppOffererUUID).Run(); err != nil {
 			return errors.Errorf("advancing remote application offerer life: %w", err)
 		}

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -693,6 +693,8 @@ WHERE uuid IN (
 func (s *baseSuite) getAllUnitUUIDs(c *tc.C, appID coreapplication.UUID) []unit.UUID {
 	var unitUUIDs []unit.UUID
 	err := s.ModelTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		unitUUIDs = nil
+
 		rows, err := tx.QueryContext(ctx, `SELECT uuid FROM unit WHERE application_uuid = ? ORDER BY name`, appID)
 		if err != nil {
 			return err
@@ -715,6 +717,8 @@ func (s *baseSuite) getAllUnitUUIDs(c *tc.C, appID coreapplication.UUID) []unit.
 func (s *baseSuite) getAllUnitAndMachineUUIDs(c *tc.C) ([]unit.UUID, []machine.UUID) {
 	result := make(map[unit.UUID]machine.UUID)
 	err := s.ModelTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = map[unit.UUID]machine.UUID{}
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT u.uuid, m.uuid
 FROM unit AS u
@@ -758,6 +762,8 @@ JOIN machine AS m ON m.net_node_uuid = nn.uuid
 func (s *baseSuite) getUnitMachineUUID(c *tc.C, unitUUID unit.UUID) machine.UUID {
 	var machineUUIDs []machine.UUID
 	err := s.ModelTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		machineUUIDs = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT m.uuid
 FROM   machine AS m
@@ -1200,6 +1206,8 @@ func (s *baseSuite) getRowCount(c *tc.C, table string) int {
 func (s *baseSuite) selectDistinctValues(c *tc.C, field, table string) []string {
 	var obtained []string
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		obtained = nil
+
 		query := fmt.Sprintf("SELECT DISTINCT %q FROM %q", field, table)
 		rows, err := tx.QueryContext(ctx, query)
 		if err != nil {

--- a/domain/removal/watcher_test.go
+++ b/domain/removal/watcher_test.go
@@ -294,6 +294,8 @@ WHERE uuid IN (
 func (s *watcherSuite) getAppUnitAndMachineUUIDs(c *tc.C, appUUID string) (units []string, machines []string) {
 	result := make(map[string]string)
 	err := s.ModelTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = map[string]string{}
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT u.uuid, m.uuid
 FROM unit AS u

--- a/domain/resolve/watcher_test.go
+++ b/domain/resolve/watcher_test.go
@@ -192,6 +192,8 @@ func (s *watcherSuite) createApplication(c *tc.C, name string, units ...applicat
 
 	var unitUUIDs = make([]coreunit.UUID, len(units))
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		unitUUIDs = make([]coreunit.UUID, len(units))
+
 		for i, unitName := range unitNames {
 			var uuid coreunit.UUID
 			err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name = ?", unitName).Scan(&uuid)

--- a/domain/resource/state/resource_test.go
+++ b/domain/resource/state/resource_test.go
@@ -191,6 +191,8 @@ func (s *resourceSuite) TestDeleteApplicationResources(c *tc.C) {
 	var remainingResources []resourceData
 	var noRowsInResourceRetrievedBy bool
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) (err error) {
+		remainingResources = nil
+
 		// fetch resources
 		rows, err := tx.Query(`
 SELECT uuid, charm_resource_name, application_uuid
@@ -401,6 +403,8 @@ func (s *resourceSuite) TestDeleteUnitResources(c *tc.C) {
 			errors.ErrorStack(err)))
 	var obtained []resourceData
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) (err error) {
+		obtained = nil
+
 		// fetch resources
 		rows, err := tx.Query(`
 SELECT uuid, name, application_uuid, unit_uuid
@@ -841,15 +845,19 @@ func (s *resourceSuite) TestSetRepositoryResource(c *tc.C) {
 	newCharmUUID := "new-charm-uuid"
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		resourcesToCheck := make([]resourceData, 0, len(notPolled)+len(alreadyPolled))
+		resourcesToCheck = append(resourcesToCheck, notPolled...)
+		resourcesToCheck = append(resourcesToCheck, alreadyPolled...)
+
 		// add the new charm
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm (uuid, reference_name, architecture_id, revision) VALUES (?, 'app',0, 1)
-`, newCharmUUID)
+	`, newCharmUUID)
 		if err != nil {
 			return errors.Capture(err)
 		}
 		// populate charm resources table for existing resources
-		for _, d := range append(notPolled, alreadyPolled...) {
+		for _, d := range resourcesToCheck {
 			_, err = tx.Exec(`
 INSERT INTO charm_resource (charm_uuid, name, kind_id, path, description)
 VALUES (?, ?, ?, ?, ?) ON CONFLICT DO NOTHING`,
@@ -859,7 +867,7 @@ VALUES (?, ?, ?, ?, ?) ON CONFLICT DO NOTHING`,
 			}
 		}
 
-		for _, input := range append(notPolled, alreadyPolled...) {
+		for _, input := range resourcesToCheck {
 			if err := input.insert(c.Context(), tx); err != nil {
 				return errors.Capture(err)
 			}
@@ -896,6 +904,8 @@ VALUES (?, ?, ?, ?, ?) ON CONFLICT DO NOTHING`,
 	}
 	var obtained []obtainedRow
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		obtained = nil
+
 		rows, err := tx.Query(`SELECT uuid, revision, charm_uuid, last_polled FROM resource WHERE state_id = 1`)
 		if err != nil {
 			return err
@@ -1492,6 +1502,9 @@ func (s *resourceSuite) TestSetUnitResourceUnsetExisting(c *tc.C) {
 	var addedAts []time.Time
 	var uuids []string
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		addedAts = nil
+		uuids = nil
+
 		rows, err := tx.Query(`
 SELECT added_at, resource_uuid FROM unit_resource
 WHERE  unit_uuid = ?`, s.constants.fakeUnitUUID1)

--- a/domain/schema/testing/schema.go
+++ b/domain/schema/testing/schema.go
@@ -40,6 +40,8 @@ func DumpChangeLogState(c *tc.C, runner database.TxnRunner) {
 		witness changeLogWitnessRow
 	)
 	err := runner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		logs = nil
+
 		rows, err := tx.QueryContext(ctx, "SELECT id, edit_type_id, namespace_id, changed, created_at FROM change_log")
 		if err != nil {
 			return err

--- a/domain/secret/state/package_test.go
+++ b/domain/secret/state/package_test.go
@@ -43,6 +43,8 @@ func (s *baseSuite) txn(c *tc.C, fn func(ctx context.Context, tx *sqlair.TX) err
 func (s *baseSuite) queryRows(c *tc.C, query string, args ...any) []map[string]any {
 	var results []map[string]any
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		results = nil
+
 		rows, err := tx.QueryContext(ctx, query, args...)
 		if err != nil {
 			return err

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -2345,10 +2345,6 @@ func (st State) GetSecretConsumer(
 		return nil, 0, errors.Capture(err)
 	}
 
-	consumer := secretUnitConsumer{
-		SecretID: uri.ID,
-	}
-
 	query := `
 SELECT suc.label AS &secretUnitConsumer.label,
        suc.current_revision AS &secretUnitConsumer.current_revision
@@ -2392,11 +2388,16 @@ WHERE  ref.secret_id = $secretRef.secret_id`
 			return errors.Capture(err)
 		}
 
-		consumer.UnitUUID, err = st.getUnitUUID(ctx, tx, unitName)
+		unitUUID, err := st.getUnitUUID(ctx, tx, unitName)
 		if err != nil {
 			return errors.Capture(err)
 		}
-		err = tx.Query(ctx, queryStmt, consumer).GetAll(&dbSecretConsumers)
+		consumerLookup := secretUnitConsumer{
+			SecretID: uri.ID,
+			UnitUUID: unitUUID,
+		}
+		secretConsumers := secretUnitConsumers{}
+		err = tx.Query(ctx, queryStmt, consumerLookup).GetAll(&secretConsumers)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf("querying secret consumers: %w", err)
 		}
@@ -2416,6 +2417,7 @@ WHERE  ref.secret_id = $secretRef.secret_id`
 		} else if err != nil {
 			return errors.Errorf("looking up latest revision for %q: %w", uri.ID, err)
 		}
+		dbSecretConsumers = secretConsumers
 		latestRevision = latest.Revision
 		migrated = latest.Migrated
 
@@ -2453,12 +2455,6 @@ ON CONFLICT(secret_id, unit_uuid) DO UPDATE SET
 		return errors.Capture(err)
 	}
 
-	consumer := secretUnitConsumer{
-		SecretID:        uri.ID,
-		SourceModelUUID: uri.SourceUUID,
-		Label:           md.Label,
-		CurrentRevision: md.CurrentRevision,
-	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		isLocal, err := st.checkExistsIfLocal(ctx, tx, uri)
 		if err != nil {
@@ -2467,11 +2463,18 @@ ON CONFLICT(secret_id, unit_uuid) DO UPDATE SET
 		if !isLocal {
 			return secreterrors.SecretIsNotLocal
 		}
-		consumer.UnitUUID, err = st.getUnitUUID(ctx, tx, unitName)
+		unitUUID, err := st.getUnitUUID(ctx, tx, unitName)
 		if err != nil {
 			return errors.Capture(err)
 		}
 
+		consumer := secretUnitConsumer{
+			SecretID:        uri.ID,
+			SourceModelUUID: uri.SourceUUID,
+			Label:           md.Label,
+			CurrentRevision: md.CurrentRevision,
+			UnitUUID:        unitUUID,
+		}
 		if err := tx.Query(ctx, insertStmt, consumer).Run(); err != nil {
 			return errors.Capture(err)
 		}
@@ -2903,11 +2906,7 @@ WHERE  secret_id = $secretPermission.secret_id
 AND    subject_type_id = $secretPermission.subject_type_id
 AND    subject_uuid = $secretPermission.subject_uuid`
 
-	perm := secretPermission{
-		SecretID:      uri.ID,
-		SubjectTypeID: params.SubjectTypeID,
-	}
-	deleteStmt, err := st.Prepare(deleteQuery, perm)
+	deleteStmt, err := st.Prepare(deleteQuery, secretPermission{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -2923,8 +2922,12 @@ AND    subject_uuid = $secretPermission.subject_uuid`
 		if err := st.checkSubjectUUIDExists(ctx, tx, params.SubjectUUID, params.SubjectTypeID); err != nil {
 			return errors.Capture(err)
 		}
-		perm.SubjectUUID = params.SubjectUUID
-		err = tx.Query(ctx, deleteStmt, perm).Run()
+		permissionToDelete := secretPermission{
+			SecretID:      uri.ID,
+			SubjectTypeID: params.SubjectTypeID,
+			SubjectUUID:   params.SubjectUUID,
+		}
+		err = tx.Query(ctx, deleteStmt, permissionToDelete).Run()
 		if err != nil {
 			return errors.Errorf("deleting secret grant for %q on %q: %w", params.SubjectUUID, uri, err)
 		}

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -1004,6 +1004,8 @@ func (s *stateSuite) setupUnits(c *tc.C, appName string) (string, []string) {
 func (s *stateSuite) addUnits(c *tc.C, appName, charmUUID string) []string {
 	unitUUIDs := make([]string, 2)
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		unitUUIDs = make([]string, 2)
+
 		// Do 2 units.
 		for i := range 2 {
 			netNodeUUID := uuid.MustNewUUID().String()

--- a/domain/secretbackend/state/state.go
+++ b/domain/secretbackend/state/state.go
@@ -289,23 +289,21 @@ func (s *State) DeleteSecretBackend(ctx context.Context, identifier secretbacken
 		return errors.Capture(err)
 	}
 
-	input := SecretBackend{ID: identifier.ID, Name: identifier.Name}
-
 	checkInUseStmt, err := s.Prepare(`
 SELECT COUNT(*) AS &Count.num
 FROM   secret_backend_reference
-WHERE  secret_backend_uuid = $SecretBackend.uuid`, input, Count{})
+WHERE  secret_backend_uuid = $SecretBackend.uuid`, SecretBackend{}, Count{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	cfgStmt, err := s.Prepare(`
-DELETE FROM secret_backend_config WHERE backend_uuid = $SecretBackend.uuid`, input)
+DELETE FROM secret_backend_config WHERE backend_uuid = $SecretBackend.uuid`, SecretBackend{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 	rotationStmt, err := s.Prepare(`
-DELETE FROM secret_backend_rotation WHERE backend_uuid = $SecretBackend.uuid`, input)
+DELETE FROM secret_backend_rotation WHERE backend_uuid = $SecretBackend.uuid`, SecretBackend{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -323,56 +321,59 @@ SET secret_backend_uuid = (
     WHEN 'caas' THEN 'kubernetes'
     END
 )
-WHERE secret_backend_uuid = $SecretBackend.uuid`, input)
+WHERE secret_backend_uuid = $SecretBackend.uuid`, SecretBackend{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 	backendStmt, err := s.Prepare(`
-DELETE FROM secret_backend WHERE uuid = $SecretBackend.uuid`, input)
+DELETE FROM secret_backend WHERE uuid = $SecretBackend.uuid`, SecretBackend{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		if identifier.ID == "" {
+		backendID := identifier.ID
+
+		if backendID == "" {
 			sb, err := s.getSecretBackend(ctx, tx, identifier)
 			if err != nil {
 				return errors.Capture(err)
 			}
-			input.ID = sb.ID
+			backendID = sb.ID
 		}
 
-		if isImmutable, err := s.isImmutable(ctx, tx, input.ID); err != nil {
+		inputToDelete := SecretBackend{ID: backendID}
+		if isImmutable, err := s.isImmutable(ctx, tx, inputToDelete.ID); err != nil {
 			return errors.Capture(err)
 		} else if isImmutable {
-			return errors.Errorf("secret backend %q is immutable", input.ID).Add(secretbackenderrors.Forbidden)
+			return errors.Errorf("secret backend %q is immutable", inputToDelete.ID).Add(secretbackenderrors.Forbidden)
 		}
 
 		if !deleteInUse {
 			var count Count
-			err := tx.Query(ctx, checkInUseStmt, input).Get(&count)
+			err := tx.Query(ctx, checkInUseStmt, inputToDelete).Get(&count)
 			if err != nil {
-				return errors.Errorf("checking if secret backend %q is in use: %w", input.ID, err)
+				return errors.Errorf("checking if secret backend %q is in use: %w", inputToDelete.ID, err)
 			}
 			if count.Num > 0 {
-				return errors.Errorf("%w: %q is in use", secretbackenderrors.Forbidden, input.ID)
+				return errors.Errorf("%w: %q is in use", secretbackenderrors.Forbidden, inputToDelete.ID)
 			}
 		}
 
-		if err := tx.Query(ctx, cfgStmt, input).Run(); err != nil {
-			return errors.Errorf("deleting secret backend config for %q: %w", input.ID, err)
+		if err := tx.Query(ctx, cfgStmt, inputToDelete).Run(); err != nil {
+			return errors.Errorf("deleting secret backend config for %q: %w", inputToDelete.ID, err)
 		}
-		if err := tx.Query(ctx, rotationStmt, input).Run(); err != nil {
-			return errors.Errorf("deleting secret backend rotation for %q: %w", input.ID, err)
+		if err := tx.Query(ctx, rotationStmt, inputToDelete).Run(); err != nil {
+			return errors.Errorf("deleting secret backend rotation for %q: %w", inputToDelete.ID, err)
 		}
-		if err = tx.Query(ctx, modelSecretBackendStmt, input).Run(); err != nil {
-			return errors.Errorf("resetting secret backend %q to NULL for models: %w", input.ID, err)
+		if err = tx.Query(ctx, modelSecretBackendStmt, inputToDelete).Run(); err != nil {
+			return errors.Errorf("resetting secret backend %q to NULL for models: %w", inputToDelete.ID, err)
 		}
-		if err := s.removeSecretBackendReferenceForBackend(ctx, tx, input.ID); err != nil {
-			return errors.Errorf("removing secret backend reference for %q: %w", input.ID, err)
+		if err := s.removeSecretBackendReferenceForBackend(ctx, tx, inputToDelete.ID); err != nil {
+			return errors.Errorf("removing secret backend reference for %q: %w", inputToDelete.ID, err)
 		}
-		err = tx.Query(ctx, backendStmt, input).Run()
+		err = tx.Query(ctx, backendStmt, inputToDelete).Run()
 		if err != nil {
-			return errors.Errorf("deleting secret backend for %q: %w", input.ID, err)
+			return errors.Errorf("deleting secret backend for %q: %w", inputToDelete.ID, err)
 		}
 		return nil
 	})

--- a/domain/status/state/model/modelstate.go
+++ b/domain/status/state/model/modelstate.go
@@ -459,12 +459,19 @@ func (st *ModelState) SetRelationStatus(
 		// If transitioning from Suspending to Suspended and the new message is
 		// empty, retain any existing message so that any previous reason for
 		// suspending is retained.
-		if sts.Message == "" &&
+		message := sts.Message
+		if message == "" &&
 			currentStatus.Status == status.RelationStatusTypeSuspending &&
 			sts.Status == status.RelationStatusTypeSuspended {
-			sts.Message = currentStatus.Message
+			message = currentStatus.Message
 		}
-		return st.updateRelationStatus(ctx, tx, relationUUID, sts)
+		statusToSet := status.StatusInfo[status.RelationStatusType]{
+			Status:  sts.Status,
+			Message: message,
+			Data:    sts.Data,
+			Since:   sts.Since,
+		}
+		return st.updateRelationStatus(ctx, tx, relationUUID, statusToSet)
 	})
 	if err != nil {
 		return errors.Errorf("updating relation status for %q: %w", relationUUID, err)
@@ -1561,6 +1568,8 @@ func (st *ModelState) GetApplicationAndUnitStatuses(ctx context.Context) (map[st
 
 	var result map[string]status.Application
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = map[string]status.Application{}
+
 		var err error
 		if result, err = st.getApplicationsStatuses(ctx, tx); err != nil {
 			return errors.Errorf("getting application statuses: %w", err)

--- a/domain/status/state/model/package_test.go
+++ b/domain/status/state/model/package_test.go
@@ -259,6 +259,8 @@ func (s *baseSuite) createIAASApplicationWithCharm(
 
 	var unitUUIDs = make([]coreunit.UUID, 0, len(units))
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		unitUUIDs = nil
+
 		_, err := tx.ExecContext(ctx, "UPDATE application SET life_id = ? WHERE name = ?", l, name)
 		if err != nil {
 			return err
@@ -281,7 +283,9 @@ func (s *baseSuite) createIAASApplicationWithCharm(
 
 		for rows.Next() {
 			var unitUUID string
-			c.Assert(rows.Scan(&unitUUID), tc.ErrorIsNil)
+			if err := rows.Scan(&unitUUID); err != nil {
+				return err
+			}
 			unitUUIDs = append(unitUUIDs, coreunit.UUID(unitUUID))
 		}
 		return nil
@@ -355,6 +359,8 @@ func (s *baseSuite) createCAASApplication(
 
 	var unitUUIDs = make([]coreunit.UUID, 0, len(units))
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		unitUUIDs = nil
+
 		_, err := tx.ExecContext(ctx, "UPDATE application SET life_id = ? WHERE name = ?", l, name)
 		if err != nil {
 			return err
@@ -377,7 +383,9 @@ func (s *baseSuite) createCAASApplication(
 
 		for rows.Next() {
 			var unitUUID string
-			c.Assert(rows.Scan(&unitUUID), tc.ErrorIsNil)
+			if err := rows.Scan(&unitUUID); err != nil {
+				return err
+			}
 			unitUUIDs = append(unitUUIDs, coreunit.UUID(unitUUID))
 		}
 		return nil

--- a/domain/status/status_test.go
+++ b/domain/status/status_test.go
@@ -169,6 +169,8 @@ func (s *statusSuite) TestMachineStatusValuesConversion(c *tc.C) {
 func (s *statusSuite) TestMachineStatusValuesAgainstDB(c *tc.C) {
 	m := make(map[string]int)
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		m = map[string]int{}
+
 		rows, err := tx.QueryContext(ctx, "SELECT status, id FROM machine_status_value")
 		if err != nil {
 			return errors.Capture(err)
@@ -270,6 +272,8 @@ func (s *statusSuite) TestInstanceStatusValuesConversion(c *tc.C) {
 func (s *statusSuite) TestInstanceStatusValuesAgainstDB(c *tc.C) {
 	m := make(map[string]int)
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		m = map[string]int{}
+
 		rows, err := tx.QueryContext(ctx, "SELECT status, id FROM machine_cloud_instance_status_value")
 		if err != nil {
 			return errors.Capture(err)

--- a/domain/status/watcher_test.go
+++ b/domain/status/watcher_test.go
@@ -310,6 +310,8 @@ func (s *watcherSuite) createIAASApplication(
 
 	var unitUUIDs = make([]coreunit.UUID, 0, len(units))
 	err = s.ModelTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		unitUUIDs = nil
+
 		_, err := tx.ExecContext(ctx, "UPDATE application SET life_id = ? WHERE name = ?", l, name)
 		if err != nil {
 			return err
@@ -332,7 +334,9 @@ func (s *watcherSuite) createIAASApplication(
 
 		for rows.Next() {
 			var unitUUID string
-			c.Assert(rows.Scan(&unitUUID), tc.ErrorIsNil)
+			if err := rows.Scan(&unitUUID); err != nil {
+				return err
+			}
 			unitUUIDs = append(unitUUIDs, coreunit.UUID(unitUUID))
 		}
 		return nil

--- a/domain/storage/state/import_test.go
+++ b/domain/storage/state/import_test.go
@@ -664,6 +664,8 @@ func (s *importSuite) TestGetBlockDevicesForMachinesByNetNodeUUIDsMany(c *tc.C) 
 func (s *importSuite) getStorageInstances(c *tc.C) []importStorageInstance {
 	var result []importStorageInstance
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = nil
+
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, charm_name, storage_name, storage_kind_id, storage_id, life_id, storage_pool_uuid, requested_size_mib 
 FROM   storage_instance`)
@@ -698,6 +700,8 @@ FROM   storage_instance`)
 func (s *importSuite) getStorageVolumes(c *tc.C) []importStorageVolume {
 	var result []importStorageVolume
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = nil
+
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, volume_id, life_id, provision_scope_id, provider_id, size_mib, wwn, persistent 
 FROM   storage_volume`)
@@ -732,6 +736,8 @@ FROM   storage_volume`)
 func (s *importSuite) getStorageAttachments(c *tc.C) []importStorageAttachment {
 	var result []importStorageAttachment
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = nil
+
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, storage_instance_uuid, unit_uuid, life_id 
 FROM storage_attachment`)
@@ -762,6 +768,8 @@ FROM storage_attachment`)
 func (s *importSuite) getStorageInstanceVolumes(c *tc.C) []importStorageInstanceVolume {
 	var result []importStorageInstanceVolume
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = nil
+
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT storage_instance_uuid, storage_volume_uuid 
 FROM   storage_instance_volume`)
@@ -788,6 +796,8 @@ FROM   storage_instance_volume`)
 func (s *importSuite) getStorageInstanceVolumeAttachmentPlans(c *tc.C) []importStorageVolumeAttachmentPlan {
 	var result []importStorageVolumeAttachmentPlan
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = nil
+
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, storage_volume_uuid, net_node_uuid, life_id, provision_scope_id, device_type_id
 FROM   storage_volume_attachment_plan`)
@@ -822,6 +832,8 @@ FROM   storage_volume_attachment_plan`)
 func (s *importSuite) getStorageVolumeAttachments(c *tc.C) []importStorageVolumeAttachment {
 	var result []importStorageVolumeAttachment
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = nil
+
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, block_device_uuid, storage_volume_uuid, net_node_uuid, life_id, provision_scope_id, provider_id, read_only
 FROM   storage_volume_attachment`)
@@ -858,6 +870,8 @@ FROM   storage_volume_attachment`)
 func (s *importSuite) getStorageInstanceVolumeAttachmentPlanAttrs(c *tc.C) []importStorageVolumePlanAttribute {
 	var result []importStorageVolumePlanAttribute
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		result = nil
+
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT attachment_plan_uuid, key, value 
 FROM   storage_volume_attachment_plan_attr`)
@@ -1039,6 +1053,9 @@ func (s *importSuite) getFilesystems(c *tc.C) ([]importStorageFilesystem, []impo
 	var filesystems []importStorageFilesystem
 	var instanceFilesystems []importStorageInstanceFilesystem
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		filesystems = nil
+		instanceFilesystems = nil
+
 		fsRows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, filesystem_id, life_id, provision_scope_id, provider_id, size_mib
 FROM storage_filesystem`)
@@ -1099,6 +1116,8 @@ FROM storage_instance_filesystem`)
 func (s *importSuite) getFilesystemAttachments(c *tc.C) []importStorageFilesystemAttachment {
 	var attachments []importStorageFilesystemAttachment
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		attachments = nil
+
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, storage_filesystem_uuid, net_node_uuid, provision_scope_id, life_id, mount_point, provider_id, read_only
 FROM storage_filesystem_attachment`)

--- a/domain/storage/state/storage.go
+++ b/domain/storage/state/storage.go
@@ -123,33 +123,18 @@ func (st *State) CreateStorageInstanceWithExistingFilesystem(
 		return "", errors.Capture(err)
 	}
 
-	storageInstance := insertStorageInstance{
-		UUID:             args.UUID.String(),
-		LifeID:           int(life.Alive),
-		StorageName:      args.Name.String(),
-		StorageKindID:    int(domainstorage.StorageKindFilesystem),
-		StoragePoolUUID:  args.StoragePoolUUID.String(),
-		RequestedSizeMiB: args.RequestedSizeMiB,
-	}
 	insertStorageInstanceStmt, err := st.Prepare(`
 INSERT INTO storage_instance (*)
 VALUES ($insertStorageInstance.*)
-`, storageInstance)
+`, insertStorageInstance{})
 	if err != nil {
 		return "", errors.Capture(err)
 	}
 
-	filesystem := insertStorageFilesystem{
-		UUID:             args.FilesystemUUID.String(),
-		LifeID:           int(life.Alive),
-		ProvisionScopeID: int(args.FilesystemProvisionScope),
-		ProviderID:       args.FilesystemProviderID,
-		SizeMiB:          args.FilesystemSize,
-	}
 	insertFilesystemStmt, err := st.Prepare(`
 INSERT INTO storage_filesystem (*)
 VALUES ($insertStorageFilesystem.*)
-`, filesystem)
+`, insertStorageFilesystem{})
 	if err != nil {
 		return "", errors.Capture(err)
 	}
@@ -180,7 +165,10 @@ VALUES ($insertStorageFilesystemStatus.*)
 		return "", errors.Capture(err)
 	}
 
+	var storageID string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		storageID = ""
+
 		exists, err := st.checkStoragePoolExists(
 			ctx, tx, args.StoragePoolUUID.String())
 		if err != nil {
@@ -201,7 +189,7 @@ VALUES ($insertStorageFilesystemStatus.*)
 		if err != nil {
 			return errors.Errorf("creating unique storage instance id: %w", err)
 		}
-		storageInstance.StorageID = corestorage.MakeID(
+		storageIDToInsert := corestorage.MakeID(
 			corestorage.Name(args.Name), storageSeq,
 		).String()
 
@@ -211,13 +199,31 @@ VALUES ($insertStorageFilesystemStatus.*)
 		if err != nil {
 			return errors.Errorf("creating unique filesystem id: %w", err)
 		}
-		filesystem.FilesystemID = fmt.Sprintf("%d", filesystemSeq)
+		filesystemID := fmt.Sprintf("%d", filesystemSeq)
 
-		err = tx.Query(ctx, insertStorageInstanceStmt, storageInstance).Run()
+		storageInstanceToInsert := insertStorageInstance{
+			UUID:             args.UUID.String(),
+			StorageName:      args.Name.String(),
+			StorageKindID:    int(domainstorage.StorageKindFilesystem),
+			StorageID:        storageIDToInsert,
+			LifeID:           int(life.Alive),
+			StoragePoolUUID:  args.StoragePoolUUID.String(),
+			RequestedSizeMiB: args.RequestedSizeMiB,
+		}
+		filesystemToInsert := insertStorageFilesystem{
+			UUID:             args.FilesystemUUID.String(),
+			FilesystemID:     filesystemID,
+			LifeID:           int(life.Alive),
+			ProvisionScopeID: int(args.FilesystemProvisionScope),
+			ProviderID:       args.FilesystemProviderID,
+			SizeMiB:          args.FilesystemSize,
+		}
+
+		err = tx.Query(ctx, insertStorageInstanceStmt, storageInstanceToInsert).Run()
 		if err != nil {
 			return errors.Errorf("inserting storage instance: %w", err)
 		}
-		err = tx.Query(ctx, insertFilesystemStmt, filesystem).Run()
+		err = tx.Query(ctx, insertFilesystemStmt, filesystemToInsert).Run()
 		if err != nil {
 			return errors.Errorf("inserting filesystem: %w", err)
 		}
@@ -230,13 +236,14 @@ VALUES ($insertStorageFilesystemStatus.*)
 			return errors.Errorf("inserting storage filesystem status: %w", err)
 		}
 
+		storageID = storageIDToInsert
 		return nil
 	})
 	if err != nil {
 		return "", errors.Capture(err)
 	}
 
-	return storageInstance.StorageID, nil
+	return storageID, nil
 }
 
 // CreateStorageInstanceWithExistingVolumeBackedFilesystem creates a new
@@ -256,33 +263,18 @@ func (st *State) CreateStorageInstanceWithExistingVolumeBackedFilesystem(
 		return "", errors.Capture(err)
 	}
 
-	storageInstance := insertStorageInstance{
-		UUID:             args.UUID.String(),
-		LifeID:           int(life.Alive),
-		StorageName:      args.Name.String(),
-		StorageKindID:    int(domainstorage.StorageKindFilesystem),
-		StoragePoolUUID:  args.StoragePoolUUID.String(),
-		RequestedSizeMiB: args.RequestedSizeMiB,
-	}
 	insertStorageInstanceStmt, err := st.Prepare(`
 INSERT INTO storage_instance (*)
 VALUES ($insertStorageInstance.*)
-`, storageInstance)
+`, insertStorageInstance{})
 	if err != nil {
 		return "", errors.Capture(err)
 	}
 
-	filesystem := insertStorageFilesystem{
-		UUID:             args.FilesystemUUID.String(),
-		LifeID:           int(life.Alive),
-		ProvisionScopeID: int(args.FilesystemProvisionScope),
-		ProviderID:       args.FilesystemProviderID,
-		SizeMiB:          args.FilesystemSize,
-	}
 	insertFilesystemStmt, err := st.Prepare(`
 INSERT INTO storage_filesystem (*)
 VALUES ($insertStorageFilesystem.*)
-`, filesystem)
+`, insertStorageFilesystem{})
 	if err != nil {
 		return "", errors.Capture(err)
 	}
@@ -313,20 +305,10 @@ VALUES ($insertStorageFilesystemStatus.*)
 		return "", errors.Capture(err)
 	}
 
-	volume := insertStorageVolume{
-		UUID:             args.VolumeUUID.String(),
-		LifeID:           int(life.Alive),
-		ProvisionScopeID: int(args.VolumeProvisionScope),
-		ProviderID:       args.VolumeProviderID,
-		SizeMiB:          args.VolumeSize,
-		HardwareID:       args.VolumeHardwareID,
-		WWN:              args.VolumeWWN,
-		Persistent:       args.VolumePersistent,
-	}
 	insertVolumeStmt, err := st.Prepare(`
 INSERT INTO storage_volume (*)
 VALUES ($insertStorageVolume.*)
-`, volume)
+`, insertStorageVolume{})
 	if err != nil {
 		return "", errors.Capture(err)
 	}
@@ -357,7 +339,10 @@ VALUES ($insertStorageVolumeStatus.*)
 		return "", errors.Capture(err)
 	}
 
+	var storageID string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		storageID = ""
+
 		exists, err := st.checkStoragePoolExists(
 			ctx, tx, args.StoragePoolUUID.String())
 		if err != nil {
@@ -377,7 +362,7 @@ VALUES ($insertStorageVolumeStatus.*)
 		if err != nil {
 			return errors.Errorf("creating unique storage instance id: %w", err)
 		}
-		storageInstance.StorageID = corestorage.MakeID(
+		storageIDToInsert := corestorage.MakeID(
 			corestorage.Name(args.Name), storageSeq,
 		).String()
 
@@ -387,7 +372,7 @@ VALUES ($insertStorageVolumeStatus.*)
 		if err != nil {
 			return errors.Errorf("creating unique filesystem id: %w", err)
 		}
-		filesystem.FilesystemID = fmt.Sprintf("%d", filesystemSeq)
+		filesystemID := fmt.Sprintf("%d", filesystemSeq)
 
 		volumeSeq, err := sequencestate.NextValue(
 			ctx, st, tx, domainstorage.VolumeSequenceNamespace,
@@ -395,13 +380,42 @@ VALUES ($insertStorageVolumeStatus.*)
 		if err != nil {
 			return errors.Errorf("creating unique volume id: %w", err)
 		}
-		volume.VolumeID = fmt.Sprintf("%d", volumeSeq)
+		volumeID := fmt.Sprintf("%d", volumeSeq)
 
-		err = tx.Query(ctx, insertStorageInstanceStmt, storageInstance).Run()
+		storageInstanceToInsert := insertStorageInstance{
+			UUID:             args.UUID.String(),
+			StorageName:      args.Name.String(),
+			StorageKindID:    int(domainstorage.StorageKindFilesystem),
+			StorageID:        storageIDToInsert,
+			LifeID:           int(life.Alive),
+			StoragePoolUUID:  args.StoragePoolUUID.String(),
+			RequestedSizeMiB: args.RequestedSizeMiB,
+		}
+		filesystemToInsert := insertStorageFilesystem{
+			UUID:             args.FilesystemUUID.String(),
+			FilesystemID:     filesystemID,
+			LifeID:           int(life.Alive),
+			ProvisionScopeID: int(args.FilesystemProvisionScope),
+			ProviderID:       args.FilesystemProviderID,
+			SizeMiB:          args.FilesystemSize,
+		}
+		volumeToInsert := insertStorageVolume{
+			UUID:             args.VolumeUUID.String(),
+			VolumeID:         volumeID,
+			LifeID:           int(life.Alive),
+			ProvisionScopeID: int(args.VolumeProvisionScope),
+			ProviderID:       args.VolumeProviderID,
+			SizeMiB:          args.VolumeSize,
+			HardwareID:       args.VolumeHardwareID,
+			WWN:              args.VolumeWWN,
+			Persistent:       args.VolumePersistent,
+		}
+
+		err = tx.Query(ctx, insertStorageInstanceStmt, storageInstanceToInsert).Run()
 		if err != nil {
 			return errors.Errorf("inserting storage instance: %w", err)
 		}
-		err = tx.Query(ctx, insertFilesystemStmt, filesystem).Run()
+		err = tx.Query(ctx, insertFilesystemStmt, filesystemToInsert).Run()
 		if err != nil {
 			return errors.Errorf("inserting filesystem: %w", err)
 		}
@@ -415,7 +429,7 @@ VALUES ($insertStorageVolumeStatus.*)
 		if err != nil {
 			return errors.Errorf("inserting storage filesystem status: %w", err)
 		}
-		err = tx.Query(ctx, insertVolumeStmt, volume).Run()
+		err = tx.Query(ctx, insertVolumeStmt, volumeToInsert).Run()
 		if err != nil {
 			return errors.Errorf("inserting volume: %w", err)
 		}
@@ -428,11 +442,12 @@ VALUES ($insertStorageVolumeStatus.*)
 			return errors.Errorf("inserting storage volume status: %w", err)
 		}
 
+		storageID = storageIDToInsert
 		return nil
 	})
 	if err != nil {
 		return "", errors.Capture(err)
 	}
 
-	return storageInstance.StorageID, nil
+	return storageID, nil
 }

--- a/domain/storageprovisioning/watcher_test.go
+++ b/domain/storageprovisioning/watcher_test.go
@@ -1912,6 +1912,8 @@ func (s *watcherSuite) newStorageAttachmentsForInstances(
 	err := s.TxnRunner().StdTxn(
 		c.Context(),
 		func(ctx context.Context, tx *sql.Tx) error {
+			rval = nil
+
 			for _, instUUID := range instances {
 				attachmentUUID, err := domainstorage.NewStorageAttachmentUUID()
 				if err != nil {

--- a/domain/unitstate/state/commithook_test.go
+++ b/domain/unitstate/state/commithook_test.go
@@ -83,6 +83,8 @@ func (s *commitHookSuite) TestUpdateCharmState(c *tc.C) {
 	// Assert
 	gotState := make(map[string]string)
 	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		gotState = map[string]string{}
+
 		q := "SELECT key, value FROM unit_state_charm WHERE unit_uuid = ?"
 		rows, err := tx.QueryContext(ctx, q, s.unitUUID)
 		if err != nil {
@@ -692,6 +694,8 @@ func (s *commitHookSuite) TestDeleteSecretsMultiple(c *tc.C) {
 	}
 	rows := make(map[string]row)
 	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		rows = map[string]row{}
+
 		r, err := tx.QueryContext(ctx,
 			"SELECT entity_uuid, arg FROM removal WHERE removal_type_id = ? ORDER BY entity_uuid",
 			int(removal.CharmSecretJob),

--- a/domain/unitstate/state/package_test.go
+++ b/domain/unitstate/state/package_test.go
@@ -272,6 +272,8 @@ VALUES (?,?,?)
 func (s *commitHookBaseSuite) getRelationUnitSettings(c *tc.C, relationUnitUUID corerelation.UnitUUID) map[string]string {
 	settings := map[string]string{}
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		settings = map[string]string{}
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT key, value
 FROM relation_unit_setting
@@ -301,6 +303,8 @@ WHERE relation_unit_uuid = ?
 func (s *commitHookBaseSuite) getRelationApplicationSettings(c *tc.C, relationEndpointUUID string) map[string]string {
 	settings := map[string]string{}
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		settings = map[string]string{}
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT key, value
 FROM relation_application_setting 

--- a/domain/unitstate/state/state_test.go
+++ b/domain/unitstate/state/state_test.go
@@ -168,6 +168,8 @@ func (s *stateSuite) TestUpdateUnitStateCharm(c *tc.C) {
 
 	gotState := make(map[string]string)
 	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		gotState = map[string]string{}
+
 		q := "SELECT key, value FROM unit_state_charm WHERE unit_uuid = ?"
 		rows, err := tx.QueryContext(ctx, q, s.unitUUID)
 		if err != nil {
@@ -202,6 +204,8 @@ func (s *stateSuite) TestUpdateUnitStateCharmEmptyMap(c *tc.C) {
 
 	var rowCount int
 	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		rowCount = 0
+
 		q := "SELECT key, value FROM unit_state_charm WHERE unit_uuid = ?"
 		rows, err := tx.QueryContext(ctx, q, s.unitUUID)
 		if err != nil {
@@ -237,6 +241,8 @@ func (s *stateSuite) TestUpdateUnitStateRelation(c *tc.C) {
 
 	gotState := make(map[int]string)
 	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		gotState = map[int]string{}
+
 		q := "SELECT key, value FROM unit_state_relation WHERE unit_uuid = ?"
 		rows, err := tx.QueryContext(ctx, q, s.unitUUID)
 		if err != nil {
@@ -272,6 +278,8 @@ func (s *stateSuite) TestUpdateUnitStateRelationEmptyMap(c *tc.C) {
 
 	var rowCount int
 	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		rowCount = 0
+
 		q := "SELECT key, value FROM unit_state_relation WHERE unit_uuid = ?"
 		rows, err := tx.QueryContext(ctx, q, s.unitUUID)
 		if err != nil {

--- a/generate/export/main.go
+++ b/generate/export/main.go
@@ -129,6 +129,8 @@ func generate(ctx context.Context, runner *txnRunner) error {
 func getTableNames(ctx context.Context, runner *txnRunner) ([]string, error) {
 	var tableNames []string
 	err := runner.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		tableNames = nil
+
 		rows, err := tx.QueryContext(ctx, "SELECT name FROM sqlite_master WHERE type='table'")
 		if err != nil {
 			return err
@@ -160,6 +162,8 @@ func getTableSchema(ctx context.Context, runner *txnRunner, tableName string) ([
 	var columns []column
 	query := fmt.Sprintf("PRAGMA table_info(%q)", tableName)
 	err := runner.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		columns = nil
+
 		rows, err := tx.QueryContext(ctx, query)
 		if err != nil {
 			return err

--- a/generate/triggergen/main.go
+++ b/generate/triggergen/main.go
@@ -137,6 +137,8 @@ func initDBRunner(ctx context.Context, db *sql.DB, dbType string) (*txnRunner, e
 func readTableColumns(ctx context.Context, runner *txnRunner, tables []string) (map[string][]columnInfo, error) {
 	tableColumns := make(map[string][]columnInfo)
 	if err := runner.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		tableColumns = map[string][]columnInfo{}
+
 		for _, table := range tables {
 			columns, err := func(table string) ([]string, error) {
 				rows, err := tx.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %s", table))

--- a/internal/changestream/stream/stream.go
+++ b/internal/changestream/stream/stream.go
@@ -517,6 +517,8 @@ func (s *Stream) readChanges() ([]changeEvent, error) {
 
 	var changes []changeEvent
 	err := s.db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		changes = nil
+
 		rows, err := tx.QueryContext(ctx, selectQuery, s.upperBound())
 		if err != nil {
 			return errors.Annotate(err, "querying for changes")

--- a/internal/worker/dbaccessor/tracker_test.go
+++ b/internal/worker/dbaccessor/tracker_test.go
@@ -441,6 +441,8 @@ func readTableNames(c *tc.C, w coredatabase.TxnRunner) []string {
 	// db.
 	var tables []string
 	err := w.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		tables = nil
+
 		rows, err := tx.Query("SELECT tbl_name FROM sqlite_schema")
 		if err != nil {
 			return err

--- a/internal/worker/dbaccessor/worker_namespace_test.go
+++ b/internal/worker/dbaccessor/worker_namespace_test.go
@@ -183,11 +183,9 @@ func (s *namespaceSuite) TestEnsureNamespaceForModelWithCache(c *tc.C) {
 	defer cancel()
 
 	var (
-		attempt int
-		num     int64
+		num int64
 	)
 	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		attempt++
 
 		stmt := "INSERT INTO namespace_list (namespace) VALUES (?);"
 		result, err := tx.ExecContext(ctx, stmt, "foo")
@@ -214,8 +212,6 @@ func (s *namespaceSuite) TestEnsureNamespaceForModelWithCache(c *tc.C) {
 	// The second query will be cached.
 	err = dbw.ensureNamespace(c.Context(), "foo")
 	c.Assert(err, tc.ErrorIsNil)
-
-	c.Assert(attempt, tc.Equals, 1)
 
 	workertest.CleanKill(c, w)
 }

--- a/internal/worker/dbrepl/worker.go
+++ b/internal/worker/dbrepl/worker.go
@@ -343,6 +343,8 @@ func (w *dbReplWorker) execModels(ctx context.Context) {
 func (w *dbReplWorker) execQueryForModels(ctx context.Context, args []string) {
 	var models []string
 	if err := w.controllerDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		models = nil
+
 		rows, err := tx.QueryContext(ctx, "SELECT uuid FROM model")
 		if err != nil {
 			return err
@@ -456,6 +458,8 @@ func (w *dbReplWorker) getForeignKeyRelations(ctx context.Context, tableName, co
 	var relations []fkRelation
 
 	err := w.currentDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		relations = nil
+
 		const fkListQuery = `
 WITH tbls(name) AS ( 
 	SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' 
@@ -514,6 +518,8 @@ func (w *dbReplWorker) displayForeignKeysWithCounts(ctx context.Context, relatio
 	var relationsWithCounts []fkRelationWithCount
 
 	err := w.currentDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		relationsWithCounts = nil
+
 		for _, rel := range relations {
 			countQuery := fmt.Sprintf("SELECT COUNT(*) FROM `%s` WHERE `%s` = ?", rel.childTable, rel.childColumn)
 
@@ -608,6 +614,8 @@ func (w *dbReplWorker) changeLog(ctx context.Context) {
 	var changelogRows []row
 
 	err := w.currentDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		changelogRows = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT c.id, t.edit_type, n.namespace, c.changed, c.created_at 
 FROM change_log AS c
@@ -665,6 +673,8 @@ func (w *dbReplWorker) changeStream(ctx context.Context) {
 	var changelogRows []row
 
 	err := w.currentDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		changelogRows = nil
+
 		rows, err := tx.QueryContext(ctx, `
 SELECT MAX(c.id), t.edit_type, n.namespace, changed, created_at
 FROM change_log AS c

--- a/scripts/txncheck/main.go
+++ b/scripts/txncheck/main.go
@@ -4,13 +4,13 @@
 package main
 
 import (
-	"bufio"
+	"bytes"
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,139 +22,433 @@ func main() {
 		os.Exit(1)
 	}
 
-	var foundAssert bool
-	err := filepath.WalkDir(os.Args[1], func(path string, d fs.DirEntry, err error) error {
+	root, err := filepath.Abs(os.Args[1])
+	check(err)
+
+	var foundIssue bool
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-
-		if d.IsDir() {
+		if d.IsDir() || filepath.Ext(path) != ".go" {
 			return nil
 		}
 
-		if filepath.Ext(path) != ".go" {
-			return nil
-		}
-
-		file, err := os.OpenFile(path, os.O_RDONLY, 0)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil
 		}
-
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-
-			if strings.Contains(scanner.Text(), "database/sql") ||
-				strings.Contains(scanner.Text(), "github.com/canonical/sqlair") {
-
-				_, _ = file.Seek(0, 0)
-
-				if checkFile(path, file) {
-					foundAssert = true
-					return nil
-				}
-
-			}
+		if !shouldCheck(data) {
+			return nil
 		}
 
+		findings, err := checkFile(path, data)
+		if err != nil {
+			return err
+		}
+		for _, finding := range findings {
+			fmt.Println(finding)
+			foundIssue = true
+		}
 		return nil
 	})
 	check(err)
 
-	// If we found an assert, we should exit with a non-zero status.
-	// Any checks, are just warnings.
-	if foundAssert {
+	if foundIssue {
 		os.Exit(1)
 	}
 }
 
-func checkFile(path string, file io.Reader) bool {
+func shouldCheck(data []byte) bool {
+	return bytes.Contains(data, []byte("database/sql")) ||
+		bytes.Contains(data, []byte("github.com/canonical/sqlair"))
+}
+
+func checkFile(path string, data []byte) ([]finding, error) {
+	return checkFileWithChecks(path, data, defaultChecks())
+}
+
+func checkFileWithChecks(path string, data []byte, checks []nodeCheck) ([]finding, error) {
 	fileSet := token.NewFileSet()
-	parsed, err := parser.ParseFile(fileSet, "", file, 0)
-	check(err)
+	parsed, err := parser.ParseFile(fileSet, path, data, 0)
+	if err != nil {
+		return nil, err
+	}
 
 	contextPath, ok := locateImportAlias(parsed.Imports, "context")
 	if !ok {
-		return false
+		return nil, nil
 	}
 	sqlPath, sqlFound := locateImportAlias(parsed.Imports, "database/sql")
 	sqlairPath, sqlairFound := locateImportAlias(parsed.Imports, "github.com/canonical/sqlair")
-
-	// We need to at least import one of these.
 	if !sqlFound && !sqlairFound {
-		return false
+		return nil, nil
 	}
 
-	// Walk over all the function declarations and look for assignment
-	// statements that have a call expression with two arguments.
-	// The first argument should be a context.Context and the second
-	// argument should be a *sql.Tx or *sqlair.Tx.
-	// If that is the case, we look for a call expression that has a
-	// selector expression with the name "Assert".
+	fileCtx := &fileContext{
+		fileSet:     fileSet,
+		contextPath: contextPath,
+		sqlPath:     sqlPath,
+		sqlairPath:  sqlairPath,
+	}
+	ast.Walk(&fileVisitor{
+		checks: checks,
+		file:   fileCtx,
+	}, parsed)
+	return fileCtx.findings, nil
+}
 
-	for _, stmt := range getFuncBodies(parsed) {
-		for _, funcLit := range getCallExprs(stmt) {
+type finding struct {
+	pos     token.Position
+	message string
+}
 
-			funcDecl := funcLit.Type
-			list := funcDecl.Params.List
-			if len(list) != 2 {
+func (f finding) String() string {
+	return fmt.Sprintf("%s: %s", f.message, f.pos)
+}
+
+type nodeCheck interface {
+	Check(*nodeContext, ast.Node)
+}
+
+func defaultChecks() []nodeCheck {
+	return []nodeCheck{
+		assertCheck{},
+		capturedAssignmentCheck{},
+		capturedBuiltinMutationCheck{},
+	}
+}
+
+type fileContext struct {
+	fileSet     *token.FileSet
+	contextPath string
+	sqlPath     string
+	sqlairPath  string
+
+	findings []finding
+}
+
+func (c *fileContext) isTxnFunc(funcLit *ast.FuncLit) bool {
+	params := funcLit.Type.Params
+	if params == nil || len(params.List) != 2 {
+		return false
+	}
+	if !isContextType(params.List[0], c.contextPath) {
+		return false
+	}
+	if !isErrorResult(funcLit.Type.Results) {
+		return false
+	}
+	return isTxnType(params.List[1], c.sqlPath, SQLTxnType) ||
+		isTxnType(params.List[1], c.sqlairPath, SQLairTxnType)
+}
+
+func (c *fileContext) addFinding(pos token.Pos, message string) {
+	c.findings = append(c.findings, finding{
+		pos:     c.fileSet.Position(pos),
+		message: message,
+	})
+}
+
+type nodeContext struct {
+	file       *fileContext
+	txn        *ast.FuncLit
+	reassigned map[*ast.Object]bool
+}
+
+func (c *nodeContext) InTxn() bool {
+	return c.txn != nil
+}
+
+func (c *nodeContext) IsCaptured(id *ast.Ident) bool {
+	if !c.InTxn() || id == nil || id.Name == "_" || id.Obj == nil {
+		return false
+	}
+	return id.Obj.Pos() < c.txn.Pos() || id.Obj.Pos() > c.txn.End()
+}
+
+func (c *nodeContext) IsReassigned(id *ast.Ident) bool {
+	return id != nil && id.Obj != nil && c.reassigned[id.Obj]
+}
+
+func (c *nodeContext) MarkReassigned(id *ast.Ident) {
+	if c.IsCaptured(id) {
+		c.reassigned[id.Obj] = true
+	}
+}
+
+func (c *nodeContext) AddFinding(pos token.Pos, message string) {
+	c.file.addFinding(pos, message)
+}
+
+type fileVisitor struct {
+	checks     []nodeCheck
+	file       *fileContext
+	txn        *ast.FuncLit
+	reassigned map[*ast.Object]bool
+}
+
+func (v *fileVisitor) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return nil
+	}
+
+	ctx := &nodeContext{
+		file:       v.file,
+		txn:        v.txn,
+		reassigned: v.reassigned,
+	}
+	for _, check := range v.checks {
+		check.Check(ctx, node)
+	}
+
+	funcLit, ok := node.(*ast.FuncLit)
+	if ok {
+		if v.file.isTxnFunc(funcLit) {
+			return v.withReassigned(funcLit, make(map[*ast.Object]bool))
+		}
+		if v.txn != nil {
+			return v.withReassigned(v.txn, cloneReassigned(v.reassigned))
+		}
+		return v
+	}
+
+	if v.txn != nil && isolatesReassignments(node) {
+		return v.withReassigned(v.txn, cloneReassigned(v.reassigned))
+	}
+	return v
+}
+
+func (v *fileVisitor) withReassigned(
+	txn *ast.FuncLit,
+	reassigned map[*ast.Object]bool,
+) *fileVisitor {
+	return &fileVisitor{
+		checks:     v.checks,
+		file:       v.file,
+		txn:        txn,
+		reassigned: reassigned,
+	}
+}
+
+func isolatesReassignments(node ast.Node) bool {
+	switch node.(type) {
+	case *ast.BlockStmt,
+		*ast.IfStmt,
+		*ast.ForStmt,
+		*ast.RangeStmt,
+		*ast.SwitchStmt,
+		*ast.TypeSwitchStmt,
+		*ast.SelectStmt:
+		return true
+	}
+	return false
+}
+
+type capturedAssignmentCheck struct{}
+
+func (capturedAssignmentCheck) Check(ctx *nodeContext, node ast.Node) {
+	if !ctx.InTxn() {
+		return
+	}
+	switch n := node.(type) {
+	case *ast.AssignStmt:
+		checkCapturedAssignment(ctx, n)
+	case *ast.IncDecStmt:
+		checkCapturedIncDec(ctx, n)
+	}
+}
+
+func checkCapturedAssignment(ctx *nodeContext, stmt *ast.AssignStmt) {
+	switch stmt.Tok {
+	case token.DEFINE:
+		return
+	case token.ASSIGN:
+		reassigned := capturedReassignments(ctx, stmt.Lhs)
+		checkCapturedBuiltinMutations(ctx, stmt.Rhs, reassigned)
+		for _, lhs := range stmt.Lhs {
+			if _, ok := lhs.(*ast.Ident); ok {
 				continue
 			}
-
-			// Is the first argument a context.Context?
-			if !isContextType(list[0], contextPath) {
-				continue
-			}
-
-			// Is the scope of the second argument a *sql.Tx or *sqlair.Tx?
-			if !isTxnType(list[1], sqlPath, SQLTxnType) && !isTxnType(list[1], sqlairPath, SQLairTxnType) {
-				continue
-			}
-
-			// Located a potential transaction function, now we need to
-			// check if it has a call expression with a selector expression
-			// that has the name "Assert" or "Check".
-			for _, items := range funcLit.Body.List {
-				switch i := items.(type) {
-				case *ast.ExprStmt:
-					call, ok := i.X.(*ast.CallExpr)
-					if !ok {
-						continue
-					}
-
-					sel, ok := call.Fun.(*ast.SelectorExpr)
-					if !ok {
-						continue
-					}
-
-					id, ok := sel.X.(*ast.Ident)
-					if !ok {
-						continue
-					}
-
-					// We only care about the "c" variable.
-					// TODO (stickupkid): This is a bit naive,
-					// we should be checking if the variable is
-					// actually gc.C.Assert or gc.C.Check.
-					if id.Name != "c" {
-						continue
-					}
-
-					start := fileSet.Position(sel.Pos())
-					if sel.Sel.Name == "Assert" {
-						fmt.Printf("found assert: %s:%s\n", path, start)
-						return true
-					}
-					if sel.Sel.Name == "Check" {
-						fmt.Printf("found check: %s:%s\n", path, start)
-						return true
-					}
+			if id := rootIdent(lhs); ctx.IsCaptured(id) {
+				if ctx.IsReassigned(id) {
+					continue
 				}
+				ctx.AddFinding(lhs.Pos(),
+					fmt.Sprintf("found captured mutation in transaction: %q is mutated by assignment", id.Name))
+			}
+		}
+		for _, id := range reassigned {
+			ctx.MarkReassigned(id)
+		}
+	default:
+		for _, lhs := range stmt.Lhs {
+			if id := rootIdent(lhs); ctx.IsCaptured(id) {
+				if ctx.IsReassigned(id) {
+					continue
+				}
+				ctx.AddFinding(lhs.Pos(),
+					fmt.Sprintf("found captured mutation in transaction: %q is mutated by compound assignment", id.Name))
 			}
 		}
 	}
+}
 
-	return false
+func checkCapturedIncDec(ctx *nodeContext, stmt *ast.IncDecStmt) {
+	if id := rootIdent(stmt.X); ctx.IsCaptured(id) {
+		if ctx.IsReassigned(id) {
+			return
+		}
+		ctx.AddFinding(stmt.Pos(),
+			fmt.Sprintf("found captured mutation in transaction: %q is mutated by increment/decrement", id.Name))
+	}
+}
+
+type assertCheck struct{}
+
+func (assertCheck) Check(ctx *nodeContext, node ast.Node) {
+	if !ctx.InTxn() {
+		return
+	}
+	call, ok := node.(*ast.CallExpr)
+	if !ok {
+		return
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok || id.Name != "c" {
+		return
+	}
+
+	switch sel.Sel.Name {
+	case "Assert":
+		ctx.AddFinding(sel.Pos(), "found assert in transaction")
+	case "Check":
+		ctx.AddFinding(sel.Pos(), "found check in transaction")
+	}
+}
+
+type capturedBuiltinMutationCheck struct{}
+
+func (capturedBuiltinMutationCheck) Check(ctx *nodeContext, node ast.Node) {
+	if !ctx.InTxn() {
+		return
+	}
+	call, ok := node.(*ast.CallExpr)
+	if !ok {
+		return
+	}
+
+	name := builtinName(call.Fun)
+	switch name {
+	case "append":
+		if len(call.Args) == 0 {
+			return
+		}
+		if id := rootIdent(call.Args[0]); ctx.IsCaptured(id) {
+			if ctx.IsReassigned(id) {
+				return
+			}
+			ctx.AddFinding(call.Pos(),
+				fmt.Sprintf("found captured mutation in transaction: %q is mutated by append", id.Name))
+		}
+	case "copy", "delete", "clear":
+		if len(call.Args) == 0 {
+			return
+		}
+		if id := rootIdent(call.Args[0]); ctx.IsCaptured(id) {
+			if ctx.IsReassigned(id) {
+				return
+			}
+			ctx.AddFinding(call.Pos(),
+				fmt.Sprintf("found captured mutation in transaction: %q is mutated by %s", id.Name, name))
+		}
+	}
+}
+
+func capturedReassignments(ctx *nodeContext, exprs []ast.Expr) map[*ast.Object]*ast.Ident {
+	reassigned := make(map[*ast.Object]*ast.Ident)
+	for _, expr := range exprs {
+		id, ok := expr.(*ast.Ident)
+		if !ok || !ctx.IsCaptured(id) {
+			continue
+		}
+		reassigned[id.Obj] = id
+	}
+	return reassigned
+}
+
+func checkCapturedBuiltinMutations(
+	ctx *nodeContext,
+	exprs []ast.Expr,
+	reassigned map[*ast.Object]*ast.Ident,
+) {
+	for _, expr := range exprs {
+		ast.Inspect(expr, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			id := capturedBuiltinMutation(call)
+			if id == nil || reassigned[id.Obj] == nil || ctx.IsReassigned(id) {
+				return true
+			}
+
+			name := builtinName(call.Fun)
+			ctx.AddFinding(call.Pos(),
+				fmt.Sprintf("found captured mutation in transaction: %q is mutated by %s", id.Name, name))
+			return true
+		})
+	}
+}
+
+func capturedBuiltinMutation(call *ast.CallExpr) *ast.Ident {
+	name := builtinName(call.Fun)
+	switch name {
+	case "append", "copy", "delete", "clear":
+		if len(call.Args) == 0 {
+			return nil
+		}
+		return rootIdent(call.Args[0])
+	}
+	return nil
+}
+
+func cloneReassigned(reassigned map[*ast.Object]bool) map[*ast.Object]bool {
+	clone := make(map[*ast.Object]bool, len(reassigned))
+	maps.Copy(clone, reassigned)
+	return clone
+}
+
+func builtinName(expr ast.Expr) string {
+	id, ok := expr.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return id.Name
+}
+
+func rootIdent(expr ast.Expr) *ast.Ident {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e
+	case *ast.IndexExpr:
+		return rootIdent(e.X)
+	case *ast.IndexListExpr:
+		return rootIdent(e.X)
+	case *ast.SelectorExpr:
+		return rootIdent(e.X)
+	case *ast.StarExpr:
+		return rootIdent(e.X)
+	case *ast.ParenExpr:
+		return rootIdent(e.X)
+	}
+	return nil
 }
 
 func check(err error) {
@@ -163,73 +457,8 @@ func check(err error) {
 	}
 }
 
-func getFuncBodies(parsed *ast.File) []ast.Stmt {
-	var stmts []ast.Stmt
-	for _, decl := range parsed.Decls {
-		switch d := decl.(type) {
-		case *ast.FuncDecl:
-			stmts = append(stmts, d.Body.List...)
-		}
-	}
-	return stmts
-}
-
-func getCallExprs(stmt ast.Stmt) []*ast.FuncLit {
-	var callExprs []*ast.FuncLit
-	switch s := stmt.(type) {
-	case *ast.AssignStmt:
-		for _, r := range s.Rhs {
-			switch x := r.(type) {
-			case *ast.CallExpr:
-				// If the call expression doesn't have two arguments,
-				// we skip it.
-				if len(x.Args) != 2 {
-					continue
-				}
-
-				// If the second argument is not a function literal, which
-				// would correspond to the following signature, we skip it.
-				//
-				//     func(context.Context, func(context.Context, *sql.Tx) error) error
-				//     func(context.Context, func(context.Context, *sqlair.TX) error) error
-				//
-				funcLit, ok := x.Args[1].(*ast.FuncLit)
-				if !ok {
-					continue
-				}
-
-				callExprs = append(callExprs, funcLit)
-			}
-		}
-	case *ast.ExprStmt:
-		// Recursive descent into the expression statement to find the
-		// call expression.
-		switch x := s.X.(type) {
-		case *ast.CallExpr:
-			if len(x.Args) == 0 {
-				return callExprs
-			}
-
-			// Check the function literal arguments.
-			for _, arg := range x.Args {
-				funcLit, ok := arg.(*ast.FuncLit)
-				if !ok {
-					continue
-				}
-				callExprs = append(callExprs, funcLit)
-
-				for _, stmt := range funcLit.Body.List {
-					callExprs = append(callExprs, getCallExprs(stmt)...)
-				}
-			}
-		}
-	}
-	return callExprs
-}
-
 func locateImportAlias(imports []*ast.ImportSpec, path string) (string, bool) {
 	for _, i := range imports {
-
 		if i.Path.Value != fmt.Sprintf(`"%s"`, path) {
 			continue
 		}
@@ -251,7 +480,8 @@ func isContextType(expr *ast.Field, importPath string) bool {
 		return false
 	}
 
-	if t.X.(*ast.Ident).Name != importPath {
+	i, ok := t.X.(*ast.Ident)
+	if !ok || i.Name != importPath {
 		return false
 	}
 
@@ -259,6 +489,14 @@ func isContextType(expr *ast.Field, importPath string) bool {
 		return false
 	}
 	return true
+}
+
+func isErrorResult(results *ast.FieldList) bool {
+	if results == nil || len(results.List) != 1 {
+		return false
+	}
+	id, ok := results.List[0].Type.(*ast.Ident)
+	return ok && id.Name == "error"
 }
 
 type txnType string

--- a/scripts/txncheck/main_test.go
+++ b/scripts/txncheck/main_test.go
@@ -1,0 +1,727 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+)
+
+type txnCheckSuite struct{}
+
+func TestTxnCheckSuite(t *testing.T) {
+	tc.Run(t, &txnCheckSuite{})
+}
+
+func (s *txnCheckSuite) TestAllowsCapturedReassignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		local := []string{"foo"}
+		result = local
+		return nil
+	})
+}
+`[1:])
+
+	c.Check(findings, tc.HasLen, 0)
+}
+
+func (s *txnCheckSuite) TestAllowsCapturedAppendAfterReassignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = []string{}
+		result = append(result, "foo")
+		return nil
+	})
+}
+`[1:])
+
+	c.Check(findings, tc.HasLen, 0)
+}
+
+func (s *txnCheckSuite) TestAllowsCapturedMapMutationAfterReassignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	result := map[string]string{}
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = map[string]string{}
+		result["foo"] = "bar"
+		delete(result, "foo")
+		clear(result)
+		return nil
+	})
+}
+`[1:])
+
+	c.Check(findings, tc.HasLen, 0)
+}
+
+func (s *txnCheckSuite) TestAllowsCapturedFieldAndIncrementAfterReassignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+type value struct {
+	name string
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	result := &value{}
+	var count int
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = &value{}
+		result.name = "foo"
+		count = 0
+		count++
+		return nil
+	})
+}
+`[1:])
+
+	c.Check(findings, tc.HasLen, 0)
+}
+
+func (s *txnCheckSuite) TestAllowsCapturedMutationInsideBranchAfterReassignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner, ok bool) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if ok {
+			result = []string{}
+			result = append(result, "foo")
+		}
+		return nil
+	})
+}
+`[1:])
+
+	c.Check(findings, tc.HasLen, 0)
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedAppend(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = append(result, "foo")
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by append`)
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedAppendAfterConditionalReassignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner, ok bool) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if ok {
+			result = []string{}
+		}
+		result = append(result, "foo")
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by append`)
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedAppendBeforeReassignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = append(result, "foo")
+		result = []string{}
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by append`)
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedAppendEvenWhenAssignedToLocal(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		local := append(result, "foo")
+		_ = local
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by append`)
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedIndexAssignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	result := map[string]string{}
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result["foo"] = "bar"
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by assignment`)
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedFieldAssignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+type result struct {
+	value string
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result result
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result.value = "foo"
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by assignment`)
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedPointerAssignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	result := new(string)
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		*result = "foo"
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by assignment`)
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedCompoundAssignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result int
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result += 1
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by compound assignment`)
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedIncrement(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result int
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result++
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by increment/decrement`)
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedBuiltinMutations(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	dst := []string{"foo"}
+	values := map[string]string{"foo": "bar"}
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		copy(dst, []string{"bar"})
+		delete(values, "foo")
+		clear(values)
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 3)
+	c.Check(findingMessages(findings), tc.SameContents, []string{
+		`found captured mutation in transaction: "dst" is mutated by copy`,
+		`found captured mutation in transaction: "values" is mutated by delete`,
+		`found captured mutation in transaction: "values" is mutated by clear`,
+	})
+}
+
+func (s *txnCheckSuite) TestRejectsCapturedMutationInNestedFunction(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		collect := func() {
+			result = append(result, "foo")
+		}
+		collect()
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by append`)
+}
+
+func (s *txnCheckSuite) TestAllowsCapturedMutationInNestedFunctionAfterReassignment(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = []string{}
+		collect := func() {
+			result = append(result, "foo")
+		}
+		collect()
+		return nil
+	})
+}
+`[1:])
+
+	c.Check(findings, tc.HasLen, 0)
+}
+
+func (s *txnCheckSuite) TestReassignmentInNestedFunctionDoesNotPermitOuterMutation(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		reset := func() {
+			result = []string{}
+		}
+		reset()
+		result = append(result, "foo")
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by append`)
+}
+
+func (s *txnCheckSuite) TestAllowsLocalMutations(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner) error {
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result := []string{}
+		result = append(result, "foo")
+		values := map[string]string{}
+		values["foo"] = "bar"
+		count := 0
+		count++
+		return nil
+	})
+}
+`[1:])
+
+	c.Check(findings, tc.HasLen, 0)
+}
+
+func (s *txnCheckSuite) TestRejectsAssertAndCheck(c *tc.C) {
+	findings := checkSource(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type C struct{}
+
+func (C) Assert(...any) {}
+func (C) Check(...any)  {}
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner, c C) error {
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		c.Assert(nil)
+		c.Check(nil)
+		return nil
+	})
+}
+`[1:])
+
+	c.Assert(findings, tc.HasLen, 2)
+	c.Check(findingMessages(findings), tc.SameContents, []string{
+		"found assert in transaction",
+		"found check in transaction",
+	})
+}
+
+func (s *txnCheckSuite) TestCanRunOnlyAssertCheck(c *tc.C) {
+	findings := checkSourceWithChecks(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type C struct{}
+
+func (C) Assert(...any) {}
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner, c C) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = append(result, "foo")
+		c.Assert(nil)
+		return nil
+	})
+}
+`[1:], []nodeCheck{assertCheck{}})
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, "found assert in transaction")
+}
+
+func (s *txnCheckSuite) TestCanRunOnlyMutationChecks(c *tc.C) {
+	findings := checkSourceWithChecks(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type C struct{}
+
+func (C) Assert(...any) {}
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner, c C) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = append(result, "foo")
+		c.Assert(nil)
+		return nil
+	})
+}
+`[1:], []nodeCheck{
+		capturedAssignmentCheck{},
+		capturedBuiltinMutationCheck{},
+	})
+
+	c.Assert(findings, tc.HasLen, 1)
+	c.Check(findings[0].message, tc.Equals, `found captured mutation in transaction: "result" is mutated by append`)
+}
+
+func (s *txnCheckSuite) TestRegisteredChecksRunTogether(c *tc.C) {
+	findings := checkSourceWithChecks(c, `
+package p
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+)
+
+type C struct{}
+
+func (C) Assert(...any) {}
+
+type txnRunner interface {
+	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
+}
+
+func f(ctx context.Context, db txnRunner, c C) error {
+	var result []string
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result = append(result, "foo")
+		c.Assert(nil)
+		return nil
+	})
+}
+`[1:], []nodeCheck{
+		assertCheck{},
+		capturedBuiltinMutationCheck{},
+	})
+
+	c.Assert(findings, tc.HasLen, 2)
+	c.Check(findingMessages(findings), tc.SameContents, []string{
+		`found captured mutation in transaction: "result" is mutated by append`,
+		"found assert in transaction",
+	})
+}
+
+func checkSource(c *tc.C, source string) []finding {
+	return checkSourceWithChecks(c, source, defaultChecks())
+}
+
+func checkSourceWithChecks(c *tc.C, source string, checks []nodeCheck) []finding {
+	findings, err := checkFileWithChecks("test.go", []byte(source), checks)
+	c.Assert(err, tc.ErrorIsNil)
+	return findings
+}
+
+func findingMessages(findings []finding) []string {
+	messages := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		messages = append(messages, finding.message)
+	}
+	return messages
+}


### PR DESCRIPTION
db.Txn has built-in retries. However, the general pattern we use to retrieve data within a transaction is to set a variable within the closure.

This leads to subtle errors when we mutate variables outside the closure in a way that isn't idempotent.

Add a static-analysis check within txncheck which asserts that _no variables declared in the outer scope are mutated within db.Txn unless they have already been reassigned._

This check was also refactored to use a visitor pattern with registered checks.

This is maybe a little bit too strict, it leads to a few false positives. But I don't believe this is a problem, even if it's technically ok we shouldn't be using bad patterns

Fix all fallout. In cases where params are partially constructed outside the txn, partially inside, move the construction fully inside the txn. 

## QA steps

#### Tests and static analysis pass

#### Apply the following diffs and check static analysis fails
```
diff --git a/domain/application/state/application_test.go b/domain/application/state/application_test.go
index 2c2c941cd7..0d1d54f488 100644
--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -847,6 +847,7 @@ func (s *applicationStateSuite) addResourcesBeforeApplication(
        }
 
        err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+               c.Assert(true, tc.IsTrue)
                for _, res := range resources {
                        insertStmt := `
 INSERT INTO resource (uuid, charm_uuid, charm_resource_name, revision,
```
```
diff --git a/domain/application/state/application_test.go b/domain/application/state/application_test.go
index 2c2c941cd7..0d1d54f488 100644
--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -847,6 +847,7 @@ func (s *applicationStateSuite) addResourcesBeforeApplication(
        }
 
        err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+               c.Check(true, tc.IsTrue)
                for _, res := range resources {
                        insertStmt := `
 INSERT INTO resource (uuid, charm_uuid, charm_resource_name, revision,
```
