### PR TITLE
fix(externalcontrollerupdater): close watcher client on shutdown race

### DIFF
--- a/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
+++ b/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
@@ -329,51 +329,53 @@ func (w *controllerWatcher) loop() error {
 }
 
 // connectAndWatch connects to the specified controller and watches for changes.
-// It aborts if signalled, which prevents the watcher loop from blocking any shutdown
-// of the watcher the may be requested by the parent worker.
+// The connection is established in a separate goroutine so that the watcher loop
+// can abort promptly if signalled, rather than blocking shutdown on a slow dial.
 func (w *controllerWatcher) connectAndWatch(apiInfo *api.Info) (ExternalControllerWatcherClientCloser, watcher.NotifyWatcher, string, error) {
 	type result struct {
 		client ExternalControllerWatcherClientCloser
 		nw     watcher.NotifyWatcher
 		ipAddr string
+		err    error
 	}
 
-	response := make(chan result)
-	errs := make(chan error)
+	// Buffered so the goroutine can always deliver its result without
+	// blocking, even when we have already selected the dying branch below.
+	// This guarantees the connection is never leaked: an opened client is
+	// either returned to the caller (which closes it on exit) or closed here.
+	resultCh := make(chan result, 1)
 
 	go func() {
 		client, ipAddr, err := w.newExternalControllerWatcherClient(apiInfo)
 		if err != nil {
-			select {
-			case <-w.catacomb.Dying():
-			case errs <- errors.Annotate(err, "getting external controller client"):
-			}
+			resultCh <- result{err: errors.Annotate(err, "getting external controller client")}
 			return
 		}
 
 		nw, err := client.WatchControllerInfo()
 		if err != nil {
 			_ = client.Close()
-			select {
-			case <-w.catacomb.Dying():
-			case errs <- errors.Annotate(err, "watching external controller"):
-			}
+			resultCh <- result{err: errors.Annotate(err, "watching external controller")}
 			return
 		}
 
-		select {
-		case <-w.catacomb.Dying():
-			_ = client.Close()
-		case response <- result{client: client, nw: nw, ipAddr: ipAddr}:
-		}
+		resultCh <- result{client: client, nw: nw, ipAddr: ipAddr}
 	}()
 
 	select {
 	case <-w.catacomb.Dying():
+		// The worker is dying. Reaping the goroutine is bounded; close the
+		// client if one was opened so we don't leave a connection dangling
+		// after the worker has reported itself stopped.
+		r := <-resultCh
+		if r.client != nil {
+			_ = r.client.Close()
+		}
 		return nil, nil, "", w.catacomb.ErrDying()
-	case err := <-errs:
-		return nil, nil, "", errors.Trace(err)
-	case r := <-response:
+	case r := <-resultCh:
+		if r.err != nil {
+			return nil, nil, "", errors.Trace(r.err)
+		}
 		return r.client, r.nw, r.ipAddr, nil
 	}
 }


### PR DESCRIPTION
  Fixes a flaky shutdown race in the `externalcontrollerupdater` worker that
  surfaced as intermittent CI failures:
```
      missing call(s) to *MockExternalControllerWatcherClientCloser.Close()
```

 `connectAndWatch` dials the remote controller in a detached goroutine so a slow
  dial can't block shutdown. On success the goroutine hands the open client back
  to the loop, which is responsible for closing it.

  If the worker was killed in the narrow window after the client was opened but
  before the hand-off completed, the parent `select` took its dying branch and
  returned a **nil** client. The loop's deferred `Close()` therefore never ran,
  and the orphaned goroutine closed the client **asynchronously** — after the
  catacomb had already reported the worker stopped. `CleanKill` does not wait for
  that goroutine, so gomock's `Finish()` ran first and reported the `Close()`
  (and sometimes `WatchControllerInfo()`) call as missing.

  This only reproduced on slow CI machines, where the scheduler widened the race
  window.

#### The fix

`connectAndWatch` now delivers its result on a single **buffered** channel.
  When the worker is dying, the loop reaps that result and closes the client
  itself, synchronously, before returning — so an opened client is always closed
  by the loop and never orphaned in a background goroutine. Shutdown is still
  non-blocking, since the dial aborts on the catacomb dying.


## QA steps

The race window is very short on a fast machine, so it has to be widened
with a 5ms sleep (the local stand-in for "slow CI machine"), then run
repeatedly. 
We therefore need to apply a patch to add a bigger window temporarily.
The diffs below are applied inline — nothing needs to be committed.

1. Confirm the bug on the original code (expected: FAIL)

  Get the original code, then inject the sleep into the connect goroutine's
  hand-off select:
```
      git checkout upstream/3.6 -- internal/worker/externalcontrollerupdater/externalcontrollerupdater.go

      git apply <<'EOF'
diff --git a/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
  b/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
      --- a/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
      +++ b/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
      @@ -362,5 +362,6 @@
                }

      +         time.Sleep(5 * time.Millisecond) // REPRODUCER: widen the shutdown race window (simulates 
  machine)
                select {
                case <-w.catacomb.Dying():
                        _ = client.Close()
EOF
```
      go test ./internal/worker/externalcontrollerupdater/ \
        -check.f 'TestWatchExternalControllersChange' -count=10 -race
      # => missing call(s) to ...Close()

2. Confirm the fix closes the window (expected: PASS)

  Restore the fixed code, then inject the same sleep before the result hand-off:
```
git checkout HEAD -- internal/worker/externalcontrollerupdater/externalcontrollerupdater.go

git apply <<'EOF'
diff --git a/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go 
  b/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
      --- a/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
      +++ b/internal/worker/externalcontrollerupdater/externalcontrollerupdater.go
      @@ -360,4 +360,5 @@
                }

      +         time.Sleep(5 * time.Millisecond) // QA: widen the shutdown race window (simulates a slow C
  machine)
                resultCh <- result{client: client, nw: nw, ipAddr: ipAddr}
        }()
EOF
```
```
go test ./internal/worker/externalcontrollerupdater/ -count=50 -race
 ```
should pass.




## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22576.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9956](https://warthogs.atlassian.net/browse/JUJU-9956)


[JUJU-9956]: https://warthogs.atlassian.net/browse/JUJU-9956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ