### PR TITLE
fix(cmr): offerer relations watcher initial query

### DIFF
--- a/domain/crossmodelrelation/service/service.go
+++ b/domain/crossmodelrelation/service/service.go
@@ -12,6 +12,7 @@ import (
 
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/offer"
@@ -296,30 +297,21 @@ func (w *WatchableService) WatchOffererRelations(ctx context.Context) (watcher.S
 	// Create a stateful mapper that maintains a cache of remote relation UUIDs.
 	// The cache is rebuilt when consumer deletions occur since we cannot query
 	// deleted consumers to determine their relation UUIDs.
-	cache := make(map[string]bool)
-	initialized := false
+	cache := make(map[string]struct{})
+	cachedInitialQuery := func(ctx context.Context, runner database.TxnRunner) ([]string, error) {
+		relationUUIDs, err := initialQuery(ctx, runner)
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		for _, uuid := range relationUUIDs {
+			cache[uuid] = struct{}{}
+		}
+		return relationUUIDs, nil
+	}
 
 	mapper := func(ctx context.Context, changes []changestream.ChangeEvent) ([]string, error) {
 		if len(changes) == 0 {
 			return nil, nil
-		}
-
-		// On first call, initialize the cache from the initial query results.
-		// The initial query returns all relation UUIDs that are remote.
-		if !initialized {
-			for _, change := range changes {
-				if change.Namespace() == relationTable {
-					cache[change.Changed()] = true
-				}
-			}
-			initialized = true
-
-			// Return all initial remote relation UUIDs.
-			result := make([]string, 0, len(cache))
-			for uuid := range cache {
-				result = append(result, uuid)
-			}
-			return result, nil
 		}
 
 		// Separate changes by namespace.
@@ -358,9 +350,9 @@ func (w *WatchableService) WatchOffererRelations(ctx context.Context) (watcher.S
 				// Continue with old cache on error.
 			} else {
 				// Rebuild cache from scratch.
-				cache = make(map[string]bool)
+				cache = make(map[string]struct{})
 				for _, uuid := range relationUUIDs {
-					cache[uuid] = true
+					cache[uuid] = struct{}{}
 				}
 			}
 		}
@@ -373,7 +365,7 @@ func (w *WatchableService) WatchOffererRelations(ctx context.Context) (watcher.S
 				// Continue processing relation changes even if cache update fails.
 			} else {
 				for _, uuid := range newRelationUUIDs {
-					cache[uuid] = true
+					cache[uuid] = struct{}{}
 				}
 			}
 		}
@@ -381,7 +373,7 @@ func (w *WatchableService) WatchOffererRelations(ctx context.Context) (watcher.S
 		// Filter relation changes based on cache.
 		var result []string
 		for _, uuid := range relationChanges {
-			if cache[uuid] {
+			if _, ok := cache[uuid]; ok {
 				result = append(result, uuid)
 			}
 		}
@@ -391,7 +383,7 @@ func (w *WatchableService) WatchOffererRelations(ctx context.Context) (watcher.S
 
 	return w.watcherFactory.NewNamespaceMapperWatcher(
 		ctx,
-		initialQuery,
+		cachedInitialQuery,
 		"offerer relations watcher",
 		mapper,
 		eventsource.NamespaceFilter(relationTable, changestream.All),

--- a/internal/changestream/testing/changestream.go
+++ b/internal/changestream/testing/changestream.go
@@ -49,14 +49,30 @@ type TestWatchableDB struct {
 func NewTestWatchableDB(c *tc.C, id string, db database.TxnRunner) *TestWatchableDB {
 	states := make(chan []string, 1)
 
-	termDeadline, _ := c.Deadline()
-	if time.Until(termDeadline) > coretesting.ShortWait {
-		termDeadline = termDeadline.Add(-coretesting.ShortWait)
+	// c.Deadline() only returns a deadline when the test binary was run with
+	// -test.timeout set (e.g. `go test`, which injects a 10m timeout). When the
+	// compiled binary is run directly (as `stress` does), there is no deadline:
+	// c.Deadline() returns the zero time with ok=false. We must not derive a
+	// timeout from it, since time.Until(zeroTime) is a huge negative duration.
+	termDeadline, hasDeadline := c.Deadline()
+
+	// A signalTimeout of 0 makes the event multiplexer fall back to its
+	// DefaultSignalTimeout. Only override it with a deadline-relative timeout
+	// when the test actually has a deadline.
+	var signalTimeout time.Duration
+	if hasDeadline {
+		if time.Until(termDeadline) > coretesting.ShortWait {
+			termDeadline = termDeadline.Add(-coretesting.ShortWait)
+		}
+		signalTimeout = time.Until(termDeadline)
 	}
 
 	logger := loggertesting.WrapCheckLog(c)
+	// NewInternalStates handles a zero termDeadline itself (it falls back to
+	// defaultWaitTermTimeout via termDeadline.IsZero()), so passing the zero
+	// time here is safe.
 	stream := stream.NewInternalStates(id, db, newNoopFileWatcher(), clock.WallClock, noopMetrics{}, logger, termDeadline, states)
-	mux, err := eventmultiplexer.New(stream, clock.WallClock, noopMetrics{}, logger, time.Until(termDeadline))
+	mux, err := eventmultiplexer.New(stream, clock.WallClock, noopMetrics{}, logger, signalTimeout)
 	c.Assert(err, tc.ErrorIsNil)
 
 	h := TestWatchableDB{


### PR DESCRIPTION
  Fixes a flaky `WatchOffererRelations` stress failure by addressing two separate issues:
  - seed the offerer relation watcher cache from the watcher's initial query
  - don't derive the changestream subscriber signal timeout from a test deadline that may not exist

  ### 1. Watcher cache seeding (`domain/crossmodelrelation/service/service.go`)

  `WatchOffererRelations` keeps a cache of known remote relation UUIDs so it can emit only meaningful
  relation changes.

  The bug was that the cache was initialized inside the mapper on the first changestream event. That is
  not how namespace mapper watchers work: the initial query runs separately and its results are sent
  directly to the watcher consumer; the mapper only sees later changestream deltas.

  Under stress, setup changes could still be delivered after the initial event had already been produced.
  The watcher then treated that replayed delta as cache initialization and could emit an unexpected extra
  change before the test's real relation update.

  This wraps the initial query so it seeds the cache with the same relation UUIDs returned as initial
  state. The mapper now handles only deltas, matching the watcher lifecycle.

  ### 2. Changestream test helper signal timeout (`internal/changestream/testing/changestream.go`)

  The test changestream helper derived the event multiplexer's per-subscriber signal timeout from the
  remaining test deadline (`time.Until(c.Deadline())`).

  That works under `go test`, which injects a 10-minute deadline. But when the compiled test binary is run
  directly — for example under `stress` — there is no deadline: `c.Deadline()` returns the zero time, so
  `time.Until(...)` is a large negative duration. That negative value was passed straight through as the
  signal timeout (the zero-check in `eventmultiplexer.New` doesn't catch a negative), so every
  subscriber's dispatch context was created already expired. Healthy watchers were then unsubscribed on
  their first change, non-deterministically (~73% of runs under stress).

  This honours the `ok` result of `c.Deadline()`: the signal timeout is only derived from the deadline
  when the test actually has one; otherwise it falls back to the multiplexer's `DefaultSignalTimeout`. The
  stream's term deadline still tracks the test deadline (it already tolerated a zero deadline via
  `IsZero()`). This keeps test cleanup bounded without creating artificial subscription closures that
  don't represent production behaviour.

  _Note: found while reviewing #22537, unrelated._


## QA steps

```
$ go test -run 'TestWatcherSuite/TestWatchOffererRelations$|TestWatcherSuite/
  TestWatchOffererRelationsCaching$' ./domain/crossmodelrelation -count=1
$ go test ./domain/crossmodelrelation -count=1
$ go test ./domain/crossmodelrelation -c -race
$ timeout 31 stress -timeout 30s ./crossmodelrelation.test -test.run 'TestWatcherSuite/TestWatchOffererRelations$

```
Without these fixes, the stress run would fail.

Regarding the CMR fix, this scenario should flex the updated worker:
```
juju add-model model-offer
juju deploy juju-qa-dummy-source --base ubuntu@22.04
juju offer dummy-source:sink dummy-offer

juju add-model model-consume
juju deploy juju-qa-dummy-sink --base ubuntu@22.04
juju consume c:admin/model-offer.dummy-offer
juju relate dummy-sink dummy-offer

# wait for the relation and offer connected count to settle, then restart the controller agent so
# WatchOffererRelations starts after the relation already exists:
juju ssh -m controller 0 'sudo systemctl restart jujud-machine-0.service'
```
When you do status again, you should see 1 connected consumer to the offer:
```
$ juju status --relations 
Model        Controller  Cloud/Region         Version   Timestamp
model-offer  c           localhost/localhost  4.0.12.1  09:55:36+02:00

App           Version  Status  Scale  Charm                 Channel        Rev  Exposed  Message
dummy-source           active      1  juju-qa-dummy-source  latest/stable    6  no       Token is edf

Unit             Workload  Agent  Machine  Public address  Ports  Message
dummy-source/0*  active    idle   0        10.134.1.245           Token is edf

Machine  State    Address       Inst id        Base          AZ                                Message
0        started  10.134.1.245  juju-48a88b-0  ubuntu@22.04  nvinuesa-ThinkPad-P16s-Gen-4-AMD  Running

Offer        Application   Charm                 Rev  Connected  Endpoint  Interface    Role
dummy-offer  dummy-source  juju-qa-dummy-source  6    1/1        sink      dummy-token  requirer
```

