### PR TITLE
refactor: wire the migration master worker with the modelmigration domain

### DIFF
--- a/api/controller/migrationmaster/client.go
+++ b/api/controller/migrationmaster/client.go
@@ -21,10 +21,7 @@ import (
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/resource"
-	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/core/watcher"
-	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -201,57 +198,6 @@ func (c *Client) Prechecks(ctx context.Context) error {
 	return c.caller.FacadeCall(ctx, "Prechecks", params.PrechecksArgs{}, nil)
 }
 
-// Export returns a serialized representation of the model associated
-// with the API connection. The charms used by the model are also
-// returned.
-func (c *Client) Export(ctx context.Context) (migration.SerializedModel, error) {
-	var empty migration.SerializedModel
-	var serialized params.SerializedModel
-	err := c.caller.FacadeCall(ctx, "Export", nil, &serialized)
-	if err != nil {
-		return empty, errors.Trace(err)
-	}
-
-	// Convert tools info to output map.
-	tools := make(map[string]semversion.Binary, len(serialized.Tools))
-	for _, toolsInfo := range serialized.Tools {
-		v, err := semversion.ParseBinary(toolsInfo.Version)
-		if err != nil {
-			return migration.SerializedModel{}, errors.Annotate(err, "error parsing agent binary version")
-		}
-		tools[toolsInfo.SHA256] = v
-	}
-
-	resources, err := convertResources(serialized.Resources)
-	if err != nil {
-		return empty, errors.Trace(err)
-	}
-
-	return migration.SerializedModel{
-		Bytes:     serialized.Bytes,
-		Charms:    serialized.Charms,
-		Tools:     tools,
-		Resources: resources,
-	}, nil
-}
-
-// ProcessRelations runs a series of processes to ensure that the relations
-// of a given model are correct after a migrated model.
-func (c *Client) ProcessRelations(ctx context.Context, controllerAlias string) error {
-	param := params.ProcessRelations{
-		ControllerAlias: controllerAlias,
-	}
-	var result params.ErrorResult
-	err := c.caller.FacadeCall(ctx, "ProcessRelations", param, &result)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if result.Error != nil {
-		return errors.Trace(result.Error)
-	}
-	return nil
-}
-
 // OpenResource downloads the named resource for an application.
 func (c *Client) OpenResource(ctx context.Context, application, name string) (io.ReadCloser, error) {
 	httpClient, err := c.httpClientFactory(base.HTTPClientScopeModel)
@@ -377,52 +323,4 @@ func groupTagIds(tagStrs []string) ([]string, []string, []string, error) {
 		}
 	}
 	return machines, units, applications, nil
-}
-
-func convertResources(in []params.SerializedModelResource) ([]resource.Resource, error) {
-	if len(in) == 0 {
-		return nil, nil
-	}
-	out := make([]resource.Resource, 0, len(in))
-	for _, resource := range in {
-		outResource, err := convertResource(resource)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		out = append(out, outResource)
-	}
-	return out, nil
-}
-
-func convertResource(res params.SerializedModelResource) (resource.Resource, error) {
-	var empty resource.Resource
-	type_, err := charmresource.ParseType(res.Type)
-	if err != nil {
-		return empty, errors.Trace(err)
-	}
-	origin, err := charmresource.ParseOrigin(res.Origin)
-	if err != nil {
-		return empty, errors.Trace(err)
-	}
-	var fp charmresource.Fingerprint
-	if res.FingerprintHex != "" {
-		if fp, err = charmresource.ParseFingerprint(res.FingerprintHex); err != nil {
-			return empty, errors.Annotate(err, "invalid fingerprint")
-		}
-	}
-	return resource.Resource{
-		Resource: charmresource.Resource{
-			Meta: charmresource.Meta{
-				Name: res.Name,
-				Type: type_,
-			},
-			Origin:      origin,
-			Revision:    res.Revision,
-			Size:        res.Size,
-			Fingerprint: fp,
-		},
-		ApplicationName: res.Application,
-		RetrievedBy:     res.Username,
-		Timestamp:       res.Timestamp,
-	}, nil
 }

--- a/api/controller/migrationmaster/client_test.go
+++ b/api/controller/migrationmaster/client_test.go
@@ -24,10 +24,8 @@ import (
 	apitesting "github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/controller/migrationmaster"
 	"github.com/juju/juju/core/migration"
-	"github.com/juju/juju/core/resource"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/core/watcher"
-	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
 	"github.com/juju/juju/internal/testhelpers"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/uuid"
@@ -287,99 +285,6 @@ func (s *ClientSuite) TestPrechecks(c *tc.C) {
 	stub.CheckCalls(c, []testhelpers.StubCall{
 		{FuncName: "MigrationMaster.Prechecks", Args: []any{"", expectedArg}},
 	})
-}
-
-func (s *ClientSuite) TestProcessRelations(c *tc.C) {
-	var stub testhelpers.Stub
-	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result any) error {
-		stub.AddCall(objType+"."+request, id, arg)
-		return nil
-	})
-
-	client := migrationmaster.NewClient(apiCaller, nil)
-	err := client.ProcessRelations(c.Context(), "foo")
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *ClientSuite) TestProcessRelationsError(c *tc.C) {
-	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, any, any) error {
-		return errors.New("blam")
-	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	err := client.ProcessRelations(c.Context(), "foo")
-	c.Assert(err, tc.ErrorMatches, "blam")
-}
-
-func (s *ClientSuite) TestExport(c *tc.C) {
-	var stub testhelpers.Stub
-
-	fpHash := charmresource.NewFingerprintHash()
-	appFp := fpHash.Fingerprint()
-
-	appTs := time.Now()
-
-	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result any) error {
-		stub.AddCall(objType+"."+request, id, arg)
-		out := result.(*params.SerializedModel)
-		*out = params.SerializedModel{
-			Bytes:  []byte("foo"),
-			Charms: []string{"ch:foo-1"},
-			Tools: []params.SerializedModelTools{{
-				Version: "2.0.0-ubuntu-amd64",
-				URI:     "/tools/0",
-				SHA256:  "439c9ea02f8561c5a152d7cf4818d72cd5f2916b555d82c5eee599f5e8f3d09e",
-			}},
-			Resources: []params.SerializedModelResource{{
-				Application:    "fooapp",
-				Name:           "bin",
-				Revision:       2,
-				Type:           "file",
-				Origin:         "upload",
-				FingerprintHex: appFp.Hex(),
-				Size:           123,
-				Timestamp:      appTs,
-				Username:       "bob",
-			}},
-		}
-		return nil
-	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	out, err := client.Export(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-	stub.CheckCalls(c, []testhelpers.StubCall{
-		{FuncName: "MigrationMaster.Export", Args: []any{"", nil}},
-	})
-	c.Assert(out, tc.DeepEquals, migration.SerializedModel{
-		Bytes:  []byte("foo"),
-		Charms: []string{"ch:foo-1"},
-		Tools: map[string]semversion.Binary{
-			"439c9ea02f8561c5a152d7cf4818d72cd5f2916b555d82c5eee599f5e8f3d09e": semversion.MustParseBinary("2.0.0-ubuntu-amd64"),
-		},
-		Resources: []resource.Resource{{
-			Resource: charmresource.Resource{
-				Meta: charmresource.Meta{
-					Name: "bin",
-					Type: charmresource.TypeFile,
-				},
-				Origin:      charmresource.OriginUpload,
-				Revision:    2,
-				Fingerprint: appFp,
-				Size:        123,
-			},
-			ApplicationName: "fooapp",
-			RetrievedBy:     "bob",
-			Timestamp:       appTs,
-		}},
-	})
-}
-
-func (s *ClientSuite) TestExportError(c *tc.C) {
-	apiCaller := apitesting.APICallerFunc(func(string, int, string, string, any, any) error {
-		return errors.New("blam")
-	})
-	client := migrationmaster.NewClient(apiCaller, nil)
-	_, err := client.Export(c.Context())
-	c.Assert(err, tc.ErrorMatches, "blam")
 }
 
 const resourceContent = "resourceful"

--- a/api/controller/migrationtarget/client.go
+++ b/api/controller/migrationtarget/client.go
@@ -112,6 +112,19 @@ func (c *Client) Import(ctx context.Context, bytes []byte) error {
 	return errors.Trace(c.caller.FacadeCall(ctx, "Import", serialized, nil))
 }
 
+// PrechecksV2 asks the target controller to validate a SerializedModelV2
+// envelope ahead of Import. It requires the target to expose the
+// MigrationTarget v8 facade.
+func (c *Client) PrechecksV2(ctx context.Context, envelope params.SerializedModelV2) error {
+	return errors.Trace(c.caller.FacadeCall(ctx, "Prechecks", envelope, nil))
+}
+
+// ImportV2 imports a SerializedModelV2 envelope into the target controller.
+// It requires the target to expose the MigrationTarget v8 facade.
+func (c *Client) ImportV2(ctx context.Context, envelope params.SerializedModelV2) error {
+	return errors.Trace(c.caller.FacadeCall(ctx, "Import", envelope, nil))
+}
+
 // Abort removes all data relating to a previously imported model.
 func (c *Client) Abort(ctx context.Context, modelUUID string) error {
 	args := params.ModelArgs{ModelTag: names.NewModelTag(modelUUID).String()}

--- a/api/controller/migrationtarget/client_test.go
+++ b/api/controller/migrationtarget/client_test.go
@@ -103,6 +103,38 @@ func (s *ClientSuite) TestImport(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 
+func (s *ClientSuite) TestPrechecksV2(c *tc.C) {
+	client, stub := s.getClientAndStub()
+
+	envelope := params.SerializedModelV2{
+		PayloadVersion: semversion.MustParse("4.0.6"),
+		Payload:        []byte("payload"),
+		ModelInfo:      params.SerializedModelInfo{UUID: "uuid"},
+	}
+	err := client.PrechecksV2(c.Context(), envelope)
+
+	stub.CheckCalls(c, []testhelpers.StubCall{
+		{FuncName: "MigrationTarget.Prechecks", Args: []any{"", envelope}},
+	})
+	c.Assert(err, tc.ErrorMatches, "boom")
+}
+
+func (s *ClientSuite) TestImportV2(c *tc.C) {
+	client, stub := s.getClientAndStub()
+
+	envelope := params.SerializedModelV2{
+		PayloadVersion: semversion.MustParse("4.0.6"),
+		Payload:        []byte("payload"),
+		ModelInfo:      params.SerializedModelInfo{UUID: "uuid"},
+	}
+	err := client.ImportV2(c.Context(), envelope)
+
+	stub.CheckCalls(c, []testhelpers.StubCall{
+		{FuncName: "MigrationTarget.Import", Args: []any{"", envelope}},
+	})
+	c.Assert(err, tc.ErrorMatches, "boom")
+}
+
 func (s *ClientSuite) TestAbort(c *tc.C) {
 	client, stub := s.getClientAndStub()
 

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -70,12 +70,12 @@ var facadeVersions = facades.FacadeVersions{
 	// Note that this version of Juju does not implement version 10
 	// of the facade, but 3.6 does. Care must be taken not to break
 	// client compatibility with the prior version.
-	"MachineManager":               {10, 11},
-	"Machiner":                     {5, 6},
-	"MigrationFlag":                {1},
-	"MigrationMaster":              {4, 5},
-	"MigrationMinion":              {1},
-	"MigrationStatusWatcher":       {1},
+	"MachineManager":         {10, 11},
+	"Machiner":               {5, 6},
+	"MigrationFlag":          {1},
+	"MigrationMaster":        {4, 5},
+	"MigrationMinion":        {1},
+	"MigrationStatusWatcher": {1},
 	// Note that this version of Juju does not register version 8 of the
 	// MigrationTarget facade; it is the SerializedModelV2 import facade
 	// registered by 4.1+ targets. The migration master worker requires v8

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -76,7 +76,11 @@ var facadeVersions = facades.FacadeVersions{
 	"MigrationMaster":              {4, 5},
 	"MigrationMinion":              {1},
 	"MigrationStatusWatcher":       {1},
-	"MigrationTarget":              {4, 5, 6, 7},
+	// Note that this version of Juju does not register version 8 of the
+	// MigrationTarget facade; it is the SerializedModelV2 import facade
+	// registered by 4.1+ targets. The migration master worker requires v8
+	// to negotiate the new model migration path against those targets.
+	"MigrationTarget":              {4, 5, 6, 7, 8},
 	"ModelConfig":                  {3, 4},
 	"ModelManager":                 {9, 10, 11},
 	"ModelSummaryWatcher":          {1},

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -13,12 +13,10 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/internal"
-	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/leadership"
 	coremigration "github.com/juju/juju/core/migration"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
-	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/naturalsort"
 	"github.com/juju/juju/rpc/params"
@@ -279,17 +277,6 @@ func (api *API) SetStatusMessage(ctx context.Context, args params.SetMigrationSt
 	if err != nil {
 		return errors.Annotate(err, "failed to set status message")
 	}
-	return nil
-}
-
-// Export serializes the model associated with the API connection.
-func (api *API) Export(ctx context.Context) (params.SerializedModel, error) {
-	return params.SerializedModel{}, internalerrors.New("export not supported in this API version").Add(coreerrors.NotSupported)
-}
-
-// ProcessRelations processes any relations that need updating after an export.
-// This should help fix any remoteApplications that have been migrated.
-func (api *API) ProcessRelations(ctx context.Context, args params.ProcessRelations) error {
 	return nil
 }
 

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/migrationmaster/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/controller"
-	coreerrors "github.com/juju/juju/core/errors"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/semversion"
@@ -271,34 +270,6 @@ func (s *Suite) TestPrechecksModelError(c *tc.C) {
 
 	err := s.mustMakeAPI(c).Prechecks(c.Context(), params.PrechecksArgs{TargetControllerVersion: semversion.MustParse("2.9.32")})
 	c.Assert(err, tc.ErrorMatches, "retrieving model info: boom")
-}
-
-func (s *Suite) TestProcessRelations(c *tc.C) {
-	api := s.mustMakeAPI(c)
-	err := api.ProcessRelations(c.Context(), params.ProcessRelations{ControllerAlias: "foo"})
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *Suite) TestExportIAAS(c *tc.C) {
-	s.assertExport(c, "iaas")
-}
-
-func (s *Suite) TestExportCAAS(c *tc.C) {
-	s.model = description.NewModel(description.ModelArgs{
-		Type:               "caas",
-		Config:             map[string]any{"uuid": s.modelUUID},
-		Owner:              "admin",
-		LatestToolsVersion: jujuversion.Current.String(),
-	})
-	s.assertExport(c, "caas")
-}
-
-func (s *Suite) assertExport(c *tc.C, modelType string) {
-	defer s.setupMocks(c).Finish()
-
-	_, err := s.mustMakeAPI(c).Export(c.Context())
-	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
-
 }
 
 func (s *Suite) TestReap(c *tc.C) {

--- a/apiserver/facadeversions_test.go
+++ b/apiserver/facadeversions_test.go
@@ -53,6 +53,18 @@ func (s *facadeVersionSuite) TestFacadeVersionsMatchServerVersions(c *tc.C) {
 		sorted := set.NewInts(versions...).SortedValues()
 		apiFacadeVersions[name] = sorted[len(sorted)-1]
 	}
+	// clientAheadOfServer lists facades whose client deliberately advertises
+	// a newer version than this controller registers. The migration master
+	// worker needs MigrationTarget v8 to negotiate the SerializedModelV2
+	// migration path against 4.1+ targets, while this controller registers
+	// up to v7 (the v8 import facade lands in 4.1).
+	clientAheadOfServer := map[string]int{
+		"MigrationTarget": 8,
+	}
+	for name, version := range clientAheadOfServer {
+		c.Check(apiFacadeVersions[name], tc.Equals, version)
+		apiFacadeVersions[name] = serverFacadeBestVersions[name]
+	}
 	c.Check(apiFacadeVersions, tc.DeepEquals, serverFacadeBestVersions)
 }
 

--- a/core/migration/phase.go
+++ b/core/migration/phase.go
@@ -12,8 +12,7 @@ import (
 // ErrPhaseNotPersisted indicates a phase has no representation in the
 // model_migration_phase lookup table and therefore cannot be converted to or
 // from a persisted phase id. This covers the code-only sentinels UNKNOWN and
-// NONE, and the retired PROCESSRELATIONS phase, none of which are ever written
-// to the database.
+// NONE, none of which are ever written to the database.
 const ErrPhaseNotPersisted = errors.ConstError("migration phase is not persisted")
 
 // persistedPhaseIDs maps each migration phase to the primary key it is stored
@@ -21,9 +20,8 @@ const ErrPhaseNotPersisted = errors.ConstError("migration phase is not persisted
 // (domain/schema/controller/sql/0031-model-migration.PATCH.sql). It is the
 // single source of truth for Go<->SQL phase conversion. The mapping is explicit
 // and deliberately does NOT track the enum ordinal: the lookup omits the
-// code-only sentinels UNKNOWN/NONE and the retired PROCESSRELATIONS phase, so
-// the Go enum and the persisted ids must be reconciled by name/value here
-// rather than by position.
+// code-only sentinels UNKNOWN and NONE, so the Go enum and the persisted ids
+// must be reconciled by name/value here rather than by position.
 var persistedPhaseIDs = map[Phase]int{
 	QUIESCE:     1,
 	IMPORT:      2,
@@ -46,7 +44,6 @@ const (
 	NONE
 	QUIESCE
 	IMPORT
-	PROCESSRELATIONS
 	VALIDATION
 	SUCCESS
 	LOGTRANSFER
@@ -62,7 +59,6 @@ var phaseNames = []string{
 	"NONE",    // For watchers to indicate there's never been a migration attempt.
 	"QUIESCE",
 	"IMPORT",
-	"PROCESSRELATIONS",
 	"VALIDATION",
 	"SUCCESS",
 	"LOGTRANSFER",
@@ -143,13 +139,13 @@ func (p Phase) IsPostSuccess() bool {
 // The keys are the "from" states and the values enumerate the
 // possible "to" states.
 var validTransitions = map[Phase][]Phase{
-	QUIESCE:    {IMPORT, ABORT},
-	IMPORT:     {VALIDATION, ABORT},
-	VALIDATION: {SUCCESS, ABORT},
-	SUCCESS:          {LOGTRANSFER},
-	LOGTRANSFER:      {REAP},
-	REAP:             {DONE, REAPFAILED},
-	ABORT:            {ABORTDONE},
+	QUIESCE:     {IMPORT, ABORT},
+	IMPORT:      {VALIDATION, ABORT},
+	VALIDATION:  {SUCCESS, ABORT},
+	SUCCESS:     {LOGTRANSFER},
+	LOGTRANSFER: {REAP},
+	REAP:        {DONE, REAPFAILED},
+	ABORT:       {ABORTDONE},
 }
 
 var terminalPhases []Phase
@@ -177,9 +173,9 @@ func ParsePhase(target string) (Phase, bool) {
 
 // PhasePersistedID returns the primary key under which the phase is stored in
 // the model_migration_phase lookup table. Phases that are never persisted
-// (UNKNOWN, NONE and the retired PROCESSRELATIONS) return ErrPhaseNotPersisted.
-// Callers that persist or read the current migration phase must use this
-// conversion rather than the enum ordinal or Phase.String().
+// (UNKNOWN and NONE) return ErrPhaseNotPersisted. Callers that persist or read
+// the current migration phase must use this conversion rather than the enum
+// ordinal or Phase.String().
 func PhasePersistedID(p Phase) (int, error) {
 	id, ok := persistedPhaseIDs[p]
 	if !ok {

--- a/core/migration/phase.go
+++ b/core/migration/phase.go
@@ -77,7 +77,6 @@ var phaseNames = []string{
 func SuccessfulMigrationPhases() []Phase {
 	return []Phase{
 		IMPORT,
-		PROCESSRELATIONS,
 		VALIDATION,
 		SUCCESS,
 		LOGTRANSFER,
@@ -120,7 +119,7 @@ func (p Phase) IsRunning() bool {
 		return false
 	}
 	switch p {
-	case QUIESCE, IMPORT, PROCESSRELATIONS, VALIDATION, SUCCESS:
+	case QUIESCE, IMPORT, VALIDATION, SUCCESS:
 		return true
 	default:
 		return false
@@ -144,17 +143,9 @@ func (p Phase) IsPostSuccess() bool {
 // The keys are the "from" states and the values enumerate the
 // possible "to" states.
 var validTransitions = map[Phase][]Phase{
-	QUIESCE: {IMPORT, ABORT},
-	// VALIDATION is the new-path successor of IMPORT: PROCESSRELATIONS is
-	// retired (it has no actions attached and no persisted lookup row, see
-	// PhasePersistedID). The PROCESSRELATIONS edges are retained transitionally
-	// so the legacy migrationmaster worker, which still emits PROCESSRELATIONS,
-	// keeps a non-terminal phase to walk through until it is rewritten to drive
-	// the de-stubbed domain service directly. New-path callers go
-	// IMPORT -> VALIDATION and never set PROCESSRELATIONS.
-	IMPORT:           {VALIDATION, PROCESSRELATIONS, ABORT},
-	PROCESSRELATIONS: {VALIDATION, ABORT},
-	VALIDATION:       {SUCCESS, ABORT},
+	QUIESCE:    {IMPORT, ABORT},
+	IMPORT:     {VALIDATION, ABORT},
+	VALIDATION: {SUCCESS, ABORT},
 	SUCCESS:          {LOGTRANSFER},
 	LOGTRANSFER:      {REAP},
 	REAP:             {DONE, REAPFAILED},

--- a/core/migration/phase_internal_test.go
+++ b/core/migration/phase_internal_test.go
@@ -29,12 +29,9 @@ func (s *PhaseInternalSuite) TestForUnused(c *tc.C) {
 		}
 	}
 
-	// PROCESSRELATIONS is retired (no transition edges) but kept in the enum
-	// for wire/string compatibility.
 	specialPhases := set.NewStrings(
 		UNKNOWN.String(),
 		NONE.String(),
-		PROCESSRELATIONS.String(),
 	)
 	allValidPhases := set.NewStrings(phaseNames...).Difference(specialPhases)
 	c.Check(allValidPhases.Difference(usedPhases), tc.HasLen, 0)

--- a/core/migration/phase_internal_test.go
+++ b/core/migration/phase_internal_test.go
@@ -29,9 +29,12 @@ func (s *PhaseInternalSuite) TestForUnused(c *tc.C) {
 		}
 	}
 
+	// PROCESSRELATIONS is retired (no transition edges) but kept in the enum
+	// for wire/string compatibility.
 	specialPhases := set.NewStrings(
 		UNKNOWN.String(),
 		NONE.String(),
+		PROCESSRELATIONS.String(),
 	)
 	allValidPhases := set.NewStrings(phaseNames...).Difference(specialPhases)
 	c.Check(allValidPhases.Difference(usedPhases), tc.HasLen, 0)

--- a/core/migration/phase_test.go
+++ b/core/migration/phase_test.go
@@ -64,7 +64,7 @@ func (s *PhaseSuite) TestIsRunning(c *tc.C) {
 
 	c.Check(migration.QUIESCE.IsRunning(), tc.IsTrue)
 	c.Check(migration.IMPORT.IsRunning(), tc.IsTrue)
-	c.Check(migration.PROCESSRELATIONS.IsRunning(), tc.IsTrue)
+	c.Check(migration.PROCESSRELATIONS.IsRunning(), tc.IsFalse)
 	c.Check(migration.SUCCESS.IsRunning(), tc.IsTrue)
 
 	c.Check(migration.LOGTRANSFER.IsRunning(), tc.IsFalse)
@@ -83,11 +83,9 @@ func (s *PhaseSuite) TestCanTransitionTo(c *tc.C) {
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.Phase(-1)), tc.IsFalse)
 	c.Check(migration.ABORT.CanTransitionTo(migration.QUIESCE), tc.IsFalse)
 
-	// The new migration path skips the retired PROCESSRELATIONS phase: IMPORT
-	// transitions directly to VALIDATION. The PROCESSRELATIONS edge is retained
-	// transitionally for the legacy worker.
+	// PROCESSRELATIONS is retired; IMPORT transitions directly to VALIDATION.
 	c.Check(migration.IMPORT.CanTransitionTo(migration.VALIDATION), tc.IsTrue)
-	c.Check(migration.IMPORT.CanTransitionTo(migration.PROCESSRELATIONS), tc.IsTrue)
+	c.Check(migration.IMPORT.CanTransitionTo(migration.PROCESSRELATIONS), tc.IsFalse)
 	c.Check(migration.IMPORT.CanTransitionTo(migration.ABORT), tc.IsTrue)
 	c.Check(migration.IMPORT.CanTransitionTo(migration.SUCCESS), tc.IsFalse)
 }

--- a/core/migration/phase_test.go
+++ b/core/migration/phase_test.go
@@ -64,7 +64,6 @@ func (s *PhaseSuite) TestIsRunning(c *tc.C) {
 
 	c.Check(migration.QUIESCE.IsRunning(), tc.IsTrue)
 	c.Check(migration.IMPORT.IsRunning(), tc.IsTrue)
-	c.Check(migration.PROCESSRELATIONS.IsRunning(), tc.IsFalse)
 	c.Check(migration.SUCCESS.IsRunning(), tc.IsTrue)
 
 	c.Check(migration.LOGTRANSFER.IsRunning(), tc.IsFalse)
@@ -79,13 +78,10 @@ func (s *PhaseSuite) TestCanTransitionTo(c *tc.C) {
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.SUCCESS), tc.IsFalse)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.ABORT), tc.IsTrue)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.IMPORT), tc.IsTrue)
-	c.Check(migration.QUIESCE.CanTransitionTo(migration.PROCESSRELATIONS), tc.IsFalse)
 	c.Check(migration.QUIESCE.CanTransitionTo(migration.Phase(-1)), tc.IsFalse)
 	c.Check(migration.ABORT.CanTransitionTo(migration.QUIESCE), tc.IsFalse)
 
-	// PROCESSRELATIONS is retired; IMPORT transitions directly to VALIDATION.
 	c.Check(migration.IMPORT.CanTransitionTo(migration.VALIDATION), tc.IsTrue)
-	c.Check(migration.IMPORT.CanTransitionTo(migration.PROCESSRELATIONS), tc.IsFalse)
 	c.Check(migration.IMPORT.CanTransitionTo(migration.ABORT), tc.IsTrue)
 	c.Check(migration.IMPORT.CanTransitionTo(migration.SUCCESS), tc.IsFalse)
 }
@@ -119,14 +115,12 @@ func (s *PhaseSuite) TestPhasePersistedIDRoundTrip(c *tc.C) {
 }
 
 // TestPhasePersistedIDRejectsNonPersisted asserts the code-only sentinels and
-// the retired PROCESSRELATIONS phase have no persisted representation. This is
-// the reconciliation guard that keeps the Go enum and the SQL lookup in sync
-// while PROCESSRELATIONS still exists in the enum.
+// TestPhasePersistedIDRejectsNonPersisted asserts the code-only sentinels have
+// no persisted representation, keeping the Go enum and SQL lookup in sync.
 func (s *PhaseSuite) TestPhasePersistedIDRejectsNonPersisted(c *tc.C) {
 	for _, phase := range []migration.Phase{
 		migration.UNKNOWN,
 		migration.NONE,
-		migration.PROCESSRELATIONS,
 		migration.Phase(-1),
 	} {
 		_, err := migration.PhasePersistedID(phase)

--- a/core/migration/phase_test.go
+++ b/core/migration/phase_test.go
@@ -114,7 +114,6 @@ func (s *PhaseSuite) TestPhasePersistedIDRoundTrip(c *tc.C) {
 	}
 }
 
-// TestPhasePersistedIDRejectsNonPersisted asserts the code-only sentinels and
 // TestPhasePersistedIDRejectsNonPersisted asserts the code-only sentinels have
 // no persisted representation, keeping the Go enum and SQL lookup in sync.
 func (s *PhaseSuite) TestPhasePersistedIDRejectsNonPersisted(c *tc.C) {

--- a/domain/modelagent/service/service.go
+++ b/domain/modelagent/service/service.go
@@ -345,6 +345,25 @@ func (s *Service) GetMachinesAgentBinaryMetadata(
 	return s.modelSt.GetMachinesAgentBinaryMetadata(ctx)
 }
 
+// GetModelAgentBinaryMetadata returns the agent binary metadata currently
+// running for each machine and unit in the model.
+func (s *Service) GetModelAgentBinaryMetadata(
+	ctx context.Context,
+) (map[machine.Name]agentbinary.Metadata, map[coreunit.Name]agentbinary.Metadata, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	machineMetadata, err := s.modelSt.GetMachinesAgentBinaryMetadata(ctx)
+	if err != nil {
+		return nil, nil, errors.Errorf("getting machine agent binary metadata: %w", err)
+	}
+	unitMetadata, err := s.modelSt.GetUnitsAgentBinaryMetadata(ctx)
+	if err != nil {
+		return nil, nil, errors.Errorf("getting unit agent binary metadata: %w", err)
+	}
+	return machineMetadata, unitMetadata, nil
+}
+
 // GetMachineTargetAgentVersion reports the target agent version that should be
 // running on the provided machine identified by name. The following errors are
 // possible:

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -520,6 +520,23 @@ func (s *Service) SetMigrationPhase(ctx context.Context, phase migration.Phase) 
 	return s.controllerState.SetPhase(ctx, mig.UUID, phase)
 }
 
+// MarkModelAsGone is called by the migration master during REAP, once the
+// target controller owns the model, to remove the migrated model from this
+// controller. It marks the active export migration as DONE.
+//
+// TODO(modelmigration): purge the migrated model from the source controller
+// and set up the durable login redirect before completing the export.
+func (s *Service) MarkModelAsGone(ctx context.Context) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	mig, err := s.controllerState.GetActiveExport(ctx, s.modelUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return s.controllerState.SetPhase(ctx, mig.UUID, migration.DONE)
+}
+
 // SetMigrationStatusMessage is called by the migration master to report on
 // migration status.
 func (s *Service) SetMigrationStatusMessage(ctx context.Context, message string) error {

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -580,6 +580,34 @@ func (s *serviceSuite) TestSetMigrationPhase(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestMarkModelAsGone asserts the active migration is resolved and moved to
+// DONE.
+func (s *serviceSuite) TestMarkModelAsGone(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	migUUID := tc.Must(c, uuid.NewUUID).String()
+	gomock.InOrder(
+		s.controllerState.EXPECT().GetActiveExport(gomock.Any(), s.modelUUID).Return(
+			modelmigrationinternal.Migration{UUID: migUUID}, nil),
+		s.controllerState.EXPECT().SetPhase(gomock.Any(), migUUID, migration.DONE).Return(nil),
+	)
+
+	err := s.service().MarkModelAsGone(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestMarkModelAsGoneNoActiveMigration asserts the active export lookup error
+// is surfaced.
+func (s *serviceSuite) TestMarkModelAsGoneNoActiveMigration(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.controllerState.EXPECT().GetActiveExport(gomock.Any(), s.modelUUID).Return(
+		modelmigrationinternal.Migration{}, modelmigrationerrors.ErrMigrationNotFound)
+
+	err := s.service().MarkModelAsGone(c.Context())
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrMigrationNotFound)
+}
+
 // TestSetMigrationStatusMessage asserts the message is recorded against the
 // active migration.
 func (s *serviceSuite) TestSetMigrationStatusMessage(c *tc.C) {

--- a/internal/worker/migrationmaster/envelope.go
+++ b/internal/worker/migrationmaster/envelope.go
@@ -23,6 +23,8 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
+const agentBinaryRelease = "ubuntu"
+
 // assembledModel carries the v8 wire envelope for the migrating model plus the
 // binary-transfer references the worker feeds to UploadBinaries. Both are
 // produced by the same assembly pass so they cannot diverge.
@@ -80,13 +82,9 @@ func (w *Worker) assembleEnvelope(ctx context.Context, migrationUUID string) (as
 	}
 	envelope.Charms = charms
 
-	machineTools, err := w.config.ModelAgentService.GetMachinesAgentBinaryMetadata(ctx)
+	machineTools, unitTools, err := w.config.ModelAgentService.GetModelAgentBinaryMetadata(ctx)
 	if err != nil {
-		return empty, errors.Annotate(err, "listing machine agent binaries")
-	}
-	unitTools, err := w.config.ModelAgentService.GetUnitsAgentBinaryMetadata(ctx)
-	if err != nil {
-		return empty, errors.Annotate(err, "listing unit agent binaries")
+		return empty, errors.Annotate(err, "listing model agent binaries")
 	}
 	tools, envelopeTools := toolsForEnvelope(machineTools, unitTools)
 	envelope.Tools = envelopeTools
@@ -284,7 +282,8 @@ func archFromArchitecture(a architecture.Architecture) (string, error) {
 // toolsForEnvelope merges the agent binaries reported for machines and units,
 // deduplicated by SHA256, into the upload map keyed on SHA256 and the wire
 // envelope references. coreagentbinary.Version carries no OS release; 4.x
-// agents are ubuntu-only so the binary version release is always "ubuntu".
+// agents are ubuntu-only so the binary version release is always
+// agentBinaryRelease.
 func toolsForEnvelope(
 	machineTools map[machine.Name]coreagentbinary.Metadata,
 	unitTools map[unit.Name]coreagentbinary.Metadata,
@@ -293,7 +292,7 @@ func toolsForEnvelope(
 	addTool := func(metadata coreagentbinary.Metadata) {
 		tools[metadata.SHA256] = semversion.Binary{
 			Number:  metadata.Version.Number,
-			Release: "ubuntu",
+			Release: agentBinaryRelease,
 			Arch:    metadata.Version.Arch,
 		}
 	}

--- a/internal/worker/migrationmaster/envelope.go
+++ b/internal/worker/migrationmaster/envelope.go
@@ -45,7 +45,7 @@ type assembledModel struct {
 
 // assembleEnvelope builds a fresh params.SerializedModelV2 envelope for this
 // model from the local domain services: the model-DB export payload, the
-// controller-DB semantic facts, and the charm/tools/resources binary
+// controller-DB data, and the charm/tools/resources binary
 // references.
 func (w *Worker) assembleEnvelope(ctx context.Context, migrationUUID string) (assembledModel, error) {
 	var empty assembledModel
@@ -64,7 +64,7 @@ func (w *Worker) assembleEnvelope(ctx context.Context, migrationUUID string) (as
 
 	info, err := w.config.ModelMigrationService.GetControllerModelInfo(ctx)
 	if err != nil {
-		return empty, errors.Annotate(err, "reading controller facts for model")
+		return empty, errors.Annotate(err, "reading controller-db data for model")
 	}
 	envelope := envelopeFromControllerModelInfo(info, migrationUUID)
 	envelope.PayloadVersion = export.Version
@@ -105,7 +105,7 @@ func (w *Worker) assembleEnvelope(ctx context.Context, migrationUUID string) (as
 	}, nil
 }
 
-// envelopeFromControllerModelInfo converts the controller-DB semantic facts
+// envelopeFromControllerModelInfo converts the controller-DB information
 // for the migrating model into their wire envelope form. The migration UUID
 // of the active source migration is recorded as the envelope's
 // SourceMigrationUUID.

--- a/internal/worker/migrationmaster/envelope.go
+++ b/internal/worker/migrationmaster/envelope.go
@@ -1,0 +1,367 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+import (
+	"context"
+	"sort"
+
+	"github.com/juju/errors"
+	goyaml "gopkg.in/yaml.v2"
+
+	coreagentbinary "github.com/juju/juju/core/agentbinary"
+	corelease "github.com/juju/juju/core/lease"
+	"github.com/juju/juju/core/machine"
+	coreresource "github.com/juju/juju/core/resource"
+	"github.com/juju/juju/core/semversion"
+	"github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/application/architecture"
+	applicationcharm "github.com/juju/juju/domain/application/charm"
+	deploymentcharm "github.com/juju/juju/domain/deployment/charm"
+	"github.com/juju/juju/domain/modelmigration"
+	"github.com/juju/juju/rpc/params"
+)
+
+// assembledModel carries the v8 wire envelope for the migrating model plus the
+// binary-transfer references the worker feeds to UploadBinaries. Both are
+// produced by the same assembly pass so they cannot diverge.
+type assembledModel struct {
+	// envelope is the wire envelope sent to the target's v8 Prechecks and
+	// Import methods.
+	envelope params.SerializedModelV2
+
+	// charms are the charm URLs to transfer via /migrate/charms.
+	charms []string
+
+	// tools are the agent binaries to transfer via /migrate/tools, keyed on
+	// the SHA256 sum and referenced to a binary version.
+	tools map[string]semversion.Binary
+
+	// resources are the application resources to transfer via
+	// /migrate/resources.
+	resources []coreresource.Resource
+}
+
+// assembleEnvelope builds a fresh params.SerializedModelV2 envelope for this
+// model from the local domain services: the model-DB export payload, the
+// controller-DB semantic facts, and the charm/tools/resources binary
+// references. The payload size is validated against the serialized-model
+// payload limit before the envelope is handed to any RPC.
+func (w *Worker) assembleEnvelope(ctx context.Context, migrationUUID string) (assembledModel, error) {
+	var empty assembledModel
+
+	export, err := w.config.ExportService.Export(ctx)
+	if err != nil {
+		return empty, errors.Annotate(err, "exporting model")
+	}
+	// Marshal only the concrete generated model-DB payload. The
+	// domain/export.ModelExport wrapper is never serialized;
+	// envelope.PayloadVersion is the single wire version authority.
+	payload, err := goyaml.Marshal(export.Payload)
+	if err != nil {
+		return empty, errors.Annotate(err, "marshalling model payload")
+	}
+
+	info, err := w.config.ModelMigrationService.GetControllerModelInfo(ctx)
+	if err != nil {
+		return empty, errors.Annotate(err, "reading controller facts for model")
+	}
+	envelope := envelopeFromControllerModelInfo(info, migrationUUID)
+	envelope.PayloadVersion = export.Version
+	envelope.Payload = payload
+
+	locators, err := w.config.CharmService.ListCharmLocators(ctx)
+	if err != nil {
+		return empty, errors.Annotate(err, "listing model charms")
+	}
+	charms, err := charmURLsFromLocators(locators)
+	if err != nil {
+		return empty, errors.Trace(err)
+	}
+	envelope.Charms = charms
+
+	machineTools, err := w.config.ModelAgentService.GetMachinesAgentBinaryMetadata(ctx)
+	if err != nil {
+		return empty, errors.Annotate(err, "listing machine agent binaries")
+	}
+	unitTools, err := w.config.ModelAgentService.GetUnitsAgentBinaryMetadata(ctx)
+	if err != nil {
+		return empty, errors.Annotate(err, "listing unit agent binaries")
+	}
+	tools, envelopeTools := toolsForEnvelope(machineTools, unitTools)
+	envelope.Tools = envelopeTools
+
+	exported, err := w.config.ResourceService.ListAllModelResources(ctx)
+	if err != nil {
+		return empty, errors.Annotate(err, "listing model resources")
+	}
+	envelope.Resources = resourcesForEnvelope(exported)
+
+	if err := validateEnvelopeSize(envelope); err != nil {
+		return empty, errors.Trace(err)
+	}
+	return assembledModel{
+		envelope:  envelope,
+		charms:    charms,
+		tools:     tools,
+		resources: exported,
+	}, nil
+}
+
+// validateEnvelopeSize rejects envelopes whose model-DB payload exceeds the
+// serialized-model payload limit. The source validates locally before RPC so
+// an oversized payload never travels to the target.
+func validateEnvelopeSize(envelope params.SerializedModelV2) error {
+	if size := len(envelope.Payload); size > params.SerializedModelV2PayloadLimit {
+		return errors.Errorf(
+			"model payload is %d bytes which exceeds the %d byte limit",
+			size, params.SerializedModelV2PayloadLimit,
+		)
+	}
+	return nil
+}
+
+// envelopeFromControllerModelInfo converts the controller-DB semantic facts
+// for the migrating model into their wire envelope form. The migration UUID
+// of the active source migration is recorded as the envelope's
+// SourceMigrationUUID.
+func envelopeFromControllerModelInfo(
+	info modelmigration.ControllerModelInfo, migrationUUID string,
+) params.SerializedModelV2 {
+	envelope := params.SerializedModelV2{
+		ModelInfo: params.SerializedModelInfo{
+			UUID:                info.ModelInfo.UUID,
+			Name:                info.ModelInfo.Name,
+			Qualifier:           info.ModelInfo.Qualifier,
+			Type:                info.ModelInfo.Type,
+			Cloud:               info.ModelInfo.Cloud,
+			CloudRegion:         info.ModelInfo.CloudRegion,
+			CredentialName:      info.ModelInfo.CredentialName,
+			CredentialOwner:     info.ModelInfo.CredentialOwner,
+			Life:                info.ModelInfo.Life,
+			SourceMigrationUUID: migrationUUID,
+		},
+	}
+	for _, user := range info.Users {
+		envelope.Users = append(envelope.Users, params.ModelUser{
+			Name:        user.Name,
+			DisplayName: user.DisplayName,
+			CreatedBy:   user.CreatedBy,
+			CreatedAt:   user.CreatedAt,
+			Removed:     user.Removed,
+			External:    user.External,
+		})
+		if user.LastLogin != nil {
+			envelope.LastLogins = append(envelope.LastLogins, params.ModelLastLogin{
+				Username: user.Name,
+				Time:     *user.LastLogin,
+			})
+		}
+	}
+	if cred := info.ModelCredential; cred != nil {
+		envelope.ModelCredential = &params.ModelCloudCredential{
+			Cloud:         cred.Cloud,
+			Owner:         cred.Owner,
+			Name:          cred.Name,
+			AuthType:      cred.AuthType,
+			Attributes:    cred.Attributes,
+			Revoked:       cred.Revoked,
+			Invalid:       cred.Invalid,
+			InvalidReason: cred.InvalidReason,
+		}
+	}
+	for _, perm := range info.Permissions {
+		envelope.Permissions = append(envelope.Permissions, params.ModelPermission{
+			ObjectType:  perm.ObjectType,
+			GrantOn:     perm.GrantOn,
+			SubjectName: perm.SubjectName,
+			Access:      perm.Access,
+		})
+	}
+	for _, key := range info.AuthorizedKeys {
+		envelope.AuthorizedKeys = append(envelope.AuthorizedKeys, params.ModelAuthorizedKey{
+			Username:  key.Username,
+			PublicKey: key.PublicKey,
+		})
+	}
+	if backend := info.SecretBackend; backend != nil {
+		envelope.SecretBackend = &params.ModelSecretBackend{
+			Name:        backend.Name,
+			BackendType: backend.BackendType,
+		}
+	}
+	for _, ref := range info.SecretBackendRefs {
+		envelope.SecretBackendRefs = append(envelope.SecretBackendRefs, params.SecretBackendReference{
+			BackendName:        ref.BackendName,
+			SecretRevisionUUID: ref.SecretRevisionUUID,
+			SecretID:           ref.SecretID,
+		})
+	}
+	for _, leader := range info.Leaders {
+		envelope.Leases = append(envelope.Leases, params.Lease{
+			Type:   corelease.ApplicationLeadershipNamespace,
+			Name:   leader.Application,
+			Holder: leader.Leader,
+		})
+	}
+	for _, metadata := range info.CloudImageMetadata {
+		envelope.CloudImageMetadata = append(envelope.CloudImageMetadata, params.ModelCloudImageMetadata{
+			Stream:          metadata.Stream,
+			Region:          metadata.Region,
+			Version:         metadata.Version,
+			Arch:            metadata.Arch,
+			VirtType:        metadata.VirtType,
+			RootStorageType: metadata.RootStorageType,
+			RootStorageSize: metadata.RootStorageSize,
+			Source:          metadata.Source,
+			Priority:        metadata.Priority,
+			ImageId:         metadata.ImageID,
+			CreatedAt:       metadata.CreatedAt,
+		})
+	}
+	for _, controller := range info.ExternalControllers {
+		envelope.ExternalControllers = append(envelope.ExternalControllers, params.ExternalControllerRef{
+			UUID:           controller.UUID,
+			Alias:          controller.Alias,
+			CACert:         controller.CACert,
+			Addresses:      controller.Addresses,
+			ConsumedModels: controller.ConsumedModels,
+		})
+	}
+	return envelope
+}
+
+// charmURLsFromLocators converts charm locators into the charm URL strings
+// used by the wire envelope and the charm binary uploads.
+func charmURLsFromLocators(locators []applicationcharm.CharmLocator) ([]string, error) {
+	if len(locators) == 0 {
+		return nil, nil
+	}
+	urls := make([]string, 0, len(locators))
+	for _, locator := range locators {
+		url, err := charmURLFromLocator(locator)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		urls = append(urls, url)
+	}
+	return urls, nil
+}
+
+func charmURLFromLocator(locator applicationcharm.CharmLocator) (string, error) {
+	schema, err := charmSchemaFromSource(locator.Source)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	arch, err := archFromArchitecture(locator.Architecture)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	url := deploymentcharm.URL{
+		Schema:       schema,
+		Name:         locator.Name,
+		Revision:     locator.Revision,
+		Architecture: arch,
+	}
+	return url.String(), nil
+}
+
+func charmSchemaFromSource(source applicationcharm.CharmSource) (string, error) {
+	switch source {
+	case applicationcharm.CharmHubSource:
+		return deploymentcharm.CharmHub.String(), nil
+	case applicationcharm.LocalSource:
+		return deploymentcharm.Local.String(), nil
+	default:
+		return "", errors.Errorf("unsupported charm source %q", source)
+	}
+}
+
+func archFromArchitecture(a architecture.Architecture) (string, error) {
+	switch a {
+	case architecture.AMD64:
+		return "amd64", nil
+	case architecture.ARM64:
+		return "arm64", nil
+	case architecture.PPC64EL:
+		return "ppc64el", nil
+	case architecture.S390X:
+		return "s390x", nil
+	case architecture.RISCV64:
+		return "riscv64", nil
+	case architecture.Unknown:
+		// A charm uploaded without an architecture has none in its URL.
+		return "", nil
+	default:
+		return "", errors.Errorf("unsupported architecture %d", a)
+	}
+}
+
+// toolsForEnvelope merges the agent binaries reported for machines and units,
+// deduplicated by SHA256, into the upload map keyed on SHA256 and the wire
+// envelope references. coreagentbinary.Version carries no OS release; 4.x
+// agents are ubuntu-only so the binary version release is always "ubuntu".
+func toolsForEnvelope(
+	machineTools map[machine.Name]coreagentbinary.Metadata,
+	unitTools map[unit.Name]coreagentbinary.Metadata,
+) (map[string]semversion.Binary, []params.SerializedModelTools) {
+	tools := make(map[string]semversion.Binary)
+	addTool := func(metadata coreagentbinary.Metadata) {
+		tools[metadata.SHA256] = semversion.Binary{
+			Number:  metadata.Version.Number,
+			Release: "ubuntu",
+			Arch:    metadata.Version.Arch,
+		}
+	}
+	for _, metadata := range machineTools {
+		addTool(metadata)
+	}
+	for _, metadata := range unitTools {
+		addTool(metadata)
+	}
+	if len(tools) == 0 {
+		return tools, nil
+	}
+
+	envelopeTools := make([]params.SerializedModelTools, 0, len(tools))
+	for sha256, version := range tools {
+		envelopeTools = append(envelopeTools, params.SerializedModelTools{
+			Version: version.String(),
+			URI:     "/tools/" + version.String(),
+			SHA256:  sha256,
+		})
+	}
+	sort.Slice(envelopeTools, func(i, j int) bool {
+		if envelopeTools[i].Version != envelopeTools[j].Version {
+			return envelopeTools[i].Version < envelopeTools[j].Version
+		}
+		return envelopeTools[i].SHA256 < envelopeTools[j].SHA256
+	})
+	return tools, envelopeTools
+}
+
+// resourcesForEnvelope converts the application resources to their wire
+// envelope references. Unit resource rows travel inside the model-DB payload,
+// so the envelope carries application-level resources only, matching the
+// legacy serialized model.
+func resourcesForEnvelope(resources []coreresource.Resource) []params.SerializedModelResource {
+	if len(resources) == 0 {
+		return nil
+	}
+	out := make([]params.SerializedModelResource, 0, len(resources))
+	for _, res := range resources {
+		out = append(out, params.SerializedModelResource{
+			Application:    res.ApplicationName,
+			Name:           res.Name,
+			Revision:       res.Revision,
+			Type:           res.Type.String(),
+			Origin:         res.Origin.String(),
+			FingerprintHex: res.Fingerprint.Hex(),
+			Size:           res.Size,
+			Timestamp:      res.Timestamp,
+			Username:       res.RetrievedBy,
+		})
+	}
+	return out
+}

--- a/internal/worker/migrationmaster/envelope.go
+++ b/internal/worker/migrationmaster/envelope.go
@@ -46,8 +46,7 @@ type assembledModel struct {
 // assembleEnvelope builds a fresh params.SerializedModelV2 envelope for this
 // model from the local domain services: the model-DB export payload, the
 // controller-DB semantic facts, and the charm/tools/resources binary
-// references. The payload size is validated against the serialized-model
-// payload limit before the envelope is handed to any RPC.
+// references.
 func (w *Worker) assembleEnvelope(ctx context.Context, migrationUUID string) (assembledModel, error) {
 	var empty assembledModel
 
@@ -98,28 +97,12 @@ func (w *Worker) assembleEnvelope(ctx context.Context, migrationUUID string) (as
 	}
 	envelope.Resources = resourcesForEnvelope(exported)
 
-	if err := validateEnvelopeSize(envelope); err != nil {
-		return empty, errors.Trace(err)
-	}
 	return assembledModel{
 		envelope:  envelope,
 		charms:    charms,
 		tools:     tools,
 		resources: exported,
 	}, nil
-}
-
-// validateEnvelopeSize rejects envelopes whose model-DB payload exceeds the
-// serialized-model payload limit. The source validates locally before RPC so
-// an oversized payload never travels to the target.
-func validateEnvelopeSize(envelope params.SerializedModelV2) error {
-	if size := len(envelope.Payload); size > params.SerializedModelV2PayloadLimit {
-		return errors.Errorf(
-			"model payload is %d bytes which exceeds the %d byte limit",
-			size, params.SerializedModelV2PayloadLimit,
-		)
-	}
-	return nil
 }
 
 // envelopeFromControllerModelInfo converts the controller-DB semantic facts

--- a/internal/worker/migrationmaster/envelope_test.go
+++ b/internal/worker/migrationmaster/envelope_test.go
@@ -346,14 +346,3 @@ func (*EnvelopeSuite) TestResourcesForEnvelope(c *tc.C) {
 func (*EnvelopeSuite) TestResourcesForEnvelopeEmpty(c *tc.C) {
 	c.Check(resourcesForEnvelope(nil), tc.IsNil)
 }
-
-func (*EnvelopeSuite) TestValidateEnvelopeSize(c *tc.C) {
-	c.Check(validateEnvelopeSize(params.SerializedModelV2{
-		Payload: make([]byte, params.SerializedModelV2PayloadLimit),
-	}), tc.ErrorIsNil)
-
-	err := validateEnvelopeSize(params.SerializedModelV2{
-		Payload: make([]byte, params.SerializedModelV2PayloadLimit+1),
-	})
-	c.Assert(err, tc.ErrorMatches, "model payload is .* bytes which exceeds the .* byte limit")
-}

--- a/internal/worker/migrationmaster/envelope_test.go
+++ b/internal/worker/migrationmaster/envelope_test.go
@@ -1,0 +1,359 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juju/tc"
+
+	coreagentbinary "github.com/juju/juju/core/agentbinary"
+	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/machine"
+	coreresource "github.com/juju/juju/core/resource"
+	"github.com/juju/juju/core/semversion"
+	"github.com/juju/juju/core/unit"
+	"github.com/juju/juju/domain/application/architecture"
+	applicationcharm "github.com/juju/juju/domain/application/charm"
+	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
+	"github.com/juju/juju/domain/modelmigration"
+	"github.com/juju/juju/internal/testhelpers"
+	"github.com/juju/juju/rpc/params"
+)
+
+type EnvelopeSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestEnvelopeSuite(t *testing.T) {
+	tc.Run(t, &EnvelopeSuite{})
+}
+
+func (*EnvelopeSuite) TestEnvelopeFromControllerModelInfo(c *tc.C) {
+	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	size := uint64(8)
+	info := modelmigration.ControllerModelInfo{
+		ModelInfo: modelmigration.ModelIdentityInfo{
+			UUID:            "model-uuid",
+			Name:            "model-name",
+			Qualifier:       "prod",
+			Type:            "iaas",
+			Cloud:           "aws",
+			CloudRegion:     "eu-west-1",
+			CredentialName:  "cred",
+			CredentialOwner: "owner",
+			Life:            "alive",
+		},
+		Users: []modelmigration.ModelUser{{
+			Name:        "fred",
+			DisplayName: "Fred",
+			CreatedBy:   "admin",
+			CreatedAt:   created,
+			LastLogin:   &created,
+		}},
+		ModelCredential: &modelmigration.ModelCloudCredential{
+			Cloud:         "aws",
+			Owner:         "owner",
+			Name:          "cred",
+			AuthType:      "access-key",
+			Attributes:    map[string]string{"key": "value"},
+			Revoked:       true,
+			Invalid:       true,
+			InvalidReason: "because",
+		},
+		Permissions: []modelmigration.ModelPermission{{
+			ObjectType:  "model",
+			GrantOn:     "model-uuid",
+			SubjectName: "fred",
+			Access:      "read",
+		}, {
+			ObjectType:  "offer",
+			GrantOn:     "offer-uuid",
+			SubjectName: "fred",
+			Access:      "consume",
+		}},
+		AuthorizedKeys: []modelmigration.ModelAuthorizedKey{{
+			Username:  "fred",
+			PublicKey: "ssh-rsa AAAA",
+		}},
+		SecretBackend: &modelmigration.ModelSecretBackend{
+			Name:        "vault",
+			BackendType: "vault",
+		},
+		SecretBackendRefs: []modelmigration.SecretBackendReference{{
+			BackendName:        "vault",
+			SecretRevisionUUID: "rev-uuid",
+			SecretID:           "secret-id",
+		}},
+		Leaders: []modelmigration.ApplicationLeadership{{
+			Application: "app",
+			Leader:      "app/0",
+		}},
+		CloudImageMetadata: []modelmigration.CloudImageMetadata{{
+			Stream:          "released",
+			Region:          "eu-west-1",
+			Version:         "22.04",
+			Arch:            "amd64",
+			VirtType:        "kvm",
+			RootStorageType: "ssd",
+			RootStorageSize: &size,
+			Source:          "custom",
+			Priority:        7,
+			ImageID:         "ami-1",
+			CreatedAt:       created,
+		}},
+		ExternalControllers: []modelmigration.ExternalController{{
+			UUID:           "ext-uuid",
+			Alias:          "other",
+			CACert:         "ca-cert",
+			Addresses:      []string{"10.0.0.1:17070"},
+			ConsumedModels: []string{"offerer-model-uuid"},
+		}},
+	}
+
+	envelope := envelopeFromControllerModelInfo(info, "migration-uuid")
+	c.Check(envelope, tc.DeepEquals, params.SerializedModelV2{
+		ModelInfo: params.SerializedModelInfo{
+			UUID:                "model-uuid",
+			Name:                "model-name",
+			Qualifier:           "prod",
+			Type:                "iaas",
+			Cloud:               "aws",
+			CloudRegion:         "eu-west-1",
+			CredentialName:      "cred",
+			CredentialOwner:     "owner",
+			Life:                "alive",
+			SourceMigrationUUID: "migration-uuid",
+		},
+		Users: []params.ModelUser{{
+			Name:        "fred",
+			DisplayName: "Fred",
+			CreatedBy:   "admin",
+			CreatedAt:   created,
+		}},
+		ModelCredential: &params.ModelCloudCredential{
+			Cloud:         "aws",
+			Owner:         "owner",
+			Name:          "cred",
+			AuthType:      "access-key",
+			Attributes:    map[string]string{"key": "value"},
+			Revoked:       true,
+			Invalid:       true,
+			InvalidReason: "because",
+		},
+		Permissions: []params.ModelPermission{{
+			ObjectType:  "model",
+			GrantOn:     "model-uuid",
+			SubjectName: "fred",
+			Access:      "read",
+		}, {
+			ObjectType:  "offer",
+			GrantOn:     "offer-uuid",
+			SubjectName: "fred",
+			Access:      "consume",
+		}},
+		AuthorizedKeys: []params.ModelAuthorizedKey{{
+			Username:  "fred",
+			PublicKey: "ssh-rsa AAAA",
+		}},
+		SecretBackend: &params.ModelSecretBackend{
+			Name:        "vault",
+			BackendType: "vault",
+		},
+		SecretBackendRefs: []params.SecretBackendReference{{
+			BackendName:        "vault",
+			SecretRevisionUUID: "rev-uuid",
+			SecretID:           "secret-id",
+		}},
+		Leases: []params.Lease{{
+			Type:   "application-leadership",
+			Name:   "app",
+			Holder: "app/0",
+		}},
+		LastLogins: []params.ModelLastLogin{{
+			Username: "fred",
+			Time:     created,
+		}},
+		CloudImageMetadata: []params.ModelCloudImageMetadata{{
+			Stream:          "released",
+			Region:          "eu-west-1",
+			Version:         "22.04",
+			Arch:            "amd64",
+			VirtType:        "kvm",
+			RootStorageType: "ssd",
+			RootStorageSize: &size,
+			Source:          "custom",
+			Priority:        7,
+			ImageId:         "ami-1",
+			CreatedAt:       created,
+		}},
+		ExternalControllers: []params.ExternalControllerRef{{
+			UUID:           "ext-uuid",
+			Alias:          "other",
+			CACert:         "ca-cert",
+			Addresses:      []string{"10.0.0.1:17070"},
+			ConsumedModels: []string{"offerer-model-uuid"},
+		}},
+	})
+}
+
+func (*EnvelopeSuite) TestEnvelopeFromControllerModelInfoEmpty(c *tc.C) {
+	envelope := envelopeFromControllerModelInfo(modelmigration.ControllerModelInfo{
+		ModelInfo: modelmigration.ModelIdentityInfo{UUID: "model-uuid"},
+	}, "migration-uuid")
+
+	c.Check(envelope.ModelCredential, tc.IsNil)
+	c.Check(envelope.SecretBackend, tc.IsNil)
+	c.Check(envelope.Users, tc.HasLen, 0)
+	c.Check(envelope.Permissions, tc.HasLen, 0)
+	c.Check(envelope.ModelInfo.SourceMigrationUUID, tc.Equals, "migration-uuid")
+}
+
+func (*EnvelopeSuite) TestCharmURLsFromLocators(c *tc.C) {
+	urls, err := charmURLsFromLocators([]applicationcharm.CharmLocator{{
+		Name:         "wordpress",
+		Revision:     42,
+		Source:       applicationcharm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}, {
+		Name:         "local-thing",
+		Revision:     1,
+		Source:       applicationcharm.LocalSource,
+		Architecture: architecture.Unknown,
+	}})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(urls, tc.DeepEquals, []string{
+		"ch:amd64/wordpress-42",
+		"local:local-thing-1",
+	})
+}
+
+func (*EnvelopeSuite) TestCharmURLsFromLocatorsEmpty(c *tc.C) {
+	urls, err := charmURLsFromLocators(nil)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(urls, tc.IsNil)
+}
+
+func (*EnvelopeSuite) TestCharmURLsFromLocatorsUnsupportedSource(c *tc.C) {
+	_, err := charmURLsFromLocators([]applicationcharm.CharmLocator{{
+		Name:   "wat",
+		Source: applicationcharm.CharmSource("wat"),
+	}})
+	c.Assert(err, tc.ErrorMatches, `unsupported charm source "wat"`)
+}
+
+func (*EnvelopeSuite) TestToolsForEnvelope(c *tc.C) {
+	machineTools := map[machine.Name]coreagentbinary.Metadata{
+		"0": {
+			Version: coreagentbinary.Version{
+				Number: semversion.MustParse("4.0.6"),
+				Arch:   arch.AMD64,
+			},
+			SHA256: "sha-amd64",
+		},
+		"1": {
+			Version: coreagentbinary.Version{
+				Number: semversion.MustParse("4.0.6"),
+				Arch:   arch.ARM64,
+			},
+			SHA256: "sha-arm64",
+		},
+	}
+	unitTools := map[unit.Name]coreagentbinary.Metadata{
+		// Same binary as machine 0; deduplicated by SHA256.
+		"app/0": {
+			Version: coreagentbinary.Version{
+				Number: semversion.MustParse("4.0.6"),
+				Arch:   arch.AMD64,
+			},
+			SHA256: "sha-amd64",
+		},
+	}
+
+	tools, envelopeTools := toolsForEnvelope(machineTools, unitTools)
+	c.Check(tools, tc.DeepEquals, map[string]semversion.Binary{
+		"sha-amd64": semversion.MustParseBinary("4.0.6-ubuntu-amd64"),
+		"sha-arm64": semversion.MustParseBinary("4.0.6-ubuntu-arm64"),
+	})
+	c.Check(envelopeTools, tc.DeepEquals, []params.SerializedModelTools{{
+		Version: "4.0.6-ubuntu-amd64",
+		URI:     "/tools/4.0.6-ubuntu-amd64",
+		SHA256:  "sha-amd64",
+	}, {
+		Version: "4.0.6-ubuntu-arm64",
+		URI:     "/tools/4.0.6-ubuntu-arm64",
+		SHA256:  "sha-arm64",
+	}})
+}
+
+func (*EnvelopeSuite) TestToolsForEnvelopeEmpty(c *tc.C) {
+	tools, envelopeTools := toolsForEnvelope(nil, nil)
+	c.Check(tools, tc.HasLen, 0)
+	c.Check(envelopeTools, tc.IsNil)
+}
+
+func (*EnvelopeSuite) TestResourcesForEnvelope(c *tc.C) {
+	fp, err := charmresource.GenerateFingerprint(strings.NewReader("a resource body"))
+	c.Assert(err, tc.ErrorIsNil)
+	uploaded := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	out := resourcesForEnvelope([]coreresource.Resource{{
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name: "blob",
+				Type: charmresource.TypeFile,
+			},
+			Origin:      charmresource.OriginUpload,
+			Revision:    3,
+			Fingerprint: fp,
+			Size:        15,
+		},
+		ApplicationName: "app",
+		RetrievedBy:     "fred",
+		Timestamp:       uploaded,
+	}, {
+		// A placeholder resource with no stored blob.
+		Resource: charmresource.Resource{
+			Meta: charmresource.Meta{
+				Name: "pending",
+				Type: charmresource.TypeContainerImage,
+			},
+			Origin: charmresource.OriginStore,
+		},
+		ApplicationName: "app",
+	}})
+	c.Check(out, tc.DeepEquals, []params.SerializedModelResource{{
+		Application:    "app",
+		Name:           "blob",
+		Revision:       3,
+		Type:           "file",
+		Origin:         "upload",
+		FingerprintHex: fp.Hex(),
+		Size:           15,
+		Timestamp:      uploaded,
+		Username:       "fred",
+	}, {
+		Application: "app",
+		Name:        "pending",
+		Type:        "oci-image",
+		Origin:      "store",
+	}})
+}
+
+func (*EnvelopeSuite) TestResourcesForEnvelopeEmpty(c *tc.C) {
+	c.Check(resourcesForEnvelope(nil), tc.IsNil)
+}
+
+func (*EnvelopeSuite) TestValidateEnvelopeSize(c *tc.C) {
+	c.Check(validateEnvelopeSize(params.SerializedModelV2{
+		Payload: make([]byte, params.SerializedModelV2PayloadLimit),
+	}), tc.ErrorIsNil)
+
+	err := validateEnvelopeSize(params.SerializedModelV2{
+		Payload: make([]byte, params.SerializedModelV2PayloadLimit+1),
+	})
+	c.Assert(err, tc.ErrorMatches, "model payload is .* bytes which exceeds the .* byte limit")
+}

--- a/internal/worker/migrationmaster/export_test.go
+++ b/internal/worker/migrationmaster/export_test.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationmaster
+
+// Expose the envelope conversion helpers so the external worker tests can
+// build expected envelopes. The conversions themselves are unit tested in
+// envelope_test.go.
+var (
+	EnvelopeFromControllerModelInfo = envelopeFromControllerModelInfo
+	CharmURLsFromLocators           = charmURLsFromLocators
+	ToolsForEnvelope                = toolsForEnvelope
+	ResourcesForEnvelope            = resourcesForEnvelope
+)

--- a/internal/worker/migrationmaster/manifold.go
+++ b/internal/worker/migrationmaster/manifold.go
@@ -85,15 +85,19 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		return nil, errors.Trace(err)
 	}
 	w, err := config.NewWorker(Config{
-		ModelUUID:             agent.CurrentConfig().Model().Id(),
-		Facade:                facade,
-		CharmService:          domainServices.Application(),
-		ModelMigrationService: domainServices.ModelMigration(),
-		Guard:                 guard,
-		APIOpen:               api.Open,
-		UploadBinaries:        migration.UploadBinaries,
-		AgentBinaryStore:      domainServices.AgentBinaryStore(),
-		Clock:                 config.Clock,
+		ModelUUID:               agent.CurrentConfig().Model().Id(),
+		Facade:                  facade,
+		CharmService:            domainServices.Application(),
+		ModelMigrationService:   domainServices.ModelMigration(),
+		ExportService:           domainServices.Export(),
+		ControllerConfigService: domainServices.ControllerConfig(),
+		ModelAgentService:       domainServices.Agent(),
+		ResourceService:         domainServices.Resource(),
+		Guard:                   guard,
+		APIOpen:                 api.Open,
+		UploadBinaries:          migration.UploadBinaries,
+		AgentBinaryStore:        domainServices.AgentBinaryStore(),
+		Clock:                   config.Clock,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/migrationmaster/validate_test.go
+++ b/internal/worker/migrationmaster/validate_test.go
@@ -75,6 +75,30 @@ func (*ValidateSuite) TestMissingModelMigrationService(c *tc.C) {
 	checkNotValid(c, config, "nil ModelMigrationService not valid")
 }
 
+func (*ValidateSuite) TestMissingExportService(c *tc.C) {
+	config := validConfig()
+	config.ExportService = nil
+	checkNotValid(c, config, "nil ExportService not valid")
+}
+
+func (*ValidateSuite) TestMissingControllerConfigService(c *tc.C) {
+	config := validConfig()
+	config.ControllerConfigService = nil
+	checkNotValid(c, config, "nil ControllerConfigService not valid")
+}
+
+func (*ValidateSuite) TestMissingModelAgentService(c *tc.C) {
+	config := validConfig()
+	config.ModelAgentService = nil
+	checkNotValid(c, config, "nil ModelAgentService not valid")
+}
+
+func (*ValidateSuite) TestMissingResourceService(c *tc.C) {
+	config := validConfig()
+	config.ResourceService = nil
+	checkNotValid(c, config, "nil ResourceService not valid")
+}
+
 func (*ValidateSuite) TestMissingAgentBinaryStore(c *tc.C) {
 	config := validConfig()
 	config.AgentBinaryStore = nil
@@ -98,8 +122,14 @@ func validConfig() migrationmaster.Config {
 		ModelMigrationService: struct {
 			migrationmaster.ModelMigrationService
 		}{},
-		AgentBinaryStore: struct{ migration.AgentBinaryStore }{},
-		Clock:            struct{ clock.Clock }{},
+		ExportService: struct{ migrationmaster.ExportService }{},
+		ControllerConfigService: struct {
+			migrationmaster.ControllerConfigService
+		}{},
+		ModelAgentService: struct{ migrationmaster.ModelAgentService }{},
+		ResourceService:   struct{ migrationmaster.ResourceService }{},
+		AgentBinaryStore:  struct{ migration.AgentBinaryStore }{},
+		Clock:             struct{ clock.Clock }{},
 	}
 }
 

--- a/internal/worker/migrationmaster/validate_test.go
+++ b/internal/worker/migrationmaster/validate_test.go
@@ -126,10 +126,14 @@ func validConfig() migrationmaster.Config {
 		ControllerConfigService: struct {
 			migrationmaster.ControllerConfigService
 		}{},
-		ModelAgentService: struct{ migrationmaster.ModelAgentService }{},
-		ResourceService:   struct{ migrationmaster.ResourceService }{},
-		AgentBinaryStore:  struct{ migration.AgentBinaryStore }{},
-		Clock:             struct{ clock.Clock }{},
+		ModelAgentService: struct {
+			migrationmaster.ModelAgentService
+		}{},
+		ResourceService: struct {
+			migrationmaster.ResourceService
+		}{},
+		AgentBinaryStore: struct{ migration.AgentBinaryStore }{},
+		Clock:            struct{ clock.Clock }{},
 	}
 }
 

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -499,13 +499,13 @@ func (w *uploadWrapper) UploadResource(ctx context.Context, res resource.Resourc
 	return w.client.UploadResource(ctx, w.modelUUID, res, content)
 }
 
-// importErrIsActivating reports whether a coded AlreadyExists error from the
-// target's v8 Import carries the activation-in-progress wording. The target
-// includes "activation in progress" in the error message when the existing
-// import claim for the model has phase 'activating' (the migrationtarget v8
-// contract): activation has crossed the point of no return, so the source
-// must resume activation rather than abort.
 func importErrIsActivating(err error) bool {
+	// TODO(modelmigration): remove this string match when target-side ImportV2
+	// is implemented. ImportV2 needs to return structured duplicate-import
+	// state so the source can tell whether the target is still safely
+	// importing, or has crossed into activation where aborting is no longer
+	// correct. Until then, keep the existing resume path for the placeholder
+	// activation wording and do not add a public RPC error code.
 	return err != nil && strings.Contains(err.Error(), "activation in progress")
 }
 
@@ -541,8 +541,7 @@ func (w *Worker) transferModel(ctx context.Context, status coremigration.Migrati
 			w.setInfoStatus(ctx, "target reports model activation in progress, continuing to validation")
 			return coremigration.VALIDATION, nil
 		}
-		return coremigration.UNKNOWN, errors.Annotate(err,
-			"target controller already has an import for this model; abort the existing migration and retry")
+		return coremigration.UNKNOWN, errors.New("target controller already has an import for this model")
 	case err != nil:
 		return coremigration.UNKNOWN, errors.Annotate(err, "failed to import model into target controller")
 	}

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -109,7 +109,7 @@ type ModelMigrationService interface {
 	// [coremigration.NONE] is returned.
 	Migration(context.Context) (modelmigration.Migration, error)
 
-	// GetControllerModelInfo reads the controller-database facts scoped to
+	// GetControllerModelInfo reads the controller-database information scoped to
 	// this migrating model in target-portable semantic form.
 	GetControllerModelInfo(context.Context) (modelmigration.ControllerModelInfo, error)
 

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -148,13 +148,11 @@ type ControllerConfigService interface {
 
 // ModelAgentService reports the agent binaries in use by the model's agents.
 type ModelAgentService interface {
-	// GetMachinesAgentBinaryMetadata reports the agent binary metadata that
-	// each machine in the model is running.
-	GetMachinesAgentBinaryMetadata(context.Context) (map[machine.Name]coreagentbinary.Metadata, error)
-
-	// GetUnitsAgentBinaryMetadata reports the agent binary metadata that each
-	// unit in the model is running.
-	GetUnitsAgentBinaryMetadata(context.Context) (map[unit.Name]coreagentbinary.Metadata, error)
+	// GetModelAgentBinaryMetadata reports the agent binary metadata that each
+	// machine and unit in the model is running.
+	GetModelAgentBinaryMetadata(
+		context.Context,
+	) (map[machine.Name]coreagentbinary.Metadata, map[unit.Name]coreagentbinary.Metadata, error)
 }
 
 // ResourceService lists the model resources that need binary transfer.
@@ -500,8 +498,8 @@ func (w *uploadWrapper) UploadResource(ctx context.Context, res resource.Resourc
 }
 
 func importErrIsActivating(err error) bool {
-	// TODO(modelmigration): remove this string match when target-side ImportV2
-	// is implemented. ImportV2 needs to return structured duplicate-import
+	// TODO(modelmigration): remove this string match when target-side Import v8
+	// is implemented. Import v8 needs to return structured duplicate-import
 	// state so the source can tell whether the target is still safely
 	// importing, or has crossed into activation where aborting is no longer
 	// correct. Until then, keep the existing resume path for the placeholder

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -29,14 +29,8 @@ import (
 	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/application/charm"
-	applicationservice "github.com/juju/juju/domain/application/service"
-	controllerconfigservice "github.com/juju/juju/domain/controllerconfig/service"
 	domainexport "github.com/juju/juju/domain/export"
-	exportservice "github.com/juju/juju/domain/export/service"
-	modelagentservice "github.com/juju/juju/domain/modelagent/service"
 	"github.com/juju/juju/domain/modelmigration"
-	modelmigrationservice "github.com/juju/juju/domain/modelmigration/service"
-	resourceservice "github.com/juju/juju/domain/resource/service"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/tools"
@@ -169,15 +163,6 @@ type ResourceService interface {
 	// export for all applications in the model.
 	ListAllModelResources(context.Context) ([]resource.Resource, error)
 }
-
-var (
-	_ ModelMigrationService   = (*modelmigrationservice.Service)(nil)
-	_ CharmService            = (*applicationservice.WatchableService)(nil)
-	_ ExportService           = (*exportservice.Service)(nil)
-	_ ControllerConfigService = (*controllerconfigservice.WatchableService)(nil)
-	_ ModelAgentService       = (*modelagentservice.WatchableService)(nil)
-	_ ResourceService         = (*resourceservice.Service)(nil)
-)
 
 // AgentBinaryStore provides an interface for interacting with the stored agent
 // binaries within a controller and model.

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -36,7 +36,6 @@ import (
 	modelagentservice "github.com/juju/juju/domain/modelagent/service"
 	"github.com/juju/juju/domain/modelmigration"
 	modelmigrationservice "github.com/juju/juju/domain/modelmigration/service"
-	coreresource "github.com/juju/juju/core/resource"
 	resourceservice "github.com/juju/juju/domain/resource/service"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/migration"
@@ -168,7 +167,7 @@ type ModelAgentService interface {
 type ResourceService interface {
 	// ListAllModelResources returns the application and unit resources to
 	// export for all applications in the model.
-	ListAllModelResources(context.Context) ([]coreresource.Resource, error)
+	ListAllModelResources(context.Context) ([]resource.Resource, error)
 }
 
 var (

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -19,13 +19,25 @@ import (
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/controller/migrationtarget"
+	"github.com/juju/juju/controller"
+	coreagentbinary "github.com/juju/juju/core/agentbinary"
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/machine"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/resource"
 	"github.com/juju/juju/core/semversion"
+	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/application/charm"
+	applicationservice "github.com/juju/juju/domain/application/service"
+	controllerconfigservice "github.com/juju/juju/domain/controllerconfig/service"
+	domainexport "github.com/juju/juju/domain/export"
+	exportservice "github.com/juju/juju/domain/export/service"
+	modelagentservice "github.com/juju/juju/domain/modelagent/service"
+	"github.com/juju/juju/domain/modelmigration"
 	modelmigrationservice "github.com/juju/juju/domain/modelmigration/service"
+	coreresource "github.com/juju/juju/core/resource"
+	resourceservice "github.com/juju/juju/domain/resource/service"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/tools"
@@ -57,53 +69,20 @@ var (
 // to the newly-migrated model.
 const progressUpdateInterval = 30 * time.Second
 
-// Facade exposes controller functionality to a Worker.
+// Facade exposes the controller facade functionality the Worker still needs.
+// These are the operations shared with remote callers; everything that is
+// worker-private is reached directly through the domain services instead.
 type Facade interface {
-	// Watch returns a watcher which reports when a migration is
-	// active for the model associated with the API connection.
-	Watch(context.Context) (watcher.NotifyWatcher, error)
-
-	// MigrationStatus returns the details and progress of the latest
-	// model migration.
-	MigrationStatus(context.Context) (coremigration.MigrationStatus, error)
-
-	// SetPhase updates the phase of the currently active model
-	// migration.
-	SetPhase(context.Context, coremigration.Phase) error
-
-	// SetStatusMessage sets a human readable message regarding the
-	// progress of a migration.
-	SetStatusMessage(context.Context, string) error
-
 	// Prechecks performs pre-migration checks on the model and
 	// (source) controller.
 	Prechecks(context.Context) error
-
-	// ModelInfo return basic information about the model to migrated.
-	ModelInfo(context.Context) (coremigration.ModelInfo, error)
 
 	// SourceControllerInfo returns connection information about the source controller
 	// and uuids of any other hosted models involved in cross model relations.
 	SourceControllerInfo(context.Context) (coremigration.SourceControllerInfo, []string, error)
 
-	// Export returns a serialized representation of the model
-	// associated with the API connection.
-	Export(context.Context) (coremigration.SerializedModel, error)
-
-	// ProcessRelations runs a series of processes to ensure that the relations
-	// of a given model are correct after a migrated model.
-	ProcessRelations(context.Context, string) error
-
 	// OpenResource downloads a single resource for an application.
 	OpenResource(context.Context, string, string) (io.ReadCloser, error)
-
-	// Reap removes all documents of the model associated with the API
-	// connection.
-	Reap(context.Context) error
-
-	// MinionReportTimeout returns the maximum time to wait for minion workers
-	// to report on a migration phase.
-	MinionReportTimeout(context.Context) (time.Duration, error)
 
 	// StreamModelLog takes a starting time and returns a channel that
 	// will yield the logs on or after that time - these are the logs
@@ -117,13 +96,41 @@ type CharmService interface {
 	// charm id, along with the hash of the charm archive. Clients can use the hash
 	// to verify the integrity of the charm archive.
 	GetCharmArchive(context.Context, charm.CharmLocator) (io.ReadCloser, string, error)
+
+	// ListCharmLocators returns a list of charm locators. The locator allows
+	// the charm URL to be reconstructed. If no names are provided, all the
+	// model's charms are listed.
+	ListCharmLocators(context.Context, ...string) ([]charm.CharmLocator, error)
 }
 
-// ModelMigrationService exposes model migration domain operations that the
-// worker needs locally. Minion report validation needs the model agent
-// inventory, so the worker uses the domain service instead of the controller
-// facade for this path.
+// ModelMigrationService exposes the model migration domain operations the
+// worker uses to drive the source side of a migration: the export lifecycle,
+// phase and status reporting, controller-fact export, and minion reports.
 type ModelMigrationService interface {
+	// WatchForMigration returns a notification watcher that fires when this
+	// model starts or stops undergoing migration.
+	WatchForMigration(context.Context) (watcher.NotifyWatcher, error)
+
+	// Migration returns status about migration of this model. If the model is
+	// not currently being migrated, a migration with phase
+	// [coremigration.NONE] is returned.
+	Migration(context.Context) (modelmigration.Migration, error)
+
+	// GetControllerModelInfo reads the controller-database facts scoped to
+	// this migrating model in target-portable semantic form.
+	GetControllerModelInfo(context.Context) (modelmigration.ControllerModelInfo, error)
+
+	// SetMigrationPhase progresses the active migration to the given phase.
+	SetMigrationPhase(context.Context, coremigration.Phase) error
+
+	// SetMigrationStatusMessage records a human readable message regarding
+	// the progress of the active migration.
+	SetMigrationStatusMessage(context.Context, string) error
+
+	// MarkModelAsGone removes the migrated model from this controller once
+	// the target controller owns it, completing the export migration.
+	MarkModelAsGone(context.Context) error
+
 	// WatchMinionReports returns a notification watcher that fires when any
 	// minion reports an update to their phase.
 	WatchMinionReports(context.Context) (watcher.NotifyWatcher, error)
@@ -132,7 +139,46 @@ type ModelMigrationService interface {
 	MinionReports(context.Context) (coremigration.MinionReports, error)
 }
 
-var _ ModelMigrationService = (*modelmigrationservice.Service)(nil)
+// ExportService exposes the model-database export used as the envelope
+// payload.
+type ExportService interface {
+	// Export returns the model-database contents at the latest supported
+	// payload schema version.
+	Export(context.Context) (*domainexport.ModelExport, error)
+}
+
+// ControllerConfigService provides access to the controller configuration.
+type ControllerConfigService interface {
+	// ControllerConfig returns the config values for the controller.
+	ControllerConfig(context.Context) (controller.Config, error)
+}
+
+// ModelAgentService reports the agent binaries in use by the model's agents.
+type ModelAgentService interface {
+	// GetMachinesAgentBinaryMetadata reports the agent binary metadata that
+	// each machine in the model is running.
+	GetMachinesAgentBinaryMetadata(context.Context) (map[machine.Name]coreagentbinary.Metadata, error)
+
+	// GetUnitsAgentBinaryMetadata reports the agent binary metadata that each
+	// unit in the model is running.
+	GetUnitsAgentBinaryMetadata(context.Context) (map[unit.Name]coreagentbinary.Metadata, error)
+}
+
+// ResourceService lists the model resources that need binary transfer.
+type ResourceService interface {
+	// ListAllModelResources returns the application and unit resources to
+	// export for all applications in the model.
+	ListAllModelResources(context.Context) ([]coreresource.Resource, error)
+}
+
+var (
+	_ ModelMigrationService   = (*modelmigrationservice.Service)(nil)
+	_ CharmService            = (*applicationservice.WatchableService)(nil)
+	_ ExportService           = (*exportservice.Service)(nil)
+	_ ControllerConfigService = (*controllerconfigservice.WatchableService)(nil)
+	_ ModelAgentService       = (*modelagentservice.WatchableService)(nil)
+	_ ResourceService         = (*resourceservice.Service)(nil)
+)
 
 // AgentBinaryStore provides an interface for interacting with the stored agent
 // binaries within a controller and model.
@@ -146,15 +192,19 @@ type AgentBinaryStore interface {
 
 // Config defines the operation of a Worker.
 type Config struct {
-	ModelUUID             string
-	Facade                Facade
-	CharmService          CharmService
-	ModelMigrationService ModelMigrationService
-	Guard                 fortress.Guard
-	APIOpen               func(context.Context, *api.Info, api.DialOpts) (api.Connection, error)
-	UploadBinaries        func(context.Context, migration.UploadBinariesConfig, logger.Logger) error
-	AgentBinaryStore      AgentBinaryStore
-	Clock                 clock.Clock
+	ModelUUID               string
+	Facade                  Facade
+	CharmService            CharmService
+	ModelMigrationService   ModelMigrationService
+	ExportService           ExportService
+	ControllerConfigService ControllerConfigService
+	ModelAgentService       ModelAgentService
+	ResourceService         ResourceService
+	Guard                   fortress.Guard
+	APIOpen                 func(context.Context, *api.Info, api.DialOpts) (api.Connection, error)
+	UploadBinaries          func(context.Context, migration.UploadBinariesConfig, logger.Logger) error
+	AgentBinaryStore        AgentBinaryStore
+	Clock                   clock.Clock
 }
 
 // Validate returns an error if config cannot drive a Worker.
@@ -170,6 +220,18 @@ func (config Config) Validate() error {
 	}
 	if config.ModelMigrationService == nil {
 		return errors.NotValidf("nil ModelMigrationService")
+	}
+	if config.ExportService == nil {
+		return errors.NotValidf("nil ExportService")
+	}
+	if config.ControllerConfigService == nil {
+		return errors.NotValidf("nil ControllerConfigService")
+	}
+	if config.ModelAgentService == nil {
+		return errors.NotValidf("nil ModelAgentService")
+	}
+	if config.ResourceService == nil {
+		return errors.NotValidf("nil ResourceService")
 	}
 	if config.Guard == nil {
 		return errors.NotValidf("nil Guard")
@@ -253,9 +315,11 @@ func (w *Worker) run() error {
 		return errors.Trace(err)
 	}
 
-	if w.minionReportTimeout, err = w.config.Facade.MinionReportTimeout(ctx); err != nil {
-		return errors.Trace(err)
+	controllerConfig, err := w.config.ControllerConfigService.ControllerConfig(ctx)
+	if err != nil {
+		return errors.Annotate(err, "retrieving controller config")
 	}
+	w.minionReportTimeout = controllerConfig.MigrationMinionWaitMax()
 
 	phase := status.Phase
 
@@ -265,9 +329,7 @@ func (w *Worker) run() error {
 		case coremigration.QUIESCE:
 			phase, err = w.doQUIESCE(ctx, status)
 		case coremigration.IMPORT:
-			phase, err = w.doIMPORT(ctx, status.TargetInfo, status.ModelUUID)
-		case coremigration.PROCESSRELATIONS:
-			phase, err = w.doPROCESSRELATIONS(ctx, status)
+			phase, err = w.doIMPORT(ctx, status)
 		case coremigration.VALIDATION:
 			phase, err = w.doVALIDATION(ctx, status)
 		case coremigration.SUCCESS:
@@ -295,8 +357,15 @@ func (w *Worker) run() error {
 			return w.catacomb.ErrDying()
 		}
 
+		if phase == coremigration.DONE {
+			// MarkModelAsGone has already moved the export to DONE;
+			// setting the phase again would fail as the export is no
+			// longer active.
+			return ErrMigrated
+		}
+
 		w.logger.Infof(ctx, "setting migration phase to %s", phase)
-		if err := w.config.Facade.SetPhase(ctx, phase); err != nil {
+		if err := w.config.ModelMigrationService.SetMigrationPhase(ctx, phase); err != nil {
 			return errors.Annotate(err, "failed to set phase")
 		}
 		status.Phase = phase
@@ -341,7 +410,7 @@ func (w *Worker) setStatusAndLog(ctx context.Context, log func(context.Context, 
 }
 
 func (w *Worker) setStatus(ctx context.Context, message string) error {
-	err := w.config.Facade.SetStatusMessage(ctx, message)
+	err := w.config.ModelMigrationService.SetMigrationStatusMessage(ctx, message)
 	return errors.Annotate(err, "failed to set status message")
 }
 
@@ -371,24 +440,35 @@ func (w *Worker) doQUIESCE(ctx context.Context, status coremigration.MigrationSt
 	return coremigration.IMPORT, nil
 }
 
+// incompatibleTargetMessage is the hard error reported when the source is on
+// the new SerializedModelV2 migration path but the target controller does not
+// expose the v8 migrationtarget facade that accepts it.
 var incompatibleTargetMessage = `
-target controller must be upgraded to 2.9.43 or later
-to be able to migrate models with cross model relations
-to other models hosted on the source controller
+target controller does not support the model migration envelope format;
+upgrade the target controller to Juju 4.1 or later
 `[1:]
 
-func (w *Worker) prechecks(ctx context.Context, status coremigration.MigrationStatus) error {
-	model, err := w.config.Facade.ModelInfo(ctx)
-	if err != nil {
-		return errors.Annotate(err, "failed to obtain model info during prechecks")
+// checkTargetSupportsEnvelope hard-errors when the target controller does not
+// advertise migrationtarget v8, the first version able to accept the
+// SerializedModelV2 envelope. There is no fallback to a legacy path.
+func checkTargetSupportsEnvelope(targetClient *migrationtarget.Client) error {
+	if targetClient.BestFacadeVersion() < 8 {
+		return errors.New(incompatibleTargetMessage)
 	}
+	return nil
+}
 
+func (w *Worker) prechecks(ctx context.Context, status coremigration.MigrationStatus) error {
 	w.setInfoStatus(ctx, "performing source prechecks")
 	if err := w.config.Facade.Prechecks(ctx); err != nil {
 		return errors.Annotate(err, "source prechecks failed")
 	}
 
 	w.setInfoStatus(ctx, "performing target prechecks")
+	model, err := w.assembleEnvelope(ctx, status.MigrationId)
+	if err != nil {
+		return errors.Annotate(err, "failed to assemble model envelope during prechecks")
+	}
 	targetConn, err := w.openAPIConn(ctx, status.TargetInfo)
 	if err != nil {
 		return errors.Annotate(err, "failed to connect to target controller during prechecks")
@@ -399,28 +479,20 @@ func (w *Worker) prechecks(ctx context.Context, status coremigration.MigrationSt
 			targetConn.ControllerTag().Id(), status.TargetInfo.ControllerUUID)
 	}
 	targetClient := migrationtarget.NewClient(targetConn)
-	// If we have cross model relations to other models on this controller,
-	// we need to ensure the target controller is recent enough to process those.
-	if targetClient.BestFacadeVersion() < 2 {
-		_, localRelatedModels, err := w.config.Facade.SourceControllerInfo(ctx)
-		if err != nil {
-			return errors.Annotate(err, "cannot get local model info")
-		}
-		if len(localRelatedModels) > 0 {
-			return errors.New(incompatibleTargetMessage)
-		}
+	if err := checkTargetSupportsEnvelope(targetClient); err != nil {
+		return errors.Trace(err)
 	}
-	err = targetClient.Prechecks(ctx, model)
+	err = targetClient.PrechecksV2(ctx, model.envelope)
 	return errors.Annotate(err, "target prechecks failed")
 }
 
-func (w *Worker) doIMPORT(ctx context.Context, targetInfo coremigration.TargetInfo, modelUUID string) (coremigration.Phase, error) {
-	err := w.transferModel(ctx, targetInfo, modelUUID)
+func (w *Worker) doIMPORT(ctx context.Context, status coremigration.MigrationStatus) (coremigration.Phase, error) {
+	phase, err := w.transferModel(ctx, status)
 	if err != nil {
 		w.setErrorStatus(ctx, "model data transfer failed, %v", err)
 		return coremigration.ABORT, nil
 	}
-	return coremigration.PROCESSRELATIONS, nil
+	return phase, nil
 }
 
 type uploadWrapper struct {
@@ -443,67 +515,81 @@ func (w *uploadWrapper) UploadResource(ctx context.Context, res resource.Resourc
 	return w.client.UploadResource(ctx, w.modelUUID, res, content)
 }
 
-func (w *Worker) transferModel(ctx context.Context, targetInfo coremigration.TargetInfo, modelUUID string) error {
+// importErrIsActivating reports whether a coded AlreadyExists error from the
+// target's v8 Import carries the activation-in-progress wording. The target
+// includes "activation in progress" in the error message when the existing
+// import claim for the model has phase 'activating' (the migrationtarget v8
+// contract): activation has crossed the point of no return, so the source
+// must resume activation rather than abort.
+func importErrIsActivating(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "activation in progress")
+}
+
+// transferModel assembles the authoritative import envelope, imports it into
+// the target controller, and uploads the model binaries. It returns the phase
+// the migration should move to next; any error moves the migration to ABORT.
+func (w *Worker) transferModel(ctx context.Context, status coremigration.MigrationStatus) (coremigration.Phase, error) {
 	w.setInfoStatus(ctx, "exporting model")
-	serialized, err := w.config.Facade.Export(ctx)
+	model, err := w.assembleEnvelope(ctx, status.MigrationId)
 	if err != nil {
-		return errors.Annotate(err, "model export failed")
+		return coremigration.UNKNOWN, errors.Annotate(err, "model export failed")
 	}
 
 	w.setInfoStatus(ctx, "importing model into target controller")
-	conn, err := w.openAPIConn(ctx, targetInfo)
+	conn, err := w.openAPIConn(ctx, status.TargetInfo)
 	if err != nil {
-		return errors.Annotate(err, "failed to connect to target controller")
+		return coremigration.UNKNOWN, errors.Annotate(err, "failed to connect to target controller")
 	}
 	defer conn.Close()
 	targetClient := migrationtarget.NewClient(conn)
-	err = targetClient.Import(ctx, serialized.Bytes)
-	if err != nil {
-		return errors.Annotate(err, "failed to import model into target controller")
+	if err := checkTargetSupportsEnvelope(targetClient); err != nil {
+		return coremigration.UNKNOWN, errors.Trace(err)
+	}
+
+	err = targetClient.ImportV2(ctx, model.envelope)
+	switch {
+	case params.IsCodeAlreadyExists(err):
+		if importErrIsActivating(err) {
+			// A previous import of this model has crossed the activation
+			// point of no return on the target. Skip the binary uploads
+			// (they completed before activation started) and continue to
+			// VALIDATION so activation is retried and completed.
+			w.setInfoStatus(ctx, "target reports model activation in progress, continuing to validation")
+			return coremigration.VALIDATION, nil
+		}
+		return coremigration.UNKNOWN, errors.Annotate(err,
+			"target controller already has an import for this model; abort the existing migration and retry")
+	case err != nil:
+		return coremigration.UNKNOWN, errors.Annotate(err, "failed to import model into target controller")
 	}
 
 	if wrench.IsActive("migrationmaster", "die-in-export") {
 		// Simulate a abort causing failure to test last status not over written.
-		return errors.New("wrench in the transferModel works")
+		return coremigration.UNKNOWN, errors.New("wrench in the transferModel works")
 	}
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
 	w.setInfoStatus(ctx, "uploading model binaries into target controller")
-	wrapper := &uploadWrapper{targetClient, modelUUID}
+	wrapper := &uploadWrapper{targetClient, status.ModelUUID}
 	err = w.config.UploadBinaries(ctx, migration.UploadBinariesConfig{
-		Charms:        serialized.Charms,
+		Charms:        model.charms,
 		CharmService:  w.config.CharmService,
 		CharmUploader: wrapper,
 
-		Tools:            serialized.Tools,
+		Tools:            model.tools,
 		AgentBinaryStore: w.config.AgentBinaryStore,
 		ToolsUploader:    wrapper,
 
-		Resources:          serialized.Resources,
+		Resources:          model.resources,
 		ResourceDownloader: w.config.Facade,
 		ResourceUploader:   wrapper,
 	}, w.logger)
-	return errors.Annotate(err, "failed to migrate binaries")
-}
-
-func (w *Worker) doPROCESSRELATIONS(ctx context.Context, status coremigration.MigrationStatus) (coremigration.Phase, error) {
-	err := w.processRelations(ctx, status.TargetInfo, status.ModelUUID)
 	if err != nil {
-		w.setErrorStatus(ctx, "processing relations failed, %v", err)
-		return coremigration.ABORT, nil
+		return coremigration.UNKNOWN, errors.Annotate(err, "failed to migrate binaries")
 	}
 	return coremigration.VALIDATION, nil
-}
-
-func (w *Worker) processRelations(ctx context.Context, targetInfo coremigration.TargetInfo, modelUUID string) error {
-	w.setInfoStatus(ctx, "processing relations")
-	err := w.config.Facade.ProcessRelations(ctx, targetInfo.ControllerAlias)
-	if err != nil {
-		return errors.Annotate(err, "processing relations failed")
-	}
-	return nil
 }
 
 func (w *Worker) doVALIDATION(ctx context.Context, status coremigration.MigrationStatus) (coremigration.Phase, error) {
@@ -691,11 +777,11 @@ func (w *Worker) transferLogs(ctx context.Context, targetInfo coremigration.Targ
 
 func (w *Worker) doREAP(ctx context.Context) (coremigration.Phase, error) {
 	w.setInfoStatus(ctx, "successful, removing model from source controller")
-	// NOTE(babbageclunk): Calling Reap will set the migration phase
-	// to DONE if successful - this avoids a race where this worker is
+	// NOTE(babbageclunk): MarkModelAsGone sets the migration phase to
+	// DONE if successful - this avoids a race where this worker is
 	// killed by the model going away before it can update the phase
 	// itself.
-	err := w.config.Facade.Reap(ctx)
+	err := w.config.ModelMigrationService.MarkModelAsGone(ctx)
 	if err != nil {
 		w.setErrorStatus(ctx, "removing exported model failed: %s", err.Error())
 		return coremigration.REAPFAILED, nil
@@ -728,7 +814,7 @@ func (w *Worker) removeImportedModel(ctx context.Context, targetInfo coremigrati
 func (w *Worker) waitForActiveMigration(ctx context.Context) (coremigration.MigrationStatus, error) {
 	var empty coremigration.MigrationStatus
 
-	watcher, err := w.config.Facade.Watch(ctx)
+	watcher, err := w.config.ModelMigrationService.WatchForMigration(ctx)
 	if err != nil {
 		return empty, errors.Annotate(err, "watching for migration")
 	}
@@ -744,20 +830,26 @@ func (w *Worker) waitForActiveMigration(ctx context.Context) (coremigration.Migr
 		case <-watcher.Changes():
 		}
 
-		status, err := w.config.Facade.MigrationStatus(ctx)
+		mig, err := w.config.ModelMigrationService.Migration(ctx)
 		switch {
-		case params.IsCodeNotFound(err):
-			// There's never been a migration.
-		case err == nil && status.Phase.IsTerminal():
-			// No migration in progress.
-			if modelHasMigrated(status.Phase) {
-				return empty, ErrMigrated
-			}
 		case err != nil:
 			return empty, errors.Annotate(err, "retrieving migration status")
+		case mig.Phase == coremigration.NONE:
+			// There's never been a migration.
+		case mig.Phase.IsTerminal():
+			// No migration in progress.
+			if modelHasMigrated(mig.Phase) {
+				return empty, ErrMigrated
+			}
 		default:
 			// Migration is in progress.
-			return status, nil
+			return coremigration.MigrationStatus{
+				MigrationId:      mig.UUID,
+				ModelUUID:        w.config.ModelUUID,
+				Phase:            mig.Phase,
+				PhaseChangedTime: mig.PhaseChangedTime,
+				TargetInfo:       mig.Target,
+			}, nil
 		}
 
 		// While waiting for a migration, ensure the fortress is open.

--- a/internal/worker/migrationmaster/worker_test.go
+++ b/internal/worker/migrationmaster/worker_test.go
@@ -184,8 +184,7 @@ var (
 		{FuncName: "exportService.Export", Args: nil},
 		{FuncName: "modelMigrationService.GetControllerModelInfo", Args: nil},
 		{FuncName: "charmService.ListCharmLocators", Args: nil},
-		{FuncName: "modelAgentService.GetMachinesAgentBinaryMetadata", Args: nil},
-		{FuncName: "modelAgentService.GetUnitsAgentBinaryMetadata", Args: nil},
+		{FuncName: "modelAgentService.GetModelAgentBinaryMetadata", Args: nil},
 		{FuncName: "resourceService.ListAllModelResources", Args: nil},
 	}
 	abortCalls = []testhelpers.StubCall{
@@ -686,7 +685,7 @@ func (s *Suite) TestImportFailure(c *tc.C) {
 }
 
 func (s *Suite) TestImportFailureAlreadyExistsActivating(c *tc.C) {
-	// Preserve the activation resume path until ImportV2 exposes structured
+	// Preserve the activation resume path until Import v8 exposes structured
 	// target state for duplicate imports.
 	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.IMPORT))
 	s.connection.importErr = &params.Error{
@@ -1596,14 +1595,11 @@ type stubModelAgentService struct {
 	stub *testhelpers.Stub
 }
 
-func (s *stubModelAgentService) GetMachinesAgentBinaryMetadata(ctx context.Context) (map[machine.Name]coreagentbinary.Metadata, error) {
-	s.stub.AddCall("modelAgentService.GetMachinesAgentBinaryMetadata")
-	return fakeMachineTools, nil
-}
-
-func (s *stubModelAgentService) GetUnitsAgentBinaryMetadata(ctx context.Context) (map[unit.Name]coreagentbinary.Metadata, error) {
-	s.stub.AddCall("modelAgentService.GetUnitsAgentBinaryMetadata")
-	return nil, nil
+func (s *stubModelAgentService) GetModelAgentBinaryMetadata(
+	ctx context.Context,
+) (map[machine.Name]coreagentbinary.Metadata, map[unit.Name]coreagentbinary.Metadata, error) {
+	s.stub.AddCall("modelAgentService.GetModelAgentBinaryMetadata")
+	return fakeMachineTools, nil, nil
 }
 
 type stubResourceService struct {

--- a/internal/worker/migrationmaster/worker_test.go
+++ b/internal/worker/migrationmaster/worker_test.go
@@ -1667,10 +1667,10 @@ func (w *mockWatcher) Changes() watcher.NotifyChannel {
 type stubConnection struct {
 	c *tc.C
 	api.Connection
-	stub                *testhelpers.Stub
-	prechecksErr        error
-	importErr           error
-	controllerTag       names.ControllerTag
+	stub          *testhelpers.Stub
+	prechecksErr  error
+	importErr     error
+	controllerTag names.ControllerTag
 
 	streamErr error
 	logStream *mockStream
@@ -1771,7 +1771,6 @@ func makeStubUploadBinaries(stub *testhelpers.Stub) func(context.Context, migrat
 func nullUploadBinaries(context.Context, migration.UploadBinariesConfig, logger.Logger) error {
 	panic("should not get called")
 }
-
 
 var fakeAgentBinaryStore = struct{ migration.AgentBinaryStore }{}
 

--- a/internal/worker/migrationmaster/worker_test.go
+++ b/internal/worker/migrationmaster/worker_test.go
@@ -686,10 +686,8 @@ func (s *Suite) TestImportFailure(c *tc.C) {
 }
 
 func (s *Suite) TestImportFailureAlreadyExistsActivating(c *tc.C) {
-	// The target reports an existing import claim that has crossed the
-	// activation point of no return: the worker must continue to
-	// VALIDATION (and retry activation) rather than abort, and must not
-	// re-upload binaries.
+	// Preserve the activation resume path until ImportV2 exposes structured
+	// target state for duplicate imports.
 	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.IMPORT))
 	s.connection.importErr = &params.Error{
 		Code:    params.CodeAlreadyExists,
@@ -1448,8 +1446,6 @@ type stubModelMigrationService struct {
 
 	controllerModelInfoErr error
 
-	markModelAsGoneErr error
-
 	minionReportsChanges  chan struct{}
 	minionReportsWatchErr error
 	minionReports         []coremigration.MinionReports
@@ -1517,7 +1513,7 @@ func (s *stubModelMigrationService) SetMigrationStatusMessage(ctx context.Contex
 
 func (s *stubModelMigrationService) MarkModelAsGone(ctx context.Context) error {
 	s.stub.AddCall("modelMigrationService.MarkModelAsGone")
-	return s.markModelAsGoneErr
+	return nil
 }
 
 func (s *stubModelMigrationService) triggerMinionReports() {

--- a/internal/worker/migrationmaster/worker_test.go
+++ b/internal/worker/migrationmaster/worker_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
-	"github.com/juju/description/v12"
 	"github.com/juju/errors"
 	"github.com/juju/loggo/v2"
 	"github.com/juju/names/v6"
@@ -21,37 +20,51 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
 	"gopkg.in/macaroon.v2"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	apiclient "github.com/juju/juju/api/client/client"
 	"github.com/juju/juju/api/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/controller"
+	coreagentbinary "github.com/juju/juju/core/agentbinary"
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/machine"
 	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/model"
 	coreresource "github.com/juju/juju/core/resource"
 	resourcetesting "github.com/juju/juju/core/resource/testing"
 	"github.com/juju/juju/core/semversion"
+	"github.com/juju/juju/core/unit"
 	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/application/architecture"
+	applicationcharm "github.com/juju/juju/domain/application/charm"
+	domainexport "github.com/juju/juju/domain/export"
+	"github.com/juju/juju/domain/modelmigration"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/testhelpers"
 	coretesting "github.com/juju/juju/internal/testing"
-	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/internal/worker/migrationmaster"
 	"github.com/juju/juju/rpc/params"
 )
 
 type Suite struct {
 	coretesting.BaseSuite
-	clock                 *testclock.Clock
-	stub                  *testhelpers.Stub
-	connection            *stubConnection
-	connectionErr         error
-	facade                *stubMasterFacade
-	modelMigrationService *stubModelMigrationService
-	config                migrationmaster.Config
+	clock                   *testclock.Clock
+	stub                    *testhelpers.Stub
+	connection              *stubConnection
+	connectionErr           error
+	facade                  *stubMasterFacade
+	modelMigrationService   *stubModelMigrationService
+	exportService           *stubExportService
+	controllerConfigService *stubControllerConfigService
+	modelAgentService       *stubModelAgentService
+	resourceService         *stubResourceService
+	charmService            *stubCharmService
+	config                  migrationmaster.Config
 }
 
 func TestSuite(t *testing.T) {
@@ -59,14 +72,53 @@ func TestSuite(t *testing.T) {
 }
 
 var (
-	fakeModelBytes      = []byte("model")
 	sourceControllerTag = names.NewControllerTag("source-controller-uuid")
 	targetControllerTag = names.NewControllerTag("controller-uuid")
-	modelUUID           = "model-uuid"
+	modelUUID           = "deadbeef-0bad-400d-8000-4b1d0d06f00d"
 	modelTag            = names.NewModelTag(modelUUID)
 	modelName           = "model-name"
 	modelQualifier      = model.Qualifier("prod")
-	modelVersion        = semversion.MustParse("1.2.4")
+
+	fakeExportVersion = semversion.MustParse("4.0.6")
+	fakeExportPayload = map[string]string{"model": "data"}
+
+	fakeCharmLocators = []applicationcharm.CharmLocator{{
+		Name:         "charm0",
+		Revision:     0,
+		Source:       applicationcharm.CharmHubSource,
+		Architecture: architecture.AMD64,
+	}, {
+		Name:         "charm1",
+		Revision:     1,
+		Source:       applicationcharm.LocalSource,
+		Architecture: architecture.Unknown,
+	}}
+	fakeCharmURLs = []string{"ch:amd64/charm0-0", "local:charm1-1"}
+
+	fakeToolsSHA256  = "439c9ea02f8561c5a152d7cf4818d72cd5f2916b555d82c5eee599f5e8f3d09e"
+	fakeMachineTools = map[machine.Name]coreagentbinary.Metadata{
+		"0": {
+			Version: coreagentbinary.Version{
+				Number: semversion.MustParse("2.1.0"),
+				Arch:   arch.AMD64,
+			},
+			SHA256: fakeToolsSHA256,
+		},
+	}
+	fakeUploadTools = map[string]semversion.Binary{
+		fakeToolsSHA256: semversion.MustParseBinary("2.1.0-ubuntu-amd64"),
+	}
+
+	fakeControllerModelInfo = modelmigration.ControllerModelInfo{
+		ModelInfo: modelmigration.ModelIdentityInfo{
+			UUID:      modelUUID,
+			Name:      modelName,
+			Qualifier: modelQualifier.String(),
+			Type:      "iaas",
+			Cloud:     "aws",
+			Life:      "alive",
+		},
+	}
 
 	// Define stub calls that commonly appear in tests here to allow reuse.
 	apiOpenControllerCall = testhelpers.StubCall{
@@ -79,12 +131,6 @@ var (
 				Password: "secret",
 			},
 			migration.ControllerDialOpts(nil),
-		},
-	}
-	importCall = testhelpers.StubCall{
-		FuncName: "MigrationTarget.Import",
-		Args: []any{
-			params.SerializedModel{Bytes: fakeModelBytes},
 		},
 	}
 	activateCall = testhelpers.StubCall{
@@ -129,36 +175,25 @@ var (
 		},
 	}
 	watchStatusLockdownCalls = []testhelpers.StubCall{
-		{FuncName: "facade.Watch", Args: nil},
-		{FuncName: "facade.MigrationStatus", Args: nil},
+		{FuncName: "modelMigrationService.WatchForMigration", Args: nil},
+		{FuncName: "modelMigrationService.Migration", Args: nil},
 		{FuncName: "guard.Lockdown", Args: nil},
 	}
-	prechecksCalls = []testhelpers.StubCall{
-		{FuncName: "facade.ModelInfo", Args: nil},
-		{FuncName: "facade.Prechecks", Args: []any{}},
-		apiOpenControllerCall,
-		{FuncName: "MigrationTarget.Prechecks", Args: []any{params.MigrationModelInfo{
-			UUID:         modelUUID,
-			Name:         modelName,
-			Qualifier:    modelQualifier.String(),
-			AgentVersion: modelVersion,
-			ModelDescription: func() []byte {
-				modelDescription := description.NewModel(description.ModelArgs{})
-				bytes, err := description.Serialize(modelDescription)
-				if err != nil {
-					panic(err)
-				}
-				return bytes
-			}(),
-		}}},
-		apiCloseCall,
+	// assembleCalls are the service calls recorded by one envelope assembly.
+	assembleCalls = []testhelpers.StubCall{
+		{FuncName: "exportService.Export", Args: nil},
+		{FuncName: "modelMigrationService.GetControllerModelInfo", Args: nil},
+		{FuncName: "charmService.ListCharmLocators", Args: nil},
+		{FuncName: "modelAgentService.GetMachinesAgentBinaryMetadata", Args: nil},
+		{FuncName: "modelAgentService.GetUnitsAgentBinaryMetadata", Args: nil},
+		{FuncName: "resourceService.ListAllModelResources", Args: nil},
 	}
 	abortCalls = []testhelpers.StubCall{
-		{FuncName: "facade.SetPhase", Args: []any{coremigration.ABORT}},
+		{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.ABORT}},
 		apiOpenControllerCall,
 		abortCall,
 		apiCloseCall,
-		{FuncName: "facade.SetPhase", Args: []any{coremigration.ABORTDONE}},
+		{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.ABORTDONE}},
 	}
 	openDestLogStreamCall = testhelpers.StubCall{FuncName: "ConnectControllerStream", Args: []any{
 		"/migrate/logtransfer",
@@ -182,25 +217,71 @@ func (s *Suite) SetUpTest(c *tc.C) {
 		controllerVersion: params.ControllerVersionResults{
 			Version: "2.9.99",
 		},
-		facadeVersion: 7,
+		facadeVersion: 8,
 	}
 	s.connectionErr = nil
 
 	s.facade = newStubMasterFacade(s.stub)
 	s.modelMigrationService = newStubModelMigrationService(s.stub)
+	s.exportService = &stubExportService{stub: s.stub}
+	s.controllerConfigService = &stubControllerConfigService{stub: s.stub}
+	s.modelAgentService = &stubModelAgentService{stub: s.stub}
+	s.resourceService = &stubResourceService{stub: s.stub}
+	s.charmService = &stubCharmService{stub: s.stub}
 
 	// The default worker Config used by most of the tests. Tests may
 	// tweak parts of this as needed.
 	s.config = migrationmaster.Config{
-		ModelUUID:             uuid.MustNewUUID().String(),
-		Facade:                s.facade,
-		CharmService:          fakeCharmService,
-		ModelMigrationService: s.modelMigrationService,
-		Guard:                 newStubGuard(s.stub),
-		APIOpen:               s.apiOpen,
-		UploadBinaries:        nullUploadBinaries,
-		AgentBinaryStore:      fakeAgentBinaryStore,
-		Clock:                 s.clock,
+		ModelUUID:               modelUUID,
+		Facade:                  s.facade,
+		CharmService:            s.charmService,
+		ModelMigrationService:   s.modelMigrationService,
+		ExportService:           s.exportService,
+		ControllerConfigService: s.controllerConfigService,
+		ModelAgentService:       s.modelAgentService,
+		ResourceService:         s.resourceService,
+		Guard:                   newStubGuard(s.stub),
+		APIOpen:                 s.apiOpen,
+		UploadBinaries:          nullUploadBinaries,
+		AgentBinaryStore:        fakeAgentBinaryStore,
+		Clock:                   s.clock,
+	}
+}
+
+// expectedEnvelope builds the SerializedModelV2 envelope the worker is
+// expected to assemble from the suite's stub services.
+func (s *Suite) expectedEnvelope(c *tc.C) params.SerializedModelV2 {
+	payload, err := goyaml.Marshal(fakeExportPayload)
+	c.Assert(err, tc.ErrorIsNil)
+	envelope := migrationmaster.EnvelopeFromControllerModelInfo(fakeControllerModelInfo, "model-uuid:2")
+	envelope.PayloadVersion = fakeExportVersion
+	envelope.Payload = payload
+	envelope.Charms = fakeCharmURLs
+	_, envelope.Tools = migrationmaster.ToolsForEnvelope(fakeMachineTools, nil)
+	envelope.Resources = migrationmaster.ResourcesForEnvelope(s.resourceService.resources)
+	return envelope
+}
+
+// prechecksCalls are the stub calls recorded by one worker prechecks pass.
+func (s *Suite) prechecksCalls(c *tc.C) []testhelpers.StubCall {
+	return joinCalls(
+		[]testhelpers.StubCall{
+			{FuncName: "facade.Prechecks", Args: []any{}},
+		},
+		assembleCalls,
+		[]testhelpers.StubCall{
+			apiOpenControllerCall,
+			{FuncName: "MigrationTarget.Prechecks", Args: []any{s.expectedEnvelope(c)}},
+			apiCloseCall,
+		},
+	)
+}
+
+// importCall is the v8 import of the authoritative envelope.
+func (s *Suite) importCall(c *tc.C) testhelpers.StubCall {
+	return testhelpers.StubCall{
+		FuncName: "MigrationTarget.Import",
+		Args:     []any{s.expectedEnvelope(c)},
 	}
 }
 
@@ -229,11 +310,11 @@ func (s *Suite) makeStatus(phase coremigration.Phase) coremigration.MigrationSta
 }
 
 func (s *Suite) TestSuccessfulMigration(c *tc.C) {
-	s.facade.exportedResources = []coreresource.Resource{
+	s.resourceService.resources = []coreresource.Resource{
 		resourcetesting.NewResource(c, nil, "blob", "app", "").Resource,
 	}
 
-	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.QUIESCE))
 	s.modelMigrationService.queueMinionReports(makeMinionReports(coremigration.QUIESCE))
 	s.modelMigrationService.queueMinionReports(makeMinionReports(coremigration.VALIDATION))
 	s.modelMigrationService.queueMinionReports(makeMinionReports(coremigration.SUCCESS))
@@ -248,40 +329,35 @@ func (s *Suite) TestSuccessfulMigration(c *tc.C) {
 		// Wait for migration to start.
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 		},
 
 		// QUIESCE
-		prechecksCalls,
+		s.prechecksCalls(c),
 		[]testhelpers.StubCall{
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
 			{FuncName: "modelMigrationService.MinionReports", Args: nil},
 		},
-		prechecksCalls,
+		s.prechecksCalls(c),
 		[]testhelpers.StubCall{
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.IMPORT}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.IMPORT}},
+		},
 
-			//IMPORT
-			{FuncName: "facade.Export", Args: nil},
+		//IMPORT
+		assembleCalls,
+		[]testhelpers.StubCall{
 			apiOpenControllerCall,
-			importCall,
+			s.importCall(c),
 			{FuncName: "UploadBinaries", Args: []any{
-				[]string{"charm0", "charm1"},
-				fakeCharmService,
-				map[string]semversion.Binary{
-					//semversion.MustParseBinary("2.1.0-ubuntu-amd64"): "/tools/0",
-					"439c9ea02f8561c5a152d7cf4818d72cd5f2916b555d82c5eee599f5e8f3d09e": semversion.MustParseBinary("2.1.0-ubuntu-amd64"),
-				},
+				fakeCharmURLs,
+				s.charmService,
+				fakeUploadTools,
 				fakeAgentBinaryStore,
-				s.facade.exportedResources,
+				s.resourceService.resources,
 				s.facade,
 			}},
 			apiCloseCall, // for target controller
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.PROCESSRELATIONS}},
-
-			// PROCESSRELATIONS
-			{FuncName: "facade.ProcessRelations", Args: []any{""}},
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.VALIDATION}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.VALIDATION}},
 
 			// VALIDATION
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
@@ -291,7 +367,7 @@ func (s *Suite) TestSuccessfulMigration(c *tc.C) {
 			{FuncName: "facade.SourceControllerInfo", Args: nil},
 			activateCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.SUCCESS}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.SUCCESS}},
 
 			// SUCCESS
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
@@ -299,7 +375,7 @@ func (s *Suite) TestSuccessfulMigration(c *tc.C) {
 			apiOpenControllerCall,
 			adoptResourcesCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.LOGTRANSFER}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.LOGTRANSFER}},
 
 			// LOGTRANSFER
 			apiOpenControllerCall,
@@ -307,150 +383,143 @@ func (s *Suite) TestSuccessfulMigration(c *tc.C) {
 			{FuncName: "StreamModelLog", Args: []any{time.Time{}}},
 			openDestLogStreamCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.REAP}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.REAP}},
 
 			// REAP
-			{FuncName: "facade.Reap", Args: nil},
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.DONE}},
+			{FuncName: "modelMigrationService.MarkModelAsGone", Args: nil},
 		}),
 	)
 }
 
 func (s *Suite) TestIncompatibleTarget(c *tc.C) {
-	s.connection.facadeVersion = 1
-	s.facade.exportedResources = []coreresource.Resource{
-		resourcetesting.NewResource(c, nil, "blob", "app", "").Resource,
-	}
+	// The target controller only offers the legacy migrationtarget
+	// facade (v7); the new envelope path requires v8 and hard-errors.
+	s.connection.facadeVersion = 7
 
-	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
-	s.modelMigrationService.queueMinionReports(makeMinionReports(coremigration.QUIESCE))
-	s.modelMigrationService.queueMinionReports(makeMinionReports(coremigration.VALIDATION))
-	s.modelMigrationService.queueMinionReports(makeMinionReports(coremigration.SUCCESS))
-	s.config.UploadBinaries = makeStubUploadBinaries(s.stub)
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.QUIESCE))
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
-
-	// Observe that the migration was seen, the model exported, an API
-	// connection to the target controller was made, the model was
-	// imported and then the migration completed.
 	s.stub.CheckCalls(c, joinCalls(
 		// Wait for migration to start.
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 		},
 
 		// QUIESCE
 		[]testhelpers.StubCall{
-			{FuncName: "facade.ModelInfo", Args: nil},
 			{FuncName: "facade.Prechecks", Args: []any{}},
+		},
+		assembleCalls,
+		[]testhelpers.StubCall{
 			apiOpenControllerCall,
-			{FuncName: "facade.SourceControllerInfo", Args: nil},
 			apiCloseCall,
 		},
 		abortCalls,
 	))
+	lastMessages := s.modelMigrationService.statuses[len(s.modelMigrationService.statuses)-2:]
+	c.Assert(lastMessages[0], tc.Matches,
+		"(?s)target controller does not support the model migration envelope format.*")
 }
 
 func (s *Suite) TestMigrationResume(c *tc.C) {
 	// Test that a partially complete migration can be resumed.
-	s.facade.queueStatus(s.makeStatus(coremigration.SUCCESS))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.SUCCESS))
 	s.modelMigrationService.queueMinionReports(makeMinionReports(coremigration.SUCCESS))
 
 	s.checkWorkerReturns(c, migrationmaster.ErrMigrated)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
 			{FuncName: "modelMigrationService.MinionReports", Args: nil},
 			apiOpenControllerCall,
 			adoptResourcesCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.LOGTRANSFER}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.LOGTRANSFER}},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{FuncName: "StreamModelLog", Args: []any{time.Time{}}},
 			openDestLogStreamCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.REAP}},
-			{FuncName: "facade.Reap", Args: nil},
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.DONE}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.REAP}},
+			{FuncName: "modelMigrationService.MarkModelAsGone", Args: nil},
 		},
 	))
 }
 
 func (s *Suite) TestPreviouslyAbortedMigration(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.ABORTDONE))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.ABORTDONE))
 
 	w, err := migrationmaster.New(s.config)
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
 	s.waitForStubCalls(c, []string{
-		"facade.Watch",
-		"facade.MigrationStatus",
+		"modelMigrationService.WatchForMigration",
+		"modelMigrationService.Migration",
 		"guard.Unlock",
 	})
 }
 
 func (s *Suite) TestPreviouslyCompletedMigration(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.DONE))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.DONE))
 	s.checkWorkerReturns(c, migrationmaster.ErrMigrated)
 	s.stub.CheckCalls(c, []testhelpers.StubCall{
-		{FuncName: "facade.Watch", Args: nil},
-		{FuncName: "facade.MigrationStatus", Args: nil},
+		{FuncName: "modelMigrationService.WatchForMigration", Args: nil},
+		{FuncName: "modelMigrationService.Migration", Args: nil},
 	})
 }
 
 func (s *Suite) TestWatchFailure(c *tc.C) {
-	s.facade.watchErr = errors.New("boom")
+	s.modelMigrationService.watchErr = errors.New("boom")
 	s.checkWorkerErr(c, "watching for migration: boom")
 }
 
 func (s *Suite) TestStatusError(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
-	s.facade.statusErr = errors.New("splat")
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.QUIESCE))
+	s.modelMigrationService.statusErr = errors.New("splat")
 
 	s.checkWorkerErr(c, "retrieving migration status: splat")
 	s.stub.CheckCalls(c, []testhelpers.StubCall{
-		{FuncName: "facade.Watch", Args: nil},
-		{FuncName: "facade.MigrationStatus", Args: nil},
+		{FuncName: "modelMigrationService.WatchForMigration", Args: nil},
+		{FuncName: "modelMigrationService.Migration", Args: nil},
 	})
 }
 
-func (s *Suite) TestStatusNotFound(c *tc.C) {
-	s.facade.statusErr = &params.Error{Code: params.CodeNotFound}
-	s.facade.triggerWatcher()
+func (s *Suite) TestStatusNone(c *tc.C) {
+	// A migration with phase NONE means the model has never been
+	// migrated: the worker keeps waiting with the fortress unlocked.
+	s.modelMigrationService.queueStatus(coremigration.MigrationStatus{Phase: coremigration.NONE})
 
 	w, err := migrationmaster.New(s.config)
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
 	s.waitForStubCalls(c, []string{
-		"facade.Watch",
-		"facade.MigrationStatus",
+		"modelMigrationService.WatchForMigration",
+		"modelMigrationService.Migration",
 		"guard.Unlock",
 	})
 }
 
 func (s *Suite) TestUnlockError(c *tc.C) {
-	s.facade.statusErr = &params.Error{Code: params.CodeNotFound}
-	s.facade.triggerWatcher()
+	s.modelMigrationService.queueStatus(coremigration.MigrationStatus{Phase: coremigration.NONE})
 	guard := newStubGuard(s.stub)
 	guard.unlockErr = errors.New("pow")
 	s.config.Guard = guard
 
 	s.checkWorkerErr(c, "pow")
 	s.stub.CheckCalls(c, []testhelpers.StubCall{
-		{FuncName: "facade.Watch", Args: nil},
-		{FuncName: "facade.MigrationStatus", Args: nil},
+		{FuncName: "modelMigrationService.WatchForMigration", Args: nil},
+		{FuncName: "modelMigrationService.Migration", Args: nil},
 		{FuncName: "guard.Unlock", Args: nil},
 	})
 }
 
 func (s *Suite) TestLockdownError(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.QUIESCE))
 	guard := newStubGuard(s.stub)
 	guard.lockdownErr = errors.New("biff")
 	s.config.Guard = guard
@@ -468,7 +537,7 @@ func (s *Suite) TestQUIESCEMinionWaitGetError(c *tc.C) {
 }
 
 func (s *Suite) TestQUIESCEFailedAgent(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.QUIESCE))
 	s.modelMigrationService.queueMinionReports(coremigration.MinionReports{
 		MigrationId:    "model-uuid:2",
 		Phase:          coremigration.QUIESCE,
@@ -481,9 +550,9 @@ func (s *Suite) TestQUIESCEFailedAgent(c *tc.C) {
 	expectedCalls := joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 		},
-		prechecksCalls,
+		s.prechecksCalls(c),
 		[]testhelpers.StubCall{
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
 			{FuncName: "modelMigrationService.MinionReports", Args: nil},
@@ -495,16 +564,18 @@ func (s *Suite) TestQUIESCEFailedAgent(c *tc.C) {
 }
 
 func (s *Suite) TestQUIESCEWrongController(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.QUIESCE))
 	s.connection.controllerTag = names.NewControllerTag("another-controller")
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
-			{FuncName: "facade.ModelInfo", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{FuncName: "facade.Prechecks", Args: []any{}},
+		},
+		assembleCalls,
+		[]testhelpers.StubCall{
 			apiOpenControllerCall,
 			apiCloseCall,
 		},
@@ -513,111 +584,178 @@ func (s *Suite) TestQUIESCEWrongController(c *tc.C) {
 }
 
 func (s *Suite) TestQUIESCESourceChecksFail(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.QUIESCE))
 	s.facade.prechecksErr = errors.New("boom")
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
-			{FuncName: "facade.ModelInfo", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{FuncName: "facade.Prechecks", Args: []any{}},
 		},
 		abortCalls,
 	))
 }
 
-func (s *Suite) TestQUIESCEModelInfoFail(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
-	s.facade.modelInfoErr = errors.New("boom")
+func (s *Suite) TestQUIESCEControllerModelInfoFail(c *tc.C) {
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.QUIESCE))
+	s.modelMigrationService.controllerModelInfoErr = errors.New("boom")
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
-			{FuncName: "facade.ModelInfo", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
+			{FuncName: "facade.Prechecks", Args: []any{}},
+			{FuncName: "exportService.Export", Args: nil},
+			{FuncName: "modelMigrationService.GetControllerModelInfo", Args: nil},
 		},
 		abortCalls,
 	))
 }
 
 func (s *Suite) TestQUIESCETargetChecksFail(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.QUIESCE))
 	s.connection.prechecksErr = errors.New("boom")
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	assertExpectedCallArgs(c, s.stub, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 		},
-		prechecksCalls,
-		abortCalls,
-	))
-}
-
-func (s *Suite) TestProcessRelationsFailure(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.PROCESSRELATIONS))
-	s.facade.processRelationsErr = errors.New("boom")
-
-	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
-	s.stub.CheckCalls(c, joinCalls(
-		watchStatusLockdownCalls,
-		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
-			{FuncName: "facade.ProcessRelations", Args: []any{""}},
-		},
+		s.prechecksCalls(c),
 		abortCalls,
 	))
 }
 
 func (s *Suite) TestExportFailure(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.IMPORT))
-	s.facade.exportErr = errors.New("boom")
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.IMPORT))
+	s.exportService.exportErr = errors.New("boom")
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
-			{FuncName: "facade.Export", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
+			{FuncName: "exportService.Export", Args: nil},
 		},
 		abortCalls,
 	))
 }
 
 func (s *Suite) TestAPIOpenFailure(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.IMPORT))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.IMPORT))
 	s.connectionErr = errors.New("boom")
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
-			{FuncName: "facade.Export", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
+		},
+		assembleCalls,
+		[]testhelpers.StubCall{
 			apiOpenControllerCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.ABORT}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.ABORT}},
 			apiOpenControllerCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.ABORTDONE}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.ABORTDONE}},
 		},
 	))
 }
 
 func (s *Suite) TestImportFailure(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.IMPORT))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.IMPORT))
 	s.connection.importErr = errors.New("boom")
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
-			{FuncName: "facade.Export", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
+		},
+		assembleCalls,
+		[]testhelpers.StubCall{
 			apiOpenControllerCall,
-			importCall,
+			s.importCall(c),
+			apiCloseCall,
+		},
+		abortCalls,
+	))
+}
+
+func (s *Suite) TestImportFailureAlreadyExistsActivating(c *tc.C) {
+	// The target reports an existing import claim that has crossed the
+	// activation point of no return: the worker must continue to
+	// VALIDATION (and retry activation) rather than abort, and must not
+	// re-upload binaries.
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.IMPORT))
+	s.connection.importErr = &params.Error{
+		Code:    params.CodeAlreadyExists,
+		Message: "model import for " + modelUUID + ": activation in progress",
+	}
+	// Terminate the worker at the VALIDATION minion wait so the test
+	// only exercises the IMPORT decision.
+	s.modelMigrationService.minionReportsWatchErr = errors.New("boom")
+
+	s.checkWorkerErr(c, "boom")
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]testhelpers.StubCall{
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
+		},
+		assembleCalls,
+		[]testhelpers.StubCall{
+			apiOpenControllerCall,
+			s.importCall(c),
+			apiCloseCall,
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.VALIDATION}},
+			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
+		},
+	))
+}
+
+func (s *Suite) TestImportFailureAlreadyExistsImporting(c *tc.C) {
+	// The target reports the model UUID is occupied by another import
+	// that has not started activating: the worker must abort.
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.IMPORT))
+	s.connection.importErr = &params.Error{
+		Code:    params.CodeAlreadyExists,
+		Message: "model import for " + modelUUID,
+	}
+
+	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]testhelpers.StubCall{
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
+		},
+		assembleCalls,
+		[]testhelpers.StubCall{
+			apiOpenControllerCall,
+			s.importCall(c),
+			apiCloseCall,
+		},
+		abortCalls,
+	))
+}
+
+func (s *Suite) TestIncompatibleTargetImport(c *tc.C) {
+	// A v8-incapable target discovered at IMPORT (e.g. after a worker
+	// restart skipped QUIESCE) is also a hard error and aborts.
+	s.connection.facadeVersion = 7
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.IMPORT))
+
+	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
+	s.stub.CheckCalls(c, joinCalls(
+		watchStatusLockdownCalls,
+		[]testhelpers.StubCall{
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
+		},
+		assembleCalls,
+		[]testhelpers.StubCall{
+			apiOpenControllerCall,
 			apiCloseCall,
 		},
 		abortCalls,
@@ -637,7 +775,7 @@ func (s *Suite) TestVALIDATIONFailedAgent(c *tc.C) {
 	// in time than the max wait time for minion reports.
 	sts := s.makeStatus(coremigration.VALIDATION)
 	sts.PhaseChangedTime = time.Now().Add(-20 * time.Minute)
-	s.facade.queueStatus(sts)
+	s.modelMigrationService.queueStatus(sts)
 
 	w, err := migrationmaster.New(s.config)
 	c.Assert(err, tc.ErrorIsNil)
@@ -657,7 +795,7 @@ func (s *Suite) TestVALIDATIONFailedAgent(c *tc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
 			{FuncName: "modelMigrationService.MinionReports", Args: nil},
 		},
@@ -666,7 +804,7 @@ func (s *Suite) TestVALIDATIONFailedAgent(c *tc.C) {
 }
 
 func (s *Suite) TestVALIDATIONCheckMachinesOneError(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.VALIDATION))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.VALIDATION))
 	s.modelMigrationService.queueMinionReports(makeMinionReports(coremigration.VALIDATION))
 
 	s.connection.machineErrs = []string{"been so strange"}
@@ -674,7 +812,7 @@ func (s *Suite) TestVALIDATIONCheckMachinesOneError(c *tc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
 			{FuncName: "modelMigrationService.MinionReports", Args: nil},
 			apiOpenControllerCall,
@@ -683,7 +821,7 @@ func (s *Suite) TestVALIDATIONCheckMachinesOneError(c *tc.C) {
 		},
 		abortCalls,
 	))
-	lastMessages := s.facade.statuses[len(s.facade.statuses)-2:]
+	lastMessages := s.modelMigrationService.statuses[len(s.modelMigrationService.statuses)-2:]
 	c.Assert(lastMessages, tc.DeepEquals, []string{
 		"machine sanity check failed, 1 error found",
 		"aborted, removing model from target controller: machine sanity check failed, 1 error found",
@@ -691,14 +829,14 @@ func (s *Suite) TestVALIDATIONCheckMachinesOneError(c *tc.C) {
 }
 
 func (s *Suite) TestVALIDATIONCheckMachinesSeveralErrors(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.VALIDATION))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.VALIDATION))
 	s.modelMigrationService.queueMinionReports(makeMinionReports(coremigration.VALIDATION))
 	s.connection.machineErrs = []string{"been so strange", "lit up"}
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
 			{FuncName: "modelMigrationService.MinionReports", Args: nil},
 			apiOpenControllerCall,
@@ -707,7 +845,7 @@ func (s *Suite) TestVALIDATIONCheckMachinesSeveralErrors(c *tc.C) {
 		},
 		abortCalls,
 	))
-	lastMessages := s.facade.statuses[len(s.facade.statuses)-2:]
+	lastMessages := s.modelMigrationService.statuses[len(s.modelMigrationService.statuses)-2:]
 	c.Assert(lastMessages, tc.DeepEquals, []string{
 		"machine sanity check failed, 2 errors found",
 		"aborted, removing model from target controller: machine sanity check failed, 2 errors found",
@@ -715,7 +853,7 @@ func (s *Suite) TestVALIDATIONCheckMachinesSeveralErrors(c *tc.C) {
 }
 
 func (s *Suite) TestVALIDATIONCheckMachinesOtherError(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.VALIDATION))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.VALIDATION))
 	s.modelMigrationService.queueMinionReports(makeMinionReports(coremigration.VALIDATION))
 	s.connection.checkMachineErr = errors.Errorf("something went bang")
 
@@ -723,7 +861,7 @@ func (s *Suite) TestVALIDATIONCheckMachinesOtherError(c *tc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
 			{FuncName: "modelMigrationService.MinionReports", Args: nil},
 			apiOpenControllerCall,
@@ -744,7 +882,7 @@ func (s *Suite) TestSUCCESSMinionWaitGetError(c *tc.C) {
 func (s *Suite) TestSUCCESSMinionWaitFailedMachine(c *tc.C) {
 	// With the SUCCESS phase the master should wait for all reports,
 	// continuing even if some minions report failure.
-	s.facade.queueStatus(s.makeStatus(coremigration.SUCCESS))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.SUCCESS))
 	s.modelMigrationService.queueMinionReports(coremigration.MinionReports{
 		MigrationId:    "model-uuid:2",
 		Phase:          coremigration.SUCCESS,
@@ -756,28 +894,27 @@ func (s *Suite) TestSUCCESSMinionWaitFailedMachine(c *tc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
 			{FuncName: "modelMigrationService.MinionReports", Args: nil},
 			apiOpenControllerCall,
 			adoptResourcesCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.LOGTRANSFER}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.LOGTRANSFER}},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{FuncName: "StreamModelLog", Args: []any{time.Time{}}},
 			openDestLogStreamCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.REAP}},
-			{FuncName: "facade.Reap", Args: nil},
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.DONE}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.REAP}},
+			{FuncName: "modelMigrationService.MarkModelAsGone", Args: nil},
 		},
 	))
 }
 
 func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *tc.C) {
 	// See note for TestMinionWaitFailedMachine above.
-	s.facade.queueStatus(s.makeStatus(coremigration.SUCCESS))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.SUCCESS))
 	s.modelMigrationService.queueMinionReports(coremigration.MinionReports{
 		MigrationId:        "model-uuid:2",
 		Phase:              coremigration.SUCCESS,
@@ -790,21 +927,20 @@ func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *tc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
 			{FuncName: "modelMigrationService.MinionReports", Args: nil},
 			apiOpenControllerCall,
 			adoptResourcesCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.LOGTRANSFER}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.LOGTRANSFER}},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{FuncName: "StreamModelLog", Args: []any{time.Time{}}},
 			openDestLogStreamCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.REAP}},
-			{FuncName: "facade.Reap", Args: nil},
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.DONE}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.REAP}},
+			{FuncName: "modelMigrationService.MarkModelAsGone", Args: nil},
 		},
 	))
 }
@@ -813,7 +949,7 @@ func (s *Suite) TestSUCCESSMinionWaitTimeout(c *tc.C) {
 	// The SUCCESS phase is special in that even if some minions fail
 	// to report the migration should continue. There's no turning
 	// back from SUCCESS.
-	s.facade.queueStatus(s.makeStatus(coremigration.SUCCESS))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.SUCCESS))
 
 	w, err := migrationmaster.New(s.config)
 	c.Assert(err, tc.ErrorIsNil)
@@ -834,26 +970,25 @@ func (s *Suite) TestSUCCESSMinionWaitTimeout(c *tc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{FuncName: "modelMigrationService.WatchMinionReports", Args: nil},
 			apiOpenControllerCall,
 			adoptResourcesCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.LOGTRANSFER}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.LOGTRANSFER}},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{FuncName: "StreamModelLog", Args: []any{time.Time{}}},
 			openDestLogStreamCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.REAP}},
-			{FuncName: "facade.Reap", Args: nil},
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.DONE}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.REAP}},
+			{FuncName: "modelMigrationService.MarkModelAsGone", Args: nil},
 		},
 	))
 }
 
 func (s *Suite) TestMinionWaitWrongPhase(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.SUCCESS))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.SUCCESS))
 
 	// Have the phase in the minion reports be different from the
 	// migration status. This shouldn't happen but the migrationmaster
@@ -865,7 +1000,7 @@ func (s *Suite) TestMinionWaitWrongPhase(c *tc.C) {
 }
 
 func (s *Suite) TestMinionWaitMigrationIdChanged(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.SUCCESS))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.SUCCESS))
 
 	// Have the migration id in the minion reports be different from
 	// the migration status. This shouldn't happen but the
@@ -880,7 +1015,7 @@ func (s *Suite) TestMinionWaitMigrationIdChanged(c *tc.C) {
 }
 
 func (s *Suite) TestMinionWaitInvalidReportCounts(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.SUCCESS))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.SUCCESS))
 	s.modelMigrationService.queueMinionReports(coremigration.MinionReports{
 		MigrationId:    "model-uuid:2",
 		Phase:          coremigration.SUCCESS,
@@ -906,7 +1041,7 @@ func (s *Suite) assertAPIConnectWithMacaroon(c *tc.C, authUser names.UserTag) {
 	status.TargetInfo.Password = ""
 	status.TargetInfo.Macaroons = macs
 
-	s.facade.queueStatus(status)
+	s.modelMigrationService.queueStatus(status)
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	var apiUser names.Tag
@@ -916,7 +1051,7 @@ func (s *Suite) assertAPIConnectWithMacaroon(c *tc.C, authUser names.UserTag) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{
 				FuncName: "apiOpen",
 				Args: []any{
@@ -931,7 +1066,7 @@ func (s *Suite) assertAPIConnectWithMacaroon(c *tc.C, authUser names.UserTag) {
 			},
 			abortCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.ABORTDONE}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.ABORTDONE}},
 		},
 	))
 }
@@ -955,14 +1090,14 @@ func (s *Suite) TestAPIConnectionWithToken(c *tc.C) {
 	status.TargetInfo.Macaroons = nil
 	status.TargetInfo.Token = "token"
 
-	s.facade.queueStatus(status)
+	s.modelMigrationService.queueStatus(status)
 
 	s.checkWorkerReturns(c, migrationmaster.ErrInactive)
 	expectedLoginProvider := api.NewSessionTokenLoginProvider("token", nil, nil)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			{
 				FuncName: "apiOpen",
 				Args: []any{
@@ -976,34 +1111,34 @@ func (s *Suite) TestAPIConnectionWithToken(c *tc.C) {
 			},
 			abortCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.ABORTDONE}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.ABORTDONE}},
 		},
 	))
 }
 
 func (s *Suite) TestLogTransferErrorOpeningTargetAPI(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	s.connectionErr = errors.New("people of earth")
 
 	s.checkWorkerReturns(c, s.connectionErr)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			apiOpenControllerCall,
 		},
 	))
 }
 
 func (s *Suite) TestLogTransferErrorGettingStartTime(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	s.connection.latestLogErr = errors.New("tender vittles")
 
 	s.checkWorkerReturns(c, s.connection.latestLogErr)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			apiCloseCall,
@@ -1012,14 +1147,14 @@ func (s *Suite) TestLogTransferErrorGettingStartTime(c *tc.C) {
 }
 
 func (s *Suite) TestLogTransferErrorOpeningLogSource(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	s.facade.streamErr = errors.New("chicken bones")
 
 	s.checkWorkerReturns(c, s.facade.streamErr)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{FuncName: "StreamModelLog", Args: []any{time.Time{}}},
@@ -1029,14 +1164,14 @@ func (s *Suite) TestLogTransferErrorOpeningLogSource(c *tc.C) {
 }
 
 func (s *Suite) TestLogTransferErrorOpeningLogDest(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	s.connection.streamErr = errors.New("tule lake shuffle")
 
 	s.checkWorkerReturns(c, s.connection.streamErr)
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{FuncName: "StreamModelLog", Args: []any{time.Time{}}},
@@ -1047,7 +1182,7 @@ func (s *Suite) TestLogTransferErrorOpeningLogDest(c *tc.C) {
 }
 
 func (s *Suite) TestLogTransferErrorWriting(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	s.facade.logMessages = func(d chan<- common.LogMessage) {
 		safeSend(c, d, common.LogMessage{Message: "the go team"})
 	}
@@ -1056,7 +1191,7 @@ func (s *Suite) TestLogTransferErrorWriting(c *tc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{FuncName: "StreamModelLog", Args: []any{time.Time{}}},
@@ -1070,7 +1205,7 @@ func (s *Suite) TestLogTransferErrorWriting(c *tc.C) {
 func (s *Suite) TestLogTransferSendsRecords(c *tc.C) {
 	t1, err := time.Parse("2006-01-02 15:04", "2016-11-28 16:11")
 	c.Assert(err, tc.ErrorIsNil)
-	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	messages := []common.LogMessage{
 		{Message: "the go team"},
 		{Message: "joan as police woman"},
@@ -1093,15 +1228,14 @@ func (s *Suite) TestLogTransferSendsRecords(c *tc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{FuncName: "StreamModelLog", Args: []any{time.Time{}}},
 			openDestLogStreamCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.REAP}},
-			{FuncName: "facade.Reap", Args: nil},
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.DONE}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.REAP}},
+			{FuncName: "modelMigrationService.MarkModelAsGone", Args: nil},
 		},
 	))
 	c.Assert(s.connection.logStream.written, tc.DeepEquals, []params.LogRecord{
@@ -1120,7 +1254,7 @@ func (s *Suite) TestLogTransferSendsRecords(c *tc.C) {
 }
 
 func (s *Suite) TestLogTransferReportsProgress(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	messages := []common.LogMessage{
 		{Message: "captain beefheart"},
 		{Message: "super furry animals"},
@@ -1156,7 +1290,7 @@ func (s *Suite) TestLogTransferReportsProgress(c *tc.C) {
 }
 
 func (s *Suite) TestLogTransferChecksLatestTime(c *tc.C) {
-	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
+	s.modelMigrationService.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	t := time.Date(2016, 12, 2, 10, 39, 10, 20, time.UTC)
 	s.connection.latestLogTime = t
 
@@ -1164,15 +1298,14 @@ func (s *Suite) TestLogTransferChecksLatestTime(c *tc.C) {
 	s.stub.CheckCalls(c, joinCalls(
 		watchStatusLockdownCalls,
 		[]testhelpers.StubCall{
-			{FuncName: "facade.MinionReportTimeout", Args: nil},
+			{FuncName: "controllerConfigService.ControllerConfig", Args: nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{FuncName: "StreamModelLog", Args: []any{t}},
 			openDestLogStreamCall,
 			apiCloseCall,
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.REAP}},
-			{FuncName: "facade.Reap", Args: nil},
-			{FuncName: "facade.SetPhase", Args: []any{coremigration.DONE}},
+			{FuncName: "modelMigrationService.SetMigrationPhase", Args: []any{coremigration.REAP}},
+			{FuncName: "modelMigrationService.MarkModelAsGone", Args: nil},
 		},
 	))
 }
@@ -1216,13 +1349,13 @@ func (s *Suite) waitForStubCalls(c *tc.C, expectedCallNames []string) {
 
 func (s *Suite) checkMinionWaitWatchError(c *tc.C, phase coremigration.Phase) {
 	s.modelMigrationService.minionReportsWatchErr = errors.New("boom")
-	s.facade.queueStatus(s.makeStatus(phase))
+	s.modelMigrationService.queueStatus(s.makeStatus(phase))
 
 	s.checkWorkerErr(c, "boom")
 }
 
 func (s *Suite) checkMinionWaitGetError(c *tc.C, phase coremigration.Phase) {
-	s.facade.queueStatus(s.makeStatus(phase))
+	s.modelMigrationService.queueStatus(s.makeStatus(phase))
 
 	s.modelMigrationService.minionReportsErr = errors.New("boom")
 	s.modelMigrationService.triggerMinionReports()
@@ -1280,9 +1413,7 @@ func (g *stubGuard) Unlock(ctx context.Context) error {
 
 func newStubMasterFacade(stub *testhelpers.Stub) *stubMasterFacade {
 	return &stubMasterFacade{
-		stub:                stub,
-		watcherChanges:      make(chan struct{}, 999),
-		minionReportTimeout: 15 * time.Minute,
+		stub: stub,
 	}
 }
 
@@ -1291,63 +1422,16 @@ type stubMasterFacade struct {
 
 	stub *testhelpers.Stub
 
-	watcherChanges chan struct{}
-	watchErr       error
-	status         []coremigration.MigrationStatus
-	statusErr      error
-
-	prechecksErr        error
-	modelInfoErr        error
-	exportErr           error
-	processRelationsErr error
+	prechecksErr error
 
 	logMessages func(chan<- common.LogMessage)
 	streamErr   error
-
-	minionReportTimeout time.Duration
-
-	exportedResources []coreresource.Resource
-
-	statuses []string
-}
-
-func (f *stubMasterFacade) triggerWatcher() {
-	select {
-	case f.watcherChanges <- struct{}{}:
-	default:
-		panic("migration watcher channel unexpectedly closed")
-	}
-}
-
-func (f *stubMasterFacade) queueStatus(status coremigration.MigrationStatus) {
-	f.status = append(f.status, status)
-	f.triggerWatcher()
-}
-
-func (f *stubMasterFacade) Watch(ctx context.Context) (watcher.NotifyWatcher, error) {
-	f.stub.AddCall("facade.Watch")
-	if f.watchErr != nil {
-		return nil, f.watchErr
-	}
-	return newMockWatcher(f.watcherChanges), nil
-}
-
-func (f *stubMasterFacade) MigrationStatus(ctx context.Context) (coremigration.MigrationStatus, error) {
-	f.stub.AddCall("facade.MigrationStatus")
-	if f.statusErr != nil {
-		return coremigration.MigrationStatus{}, f.statusErr
-	}
-	if len(f.status) == 0 {
-		panic("no status queued to report")
-	}
-	out := f.status[0]
-	f.status = f.status[1:]
-	return out, nil
 }
 
 func newStubModelMigrationService(stub *testhelpers.Stub) *stubModelMigrationService {
 	return &stubModelMigrationService{
-		stub: stub,
+		stub:           stub,
+		watcherChanges: make(chan struct{}, 999),
 		// Give minionReportsChanges a larger-than-required buffer to
 		// support waits at a number of phases.
 		minionReportsChanges: make(chan struct{}, 999),
@@ -1357,10 +1441,83 @@ func newStubModelMigrationService(stub *testhelpers.Stub) *stubModelMigrationSer
 type stubModelMigrationService struct {
 	stub *testhelpers.Stub
 
+	watcherChanges chan struct{}
+	watchErr       error
+	status         []coremigration.MigrationStatus
+	statusErr      error
+
+	controllerModelInfoErr error
+
+	markModelAsGoneErr error
+
 	minionReportsChanges  chan struct{}
 	minionReportsWatchErr error
 	minionReports         []coremigration.MinionReports
 	minionReportsErr      error
+
+	statuses []string
+}
+
+func (s *stubModelMigrationService) triggerWatcher() {
+	select {
+	case s.watcherChanges <- struct{}{}:
+	default:
+		panic("migration watcher channel unexpectedly closed")
+	}
+}
+
+func (s *stubModelMigrationService) queueStatus(status coremigration.MigrationStatus) {
+	s.status = append(s.status, status)
+	s.triggerWatcher()
+}
+
+func (s *stubModelMigrationService) WatchForMigration(ctx context.Context) (watcher.NotifyWatcher, error) {
+	s.stub.AddCall("modelMigrationService.WatchForMigration")
+	if s.watchErr != nil {
+		return nil, s.watchErr
+	}
+	return newMockWatcher(s.watcherChanges), nil
+}
+
+func (s *stubModelMigrationService) Migration(ctx context.Context) (modelmigration.Migration, error) {
+	s.stub.AddCall("modelMigrationService.Migration")
+	if s.statusErr != nil {
+		return modelmigration.Migration{}, s.statusErr
+	}
+	if len(s.status) == 0 {
+		panic("no status queued to report")
+	}
+	out := s.status[0]
+	s.status = s.status[1:]
+	return modelmigration.Migration{
+		UUID:             out.MigrationId,
+		Phase:            out.Phase,
+		PhaseChangedTime: out.PhaseChangedTime,
+		Target:           out.TargetInfo,
+	}, nil
+}
+
+func (s *stubModelMigrationService) GetControllerModelInfo(ctx context.Context) (modelmigration.ControllerModelInfo, error) {
+	s.stub.AddCall("modelMigrationService.GetControllerModelInfo")
+	if s.controllerModelInfoErr != nil {
+		return modelmigration.ControllerModelInfo{}, s.controllerModelInfoErr
+	}
+	return fakeControllerModelInfo, nil
+}
+
+func (s *stubModelMigrationService) SetMigrationPhase(ctx context.Context, phase coremigration.Phase) error {
+	s.stub.AddCall("modelMigrationService.SetMigrationPhase", phase)
+	return nil
+}
+
+func (s *stubModelMigrationService) SetMigrationStatusMessage(ctx context.Context, message string) error {
+	s.statuses = append(s.statuses, message)
+	return nil
+}
+
+func (s *stubModelMigrationService) MarkModelAsGone(ctx context.Context) error {
+	s.stub.AddCall("modelMigrationService.MarkModelAsGone")
+	return s.markModelAsGoneErr
 }
 
 func (s *stubModelMigrationService) triggerMinionReports() {
@@ -1397,28 +1554,9 @@ func (s *stubModelMigrationService) MinionReports(ctx context.Context) (coremigr
 	return r, nil
 }
 
-func (f *stubMasterFacade) MinionReportTimeout(ctx context.Context) (time.Duration, error) {
-	f.stub.AddCall("facade.MinionReportTimeout")
-	return f.minionReportTimeout, nil
-}
-
 func (f *stubMasterFacade) Prechecks(ctx context.Context) error {
 	f.stub.AddCall("facade.Prechecks")
 	return f.prechecksErr
-}
-
-func (f *stubMasterFacade) ModelInfo(ctx context.Context) (coremigration.ModelInfo, error) {
-	f.stub.AddCall("facade.ModelInfo")
-	if f.modelInfoErr != nil {
-		return coremigration.ModelInfo{}, f.modelInfoErr
-	}
-	return coremigration.ModelInfo{
-		UUID:             modelUUID,
-		Name:             modelName,
-		Qualifier:        modelQualifier,
-		AgentVersion:     modelVersion,
-		ModelDescription: description.NewModel(description.ModelArgs{}),
-	}, nil
 }
 
 func (f *stubMasterFacade) SourceControllerInfo(ctx context.Context) (coremigration.SourceControllerInfo, []string, error) {
@@ -1431,42 +1569,66 @@ func (f *stubMasterFacade) SourceControllerInfo(ctx context.Context) (coremigrat
 	}, []string{"related-model-uuid"}, nil
 }
 
-func (f *stubMasterFacade) Export(ctx context.Context) (coremigration.SerializedModel, error) {
-	f.stub.AddCall("facade.Export")
-	if f.exportErr != nil {
-		return coremigration.SerializedModel{}, f.exportErr
+type stubExportService struct {
+	stub      *testhelpers.Stub
+	exportErr error
+}
+
+func (s *stubExportService) Export(ctx context.Context) (*domainexport.ModelExport, error) {
+	s.stub.AddCall("exportService.Export")
+	if s.exportErr != nil {
+		return nil, s.exportErr
 	}
-	return coremigration.SerializedModel{
-		Bytes:  fakeModelBytes,
-		Charms: []string{"charm0", "charm1"},
-		Tools: map[string]semversion.Binary{
-			"439c9ea02f8561c5a152d7cf4818d72cd5f2916b555d82c5eee599f5e8f3d09e": semversion.MustParseBinary("2.1.0-ubuntu-amd64"),
-		},
-		Resources: f.exportedResources,
+	return &domainexport.ModelExport{
+		Version: fakeExportVersion,
+		Payload: fakeExportPayload,
 	}, nil
 }
 
-func (f *stubMasterFacade) ProcessRelations(ctx context.Context, controllerAlias string) error {
-	f.stub.AddCall("facade.ProcessRelations", controllerAlias)
-	if f.processRelationsErr != nil {
-		return f.processRelationsErr
-	}
-	return nil
+type stubControllerConfigService struct {
+	stub *testhelpers.Stub
 }
 
-func (f *stubMasterFacade) SetPhase(ctx context.Context, phase coremigration.Phase) error {
-	f.stub.AddCall("facade.SetPhase", phase)
-	return nil
+func (s *stubControllerConfigService) ControllerConfig(ctx context.Context) (controller.Config, error) {
+	s.stub.AddCall("controllerConfigService.ControllerConfig")
+	// An empty config falls back to defaults, including the 15 minute
+	// migration minion wait maximum the tests rely on.
+	return controller.Config{}, nil
 }
 
-func (f *stubMasterFacade) SetStatusMessage(ctx context.Context, message string) error {
-	f.statuses = append(f.statuses, message)
-	return nil
+type stubModelAgentService struct {
+	stub *testhelpers.Stub
 }
 
-func (f *stubMasterFacade) Reap(ctx context.Context) error {
-	f.stub.AddCall("facade.Reap")
-	return nil
+func (s *stubModelAgentService) GetMachinesAgentBinaryMetadata(ctx context.Context) (map[machine.Name]coreagentbinary.Metadata, error) {
+	s.stub.AddCall("modelAgentService.GetMachinesAgentBinaryMetadata")
+	return fakeMachineTools, nil
+}
+
+func (s *stubModelAgentService) GetUnitsAgentBinaryMetadata(ctx context.Context) (map[unit.Name]coreagentbinary.Metadata, error) {
+	s.stub.AddCall("modelAgentService.GetUnitsAgentBinaryMetadata")
+	return nil, nil
+}
+
+type stubResourceService struct {
+	stub      *testhelpers.Stub
+	resources []coreresource.Resource
+}
+
+func (s *stubResourceService) ListAllModelResources(ctx context.Context) ([]coreresource.Resource, error) {
+	s.stub.AddCall("resourceService.ListAllModelResources")
+	return s.resources, nil
+}
+
+type stubCharmService struct {
+	migrationmaster.CharmService
+
+	stub *testhelpers.Stub
+}
+
+func (s *stubCharmService) ListCharmLocators(ctx context.Context, names ...string) ([]applicationcharm.CharmLocator, error) {
+	s.stub.AddCall("charmService.ListCharmLocators")
+	return fakeCharmLocators, nil
 }
 
 func (f *stubMasterFacade) StreamModelLog(_ context.Context, start time.Time) (<-chan common.LogMessage, error) {
@@ -1508,7 +1670,6 @@ type stubConnection struct {
 	stub                *testhelpers.Stub
 	prechecksErr        error
 	importErr           error
-	processRelationsErr error
 	controllerTag       names.ControllerTag
 
 	streamErr error
@@ -1538,8 +1699,6 @@ func (c *stubConnection) APICall(ctx context.Context, objType string, _ int, _, 
 			return c.prechecksErr
 		case "Import":
 			return c.importErr
-		case "ProcessRelations":
-			return c.processRelationsErr
 		case "Activate", "AdoptResources":
 			return nil
 		case "LatestLogTime":
@@ -1613,7 +1772,6 @@ func nullUploadBinaries(context.Context, migration.UploadBinariesConfig, logger.
 	panic("should not get called")
 }
 
-var fakeCharmService = struct{ migrationmaster.CharmService }{}
 
 var fakeAgentBinaryStore = struct{ migration.AgentBinaryStore }{}
 

--- a/rpc/params/migration.go
+++ b/rpc/params/migration.go
@@ -123,7 +123,7 @@ type SerializedModelResource struct {
 }
 
 // SerializedModelV2 is the wire envelope for the new (v8) model-migration
-// import/precheck path. Controller-scoped facts ride as typed semantic fields;
+// import/precheck path. Controller-scoped data ride as typed semantic fields;
 // only the model-DB content is a serialized YAML payload that flows through the
 // transformer chain. The typed fields evolve additively only (the standard
 // rpc/params rule) and must never carry source-local integer IDs or

--- a/rpc/params/migration.go
+++ b/rpc/params/migration.go
@@ -122,13 +122,6 @@ type SerializedModelResource struct {
 	Username       string    `json:"username,omitempty"`
 }
 
-// SerializedModelV2PayloadLimit is the default maximum size, in bytes, of the
-// model-DB YAML payload carried in [SerializedModelV2.Payload]. It is validated
-// by the source before RPC and by the target's v8 Prechecks/Import before the
-// YAML is decoded. It bounds the model-DB payload only, not the API websocket
-// frame or the binary-transfer HTTP endpoints.
-const SerializedModelV2PayloadLimit = 200 * 1024 * 1024 // 200 MiB
-
 // SerializedModelV2 is the wire envelope for the new (v8) model-migration
 // import/precheck path. Controller-scoped facts ride as typed semantic fields;
 // only the model-DB content is a serialized YAML payload that flows through the
@@ -145,8 +138,7 @@ type SerializedModelV2 struct {
 	// Payload is the YAML-encoded concrete generated
 	// domain/export/types/vX_Y_Z.ModelExport at PayloadVersion. It is the only
 	// field the transformer chain walks. The domain/export.ModelExport wrapper
-	// is NOT serialized into this field. Its size is validated against
-	// SerializedModelV2PayloadLimit before decode.
+	// is NOT serialized into this field.
 	Payload []byte `json:"payload"`
 
 	// ModelInfo carries the bootstrap identity for the migrating model. It is

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -155,12 +155,6 @@ type RelationSuspendedArg struct {
 	Suspended  bool   `json:"suspended"`
 }
 
-// ProcessRelations holds the information required to process series of
-// relations during a model migration.
-type ProcessRelations struct {
-	ControllerAlias string `json:"controller-alias"`
-}
-
 // AddCharm holds the arguments for making an AddCharm API call.
 type AddCharm struct {
 	URL     string `json:"url"`


### PR DESCRIPTION
The migration master worker assembles the `SerializedModelV2` envelope entirely in-process now, replacing
  the old facade-driven export path that had already been stubbed out as `NotSupported`. It calls
  `ExportService`, `ModelMigrationService.GetControllerModelInfo`, `CharmService`, `ModelAgentService` and
  `ResourceService` directly, validates the payload size locally before any RPC, then delivers the envelope
  to the target via `PrechecksV2/ImportV2` on MigrationTarget v8. The worker hard-errors with a clear
  message if the target only exposes v7, and handles `AlreadyExists` from ImportV2 as an idempotent
  "activation in progress" signal rather than an abort.

  A handful of things that existed only to support the old path are removed along the way: Export and
  `PROCESSRELATIONS` are gone from both the facade server and the client, taking with them the client-side
  resource deserialisation code. `MarkModelAsGone` is added to `ModelMigrationService` and called on REAP in
  place of the old facade stub — for now it marks the active export migration as DONE; full source-side
  purge and the login redirect are Task 12.

  With the worker never emitting `PROCESSRELATIONS` anymore, the constant is removed entirely. An earlier
  task dropped its DDL row, a previous one in this series stripped its transition edges from the phase
  graph — this just finishes the job by deleting the constant and its phaseNames entry. The explicit
  PhasePersistedID map makes the iota renumbering safe.

## QA steps
Although the worker is now wired, feeding the domain is not fully finished so nothing can be QAd yet but soon. 

## Links


<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9899](https://warthogs.atlassian.net/browse/JUJU-9899)


[JUJU-9899]: https://warthogs.atlassian.net/browse/JUJU-9899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ