### PR TITLE
feat: support adding manual clouds to a controller

### DIFF
--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -731,6 +731,17 @@ func (api *CloudAPI) AddCloud(cloudArgs params.AddCloudArgs) error {
 	if len(aCloud.Regions) == 0 {
 		aCloud.Regions = []cloud.Region{{Name: cloud.DefaultCloudRegion}}
 	}
+	// Add the empty auth type if needed.
+	if len(aCloud.AuthTypes) == 0 {
+		aProvider, err := environs.Provider(aCloud.Type)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		schema := aProvider.CredentialSchemas()
+		if _, ok := schema[jujucloud.EmptyAuthType]; ok {
+			aCloud.AuthTypes = []cloud.AuthType{jujucloud.EmptyAuthType}
+		}
+	}
 
 	err = api.backend.AddCloud(aCloud, api.apiUser.Id())
 	return errors.Trace(err)
@@ -747,8 +758,41 @@ func (api *CloudAPI) UpdateCloud(cloudArgs params.UpdateCloudArgs) (params.Error
 	} else if err != nil {
 		return results, apiservererrors.ServerError(err)
 	}
+
+	schemaCache := make(map[string]map[cloud.AuthType]cloud.CredentialSchema)
+	credentialSchemas := func(cloudName string) (map[cloud.AuthType]cloud.CredentialSchema, error) {
+		if s, ok := schemaCache[cloudName]; ok {
+			return s, nil
+		}
+		aCloud, err := api.backend.Cloud(cloudName)
+		if err != nil {
+			return nil, err
+		}
+		aProvider, err := environs.Provider(aCloud.Type)
+		if err != nil {
+			return nil, err
+		}
+		schema := aProvider.CredentialSchemas()
+		schemaCache[cloudName] = schema
+		return schema, nil
+	}
 	for i, aCloud := range cloudArgs.Clouds {
-		err := api.backend.UpdateCloud(cloudFromParams(aCloud.Name, aCloud.Cloud))
+		aCloud := cloudFromParams(aCloud.Name, aCloud.Cloud)
+		// All clouds must have at least one 'default' region, lp#1819409.
+		if len(aCloud.Regions) == 0 {
+			aCloud.Regions = []cloud.Region{{Name: cloud.DefaultCloudRegion}}
+		}
+		// Add the empty auth type if needed.
+		if len(aCloud.AuthTypes) == 0 {
+			schema, err := credentialSchemas(aCloud.Name)
+			if err != nil {
+				results.Results[i].Error = apiservererrors.ServerError(err)
+			}
+			if _, ok := schema[jujucloud.EmptyAuthType]; ok {
+				aCloud.AuthTypes = []cloud.AuthType{jujucloud.EmptyAuthType}
+			}
+		}
+		err := api.backend.UpdateCloud(aCloud)
 		results.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return results, nil

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -759,40 +759,68 @@ func (api *CloudAPI) UpdateCloud(cloudArgs params.UpdateCloudArgs) (params.Error
 		return results, apiservererrors.ServerError(err)
 	}
 
-	schemaCache := make(map[string]map[cloud.AuthType]cloud.CredentialSchema)
-	credentialSchemas := func(cloudName string) (map[cloud.AuthType]cloud.CredentialSchema, error) {
-		if s, ok := schemaCache[cloudName]; ok {
-			return s, nil
+	type cloudUpdateMeta struct {
+		cloudType string
+		schemas   map[cloud.AuthType]cloud.CredentialSchema
+	}
+	metaCache := make(map[string]*cloudUpdateMeta)
+	cloudMetadata := func(cloudName string) (*cloudUpdateMeta, error) {
+		if meta, ok := metaCache[cloudName]; ok {
+			return meta, nil
 		}
-		aCloud, err := api.backend.Cloud(cloudName)
+		existingCloud, err := api.backend.Cloud(cloudName)
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
-		aProvider, err := environs.Provider(aCloud.Type)
+		// Only fetch the cloud type for now.
+		// Defer the schemas until (if) actually needed below.
+		meta := &cloudUpdateMeta{cloudType: existingCloud.Type}
+		metaCache[cloudName] = meta
+		return meta, nil
+	}
+	credentialSchemasForUpdate := func(meta *cloudUpdateMeta) (map[cloud.AuthType]cloud.CredentialSchema, error) {
+		if meta.schemas != nil {
+			return meta.schemas, nil
+		}
+		aProvider, err := environs.Provider(meta.cloudType)
 		if err != nil {
-			return nil, err
+			return nil, errors.Trace(err)
 		}
-		schema := aProvider.CredentialSchemas()
-		schemaCache[cloudName] = schema
-		return schema, nil
+		meta.schemas = aProvider.CredentialSchemas()
+		return meta.schemas, nil
 	}
 	for i, aCloud := range cloudArgs.Clouds {
 		aCloud := cloudFromParams(aCloud.Name, aCloud.Cloud)
+		meta, err := cloudMetadata(aCloud.Name)
+		if err != nil {
+			results.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		if meta.cloudType != aCloud.Type {
+			results.Results[i].Error = apiservererrors.ServerError(errors.Errorf(
+				"cannot change cloud %q type from %q to %q",
+				aCloud.Name,
+				meta.cloudType,
+				aCloud.Type,
+			))
+			continue
+		}
+
 		// All clouds must have at least one 'default' region.
 		if len(aCloud.Regions) == 0 {
 			aCloud.Regions = []cloud.Region{{Name: cloud.DefaultCloudRegion}}
 		}
 		// Add the empty auth type if needed.
 		if len(aCloud.AuthTypes) == 0 {
-			schema, err := credentialSchemas(aCloud.Name)
+			schema, err := credentialSchemasForUpdate(meta)
 			if err != nil {
 				results.Results[i].Error = apiservererrors.ServerError(err)
-			}
-			if _, ok := schema[jujucloud.EmptyAuthType]; ok {
+				continue
+			} else if _, ok := schema[jujucloud.EmptyAuthType]; ok {
 				aCloud.AuthTypes = []cloud.AuthType{jujucloud.EmptyAuthType}
 			}
 		}
-		err := api.backend.UpdateCloud(aCloud)
+		err = api.backend.UpdateCloud(aCloud)
 		results.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return results, nil

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -727,7 +727,7 @@ func (api *CloudAPI) AddCloud(cloudArgs params.AddCloudArgs) error {
 	}
 
 	aCloud := cloudFromParams(cloudArgs.Name, cloudArgs.Cloud)
-	// All clouds must have at least one 'default' region, lp#1819409.
+	// All clouds must have at least one 'default' region.
 	if len(aCloud.Regions) == 0 {
 		aCloud.Regions = []cloud.Region{{Name: cloud.DefaultCloudRegion}}
 	}
@@ -778,7 +778,7 @@ func (api *CloudAPI) UpdateCloud(cloudArgs params.UpdateCloudArgs) (params.Error
 	}
 	for i, aCloud := range cloudArgs.Clouds {
 		aCloud := cloudFromParams(aCloud.Name, aCloud.Cloud)
-		// All clouds must have at least one 'default' region, lp#1819409.
+		// All clouds must have at least one 'default' region.
 		if len(aCloud.Regions) == 0 {
 			aCloud.Regions = []cloud.Region{{Name: cloud.DefaultCloudRegion}}
 		}

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -543,6 +543,7 @@ func (s *cloudSuite) TestUpdateCloud(c *gc.C) {
 	}
 
 	backend := s.backend.EXPECT()
+	backend.Cloud("dummy").Return(jujucloud.Cloud{Name: "dummy", Type: "dummy"}, nil)
 	backend.UpdateCloud(dummyCloud).Return(nil)
 
 	updatedCloud := jujucloud.Cloud{
@@ -575,6 +576,7 @@ func (s *cloudSuite) TestUpdateCloudNoRegion(c *gc.C) {
 	}
 
 	backend := s.backend.EXPECT()
+	backend.Cloud("dummy").Return(jujucloud.Cloud{Name: "dummy", Type: "dummy"}, nil)
 	backend.UpdateCloud(expectedCloud).Return(nil)
 
 	results, err := s.api.UpdateCloud(params.UpdateCloudArgs{
@@ -630,6 +632,28 @@ func (s *cloudSuite) TestUpdateCloudNoAuthTypesAddsEmptyAuthType(c *gc.C) {
 	c.Assert(results.Results[1].Error, gc.IsNil)
 }
 
+func (s *cloudSuite) TestUpdateCloudTypeImmutable(c *gc.C) {
+	adminTag := names.NewUserTag("admin")
+	defer s.setup(c, adminTag).Finish()
+
+	backend := s.backend.EXPECT()
+	backend.Cloud("dummy").Return(jujucloud.Cloud{Name: "dummy", Type: "dummy"}, nil)
+
+	results, err := s.api.UpdateCloud(params.UpdateCloudArgs{
+		Clouds: []params.AddCloudArgs{{
+			Name: "dummy",
+			Cloud: params.Cloud{
+				Type:      "another",
+				AuthTypes: []string{"empty", "userpass"},
+				Regions:   []params.CloudRegion{{Name: "nether-updated", Endpoint: "endpoint-updated"}},
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.ErrorMatches, `cannot change cloud "dummy" type from "dummy" to "another"`)
+}
+
 func (s *cloudSuite) TestUpdateCloudNonAdminPerm(c *gc.C) {
 	frankTag := names.NewUserTag("frank")
 	defer s.setup(c, frankTag).Finish()
@@ -655,15 +679,8 @@ func (s *cloudSuite) TestUpdateNonExistentCloud(c *gc.C) {
 	adminTag := names.NewUserTag("admin")
 	defer s.setup(c, adminTag).Finish()
 
-	dummyCloud := jujucloud.Cloud{
-		Name:      "nope",
-		Type:      "dummy",
-		AuthTypes: []jujucloud.AuthType{jujucloud.EmptyAuthType, jujucloud.UserPassAuthType},
-		Regions:   []jujucloud.Region{{Name: "nether-updated", Endpoint: "endpoint-updated"}},
-	}
-
 	backend := s.backend.EXPECT()
-	backend.UpdateCloud(dummyCloud).Return(errors.New("cloud \"nope\" not found"))
+	backend.Cloud("nope").Return(jujucloud.Cloud{}, errors.NotFoundf("cloud %q", "nope"))
 
 	updatedCloud := jujucloud.Cloud{
 		Name:      "nope",
@@ -681,6 +698,27 @@ func (s *cloudSuite) TestUpdateNonExistentCloud(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.ErrorMatches, fmt.Sprintf("cloud %q not found", updatedCloud.Name))
+}
+
+func (s *cloudSuite) TestUpdateCloudSchemaLookupError(c *gc.C) {
+	adminTag := names.NewUserTag("admin")
+	defer s.setup(c, adminTag).Finish()
+
+	backend := s.backend.EXPECT()
+	backend.Cloud("dummy").Return(jujucloud.Cloud{Name: "dummy", Type: "unknown-provider"}, nil)
+
+	results, err := s.api.UpdateCloud(params.UpdateCloudArgs{
+		Clouds: []params.AddCloudArgs{{
+			Name: "dummy",
+			Cloud: params.Cloud{
+				Type:    "unknown-provider",
+				Regions: []params.CloudRegion{{Name: "nether-updated", Endpoint: "endpoint-updated"}},
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.NotNil)
 }
 
 func (s *cloudSuite) TestListCloudInfo(c *gc.C) {

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -479,6 +479,42 @@ func (s *cloudSuite) TestAddCloudNoRegion(c *gc.C) {
 
 }
 
+func (s *cloudSuite) TestAddCloudNoAuthTypesAddsEmptyAuthType(c *gc.C) {
+	adminTag := names.NewUserTag("admin")
+	defer s.setup(c, adminTag).Finish()
+
+	controllerCloud := jujucloud.Cloud{
+		Name: "dummy-controller",
+		Type: "dummy",
+	}
+	newCloud := jujucloud.Cloud{
+		Name:     "newcloudname",
+		Type:     "dummy",
+		Endpoint: "fake-endpoint",
+		AuthTypes: []jujucloud.AuthType{
+			jujucloud.EmptyAuthType,
+		},
+		Regions: []jujucloud.Region{{Name: "nether", Endpoint: "nether-endpoint"}},
+	}
+
+	backend := s.backend.EXPECT()
+	backend.ControllerInfo().Return(&state.ControllerInfo{CloudName: "dummy-controller"}, nil)
+	backend.Cloud("dummy-controller").Return(controllerCloud, nil)
+	backend.AddCloud(newCloud, adminTag.Name()).Return(nil)
+
+	force := true
+	err := s.api.AddCloud(params.AddCloudArgs{
+		Name: "newcloudname",
+		Cloud: params.Cloud{
+			Type:     "dummy",
+			Endpoint: "fake-endpoint",
+			Regions:  []params.CloudRegion{{Name: "nether", Endpoint: "nether-endpoint"}},
+		},
+		Force: &force,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *cloudSuite) TestAddCloudNoAdminPerms(c *gc.C) {
 	frankTag := names.NewUserTag("frank")
 	defer s.setup(c, frankTag).Finish()
@@ -525,6 +561,73 @@ func (s *cloudSuite) TestUpdateCloud(c *gc.C) {
 
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Error, gc.IsNil)
+}
+
+func (s *cloudSuite) TestUpdateCloudNoRegion(c *gc.C) {
+	adminTag := names.NewUserTag("admin")
+	defer s.setup(c, adminTag).Finish()
+
+	expectedCloud := jujucloud.Cloud{
+		Name:      "dummy",
+		Type:      "dummy",
+		AuthTypes: []jujucloud.AuthType{jujucloud.EmptyAuthType, jujucloud.UserPassAuthType},
+		Regions:   []jujucloud.Region{{Name: jujucloud.DefaultCloudRegion}},
+	}
+
+	backend := s.backend.EXPECT()
+	backend.UpdateCloud(expectedCloud).Return(nil)
+
+	results, err := s.api.UpdateCloud(params.UpdateCloudArgs{
+		Clouds: []params.AddCloudArgs{{
+			Name: "dummy",
+			Cloud: params.Cloud{
+				Type:      "dummy",
+				AuthTypes: []string{"empty", "userpass"},
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+}
+
+func (s *cloudSuite) TestUpdateCloudNoAuthTypesAddsEmptyAuthType(c *gc.C) {
+	adminTag := names.NewUserTag("admin")
+	defer s.setup(c, adminTag).Finish()
+
+	expectedCloud := jujucloud.Cloud{
+		Name:      "dummy",
+		Type:      "dummy",
+		AuthTypes: []jujucloud.AuthType{jujucloud.EmptyAuthType},
+		Endpoint:  "fake-endpoint",
+		Regions:   []jujucloud.Region{{Name: "nether", Endpoint: "endpoint"}},
+	}
+
+	backend := s.backend.EXPECT()
+	backend.Cloud("dummy").Return(jujucloud.Cloud{Name: "dummy", Type: "dummy"}, nil).Times(1)
+	backend.UpdateCloud(expectedCloud).Return(nil).Times(2)
+
+	results, err := s.api.UpdateCloud(params.UpdateCloudArgs{
+		Clouds: []params.AddCloudArgs{{
+			Name: "dummy",
+			Cloud: params.Cloud{
+				Type:     "dummy",
+				Endpoint: "fake-endpoint",
+				Regions:  []params.CloudRegion{{Name: "nether", Endpoint: "endpoint"}},
+			},
+		}, {
+			Name: "dummy",
+			Cloud: params.Cloud{
+				Type:     "dummy",
+				Endpoint: "fake-endpoint",
+				Regions:  []params.CloudRegion{{Name: "nether", Endpoint: "endpoint"}},
+			},
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 2)
+	c.Assert(results.Results[0].Error, gc.IsNil)
+	c.Assert(results.Results[1].Error, gc.IsNil)
 }
 
 func (s *cloudSuite) TestUpdateCloudNonAdminPerm(c *gc.C) {

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -288,22 +288,22 @@ func (m *ModelManagerAPI) createModel(args params.ModelCreateArgs, withDefaultOS
 			return result, errors.Trace(err)
 		}
 	} else {
-		if ownerTag == controllerModel.Owner() {
-			cloudCredentialTag, _ = controllerModel.CloudCredentialTag()
-		} else {
-			// TODO(axw) check if the user has one and only one
-			// cloud credential, and if so, use it? For now, we
-			// require the user to specify a credential unless
-			// the cloud does not require one.
-			var hasEmpty bool
-			for _, authType := range cloud.AuthTypes {
-				if authType != jujucloud.EmptyAuthType {
-					continue
-				}
-				hasEmpty = true
-				break
+		var hasEmpty bool
+		for _, authType := range cloud.AuthTypes {
+			if authType != jujucloud.EmptyAuthType {
+				continue
 			}
-			if !hasEmpty {
+			hasEmpty = true
+			break
+		}
+		if !hasEmpty {
+			if ownerTag == controllerModel.Owner() {
+				cloudCredentialTag, _ = controllerModel.CloudCredentialTag()
+			} else {
+				// TODO(axw) check if the user has one and only one
+				// cloud credential, and if so, use it? For now, we
+				// require the user to specify a credential unless
+				// the cloud does not require one.
 				return result, errors.NewNotValid(nil, "no credential specified")
 			}
 		}

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -451,6 +451,18 @@ func (s *modelManagerSuite) TestCreateModelEmptyCredentialNonAdmin(c *gc.C) {
 	c.Assert(newModelArgs.CloudCredential, gc.Equals, names.CloudCredentialTag{})
 }
 
+func (s *modelManagerSuite) TestCreateModelEmptyCredentialAdmin(c *gc.C) {
+	args := params.ModelCreateArgs{
+		Name:     "foo",
+		OwnerTag: "user-admin",
+	}
+	_, err := s.api.CreateModel(args)
+	c.Assert(err, jc.ErrorIsNil)
+
+	newModelArgs := s.getModelArgs(c)
+	c.Assert(newModelArgs.CloudCredential, gc.Equals, names.CloudCredentialTag{})
+}
+
 func (s *modelManagerSuite) TestCreateModelNoDefaultCredentialNonAdmin(c *gc.C) {
 	s.st.cloud.AuthTypes = nil
 	args := params.ModelCreateArgs{

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -320,7 +320,7 @@ func (c *AddCloudCommand) Run(ctxt *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	// All clouds must have at least one default region - lp#1819409.
+	// All clouds must have at least one default region.
 	if len(newCloud.Regions) == 0 {
 		newCloud.Regions = []jujucloud.Region{{Name: jujucloud.DefaultCloudRegion}}
 	}

--- a/cmd/juju/cloud/add.go
+++ b/cmd/juju/cloud/add.go
@@ -372,7 +372,11 @@ func (c *AddCloudCommand) addRemoteCloud(ctxt *cmd.Context, newCloud *jujucloud.
 		return err
 	}
 	ctxt.Infof("Cloud %q added to controller %q.", c.Cloud, c.ControllerName)
-	// Add a credential for the newly added cloud.
+	// Add a credential for the newly added cloud, if needed.
+	if len(newCloud.AuthTypes) == 0 ||
+		len(newCloud.AuthTypes) == 1 && newCloud.AuthTypes[0] == jujucloud.EmptyAuthType {
+		return nil
+	}
 	err = c.addCredentialToController(ctxt, *newCloud, api)
 	if err != nil {
 		logger.Warningf("%v", err)

--- a/cmd/juju/cloud/add_test.go
+++ b/cmd/juju/cloud/add_test.go
@@ -441,6 +441,21 @@ func (s *addSuite) TestForceAddToController(c *gc.C) {
 	s.asssertAddToController(c, true)
 }
 
+func (s *addSuite) TestAddToControllerSingleEmptyAuthSkipsCredential(c *gc.C) {
+	const emptyAuthCloudYAML = `
+        clouds:
+          local-manual:
+            type: manual
+            auth-types: [empty]
+            endpoint: "http://dummy"`
+
+	cloudFileName, command, _, api, _, _ := s.setupControllerCloudScenarioWithFile(c, emptyAuthCloudYAML)
+	ctx, err := cmdtesting.RunCommand(c, command, "local-manual", cloudFileName, "-c", "mycontroller")
+	c.Assert(err, jc.ErrorIsNil)
+	api.CheckCallNames(c, "AddCloud", "Close")
+	c.Assert(cmdtesting.Stderr(ctx), gc.DeepEquals, "Cloud \"local-manual\" added to controller \"mycontroller\".\n")
+}
+
 func (s *addSuite) TestAddLocal(c *gc.C) {
 	cloudFileName, command, _, api, _, numCalls := s.setupControllerCloudScenario(c)
 

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -261,6 +261,13 @@ func (st *State) UpdateCloud(c cloud.Cloud) error {
 	if err := validateCloud(c); err != nil {
 		return errors.Trace(err)
 	}
+	existingCloud, err := st.Cloud(c.Name)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if existingCloud.Type != c.Type {
+		return errors.Errorf("cannot change cloud %q type from %q to %q", c.Name, existingCloud.Type, c.Type)
+	}
 
 	if err := st.db().RunTransaction([]txn.Op{updateCloudOps(c)}); err != nil {
 		if err == txn.ErrAborted {

--- a/state/cloud_test.go
+++ b/state/cloud_test.go
@@ -197,6 +197,17 @@ func (s *CloudSuite) TestUpdateNonExistentCloud(c *gc.C) {
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *CloudSuite) TestUpdateCloudTypeImmutable(c *gc.C) {
+	cloudToAdd := lowCloud
+	err := s.State.AddCloud(cloudToAdd, s.Owner.Name())
+	c.Assert(err, jc.ErrorIsNil)
+
+	updatedCloud := lowCloud
+	updatedCloud.Type = "another"
+	err = s.State.UpdateCloud(updatedCloud)
+	c.Assert(err, gc.ErrorMatches, `cannot change cloud "stratus" type from "low" to "another"`)
+}
+
 func (s *CloudSuite) TestRemoveNonExistentCloud(c *gc.C) {
 	err := s.State.RemoveCloud("foo")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)


### PR DESCRIPTION
If you have a manual cloud defined locally, attempting to add it to a controller fails because there's a check in state that clouds must have at least one auth type. For manual clouds, it can be that the auth types list is zero length (it should really be `[empty]` but we can't change it now). eg in a local `clouds.yaml`

```
  mycloud:
    type: manual
    endpoint: ubuntu@10.68.47.38
    regions:
      default: {}
```

So the fix is to have the facade layer add in an Empty auth type if the cloud credential schema supports it.
A similar change is done for updating clouds. We also copy the default region logic for update cloud to be consistent with add cloud.

The above is the least cost solution. It allows yaml cloud definitions etc to remain the same, and fixes the cloud definition as it gets saved to the controller.

I also needed to fix add model because once the add cloud issue was fixed, adding models failed with you are the same user who did the bootstrap.

## QA steps

juju bootstrap lxd test
juju add-cloud -c test mycloud --force
juju clouds
juju add-model foo
juju add-machine ssh:ubuntu@10.68.47.215 
juju status

## Links

**Issue:** Fixes #22571.

Originally a LP bug https://bugs.launchpad.net/juju/+bug/2048805

