### PR TITLE
fix(migration): import application storage directives

### DIFF
--- a/domain/application/modelmigration/import.go
+++ b/domain/application/modelmigration/import.go
@@ -185,9 +185,6 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		// Investigate how device constraints for an application are
 		// migrated and implemented if necessary.
 
-		// TODO hml 04-30-2024
-		// Investigate how storage directives for an application are
-		// migrated and implemented if necessary.
 		args := service.ImportApplicationArgs{
 			UUID:                   appUUID,
 			Charm:                  charm,
@@ -197,6 +194,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			ApplicationConstraints: constraintsmigration.DecodeConstraints(app.Constraints()),
 			EndpointBindings:       endpointBindings,
 			ExposedEndpoints:       exposedEndpoints,
+			StorageDirectives:      importStorageDirectives(app.StorageDirectives()),
 
 			// ReferenceName is the name of the charm URL, not the application
 			// name and not the charm name in the metadata, but the name of
@@ -249,6 +247,26 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	}
 
 	return nil
+}
+
+// importStorageDirectives converts the storage directives from the description
+// model into the import arguments understood by the application service. The
+// pool is referenced by name and is resolved to a storage pool UUID later, in
+// the state layer.
+func importStorageDirectives(directives map[string]description.StorageDirective) []service.ImportStorageDirectiveArg {
+	if len(directives) == 0 {
+		return nil
+	}
+	result := make([]service.ImportStorageDirectiveArg, 0, len(directives))
+	for name, directive := range directives {
+		result = append(result, service.ImportStorageDirectiveArg{
+			Name:  name,
+			Pool:  directive.Pool(),
+			Size:  directive.Size(),
+			Count: directive.Count(),
+		})
+	}
+	return result
 }
 
 func (i *importOperation) importApplicationConfig(app description.Application) (internalcharm.Config, error) {

--- a/domain/application/modelmigration/import_test.go
+++ b/domain/application/modelmigration/import_test.go
@@ -168,6 +168,70 @@ func (s *importSuite) TestApplicationImportWithMinimalCharmForCAAS(c *tc.C) {
 	}})
 }
 
+func (s *importSuite) TestApplicationImportStorageDirectivesForCAAS(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	model := description.NewModel(description.ModelArgs{
+		Type: coremodel.CAAS.String(),
+	})
+
+	appArgs := description.ApplicationArgs{
+		Name:     "prometheus",
+		CharmURL: "ch:prometheus-1",
+		StorageDirectives: map[string]description.StorageDirectiveArgs{
+			"pgdata": {
+				Pool:  "fast",
+				Size:  2048,
+				Count: 3,
+			},
+		},
+	}
+	app := model.AddApplication(appArgs)
+	app.SetCharmMetadata(description.CharmMetadataArgs{
+		Name: "prometheus",
+	})
+	app.SetCharmManifest(description.CharmManifestArgs{
+		Bases: []description.CharmManifestBase{baseType{
+			name:          "ubuntu",
+			channel:       "24.04",
+			architectures: []string{"amd64"},
+		}},
+	})
+	app.SetCharmOrigin(description.CharmOriginArgs{
+		Source:   "charm-hub",
+		ID:       "1234",
+		Hash:     "deadbeef",
+		Revision: 1,
+		Channel:  "666/stable",
+		Platform: "arm64/ubuntu/24.04",
+	})
+
+	var importArgs service.ImportCAASApplicationArgs
+	s.importService.EXPECT().ImportCAASApplication(
+		gomock.Any(),
+		"prometheus",
+		gomock.Any(),
+	).DoAndReturn(func(_ context.Context, _ string, args service.ImportCAASApplicationArgs) error {
+		importArgs = args
+		return nil
+	})
+
+	importOp := importOperation{
+		service: s.importService,
+		logger:  loggertesting.WrapCheckLog(c),
+	}
+
+	err := importOp.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(importArgs.StorageDirectives, tc.DeepEquals, []service.ImportStorageDirectiveArg{{
+		Name:  "pgdata",
+		Pool:  "fast",
+		Size:  2048,
+		Count: 3,
+	}})
+}
+
 func (s *importSuite) TestApplicationImportWithMinimalCharmForIAAS(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -417,16 +417,44 @@ func makeInsertApplicationArg(
 		return application.InsertApplicationArgs{}, errors.Errorf("encoding application config: %w", err)
 	}
 
+	storageDirectives, err := makeMigratingStorageDirectiveArgs(args.StorageDirectives)
+	if err != nil {
+		return application.InsertApplicationArgs{}, errors.Errorf("encoding storage directives: %w", err)
+	}
+
 	return application.InsertApplicationArgs{
-		ApplicationUUID:  args.UUID.String(),
-		Charm:            ch,
-		Platform:         platformArg,
-		Channel:          channelArg,
-		EndpointBindings: args.EndpointBindings,
-		Resources:        makeResourcesArgs(args.ResolvedResources),
-		Config:           applicationConfig,
-		Settings:         args.ApplicationSettings,
+		ApplicationUUID:   args.UUID.String(),
+		Charm:             ch,
+		Platform:          platformArg,
+		Channel:           channelArg,
+		EndpointBindings:  args.EndpointBindings,
+		Resources:         makeResourcesArgs(args.ResolvedResources),
+		Config:            applicationConfig,
+		Settings:          args.ApplicationSettings,
+		StorageDirectives: storageDirectives,
 	}, nil
+}
+
+// makeMigratingStorageDirectiveArgs converts the imported storage directive
+// arguments into the migrating storage directive arguments understood by the
+// state layer. The storage pool is left as a name; the state layer resolves it
+// to a storage pool UUID.
+func makeMigratingStorageDirectiveArgs(
+	directives []ImportStorageDirectiveArg,
+) ([]application.MigratingStorageDirectiveArg, error) {
+	if len(directives) == 0 {
+		return nil, nil
+	}
+	result := make([]application.MigratingStorageDirectiveArg, 0, len(directives))
+	for _, d := range directives {
+		result = append(result, application.MigratingStorageDirectiveArg{
+			Name:     d.Name,
+			PoolName: d.Pool,
+			Size:     d.Size,
+			Count:    uint32(d.Count),
+		})
+	}
+	return result, nil
 }
 
 // IsApplicationExposed returns whether the provided application is exposed or not.

--- a/domain/application/service/migration_test.go
+++ b/domain/application/service/migration_test.go
@@ -38,6 +38,28 @@ func TestMigrationServiceSuite(t *testing.T) {
 	tc.Run(t, &migrationServiceSuite{})
 }
 
+func (s *migrationServiceSuite) TestMakeMigratingStorageDirectiveArgs(c *tc.C) {
+	result, err := makeMigratingStorageDirectiveArgs([]ImportStorageDirectiveArg{{
+		Name:  "pgdata",
+		Pool:  "fast",
+		Size:  2048,
+		Count: 3,
+	}})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, []application.MigratingStorageDirectiveArg{{
+		Name:     "pgdata",
+		PoolName: "fast",
+		Size:     2048,
+		Count:    3,
+	}})
+}
+
+func (s *migrationServiceSuite) TestMakeMigratingStorageDirectiveArgsEmpty(c *tc.C) {
+	result, err := makeMigratingStorageDirectiveArgs(nil)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.IsNil)
+}
+
 func (s *migrationServiceSuite) TestGetCharmIDWithoutRevision(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -248,6 +248,26 @@ type ImportApplicationArgs struct {
 
 	// ExposedEndpoints is the exposed endpoints for the application.
 	ExposedEndpoints map[string]application.ExposedEndpoint
+
+	// StorageDirectives are the storage directives for the application. The
+	// Name values must match the storage defined in the charm.
+	StorageDirectives []ImportStorageDirectiveArg
+}
+
+// ImportStorageDirectiveArg contains the arguments for importing a single
+// application storage directive during model migration.
+type ImportStorageDirectiveArg struct {
+	// Name is the charm storage name the directive applies to.
+	Name string
+
+	// Pool is the name of the storage pool the directive uses.
+	Pool string
+
+	// Size is the size of the storage directive in MiB.
+	Size uint64
+
+	// Count is the number of storage instances the directive requests.
+	Count uint64
 }
 
 // ImportIAASApplicationArgs contains arguments for importing an IAAS

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -17,6 +17,7 @@ import (
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
 	domainnetwork "github.com/juju/juju/domain/network"
+	domainstorage "github.com/juju/juju/domain/storage"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -190,12 +191,87 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 				return errors.Errorf("inserting channel row for application %q: %w", name, err)
 			}
 		}
+
+		if err := st.insertMigratingApplicationStorageDirectives(
+			ctx, tx, applicationDetails.UUID, charmUUID, args.StorageDirectives,
+		); err != nil {
+			return errors.Errorf("inserting storage directives for application %q: %w", name, err)
+		}
 		return nil
 	})
 	if err != nil {
 		return errors.Errorf("creating application %q: %w", name, err)
 	}
 	return nil
+}
+
+// insertMigratingApplicationStorageDirectives resolves the storage pool for
+// each migrating storage directive by name and inserts the directives for the
+// application. It must run after the application and charm (including charm
+// storage) rows have been inserted, and after the storage pools have been
+// imported.
+func (st *State) insertMigratingApplicationStorageDirectives(
+	ctx context.Context,
+	tx *sqlair.TX,
+	appUUID, charmUUID string,
+	directives []application.MigratingStorageDirectiveArg,
+) error {
+	if len(directives) == 0 {
+		return nil
+	}
+
+	poolUUIDsByName, err := st.getStoragePoolUUIDsByName(ctx, tx)
+	if err != nil {
+		return errors.Errorf("getting storage pool UUIDs: %w", err)
+	}
+
+	resolved := make([]domainstorage.DirectiveArg, 0, len(directives))
+	for _, d := range directives {
+		if d.PoolName == "" {
+			return errors.Errorf(
+				"storage directive %q has no storage pool", d.Name)
+		}
+		poolUUID, ok := poolUUIDsByName[d.PoolName]
+		if !ok {
+			return errors.Errorf(
+				"storage pool %q not found for storage directive %q",
+				d.PoolName, d.Name)
+		}
+		resolved = append(resolved, domainstorage.DirectiveArg{
+			Name:     domainstorage.Name(d.Name),
+			PoolUUID: domainstorage.StoragePoolUUID(poolUUID),
+			Size:     d.Size,
+			Count:    d.Count,
+		})
+	}
+
+	return st.insertApplicationStorageDirectives(ctx, tx, appUUID, charmUUID, resolved)
+}
+
+// getStoragePoolUUIDsByName returns a mapping of storage pool name to UUID for
+// all storage pools in the model.
+func (st *State) getStoragePoolUUIDsByName(
+	ctx context.Context,
+	tx *sqlair.TX,
+) (map[string]string, error) {
+	stmt, err := st.Prepare(`
+SELECT &storagePoolNameUUID.*
+FROM   storage_pool
+`, storagePoolNameUUID{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var rows []storagePoolNameUUID
+	if err := tx.Query(ctx, stmt).GetAll(&rows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return nil, errors.Capture(err)
+	}
+
+	result := make(map[string]string, len(rows))
+	for _, row := range rows {
+		result[row.Name] = row.UUID
+	}
+	return result, nil
 }
 
 // InsertMigratingIAASUnits imports the fully formed units for the specified IAAS

--- a/domain/application/state/migration_test.go
+++ b/domain/application/state/migration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/domain/life"
 	machinestate "github.com/juju/juju/domain/machine/state"
 	domainnetwork "github.com/juju/juju/domain/network"
+	domainstorage "github.com/juju/juju/domain/storage"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
@@ -90,6 +91,145 @@ func (s *migrationStateSuite) TestInsertMigratingApplication(c *tc.C) {
 		},
 	})
 	c.Check(settings, tc.DeepEquals, application.ApplicationSettings{Trust: true})
+}
+
+func (s *migrationStateSuite) TestInsertMigratingApplicationStorageDirectives(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), s.modelUUID, clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+	_, err := s.DB().Exec(`
+INSERT INTO storage_pool (uuid, name, type) VALUES (?, ?, ?)`,
+		poolUUID, "fast", "kubernetes")
+	c.Assert(err, tc.ErrorIsNil)
+
+	metadata := s.minimalMetadata(c, "666")
+	metadata.Storage = map[string]charm.Storage{
+		"pgdata": {
+			Name:     "pgdata",
+			Type:     charm.StorageFilesystem,
+			CountMin: 1,
+			CountMax: 1,
+		},
+	}
+
+	id := tc.Must(c, coreapplication.NewUUID)
+	args := application.InsertApplicationArgs{
+		ApplicationUUID: id.String(),
+		Platform: deployment.Platform{
+			Channel:      "666",
+			OSType:       deployment.Ubuntu,
+			Architecture: architecture.ARM64,
+		},
+		Charm: charm.Charm{
+			Metadata:      metadata,
+			Manifest:      s.minimalManifest(c),
+			Source:        charm.CharmHubSource,
+			ReferenceName: "666",
+			Revision:      42,
+			Architecture:  architecture.ARM64,
+		},
+		Scale: 1,
+		StorageDirectives: []application.MigratingStorageDirectiveArg{{
+			Name:     "pgdata",
+			PoolName: "fast",
+			Size:     2048,
+			Count:    3,
+		}},
+	}
+
+	err = st.InsertMigratingApplication(c.Context(), "666", args)
+	c.Assert(err, tc.ErrorIsNil, tc.Commentf("%s", errors.ErrorStack(err)))
+
+	directives := s.getApplicationStorageDirectives(c, id)
+	c.Check(directives, tc.DeepEquals, []storageDirectiveRow{{
+		StorageName:     "pgdata",
+		StoragePoolUUID: poolUUID.String(),
+		SizeMiB:         2048,
+		Count:           3,
+	}})
+}
+
+func (s *migrationStateSuite) TestInsertMigratingApplicationStorageDirectivesPoolNotFound(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), s.modelUUID, clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	metadata := s.minimalMetadata(c, "666")
+	metadata.Storage = map[string]charm.Storage{
+		"pgdata": {
+			Name:     "pgdata",
+			Type:     charm.StorageFilesystem,
+			CountMin: 1,
+			CountMax: 1,
+		},
+	}
+
+	id := tc.Must(c, coreapplication.NewUUID)
+	args := application.InsertApplicationArgs{
+		ApplicationUUID: id.String(),
+		Platform: deployment.Platform{
+			Channel:      "666",
+			OSType:       deployment.Ubuntu,
+			Architecture: architecture.ARM64,
+		},
+		Charm: charm.Charm{
+			Metadata:      metadata,
+			Manifest:      s.minimalManifest(c),
+			Source:        charm.CharmHubSource,
+			ReferenceName: "666",
+			Revision:      42,
+			Architecture:  architecture.ARM64,
+		},
+		Scale: 1,
+		StorageDirectives: []application.MigratingStorageDirectiveArg{{
+			Name:     "pgdata",
+			PoolName: "missing",
+			Size:     2048,
+			Count:    1,
+		}},
+	}
+
+	err := st.InsertMigratingApplication(c.Context(), "666", args)
+	c.Assert(err, tc.ErrorMatches, `.*storage pool "missing" not found for storage directive "pgdata".*`)
+}
+
+type storageDirectiveRow struct {
+	StorageName     string
+	StoragePoolUUID string
+	SizeMiB         int
+	Count           int
+}
+
+func (s *migrationStateSuite) getApplicationStorageDirectives(
+	c *tc.C, appID coreapplication.UUID,
+) []storageDirectiveRow {
+	var rows []storageDirectiveRow
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		queryRows, err := tx.QueryContext(ctx, `
+SELECT   storage_name, storage_pool_uuid, size_mib, count
+FROM     application_storage_directive
+WHERE    application_uuid = ?
+ORDER BY storage_name`, appID.String())
+		if err != nil {
+			return err
+		}
+		defer queryRows.Close()
+		var result []storageDirectiveRow
+		for queryRows.Next() {
+			var row storageDirectiveRow
+			if err := queryRows.Scan(
+				&row.StorageName, &row.StoragePoolUUID, &row.SizeMiB, &row.Count,
+			); err != nil {
+				return err
+			}
+			result = append(result, row)
+		}
+		if err := queryRows.Err(); err != nil {
+			return err
+		}
+		rows = result
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return rows
 }
 
 func (s *migrationStateSuite) assertDownloadProvenance(c *tc.C, appID coreapplication.UUID, expectedProvenance charm.Provenance) {

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -1319,6 +1319,12 @@ type insertApplicationStorageDirective struct {
 	StoragePoolUUID string `db:"storage_pool_uuid"`
 }
 
+// storagePoolNameUUID represents a storage pool name and its UUID.
+type storagePoolNameUUID struct {
+	Name string `db:"name"`
+	UUID string `db:"uuid"`
+}
+
 // insertStorageUnitOwner represents the set of values required for creating a
 // new storage_unit_owner record.
 type insertStorageUnitOwner struct {

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -462,6 +462,30 @@ type InsertApplicationArgs struct {
 	// EndpointBindings is a map to bind application endpoint by name to a
 	// specific space. The default space is referenced by an empty key, if any.
 	EndpointBindings map[string]network.SpaceName
+	// StorageDirectives defines the list of storage directives to add to an
+	// application during migration import. The Name values must match the
+	// storage defined in the Charm. The pool is referenced by name and is
+	// resolved to a storage pool UUID by the state layer.
+	StorageDirectives []MigratingStorageDirectiveArg
+}
+
+// MigratingStorageDirectiveArg describes a storage directive to be inserted
+// during migration import. Unlike [domainstorage.DirectiveArg], the storage
+// pool is referenced by name; the state layer resolves it to a storage pool
+// UUID.
+type MigratingStorageDirectiveArg struct {
+	// Name relates to the charm storage name definition and must match up.
+	Name string
+
+	// PoolName is the name of the storage pool the directive uses.
+	PoolName string
+
+	// Size defines the size of the storage directive in MiB.
+	Size uint64
+
+	// Count represents the number of storage instances that should be made for
+	// this directive.
+	Count uint32
 }
 
 // SetCharmParams contains the parameters for updating

--- a/domain/modelmigration/import.go
+++ b/domain/modelmigration/import.go
@@ -79,12 +79,18 @@ func ImportOperations(
 	network.RegisterImportSubnets(coordinator, logger.Child("subnets"))
 	machine.RegisterImport(coordinator, clock, logger.Child("machine"))
 	network.RegisterLinkLayerDevicesImport(coordinator, logger.Child("linklayerdevices"))
+	// Storage pools must be imported before applications so that application
+	// storage directives are able to resolve their pools.
+	storage.RegisterImportStoragePools(
+		coordinator, configGetter, logger.Child("storagepool"),
+	)
 	application.RegisterImport(coordinator, clock, logger.Child("application"))
 	// BlockDevice requires machines to be imported first.
 	blockdevice.RegisterImport(coordinator, logger.Child("blockdevice"))
 	// Storage requires the following domains be imported first:
-	// block devices, machines, application (for units), and model config.
-	storage.RegisterImport(
+	// block devices, machines, application (for units), storage pools and
+	// model config.
+	storage.RegisterImportStorage(
 		coordinator, configGetter, logger.Child("storage"),
 	)
 	network.RegisterImportK8sService(coordinator, logger.Child("k8sservice"))

--- a/domain/storage/import_integration_test.go
+++ b/domain/storage/import_integration_test.go
@@ -248,7 +248,12 @@ func (s *importSuite) TestIAASImportStorageInstancesVolumeBackedFilesystems(c *t
 		WWN:         "wwn-cache-1",
 	})
 
-	storagemodelmigration.RegisterImport(
+	storagemodelmigration.RegisterImportStoragePools(
+		s.coordinator,
+		s.ephemeralConfigGetter,
+		s.logger,
+	)
+	storagemodelmigration.RegisterImportStorage(
 		s.coordinator,
 		s.ephemeralConfigGetter,
 		s.logger,
@@ -496,7 +501,12 @@ func (s *importSuite) TestIAASImportStorageInstancesNonVolumeBackedFilesystems(c
 		MountPoint:  "/srv/scratch",
 	})
 
-	storagemodelmigration.RegisterImport(
+	storagemodelmigration.RegisterImportStoragePools(
+		s.coordinator,
+		s.ephemeralConfigGetter,
+		s.logger,
+	)
+	storagemodelmigration.RegisterImportStorage(
 		s.coordinator,
 		s.ephemeralConfigGetter,
 		s.logger,
@@ -739,7 +749,12 @@ func (s *importSuite) TestIAASImportStorageInstancesVolumesOnly(c *tc.C) {
 		},
 	})
 
-	storagemodelmigration.RegisterImport(
+	storagemodelmigration.RegisterImportStoragePools(
+		s.coordinator,
+		s.ephemeralConfigGetter,
+		s.logger,
+	)
+	storagemodelmigration.RegisterImportStorage(
 		s.coordinator,
 		s.ephemeralConfigGetter,
 		s.logger,

--- a/domain/storage/modelmigration/import.go
+++ b/domain/storage/modelmigration/import.go
@@ -27,15 +27,35 @@ type Coordinator interface {
 	Add(modelmigration.Operation)
 }
 
-// RegisterImport registers the import operations with the given coordinator.
-func RegisterImport(
+// RegisterImportStoragePools registers the storage pool import operation with
+// the given coordinator. Storage pools must be imported before applications so
+// that application storage directives are able to resolve their pools.
+func RegisterImportStoragePools(
 	coordinator Coordinator,
 	ephemeralProviderConfigGetter providertracker.EphemeralProviderConfigGetter,
 	logger logger.Logger,
 ) {
-	coordinator.Add(&importOperation{
-		ephemeralProviderConfigGetter: ephemeralProviderConfigGetter,
-		logger:                        logger,
+	coordinator.Add(&importStoragePoolOperation{
+		baseImportOperation: baseImportOperation{
+			ephemeralProviderConfigGetter: ephemeralProviderConfigGetter,
+			logger:                        logger,
+		},
+	})
+}
+
+// RegisterImportStorage registers the storage import operation with the given
+// coordinator. This imports storage instances, volumes and filesystems and
+// must run after applications (for units) and storage pools are imported.
+func RegisterImportStorage(
+	coordinator Coordinator,
+	ephemeralProviderConfigGetter providertracker.EphemeralProviderConfigGetter,
+	logger logger.Logger,
+) {
+	coordinator.Add(&importStorageOperation{
+		baseImportOperation: baseImportOperation{
+			ephemeralProviderConfigGetter: ephemeralProviderConfigGetter,
+			logger:                        logger,
+		},
 	})
 }
 
@@ -111,7 +131,7 @@ func (g *ephemeralStorageRegistryGetter) GetStorageRegistry(
 	return registry, nil
 }
 
-type importOperation struct {
+type baseImportOperation struct {
 	modelmigration.BaseOperation
 
 	ephemeralProviderConfigGetter providertracker.EphemeralProviderConfigGetter
@@ -120,13 +140,8 @@ type importOperation struct {
 	logger  logger.Logger
 }
 
-// Name returns the name of this operation.
-func (i *importOperation) Name() string {
-	return "import storage"
-}
-
-// Setup implements Operation.
-func (i *importOperation) Setup(scope modelmigration.Scope) error {
+// setup creates the storage service used by the import operations.
+func (i *baseImportOperation) setup(scope modelmigration.Scope) error {
 	// Create a storage registry getter from the ephemeral provider.
 	// This ensures the registry matches the model being imported, rather than matching
 	// by the controller model's cloud type. For example, this is useful when importing
@@ -146,8 +161,25 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	return nil
 }
 
+// importStoragePoolOperation imports the storage pools contained in the model.
+// It runs before applications are imported so that application storage
+// directives can resolve their pools.
+type importStoragePoolOperation struct {
+	baseImportOperation
+}
+
+// Name returns the name of this operation.
+func (i *importStoragePoolOperation) Name() string {
+	return "import storage pools"
+}
+
+// Setup implements Operation.
+func (i *importStoragePoolOperation) Setup(scope modelmigration.Scope) error {
+	return i.setup(scope)
+}
+
 // Execute the import on the storage pools contained in the model.
-func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
+func (i *importStoragePoolOperation) Execute(ctx context.Context, model description.Model) error {
 	// TODO: Combine the storage pool import calls into a single service call,
 	// and stop passing through a description entity into the service layer.
 	// This must be done ASAP
@@ -166,6 +198,29 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		return errors.Errorf("setting recommended storage pools: %w", err)
 	}
 
+	return nil
+}
+
+// importStorageOperation imports the storage instances, volumes and filesystems
+// contained in the model. It runs after applications (for units) and storage
+// pools have been imported.
+type importStorageOperation struct {
+	baseImportOperation
+}
+
+// Name returns the name of this operation.
+func (i *importStorageOperation) Name() string {
+	return "import storage"
+}
+
+// Setup implements Operation.
+func (i *importStorageOperation) Setup(scope modelmigration.Scope) error {
+	return i.setup(scope)
+}
+
+// Execute the import on the storage instances, volumes and filesystems
+// contained in the model.
+func (i *importStorageOperation) Execute(ctx context.Context, model description.Model) error {
 	if err := i.importStorageInstances(ctx, model.Storages()); err != nil {
 		return errors.Errorf("importing storage instances: %w", err)
 	}
@@ -189,7 +244,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	return nil
 }
 
-func (i *importOperation) importStorageInstances(ctx context.Context, instances []description.Storage) error {
+func (i *importStorageOperation) importStorageInstances(ctx context.Context, instances []description.Storage) error {
 	if len(instances) == 0 {
 		return nil
 	}
@@ -224,7 +279,7 @@ func (i *importOperation) importStorageInstances(ctx context.Context, instances 
 	return i.service.ImportStorageInstances(ctx, args)
 }
 
-func (i *importOperation) importFilesystemsIAAS(ctx context.Context, filesystems []description.Filesystem) error {
+func (i *importStorageOperation) importFilesystemsIAAS(ctx context.Context, filesystems []description.Filesystem) error {
 	if len(filesystems) == 0 {
 		return nil
 	}
@@ -258,7 +313,7 @@ func (i *importOperation) importFilesystemsIAAS(ctx context.Context, filesystems
 // importVolumesAndFilesystemsCAAS imports CAAS storage a filesystems and
 // filesystem attachments. In previous version of juju these were volumes
 // and filesystems.
-func (i *importOperation) importVolumesAndFilesystemsCAAS(
+func (i *importStorageOperation) importVolumesAndFilesystemsCAAS(
 	ctx context.Context,
 	filesystems []description.Filesystem,
 	volumes []description.Volume) error {
@@ -332,7 +387,7 @@ func getCAASFilesystemAttachment(
 	}, nil
 }
 
-func (i *importOperation) importVolumes(ctx context.Context, volumes []description.Volume) error {
+func (i *importStorageOperation) importVolumes(ctx context.Context, volumes []description.Volume) error {
 	if len(volumes) == 0 {
 		return nil
 	}

--- a/domain/storage/modelmigration/import_test.go
+++ b/domain/storage/modelmigration/import_test.go
@@ -47,18 +47,40 @@ func (s *importSuite) setupMocks(c *tc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *importSuite) newImportOperation() *importOperation {
-	return &importOperation{
-		service: s.service,
+func (s *importSuite) newStoragePoolImportOperation() *importStoragePoolOperation {
+	return &importStoragePoolOperation{
+		baseImportOperation: baseImportOperation{
+			service: s.service,
+		},
 	}
 }
 
-func (s *importSuite) TestRegisterImport(c *tc.C) {
+func (s *importSuite) newImportOperation() *importStorageOperation {
+	return &importStorageOperation{
+		baseImportOperation: baseImportOperation{
+			service: s.service,
+		},
+	}
+}
+
+func (s *importSuite) TestRegisterImportStoragePools(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.coordinator.EXPECT().Add(gomock.Any())
 
-	RegisterImport(
+	RegisterImportStoragePools(
+		s.coordinator,
+		nil,
+		loggertesting.WrapCheckLog(c),
+	)
+}
+
+func (s *importSuite) TestRegisterImportStorage(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.coordinator.EXPECT().Add(gomock.Any())
+
+	RegisterImportStorage(
 		s.coordinator,
 		nil,
 		loggertesting.WrapCheckLog(c),
@@ -72,7 +94,6 @@ func (s *importSuite) TestImportEmpty(c *tc.C) {
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
 	})
-	s.noopStoragePoolImport()
 
 	// Act
 	op := s.newImportOperation()
@@ -135,7 +156,7 @@ func (s *importSuite) TestNoUserDefinedStoragePools(c *tc.C) {
 			Return(nil),
 	)
 
-	op := s.newImportOperation()
+	op := s.newStoragePoolImportOperation()
 	err := op.Execute(ctx, model)
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -193,7 +214,7 @@ func (s *importSuite) TestImportStoragePools(c *tc.C) {
 			Return(nil),
 	)
 
-	op := s.newImportOperation()
+	op := s.newStoragePoolImportOperation()
 	err := op.Execute(ctx, model)
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -212,7 +233,7 @@ func (s *importSuite) TestExecuteGetStoragePoolsToImportError(c *tc.C) {
 		GetStoragePoolsToImport(gomock.Any(), model.StoragePools()).
 		Return(nil, nil, expectedErr)
 
-	op := s.newImportOperation()
+	op := s.newStoragePoolImportOperation()
 	err := op.Execute(c.Context(), model)
 
 	c.Assert(err, tc.ErrorMatches, "getting pools to import: .*boom")
@@ -255,7 +276,7 @@ func (s *importSuite) TestExecuteImportStoragePoolsError(c *tc.C) {
 			Return(expectedErr),
 	)
 
-	op := s.newImportOperation()
+	op := s.newStoragePoolImportOperation()
 	err := op.Execute(c.Context(), model)
 
 	c.Assert(err, tc.ErrorMatches, "importing storage pools .*: .*import failed")
@@ -302,7 +323,7 @@ func (s *importSuite) TestExecuteSetRecommendedStoragePoolsError(c *tc.C) {
 			Return(expectedErr),
 	)
 
-	op := s.newImportOperation()
+	op := s.newStoragePoolImportOperation()
 	err := op.Execute(c.Context(), model)
 
 	c.Assert(err, tc.ErrorMatches, "setting recommended storage pools: .*recommendation failed")
@@ -323,7 +344,6 @@ func (s *importSuite) TestImportStorageInstances(c *tc.C) {
 			AttachedUnitNames: []string{"foo/0", "bar/1"},
 		},
 	}
-	s.noopStoragePoolImport()
 	s.service.EXPECT().ImportStorageInstances(gomock.Any(), expected).Return(nil)
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
@@ -365,7 +385,6 @@ func (s *importSuite) TestImportStorageInstancesValidate(c *tc.C) {
 			Size: 1024,
 		},
 	})
-	s.noopStoragePoolImport()
 
 	// Act
 	op := s.newImportOperation()
@@ -408,7 +427,6 @@ func (s *importSuite) TestImportFilesystemsIAAS(c *tc.C) {
 		MountPoint: "/opt",
 	})
 
-	s.noopStoragePoolImport()
 	s.service.EXPECT().ImportFilesystemsIAAS(gomock.Any(), tc.Bind(tc.SameContents, []domainstorage.ImportFilesystemParams{{
 		ID:                "fs-1",
 		SizeInMiB:         2048,
@@ -498,7 +516,6 @@ func (s *importSuite) TestImportFilesystemsCAAS(c *tc.C) {
 		VolumeID:    "pvc-deadbeef-6d0d-4d2c-b1e5-e2b3c02284f9",
 	})
 
-	s.noopStoragePoolImport()
 	s.service.EXPECT().ImportFilesystemsCAAS(gomock.Any(), tc.Bind(tc.SameContents, []domainstorage.ImportFilesystemParams{{
 		ID:                "fs-1",
 		SizeInMiB:         1024,
@@ -639,7 +656,6 @@ func (s *importSuite) TestImportVolumes(c *tc.C) {
 		},
 	}
 	s.service.EXPECT().ImportVolumes(gomock.Any(), expected).Return(nil)
-	s.noopStoragePoolImport()
 
 	// Act
 	op := s.newImportOperation()
@@ -656,7 +672,6 @@ func (s *importSuite) TestImportVolumesZeroLength(c *tc.C) {
 	model := description.NewModel(description.ModelArgs{
 		Type: coremodel.IAAS.String(),
 	})
-	s.noopStoragePoolImport()
 
 	// Act
 	op := s.newImportOperation()
@@ -664,10 +679,4 @@ func (s *importSuite) TestImportVolumesZeroLength(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *importSuite) noopStoragePoolImport() {
-	s.service.EXPECT().GetStoragePoolsToImport(gomock.Any(), gomock.Any()).Return(nil, nil, nil)
-	s.service.EXPECT().ImportStoragePools(gomock.Any(), gomock.Any()).Return(nil)
-	s.service.EXPECT().SetRecommendedStoragePools(gomock.Any(), gomock.Any()).Return(nil)
 }


### PR DESCRIPTION
Imported applications previously lost their storage directives because the migration import path never populated application_storage_directive. For CAAS applications this left StatefulSets without volume claim templates, so imported workloads failed to start.

Storage pools are now imported in their own operation before applications, allowing application storage directives to resolve their pool by name during application import. The remaining storage entities (instances, volumes and filesystems) continue to import after applications.

Fixes #22129

## QA steps

```
$ juju-40 bootstrap minikube minikube40
$ juju-36 bootstrap minikube minikube36
$ juju add-model moveme
$ juju deploy postgresql-k8s --channel 14/stable --trust
$ juju migrate src:moveme
$ juju ssh -m minikube40:controller 0
$ juju_db_repl
repl (controller)> .switch model-moveme
repl (model-moveme)> SELECT * FROM application_storage_directive
application_uuid			charm_uuid				storage_name	storage_pool_uuid			size_mib	count	
340e4363-0da4-4cce-8eda-7b385e033e25	717fcffc-5f5d-4304-818b-0a7b839c0af3	pgdata		47052c4e-2955-5768-a053-bf91f52d54e0	1024		1	
```