### PR TITLE
fix: db repl

### DIFF
--- a/cmd/jujud-controller/agent/dbrepl.go
+++ b/cmd/jujud-controller/agent/dbrepl.go
@@ -33,6 +33,7 @@ import (
 	k8sconstants "github.com/juju/juju/internal/provider/kubernetes/constants"
 	internalworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/dbreplaccessor"
+	"github.com/juju/juju/internal/worker/gate"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -215,6 +216,8 @@ type replMachineAgent struct {
 
 	newDBReplWorkerFunc dbreplaccessor.NewDBReplWorkerFunc
 
+	controllerUnlocker gate.Lock
+
 	isCaasAgent bool
 }
 
@@ -247,6 +250,9 @@ func (a *replMachineAgent) Run(ctx *cmd.Context) (err error) {
 	agentConfig := a.CurrentConfig()
 
 	agentconf.SetupAgentLogging(internallogger.DefaultContext(), agentConfig)
+
+	a.controllerUnlocker = gate.NewLock()
+	a.controllerUnlocker.Unlock()
 
 	createEngine := a.makeEngineCreator(ctx.Stdout, ctx.Stderr, ctx.Stdin)
 	_ = a.runner.StartWorker(ctx, "engine", createEngine)
@@ -292,6 +298,7 @@ func (a *replMachineAgent) makeEngineCreator(
 			Agent:               agent.APIHostPortsSetter{Agent: a},
 			AgentConfigChanged:  a.configChangedVal,
 			NewDBReplWorkerFunc: a.newDBReplWorkerFunc,
+			ControllerUnlocker:  a.controllerUnlocker,
 			Clock:               clock.WallClock,
 
 			Stdout: stdout,

--- a/cmd/jujud-controller/agent/dbrepl/manifolds.go
+++ b/cmd/jujud-controller/agent/dbrepl/manifolds.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/internal/worker/controlleragentconfig"
 	"github.com/juju/juju/internal/worker/dbrepl"
 	"github.com/juju/juju/internal/worker/dbreplaccessor"
+	"github.com/juju/juju/internal/worker/gate"
 	"github.com/juju/juju/internal/worker/stateconfigwatcher"
 	"github.com/juju/juju/internal/worker/terminationworker"
 )
@@ -36,6 +37,12 @@ type ManifoldsConfig struct {
 
 	// NewDBReplWorkerFunc returns a tracked db worker.
 	NewDBReplWorkerFunc dbreplaccessor.NewDBReplWorkerFunc
+
+	// ControllerUnlocker is passed to allow the controller agent config
+	// manifold to unlock the controller agent config ready lock when the
+	// controller agent config is ready. This isn't strictly required for
+	// the db-repl, but it is a dependency.
+	ControllerUnlocker gate.Lock
 
 	// Clock supplies timekeeping services to various workers.
 	Clock clock.Clock
@@ -93,6 +100,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:            internallogger.GetLogger("juju.worker.controlleragentconfig"),
 			NewSocketListener: controlleragentconfig.NewSocketListener,
 			SocketName:        path.Join(agentConfig.DataDir(), "configchange.socket"),
+			ReadyUnlocker:     config.ControllerUnlocker,
 		})),
 
 		// The db-repl manifold is responsible for managing the


### PR DESCRIPTION
The DB repl was not considered when we implemented the fix for the control socket. So now the db repl was broken. This is the fix.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju ssh -m controller 0
$ juju_db_repl
```