### PR TITLE
feat: re-enable migrate check

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -16,14 +16,15 @@ jobs:
       - arm64
       - ${{ (github.repository_owner == 'juju' && 'aws') || (github.repository_owner == 'canonical' && 'noble') }}
       - xlarge
-    # TODO: Migration broken until Juju 4 migration infra is fixed.
-    if: false
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:
         # TODO: add microk8s tests
         cloud: ["lxd"]
-        channel: ["local", "3.6/edge"]
+        # Reinstate when 4.x -> 4.x migrations are supported.
+        # channel: ["local", "4.0/stable", "3.6/edge"]
+        channel: ["3.6/edge"]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Re-enable migrate check

While the migration work was still in progress, we disabled this job. Now that we support migrations from 3.6 -> 4.0, we should re-able this job

Note however that we do not support migrations from 4.x to 4.x yet. That will work via another mechanism. So keep this side disabled for now

## QA Steps

migration gh action passes