### PR TITLE
domain/removal: allow marking unprovisioned machines as dead with live units

### DIFF
--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -415,7 +415,7 @@ AND     lld.mac_address IS NOT NULL;`, entityUUID{UUID: machineUUID}, linkLayerD
 // - [machineerrors.MachineNotFound] if the machine does not exist.
 // - [removalerrors.EntityStillAlive] if the machine is alive.
 // - [removalerrors.MachineHasContainers] if the machine hosts containers.
-// - [removalerrors.MachineHasUnits] if the machine hosts units.
+// - [removalerrors.MachineHasUnits] if the machine is provisioned and hosts units.
 // - [removalerrors.MachineHasStorage] if the machine hosts storage.
 func (st *State) MarkMachineAsDead(ctx context.Context, mUUID string) error {
 	db, err := st.DB(ctx)
@@ -432,6 +432,14 @@ AND    life_id = 1`, machineUUID)
 	if err != nil {
 		return errors.Errorf("preparing machine life update: %w", err)
 	}
+	provisionedStmt, err := st.Prepare(`
+SELECT COUNT(*) AS &count.count
+FROM   machine_cloud_instance
+WHERE  machine_uuid = $entityUUID.uuid
+AND    instance_id IS NOT NULL`, count{}, machineUUID)
+	if err != nil {
+		return errors.Errorf("preparing machine provisioned check: %w", err)
+	}
 	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if l, err := st.getMachineLife(ctx, tx, mUUID); err != nil {
 			return errors.Errorf("getting machine life: %w", err)
@@ -446,7 +454,7 @@ AND    life_id = 1`, machineUUID)
 		// intentionally skipped. Containers and storage are still checked
 		// because their own removal jobs must complete regardless. DeleteMachine
 		// retains its own full dependency guards.
-		provisioned, err := st.machineIsProvisioned(ctx, tx, machineUUID)
+		provisioned, err := st.machineIsProvisioned(ctx, tx, machineUUID, provisionedStmt)
 		if err != nil {
 			return errors.Errorf("checking if machine is provisioned: %w", err)
 		}
@@ -470,7 +478,7 @@ AND    life_id = 1`, machineUUID)
 // - [machineerrors.MachineNotFound] if the machine does not exist.
 // - [removalerrors.EntityStillAlive] if the machine is alive.
 // - [removalerrors.MachineHasContainers] if the machine hosts containers.
-// - [removalerrors.MachineHasUnits] if the machine hosts units.
+// - [removalerrors.MachineHasUnits] if the machine is provisioned and hosts units.
 func (st *State) MarkInstanceAsDead(ctx context.Context, mUUID string) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -486,6 +494,14 @@ AND    life_id = 1`, machineUUID)
 	if err != nil {
 		return errors.Errorf("preparing instance life update: %w", err)
 	}
+	provisionedStmt, err := st.Prepare(`
+SELECT COUNT(*) AS &count.count
+FROM   machine_cloud_instance
+WHERE  machine_uuid = $entityUUID.uuid
+AND    instance_id IS NOT NULL`, count{}, machineUUID)
+	if err != nil {
+		return errors.Errorf("preparing machine provisioned check: %w", err)
+	}
 	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if l, err := st.getInstanceLife(ctx, tx, mUUID); err != nil {
 			return errors.Errorf("getting machine instance life: %w", err)
@@ -497,9 +513,10 @@ AND    life_id = 1`, machineUUID)
 
 		// For a machine that was never provisioned (instance_id IS NULL) there
 		// is no cloud resource to protect, so the unit dependency check is
-		// intentionally skipped. Containers and storage are still checked.
-		// DeleteMachine retains its own full dependency guards.
-		provisioned, err := st.machineIsProvisioned(ctx, tx, machineUUID)
+		// intentionally skipped. Containers and storage are still checked
+		// because their own removal jobs must complete regardless. DeleteMachine
+		// retains its own full dependency guards.
+		provisioned, err := st.machineIsProvisioned(ctx, tx, machineUUID, provisionedStmt)
 		if err != nil {
 			return errors.Errorf("checking if machine is provisioned: %w", err)
 		}
@@ -515,6 +532,19 @@ AND    life_id = 1`, machineUUID)
 
 		return nil
 	}))
+}
+
+// machineIsProvisioned returns true if a cloud instance has been assigned to
+// the machine (i.e. instance_id IS NOT NULL). Machines that have never been
+// successfully started by a provisioner will have a NULL instance_id.
+// The caller is responsible for preparing stmt with the appropriate query
+// outside the transaction to avoid repeated preparation on retries.
+func (st *State) machineIsProvisioned(ctx context.Context, tx *sqlair.TX, machineUUID entityUUID, stmt *sqlair.Statement) (bool, error) {
+	var c count
+	if err := tx.Query(ctx, stmt, machineUUID).Get(&c); err != nil {
+		return false, errors.Errorf("querying machine_cloud_instance for provisioned check: %w", err)
+	}
+	return c.Count > 0, nil
 }
 
 // DeleteMachine deletes the specified machine and any dependent child records.
@@ -672,7 +702,7 @@ SELECT COUNT(*) AS &count.count
 FROM unit
 JOIN machine ON machine.net_node_uuid = unit.net_node_uuid
 WHERE machine.uuid = $entityUUID.uuid
-AND unit.life_id != 2
+AND unit.life_id != 2  -- 2 = Dead
 `, count{}, machineUUIDParam)
 	if err != nil {
 		return errors.Capture(err)
@@ -719,7 +749,7 @@ SELECT SUM(count) AS &count.count FROM (
 	if err != nil {
 		return errors.Errorf("getting container count: %w", err)
 	} else if containerCount.Count > 0 {
-		return errors.Errorf("cannot delete machine %q, it hosts has %d container(s)", machineUUIDParam.UUID, containerCount.Count).
+		return errors.Errorf("cannot delete machine %q, it hosts %d container(s)", machineUUIDParam.UUID, containerCount.Count).
 			Add(removalerrors.MachineHasContainers)
 	}
 
@@ -729,7 +759,7 @@ SELECT SUM(count) AS &count.count FROM (
 		if err != nil {
 			return errors.Errorf("getting unit count: %w", err)
 		} else if unitCount.Count > 0 {
-			return errors.Errorf("cannot delete machine %q, it hosts has %d unit(s)", machineUUIDParam.UUID, unitCount.Count).
+			return errors.Errorf("cannot delete machine %q, it hosts %d unit(s)", machineUUIDParam.UUID, unitCount.Count).
 				Add(removalerrors.MachineHasUnits)
 		}
 	}
@@ -901,25 +931,6 @@ WHERE  net_node_uuid = $node.uuid`
 		}
 	}
 	return nil
-}
-
-// machineIsProvisioned returns true if a cloud instance has been assigned to
-// the machine (i.e. instance_id IS NOT NULL). Machines that have never been
-// successfully started by a provisioner will have a NULL instance_id.
-func (st *State) machineIsProvisioned(ctx context.Context, tx *sqlair.TX, machineUUID entityUUID) (bool, error) {
-	stmt, err := st.Prepare(`
-SELECT COUNT(*) AS &count.count
-FROM   machine_cloud_instance
-WHERE  machine_uuid = $entityUUID.uuid
-AND    instance_id IS NOT NULL`, count{}, machineUUID)
-	if err != nil {
-		return false, errors.Errorf("preparing machine provisioned check: %w", err)
-	}
-	var c count
-	if err := tx.Query(ctx, stmt, machineUUID).Get(&c); err != nil {
-		return false, errors.Errorf("checking if machine is provisioned: %w", err)
-	}
-	return c.Count > 0, nil
 }
 
 func (st *State) getMachineLife(ctx context.Context, tx *sqlair.TX, mUUID string) (life.Life, error) {

--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -441,11 +441,21 @@ AND    life_id = 1`, machineUUID)
 			return removalerrors.EntityStillAlive
 		}
 
-		if err := st.checkNoMachineDependents(ctx, tx, machineUUID); err != nil {
+		// For a machine that was never provisioned (instance_id IS NULL) there
+		// is no cloud resource to protect, so the unit dependency check is
+		// intentionally skipped. Containers and storage are still checked
+		// because their own removal jobs must complete regardless. DeleteMachine
+		// retains its own full dependency guards.
+		provisioned, err := st.machineIsProvisioned(ctx, tx, machineUUID)
+		if err != nil {
+			return errors.Errorf("checking if machine is provisioned: %w", err)
+		}
+		skipUnitsCheck := !provisioned
+		if err := st.checkNoMachineDependents(ctx, tx, machineUUID, skipUnitsCheck); err != nil {
 			return errors.Capture(err)
 		}
 
-		err := tx.Query(ctx, updateStmt, machineUUID).Run()
+		err = tx.Query(ctx, updateStmt, machineUUID).Run()
 		if err != nil {
 			return errors.Errorf("marking machine as dead: %w", err)
 		}
@@ -485,11 +495,20 @@ AND    life_id = 1`, machineUUID)
 			return removalerrors.EntityStillAlive
 		}
 
-		if err := st.checkNoMachineDependents(ctx, tx, machineUUID); err != nil {
+		// For a machine that was never provisioned (instance_id IS NULL) there
+		// is no cloud resource to protect, so the unit dependency check is
+		// intentionally skipped. Containers and storage are still checked.
+		// DeleteMachine retains its own full dependency guards.
+		provisioned, err := st.machineIsProvisioned(ctx, tx, machineUUID)
+		if err != nil {
+			return errors.Errorf("checking if machine is provisioned: %w", err)
+		}
+		skipUnitsCheck := !provisioned
+		if err := st.checkNoMachineDependents(ctx, tx, machineUUID, skipUnitsCheck); err != nil {
 			return errors.Capture(err)
 		}
 
-		err := tx.Query(ctx, updateStmt, machineUUID).Run()
+		err = tx.Query(ctx, updateStmt, machineUUID).Run()
 		if err != nil {
 			return errors.Errorf("marking machine instance as dead: %w", err)
 		}
@@ -571,7 +590,7 @@ WHERE uuid = $machine.uuid;
 
 			// If force is not set, check for dependents before allowing deletion.
 			// This prevents accidental data loss.
-			if err := st.checkNoMachineDependents(ctx, tx, machineUUIDParam); err != nil {
+			if err := st.checkNoMachineDependents(ctx, tx, machineUUIDParam, false); err != nil {
 				return errors.Errorf("checking for dependents: %w", err).Add(removalerrors.RemovalJobIncomplete)
 			}
 		}
@@ -631,7 +650,14 @@ WHERE  net_node_uuid = $node.uuid`, count{}, node)
 	return nil
 }
 
-func (st *State) checkNoMachineDependents(ctx context.Context, tx *sqlair.TX, machineUUIDParam entityUUID) error {
+// checkNoMachineDependents returns an error if the machine still has
+// containers, units (unless skipUnitsCheck is true), filesystems, or volumes
+// that would prevent safe deletion. skipUnitsCheck should be set when the
+// machine was never provisioned: there is no cloud resource to protect so
+// blocking on living units serves no purpose.
+func (st *State) checkNoMachineDependents(
+	ctx context.Context, tx *sqlair.TX, machineUUIDParam entityUUID, skipUnitsCheck bool,
+) error {
 	countContainersOnMachine, err := st.Prepare(`
 SELECT COUNT(*) AS &count.count
 FROM machine_parent
@@ -697,13 +723,15 @@ SELECT SUM(count) AS &count.count FROM (
 			Add(removalerrors.MachineHasContainers)
 	}
 
-	var unitCount count
-	err = tx.Query(ctx, countUnitsOnMachine, machineUUIDParam).Get(&unitCount)
-	if err != nil {
-		return errors.Errorf("getting unit count: %w", err)
-	} else if unitCount.Count > 0 {
-		return errors.Errorf("cannot delete machine %q, it hosts has %d unit(s)", machineUUIDParam.UUID, unitCount.Count).
-			Add(removalerrors.MachineHasUnits)
+	if !skipUnitsCheck {
+		var unitCount count
+		err = tx.Query(ctx, countUnitsOnMachine, machineUUIDParam).Get(&unitCount)
+		if err != nil {
+			return errors.Errorf("getting unit count: %w", err)
+		} else if unitCount.Count > 0 {
+			return errors.Errorf("cannot delete machine %q, it hosts has %d unit(s)", machineUUIDParam.UUID, unitCount.Count).
+				Add(removalerrors.MachineHasUnits)
+		}
 	}
 
 	var filesystemCount count
@@ -873,6 +901,25 @@ WHERE  net_node_uuid = $node.uuid`
 		}
 	}
 	return nil
+}
+
+// machineIsProvisioned returns true if a cloud instance has been assigned to
+// the machine (i.e. instance_id IS NOT NULL). Machines that have never been
+// successfully started by a provisioner will have a NULL instance_id.
+func (st *State) machineIsProvisioned(ctx context.Context, tx *sqlair.TX, machineUUID entityUUID) (bool, error) {
+	stmt, err := st.Prepare(`
+SELECT COUNT(*) AS &count.count
+FROM   machine_cloud_instance
+WHERE  machine_uuid = $entityUUID.uuid
+AND    instance_id IS NOT NULL`, count{}, machineUUID)
+	if err != nil {
+		return false, errors.Errorf("preparing machine provisioned check: %w", err)
+	}
+	var c count
+	if err := tx.Query(ctx, stmt, machineUUID).Get(&c); err != nil {
+		return false, errors.Errorf("checking if machine is provisioned: %w", err)
+	}
+	return c.Count > 0, nil
 }
 
 func (st *State) getMachineLife(ctx context.Context, tx *sqlair.TX, mUUID string) (life.Life, error) {

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -1277,13 +1277,37 @@ func (s *machineSuite) TestMarkMachineAsDeadMachineHasContainers(c *tc.C) {
 	s.checkMachineLife(c, machineUUID.String(), life.Dying)
 }
 
-func (s *machineSuite) TestMarkMachineAsDeadMachineHasUnits(c *tc.C) {
+// TestMarkMachineAsDeadNotProvisionedMachineHasUnits verifies that a machine
+// that was never provisioned (instance_id IS NULL) can be marked as dead even
+// when it still has living units. The dependency check is intentionally skipped
+// for unprovisioned machines because there is no cloud resource to protect.
+func (s *machineSuite) TestMarkMachineAsDeadNotProvisionedMachineHasUnits(c *tc.C) {
 	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
+	s.advanceMachineLife(c, machineUUID, life.Dying)
+
+	err := st.MarkMachineAsDead(c.Context(), machineUUID.String())
+	c.Check(err, tc.ErrorIsNil)
+
+	s.checkMachineLife(c, machineUUID.String(), life.Dead)
+}
+
+// TestMarkMachineAsDeadProvisionedMachineHasUnits verifies that a provisioned
+// machine (instance_id IS NOT NULL) cannot be marked as dead while it still
+// has living units. The cloud instance must be protected until dependents are
+// cleaned up.
+func (s *machineSuite) TestMarkMachineAsDeadProvisionedMachineHasUnits(c *tc.C) {
+	svc := s.setupApplicationService(c)
+	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
+	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	s.setMachineInstanceID(c, machineUUID, "i-abc123")
 	s.advanceMachineLife(c, machineUUID, life.Dying)
 
 	err := st.MarkMachineAsDead(c.Context(), machineUUID.String())
@@ -1431,13 +1455,38 @@ func (s *machineSuite) TestMarkInstanceAsDeadMachineHasContainers(c *tc.C) {
 	s.checkInstanceLife(c, machineUUID.String(), life.Dying)
 }
 
-func (s *machineSuite) TestMarkInstanceAsDeadMachineHasUnits(c *tc.C) {
+// TestMarkInstanceAsDeadNotProvisionedMachineHasUnits verifies that the cloud
+// instance record for a machine that was never provisioned (instance_id IS
+// NULL) can be marked as dead even when the machine still has living units.
+// The dependency check is intentionally skipped for unprovisioned machines
+// because there is no cloud resource to protect.
+func (s *machineSuite) TestMarkInstanceAsDeadNotProvisionedMachineHasUnits(c *tc.C) {
 	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
 	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
+	s.advanceInstanceLife(c, machineUUID, life.Dying)
+
+	err := st.MarkInstanceAsDead(c.Context(), machineUUID.String())
+	c.Check(err, tc.ErrorIsNil)
+
+	s.checkInstanceLife(c, machineUUID.String(), life.Dead)
+}
+
+// TestMarkInstanceAsDeadProvisionedMachineHasUnits verifies that the cloud
+// instance record for a provisioned machine (instance_id IS NOT NULL) cannot
+// be marked as dead while it still has living units. The cloud resource must
+// be protected until its dependents are cleaned up.
+func (s *machineSuite) TestMarkInstanceAsDeadProvisionedMachineHasUnits(c *tc.C) {
+	svc := s.setupApplicationService(c)
+	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})
+	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	s.setMachineInstanceID(c, machineUUID, "i-abc123")
 	s.advanceInstanceLife(c, machineUUID, life.Dying)
 
 	err := st.MarkInstanceAsDead(c.Context(), machineUUID.String())

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -1316,6 +1316,63 @@ func (s *machineSuite) TestMarkMachineAsDeadProvisionedMachineHasUnits(c *tc.C) 
 	s.checkMachineLife(c, machineUUID.String(), life.Dying)
 }
 
+// TestMarkMachineAsDeadNotProvisionedMachineHasContainers verifies that even
+// for an unprovisioned machine the container dependency check still applies:
+// the caller must drain containers before the machine can be marked dead.
+func (s *machineSuite) TestMarkMachineAsDeadNotProvisionedMachineHasContainers(c *tc.C) {
+	svc := s.setupMachineService(c)
+	machineRes, err := svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "24.04",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, err := svc.GetMachineUUID(c.Context(), machineRes.MachineName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "24.04",
+		},
+		Directive: deployment.Placement{
+			Type:      deployment.PlacementTypeContainer,
+			Container: deployment.ContainerTypeLXD,
+			Directive: machineRes.MachineName.String(),
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Machine is not provisioned: instance_id remains NULL.
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	s.advanceMachineLife(c, machineUUID, life.Dying)
+
+	err = st.MarkMachineAsDead(c.Context(), machineUUID.String())
+	c.Check(err, tc.ErrorIs, removalerrors.MachineHasContainers)
+
+	s.checkMachineLife(c, machineUUID.String(), life.Dying)
+}
+
+// TestMarkMachineAsDeadNotProvisionedMachineHasStorage verifies that even for
+// an unprovisioned machine the storage dependency check still applies: the
+// caller must drain storage before the machine can be marked dead.
+func (s *machineSuite) TestMarkMachineAsDeadNotProvisionedMachineHasStorage(c *tc.C) {
+	machineUUID := s.addMachine(c, "0")
+	s.createMachineFilesystem(c, machineUUID)
+
+	// Machine is not provisioned: instance_id remains NULL.
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	s.advanceMachineLife(c, coremachine.UUID(machineUUID), life.Dying)
+
+	err := st.MarkMachineAsDead(c.Context(), machineUUID)
+	c.Check(err, tc.ErrorIs, removalerrors.MachineHasStorage)
+
+	s.checkMachineLife(c, machineUUID, life.Dying)
+}
+
 func (s *machineSuite) TestMarkMachineAsDeadMachineHasUnitsWithDeadUnits(c *tc.C) {
 	svc := s.setupApplicationService(c)
 	appUUID := s.createIAASApplication(c, svc, "some-app", applicationservice.AddIAASUnitArg{})

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -835,6 +835,13 @@ func (s *baseSuite) advanceInstanceLife(c *tc.C, machineUUID machine.UUID, newLi
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// setMachineInstanceID simulates a successfully provisioned machine by setting
+// a non-NULL instance_id on the machine_cloud_instance row.
+func (s *baseSuite) setMachineInstanceID(c *tc.C, machineUUID machine.UUID, instanceID string) {
+	_, err := s.DB().Exec("UPDATE machine_cloud_instance SET instance_id = ? WHERE machine_uuid = ?", instanceID, machineUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *baseSuite) advanceModelLife(c *tc.C, modelUUID string, newLife life.Life) {
 	_, err := s.DB().Exec("UPDATE model_life SET life_id = ? WHERE model_uuid = ?", newLife, modelUUID)
 	c.Assert(err, tc.ErrorIsNil)


### PR DESCRIPTION
## Summary

When a machine fails to provision (e.g. "instance already exists" on LXD), its `machine_cloud_instance.instance_id` remains `NULL`. During `destroy-controller` the removal worker calls `MarkMachineAsDead` / `MarkInstanceAsDead`, but both functions call `checkNoMachineDependents` which returns `MachineHasUnits`. This causes the provisioner task to crash before it can call `MarkForRemoval`, the instance life is stuck at `Dying`, and the removal job loops on `EntityNotDead` every 10 s — hanging the destroy indefinitely.

## Root Cause

`checkNoMachineDependents` blocks the `Dying → Dead` transition on living units to protect cloud resources. For a machine that was **never provisioned** there is no cloud resource to protect, so this guard is inappropriate.

## Fix

Introduce `machineIsProvisioned` (checks `instance_id IS NOT NULL`) and add a `skipUnitsCheck bool` parameter to `checkNoMachineDependents`. Both `MarkMachineAsDead` and `MarkInstanceAsDead` skip the unit check when the machine is unprovisioned. Container and storage checks remain unconditional. `DeleteMachine` passes `skipUnitsCheck: false` (unchanged behaviour) and retains its own net-node unit guard, so the machine row is never deleted while units still exist in the DB.

## Tests

- Renamed `TestMarkMachineAsDeadMachineHasUnits` → `TestMarkMachineAsDeadNotProvisionedMachineHasUnits` (now expects success, machine → Dead)
- Renamed `TestMarkInstanceAsDeadMachineHasUnits` → `TestMarkInstanceAsDeadNotProvisionedMachineHasUnits` (now expects success, instance → Dead)
- Added `TestMarkMachineAsDeadProvisionedMachineHasUnits`: sets `instance_id`, verifies `MachineHasUnits` is still returned for provisioned machines
- Added `TestMarkInstanceAsDeadProvisionedMachineHasUnits`: same for the instance path
- Added `setMachineInstanceID` test helper

## Observed Failure

Smoke/Deploy LXD CI run: machine 0 stuck with `Instance "juju-65d812-0" already exists", 11 retries all fail, machine → error state, `destroy-controller` hangs `Waiting for 1 model, 1 machine, 1 application` for ~14 minutes until CI cancels.