### PR TITLE
feat: include workload version in history logging

### DIFF
--- a/core/status/status.go
+++ b/core/status/status.go
@@ -273,11 +273,6 @@ const (
 	ProvisioningError Status = "provisioning error"
 )
 
-// ModificationStatus
-const (
-	Applied Status = "applied"
-)
-
 const (
 	MessageWaitForMachine    = "waiting for machine"
 	MessageWaitForContainer  = "waiting for container"
@@ -292,7 +287,6 @@ func (s Status) KnownModificationStatus() bool {
 	switch s {
 	case
 		Idle,
-		Applied,
 		Error,
 		Unknown:
 		return true

--- a/core/status/status_test.go
+++ b/core/status/status_test.go
@@ -24,11 +24,6 @@ func (s *StatusSuite) TestModification(c *tc.C) {
 		valid  bool
 	}{
 		{
-			name:   "applied",
-			status: status.Applied,
-			valid:  true,
-		},
-		{
 			name:   "error",
 			status: status.Error,
 			valid:  true,
@@ -71,7 +66,6 @@ func (s *StatusSuite) TestInvalidModelStatus(c *tc.C) {
 	for _, v := range []status.Status{
 		status.Active,
 		status.Allocating,
-		status.Applied,
 		status.Attached,
 		status.Attaching,
 		status.Blocked,
@@ -208,7 +202,6 @@ func (s *StatusSuite) TestKnownMachineStatus(c *tc.C) {
 		known  bool
 	}{
 		{status.Active, false},
-		{status.Applied, false},
 		{status.Attached, false},
 		{status.Attaching, false},
 		{status.Available, false},

--- a/docs/howto/manage-machines.md
+++ b/docs/howto/manage-machines.md
@@ -102,7 +102,7 @@ machines:
       message: Running
       since: 27 Oct 2022 09:36:10+02:00
     modification-status:
-      current: applied
+      current: idle
       since: 27 Oct 2022 09:36:07+02:00
     base:
       name: ubuntu
@@ -228,7 +228,7 @@ machines:
       message: Running
       since: 07 Feb 2023 13:53:20+01:00
     modification-status:
-      current: applied
+      current: idle
       since: 20 Mar 2023 08:53:12+01:00
     base:
       name: ubuntu

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -1364,7 +1364,18 @@ func (s *Service) SetUnitWorkloadVersion(ctx context.Context, unitName coreunit.
 		return errors.Capture(err)
 	}
 
-	return s.st.SetUnitWorkloadVersion(ctx, unitName, version)
+	if err := s.st.SetUnitWorkloadVersion(ctx, unitName, version); err != nil {
+		return errors.Capture(err)
+	}
+
+	namespace := status.UnitWorkloadVersionNamespace.WithID(unitName.String())
+	statusInfo := corestatus.StatusInfo{
+		Message: version,
+	}
+	if err := s.statusHistory.RecordStatus(ctx, namespace, statusInfo); err != nil {
+		s.logger.Warningf(ctx, "recording workload version history for unit %q: %v", unitName, err)
+	}
+	return nil
 }
 
 // GetUnitWorkloadVersion returns the workload version for the given unit.

--- a/domain/application/service/unit_test.go
+++ b/domain/application/service/unit_test.go
@@ -513,12 +513,46 @@ func (s *unitServiceSuite) TestGetUnitNamesOnMachine(c *tc.C) {
 }
 
 func (s *unitServiceSuite) TestSetUnitWorkloadVersion(c *tc.C) {
-	defer s.setupMocks(c).Finish()
+	var statusHistory *MockStatusHistory
+	defer s.setupMocksWithStatusHistory(c, func(ctrl *gomock.Controller) StatusHistory {
+		statusHistory = NewMockStatusHistory(ctrl)
+		return statusHistory
+	}).Finish()
 
 	unitName := coreunit.Name("foo/666")
 	workloadVersion := "v1.0.0"
 
 	s.state.EXPECT().SetUnitWorkloadVersion(gomock.Any(), unitName, workloadVersion).Return(nil)
+	statusHistory.EXPECT().RecordStatus(
+		gomock.Any(),
+		status.UnitWorkloadVersionNamespace.WithID(unitName.String()),
+		corestatus.StatusInfo{
+			Message: workloadVersion,
+		},
+	).Return(nil)
+
+	err := s.service.SetUnitWorkloadVersion(c.Context(), unitName, workloadVersion)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *unitServiceSuite) TestSetUnitWorkloadVersionHistoryError(c *tc.C) {
+	var statusHistory *MockStatusHistory
+	defer s.setupMocksWithStatusHistory(c, func(ctrl *gomock.Controller) StatusHistory {
+		statusHistory = NewMockStatusHistory(ctrl)
+		return statusHistory
+	}).Finish()
+
+	unitName := coreunit.Name("foo/666")
+	workloadVersion := "v1.0.0"
+
+	s.state.EXPECT().SetUnitWorkloadVersion(gomock.Any(), unitName, workloadVersion).Return(nil)
+	statusHistory.EXPECT().RecordStatus(
+		gomock.Any(),
+		status.UnitWorkloadVersionNamespace.WithID(unitName.String()),
+		corestatus.StatusInfo{
+			Message: workloadVersion,
+		},
+	).Return(errors.Errorf("boom"))
 
 	err := s.service.SetUnitWorkloadVersion(c.Context(), unitName, workloadVersion)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/status/history.go
+++ b/domain/status/history.go
@@ -8,6 +8,12 @@ import (
 	"github.com/juju/juju/internal/statushistory"
 )
 
+const (
+	// WorkloadVersionHistoryKind is a structured log kind for workload version
+	// changes. It is not a user-facing status history kind.
+	WorkloadVersionHistoryKind status.HistoryKind = "workload-version"
+)
+
 var (
 	// ApplicationNamespace is the namespace for application status.
 	ApplicationNamespace = statushistory.Namespace{Kind: status.KindApplication}
@@ -17,6 +23,10 @@ var (
 
 	// UnitWorkloadNamespace is the namespace for unit workload status.
 	UnitWorkloadNamespace = statushistory.Namespace{Kind: status.KindWorkload}
+
+	// UnitWorkloadVersionNamespace is the namespace for unit workload version
+	// changes.
+	UnitWorkloadVersionNamespace = statushistory.Namespace{Kind: WorkloadVersionHistoryKind}
 
 	// MachineNamespace is the namespace for machine status.
 	MachineNamespace = statushistory.Namespace{Kind: status.KindMachine}

--- a/domain/status/service/service_test.go
+++ b/domain/status/service/service_test.go
@@ -2655,7 +2655,7 @@ func (s *serviceSuite) TestSetRemoteRelationStatus(c *tc.C) {
 func (s *serviceSuite) TestSetRemoteRelationStatusInvalidStatus(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	newStatus := corestatus.StatusInfo{Status: corestatus.Applied}
+	newStatus := corestatus.StatusInfo{Status: corestatus.Active}
 
 	err := s.modelService.SetRemoteRelationStatus(c.Context(), corerelation.UUID("relation-uuid"), newStatus)
 	c.Check(err, tc.ErrorMatches, ".*unknown relation status.*")

--- a/internal/statushistory/logger.go
+++ b/internal/statushistory/logger.go
@@ -31,11 +31,6 @@ func NewLogRecorder(log logger.Logger) Recorder {
 
 // Record implements Recorder.Record.
 func (r *logRecorder) Record(ctx context.Context, record Record) error {
-	data, err := json.Marshal(record.Data)
-	if err != nil {
-		return errors.Errorf("failed to marshal data: %v", err).Add(DataMarshalError)
-	}
-
 	labels := logger.Labels{
 		categoryKey:    statusHistoryCategory,
 		kindKey:        record.Kind.String(),
@@ -43,7 +38,13 @@ func (r *logRecorder) Record(ctx context.Context, record Record) error {
 		statusKey:      record.Status,
 		messageKey:     record.Message,
 		sinceKey:       record.Time,
-		dataKey:        string(data),
+	}
+	if len(record.Data) > 0 {
+		data, err := json.Marshal(record.Data)
+		if err != nil {
+			return errors.Errorf("failed to marshal data: %v", err).Add(DataMarshalError)
+		}
+		labels[dataKey] = string(data)
 	}
 	r.logger.Logf(ctx, logger.INFO, labels, "status-history (status: %q, status-message: %q)", record.Status, record.Message)
 	return nil

--- a/internal/statushistory/logger_test.go
+++ b/internal/statushistory/logger_test.go
@@ -54,6 +54,32 @@ func (s *loggerSuite) TestRecord(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *loggerSuite) TestRecordNoData(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	labels := logger.Labels{
+		categoryKey:    statusHistoryCategory,
+		kindKey:        status.KindApplication.String(),
+		namespaceIDKey: "123",
+		statusKey:      "active",
+		messageKey:     "foo",
+		sinceKey:       "2019-01-01T00:00:00Z",
+	}
+
+	s.logger.EXPECT().Child("status-history", logger.STATUS_HISTORY).Return(s.logger)
+	s.logger.EXPECT().Logf(gomock.Any(), logger.INFO, labels, "status-history (status: %q, status-message: %q)", "active", "foo")
+
+	logger := NewLogRecorder(s.logger)
+	err := logger.Record(c.Context(), Record{
+		Kind:    status.KindApplication,
+		ID:      "123",
+		Status:  "active",
+		Message: "foo",
+		Time:    "2019-01-01T00:00:00Z",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *loggerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 


### PR DESCRIPTION
Makes 4.0 congruent with 3.6 in that changes to workload version are captured as historical status. 

In 3.6 workload version time-series data is not surfaced to the user, but here it is visible as structured logging.

As a drive-by, the unused `Applied` status is removed. It was only relevant to LXD profiles, which are no longer supported.

## QA steps

- Deploy `ubuntu`.
- `juju debug-log --replay|grep workload-version`
- There should be at least one line of the form:
```
machine-0: 11:40:35 INFO juju.services.application.status-history category:status-history,kind:workload-version,logger-tags:status-history,message:24.04,namespace_id:ubuntu/0,since:2026-06-15T09:40:35Z,status: status-history (status: "", status-message: "24.04")
```

## Links

**Issue:** Addresses #22583 in a slightly obtuse fashion for Juju 4+. 3.6 would need a new CLI mechanism to retrieve the entries in the status table for this update type.
