### PR TITLE
Docs migrate 29

### DIFF
--- a/docs/.sphinx/_static/js/overwrite_links.js
+++ b/docs/.sphinx/_static/js/overwrite_links.js
@@ -1,0 +1,37 @@
+// Replace oldDomain with newDomain
+const oldDomain = 'canonical-juju-1.readthedocs-hosted.com';
+const newDomain = 'canonical.com/juju/docs/juju-cli';
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function overwriteMatchingAnchorUrls(container) {
+    if (!container) return;
+
+    const anchors = container.querySelectorAll('a[href], link[href]');
+    const oldDomainRegex = new RegExp(escapeRegExp(oldDomain), 'g');
+
+    anchors.forEach(anchor => {
+        anchor.href = anchor.href.replace(oldDomainRegex, newDomain);
+    });
+}
+
+overwriteMatchingAnchorUrls(document.querySelector('header'));
+
+// Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+const observer = new MutationObserver(function(mutations, obs) {
+    const rtdFlyout = document.querySelector('readthedocs-flyout');
+    if (!rtdFlyout) return;
+
+    obs.disconnect();
+
+    rtdFlyout.addEventListener('click', function() {
+        const shadowRoot = rtdFlyout.shadowRoot;
+        if (!shadowRoot) return;
+
+        overwriteMatchingAnchorUrls(shadowRoot);
+    });
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,9 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical-starter-pack.readthedocs-hosted.com/"
+version_slug = f"{os.environ.get('READTHEDOCS_VERSION', 'local')}"
+
+ogp_site_url = f"https://canonical.com/juju/docs/juju-cli/{version_slug}/"
 
 
 # Preview name of the documentation website
@@ -131,8 +133,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
-
+slug = 'juju/docs/juju-cli'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
@@ -140,7 +141,7 @@ html_context = {
 
 # Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
 
-html_baseurl = 'https://documentation.ubuntu.com/juju/'
+html_baseurl = f'https://canonical.com/juju/docs/juju-cli/{version_slug}/'
 
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
@@ -150,6 +151,8 @@ if 'READTHEDOCS_VERSION' in os.environ:
     sitemap_url_scheme = '{version}{link}'
 else:
     sitemap_url_scheme = 'MANUAL/{link}'
+
+sitemap_filename = "doc-sitemap.xml"
 
 # Include `lastmod` dates in the sitemap:
 
@@ -290,6 +293,7 @@ html_css_files = [
 
 html_js_files = [
     "https://assets.ubuntu.com/v1/287a5e8f-bundle.js",
+    'js/overwrite_links.js',
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,11 +146,7 @@ html_baseurl = f'https://canonical.com/juju/docs/juju-cli/{version_slug}/'
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
 
-if 'READTHEDOCS_VERSION' in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = '{version}{link}'
-else:
-    sitemap_url_scheme = 'MANUAL/{link}'
+sitemap_url_scheme = '{link}'
 
 sitemap_filename = "doc-sitemap.xml"
 


### PR DESCRIPTION
Part of our docs migration to canonical.com/juju/docs/juju-cli.

For reference see https://canonical-rtd-proxy.readthedocs-hosted.com/how-to/migrate/ 
