### PR TITLE
fix: add model tag to JWT AuthInfo

### DIFF
--- a/apiserver/authentication/jwt/jwt.go
+++ b/apiserver/authentication/jwt/jwt.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/core/permission"
 )
 
@@ -101,10 +102,15 @@ func (j *JWTAuthenticator) Authenticate(req *http.Request) (authentication.AuthI
 		return authentication.AuthInfo{}, fmt.Errorf("parsing jwt: %w", err)
 	}
 
-	return authentication.AuthInfo{
+	authInfo := authentication.AuthInfo{
 		Entity:    entity,
 		Delegator: &PermissionDelegator{token},
-	}, nil
+	}
+	if modelUUID := httpcontext.RequestModelUUID(req); modelUUID != "" {
+		authInfo.ModelTag = names.NewModelTag(modelUUID)
+	}
+
+	return authInfo, nil
 }
 
 // AuthenticateLoginRequest implements LoginAuthenticator

--- a/apiserver/authentication/jwt/jwt_test.go
+++ b/apiserver/authentication/jwt/jwt_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"net/http"
+	"net/http/httptest"
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
@@ -17,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/authentication/jwt"
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/testing"
 )
@@ -63,6 +65,48 @@ func (s *loginTokenSuite) TestAuthenticate(c *gc.C) {
 	perm, err = authInfo.SubjectPermissions(applicationOfferTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(perm, gc.Equals, permission.ConsumeAccess)
+	c.Assert(authInfo.ModelTag.Id(), gc.Equals, "")
+}
+
+func (s *loginTokenSuite) TestAuthenticateSetsModelTagFromRequestContext(c *gc.C) {
+	tok, err := EncodedJWT(JWTParams{
+		Controller: testing.ControllerTag.Id(),
+		User:       "user-fred",
+		Access: map[string]string{
+			testing.ModelTag.String(): "write",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	authenticator := jwt.NewAuthenticator(&testJWTParser{})
+	req, err := http.NewRequest("", "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	req.Header.Add("Authorization", "Bearer "+base64.StdEncoding.EncodeToString(tok))
+	req = requestWithModelContext(c, testing.ModelTag.Id(), req)
+
+	authInfo, err := authenticator.Authenticate(req)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(authInfo.ModelTag.Id(), gc.Equals, testing.ModelTag.Id())
+}
+
+func (s *loginTokenSuite) TestAuthenticateWithoutModelContextLeavesModelTagEmpty(c *gc.C) {
+	tok, err := EncodedJWT(JWTParams{
+		Controller: testing.ControllerTag.Id(),
+		User:       "user-fred",
+		Access: map[string]string{
+			testing.ModelTag.String(): "write",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	authenticator := jwt.NewAuthenticator(&testJWTParser{})
+	req, err := http.NewRequest("", "", nil)
+	c.Assert(err, jc.ErrorIsNil)
+	req.Header.Add("Authorization", "Bearer "+base64.StdEncoding.EncodeToString(tok))
+
+	authInfo, err := authenticator.Authenticate(req)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(authInfo.ModelTag.Id(), gc.Equals, "")
 }
 
 func (s *loginTokenSuite) TestAuthenticateInvalidHeader(c *gc.C) {
@@ -109,6 +153,7 @@ func (s *loginTokenSuite) TestUsesLoginToken(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(authInfo.Entity.Tag().String(), gc.Equals, "user-fred")
+	c.Assert(authInfo.ModelTag.Id(), gc.Equals, "")
 	perm, err := authInfo.SubjectPermissions(modelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(perm, gc.Equals, permission.WriteAccess)
@@ -202,4 +247,17 @@ func (s *loginTokenSuite) TestNotAvailableJWTParser(c *gc.C) {
 	req.Header.Add("Authorization", "Bearer aaaaa")
 	_, err = authenticator.Authenticate(req)
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
+func requestWithModelContext(c *gc.C, modelUUID string, req *http.Request) *http.Request {
+	var modelReq *http.Request
+	handler := &httpcontext.ImpliedModelHandler{
+		Handler: http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+			modelReq = req
+		}),
+		ModelUUID: modelUUID,
+	}
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	c.Assert(modelReq, gc.NotNil)
+	return modelReq
 }

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -4,6 +4,7 @@
 package apiserver_test
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -14,10 +15,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	gc "gopkg.in/check.v1"
 
+	authjwt "github.com/juju/juju/apiserver/authentication/jwt"
 	apitesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/testcharms"
@@ -169,6 +174,54 @@ func (s *putObjectsSuite) TestCannotUploadCharmhubCharm(c *gc.C) {
 	resp.Body.Close()
 }
 
+func (s *putObjectsSuite) TestUploadAllowsJWTUserWithModelWritePermission(c *gc.C) {
+	token, err := apitesting.NewJWT(apitesting.JWTParams{
+		Controller: s.State.ControllerUUID(),
+		User:       s.Owner.String(),
+		Access: map[string]any{
+			s.Model.ModelTag().String(): permission.WriteAccess,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.restartServerWithJWT(c, token)
+
+	empty := strings.NewReader("")
+	resp := s.jwtUploadRequest(
+		c,
+		s.objectsCharmsURI("somecharm-"+getCharmHash(c, empty)),
+		"local:somecharm",
+		empty,
+	)
+	defer resp.Body.Close()
+	s.assertErrorResponse(c, resp, http.StatusBadRequest, `.*zip: not a valid zip file$`)
+}
+
+func (s *putObjectsSuite) TestUploadRejectsJWTUserWithWritePermissionOnDifferentModel(c *gc.C) {
+	otherModel := s.Factory.MakeModel(c, nil)
+	defer otherModel.Close()
+
+	token, err := apitesting.NewJWT(apitesting.JWTParams{
+		Controller: s.State.ControllerUUID(),
+		User:       s.Owner.String(),
+		Access: map[string]any{
+			names.NewModelTag(otherModel.ModelUUID()).String(): permission.WriteAccess,
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	s.restartServerWithJWT(c, token)
+
+	empty := strings.NewReader("")
+	resp := s.jwtUploadRequest(
+		c,
+		s.objectsCharmsURI("somecharm-"+getCharmHash(c, empty)),
+		"local:somecharm",
+		empty,
+	)
+	defer resp.Body.Close()
+	body := apitesting.AssertResponse(c, resp, http.StatusForbidden, "text/plain; charset=utf-8")
+	c.Assert(string(body), gc.Equals, "authorization failed: permission denied\n")
+}
+
 func (s *putObjectsSuite) TestUploadBumpsRevision(c *gc.C) {
 	// Add the dummy charm with revision 1.
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
@@ -199,6 +252,32 @@ func (s *putObjectsSuite) TestUploadBumpsRevision(c *gc.C) {
 	// No more checks for the hash here, because it is
 	// verified in TestUploadRespectsLocalRevision.
 	c.Assert(sch.BundleSha256(), gc.Not(gc.Equals), "")
+}
+
+func (s *putObjectsSuite) restartServerWithJWT(c *gc.C, token jwt.Token) {
+	s.config.JWTAuthenticator = authjwt.NewAuthenticator(fixedTokenParser{token: token})
+	s.newServer(c, s.config)
+}
+
+func (s *putObjectsSuite) jwtUploadRequest(c *gc.C, url, curl string, content io.Reader) *http.Response {
+	return apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Method:      "PUT",
+		URL:         url,
+		ContentType: "application/zip",
+		Body:        content,
+		ExtraHeaders: map[string]string{
+			"Authorization": "Bearer test-token",
+			"Juju-Curl":     curl,
+		},
+	})
+}
+
+type fixedTokenParser struct {
+	token jwt.Token
+}
+
+func (p fixedTokenParser) Parse(context.Context, string) (jwt.Token, error) {
+	return p.token, nil
 }
 
 func getCharmHash(c *gc.C, stream io.ReadSeeker) string {


### PR DESCRIPTION
This change fixes a bug causing authz with JWT tokens to always fail under certain conditions. In https://github.com/juju/juju/blob/3.6/apiserver/authentication/jwt/jwt.go#L104 when a client logs in with a JWT, we create an `AuthInfo` object that does not include the relevant model tag that the request relates to (if the request was model scoped). I.e. we always return
```go
authentication.AuthInfo{
		Entity:    entity,
		Delegator: &PermissionDelegator{token},
}
```
Later when we check permissions in https://github.com/juju/juju/blob/3.6/apiserver/httpcontext.go#L278 for model level access, it will always fail,
```go
if !names.IsValidModel(authInfo.ModelTag.Id()) {
		return errors.Errorf("%q is not a valid model", authInfo.ModelTag.Id())
}
```  
because `authInfo.ModelTag` is always empty.

This issue was surfaced by a change in JIMM where we began minting JWT tokens with the user's permissions rather than using the controller' admin username/password which cause commands like `juju deploy ./<local-charm>` to fail with `authorization failed: permission denied`. When the `CompositeAuthorizer` in https://github.com/juju/juju/blob/3.6/apiserver/httpcontext/auth.go#L91 fails to authorize the user, the underlying error is masked and a `permission denied` error is returned instead,
```go
// Authorize is part of the [Authorizer] interface.
func (c CompositeAuthorizer) Authorize(authInfo authentication.AuthInfo) error {
	for _, a := range c {
		if err := a.Authorize(authInfo); err == nil {
			return nil
		}
	}
	return apiservererrors.ErrPerm
}
```


I have applied the fix in the `apiserver/authentication/jwt` package and added tests both here (unit test) and a slightly more integrated test in `apiserver/objects_test.go` that verifies the JWT login behaviour against an api server.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Links

**Jira card:** [JUJU-9988](https://warthogs.atlassian.net/browse/JUJU-9988)


[JUJU-9988]: https://warthogs.atlassian.net/browse/JUJU-9988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ