### PR TITLE
fix: token transport for bearer token auth had a typo

### DIFF
--- a/docker/registry/internal/transports.go
+++ b/docker/registry/internal/transports.go
@@ -69,7 +69,7 @@ func (t *challengeTransport) RoundTrip(req *http.Request) (*http.Response, error
 		case "bearer":
 			tokenTransport := &tokenTransport{
 				transport: t.baseTransport,
-				username:  t.password,
+				username:  t.username,
 				password:  t.password,
 				authToken: t.authToken,
 			}

--- a/docker/registry/internal/transports_test.go
+++ b/docker/registry/internal/transports_test.go
@@ -543,3 +543,60 @@ func (s *transportSuite) TestChallengeTransportMulti(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 }
+
+func (s *transportSuite) TestChallengeTransportTokenRefreshWithCredentials(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	mockRoundTripper := mocks.NewMockRoundTripper(ctrl)
+
+	url, err := url.Parse(`https://example.com`)
+	c.Assert(err, jc.ErrorIsNil)
+
+	gomock.InOrder(
+		// 1st try failed - bearer token was missing.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Check(req.Header, jc.DeepEquals, http.Header{})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(nil),
+					Header: http.Header{
+						http.CanonicalHeaderKey("WWW-Authenticate"): []string{
+							`Bearer realm="https://auth.example.com/token",service="registry.example.com",scope="repository:jujuqa/jujud-operator:pull"`,
+						},
+					},
+				}, nil
+			},
+		),
+		// Refresh OAuth Token using username/password (no authToken provided).
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				// Expect Basic auth built from username:password
+				expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("username:pwd1"))
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{expected}})
+				c.Check(req.URL.String(), gc.Equals, `https://auth.example.com/token?scope=repository%3Ajujuqa%2Fjujud-operator%3Apull&service=registry.example.com`)
+				return &http.Response{
+					Request:    req,
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"token": "OAuth-jwt-token", "access_token": "OAuth-jwt-token","expires_in": 300}`)),
+				}, nil
+			},
+		),
+		// retry.
+		mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+			func(req *http.Request) (*http.Response, error) {
+				c.Check(req.Header, jc.DeepEquals, http.Header{"Authorization": []string{"Bearer " + `OAuth-jwt-token`}})
+				c.Check(req.URL.String(), gc.Equals, `https://example.com`)
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(nil)}, nil
+			},
+		),
+	)
+	t := internal.NewChallengeTransport(mockRoundTripper, "username", "pwd1", "")
+	_, err = t.RoundTrip(&http.Request{ //nolint:bodyclose // nop closer in mock
+		Header: http.Header{},
+		URL:    url,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}


### PR DESCRIPTION
The transport used for bearer token auth workflow for oci registries had a typo. `password` was used for `username`.

## QA steps

unit tests

## Links

**Issue:** Fixes #22563.