### PR TITLE
feat: loki logger facade

### DIFF
--- a/api/agent/logger/logger.go
+++ b/api/agent/logger/logger.go
@@ -5,13 +5,13 @@ package logger
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/core/watcher"
+	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -27,10 +27,16 @@ type Client struct {
 	facade base.FacadeCaller
 }
 
+// ControllerLokiConfig holds the controller-wide Loki push API configuration.
+type ControllerLokiConfig struct {
+	Endpoint string
+	CACert   string
+}
+
 // NewClient returns a version of the logger client that provides functionality
 // required by the logger worker.
 func NewClient(caller base.APICaller, options ...Option) *Client {
-	return &Client{base.NewFacadeCaller(caller, "Logger", options...)}
+	return &Client{facade: base.NewFacadeCaller(caller, "Logger", options...)}
 }
 
 // LoggingConfig returns the loggo configuration string for the agent
@@ -42,18 +48,44 @@ func (c *Client) LoggingConfig(ctx context.Context, agentTag names.Tag) (string,
 	}
 	err := c.facade.FacadeCall(ctx, "LoggingConfig", args, &results)
 	if err != nil {
-		// TODO: Not directly tested
-		return "", err
+		return "", internalerrors.Capture(err)
 	}
 	if len(results.Results) != 1 {
-		// TODO: Not directly tested
-		return "", fmt.Errorf("expected 1 result, got %d", len(results.Results))
+		return "", internalerrors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if err := result.Error; err != nil {
-		return "", err
+		return "", internalerrors.Capture(err)
 	}
 	return result.Result, nil
+}
+
+// GetControllerLokiConfig returns the controller-wide Loki configuration for
+// the agent specified by agentTag.
+func (c *Client) GetControllerLokiConfig(ctx context.Context, agentTag names.Tag) (ControllerLokiConfig, error) {
+	var results params.LokiConfigResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: agentTag.String()}},
+	}
+	err := c.facade.FacadeCall(ctx, "GetControllerLokiConfig", args, &results)
+	if err != nil {
+		return ControllerLokiConfig{}, internalerrors.Capture(err)
+	}
+	if len(results.Results) != 1 {
+		return ControllerLokiConfig{}, internalerrors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if err := result.Error; err != nil {
+		return ControllerLokiConfig{}, internalerrors.Capture(err)
+	}
+	var caCert string
+	if result.CACert != nil {
+		caCert = *result.CACert
+	}
+	return ControllerLokiConfig{
+		Endpoint: result.Endpoint,
+		CACert:   caCert,
+	}, nil
 }
 
 // WatchLoggingConfig returns a notify watcher that looks for changes in the
@@ -65,18 +97,35 @@ func (c *Client) WatchLoggingConfig(ctx context.Context, agentTag names.Tag) (wa
 	}
 	err := c.facade.FacadeCall(ctx, "WatchLoggingConfig", args, &results)
 	if err != nil {
-		// TODO: Not directly tested
-		return nil, err
+		return nil, internalerrors.Capture(err)
 	}
 	if len(results.Results) != 1 {
-		// TODO: Not directly tested
-		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
+		return nil, internalerrors.Errorf("expected 1 result, got %d", len(results.Results))
 	}
 	result := results.Results[0]
 	if result.Error != nil {
-		//  TODO: Not directly tested
-		return nil, result.Error
+		return nil, internalerrors.Capture(result.Error)
 	}
-	w := apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result)
-	return w, nil
+	return apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result), nil
+}
+
+// WatchControllerLokiConfig returns a notify watcher that looks for changes in
+// the controller-wide Loki configuration for the agent specified by agentTag.
+func (c *Client) WatchControllerLokiConfig(ctx context.Context, agentTag names.Tag) (watcher.NotifyWatcher, error) {
+	var results params.NotifyWatchResults
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: agentTag.String()}},
+	}
+	err := c.facade.FacadeCall(ctx, "WatchControllerLokiConfig", args, &results)
+	if err != nil {
+		return nil, internalerrors.Capture(err)
+	}
+	if len(results.Results) != 1 {
+		return nil, internalerrors.Errorf("expected 1 result, got %d", len(results.Results))
+	}
+	result := results.Results[0]
+	if result.Error != nil {
+		return nil, internalerrors.Capture(result.Error)
+	}
+	return apiwatcher.NewNotifyWatcher(c.facade.RawAPICaller(), result), nil
 }

--- a/api/agent/logger/logger.go
+++ b/api/agent/logger/logger.go
@@ -63,18 +63,12 @@ func (c *Client) LoggingConfig(ctx context.Context, agentTag names.Tag) (string,
 // GetControllerLokiConfig returns the controller-wide Loki configuration for
 // the agent specified by agentTag.
 func (c *Client) GetControllerLokiConfig(ctx context.Context, agentTag names.Tag) (ControllerLokiConfig, error) {
-	var results params.LokiConfigResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: agentTag.String()}},
-	}
-	err := c.facade.FacadeCall(ctx, "GetControllerLokiConfig", args, &results)
+	var result params.LokiConfigResult
+	args := params.Entity{Tag: agentTag.String()}
+	err := c.facade.FacadeCall(ctx, "GetControllerLokiConfig", args, &result)
 	if err != nil {
 		return ControllerLokiConfig{}, internalerrors.Capture(err)
 	}
-	if len(results.Results) != 1 {
-		return ControllerLokiConfig{}, internalerrors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
 	if err := result.Error; err != nil {
 		return ControllerLokiConfig{}, internalerrors.Capture(err)
 	}
@@ -112,18 +106,12 @@ func (c *Client) WatchLoggingConfig(ctx context.Context, agentTag names.Tag) (wa
 // WatchControllerLokiConfig returns a notify watcher that looks for changes in
 // the controller-wide Loki configuration for the agent specified by agentTag.
 func (c *Client) WatchControllerLokiConfig(ctx context.Context, agentTag names.Tag) (watcher.NotifyWatcher, error) {
-	var results params.NotifyWatchResults
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: agentTag.String()}},
-	}
-	err := c.facade.FacadeCall(ctx, "WatchControllerLokiConfig", args, &results)
+	var result params.NotifyWatchResult
+	args := params.Entity{Tag: agentTag.String()}
+	err := c.facade.FacadeCall(ctx, "WatchControllerLokiConfig", args, &result)
 	if err != nil {
 		return nil, internalerrors.Capture(err)
 	}
-	if len(results.Results) != 1 {
-		return nil, internalerrors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
 	if result.Error != nil {
 		return nil, internalerrors.Capture(result.Error)
 	}

--- a/api/agent/logger/logger_test.go
+++ b/api/agent/logger/logger_test.go
@@ -46,6 +46,34 @@ func (s *loggerSuite) TestLoggingConfig(c *tc.C) {
 	c.Assert(result, tc.Equals, "juju.worker=TRACE")
 }
 
+func (s *loggerSuite) TestGetControllerLokiConfig(c *tc.C) {
+	caCert := "ca-cert"
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result any) error {
+		c.Check(objType, tc.Equals, "Logger")
+		c.Check(version, tc.Equals, 0)
+		c.Check(id, tc.Equals, "")
+		c.Check(request, tc.Equals, "GetControllerLokiConfig")
+		c.Check(arg, tc.DeepEquals, params.Entities{Entities: []params.Entity{{
+			Tag: "machine-666",
+		}}})
+		c.Assert(result, tc.FitsTypeOf, &params.LokiConfigResults{})
+		*(result.(*params.LokiConfigResults)) = params.LokiConfigResults{
+			Results: []params.LokiConfigResult{{
+				Endpoint: "https://loki.example.com/loki/api/v1/push",
+				CACert:   &caCert,
+			}},
+		}
+		return nil
+	})
+
+	client := logger.NewClient(apiCaller)
+	tag := names.NewMachineTag("666")
+	result, err := client.GetControllerLokiConfig(c.Context(), tag)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result.Endpoint, tc.Equals, "https://loki.example.com/loki/api/v1/push")
+	c.Check(result.CACert, tc.Equals, "ca-cert")
+}
+
 func (s *loggerSuite) TestWatchLoggingConfig(c *tc.C) {
 	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result any) error {
 		c.Check(objType, tc.Equals, "Logger")
@@ -67,5 +95,29 @@ func (s *loggerSuite) TestWatchLoggingConfig(c *tc.C) {
 	client := logger.NewClient(apiCaller)
 	tag := names.NewMachineTag("666")
 	_, err := client.WatchLoggingConfig(c.Context(), tag)
+	c.Assert(err, tc.ErrorMatches, "FAIL")
+}
+
+func (s *loggerSuite) TestWatchControllerLokiConfig(c *tc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result any) error {
+		c.Check(objType, tc.Equals, "Logger")
+		c.Check(version, tc.Equals, 0)
+		c.Check(id, tc.Equals, "")
+		c.Check(request, tc.Equals, "WatchControllerLokiConfig")
+		c.Check(arg, tc.DeepEquals, params.Entities{Entities: []params.Entity{{
+			Tag: "machine-666",
+		}}})
+		c.Assert(result, tc.FitsTypeOf, &params.NotifyWatchResults{})
+		*(result.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
+			Results: []params.NotifyWatchResult{{
+				Error: &params.Error{Message: "FAIL"},
+			}},
+		}
+		return nil
+	})
+
+	client := logger.NewClient(apiCaller)
+	tag := names.NewMachineTag("666")
+	_, err := client.WatchControllerLokiConfig(c.Context(), tag)
 	c.Assert(err, tc.ErrorMatches, "FAIL")
 }

--- a/api/agent/logger/logger_test.go
+++ b/api/agent/logger/logger_test.go
@@ -53,15 +53,13 @@ func (s *loggerSuite) TestGetControllerLokiConfig(c *tc.C) {
 		c.Check(version, tc.Equals, 0)
 		c.Check(id, tc.Equals, "")
 		c.Check(request, tc.Equals, "GetControllerLokiConfig")
-		c.Check(arg, tc.DeepEquals, params.Entities{Entities: []params.Entity{{
+		c.Check(arg, tc.DeepEquals, params.Entity{
 			Tag: "machine-666",
-		}}})
-		c.Assert(result, tc.FitsTypeOf, &params.LokiConfigResults{})
-		*(result.(*params.LokiConfigResults)) = params.LokiConfigResults{
-			Results: []params.LokiConfigResult{{
-				Endpoint: "https://loki.example.com/loki/api/v1/push",
-				CACert:   &caCert,
-			}},
+		})
+		c.Assert(result, tc.FitsTypeOf, &params.LokiConfigResult{})
+		*(result.(*params.LokiConfigResult)) = params.LokiConfigResult{
+			Endpoint: "https://loki.example.com/loki/api/v1/push",
+			CACert:   &caCert,
 		}
 		return nil
 	})
@@ -104,14 +102,12 @@ func (s *loggerSuite) TestWatchControllerLokiConfig(c *tc.C) {
 		c.Check(version, tc.Equals, 0)
 		c.Check(id, tc.Equals, "")
 		c.Check(request, tc.Equals, "WatchControllerLokiConfig")
-		c.Check(arg, tc.DeepEquals, params.Entities{Entities: []params.Entity{{
+		c.Check(arg, tc.DeepEquals, params.Entity{
 			Tag: "machine-666",
-		}}})
-		c.Assert(result, tc.FitsTypeOf, &params.NotifyWatchResults{})
-		*(result.(*params.NotifyWatchResults)) = params.NotifyWatchResults{
-			Results: []params.NotifyWatchResult{{
-				Error: &params.Error{Message: "FAIL"},
-			}},
+		})
+		c.Assert(result, tc.FitsTypeOf, &params.NotifyWatchResult{})
+		*(result.(*params.NotifyWatchResult)) = params.NotifyWatchResult{
+			Error: &params.Error{Message: "FAIL"},
 		}
 		return nil
 	})

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -65,7 +65,7 @@ var facadeVersions = facades.FacadeVersions{
 	"KeyManager":                   {1},
 	"KeyUpdater":                   {1},
 	"LeadershipService":            {2},
-	"Logger":                       {1},
+	"Logger":                       {1, 2},
 	"MachineActions":               {1},
 	// Note that this version of Juju does not implement version 10
 	// of the facade, but 3.6 does. Care must be taken not to break

--- a/apiserver/facades/agent-schema.json
+++ b/apiserver/facades/agent-schema.json
@@ -3069,10 +3069,10 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/Entities"
+                            "$ref": "#/definitions/Entity"
                         },
                         "Result": {
-                            "$ref": "#/definitions/LokiConfigResults"
+                            "$ref": "#/definitions/LokiConfigResult"
                         }
                     }
                 },
@@ -3091,10 +3091,10 @@
                     "type": "object",
                     "properties": {
                         "Params": {
-                            "$ref": "#/definitions/Entities"
+                            "$ref": "#/definitions/Entity"
                         },
                         "Result": {
-                            "$ref": "#/definitions/NotifyWatchResults"
+                            "$ref": "#/definitions/NotifyWatchResult"
                         }
                     }
                 },
@@ -3179,21 +3179,6 @@
                     "additionalProperties": false,
                     "required": [
                         "endpoint"
-                    ]
-                },
-                "LokiConfigResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/LokiConfigResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
                     ]
                 },
                 "NotifyWatchResult": {

--- a/apiserver/facades/agent-schema.json
+++ b/apiserver/facades/agent-schema.json
@@ -3061,10 +3061,21 @@
     {
         "Name": "Logger",
         "Description": "",
-        "Version": 1,
+        "Version": 2,
         "Schema": {
             "type": "object",
             "properties": {
+                "GetControllerLokiConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LokiConfigResults"
+                        }
+                    }
+                },
                 "LoggingConfig": {
                     "type": "object",
                     "properties": {
@@ -3073,6 +3084,17 @@
                         },
                         "Result": {
                             "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "WatchControllerLokiConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
                         }
                     }
                 },
@@ -3139,6 +3161,39 @@
                     "required": [
                         "message",
                         "code"
+                    ]
+                },
+                "LokiConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "ca-cert": {
+                            "type": "string"
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "endpoint"
+                    ]
+                },
+                "LokiConfigResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LokiConfigResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
                     ]
                 },
                 "NotifyWatchResult": {

--- a/apiserver/facades/agent/logger/logger.go
+++ b/apiserver/facades/agent/logger/logger.go
@@ -12,6 +12,8 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/internal"
 	"github.com/juju/juju/core/watcher"
+	loggingerrors "github.com/juju/juju/domain/logging/errors"
+	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -33,13 +35,13 @@ type Logger interface {
 type LoggerV2 interface {
 	Logger
 
-	// GetControllerLokiConfig reports the controller-wide Loki configuration
-	// for the requested agent entities.
-	GetControllerLokiConfig(ctx context.Context, args params.Entities) params.LokiConfigResults
+	// GetControllerLokiConfig reports the controller-wide Loki configuration for
+	// the requested agent entity.
+	GetControllerLokiConfig(ctx context.Context, args params.Entity) params.LokiConfigResult
 
-	// WatchControllerLokiConfig starts watchers for controller-wide Loki
-	// configuration changes for the requested agent entities.
-	WatchControllerLokiConfig(ctx context.Context, args params.Entities) params.NotifyWatchResults
+	// WatchControllerLokiConfig starts a watcher for controller-wide Loki
+	// configuration changes for the requested agent entity.
+	WatchControllerLokiConfig(ctx context.Context, args params.Entity) params.NotifyWatchResult
 }
 
 // LoggerAPI implements the Logger interface and is the concrete
@@ -161,73 +163,53 @@ func (api *LoggerAPI) LoggingConfig(ctx context.Context, arg params.Entities) pa
 }
 
 // GetControllerLokiConfig reports the controller-wide Loki configuration for
-// the agents specified.
-func (api *LoggerAPIV2) GetControllerLokiConfig(ctx context.Context, arg params.Entities) params.LokiConfigResults {
-	if len(arg.Entities) == 0 {
-		return params.LokiConfigResults{}
+// the agent specified.
+func (api *LoggerAPIV2) GetControllerLokiConfig(ctx context.Context, arg params.Entity) params.LokiConfigResult {
+	tag, err := names.ParseTag(arg.Tag)
+	if err != nil {
+		return params.LokiConfigResult{Error: apiservererrors.ServerError(err)}
+	}
+	if !api.authorizer.AuthOwner(tag) {
+		return params.LokiConfigResult{Error: apiservererrors.ServerError(apiservererrors.ErrPerm)}
 	}
 
-	results := make([]params.LokiConfigResult, len(arg.Entities))
-	authorized := false
-	for i, entity := range arg.Entities {
-		tag, err := names.ParseTag(entity.Tag)
-		if err != nil {
-			results[i].Error = apiservererrors.ServerError(err)
-			continue
+	config, err := api.controllerLokiConfigService.GetLokiConfig(ctx)
+	if internalerrors.Is(err, loggingerrors.LokiConfigNotFound) {
+		return params.LokiConfigResult{
+			Error: apiservererrors.ParamsErrorf(params.CodeNotFound, "loki config not found"),
 		}
-		if !api.authorizer.AuthOwner(tag) {
-			results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
-			continue
-		}
-		authorized = true
 	}
-	if !authorized {
-		return params.LokiConfigResults{Results: results}
+	if err != nil {
+		return params.LokiConfigResult{Error: apiservererrors.ServerError(err)}
 	}
 
-	config, configErr := api.controllerLokiConfigService.GetLokiConfig(ctx)
-	for i := range results {
-		if results[i].Error != nil {
-			continue
-		}
-		if configErr != nil {
-			results[i].Error = apiservererrors.ServerError(configErr)
-			continue
-		}
-		results[i].Endpoint = config.Endpoint
-		if config.CACertificate != "" {
-			results[i].CACert = &config.CACertificate
-		}
+	result := params.LokiConfigResult{Endpoint: config.Endpoint}
+	if config.CACertificate != "" {
+		result.CACert = &config.CACertificate
 	}
-	return params.LokiConfigResults{Results: results}
+	return result
 }
 
 // WatchControllerLokiConfig starts a watcher to track changes to the
-// controller-wide Loki configuration for the agents specified.
-func (api *LoggerAPIV2) WatchControllerLokiConfig(ctx context.Context, arg params.Entities) params.NotifyWatchResults {
-	result := make([]params.NotifyWatchResult, len(arg.Entities))
-	for i, entity := range arg.Entities {
-		tag, err := names.ParseTag(entity.Tag)
-		if err != nil {
-			result[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-		if !api.authorizer.AuthOwner(tag) {
-			result[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
-			continue
-		}
-
-		watch, err := api.controllerLokiConfigService.WatchLokiConfig(ctx)
-		if err != nil {
-			result[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-
-		result[i].NotifyWatcherId, _, err = internal.EnsureRegisterWatcher[struct{}](ctx, api.watcherRegistry, watch)
-		if err != nil {
-			result[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
+// controller-wide Loki configuration for the agent specified.
+func (api *LoggerAPIV2) WatchControllerLokiConfig(ctx context.Context, arg params.Entity) params.NotifyWatchResult {
+	tag, err := names.ParseTag(arg.Tag)
+	if err != nil {
+		return params.NotifyWatchResult{Error: apiservererrors.ServerError(err)}
 	}
-	return params.NotifyWatchResults{Results: result}
+	if !api.authorizer.AuthOwner(tag) {
+		return params.NotifyWatchResult{Error: apiservererrors.ServerError(apiservererrors.ErrPerm)}
+	}
+
+	watch, err := api.controllerLokiConfigService.WatchLokiConfig(ctx)
+	if err != nil {
+		return params.NotifyWatchResult{Error: apiservererrors.ServerError(err)}
+	}
+
+	result := params.NotifyWatchResult{}
+	result.NotifyWatcherId, _, err = internal.EnsureRegisterWatcher(ctx, api.watcherRegistry, watch)
+	if err != nil {
+		result.Error = apiservererrors.ServerError(err)
+	}
+	return result
 }

--- a/apiserver/facades/agent/logger/logger.go
+++ b/apiserver/facades/agent/logger/logger.go
@@ -20,8 +20,26 @@ import (
 // endpoint because our rpc mechanism panics.  However, I still feel that this
 // provides a useful documentation purpose.
 type Logger interface {
+	// WatchLoggingConfig starts watchers for model logging-config changes for
+	// the requested agent entities.
 	WatchLoggingConfig(ctx context.Context, args params.Entities) params.NotifyWatchResults
+
+	// LoggingConfig reports the model logging-config value for the requested
+	// agent entities.
 	LoggingConfig(ctx context.Context, args params.Entities) params.StringResults
+}
+
+// LoggerV2 defines the methods on the v2 logger API end point.
+type LoggerV2 interface {
+	Logger
+
+	// GetControllerLokiConfig reports the controller-wide Loki configuration
+	// for the requested agent entities.
+	GetControllerLokiConfig(ctx context.Context, args params.Entities) params.LokiConfigResults
+
+	// WatchControllerLokiConfig starts watchers for controller-wide Loki
+	// configuration changes for the requested agent entities.
+	WatchControllerLokiConfig(ctx context.Context, args params.Entities) params.NotifyWatchResults
 }
 
 // LoggerAPI implements the Logger interface and is the concrete
@@ -34,6 +52,15 @@ type LoggerAPI struct {
 }
 
 var _ Logger = (*LoggerAPI)(nil)
+
+// LoggerAPIV2 implements version 2 of the Logger facade.
+type LoggerAPIV2 struct {
+	*LoggerAPI
+
+	controllerLokiConfigService ControllerLokiConfigService
+}
+
+var _ LoggerV2 = (*LoggerAPIV2)(nil)
 
 // NewLoggerAPI returns a LoggerAPI facade.
 func NewLoggerAPI(authorizer facade.Authorizer,
@@ -50,6 +77,21 @@ func NewLoggerAPI(authorizer facade.Authorizer,
 		authorizer:         authorizer,
 		watcherRegistry:    watcherRegistry,
 		modelConfigService: modelConfigService,
+	}, nil
+}
+
+// NewLoggerAPIV2 returns a v2 LoggerAPI facade.
+func NewLoggerAPIV2(authorizer facade.Authorizer,
+	watcherRegistry facade.WatcherRegistry,
+	modelConfigService ModelConfigService,
+	controllerLokiConfigService ControllerLokiConfigService) (*LoggerAPIV2, error) {
+	loggerAPI, err := NewLoggerAPI(authorizer, watcherRegistry, modelConfigService)
+	if err != nil {
+		return nil, err
+	}
+	return &LoggerAPIV2{
+		LoggerAPI:                   loggerAPI,
+		controllerLokiConfigService: controllerLokiConfigService,
 	}, nil
 }
 
@@ -116,4 +158,76 @@ func (api *LoggerAPI) LoggingConfig(ctx context.Context, arg params.Entities) pa
 		results[i].Result = config.LoggingConfig()
 	}
 	return params.StringResults{Results: results}
+}
+
+// GetControllerLokiConfig reports the controller-wide Loki configuration for
+// the agents specified.
+func (api *LoggerAPIV2) GetControllerLokiConfig(ctx context.Context, arg params.Entities) params.LokiConfigResults {
+	if len(arg.Entities) == 0 {
+		return params.LokiConfigResults{}
+	}
+
+	results := make([]params.LokiConfigResult, len(arg.Entities))
+	authorized := false
+	for i, entity := range arg.Entities {
+		tag, err := names.ParseTag(entity.Tag)
+		if err != nil {
+			results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		if !api.authorizer.AuthOwner(tag) {
+			results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
+			continue
+		}
+		authorized = true
+	}
+	if !authorized {
+		return params.LokiConfigResults{Results: results}
+	}
+
+	config, configErr := api.controllerLokiConfigService.GetLokiConfig(ctx)
+	for i := range results {
+		if results[i].Error != nil {
+			continue
+		}
+		if configErr != nil {
+			results[i].Error = apiservererrors.ServerError(configErr)
+			continue
+		}
+		results[i].Endpoint = config.Endpoint
+		if config.CACertificate != "" {
+			results[i].CACert = &config.CACertificate
+		}
+	}
+	return params.LokiConfigResults{Results: results}
+}
+
+// WatchControllerLokiConfig starts a watcher to track changes to the
+// controller-wide Loki configuration for the agents specified.
+func (api *LoggerAPIV2) WatchControllerLokiConfig(ctx context.Context, arg params.Entities) params.NotifyWatchResults {
+	result := make([]params.NotifyWatchResult, len(arg.Entities))
+	for i, entity := range arg.Entities {
+		tag, err := names.ParseTag(entity.Tag)
+		if err != nil {
+			result[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		if !api.authorizer.AuthOwner(tag) {
+			result[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
+			continue
+		}
+
+		watch, err := api.controllerLokiConfigService.WatchLokiConfig(ctx)
+		if err != nil {
+			result[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+
+		result[i].NotifyWatcherId, _, err = internal.EnsureRegisterWatcher[struct{}](ctx, api.watcherRegistry, watch)
+		if err != nil {
+			result[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+	}
+	return params.NotifyWatchResults{Results: result}
 }

--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -4,6 +4,7 @@
 package logger_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/juju/names/v6"
@@ -13,7 +14,9 @@ import (
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/apiserver/facades/agent/logger"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/domain/logging"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
 )
@@ -24,11 +27,13 @@ var (
 
 type loggerSuite struct {
 	logger     *logger.LoggerAPI
+	loggerV2   *logger.LoggerAPIV2
 	authorizer apiservertesting.FakeAuthorizer
 
 	watcherRegistry *facademocks.MockWatcherRegistry
 
-	modelConfigService *MockModelConfigService
+	modelConfigService          *MockModelConfigService
+	controllerLokiConfigService *stubControllerLokiConfigService
 }
 
 func TestLoggerSuite(t *testing.T) {
@@ -41,6 +46,7 @@ func (s *loggerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.watcherRegistry = facademocks.NewMockWatcherRegistry(ctrl)
 
 	s.modelConfigService = NewMockModelConfigService(ctrl)
+	s.controllerLokiConfigService = &stubControllerLokiConfigService{}
 
 	return ctrl
 }
@@ -51,6 +57,20 @@ func (s *loggerSuite) setupAPI(c *tc.C) {
 		Tag: defaultMachineTag,
 	}
 	s.logger, err = logger.NewLoggerAPI(s.authorizer, s.watcherRegistry, s.modelConfigService)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *loggerSuite) setupAPIV2(c *tc.C) {
+	var err error
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag: defaultMachineTag,
+	}
+	s.loggerV2, err = logger.NewLoggerAPIV2(
+		s.authorizer,
+		s.watcherRegistry,
+		s.modelConfigService,
+		s.controllerLokiConfigService,
+	)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -185,4 +205,116 @@ func (s *loggerSuite) TestLoggingConfigForAgent(c *tc.C) {
 	result := results.Results[0]
 	c.Assert(result.Error, tc.IsNil)
 	c.Assert(result.Result, tc.Equals, "<root>=WARN;juju.log.test=DEBUG;unit=INFO")
+}
+
+func (s *loggerSuite) TestGetControllerLokiConfigForNoone(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+	s.setupAPIV2(c)
+
+	results := s.loggerV2.GetControllerLokiConfig(c.Context(), params.Entities{})
+	c.Assert(results.Results, tc.HasLen, 0)
+	c.Check(s.controllerLokiConfigService.getCalls, tc.Equals, 0)
+}
+
+func (s *loggerSuite) TestGetControllerLokiConfigRefusesWrongAgent(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+	s.setupAPIV2(c)
+
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: "machine-12354"}},
+	}
+	results := s.loggerV2.GetControllerLokiConfig(c.Context(), args)
+	c.Assert(results.Results, tc.HasLen, 1)
+	result := results.Results[0]
+	c.Assert(result.Error, tc.DeepEquals, apiservertesting.ErrUnauthorized)
+	c.Check(s.controllerLokiConfigService.getCalls, tc.Equals, 0)
+}
+
+func (s *loggerSuite) TestGetControllerLokiConfigForAgent(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+	s.setupAPIV2(c)
+
+	s.controllerLokiConfigService.config = logging.LokiConfig{
+		Endpoint:      "https://loki.example.com/loki/api/v1/push",
+		CACertificate: "ca-cert",
+	}
+
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: defaultMachineTag.String()}},
+	}
+	results := s.loggerV2.GetControllerLokiConfig(c.Context(), args)
+	c.Assert(results.Results, tc.HasLen, 1)
+	result := results.Results[0]
+	c.Assert(result.Error, tc.IsNil)
+	c.Check(result.Endpoint, tc.Equals, "https://loki.example.com/loki/api/v1/push")
+	c.Assert(result.CACert, tc.NotNil)
+	c.Check(*result.CACert, tc.Equals, "ca-cert")
+	c.Check(s.controllerLokiConfigService.getCalls, tc.Equals, 1)
+}
+
+func (s *loggerSuite) TestWatchControllerLokiConfigNothing(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+	s.setupAPIV2(c)
+
+	results := s.loggerV2.WatchControllerLokiConfig(c.Context(), params.Entities{})
+	c.Assert(results.Results, tc.HasLen, 0)
+	c.Check(s.controllerLokiConfigService.watchCalls, tc.Equals, 0)
+}
+
+func (s *loggerSuite) TestWatchControllerLokiConfig(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+	s.setupAPIV2(c)
+
+	notifyCh := make(chan struct{}, 1)
+	notifyCh <- struct{}{}
+	s.controllerLokiConfigService.watcher = watchertest.NewMockNotifyWatcher(notifyCh)
+	s.watcherRegistry.EXPECT().Register(gomock.Any(), gomock.Any()).Return("1", nil)
+
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: defaultMachineTag.String()}},
+	}
+	results := s.loggerV2.WatchControllerLokiConfig(c.Context(), args)
+	c.Assert(results.Results, tc.HasLen, 1)
+	c.Assert(results.Results[0].NotifyWatcherId, tc.Not(tc.Equals), "")
+	c.Assert(results.Results[0].Error, tc.IsNil)
+	c.Check(s.controllerLokiConfigService.watchCalls, tc.Equals, 1)
+}
+
+func (s *loggerSuite) TestWatchControllerLokiConfigRefusesWrongAgent(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+	s.setupAPIV2(c)
+
+	args := params.Entities{
+		Entities: []params.Entity{{Tag: "machine-12354"}},
+	}
+	results := s.loggerV2.WatchControllerLokiConfig(c.Context(), args)
+	c.Assert(results.Results, tc.HasLen, 1)
+	c.Assert(results.Results[0].NotifyWatcherId, tc.Equals, "")
+	c.Assert(results.Results[0].Error, tc.DeepEquals, apiservertesting.ErrUnauthorized)
+	c.Check(s.controllerLokiConfigService.watchCalls, tc.Equals, 0)
+}
+
+type stubControllerLokiConfigService struct {
+	config     logging.LokiConfig
+	getErr     error
+	getCalls   int
+	watcher    *watchertest.MockNotifyWatcher
+	watchErr   error
+	watchCalls int
+}
+
+func (s *stubControllerLokiConfigService) GetLokiConfig(ctx context.Context) (logging.LokiConfig, error) {
+	s.getCalls++
+	return s.config, s.getErr
+}
+
+func (s *stubControllerLokiConfigService) WatchLokiConfig(ctx context.Context) (watcher.NotifyWatcher, error) {
+	s.watchCalls++
+	return s.watcher, s.watchErr
 }

--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain/logging"
+	loggingerrors "github.com/juju/juju/domain/logging/errors"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
 )
@@ -207,27 +208,13 @@ func (s *loggerSuite) TestLoggingConfigForAgent(c *tc.C) {
 	c.Assert(result.Result, tc.Equals, "<root>=WARN;juju.log.test=DEBUG;unit=INFO")
 }
 
-func (s *loggerSuite) TestGetControllerLokiConfigForNoone(c *tc.C) {
-	ctrl := s.setupMocks(c)
-	defer ctrl.Finish()
-	s.setupAPIV2(c)
-
-	results := s.loggerV2.GetControllerLokiConfig(c.Context(), params.Entities{})
-	c.Assert(results.Results, tc.HasLen, 0)
-	c.Check(s.controllerLokiConfigService.getCalls, tc.Equals, 0)
-}
-
 func (s *loggerSuite) TestGetControllerLokiConfigRefusesWrongAgent(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 	s.setupAPIV2(c)
 
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: "machine-12354"}},
-	}
-	results := s.loggerV2.GetControllerLokiConfig(c.Context(), args)
-	c.Assert(results.Results, tc.HasLen, 1)
-	result := results.Results[0]
+	args := params.Entity{Tag: "machine-12354"}
+	result := s.loggerV2.GetControllerLokiConfig(c.Context(), args)
 	c.Assert(result.Error, tc.DeepEquals, apiservertesting.ErrUnauthorized)
 	c.Check(s.controllerLokiConfigService.getCalls, tc.Equals, 0)
 }
@@ -242,12 +229,8 @@ func (s *loggerSuite) TestGetControllerLokiConfigForAgent(c *tc.C) {
 		CACertificate: "ca-cert",
 	}
 
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: defaultMachineTag.String()}},
-	}
-	results := s.loggerV2.GetControllerLokiConfig(c.Context(), args)
-	c.Assert(results.Results, tc.HasLen, 1)
-	result := results.Results[0]
+	args := params.Entity{Tag: defaultMachineTag.String()}
+	result := s.loggerV2.GetControllerLokiConfig(c.Context(), args)
 	c.Assert(result.Error, tc.IsNil)
 	c.Check(result.Endpoint, tc.Equals, "https://loki.example.com/loki/api/v1/push")
 	c.Assert(result.CACert, tc.NotNil)
@@ -255,14 +238,20 @@ func (s *loggerSuite) TestGetControllerLokiConfigForAgent(c *tc.C) {
 	c.Check(s.controllerLokiConfigService.getCalls, tc.Equals, 1)
 }
 
-func (s *loggerSuite) TestWatchControllerLokiConfigNothing(c *tc.C) {
+func (s *loggerSuite) TestGetControllerLokiConfigReturnsNotFoundError(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 	s.setupAPIV2(c)
 
-	results := s.loggerV2.WatchControllerLokiConfig(c.Context(), params.Entities{})
-	c.Assert(results.Results, tc.HasLen, 0)
-	c.Check(s.controllerLokiConfigService.watchCalls, tc.Equals, 0)
+	s.controllerLokiConfigService.getErr = loggingerrors.LokiConfigNotFound
+
+	args := params.Entity{Tag: defaultMachineTag.String()}
+	result := s.loggerV2.GetControllerLokiConfig(c.Context(), args)
+	c.Assert(result.Error, tc.ErrorMatches, "loki config not found")
+	c.Check(result.Error.Code, tc.Equals, params.CodeNotFound)
+	c.Check(result.Endpoint, tc.Equals, "")
+	c.Check(result.CACert, tc.IsNil)
+	c.Check(s.controllerLokiConfigService.getCalls, tc.Equals, 1)
 }
 
 func (s *loggerSuite) TestWatchControllerLokiConfig(c *tc.C) {
@@ -275,13 +264,10 @@ func (s *loggerSuite) TestWatchControllerLokiConfig(c *tc.C) {
 	s.controllerLokiConfigService.watcher = watchertest.NewMockNotifyWatcher(notifyCh)
 	s.watcherRegistry.EXPECT().Register(gomock.Any(), gomock.Any()).Return("1", nil)
 
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: defaultMachineTag.String()}},
-	}
-	results := s.loggerV2.WatchControllerLokiConfig(c.Context(), args)
-	c.Assert(results.Results, tc.HasLen, 1)
-	c.Assert(results.Results[0].NotifyWatcherId, tc.Not(tc.Equals), "")
-	c.Assert(results.Results[0].Error, tc.IsNil)
+	args := params.Entity{Tag: defaultMachineTag.String()}
+	result := s.loggerV2.WatchControllerLokiConfig(c.Context(), args)
+	c.Assert(result.NotifyWatcherId, tc.Not(tc.Equals), "")
+	c.Assert(result.Error, tc.IsNil)
 	c.Check(s.controllerLokiConfigService.watchCalls, tc.Equals, 1)
 }
 
@@ -290,13 +276,10 @@ func (s *loggerSuite) TestWatchControllerLokiConfigRefusesWrongAgent(c *tc.C) {
 	defer ctrl.Finish()
 	s.setupAPIV2(c)
 
-	args := params.Entities{
-		Entities: []params.Entity{{Tag: "machine-12354"}},
-	}
-	results := s.loggerV2.WatchControllerLokiConfig(c.Context(), args)
-	c.Assert(results.Results, tc.HasLen, 1)
-	c.Assert(results.Results[0].NotifyWatcherId, tc.Equals, "")
-	c.Assert(results.Results[0].Error, tc.DeepEquals, apiservertesting.ErrUnauthorized)
+	args := params.Entity{Tag: "machine-12354"}
+	result := s.loggerV2.WatchControllerLokiConfig(c.Context(), args)
+	c.Assert(result.NotifyWatcherId, tc.Equals, "")
+	c.Assert(result.Error, tc.DeepEquals, apiservertesting.ErrUnauthorized)
 	c.Check(s.controllerLokiConfigService.watchCalls, tc.Equals, 0)
 }
 

--- a/apiserver/facades/agent/logger/register.go
+++ b/apiserver/facades/agent/logger/register.go
@@ -15,6 +15,9 @@ func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Logger", 1, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
 		return newLoggerAPIV1(ctx)
 	}, reflect.TypeFor[*LoggerAPI]())
+	registry.MustRegister("Logger", 2, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
+		return newLoggerAPIV2(ctx)
+	}, reflect.TypeFor[*LoggerAPIV2]())
 }
 
 // newLoggerAPIV1 creates a new server-side logger API end point.
@@ -22,4 +25,12 @@ func newLoggerAPIV1(ctx facade.ModelContext) (*LoggerAPI, error) {
 	return NewLoggerAPI(ctx.Auth(),
 		ctx.WatcherRegistry(),
 		ctx.DomainServices().Config())
+}
+
+// newLoggerAPIV2 creates a new server-side logger API end point.
+func newLoggerAPIV2(ctx facade.ModelContext) (*LoggerAPIV2, error) {
+	return NewLoggerAPIV2(ctx.Auth(),
+		ctx.WatcherRegistry(),
+		ctx.DomainServices().Config(),
+		ctx.DomainServices().Logging())
 }

--- a/apiserver/facades/agent/logger/service.go
+++ b/apiserver/facades/agent/logger/service.go
@@ -7,12 +7,27 @@ import (
 	"context"
 
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/logging"
 	"github.com/juju/juju/environs/config"
 )
 
 // ModelConfigService is an interface that provides access to the
 // model configuration.
 type ModelConfigService interface {
+	// ModelConfig reports the model logging-config value.
 	ModelConfig(ctx context.Context) (*config.Config, error)
+
+	// Watch starts a watcher for model logging-config changes.
 	Watch(ctx context.Context) (watcher.StringsWatcher, error)
+}
+
+// ControllerLokiConfigService is an interface that provides access to the
+// controller Loki configuration.
+type ControllerLokiConfigService interface {
+	// GetLokiConfig reports the controller-wide Loki configuration.
+	GetLokiConfig(ctx context.Context) (logging.LokiConfig, error)
+
+	// WatchLokiConfig starts a watcher for controller-wide Loki configuration
+	// changes.
+	WatchLokiConfig(ctx context.Context) (watcher.NotifyWatcher, error)
 }

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -103,12 +103,6 @@ type LokiConfigResult struct {
 	CACert   *string `json:"ca-cert,omitempty"`
 }
 
-// LokiConfigResults holds the bulk operation result of an API call that
-// returns a controller Loki configuration or an error.
-type LokiConfigResults struct {
-	Results []LokiConfigResult `json:"results"`
-}
-
 // MapResult holds a generic map or an error.
 type MapResult struct {
 	Result map[string]any `json:"result"`

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -96,6 +96,19 @@ type StringResults struct {
 	Results []StringResult `json:"results"`
 }
 
+// LokiConfigResult holds a controller Loki configuration or an error.
+type LokiConfigResult struct {
+	Error    *Error  `json:"error,omitempty"`
+	Endpoint string  `json:"endpoint"`
+	CACert   *string `json:"ca-cert,omitempty"`
+}
+
+// LokiConfigResults holds the bulk operation result of an API call that
+// returns a controller Loki configuration or an error.
+type LokiConfigResults struct {
+	Results []LokiConfigResult `json:"results"`
+}
+
 // MapResult holds a generic map or an error.
 type MapResult struct {
 	Result map[string]any `json:"result"`


### PR DESCRIPTION
~~Requires https://github.com/juju/juju/pull/22606 to land first.~~

This implements the agent-facing distribution path for controller Loki logging configuration, as required for the Loki integration work. Agents need a stable Logger facade surface that can retrieve and watch controller-wide Loki endpoint data without reading it from model-scoped logging-config. Keeping this behind a
  new Logger facade version preserves existing Logger v1 behaviour for older agents.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju model-config -m controller logging-config="<root>=DEBUG;juju.charmhub=TRACE" 
$ juju add-model foo
$ juju deploy juju-qa-test
$ juju debug-log -m controller
$ juju debug-log
```

## Links

Jira card: [JUJU-9975](https://warthogs.atlassian.net/browse/JUJU-9975)



[JUJU-9975]: https://warthogs.atlassian.net/browse/JUJU-9975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ