### PR TITLE
fix(secrets): make YAML test order-independent

### DIFF
--- a/cmd/juju/secrets/list_test.go
+++ b/cmd/juju/secrets/list_test.go
@@ -174,7 +174,6 @@ func (s *ListSuite) TestListWithRevisionsUnitFilterYAML(c *tc.C) {
 	defer s.setup(c).Finish()
 
 	uris := []*coresecrets.URI{coresecrets.NewURI(), coresecrets.NewURI()}
-	slices.SortFunc(uris, coresecrets.CompareURI)
 	backend := "alvinmini410model3-local"
 
 	s.secretsAPI.EXPECT().ListSecrets(
@@ -190,7 +189,7 @@ func (s *ListSuite) TestListWithRevisionsUnitFilterYAML(c *tc.C) {
 				Owner:          coresecrets.Owner{Kind: coresecrets.UnitOwner, ID: "traefik-k8s/0"},
 				Label:          "afd8c2bccf834997afce12c2706d2ede-private-key-0-certificates",
 			},
-			Revisions: []coresecrets.SecretRevisionMetadata{ // This type path aligns with coresecrets used in API details
+			Revisions: []coresecrets.SecretRevisionMetadata{
 				{
 					Revision:    1,
 					BackendName: &backend,
@@ -205,7 +204,7 @@ func (s *ListSuite) TestListWithRevisionsUnitFilterYAML(c *tc.C) {
 				Owner:          coresecrets.Owner{Kind: coresecrets.UnitOwner, ID: "traefik-k8s/1"},
 				Label:          "dsajnjsdandjwajwdnjwndjw-private-key-0-certificates",
 			},
-			Revisions: []coresecrets.SecretRevisionMetadata{ // This type path aligns with coresecrets used in API details
+			Revisions: []coresecrets.SecretRevisionMetadata{
 				{
 					Revision:    1,
 					BackendName: &backend,
@@ -218,7 +217,7 @@ func (s *ListSuite) TestListWithRevisionsUnitFilterYAML(c *tc.C) {
 	ctx, err := cmdtesting.RunCommand(c, secrets.NewListCommandForTest(s.store, s.secretsAPI), "--revisions", "--format", "yaml")
 	c.Assert(err, tc.ErrorIsNil)
 	out := cmdtesting.Stdout(ctx)
-	c.Assert(out, tc.Equals, fmt.Sprintf(`%s:
+	c.Assert(out, tc.Contains, fmt.Sprintf(`%s:
   revision: 1
   rotation: never
   owner: traefik-k8s/0
@@ -230,7 +229,8 @@ func (s *ListSuite) TestListWithRevisionsUnitFilterYAML(c *tc.C) {
     backend: alvinmini410model3-local
     created: 0001-01-01T00:00:00Z
     updated: 0001-01-01T00:00:00Z
-%s:
+`, uris[0].ID))
+	c.Assert(out, tc.Contains, fmt.Sprintf(`%s:
   revision: 1
   rotation: never
   owner: traefik-k8s/1
@@ -242,7 +242,7 @@ func (s *ListSuite) TestListWithRevisionsUnitFilterYAML(c *tc.C) {
     backend: alvinmini410model3-local
     created: 0001-01-01T00:00:00Z
     updated: 0001-01-01T00:00:00Z
-`, uris[0].ID, uris[1].ID))
+`, uris[1].ID))
 }
 
 func (s *ListSuite) TestListWithRevisionsApplicationFilterJSON(c *tc.C) {


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->
`TestListWithRevisionsUnitFilterYAML` asserted on the raw YAML string output using `tc.Equals`, which implicitly required a specific key ordering. The `juju/yaml/v2` fork uses **natural sort** for map keys (digit sequences compared numerically, e.g. `8 < 77`), which can disagree with the lexicographic `CompareURI` sort used to order the test URIs (where `77... < 8b...`). Since URI IDs are randomly generated, this mismatch causes the test to fail non-deterministically when numeric prefixes disagree between the two sort orders.

Replace the single `tc.Equals` on the full output with two `tc.Contains` assertions (one per URI), matching the pattern already used in `TestListYAML` in the same file. This makes the test order-independent and eliminates the flakiness. No production code change.

## Checklist

<!-- If an item is not applicable, use ~strikethrough~. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] Integration tests~
- ~[ ] doc.go added or updated in changed packages~

## QA steps

```sh
cd cmd/juju/secrets
go test ./... -c -race
timeout 31 stress -timeout 30s ./secrets.test -test.run TestListSuite/TestListWithRevisionsUnitFilterYAML
# Expected: N runs, 0 failures
```

## Documentation changes

None — test-only change with no user-visible behaviour change.

## Links

Observed on PR #22531 CI run.