### PR TITLE
fix: update charmhub find featured query

### DIFF
--- a/charmhub/find.go
+++ b/charmhub/find.go
@@ -104,6 +104,10 @@ func (c *FindClient) Find(ctx context.Context, query string, options ...FindOpti
 	for _, option := range options {
 		option(opts)
 	}
+	if strings.TrimSpace(query) == "" && opts.category == nil {
+		featured := "featured"
+		opts.category = &featured
+	}
 
 	c.logger.Tracef("Find(%s)", query)
 	path, err := c.path.Query("q", query)

--- a/charmhub/find_test.go
+++ b/charmhub/find_test.go
@@ -44,6 +44,50 @@ func (s *FindSuite) TestFind(c *gc.C) {
 	c.Assert(responses[0].Name, gc.Equals, name)
 }
 
+func (s *FindSuite) TestFindEmptyQueryDefaultsToFeaturedCategory(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := path.MakePath(baseURL)
+	query := ""
+
+	expect, err := path.Query("category", "featured")
+	c.Assert(err, jc.ErrorIsNil)
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGet(c, restClient, expect, query)
+
+	client := NewFindClient(path, restClient, &FakeLogger{})
+	responses, err := client.Find(context.TODO(), query)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(responses), gc.Equals, 1)
+	c.Assert(responses[0].Name, gc.Equals, query)
+}
+
+func (s *FindSuite) TestFindEmptyQueryWithCategoryOption(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	baseURL := MustParseURL(c, "http://api.foo.bar")
+
+	path := path.MakePath(baseURL)
+	query := ""
+
+	expect, err := path.Query("category", "database")
+	c.Assert(err, jc.ErrorIsNil)
+
+	restClient := NewMockRESTClient(ctrl)
+	s.expectGet(c, restClient, expect, query)
+
+	client := NewFindClient(path, restClient, &FakeLogger{})
+	responses, err := client.Find(context.TODO(), query, WithFindCategory("database"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(len(responses), gc.Equals, 1)
+	c.Assert(responses[0].Name, gc.Equals, query)
+}
+
 func (s *FindSuite) TestFindWithOptions(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
Charmhub appears to have changed `/v2/charms/find` behavior for empty queries.
 `juju find` with no args was sending an empty query and now gets a 500.

For reference, broken upstream API call appears to be:
 https://api.charmhub.io/v2/charms/find?fields=result.publisher.display-name,result.summary,result.store-url,default-release.revision.bases.architecture,default-release.revision.bases.name,default-release.revision.bases.channel,default-release.revision.version

What seems to work is to default to `category=featured` when query is empty and no category is provided.
If an explicit category is provided, use that.
 
## QA steps

Before this change
```
juju find
ERROR server error "https://api.charmhub.io/v2/charms/find?fields=result.publisher.display-name%2Cresult.summary%2Cresult.store-url%2Cdefault-release.revision.bases.architecture%2Cdefault-release.revision.bases.name%2Cdefault-release.revision.bases.channel%2Cdefault-release.revision.version"
```

With this change
```
juju find
No search term specified. Here are some interesting charms:

Name              Bundle  Version            Publisher                Summary
traefik-k8s       -       rev294-2-g0085e32  Canonical IS DevOps      A Juju charm to run a Traefik-powered ingress
                                                                      controller on Kubernetes.
kafka             -       248                Canonical                Charmed Apache Kafka Operator
vault-k8s         -       502                Canonical Telco          A tool for managing secrets
parca-k8s         -       9e85d3f            Canonical Observability  Parca continuous profiling tool.
postgresql        -       1091               Canonical                Charmed PostgreSQL 14 for VMs
prometheus-k8s    -       66d201e            Canonical Observability  Prometheus for Kubernetes clusters
landscape-server  -       134                Landscape Charmers       Charm for installing and using Self-Hosted
                                                                      Landscape Server.
grafana-k8s       -       bb3eed3            Canonical Observability  Data visualization and observability with
                                                                      Grafana
mysql             -       444                Canonical                Charmed MySQL VM operator
lxd               -       859                The LXD Charm            A next generation system container and virtual
                                                                      machine manager
postgresql-k8s    -       775                Canonical                Charmed PostgreSQL 14 for Kubernetes
mattermost-k8s    -       27                 Canonical IS DevOps      Mattermost is a flexible, open source messaging
                                                                      platform that enables secure team collaboration.
discourse-k8s     -       229                Canonical IS DevOps      Discourse is the modern forum for your community.
mongodb           -       265                Canonical                A MongoDB operator charm
loki-k8s          -       1b0095d            Canonical Observability  Loki is a log aggregation system inspired
                                                                      by Prometheus.


Provide a search term for more specific results.
```

## Links

**Issue:** Fixes #22586.

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
