### PR TITLE
fix(deps): eliminate github.com/juju/utils/v3 indirect dependency (GO-2025-3798)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,11 +61,11 @@ require (
 	github.com/juju/gojsonschema v1.0.0
 	github.com/juju/gomaasapi/v2 v2.3.0
 	github.com/juju/idmclient/v2 v2.0.1
-	github.com/juju/jsonschema v1.0.0
+	github.com/juju/jsonschema v1.0.1
 	github.com/juju/loggo/v2 v2.2.0
 	github.com/juju/lumberjack/v2 v2.0.2
 	github.com/juju/mutex/v2 v2.0.0
-	github.com/juju/names/v6 v6.0.0-20250512075813-b50ca77a4137
+	github.com/juju/names/v6 v6.0.0
 	github.com/juju/os/v2 v2.2.5
 	github.com/juju/persistent-cookiejar v1.0.0
 	github.com/juju/proxy v1.0.0
@@ -73,7 +73,7 @@ require (
 	github.com/juju/retry v1.0.1
 	github.com/juju/schema v1.2.0
 	github.com/juju/tc v0.0.0-20251023013639-77c6a1d20e5a
-	github.com/juju/testing v1.2.0
+	github.com/juju/testing v1.2.1
 	github.com/juju/utils/v4 v4.0.5
 	github.com/juju/webbrowser v1.0.0
 	github.com/juju/worker/v5 v5.0.0
@@ -212,7 +212,6 @@ require (
 	github.com/juju/loggo v1.0.0 // indirect
 	github.com/juju/mgo/v2 v2.0.2 // indirect
 	github.com/juju/usso v1.0.1 // indirect
-	github.com/juju/utils/v3 v3.2.2 // indirect
 	github.com/juju/version v0.0.0-20210303051006-2015802527a8 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/kr/fs v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/juju/gomaasapi/v2 v2.3.0/go.mod h1:ZsohFbU4xShV1aSQYQ21hR1lKj7naNGY0S
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
 github.com/juju/idmclient/v2 v2.0.1 h1:DRT3w1aXKlhw66fscPhESIwe6yj5Swy3bgQ1CEM7uIE=
 github.com/juju/idmclient/v2 v2.0.1/go.mod h1:EOiFbPmnkqKvCUS/DHpDRWhL7eKF0AJaTvMjIYlIUak=
-github.com/juju/jsonschema v1.0.0 h1:2ScR9hhVdHxft+Te3fnclVx61MmlikHNEOirTGi+hV4=
-github.com/juju/jsonschema v1.0.0/go.mod h1:SlFW+jFtpWX0P4Tb+zTTPR4ufttLrnJIdQPePxVEfkM=
+github.com/juju/jsonschema v1.0.1 h1:VrFC7Ug2JJMe7lfiTS1+SFw1LSO36JP8pD8Ty48pz3w=
+github.com/juju/jsonschema v1.0.1/go.mod h1:EP8dAa+lQk4Quz8457d+yclqNXNvTfZCE+JrbIVCO+s=
 github.com/juju/loggo v0.0.0-20170605014607-8232ab8918d9/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4/go.mod h1:NIXFioti1SmKAlKNuUwbMenNdef59IF52+ZzuOmHYkg=
@@ -436,8 +436,8 @@ github.com/juju/mutex/v2 v2.0.0-20220128011612-57176ebdcfa3/go.mod h1:TTCG9BJD9r
 github.com/juju/mutex/v2 v2.0.0-20220203023141-11eeddb42c6c/go.mod h1:jwCfBs/smYDaeZLqeaCi8CB8M+tOes4yf827HoOEoqk=
 github.com/juju/mutex/v2 v2.0.0 h1:rVmJdOaXGWF8rjcFHBNd4x57/1tks5CgXHx55O55SB0=
 github.com/juju/mutex/v2 v2.0.0/go.mod h1:jwCfBs/smYDaeZLqeaCi8CB8M+tOes4yf827HoOEoqk=
-github.com/juju/names/v6 v6.0.0-20250512075813-b50ca77a4137 h1:y78AjQajOIz8xxLXENqZ/QlLNKrp4HL2VHeT+iXTDPM=
-github.com/juju/names/v6 v6.0.0-20250512075813-b50ca77a4137/go.mod h1:msqFCjHhF+wL7NR5aEDRlpxCybna0+5E9kbRSb2fiz4=
+github.com/juju/names/v6 v6.0.0 h1:rYepZZVSYd+ktCFtwqoJTctyxiMx1XPRufF8qltv2LY=
+github.com/juju/names/v6 v6.0.0/go.mod h1:/OXH4hTa02eQjb8JE0J9S1D3pMBzY5AHMbq5HU5GEBo=
 github.com/juju/os/v2 v2.2.5 h1:Ayw9aC7axKtGgzy3dFRKx84FxasfISMege0iYDsH6io=
 github.com/juju/os/v2 v2.2.5/go.mod h1:igGQLjgRSwUery5ZhV/1pZjZkMwnfkAwWCwh5ZfIg+c=
 github.com/juju/persistent-cookiejar v1.0.0 h1:Ag7+QLzqC2m+OYXy2QQnRjb3gTkEBSZagZ6QozwT3EQ=
@@ -472,8 +472,6 @@ github.com/juju/utils/v3 v3.0.0-20220130232349-cd7ecef0e94a/go.mod h1:LzwbbEN7bu
 github.com/juju/utils/v3 v3.0.0-20220202114721-338bb0530e89/go.mod h1:wf5w+8jyTh2IYnSX0sHnMJo4ZPwwuiBWn+xN3DkQg4k=
 github.com/juju/utils/v3 v3.0.0-20220203023959-c3fbc78a33b0/go.mod h1:8csUcj1VRkfjNIRzBFWzLFCMLwLqsRWvkmhfVAUwbC4=
 github.com/juju/utils/v3 v3.0.0/go.mod h1:8csUcj1VRkfjNIRzBFWzLFCMLwLqsRWvkmhfVAUwbC4=
-github.com/juju/utils/v3 v3.2.2 h1:TT6KIhDgzAJh7h3L6UwQCOPii4jqtFLNnUCcBPeUWQw=
-github.com/juju/utils/v3 v3.2.2/go.mod h1:/FQv9Tl4hsnPo8O6/aOhImW13yfkU95i+L/JnVmDJPY=
 github.com/juju/utils/v4 v4.0.5 h1:+frjTpgWSaB+YTgG/inWiYPpkP4ktCBIo0pwG2OFsaw=
 github.com/juju/utils/v4 v4.0.5/go.mod h1:cxa5Ngrq7zAHnQbIG8hRutKL5v278hDSd25/Q8wEVz0=
 github.com/juju/version v0.0.0-20161031051906-1f41e27e54f2/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -133,10 +133,6 @@ join() {
 
 run_govulncheck() {
 	ignore=(
-		# The vulnerability below is for a method not used since Juju 1.x.
-		#
-		# https://pkg.go.dev/vuln/GO-2025-3798
-		"GO-2025-3798"
 		# false positive vulnerabilities in github.com/canonical/lxd. These are
 		# resolved in lxd-5.21.4.
 		#


### PR DESCRIPTION
## Summary

`github.com/juju/utils/v3` carries vulnerability **GO-2025-3798 / CVE-2025-6224** that leaks private keys in certificates via the `winrm` and `cert` packages. The fix exists only in `v4.0.4+`; v3 will not receive a patch.

## Root causes

Two transitive dependencies directly imported `utils/v3`. Both have been fixed upstream and released:

| Package | Fix | Release |
|---------|-----|---------|
| `github.com/juju/names/v6` | Inlined UUID helpers; `utils` dependency removed entirely | [names#121](https://github.com/juju/names/pull/121) → `v6.0.0` |
| `github.com/juju/jsonschema` | Inlined `ConformYAML`; `utils` dependency removed entirely | [jsonschema#5](https://github.com/juju/jsonschema/pull/5) → `v1.0.1` |

## Changes

- `go.mod`: bump `github.com/juju/names/v6` to `v6.0.0`, `github.com/juju/jsonschema` to `v1.0.1`; remove `github.com/juju/utils/v3` indirect require
- `go.sum`: updated accordingly
- `tests/suites/static_analysis/lint_go.sh`: remove `GO-2025-3798` from the govulncheck ignore list

## Verification

```
$ go mod why github.com/juju/utils/v3
# github.com/juju/utils/v3
(main module does not need package github.com/juju/utils/v3)
```

## References

- https://pkg.go.dev/vuln/GO-2025-3798
- https://github.com/juju/utils/security/advisories/GHSA-h34r-jxqm-qgpr