### PR TITLE
fix: when upgrading, allow for the controller app to be missing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/vmware/govmomi v0.34.1
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.53.0
-	golang.org/x/net v0.55.0
+	golang.org/x/net v0.56.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,8 @@ golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -338,6 +338,7 @@ func ExposeControllerApplication(pool *StatePool) error {
 	if err == mgo.ErrNotFound {
 		// If there was a problem deploying the controller charm at bootstrap
 		// then there won't be a record to update.
+		logger.Warningf("controller application not found, skipping expose controller application upgrade")
 		return nil
 	}
 	if err != nil {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/errors"
+	"github.com/juju/mgo/v3"
 	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/mgo/v3/txn"
 
@@ -334,6 +335,11 @@ func ExposeControllerApplication(pool *StatePool) error {
 	defer closer()
 	var appData bson.M
 	err = appsColl.Find(bson.M{"_id": controllerAppName}).Select(bson.M{"exposed": 1}).One(&appData)
+	if err == mgo.ErrNotFound {
+		// If there was a problem deploying the controller charm at bootstrap
+		// then there won't be a record to update.
+		return nil
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -306,6 +306,11 @@ func (s *upgradesSuite) TestExposeControllerApplication(c *gc.C) {
 	)
 }
 
+func (s *upgradesSuite) TestExposeControllerApplicationMissing(c *gc.C) {
+	err := ExposeControllerApplication(s.pool)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *upgradesSuite) TestPopulateApplicationStorageUniqueID(c *gc.C) {
 	state1 := s.makeModel(c, "m1", coretesting.Attrs{}, ModelArgs{Type: ModelTypeCAAS})
 	state2 := s.makeModel(c, "m2", coretesting.Attrs{}, ModelArgs{Type: ModelTypeCAAS})


### PR DESCRIPTION
It's possible to bootstrap juju 3.6 and the controller app fails to deploy.
There's an upgrade step - ExposeControllerApplication - that expects it to be there and fails if not.
This PR skips the step if the controller app is missing.

## QA steps

make microk8s-operator-update
juju bootstrap microk8s test --config charmhub-url=https://localhost

Run a script to directly update the target agent version.
[k8supgrade.sh](https://github.com/user-attachments/files/28816859/k8supgrade.sh)

## Links

**Issue:** Fixes #22621.

**Jira card:** [JUJU-10002](https://warthogs.atlassian.net/browse/JUJU-10002)


[JUJU-10002]: https://warthogs.atlassian.net/browse/JUJU-10002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ