### PR TITLE
fix: guard against cloud init overwriting agent.conf on reboot

### DIFF
--- a/cloudconfig/userdatacfg.go
+++ b/cloudconfig/userdatacfg.go
@@ -96,7 +96,9 @@ func (c *baseConfigure) addAgentInfo(tag names.Tag) (agent.Config, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to write commands")
 	}
+	c.conf.AddScripts(fmt.Sprintf("if [ ! -e %s ]; then", shquote(agent.ConfigPath(c.icfg.DataDir, tag))))
 	c.conf.AddScripts(cmds...)
+	c.conf.AddScripts("fi")
 	return acfg, nil
 }
 

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -660,10 +660,12 @@ func (*cloudinitSuite) TestCloudInitWithLocalControllerCharmDir(c *gc.C) {
 
 	cfg := makeBootstrapConfig(jammy, 0).setControllerCharm(controllerCharmPath)
 	base64Content := base64.StdEncoding.EncodeToString(content)
-	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`chmod 0600 '/var/lib/juju/agents/machine-0/agent.conf'
+	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`if [ ! -e %s ]; then
+chmod 0600 '/var/lib/juju/agents/machine-0/agent.conf'
+fi
 install -D -m 644 /dev/null '/var/lib/juju/charms/controller.charm'
 echo -n %s | base64 -d > '/var/lib/juju/charms/controller.charm'
-`, base64Content))
+`, "'/var/lib/juju/agents/machine-0/agent.conf'", base64Content))
 	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 }
 
@@ -684,10 +686,12 @@ func (*cloudinitSuite) TestCloudInitWithLocalControllerCharmArchive(c *gc.C) {
 
 	cfg := makeBootstrapConfig(jammy, 0).setControllerCharm(controllerCharmPath)
 	base64Content := base64.StdEncoding.EncodeToString(content)
-	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`chmod 0600 '/var/lib/juju/agents/machine-0/agent.conf'
+	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`if [ ! -e %s ]; then
+chmod 0600 '/var/lib/juju/agents/machine-0/agent.conf'
+fi
 install -D -m 644 /dev/null '/var/lib/juju/charms/controller.charm'
 echo -n %s | base64 -d > '/var/lib/juju/charms/controller.charm'
-`, base64Content))
+`, "'/var/lib/juju/agents/machine-0/agent.conf'", base64Content))
 	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 }
 


### PR DESCRIPTION
We have had reports over the years of juju agents showing as down "for no reason".  A recent bug report showed how to reproduce something with the same symptoms deterministically. Essentially:

- bootstrap lxd
- deploy a charm
- add a nic to the lxd instance
- reboot the instance

What is looks like is that adding the nic changes the instance-id. Thus on reboot, cloud it runs the per-instance scripts again. When Juju creates the seed agent.conf for bootstrap, it just contains the oldpassword and first connect sets up the connection properly and fills in apipassword etc. The reboot resets the agent.conf back to the initial pre-bootstrap value and login auth is broken.

This can be seem by looking at `/var/lib/cloud/instances` and seeing there's now a second instance UUID. And the user-data.txt contains the juju generated script to write the initial agent.conf.

The simplest fix I could think of was just to put a guard around the agent.conf creation. If it exists, leave it alone. This stops cloud init replacing a valid agent.conf with a bad one on bootstrap.

ie
```
- if [ ! -e '/var/lib/juju/agents/machine-1/agent.conf' ]; then
- mkdir -p '/var/lib/juju/agents/machine-1'
- |-
  cat > '/var/lib/juju/agents/machine-1/agent.conf' << 'EOF'
  # format 2.0
...
- fi
```

This could be the root cause of similar issues on other clouds perhaps?

## QA steps

From the bug report:
bootstrap lxd and add a model

```
juju deploy ubuntu
# retrieve the newly created machine's name
MACHINE=$(juju machines --format yaml | grep instance | awk '{ print $2 }')

# add with LXD the network interface to the VM/container 
lxc config device add $MACHINE eth1 nic name=eth1 nictype=bridged parent=lxdbr1

# Add a configuration on netplan, to have the supplementary IP
juju ssh 0 "cat <<EOF | sudo tee /etc/netplan/100-cfg.yaml
network:
  version: 2
  ethernets:
    eth1:
      dhcp4: true
      dhcp4-overrides:
        use-routes: false
      dhcp6: false
EOF"
# apply the network config
juju ssh 0 "sudo netplan apply"
```

The issue shows up you reboot twice.

With the fix, you can reboot forever and nothing breaks. And you can verify the agent.conf is untouched.

## Links

**Issue:** Fixes #22133.

**Jira card:** [JUJU-9626](https://warthogs.atlassian.net/browse/JUJU-9626)


[JUJU-9626]: https://warthogs.atlassian.net/browse/JUJU-9626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ