### PR TITLE
refactor: loki client changes

### DIFF
--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -9,11 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/juju/clock"
@@ -31,10 +32,24 @@ type Record struct {
 	// Line is the log message text.
 	Line string
 
-	// Labels are the Loki stream labels for this entry.
-	// Records with identical label sets are grouped into
-	// the same stream.
-	Labels map[string]string
+	// ControllerUUID is the Juju controller UUID for topology labeling.
+	ControllerUUID string
+
+	// ModelUUID is the Juju model UUID for topology labeling.
+	ModelUUID string
+
+	// AgentID is the stable Juju agent identity for topology labeling.
+	AgentID string
+
+	// Fields are structured log fields. High-cardinality values belong here,
+	// not in Loki labels.
+	Fields map[string]string
+
+	// TraceID is the OpenTelemetry trace ID for this record, if present.
+	TraceID string
+
+	// SpanID is the OpenTelemetry span ID for this record, if present.
+	SpanID string
 }
 
 // Config holds configuration for the Loki push client.
@@ -42,6 +57,10 @@ type Config struct {
 	// BatchSize is the maximum number of records to
 	// accumulate before flushing to Loki. Default: 100.
 	BatchSize int
+
+	// BufferSize is the maximum number of queued records waiting to be
+	// batched. When full, Push drops the oldest queued records. Default: 500.
+	BufferSize int
 
 	// FlushInterval is how long to wait before flushing
 	// buffered records even if BatchSize hasn't been
@@ -74,10 +93,12 @@ type Config struct {
 	AsyncFlush *bool
 
 	// OnError is called when a push fails after all retry
-	// attempts are exhausted. If nil, errors are silently
-	// dropped. This can be used to write to stderr or any
-	// other error reporting mechanism.
+	// attempts are exhausted. If nil, a warning is written to stderr.
 	OnError func(error)
+
+	// OnDrop is called when records are dropped from the circular buffer. If
+	// nil, a warning is written to stderr.
+	OnDrop func(int)
 
 	// Clock is passed to the retry logic for testing.
 	// If nil, the wall clock is used.
@@ -88,6 +109,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		BatchSize:      100,
+		BufferSize:     500,
 		FlushInterval:  10 * time.Second,
 		MaxRetries:     3,
 		InitialBackoff: 500 * time.Millisecond,
@@ -107,8 +129,19 @@ type Client struct {
 	http       *http.Client
 	asyncFlush bool
 	onError    func(error)
+	onDrop     func(int)
 	records    chan Record
+	stats      report
 	tomb       tomb.Tomb
+}
+
+type report struct {
+	Enqueued          uint64
+	Dropped           uint64
+	Sent              uint64
+	PushErrors        uint64
+	Retries           uint64
+	LastPushTimestamp int64
 }
 
 // NewClient creates and starts a new Loki push client worker.
@@ -122,6 +155,9 @@ func NewClient(endpoint string, cfg Config) (*Client, error) {
 	}
 	if cfg.BatchSize <= 0 {
 		cfg.BatchSize = 100
+	}
+	if cfg.BufferSize <= 0 {
+		cfg.BufferSize = 500
 	}
 	if cfg.FlushInterval <= 0 {
 		cfg.FlushInterval = 10 * time.Second
@@ -144,7 +180,15 @@ func NewClient(endpoint string, cfg Config) (*Client, error) {
 	}
 	onError := cfg.OnError
 	if onError == nil {
-		onError = func(error) {}
+		onError = func(err error) {
+			fmt.Fprintf(os.Stderr, "loki push failed: %v\n", err)
+		}
+	}
+	onDrop := cfg.OnDrop
+	if onDrop == nil {
+		onDrop = func(count int) {
+			fmt.Fprintf(os.Stderr, "dropped %d loki log records\n", count)
+		}
 	}
 	asyncFlush := cfg.AsyncFlush == nil || *cfg.AsyncFlush
 	c := &Client{
@@ -153,7 +197,8 @@ func NewClient(endpoint string, cfg Config) (*Client, error) {
 		http:       httpClient,
 		asyncFlush: asyncFlush,
 		onError:    onError,
-		records:    make(chan Record, cfg.BatchSize),
+		onDrop:     onDrop,
+		records:    make(chan Record, cfg.BufferSize),
 	}
 	c.tomb.Go(c.loop)
 	return c, nil
@@ -161,21 +206,52 @@ func NewClient(endpoint string, cfg Config) (*Client, error) {
 
 // Push sends records to the client for delivery to Loki.
 // Records are buffered internally and flushed when the batch
-// size is reached or the flush interval elapses. Push blocks
-// if the internal channel is full, providing backpressure to
-// the caller. Returns tomb.ErrDying if the client is shutting
-// down. Push does not deep-copy records, so callers should not
-// mutate record contents (especially Labels maps) after calling
-// this method.
+// size is reached or the flush interval elapses. Push does not
+// block on a full queue; it drops the oldest queued records first.
+// Returns tomb.ErrDying if the client is shutting down. Push does
+// not deep-copy records, so callers should not mutate record
+// contents after calling this method.
 func (c *Client) Push(records ...Record) error {
 	for _, r := range records {
-		select {
-		case c.records <- r:
-		case <-c.tomb.Dying():
-			return tomb.ErrDying
+		if err := c.pushOne(r); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func (c *Client) pushOne(r Record) error {
+	for {
+		select {
+		case c.records <- r:
+			atomic.AddUint64(&c.stats.Enqueued, 1)
+			return nil
+		case <-c.tomb.Dying():
+			return tomb.ErrDying
+		default:
+		}
+
+		select {
+		case <-c.records:
+			atomic.AddUint64(&c.stats.Dropped, 1)
+			c.onDrop(1)
+		case <-c.tomb.Dying():
+			return tomb.ErrDying
+		default:
+		}
+	}
+}
+
+// Report implements worker.Reporter.
+func (c *Client) Report(context.Context) map[string]any {
+	return map[string]any{
+		"enqueued":            atomic.LoadUint64(&c.stats.Enqueued),
+		"dropped":             atomic.LoadUint64(&c.stats.Dropped),
+		"sent":                atomic.LoadUint64(&c.stats.Sent),
+		"push-errors":         atomic.LoadUint64(&c.stats.PushErrors),
+		"retries":             atomic.LoadUint64(&c.stats.Retries),
+		"last-push-timestamp": atomic.LoadInt64(&c.stats.LastPushTimestamp),
+	}
 }
 
 // Kill requests the client to stop. Any buffered records are
@@ -208,7 +284,7 @@ func (c *Client) loop() error {
 			c.drainChannel(&buffer)
 			if len(buffer) > 0 {
 				ctx, cancel := context.WithTimeout(
-					context.Background(), 5*time.Second,
+					ctx, 5*time.Second,
 				)
 				defer cancel()
 				c.pushAll(ctx, buffer)
@@ -285,8 +361,12 @@ func (c *Client) pushAll(
 	for i := 0; i < len(records); i += c.cfg.BatchSize {
 		end := min(i+c.cfg.BatchSize, len(records))
 		if err := c.pushBatch(ctx, records[i:end]); err != nil {
+			atomic.AddUint64(&c.stats.PushErrors, 1)
 			c.onError(err)
+			continue
 		}
+		atomic.AddUint64(&c.stats.Sent, uint64(end-i))
+		atomic.StoreInt64(&c.stats.LastPushTimestamp, c.cfg.Clock.Now().Unix())
 	}
 }
 
@@ -315,11 +395,16 @@ func (c *Client) pushBatch(
 	}
 
 	attempts := c.cfg.MaxRetries + 1
+	attempt := 0
 	err = retry.Call(retry.CallArgs{
 		Attempts: attempts,
 		Delay:    c.cfg.InitialBackoff,
 		MaxDelay: c.cfg.MaxBackoff,
 		Func: func() error {
+			if attempt > 0 {
+				atomic.AddUint64(&c.stats.Retries, 1)
+			}
+			attempt++
 			return c.doRequest(ctx, data)
 		},
 		IsFatalError: func(err error) bool {
@@ -415,7 +500,42 @@ type pushPayload struct {
 // pushStream is a single stream within a push payload.
 type pushStream struct {
 	Stream map[string]string `json:"stream"`
-	Values [][]string        `json:"values"`
+	Values []pushValue       `json:"values"`
+}
+
+type pushValue struct {
+	Timestamp string
+	Line      string
+	Fields    map[string]string
+}
+
+func (v pushValue) MarshalJSON() ([]byte, error) {
+	if len(v.Fields) == 0 {
+		return json.Marshal([]string{v.Timestamp, v.Line})
+	}
+	return json.Marshal([]any{v.Timestamp, v.Line, v.Fields})
+}
+
+func (v *pushValue) UnmarshalJSON(data []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if len(raw) != 2 && len(raw) != 3 {
+		return internalerrors.Errorf("expected loki value tuple with 2 or 3 fields")
+	}
+	if err := json.Unmarshal(raw[0], &v.Timestamp); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(raw[1], &v.Line); err != nil {
+		return err
+	}
+	if len(raw) == 3 {
+		if err := json.Unmarshal(raw[2], &v.Fields); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // buildPayload groups records by label set into streams.
@@ -424,20 +544,19 @@ func buildPayload(records []Record) pushPayload {
 	order := make([]string, 0)
 
 	for _, r := range records {
-		key := labelKey(r.Labels)
+		labels := topologyLabels(r)
+		key := labelKey(labels)
 		s, ok := groups[key]
 		if !ok {
-			labels := make(map[string]string, len(r.Labels))
-			maps.Copy(labels, r.Labels)
-
 			s = &pushStream{Stream: labels}
 			groups[key] = s
 			order = append(order, key)
 		}
-		ts := strconv.FormatInt(
-			r.Timestamp.UnixNano(), 10,
-		)
-		s.Values = append(s.Values, []string{ts, r.Line})
+		s.Values = append(s.Values, pushValue{
+			Timestamp: strconv.FormatInt(r.Timestamp.UnixNano(), 10),
+			Line:      r.Line,
+			Fields:    structuredFields(r),
+		})
 	}
 
 	streams := make([]pushStream, 0, len(order))
@@ -445,6 +564,49 @@ func buildPayload(records []Record) pushPayload {
 		streams = append(streams, *groups[key])
 	}
 	return pushPayload{Streams: streams}
+}
+
+func topologyLabels(r Record) map[string]string {
+	labels := make(map[string]string, 3)
+	if r.ControllerUUID != "" {
+		labels["juju_controller"] = r.ControllerUUID
+	}
+	if r.ModelUUID != "" {
+		labels["juju_model"] = r.ModelUUID
+	}
+	if r.AgentID != "" {
+		labels["juju_agent"] = r.AgentID
+	}
+	return labels
+}
+
+func structuredFields(r Record) map[string]string {
+	fields := make(map[string]string, len(r.Fields)+2)
+	for k, v := range r.Fields {
+		fields[k] = v
+	}
+	if isLowerHex(r.TraceID, 32) {
+		fields["trace_id"] = r.TraceID
+	}
+	if isLowerHex(r.SpanID, 16) {
+		fields["span_id"] = r.SpanID
+	}
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}
+
+func isLowerHex(s string, length int) bool {
+	if len(s) != length {
+		return false
+	}
+	for _, r := range s {
+		if !('0' <= r && r <= '9') && !('a' <= r && r <= 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // labelKey produces a deterministic string key from a label

--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"sort"
 	"strconv"
@@ -581,9 +582,7 @@ func topologyLabels(r Record) map[string]string {
 
 func structuredFields(r Record) map[string]string {
 	fields := make(map[string]string, len(r.Fields)+2)
-	for k, v := range r.Fields {
-		fields[k] = v
-	}
+	maps.Copy(fields, r.Fields)
 	if isLowerHex(r.TraceID, 32) {
 		fields["trace_id"] = r.TraceID
 	}

--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -21,6 +20,7 @@ import (
 	"github.com/juju/retry"
 	"gopkg.in/tomb.v2"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	internalerrors "github.com/juju/juju/internal/errors"
 )
 
@@ -50,6 +50,11 @@ type Record struct {
 
 	// SpanID is the OpenTelemetry span ID for this record, if present.
 	SpanID string
+}
+
+// HTTPClient is the HTTP client surface used by the Loki push client.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
 }
 
 // Config holds configuration for the Loki push client.
@@ -83,7 +88,7 @@ type Config struct {
 
 	// HTTPClient is an optional HTTP client. If nil, a
 	// default client with a 10s timeout is used.
-	HTTPClient *http.Client
+	HTTPClient HTTPClient
 
 	// AsyncFlush controls whether batches are pushed in a
 	// background goroutine. When true (the default), the
@@ -103,6 +108,33 @@ type Config struct {
 	// Clock is passed to the retry logic for testing.
 	// If nil, the wall clock is used.
 	Clock clock.Clock
+}
+
+// Validate checks that the Config has valid values and returns an
+// error if any field is invalid.
+func (c Config) Validate() error {
+	if c.BatchSize <= 0 {
+		return internalerrors.Errorf("BatchSize must be positive")
+	}
+	if c.BufferSize <= 0 {
+		return internalerrors.Errorf("BufferSize must be positive")
+	}
+	if c.FlushInterval <= 0 {
+		return internalerrors.Errorf("FlushInterval must be positive")
+	}
+	if c.MaxRetries < 0 {
+		return internalerrors.Errorf("MaxRetries must not be negative")
+	}
+	if c.InitialBackoff <= 0 {
+		return internalerrors.Errorf("InitialBackoff must be positive")
+	}
+	if c.MaxBackoff <= 0 {
+		return internalerrors.Errorf("MaxBackoff must be positive")
+	}
+	if c.Clock == nil {
+		return internalerrors.Errorf("Clock must not be nil")
+	}
+	return nil
 }
 
 // DefaultConfig returns a Config with sensible defaults.
@@ -126,7 +158,7 @@ func DefaultConfig() Config {
 type Client struct {
 	endpoint   string
 	cfg        Config
-	http       *http.Client
+	http       HTTPClient
 	asyncFlush bool
 	onError    func(error)
 	onDrop     func(int)
@@ -147,57 +179,21 @@ type report struct {
 // NewClient creates and starts a new Loki push client worker.
 // The endpoint should be the full URL to the Loki push API
 // (e.g. http://loki:3100/loki/api/v1/push).
-// Invalid and unset fields in cfg are replaced with defaults.
-// MaxRetries follows retry-count semantics: 0 disables retries.
 func NewClient(endpoint string, cfg Config) (*Client, error) {
 	if endpoint == "" {
-		return nil, internalerrors.Errorf("endpoint must not be empty")
+		return nil, internalerrors.Errorf("endpoint must not be empty").Add(coreerrors.NotValid)
 	}
-	if cfg.BatchSize <= 0 {
-		cfg.BatchSize = 100
+	if err := cfg.Validate(); err != nil {
+		return nil, err
 	}
-	if cfg.BufferSize <= 0 {
-		cfg.BufferSize = 500
-	}
-	if cfg.FlushInterval <= 0 {
-		cfg.FlushInterval = 10 * time.Second
-	}
-	if cfg.MaxRetries < 0 {
-		cfg.MaxRetries = 3
-	}
-	if cfg.InitialBackoff <= 0 {
-		cfg.InitialBackoff = 500 * time.Millisecond
-	}
-	if cfg.MaxBackoff <= 0 {
-		cfg.MaxBackoff = 30 * time.Second
-	}
-	if cfg.Clock == nil {
-		cfg.Clock = clock.WallClock
-	}
-	httpClient := cfg.HTTPClient
-	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 10 * time.Second}
-	}
-	onError := cfg.OnError
-	if onError == nil {
-		onError = func(err error) {
-			fmt.Fprintf(os.Stderr, "loki push failed: %v\n", err)
-		}
-	}
-	onDrop := cfg.OnDrop
-	if onDrop == nil {
-		onDrop = func(count int) {
-			fmt.Fprintf(os.Stderr, "dropped %d loki log records\n", count)
-		}
-	}
-	asyncFlush := cfg.AsyncFlush == nil || *cfg.AsyncFlush
+
 	c := &Client{
 		endpoint:   endpoint,
 		cfg:        cfg,
-		http:       httpClient,
-		asyncFlush: asyncFlush,
-		onError:    onError,
-		onDrop:     onDrop,
+		http:       cfg.HTTPClient,
+		asyncFlush: cfg.AsyncFlush == nil || *cfg.AsyncFlush,
+		onError:    cfg.OnError,
+		onDrop:     cfg.OnDrop,
 		records:    make(chan Record, cfg.BufferSize),
 	}
 	c.tomb.Go(c.loop)
@@ -257,8 +253,8 @@ func (c *Client) Report(context.Context) map[string]any {
 // Kill requests the client to stop. Any buffered records are
 // flushed on a best-effort basis before the client exits.
 // Records in-flight during shutdown may be dropped.
-func (c *Client) Kill(reason error) {
-	c.tomb.Kill(reason)
+func (c *Client) Kill() {
+	c.tomb.Kill(nil)
 }
 
 // Wait blocks until the client has stopped.
@@ -283,11 +279,14 @@ func (c *Client) loop() error {
 		case <-c.tomb.Dying():
 			c.drainChannel(&buffer)
 			if len(buffer) > 0 {
-				ctx, cancel := context.WithTimeout(
-					ctx, 5*time.Second,
-				)
-				defer cancel()
-				c.pushAll(ctx, buffer)
+				func() {
+					// Don't use the tomb context here, because we want to give
+					// the flush a chance to complete even if the tomb is dying.
+					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+
+					c.pushAll(ctx, buffer)
+				}()
 			}
 			return tomb.ErrDying
 

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -81,9 +81,11 @@ func (s *clientSuite) TestPushNoRetriesWhenMaxRetriesZero(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "no retries",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "no retries",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -105,15 +107,17 @@ func (s *clientSuite) TestPushUsesWallClockWhenUnset(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "clock default",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "clock default",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	p := waitPayload(c, payloads)
 	c.Assert(p.Streams, tc.HasLen, 1)
-	c.Check(p.Streams[0].Values[0][1], tc.Equals, "clock default")
+	c.Check(p.Streams[0].Values[0].Line, tc.Equals, "clock default")
 }
 
 func (s *clientSuite) TestPushFlushOnBatchSize(c *tc.C) {
@@ -129,9 +133,11 @@ func (s *clientSuite) TestPushFlushOnBatchSize(c *tc.C) {
 	ts := time.Now()
 	for range 3 {
 		err := client.Push(Record{
-			Timestamp: ts,
-			Line:      "line",
-			Labels:    map[string]string{"job": "test"},
+			Timestamp:      ts,
+			Line:           "line",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
 		})
 		c.Assert(err, tc.ErrorIsNil)
 	}
@@ -155,10 +161,10 @@ func (s *clientSuite) TestPushSyncFlush(c *tc.C) {
 
 	ts := time.Now()
 	err = client.Push(
-		Record{Timestamp: ts, Line: "s1",
-			Labels: map[string]string{"job": "test"}},
-		Record{Timestamp: ts, Line: "s2",
-			Labels: map[string]string{"job": "test"}},
+		Record{Timestamp: ts, Line: "s1", ControllerUUID: "controller",
+			ModelUUID: "model", AgentID: "machine-0"},
+		Record{Timestamp: ts, Line: "s2", ControllerUUID: "controller",
+			ModelUUID: "model", AgentID: "machine-0"},
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -179,18 +185,20 @@ func (s *clientSuite) TestPushFlushOnInterval(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "timer flush",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "timer flush",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	p := waitPayload(c, payloads)
 	c.Assert(p.Streams, tc.HasLen, 1)
-	c.Check(p.Streams[0].Values[0][1], tc.Equals, "timer flush")
+	c.Check(p.Streams[0].Values[0].Line, tc.Equals, "timer flush")
 }
 
-func (s *clientSuite) TestPushGroupsByLabels(c *tc.C) {
+func (s *clientSuite) TestPushGroupsByTopologyLabels(c *tc.C) {
 	srv, payloads := newTestServer(c)
 	defer srv.Close()
 
@@ -203,28 +211,34 @@ func (s *clientSuite) TestPushGroupsByLabels(c *tc.C) {
 	ts := time.Now()
 	err = client.Push(
 		Record{
-			Timestamp: ts,
-			Line:      "a1",
-			Labels:    map[string]string{"job": "a"},
+			Timestamp:      ts,
+			Line:           "a1",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
 		},
 		Record{
-			Timestamp: ts,
-			Line:      "b1",
-			Labels:    map[string]string{"job": "b"},
+			Timestamp:      ts,
+			Line:           "b1",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "unit-app-0",
 		},
 		Record{
-			Timestamp: ts,
-			Line:      "a2",
-			Labels:    map[string]string{"job": "a"},
+			Timestamp:      ts,
+			Line:           "a2",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
 		},
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
 	p := waitPayload(c, payloads)
 	c.Assert(p.Streams, tc.HasLen, 2)
-	c.Check(p.Streams[0].Stream["job"], tc.Equals, "a")
+	c.Check(p.Streams[0].Stream["juju_agent"], tc.Equals, "machine-0")
 	c.Check(p.Streams[0].Values, tc.HasLen, 2)
-	c.Check(p.Streams[1].Stream["job"], tc.Equals, "b")
+	c.Check(p.Streams[1].Stream["juju_agent"], tc.Equals, "unit-app-0")
 	c.Check(p.Streams[1].Values, tc.HasLen, 1)
 }
 
@@ -250,9 +264,11 @@ func (s *clientSuite) TestPushBatching(c *tc.C) {
 	// Send 6 records: triggers 2 flushes of 3.
 	for range 6 {
 		err := client.Push(Record{
-			Timestamp: ts,
-			Line:      "line",
-			Labels:    map[string]string{"job": "test"},
+			Timestamp:      ts,
+			Line:           "line",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
 		})
 		c.Assert(err, tc.ErrorIsNil)
 	}
@@ -291,9 +307,11 @@ func (s *clientSuite) TestPushRetryOnServerError(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "retry me",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "retry me",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -328,9 +346,11 @@ func (s *clientSuite) TestPushRetryOnTooManyRequests(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "throttled",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "throttled",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -362,9 +382,11 @@ func (s *clientSuite) TestOnErrorCalledOnPushFailure(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "will fail",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "will fail",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -377,6 +399,65 @@ func (s *clientSuite) TestOnErrorCalledOnPushFailure(c *tc.C) {
 	case <-time.After(5 * time.Second):
 		c.Fatal("timed out waiting for OnError callback")
 	}
+}
+
+func (s *clientSuite) TestPushDropsOldestWhenQueueFull(c *tc.C) {
+	block := make(chan struct{})
+	started := make(chan struct{}, 1)
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-block
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+	defer srv.Close()
+
+	drops := make(chan int, 3)
+	cfg := testConfig()
+	cfg.BatchSize = 1
+	cfg.BufferSize = 2
+	cfg.MaxRetries = 0
+	asyncFlush := false
+	cfg.AsyncFlush = &asyncFlush
+	cfg.OnDrop = func(count int) {
+		drops <- count
+	}
+
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	ts := time.Now()
+	err = client.Push(Record{Timestamp: ts, Line: "first"})
+	c.Assert(err, tc.ErrorIsNil)
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for first request")
+	}
+
+	// The first record blocks the worker in HTTP I/O. The queue can then fill
+	// and must drop oldest records without blocking this caller.
+	err = client.Push(
+		Record{Timestamp: ts, Line: "second"},
+		Record{Timestamp: ts, Line: "third"},
+		Record{Timestamp: ts, Line: "fourth"},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	select {
+	case count := <-drops:
+		c.Check(count, tc.Equals, 1)
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for drop callback")
+	}
+	c.Check(client.Report(c.Context())["dropped"], tc.Equals, uint64(1))
+
+	close(block)
+	killAndWait(c, client)
 }
 
 func (s *clientSuite) TestKillDrainsBufferedRecords(c *tc.C) {
@@ -393,9 +474,11 @@ func (s *clientSuite) TestKillDrainsBufferedRecords(c *tc.C) {
 	ts := time.Now()
 	err = client.Push(
 		Record{
-			Timestamp: ts,
-			Line:      "drain me",
-			Labels:    map[string]string{"job": "test"},
+			Timestamp:      ts,
+			Line:           "drain me",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
 		},
 	)
 	c.Assert(err, tc.ErrorIsNil)
@@ -405,13 +488,13 @@ func (s *clientSuite) TestKillDrainsBufferedRecords(c *tc.C) {
 	p := waitPayload(c, payloads)
 	c.Assert(p.Streams, tc.HasLen, 1)
 	c.Check(
-		p.Streams[0].Values[0][1],
+		p.Streams[0].Values[0].Line,
 		tc.Equals,
 		"drain me",
 	)
 }
 
-func (s *clientSuite) TestPushNilLabels(c *tc.C) {
+func (s *clientSuite) TestPushNoTopologyLabels(c *tc.C) {
 	srv, payloads := newTestServer(c)
 	defer srv.Close()
 
@@ -436,23 +519,35 @@ func (s *clientSuite) TestBuildPayload(c *tc.C) {
 	ts := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 	records := []Record{
 		{
-			Timestamp: ts,
-			Line:      "a1",
-			Labels: map[string]string{
-				"job": "x", "env": "prod",
+			Timestamp:      ts,
+			Line:           "a1",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
+			Fields: map[string]string{
+				"module": "apiserver",
 			},
+			TraceID: "0123456789abcdef0123456789abcdef",
+			SpanID:  "0123456789abcdef",
 		},
 		{
-			Timestamp: ts.Add(time.Second),
-			Line:      "b1",
-			Labels:    map[string]string{"job": "y"},
+			Timestamp:      ts.Add(time.Second),
+			Line:           "b1",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "unit-app-0",
 		},
 		{
-			Timestamp: ts.Add(2 * time.Second),
-			Line:      "a2",
-			Labels: map[string]string{
-				"env": "prod", "job": "x",
+			Timestamp:      ts.Add(2 * time.Second),
+			Line:           "a2",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
+			Fields: map[string]string{
+				"request_id": "req-123",
 			},
+			TraceID: "NOT-CANONICAL",
+			SpanID:  "0123456789abcdef",
 		},
 	}
 
@@ -462,16 +557,33 @@ func (s *clientSuite) TestBuildPayload(c *tc.C) {
 	c.Check(
 		payload.Streams[0].Stream,
 		tc.DeepEquals,
-		map[string]string{"job": "x", "env": "prod"},
+		map[string]string{
+			"juju_controller": "controller",
+			"juju_model":      "model",
+			"juju_agent":      "machine-0",
+		},
 	)
 	c.Check(payload.Streams[0].Values, tc.HasLen, 2)
-	c.Check(payload.Streams[0].Values[0][1], tc.Equals, "a1")
-	c.Check(payload.Streams[0].Values[1][1], tc.Equals, "a2")
+	c.Check(payload.Streams[0].Values[0].Line, tc.Equals, "a1")
+	c.Check(payload.Streams[0].Values[0].Fields, tc.DeepEquals, map[string]string{
+		"module":   "apiserver",
+		"trace_id": "0123456789abcdef0123456789abcdef",
+		"span_id":  "0123456789abcdef",
+	})
+	c.Check(payload.Streams[0].Values[1].Line, tc.Equals, "a2")
+	c.Check(payload.Streams[0].Values[1].Fields, tc.DeepEquals, map[string]string{
+		"request_id": "req-123",
+		"span_id":    "0123456789abcdef",
+	})
 
 	c.Check(
 		payload.Streams[1].Stream,
 		tc.DeepEquals,
-		map[string]string{"job": "y"},
+		map[string]string{
+			"juju_controller": "controller",
+			"juju_model":      "model",
+			"juju_agent":      "unit-app-0",
+		},
 	)
 	c.Check(payload.Streams[1].Values, tc.HasLen, 1)
 }
@@ -494,11 +606,14 @@ func (s *clientSuite) TestLabelKeyEmpty(c *tc.C) {
 func testConfig() Config {
 	return Config{
 		BatchSize:      100,
+		BufferSize:     500,
 		FlushInterval:  50 * time.Millisecond,
 		MaxRetries:     3,
 		InitialBackoff: time.Millisecond,
 		MaxBackoff:     10 * time.Millisecond,
 		Clock:          clock.WallClock,
+		OnError:        func(error) {},
+		OnDrop:         func(int) {},
 	}
 }
 

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -51,10 +51,31 @@ func (s *clientSuite) TestNewClientDefaults(c *tc.C) {
 }
 
 func (s *clientSuite) TestNewClientZeroRetriesIsValid(c *tc.C) {
-	client, err := NewClient("http://loki:3100", Config{})
+	cfg := testConfig()
+	cfg.MaxRetries = 0
+	client, err := NewClient("http://loki:3100", cfg)
 	c.Assert(err, tc.ErrorIsNil)
 	defer killAndWait(c, client)
 	c.Check(client.cfg.MaxRetries, tc.Equals, 0)
+}
+
+func (s *clientSuite) TestConfigValidateRejectsEmptyConfig(c *tc.C) {
+	err := Config{}.Validate()
+	c.Assert(err, tc.ErrorMatches, "BatchSize must be positive")
+}
+
+func (s *clientSuite) TestConfigValidateRejectsNegativeMaxRetries(c *tc.C) {
+	cfg := testConfig()
+	cfg.MaxRetries = -1
+	err := cfg.Validate()
+	c.Assert(err, tc.ErrorMatches, "MaxRetries must not be negative")
+}
+
+func (s *clientSuite) TestConfigValidateRejectsNilClock(c *tc.C) {
+	cfg := testConfig()
+	cfg.Clock = nil
+	err := cfg.Validate()
+	c.Assert(err, tc.ErrorMatches, "Clock must not be nil")
 }
 
 func (s *clientSuite) TestPushNoRetriesWhenMaxRetriesZero(c *tc.C) {
@@ -94,13 +115,12 @@ func (s *clientSuite) TestPushNoRetriesWhenMaxRetriesZero(c *tc.C) {
 	c.Check(attempts.Load(), tc.Equals, int32(1))
 }
 
-func (s *clientSuite) TestPushUsesWallClockWhenUnset(c *tc.C) {
+func (s *clientSuite) TestPushUsesWallClock(c *tc.C) {
 	srv, payloads := newTestServer(c)
 	defer srv.Close()
 
 	cfg := testConfig()
 	cfg.BatchSize = 1
-	cfg.Clock = nil
 
 	client, err := NewClient(srv.URL, cfg)
 	c.Assert(err, tc.ErrorIsNil)
@@ -662,7 +682,7 @@ func waitError(c *tc.C, ch <-chan error) error {
 }
 
 func killAndWait(c *tc.C, client *Client) {
-	client.Kill(nil)
+	client.Kill()
 	err := client.Wait()
 	c.Assert(err, tc.ErrorIsNil)
 }

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -634,6 +634,7 @@ func testConfig() Config {
 		Clock:          clock.WallClock,
 		OnError:        func(error) {},
 		OnDrop:         func(int) {},
+		HTTPClient:     http.DefaultClient,
 	}
 }
 


### PR DESCRIPTION
~~Requires: https://github.com/juju/juju/pull/22628~~

This prepares the Loki client for Juju’s broader observability work, where logs need to be useful alongside traces and metrics rather than existing as a separate stream of text.

  The main motivation is correlation. When an operator is investigating controller or workload behaviour, a log line by itself is often not enough. The useful path is to move from a symptom in logs to the related trace, span, controller, model, and agent context without guessing. This change makes the Loki payload
  shape support that by carrying trace/span IDs and Juju topology information in a way Loki can query efficiently.

  It also tightens the boundary around Loki labels. Arbitrary log labels are risky because they can create high-cardinality streams and make Loki expensive or difficult to operate. The client now treats Juju topology as the stable stream identity and keeps higher-cardinality data as structured fields. That gives us
  the context we need without turning every request, trace, or dynamic field into a new Loki stream.

## QA steps

Not wired up yet.

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9977](https://warthogs.atlassian.net/browse/JUJU-9977)


[JUJU-9977]: https://warthogs.atlassian.net/browse/JUJU-9977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ