### PR TITLE
feat: handle logsink 503 failure

### DIFF
--- a/api/logsender/logsender_test.go
+++ b/api/logsender/logsender_test.go
@@ -5,7 +5,6 @@ package logsender_test
 
 import (
 	"context"
-	stderrors "errors"
 	"io"
 	"net/url"
 	"testing"
@@ -54,7 +53,7 @@ func (s *LogSenderSuite) TestNewAPI(c *tc.C) {
 func (s *LogSenderSuite) TestNewAPIWriteLogError(c *tc.C) {
 	conn := &mockConnector{
 		c:            c,
-		connectError: stderrors.New("foo"),
+		connectError: errors.New("foo"),
 	}
 	a := logsender.NewAPI(conn)
 	w, err := a.LogWriter(c.Context())
@@ -65,7 +64,7 @@ func (s *LogSenderSuite) TestNewAPIWriteLogError(c *tc.C) {
 func (s *LogSenderSuite) TestNewAPIWriteError(c *tc.C) {
 	conn := &mockConnector{
 		c:          c,
-		writeError: stderrors.New("foo"),
+		writeError: errors.New("foo"),
 	}
 	a := logsender.NewAPI(conn)
 	w, err := a.LogWriter(c.Context())
@@ -80,7 +79,7 @@ func (s *LogSenderSuite) TestNewAPIWriteServiceUnavailableError(c *tc.C) {
 	conn := &mockConnector{
 		c: c,
 		writeError: errors.WithType(
-			stderrors.New("server returned HTTP status 503"),
+			errors.New("server returned HTTP status 503"),
 			api.HTTPStatusServiceUnavailable,
 		),
 	}
@@ -99,7 +98,7 @@ func (s *LogSenderSuite) testCleanCloseReturnsEOF(c *tc.C, code int) {
 		c:          c,
 		closed:     make(chan bool),
 		readError:  &gorillaws.CloseError{Code: code},
-		writeError: stderrors.New("use of closed network connection"),
+		writeError: errors.New("use of closed network connection"),
 	}
 	a := logsender.NewAPI(conn)
 	w, err := a.LogWriter(c.Context())
@@ -136,8 +135,8 @@ func (s *LogSenderSuite) TestNewAPIReadError(c *tc.C) {
 	conn := &mockConnector{
 		c:          c,
 		closed:     make(chan bool),
-		readError:  stderrors.New("read foo"),
-		writeError: stderrors.New("closed yo"),
+		readError:  errors.New("read foo"),
+		writeError: errors.New("closed yo"),
 	}
 	a := logsender.NewAPI(conn)
 	w, err := a.LogWriter(c.Context())

--- a/api/logsender/logsender_test.go
+++ b/api/logsender/logsender_test.go
@@ -5,15 +5,17 @@ package logsender_test
 
 import (
 	"context"
-	"errors"
+	stderrors "errors"
 	"io"
 	"net/url"
 	"testing"
 	"time"
 
 	gorillaws "github.com/gorilla/websocket"
+	"github.com/juju/errors"
 	"github.com/juju/tc"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/logsender"
 	"github.com/juju/juju/internal/testhelpers"
@@ -52,7 +54,7 @@ func (s *LogSenderSuite) TestNewAPI(c *tc.C) {
 func (s *LogSenderSuite) TestNewAPIWriteLogError(c *tc.C) {
 	conn := &mockConnector{
 		c:            c,
-		connectError: errors.New("foo"),
+		connectError: stderrors.New("foo"),
 	}
 	a := logsender.NewAPI(conn)
 	w, err := a.LogWriter(c.Context())
@@ -63,7 +65,7 @@ func (s *LogSenderSuite) TestNewAPIWriteLogError(c *tc.C) {
 func (s *LogSenderSuite) TestNewAPIWriteError(c *tc.C) {
 	conn := &mockConnector{
 		c:          c,
-		writeError: errors.New("foo"),
+		writeError: stderrors.New("foo"),
 	}
 	a := logsender.NewAPI(conn)
 	w, err := a.LogWriter(c.Context())
@@ -74,12 +76,30 @@ func (s *LogSenderSuite) TestNewAPIWriteError(c *tc.C) {
 	c.Assert(conn.written, tc.HasLen, 0)
 }
 
+func (s *LogSenderSuite) TestNewAPIWriteServiceUnavailableError(c *tc.C) {
+	conn := &mockConnector{
+		c: c,
+		writeError: errors.WithType(
+			stderrors.New("server returned HTTP status 503"),
+			api.HTTPStatusServiceUnavailable,
+		),
+	}
+	a := logsender.NewAPI(conn)
+	w, err := a.LogWriter(c.Context())
+	c.Assert(err, tc.IsNil)
+
+	err = w.WriteLog(new(params.LogRecord))
+	c.Assert(err, tc.ErrorMatches, "sending log message: server returned HTTP status 503")
+	c.Assert(err, tc.ErrorIs, api.HTTPStatusServiceUnavailable)
+	c.Assert(conn.written, tc.HasLen, 0)
+}
+
 func (s *LogSenderSuite) testCleanCloseReturnsEOF(c *tc.C, code int) {
 	conn := &mockConnector{
 		c:          c,
 		closed:     make(chan bool),
 		readError:  &gorillaws.CloseError{Code: code},
-		writeError: errors.New("use of closed network connection"),
+		writeError: stderrors.New("use of closed network connection"),
 	}
 	a := logsender.NewAPI(conn)
 	w, err := a.LogWriter(c.Context())
@@ -116,8 +136,8 @@ func (s *LogSenderSuite) TestNewAPIReadError(c *tc.C) {
 	conn := &mockConnector{
 		c:          c,
 		closed:     make(chan bool),
-		readError:  errors.New("read foo"),
-		writeError: errors.New("closed yo"),
+		readError:  stderrors.New("read foo"),
+		writeError: stderrors.New("closed yo"),
 	}
 	a := logsender.NewAPI(conn)
 	w, err := a.LogWriter(c.Context())

--- a/api/websocket.go
+++ b/api/websocket.go
@@ -26,6 +26,12 @@ const websocketTimeout = 30 * time.Second
 // tests.
 var WebsocketDial = WebsocketDialWithErrors
 
+const (
+	// HTTPStatusServiceUnavailable is added to websocket handshake errors
+	// when the API response status code is 503.
+	HTTPStatusServiceUnavailable = errors.ConstError("http status service unavailable")
+)
+
 // WebsocketDialer is something that can make a websocket connection. Enables
 // testing the error unpacking in websocketDialWithErrors.
 type WebsocketDialer interface {
@@ -66,11 +72,21 @@ func WebsocketDialWithErrors(dialer WebsocketDialer, urlStr string, requestHeade
 				strings.TrimSpace(string(body)),
 				http.StatusText(resp.StatusCode),
 			)
+			err = addHTTPStatusError(err, resp.StatusCode)
 		}
 		return nil, err
 	}
 	result := DeadlineStream{Conn: c, Timeout: websocketTimeout}
 	return &result, nil
+}
+
+func addHTTPStatusError(err error, statusCode int) error {
+	switch statusCode {
+	case http.StatusServiceUnavailable:
+		return errors.WithType(err, HTTPStatusServiceUnavailable)
+	default:
+		return err
+	}
 }
 
 // DeadlineStream wraps a websocket connection and applies a write

--- a/api/websocket.go
+++ b/api/websocket.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 	"time"
@@ -58,13 +59,13 @@ func WebsocketDialWithErrors(dialer WebsocketDialer, urlStr string, requestHeade
 			if readErr != nil {
 				return nil, err
 			}
-			if resp.Header.Get("Content-Type") == "application/json" {
+			if isJSONContentType(resp.Header.Get("Content-Type")) {
 				var result params.ErrorResult
 				jsonErr := json.Unmarshal(body, &result)
 				if jsonErr != nil {
 					return nil, errors.Annotate(jsonErr, "reading error response")
 				}
-				return nil, result.Error
+				return nil, addHTTPStatusError(result.Error, resp.StatusCode)
 			}
 
 			err = errors.Errorf(
@@ -72,7 +73,7 @@ func WebsocketDialWithErrors(dialer WebsocketDialer, urlStr string, requestHeade
 				strings.TrimSpace(string(body)),
 				http.StatusText(resp.StatusCode),
 			)
-			err = addHTTPStatusError(err, resp.StatusCode)
+			return nil, addHTTPStatusError(err, resp.StatusCode)
 		}
 		return nil, err
 	}
@@ -83,10 +84,21 @@ func WebsocketDialWithErrors(dialer WebsocketDialer, urlStr string, requestHeade
 func addHTTPStatusError(err error, statusCode int) error {
 	switch statusCode {
 	case http.StatusServiceUnavailable:
+		if err == nil {
+			return HTTPStatusServiceUnavailable
+		}
 		return errors.WithType(err, HTTPStatusServiceUnavailable)
 	default:
 		return err
 	}
+}
+
+func isJSONContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	return mediaType == "application/json"
 }
 
 // DeadlineStream wraps a websocket connection and applies a write

--- a/api/websocket_test.go
+++ b/api/websocket_test.go
@@ -4,6 +4,7 @@
 package api_test
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/rpc/params"
 )
 
 type websocketSuite struct{}
@@ -22,18 +24,83 @@ func TestWebsocketSuite(t *testing.T) {
 }
 
 func (s *websocketSuite) TestWebsocketDialAddsServiceUnavailableError(c *tc.C) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		expect      string
+	}{{
+		name:   "no content type",
+		body:   "logsink unavailable",
+		expect: "logsink unavailable \\(Service Unavailable\\)",
+	}, {
+		name:        "plain text content type",
+		contentType: "text/plain; charset=utf-8",
+		body:        "logsink unavailable\n",
+		expect:      "logsink unavailable \\(Service Unavailable\\)",
+	}, {
+		name:        "html content type",
+		contentType: "text/html",
+		body:        "<html>logsink unavailable</html>",
+		expect:      "<html>logsink unavailable</html> \\(Service Unavailable\\)",
+	}, {
+		name:        "json content type",
+		contentType: "application/json",
+		body:        jsonErrorBody(c, "logsink unavailable"),
+		expect:      "logsink unavailable",
+	}, {
+		name:        "json content type with charset",
+		contentType: "application/json; charset=utf-8",
+		body:        jsonErrorBody(c, "logsink unavailable"),
+		expect:      "logsink unavailable",
+	},
+	}
+
+	for _, test := range tests {
+		c.Logf("test %s", test.name)
+		header := make(http.Header)
+		if test.contentType != "" {
+			header.Set("Content-Type", test.contentType)
+		}
+		dialer := badHandshakeDialer{
+			response: &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Body:       io.NopCloser(strings.NewReader(test.body)),
+				Header:     header,
+			},
+		}
+
+		stream, err := api.WebsocketDialWithErrors(dialer, "wss://example.invalid", nil)
+		c.Assert(stream, tc.IsNil)
+		c.Assert(err, tc.ErrorMatches, test.expect)
+		c.Assert(err, tc.ErrorIs, api.HTTPStatusServiceUnavailable)
+	}
+}
+
+func (s *websocketSuite) TestWebsocketDialDoesNotAddServiceUnavailableErrorForOtherStatus(c *tc.C) {
 	dialer := badHandshakeDialer{
 		response: &http.Response{
-			StatusCode: http.StatusServiceUnavailable,
-			Body:       io.NopCloser(strings.NewReader("logsink unavailable")),
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(strings.NewReader("logsink failed")),
 			Header:     make(http.Header),
 		},
 	}
 
 	stream, err := api.WebsocketDialWithErrors(dialer, "wss://example.invalid", nil)
 	c.Assert(stream, tc.IsNil)
-	c.Assert(err, tc.ErrorMatches, "logsink unavailable \\(Service Unavailable\\)")
-	c.Assert(err, tc.ErrorIs, api.HTTPStatusServiceUnavailable)
+	c.Assert(err, tc.ErrorMatches, "logsink failed \\(Internal Server Error\\)")
+	c.Assert(err, tc.Not(tc.ErrorIs), api.HTTPStatusServiceUnavailable)
+}
+
+func jsonErrorBody(c *tc.C, message string) string {
+	result := params.ErrorResult{
+		Error: &params.Error{
+			Message: message,
+		},
+	}
+	body, err := json.Marshal(result)
+	c.Assert(err, tc.ErrorIsNil)
+	return string(body)
 }
 
 type badHandshakeDialer struct {

--- a/api/websocket_test.go
+++ b/api/websocket_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package api_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	gorillaws "github.com/gorilla/websocket"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/api"
+)
+
+type websocketSuite struct{}
+
+func TestWebsocketSuite(t *testing.T) {
+	tc.Run(t, &websocketSuite{})
+}
+
+func (s *websocketSuite) TestWebsocketDialAddsServiceUnavailableError(c *tc.C) {
+	dialer := badHandshakeDialer{
+		response: &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(strings.NewReader("logsink unavailable")),
+			Header:     make(http.Header),
+		},
+	}
+
+	stream, err := api.WebsocketDialWithErrors(dialer, "wss://example.invalid", nil)
+	c.Assert(stream, tc.IsNil)
+	c.Assert(err, tc.ErrorMatches, "logsink unavailable \\(Service Unavailable\\)")
+	c.Assert(err, tc.ErrorIs, api.HTTPStatusServiceUnavailable)
+}
+
+type badHandshakeDialer struct {
+	response *http.Response
+}
+
+func (d badHandshakeDialer) Dial(_ string, _ http.Header) (*gorillaws.Conn, *http.Response, error) {
+	return nil, d.response, gorillaws.ErrBadHandshake
+}

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -792,6 +792,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		logsinkMetricsCollectorWrapper{collector: srv.metricsCollector},
 		controllerModelUUID.String(),
 	)
+	logSinkHandler = maybeWrapLogSink503Wrench(logSinkHandler)
 	logSinkAuthorizer := tagKindAuthorizer(stateauthenticator.AgentTags)
 	logTransferHandler := logsink.NewHTTPHandler(
 		// We don't need to save the migrated logs

--- a/apiserver/logsink_wrench.go
+++ b/apiserver/logsink_wrench.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/juju/juju/internal/wrench"
+)
+
+const (
+	logSinkWrenchCategory   = "logsink"
+	logSink503WrenchFeature = "return-503"
+)
+
+var logSink503WrenchActive = func() bool {
+	return wrench.IsActive(logSinkWrenchCategory, logSink503WrenchFeature)
+}
+
+func maybeWrapLogSink503Wrench(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if logSink503WrenchActive() {
+			logger.Warningf(req.Context(), "logsink QA wrench returning HTTP 503")
+			http.Error(w, "logsink unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		next.ServeHTTP(w, req)
+	})
+}

--- a/apiserver/logsink_wrench_test.go
+++ b/apiserver/logsink_wrench_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/juju/tc"
+
+	coretesting "github.com/juju/juju/internal/testing"
+)
+
+type logSinkWrenchSuite struct {
+	coretesting.BaseSuite
+}
+
+func TestLogSinkWrenchSuite(t *testing.T) {
+	tc.Run(t, &logSinkWrenchSuite{})
+}
+
+func (s *logSinkWrenchSuite) SetUpTest(c *tc.C) {
+	s.BaseSuite.SetUpTest(c)
+}
+
+func (s *logSinkWrenchSuite) TestLogSink503WrenchDisabled(c *tc.C) {
+	s.PatchValue(&logSink503WrenchActive, func() bool {
+		return false
+	})
+
+	called := false
+	handler := maybeWrapLogSink503Wrench(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/model/uuid/logsink", nil))
+
+	c.Check(called, tc.IsTrue)
+	c.Check(recorder.Code, tc.Equals, http.StatusNoContent)
+}
+
+func (s *logSinkWrenchSuite) TestLogSink503WrenchEnabled(c *tc.C) {
+	s.PatchValue(&logSink503WrenchActive, func() bool {
+		return true
+	})
+
+	called := false
+	handler := maybeWrapLogSink503Wrench(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/model/uuid/logsink", nil))
+
+	c.Check(called, tc.IsFalse)
+	c.Check(recorder.Code, tc.Equals, http.StatusServiceUnavailable)
+	c.Check(recorder.Body.String(), tc.Equals, "logsink unavailable\n")
+}

--- a/cmd/juju/application/store/charmadaptor.go
+++ b/cmd/juju/application/store/charmadaptor.go
@@ -5,9 +5,14 @@ package store
 
 import (
 	"context"
+	stderrors "errors"
+	"net"
 	"net/url"
+	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/retry"
 
 	apicharm "github.com/juju/juju/api/client/charms"
 	commoncharm "github.com/juju/juju/api/common/charm"
@@ -15,6 +20,11 @@ import (
 	"github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/internal/charmhub"
 	"github.com/juju/juju/internal/charmhub/transport"
+)
+
+const (
+	bundleDownloadRetryAttempts = 3
+	bundleDownloadRetryDelay    = 20 * time.Second
 )
 
 // DownloadBundleClient represents a way to download a bundle from a given
@@ -55,6 +65,8 @@ func NewCharmAdaptor(charmsAPI CharmsAPI, downloadBundleClientFunc DownloadBundl
 				charmsAPI:                charmsAPI,
 				charmReader:              charmReader{},
 				downloadBundleClientFunc: downloadBundleClientFunc,
+				downloadRetryClock:       clock.WallClock,
+				downloadRetryDelay:       bundleDownloadRetryDelay,
 			}, nil
 		},
 	}
@@ -117,6 +129,8 @@ type chBundleFactory struct {
 	charmsAPI                CharmsAPI
 	charmReader              CharmReader
 	downloadBundleClientFunc DownloadBundleClientFunc
+	downloadRetryClock       clock.Clock
+	downloadRetryDelay       time.Duration
 }
 
 func (ch chBundleFactory) GetBundle(ctx context.Context, curl *charm.URL, origin commoncharm.Origin, path string) (charm.Bundle, error) {
@@ -133,8 +147,7 @@ func (ch chBundleFactory) GetBundle(ctx context.Context, curl *charm.URL, origin
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	_, err = client.Download(ctx, url, path)
-	if err != nil {
+	if err := ch.downloadBundle(ctx, client, url, path); err != nil {
 		return nil, errors.Trace(err)
 	}
 	bundle, err := ch.charmReader.ReadBundleArchive(path)
@@ -142,4 +155,55 @@ func (ch chBundleFactory) GetBundle(ctx context.Context, curl *charm.URL, origin
 		return nil, errors.Trace(err)
 	}
 	return bundle, nil
+}
+
+func (ch chBundleFactory) downloadBundle(ctx context.Context, client DownloadBundleClient, url *url.URL, path string) error {
+	return retry.Call(retry.CallArgs{
+		Func: func() error {
+			_, err := client.Download(ctx, url, path)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			return nil
+		},
+		IsFatalError: func(err error) bool {
+			return !isTransientBundleDownloadError(err)
+		},
+		Attempts: bundleDownloadRetryAttempts,
+		Clock:    ch.effectiveDownloadRetryClock(),
+		Delay:    ch.effectiveDownloadRetryDelay(),
+		Stop:     ctx.Done(),
+	})
+}
+
+func (ch chBundleFactory) effectiveDownloadRetryClock() clock.Clock {
+	if ch.downloadRetryClock != nil {
+		return ch.downloadRetryClock
+	}
+	return clock.WallClock
+}
+
+func (ch chBundleFactory) effectiveDownloadRetryDelay() time.Duration {
+	if ch.downloadRetryDelay > 0 {
+		return ch.downloadRetryDelay
+	}
+	return bundleDownloadRetryDelay
+}
+
+func isTransientBundleDownloadError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// TODO (stickupkid): We can add more transient error types here as we
+	// identify them, for example, errors related to temporary network issues.
+
+	var netErr net.Error
+	if stderrors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return false
 }

--- a/cmd/juju/application/store/charmadaptor_test.go
+++ b/cmd/juju/application/store/charmadaptor_test.go
@@ -5,8 +5,11 @@ package store
 
 import (
 	"context"
+	stderrors "errors"
+	"net"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/tc"
@@ -141,6 +144,68 @@ func (s *resolveSuite) TestCharmHubGetBundle(c *tc.C) {
 	c.Assert(bundle, tc.DeepEquals, s.bundle)
 }
 
+func (s *resolveSuite) TestCharmHubGetBundleRetriesTransientDownloadError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	curl, err := charm.ParseURL("ch:testme-1")
+	c.Assert(err, tc.ErrorIsNil)
+
+	origin := commoncharm.Origin{
+		Source: commoncharm.OriginCharmHub,
+		Type:   "bundle",
+		Risk:   "edge",
+	}
+	s.expectDownloadInfo(c, curl, origin, "http://messhuggah.com")
+	downloadURL, err := url.Parse("http://messhuggah.com")
+	c.Assert(err, tc.ErrorIsNil)
+
+	gomock.InOrder(
+		s.downloadClient.EXPECT().Download(gomock.Any(), downloadURL, "/tmp/bundle.bundle").Return(nil, timeoutError{}),
+		s.downloadClient.EXPECT().Download(gomock.Any(), downloadURL, "/tmp/bundle.bundle").Return(&charmhub.Digest{}, nil),
+		s.charmReader.EXPECT().ReadBundleArchive("/tmp/bundle.bundle").Return(s.bundle, nil),
+	)
+
+	charmAdaptor := s.newCharmAdaptorWithBundleDownloadRetryDelay(time.Nanosecond)
+	bundle, err := charmAdaptor.GetBundle(c.Context(), curl, origin, "/tmp/bundle.bundle")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(bundle, tc.DeepEquals, s.bundle)
+}
+
+func (s *resolveSuite) TestCharmHubGetBundleDoesNotRetryPermanentDownloadError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	curl, err := charm.ParseURL("ch:testme-1")
+	c.Assert(err, tc.ErrorIsNil)
+
+	origin := commoncharm.Origin{
+		Source: commoncharm.OriginCharmHub,
+		Type:   "bundle",
+		Risk:   "edge",
+	}
+	s.expectDownloadInfo(c, curl, origin, "http://messhuggah.com")
+	downloadURL, err := url.Parse("http://messhuggah.com")
+	c.Assert(err, tc.ErrorIsNil)
+
+	downloadErr := errors.New("boom")
+	s.downloadClient.EXPECT().Download(gomock.Any(), downloadURL, "/tmp/bundle.bundle").Return(nil, downloadErr)
+
+	charmAdaptor := s.newCharmAdaptorWithBundleDownloadRetryDelay(time.Nanosecond)
+	_, err = charmAdaptor.GetBundle(c.Context(), curl, origin, "/tmp/bundle.bundle")
+	c.Assert(err, tc.ErrorIs, downloadErr)
+}
+
+func (s *resolveSuite) TestTransientBundleDownloadError(c *tc.C) {
+	c.Check(isTransientBundleDownloadError(timeoutError{}), tc.IsTrue)
+	c.Check(isTransientBundleDownloadError(context.Canceled), tc.IsFalse)
+	c.Check(isTransientBundleDownloadError(context.DeadlineExceeded), tc.IsFalse)
+	c.Check(isTransientBundleDownloadError(errors.New("boom")), tc.IsFalse)
+
+	err := errors.Annotate(timeoutError{}, "cannot get archive")
+	var netErr net.Error
+	c.Assert(stderrors.As(err, &netErr), tc.IsTrue)
+	c.Check(isTransientBundleDownloadError(err), tc.IsTrue)
+}
+
 func (s *resolveSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.charmsAPI = mocks.NewMockCharmsAPI(ctrl)
@@ -151,6 +216,10 @@ func (s *resolveSuite) setupMocks(c *tc.C) *gomock.Controller {
 }
 
 func (s *resolveSuite) newCharmAdaptor() *CharmAdaptor {
+	return s.newCharmAdaptorWithBundleDownloadRetryDelay(bundleDownloadRetryDelay)
+}
+
+func (s *resolveSuite) newCharmAdaptorWithBundleDownloadRetryDelay(delay time.Duration) *CharmAdaptor {
 	return &CharmAdaptor{
 		charmsAPI: s.charmsAPI,
 		bundleRepoFn: func(curl *charm.URL) (BundleFactory, error) {
@@ -160,6 +229,7 @@ func (s *resolveSuite) newCharmAdaptor() *CharmAdaptor {
 				downloadBundleClientFunc: func(ctx context.Context) (DownloadBundleClient, error) {
 					return s.downloadClient, nil
 				},
+				downloadRetryDelay: delay,
 			}, nil
 		},
 	}
@@ -219,11 +289,29 @@ func (s *resolveSuite) expectCharmResolutionCallWithAPIError(curl *charm.URL, ou
 
 func (s *resolveSuite) expectedCharmHubGetBundle(c *tc.C, curl *charm.URL, origin commoncharm.Origin) {
 	surl := "http://messhuggah.com"
-	s.charmsAPI.EXPECT().GetDownloadInfo(gomock.Any(), curl, origin).Return(apicharm.DownloadInfo{
-		URL: surl,
-	}, nil)
+	s.expectDownloadInfo(c, curl, origin, surl)
 	url, err := url.Parse(surl)
 	c.Assert(err, tc.ErrorIsNil)
-	s.downloadClient.EXPECT().Download(gomock.Any(), url, "/tmp/bundle.bundle", gomock.Any()).Return(&charmhub.Digest{}, nil)
+	s.downloadClient.EXPECT().Download(gomock.Any(), url, "/tmp/bundle.bundle").Return(&charmhub.Digest{}, nil)
 	s.charmReader.EXPECT().ReadBundleArchive("/tmp/bundle.bundle").Return(s.bundle, nil)
+}
+
+func (s *resolveSuite) expectDownloadInfo(c *tc.C, curl *charm.URL, origin commoncharm.Origin, rawURL string) {
+	s.charmsAPI.EXPECT().GetDownloadInfo(gomock.Any(), curl, origin).Return(apicharm.DownloadInfo{
+		URL: rawURL,
+	}, nil)
+}
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string {
+	return "timeout"
+}
+
+func (timeoutError) Timeout() bool {
+	return true
+}
+
+func (timeoutError) Temporary() bool {
+	return false
 }

--- a/internal/bootstrap/deployer.go
+++ b/internal/bootstrap/deployer.go
@@ -8,13 +8,17 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	stderrors "errors"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/juju/clock"
+	"github.com/juju/retry"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/controller"
@@ -33,6 +37,11 @@ import (
 	"github.com/juju/juju/domain/deployment/charm/repository"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/errors"
+)
+
+const (
+	controllerCharmDownloadRetryAttempts = 3
+	controllerCharmDownloadRetryDelay    = 20 * time.Second
 )
 
 // DeployCharmResult holds the result of deploying a charm.
@@ -336,7 +345,7 @@ func (b *baseDeployer) DeployCharmhubCharm(ctx context.Context, arch string, bas
 	}
 
 	charmDownloader := b.charmDownloader(b.charmhubHTTPClient, b.logger)
-	downloadResult, err := charmDownloader.Download(ctx, downloadURL, resolved.Origin.Hash)
+	downloadResult, err := b.downloadControllerCharm(ctx, charmDownloader, downloadURL, resolved.Origin.Hash)
 	if err != nil {
 		return DeployCharmInfo{}, errors.Errorf("downloading %q: %w", downloadURL, err)
 	}
@@ -372,6 +381,61 @@ func (b *baseDeployer) DeployCharmhubCharm(ctx context.Context, arch string, bas
 		ArchivePath:     result.ArchivePath,
 		ObjectStoreUUID: result.ObjectStoreUUID,
 	}, nil
+}
+
+func (b *baseDeployer) downloadControllerCharm(
+	ctx context.Context,
+	charmDownloader Downloader,
+	downloadURL *url.URL,
+	hash string,
+) (*charmdownloader.DownloadResult, error) {
+	var downloadResult *charmdownloader.DownloadResult
+	err := retry.Call(retry.CallArgs{
+		Func: func() error {
+			result, err := charmDownloader.Download(ctx, downloadURL, hash)
+			if err != nil {
+				return errors.Capture(err)
+			}
+			downloadResult = result
+			return nil
+		},
+		IsFatalError: func(err error) bool {
+			return !isTransientControllerCharmDownloadError(err)
+		},
+		Attempts: controllerCharmDownloadRetryAttempts,
+		Delay:    controllerCharmDownloadRetryDelay,
+		Clock:    b.clock,
+		NotifyFunc: func(err error, attempt int) {
+			b.logger.Warningf(
+				ctx,
+				"failed to download controller charm, attempt %d: %v",
+				attempt,
+				err,
+			)
+		},
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return downloadResult, nil
+}
+
+func isTransientControllerCharmDownloadError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// TODO (stickupkid): We can add more transient error types here as we
+	// identify them, for example, errors related to temporary network issues.
+
+	var netErr net.Error
+	if stderrors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return false
 }
 
 // AddIAASControllerApplication adds the IAAS controller application.

--- a/internal/bootstrap/deployer_test.go
+++ b/internal/bootstrap/deployer_test.go
@@ -5,10 +5,12 @@ package bootstrap
 
 import (
 	"bytes"
+	stderrors "errors"
 	"net/url"
 	"os"
 	"path/filepath"
 	stdtesting "testing"
+	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/tc"
@@ -189,6 +191,54 @@ func (s *deployerSuite) TestDeployCharmhubCharm(c *tc.C) {
 		},
 	})
 	c.Assert(info.Charm, tc.NotNil)
+}
+
+func (s *deployerSuite) TestDeployCharmhubCharmRetriesTransientDownloadError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cfg := s.newConfig(c)
+	cfg.Clock = s.clock
+
+	downloadURL := s.expectCharmhubResolve(c, "juju-controller")
+	s.expectRetryDelay()
+
+	downloadResult := &charmdownloader.DownloadResult{
+		SHA256: "sha-256",
+		SHA384: "sha-384",
+		Path:   "path",
+		Size:   42,
+	}
+	gomock.InOrder(
+		s.charmDownloader.EXPECT().Download(gomock.Any(), downloadURL, "sha-256").
+			Return(nil, timeoutError{}),
+		s.charmDownloader.EXPECT().Download(gomock.Any(), downloadURL, "sha-256").
+			Return(downloadResult, nil),
+	)
+	s.expectResolveControllerCharmDownload(c, downloadResult)
+
+	deployer := s.newBaseDeployer(c, cfg)
+
+	info, err := deployer.DeployCharmhubCharm(c.Context(), "arm64", corebase.MakeDefaultBase("ubuntu", "22.04"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(info.Charm, tc.NotNil)
+}
+
+func (s *deployerSuite) TestDeployCharmhubCharmDoesNotRetryPermanentDownloadError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cfg := s.newConfig(c)
+	cfg.Clock = s.clock
+
+	downloadURL := s.expectCharmhubResolve(c, "juju-controller")
+	s.expectRetryClockNow()
+
+	s.charmDownloader.EXPECT().Download(gomock.Any(), downloadURL, "sha-256").
+		Return(nil, stderrors.New("invalid digest"))
+
+	deployer := s.newBaseDeployer(c, cfg)
+
+	_, err := deployer.DeployCharmhubCharm(c.Context(), "arm64", corebase.MakeDefaultBase("ubuntu", "22.04"))
+	c.Assert(err, tc.ErrorMatches, `downloading "https://inferi.com": invalid digest`)
 }
 
 func (s *deployerSuite) TestDeployCharmhubCharmWithCustomName(c *tc.C) {
@@ -387,6 +437,19 @@ func (s *deployerSuite) newBaseDeployer(c *tc.C, cfg BaseDeployerConfig) baseDep
 }
 
 func (s *deployerSuite) expectDownloadAndResolve(c *tc.C, name string) {
+	downloadURL := s.expectCharmhubResolve(c, name)
+
+	downloadResult := &charmdownloader.DownloadResult{
+		SHA256: "sha-256",
+		SHA384: "sha-384",
+		Path:   "path",
+		Size:   42,
+	}
+	s.charmDownloader.EXPECT().Download(gomock.Any(), downloadURL, "sha-256").Return(downloadResult, nil)
+	s.expectResolveControllerCharmDownload(c, downloadResult)
+}
+
+func (s *deployerSuite) expectCharmhubResolve(c *tc.C, name string) *url.URL {
 	uuid := testing.ModelTag.Id()
 	cfg, err := config.New(config.UseDefaults, map[string]any{
 		"name":         "model",
@@ -439,26 +502,51 @@ func (s *deployerSuite) expectDownloadAndResolve(c *tc.C, name string) {
 
 	url, err := url.Parse("https://inferi.com")
 	c.Assert(err, tc.ErrorIsNil)
+	return url
+}
 
-	s.charmDownloader.EXPECT().Download(gomock.Any(), url, "sha-256").Return(&charmdownloader.DownloadResult{
-		SHA256: "sha-256",
-		SHA384: "sha-384",
-		Path:   "path",
-		Size:   42,
-	}, nil)
-
+func (s *deployerSuite) expectResolveControllerCharmDownload(c *tc.C, result *charmdownloader.DownloadResult) {
 	objectStoreUUID := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.applicationService.EXPECT().ResolveControllerCharmDownload(gomock.Any(), domainapplication.ResolveControllerCharmDownload{
 		SHA256: "sha-256",
-		SHA384: "sha-384",
-		Path:   "path",
-		Size:   42,
+		SHA384: result.SHA384,
+		Path:   result.Path,
+		Size:   result.Size,
 	}).Return(domainapplication.ResolvedControllerCharmDownload{
 		Charm:           s.charm,
-		ArchivePath:     "path",
+		ArchivePath:     result.Path,
 		ObjectStoreUUID: objectStoreUUID,
 	}, nil)
+}
+
+func (s *deployerSuite) expectRetryDelay() {
+	s.expectRetryClockNow()
+	s.clock.EXPECT().After(controllerCharmDownloadRetryDelay).Return(closedTimeChannel())
+}
+
+func (s *deployerSuite) expectRetryClockNow() {
+	s.clock.EXPECT().Now().Return(time.Now()).AnyTimes()
+}
+
+func closedTimeChannel() <-chan time.Time {
+	ch := make(chan time.Time)
+	close(ch)
+	return ch
+}
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string {
+	return "net/http: TLS handshake timeout"
+}
+
+func (timeoutError) Timeout() bool {
+	return true
+}
+
+func (timeoutError) Temporary() bool {
+	return true
 }
 
 func (s *deployerSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/internal/charmhub/download_test.go
+++ b/internal/charmhub/download_test.go
@@ -9,7 +9,9 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	stderrors "errors"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -198,6 +200,31 @@ func (s *DownloadSuite) TestDownloadWithFailedStatusCode(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": unable to locate archive \(store API responded with status: Internal Server Error\)`)
 }
 
+func (s *DownloadSuite) TestDownloadPreservesHTTPClientErrorType(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	tmpFile, close := s.expectTmpFile(c)
+	defer close()
+
+	fileSystem := NewMockFileSystem(ctrl)
+	fileSystem.EXPECT().Create(tmpFile.Name()).Return(tmpFile, nil)
+
+	httpClient := NewMockHTTPClient(ctrl)
+	httpClient.EXPECT().Do(gomock.Any()).Return(nil, timeoutError{})
+
+	serverURL, err := url.Parse("http://meshuggah.rocks")
+	c.Assert(err, tc.ErrorIsNil)
+
+	client := NewDownloadClient(httpClient, fileSystem, s.logger)
+	_, err = client.Download(c.Context(), serverURL, tmpFile.Name())
+	c.Assert(err, tc.ErrorMatches, `cannot retrieve "http://meshuggah.rocks": cannot get archive: net/http: TLS handshake timeout`)
+
+	var netErr net.Error
+	c.Assert(stderrors.As(err, &netErr), tc.IsTrue)
+	c.Check(netErr.Timeout(), tc.IsTrue)
+}
+
 func (s *DownloadSuite) createCharmAchieve(c *tc.C) []byte {
 	tmpDir, err := os.MkdirTemp("", "charm")
 	c.Assert(err, tc.ErrorIsNil)
@@ -234,4 +261,18 @@ func readSHA384(c *tc.C, reader io.Reader) string {
 	c.Assert(err, tc.ErrorIsNil)
 
 	return hex.EncodeToString(hash.Sum(nil))
+}
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string {
+	return "net/http: TLS handshake timeout"
+}
+
+func (timeoutError) Timeout() bool {
+	return true
+}
+
+func (timeoutError) Temporary() bool {
+	return true
 }

--- a/internal/worker/logsender/errors.go
+++ b/internal/worker/logsender/errors.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logsender
+
+import (
+	stderrors "errors"
+	"io"
+	"net"
+	"strings"
+	"syscall"
+
+	gorillaws "github.com/gorilla/websocket"
+	"github.com/juju/errors"
+)
+
+func isTransientLogDeliveryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+
+	var netErr net.Error
+	if stderrors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary()) {
+		return true
+	}
+
+	if gorillaws.IsCloseError(err,
+		gorillaws.CloseNormalClosure,
+		gorillaws.CloseGoingAway,
+		gorillaws.CloseNoStatusReceived,
+		gorillaws.CloseAbnormalClosure,
+	) || gorillaws.IsUnexpectedCloseError(err) {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "server returned http status 503") ||
+		strings.Contains(message, "service unavailable") ||
+		strings.Contains(message, "use of closed network connection") ||
+		strings.Contains(message, "connection reset by peer") ||
+		strings.Contains(message, "broken pipe") ||
+		strings.Contains(message, "write failed") ||
+		strings.Contains(message, "api caller disconnected") ||
+		strings.Contains(message, "api connection is broken") ||
+		strings.Contains(message, "connection is shut down") ||
+		strings.Contains(message, "connection is closed")
+}

--- a/internal/worker/logsender/errors.go
+++ b/internal/worker/logsender/errors.go
@@ -4,50 +4,14 @@
 package logsender
 
 import (
-	stderrors "errors"
-	"io"
-	"net"
-	"strings"
-	"syscall"
-
-	gorillaws "github.com/gorilla/websocket"
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/api"
 )
 
-func isTransientLogDeliveryError(err error) bool {
+func isLogSinkUnavailableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, io.EOF) ||
-		errors.Is(err, syscall.ECONNRESET) ||
-		errors.Is(err, syscall.EPIPE) ||
-		errors.Is(err, syscall.ETIMEDOUT) {
-		return true
-	}
-
-	var netErr net.Error
-	if stderrors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary()) {
-		return true
-	}
-
-	if gorillaws.IsCloseError(err,
-		gorillaws.CloseNormalClosure,
-		gorillaws.CloseGoingAway,
-		gorillaws.CloseNoStatusReceived,
-		gorillaws.CloseAbnormalClosure,
-	) || gorillaws.IsUnexpectedCloseError(err) {
-		return true
-	}
-
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "server returned http status 503") ||
-		strings.Contains(message, "service unavailable") ||
-		strings.Contains(message, "use of closed network connection") ||
-		strings.Contains(message, "connection reset by peer") ||
-		strings.Contains(message, "broken pipe") ||
-		strings.Contains(message, "write failed") ||
-		strings.Contains(message, "api caller disconnected") ||
-		strings.Contains(message, "api connection is broken") ||
-		strings.Contains(message, "connection is shut down") ||
-		strings.Contains(message, "connection is closed")
+	return errors.Is(err, api.HTTPStatusServiceUnavailable)
 }

--- a/internal/worker/logsender/errors_test.go
+++ b/internal/worker/logsender/errors_test.go
@@ -5,117 +5,29 @@ package logsender
 
 import (
 	stderrors "errors"
-	"io"
-	"net"
-	"syscall"
 	"testing"
-	"time"
 
-	gorillaws "github.com/gorilla/websocket"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
+
+	"github.com/juju/juju/api"
 )
 
-type transientLogDeliveryErrorSuite struct{}
+type logDeliveryErrorSuite struct{}
 
-func TestTransientLogDeliveryErrorSuite(t *testing.T) {
-	tc.Run(t, &transientLogDeliveryErrorSuite{})
+func TestLogDeliveryErrorSuite(t *testing.T) {
+	tc.Run(t, &logDeliveryErrorSuite{})
 }
 
-func (s *transientLogDeliveryErrorSuite) TestTransientErrors(c *tc.C) {
-	tests := []struct {
-		name string
-		err  error
-	}{{
-		name: "EOF",
-		err:  io.EOF,
-	}, {
-		name: "wrapped EOF",
-		err:  errors.Annotate(io.EOF, "sending log message"),
-	}, {
-		name: "websocket normal close",
-		err:  &gorillaws.CloseError{Code: gorillaws.CloseNormalClosure},
-	}, {
-		name: "websocket going away",
-		err:  &gorillaws.CloseError{Code: gorillaws.CloseGoingAway},
-	}, {
-		name: "websocket no status",
-		err:  &gorillaws.CloseError{Code: gorillaws.CloseNoStatusReceived},
-	}, {
-		name: "websocket abnormal close",
-		err:  &gorillaws.CloseError{Code: gorillaws.CloseAbnormalClosure},
-	}, {
-		name: "websocket unexpected close",
-		err:  &gorillaws.CloseError{Code: gorillaws.CloseUnsupportedData},
-	}, {
-		name: "503 status",
-		err:  stderrors.New("cannot connect to /logsink: server returned HTTP status 503"),
-	}, {
-		name: "service unavailable",
-		err:  stderrors.New("cannot connect to /logsink: Service Unavailable"),
-	}, {
-		name: "write failed",
-		err:  stderrors.New("sending log message: write failed"),
-	}, {
-		name: "closed network connection",
-		err:  stderrors.New("use of closed network connection"),
-	}, {
-		name: "disconnected api caller",
-		err:  stderrors.New("api caller disconnected"),
-	}, {
-		name: "network timeout",
-		err: &net.DNSError{
-			Err:         "i/o timeout",
-			IsTimeout:   true,
-			IsTemporary: true,
-		},
-	}, {
-		name: "connection reset",
-		err:  syscall.ECONNRESET,
-	}, {
-		name: "broken pipe",
-		err:  syscall.EPIPE,
-	}}
+func (s *logDeliveryErrorSuite) TestLogSinkUnavailableError(c *tc.C) {
+	err := errors.WithType(
+		stderrors.New("cannot connect to /logsink: server returned HTTP status 503"),
+		api.HTTPStatusServiceUnavailable,
+	)
 
-	for _, test := range tests {
-		c.Check(isTransientLogDeliveryError(test.err), tc.IsTrue, tc.Commentf(test.name))
-	}
-}
-
-func (s *transientLogDeliveryErrorSuite) TestNonTransientErrors(c *tc.C) {
-	tests := []struct {
-		name string
-		err  error
-	}{{
-		name: "nil",
-		err:  nil,
-	}, {
-		name: "unknown error",
-		err:  stderrors.New("permission denied"),
-	}, {
-		name: "context deadline",
-		err:  contextDeadlineError{},
-	}}
-
-	for _, test := range tests {
-		c.Check(isTransientLogDeliveryError(test.err), tc.IsFalse, tc.Commentf(test.name))
-	}
-}
-
-type contextDeadlineError struct{}
-
-func (contextDeadlineError) Error() string {
-	return "context deadline exceeded"
-}
-
-func (contextDeadlineError) Timeout() bool {
-	return false
-}
-
-func (contextDeadlineError) Temporary() bool {
-	return false
-}
-
-func (contextDeadlineError) Deadline() (time.Time, bool) {
-	return time.Time{}, false
+	c.Check(isLogSinkUnavailableError(err), tc.IsTrue)
+	c.Check(isLogSinkUnavailableError(stderrors.New(
+		"cannot connect to /logsink: server returned HTTP status 503",
+	)), tc.IsFalse)
+	c.Check(isLogSinkUnavailableError(nil), tc.IsFalse)
 }

--- a/internal/worker/logsender/errors_test.go
+++ b/internal/worker/logsender/errors_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logsender
+
+import (
+	stderrors "errors"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+
+	gorillaws "github.com/gorilla/websocket"
+	"github.com/juju/errors"
+	"github.com/juju/tc"
+)
+
+type transientLogDeliveryErrorSuite struct{}
+
+func TestTransientLogDeliveryErrorSuite(t *testing.T) {
+	tc.Run(t, &transientLogDeliveryErrorSuite{})
+}
+
+func (s *transientLogDeliveryErrorSuite) TestTransientErrors(c *tc.C) {
+	tests := []struct {
+		name string
+		err  error
+	}{{
+		name: "EOF",
+		err:  io.EOF,
+	}, {
+		name: "wrapped EOF",
+		err:  errors.Annotate(io.EOF, "sending log message"),
+	}, {
+		name: "websocket normal close",
+		err:  &gorillaws.CloseError{Code: gorillaws.CloseNormalClosure},
+	}, {
+		name: "websocket going away",
+		err:  &gorillaws.CloseError{Code: gorillaws.CloseGoingAway},
+	}, {
+		name: "websocket no status",
+		err:  &gorillaws.CloseError{Code: gorillaws.CloseNoStatusReceived},
+	}, {
+		name: "websocket abnormal close",
+		err:  &gorillaws.CloseError{Code: gorillaws.CloseAbnormalClosure},
+	}, {
+		name: "websocket unexpected close",
+		err:  &gorillaws.CloseError{Code: gorillaws.CloseUnsupportedData},
+	}, {
+		name: "503 status",
+		err:  stderrors.New("cannot connect to /logsink: server returned HTTP status 503"),
+	}, {
+		name: "service unavailable",
+		err:  stderrors.New("cannot connect to /logsink: Service Unavailable"),
+	}, {
+		name: "write failed",
+		err:  stderrors.New("sending log message: write failed"),
+	}, {
+		name: "closed network connection",
+		err:  stderrors.New("use of closed network connection"),
+	}, {
+		name: "disconnected api caller",
+		err:  stderrors.New("api caller disconnected"),
+	}, {
+		name: "network timeout",
+		err: &net.DNSError{
+			Err:         "i/o timeout",
+			IsTimeout:   true,
+			IsTemporary: true,
+		},
+	}, {
+		name: "connection reset",
+		err:  syscall.ECONNRESET,
+	}, {
+		name: "broken pipe",
+		err:  syscall.EPIPE,
+	}}
+
+	for _, test := range tests {
+		c.Check(isTransientLogDeliveryError(test.err), tc.IsTrue, tc.Commentf(test.name))
+	}
+}
+
+func (s *transientLogDeliveryErrorSuite) TestNonTransientErrors(c *tc.C) {
+	tests := []struct {
+		name string
+		err  error
+	}{{
+		name: "nil",
+		err:  nil,
+	}, {
+		name: "unknown error",
+		err:  stderrors.New("permission denied"),
+	}, {
+		name: "context deadline",
+		err:  contextDeadlineError{},
+	}}
+
+	for _, test := range tests {
+		c.Check(isTransientLogDeliveryError(test.err), tc.IsFalse, tc.Commentf(test.name))
+	}
+}
+
+type contextDeadlineError struct{}
+
+func (contextDeadlineError) Error() string {
+	return "context deadline exceeded"
+}
+
+func (contextDeadlineError) Timeout() bool {
+	return false
+}
+
+func (contextDeadlineError) Temporary() bool {
+	return false
+}
+
+func (contextDeadlineError) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}

--- a/internal/worker/logsender/worker.go
+++ b/internal/worker/logsender/worker.go
@@ -22,6 +22,9 @@ const loggerName = "juju.worker.logsender"
 
 // LogSenderAPI provides a log writer.
 type LogSenderAPI interface {
+	// LogWriter returns a logsender.LogWriter which can be used to send log
+	// messages to the controller. The LogWriter should be closed when finished
+	// with it to free up resources.
 	LogWriter(ctx context.Context) (logsender.LogWriter, error)
 }
 
@@ -57,16 +60,28 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 		select {
 		case logWriter = <-sender:
 		case err = <-errChan:
+			if isLogSinkUnavailableError(err) {
+				return discardLogsUntilDone(ctx, logs)
+			}
 			return errors.Annotate(err, "logsender dial failed")
 		case <-ctx.Done():
 			return nil
 		}
-		// the logwriter has been successfully retrieved from the inside goroutine and its lifecycle is now handled
-		// in the loop function.
-		defer logWriter.Close()
+		// the logwriter has been successfully retrieved from the inside
+		// goroutine and its lifecycle is now handled in the loop function.
+		closeLogWriter := func() {
+			if logWriter != nil {
+				_ = logWriter.Close()
+				logWriter = nil
+			}
+		}
+		defer closeLogWriter()
 		for {
 			select {
-			case rec := <-logs:
+			case rec, ok := <-logs:
+				if !ok {
+					return nil
+				}
 				err := logWriter.WriteLog(&params.LogRecord{
 					Time:     rec.Time,
 					Module:   rec.Module,
@@ -76,6 +91,10 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 					Labels:   rec.Labels,
 				})
 				if err != nil {
+					if isLogSinkUnavailableError(err) {
+						closeLogWriter()
+						return discardLogsUntilDone(ctx, logs)
+					}
 					if errors.Is(err, io.EOF) {
 						return dependency.ErrBounce
 					}
@@ -104,6 +123,10 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 						Message: fmt.Sprintf("%d log messages dropped due to lack of API connectivity", rec.DroppedAfter),
 					})
 					if err != nil {
+						if isLogSinkUnavailableError(err) {
+							closeLogWriter()
+							return discardLogsUntilDone(ctx, logs)
+						}
 						if errors.Is(err, io.EOF) {
 							return dependency.ErrBounce
 						}
@@ -117,4 +140,17 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 		}
 	}
 	return jworker.NewSimpleWorker(loop)
+}
+
+func discardLogsUntilDone(ctx context.Context, logs LogRecordCh) error {
+	for {
+		select {
+		case _, ok := <-logs:
+			if !ok {
+				return nil
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
 }

--- a/internal/worker/logsender/worker.go
+++ b/internal/worker/logsender/worker.go
@@ -38,7 +38,7 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 		sender := make(chan logsender.LogWriter)
 		errChan := make(chan error)
 		go func() {
-			logWriter, err := logSenderAPI.LogWriter(context.TODO())
+			logWriter, err := logSenderAPI.LogWriter(ctx)
 			if err != nil {
 				select {
 				case errChan <- err:

--- a/internal/worker/logsender/worker.go
+++ b/internal/worker/logsender/worker.go
@@ -61,7 +61,7 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 		case logWriter = <-sender:
 		case err = <-errChan:
 			if isLogSinkUnavailableError(err) {
-				return discardLogsUntilDone(ctx, logs)
+				return discardRemoteLogsUntilDone(ctx, logs)
 			}
 			return errors.Annotate(err, "logsender dial failed")
 		case <-ctx.Done():
@@ -93,7 +93,7 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 				if err != nil {
 					if isLogSinkUnavailableError(err) {
 						closeLogWriter()
-						return discardLogsUntilDone(ctx, logs)
+						return discardRemoteLogsUntilDone(ctx, logs)
 					}
 					if errors.Is(err, io.EOF) {
 						return dependency.ErrBounce
@@ -125,7 +125,7 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 					if err != nil {
 						if isLogSinkUnavailableError(err) {
 							closeLogWriter()
-							return discardLogsUntilDone(ctx, logs)
+							return discardRemoteLogsUntilDone(ctx, logs)
 						}
 						if errors.Is(err, io.EOF) {
 							return dependency.ErrBounce
@@ -142,7 +142,9 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 	return jworker.NewSimpleWorker(loop)
 }
 
-func discardLogsUntilDone(ctx context.Context, logs LogRecordCh) error {
+// discardRemoteLogsUntilDone drains remote log records after /logsink reports
+// that it is unavailable. Local file logging is handled separately by loggo.
+func discardRemoteLogsUntilDone(ctx context.Context, logs LogRecordCh) error {
 	for {
 		select {
 		case _, ok := <-logs:

--- a/internal/worker/logsender/worker_test.go
+++ b/internal/worker/logsender/worker_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/logsender"
+	"github.com/juju/juju/internal/worker/logsender/logsendertest"
 	"github.com/juju/juju/internal/worker/logsender/mocks"
 	"github.com/juju/juju/rpc/params"
 )
@@ -184,7 +185,7 @@ func (s *workerSuite) TestDroppedLogs(c *tc.C) {
 	<-done
 }
 
-func (s *workerSuite) TestLogSinkUnavailableKeepsWorkerAlive(c *tc.C) {
+func (s *workerSuite) TestLogSinkUnavailableDrainsRemoteLogs(c *tc.C) {
 	logsCh := make(logsender.LogRecordCh)
 	logSenderAPI := logsenderAPI{
 		err: errors.WithType(
@@ -196,6 +197,8 @@ func (s *workerSuite) TestLogSinkUnavailableKeepsWorkerAlive(c *tc.C) {
 	w := logsender.New(logsCh, logSenderAPI)
 	defer workertest.CleanKill(c, w)
 
+	sendLog(c, logsCh, "one")
+	sendLog(c, logsCh, "two")
 	workertest.CheckAlive(c, w)
 }
 
@@ -232,11 +235,11 @@ func (s *workerSuite) TestWriteLogFailureTerminatesWorker(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "write failed")
 }
 
-func (s *workerSuite) TestWriteLogServiceUnavailableKeepsWorkerAlive(c *tc.C) {
+func (s *workerSuite) TestWriteLogServiceUnavailableDrainsRemoteLogs(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
-	logsCh := make(logsender.LogRecordCh, 1)
+	logsCh := make(logsender.LogRecordCh)
 	writer := mocks.NewMockLogWriter(ctrl)
 	writer.EXPECT().WriteLog(gomock.Any()).Return(errors.WithType(
 		stderrors.New("sending log message: server returned HTTP status 503"),
@@ -244,18 +247,58 @@ func (s *workerSuite) TestWriteLogServiceUnavailableKeepsWorkerAlive(c *tc.C) {
 	))
 	writer.EXPECT().Close()
 
-	logsCh <- &logsender.LogRecord{
+	w := logsender.New(logsCh, logsenderAPI{writer: writer})
+	defer workertest.CleanKill(c, w)
+
+	sendLog(c, logsCh, "one")
+	sendLog(c, logsCh, "two")
+	workertest.CheckAlive(c, w)
+}
+
+func (s *workerSuite) TestLogSinkUnavailableDrainsBufferedLogs(c *tc.C) {
+	bufferedLogger := logsender.NewBufferedLogWriter(10)
+	defer bufferedLogger.Close()
+
+	logSenderAPI := logsenderAPI{
+		err: errors.WithType(
+			stderrors.New("cannot connect to /logsink: server returned HTTP status 503"),
+			api.HTTPStatusServiceUnavailable,
+		),
+	}
+
+	w := logsender.New(bufferedLogger.Logs(), logSenderAPI)
+	defer workertest.CleanKill(c, w)
+
+	for i := range 5 {
+		bufferedLogger.Write(loggo.Entry{
+			Level:     loggo.INFO,
+			Module:    "test",
+			Filename:  "test.go",
+			Line:      i,
+			Timestamp: time.Now(),
+			Message:   fmt.Sprintf("message%d", i),
+		})
+	}
+
+	logsendertest.ExpectLogStats(c, bufferedLogger, logsender.LogStats{
+		Enqueued: 5,
+		Sent:     5,
+	})
+	workertest.CheckAlive(c, w)
+}
+
+func sendLog(c *tc.C, logsCh logsender.LogRecordCh, message string) {
+	select {
+	case logsCh <- &logsender.LogRecord{
 		Time:     time.Now(),
 		Module:   "test",
 		Location: "test:1",
 		Level:    loggo.INFO,
-		Message:  "hello",
+		Message:  message,
+	}:
+	case <-c.Context().Done():
+		c.Fatalf("timed out sending log record")
 	}
-
-	w := logsender.New(logsCh, logsenderAPI{writer: writer})
-	defer workertest.CleanKill(c, w)
-
-	workertest.CheckAlive(c, w)
 }
 
 type workerBounceSuite struct {

--- a/internal/worker/logsender/worker_test.go
+++ b/internal/worker/logsender/worker_test.go
@@ -5,7 +5,7 @@ package logsender_test
 
 import (
 	"context"
-	"errors"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -15,12 +15,14 @@ import (
 	"time"
 
 	gorillaws "github.com/gorilla/websocket"
+	"github.com/juju/errors"
 	"github.com/juju/loggo/v2"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/dependency"
 	"github.com/juju/worker/v5/workertest"
 	"go.uber.org/mock/gomock"
 
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	apilogsender "github.com/juju/juju/api/logsender"
 	"github.com/juju/juju/internal/testhelpers"
@@ -182,21 +184,25 @@ func (s *workerSuite) TestDroppedLogs(c *tc.C) {
 	<-done
 }
 
-func (s *workerSuite) TestLogWriterDialFailureTerminatesWorker(c *tc.C) {
+func (s *workerSuite) TestLogSinkUnavailableKeepsWorkerAlive(c *tc.C) {
 	logsCh := make(logsender.LogRecordCh)
 	logSenderAPI := logsenderAPI{
-		err: errors.New("cannot connect to /logsink: server returned HTTP status 503"),
+		err: errors.WithType(
+			stderrors.New("cannot connect to /logsink: server returned HTTP status 503"),
+			api.HTTPStatusServiceUnavailable,
+		),
 	}
 
 	w := logsender.New(logsCh, logSenderAPI)
-	err := w.Wait()
-	c.Assert(err, tc.ErrorMatches, "logsender dial failed: cannot connect to /logsink: server returned HTTP status 503")
+	defer workertest.CleanKill(c, w)
+
+	workertest.CheckAlive(c, w)
 }
 
 func (s *workerSuite) TestDisconnectedAPICallerTerminatesWorker(c *tc.C) {
 	logsCh := make(logsender.LogRecordCh)
 	logSenderAPI := logsenderAPI{
-		err: errors.New("api caller disconnected"),
+		err: stderrors.New("api caller disconnected"),
 	}
 
 	w := logsender.New(logsCh, logSenderAPI)
@@ -210,7 +216,7 @@ func (s *workerSuite) TestWriteLogFailureTerminatesWorker(c *tc.C) {
 
 	logsCh := make(logsender.LogRecordCh, 1)
 	writer := mocks.NewMockLogWriter(ctrl)
-	writer.EXPECT().WriteLog(gomock.Any()).Return(errors.New("write failed"))
+	writer.EXPECT().WriteLog(gomock.Any()).Return(stderrors.New("write failed"))
 	writer.EXPECT().Close()
 
 	logsCh <- &logsender.LogRecord{
@@ -224,6 +230,32 @@ func (s *workerSuite) TestWriteLogFailureTerminatesWorker(c *tc.C) {
 	w := logsender.New(logsCh, logsenderAPI{writer: writer})
 	err := w.Wait()
 	c.Assert(err, tc.ErrorMatches, "write failed")
+}
+
+func (s *workerSuite) TestWriteLogServiceUnavailableKeepsWorkerAlive(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	logsCh := make(logsender.LogRecordCh, 1)
+	writer := mocks.NewMockLogWriter(ctrl)
+	writer.EXPECT().WriteLog(gomock.Any()).Return(errors.WithType(
+		stderrors.New("sending log message: server returned HTTP status 503"),
+		api.HTTPStatusServiceUnavailable,
+	))
+	writer.EXPECT().Close()
+
+	logsCh <- &logsender.LogRecord{
+		Time:     time.Now(),
+		Module:   "test",
+		Location: "test:1",
+		Level:    loggo.INFO,
+		Message:  "hello",
+	}
+
+	w := logsender.New(logsCh, logsenderAPI{writer: writer})
+	defer workertest.CleanKill(c, w)
+
+	workertest.CheckAlive(c, w)
 }
 
 type workerBounceSuite struct {

--- a/internal/worker/logsender/worker_test.go
+++ b/internal/worker/logsender/worker_test.go
@@ -5,6 +5,7 @@ package logsender_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -39,9 +40,13 @@ func TestWorkerSuite(t *stdtesting.T) {
 
 type logsenderAPI struct {
 	writer *mocks.MockLogWriter
+	err    error
 }
 
 func (s logsenderAPI) LogWriter(_ context.Context) (apilogsender.LogWriter, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
 	return s.writer, nil
 }
 
@@ -75,7 +80,7 @@ func (s *workerSuite) TestLogSending(c *tc.C) {
 	writer.EXPECT().Close()
 
 	// Start the logsender worker.
-	worker := logsender.New(logsCh, logsenderAPI{writer})
+	worker := logsender.New(logsCh, logsenderAPI{writer: writer})
 	defer workertest.CleanKill(c, worker)
 
 	// Send some logs, also building up what should appear in the
@@ -145,7 +150,7 @@ func (s *workerSuite) TestDroppedLogs(c *tc.C) {
 	writer.EXPECT().Close()
 
 	// Start the logsender worker.
-	worker := logsender.New(logsCh, logsenderAPI{writer})
+	worker := logsender.New(logsCh, logsenderAPI{writer: writer})
 	defer workertest.CleanKill(c, worker)
 
 	// Send a log record which indicates some messages after it were
@@ -175,6 +180,50 @@ func (s *workerSuite) TestDroppedLogs(c *tc.C) {
 	}()
 
 	<-done
+}
+
+func (s *workerSuite) TestLogWriterDialFailureTerminatesWorker(c *tc.C) {
+	logsCh := make(logsender.LogRecordCh)
+	logSenderAPI := logsenderAPI{
+		err: errors.New("cannot connect to /logsink: server returned HTTP status 503"),
+	}
+
+	w := logsender.New(logsCh, logSenderAPI)
+	err := w.Wait()
+	c.Assert(err, tc.ErrorMatches, "logsender dial failed: cannot connect to /logsink: server returned HTTP status 503")
+}
+
+func (s *workerSuite) TestDisconnectedAPICallerTerminatesWorker(c *tc.C) {
+	logsCh := make(logsender.LogRecordCh)
+	logSenderAPI := logsenderAPI{
+		err: errors.New("api caller disconnected"),
+	}
+
+	w := logsender.New(logsCh, logSenderAPI)
+	err := w.Wait()
+	c.Assert(err, tc.ErrorMatches, "logsender dial failed: api caller disconnected")
+}
+
+func (s *workerSuite) TestWriteLogFailureTerminatesWorker(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	logsCh := make(logsender.LogRecordCh, 1)
+	writer := mocks.NewMockLogWriter(ctrl)
+	writer.EXPECT().WriteLog(gomock.Any()).Return(errors.New("write failed"))
+	writer.EXPECT().Close()
+
+	logsCh <- &logsender.LogRecord{
+		Time:     time.Now(),
+		Module:   "test",
+		Location: "test:1",
+		Level:    loggo.INFO,
+		Message:  "hello",
+	}
+
+	w := logsender.New(logsCh, logsenderAPI{writer: writer})
+	err := w.Wait()
+	c.Assert(err, tc.ErrorMatches, "write failed")
 }
 
 type workerBounceSuite struct {


### PR DESCRIPTION
With the up and coming work to allow log forwarding to loki (and OTEL) endpoints. We want to ensure that the logsender is resilient to logs being sent to a controller and the endpoint being unavailable. The endpoint will return 503 status codes from the endpoint, which will indicate that log forwarding is active. Officially, we're doing the change in the main branch, but we need to handle one user case. That is, when a migration from 4.0.x (where x migrates from 4.0.x to 4.1, which is currently in progress) to 4.1, all binaries are auto upgraded from their original version (4.0.12 for example) to match the same as the controller. But for a short amount of time 4.0.12 will be running **and** it will be attempting to send logs to the 4.1 controller. If the 4.1 controller is setup for log forwarding, then this will cause the logsender to bounce and prevent forward progress of the upgrade. The solution, is to drop all messages when faced with the 503 status code and to fallback to local log files. Once the upgrade happens, it will synchronize with the controller and forward the logs to the appropriate location.

## QA steps

```sh
$ juju boostrap lxd test
$ juju add-model foo
$ juju deploy juju-qa-test
```

Ensure that logging still works.

```sh
$ juju ssh -m controller 0
$ sudo touch /var/lib/juju/wrench/logsink
$ echo "return-503" | sudo tee /var/lib/juju/wrench/logsink
```

We need to bounce the unit agent so that it picks up the 503.

```sh
$ sudo systemctl restart jujud-*.service
```

Trigger some changes to the unit as well.

```sh
$ juju config juju-qa-test status="foo"
```

Ensure that there are no issues 


## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9973](https://warthogs.atlassian.net/browse/JUJU-9973)


[JUJU-9973]: https://warthogs.atlassian.net/browse/JUJU-9973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ