### PR TITLE
feat: add ca cert for loki integration

### DIFF
--- a/domain/logging/config.go
+++ b/domain/logging/config.go
@@ -1,0 +1,12 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logging
+
+// LokiConfig holds the controller-wide Loki push API configuration.
+type LokiConfig struct {
+	// Endpoint is the Loki push API URL.
+	Endpoint string
+	// CACertificate is the CA certificate used to validate the Loki endpoint.
+	CACertificate string
+}

--- a/domain/logging/errors/errors.go
+++ b/domain/logging/errors/errors.go
@@ -6,7 +6,6 @@ package errors
 import "github.com/juju/juju/internal/errors"
 
 const (
-	// LokiEndpointNotFound is returned when no Loki endpoint has been
-	// configured.
-	LokiEndpointNotFound = errors.ConstError("loki endpoint not found")
+	// LokiConfigNotFound is returned when no Loki config has been configured.
+	LokiConfigNotFound = errors.ConstError("loki config not found")
 )

--- a/domain/logging/service/service.go
+++ b/domain/logging/service/service.go
@@ -12,29 +12,30 @@ import (
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
+	"github.com/juju/juju/domain/logging"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
 // State defines an interface for interacting with the underlying state.
 type State interface {
-	// SetLokiEndpoint sets the Loki push API endpoint. Any previously stored
-	// endpoint is replaced. The uuid is the unique identifier for the new
-	// endpoint row.
-	SetLokiEndpoint(ctx context.Context, uuid string, endpoint string) error
+	// SetLokiConfig sets the Loki push API endpoint and CA certificate. Any
+	// previously stored config is replaced. The uuid is the unique identifier
+	// for the new config row.
+	SetLokiConfig(ctx context.Context, uuid string, config logging.LokiConfig) error
 
-	// GetLokiEndpoint returns the configured Loki push API endpoint. If no
-	// endpoint is configured, an error satisfying
-	// [loggingerrors.LokiEndpointNotFound] is returned.
-	GetLokiEndpoint(ctx context.Context) (string, error)
+	// GetLokiConfig returns the configured Loki push API endpoint and CA
+	// certificate. If no endpoint is configured, an error satisfying
+	// [loggingerrors.LokiConfigNotFound] is returned.
+	GetLokiConfig(ctx context.Context) (logging.LokiConfig, error)
 
-	// DeleteLokiEndpoint removes the configured Loki push API endpoint. If
-	// no endpoint is configured, this is a no-op.
-	DeleteLokiEndpoint(ctx context.Context) error
+	// DeleteLokiConfig removes the configured Loki push API config. If no
+	// config is configured, this is a no-op.
+	DeleteLokiConfig(ctx context.Context) error
 
-	// NamespaceForWatchLokiEndpoint returns the namespace identifier used
-	// for watching Loki endpoint changes.
-	NamespaceForWatchLokiEndpoint() string
+	// NamespaceForWatchLokiConfig returns the namespace identifier used
+	// for watching Loki config changes.
+	NamespaceForWatchLokiConfig() string
 }
 
 // WatcherFactory describes methods for creating watchers.
@@ -82,22 +83,22 @@ func NewWatchableService(st State, wf WatcherFactory) *WatchableService {
 	}
 }
 
-// SetLokiEndpoint sets the Loki push API endpoint. The endpoint must be
-// non-empty; an error is returned otherwise.
-func (s *Service) SetLokiEndpoint(ctx context.Context, endpoint string) error {
+// SetLokiConfig sets the Loki push API endpoint and CA certificate. The
+// endpoint must be non-empty; an error is returned otherwise.
+func (s *Service) SetLokiConfig(ctx context.Context, config logging.LokiConfig) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	if endpoint == "" {
+	if config.Endpoint == "" {
 		return errors.Errorf("empty loki endpoint").Add(coreerrors.NotValid)
 	}
 
-	u, err := url.Parse(endpoint)
+	u, err := url.Parse(config.Endpoint)
 	if err != nil {
-		return errors.Errorf("loki endpoint %q: %w", endpoint, err).Add(coreerrors.NotValid)
+		return errors.Errorf("loki endpoint %q: %w", config.Endpoint, err).Add(coreerrors.NotValid)
 	}
 	if u.Scheme == "" || u.Host == "" {
-		return errors.Errorf("loki endpoint %q missing scheme or host", endpoint).Add(coreerrors.NotValid)
+		return errors.Errorf("loki endpoint %q missing scheme or host", config.Endpoint).Add(coreerrors.NotValid)
 	}
 
 	id, err := uuid.NewUUID()
@@ -105,39 +106,39 @@ func (s *Service) SetLokiEndpoint(ctx context.Context, endpoint string) error {
 		return errors.Errorf("generating UUID: %w", err)
 	}
 
-	return s.st.SetLokiEndpoint(ctx, id.String(), endpoint)
+	return s.st.SetLokiConfig(ctx, id.String(), config)
 }
 
-// GetLokiEndpoint returns the configured Loki push API endpoint.
-// If no endpoint is configured, an error satisfying
-// [loggingerrors.LokiEndpointNotFound] is returned.
-func (s *Service) GetLokiEndpoint(ctx context.Context) (string, error) {
+// GetLokiConfig returns the configured Loki push API endpoint and CA
+// certificate. If no endpoint is configured, an error satisfying
+// [loggingerrors.LokiConfigNotFound] is returned.
+func (s *Service) GetLokiConfig(ctx context.Context) (logging.LokiConfig, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	return s.st.GetLokiEndpoint(ctx)
+	return s.st.GetLokiConfig(ctx)
 }
 
-// DeleteLokiEndpoint removes the configured Loki push API endpoint.
-// If no endpoint is configured, this is a no-op.
-func (s *Service) DeleteLokiEndpoint(ctx context.Context) error {
+// DeleteLokiConfig removes the configured Loki push API config.
+// If no config is configured, this is a no-op.
+func (s *Service) DeleteLokiConfig(ctx context.Context) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	return s.st.DeleteLokiEndpoint(ctx)
+	return s.st.DeleteLokiConfig(ctx)
 }
 
-// WatchLokiEndpoint returns a watcher that emits notifications when the
-// Loki push API endpoint configuration changes.
-func (s *WatchableService) WatchLokiEndpoint(ctx context.Context) (watcher.NotifyWatcher, error) {
+// WatchLokiConfig returns a watcher that emits notifications when the Loki push
+// API endpoint or CA certificate configuration changes.
+func (s *WatchableService) WatchLokiConfig(ctx context.Context) (watcher.NotifyWatcher, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	namespace := s.st.NamespaceForWatchLokiEndpoint()
+	namespace := s.st.NamespaceForWatchLokiConfig()
 
 	return s.watcherFactory.NewNotifyWatcher(
 		ctx,
-		"loki endpoint watcher",
+		"loki config watcher",
 		eventsource.NamespaceFilter(namespace, changestream.All),
 	)
 }

--- a/domain/logging/service/service_test.go
+++ b/domain/logging/service/service_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/domain/logging"
 	loggingerrors "github.com/juju/juju/domain/logging/errors"
 	"github.com/juju/juju/internal/errors"
 )
@@ -24,108 +25,122 @@ func TestServiceSuite(t *testing.T) {
 	tc.Run(t, &serviceSuite{})
 }
 
-func (s *serviceSuite) TestSetLokiEndpoint(c *tc.C) {
+func (s *serviceSuite) TestSetLokiConfig(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.st.EXPECT().SetLokiEndpoint(gomock.Any(), gomock.Any(), "http://loki:3100/loki/api/v1/push").Return(nil)
+	config := logging.LokiConfig{
+		Endpoint:      "http://loki:3100/loki/api/v1/push",
+		CACertificate: "ca-cert",
+	}
+	s.st.EXPECT().SetLokiConfig(gomock.Any(), gomock.Any(), config).Return(nil)
 
-	err := NewWatchableService(s.st, s.watcherFactory).SetLokiEndpoint(c.Context(), "http://loki:3100/loki/api/v1/push")
+	err := NewWatchableService(s.st, s.watcherFactory).SetLokiConfig(c.Context(), config)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TestSetLokiEndpointEmptyReturnsError(c *tc.C) {
+func (s *serviceSuite) TestSetLokiConfigEmptyReturnsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := NewWatchableService(s.st, s.watcherFactory).SetLokiEndpoint(c.Context(), "")
+	err := NewWatchableService(s.st, s.watcherFactory).SetLokiConfig(c.Context(), logging.LokiConfig{})
 	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
 }
 
-func (s *serviceSuite) TestSetLokiEndpointInvalidURLReturnsError(c *tc.C) {
+func (s *serviceSuite) TestSetLokiConfigInvalidURLReturnsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := NewWatchableService(s.st, s.watcherFactory).SetLokiEndpoint(c.Context(), "not-a-valid-url")
+	err := NewWatchableService(s.st, s.watcherFactory).SetLokiConfig(c.Context(), logging.LokiConfig{
+		Endpoint: "not-a-valid-url",
+	})
 	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
 }
 
-func (s *serviceSuite) TestSetLokiEndpointStateError(c *tc.C) {
+func (s *serviceSuite) TestSetLokiConfigStateError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.st.EXPECT().SetLokiEndpoint(gomock.Any(), gomock.Any(), "http://loki:3100/loki/api/v1/push").Return(
+	config := logging.LokiConfig{
+		Endpoint:      "http://loki:3100/loki/api/v1/push",
+		CACertificate: "ca-cert",
+	}
+	s.st.EXPECT().SetLokiConfig(gomock.Any(), gomock.Any(), config).Return(
 		errors.Errorf("boom"),
 	)
 
-	err := NewWatchableService(s.st, s.watcherFactory).SetLokiEndpoint(c.Context(), "http://loki:3100/loki/api/v1/push")
+	err := NewWatchableService(s.st, s.watcherFactory).SetLokiConfig(c.Context(), config)
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 
-func (s *serviceSuite) TestGetLokiEndpoint(c *tc.C) {
+func (s *serviceSuite) TestGetLokiConfig(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.st.EXPECT().GetLokiEndpoint(gomock.Any()).Return("http://loki:3100/loki/api/v1/push", nil)
+	s.st.EXPECT().GetLokiConfig(gomock.Any()).Return(logging.LokiConfig{
+		Endpoint:      "http://loki:3100/loki/api/v1/push",
+		CACertificate: "ca-cert",
+	}, nil)
 
-	endpoint, err := NewWatchableService(s.st, s.watcherFactory).GetLokiEndpoint(c.Context())
+	config, err := NewWatchableService(s.st, s.watcherFactory).GetLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(endpoint, tc.Equals, "http://loki:3100/loki/api/v1/push")
+	c.Check(config.Endpoint, tc.Equals, "http://loki:3100/loki/api/v1/push")
+	c.Check(config.CACertificate, tc.Equals, "ca-cert")
 }
 
-func (s *serviceSuite) TestGetLokiEndpointNotFound(c *tc.C) {
+func (s *serviceSuite) TestGetLokiConfigNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.st.EXPECT().GetLokiEndpoint(gomock.Any()).Return("", loggingerrors.LokiEndpointNotFound)
+	s.st.EXPECT().GetLokiConfig(gomock.Any()).Return(logging.LokiConfig{}, loggingerrors.LokiConfigNotFound)
 
-	_, err := NewWatchableService(s.st, s.watcherFactory).GetLokiEndpoint(c.Context())
-	c.Assert(err, tc.ErrorIs, loggingerrors.LokiEndpointNotFound)
+	_, err := NewWatchableService(s.st, s.watcherFactory).GetLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIs, loggingerrors.LokiConfigNotFound)
 }
 
-func (s *serviceSuite) TestGetLokiEndpointStateError(c *tc.C) {
+func (s *serviceSuite) TestGetLokiConfigStateError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.st.EXPECT().GetLokiEndpoint(gomock.Any()).Return("", errors.Errorf("boom"))
+	s.st.EXPECT().GetLokiConfig(gomock.Any()).Return(logging.LokiConfig{}, errors.Errorf("boom"))
 
-	_, err := NewWatchableService(s.st, s.watcherFactory).GetLokiEndpoint(c.Context())
+	_, err := NewWatchableService(s.st, s.watcherFactory).GetLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 
-func (s *serviceSuite) TestDeleteLokiEndpoint(c *tc.C) {
+func (s *serviceSuite) TestDeleteLokiConfig(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.st.EXPECT().DeleteLokiEndpoint(gomock.Any()).Return(nil)
+	s.st.EXPECT().DeleteLokiConfig(gomock.Any()).Return(nil)
 
-	err := NewWatchableService(s.st, s.watcherFactory).DeleteLokiEndpoint(c.Context())
+	err := NewWatchableService(s.st, s.watcherFactory).DeleteLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TestDeleteLokiEndpointStateError(c *tc.C) {
+func (s *serviceSuite) TestDeleteLokiConfigStateError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.st.EXPECT().DeleteLokiEndpoint(gomock.Any()).Return(errors.Errorf("boom"))
+	s.st.EXPECT().DeleteLokiConfig(gomock.Any()).Return(errors.Errorf("boom"))
 
-	err := NewWatchableService(s.st, s.watcherFactory).DeleteLokiEndpoint(c.Context())
+	err := NewWatchableService(s.st, s.watcherFactory).DeleteLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 
-func (s *serviceSuite) TestWatchLokiEndpoint(c *tc.C) {
+func (s *serviceSuite) TestWatchLokiConfig(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.st.EXPECT().NamespaceForWatchLokiEndpoint().Return("logging_loki_config")
+	s.st.EXPECT().NamespaceForWatchLokiConfig().Return("logging_loki_config")
 	s.watcherFactory.EXPECT().NewNotifyWatcher(
 		gomock.Any(), gomock.Any(), gomock.Any(),
 	).Return(s.notifyWatcher, nil)
 
-	w, err := NewWatchableService(s.st, s.watcherFactory).WatchLokiEndpoint(c.Context())
+	w, err := NewWatchableService(s.st, s.watcherFactory).WatchLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(w, tc.Not(tc.IsNil))
 }
 
-func (s *serviceSuite) TestWatchLokiEndpointWatcherFactoryError(c *tc.C) {
+func (s *serviceSuite) TestWatchLokiConfigWatcherFactoryError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.st.EXPECT().NamespaceForWatchLokiEndpoint().Return("logging_loki_config")
+	s.st.EXPECT().NamespaceForWatchLokiConfig().Return("logging_loki_config")
 	s.watcherFactory.EXPECT().NewNotifyWatcher(
 		gomock.Any(), gomock.Any(), gomock.Any(),
 	).Return(nil, errors.Errorf("watcher boom"))
 
-	_, err := NewWatchableService(s.st, s.watcherFactory).WatchLokiEndpoint(c.Context())
+	_, err := NewWatchableService(s.st, s.watcherFactory).WatchLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorMatches, "watcher boom")
 }
 

--- a/domain/logging/service/state_mock_test.go
+++ b/domain/logging/service/state_mock_test.go
@@ -15,6 +15,7 @@ import (
 
 	watcher "github.com/juju/juju/core/watcher"
 	eventsource "github.com/juju/juju/core/watcher/eventsource"
+	logging "github.com/juju/juju/domain/logging"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,155 +42,155 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// DeleteLokiEndpoint mocks base method.
-func (m *MockState) DeleteLokiEndpoint(arg0 context.Context) error {
+// DeleteLokiConfig mocks base method.
+func (m *MockState) DeleteLokiConfig(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteLokiEndpoint", arg0)
+	ret := m.ctrl.Call(m, "DeleteLokiConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteLokiEndpoint indicates an expected call of DeleteLokiEndpoint.
-func (mr *MockStateMockRecorder) DeleteLokiEndpoint(arg0 any) *MockStateDeleteLokiEndpointCall {
+// DeleteLokiConfig indicates an expected call of DeleteLokiConfig.
+func (mr *MockStateMockRecorder) DeleteLokiConfig(arg0 any) *MockStateDeleteLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLokiEndpoint", reflect.TypeOf((*MockState)(nil).DeleteLokiEndpoint), arg0)
-	return &MockStateDeleteLokiEndpointCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLokiConfig", reflect.TypeOf((*MockState)(nil).DeleteLokiConfig), arg0)
+	return &MockStateDeleteLokiConfigCall{Call: call}
 }
 
-// MockStateDeleteLokiEndpointCall wrap *gomock.Call
-type MockStateDeleteLokiEndpointCall struct {
+// MockStateDeleteLokiConfigCall wrap *gomock.Call
+type MockStateDeleteLokiConfigCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateDeleteLokiEndpointCall) Return(arg0 error) *MockStateDeleteLokiEndpointCall {
+func (c *MockStateDeleteLokiConfigCall) Return(arg0 error) *MockStateDeleteLokiConfigCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateDeleteLokiEndpointCall) Do(f func(context.Context) error) *MockStateDeleteLokiEndpointCall {
+func (c *MockStateDeleteLokiConfigCall) Do(f func(context.Context) error) *MockStateDeleteLokiConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateDeleteLokiEndpointCall) DoAndReturn(f func(context.Context) error) *MockStateDeleteLokiEndpointCall {
+func (c *MockStateDeleteLokiConfigCall) DoAndReturn(f func(context.Context) error) *MockStateDeleteLokiConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// GetLokiEndpoint mocks base method.
-func (m *MockState) GetLokiEndpoint(arg0 context.Context) (string, error) {
+// GetLokiConfig mocks base method.
+func (m *MockState) GetLokiConfig(arg0 context.Context) (logging.LokiConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLokiEndpoint", arg0)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "GetLokiConfig", arg0)
+	ret0, _ := ret[0].(logging.LokiConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLokiEndpoint indicates an expected call of GetLokiEndpoint.
-func (mr *MockStateMockRecorder) GetLokiEndpoint(arg0 any) *MockStateGetLokiEndpointCall {
+// GetLokiConfig indicates an expected call of GetLokiConfig.
+func (mr *MockStateMockRecorder) GetLokiConfig(arg0 any) *MockStateGetLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLokiEndpoint", reflect.TypeOf((*MockState)(nil).GetLokiEndpoint), arg0)
-	return &MockStateGetLokiEndpointCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLokiConfig", reflect.TypeOf((*MockState)(nil).GetLokiConfig), arg0)
+	return &MockStateGetLokiConfigCall{Call: call}
 }
 
-// MockStateGetLokiEndpointCall wrap *gomock.Call
-type MockStateGetLokiEndpointCall struct {
+// MockStateGetLokiConfigCall wrap *gomock.Call
+type MockStateGetLokiConfigCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetLokiEndpointCall) Return(arg0 string, arg1 error) *MockStateGetLokiEndpointCall {
+func (c *MockStateGetLokiConfigCall) Return(arg0 logging.LokiConfig, arg1 error) *MockStateGetLokiConfigCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetLokiEndpointCall) Do(f func(context.Context) (string, error)) *MockStateGetLokiEndpointCall {
+func (c *MockStateGetLokiConfigCall) Do(f func(context.Context) (logging.LokiConfig, error)) *MockStateGetLokiConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetLokiEndpointCall) DoAndReturn(f func(context.Context) (string, error)) *MockStateGetLokiEndpointCall {
+func (c *MockStateGetLokiConfigCall) DoAndReturn(f func(context.Context) (logging.LokiConfig, error)) *MockStateGetLokiConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// NamespaceForWatchLokiEndpoint mocks base method.
-func (m *MockState) NamespaceForWatchLokiEndpoint() string {
+// NamespaceForWatchLokiConfig mocks base method.
+func (m *MockState) NamespaceForWatchLokiConfig() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NamespaceForWatchLokiEndpoint")
+	ret := m.ctrl.Call(m, "NamespaceForWatchLokiConfig")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// NamespaceForWatchLokiEndpoint indicates an expected call of NamespaceForWatchLokiEndpoint.
-func (mr *MockStateMockRecorder) NamespaceForWatchLokiEndpoint() *MockStateNamespaceForWatchLokiEndpointCall {
+// NamespaceForWatchLokiConfig indicates an expected call of NamespaceForWatchLokiConfig.
+func (mr *MockStateMockRecorder) NamespaceForWatchLokiConfig() *MockStateNamespaceForWatchLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceForWatchLokiEndpoint", reflect.TypeOf((*MockState)(nil).NamespaceForWatchLokiEndpoint))
-	return &MockStateNamespaceForWatchLokiEndpointCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceForWatchLokiConfig", reflect.TypeOf((*MockState)(nil).NamespaceForWatchLokiConfig))
+	return &MockStateNamespaceForWatchLokiConfigCall{Call: call}
 }
 
-// MockStateNamespaceForWatchLokiEndpointCall wrap *gomock.Call
-type MockStateNamespaceForWatchLokiEndpointCall struct {
+// MockStateNamespaceForWatchLokiConfigCall wrap *gomock.Call
+type MockStateNamespaceForWatchLokiConfigCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateNamespaceForWatchLokiEndpointCall) Return(arg0 string) *MockStateNamespaceForWatchLokiEndpointCall {
+func (c *MockStateNamespaceForWatchLokiConfigCall) Return(arg0 string) *MockStateNamespaceForWatchLokiConfigCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateNamespaceForWatchLokiEndpointCall) Do(f func() string) *MockStateNamespaceForWatchLokiEndpointCall {
+func (c *MockStateNamespaceForWatchLokiConfigCall) Do(f func() string) *MockStateNamespaceForWatchLokiConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateNamespaceForWatchLokiEndpointCall) DoAndReturn(f func() string) *MockStateNamespaceForWatchLokiEndpointCall {
+func (c *MockStateNamespaceForWatchLokiConfigCall) DoAndReturn(f func() string) *MockStateNamespaceForWatchLokiConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// SetLokiEndpoint mocks base method.
-func (m *MockState) SetLokiEndpoint(arg0 context.Context, arg1, arg2 string) error {
+// SetLokiConfig mocks base method.
+func (m *MockState) SetLokiConfig(arg0 context.Context, arg1 string, arg2 logging.LokiConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetLokiEndpoint", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetLokiConfig", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetLokiEndpoint indicates an expected call of SetLokiEndpoint.
-func (mr *MockStateMockRecorder) SetLokiEndpoint(arg0, arg1, arg2 any) *MockStateSetLokiEndpointCall {
+// SetLokiConfig indicates an expected call of SetLokiConfig.
+func (mr *MockStateMockRecorder) SetLokiConfig(arg0, arg1, arg2 any) *MockStateSetLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLokiEndpoint", reflect.TypeOf((*MockState)(nil).SetLokiEndpoint), arg0, arg1, arg2)
-	return &MockStateSetLokiEndpointCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLokiConfig", reflect.TypeOf((*MockState)(nil).SetLokiConfig), arg0, arg1, arg2)
+	return &MockStateSetLokiConfigCall{Call: call}
 }
 
-// MockStateSetLokiEndpointCall wrap *gomock.Call
-type MockStateSetLokiEndpointCall struct {
+// MockStateSetLokiConfigCall wrap *gomock.Call
+type MockStateSetLokiConfigCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateSetLokiEndpointCall) Return(arg0 error) *MockStateSetLokiEndpointCall {
+func (c *MockStateSetLokiConfigCall) Return(arg0 error) *MockStateSetLokiConfigCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetLokiEndpointCall) Do(f func(context.Context, string, string) error) *MockStateSetLokiEndpointCall {
+func (c *MockStateSetLokiConfigCall) Do(f func(context.Context, string, logging.LokiConfig) error) *MockStateSetLokiConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetLokiEndpointCall) DoAndReturn(f func(context.Context, string, string) error) *MockStateSetLokiEndpointCall {
+func (c *MockStateSetLokiConfigCall) DoAndReturn(f func(context.Context, string, logging.LokiConfig) error) *MockStateSetLokiConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/logging/state/state.go
+++ b/domain/logging/state/state.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/logging"
 	loggingerrors "github.com/juju/juju/domain/logging/errors"
 	"github.com/juju/juju/internal/errors"
 )
@@ -26,9 +27,9 @@ func NewState(factory database.TxnRunnerFactory) *State {
 	}
 }
 
-// SetLokiEndpoint sets the Loki push API endpoint. Any previously stored
-// endpoint is replaced.
-func (st *State) SetLokiEndpoint(ctx context.Context, id string, endpoint string) error {
+// SetLokiConfig sets the Loki push API endpoint and CA certificate. Any
+// previously stored config is replaced.
+func (st *State) SetLokiConfig(ctx context.Context, id string, config logging.LokiConfig) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Errorf("getting database: %w", err)
@@ -40,22 +41,23 @@ func (st *State) SetLokiEndpoint(ctx context.Context, id string, endpoint string
 	}
 
 	insertStmt, err := st.Prepare(`
-INSERT INTO logging_loki_config (uuid, endpoint)
-VALUES ($lokiConfig.uuid, $lokiConfig.endpoint)`, lokiConfig{})
+	INSERT INTO logging_loki_config (uuid, endpoint, ca_cert)
+	VALUES ($lokiConfig.uuid, $lokiConfig.endpoint, $lokiConfig.ca_cert)`, lokiConfig{})
 	if err != nil {
 		return errors.Errorf("preparing insert statement: %w", err)
 	}
 
-	config := lokiConfig{
-		UUID:     id,
-		Endpoint: endpoint,
+	dbConfig := lokiConfig{
+		UUID:          id,
+		Endpoint:      config.Endpoint,
+		CACertificate: config.CACertificate,
 	}
 
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := tx.Query(ctx, deleteStmt).Run(); err != nil {
 			return errors.Errorf("deleting existing loki endpoint: %w", err)
 		}
-		if err := tx.Query(ctx, insertStmt, config).Run(); err != nil {
+		if err := tx.Query(ctx, insertStmt, dbConfig).Run(); err != nil {
 			return errors.Errorf("inserting loki endpoint: %w", err)
 		}
 		return nil
@@ -65,37 +67,42 @@ VALUES ($lokiConfig.uuid, $lokiConfig.endpoint)`, lokiConfig{})
 	return nil
 }
 
-// GetLokiEndpoint returns the configured Loki push API endpoint. If no
-// endpoint is configured, an error satisfying [loggingerrors.LokiEndpointNotFound]
-// is returned.
-func (st *State) GetLokiEndpoint(ctx context.Context) (string, error) {
+// GetLokiConfig returns the configured Loki push API endpoint and CA
+// certificate. If no endpoint is configured, an error satisfying
+// [loggingerrors.LokiConfigNotFound] is returned.
+func (st *State) GetLokiConfig(ctx context.Context) (logging.LokiConfig, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
-		return "", errors.Errorf("getting database: %w", err)
+		return logging.LokiConfig{}, errors.Errorf("getting database: %w", err)
 	}
 
-	stmt, err := st.Prepare(`SELECT &lokiConfig.endpoint FROM logging_loki_config`, lokiConfig{})
+	stmt, err := st.Prepare(`
+SELECT &lokiConfig.endpoint, &lokiConfig.ca_cert FROM logging_loki_config
+`, lokiConfig{})
 	if err != nil {
-		return "", errors.Errorf("preparing select statement: %w", err)
+		return logging.LokiConfig{}, errors.Errorf("preparing select statement: %w", err)
 	}
 
 	var config lokiConfig
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := tx.Query(ctx, stmt).Get(&config); errors.Is(err, sqlair.ErrNoRows) {
-			return loggingerrors.LokiEndpointNotFound
+			return loggingerrors.LokiConfigNotFound
 		} else if err != nil {
-			return errors.Errorf("getting loki endpoint: %w", err)
+			return errors.Errorf("getting loki config: %w", err)
 		}
 		return nil
 	}); err != nil {
-		return "", errors.Errorf("getting loki endpoint: %w", err)
+		return logging.LokiConfig{}, errors.Errorf("getting loki config: %w", err)
 	}
-	return config.Endpoint, nil
+	return logging.LokiConfig{
+		Endpoint:      config.Endpoint,
+		CACertificate: config.CACertificate,
+	}, nil
 }
 
-// DeleteLokiEndpoint removes the configured Loki push API endpoint. If no
-// endpoint is configured, this is a no-op.
-func (st *State) DeleteLokiEndpoint(ctx context.Context) error {
+// DeleteLokiConfig removes the configured Loki push API config. If no config
+// is configured, this is a no-op.
+func (st *State) DeleteLokiConfig(ctx context.Context) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Errorf("getting database: %w", err)
@@ -118,12 +125,13 @@ func (st *State) DeleteLokiEndpoint(ctx context.Context) error {
 }
 
 type lokiConfig struct {
-	UUID     string `db:"uuid"`
-	Endpoint string `db:"endpoint"`
+	UUID          string `db:"uuid"`
+	Endpoint      string `db:"endpoint"`
+	CACertificate string `db:"ca_cert"`
 }
 
-// NamespaceForWatchLokiEndpoint returns the namespace identifier used for
-// watching Loki endpoint changes.
-func (*State) NamespaceForWatchLokiEndpoint() string {
+// NamespaceForWatchLokiConfig returns the namespace identifier used for
+// watching Loki config changes.
+func (*State) NamespaceForWatchLokiConfig() string {
 	return "logging_loki_config"
 }

--- a/domain/logging/state/state_test.go
+++ b/domain/logging/state/state_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/tc"
 
+	"github.com/juju/juju/domain/logging"
 	loggingerrors "github.com/juju/juju/domain/logging/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
@@ -20,55 +21,69 @@ func TestStateSuite(t *testing.T) {
 	tc.Run(t, &stateSuite{})
 }
 
-func (s *stateSuite) TestSetLokiEndpoint(c *tc.C) {
+func (s *stateSuite) TestSetLokiConfig(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	err := st.SetLokiEndpoint(c.Context(), "some-uuid-1", "http://loki:3100/loki/api/v1/push")
+	err := st.SetLokiConfig(c.Context(), "some-uuid-1", logging.LokiConfig{
+		Endpoint:      "http://loki:3100/loki/api/v1/push",
+		CACertificate: "ca-cert",
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	endpoint, err := st.GetLokiEndpoint(c.Context())
+	config, err := st.GetLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(endpoint, tc.Equals, "http://loki:3100/loki/api/v1/push")
+	c.Check(config.Endpoint, tc.Equals, "http://loki:3100/loki/api/v1/push")
+	c.Check(config.CACertificate, tc.Equals, "ca-cert")
 }
 
-func (s *stateSuite) TestSetLokiEndpointReplacesExisting(c *tc.C) {
+func (s *stateSuite) TestSetLokiConfigReplacesExisting(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	err := st.SetLokiEndpoint(c.Context(), "some-uuid-1", "http://old-loki:3100/loki/api/v1/push")
+	err := st.SetLokiConfig(c.Context(), "some-uuid-1", logging.LokiConfig{
+		Endpoint:      "http://old-loki:3100/loki/api/v1/push",
+		CACertificate: "old-ca",
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.SetLokiEndpoint(c.Context(), "some-uuid-2", "http://new-loki:3100/loki/api/v1/push")
+	err = st.SetLokiConfig(c.Context(), "some-uuid-2", logging.LokiConfig{
+		Endpoint:      "http://new-loki:3100/loki/api/v1/push",
+		CACertificate: "new-ca",
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	endpoint, err := st.GetLokiEndpoint(c.Context())
+	config, err := st.GetLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(endpoint, tc.Equals, "http://new-loki:3100/loki/api/v1/push")
+	c.Check(config.Endpoint, tc.Equals, "http://new-loki:3100/loki/api/v1/push")
+	c.Check(config.CACertificate, tc.Equals, "new-ca")
 }
 
-func (s *stateSuite) TestGetLokiEndpointNotFound(c *tc.C) {
+func (s *stateSuite) TestGetLokiConfigNotFound(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	_, err := st.GetLokiEndpoint(c.Context())
-	c.Assert(err, tc.ErrorIs, loggingerrors.LokiEndpointNotFound)
+	_, err := st.GetLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIs, loggingerrors.LokiConfigNotFound)
 }
 
-func (s *stateSuite) TestDeleteLokiEndpoint(c *tc.C) {
+func (s *stateSuite) TestDeleteLokiConfig(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	err := st.SetLokiEndpoint(c.Context(), "some-uuid-1", "http://loki:3100/loki/api/v1/push")
+	err := st.SetLokiConfig(c.Context(), "some-uuid-1", logging.LokiConfig{
+		Endpoint:      "http://loki:3100/loki/api/v1/push",
+		CACertificate: "ca-cert",
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.DeleteLokiEndpoint(c.Context())
+	err = st.DeleteLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
-	_, err = st.GetLokiEndpoint(c.Context())
-	c.Assert(err, tc.ErrorIs, loggingerrors.LokiEndpointNotFound)
+	_, err = st.GetLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIs, loggingerrors.LokiConfigNotFound)
 }
 
-func (s *stateSuite) TestDeleteLokiEndpointWhenEmpty(c *tc.C) {
+func (s *stateSuite) TestDeleteLokiConfigWhenEmpty(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	// Delete when nothing is set should be a no-op.
-	err := st.DeleteLokiEndpoint(c.Context())
+	err := st.DeleteLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 }

--- a/domain/logging/watcher_test.go
+++ b/domain/logging/watcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/logging"
 	"github.com/juju/juju/domain/logging/service"
 	"github.com/juju/juju/domain/logging/state"
 	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
@@ -27,17 +28,20 @@ func TestWatcherSuite(t *testing.T) {
 	tc.Run(t, &watcherSuite{})
 }
 
-func (s *watcherSuite) TestWatchLokiEndpointSet(c *tc.C) {
+func (s *watcherSuite) TestWatchLokiConfigSet(c *tc.C) {
 	svc := s.setupService(c)
 
-	watcher, err := svc.WatchLokiEndpoint(c.Context())
+	watcher, err := svc.WatchLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
 
 	// Setting a new loki endpoint should trigger a change.
 	harness.AddTest(c, func(c *tc.C) {
-		err := svc.SetLokiEndpoint(c.Context(), "http://loki:3100/loki/api/v1/push")
+		err := svc.SetLokiConfig(c.Context(), logging.LokiConfig{
+			Endpoint:      "http://loki:3100/loki/api/v1/push",
+			CACertificate: "ca-cert",
+		})
 		c.Assert(err, tc.ErrorIsNil)
 	}, func(w watchertest.WatcherC[struct{}]) {
 		w.AssertChange()
@@ -46,21 +50,27 @@ func (s *watcherSuite) TestWatchLokiEndpointSet(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
-func (s *watcherSuite) TestWatchLokiEndpointUpdate(c *tc.C) {
+func (s *watcherSuite) TestWatchLokiConfigEndpointUpdate(c *tc.C) {
 	svc := s.setupService(c)
 
 	// Set an initial endpoint before starting the watcher.
-	err := svc.SetLokiEndpoint(c.Context(), "http://old-loki:3100/loki/api/v1/push")
+	err := svc.SetLokiConfig(c.Context(), logging.LokiConfig{
+		Endpoint:      "http://old-loki:3100/loki/api/v1/push",
+		CACertificate: "old-ca",
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	watcher, err := svc.WatchLokiEndpoint(c.Context())
+	watcher, err := svc.WatchLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
 
 	// Updating the endpoint should trigger a change.
 	harness.AddTest(c, func(c *tc.C) {
-		err := svc.SetLokiEndpoint(c.Context(), "http://new-loki:3100/loki/api/v1/push")
+		err := svc.SetLokiConfig(c.Context(), logging.LokiConfig{
+			Endpoint:      "http://new-loki:3100/loki/api/v1/push",
+			CACertificate: "old-ca",
+		})
 		c.Assert(err, tc.ErrorIsNil)
 	}, func(w watchertest.WatcherC[struct{}]) {
 		w.AssertChange()
@@ -69,21 +79,53 @@ func (s *watcherSuite) TestWatchLokiEndpointUpdate(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
-func (s *watcherSuite) TestWatchLokiEndpointDelete(c *tc.C) {
+func (s *watcherSuite) TestWatchLokiConfigCACertificateUpdate(c *tc.C) {
 	svc := s.setupService(c)
 
 	// Set an initial endpoint before starting the watcher.
-	err := svc.SetLokiEndpoint(c.Context(), "http://loki:3100/loki/api/v1/push")
+	err := svc.SetLokiConfig(c.Context(), logging.LokiConfig{
+		Endpoint:      "http://loki:3100/loki/api/v1/push",
+		CACertificate: "old-ca",
+	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	watcher, err := svc.WatchLokiEndpoint(c.Context())
+	watcher, err := svc.WatchLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
+
+	// Updating only the CA certificate should trigger a change.
+	harness.AddTest(c, func(c *tc.C) {
+		err := svc.SetLokiConfig(c.Context(), logging.LokiConfig{
+			Endpoint:      "http://loki:3100/loki/api/v1/push",
+			CACertificate: "new-ca",
+		})
+		c.Assert(err, tc.ErrorIsNil)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	harness.Run(c, struct{}{})
+}
+
+func (s *watcherSuite) TestWatchLokiConfigDelete(c *tc.C) {
+	svc := s.setupService(c)
+
+	// Set an initial endpoint before starting the watcher.
+	err := svc.SetLokiConfig(c.Context(), logging.LokiConfig{
+		Endpoint:      "http://loki:3100/loki/api/v1/push",
+		CACertificate: "ca-cert",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	watcher, err := svc.WatchLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
 
 	// Deleting the endpoint should trigger a change.
 	harness.AddTest(c, func(c *tc.C) {
-		err := svc.DeleteLokiEndpoint(c.Context())
+		err := svc.DeleteLokiConfig(c.Context())
 		c.Assert(err, tc.ErrorIsNil)
 	}, func(w watchertest.WatcherC[struct{}]) {
 		w.AssertChange()
@@ -92,10 +134,10 @@ func (s *watcherSuite) TestWatchLokiEndpointDelete(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
-func (s *watcherSuite) TestWatchLokiEndpointNoChange(c *tc.C) {
+func (s *watcherSuite) TestWatchLokiConfigNoChange(c *tc.C) {
 	svc := s.setupService(c)
 
-	watcher, err := svc.WatchLokiEndpoint(c.Context())
+	watcher, err := svc.WatchLokiConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
 	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))

--- a/domain/schema/controller/sql/0027-logging.sql
+++ b/domain/schema/controller/sql/0027-logging.sql
@@ -1,6 +1,7 @@
 CREATE TABLE logging_loki_config (
     uuid TEXT NOT NULL PRIMARY KEY,
-    endpoint TEXT NOT NULL
+    endpoint TEXT NOT NULL,
+    ca_cert TEXT NOT NULL DEFAULT ''
 );
 
 CREATE UNIQUE INDEX idx_singleton_logging_loki_config ON logging_loki_config ((1));

--- a/domain/schema/controller/triggers/logging-triggers.gen.go
+++ b/domain/schema/controller/triggers/logging-triggers.gen.go
@@ -30,7 +30,8 @@ CREATE TRIGGER trg_log_logging_loki_config_update
 AFTER UPDATE ON logging_loki_config FOR EACH ROW
 WHEN 
 	NEW.uuid != OLD.uuid OR
-	NEW.endpoint != OLD.endpoint
+	NEW.endpoint != OLD.endpoint OR
+	NEW.ca_cert != OLD.ca_cert
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));

--- a/internal/worker/controlsocket/services_mock_test.go
+++ b/internal/worker/controlsocket/services_mock_test.go
@@ -16,6 +16,7 @@ import (
 	permission "github.com/juju/juju/core/permission"
 	user "github.com/juju/juju/core/user"
 	service "github.com/juju/juju/domain/access/service"
+	logging "github.com/juju/juju/domain/logging"
 	objectstore "github.com/juju/juju/domain/objectstore"
 	service0 "github.com/juju/juju/domain/tracing/service"
 	auth "github.com/juju/juju/internal/auth"
@@ -362,78 +363,78 @@ func (m *MockLoggingService) EXPECT() *MockLoggingServiceMockRecorder {
 	return m.recorder
 }
 
-// DeleteLokiEndpoint mocks base method.
-func (m *MockLoggingService) DeleteLokiEndpoint(arg0 context.Context) error {
+// DeleteLokiConfig mocks base method.
+func (m *MockLoggingService) DeleteLokiConfig(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteLokiEndpoint", arg0)
+	ret := m.ctrl.Call(m, "DeleteLokiConfig", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteLokiEndpoint indicates an expected call of DeleteLokiEndpoint.
-func (mr *MockLoggingServiceMockRecorder) DeleteLokiEndpoint(arg0 any) *MockLoggingServiceDeleteLokiEndpointCall {
+// DeleteLokiConfig indicates an expected call of DeleteLokiConfig.
+func (mr *MockLoggingServiceMockRecorder) DeleteLokiConfig(arg0 any) *MockLoggingServiceDeleteLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLokiEndpoint", reflect.TypeOf((*MockLoggingService)(nil).DeleteLokiEndpoint), arg0)
-	return &MockLoggingServiceDeleteLokiEndpointCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLokiConfig", reflect.TypeOf((*MockLoggingService)(nil).DeleteLokiConfig), arg0)
+	return &MockLoggingServiceDeleteLokiConfigCall{Call: call}
 }
 
-// MockLoggingServiceDeleteLokiEndpointCall wrap *gomock.Call
-type MockLoggingServiceDeleteLokiEndpointCall struct {
+// MockLoggingServiceDeleteLokiConfigCall wrap *gomock.Call
+type MockLoggingServiceDeleteLokiConfigCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockLoggingServiceDeleteLokiEndpointCall) Return(arg0 error) *MockLoggingServiceDeleteLokiEndpointCall {
+func (c *MockLoggingServiceDeleteLokiConfigCall) Return(arg0 error) *MockLoggingServiceDeleteLokiConfigCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockLoggingServiceDeleteLokiEndpointCall) Do(f func(context.Context) error) *MockLoggingServiceDeleteLokiEndpointCall {
+func (c *MockLoggingServiceDeleteLokiConfigCall) Do(f func(context.Context) error) *MockLoggingServiceDeleteLokiConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLoggingServiceDeleteLokiEndpointCall) DoAndReturn(f func(context.Context) error) *MockLoggingServiceDeleteLokiEndpointCall {
+func (c *MockLoggingServiceDeleteLokiConfigCall) DoAndReturn(f func(context.Context) error) *MockLoggingServiceDeleteLokiConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// SetLokiEndpoint mocks base method.
-func (m *MockLoggingService) SetLokiEndpoint(arg0 context.Context, arg1 string) error {
+// SetLokiConfig mocks base method.
+func (m *MockLoggingService) SetLokiConfig(arg0 context.Context, arg1 logging.LokiConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetLokiEndpoint", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetLokiConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetLokiEndpoint indicates an expected call of SetLokiEndpoint.
-func (mr *MockLoggingServiceMockRecorder) SetLokiEndpoint(arg0, arg1 any) *MockLoggingServiceSetLokiEndpointCall {
+// SetLokiConfig indicates an expected call of SetLokiConfig.
+func (mr *MockLoggingServiceMockRecorder) SetLokiConfig(arg0, arg1 any) *MockLoggingServiceSetLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLokiEndpoint", reflect.TypeOf((*MockLoggingService)(nil).SetLokiEndpoint), arg0, arg1)
-	return &MockLoggingServiceSetLokiEndpointCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLokiConfig", reflect.TypeOf((*MockLoggingService)(nil).SetLokiConfig), arg0, arg1)
+	return &MockLoggingServiceSetLokiConfigCall{Call: call}
 }
 
-// MockLoggingServiceSetLokiEndpointCall wrap *gomock.Call
-type MockLoggingServiceSetLokiEndpointCall struct {
+// MockLoggingServiceSetLokiConfigCall wrap *gomock.Call
+type MockLoggingServiceSetLokiConfigCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockLoggingServiceSetLokiEndpointCall) Return(arg0 error) *MockLoggingServiceSetLokiEndpointCall {
+func (c *MockLoggingServiceSetLokiConfigCall) Return(arg0 error) *MockLoggingServiceSetLokiConfigCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockLoggingServiceSetLokiEndpointCall) Do(f func(context.Context, string) error) *MockLoggingServiceSetLokiEndpointCall {
+func (c *MockLoggingServiceSetLokiConfigCall) Do(f func(context.Context, logging.LokiConfig) error) *MockLoggingServiceSetLokiConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLoggingServiceSetLokiEndpointCall) DoAndReturn(f func(context.Context, string) error) *MockLoggingServiceSetLokiEndpointCall {
+func (c *MockLoggingServiceSetLokiConfigCall) DoAndReturn(f func(context.Context, logging.LokiConfig) error) *MockLoggingServiceSetLokiConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/controlsocket/worker.go
+++ b/internal/worker/controlsocket/worker.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/core/user"
 	usererrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/domain/access/service"
+	"github.com/juju/juju/domain/logging"
 	domainobjectstore "github.com/juju/juju/domain/objectstore"
 	tracingservice "github.com/juju/juju/domain/tracing/service"
 	"github.com/juju/juju/internal/auth"
@@ -111,11 +112,11 @@ type TracingService interface {
 
 // LoggingService is the interface for the logging service.
 type LoggingService interface {
-	// SetLokiEndpoint sets the Loki push API endpoint.
-	SetLokiEndpoint(ctx context.Context, endpoint string) error
+	// SetLokiConfig sets the Loki push API endpoint and CA certificate.
+	SetLokiConfig(ctx context.Context, config logging.LokiConfig) error
 
-	// DeleteLokiEndpoint removes the configured Loki push API endpoint.
-	DeleteLokiEndpoint(ctx context.Context) error
+	// DeleteLokiConfig removes the configured Loki push API config.
+	DeleteLokiConfig(ctx context.Context) error
 }
 
 // Config represents configuration for the controlsocket worker.
@@ -599,7 +600,8 @@ func (w *Worker) handleRemoveS3Credentials(resp http.ResponseWriter, req *http.R
 }
 
 type lokiEndpointRequest struct {
-	URL string `json:"url"`
+	URL           string `json:"url"`
+	CACertificate string `json:"ca_cert"`
 }
 
 func (w *Worker) handleSetLokiEndpoint(resp http.ResponseWriter, req *http.Request) {
@@ -622,7 +624,10 @@ func (w *Worker) handleSetLokiEndpoint(resp http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	if err := w.loggingService.SetLokiEndpoint(ctx, parsedBody.URL); internalerrors.Is(err, coreerrors.NotValid) {
+	if err := w.loggingService.SetLokiConfig(ctx, logging.LokiConfig{
+		Endpoint:      parsedBody.URL,
+		CACertificate: parsedBody.CACertificate,
+	}); internalerrors.Is(err, coreerrors.NotValid) {
 		w.writeErrorResponse(ctx, resp, http.StatusBadRequest, internalerrors.Errorf("invalid loki endpoint: %w", err))
 		return
 	} else if err != nil {
@@ -636,7 +641,7 @@ func (w *Worker) handleSetLokiEndpoint(resp http.ResponseWriter, req *http.Reque
 func (w *Worker) handleRemoveLokiEndpoint(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	if err := w.loggingService.DeleteLokiEndpoint(ctx); err != nil {
+	if err := w.loggingService.DeleteLokiConfig(ctx); err != nil {
 		w.writeErrorResponse(ctx, resp, http.StatusInternalServerError, internalerrors.Errorf("removing loki endpoint: %w", err))
 		return
 	}

--- a/internal/worker/controlsocket/worker_test.go
+++ b/internal/worker/controlsocket/worker_test.go
@@ -26,6 +26,7 @@ import (
 	usertesting "github.com/juju/juju/core/user/testing"
 	usererrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/domain/access/service"
+	"github.com/juju/juju/domain/logging"
 	domainobjectstore "github.com/juju/juju/domain/objectstore"
 	tracingservice "github.com/juju/juju/domain/tracing/service"
 	auth "github.com/juju/juju/internal/auth"
@@ -1124,7 +1125,10 @@ func (s *workerSuite) TestAddS3CredentialsUnsupportedContentType(c *tc.C) {
 func (s *workerSuite) TestSetLokiEndpoint(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.loggingService.EXPECT().SetLokiEndpoint(gomock.Any(), "http://loki:3100/loki/api/v1/push").Return(nil)
+	s.loggingService.EXPECT().SetLokiConfig(gomock.Any(), logging.LokiConfig{
+		Endpoint:      "http://loki:3100/loki/api/v1/push",
+		CACertificate: "ca-cert",
+	}).Return(nil)
 
 	socket := s.newSocket(c)
 
@@ -1134,7 +1138,7 @@ func (s *workerSuite) TestSetLokiEndpoint(c *tc.C) {
 	s.runHandlerTest(c, socket, handlerTest{
 		method:     http.MethodPost,
 		endpoint:   "/loki-endpoint",
-		body:       `{"url":"http://loki:3100/loki/api/v1/push"}`,
+		body:       `{"url":"http://loki:3100/loki/api/v1/push","ca_cert":"ca-cert"}`,
 		statusCode: http.StatusOK,
 		response:   ".*updated loki endpoint.*",
 	})
@@ -1143,7 +1147,7 @@ func (s *workerSuite) TestSetLokiEndpoint(c *tc.C) {
 func (s *workerSuite) TestSetLokiEndpointEmptyURL(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.loggingService.EXPECT().SetLokiEndpoint(gomock.Any(), "").Return(
+	s.loggingService.EXPECT().SetLokiConfig(gomock.Any(), logging.LokiConfig{}).Return(
 		internalerrors.Errorf("empty loki endpoint").Add(coreerrors.NotValid),
 	)
 
@@ -1181,7 +1185,7 @@ func (s *workerSuite) TestSetLokiEndpointMissingBody(c *tc.C) {
 func (s *workerSuite) TestRemoveLokiEndpoint(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.loggingService.EXPECT().DeleteLokiEndpoint(gomock.Any()).Return(nil)
+	s.loggingService.EXPECT().DeleteLokiConfig(gomock.Any()).Return(nil)
 
 	socket := s.newSocket(c)
 
@@ -1199,7 +1203,7 @@ func (s *workerSuite) TestRemoveLokiEndpoint(c *tc.C) {
 func (s *workerSuite) TestRemoveLokiEndpointError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.loggingService.EXPECT().DeleteLokiEndpoint(gomock.Any()).Return(
+	s.loggingService.EXPECT().DeleteLokiConfig(gomock.Any()).Return(
 		internalerrors.New("database error"),
 	)
 


### PR DESCRIPTION
Adds ca_cert to logging_loki_config schema and extend domain/logging service/state for atomic url+ca_cert tuple.

Prior to this change we only wrote the endpoint, but that isn't enough to run loki (or OTEL logging) securely. This rectifies this.

## QA steps

Nothing yet, this is starting up of wire up.

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9974](https://warthogs.atlassian.net/browse/JUJU-9974)


[JUJU-9974]: https://warthogs.atlassian.net/browse/JUJU-9974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ