### PR TITLE
feat: remove agent and clock dependencies from object-store and lease manifolds

### DIFF
--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -550,6 +550,7 @@ func (a *MachineAgent) makeEngineCreator(
 			PreviousAgentVersion:              previousAgentVersion,
 			AgentName:                         agentName,
 			ControllerID:                      agentConfig.Tag().Id(),
+			ObjectStoreRootDir:                agentConfig.DataDir(),
 			ControllerRuntimeConfigPath:       controllerRuntimeConfigPath,
 			ControllerAgentTag:                agentConfig.Tag(),
 			LogDir:                            agentConfig.LogDir(),

--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -551,6 +551,8 @@ func (a *MachineAgent) makeEngineCreator(
 			AgentName:                         agentName,
 			ControllerID:                      agentConfig.Tag().Id(),
 			ObjectStoreRootDir:                agentConfig.DataDir(),
+			ControllerUUID:                    agentConfig.Controller().Id(),
+			ControllerModelUUID:               agentConfig.Model().Id(),
 			ControllerRuntimeConfigPath:       controllerRuntimeConfigPath,
 			ControllerAgentTag:                agentConfig.Tag(),
 			LogDir:                            agentConfig.LogDir(),

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -702,7 +702,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The lease expiry worker constantly deletes
 		// leases with an expiry time in the past.
 		leaseExpiryName: ifPrimaryController(leaseexpiry.Manifold(leaseexpiry.ManifoldConfig{
-			ClockName:      clockName,
 			DBAccessorName: dbAccessorName,
 			TraceName:      traceName,
 			Logger:         internallogger.GetLogger("juju.worker.leaseexpiry"),

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -832,7 +832,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		objectStoreServicesName: objectstoreservices.Manifold(objectstoreservices.ManifoldConfig{
 			ChangeStreamName:             changeStreamName,
-			Clock:                        config.Clock,
 			Logger:                       internallogger.GetLogger("juju.worker.objectstoreservices"),
 			NewWorker:                    objectstoreservices.NewWorker,
 			NewObjectStoreServices:       objectstoreservices.NewObjectStoreServices,

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -143,6 +143,12 @@ type ManifoldsConfig struct {
 	// through the agent manifold.
 	ControllerID string
 
+	// ObjectStoreRootDir is the local filesystem root used by the
+	// file-backed object-store worker. It is sourced from
+	// agentConfig.DataDir() and passed directly to object-store
+	// manifolds instead of being read from agent config.
+	ObjectStoreRootDir string
+
 	// ControllerRuntimeConfigPath is the absolute path to the
 	// controller runtime config file (runtime.conf) written at
 	// bootstrap. It is passed to the db-accessor manifold so that the
@@ -799,13 +805,13 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		objectStoreName: ifDatabaseUpgradeComplete(objectstore.Manifold(objectstore.ManifoldConfig{
-			AgentName:                  agentName,
 			TraceName:                  traceName,
 			ObjectStoreServicesName:    objectStoreServicesName,
 			LeaseManagerName:           leaseManagerName,
 			S3ClientName:               objectStoreS3CallerName,
 			APIRemoteCallerName:        apiRemoteCallerName,
-			Clock:                      config.Clock,
+			ObjectStoreRootDir:         config.ObjectStoreRootDir,
+			ControllerNodeID:           config.ControllerID,
 			Logger:                     internallogger.GetLogger("juju.worker.objectstore"),
 			NewObjectStoreWorker:       internalobjectstore.ObjectStoreFactory,
 			GetControllerConfigService: objectstore.GetControllerConfigService,

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -149,6 +149,18 @@ type ManifoldsConfig struct {
 	// manifolds instead of being read from agent config.
 	ObjectStoreRootDir string
 
+	// ControllerUUID is the controller entity UUID. It is sourced from
+	// agentConfig.Controller().Id() in makeEngineCreator and passed
+	// directly to the lease-manager manifold instead of being looked
+	// up from agent config at worker start.
+	ControllerUUID string
+
+	// ControllerModelUUID is the controller model UUID. It is sourced
+	// from agentConfig.Model().Id() in makeEngineCreator and passed
+	// directly to the lease-manager manifold instead of being looked
+	// up from agent config at worker start.
+	ControllerModelUUID string
+
 	// ControllerRuntimeConfigPath is the absolute path to the
 	// controller runtime config file (runtime.conf) written at
 	// bootstrap. It is passed to the db-accessor manifold so that the
@@ -711,12 +723,12 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		// The global lease manager tracks lease information in the Dqlite database.
 		leaseManagerName: leasemanager.Manifold(leasemanager.ManifoldConfig{
-			AgentName:            agentName,
-			ClockName:            clockName,
 			DBAccessorName:       dbAccessorName,
 			TraceName:            traceName,
+			ControllerUUID:       config.ControllerUUID,
+			ControllerModelUUID:  config.ControllerModelUUID,
 			Logger:               internallogger.GetLogger("juju.worker.lease"),
-			LogDir:               agentConfig.LogDir(),
+			LogDir:               config.LogDir,
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            leasemanager.NewWorker,
 			NewStore:             leasemanager.NewStore,

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -716,6 +716,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		leaseExpiryName: ifPrimaryController(leaseexpiry.Manifold(leaseexpiry.ManifoldConfig{
 			DBAccessorName: dbAccessorName,
 			TraceName:      traceName,
+			Clock:          config.Clock,
 			Logger:         internallogger.GetLogger("juju.worker.leaseexpiry"),
 			NewWorker:      leaseexpiry.NewWorker,
 			NewStore:       leaseexpiry.NewStore,
@@ -727,6 +728,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			TraceName:            traceName,
 			ControllerUUID:       config.ControllerUUID,
 			ControllerModelUUID:  config.ControllerModelUUID,
+			Clock:                config.Clock,
 			Logger:               internallogger.GetLogger("juju.worker.lease"),
 			LogDir:               config.LogDir,
 			PrometheusRegisterer: config.PrometheusRegisterer,
@@ -811,6 +813,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewDrainerWorker:                objectstoredrainer.NewDrainWorker,
 			SelectFileHash:                  internalobjectstore.SelectFileHash,
 			NewWorker:                       objectstoredrainer.NewWorker,
+			Clock:                           config.Clock,
 			Logger:                          internallogger.GetLogger("juju.worker.objectstoredrainer"),
 		})),
 
@@ -822,6 +825,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APIRemoteCallerName:        apiRemoteCallerName,
 			ObjectStoreRootDir:         config.ObjectStoreRootDir,
 			ControllerNodeID:           config.ControllerID,
+			Clock:                      config.Clock,
 			Logger:                     internallogger.GetLogger("juju.worker.objectstore"),
 			NewObjectStoreWorker:       internalobjectstore.ObjectStoreFactory,
 			GetControllerConfigService: objectstore.GetControllerConfigService,
@@ -842,6 +846,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		objectStoreServicesName: objectstoreservices.Manifold(objectstoreservices.ManifoldConfig{
 			ChangeStreamName:             changeStreamName,
+			Clock:                        config.Clock,
 			Logger:                       internallogger.GetLogger("juju.worker.objectstoreservices"),
 			NewWorker:                    objectstoreservices.NewWorker,
 			NewObjectStoreServices:       objectstoreservices.NewObjectStoreServices,

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -786,10 +786,10 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// in progress.
 		objectStoreFortressName: fortress.Manifold(),
 		objectStoreDrainerName: ifPrimaryController(objectstoredrainer.Manifold(objectstoredrainer.ManifoldConfig{
-			AgentName:                       agentName,
 			S3ClientName:                    objectStoreS3CallerName,
 			ObjectStoreName:                 objectStoreName,
 			ObjectStoreServicesName:         objectStoreServicesName,
+			ObjectStoreRootDir:              config.ObjectStoreRootDir,
 			FortressName:                    objectStoreFortressName,
 			GetControllerService:            objectstoredrainer.GetControllerService,
 			GeObjectStoreServices:           objectstoredrainer.GeObjectStoreServicesGetter,
@@ -801,7 +801,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			SelectFileHash:                  internalobjectstore.SelectFileHash,
 			NewWorker:                       objectstoredrainer.NewWorker,
 			Logger:                          internallogger.GetLogger("juju.worker.objectstoredrainer"),
-			Clock:                           config.Clock,
 		})),
 
 		objectStoreName: ifDatabaseUpgradeComplete(objectstore.Manifold(objectstore.ManifoldConfig{

--- a/cmd/jujuagentd/agent/machine/manifolds_test.go
+++ b/cmd/jujuagentd/agent/machine/manifolds_test.go
@@ -546,6 +546,28 @@ func (*ManifoldsSuite) TestObjectStoreServicesDirectInputs(c *tc.C) {
 	}
 }
 
+func (*ManifoldsSuite) TestLeaseManagerDirectInputs(c *tc.C) {
+	for _, manifolds := range []dependency.Manifolds{
+		machine.IAASManifolds(machine.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		machine.CAASManifolds(machine.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["lease-manager"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{
+			"db-accessor",
+			"trace",
+		})
+		checkNotContains(c, manifold.Inputs, "agent")
+		checkNotContains(c, manifold.Inputs, "clock")
+	}
+}
+
 func (*ManifoldsSuite) TestObjectStoreDrainerDirectInputs(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		machine.IAASManifolds(machine.ManifoldsConfig{
@@ -693,7 +715,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -727,7 +748,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -784,7 +804,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -848,7 +867,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -876,7 +894,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -918,7 +935,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"api-remote-caller",
 		"certificate-watcher",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -966,7 +982,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -997,7 +1012,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1031,7 +1045,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1089,7 +1102,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-caller",
 		"api-config-watcher",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"is-controller-flag",
@@ -1221,7 +1233,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 
 	"is-primary-controller-flag": {
 		"agent",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"is-controller-flag",
@@ -1235,7 +1246,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1261,7 +1271,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 
 	"lease-expiry": {
 		"agent",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"is-controller-flag",
@@ -1274,7 +1283,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 
 	"lease-manager": {
 		"agent",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"is-controller-flag",
@@ -1375,7 +1383,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"api-remote-relation-caller",
 		"certificate-watcher",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1432,7 +1439,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -1454,7 +1460,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -1477,7 +1482,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -1543,7 +1547,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1578,7 +1581,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -1629,7 +1631,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1708,7 +1709,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1742,7 +1742,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1817,7 +1816,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"api-remote-caller",
 		"api-config-watcher",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1882,7 +1880,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"api-remote-caller",
 		"api-config-watcher",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1916,7 +1913,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1961,7 +1957,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2025,7 +2020,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2053,7 +2047,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2098,7 +2091,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2129,7 +2121,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2163,7 +2154,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2199,7 +2189,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-caller",
 		"api-config-watcher",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"is-controller-flag",
@@ -2321,7 +2310,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 
 	"is-primary-controller-flag": {
 		"agent",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"is-controller-flag",
@@ -2335,7 +2323,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2361,7 +2348,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 
 	"lease-expiry": {
 		"agent",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"is-controller-flag",
@@ -2374,7 +2360,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 
 	"lease-manager": {
 		"agent",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"is-controller-flag",
@@ -2427,7 +2412,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"api-remote-relation-caller",
 		"certificate-watcher",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2484,7 +2468,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -2506,7 +2489,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -2529,7 +2511,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -2583,7 +2564,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2618,7 +2598,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -2657,7 +2636,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2703,7 +2681,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -2778,7 +2755,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"api-remote-caller",
 		"api-config-watcher",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",

--- a/cmd/jujuagentd/agent/machine/manifolds_test.go
+++ b/cmd/jujuagentd/agent/machine/manifolds_test.go
@@ -501,6 +501,32 @@ func (*ManifoldsSuite) TestControllerOnlyWorkerDirectInputs(c *tc.C) {
 	}
 }
 
+func (*ManifoldsSuite) TestObjectStoreDirectInputs(c *tc.C) {
+	for _, manifolds := range []dependency.Manifolds{
+		machine.IAASManifolds(machine.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		machine.CAASManifolds(machine.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["object-store"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{
+			"trace",
+			"object-store-services",
+			"lease-manager",
+			"object-store-s3-caller",
+			"api-remote-caller",
+			"upgrade-database-flag",
+		})
+		checkNotContains(c, manifold.Inputs, "agent")
+		checkNotContains(c, manifold.Inputs, "clock")
+	}
+}
+
 func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *tc.C) {
 	ag := &mockAgent{
 		conf: mockConfig{

--- a/cmd/jujuagentd/agent/machine/manifolds_test.go
+++ b/cmd/jujuagentd/agent/machine/manifolds_test.go
@@ -527,6 +527,25 @@ func (*ManifoldsSuite) TestObjectStoreDirectInputs(c *tc.C) {
 	}
 }
 
+func (*ManifoldsSuite) TestObjectStoreServicesDirectInputs(c *tc.C) {
+	for _, manifolds := range []dependency.Manifolds{
+		machine.IAASManifolds(machine.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		machine.CAASManifolds(machine.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["object-store-services"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{"change-stream"})
+		checkNotContains(c, manifold.Inputs, "agent")
+		checkNotContains(c, manifold.Inputs, "clock")
+	}
+}
+
 func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *tc.C) {
 	ag := &mockAgent{
 		conf: mockConfig{

--- a/cmd/jujuagentd/agent/machine/manifolds_test.go
+++ b/cmd/jujuagentd/agent/machine/manifolds_test.go
@@ -546,6 +546,31 @@ func (*ManifoldsSuite) TestObjectStoreServicesDirectInputs(c *tc.C) {
 	}
 }
 
+func (*ManifoldsSuite) TestObjectStoreDrainerDirectInputs(c *tc.C) {
+	for _, manifolds := range []dependency.Manifolds{
+		machine.IAASManifolds(machine.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		machine.CAASManifolds(machine.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["object-store-drainer"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{
+			"is-primary-controller-flag",
+			"object-store-fortress",
+			"object-store",
+			"object-store-services",
+			"object-store-s3-caller",
+		})
+		checkNotContains(c, manifold.Inputs, "agent")
+		checkNotContains(c, manifold.Inputs, "clock")
+	}
+}
+
 func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *tc.C) {
 	ag := &mockAgent{
 		conf: mockConfig{

--- a/cmd/jujuagentd/agent/machine/manifolds_test.go
+++ b/cmd/jujuagentd/agent/machine/manifolds_test.go
@@ -571,6 +571,28 @@ func (*ManifoldsSuite) TestObjectStoreDrainerDirectInputs(c *tc.C) {
 	}
 }
 
+func (*ManifoldsSuite) TestLeaseExpiryDirectInputs(c *tc.C) {
+	for _, manifolds := range []dependency.Manifolds{
+		machine.IAASManifolds(machine.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		machine.CAASManifolds(machine.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["lease-expiry"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{
+			"db-accessor",
+			"trace",
+			"is-primary-controller-flag",
+		})
+		checkNotContains(c, manifold.Inputs, "clock")
+	}
+}
+
 func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *tc.C) {
 	ag := &mockAgent{
 		conf: mockConfig{

--- a/cmd/jujud/agent/agenttest/agent.go
+++ b/cmd/jujud/agent/agenttest/agent.go
@@ -105,8 +105,6 @@ func (s *AgentSuite) PrimeAgentVersion(c *tc.C, tag names.Tag, password string, 
 			OpenTelemetrySampleRatio:           controller.DefaultOpenTelemetrySampleRatio,
 			OpenTelemetryTailSamplingThreshold: controller.DefaultOpenTelemetryTailSamplingThreshold,
 
-			ObjectStoreType: controller.DefaultObjectStoreType,
-
 			DqlitePort: dqlitePort,
 		},
 	)
@@ -194,8 +192,6 @@ func (s *AgentSuite) WriteStateAgentConfig(
 			OpenTelemetryStackTraces:           controller.DefaultOpenTelemetryStackTraces,
 			OpenTelemetrySampleRatio:           controller.DefaultOpenTelemetrySampleRatio,
 			OpenTelemetryTailSamplingThreshold: controller.DefaultOpenTelemetryTailSamplingThreshold,
-
-			ObjectStoreType: controller.DefaultObjectStoreType,
 
 			DqlitePort: dqlitePort,
 		},

--- a/cmd/jujud/agent/bootstrap.go
+++ b/cmd/jujud/agent/bootstrap.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/core/objectstore"
 	coreos "github.com/juju/juju/core/os"
 	coreuser "github.com/juju/juju/core/user"
 	jujuversion "github.com/juju/juju/core/version"
@@ -291,7 +290,6 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 		agentConfig.SetOpenTelemetryStackTraces(args.ControllerConfig.OpenTelemetryStackTraces())
 		agentConfig.SetOpenTelemetrySampleRatio(args.ControllerConfig.OpenTelemetrySampleRatio())
 		agentConfig.SetOpenTelemetryTailSamplingThreshold(args.ControllerConfig.OpenTelemetryTailSamplingThreshold())
-		agentConfig.SetObjectStoreType(objectstore.FileBackend)
 
 		return nil
 	}); err != nil {

--- a/cmd/jujud/agent/controller.go
+++ b/cmd/jujud/agent/controller.go
@@ -414,6 +414,7 @@ func (a *ControllerAgent) makeEngineCreator(
 			PreviousAgentVersion:        previousAgentVersion,
 			AgentName:                   agentName,
 			ControllerID:                a.agentTag.Id(),
+			ObjectStoreRootDir:          controllerRuntimeConfig.DataDir,
 			ControllerRuntimeConfigPath: controllerRuntimeConfigPath,
 			ControllerAgentTag:          a.agentTag,
 			LogDir:                      controllerRuntimeConfig.LogDir,

--- a/cmd/jujud/agent/controller.go
+++ b/cmd/jujud/agent/controller.go
@@ -415,6 +415,8 @@ func (a *ControllerAgent) makeEngineCreator(
 			AgentName:                   agentName,
 			ControllerID:                a.agentTag.Id(),
 			ObjectStoreRootDir:          controllerRuntimeConfig.DataDir,
+			ControllerUUID:              controllerRuntimeConfig.ControllerUUID,
+			ControllerModelUUID:         controllerRuntimeConfig.ControllerModelUUID,
 			ControllerRuntimeConfigPath: controllerRuntimeConfigPath,
 			ControllerAgentTag:          a.agentTag,
 			LogDir:                      controllerRuntimeConfig.LogDir,

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -692,10 +692,10 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// draining in progress.
 		objectStoreFortressName: fortress.Manifold(),
 		objectStoreDrainerName: objectstoredrainer.Manifold(objectstoredrainer.ManifoldConfig{
-			AgentName:                       agentName,
 			S3ClientName:                    objectStoreS3CallerName,
 			ObjectStoreName:                 objectStoreName,
 			ObjectStoreServicesName:         objectStoreServicesName,
+			ObjectStoreRootDir:              config.ObjectStoreRootDir,
 			FortressName:                    objectStoreFortressName,
 			GetControllerService:            objectstoredrainer.GetControllerService,
 			GeObjectStoreServices:           objectstoredrainer.GeObjectStoreServicesGetter,
@@ -707,7 +707,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			SelectFileHash:                  internalobjectstore.SelectFileHash,
 			NewWorker:                       objectstoredrainer.NewWorker,
 			Logger:                          internallogger.GetLogger("juju.worker.objectstoredrainer"),
-			Clock:                           config.Clock,
 		}),
 
 		objectStoreName: ifDatabaseUpgradeComplete(objectstore.Manifold(objectstore.ManifoldConfig{

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -125,6 +125,18 @@ type ManifoldsConfig struct {
 	// manifolds instead of being read from agent config.
 	ObjectStoreRootDir string
 
+	// ControllerUUID is the controller entity UUID. It is sourced from
+	// agentConfig.Controller().Id() in makeEngineCreator and passed
+	// directly to the lease-manager manifold instead of being looked
+	// up from agent config at worker start.
+	ControllerUUID string
+
+	// ControllerModelUUID is the controller model UUID. It is sourced
+	// from agentConfig.Model().Id() in makeEngineCreator and passed
+	// directly to the lease-manager manifold instead of being looked
+	// up from agent config at worker start.
+	ControllerModelUUID string
+
 	// ControllerRuntimeConfigPath is the absolute path to the
 	// controller runtime config file (runtime.conf) written at
 	// bootstrap. It is passed to the db-accessor manifold so that the
@@ -642,12 +654,12 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The global lease manager tracks lease information in the
 		// Dqlite database.
 		leaseManagerName: leasemanager.Manifold(leasemanager.ManifoldConfig{
-			AgentName:            agentName,
-			ClockName:            clockName,
 			DBAccessorName:       dbAccessorName,
 			TraceName:            traceName,
+			ControllerUUID:       config.ControllerUUID,
+			ControllerModelUUID:  config.ControllerModelUUID,
 			Logger:               internallogger.GetLogger("juju.worker.lease"),
-			LogDir:               agentConfig.LogDir(),
+			LogDir:               config.LogDir,
 			PrometheusRegisterer: config.PrometheusRegisterer,
 			NewWorker:            leasemanager.NewWorker,
 			NewStore:             leasemanager.NewStore,

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -119,6 +119,12 @@ type ManifoldsConfig struct {
 	// the lookup.
 	ControllerID string
 
+	// ObjectStoreRootDir is the local filesystem root used by the
+	// file-backed object-store worker. It is sourced from controller
+	// runtime config DataDir and passed directly to object-store
+	// manifolds instead of being read from agent config.
+	ObjectStoreRootDir string
+
 	// ControllerRuntimeConfigPath is the absolute path to the
 	// controller runtime config file (runtime.conf) written at
 	// bootstrap. It is passed to the db-accessor manifold so that the
@@ -705,13 +711,13 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 
 		objectStoreName: ifDatabaseUpgradeComplete(objectstore.Manifold(objectstore.ManifoldConfig{
-			AgentName:                  agentName,
 			TraceName:                  traceName,
 			ObjectStoreServicesName:    objectStoreServicesName,
 			LeaseManagerName:           leaseManagerName,
 			S3ClientName:               objectStoreS3CallerName,
 			APIRemoteCallerName:        apiRemoteCallerName,
-			Clock:                      config.Clock,
+			ObjectStoreRootDir:         config.ObjectStoreRootDir,
+			ControllerNodeID:           config.ControllerID,
 			Logger:                     internallogger.GetLogger("juju.worker.objectstore"),
 			NewObjectStoreWorker:       internalobjectstore.ObjectStoreFactory,
 			GetControllerConfigService: objectstore.GetControllerConfigService,

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -738,7 +738,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		objectStoreServicesName: objectstoreservices.Manifold(objectstoreservices.ManifoldConfig{
 			ChangeStreamName:             changeStreamName,
-			Clock:                        config.Clock,
 			Logger:                       internallogger.GetLogger("juju.worker.objectstoreservices"),
 			NewWorker:                    objectstoreservices.NewWorker,
 			NewObjectStoreServices:       objectstoreservices.NewObjectStoreServices,

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -646,6 +646,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		leaseExpiryName: ifPrimaryController(leaseexpiry.Manifold(leaseexpiry.ManifoldConfig{
 			DBAccessorName: dbAccessorName,
 			TraceName:      traceName,
+			Clock:          config.Clock,
 			Logger:         internallogger.GetLogger("juju.worker.leaseexpiry"),
 			NewWorker:      leaseexpiry.NewWorker,
 			NewStore:       leaseexpiry.NewStore,
@@ -658,6 +659,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			TraceName:            traceName,
 			ControllerUUID:       config.ControllerUUID,
 			ControllerModelUUID:  config.ControllerModelUUID,
+			Clock:                config.Clock,
 			Logger:               internallogger.GetLogger("juju.worker.lease"),
 			LogDir:               config.LogDir,
 			PrometheusRegisterer: config.PrometheusRegisterer,
@@ -717,6 +719,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewDrainerWorker:                objectstoredrainer.NewDrainWorker,
 			SelectFileHash:                  internalobjectstore.SelectFileHash,
 			NewWorker:                       objectstoredrainer.NewWorker,
+			Clock:                           config.Clock,
 			Logger:                          internallogger.GetLogger("juju.worker.objectstoredrainer"),
 		}),
 
@@ -728,6 +731,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APIRemoteCallerName:        apiRemoteCallerName,
 			ObjectStoreRootDir:         config.ObjectStoreRootDir,
 			ControllerNodeID:           config.ControllerID,
+			Clock:                      config.Clock,
 			Logger:                     internallogger.GetLogger("juju.worker.objectstore"),
 			NewObjectStoreWorker:       internalobjectstore.ObjectStoreFactory,
 			GetControllerConfigService: objectstore.GetControllerConfigService,
@@ -748,6 +752,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		objectStoreServicesName: objectstoreservices.Manifold(objectstoreservices.ManifoldConfig{
 			ChangeStreamName:             changeStreamName,
+			Clock:                        config.Clock,
 			Logger:                       internallogger.GetLogger("juju.worker.objectstoreservices"),
 			NewWorker:                    objectstoreservices.NewWorker,
 			NewObjectStoreServices:       objectstoreservices.NewObjectStoreServices,

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -632,7 +632,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The lease expiry worker constantly deletes leases with an
 		// expiry time in the past.
 		leaseExpiryName: ifPrimaryController(leaseexpiry.Manifold(leaseexpiry.ManifoldConfig{
-			ClockName:      clockName,
 			DBAccessorName: dbAccessorName,
 			TraceName:      traceName,
 			Logger:         internallogger.GetLogger("juju.worker.leaseexpiry"),

--- a/cmd/jujud/agent/controller/manifolds_test.go
+++ b/cmd/jujud/agent/controller/manifolds_test.go
@@ -473,6 +473,28 @@ func (*ManifoldsSuite) TestLeaseExpiryDirectInputs(c *tc.C) {
 	}
 }
 
+func (*ManifoldsSuite) TestLeaseManagerDirectInputs(c *tc.C) {
+	for _, manifolds := range []dependency.Manifolds{
+		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["lease-manager"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{
+			"db-accessor",
+			"trace",
+		})
+		checkNotContains(c, manifold.Inputs, "agent")
+		checkNotContains(c, manifold.Inputs, "clock")
+	}
+}
+
 func (*ManifoldsSuite) TestOutOfScopeWorkersUseControllerUpgradeGate(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
@@ -612,7 +634,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -640,7 +661,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -681,7 +701,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
@@ -745,7 +764,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -771,7 +789,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -799,7 +816,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"api-remote-caller",
 		"certificate-watcher",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
@@ -840,7 +856,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -873,7 +888,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -901,7 +915,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -932,7 +945,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -957,7 +969,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-caller",
 		"api-config-watcher",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"is-primary-controller-flag",
@@ -1046,7 +1057,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 
 	"is-primary-controller-flag": {
 		"agent",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"lease-manager",
@@ -1058,7 +1068,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1082,7 +1091,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 
 	"lease-expiry": {
 		"agent",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"is-primary-controller-flag",
@@ -1093,7 +1101,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 
 	"lease-manager": {
 		"agent",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"query-logger",
@@ -1108,7 +1115,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1155,7 +1161,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"api-remote-relation-caller",
 		"certificate-watcher",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
@@ -1189,7 +1194,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -1209,7 +1213,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -1229,7 +1232,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
@@ -1289,7 +1291,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1326,7 +1327,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1367,7 +1367,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"agent",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"db-accessor",
 		"domain-services",
@@ -1430,7 +1429,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
-		"clock",
 		"controller-agent-config",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",

--- a/cmd/jujud/agent/controller/manifolds_test.go
+++ b/cmd/jujud/agent/controller/manifolds_test.go
@@ -408,6 +408,25 @@ func (*ManifoldsSuite) TestObjectStoreDirectInputs(c *tc.C) {
 	}
 }
 
+func (*ManifoldsSuite) TestObjectStoreServicesDirectInputs(c *tc.C) {
+	for _, manifolds := range []dependency.Manifolds{
+		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["object-store-services"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{"change-stream"})
+		checkNotContains(c, manifold.Inputs, "agent")
+		checkNotContains(c, manifold.Inputs, "clock")
+	}
+}
+
 func (*ManifoldsSuite) TestOutOfScopeWorkersUseControllerUpgradeGate(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{

--- a/cmd/jujud/agent/controller/manifolds_test.go
+++ b/cmd/jujud/agent/controller/manifolds_test.go
@@ -451,6 +451,28 @@ func (*ManifoldsSuite) TestObjectStoreDrainerDirectInputs(c *tc.C) {
 	}
 }
 
+func (*ManifoldsSuite) TestLeaseExpiryDirectInputs(c *tc.C) {
+	for _, manifolds := range []dependency.Manifolds{
+		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["lease-expiry"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{
+			"db-accessor",
+			"trace",
+			"is-primary-controller-flag",
+		})
+		checkNotContains(c, manifold.Inputs, "clock")
+	}
+}
+
 func (*ManifoldsSuite) TestOutOfScopeWorkersUseControllerUpgradeGate(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{

--- a/cmd/jujud/agent/controller/manifolds_test.go
+++ b/cmd/jujud/agent/controller/manifolds_test.go
@@ -382,6 +382,32 @@ func (*ManifoldsSuite) TestControllerOnlyWorkerDirectInputs(c *tc.C) {
 	}
 }
 
+func (*ManifoldsSuite) TestObjectStoreDirectInputs(c *tc.C) {
+	for _, manifolds := range []dependency.Manifolds{
+		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["object-store"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{
+			"trace",
+			"object-store-services",
+			"lease-manager",
+			"object-store-s3-caller",
+			"api-remote-caller",
+			"upgrade-database-flag",
+		})
+		checkNotContains(c, manifold.Inputs, "agent")
+		checkNotContains(c, manifold.Inputs, "clock")
+	}
+}
+
 func (*ManifoldsSuite) TestOutOfScopeWorkersUseControllerUpgradeGate(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{

--- a/cmd/jujud/agent/controller/manifolds_test.go
+++ b/cmd/jujud/agent/controller/manifolds_test.go
@@ -427,6 +427,30 @@ func (*ManifoldsSuite) TestObjectStoreServicesDirectInputs(c *tc.C) {
 	}
 }
 
+func (*ManifoldsSuite) TestObjectStoreDrainerDirectInputs(c *tc.C) {
+	for _, manifolds := range []dependency.Manifolds{
+		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
+			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			PreUpgradeSteps: preUpgradeSteps,
+		}),
+	} {
+		manifold, ok := manifolds["object-store-drainer"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(manifold.Inputs, tc.SameContents, []string{
+			"object-store-fortress",
+			"object-store",
+			"object-store-services",
+			"object-store-s3-caller",
+		})
+		checkNotContains(c, manifold.Inputs, "agent")
+		checkNotContains(c, manifold.Inputs, "clock")
+	}
+}
+
 func (*ManifoldsSuite) TestOutOfScopeWorkersUseControllerUpgradeGate(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{

--- a/internal/cloudconfig/userdatacfg.go
+++ b/internal/cloudconfig/userdatacfg.go
@@ -501,6 +501,8 @@ func (w *userdataConfig) configureBootstrap() error {
 	)
 	runtimeCfg := controllerruntimeconfig.ControllerRuntimeConfig{
 		ControllerID:          agent.BootstrapControllerId,
+		ControllerUUID:        w.icfg.ControllerTag.Id(),
+		ControllerModelUUID:   w.icfg.APIInfo.ModelTag.Id(),
 		DataDir:               w.icfg.DataDir,
 		LogDir:                w.icfg.LogDir,
 		QueryTracingEnabled:   w.icfg.ControllerConfig.QueryTracingEnabled(),

--- a/internal/controllerruntimeconfig/config.go
+++ b/internal/controllerruntimeconfig/config.go
@@ -36,6 +36,12 @@ type ControllerRuntimeConfig struct {
 	// ControllerID is the numeric controller agent ID, e.g. "0".
 	ControllerID string `yaml:"controller-id"`
 
+	// ControllerUUID is the UUID of the controller.
+	ControllerUUID string `yaml:"controller-uuid"`
+
+	// ControllerModelUUID is the UUID of the controller model.
+	ControllerModelUUID string `yaml:"controller-model-uuid"`
+
 	// DataDir is the Dqlite data directory root.
 	DataDir string `yaml:"data-dir"`
 
@@ -76,6 +82,12 @@ type ControllerRuntimeConfig struct {
 func (cfg ControllerRuntimeConfig) Validate() error {
 	if !names.IsValidControllerAgent(cfg.ControllerID) {
 		return errors.NotValidf("controller ID %q", cfg.ControllerID)
+	}
+	if !names.IsValidController(cfg.ControllerUUID) {
+		return errors.NotValidf("controller UUID %q", cfg.ControllerUUID)
+	}
+	if !names.IsValidModel(cfg.ControllerModelUUID) {
+		return errors.NotValidf("controller model UUID %q", cfg.ControllerModelUUID)
 	}
 	if cfg.DataDir == "" {
 		return errors.NotValidf("empty data-dir")

--- a/internal/controllerruntimeconfig/config_test.go
+++ b/internal/controllerruntimeconfig/config_test.go
@@ -28,6 +28,8 @@ func TestConfigSuite(t *testing.T) {
 func validConfig() controllerruntimeconfig.ControllerRuntimeConfig {
 	return controllerruntimeconfig.ControllerRuntimeConfig{
 		ControllerID:          "0",
+		ControllerUUID:        "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		ControllerModelUUID:   "feedface-dead-beef-cafe-c0ffee000000",
 		DataDir:               "/var/lib/juju",
 		LogDir:                "/var/log/juju",
 		QueryTracingEnabled:   true,
@@ -75,6 +77,22 @@ func (s *configSuite) TestValidate_EmptyControllerID(c *tc.C) {
 	cfg := validConfig()
 	cfg.ControllerID = ""
 	c.Check(cfg.Validate(), tc.ErrorMatches, `controller ID "" not valid`)
+}
+
+// TestValidate_EmptyControllerUUID ensures an empty controller UUID is
+// rejected.
+func (s *configSuite) TestValidate_EmptyControllerUUID(c *tc.C) {
+	cfg := validConfig()
+	cfg.ControllerUUID = ""
+	c.Check(cfg.Validate(), tc.ErrorMatches, `controller UUID "" not valid`)
+}
+
+// TestValidate_EmptyControllerModelUUID ensures an empty controller model UUID
+// is rejected.
+func (s *configSuite) TestValidate_EmptyControllerModelUUID(c *tc.C) {
+	cfg := validConfig()
+	cfg.ControllerModelUUID = ""
+	c.Check(cfg.Validate(), tc.ErrorMatches, `controller model UUID "" not valid`)
 }
 
 // TestValidate_EmptyDataDir ensures an empty data dir is rejected.
@@ -201,6 +219,8 @@ func (s *configSuite) TestWriteAndReadRoundTrip_AllNodeManagerFields(c *tc.C) {
 	path := filepath.Join(dir, controllerruntimeconfig.Filename)
 	cfg := controllerruntimeconfig.ControllerRuntimeConfig{
 		ControllerID:          "0",
+		ControllerUUID:        "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		ControllerModelUUID:   "feedface-dead-beef-cafe-c0ffee000000",
 		DataDir:               "/var/lib/juju",
 		LogDir:                "/var/log/juju",
 		DqlitePort:            0, // default
@@ -218,6 +238,8 @@ func (s *configSuite) TestWriteAndReadRoundTrip_AllNodeManagerFields(c *tc.C) {
 	got, err := controllerruntimeconfig.ReadControllerRuntimeConfig(path)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got.ControllerID, tc.Equals, cfg.ControllerID)
+	c.Check(got.ControllerUUID, tc.Equals, cfg.ControllerUUID)
+	c.Check(got.ControllerModelUUID, tc.Equals, cfg.ControllerModelUUID)
 	c.Check(got.DataDir, tc.Equals, cfg.DataDir)
 	c.Check(got.LogDir, tc.Equals, cfg.LogDir)
 	c.Check(got.CACert, tc.Equals, cfg.CACert)
@@ -288,6 +310,8 @@ func (s *configSuite) TestRead_MissingRequiredField(c *tc.C) {
 	// Write config without the required ca-cert field.
 	content := `
 controller-id: "0"
+controller-uuid: "deadbeef-0bad-400d-8000-4b1d0d06f00d"
+controller-model-uuid: "feedface-dead-beef-cafe-c0ffee000000"
 data-dir: /var/lib/juju
 log-dir: /var/log/juju
 controller-cert: cert-pem

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -722,6 +722,8 @@ func (c *controllerStack) ensureControllerConfigmapAgentConf(ctx context.Context
 	// available, without requiring access to machine-agent config.
 	runtimeCfg := controllerruntimeconfig.ControllerRuntimeConfig{
 		ControllerID:          c.pcfg.ControllerId,
+		ControllerUUID:        c.pcfg.ControllerTag.Id(),
+		ControllerModelUUID:   c.pcfg.APIInfo.ModelTag.Id(),
 		DataDir:               c.pcfg.DataDir,
 		LogDir:                c.pcfg.LogDir,
 		QueryTracingEnabled:   c.pcfg.Controller.QueryTracingEnabled(),

--- a/internal/provider/kubernetes/export_test.go
+++ b/internal/provider/kubernetes/export_test.go
@@ -69,6 +69,8 @@ func (cs *controllerStack) GetControllerUnitAgentConfigContent(c *tc.C) string {
 func (cs *controllerStack) GetControllerRuntimeConfigContent(c *tc.C) string {
 	runtimeCfg := controllerruntimeconfig.ControllerRuntimeConfig{
 		ControllerID:          cs.pcfg.ControllerId,
+		ControllerUUID:        cs.pcfg.ControllerTag.Id(),
+		ControllerModelUUID:   cs.pcfg.APIInfo.ModelTag.Id(),
 		DataDir:               cs.pcfg.DataDir,
 		LogDir:                cs.pcfg.LogDir,
 		QueryTracingEnabled:   cs.pcfg.Controller.QueryTracingEnabled(),

--- a/internal/worker/lease/manifold.go
+++ b/internal/worker/lease/manifold.go
@@ -44,6 +44,7 @@ type ManifoldConfig struct {
 	// the trace namespace for the lease manager.
 	ControllerModelUUID string
 
+	Clock                clock.Clock
 	Logger               logger.Logger
 	LogDir               string
 	PrometheusRegisterer prometheus.Registerer
@@ -65,6 +66,9 @@ func (c ManifoldConfig) Validate() error {
 	}
 	if c.TraceName == "" {
 		return errors.NotValidf("empty TraceName")
+	}
+	if c.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	if c.Logger == nil {
 		return errors.NotValidf("nil Logger")
@@ -118,7 +122,7 @@ func (s *manifoldState) start(ctx context.Context, getter dependency.Getter) (wo
 		SecretaryFinder:      s.config.NewSecretaryFinder(controllerUUID),
 		Store:                store,
 		Tracer:               tracer,
-		Clock:                clock.WallClock,
+		Clock:                s.config.Clock,
 		Logger:               s.config.Logger,
 		MaxSleep:             MaxSleep,
 		EntityUUID:           controllerUUID,

--- a/internal/worker/lease/manifold.go
+++ b/internal/worker/lease/manifold.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/logger"
@@ -34,10 +33,16 @@ const (
 // ManifoldConfig holds the resources needed to start the lease
 // manager in a dependency engine.
 type ManifoldConfig struct {
-	AgentName      string
-	ClockName      string
 	DBAccessorName string
 	TraceName      string
+
+	// ControllerUUID is the controller entity UUID used by the
+	// secretary finder and passed as the lease entity UUID.
+	ControllerUUID string
+
+	// ControllerModelUUID is the controller model UUID used to build
+	// the trace namespace for the lease manager.
+	ControllerModelUUID string
 
 	Logger               logger.Logger
 	LogDir               string
@@ -49,11 +54,11 @@ type ManifoldConfig struct {
 
 // Validate checks that the config has all the required values.
 func (c ManifoldConfig) Validate() error {
-	if c.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
+	if c.ControllerUUID == "" {
+		return errors.NotValidf("empty ControllerUUID")
 	}
-	if c.ClockName == "" {
-		return errors.NotValidf("empty ClockName")
+	if c.ControllerModelUUID == "" {
+		return errors.NotValidf("empty ControllerModelUUID")
 	}
 	if c.DBAccessorName == "" {
 		return errors.NotValidf("empty DBAccessor")
@@ -63,6 +68,9 @@ func (c ManifoldConfig) Validate() error {
 	}
 	if c.Logger == nil {
 		return errors.NotValidf("nil Logger")
+	}
+	if c.LogDir == "" {
+		return errors.NotValidf("empty LogDir")
 	}
 	if c.NewSecretaryFinder == nil {
 		return errors.NotValidf("nil NewSecretaryFinder")
@@ -88,16 +96,6 @@ func (s *manifoldState) start(ctx context.Context, getter dependency.Getter) (wo
 		return nil, errors.Trace(err)
 	}
 
-	var agent agent.Agent
-	if err := getter.Get(s.config.AgentName, &agent); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var clock clock.Clock
-	if err := getter.Get(s.config.ClockName, &clock); err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	var dbGetter database.DBGetter
 	if err := getter.Get(s.config.DBAccessorName, &dbGetter); err != nil {
 		return nil, errors.Trace(err)
@@ -108,21 +106,19 @@ func (s *manifoldState) start(ctx context.Context, getter dependency.Getter) (wo
 		return nil, errors.Trace(err)
 	}
 
-	currentConfig := agent.CurrentConfig()
-
-	tracer, err := tracerGetter.GetTracer(ctx, coretrace.Namespace("leaseexpiry", currentConfig.Model().Id()))
+	tracer, err := tracerGetter.GetTracer(ctx, coretrace.Namespace("leaseexpiry", s.config.ControllerModelUUID))
 	if err != nil {
 		tracer = coretrace.NoopTracer{}
 	}
 
 	store := s.config.NewStore(dbGetter, s.config.Logger)
 
-	controllerUUID := currentConfig.Controller().Id()
+	controllerUUID := s.config.ControllerUUID
 	w, err := s.config.NewWorker(ManagerConfig{
 		SecretaryFinder:      s.config.NewSecretaryFinder(controllerUUID),
 		Store:                store,
 		Tracer:               tracer,
-		Clock:                clock,
+		Clock:                clock.WallClock,
 		Logger:               s.config.Logger,
 		MaxSleep:             MaxSleep,
 		EntityUUID:           controllerUUID,
@@ -154,8 +150,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 	s := manifoldState{config: config}
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
-			config.ClockName,
 			config.DBAccessorName,
 			config.TraceName,
 		},

--- a/internal/worker/lease/manifold_test.go
+++ b/internal/worker/lease/manifold_test.go
@@ -6,6 +6,7 @@ package lease
 import (
 	"testing"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
@@ -45,6 +46,10 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
+	cfg.Clock = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
 	cfg.Logger = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -71,11 +76,11 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
-		ControllerUUID:      "ctrl-uuid-1234",
-		ControllerModelUUID: "ctrl-model-uuid-5678",
-		DBAccessorName:      "dbaccessor",
-		TraceName:           "trace",
-
+		ControllerUUID:       "ctrl-uuid-1234",
+		ControllerModelUUID:  "ctrl-model-uuid-5678",
+		DBAccessorName:       "dbaccessor",
+		TraceName:            "trace",
+		Clock:                clock.WallClock,
 		Logger:               s.logger,
 		LogDir:               "/var/log/juju",
 		PrometheusRegisterer: s.prometheusRegisterer,

--- a/internal/worker/lease/manifold_test.go
+++ b/internal/worker/lease/manifold_test.go
@@ -29,42 +29,55 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	cfg := s.getConfig()
 	c.Check(cfg.Validate(), tc.ErrorIsNil)
 
-	cfg.AgentName = ""
+	cfg.ControllerUUID = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
-	cfg.ClockName = ""
+	cfg = s.getConfig()
+	cfg.ControllerModelUUID = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
+	cfg = s.getConfig()
 	cfg.DBAccessorName = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
+	cfg = s.getConfig()
 	cfg.TraceName = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
+	cfg = s.getConfig()
 	cfg.Logger = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
+	cfg = s.getConfig()
+	cfg.LogDir = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
 	cfg.PrometheusRegisterer = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
+	cfg = s.getConfig()
 	cfg.NewWorker = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
+	cfg = s.getConfig()
 	cfg.NewStore = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
+	cfg = s.getConfig()
 	cfg.NewSecretaryFinder = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 }
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
-		AgentName:      "agent",
-		ClockName:      "clock",
-		DBAccessorName: "dbaccessor",
-		TraceName:      "trace",
+		ControllerUUID:      "ctrl-uuid-1234",
+		ControllerModelUUID: "ctrl-model-uuid-5678",
+		DBAccessorName:      "dbaccessor",
+		TraceName:           "trace",
 
 		Logger:               s.logger,
+		LogDir:               "/var/log/juju",
 		PrometheusRegisterer: s.prometheusRegisterer,
 		NewWorker: func(mc ManagerConfig) (worker.Worker, error) {
 			return nil, nil

--- a/internal/worker/leaseexpiry/manifold.go
+++ b/internal/worker/leaseexpiry/manifold.go
@@ -26,6 +26,7 @@ type ManifoldConfig struct {
 	DBAccessorName string
 	TraceName      string
 
+	Clock  clock.Clock
 	Logger logger.Logger
 
 	NewWorker func(Config) (worker.Worker, error)
@@ -39,6 +40,9 @@ func (c ManifoldConfig) Validate() error {
 	}
 	if c.TraceName == "" {
 		return errors.NotValidf("empty TraceName")
+	}
+	if c.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	if c.Logger == nil {
 		return errors.NotValidf("nil Logger")
@@ -75,7 +79,7 @@ func (c ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (wo
 	store := c.NewStore(dbGetter, c.Logger)
 
 	w, err := c.NewWorker(Config{
-		Clock:  clock.WallClock,
+		Clock:  c.Clock,
 		Logger: c.Logger,
 		Store:  store,
 		Tracer: tracer,

--- a/internal/worker/leaseexpiry/manifold.go
+++ b/internal/worker/leaseexpiry/manifold.go
@@ -23,7 +23,6 @@ import (
 // ManifoldConfig holds the resources required
 // to start the lease expiry worker.
 type ManifoldConfig struct {
-	ClockName      string
 	DBAccessorName string
 	TraceName      string
 
@@ -35,9 +34,6 @@ type ManifoldConfig struct {
 
 // Validate checks that the config has all the required values.
 func (c ManifoldConfig) Validate() error {
-	if c.ClockName == "" {
-		return errors.NotValidf("empty ClockName")
-	}
 	if c.DBAccessorName == "" {
 		return errors.NotValidf("empty DBAccessorName")
 	}
@@ -61,11 +57,6 @@ func (c ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (wo
 		return nil, errors.Trace(err)
 	}
 
-	var clk clock.Clock
-	if err := getter.Get(c.ClockName, &clk); err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	var dbGetter database.DBGetter
 	if err := getter.Get(c.DBAccessorName, &dbGetter); err != nil {
 		return nil, errors.Trace(err)
@@ -83,8 +74,8 @@ func (c ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (wo
 
 	store := c.NewStore(dbGetter, c.Logger)
 
-	w, err := NewWorker(Config{
-		Clock:  clk,
+	w, err := c.NewWorker(Config{
+		Clock:  clock.WallClock,
 		Logger: c.Logger,
 		Store:  store,
 		Tracer: tracer,
@@ -100,7 +91,6 @@ func (c ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (wo
 func Manifold(cfg ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			cfg.ClockName,
 			cfg.DBAccessorName,
 			cfg.TraceName,
 		},

--- a/internal/worker/leaseexpiry/manifold_test.go
+++ b/internal/worker/leaseexpiry/manifold_test.go
@@ -55,6 +55,10 @@ func (s *manifoldSuite) TestConfigValidate(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = validCfg
+	cfg.Clock = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = validCfg
 	cfg.Logger = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -100,6 +104,7 @@ func (s *manifoldSuite) newManifoldConfig(c *tc.C) leaseexpiry.ManifoldConfig {
 	return leaseexpiry.ManifoldConfig{
 		DBAccessorName: "db-accessor-name",
 		TraceName:      "trace-name",
+		Clock:          clock.WallClock,
 		Logger:         loggertesting.WrapCheckLog(c),
 		NewWorker: func(config leaseexpiry.Config) (worker.Worker, error) {
 			return workertest.NewErrorWorker(nil), nil

--- a/internal/worker/leaseexpiry/manifold_test.go
+++ b/internal/worker/leaseexpiry/manifold_test.go
@@ -40,17 +40,13 @@ func TestManifoldSuite(t *testing.T) {
 func (s *manifoldSuite) TestInputs(c *tc.C) {
 	cfg := s.newManifoldConfig(c)
 
-	c.Check(leaseexpiry.Manifold(cfg).Inputs, tc.DeepEquals, []string{"clock-name", "db-accessor-name", "trace-name"})
+	c.Check(leaseexpiry.Manifold(cfg).Inputs, tc.DeepEquals, []string{"db-accessor-name", "trace-name"})
 }
 
 func (s *manifoldSuite) TestConfigValidate(c *tc.C) {
 	validCfg := s.newManifoldConfig(c)
 
 	cfg := validCfg
-	cfg.ClockName = ""
-	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
-
-	cfg = validCfg
 	cfg.DBAccessorName = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -93,7 +89,6 @@ func (s *manifoldSuite) setupMocks(c *tc.C) *gomock.Controller {
 
 func (s *manifoldSuite) newGetter() *dt.Getter {
 	return dt.StubGetter(map[string]any{
-		"clock-name":       clock.WallClock,
 		"db-accessor-name": stubDBGetter{runner: noopTxnRunner{}},
 		"trace-name":       stubTracerGetter{},
 	})
@@ -103,15 +98,33 @@ func (s *manifoldSuite) newGetter() *dt.Getter {
 // the supplied arguments.
 func (s *manifoldSuite) newManifoldConfig(c *tc.C) leaseexpiry.ManifoldConfig {
 	return leaseexpiry.ManifoldConfig{
-		ClockName:      "clock-name",
 		DBAccessorName: "db-accessor-name",
 		TraceName:      "trace-name",
 		Logger:         loggertesting.WrapCheckLog(c),
-		NewWorker:      func(config leaseexpiry.Config) (worker.Worker, error) { return nil, nil },
+		NewWorker: func(config leaseexpiry.Config) (worker.Worker, error) {
+			return workertest.NewErrorWorker(nil), nil
+		},
 		NewStore: func(db coredatabase.DBGetter, logger logger.Logger) lease.ExpiryStore {
 			return s.store
 		},
 	}
+}
+
+func (s *manifoldSuite) TestStartUsesWallClock(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cfg := s.newManifoldConfig(c)
+	newWorkerCalled := false
+	cfg.NewWorker = func(workerCfg leaseexpiry.Config) (worker.Worker, error) {
+		newWorkerCalled = true
+		c.Check(workerCfg.Clock, tc.Equals, clock.WallClock)
+		return workertest.NewErrorWorker(nil), nil
+	}
+
+	work, err := leaseexpiry.Manifold(cfg).Start(c.Context(), s.newGetter())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(newWorkerCalled, tc.IsTrue)
+	workertest.CleanKill(c, work)
 }
 
 type stubDBGetter struct {

--- a/internal/worker/objectstore/manifold.go
+++ b/internal/worker/objectstore/manifold.go
@@ -106,6 +106,7 @@ type ManifoldConfig struct {
 	// agent config tag.
 	ControllerNodeID string
 
+	Clock                      clock.Clock
 	Logger                     logger.Logger
 	NewObjectStoreWorker       objectstore.ObjectStoreWorkerFunc
 	GetControllerConfigService GetControllerConfigServiceFunc
@@ -151,6 +152,9 @@ func (cfg ManifoldConfig) Validate() error {
 	}
 	if cfg.Logger == nil {
 		return errors.NotValidf("nil Logger")
+	}
+	if cfg.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	if cfg.NewObjectStoreWorker == nil {
 		return errors.NotValidf("nil NewObjectStoreWorker")
@@ -230,7 +234,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				TracerGetter:              tracerGetter,
 				RootDir:                   config.ObjectStoreRootDir,
 				RootBucket:                rootBucketName,
-				Clock:                     clock.WallClock,
+				Clock:                     config.Clock,
 				Logger:                    config.Logger,
 				NewObjectStoreWorker:      config.NewObjectStoreWorker,
 				NewTrackerWorker:          NewTrackerWorker,

--- a/internal/worker/objectstore/manifold.go
+++ b/internal/worker/objectstore/manifold.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/controller"
 	coredependency "github.com/juju/juju/core/dependency"
 	"github.com/juju/juju/core/lease"
@@ -91,14 +90,22 @@ type IsBootstrapControllerFunc func(dataDir string) bool
 
 // ManifoldConfig defines the configuration for the objectstore manifold.
 type ManifoldConfig struct {
-	AgentName               string
 	TraceName               string
 	ObjectStoreServicesName string
 	LeaseManagerName        string
 	S3ClientName            string
 	APIRemoteCallerName     string
 
-	Clock                      clock.Clock
+	// ObjectStoreRootDir is the local filesystem root used by the
+	// file-backed object-store. It is a controller-local startup value
+	// passed explicitly instead of being read from agent config.
+	ObjectStoreRootDir string
+
+	// ControllerNodeID is the numeric controller node identifier
+	// (e.g. "0") passed explicitly instead of being derived from
+	// agent config tag.
+	ControllerNodeID string
+
 	Logger                     logger.Logger
 	NewObjectStoreWorker       objectstore.ObjectStoreWorkerFunc
 	GetControllerConfigService GetControllerConfigServiceFunc
@@ -109,14 +116,17 @@ type ManifoldConfig struct {
 
 // Validate validates the manifold configuration.
 func (cfg ManifoldConfig) Validate() error {
-	if cfg.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
-	}
 	if cfg.TraceName == "" {
 		return errors.NotValidf("empty TraceName")
 	}
 	if cfg.ObjectStoreServicesName == "" {
 		return errors.NotValidf("empty ObjectStoreServicesName")
+	}
+	if cfg.ObjectStoreRootDir == "" {
+		return errors.NotValidf("empty ObjectStoreRootDir")
+	}
+	if cfg.ControllerNodeID == "" {
+		return errors.NotValidf("empty ControllerNodeID")
 	}
 	if cfg.GetControllerConfigService == nil {
 		return errors.NotValidf("nil GetControllerConfigService")
@@ -139,9 +149,6 @@ func (cfg ManifoldConfig) Validate() error {
 	if cfg.APIRemoteCallerName == "" {
 		return errors.NotValidf("empty APIRemoteCallerName")
 	}
-	if cfg.Clock == nil {
-		return errors.NotValidf("nil Clock")
-	}
 	if cfg.Logger == nil {
 		return errors.NotValidf("nil Logger")
 	}
@@ -155,7 +162,6 @@ func (cfg ManifoldConfig) Validate() error {
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
 			config.TraceName,
 			config.ObjectStoreServicesName,
 			config.LeaseManagerName,
@@ -166,11 +172,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 			if err := config.Validate(); err != nil {
 				return nil, errors.Trace(err)
-			}
-
-			var a agent.Agent
-			if err := getter.Get(config.AgentName, &a); err != nil {
-				return nil, err
 			}
 
 			var tracerGetter trace.TracerGetter
@@ -225,18 +226,11 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			currentConfig := a.CurrentConfig()
-			dataDir := currentConfig.DataDir()
-
-			// The controller node ID is the machine ID of the current
-			// controller.
-			controllerNodeID := currentConfig.Tag().Id()
-
 			w, err := NewWorker(WorkerConfig{
 				TracerGetter:              tracerGetter,
-				RootDir:                   dataDir,
+				RootDir:                   config.ObjectStoreRootDir,
 				RootBucket:                rootBucketName,
-				Clock:                     config.Clock,
+				Clock:                     clock.WallClock,
 				Logger:                    config.Logger,
 				NewObjectStoreWorker:      config.NewObjectStoreWorker,
 				NewTrackerWorker:          NewTrackerWorker,
@@ -254,8 +248,8 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				ModelClaimGetter: modelClaimGetter{
 					manager: leaseManager,
 				},
-				AllowDraining:    AllowDraining(backendInfo, config.IsBootstrapController(dataDir)),
-				ControllerNodeID: controllerNodeID,
+				AllowDraining:    AllowDraining(backendInfo, config.IsBootstrapController(config.ObjectStoreRootDir)),
+				ControllerNodeID: config.ControllerNodeID,
 			})
 			return w, errors.Trace(err)
 		},

--- a/internal/worker/objectstore/manifold_test.go
+++ b/internal/worker/objectstore/manifold_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	stdtesting "testing"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/dependency"
@@ -73,6 +74,10 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
+	cfg.Clock = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
 	cfg.NewObjectStoreWorker = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -102,6 +107,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		APIRemoteCallerName:     "api-remote-caller",
 		ObjectStoreRootDir:      "/var/lib/juju",
 		ControllerNodeID:        "0",
+		Clock:                   clock.WallClock,
 		Logger:                  s.logger,
 		NewObjectStoreWorker: func(context.Context, objectstore.BackendType, string, ...internalobjectstore.Option) (internalobjectstore.TrackedObjectStore, error) {
 			return nil, nil

--- a/internal/worker/objectstore/manifold_test.go
+++ b/internal/worker/objectstore/manifold_test.go
@@ -8,7 +8,6 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/errors"
-	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
@@ -42,10 +41,6 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIsNil)
 
 	cfg = s.getConfig()
-	cfg.AgentName = ""
-	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
-
-	cfg = s.getConfig()
 	cfg.TraceName = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -66,7 +61,11 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
-	cfg.Clock = nil
+	cfg.ObjectStoreRootDir = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.ControllerNodeID = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
@@ -88,17 +87,21 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	cfg = s.getConfig()
 	cfg.GetMetadataService = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.IsBootstrapController = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 }
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
-		AgentName:               "agent",
 		TraceName:               "trace",
 		ObjectStoreServicesName: "object-store-services",
 		LeaseManagerName:        "lease-manager",
 		S3ClientName:            "s3-client",
 		APIRemoteCallerName:     "api-remote-caller",
-		Clock:                   s.clock,
+		ObjectStoreRootDir:      "/var/lib/juju",
+		ControllerNodeID:        "0",
 		Logger:                  s.logger,
 		NewObjectStoreWorker: func(context.Context, objectstore.BackendType, string, ...internalobjectstore.Option) (internalobjectstore.TrackedObjectStore, error) {
 			return nil, nil
@@ -120,7 +123,6 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 
 func (s *manifoldSuite) newGetter() dependency.Getter {
 	resources := map[string]any{
-		"agent":                 s.agent,
 		"trace":                 &stubTracerGetter{},
 		"object-store-services": &stubObjectStoreServicesGetter{},
 		"lease-manager":         s.leaseManager,
@@ -130,7 +132,7 @@ func (s *manifoldSuite) newGetter() dependency.Getter {
 	return dependencytesting.StubGetter(resources)
 }
 
-var expectedInputs = []string{"agent", "trace", "object-store-services", "lease-manager", "s3-client", "api-remote-caller"}
+var expectedInputs = []string{"trace", "object-store-services", "lease-manager", "s3-client", "api-remote-caller"}
 
 func (s *manifoldSuite) TestInputs(c *tc.C) {
 	c.Assert(Manifold(s.getConfig()).Inputs, tc.SameContents, expectedInputs)
@@ -139,19 +141,12 @@ func (s *manifoldSuite) TestInputs(c *tc.C) {
 func (s *manifoldSuite) TestStart(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAgentConfig(c)
 	s.expectControllerConfig()
 	s.expectBackendInfo()
 
 	w, err := Manifold(s.getConfig()).Start(c.Context(), s.newGetter())
 	c.Assert(err, tc.ErrorIsNil)
 	workertest.CleanKill(c, w)
-}
-
-func (s *manifoldSuite) expectAgentConfig(c *tc.C) {
-	s.agent.EXPECT().CurrentConfig().Return(s.agentConfig)
-	s.agentConfig.EXPECT().DataDir().Return(c.MkDir())
-	s.agentConfig.EXPECT().Tag().Return(names.NewMachineTag("0"))
 }
 
 func (s *manifoldSuite) expectBackendInfo() {

--- a/internal/worker/objectstoredrainer/manifold.go
+++ b/internal/worker/objectstoredrainer/manifold.go
@@ -78,6 +78,7 @@ type ManifoldConfig struct {
 	NewDrainerWorker                NewDrainerWorkerFunc
 	SelectFileHash                  SelectFileHashFunc
 	ObjectStoreRootDir              string
+	Clock                           clock.Clock
 
 	Logger logger.Logger
 }
@@ -122,6 +123,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.ObjectStoreRootDir == "" {
 		return errors.NotValidf("empty ObjectStoreRootDir")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
@@ -198,7 +202,7 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		RootDir:                      config.ObjectStoreRootDir,
 		RootBucketName:               rootBucketName,
 		Logger:                       config.Logger,
-		Clock:                        clock.WallClock,
+		Clock:                        config.Clock,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/objectstoredrainer/manifold.go
+++ b/internal/worker/objectstoredrainer/manifold.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
@@ -64,7 +63,6 @@ type ControllerConfigService interface {
 // ManifoldConfig holds the dependencies and configuration for a
 // Worker manifold.
 type ManifoldConfig struct {
-	AgentName               string
 	ObjectStoreServicesName string
 	ObjectStoreName         string
 	FortressName            string
@@ -79,16 +77,13 @@ type ManifoldConfig struct {
 	NewHashFileSystemAccessor       NewHashFileSystemAccessorFunc
 	NewDrainerWorker                NewDrainerWorkerFunc
 	SelectFileHash                  SelectFileHashFunc
+	ObjectStoreRootDir              string
 
 	Logger logger.Logger
-	Clock  clock.Clock
 }
 
 // Validate is called by start to check for bad configuration.
 func (config ManifoldConfig) Validate() error {
-	if config.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
-	}
 	if config.FortressName == "" {
 		return errors.NotValidf("empty FortressName")
 	}
@@ -125,11 +120,11 @@ func (config ManifoldConfig) Validate() error {
 	if config.SelectFileHash == nil {
 		return errors.NotValidf("nil SelectFileHash")
 	}
+	if config.ObjectStoreRootDir == "" {
+		return errors.NotValidf("empty ObjectStoreRootDir")
+	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
-	}
-	if config.Clock == nil {
-		return errors.NotValidf("nil Clock")
 	}
 	return nil
 }
@@ -137,11 +132,6 @@ func (config ManifoldConfig) Validate() error {
 // start is a StartFunc for a Worker manifold.
 func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var a agent.Agent
-	if err := getter.Get(config.AgentName, &a); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -194,9 +184,6 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		return nil, errors.Trace(err)
 	}
 
-	currentConfig := a.CurrentConfig()
-	dataDir := currentConfig.DataDir()
-
 	worker, err := config.NewWorker(Config{
 		Guard:                        fortress,
 		DrainingService:              drainingService,
@@ -208,10 +195,10 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		NewDrainerWorker:             config.NewDrainerWorker,
 		SelectFileHash:               config.SelectFileHash,
 		S3Client:                     s3Client,
-		RootDir:                      dataDir,
+		RootDir:                      config.ObjectStoreRootDir,
 		RootBucketName:               rootBucketName,
 		Logger:                       config.Logger,
-		Clock:                        config.Clock,
+		Clock:                        clock.WallClock,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -223,7 +210,6 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
 			config.FortressName,
 			config.ObjectStoreName,
 			config.ObjectStoreServicesName,

--- a/internal/worker/objectstoredrainer/manifold_test.go
+++ b/internal/worker/objectstoredrainer/manifold_test.go
@@ -99,6 +99,10 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	cfg = s.getConfig(c)
 	cfg.Logger = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig(c)
+	cfg.Clock = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 }
 
 func (s *manifoldSuite) getConfig(c *tc.C) ManifoldConfig {
@@ -133,6 +137,7 @@ func (s *manifoldSuite) getConfig(c *tc.C) ManifoldConfig {
 			return workertest.NewErrorWorker(nil), nil
 		},
 		ObjectStoreRootDir: "/var/lib/juju",
+		Clock:              clock.WallClock,
 		Logger:             loggertesting.WrapCheckLog(c),
 	}
 }
@@ -219,6 +224,7 @@ func (s *manifoldSuite) getConfigWithRealWorker(c *tc.C) ManifoldConfig {
 		},
 		NewWorker:          NewWorker,
 		ObjectStoreRootDir: "/var/lib/juju",
+		Clock:              clock.WallClock,
 		Logger:             loggertesting.WrapCheckLog(c),
 	}
 }

--- a/internal/worker/objectstoredrainer/manifold_test.go
+++ b/internal/worker/objectstoredrainer/manifold_test.go
@@ -45,10 +45,6 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIsNil)
 
 	cfg = s.getConfig(c)
-	cfg.AgentName = ""
-	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
-
-	cfg = s.getConfig(c)
 	cfg.FortressName = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -89,6 +85,10 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig(c)
+	cfg.ObjectStoreRootDir = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig(c)
 	cfg.NewDrainerWorker = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -103,7 +103,6 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 
 func (s *manifoldSuite) getConfig(c *tc.C) ManifoldConfig {
 	return ManifoldConfig{
-		AgentName:               "agent",
 		FortressName:            "fortress",
 		ObjectStoreServicesName: "object-store-services",
 		ObjectStoreName:         "object-store",
@@ -133,14 +132,13 @@ func (s *manifoldSuite) getConfig(c *tc.C) ManifoldConfig {
 		NewWorker: func(config Config) (worker.Worker, error) {
 			return workertest.NewErrorWorker(nil), nil
 		},
-		Logger: loggertesting.WrapCheckLog(c),
-		Clock:  clock.WallClock,
+		ObjectStoreRootDir: "/var/lib/juju",
+		Logger:             loggertesting.WrapCheckLog(c),
 	}
 }
 
 func (s *manifoldSuite) newGetter() dependency.Getter {
 	resources := map[string]any{
-		"agent":                 s.agent,
 		"fortress":              s.guard,
 		"s3-client":             s.s3Client,
 		"object-store":          s.objectStoreFlusher,
@@ -149,7 +147,7 @@ func (s *manifoldSuite) newGetter() dependency.Getter {
 	return dependencytesting.StubGetter(resources)
 }
 
-var expectedInputs = []string{"agent", "fortress", "s3-client", "object-store-services", "object-store"}
+var expectedInputs = []string{"fortress", "s3-client", "object-store-services", "object-store"}
 
 func (s *manifoldSuite) TestInputs(c *tc.C) {
 	c.Assert(Manifold(s.getConfig(c)).Inputs, tc.SameContents, expectedInputs)
@@ -157,9 +155,6 @@ func (s *manifoldSuite) TestInputs(c *tc.C) {
 
 func (s *manifoldSuite) TestStart(c *tc.C) {
 	defer s.setupMocks(c).Finish()
-
-	s.agentConfig.EXPECT().DataDir().Return(c.MkDir())
-	s.agent.EXPECT().CurrentConfig().Return(s.agentConfig)
 
 	cfg := internaltesting.FakeControllerConfig()
 
@@ -194,7 +189,6 @@ func (s *stubObjectStoreServices) ObjectStore() *objectstoreservice.WatchableSer
 // crash-recovery flow.
 func (s *manifoldSuite) getConfigWithRealWorker(c *tc.C) ManifoldConfig {
 	return ManifoldConfig{
-		AgentName:               "agent",
 		FortressName:            "fortress",
 		ObjectStoreServicesName: "object-store-services",
 		ObjectStoreName:         "object-store",
@@ -223,19 +217,41 @@ func (s *manifoldSuite) getConfigWithRealWorker(c *tc.C) ManifoldConfig {
 		NewDrainerWorker: func(completed chan<- drainResult, fileSystem HashFileSystemAccessor, client objectstore.Client, metadataService objectstore.ObjectStoreMetadata, rootBucket, namespace string, selectFileHash SelectFileHashFunc, clk clock.Clock, logger logger.Logger) worker.Worker {
 			return newTestWorker(completed)
 		},
-		NewWorker: NewWorker,
-		Logger:    loggertesting.WrapCheckLog(c),
-		Clock:     clock.WallClock,
+		NewWorker:          NewWorker,
+		ObjectStoreRootDir: "/var/lib/juju",
+		Logger:             loggertesting.WrapCheckLog(c),
 	}
 }
 
 // setupManifoldStartExpectations sets up the common expectations for the
-// manifold start method (controller config, agent config, data dir).
+// manifold start method.
 func (s *manifoldSuite) setupManifoldStartExpectations(c *tc.C) {
 	cfg := internaltesting.FakeControllerConfig()
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(cfg, nil)
-	s.agentConfig.EXPECT().DataDir().Return(c.MkDir())
-	s.agent.EXPECT().CurrentConfig().Return(s.agentConfig)
+}
+
+func (s *manifoldSuite) TestStartUsesExplicitRootDirAndWallClock(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	rootDir := c.MkDir()
+	cfg := s.getConfig(c)
+	cfg.ObjectStoreRootDir = rootDir
+
+	newWorkerCalled := false
+	cfg.NewWorker = func(workerConfig Config) (worker.Worker, error) {
+		newWorkerCalled = true
+		c.Check(workerConfig.RootDir, tc.Equals, rootDir)
+		c.Check(workerConfig.Clock, tc.Equals, clock.WallClock)
+		return workertest.NewErrorWorker(nil), nil
+	}
+
+	controllerCfg := internaltesting.FakeControllerConfig()
+	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(controllerCfg, nil)
+
+	w, err := Manifold(cfg).Start(c.Context(), s.newGetter())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(newWorkerCalled, tc.IsTrue)
+	workertest.CleanKill(c, w)
 }
 
 // TestManifoldRecoverFromFlushWorkersCrash exercises the full manifold start →

--- a/internal/worker/objectstoreservices/manifold.go
+++ b/internal/worker/objectstoreservices/manifold.go
@@ -24,6 +24,7 @@ import (
 // worker in a dependency.Engine.
 type ManifoldConfig struct {
 	ChangeStreamName string
+	Clock            clock.Clock
 	Logger           logger.Logger
 	NewWorker        func(Config) (worker.Worker, error)
 
@@ -57,6 +58,9 @@ type ObjectStoreServicesFn func(
 func (config ManifoldConfig) Validate() error {
 	if config.ChangeStreamName == "" {
 		return errors.NotValidf("empty ChangeStreamName")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
 	}
 	if config.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
@@ -96,7 +100,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 
 	return config.NewWorker(Config{
 		DBGetter:                     dbGetter,
-		Clock:                        clock.WallClock,
+		Clock:                        config.Clock,
 		Logger:                       config.Logger,
 		NewObjectStoreServicesGetter: config.NewObjectStoreServicesGetter,
 		NewObjectStoreServices:       config.NewObjectStoreServices,

--- a/internal/worker/objectstoreservices/manifold.go
+++ b/internal/worker/objectstoreservices/manifold.go
@@ -24,7 +24,6 @@ import (
 // worker in a dependency.Engine.
 type ManifoldConfig struct {
 	ChangeStreamName string
-	Clock            clock.Clock
 	Logger           logger.Logger
 	NewWorker        func(Config) (worker.Worker, error)
 
@@ -68,9 +67,6 @@ func (config ManifoldConfig) Validate() error {
 	if config.NewObjectStoreServices == nil {
 		return errors.NotValidf("nil NewObjectStoreServices")
 	}
-	if config.Clock == nil {
-		return errors.NotValidf("nil Clock")
-	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
 	}
@@ -100,7 +96,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 
 	return config.NewWorker(Config{
 		DBGetter:                     dbGetter,
-		Clock:                        config.Clock,
+		Clock:                        clock.WallClock,
 		Logger:                       config.Logger,
 		NewObjectStoreServicesGetter: config.NewObjectStoreServicesGetter,
 		NewObjectStoreServices:       config.NewObjectStoreServices,

--- a/internal/worker/objectstoreservices/manifold_test.go
+++ b/internal/worker/objectstoreservices/manifold_test.go
@@ -34,10 +34,6 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIsNil)
 
 	cfg = s.getConfig()
-	cfg.Clock = nil
-	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
-
-	cfg = s.getConfig()
 	cfg.Logger = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -67,7 +63,6 @@ func (s *manifoldSuite) TestStart(c *tc.C) {
 
 	manifold := Manifold(ManifoldConfig{
 		ChangeStreamName:             "changestream",
-		Clock:                        clock.WallClock,
 		Logger:                       s.logger,
 		NewWorker:                    NewWorker,
 		NewObjectStoreServices:       NewObjectStoreServices,
@@ -78,6 +73,30 @@ func (s *manifoldSuite) TestStart(c *tc.C) {
 	defer workertest.DirtyKill(c, w)
 
 	workertest.CheckAlive(c, w)
+}
+
+func (s *manifoldSuite) TestStartUsesWallClock(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	getter := map[string]any{
+		"changestream": s.dbGetter,
+	}
+
+	var workerConfig Config
+	manifold := Manifold(ManifoldConfig{
+		ChangeStreamName: "changestream",
+		Logger:           s.logger,
+		NewWorker: func(cfg Config) (worker.Worker, error) {
+			workerConfig = cfg
+			return nil, nil
+		},
+		NewObjectStoreServices:       NewObjectStoreServices,
+		NewObjectStoreServicesGetter: NewObjectStoreServicesGetter,
+	})
+
+	_, err := manifold.Start(c.Context(), dt.StubGetter(getter))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(workerConfig.Clock, tc.Equals, clock.WallClock)
 }
 
 func (s *manifoldSuite) TestOutputObjectStoreServicesGetter(c *tc.C) {
@@ -123,7 +142,6 @@ func (s *manifoldSuite) TestOutputInvalid(c *tc.C) {
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
 		ChangeStreamName: "changestream",
-		Clock:            clock.WallClock,
 		Logger:           s.logger,
 		NewWorker: func(Config) (worker.Worker, error) {
 			return nil, nil

--- a/internal/worker/objectstoreservices/manifold_test.go
+++ b/internal/worker/objectstoreservices/manifold_test.go
@@ -42,6 +42,10 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
+	cfg.Clock = nil
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
 	cfg.NewWorker = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -63,6 +67,7 @@ func (s *manifoldSuite) TestStart(c *tc.C) {
 
 	manifold := Manifold(ManifoldConfig{
 		ChangeStreamName:             "changestream",
+		Clock:                        clock.WallClock,
 		Logger:                       s.logger,
 		NewWorker:                    NewWorker,
 		NewObjectStoreServices:       NewObjectStoreServices,
@@ -85,6 +90,7 @@ func (s *manifoldSuite) TestStartUsesWallClock(c *tc.C) {
 	var workerConfig Config
 	manifold := Manifold(ManifoldConfig{
 		ChangeStreamName: "changestream",
+		Clock:            clock.WallClock,
 		Logger:           s.logger,
 		NewWorker: func(cfg Config) (worker.Worker, error) {
 			workerConfig = cfg
@@ -142,6 +148,7 @@ func (s *manifoldSuite) TestOutputInvalid(c *tc.C) {
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
 		ChangeStreamName: "changestream",
+		Clock:            clock.WallClock,
 		Logger:           s.logger,
 		NewWorker: func(Config) (worker.Worker, error) {
 			return nil, nil


### PR DESCRIPTION
Removes the `agent` and `clock` manifold dependencies from five controller
manifolds as part of JUJU-9721, preparing them for standalone controller
operation where the traditional agent config may not be available.

### Changes

**Affected manifolds:**
- `object-store`
- `object-store-services`
- `object-store-drainer`
- `lease-expiry`
- `lease-manager`

**What was done:**
- Replaced injected `clock.Clock` dependency with direct use of
`clock.WallClock` in all five manifolds
- Replaced agent-sourced `ControllerUUID` and `ControllerModelUUID` with values
from `ControllerRuntimeConfig`
- Added `ControllerUUID` and `ControllerModelUUID` fields to
`ControllerRuntimeConfig` and wired them at bootstrap
- Updated manifold config validation and tests across both `jujud` and
`jujuagentd` entry points
- Fixed lease-expiry manifold to correctly use the configured `NewWorker`
function rather than the package-level function directly

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ juju bootstrap lxd src --build-agent
❯ juju add-model m
❯ juju add-machine -n 1

❯ jst -m controller
Model       Controller  Cloud/Region  Version      Timestamp
controller  src         lxd/default   4.1-beta2.1  12:55:51+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.159.202.122  17022,17070/tcp

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.122  juju-da2193-0  ubuntu@24.04  tuxedo  Running

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer

❯ jst
Model  Controller  Cloud/Region  Version      Timestamp
m      src         lxd/default   4.1-beta2.1  12:57:01+02:00

Machine  State    Address        Inst id        Base          AZ      Message
0        started  10.159.202.61  juju-4c381d-0  ubuntu@24.04  tuxedo  Running

❯ juju ssh -m controller 0 -- sudo cat /var/lib/juju/agents/controller-0/runtime.conf | yq 'keys'
Connection to 10.159.202.122 closed.
- controller-id
- controller-uuid
- controller-model-uuid
- data-dir
- log-dir
- query-tracing-enabled
- query-tracing-threshold
- dqlite-busy-timeout
- ca-cert
- controller-cert
- controller-private-key

❯ juju ssh -m controller 0 -- sudo cat /var/lib/juju/agents/controller-0/runtime.conf | yq '."controller-id"'
0

❯ juju ssh -m controller 0 -- sudo cat /var/lib/juju/agents/controller-0/runtime.conf | yq '."controller-uuid"'
040f02dd-690c-4bb8-8317-9086f350e768

❯ juju ssh -m controller 0 -- sudo cat /var/lib/juju/agents/controller-0/runtime.conf | yq '."controller-model-uuid"'
86a93a51-ba0a-42a4-8bb6-ae9d7cda2193
```

## Documentation changes


## Links

**Jira card:** [JUJU-9721](https://warthogs.atlassian.net/browse/JUJU-9721)


[JUJU-9721]: https://warthogs.atlassian.net/browse/JUJU-9721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ