### PR TITLE
fix: restore removed modeloperator manifolds

### DIFF
--- a/cmd/jujud/agent/model.go
+++ b/cmd/jujud/agent/model.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/names/v6"
+	"github.com/juju/utils/v4/voyeur"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/dependency"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/agent/engine"
+	agenterrors "github.com/juju/juju/agent/errors"
+	"github.com/juju/juju/caas"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/cmd"
+	"github.com/juju/juju/cmd/internal/agent/agentconf"
+	"github.com/juju/juju/cmd/jujud/agent/modeloperator"
+	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	jujuversion "github.com/juju/juju/core/version"
+	internaldependency "github.com/juju/juju/internal/dependency"
+	internallogger "github.com/juju/juju/internal/logger"
+	caasprovider "github.com/juju/juju/internal/provider/kubernetes"
+	caasconstants "github.com/juju/juju/internal/provider/kubernetes/constants"
+	"github.com/juju/juju/internal/upgrade"
+	internalworker "github.com/juju/juju/internal/worker"
+	"github.com/juju/juju/internal/worker/gate"
+	"github.com/juju/juju/internal/worker/logsender"
+)
+
+// ModelCommand is a cmd.Command responsible for running a model agent.
+type ModelCommand struct {
+	agentconf.AgentConf
+	cmd.CommandBase
+	configChangedVal *voyeur.Value
+	dead             chan struct{}
+	errReason        error
+	ModelUUID        string
+	runner           *worker.Runner
+	upgradeStepsLock gate.Lock
+	bufferedLogger   *logsender.BufferedLogWriter
+}
+
+// Done signals the model agent is finished
+func (m *ModelCommand) Done(err error) {
+	m.errReason = err
+	close(m.dead)
+}
+
+// Info implements Command
+func (m *ModelCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:    "model",
+		Purpose: "run a juju model operator",
+	})
+}
+
+// Init initializers the command for running
+func (m *ModelCommand) Init(args []string) error {
+	if m.ModelUUID == "" {
+		return agenterrors.RequiredError("model-uuid")
+	}
+
+	if err := m.AgentConf.CheckArgs(args); err != nil {
+		return err
+	}
+
+	var err error
+	m.runner, err = worker.NewRunner(worker.RunnerParams{
+		Name:          "model",
+		IsFatal:       agenterrors.IsFatal,
+		MoreImportant: agenterrors.MoreImportant,
+		RestartDelay:  internalworker.RestartDelay,
+		Logger:        internalworker.WrapLogger(logger),
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// maybeCopyAgentConfig copies the read-only agent config template
+// to the writeable agent config file if the file doesn't yet exist.
+func (m *ModelCommand) maybeCopyAgentConfig() error {
+	err := m.ReadConfig(m.Tag().String())
+	if err == nil {
+		return nil
+	}
+	if !os.IsNotExist(errors.Cause(err)) {
+		logger.Errorf(context.TODO(), "reading initial agent config file: %v", err)
+		return errors.Trace(err)
+	}
+
+	templateFile := filepath.Join(agent.Dir(m.DataDir(), m.Tag()), caasconstants.TemplateFileNameAgentConf)
+	if err := copyFile(agent.ConfigPath(m.DataDir(), m.Tag()), templateFile); err != nil {
+		logger.Errorf(context.TODO(), "copying agent config file template: %v", err)
+		return errors.Trace(err)
+	}
+	return m.ReadConfig(m.Tag().String())
+}
+
+// NewModelCommand creates a new ModelCommand instance properly initialized
+func NewModelCommand(
+	bufferedLogger *logsender.BufferedLogWriter,
+) *ModelCommand {
+	return &ModelCommand{
+		AgentConf:        agentconf.NewAgentConf(""),
+		configChangedVal: voyeur.NewValue(true),
+		dead:             make(chan struct{}),
+		bufferedLogger:   bufferedLogger,
+	}
+}
+
+// Run implements Command
+func (m *ModelCommand) Run(ctx *cmd.Context) error {
+	logger.Infof(ctx, "caas model operator start (%s [%s])", jujuversion.Current,
+		runtime.Compiler)
+
+	if err := m.maybeCopyAgentConfig(); err != nil {
+		return errors.Annotate(err, "creating agent config from template")
+	}
+
+	m.upgradeStepsLock = upgrade.NewLock(m.CurrentConfig(), jujuversion.Current)
+
+	_ = m.runner.StartWorker(ctx, "modeloperator", m.Workers)
+	return cmdutil.AgentDone(logger, m.runner.Wait())
+}
+
+// SetFlags implements Command
+func (m *ModelCommand) SetFlags(f *gnuflag.FlagSet) {
+	m.AgentConf.AddFlags(f)
+	f.StringVar(&m.ModelUUID, "model-uuid", "", "uuid of the model")
+}
+
+// Stop implements worker
+func (m *ModelCommand) Stop() error {
+	m.runner.Kill()
+	return m.Wait()
+}
+
+func (m *ModelCommand) Tag() names.Tag {
+	return names.NewModelTag(m.ModelUUID)
+}
+
+func (m *ModelCommand) Wait() error {
+	<-m.dead
+	return m.errReason
+}
+
+func (m *ModelCommand) Workers(_ context.Context) (worker.Worker, error) {
+	port := os.Getenv(caasprovider.EnvModelAgentHTTPPort)
+	if port == "" {
+		return nil, errors.NotValidf("env %s missing", caasprovider.EnvModelAgentHTTPPort)
+	}
+
+	svcName := os.Getenv(caasprovider.EnvModelAgentCAASServiceName)
+	if svcName == "" {
+		return nil, errors.NotValidf("env %s missing", caasprovider.EnvModelAgentCAASServiceName)
+	}
+
+	svcNamespace := os.Getenv(caasprovider.EnvModelAgentCAASServiceNamespace)
+	if svcNamespace == "" {
+		return nil, errors.NotValidf("env %s missing", caasprovider.EnvModelAgentCAASServiceNamespace)
+	}
+
+	updateAgentConfLogging := func(loggingConfig string) error {
+		return m.AgentConf.ChangeConfig(func(setter agent.ConfigSetter) error {
+			setter.SetLoggingConfig(loggingConfig)
+			return nil
+		})
+	}
+
+	manifolds := modeloperator.Manifolds(modeloperator.ManifoldConfig{
+		Agent:                  agent.APIHostPortsSetter{Agent: m},
+		AgentConfigChanged:     m.configChangedVal,
+		NewContainerBrokerFunc: caas.New,
+		Port:                   port,
+		LogSource:              m.bufferedLogger.Logs(),
+		ServiceName:            svcName,
+		ServiceNamespace:       svcNamespace,
+		UpdateLoggerConfig:     updateAgentConfLogging,
+		PreviousAgentVersion:   m.CurrentConfig().UpgradedToVersion(),
+		UpgradeStepsLock:       m.upgradeStepsLock,
+	})
+
+	// TODO (stickupkid): There is no Prometheus registry at this level, we
+	// should work out the best way to get it into here.
+	e, err := dependency.NewEngine(engine.DependencyEngineConfig(
+		dependency.DefaultMetrics(),
+		internaldependency.WrapLogger(internallogger.GetLogger("juju.worker.dependency")),
+	))
+	if err != nil {
+		return nil, err
+	}
+	if err := dependency.Install(e, manifolds); err != nil {
+		if err := worker.Stop(e); err != nil {
+			logger.Errorf(context.TODO(), "while stopping engine with bad manifolds: %v", err)
+		}
+		return nil, err
+	}
+
+	return e, nil
+}

--- a/cmd/jujud/agent/modeloperator/doc.go
+++ b/cmd/jujud/agent/modeloperator/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package modeloperator provides the agent configuration for a Juju model
+// operator running inside a CAAS (Kubernetes) cluster.
+//
+// A model operator is a dedicated Juju agent deployed as a pod within the
+// Kubernetes namespace allocated to a CAAS model -- one operator per model.
+// It acts as the in-cluster representative of the model, bridging the Juju
+// controller (which may be external to the cluster) with the Kubernetes
+// namespace where the model's application workloads run. The model operator
+// carries the model's own agent identity, separate from unit and application
+// agents, and is provisioned automatically by the controller whenever a CAAS
+// model is active.
+//
+// See github.com/juju/juju/internal/worker/caasmodeloperator for the
+// controller-side worker that provisions model operator deployments in
+// Kubernetes. See github.com/juju/juju/caas for the broker interface that
+// manages the model operator lifecycle.
+package modeloperator

--- a/cmd/jujud/agent/modeloperator/manifolds.go
+++ b/cmd/jujud/agent/modeloperator/manifolds.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modeloperator
+
+import (
+	"github.com/juju/utils/v4/voyeur"
+	"github.com/juju/worker/v5/dependency"
+
+	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/core/semversion"
+	internallogger "github.com/juju/juju/internal/logger"
+	"github.com/juju/juju/internal/worker/agent"
+	"github.com/juju/juju/internal/worker/apicaller"
+	"github.com/juju/juju/internal/worker/apiconfigwatcher"
+	"github.com/juju/juju/internal/worker/apiservercertwatcher"
+	"github.com/juju/juju/internal/worker/caasadmission"
+	"github.com/juju/juju/internal/worker/caasbroker"
+	"github.com/juju/juju/internal/worker/caasrbacmapper"
+	"github.com/juju/juju/internal/worker/caasupgrader"
+	"github.com/juju/juju/internal/worker/gate"
+	"github.com/juju/juju/internal/worker/logger"
+	"github.com/juju/juju/internal/worker/logsender"
+	"github.com/juju/juju/internal/worker/muxhttpserver"
+)
+
+type ManifoldConfig struct {
+	// Agent contains the agent that will be wrapped and made available to
+	// its dependencies via a dependency.Engine.
+	Agent coreagent.Agent
+
+	// LogSource will be read from by the logsender component.
+	LogSource logsender.LogRecordCh
+
+	// AgentConfigChanged is set whenever the unit agent's config
+	// is updated.
+	AgentConfigChanged *voyeur.Value
+
+	// NewContainerBrokerFunc is a function opens a CAAS provider.
+	NewContainerBrokerFunc caas.NewContainerBrokerFunc
+	Port                   string
+	ServiceName            string
+	ServiceNamespace       string
+
+	// UpdateLoggerConfig is a function that will save the specified
+	// config value as the logging config in the agent.conf file.
+	UpdateLoggerConfig func(string) error
+
+	// PreviousAgentVersion passes through the version the unit
+	// agent was running before the current restart.
+	PreviousAgentVersion semversion.Number
+
+	// UpgradeStepsLock is passed to the upgrade steps gate to
+	// coordinate workers that shouldn't do anything until the
+	// upgrade-steps worker is done.
+	UpgradeStepsLock gate.Lock
+}
+
+// Manifolds return a set of co-configured manifolds covering the various
+// responsibilities of a model operator agent.
+func Manifolds(config ManifoldConfig) dependency.Manifolds {
+	return dependency.Manifolds{
+		agentName: agent.Manifold(config.Agent),
+
+		apiConfigWatcherName: apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
+			AgentName:          agentName,
+			AgentConfigChanged: config.AgentConfigChanged,
+			Logger:             internallogger.GetLogger("juju.worker.apiconfigwatcher"),
+		}),
+
+		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
+			AgentName:            agentName,
+			APIOpen:              api.Open,
+			APIConfigWatcherName: apiConfigWatcherName,
+			NewConnection:        apicaller.OnlyConnect,
+			Logger:               internallogger.GetLogger("juju.worker.apicaller"),
+		}),
+
+		// The log sender is a leaf worker that sends log messages to some
+		// API server, when configured so to do. We should only need one of
+		// these in a consolidated agent.
+		logSenderName: logsender.Manifold(logsender.ManifoldConfig{
+			APICallerName: apiCallerName,
+			LogSource:     config.LogSource,
+		}),
+
+		caasAdmissionName: caasadmission.Manifold(caasadmission.ManifoldConfig{
+			AgentName:        agentName,
+			AuthorityName:    certificateWatcherName,
+			BrokerName:       caasBrokerTrackerName,
+			Logger:           internallogger.GetLogger("juju.worker.caasadmission"),
+			MuxName:          modelHTTPServerName,
+			ServerInfoName:   modelHTTPServerName,
+			RBACMapperName:   caasRBACMapperName,
+			ServiceName:      config.ServiceName,
+			ServiceNamespace: config.ServiceNamespace,
+		}),
+
+		caasBrokerTrackerName: caasbroker.Manifold(caasbroker.ManifoldConfig{
+			APICallerName:          apiCallerName,
+			NewContainerBrokerFunc: config.NewContainerBrokerFunc,
+			Logger:                 internallogger.GetLogger("juju.worker.caas"),
+		}),
+
+		caasRBACMapperName: caasrbacmapper.Manifold(
+			caasrbacmapper.ManifoldConfig{
+				BrokerName: caasBrokerTrackerName,
+				Logger:     internallogger.GetLogger("juju.worker.caasrbacmapper"),
+			},
+		),
+
+		certificateWatcherName: apiservercertwatcher.Manifold(apiservercertwatcher.ManifoldConfig{
+			AgentName:           agentName,
+			CertWatcherWorkerFn: apiservercertwatcher.NewAuthorityWorker,
+		}),
+
+		// The logging config updater is a leaf worker that indirectly
+		// controls the messages sent via the log sender or rsyslog,
+		// according to changes in model config. We should only need
+		// one of these in a consolidated agent.
+		loggingConfigUpdaterName: logger.Manifold(logger.ManifoldConfig{
+			AgentName:       agentName,
+			APICallerName:   apiCallerName,
+			LoggerContext:   internallogger.DefaultContext(),
+			Logger:          internallogger.GetLogger("juju.worker.loggerconfig"),
+			UpdateAgentFunc: config.UpdateLoggerConfig,
+		}),
+
+		modelHTTPServerName: muxhttpserver.Manifold(
+			muxhttpserver.ManifoldConfig{
+				AuthorityName: certificateWatcherName,
+				Logger:        internallogger.GetLogger("juju.worker.muxhttpserver"),
+				Port:          config.Port,
+			},
+		),
+
+		upgraderName: caasupgrader.Manifold(caasupgrader.ManifoldConfig{
+			AgentName:            agentName,
+			APICallerName:        apiCallerName,
+			UpgradeStepsGateName: upgradeStepsGateName,
+			PreviousAgentVersion: config.PreviousAgentVersion,
+		}),
+
+		upgradeStepsGateName: gate.ManifoldEx(config.UpgradeStepsLock),
+	}
+}
+
+const (
+	agentName                = "agent"
+	apiCallerName            = "api-caller"
+	apiConfigWatcherName     = "api-config-watcher"
+	caasAdmissionName        = "caas-admission"
+	caasBrokerTrackerName    = "caas-broker-tracker"
+	caasRBACMapperName       = "caas-rbac-mapper"
+	certificateWatcherName   = "certificate-watcher"
+	loggingConfigUpdaterName = "logging-config-updater"
+	modelHTTPServerName      = "model-http-server"
+	upgraderName             = "upgrader"
+	upgradeStepsGateName     = "upgrade-steps-gate"
+	logSenderName            = "log-sender"
+)

--- a/cmd/jujud/agent/modeloperator/manifolds.go
+++ b/cmd/jujud/agent/modeloperator/manifolds.go
@@ -26,6 +26,8 @@ import (
 	"github.com/juju/juju/internal/worker/muxhttpserver"
 )
 
+// ManifoldConfig holds the configuration required to build the set of
+// manifolds that form a model operator agent.
 type ManifoldConfig struct {
 	// Agent contains the agent that will be wrapped and made available to
 	// its dependencies via a dependency.Engine.
@@ -40,9 +42,16 @@ type ManifoldConfig struct {
 
 	// NewContainerBrokerFunc is a function opens a CAAS provider.
 	NewContainerBrokerFunc caas.NewContainerBrokerFunc
-	Port                   string
-	ServiceName            string
-	ServiceNamespace       string
+
+	// Port is the port on which the model HTTP server will listen.
+	Port string
+
+	// ServiceName is the Kubernetes service name for the model operator.
+	ServiceName string
+
+	// ServiceNamespace is the Kubernetes namespace in which the model
+	// operator service resides.
+	ServiceNamespace string
 
 	// UpdateLoggerConfig is a function that will save the specified
 	// config value as the logging config in the agent.conf file.

--- a/cmd/jujud/agent/modeloperator/manifolds_test.go
+++ b/cmd/jujud/agent/modeloperator/manifolds_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modeloperator_test
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/agent/agenttest"
+	"github.com/juju/juju/cmd/jujud/agent/modeloperator"
+	"github.com/juju/juju/internal/testing"
+)
+
+type ManifoldsSuite struct {
+	testing.BaseSuite
+}
+
+func TestManifoldsSuite(t *stdtesting.T) {
+	tc.Run(t, &ManifoldsSuite{})
+}
+
+type fakeAgent struct {
+	agent.Agent
+}
+
+func (s *ManifoldsSuite) TestStartFuncs(c *tc.C) {
+	manifolds := modeloperator.Manifolds(modeloperator.ManifoldConfig{
+		Agent: fakeAgent{},
+	})
+
+	for name, manifold := range manifolds {
+		c.Logf("checking %q manifold", name)
+		c.Check(manifold.Start, tc.NotNil)
+	}
+}
+
+func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
+	manifolds := modeloperator.Manifolds(modeloperator.ManifoldConfig{Agent: &fakeAgent{}})
+	keys := make([]string, 0, len(manifolds))
+	for k := range manifolds {
+		keys = append(keys, k)
+	}
+
+	c.Check(keys, tc.SameContents, []string{
+		"caas-broker-tracker",
+		"api-caller",
+		"log-sender",
+		"caas-admission",
+		"caas-rbac-mapper",
+		"certificate-watcher",
+		"logging-config-updater",
+		"agent",
+		"api-config-watcher",
+		"upgrade-steps-gate",
+		"model-http-server",
+		"upgrader",
+	})
+}
+
+func (s *ManifoldsSuite) TestManifoldsDependencies(c *tc.C) {
+	agenttest.AssertManifoldsDependencies(c,
+		modeloperator.Manifolds(modeloperator.ManifoldConfig{
+			Agent: &fakeAgent{},
+		}),
+		expectedManifoldsWithDependencies,
+	)
+}
+
+var expectedManifoldsWithDependencies = map[string][]string{
+
+	"caas-broker-tracker": {"agent", "api-caller", "api-config-watcher"},
+
+	"api-caller": {"agent", "api-config-watcher"},
+
+	"log-sender": {"agent", "api-caller", "api-config-watcher"},
+
+	"caas-admission": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"caas-broker-tracker",
+		"caas-rbac-mapper",
+		"certificate-watcher",
+		"model-http-server",
+	},
+
+	"caas-rbac-mapper": {"agent", "api-caller", "api-config-watcher", "caas-broker-tracker"},
+
+	"certificate-watcher": {"agent"},
+
+	"logging-config-updater": {"agent", "api-caller", "api-config-watcher"},
+
+	"agent": {},
+
+	"api-config-watcher": {"agent"},
+
+	"upgrade-steps-gate": {},
+
+	"model-http-server": {"agent", "certificate-watcher"},
+
+	"upgrader": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"upgrade-steps-gate",
+	},
+}

--- a/cmd/jujud/run.go
+++ b/cmd/jujud/run.go
@@ -44,6 +44,7 @@ import (
 	"github.com/juju/juju/internal/upgrades"
 	"github.com/juju/juju/internal/worker/dbaccessor"
 	"github.com/juju/juju/internal/worker/dbreplaccessor"
+	"github.com/juju/juju/internal/worker/logsender"
 	"github.com/juju/juju/internal/worker/uniter/runner/jujuc"
 	jujunames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/juju/osenv"
@@ -74,6 +75,13 @@ const (
 	ExitStatusCodeErr = 2
 	// ExitStatusCodePanic is the value that is returned when we exit due to an unhandled panic.
 	ExitStatusCodePanic = 3
+
+	// bufferedLogWriterMaxLength is the maximum number of bytes that the
+	// buffered log writer will keep in memory before it starts dropping
+	// log messages. This is a safeguard to prevent unbounded memory usage
+	// if the agent produces a large amount of log output before the unit
+	// agent can read it.
+	bufferedLogWriterMaxLength = 1048576
 )
 
 func getenv(name string) (string, error) {
@@ -249,6 +257,12 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	jujud.Log.NewWriter = func(target io.Writer) loggo.Writer {
 		return &jujudWriter{target: target}
 	}
+
+	bufferedLogger, err := logsender.InstallBufferedLogWriter(loggo.DefaultContext(), bufferedLogWriterMaxLength)
+	if err != nil {
+		return 1, errors.Trace(err)
+	}
+	jujud.Register(agentcmd.NewModelCommand(bufferedLogger))
 
 	jujud.Register(agentcmd.NewBootstrapCommand())
 


### PR DESCRIPTION
model operator manifolds were mistakenly removed in #22317

The removal left Kubernetes model operator pods starting with
`jujud model`, but the corresponding command/manifolds were no longer
present, causing modeloperator to crashloop on bootstrap.

This PR reverts the removal.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap on microk8s:

```sh
❯ make go-install
❯ make microk8s-operator-update

❯ juju bootstrap microk8s src
❯ juju add-model m
❯ juju deploy juju-qa-test
```

Verify juju:

```sh
❯ jst -m controller
Model       Controller  Cloud/Region        Version    Timestamp
controller  src         microk8s/localhost  4.1-beta2  14:03:49+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Address         Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  10.152.183.196  no

Unit           Workload  Agent  Address      Ports            Message
controller/0*  active    idle   10.1.180.90  17022,17070/tcp

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer

❯ jst
Model  Controller  Cloud/Region        Version    Timestamp
m      src         microk8s/localhost  4.1-beta2  14:03:53+02:00

App           Version  Status  Scale  Charm         Channel        Rev  Address         Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   25  10.152.183.147  no       hello

Unit             Workload  Agent  Address      Ports  Message
juju-qa-test/0*  active    idle   10.1.180.67         hello
```

Verify kubernetes:

```sh
❯ kubectl get pods -n controller-src
NAME                             READY   STATUS    RESTARTS   AGE
controller-0                     2/2     Running   0          109s
modeloperator-74b75654bb-h6c78   1/1     Running   0          94s

❯ kubectl get pods -n m
NAME                             READY   STATUS    RESTARTS   AGE
juju-qa-test-0                   1/1     Running   0          62s
modeloperator-659d8fd7b4-c7zz9   1/1     Running   0          82s
```


## Documentation changes


## Links

