### PR TITLE
fix: 3.6 → 4.0 migration fails due to missing subnet (JUJU-9647)

### DIFF
--- a/domain/network/import_integration_test.go
+++ b/domain/network/import_integration_test.go
@@ -682,6 +682,71 @@ func (s *importSuite) TestImportLinkLayerDevicesWithAddressesLXDMissingSubnet(c 
 	s.checkSubnetExists(c, "10.136.55.0/24")
 }
 
+// TestImportLinkLayerDevicesWithAddressesLXDMissingSubnetDedup verifies that
+// when two addresses on the same device share the same missing /24 CIDR,
+// the import auto-creates only a single subnet row (no duplicate with a
+// different UUID).
+func (s *importSuite) TestImportLinkLayerDevicesWithAddressesLXDMissingSubnetDedup(c *tc.C) {
+	s.setModel(c, "lxd", model.IAAS.String())
+
+	machineSvc := s.setupMachineService(c)
+	res, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	desc := description.NewModel(description.ModelArgs{
+		Type: string(model.IAAS),
+	})
+
+	desc.AddLinkLayerDevice(description.LinkLayerDeviceArgs{
+		Name:        "lxdbr0",
+		MTU:         1500,
+		ProviderID:  "net-lxdbr0",
+		MachineID:   res.MachineName.String(),
+		Type:        "bridge",
+		MACAddress:  "00:16:3e:00:00:01",
+		IsAutoStart: true,
+		IsUp:        true,
+	})
+
+	// Two addresses on the same device sharing the same missing /24 subnet.
+	desc.AddIPAddress(description.IPAddressArgs{
+		Value:            "10.136.55.1",
+		SubnetCIDR:       "10.136.55.0/24",
+		ProviderSubnetID: "subnet-lxdbr0-10.136.55.0/24",
+		Origin:           "machine",
+		MachineID:        res.MachineName.String(),
+		DeviceName:       "lxdbr0",
+		ConfigMethod:     string(network.ConfigStatic),
+	})
+	desc.AddIPAddress(description.IPAddressArgs{
+		Value:            "10.136.55.2",
+		SubnetCIDR:       "10.136.55.0/24",
+		ProviderSubnetID: "subnet-lxdbr0-10.136.55.0/24",
+		Origin:           "machine",
+		MachineID:        res.MachineName.String(),
+		DeviceName:       "lxdbr0",
+		ConfigMethod:     string(network.ConfigStatic),
+	})
+
+	networkmodelmigration.RegisterLinkLayerDevicesImport(s.coordinator, loggertesting.WrapCheckLog(c))
+
+	// Act
+	err = s.coordinator.Perform(c.Context(), s.scope, desc)
+
+	// Assert: import succeeds; the missing subnet is auto-created only once.
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.checkLinkLayerDeviceExistsOnMachine(c, res.MachineName, "lxdbr0")
+	s.checkAddressExistsForDeviceOnMachine(c, res.MachineName, "lxdbr0", "10.136.55.1/24")
+	s.checkAddressExistsForDeviceOnMachine(c, res.MachineName, "lxdbr0", "10.136.55.2/24")
+	s.checkSubnetExists(c, "10.136.55.0/24")
+}
+
 func (s *importSuite) TestImportK8sServices(c *tc.C) {
 	s.createCAASApplication(c, "foo")
 	s.createCAASApplication(c, "bar")

--- a/domain/network/import_integration_test.go
+++ b/domain/network/import_integration_test.go
@@ -618,6 +618,70 @@ func (s *importSuite) TestImportLinkLayerDevicesWithAddressesLXD(c *tc.C) {
 	s.checkSubnetExists(c, "203.0.113.0/32")
 }
 
+// TestImportLinkLayerDevicesWithAddressesLXDMissingSubnet reproduces
+// the failure reported in GitHub issue juju/juju#22224 (JUJU-9647): a 3.6 LXD
+// model migrated to 4.0 fails when the host machine has a bridge device (e.g.
+// lxdbr0) whose /24 subnet was never formally registered in the 3.6 model's
+// subnet topology.
+//
+// In 3.6, the SubnetCIDR was stored as a plain string with no FK constraint,
+// so the import succeeded silently. In 4.0 the ip_address table has a proper
+// FK to subnet_uuid, requiring the subnet to exist. The fix auto-creates a
+// minimal subnet record (in the default space) and emits a warning.
+func (s *importSuite) TestImportLinkLayerDevicesWithAddressesLXDMissingSubnet(c *tc.C) {
+	s.setModel(c, "lxd", model.IAAS.String())
+
+	// Arrange: machine with no pre-seeded subnets (simulates a 3.6 model
+	// where the lxdbr0 bridge subnet was never registered).
+	machineSvc := s.setupMachineService(c)
+	res, err := machineSvc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	desc := description.NewModel(description.ModelArgs{
+		Type: string(model.IAAS),
+	})
+
+	// lxdbr0 on the host machine; its /24 subnet is deliberately absent from
+	// the description (and therefore absent from the DB after subnet import).
+	desc.AddLinkLayerDevice(description.LinkLayerDeviceArgs{
+		Name:        "lxdbr0",
+		MTU:         1500,
+		ProviderID:  "net-lxdbr0",
+		MachineID:   res.MachineName.String(),
+		Type:        "bridge",
+		MACAddress:  "00:16:3e:00:00:01",
+		IsAutoStart: true,
+		IsUp:        true,
+	})
+
+	desc.AddIPAddress(description.IPAddressArgs{
+		Value:            "10.136.55.1",
+		SubnetCIDR:       "10.136.55.0/24",
+		ProviderSubnetID: "subnet-lxdbr0-10.136.55.0/24",
+		Origin:           "machine",
+		MachineID:        res.MachineName.String(),
+		DeviceName:       "lxdbr0",
+		ConfigMethod:     string(network.ConfigStatic),
+	})
+
+	networkmodelmigration.RegisterLinkLayerDevicesImport(s.coordinator, loggertesting.WrapCheckLog(c))
+
+	// Act
+	err = s.coordinator.Perform(c.Context(), s.scope, desc)
+
+	// Assert: import succeeds; the missing subnet is auto-created.
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.checkLinkLayerDeviceExistsOnMachine(c, res.MachineName, "lxdbr0")
+	s.checkAddressExistsForDeviceOnMachine(c, res.MachineName, "lxdbr0", "10.136.55.1/24")
+	s.checkSubnetExists(c, "10.136.55.0/24")
+}
+
 func (s *importSuite) TestImportK8sServices(c *tc.C) {
 	s.createCAASApplication(c, "foo")
 	s.createCAASApplication(c, "bar")

--- a/domain/network/service/migration.go
+++ b/domain/network/service/migration.go
@@ -184,18 +184,27 @@ func (s *MigrationService) transformImportIPAddress(
 	return addr, errors.Capture(err)
 }
 
-// maybeAddSubnet creates a subnet if the address provided is a /32
-// or /128. Should only be called if an existing subnet does not match.
+// maybeAddSubnet creates a minimal subnet record for addr.SubnetCIDR when
+// no existing subnet matches. It handles two distinct cases:
+//
+//   - /32 (IPv4) or /128 (IPv6) host-only addresses (e.g. Cilium): these
+//     genuinely have no corresponding network subnet in any provider, so
+//     auto-creation is expected.
+//   - Regular network CIDRs (e.g. /24): these should have been exported from
+//     the source model, but some 3.6 LXD models omit bridge subnets (e.g.
+//     lxdbr0) because they were referenced by IP address records without
+//     being formally registered in the model's subnet topology. A warning is
+//     logged so that operators can reassign the auto-created subnet to the
+//     correct space after migration.
 func (s *MigrationService) maybeAddSubnet(ctx context.Context, addr internal.ImportIPAddress) (internal.ImportIPAddress, error) {
-	// Check to see if we have a /32 or /128 CIDR.
-	_, ipNet, err := net.ParseCIDR(addr.SubnetCIDR)
-	if err != nil {
+	if _, _, err := net.ParseCIDR(addr.SubnetCIDR); err != nil {
 		return internal.ImportIPAddress{}, errors.Capture(err)
 	}
-	ones, bits := ipNet.Mask.Size()
-	if ones != bits && (bits == 32 || bits == 128) {
-		return internal.ImportIPAddress{}, errors.Errorf("no subnet found, nor created")
-	}
+
+	s.logger.Warningf(ctx,
+		"subnet %q not found in model; auto-creating a minimal record in the default space — "+
+			"reassign it to the correct space after migration if needed",
+		addr.SubnetCIDR)
 
 	subnetUUID, err := uuid.NewUUID()
 	if err != nil {

--- a/domain/network/service/migration.go
+++ b/domain/network/service/migration.go
@@ -99,10 +99,15 @@ func (s *MigrationService) ImportLinkLayerDevices(ctx context.Context, data []in
 		subnetByProviderId[subnet.ProviderId.String()] = subnet
 	}
 
+	// Cache for subnets auto-created during this import so that multiple
+	// addresses sharing the same missing CIDR (e.g. two IPs on the same
+	// /24 bridge) result in a single subnet row.
+	createdSubnetsByCIDR := make(map[string]string)
+
 	// Process each device
 	useData := make([]internal.ImportLinkLayerDevice, 0, len(data))
 	for _, device := range data {
-		dev, err := s.transformImportLinkLayerDevice(ctx, device, namesToUUIDs, subnets, subnetByProviderId)
+		dev, err := s.transformImportLinkLayerDevice(ctx, device, namesToUUIDs, subnets, subnetByProviderId, createdSubnetsByCIDR)
 		if err != nil {
 			return errors.Errorf("converting device %q on machine %q: %w", device.Name, device.MachineID, err)
 		}
@@ -122,6 +127,7 @@ func (s *MigrationService) transformImportLinkLayerDevice(
 	namesToUUIDs map[string]string,
 	subnets corenetwork.SubnetInfos,
 	subnetByProviderId map[string]corenetwork.SubnetInfo,
+	createdSubnetsByCIDR map[string]string,
 ) (internal.ImportLinkLayerDevice, error) {
 	// Set the net node UUID
 	netNodeUUID, ok := namesToUUIDs[device.MachineID]
@@ -134,7 +140,7 @@ func (s *MigrationService) transformImportLinkLayerDevice(
 	if len(device.Addresses) > 0 {
 		transformedAddresses := make([]internal.ImportIPAddress, 0, len(device.Addresses))
 		for _, addr := range device.Addresses {
-			transformedAddr, err := s.transformImportIPAddress(ctx, addr, subnets, subnetByProviderId)
+			transformedAddr, err := s.transformImportIPAddress(ctx, addr, subnets, subnetByProviderId, createdSubnetsByCIDR)
 			if err != nil {
 				return internal.ImportLinkLayerDevice{}, errors.Errorf("converting address %q: %w",
 					addr.AddressValue, err)
@@ -152,6 +158,7 @@ func (s *MigrationService) transformImportIPAddress(
 	addr internal.ImportIPAddress,
 	subnets corenetwork.SubnetInfos,
 	subnetByProviderId map[string]corenetwork.SubnetInfo,
+	createdSubnetsByCIDR map[string]string,
 ) (internal.ImportIPAddress, error) {
 	if addr.ConfigType == corenetwork.ConfigLoopback {
 		// Loopback addresses will not have an associated subnet, return the
@@ -179,7 +186,7 @@ func (s *MigrationService) transformImportIPAddress(
 	var err error
 	addr.SubnetUUID, err = s.ensureOneSubnet(candidateSubnets)
 	if errors.Is(err, networkerrors.SubnetNotFound) {
-		return s.maybeAddSubnet(ctx, addr)
+		return s.maybeAddSubnet(ctx, addr, createdSubnetsByCIDR)
 	}
 	return addr, errors.Capture(err)
 }
@@ -196,9 +203,18 @@ func (s *MigrationService) transformImportIPAddress(
 //     being formally registered in the model's subnet topology. A warning is
 //     logged so that operators can reassign the auto-created subnet to the
 //     correct space after migration.
-func (s *MigrationService) maybeAddSubnet(ctx context.Context, addr internal.ImportIPAddress) (internal.ImportIPAddress, error) {
+//
+// The createdSubnetsByCIDR map is used to deduplicate subnet creation: if
+// multiple addresses share the same missing CIDR, only the first call
+// inserts a row; subsequent calls reuse the cached UUID.
+func (s *MigrationService) maybeAddSubnet(ctx context.Context, addr internal.ImportIPAddress, createdSubnetsByCIDR map[string]string) (internal.ImportIPAddress, error) {
 	if _, _, err := net.ParseCIDR(addr.SubnetCIDR); err != nil {
 		return internal.ImportIPAddress{}, errors.Capture(err)
+	}
+
+	if uuid, ok := createdSubnetsByCIDR[addr.SubnetCIDR]; ok {
+		addr.SubnetUUID = uuid
+		return addr, nil
 	}
 
 	s.logger.Warningf(ctx,
@@ -217,6 +233,7 @@ func (s *MigrationService) maybeAddSubnet(ctx context.Context, addr internal.Imp
 	if err := s.st.AddSubnet(ctx, subnetInfo); err != nil {
 		return internal.ImportIPAddress{}, errors.Capture(err)
 	}
+	createdSubnetsByCIDR[addr.SubnetCIDR] = subnetUUID.String()
 	addr.SubnetUUID = subnetUUID.String()
 	return addr, nil
 }

--- a/domain/network/service/migration_test.go
+++ b/domain/network/service/migration_test.go
@@ -317,6 +317,63 @@ func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProviderNoSubnet
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestImportLinkLayerDevicesSubnetWithoutProviderNoSubnetDedup verifies that
+// when two addresses on the same device share the same missing /24 CIDR,
+// only a single subnet is created (no duplicate with a different UUID).
+func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProviderNoSubnetDedup(c *tc.C) {
+	// Arrange
+	defer s.setupMocks(c).Finish()
+	netNodeUUID := uuid.MustNewUUID().String()
+	nameMap := map[string]string{
+		"0": netNodeUUID,
+	}
+
+	s.st.EXPECT().AllMachinesAndNetNodes(gomock.Any()).Return(nameMap, nil)
+	s.st.EXPECT().GetAllSubnets(gomock.Any()).Return(nil, nil)
+
+	// Expect a single /24 subnet to be auto-created (not two).
+	subnetInfo := corenetwork.SubnetInfo{
+		CIDR: "10.136.55.0/24",
+	}
+	matcher := &spaceInfoAsArgMatcher{
+		c:        c,
+		expected: subnetInfo,
+	}
+	s.st.EXPECT().AddSubnet(gomock.Any(), matcher).Return(nil)
+
+	args := []internal.ImportLinkLayerDevice{
+		{
+			MachineID: "0",
+			Name:      "lxdbr0",
+			Addresses: []internal.ImportIPAddress{
+				{
+					AddressValue: "10.136.55.1",
+					SubnetCIDR:   "10.136.55.0/24",
+				},
+				{
+					AddressValue: "10.136.55.2",
+					SubnetCIDR:   "10.136.55.0/24",
+				},
+			},
+		},
+	}
+
+	expectedArgs := make([]internal.ImportLinkLayerDevice, len(args))
+	copy(expectedArgs, args)
+	expectedArgs[0].NetNodeUUID = netNodeUUID
+	matcherTwo := &importLinkLayerDeviceArgMatcher{
+		c:        c,
+		expected: expectedArgs,
+	}
+	s.st.EXPECT().ImportLinkLayerDevices(gomock.Any(), matcherTwo).Return(nil)
+
+	// Act
+	err := s.migrationService(c).ImportLinkLayerDevices(c.Context(), args)
+
+	// Assert: no error; single subnet shared by both addresses.
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProviderTooMuchSubnet(c *tc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()

--- a/domain/network/service/migration_test.go
+++ b/domain/network/service/migration_test.go
@@ -260,6 +260,63 @@ func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProviderNoSubnet
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestImportLinkLayerDevicesSubnetWithoutProviderNoSubnetSlash24 verifies that
+// when an address references a /24 CIDR that is absent from the model (e.g.
+// an LXD bridge subnet that was never formally registered in the 3.6 model's
+// subnet topology), the import auto-creates a minimal subnet record and emits
+// a warning rather than failing. This mirrors the 3.6 behaviour where the
+// SubnetCIDR was stored as a plain string with no FK constraint.
+func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProviderNoSubnetSlash24(c *tc.C) {
+	// Arrange
+	defer s.setupMocks(c).Finish()
+	netNodeUUID := uuid.MustNewUUID().String()
+	nameMap := map[string]string{
+		"0": netNodeUUID,
+	}
+
+	s.st.EXPECT().AllMachinesAndNetNodes(gomock.Any()).Return(nameMap, nil)
+	s.st.EXPECT().GetAllSubnets(gomock.Any()).Return(nil, nil)
+
+	// Expect a /24 subnet to be auto-created.
+	subnetInfo := corenetwork.SubnetInfo{
+		CIDR: "10.136.55.0/24",
+	}
+	matcher := &spaceInfoAsArgMatcher{
+		c:        c,
+		expected: subnetInfo,
+	}
+	s.st.EXPECT().AddSubnet(gomock.Any(), matcher).Return(nil)
+
+	args := []internal.ImportLinkLayerDevice{
+		{
+			MachineID: "0",
+			Name:      "lxdbr0",
+			Addresses: []internal.ImportIPAddress{
+				{
+					AddressValue: "10.136.55.1",
+					SubnetCIDR:   "10.136.55.0/24",
+				},
+			},
+		},
+	}
+
+	expectedArgs := make([]internal.ImportLinkLayerDevice, len(args))
+	copy(expectedArgs, args)
+	expectedArgs[0].NetNodeUUID = netNodeUUID
+	matcherTwo := &importLinkLayerDeviceArgMatcher{
+		c:        c,
+		expected: expectedArgs,
+	}
+	s.st.EXPECT().ImportLinkLayerDevices(gomock.Any(), matcherTwo).Return(nil)
+
+	// Act
+	err := s.migrationService(c).ImportLinkLayerDevices(c.Context(), args)
+
+	// Assert: no error; subnet auto-created; warning logged (not asserted here,
+	// captured by the test logger).
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *migrationSuite) TestImportLinkLayerDevicesSubnetWithoutProviderTooMuchSubnet(c *tc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()


### PR DESCRIPTION
## Summary

Migrating a 3.6 LXD model to a 4.0 controller fails when the host machine
has a bridge device (e.g. \`lxdbr0\`) whose subnet was never formally
registered in the 3.6 model's subnet topology.

Fixes: https://warthogs.atlassian.net/browse/JUJU-9647
Closes: #22224

## Root cause

\`maybeAddSubnet\` in \`domain/network/service/migration.go\` refused to
auto-create any subnet with a prefix length other than /32 or /128, returning
\`"no subnet found, nor created"\` for regular CIDRs like \`10.136.55.0/24\`.

In 3.6 (MongoDB-based), IP addresses stored \`SubnetCIDR\` as a plain string
with no FK constraint, so this case was silently accepted. The 4.0 domain
introduced a proper FK from \`ip_address\` to \`subnet_uuid\`, requiring the
subnet to exist before the import can proceed.

## Fix

Extend \`maybeAddSubnet\` to auto-create a minimal subnet record (in the
default space, no provider metadata) for any missing CIDR — not just /32
and /128. A \`WARNING\`-level log is emitted so operators are aware that a
subnet was auto-created outside any space and can reassign it after migration.

## Testing

- Unit: \`TestImportLinkLayerDevicesSubnetWithoutProviderNoSubnetSlash24\` — verifies a /24 absent from the DB is auto-created.
- Integration: \`TestImportLinkLayerDevicesWithAddressesLXDMissingSubnet\` — end-to-end reproduction of the exact failure scenario (LXD model, \`lxdbr0\`, no subnet in description).