### PR TITLE
fix: use the model's project when checking LXD version on upgrade

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -208,6 +208,9 @@ func (s *modelUpgradeSuite) assertUpgradeModelForControllerModelJuju3(c *gc.C, d
 	ctrlModel := mocks.NewMockModel(ctrl)
 	model1 := mocks.NewMockModel(ctrl)
 	ctrlModel.EXPECT().IsControllerModel().Return(true).AnyTimes()
+	// The LXD version check reads the model's project from its config.
+	ctrlModel.EXPECT().Config().Return(coretesting.ModelConfig(c), nil).AnyTimes()
+	model1.EXPECT().Config().Return(coretesting.ModelConfig(c), nil).AnyTimes()
 
 	ctrlState := mocks.NewMockState(ctrl)
 	state1 := mocks.NewMockState(ctrl)
@@ -334,6 +337,9 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerDyingHostedModelJuju3(c
 	ctrlModel := mocks.NewMockModel(ctrl)
 	model1 := mocks.NewMockModel(ctrl)
 	ctrlModel.EXPECT().IsControllerModel().Return(true).AnyTimes()
+	// The LXD version check reads the model's project from its config.
+	ctrlModel.EXPECT().Config().Return(coretesting.ModelConfig(c), nil).AnyTimes()
+	model1.EXPECT().Config().Return(coretesting.ModelConfig(c), nil).AnyTimes()
 
 	ctrlState := mocks.NewMockState(ctrl)
 	state1 := mocks.NewMockState(ctrl)
@@ -438,6 +444,9 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 	ctrlModel := mocks.NewMockModel(ctrl)
 	model1 := mocks.NewMockModel(ctrl)
 	ctrlModel.EXPECT().IsControllerModel().Return(true).AnyTimes()
+	// The LXD version check reads the model's project from its config.
+	ctrlModel.EXPECT().Config().Return(coretesting.ModelConfig(c), nil).AnyTimes()
+	model1.EXPECT().Config().Return(coretesting.ModelConfig(c), nil).AnyTimes()
 
 	ctrlState := mocks.NewMockState(ctrl)
 	state1 := mocks.NewMockState(ctrl)
@@ -600,7 +609,8 @@ func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, ctrlModelVers strin
 	st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	// - check if the model has deprecated ubuntu machines;
 	st.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
-	// - check LXD version.
+	// - check LXD version (reads the model's project from its config).
+	model.EXPECT().Config().Return(coretesting.ModelConfig(c), nil)
 	serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 
@@ -688,7 +698,8 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 	}, nil)
 	// - check if model has charm store charms;
 	st.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
-	// - check LXD version.
+	// - check LXD version (reads the model's project from its config).
+	model.EXPECT().Config().Return(coretesting.ModelConfig(c), nil)
 	serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("4.0")
 	model.EXPECT().Owner().Return(names.NewUserTag("admin"))

--- a/internal/provider/lxd/config.go
+++ b/internal/provider/lxd/config.go
@@ -81,3 +81,12 @@ func (c *environConfig) project() string {
 	}
 	return project.(string)
 }
+
+// ProjectFromConfig returns the LXD project name configured for the model,
+// or the empty string when unset (matching environConfig.project()). It lets
+// callers outside this package - notably the upgrade/migration validators -
+// resolve the project the same way the environ does when it connects in
+// SetCloudSpec.
+func ProjectFromConfig(cfg *config.Config) string {
+	return newConfig(cfg).project()
+}

--- a/migration/interface.go
+++ b/migration/interface.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/status"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/tools"
 )
@@ -52,6 +53,7 @@ type PrecheckModel interface {
 	MigrationMode() state.MigrationMode
 	AgentVersion() (version.Number, error)
 	CloudCredentialTag() (names.CloudCredentialTag, bool)
+	Config() (*config.Config, error)
 }
 
 // PrecheckMachine describes the state interface for a machine needed

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/status"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/provider/lxd"
 	"github.com/juju/juju/migration"
 	"github.com/juju/juju/state"
@@ -1052,6 +1053,10 @@ func (m *fakeModel) CloudCredentialTag() (names.CloudCredentialTag, bool) {
 		return names.NewCloudCredentialTag(m.credential), true
 	}
 	return names.CloudCredentialTag{}, false
+}
+
+func (m *fakeModel) Config() (*config.Config, error) {
+	return config.New(config.UseDefaults, testing.FakeConfig())
 }
 
 type fakeMachine struct {

--- a/upgrades/upgradevalidation/interfaces.go
+++ b/upgrades/upgradevalidation/interfaces.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/replicaset/v3"
 	"github.com/juju/version/v2"
 
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/state"
 )
 
@@ -31,4 +32,5 @@ type Model interface {
 	Owner() names.UserTag
 	AgentVersion() (version.Number, error)
 	MigrationMode() state.MigrationMode
+	Config() (*config.Config, error)
 }

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -100,6 +100,7 @@ func (s *migrateSuite) setupMocks(c *gc.C) (*gomock.Controller, environscloudspe
 	serverFactory := mocks.NewMockServerFactory(ctrl)
 	// - check LXD version.
 	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: "lxd"}}
+	s.model.EXPECT().Config().Return(lxdModelConfig(c, ""), nil)
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 

--- a/upgrades/upgradevalidation/mocks/state_mock.go
+++ b/upgrades/upgradevalidation/mocks/state_mock.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	reflect "reflect"
 
+	config "github.com/juju/juju/environs/config"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v5"
 	replicaset "github.com/juju/replicaset/v3"
@@ -180,6 +181,21 @@ func (m *MockModel) AgentVersion() (version.Number, error) {
 func (mr *MockModelMockRecorder) AgentVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentVersion", reflect.TypeOf((*MockModel)(nil).AgentVersion))
+}
+
+// Config mocks base method.
+func (m *MockModel) Config() (*config.Config, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Config")
+	ret0, _ := ret[0].(*config.Config)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Config indicates an expected call of Config.
+func (mr *MockModelMockRecorder) Config() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockModel)(nil).Config))
 }
 
 // MigrationMode mocks base method.

--- a/upgrades/upgradevalidation/upgrade_test.go
+++ b/upgrades/upgradevalidation/upgrade_test.go
@@ -78,6 +78,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	// - check no charm store charms
 	ctrlState.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 	// - check LXD version.
+	ctrlModel.EXPECT().Config().Return(lxdModelConfig(c, ""), nil)
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 	// 2. Check hosted models.
@@ -91,6 +92,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	// - check no charm store charms
 	state1.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 	// - check LXD version.
+	model1.EXPECT().Config().Return(lxdModelConfig(c, ""), nil)
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 
@@ -132,6 +134,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju3(c *gc.C) {
 	state.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	state.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
 	// - check LXD version.
+	model.EXPECT().Config().Return(lxdModelConfig(c, ""), nil)
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -349,11 +349,21 @@ func getCheckForLXDVersion(cloudspec environscloudspec.CloudSpec) Validator {
 		if !lxdnames.IsDefaultCloud(cloudspec.Type) {
 			return nil, nil
 		}
+		// The configured LXD project lives in the model config, not the cloud
+		// spec. Resolve it the same way the environ does when it connects, so
+		// the version check connects to the model's project rather than LXD's
+		// "default" project, which a restricted TLS client may not be allowed
+		// to access.
+		modelCfg, err := model.Config()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		project := lxd.ProjectFromConfig(modelCfg)
 		server, err := NewServerFactory(lxd.NewHTTPClientFunc(func() *http.Client {
 			return jujuhttp.NewClient(
 				jujuhttp.WithLogger(logger.ChildWithLabels("http", corelogger.HTTP)),
 			).Client()
-		})).RemoteServer(lxd.CloudSpec{CloudSpec: cloudspec})
+		})).RemoteServer(lxd.CloudSpec{CloudSpec: cloudspec, Project: project})
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -16,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/provider/lxd"
 	"github.com/juju/juju/state"
 	coretesting "github.com/juju/juju/testing"
@@ -329,12 +330,23 @@ func (s *upgradeValidationSuite) TestCheckMongoVersionForControllerModel(c *gc.C
 	c.Assert(blocker.Error(), gc.Equals, `mongo version has to be "4.4" at least, but current version is "4.3"`)
 }
 
-func (s *upgradeValidationSuite) assertGetCheckForLXDVersion(c *gc.C, cloudType string) {
+// lxdModelConfig returns a model config carrying the given LXD project, or a
+// project-less config when project is empty.
+func lxdModelConfig(c *gc.C, project string) *config.Config {
+	extra := coretesting.Attrs{}
+	if project != "" {
+		extra["project"] = project
+	}
+	return coretesting.CustomModelConfig(c, extra)
+}
+
+func (s *upgradeValidationSuite) assertGetCheckForLXDVersion(c *gc.C, cloudType, project string) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
 	server := mocks.NewMockServer(ctrl)
 	serverFactory := mocks.NewMockServerFactory(ctrl)
+	model := mocks.NewMockModel(ctrl)
 
 	s.PatchValue(&upgradevalidation.NewServerFactory,
 		func(_ lxd.NewHTTPClientFunc) lxd.ServerFactory {
@@ -342,21 +354,32 @@ func (s *upgradeValidationSuite) assertGetCheckForLXDVersion(c *gc.C, cloudType 
 		},
 	)
 
-	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: cloudType}}
+	model.EXPECT().Config().Return(lxdModelConfig(c, project), nil)
+
+	// The model's configured project must be carried on the cloud spec, so a
+	// restricted TLS client connects to its own project rather than "default".
+	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: cloudType}, Project: project}
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
 
-	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec.CloudSpec)("", nil, nil, nil)
+	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec.CloudSpec)("", nil, nil, model)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.IsNil)
 }
 
 func (s *upgradeValidationSuite) TestGetCheckForLXDVersionLXD(c *gc.C) {
-	s.assertGetCheckForLXDVersion(c, "lxd")
+	s.assertGetCheckForLXDVersion(c, "lxd", "")
 }
 
 func (s *upgradeValidationSuite) TestGetCheckForLXDVersionLocalhost(c *gc.C) {
-	s.assertGetCheckForLXDVersion(c, "localhost")
+	s.assertGetCheckForLXDVersion(c, "localhost", "")
+}
+
+// TestGetCheckForLXDVersionUsesModelProject is a regression test for
+// https://github.com/juju/juju/issues/22486: the version check must connect
+// using the model's configured LXD project.
+func (s *upgradeValidationSuite) TestGetCheckForLXDVersionUsesModelProject(c *gc.C) {
+	s.assertGetCheckForLXDVersion(c, "lxd", "juju-reproducer")
 }
 
 func (s *upgradeValidationSuite) TestGetCheckForLXDVersionSkippedForNonLXDCloud(c *gc.C) {
@@ -382,17 +405,19 @@ func (s *upgradeValidationSuite) TestGetCheckForLXDVersionFailed(c *gc.C) {
 
 	server := mocks.NewMockServer(ctrl)
 	serverFactory := mocks.NewMockServerFactory(ctrl)
+	model := mocks.NewMockModel(ctrl)
 
 	s.PatchValue(&upgradevalidation.NewServerFactory,
 		func(_ lxd.NewHTTPClientFunc) lxd.ServerFactory {
 			return serverFactory
 		},
 	)
+	model.EXPECT().Config().Return(lxdModelConfig(c, ""), nil)
 	cloudSpec := lxd.CloudSpec{CloudSpec: environscloudspec.CloudSpec{Type: "lxd"}}
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("4.0")
 
-	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec.CloudSpec)("", nil, nil, nil)
+	blocker, err := upgradevalidation.GetCheckForLXDVersion(cloudSpec.CloudSpec)("", nil, nil, model)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(blocker, gc.NotNil)
 	c.Assert(blocker.Error(), gc.Equals, `LXD version has to be at least "5.0.0", but current version is only "4.0.0"`)


### PR DESCRIPTION
LXD controllers bootstrapped with a TLS client certificate that LXD
  restricts to a single project could not be upgraded (or migrated):
  `juju upgrade-controller` failed with

      ERROR User does not have permission for project "default"

  The pre-upgrade LXD-version validator (`getCheckForLXDVersion`) opens a
  fresh LXD connection from the cloud spec but never set the project. The
  LXD project is a *model-config* attribute, not part of the cloud spec, so
  the connection fell back to LXD's `default` project and the restricted
  certificate was denied. Bootstrap and day-to-day operations work because
  those paths already pass the configured project (see
  `provider/lxd/environ.go` `SetCloudSpec`).

  This reads the project from the model config and passes it on the
  `lxd.CloudSpec`, matching how the environ connects during normal
  operation. The same validator is shared by the model-migration source
  precheck, so this also fixes the identical latent failure there.

  The change is contained to the validator: no validator-factory signatures,
  facade, or migration call sites change — `getCheckForLXDVersion` now reads
  `model.Config()`, plus a small `Config()` addition to the
  `upgradevalidation.Model` and `migration.PrecheckModel` interfaces (both
  already satisfied by `*state.Model`).

__Note: this fix will not be forwarded to 4.0 since we no longer perform these checks:
From #19551: One use of the cloudspec was to create a provider which was used with migration and upgrades to check lxd version.
We no longer need to do this in 4.0 since migrating from 3.6 requires everything is up to date.__

## QA steps

1. Save LXD server certificate 
```
$ lxc info local: | yq .environment.certificate > server.crt
```
 
2. Generate TLS client cert/key
```
$ openssl req -x509 -newkey ec:<(openssl ecparam -name secp384r1) -keyout client.key -nodes -out client.crt -days 365 -subj "/CN=lxd-juju-client"
```

3. Create LXD project & profile
```
$ lxc project create juju-reproducer --config features.images=true --config features.profiles=true
$ lxc profile --project juju-reproducer device add default eth0 nic network=lxdbr0
$ lxc profile --project juju-reproducer device add default root disk path="/" pool=default
```

4. Authorise TLS client
```
$ lxc config trust add --name juju-reproducer --restricted --projects juju-reproducer client.crt 
```

5. Add Juju cloud
```
# Confirm IP address of lxdbr0 interface
$ ip -br -4 addr show lxdbr0 | awk '{split($3,a,"/"); print a[1]}'
$ juju add-cloud --client juju-reproducer-lxd
```
Follow the interactive prompts:
```
Cloud Types
  lxd
  maas
  manual
  openstack
  vsphere

Select cloud type: lxd

Enter the API endpoint url for the remote LXD server: https://{ip address per above command}:8443

Auth Types
  certificate

Enter region [default]: 

Enter the API endpoint url for the region [use cloud api url]: 

Enter another region? (y/N): 
```

4. Add Juju credential
```
$ juju add-credential juju-reproducer-lxd --client
```

Follow the interactive prompts:
```
Enter credential name: juju-reproducer

Regions
  default

Select region [any region, credential is not region specific]:        

Auth Types
  certificate
  interactive

Select auth type [interactive]: certificate

Enter the path to the PEM-encoded LXD server certificate file: server.crt

Enter the path to the PEM-encoded LXD client certificate file: client.crt

Enter the path to the PEM-encoded LXD client key file: client.key 

Credential "juju-reproducer" added locally for cloud "juju-reproducer-lxd".
```

5. Bootstrap controller
```
$ juju bootstrap --build-agent --credential=juju-reproducer --config=project=juju-reproducer --bootstrap-constraints virt-type=virtual-machine juju-reproducer-lxd juju-reproducer
```


6. Attempt to upgrade

Switch to the new model and verify there's an upgrade available
```bash
$ juju switch controller
$ juju status
```

Output:
```
Model       Controller       Cloud/Region                 Version   SLA          Timestamp
controller  juju-reproducer  juju-reproducer-lxd/default  3.6.24.1  unsupported  18:59:49+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable  234  yes      

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.134.1.59     17022,17070/tcp  

Machine  State    Address      Inst id        Base          AZ                                Message
0        started  10.134.1.59  juju-87c002-0  ubuntu@24.04  nvinuesa-ThinkPad-P16s-Gen-4-AMD  Running
```

Attempt to upgrade:
```
$ juju upgrade-controller --build-agent
no prepackaged agent binaries available, using local agent binary 3.6.24.2 (built from source)
best version:
    3.6.24.2
started upgrade to 3.6.24.2
$  juju status
Model       Controller       Cloud/Region                 Version   SLA          Timestamp
controller  juju-reproducer  juju-reproducer-lxd/default  3.6.24.2  unsupported  19:00:20+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable  234  yes      

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.134.1.59     17022,17070/tcp  

Machine  State    Address      Inst id        Base          AZ                                Message
0        started  10.134.1.59  juju-87c002-0  ubuntu@24.04  nvinuesa-ThinkPad-P16s-Gen-4-AMD  Running
```
## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22486.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9858](https://warthogs.atlassian.net/browse/JUJU-9858)


[JUJU-9858]: https://warthogs.atlassian.net/browse/JUJU-9858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ