### PR TITLE
test: goroutine leak profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,6 +502,7 @@ run-tests: musl-install-if-missing dqlite-install-if-missing
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
+		GOEXPERIMENT=goroutineleakprofile \
 		go test -mod=$(JUJU_GOMOD_MODE) -tags=$(TEST_BUILD_TAGS) $(TEST_ARGS) -ldflags ${CGO_LINK_FLAGS} $(TEST_PACKAGES) $(TEST_EXTRA_ARGS)
 	@rm -r $(TMP)
 
@@ -536,6 +537,7 @@ run-go-tests: musl-install-if-missing dqlite-install-if-missing
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
+		GOEXPERIMENT=goroutineleakprofile \
 		go test -mod=$(JUJU_GOMOD_MODE) -tags=$(TEST_BUILD_TAGS) $(TEST_ARGS) -ldflags ${CGO_LINK_FLAGS} ${TEST_PACKAGES} -test.run $(TEST_FILTER) $(TEST_EXTRA_ARGS)
 
 .PHONY: go-test-alias
@@ -549,6 +551,7 @@ go-test-alias: musl-install-if-missing dqlite-install-if-missing
 		CGO_LDFLAGS_ALLOW=\""(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"\" \
 		LD_LIBRARY_PATH=\"${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}\" \
 		CGO_ENABLED=\"1\" \
+		GOEXPERIMENT=goroutineleakprofile \
 		go test -mod=\"$(JUJU_GOMOD_MODE)\" -tags=\"$(TEST_BUILD_TAGS)\" -ldflags \"${CGO_LINK_FLAGS}\"\'
 
 .PHONY: install

--- a/apiserver/facades/controller/crosscontroller/crosscontroller_test.go
+++ b/apiserver/facades/controller/crosscontroller/crosscontroller_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/controller"
@@ -20,8 +19,9 @@ import (
 )
 
 func TestCrossControllerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &CrossControllerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &CrossControllerSuite{})
+	})
 }
 
 type CrossControllerSuite struct {

--- a/core/agent/tag.go
+++ b/core/agent/tag.go
@@ -6,7 +6,8 @@ package agent
 import "github.com/juju/names/v6"
 
 // IsAllowedControllerTag returns true if the tag kind can be for a controller.
-// TODO(controlleragent) - this method is needed while IAAS controllers are still machines.
+// TODO(controlleragent) - this method is needed while IAAS controllers are
+// still machines.
 func IsAllowedControllerTag(kind string) bool {
 	return kind == names.ControllerAgentTagKind || kind == names.MachineTagKind
 }

--- a/core/watcher/eventsource/consume_test.go
+++ b/core/watcher/eventsource/consume_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -21,8 +21,9 @@ type consumeSuite struct {
 }
 
 func TestConsumeSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &consumeSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &consumeSuite{})
+	})
 }
 
 func (s *consumeSuite) TestConsumeInitialEventReturnsChanges(c *tc.C) {

--- a/core/watcher/eventsource/filter_test.go
+++ b/core/watcher/eventsource/filter_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/internal/testhelpers"
@@ -18,8 +17,9 @@ type filterSuite struct {
 }
 
 func TestFilterSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &filterSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &filterSuite{})
+	})
 }
 
 func (s *filterSuite) TestPredicateFilter(c *tc.C) {

--- a/core/watcher/eventsource/legacy_test.go
+++ b/core/watcher/eventsource/legacy_test.go
@@ -8,16 +8,17 @@ import (
 
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type multiWatcherSuite struct{}
 
 func TestMultiWatcherSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &multiWatcherSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &multiWatcherSuite{})
+	})
 }
 
 func (*multiWatcherSuite) TestNotifyMultiWatcher(c *tc.C) {

--- a/core/watcher/eventsource/namespace_test.go
+++ b/core/watcher/eventsource/namespace_test.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/database/schema"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -28,8 +28,9 @@ type namespaceSuite struct {
 }
 
 func TestNamespaceSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &namespaceSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &namespaceSuite{})
+	})
 }
 
 func (s *namespaceSuite) SetUpTest(c *tc.C) {

--- a/core/watcher/eventsource/notify_test.go
+++ b/core/watcher/eventsource/notify_test.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -25,8 +25,9 @@ type notifySuite struct {
 var _ watcher.NotifyWatcher = &NotifyWatcher{}
 
 func TestNotifySuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &notifySuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &notifySuite{})
+	})
 }
 
 func (s *notifySuite) TestNotificationsByNamespaceFilter(c *tc.C) {

--- a/core/watcher/eventsource/package_test.go
+++ b/core/watcher/eventsource/package_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
 	dbtesting "github.com/juju/juju/internal/database/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	coretesting "github.com/juju/juju/internal/testing"
 )
 
@@ -24,8 +24,9 @@ import (
 type ImportTest struct{}
 
 func TestImportTest(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &ImportTest{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &ImportTest{})
+	})
 }
 
 func (*ImportTest) TestImports(c *tc.C) {

--- a/domain/errors_test.go
+++ b/domain/errors_test.go
@@ -12,9 +12,9 @@ import (
 	dqlite "github.com/canonical/go-dqlite/v3/driver"
 	"github.com/juju/tc"
 	"github.com/mattn/go-sqlite3"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type asError struct {
@@ -28,8 +28,9 @@ func (a asError) Error() string {
 type errorsSuite struct{}
 
 func TestErrorsSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &errorsSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &errorsSuite{})
+	})
 }
 
 // TestCoerceForNilError checks that if you pass a nil error to CoerceError you

--- a/domain/leaseservice_test.go
+++ b/domain/leaseservice_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/leadership"
@@ -30,8 +29,9 @@ type leaseServiceSuite struct {
 }
 
 func TestLeaseServiceSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &leaseServiceSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &leaseServiceSuite{})
+	})
 }
 
 func (s *leaseServiceSuite) TestApplicationLeader(c *tc.C) {

--- a/domain/lifewatcher_test.go
+++ b/domain/lifewatcher_test.go
@@ -8,12 +8,12 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/changestream"
 	changestreamtesting "github.com/juju/juju/core/changestream/testing"
 	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type lifeWatcherSuite struct {
@@ -21,8 +21,9 @@ type lifeWatcherSuite struct {
 }
 
 func TestLifeWatcherSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &lifeWatcherSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &lifeWatcherSuite{})
+	})
 }
 
 func (s *lifeWatcherSuite) lifeGetter(ctx context.Context, ids []string) (map[string]life.Life, error) {

--- a/domain/state_test.go
+++ b/domain/state_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type stateSuite struct {
@@ -19,8 +19,9 @@ type stateSuite struct {
 }
 
 func TestStateSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &stateSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &stateSuite{})
+	})
 }
 
 func (s *stateSuite) TestStateBaseGetDB(c *tc.C) {

--- a/domain/watcher_test.go
+++ b/domain/watcher_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/juju/collections/transform"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/watcher/eventsource"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/testhelpers"
 	jujutesting "github.com/juju/juju/internal/testing"
 )
 
@@ -31,8 +31,9 @@ type watcherSuite struct {
 }
 
 func TestWatcherSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &watcherSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &watcherSuite{})
+	})
 }
 
 func (*watcherSuite) TestNewUUIDsWatcherFail(c *tc.C) {

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0

--- a/internal/changestream/eventmultiplexer/eventmultiplexer_test.go
+++ b/internal/changestream/eventmultiplexer/eventmultiplexer_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/changestream"
 	changestreamtesting "github.com/juju/juju/core/changestream/testing"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 const (
@@ -33,8 +33,9 @@ type eventMultiplexerSuite struct {
 }
 
 func TestEventMultiplexerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &eventMultiplexerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &eventMultiplexerSuite{})
+	})
 }
 
 func (s *eventMultiplexerSuite) TestSubscribe(c *tc.C) {

--- a/internal/changestream/eventmultiplexer/subscription_test.go
+++ b/internal/changestream/eventmultiplexer/subscription_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	changestreamtesting "github.com/juju/juju/core/changestream/testing"
 	"github.com/juju/juju/core/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type subscriptionSuite struct {
@@ -21,8 +21,9 @@ type subscriptionSuite struct {
 }
 
 func TestSubscriptionSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &subscriptionSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &subscriptionSuite{})
+	})
 }
 
 func (s *subscriptionSuite) TestSubscriptionIsDone(c *tc.C) {

--- a/internal/changestream/stream/stream_test.go
+++ b/internal/changestream/stream/stream_test.go
@@ -17,11 +17,11 @@ import (
 	gomock "github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/changestream"
 	changestreamtesting "github.com/juju/juju/core/changestream/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -38,8 +38,9 @@ type streamSuite struct {
 }
 
 func TestStreamSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &streamSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &streamSuite{})
+	})
 }
 
 func (s *streamSuite) TestWithNoNamespace(c *tc.C) {

--- a/internal/logsink/logsink_test.go
+++ b/internal/logsink/logsink_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/testhelpers"
@@ -32,8 +31,9 @@ type logSinkSuite struct {
 }
 
 func TestLogSinkSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &logSinkSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &logSinkSuite{})
+	})
 }
 
 func (s *logSinkSuite) TestLogWithNoBatching(c *tc.C) {

--- a/internal/objectstore/base_test.go
+++ b/internal/objectstore/base_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/clock"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/objectstore"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -27,8 +26,9 @@ type baseObjectStoreSuite struct {
 }
 
 func TestBaseObjectStoreSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &baseObjectStoreSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &baseObjectStoreSuite{})
+	})
 }
 
 func (s *baseObjectStoreSuite) TestLockOnCancelledContext(c *tc.C) {

--- a/internal/objectstore/factory_test.go
+++ b/internal/objectstore/factory_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/objectstore"
 	watcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type objectStoreFactorySuite struct {
@@ -27,8 +27,9 @@ type objectStoreFactorySuite struct {
 }
 
 func TestObjectStoreFactorySuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &objectStoreFactorySuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &objectStoreFactorySuite{})
+	})
 }
 
 func (s *objectStoreFactorySuite) TestNewObjectStore(c *tc.C) {

--- a/internal/objectstore/fileobjectstore_test.go
+++ b/internal/objectstore/fileobjectstore_test.go
@@ -19,7 +19,6 @@ import (
 	jujuerrors "github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/objectstore"
@@ -30,6 +29,7 @@ import (
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	objectstoreerrors "github.com/juju/juju/internal/objectstore/errors"
 	"github.com/juju/juju/internal/objectstore/remote"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type fileObjectStoreSuite struct {
@@ -39,8 +39,9 @@ type fileObjectStoreSuite struct {
 }
 
 func TestFileObjectStoreSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &fileObjectStoreSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &fileObjectStoreSuite{})
+	})
 }
 
 var _ TrackedObjectStore = (*fileObjectStore)(nil)

--- a/internal/objectstore/hash_test.go
+++ b/internal/objectstore/hash_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type hashFileStoreSuite struct {
@@ -22,8 +22,9 @@ type hashFileStoreSuite struct {
 }
 
 func TestHashFileStoreSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &hashFileStoreSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &hashFileStoreSuite{})
+	})
 }
 
 func (s *hashFileStoreSuite) TestHashExistsNotFound(c *tc.C) {

--- a/internal/objectstore/remote/retriever_test.go
+++ b/internal/objectstore/remote/retriever_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
 	api "github.com/juju/juju/api"
@@ -41,8 +40,9 @@ type retrieverSuite struct {
 }
 
 func TestRetrieverSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &retrieverSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &retrieverSuite{})
+	})
 }
 
 func (s *retrieverSuite) TestRetrieve(c *tc.C) {

--- a/internal/objectstore/remote_test.go
+++ b/internal/objectstore/remote_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/core/objectstore"
@@ -32,8 +31,9 @@ type remoteFileObjectStoreSuite struct {
 var _ TrackedObjectStore = (*remoteFileObjectStore)(nil)
 
 func TestRemoteFileObjectStoreSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &remoteFileObjectStoreSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &remoteFileObjectStoreSuite{})
+	})
 }
 
 func (s *remoteFileObjectStoreSuite) TestNewRemoteFileObjectStoreDies(c *tc.C) {

--- a/internal/objectstore/s3objectstore_test.go
+++ b/internal/objectstore/s3objectstore_test.go
@@ -19,13 +19,13 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/objectstore"
 	objectstoretesting "github.com/juju/juju/core/objectstore/testing"
 	domainobjectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	objectstoreerrors "github.com/juju/juju/internal/objectstore/errors"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -44,8 +44,9 @@ type s3ObjectStoreSuite struct {
 var _ TrackedObjectStore = (*s3ObjectStore)(nil)
 
 func TestS3ObjectStoreSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &s3ObjectStoreSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &s3ObjectStoreSuite{})
+	})
 }
 
 func (s *s3ObjectStoreSuite) TestGetMetadataNotFound(c *tc.C) {

--- a/internal/testhelpers/goleak.go
+++ b/internal/testhelpers/goleak.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Code extracted from github.com/Canonical/pebble
+
+package testhelpers
+
+import (
+	"bytes"
+	"runtime"
+	"runtime/pprof"
+	"testing"
+)
+
+// PrintGoroutineLeaks runs the provided test function and prints any goroutine
+// leaks that are detected after the test function returns. The test is marked
+// as failed if any leaks are found. The provided test function should not
+// create goroutines that outlive the function itself, otherwise they will be
+// reported as leaks.
+func PrintGoroutineLeaks(t *testing.T, f func(t *testing.T)) {
+	t.Helper()
+
+	leakProfile := pprof.Lookup("goroutineleak")
+	if leakProfile == nil {
+		f(t)
+		return
+	}
+
+	done := make(chan struct{})
+	collapse := done
+	go leakSentinel(done)
+	defer func() {
+		defer close(collapse)
+
+		// Leak the sentinel.
+		done = nil
+
+		// Find the sentinal in the goroutine leak profile.
+		out := &bytes.Buffer{}
+		sentinelBytes := []byte("leakSentinel")
+		for {
+			_ = leakProfile.WriteTo(out, 2)
+			// Break out of the loop if the leaked sentinel was discovered in
+			// the leak profile. Otherwise continue until the test harness times
+			// out.
+			if bytes.Contains(out.Bytes(), sentinelBytes) {
+				break
+			}
+			out.Reset()
+			runtime.GC()
+		}
+
+		// Find any leaked goroutines other than the sentinel.
+		leakedBytes := []byte("(leaked)")
+		leaked := false
+		for stack := range bytes.SplitSeq(out.Bytes(), []byte("\n\n")) {
+			isSentinel := bytes.Contains(stack, sentinelBytes)
+			isLeak := bytes.Contains(stack, leakedBytes)
+			if isSentinel || !isLeak {
+				// Ignore both the sentinel leak and non-leaked goroutines.
+				continue
+			}
+			if leaked {
+				_, _ = t.Output().Write([]byte("\n\n"))
+			}
+			_, _ = t.Output().Write(stack)
+			leaked = true
+		}
+
+		// Mark the test as failed if any leaked goroutines were found.
+		if leaked {
+			t.Fail()
+		}
+	}()
+
+	f(t)
+}
+
+func leakSentinel(done chan struct{}) {
+	<-done
+}

--- a/internal/worker/agentbinaryfetcher/manifold_test.go
+++ b/internal/worker/agentbinaryfetcher/manifold_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -28,8 +27,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/agentbinaryfetcher/worker_test.go
+++ b/internal/worker/agentbinaryfetcher/worker_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/agentbinary"
 	"github.com/juju/juju/core/arch"
@@ -28,8 +27,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestWorkerGetsMissingArch(c *tc.C) {

--- a/internal/worker/agentconfigupdater/manifold_test.go
+++ b/internal/worker/agentconfigupdater/manifold_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/agent"
 	basetesting "github.com/juju/juju/api/base/testing"
@@ -26,6 +25,7 @@ import (
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/agentconfigupdater"
 	"github.com/juju/juju/internal/worker/trace"
@@ -42,8 +42,9 @@ type AgentConfigUpdaterSuite struct {
 }
 
 func TestAgentConfigUpdaterSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &AgentConfigUpdaterSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &AgentConfigUpdaterSuite{})
+	})
 }
 
 func (s *AgentConfigUpdaterSuite) TestInputs(c *tc.C) {

--- a/internal/worker/agentconfigupdater/worker_test.go
+++ b/internal/worker/agentconfigupdater/worker_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/controller"
 	watcher "github.com/juju/juju/core/watcher"
@@ -35,8 +34,9 @@ type WorkerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &WorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &WorkerSuite{})
+	})
 }
 
 func (s *WorkerSuite) TestWorkerConfig(c *tc.C) {

--- a/internal/worker/apiaddresssetter/manifold_test.go
+++ b/internal/worker/apiaddresssetter/manifold_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
-	"go.uber.org/goleak"
 
 	controller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/errors"
@@ -26,8 +25,9 @@ type manifoldConfigSuite struct {
 }
 
 func TestManifoldConfigSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldConfigSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &manifoldConfigSuite{})
+	})
 }
 
 func (s *manifoldConfigSuite) SetUpTest(c *tc.C) {
@@ -87,8 +87,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/internal/worker/apiaddresssetter/worker_test.go
+++ b/internal/worker/apiaddresssetter/worker_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
@@ -34,8 +33,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) setUpMocks(c *tc.C) *gomock.Controller {

--- a/internal/worker/apiremotecaller/manifold_test.go
+++ b/internal/worker/apiremotecaller/manifold_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -29,8 +28,9 @@ type ManifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &ManifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &ManifoldSuite{})
+	})
 }
 
 func (s *ManifoldSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/apiremotecaller/remote_test.go
+++ b/internal/worker/apiremotecaller/remote_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/api"
@@ -32,8 +31,9 @@ type RemoteSuite struct {
 }
 
 func TestRemoteSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &RemoteSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &RemoteSuite{})
+	})
 }
 
 func (s *RemoteSuite) TestControllerID(c *tc.C) {

--- a/internal/worker/apiremotecaller/worker_test.go
+++ b/internal/worker/apiremotecaller/worker_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/api"
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/core/watcher/watchertest"
 	controllernodeerrors "github.com/juju/juju/domain/controllernode/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type WorkerSuite struct {
@@ -35,8 +35,9 @@ type WorkerSuite struct {
 }
 
 func TestWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &WorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &WorkerSuite{})
+	})
 }
 
 func (s *WorkerSuite) TestWorkerConfig(c *tc.C) {

--- a/internal/worker/apiremoterelationcaller/manifold_test.go
+++ b/internal/worker/apiremoterelationcaller/manifold_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/core/crossmodel"
@@ -25,6 +24,7 @@ import (
 	"github.com/juju/juju/core/network"
 	domainmodel "github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/internal/testhelpers"
 	jujutesting "github.com/juju/juju/internal/testing"
 )
 
@@ -33,8 +33,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
@@ -102,8 +103,9 @@ type connectionSuite struct {
 }
 
 func TestConnectionSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &connectionSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &connectionSuite{})
+	})
 }
 
 func (s *connectionSuite) TestGetConnectionForModel(c *tc.C) {
@@ -269,8 +271,9 @@ type apiInfoSuite struct {
 }
 
 func TestAPIInfoSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &apiInfoSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &apiInfoSuite{})
+	})
 }
 
 func (s *apiInfoSuite) TestGetAPIInfoForModelLocalModel(c *tc.C) {

--- a/internal/worker/apiremoterelationcaller/worker_test.go
+++ b/internal/worker/apiremoterelationcaller/worker_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type workerSuite struct {
@@ -25,8 +25,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestWorkerKill(c *tc.C) {

--- a/internal/worker/asynccharmdownloader/downloader_test.go
+++ b/internal/worker/asynccharmdownloader/downloader_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/application"
 	charmtesting "github.com/juju/juju/core/charm/testing"
@@ -23,6 +22,7 @@ import (
 	"github.com/juju/juju/domain/deployment/charm/charmdownloader"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -31,8 +31,9 @@ type asyncWorkerSuite struct {
 }
 
 func TestAsyncWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &asyncWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &asyncWorkerSuite{})
+	})
 }
 
 func (s *asyncWorkerSuite) TestDownloadWorker(c *tc.C) {

--- a/internal/worker/asynccharmdownloader/downloadworker_test.go
+++ b/internal/worker/asynccharmdownloader/downloadworker_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/errors"
@@ -25,6 +24,7 @@ import (
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/internal/charmhub"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -36,8 +36,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestWorkerConfig(c *tc.C) {

--- a/internal/worker/asynccharmdownloader/manifold_test.go
+++ b/internal/worker/asynccharmdownloader/manifold_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
@@ -21,8 +20,9 @@ type ManifoldConfigSuite struct {
 }
 
 func TestManifoldConfigSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &ManifoldConfigSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &ManifoldConfigSuite{})
+	})
 }
 
 func (s *ManifoldConfigSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/bootstrap/addressfinder_test.go
+++ b/internal/worker/bootstrap/addressfinder_test.go
@@ -10,7 +10,6 @@ import (
 	gomock "github.com/canonical/gomock/gomock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/instance"
@@ -19,6 +18,7 @@ import (
 	"github.com/juju/juju/environs"
 	instances "github.com/juju/juju/environs/instances"
 	k8sconstants "github.com/juju/juju/internal/provider/kubernetes/constants"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type iaasAddressFinderSuite struct {
@@ -27,8 +27,9 @@ type iaasAddressFinderSuite struct {
 }
 
 func TestIAASAddressFinderSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &iaasAddressFinderSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &iaasAddressFinderSuite{})
+	})
 }
 
 func (s *iaasAddressFinderSuite) setupMocks(c *tc.C) *gomock.Controller {
@@ -108,8 +109,9 @@ type caasAddressFinderSuite struct {
 }
 
 func TestCAASAddressFinderSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &caasAddressFinderSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &caasAddressFinderSuite{})
+	})
 }
 
 func (s *caasAddressFinderSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/internal/worker/bootstrap/manifold_test.go
+++ b/internal/worker/bootstrap/manifold_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
-	"go.uber.org/goleak"
 
 	agent "github.com/juju/juju/agent"
 	"github.com/juju/juju/core/logger"
@@ -20,6 +19,7 @@ import (
 	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/internal/bootstrap"
 	"github.com/juju/juju/internal/cloudconfig/instancecfg"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -27,8 +27,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	agent "github.com/juju/juju/agent"
 	"github.com/juju/juju/controller"
@@ -38,6 +37,7 @@ import (
 	"github.com/juju/juju/internal/cloudconfig"
 	"github.com/juju/juju/internal/cloudconfig/instancecfg"
 	"github.com/juju/juju/internal/storage"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -51,8 +51,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/caasfirewaller/appfirewaller_test.go
+++ b/internal/worker/caasfirewaller/appfirewaller_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/caas"
 	caasmocks "github.com/juju/juju/caas/mocks"
@@ -19,6 +18,7 @@ import (
 	"github.com/juju/juju/core/watcher/watchertest"
 	domainapplicationerrors "github.com/juju/juju/domain/application/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/worker/caasfirewaller/mocks"
 )
 
@@ -33,8 +33,9 @@ type appFirewallerSuite struct {
 
 // TestAppFirewallerSuite runs the tests defined by [appFirewallerSuite].
 func TestAppFirewallerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &appFirewallerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &appFirewallerSuite{})
+	})
 }
 
 // setupMocks is responsible for creating a testing gomock controller and

--- a/internal/worker/caasfirewaller/firewaller_test.go
+++ b/internal/worker/caasfirewaller/firewaller_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
-	"go.uber.org/goleak"
 
 	coreapplication "github.com/juju/juju/core/application"
 	coreerrors "github.com/juju/juju/core/errors"
@@ -19,6 +18,7 @@ import (
 	"github.com/juju/juju/core/watcher/watchertest"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	internaltesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/caasfirewaller/mocks"
 )
@@ -32,8 +32,9 @@ type firewallerSuite struct {
 
 // TestFirewallerSuite runs the tests defined in [firewallerSuite].
 func TestFirewallerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &firewallerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &firewallerSuite{})
+	})
 }
 
 func (s *firewallerSuite) setupMocks(c *testing.T) *gomock.Controller {

--- a/internal/worker/caasfirewaller/manifold_test.go
+++ b/internal/worker/caasfirewaller/manifold_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
-	"go.uber.org/goleak"
 
 	coreapplication "github.com/juju/juju/core/application"
 	coreerrors "github.com/juju/juju/core/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/worker/caasfirewaller/mocks"
 )
 
@@ -31,8 +31,9 @@ type manifoldSuite struct {
 
 // TestManifoldSuite runs all of the tests contained within the [manifoldSuite].
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/internal/worker/certupdater/certupdater_test.go
+++ b/internal/worker/certupdater/certupdater_test.go
@@ -14,7 +14,6 @@ import (
 	jujutesting "github.com/juju/testing"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -32,8 +31,9 @@ type certUpdaterSuite struct {
 }
 
 func TestCertUpdaterSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &certUpdaterSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &certUpdaterSuite{})
+	})
 }
 
 func (s *certUpdaterSuite) TestWorkerCleanKill(c *tc.C) {

--- a/internal/worker/certupdater/manifold_test.go
+++ b/internal/worker/certupdater/manifold_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -28,8 +27,9 @@ type manifoldConfigSuite struct {
 }
 
 func TestManifoldConfigSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldConfigSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldConfigSuite{})
+	})
 }
 
 func (s *manifoldConfigSuite) SetUpTest(c *tc.C) {
@@ -89,8 +89,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/internal/worker/changestream/manifold_test.go
+++ b/internal/worker/changestream/manifold_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -21,8 +21,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/changestream/metrics_test.go
+++ b/internal/worker/changestream/metrics_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/juju/tc"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"go.uber.org/goleak"
 
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -20,8 +20,9 @@ type metricsSuite struct {
 }
 
 func TestMetricsSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &metricsSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &metricsSuite{})
+	})
 }
 
 func (s *metricsSuite) TestMetricsAreCollected(c *tc.C) {

--- a/internal/worker/changestream/worker_test.go
+++ b/internal/worker/changestream/worker_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -26,8 +26,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/changestreampruner/manifold_test.go
+++ b/internal/worker/changestreampruner/manifold_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
-	"go.uber.org/goleak"
 
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -20,8 +20,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/changestreampruner/pruner_test.go
+++ b/internal/worker/changestreampruner/pruner_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/domain/changestream"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type prunerWorkerSuite struct {
@@ -20,8 +20,9 @@ type prunerWorkerSuite struct {
 }
 
 func TestPrunerWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &prunerWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &prunerWorkerSuite{})
+	})
 }
 
 func (s *prunerWorkerSuite) TestPrunerDies(c *tc.C) {

--- a/internal/worker/charmrevisioner/manifold_test.go
+++ b/internal/worker/charmrevisioner/manifold_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
@@ -24,8 +23,9 @@ type ManifoldConfigSuite struct {
 }
 
 func TestManifoldConfigSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &ManifoldConfigSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &ManifoldConfigSuite{})
+	})
 }
 
 func (s *ManifoldConfigSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/charmrevisioner/worker_test.go
+++ b/internal/worker/charmrevisioner/worker_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/charm"
 	charmmetrics "github.com/juju/juju/core/charm/metrics"
@@ -59,8 +58,9 @@ type WorkerSuite struct {
 }
 
 func TestWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &WorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &WorkerSuite{})
+	})
 }
 
 // advanceClockUntil advances the fake clock in small increments until either

--- a/internal/worker/controllerpresence/manifold_test.go
+++ b/internal/worker/controllerpresence/manifold_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/model"
@@ -32,8 +31,9 @@ type ManifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &ManifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &ManifoldSuite{})
+	})
 }
 
 func (s *ManifoldSuite) TestInputs(c *tc.C) {

--- a/internal/worker/controllerpresence/worker_test.go
+++ b/internal/worker/controllerpresence/worker_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/api"
 	coreerrors "github.com/juju/juju/core/errors"
@@ -23,8 +22,9 @@ import (
 )
 
 func TestWorker(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &WorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &WorkerSuite{})
+	})
 }
 
 type WorkerSuite struct {

--- a/internal/worker/controlsocket/worker_test.go
+++ b/internal/worker/controlsocket/worker_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
@@ -28,6 +27,7 @@ import (
 	tracingservice "github.com/juju/juju/domain/tracing/service"
 	auth "github.com/juju/juju/internal/auth"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	jujujujutesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/juju/sockets"
 )
@@ -41,8 +41,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *testing.T) {
-	goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/dbaccessor/config_test.go
+++ b/internal/worker/dbaccessor/config_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/internal/testhelpers"
 )
@@ -21,9 +20,9 @@ type configSuite struct {
 }
 
 func TestConfigSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-
-	tc.Run(t, &configSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &configSuite{})
+	})
 }
 
 func (s *configSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/dbaccessor/manifold_test.go
+++ b/internal/worker/dbaccessor/manifold_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/database/app"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -22,8 +22,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/dbaccessor/metrics_test.go
+++ b/internal/worker/dbaccessor/metrics_test.go
@@ -10,16 +10,17 @@ import (
 
 	"github.com/juju/tc"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"go.uber.org/goleak"
 
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
 type metricsSuite struct{}
 
 func TestMetricsSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &metricsSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &metricsSuite{})
+	})
 }
 
 func (s *metricsSuite) TestMetricsAreCollected(c *tc.C) {

--- a/internal/worker/dbaccessor/tracker_test.go
+++ b/internal/worker/dbaccessor/tracker_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 // Ensure that the trackedDBWorker is a killableWorker.
@@ -34,8 +34,9 @@ type trackedDBWorkerSuite struct {
 }
 
 func TestTrackedDBWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &trackedDBWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &trackedDBWorkerSuite{})
+	})
 }
 
 func (s *trackedDBWorkerSuite) TestWorkerStartup(c *tc.C) {

--- a/internal/worker/dbaccessor/worker_integration_test.go
+++ b/internal/worker/dbaccessor/worker_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
@@ -28,6 +27,7 @@ import (
 	"github.com/juju/juju/internal/database/pragma"
 	databasetesting "github.com/juju/juju/internal/database/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/dbaccessor"
 )
@@ -42,8 +42,9 @@ type integrationSuite struct {
 }
 
 func TestIntegrationSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &integrationSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &integrationSuite{})
+	})
 }
 
 func (s *integrationSuite) SetUpSuite(c *tc.C) {

--- a/internal/worker/dbaccessor/worker_namespace_test.go
+++ b/internal/worker/dbaccessor/worker_namespace_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/core/database"
@@ -25,8 +24,9 @@ type namespaceSuite struct {
 }
 
 func TestNamespaceSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &namespaceSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &namespaceSuite{})
+	})
 }
 
 func (s *namespaceSuite) TestEnsureNamespaceForController(c *tc.C) {

--- a/internal/worker/dbaccessor/worker_test.go
+++ b/internal/worker/dbaccessor/worker_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/internal/database/dqlite"
@@ -29,8 +28,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestFirstClosedCancelStopsGoroutines(c *tc.C) {

--- a/internal/worker/dbrepl/manifold_test.go
+++ b/internal/worker/dbrepl/manifold_test.go
@@ -10,7 +10,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
+
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -18,8 +19,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/dbrepl/worker_test.go
+++ b/internal/worker/dbrepl/worker_test.go
@@ -9,11 +9,11 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/domain/schema"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/database/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type dbReplSuite struct {
@@ -21,8 +21,9 @@ type dbReplSuite struct {
 }
 
 func TestDbReplSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &dbReplSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &dbReplSuite{})
+	})
 }
 
 func (s *dbReplSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/dbreplaccessor/manifold_test.go
+++ b/internal/worker/dbreplaccessor/manifold_test.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -21,8 +21,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/dbreplaccessor/tracker_test.go
+++ b/internal/worker/dbreplaccessor/tracker_test.go
@@ -14,8 +14,8 @@ import (
 	sqlair "github.com/canonical/sqlair"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -26,8 +26,9 @@ type trackedDBReplWorkerSuite struct {
 }
 
 func TestTrackedDBReplWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &trackedDBReplWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &trackedDBReplWorkerSuite{})
+	})
 }
 
 func (s *trackedDBReplWorkerSuite) TestWorkerStartup(c *tc.C) {

--- a/internal/worker/dbreplaccessor/worker_test.go
+++ b/internal/worker/dbreplaccessor/worker_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type workerSuite struct {
@@ -23,8 +23,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestKilledGetDBErrDying(c *tc.C) {

--- a/internal/worker/flightrecorder/flightrecorder_test.go
+++ b/internal/worker/flightrecorder/flightrecorder_test.go
@@ -10,15 +10,16 @@ import (
 	gomock "github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/flightrecorder"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 func TestFlightRecorderWorker(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &flightRecorderSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &flightRecorderSuite{})
+	})
 }
 
 type flightRecorderSuite struct {

--- a/internal/worker/fortress/fortress_test.go
+++ b/internal/worker/fortress/fortress_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/internal/testhelpers"
 	coretesting "github.com/juju/juju/internal/testing"
@@ -24,8 +23,9 @@ type FortressSuite struct {
 }
 
 func TestFortressSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &FortressSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &FortressSuite{})
+	})
 }
 
 func (s *FortressSuite) TestOutputBadSource(c *tc.C) {

--- a/internal/worker/fortress/occupy_test.go
+++ b/internal/worker/fortress/occupy_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/internal/testhelpers"
 	coretesting "github.com/juju/juju/internal/testing"
@@ -24,8 +23,9 @@ type OccupySuite struct {
 }
 
 func TestOccupySuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &OccupySuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &OccupySuite{})
+	})
 }
 
 func (*OccupySuite) TestAbort(c *tc.C) {

--- a/internal/worker/httpclient/manifold_test.go
+++ b/internal/worker/httpclient/manifold_test.go
@@ -13,10 +13,10 @@ import (
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/goleak"
 
 	corehttp "github.com/juju/juju/core/http"
 	internalhttp "github.com/juju/juju/internal/http"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -24,8 +24,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/httpclient/trackedworker_test.go
+++ b/internal/worker/httpclient/trackedworker_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	internalhttp "github.com/juju/juju/internal/http"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type trackedWorkerSuite struct {
@@ -22,8 +22,9 @@ type trackedWorkerSuite struct {
 }
 
 func TestTrackedWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &trackedWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &trackedWorkerSuite{})
+	})
 }
 
 func (s *trackedWorkerSuite) TestKilled(c *tc.C) {

--- a/internal/worker/httpclient/worker_test.go
+++ b/internal/worker/httpclient/worker_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	corehttp "github.com/juju/juju/core/http"
 	internalhttp "github.com/juju/juju/internal/http"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -32,8 +32,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestKilledGetHTTPClientErrDying(c *tc.C) {

--- a/internal/worker/modellife/manifold_test.go
+++ b/internal/worker/modellife/manifold_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/errors"
 	"github.com/juju/juju/internal/testhelpers"
@@ -27,8 +26,9 @@ type ManifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &ManifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &ManifoldSuite{})
+	})
 }
 
 func (s *ManifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/modellife/worker_test.go
+++ b/internal/worker/modellife/worker_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/dependency"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
@@ -32,8 +31,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/modelworkermanager/manifold_test.go
+++ b/internal/worker/modelworkermanager/manifold_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/http"
@@ -53,8 +52,9 @@ type ManifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &ManifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &ManifoldSuite{})
+	})
 }
 
 func (s *ManifoldSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/modelworkermanager/modelworkermanager_test.go
+++ b/internal/worker/modelworkermanager/modelworkermanager_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/controller"
@@ -34,8 +33,9 @@ import (
 )
 
 func TestSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &suite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &suite{})
+	})
 }
 
 type suite struct {

--- a/internal/worker/objectstore/controllerworker_test.go
+++ b/internal/worker/objectstore/controllerworker_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/trace"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type controllerWorkerSuite struct {
@@ -21,8 +21,9 @@ type controllerWorkerSuite struct {
 var _ objectstore.ObjectStore = (*controllerWorker)(nil)
 
 func TestControllerWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &controllerWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &controllerWorkerSuite{})
+	})
 }
 
 func (s *controllerWorkerSuite) TestWorkerStartup(c *tc.C) {

--- a/internal/worker/objectstore/manifold_test.go
+++ b/internal/worker/objectstore/manifold_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
@@ -22,6 +21,7 @@ import (
 	controllerconfigservice "github.com/juju/juju/domain/controllerconfig/service"
 	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	"github.com/juju/juju/internal/services"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -30,8 +30,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/objectstore/trackerworker_test.go
+++ b/internal/worker/objectstore/trackerworker_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/core/life"
@@ -20,6 +19,7 @@ import (
 	watcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type trackerWorkerSuite struct {
@@ -29,8 +29,9 @@ type trackerWorkerSuite struct {
 var _ objectstore.ObjectStore = (*trackerWorker)(nil)
 
 func TestTrackerWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &trackerWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &trackerWorkerSuite{})
+	})
 }
 
 func (s *trackerWorkerSuite) TestWorkerStartup(c *tc.C) {

--- a/internal/worker/objectstore/worker_test.go
+++ b/internal/worker/objectstore/worker_test.go
@@ -15,13 +15,13 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/objectstore"
 	watcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	internalobjectstore "github.com/juju/juju/internal/objectstore"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -41,8 +41,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestKilledGetObjectStoreErrDying(c *tc.C) {

--- a/internal/worker/objectstoredrainer/drainer_test.go
+++ b/internal/worker/objectstoredrainer/drainer_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	objectstore "github.com/juju/juju/core/objectstore"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -34,8 +34,9 @@ type drainerSuite struct {
 }
 
 func TestDrainer(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &drainerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &drainerSuite{})
+	})
 }
 
 func (s *drainerSuite) TestDrainFilesWithNoFiles(c *tc.C) {

--- a/internal/worker/objectstoredrainer/manifold_test.go
+++ b/internal/worker/objectstoredrainer/manifold_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	agent "github.com/juju/juju/agent"
 	controller "github.com/juju/juju/controller"
@@ -24,6 +23,7 @@ import (
 	objectstoreservice "github.com/juju/juju/domain/objectstore/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/services"
+	"github.com/juju/juju/internal/testhelpers"
 	internaltesting "github.com/juju/juju/internal/testing"
 	internalworker "github.com/juju/juju/internal/worker"
 )
@@ -33,9 +33,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/objectstoredrainer/worker_test.go
+++ b/internal/worker/objectstoredrainer/worker_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
 	agent "github.com/juju/juju/agent"
@@ -25,6 +24,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	internaltesting "github.com/juju/juju/internal/testing"
 )
 
@@ -35,9 +35,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestObjectStoreDrainingNotDraining(c *tc.C) {

--- a/internal/worker/objectstorefacade/manifold_test.go
+++ b/internal/worker/objectstorefacade/manifold_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	coreobjectstore "github.com/juju/juju/core/objectstore"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -23,9 +23,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/objectstorefacade/worker_test.go
+++ b/internal/worker/objectstorefacade/worker_test.go
@@ -13,11 +13,11 @@ import (
 	jujuerrors "github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/worker/fortress"
 )
 
@@ -29,9 +29,9 @@ var _ coreobjectstore.ObjectStore = (*objectStoreFacade)(nil)
 var _ coreobjectstore.ObjectStoreRemover = (*objectStoreFacade)(nil)
 
 func TestWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestObjectStoreGetObjectStore(c *tc.C) {

--- a/internal/worker/objectstores3caller/manifold_test.go
+++ b/internal/worker/objectstores3caller/manifold_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/internal/s3client"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -27,8 +27,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/objectstores3caller/worker_test.go
+++ b/internal/worker/objectstores3caller/worker_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	controller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/internal/s3client"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -29,8 +29,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestCleanKill(c *tc.C) {

--- a/internal/worker/providertracker/manifold_test.go
+++ b/internal/worker/providertracker/manifold_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/caas"
@@ -24,6 +23,7 @@ import (
 	"github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/storage"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -31,8 +31,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/providertracker/providerworker_test.go
+++ b/internal/worker/providertracker/providerworker_test.go
@@ -18,12 +18,12 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/catacomb"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/cloudspec"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -36,8 +36,9 @@ type providerWorkerSuite struct {
 }
 
 func TestProviderWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &providerWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &providerWorkerSuite{})
+	})
 }
 
 func (s *providerWorkerSuite) TestKilledSingularWorkerProviderErrDying(c *tc.C) {

--- a/internal/worker/providertracker/trackertype_test.go
+++ b/internal/worker/providertracker/trackertype_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/internal/testhelpers"
 )
@@ -17,8 +16,9 @@ type trackerTypeSuite struct {
 }
 
 func TestTrackerTypeSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &trackerTypeSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &trackerTypeSuite{})
+	})
 }
 
 func (s *trackerTypeSuite) TestSingularNamespace(c *tc.C) {

--- a/internal/worker/providertracker/trackerworker_test.go
+++ b/internal/worker/providertracker/trackerworker_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloud"
@@ -22,6 +21,7 @@ import (
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -30,8 +30,9 @@ type trackerWorkerSuite struct {
 }
 
 func TestTrackerWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &trackerWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &trackerWorkerSuite{})
+	})
 }
 
 func (s *trackerWorkerSuite) TestWorkerStartup(c *tc.C) {

--- a/internal/worker/remoterelationconsumer/consumerunitrelations/worker_test.go
+++ b/internal/worker/remoterelationconsumer/consumerunitrelations/worker_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/macaroon.v2"
 
 	coreapplication "github.com/juju/juju/core/application"
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/core/watcher/watchertest"
 	relation "github.com/juju/juju/domain/relation"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type localUnitRelationsWorker struct {
@@ -36,8 +36,9 @@ type localUnitRelationsWorker struct {
 }
 
 func TestLocalUnitRelationsWorker(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &localUnitRelationsWorker{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &localUnitRelationsWorker{})
+	})
 }
 
 func (s *localUnitRelationsWorker) SetUpTest(c *tc.C) {

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/core/application"
@@ -36,6 +35,7 @@ import (
 	relationerrors "github.com/juju/juju/domain/relation/errors"
 	"github.com/juju/juju/domain/removal"
 	internalerrors "github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/internal/worker/remoterelationconsumer/consumerunitrelations"
 	"github.com/juju/juju/internal/worker/remoterelationconsumer/offererrelations"
@@ -44,8 +44,9 @@ import (
 )
 
 func TestLocalConsumerWorker(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &localConsumerWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &localConsumerWorkerSuite{})
+	})
 }
 
 type localConsumerWorkerSuite struct {

--- a/internal/worker/remoterelationconsumer/manifold_test.go
+++ b/internal/worker/remoterelationconsumer/manifold_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/worker/apiremoterelationcaller"
 	"github.com/juju/juju/internal/worker/remoterelationconsumer/consumerunitrelations"
 	"github.com/juju/juju/internal/worker/remoterelationconsumer/offererrelations"
@@ -29,8 +29,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/remoterelationconsumer/offererrelations/worker_test.go
+++ b/internal/worker/remoterelationconsumer/offererrelations/worker_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/macaroon.v2"
 
 	coreapplication "github.com/juju/juju/core/application"
@@ -23,6 +22,7 @@ import (
 	watcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -37,8 +37,9 @@ type offererRelationsWorkerSuite struct {
 }
 
 func TestOffererRelationsWorker(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &offererRelationsWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &offererRelationsWorkerSuite{})
+	})
 }
 
 func (s *offererRelationsWorkerSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/remoterelationconsumer/offererunitrelations/worker_test.go
+++ b/internal/worker/remoterelationconsumer/offererunitrelations/worker_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api/watcher"
@@ -22,6 +21,7 @@ import (
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/watcher/watchertest"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -38,8 +38,9 @@ type offererUnitRelationsWorker struct {
 }
 
 func TestOffererUnitRelationsWorker(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &offererUnitRelationsWorker{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &offererUnitRelationsWorker{})
+	})
 }
 
 func (s *offererUnitRelationsWorker) SetUpTest(c *tc.C) {

--- a/internal/worker/remoterelationconsumer/worker_test.go
+++ b/internal/worker/remoterelationconsumer/worker_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain/crossmodelrelation"
 	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/internal/worker/remoterelationconsumer/consumerunitrelations"
 	"github.com/juju/juju/internal/worker/remoterelationconsumer/offererrelations"
@@ -25,8 +25,9 @@ import (
 )
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 type workerSuite struct {

--- a/internal/worker/removal/manifold_test.go
+++ b/internal/worker/removal/manifold_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -24,8 +23,9 @@ type manifoldConfigSuite struct {
 }
 
 func TestManifoldConfigSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldConfigSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldConfigSuite{})
+	})
 }
 
 func (s *manifoldConfigSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/removal/worker_test.go
+++ b/internal/worker/removal/worker_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain/removal"
@@ -30,8 +29,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestWorkerStartStop(c *tc.C) {

--- a/internal/worker/singular/flag_test.go
+++ b/internal/worker/singular/flag_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/internal/errors"
@@ -35,8 +34,9 @@ type FlagSuite struct {
 }
 
 func TestFlagSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &FlagSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &FlagSuite{})
+	})
 }
 
 func (s *FlagSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/singular/manifold_test.go
+++ b/internal/worker/singular/manifold_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/internal/testhelpers"
@@ -35,8 +34,9 @@ type ManifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &ManifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &ManifoldSuite{})
+	})
 }
 
 func (s *ManifoldSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/sshserver/listener_test.go
+++ b/internal/worker/sshserver/listener_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/testing"
 	"github.com/juju/juju/internal/testhelpers"
@@ -22,8 +21,9 @@ type listenerSuite struct {
 }
 
 func TestListenerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &listenerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &listenerSuite{})
+	})
 }
 
 func (s *listenerSuite) TestSyncListenerAfterAccept(c *tc.C) {

--- a/internal/worker/sshserver/manifold_test.go
+++ b/internal/worker/sshserver/manifold_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -32,8 +31,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) SetUpTest(c *tc.C) {

--- a/internal/worker/sshserver/server_test.go
+++ b/internal/worker/sshserver/server_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/logger"
@@ -38,8 +37,9 @@ type sshServerSuite struct {
 }
 
 func TestSshServerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &sshServerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &sshServerSuite{})
+	})
 }
 
 func (s *sshServerSuite) SetUpSuite(c *tc.C) {

--- a/internal/worker/sshserver/session_test.go
+++ b/internal/worker/sshserver/session_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
 	gossh "golang.org/x/crypto/ssh"
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/virtualhostname"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type machineSessionSuite struct {
@@ -29,8 +29,9 @@ type machineSessionSuite struct {
 }
 
 func TestMachineSessionSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &machineSessionSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &machineSessionSuite{})
+	})
 }
 
 type testServer struct {

--- a/internal/worker/sshserver/worker_test.go
+++ b/internal/worker/sshserver/worker_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -25,8 +24,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func newServerWrapperWorkerConfig(

--- a/internal/worker/storageregistry/manifold_test.go
+++ b/internal/worker/storageregistry/manifold_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/internal/storage"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -22,8 +22,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/storageregistry/trackedworker_test.go
+++ b/internal/worker/storageregistry/trackedworker_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/internal/storage"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type trackedWorkerSuite struct {
@@ -23,8 +23,9 @@ type trackedWorkerSuite struct {
 }
 
 func TestTrackedWorkerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &trackedWorkerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &trackedWorkerSuite{})
+	})
 }
 
 // TestTrackedWorkerImplementsProviderRegistry is a regression test to make sure

--- a/internal/worker/storageregistry/worker_test.go
+++ b/internal/worker/storageregistry/worker_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/providertracker"
 	corestorage "github.com/juju/juju/core/storage"
 	"github.com/juju/juju/internal/storage"
+	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -32,8 +32,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestKilledGetStorageRegistryErrDying(c *tc.C) {

--- a/internal/worker/toolsversionchecker/package_test.go
+++ b/internal/worker/toolsversionchecker/package_test.go
@@ -7,18 +7,21 @@ import (
 	"testing"
 
 	"github.com/juju/tc"
-	"go.uber.org/goleak"
+
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 //go:generate go run github.com/canonical/gomock/mockgen -package toolsversionchecker -destination service_mock_test.go github.com/juju/juju/internal/worker/toolsversionchecker ModelConfigService,ModelAgentService,MachineService
 //go:generate go run github.com/canonical/gomock/mockgen -package toolsversionchecker -destination environs_mock_test.go github.com/juju/juju/environs BootstrapEnviron
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &ManifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &ManifoldSuite{})
+	})
 }
 
 func TestToolsCheckerSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &ToolsCheckerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &ToolsCheckerSuite{})
+	})
 }

--- a/internal/worker/trace/worker_test.go
+++ b/internal/worker/trace/worker_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	"github.com/juju/juju/core/logger"
 	coretrace "github.com/juju/juju/core/trace"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type workerSuite struct {
@@ -31,8 +31,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestKilledGetTracerErrDying(c *tc.C) {

--- a/internal/worker/undertaker/manifold_test.go
+++ b/internal/worker/undertaker/manifold_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
+
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type manifoldSuite struct {
@@ -22,8 +23,9 @@ type manifoldSuite struct {
 }
 
 func TestManifoldSuite(t *testing.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &manifoldSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *testing.T) {
+		tc.Run(t, &manifoldSuite{})
+	})
 }
 
 func (s *manifoldSuite) TestValidateConfig(c *tc.C) {

--- a/internal/worker/undertaker/worker_test.go
+++ b/internal/worker/undertaker/worker_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/internal/testhelpers"
 )
 
 type workerSuite struct {
@@ -26,8 +26,9 @@ type workerSuite struct {
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &workerSuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &workerSuite{})
+	})
 }
 
 func (s *workerSuite) TestRemoveDeadModel(c *tc.C) {

--- a/internal/worker/watcherregistry/worker_test.go
+++ b/internal/worker/watcherregistry/worker_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
-	"go.uber.org/goleak"
 
 	coreerrors "github.com/juju/juju/core/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -25,8 +24,9 @@ type registrySuite struct {
 }
 
 func TestRegistrySuite(t *stdtesting.T) {
-	defer goleak.VerifyNone(t)
-	tc.Run(t, &registrySuite{})
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &registrySuite{})
+	})
 }
 
 func (s *registrySuite) TestRegisterCount(c *tc.C) {


### PR DESCRIPTION
With 1.26 there is a way to experiment with goroutineleakprofiles. This might be useful in production code, but we'd need to experiement with that at a later date. For now run it in tests and weed out issues.

## QA steps

All the tests pass.