### PR TITLE
fix: restore current-value startup reads for bounced standalone-controller workers

### DIFF
--- a/cmd/jujuagentd/agent/agent_test.go
+++ b/cmd/jujuagentd/agent/agent_test.go
@@ -6,12 +6,14 @@ package agent
 import (
 	"testing"
 
+	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/cmd/cmd"
 	"github.com/juju/juju/cmd/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/internal/agent/agentconf"
+	"github.com/juju/juju/controller"
 	corelogger "github.com/juju/juju/core/logger"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/testhelpers"
@@ -97,4 +99,119 @@ func (f *fakeLoggingConfig) Value(key string) string {
 		return f.loggingOverride
 	}
 	return ""
+}
+
+type machineControllerStartupValueProviderSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestMachineControllerStartupValueProviderSuite(t *testing.T) {
+	tc.Run(t, &machineControllerStartupValueProviderSuite{})
+}
+
+func (s *machineControllerStartupValueProviderSuite) TestLocalValuesReadCurrentAgentConfig(c *tc.C) {
+	provider := machineControllerStartupValueProvider{
+		agent: &MachineAgent{AgentConfigWriter: &fakeMachineAgentConfigWriter{
+			config: &fakeMachineConfig{dataDir: "/data/one", logDir: "/log/one"},
+		}},
+	}
+
+	values, err := provider.LocalValues()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(values.DataDir, tc.Equals, "/data/one")
+	c.Check(values.LogDir, tc.Equals, "/log/one")
+
+	provider.agent.AgentConfigWriter = &fakeMachineAgentConfigWriter{
+		config: &fakeMachineConfig{dataDir: "/data/two", logDir: "/log/two"},
+	}
+	values, err = provider.LocalValues()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(values.DataDir, tc.Equals, "/data/two")
+	c.Check(values.LogDir, tc.Equals, "/log/two")
+}
+
+func (s *machineControllerStartupValueProviderSuite) TestCertMaterialReadsCurrentAgentConfig(c *tc.C) {
+	provider := machineControllerStartupValueProvider{
+		agent: &MachineAgent{AgentConfigWriter: &fakeMachineAgentConfigWriter{
+			config: &fakeMachineConfig{
+				caCert: "ca-one",
+				controllerAgentInfo: controller.ControllerAgentInfo{
+					CAPrivateKey: "ca-key-one",
+					Cert:         "cert-one",
+					PrivateKey:   "key-one",
+				},
+			},
+		}},
+	}
+
+	material, err := provider.CertMaterial()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(material.CACert, tc.Equals, "ca-one")
+	c.Check(material.CAPrivateKey, tc.Equals, "ca-key-one")
+	c.Check(material.ControllerCert, tc.Equals, "cert-one")
+	c.Check(material.ControllerPrivateKey, tc.Equals, "key-one")
+
+	provider.agent.AgentConfigWriter = &fakeMachineAgentConfigWriter{
+		config: &fakeMachineConfig{
+			caCert: "ca-two",
+			controllerAgentInfo: controller.ControllerAgentInfo{
+				CAPrivateKey: "ca-key-two",
+				Cert:         "cert-two",
+				PrivateKey:   "key-two",
+			},
+		},
+	}
+	material, err = provider.CertMaterial()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(material.CACert, tc.Equals, "ca-two")
+	c.Check(material.CAPrivateKey, tc.Equals, "ca-key-two")
+	c.Check(material.ControllerCert, tc.Equals, "cert-two")
+	c.Check(material.ControllerPrivateKey, tc.Equals, "key-two")
+}
+
+type fakeMachineAgentConfigWriter struct {
+	agentconf.AgentConf
+	config agent.Config
+}
+
+func (f *fakeMachineAgentConfigWriter) CurrentConfig() agent.Config {
+	return f.config
+}
+
+type fakeMachineConfig struct {
+	agent.Config
+	dataDir             string
+	logDir              string
+	caCert              string
+	controllerAgentInfo controller.ControllerAgentInfo
+}
+
+func (f *fakeMachineConfig) DataDir() string {
+	return f.dataDir
+}
+
+func (f *fakeMachineConfig) LogDir() string {
+	return f.logDir
+}
+
+func (f *fakeMachineConfig) CACert() string {
+	return f.caCert
+}
+
+func (f *fakeMachineConfig) ControllerAgentInfo() (controller.ControllerAgentInfo, bool) {
+	return f.controllerAgentInfo, true
+}
+
+func (f *fakeMachineConfig) Value(key string) string {
+	if key == agent.LogSinkRateLimitBurst {
+		return "0"
+	}
+	if key == agent.LogSinkRateLimitRefill {
+		return "0"
+	}
+	return ""
+}
+
+func (f *fakeMachineConfig) Tag() names.Tag {
+	return names.NewMachineTag("0")
 }

--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -69,6 +69,8 @@ import (
 	"github.com/juju/juju/internal/upgrades"
 	"github.com/juju/juju/internal/upgradesteps"
 	internalworker "github.com/juju/juju/internal/worker"
+	"github.com/juju/juju/internal/worker/apiserver"
+	"github.com/juju/juju/internal/worker/apiservercertwatcher"
 	"github.com/juju/juju/internal/worker/dbaccessor"
 	"github.com/juju/juju/internal/worker/deployer"
 	workerflightrecorder "github.com/juju/juju/internal/worker/flightrecorder"
@@ -80,6 +82,38 @@ import (
 	jujunames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/rpc/params"
 )
+
+type machineControllerStartupValueProvider struct {
+	agent *MachineAgent
+}
+
+func (p machineControllerStartupValueProvider) CertMaterial() (apiservercertwatcher.CertMaterial, error) {
+	cfg := p.agent.CurrentConfig()
+	info, _ := cfg.ControllerAgentInfo()
+	return apiservercertwatcher.CertMaterial{
+		CACert:               cfg.CACert(),
+		CAPrivateKey:         info.CAPrivateKey,
+		ControllerCert:       info.Cert,
+		ControllerPrivateKey: info.PrivateKey,
+	}, nil
+}
+
+func (p machineControllerStartupValueProvider) LocalValues() (apiserver.LocalValues, error) {
+	cfg := p.agent.CurrentConfig()
+	logSinkConfig, err := logSinkConfigFromAgentConfig(cfg)
+	if err != nil {
+		return apiserver.LocalValues{}, errors.Annotate(err, "getting log sink config")
+	}
+	return apiserver.LocalValues{
+		DataDir:       cfg.DataDir(),
+		LogDir:        cfg.LogDir(),
+		LogSinkConfig: logSinkConfig,
+	}, nil
+}
+
+func (p machineControllerStartupValueProvider) ObjectStoreRootDir() (string, error) {
+	return p.agent.CurrentConfig().DataDir(), nil
+}
 
 type (
 	// The following allows the upgrade steps to be overridden by brittle
@@ -547,46 +581,20 @@ func (a *MachineAgent) makeEngineCreator(
 			filepath.Join(agentConfig.DataDir(), "agents", "controller-"+agentConfig.Tag().Id()),
 		)
 		flightRecorder := workerflightrecorder.New(flightrecorder.NewRecorder(clock), "", internallogger.GetLogger("juju.flightrecorder"))
-
-		// Read controller certificate material from the agent config for
-		// the transitional controller-on-machine path. The values are
-		// supplied as explicit startup fields so that the cert-watcher
-		// manifold does not need to read the controller runtime config
-		// file or depend on the agent manifold at worker start.
-		controllerAgentInfo, hasControllerInfo := agentConfig.ControllerAgentInfo()
-		var (
-			caCert               = agentConfig.CACert()
-			caPrivateKey         string
-			controllerCert       string
-			controllerPrivateKey string
-		)
-		if hasControllerInfo {
-			caPrivateKey = controllerAgentInfo.CAPrivateKey
-			controllerCert = controllerAgentInfo.Cert
-			controllerPrivateKey = controllerAgentInfo.PrivateKey
-		}
-
-		logSinkConfig, err := logSinkConfigFromAgentConfig(agentConfig)
-		if err != nil {
-			return nil, errors.Annotate(err, "getting log sink config")
-		}
+		startupValueProvider := machineControllerStartupValueProvider{agent: a}
 
 		manifoldsCfg := machine.ManifoldsConfig{
 			PreviousAgentVersion:              previousAgentVersion,
 			AgentName:                         agentName,
 			ControllerID:                      agentConfig.Tag().Id(),
-			ObjectStoreRootDir:                agentConfig.DataDir(),
+			ObjectStoreRootDirReader:          startupValueProvider,
 			ControllerUUID:                    agentConfig.Controller().Id(),
 			ControllerModelUUID:               agentConfig.Model().Id(),
 			ControllerRuntimeConfigPath:       controllerRuntimeConfigPath,
 			ControllerAgentTag:                agentConfig.Tag(),
 			LogDir:                            agentConfig.LogDir(),
-			DataDir:                           agentConfig.DataDir(),
-			APIServerLogSinkConfig:            logSinkConfig,
-			CACert:                            caCert,
-			CAPrivateKey:                      caPrivateKey,
-			ControllerCert:                    controllerCert,
-			ControllerPrivateKey:              controllerPrivateKey,
+			CertReader:                        startupValueProvider,
+			APIServerLocalConfigReader:        startupValueProvider,
 			ConfigChangeSocketPath:            path.Join(agentConfig.DataDir(), "configchange.socket"),
 			ControlSocketPath:                 path.Join(agentConfig.DataDir(), "control.socket"),
 			Agent:                             agent.APIHostPortsSetter{Agent: a},

--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -83,10 +83,16 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
+// machineControllerStartupValueProvider supplies current controller-local
+// startup values for the transitional controller-on-machine path. It re-reads
+// current agent config on each call so bounced workers do not keep stale
+// values.
 type machineControllerStartupValueProvider struct {
 	agent *MachineAgent
 }
 
+// CertMaterial returns the current controller certificate material from agent
+// config.
 func (p machineControllerStartupValueProvider) CertMaterial() (apiservercertwatcher.CertMaterial, error) {
 	cfg := p.agent.CurrentConfig()
 	info, _ := cfg.ControllerAgentInfo()
@@ -98,6 +104,8 @@ func (p machineControllerStartupValueProvider) CertMaterial() (apiservercertwatc
 	}, nil
 }
 
+// LocalValues returns the current controller-local API server values from
+// agent config.
 func (p machineControllerStartupValueProvider) LocalValues() (apiserver.LocalValues, error) {
 	cfg := p.agent.CurrentConfig()
 	logSinkConfig, err := logSinkConfigFromAgentConfig(cfg)
@@ -111,6 +119,8 @@ func (p machineControllerStartupValueProvider) LocalValues() (apiserver.LocalVal
 	}, nil
 }
 
+// ObjectStoreRootDir returns the current local root dir for file-backed object
+// store workers.
 func (p machineControllerStartupValueProvider) ObjectStoreRootDir() (string, error) {
 	return p.agent.CurrentConfig().DataDir(), nil
 }

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller/crosscontroller"
 	proxyconfig "github.com/juju/juju/api/proxy/config"
-	coreapiserver "github.com/juju/juju/apiserver"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cmd/jujuagentd/util"
 	"github.com/juju/juju/core/flightrecorder"
@@ -140,11 +139,9 @@ type ManifoldsConfig struct {
 	// through the agent manifold.
 	ControllerID string
 
-	// ObjectStoreRootDir is the local filesystem root used by the
-	// file-backed object-store worker. It is sourced from
-	// agentConfig.DataDir() and passed directly to object-store
-	// manifolds instead of being read from agent config.
-	ObjectStoreRootDir string
+	// ObjectStoreRootDirReader returns the current local filesystem root used by
+	// object-store workers.
+	ObjectStoreRootDirReader objectstore.RootDirReader
 
 	// ControllerUUID is the controller entity UUID. It is sourced from
 	// agentConfig.Controller().Id() in makeEngineCreator and passed
@@ -165,42 +162,18 @@ type ManifoldsConfig struct {
 	// through the legacy agent.Config.
 	ControllerRuntimeConfigPath string
 
-	// CACert is the TLS CA certificate PEM block for the controller.
-	// For the transitional controller-on-machine path it is sourced
-	// from agentConfig.CACert() at engine creation time and passed
-	// directly to the certificate-watcher manifold.
-	CACert string
-
-	// CAPrivateKey is the TLS CA private key PEM block. For the
-	// transitional path it is sourced from
-	// agentConfig.ControllerAgentInfo(). This field is sensitive.
-	CAPrivateKey string
-
-	// ControllerCert is the controller TLS certificate PEM block.
-	// Sourced from agentConfig.ControllerAgentInfo() for the
-	// transitional path.
-	ControllerCert string
-
-	// ControllerPrivateKey is the controller TLS private key PEM
-	// block. Sourced from agentConfig.ControllerAgentInfo(). This
-	// field is sensitive.
-	ControllerPrivateKey string
+	// CertReader returns the current controller certificate material.
+	CertReader apiservercertwatcher.CertReader
 
 	// ControllerAgentTag is the tag used for controller-agent log records.
 	ControllerAgentTag names.Tag
 
-	// LogDir is the controller process log directory.
+	// LogDir is the controller process log directory for workers in this change
+	// area that still take a fixed local path.
 	LogDir string
 
-	// DataDir is the controller process data directory. It is passed
-	// directly to the api-server worker instead of being read from
-	// agent config at worker start.
-	DataDir string
-
-	// APIServerLogSinkConfig holds rate-limit parameters for the API
-	// server log sink. It is populated from controller-owned startup
-	// state and passed directly to the api-server manifold.
-	APIServerLogSinkConfig coreapiserver.LogSinkConfig
+	// APIServerLocalConfigReader returns the current API-server local values.
+	APIServerLocalConfigReader apiserver.LocalConfigReader
 
 	// ConfigChangeSocketPath is the path to the config-change reload socket.
 	ConfigChangeSocketPath string
@@ -448,10 +421,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// and offers the result to other manifolds. This is only
 		// run by state servers.
 		certificateWatcherName: ifController(apiservercertwatcher.Manifold(apiservercertwatcher.ManifoldConfig{
-			CACert:               config.CACert,
-			CAPrivateKey:         config.CAPrivateKey,
-			ControllerCert:       config.ControllerCert,
-			ControllerPrivateKey: config.ControllerPrivateKey,
+			CertReader: config.CertReader,
 		})),
 
 		// The api caller is a thin concurrent wrapper around a connection
@@ -635,9 +605,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AuthenticatorName:      httpServerArgsName,
 			Clock:                  clock.WallClock,
 			ControllerTag:          config.ControllerAgentTag,
-			DataDir:                config.DataDir,
-			LogDir:                 config.LogDir,
-			LogSinkConfig:          config.APIServerLogSinkConfig,
+			LocalConfigReader:      config.APIServerLocalConfigReader,
 			LogSinkName:            logSinkName,
 			MuxName:                httpServerArgsName,
 			LeaseManagerName:       leaseManagerName,
@@ -836,7 +804,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			S3ClientName:                    objectStoreS3CallerName,
 			ObjectStoreName:                 objectStoreName,
 			ObjectStoreServicesName:         objectStoreServicesName,
-			ObjectStoreRootDir:              config.ObjectStoreRootDir,
+			RootDirReader:                   config.ObjectStoreRootDirReader,
 			FortressName:                    objectStoreFortressName,
 			GetControllerService:            objectstoredrainer.GetControllerService,
 			GeObjectStoreServices:           objectstoredrainer.GeObjectStoreServicesGetter,
@@ -857,7 +825,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			LeaseManagerName:           leaseManagerName,
 			S3ClientName:               objectStoreS3CallerName,
 			APIRemoteCallerName:        apiRemoteCallerName,
-			ObjectStoreRootDir:         config.ObjectStoreRootDir,
+			RootDirReader:              config.ObjectStoreRootDirReader,
 			ControllerNodeID:           config.ControllerID,
 			Clock:                      config.Clock,
 			Logger:                     internallogger.GetLogger("juju.worker.objectstore"),

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -4,8 +4,10 @@
 package agent
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/agent"
@@ -13,6 +15,7 @@ import (
 	"github.com/juju/juju/cmd/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/internal/agent/agentconf"
 	corelogger "github.com/juju/juju/core/logger"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/testhelpers"
 )
@@ -97,4 +100,114 @@ func (f *fakeLoggingConfig) Value(key string) string {
 		return f.loggingOverride
 	}
 	return ""
+}
+
+type controllerStartupValueProviderSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestControllerStartupValueProviderSuite(t *testing.T) {
+	tc.Run(t, &controllerStartupValueProviderSuite{})
+}
+
+func (s *controllerStartupValueProviderSuite) TestLoggingOverrideReadsCurrentAgentConfig(c *tc.C) {
+	provider := controllerStartupValueProvider{
+		agent: &ControllerAgent{AgentConfigWriter: &fakeAgentConfigWriter{
+			config: &fakeControllerConfig{loggingConfig: "first"},
+		}},
+	}
+
+	override, err := provider.LoggingOverride()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(override, tc.Equals, "first")
+
+	provider.agent.AgentConfigWriter = &fakeAgentConfigWriter{
+		config: &fakeControllerConfig{loggingConfig: "second"},
+	}
+	override, err = provider.LoggingOverride()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(override, tc.Equals, "second")
+}
+
+func (s *controllerStartupValueProviderSuite) TestSystemIdentityValuesUseCurrentRuntimeAndAgentConfig(c *tc.C) {
+	runtimeDir := c.MkDir()
+	runtimePath := filepath.Join(runtimeDir, "runtime.conf")
+	err := controllerruntimeconfig.WriteControllerRuntimeConfig(runtimePath, controllerruntimeconfig.ControllerRuntimeConfig{
+		ControllerID:         "0",
+		ControllerUUID:       "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		ControllerModelUUID:  "feedface-dead-beef-cafe-c0ffee000000",
+		DataDir:              filepath.Join(runtimeDir, "data-one"),
+		LogDir:               filepath.Join(runtimeDir, "log-one"),
+		CACert:               "ca-cert",
+		CAPrivateKey:         "ca-key",
+		ControllerCert:       "server-cert",
+		ControllerPrivateKey: "server-key",
+		SystemIdentity:       "identity-one",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	provider := controllerStartupValueProvider{
+		agent: &ControllerAgent{AgentConfigWriter: &fakeAgentConfigWriter{
+			config: &fakeControllerConfig{systemIdentityPath: "/path/one"},
+		}},
+		controllerRuntimePath: runtimePath,
+	}
+
+	values, err := provider.SystemIdentityValues()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(values.SystemIdentity, tc.Equals, "identity-one")
+	c.Check(values.SystemIdentityPath, tc.Equals, "/path/one")
+
+	err = controllerruntimeconfig.WriteControllerRuntimeConfig(runtimePath, controllerruntimeconfig.ControllerRuntimeConfig{
+		ControllerID:         "0",
+		ControllerUUID:       "deadbeef-0bad-400d-8000-4b1d0d06f00d",
+		ControllerModelUUID:  "feedface-dead-beef-cafe-c0ffee000000",
+		DataDir:              filepath.Join(runtimeDir, "data-two"),
+		LogDir:               filepath.Join(runtimeDir, "log-two"),
+		CACert:               "ca-cert",
+		CAPrivateKey:         "ca-key",
+		ControllerCert:       "server-cert",
+		ControllerPrivateKey: "server-key",
+		SystemIdentity:       "identity-two",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	provider.agent.AgentConfigWriter = &fakeAgentConfigWriter{
+		config: &fakeControllerConfig{systemIdentityPath: "/path/two"},
+	}
+
+	values, err = provider.SystemIdentityValues()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(values.SystemIdentity, tc.Equals, "identity-two")
+	c.Check(values.SystemIdentityPath, tc.Equals, "/path/two")
+}
+
+type fakeAgentConfigWriter struct {
+	agentconf.AgentConf
+	config agent.Config
+}
+
+func (f *fakeAgentConfigWriter) CurrentConfig() agent.Config {
+	return f.config
+}
+
+type fakeControllerConfig struct {
+	agent.Config
+	loggingConfig      string
+	systemIdentityPath string
+}
+
+func (f *fakeControllerConfig) LoggingConfig() string {
+	return f.loggingConfig
+}
+
+func (f *fakeControllerConfig) SystemIdentityPath() string {
+	return f.systemIdentityPath
+}
+
+func (f *fakeControllerConfig) Tag() names.Tag {
+	return names.NewControllerAgentTag("0")
+}
+
+func (f *fakeControllerConfig) Model() names.ModelTag {
+	return names.NewModelTag("model-uuid")
 }

--- a/cmd/jujud/agent/controller.go
+++ b/cmd/jujud/agent/controller.go
@@ -61,15 +61,20 @@ import (
 	"github.com/juju/juju/internal/wrench"
 )
 
+// controllerStartupValueProvider supplies current controller-local startup
+// values to workers when they start. It re-reads runtime.conf and current
+// agent config on each call so bounced workers do not keep stale values.
 type controllerStartupValueProvider struct {
 	agent                 *ControllerAgent
 	controllerRuntimePath string
 }
 
+// readRuntimeConfig returns the current controller runtime config from disk.
 func (p controllerStartupValueProvider) readRuntimeConfig() (controllerruntimeconfig.ControllerRuntimeConfig, error) {
 	return controllerruntimeconfig.ReadControllerRuntimeConfig(p.controllerRuntimePath)
 }
 
+// CertMaterial returns the current controller certificate material.
 func (p controllerStartupValueProvider) CertMaterial() (apiservercertwatcher.CertMaterial, error) {
 	cfg, err := p.readRuntimeConfig()
 	if err != nil {
@@ -83,6 +88,7 @@ func (p controllerStartupValueProvider) CertMaterial() (apiservercertwatcher.Cer
 	}, nil
 }
 
+// LocalValues returns the current controller-local API server values.
 func (p controllerStartupValueProvider) LocalValues() (apiserver.LocalValues, error) {
 	cfg, err := p.readRuntimeConfig()
 	if err != nil {
@@ -95,6 +101,8 @@ func (p controllerStartupValueProvider) LocalValues() (apiserver.LocalValues, er
 	}, nil
 }
 
+// ObjectStoreRootDir returns the current local root dir for file-backed object
+// store workers.
 func (p controllerStartupValueProvider) ObjectStoreRootDir() (string, error) {
 	cfg, err := p.readRuntimeConfig()
 	if err != nil {
@@ -103,10 +111,13 @@ func (p controllerStartupValueProvider) ObjectStoreRootDir() (string, error) {
 	return cfg.DataDir, nil
 }
 
+// LoggingOverride returns the current persisted logging override.
 func (p controllerStartupValueProvider) LoggingOverride() (string, error) {
 	return p.agent.CurrentConfig().LoggingConfig(), nil
 }
 
+// SystemIdentityValues returns the current system identity file contents and
+// path used by the controller identity writer.
 func (p controllerStartupValueProvider) SystemIdentityValues() (identityfilewriter.SystemIdentityValues, error) {
 	cfg, err := p.readRuntimeConfig()
 	if err != nil {

--- a/cmd/jujud/agent/controller.go
+++ b/cmd/jujud/agent/controller.go
@@ -49,14 +49,74 @@ import (
 	internalupgrade "github.com/juju/juju/internal/upgrade"
 	"github.com/juju/juju/internal/upgradesteps"
 	internalworker "github.com/juju/juju/internal/worker"
+	"github.com/juju/juju/internal/worker/apiserver"
+	"github.com/juju/juju/internal/worker/apiservercertwatcher"
 	"github.com/juju/juju/internal/worker/dbaccessor"
 	workerflightrecorder "github.com/juju/juju/internal/worker/flightrecorder"
 	"github.com/juju/juju/internal/worker/gate"
+	"github.com/juju/juju/internal/worker/identityfilewriter"
 	"github.com/juju/juju/internal/worker/introspection"
 	"github.com/juju/juju/internal/worker/migrationmaster"
 	"github.com/juju/juju/internal/worker/modelworkermanager"
 	"github.com/juju/juju/internal/wrench"
 )
+
+type controllerStartupValueProvider struct {
+	agent                 *ControllerAgent
+	controllerRuntimePath string
+}
+
+func (p controllerStartupValueProvider) readRuntimeConfig() (controllerruntimeconfig.ControllerRuntimeConfig, error) {
+	return controllerruntimeconfig.ReadControllerRuntimeConfig(p.controllerRuntimePath)
+}
+
+func (p controllerStartupValueProvider) CertMaterial() (apiservercertwatcher.CertMaterial, error) {
+	cfg, err := p.readRuntimeConfig()
+	if err != nil {
+		return apiservercertwatcher.CertMaterial{}, errors.Trace(err)
+	}
+	return apiservercertwatcher.CertMaterial{
+		CACert:               cfg.CACert,
+		CAPrivateKey:         cfg.CAPrivateKey,
+		ControllerCert:       cfg.ControllerCert,
+		ControllerPrivateKey: cfg.ControllerPrivateKey,
+	}, nil
+}
+
+func (p controllerStartupValueProvider) LocalValues() (apiserver.LocalValues, error) {
+	cfg, err := p.readRuntimeConfig()
+	if err != nil {
+		return apiserver.LocalValues{}, errors.Trace(err)
+	}
+	return apiserver.LocalValues{
+		DataDir:       cfg.DataDir,
+		LogDir:        cfg.LogDir,
+		LogSinkConfig: logSinkConfigFromRuntimeConfig(cfg),
+	}, nil
+}
+
+func (p controllerStartupValueProvider) ObjectStoreRootDir() (string, error) {
+	cfg, err := p.readRuntimeConfig()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return cfg.DataDir, nil
+}
+
+func (p controllerStartupValueProvider) LoggingOverride() (string, error) {
+	return p.agent.CurrentConfig().LoggingConfig(), nil
+}
+
+func (p controllerStartupValueProvider) SystemIdentityValues() (identityfilewriter.SystemIdentityValues, error) {
+	cfg, err := p.readRuntimeConfig()
+	if err != nil {
+		return identityfilewriter.SystemIdentityValues{}, errors.Trace(err)
+	}
+	return identityfilewriter.SystemIdentityValues{
+		SystemIdentity:     cfg.SystemIdentity,
+		SystemIdentityPath: p.agent.CurrentConfig().SystemIdentityPath(),
+	}, nil
+}
 
 type controllerAgentFactoryFnType func(names.Tag) (*ControllerAgent, error)
 
@@ -406,6 +466,10 @@ func (a *ControllerAgent) makeEngineCreator(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		startupValueProvider := controllerStartupValueProvider{
+			agent:                 a,
+			controllerRuntimePath: controllerRuntimeConfigPath,
+		}
 		flightRecorder := workerflightrecorder.New(
 			flightrecorder.NewRecorder(c), "",
 			internallogger.GetLogger("juju.flightrecorder"),
@@ -415,18 +479,14 @@ func (a *ControllerAgent) makeEngineCreator(
 			PreviousAgentVersion:        previousAgentVersion,
 			AgentName:                   agentName,
 			ControllerID:                a.agentTag.Id(),
-			ObjectStoreRootDir:          controllerRuntimeConfig.DataDir,
+			ObjectStoreRootDirReader:    startupValueProvider,
 			ControllerUUID:              controllerRuntimeConfig.ControllerUUID,
 			ControllerModelUUID:         controllerRuntimeConfig.ControllerModelUUID,
 			ControllerRuntimeConfigPath: controllerRuntimeConfigPath,
 			ControllerAgentTag:          a.agentTag,
 			LogDir:                      controllerRuntimeConfig.LogDir,
-			DataDir:                     controllerRuntimeConfig.DataDir,
-			APIServerLogSinkConfig:      logSinkConfigFromRuntimeConfig(controllerRuntimeConfig),
-			CACert:                      controllerRuntimeConfig.CACert,
-			CAPrivateKey:                controllerRuntimeConfig.CAPrivateKey,
-			ControllerCert:              controllerRuntimeConfig.ControllerCert,
-			ControllerPrivateKey:        controllerRuntimeConfig.ControllerPrivateKey,
+			CertReader:                  startupValueProvider,
+			APIServerLocalConfigReader:  startupValueProvider,
 			ConfigChangeSocketPath: path.Join(
 				controllerRuntimeConfig.DataDir, "configchange.socket",
 			),
@@ -459,7 +519,8 @@ func (a *ControllerAgent) makeEngineCreator(
 			SetupLogging:                      agentconf.SetupAgentLogging,
 			DependencyEngineMetrics:           metrics,
 			NewEnvironFunc:                    newEnvirons,
-			SystemIdentity:                    controllerRuntimeConfig.SystemIdentity,
+			LoggingOverrideReader:             startupValueProvider,
+			SystemIdentityReader:              startupValueProvider,
 		}
 		manifolds := agentcontroller.IAASManifolds(manifoldsCfg)
 		if agentConfig.Value(agent.ProviderType) == k8sconstants.CAASProviderType {

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"maps"
 	"net/http"
-	"path/filepath"
 	"time"
 
 	"github.com/juju/clock"
@@ -23,7 +22,6 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller/crosscontroller"
-	coreapiserver "github.com/juju/juju/apiserver"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/flightrecorder"
 	corehttp "github.com/juju/juju/core/http"
@@ -116,11 +114,9 @@ type ManifoldsConfig struct {
 	// the lookup.
 	ControllerID string
 
-	// ObjectStoreRootDir is the local filesystem root used by the
-	// file-backed object-store worker. It is sourced from controller
-	// runtime config DataDir and passed directly to object-store
-	// manifolds instead of being read from agent config.
-	ObjectStoreRootDir string
+	// ObjectStoreRootDirReader returns the current local filesystem root used by
+	// object-store workers.
+	ObjectStoreRootDirReader objectstore.RootDirReader
 
 	// ControllerUUID is the controller entity UUID. It is sourced from
 	// agentConfig.Controller().Id() in makeEngineCreator and passed
@@ -141,38 +137,18 @@ type ManifoldsConfig struct {
 	// through the legacy agent.Config.
 	ControllerRuntimeConfigPath string
 
-	// CACert is the TLS CA certificate PEM block for the controller.
-	// It is sourced from controller runtime config at engine creation
-	// and passed directly to the certificate-watcher manifold.
-	CACert string
-
-	// CAPrivateKey is the TLS CA private key PEM block. It is sourced
-	// from controller runtime config. This field is sensitive.
-	CAPrivateKey string
-
-	// ControllerCert is the controller TLS certificate PEM block.
-	// Sourced from controller runtime config at engine creation.
-	ControllerCert string
-
-	// ControllerPrivateKey is the controller TLS private key PEM block.
-	// Sourced from controller runtime config. This field is sensitive.
-	ControllerPrivateKey string
+	// CertReader returns the current controller certificate material.
+	CertReader apiservercertwatcher.CertReader
 
 	// ControllerAgentTag is the tag used for controller-agent log records.
 	ControllerAgentTag names.Tag
 
-	// LogDir is the controller process log directory.
+	// LogDir is the controller process log directory for workers in this change
+	// area that still take a fixed local path.
 	LogDir string
 
-	// DataDir is the controller process data directory. It is passed
-	// directly to the api-server worker instead of being read from
-	// agent config at worker start.
-	DataDir string
-
-	// APIServerLogSinkConfig holds rate-limit parameters for the API
-	// server log sink. It is populated from controller-owned startup
-	// state and passed directly to the api-server manifold.
-	APIServerLogSinkConfig coreapiserver.LogSinkConfig
+	// APIServerLocalConfigReader returns the current API-server local values.
+	APIServerLocalConfigReader apiserver.LocalConfigReader
 
 	// ConfigChangeSocketPath is the path to the config-change reload socket.
 	ConfigChangeSocketPath string
@@ -298,11 +274,11 @@ type ManifoldsConfig struct {
 	// "environment" (typically environs.New).
 	NewEnvironFunc func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.Environ, error)
 
-	// SystemIdentity is the SSH private key sourced from the
-	// controller runtime config, written to the system identity file
-	// by the ssh-identity-writer worker. An empty value causes the
-	// file to be removed.
-	SystemIdentity string
+	// LoggingOverrideReader returns the current persisted logging override.
+	LoggingOverrideReader controllerlogger.LoggingOverrideReader
+
+	// SystemIdentityReader returns the current system identity values.
+	SystemIdentityReader identityfilewriter.SystemIdentityReader
 }
 
 // commonManifolds returns the shared controller manifolds.
@@ -389,10 +365,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// certificate in the agent config for changes, and parses and
 		// offers the result to other manifolds.
 		certificateWatcherName: apiservercertwatcher.Manifold(apiservercertwatcher.ManifoldConfig{
-			CACert:               config.CACert,
-			CAPrivateKey:         config.CAPrivateKey,
-			ControllerCert:       config.ControllerCert,
-			ControllerPrivateKey: config.ControllerPrivateKey,
+			CertReader: config.CertReader,
 		}),
 
 		// The api caller is a thin concurrent wrapper around a connection
@@ -499,18 +472,17 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The logging config updater controls the messages sent via the
 		// log sender, according to changes in environment config.
 		loggingControllerConfigUpdaterName: ifNotMigrating(controllerlogger.Manifold(controllerlogger.ManifoldConfig{
-			DomainServicesName: domainServicesName,
-			LoggerContext:      internallogger.DefaultContext(),
-			Logger:             internallogger.GetLogger("juju.worker.logger"),
-			Tag:                agentTag,
-			LoggingOverride:    agentConfig.LoggingConfig(),
-			UpdateAgentFunc:    config.UpdateLoggerConfig,
+			DomainServicesName:    domainServicesName,
+			LoggerContext:         internallogger.DefaultContext(),
+			Logger:                internallogger.GetLogger("juju.worker.logger"),
+			Tag:                   agentTag,
+			LoggingOverrideReader: config.LoggingOverrideReader,
+			UpdateAgentFunc:       config.UpdateLoggerConfig,
 		})),
 
 		identityFileWriterName: ifNotMigrating(identityfilewriter.Manifold(identityfilewriter.ManifoldConfig{
-			SystemIdentity:     config.SystemIdentity,
-			SystemIdentityPath: filepath.Join(agentConfig.DataDir(), coreagent.SystemIdentity),
-			NewWorker:          identityfilewriter.NewWorker,
+			SystemIdentityReader: config.SystemIdentityReader,
+			NewWorker:            identityfilewriter.NewWorker,
 		})),
 
 		externalControllerUpdaterName: ifNotMigrating(ifPrimaryController(externalcontrollerupdater.Manifold(
@@ -560,9 +532,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AuthenticatorName:      httpServerArgsName,
 			Clock:                  clock.WallClock,
 			ControllerTag:          config.ControllerAgentTag,
-			DataDir:                config.DataDir,
-			LogDir:                 config.LogDir,
-			LogSinkConfig:          config.APIServerLogSinkConfig,
+			LocalConfigReader:      config.APIServerLocalConfigReader,
 			LogSinkName:            logSinkName,
 			MuxName:                httpServerArgsName,
 			LeaseManagerName:       leaseManagerName,
@@ -738,7 +708,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			S3ClientName:                    objectStoreS3CallerName,
 			ObjectStoreName:                 objectStoreName,
 			ObjectStoreServicesName:         objectStoreServicesName,
-			ObjectStoreRootDir:              config.ObjectStoreRootDir,
+			RootDirReader:                   config.ObjectStoreRootDirReader,
 			FortressName:                    objectStoreFortressName,
 			GetControllerService:            objectstoredrainer.GetControllerService,
 			GeObjectStoreServices:           objectstoredrainer.GeObjectStoreServicesGetter,
@@ -759,7 +729,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			LeaseManagerName:           leaseManagerName,
 			S3ClientName:               objectStoreS3CallerName,
 			APIRemoteCallerName:        apiRemoteCallerName,
-			ObjectStoreRootDir:         config.ObjectStoreRootDir,
+			RootDirReader:              config.ObjectStoreRootDirReader,
 			ControllerNodeID:           config.ControllerID,
 			Clock:                      config.Clock,
 			Logger:                     internallogger.GetLogger("juju.worker.objectstore"),

--- a/internal/worker/apiserver/manifold.go
+++ b/internal/worker/apiserver/manifold.go
@@ -62,6 +62,19 @@ func GetModelService(getter dependency.Getter, name string) (ModelService, error
 	})
 }
 
+// LocalValues are the controller-local values needed to start the API server.
+type LocalValues struct {
+	DataDir       string
+	LogDir        string
+	LogSinkConfig apiserver.LogSinkConfig
+}
+
+// LocalConfigReader returns the current controller-local values when the
+// manifold starts.
+type LocalConfigReader interface {
+	LocalValues() (LocalValues, error)
+}
+
 // ManifoldConfig holds the information necessary to run an apiserver
 // worker in a dependency.Engine.
 type ManifoldConfig struct {
@@ -86,12 +99,8 @@ type ManifoldConfig struct {
 	Clock clock.Clock
 	// ControllerTag is the tag of the controller running the API server.
 	ControllerTag names.Tag
-	// DataDir is the controller process data directory.
-	DataDir string
-	// LogDir is the controller process log directory.
-	LogDir string
-	// LogSinkConfig holds rate-limit parameters for the API server log sink.
-	LogSinkConfig apiserver.LogSinkConfig
+	// LocalConfigReader returns current controller-local startup values.
+	LocalConfigReader LocalConfigReader
 
 	PrometheusRegisterer              prometheus.Registerer
 	RegisterIntrospectionHTTPHandlers func(func(path string, _ http.Handler))
@@ -110,11 +119,8 @@ func (config ManifoldConfig) Validate() error {
 	if config.ControllerTag == nil {
 		return errors.NotValidf("nil ControllerTag")
 	}
-	if config.DataDir == "" {
-		return errors.NotValidf("empty DataDir")
-	}
-	if config.LogDir == "" {
-		return errors.NotValidf("empty LogDir")
+	if config.LocalConfigReader == nil {
+		return errors.NotValidf("nil LocalConfigReader")
 	}
 	if config.AuthenticatorName == "" {
 		return errors.NotValidf("empty AuthenticatorName")
@@ -213,6 +219,17 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
+	}
+
+	localValues, err := config.LocalConfigReader.LocalValues()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if localValues.DataDir == "" {
+		return nil, errors.NotValidf("empty DataDir")
+	}
+	if localValues.LogDir == "" {
+		return nil, errors.NotValidf("empty LogDir")
 	}
 
 	var mux *apiserverhttp.Mux
@@ -322,9 +339,9 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 
 	w, err := config.NewWorker(ctx, Config{
 		ControllerTag:                     config.ControllerTag,
-		DataDir:                           config.DataDir,
-		LogDir:                            config.LogDir,
-		LogSinkConfig:                     config.LogSinkConfig,
+		DataDir:                           localValues.DataDir,
+		LogDir:                            localValues.LogDir,
+		LogSinkConfig:                     localValues.LogSinkConfig,
 		Clock:                             config.Clock,
 		Mux:                               mux,
 		LeaseManager:                      leaseManager,

--- a/internal/worker/apiserver/manifold_test.go
+++ b/internal/worker/apiserver/manifold_test.go
@@ -76,6 +76,15 @@ type ManifoldSuite struct {
 	stub testhelpers.Stub
 }
 
+type stubLocalConfigReader struct {
+	values apiserver.LocalValues
+	err    error
+}
+
+func (s stubLocalConfigReader) LocalValues() (apiserver.LocalValues, error) {
+	return s.values, s.err
+}
+
 func TestManifoldSuite(t *testing.T) {
 	tc.Run(t, &ManifoldSuite{})
 }
@@ -112,9 +121,7 @@ func (s *ManifoldSuite) setupMocks(c *tc.C) *gomock.Controller {
 		AuthenticatorName:                 "authenticator",
 		Clock:                             clock.WallClock,
 		ControllerTag:                     names.NewControllerAgentTag("0"),
-		DataDir:                           c.MkDir(),
-		LogDir:                            c.MkDir(),
-		LogSinkConfig:                     coreapiserver.DefaultLogSinkConfig(),
+		LocalConfigReader:                 stubLocalConfigReader{values: apiserver.LocalValues{DataDir: c.MkDir(), LogDir: c.MkDir(), LogSinkConfig: coreapiserver.DefaultLogSinkConfig()}},
 		MuxName:                           "mux",
 		UpgradeGateName:                   "upgrade",
 		AuditConfigUpdaterName:            "auditconfig-updater",

--- a/internal/worker/apiservercertwatcher/manifold.go
+++ b/internal/worker/apiservercertwatcher/manifold.go
@@ -19,41 +19,60 @@ type AuthorityWorker interface {
 	worker.Worker
 }
 
-// ManifoldConfig holds the certificate material needed to start the
-// certificate-watcher worker. All fields are controller-owned startup
-// values supplied at engine-creation time; the manifold does not read
-// any config file or look up values through the agent manifold.
-type ManifoldConfig struct {
-	// CACert is the TLS CA certificate PEM block.
+// CertMaterial holds the certificate material needed to construct the
+// controller authority.
+type CertMaterial struct {
+	// CACert is the TLS CA certificate PEM block for the controller.
 	CACert string
 
-	// CAPrivateKey is the TLS CA private key PEM block. This field
-	// is sensitive and must not be logged.
+	// CAPrivateKey is the TLS CA private key PEM block.
 	CAPrivateKey string
 
 	// ControllerCert is the controller TLS certificate PEM block.
 	ControllerCert string
 
-	// ControllerPrivateKey is the controller TLS private key PEM block.
-	// This field is sensitive and must not be logged.
+	// ControllerPrivateKey is the controller TLS private key PEM
+	// block.
 	ControllerPrivateKey string
+}
+
+// CertReader returns the current controller certificate material when the
+// manifold starts.
+type CertReader interface {
+	CertMaterial() (CertMaterial, error)
+}
+
+// ManifoldConfig holds the certificate material needed to start the
+// certificate-watcher worker. The reader is evaluated when the manifold starts
+// so bounced workers observe current controller certificate material.
+type ManifoldConfig struct {
+	// CertReader returns the current controller certificate material.
+	CertReader CertReader
 
 	// CertWatcherWorkerFn is an optional override for tests.
-	CertWatcherWorkerFn func(config ManifoldConfig) (AuthorityWorker, error)
+	CertWatcherWorkerFn func(material CertMaterial) (AuthorityWorker, error)
 }
 
 // Validate returns an error if the config is incomplete.
 func (c ManifoldConfig) Validate() error {
-	if c.CACert == "" {
+	if c.CertReader == nil {
+		return errors.NotValidf("nil CertReader")
+	}
+	return nil
+}
+
+// Validate returns an error if the cert material is incomplete.
+func (m CertMaterial) Validate() error {
+	if m.CACert == "" {
 		return errors.NotValidf("empty CACert")
 	}
-	if c.CAPrivateKey == "" {
+	if m.CAPrivateKey == "" {
 		return errors.NotValidf("empty CAPrivateKey")
 	}
-	if c.ControllerCert == "" {
+	if m.ControllerCert == "" {
 		return errors.NotValidf("empty ControllerCert")
 	}
-	if c.ControllerPrivateKey == "" {
+	if m.ControllerPrivateKey == "" {
 		return errors.NotValidf("empty ControllerPrivateKey")
 	}
 	return nil
@@ -70,12 +89,20 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
+			material, err := config.CertReader.CertMaterial()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if err := material.Validate(); err != nil {
+				return nil, errors.Trace(err)
+			}
+
 			if config.CertWatcherWorkerFn != nil {
-				return config.CertWatcherWorkerFn(config)
+				return config.CertWatcherWorkerFn(material)
 			}
 
 			w := &apiserverCertWatcher{}
-			if err := w.setup(config); err != nil {
+			if err := w.setup(material); err != nil {
 				return nil, errors.Annotate(err, "setting up initial ca authority")
 			}
 
@@ -121,13 +148,13 @@ func (w *apiserverCertWatcher) Kill() {
 	w.tomb.Kill(nil)
 }
 
-func (w *apiserverCertWatcher) setup(config ManifoldConfig) error {
-	caCert := config.CACert
+func (w *apiserverCertWatcher) setup(material CertMaterial) error {
+	caCert := material.CACert
 	if caCert == "" {
 		return errors.New("no ca certificate found in config")
 	}
 
-	caPrivateKey := config.CAPrivateKey
+	caPrivateKey := material.CAPrivateKey
 	if caPrivateKey == "" {
 		return errors.New("no CA private key found in config")
 	}
@@ -139,12 +166,12 @@ func (w *apiserverCertWatcher) setup(config ManifoldConfig) error {
 	}
 
 	_, err = authority.LeafGroupFromPemCertKey(pki.DefaultLeafGroup,
-		[]byte(config.ControllerCert), []byte(config.ControllerPrivateKey))
+		[]byte(material.ControllerCert), []byte(material.ControllerPrivateKey))
 	if err != nil {
 		return errors.Annotate(err, "loading default certificate for controller")
 	}
 
-	_, signers, err := pki.UnmarshalPemData([]byte(config.ControllerPrivateKey))
+	_, signers, err := pki.UnmarshalPemData([]byte(material.ControllerPrivateKey))
 	if err != nil {
 		return errors.Annotate(err, "setting default certificate signing key")
 	}

--- a/internal/worker/apiservercertwatcher/manifold_test.go
+++ b/internal/worker/apiservercertwatcher/manifold_test.go
@@ -25,6 +25,15 @@ type ManifoldSuite struct {
 	getter   dependency.Getter
 }
 
+type stubCertReader struct {
+	material apiservercertwatcher.CertMaterial
+	err      error
+}
+
+func (s stubCertReader) CertMaterial() (apiservercertwatcher.CertMaterial, error) {
+	return s.material, s.err
+}
+
 func TestManifoldSuite(t *testing.T) {
 	tc.Run(t, &ManifoldSuite{})
 }
@@ -34,10 +43,12 @@ func (s *ManifoldSuite) SetUpTest(c *tc.C) {
 
 	s.getter = dt.StubGetter(map[string]any{})
 	s.manifold = apiservercertwatcher.Manifold(apiservercertwatcher.ManifoldConfig{
-		CACert:               coretesting.OtherCACert,
-		CAPrivateKey:         coretesting.OtherCAKey,
-		ControllerCert:       coretesting.ServerCert,
-		ControllerPrivateKey: coretesting.ServerKey,
+		CertReader: stubCertReader{material: apiservercertwatcher.CertMaterial{
+			CACert:               coretesting.OtherCACert,
+			CAPrivateKey:         coretesting.OtherCAKey,
+			ControllerCert:       coretesting.ServerCert,
+			ControllerPrivateKey: coretesting.ServerKey,
+		}},
 	})
 }
 
@@ -47,38 +58,52 @@ func (s *ManifoldSuite) TestInputs(c *tc.C) {
 
 func (s *ManifoldSuite) TestValidate_EmptyCACert(c *tc.C) {
 	cfg := apiservercertwatcher.ManifoldConfig{
-		CAPrivateKey:         coretesting.OtherCAKey,
-		ControllerCert:       coretesting.ServerCert,
-		ControllerPrivateKey: coretesting.ServerKey,
+		CertReader: stubCertReader{material: apiservercertwatcher.CertMaterial{
+			CAPrivateKey:         coretesting.OtherCAKey,
+			ControllerCert:       coretesting.ServerCert,
+			ControllerPrivateKey: coretesting.ServerKey,
+		}},
 	}
-	c.Assert(cfg.Validate(), tc.ErrorMatches, `.*CACert.*not valid`)
+	c.Assert(cfg.Validate(), tc.ErrorIsNil)
+	_, err := cfg.CertReader.CertMaterial()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(cfg.CertReader.(stubCertReader).material.Validate(), tc.ErrorMatches, `.*CACert.*not valid`)
 }
 
 func (s *ManifoldSuite) TestValidate_EmptyCAPrivateKey(c *tc.C) {
 	cfg := apiservercertwatcher.ManifoldConfig{
-		CACert:               coretesting.OtherCACert,
-		ControllerCert:       coretesting.ServerCert,
-		ControllerPrivateKey: coretesting.ServerKey,
+		CertReader: stubCertReader{material: apiservercertwatcher.CertMaterial{
+			CACert:               coretesting.OtherCACert,
+			ControllerCert:       coretesting.ServerCert,
+			ControllerPrivateKey: coretesting.ServerKey,
+		}},
 	}
-	c.Assert(cfg.Validate(), tc.ErrorMatches, `.*CAPrivateKey.*not valid`)
+	c.Assert(cfg.Validate(), tc.ErrorIsNil)
+	c.Assert(cfg.CertReader.(stubCertReader).material.Validate(), tc.ErrorMatches, `.*CAPrivateKey.*not valid`)
 }
 
 func (s *ManifoldSuite) TestValidate_EmptyControllerCert(c *tc.C) {
 	cfg := apiservercertwatcher.ManifoldConfig{
-		CACert:               coretesting.OtherCACert,
-		CAPrivateKey:         coretesting.OtherCAKey,
-		ControllerPrivateKey: coretesting.ServerKey,
+		CertReader: stubCertReader{material: apiservercertwatcher.CertMaterial{
+			CACert:               coretesting.OtherCACert,
+			CAPrivateKey:         coretesting.OtherCAKey,
+			ControllerPrivateKey: coretesting.ServerKey,
+		}},
 	}
-	c.Assert(cfg.Validate(), tc.ErrorMatches, `.*ControllerCert.*not valid`)
+	c.Assert(cfg.Validate(), tc.ErrorIsNil)
+	c.Assert(cfg.CertReader.(stubCertReader).material.Validate(), tc.ErrorMatches, `.*ControllerCert.*not valid`)
 }
 
 func (s *ManifoldSuite) TestValidate_EmptyControllerPrivateKey(c *tc.C) {
 	cfg := apiservercertwatcher.ManifoldConfig{
-		CACert:         coretesting.OtherCACert,
-		CAPrivateKey:   coretesting.OtherCAKey,
-		ControllerCert: coretesting.ServerCert,
+		CertReader: stubCertReader{material: apiservercertwatcher.CertMaterial{
+			CACert:         coretesting.OtherCACert,
+			CAPrivateKey:   coretesting.OtherCAKey,
+			ControllerCert: coretesting.ServerCert,
+		}},
 	}
-	c.Assert(cfg.Validate(), tc.ErrorMatches, `.*ControllerPrivateKey.*not valid`)
+	c.Assert(cfg.Validate(), tc.ErrorIsNil)
+	c.Assert(cfg.CertReader.(stubCertReader).material.Validate(), tc.ErrorMatches, `.*ControllerPrivateKey.*not valid`)
 }
 
 func (s *ManifoldSuite) TestStart(c *tc.C) {
@@ -109,15 +134,17 @@ func (s *ManifoldSuite) TestStart_NoAgentDependency(c *tc.C) {
 func (s *ManifoldSuite) TestStart_CertFieldsPassedToWorker(c *tc.C) {
 	var gotCACert, gotCAKey, gotCert, gotKey string
 	manifold := apiservercertwatcher.Manifold(apiservercertwatcher.ManifoldConfig{
-		CACert:               coretesting.OtherCACert,
-		CAPrivateKey:         coretesting.OtherCAKey,
-		ControllerCert:       coretesting.ServerCert,
-		ControllerPrivateKey: coretesting.ServerKey,
-		CertWatcherWorkerFn: func(cfg apiservercertwatcher.ManifoldConfig) (apiservercertwatcher.AuthorityWorker, error) {
-			gotCACert = cfg.CACert
-			gotCAKey = cfg.CAPrivateKey
-			gotCert = cfg.ControllerCert
-			gotKey = cfg.ControllerPrivateKey
+		CertReader: stubCertReader{material: apiservercertwatcher.CertMaterial{
+			CACert:               coretesting.OtherCACert,
+			CAPrivateKey:         coretesting.OtherCAKey,
+			ControllerCert:       coretesting.ServerCert,
+			ControllerPrivateKey: coretesting.ServerKey,
+		}},
+		CertWatcherWorkerFn: func(material apiservercertwatcher.CertMaterial) (apiservercertwatcher.AuthorityWorker, error) {
+			gotCACert = material.CACert
+			gotCAKey = material.CAPrivateKey
+			gotCert = material.ControllerCert
+			gotKey = material.ControllerPrivateKey
 			return nil, dependency.ErrUninstall
 		},
 	})

--- a/internal/worker/controllerlogger/manifold.go
+++ b/internal/worker/controllerlogger/manifold.go
@@ -33,6 +33,12 @@ type ModelService interface {
 	GetControllerModelUUID(ctx context.Context) (coremodel.UUID, error)
 }
 
+// LoggingOverrideReader returns the current persisted logging override when the
+// manifold starts.
+type LoggingOverrideReader interface {
+	LoggingOverride() (string, error)
+}
+
 // ManifoldConfig defines the configuration for a controller-only logging
 // worker manifold.
 type ManifoldConfig struct {
@@ -48,9 +54,9 @@ type ManifoldConfig struct {
 	// Tag is the controller agent tag.
 	Tag names.Tag
 
-	// LoggingOverride is the persisted logging override from the controller
-	// agent config.
-	LoggingOverride string
+	// LoggingOverrideReader returns the current persisted logging override from
+	// the controller agent config.
+	LoggingOverrideReader LoggingOverrideReader
 
 	// UpdateAgentFunc persists the current logging config.
 	UpdateAgentFunc func(string) error
@@ -69,6 +75,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.Tag == nil {
 		return errors.NotValidf("nil Tag")
+	}
+	if config.LoggingOverrideReader == nil {
+		return errors.NotValidf("nil LoggingOverrideReader")
 	}
 	return nil
 }
@@ -104,12 +113,17 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		return nil, errors.Trace(err)
 	}
 
+	loggingOverride, err := config.LoggingOverrideReader.LoggingOverride()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	workerConfig := Config{
 		Context:         config.LoggerContext,
 		ModelConfigSvc:  modelConfigService,
 		Tag:             config.Tag,
 		Logger:          config.Logger,
-		Override:        config.LoggingOverride,
+		Override:        loggingOverride,
 		UpdateAgentFunc: config.UpdateAgentFunc,
 	}
 	return NewWorker(ctx, workerConfig)

--- a/internal/worker/controllerlogger/manifold_test.go
+++ b/internal/worker/controllerlogger/manifold_test.go
@@ -25,6 +25,15 @@ type ManifoldSuite struct {
 	config controllerlogger.ManifoldConfig
 }
 
+type stubLoggingOverrideReader struct {
+	override string
+	err      error
+}
+
+func (s stubLoggingOverrideReader) LoggingOverride() (string, error) {
+	return s.override, s.err
+}
+
 func TestManifoldSuite(t *testing.T) {
 	tc.Run(t, &ManifoldSuite{})
 }
@@ -36,12 +45,12 @@ func (s *ManifoldSuite) SetUpTest(c *tc.C) {
 
 func validManifoldConfig(c *tc.C) controllerlogger.ManifoldConfig {
 	return controllerlogger.ManifoldConfig{
-		DomainServicesName: "domain-services",
-		LoggerContext:      internallogger.WrapLoggoContext(loggo.NewContext(loggo.DEBUG)),
-		Logger:             loggertesting.WrapCheckLog(c),
-		Tag:                names.NewControllerAgentTag("0"),
-		LoggingOverride:    "",
-		UpdateAgentFunc:    func(string) error { return nil },
+		DomainServicesName:    "domain-services",
+		LoggerContext:         internallogger.WrapLoggoContext(loggo.NewContext(loggo.DEBUG)),
+		Logger:                loggertesting.WrapCheckLog(c),
+		Tag:                   names.NewControllerAgentTag("0"),
+		LoggingOverrideReader: stubLoggingOverrideReader{},
+		UpdateAgentFunc:       func(string) error { return nil },
 	}
 }
 

--- a/internal/worker/identityfilewriter/manifold.go
+++ b/internal/worker/identityfilewriter/manifold.go
@@ -73,17 +73,26 @@ var NewLegacyWorker = func(agentConfig agent.Config) (worker.Worker, error) {
 	return jworker.NewSimpleWorker(inner), nil
 }
 
-// ManifoldConfig defines the explicit controller-owned inputs needed to write
-// the controller system identity file in the jujud-only path. Values are
-// sourced from controller runtime config at wiring time and do not require a
-// running api-caller or an IsController API lookup.
-type ManifoldConfig struct {
-	// SystemIdentity is the SSH private key written to the system identity
-	// file. An empty value removes the file instead of writing it.
-	SystemIdentity string
-
-	// SystemIdentityPath is the absolute path of the system identity file.
+// SystemIdentityValues are the current system identity values used by the
+// jujud-only worker when the manifold starts.
+type SystemIdentityValues struct {
+	SystemIdentity     string
 	SystemIdentityPath string
+}
+
+// SystemIdentityReader returns the current system identity values when the
+// manifold starts.
+type SystemIdentityReader interface {
+	SystemIdentityValues() (SystemIdentityValues, error)
+}
+
+// ManifoldConfig defines the explicit controller-owned inputs needed to write
+// the controller system identity file in the jujud-only path. The reader is
+// evaluated when the manifold starts so bounced workers observe current
+// values without reintroducing broad agent dependencies.
+type ManifoldConfig struct {
+	// SystemIdentityReader returns the current identity values.
+	SystemIdentityReader SystemIdentityReader
 
 	// NewWorker is the constructor for the identity file writer worker. It
 	// is exported for injection in unit tests.
@@ -92,11 +101,19 @@ type ManifoldConfig struct {
 
 // Validate returns an error if the config is incomplete.
 func (cfg ManifoldConfig) Validate() error {
-	if cfg.SystemIdentityPath == "" {
-		return errors.NotValidf("empty SystemIdentityPath")
+	if cfg.SystemIdentityReader == nil {
+		return errors.NotValidf("nil SystemIdentityReader")
 	}
 	if cfg.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+// Validate returns an error if the values are incomplete.
+func (v SystemIdentityValues) Validate() error {
+	if v.SystemIdentityPath == "" {
+		return errors.NotValidf("empty SystemIdentityPath")
 	}
 	return nil
 }
@@ -112,17 +129,38 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err := config.Validate(); err != nil {
 				return nil, errors.Trace(err)
 			}
+			values, err := config.SystemIdentityReader.SystemIdentityValues()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if err := values.Validate(); err != nil {
+				return nil, errors.Trace(err)
+			}
+			config := config
+			config.SystemIdentityReader = staticSystemIdentityReader{values: values}
 			return config.NewWorker(config)
 		},
 	}
+}
+
+type staticSystemIdentityReader struct {
+	values SystemIdentityValues
+}
+
+func (r staticSystemIdentityReader) SystemIdentityValues() (SystemIdentityValues, error) {
+	return r.values, nil
 }
 
 // NewWorker is the default constructor for the jujud-only SSH identity file
 // writer worker. It writes or removes the system identity file based on the
 // SystemIdentity value in cfg.
 var NewWorker = func(cfg ManifoldConfig) (worker.Worker, error) {
+	values, err := cfg.SystemIdentityReader.SystemIdentityValues()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	inner := func(ctx context.Context) error {
-		return writeSystemIdentityFile(cfg.SystemIdentity, cfg.SystemIdentityPath)
+		return writeSystemIdentityFile(values.SystemIdentity, values.SystemIdentityPath)
 	}
 	return jworker.NewSimpleWorker(inner), nil
 }

--- a/internal/worker/identityfilewriter/manifold_test.go
+++ b/internal/worker/identityfilewriter/manifold_test.go
@@ -108,15 +108,26 @@ type ManifoldSuite struct {
 	testhelpers.IsolationSuite
 }
 
+type stubSystemIdentityReader struct {
+	values identityfilewriter.SystemIdentityValues
+	err    error
+}
+
+func (s stubSystemIdentityReader) SystemIdentityValues() (identityfilewriter.SystemIdentityValues, error) {
+	return s.values, s.err
+}
+
 func TestManifoldSuite(t *testing.T) {
 	tc.Run(t, &ManifoldSuite{})
 }
 
 func validManifoldConfig(identityPath string) identityfilewriter.ManifoldConfig {
 	return identityfilewriter.ManifoldConfig{
-		SystemIdentity:     "test-ssh-key",
-		SystemIdentityPath: identityPath,
-		NewWorker:          identityfilewriter.NewWorker,
+		SystemIdentityReader: stubSystemIdentityReader{values: identityfilewriter.SystemIdentityValues{
+			SystemIdentity:     "test-ssh-key",
+			SystemIdentityPath: identityPath,
+		}},
+		NewWorker: identityfilewriter.NewWorker,
 	}
 }
 
@@ -133,19 +144,24 @@ func (s *ManifoldSuite) TestManifold_NoInputs(c *tc.C) {
 // SystemIdentityPath.
 func (s *ManifoldSuite) TestManifold_Validate_EmptyPath(c *tc.C) {
 	cfg := identityfilewriter.ManifoldConfig{
-		SystemIdentity:     "some-key",
-		SystemIdentityPath: "",
-		NewWorker:          identityfilewriter.NewWorker,
+		SystemIdentityReader: stubSystemIdentityReader{values: identityfilewriter.SystemIdentityValues{
+			SystemIdentity:     "some-key",
+			SystemIdentityPath: "",
+		}},
+		NewWorker: identityfilewriter.NewWorker,
 	}
-	c.Check(cfg.Validate(), tc.ErrorMatches, `empty SystemIdentityPath not valid`)
+	c.Check(cfg.Validate(), tc.ErrorIsNil)
+	c.Check(cfg.SystemIdentityReader.(stubSystemIdentityReader).values.Validate(), tc.ErrorMatches, `empty SystemIdentityPath not valid`)
 }
 
 // TestManifold_Validate_NilNewWorker ensures Validate rejects a nil NewWorker.
 func (s *ManifoldSuite) TestManifold_Validate_NilNewWorker(c *tc.C) {
 	cfg := identityfilewriter.ManifoldConfig{
-		SystemIdentity:     "some-key",
-		SystemIdentityPath: "/tmp/system-identity",
-		NewWorker:          nil,
+		SystemIdentityReader: stubSystemIdentityReader{values: identityfilewriter.SystemIdentityValues{
+			SystemIdentity:     "some-key",
+			SystemIdentityPath: "/tmp/system-identity",
+		}},
+		NewWorker: nil,
 	}
 	c.Check(cfg.Validate(), tc.ErrorMatches, `nil NewWorker not valid`)
 }
@@ -184,9 +200,11 @@ func (s *ManifoldSuite) TestManifold_Start_EmptyIdentityRemovesFile(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	cfg := identityfilewriter.ManifoldConfig{
-		SystemIdentity:     "",
-		SystemIdentityPath: identityPath,
-		NewWorker:          identityfilewriter.NewWorker,
+		SystemIdentityReader: stubSystemIdentityReader{values: identityfilewriter.SystemIdentityValues{
+			SystemIdentity:     "",
+			SystemIdentityPath: identityPath,
+		}},
+		NewWorker: identityfilewriter.NewWorker,
 	}
 	manifold := identityfilewriter.Manifold(cfg)
 
@@ -208,9 +226,11 @@ func (s *ManifoldSuite) TestManifold_Start_EmptyIdentityNoFileIsIdempotent(c *tc
 	// File does not exist — no pre-creation.
 
 	cfg := identityfilewriter.ManifoldConfig{
-		SystemIdentity:     "",
-		SystemIdentityPath: identityPath,
-		NewWorker:          identityfilewriter.NewWorker,
+		SystemIdentityReader: stubSystemIdentityReader{values: identityfilewriter.SystemIdentityValues{
+			SystemIdentity:     "",
+			SystemIdentityPath: identityPath,
+		}},
+		NewWorker: identityfilewriter.NewWorker,
 	}
 	manifold := identityfilewriter.Manifold(cfg)
 
@@ -228,8 +248,10 @@ func (s *ManifoldSuite) TestManifold_Start_InjectableWorker(c *tc.C) {
 	identityPath := filepath.Join(dir, "system-identity")
 	called := false
 	cfg := identityfilewriter.ManifoldConfig{
-		SystemIdentity:     "test-key",
-		SystemIdentityPath: identityPath,
+		SystemIdentityReader: stubSystemIdentityReader{values: identityfilewriter.SystemIdentityValues{
+			SystemIdentity:     "test-key",
+			SystemIdentityPath: identityPath,
+		}},
 		NewWorker: func(cfg identityfilewriter.ManifoldConfig) (worker.Worker, error) {
 			called = true
 			return nil, nil

--- a/internal/worker/objectstore/manifold.go
+++ b/internal/worker/objectstore/manifold.go
@@ -88,6 +88,12 @@ type GetMetadataServiceFunc func(getter dependency.Getter, name string) (Metadat
 // is the initial bootstrap controller.
 type IsBootstrapControllerFunc func(dataDir string) bool
 
+// RootDirReader returns the current local object-store root dir when the
+// manifold starts.
+type RootDirReader interface {
+	ObjectStoreRootDir() (string, error)
+}
+
 // ManifoldConfig defines the configuration for the objectstore manifold.
 type ManifoldConfig struct {
 	TraceName               string
@@ -96,10 +102,9 @@ type ManifoldConfig struct {
 	S3ClientName            string
 	APIRemoteCallerName     string
 
-	// ObjectStoreRootDir is the local filesystem root used by the
-	// file-backed object-store. It is a controller-local startup value
-	// passed explicitly instead of being read from agent config.
-	ObjectStoreRootDir string
+	// RootDirReader returns the current local filesystem root used by the
+	// file-backed object-store.
+	RootDirReader RootDirReader
 
 	// ControllerNodeID is the numeric controller node identifier
 	// (e.g. "0") passed explicitly instead of being derived from
@@ -123,8 +128,8 @@ func (cfg ManifoldConfig) Validate() error {
 	if cfg.ObjectStoreServicesName == "" {
 		return errors.NotValidf("empty ObjectStoreServicesName")
 	}
-	if cfg.ObjectStoreRootDir == "" {
-		return errors.NotValidf("empty ObjectStoreRootDir")
+	if cfg.RootDirReader == nil {
+		return errors.NotValidf("nil RootDirReader")
 	}
 	if cfg.ControllerNodeID == "" {
 		return errors.NotValidf("empty ControllerNodeID")
@@ -176,6 +181,14 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 			if err := config.Validate(); err != nil {
 				return nil, errors.Trace(err)
+			}
+
+			rootDir, err := config.RootDirReader.ObjectStoreRootDir()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if rootDir == "" {
+				return nil, errors.NotValidf("empty ObjectStoreRootDir")
 			}
 
 			var tracerGetter trace.TracerGetter
@@ -232,7 +245,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 			w, err := NewWorker(WorkerConfig{
 				TracerGetter:              tracerGetter,
-				RootDir:                   config.ObjectStoreRootDir,
+				RootDir:                   rootDir,
 				RootBucket:                rootBucketName,
 				Clock:                     config.Clock,
 				Logger:                    config.Logger,
@@ -252,7 +265,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				ModelClaimGetter: modelClaimGetter{
 					manager: leaseManager,
 				},
-				AllowDraining:    AllowDraining(backendInfo, config.IsBootstrapController(config.ObjectStoreRootDir)),
+				AllowDraining:    AllowDraining(backendInfo, config.IsBootstrapController(rootDir)),
 				ControllerNodeID: config.ControllerNodeID,
 			})
 			return w, errors.Trace(err)

--- a/internal/worker/objectstore/manifold_test.go
+++ b/internal/worker/objectstore/manifold_test.go
@@ -30,6 +30,15 @@ type manifoldSuite struct {
 	baseSuite
 }
 
+type stubRootDirReader struct {
+	rootDir string
+	err     error
+}
+
+func (s stubRootDirReader) ObjectStoreRootDir() (string, error) {
+	return s.rootDir, s.err
+}
+
 func TestManifoldSuite(t *stdtesting.T) {
 	defer goleak.VerifyNone(t)
 	tc.Run(t, &manifoldSuite{})
@@ -62,7 +71,7 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
-	cfg.ObjectStoreRootDir = ""
+	cfg.RootDirReader = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
@@ -105,7 +114,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		LeaseManagerName:        "lease-manager",
 		S3ClientName:            "s3-client",
 		APIRemoteCallerName:     "api-remote-caller",
-		ObjectStoreRootDir:      "/var/lib/juju",
+		RootDirReader:           stubRootDirReader{rootDir: "/var/lib/juju"},
 		ControllerNodeID:        "0",
 		Clock:                   clock.WallClock,
 		Logger:                  s.logger,

--- a/internal/worker/objectstoredrainer/manifold.go
+++ b/internal/worker/objectstoredrainer/manifold.go
@@ -60,6 +60,12 @@ type ControllerConfigService interface {
 	ControllerConfig(context.Context) (controller.Config, error)
 }
 
+// RootDirReader returns the current local object-store root dir when the
+// manifold starts.
+type RootDirReader interface {
+	ObjectStoreRootDir() (string, error)
+}
+
 // ManifoldConfig holds the dependencies and configuration for a
 // Worker manifold.
 type ManifoldConfig struct {
@@ -77,7 +83,7 @@ type ManifoldConfig struct {
 	NewHashFileSystemAccessor       NewHashFileSystemAccessorFunc
 	NewDrainerWorker                NewDrainerWorkerFunc
 	SelectFileHash                  SelectFileHashFunc
-	ObjectStoreRootDir              string
+	RootDirReader                   RootDirReader
 	Clock                           clock.Clock
 
 	Logger logger.Logger
@@ -121,8 +127,8 @@ func (config ManifoldConfig) Validate() error {
 	if config.SelectFileHash == nil {
 		return errors.NotValidf("nil SelectFileHash")
 	}
-	if config.ObjectStoreRootDir == "" {
-		return errors.NotValidf("empty ObjectStoreRootDir")
+	if config.RootDirReader == nil {
+		return errors.NotValidf("nil RootDirReader")
 	}
 	if config.Clock == nil {
 		return errors.NotValidf("nil Clock")
@@ -137,6 +143,14 @@ func (config ManifoldConfig) Validate() error {
 func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
+	}
+
+	rootDir, err := config.RootDirReader.ObjectStoreRootDir()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if rootDir == "" {
+		return nil, errors.NotValidf("empty ObjectStoreRootDir")
 	}
 
 	controllerConfigService, err := config.GetControllerConfigService(getter, config.ObjectStoreServicesName)
@@ -199,7 +213,7 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		NewDrainerWorker:             config.NewDrainerWorker,
 		SelectFileHash:               config.SelectFileHash,
 		S3Client:                     s3Client,
-		RootDir:                      config.ObjectStoreRootDir,
+		RootDir:                      rootDir,
 		RootBucketName:               rootBucketName,
 		Logger:                       config.Logger,
 		Clock:                        config.Clock,

--- a/internal/worker/objectstoredrainer/manifold_test.go
+++ b/internal/worker/objectstoredrainer/manifold_test.go
@@ -32,6 +32,15 @@ type manifoldSuite struct {
 	baseSuite
 }
 
+type stubRootDirReader struct {
+	rootDir string
+	err     error
+}
+
+func (s stubRootDirReader) ObjectStoreRootDir() (string, error) {
+	return s.rootDir, s.err
+}
+
 func TestManifoldSuite(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
@@ -85,7 +94,7 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig(c)
-	cfg.ObjectStoreRootDir = ""
+	cfg.RootDirReader = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig(c)
@@ -136,9 +145,9 @@ func (s *manifoldSuite) getConfig(c *tc.C) ManifoldConfig {
 		NewWorker: func(config Config) (worker.Worker, error) {
 			return workertest.NewErrorWorker(nil), nil
 		},
-		ObjectStoreRootDir: "/var/lib/juju",
-		Clock:              clock.WallClock,
-		Logger:             loggertesting.WrapCheckLog(c),
+		RootDirReader: stubRootDirReader{rootDir: "/var/lib/juju"},
+		Clock:         clock.WallClock,
+		Logger:        loggertesting.WrapCheckLog(c),
 	}
 }
 
@@ -222,10 +231,10 @@ func (s *manifoldSuite) getConfigWithRealWorker(c *tc.C) ManifoldConfig {
 		NewDrainerWorker: func(completed chan<- drainResult, fileSystem HashFileSystemAccessor, client objectstore.Client, metadataService objectstore.ObjectStoreMetadata, rootBucket, namespace string, selectFileHash SelectFileHashFunc, clk clock.Clock, logger logger.Logger) worker.Worker {
 			return newTestWorker(completed)
 		},
-		NewWorker:          NewWorker,
-		ObjectStoreRootDir: "/var/lib/juju",
-		Clock:              clock.WallClock,
-		Logger:             loggertesting.WrapCheckLog(c),
+		NewWorker:     NewWorker,
+		RootDirReader: stubRootDirReader{rootDir: "/var/lib/juju"},
+		Clock:         clock.WallClock,
+		Logger:        loggertesting.WrapCheckLog(c),
 	}
 }
 
@@ -241,7 +250,7 @@ func (s *manifoldSuite) TestStartUsesExplicitRootDirAndWallClock(c *tc.C) {
 
 	rootDir := c.MkDir()
 	cfg := s.getConfig(c)
-	cfg.ObjectStoreRootDir = rootDir
+	cfg.RootDirReader = stubRootDirReader{rootDir: rootDir}
 
 	newWorkerCalled := false
 	cfg.NewWorker = func(workerConfig Config) (worker.Worker, error) {


### PR DESCRIPTION
This change restores correct bounce/restart semantics for standalone-controller
workers that had moved from live startup reads to engine-time snapshots during
the controller cleanup work.

The explicit-contract direction is kept, but fixed startup values are replaced
with lazy readers evaluated when each worker/manifold starts. That means a
bounced worker now picks up current values instead of reusing stale values
captured when the engine was first created.

### Problem

Some controller-side workers previously read current values at manifold/worker
start time. During the standalone-controller cleanup, those reads were replaced
with explicit values captured once during engine creation.

That changed behavior on worker bounce:
- if controller-local config changed
- and a worker restarted
- the restarted worker could continue using stale values until the whole agent
restarted

### Approach

This change keeps explicit contracts and avoids reintroducing broad agent
dependencies.

Instead:
- each affected worker defines its own small reader interface
- `jujud` provides one runtime-config-backed implementation of those interfaces
- `jujuagentd` provides one current-agent-config-backed implementation of those
interfaces
- readers are invoked at worker/manifold start time

No caching is used, so bounced workers see current values.

### Modified workers

The affected workers/manifolds updated in this change are:

- API server certificate watcher
- API server
- Object store
- Object store drainer
- Controller logger
- SSH identity file writer

### Behavior after this change

For `jujud`:
- current values are read lazily from controller runtime config
- logging override is read lazily from current agent config

For `jujuagentd`:
- current values are read lazily from current agent config

Values intentionally left fixed:
- controller UUID
- controller model UUID
- controller node ID


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ juju bootstrap microk8s src
❯ juju add-model m
❯ juju deploy juju-qa-test

❯ jst
Model  Controller  Cloud/Region        Version    Timestamp
m      src         microk8s/localhost  4.1-beta2  10:11:49+02:00

App           Version  Status  Scale  Charm         Channel        Rev  Address        Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   25  10.152.183.70  no       hello

Unit             Workload  Agent  Address      Ports  Message
juju-qa-test/0*  active    idle   10.1.180.89         hello

❯ jst -m controller
Model       Controller  Cloud/Region        Version    Timestamp
controller  src         microk8s/localhost  4.1-beta2  10:11:52+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Address         Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  10.152.183.178  no

Unit           Workload  Agent  Address      Ports            Message
controller/0*  active    idle   10.1.180.76  17022,17070/tcp

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer

❯ juju ssh -m controller 0
juju@controller-0:/var/lib/juju$ grep ":" /var/lib/juju/agents/controller-0/runtime.conf
controller-id: "0"
controller-uuid: 79d1021c-d328-4354-8220-5b2431beb877
controller-model-uuid: 5f1a5fe1-9533-42e9-8526-cb2df02947f7
data-dir: /var/lib/juju
log-dir: /var/log/juju
query-tracing-enabled: false
query-tracing-threshold: 1s
dqlite-busy-timeout: 1s
ca-cert: |
ca-private-key: |
controller-cert: |
controller-private-key: |
log-sink-rate-limit-burst: 2000
log-sink-rate-limit-refill: 5ms

```

## Documentation changes


## Links

**Jira card:** [JUJU-9715](https://warthogs.atlassian.net/browse/JUJU-9715)

Addresses review comment: https://github.com/juju/juju/pull/22602#discussion_r3381685530

[JUJU-9715]: https://warthogs.atlassian.net/browse/JUJU-9715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ