### PR TITLE
fix(ci): use branch-built operator image in upgrade smoke

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -259,11 +259,13 @@ jobs:
 
           make operator-image
 
+          LOCAL_OPERATOR_IMAGE=$(bash -c '. ./make_functions.sh; operator_image_path')
+
           # Shim in recognition for our CA to jujud-operator
           BUILD_TEMP=$(mktemp -d)
           cp ~/certs/ca.crt $BUILD_TEMP/
           cat >$BUILD_TEMP/Dockerfile <<EOL
-            FROM ghcr.io/juju/jujud-operator:${TARGET_JUJU_VERSION}          
+            FROM ${LOCAL_OPERATOR_IMAGE}
 
             COPY ca.crt /usr/local/share/ca-certificates/ca.crt
 


### PR DESCRIPTION
The microk8s upgrade smoke job was validating controller upgrades
against an operator image rebuilt from the published upstream tag, so
branch-only CAAS fixes in the local operator image were never exercised
in CI. That made the workflow report upgrade failures that could not be
reproduced when testing the branch locally. This change makes the
workflow rebase its CA-cert shim onto the operator image built from the
current branch and prevents the test build from pulling an upstream base
image, ensuring the upgrade job verifies the code under test instead of
a released image.

## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
CI change only

## Documentation changes

## Links
