### PR TITLE
feat(migration): add TLA+ specification suite and Go drift test

### DIFF
--- a/core/migration/phase_tla_test.go
+++ b/core/migration/phase_tla_test.go
@@ -1,0 +1,340 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/migration"
+)
+
+// These tests are the drift guard for core/migration/tla/. They parse the TLA+
+// spec and config and assert they match core/migration/phase.go (the source of
+// truth). TLC itself is run by tests/suites/tla/task.sh; here we only check that
+// the model the suite checks is faithful to the Go state machine, so editing the
+// transition map in phase.go without updating the spec fails the build.
+
+var tlaQuotedStringRe = regexp.MustCompile(`"([^"]+)"`)
+
+func (s *PhaseSuite) TestTLASpecMatchesGo(c *tc.C) {
+	specPath := filepath.Join("tla", "MigrationTransitionPhases.tla")
+	specBytes, err := os.ReadFile(specPath)
+	c.Assert(err, tc.ErrorIsNil)
+	spec := string(specBytes)
+
+	tlaPhases, err := parseTLANamedSet(spec, "Phases")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(tlaPhases, tc.DeepEquals, allPhaseNames())
+
+	initialPhase, err := parseTLANamedString(spec, "InitialPhase")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(initialPhase, tc.Equals, migration.QUIESCE.String())
+
+	tlaTransitions, err := parseTLATransitions(spec)
+	c.Assert(err, tc.ErrorIsNil)
+	goTransitions := goTransitionNames()
+	c.Check(tlaTransitions, tc.DeepEquals, goTransitions)
+
+	c.Check(
+		terminalPhasesFromTransitions(tlaPhases, tlaTransitions),
+		tc.DeepEquals,
+		goTerminalPhaseNames(),
+	)
+
+	tlaRunning, err := parseTLANamedSet(spec, "RunningPhases")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(tlaRunning, tc.DeepEquals, goRunningPhaseNames())
+
+	tlaPostSuccess, err := parseTLANamedSet(spec, "PostSuccessPhases")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(tlaPostSuccess, tc.DeepEquals, goPostSuccessPhaseNames())
+
+	maxTransitions, err := parseTLANamedInt(spec, "MaxTransitions")
+	c.Assert(err, tc.ErrorIsNil)
+	longestPath, err := longestTransitionPath(migration.QUIESCE.String(), goTransitions)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(maxTransitions, tc.Equals, longestPath)
+}
+
+func (s *PhaseSuite) TestTLAConfigMatchesExpectedChecks(c *tc.C) {
+	cfgPath := filepath.Join("tla", "MigrationTransitionPhases.cfg")
+	cfgBytes, err := os.ReadFile(cfgPath)
+	c.Assert(err, tc.ErrorIsNil)
+
+	cfg, err := parseTLAConfig(string(cfgBytes))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cfg.specification, tc.Equals, "Spec")
+	c.Check(cfg.invariants, tc.DeepEquals, []string{
+		"TypeInvariant",
+		"StepBoundInvariant",
+	})
+	c.Check(cfg.properties, tc.DeepEquals, []string{
+		"TransitionSafety",
+		"TerminalStability",
+		"EventuallyTerminal",
+	})
+}
+
+func parseTLANamedSet(spec, name string) ([]string, error) {
+	pattern := regexp.MustCompile(
+		fmt.Sprintf(`(?ms)\b%s\s*==\s*\{([^}]*)\}`, regexp.QuoteMeta(name)),
+	)
+	matches := pattern.FindStringSubmatch(spec)
+	if len(matches) != 2 {
+		return nil, fmt.Errorf("%s set definition not found", name)
+	}
+	return sortedUniqueStrings(parseQuotedStrings(matches[1])), nil
+}
+
+func parseTLANamedString(spec, name string) (string, error) {
+	pattern := regexp.MustCompile(
+		fmt.Sprintf(`(?m)\b%s\s*==\s*"([^"]+)"`, regexp.QuoteMeta(name)),
+	)
+	matches := pattern.FindStringSubmatch(spec)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("%s string definition not found", name)
+	}
+	return matches[1], nil
+}
+
+func parseTLANamedInt(spec, name string) (int, error) {
+	pattern := regexp.MustCompile(
+		fmt.Sprintf(`(?m)\b%s\s*==\s*(\d+)`, regexp.QuoteMeta(name)),
+	)
+	matches := pattern.FindStringSubmatch(spec)
+	if len(matches) != 2 {
+		return 0, fmt.Errorf("%s integer definition not found", name)
+	}
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, fmt.Errorf("parsing %s: %w", name, err)
+	}
+	return value, nil
+}
+
+func parseTLATransitions(spec string) (map[string][]string, error) {
+	const transitionPattern = `(?m)p\s*=\s*"([^"]+)"\s*->\s*\{([^}]*)\}`
+	matches := regexp.MustCompile(transitionPattern).FindAllStringSubmatch(spec, -1)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("transition definitions not found")
+	}
+
+	transitions := make(map[string][]string, len(matches))
+	for _, match := range matches {
+		source := match[1]
+		if _, exists := transitions[source]; exists {
+			return nil, fmt.Errorf("duplicate transition definition for %q", source)
+		}
+		transitions[source] = sortedUniqueStrings(parseQuotedStrings(match[2]))
+	}
+	return transitions, nil
+}
+
+func parseQuotedStrings(value string) []string {
+	matches := tlaQuotedStringRe.FindAllStringSubmatch(value, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	result := make([]string, 0, len(matches))
+	for _, match := range matches {
+		result = append(result, match[1])
+	}
+	return result
+}
+
+func parseTLAConfig(cfgText string) (tlaConfig, error) {
+	cfg := tlaConfig{}
+	section := ""
+
+	for raw := range strings.SplitSeq(cfgText, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, `\*`) {
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, "SPECIFICATION "):
+			fields := strings.Fields(line)
+			if len(fields) != 2 {
+				return tlaConfig{}, fmt.Errorf("invalid specification line %q", line)
+			}
+			cfg.specification = fields[1]
+			section = ""
+		case line == "INVARIANTS":
+			section = "invariants"
+		case line == "PROPERTIES":
+			section = "properties"
+		default:
+			switch section {
+			case "invariants":
+				cfg.invariants = append(cfg.invariants, line)
+			case "properties":
+				cfg.properties = append(cfg.properties, line)
+			default:
+				return tlaConfig{}, fmt.Errorf("unexpected config line %q", line)
+			}
+		}
+	}
+
+	if cfg.specification == "" {
+		return tlaConfig{}, fmt.Errorf("missing specification")
+	}
+	return cfg, nil
+}
+
+func goTransitionNames() map[string][]string {
+	transitions := make(map[string][]string)
+	phases := allPhases()
+
+	for _, source := range phases {
+		var allowed []string
+		for _, target := range phases {
+			if source.CanTransitionTo(target) {
+				allowed = append(allowed, target.String())
+			}
+		}
+		if len(allowed) == 0 {
+			continue
+		}
+		transitions[source.String()] = sortedUniqueStrings(allowed)
+	}
+	return transitions
+}
+
+func terminalPhasesFromTransitions(phases []string, transitions map[string][]string) []string {
+	var terminals []string
+	for _, phase := range phases {
+		if len(transitions[phase]) == 0 {
+			terminals = append(terminals, phase)
+		}
+	}
+	return sortedUniqueStrings(terminals)
+}
+
+func goTerminalPhaseNames() []string {
+	var phases []string
+	for _, phase := range allPhases() {
+		if phase.IsTerminal() {
+			phases = append(phases, phase.String())
+		}
+	}
+	return sortedUniqueStrings(phases)
+}
+
+func goRunningPhaseNames() []string {
+	var phases []string
+	for _, phase := range allPhases() {
+		if phase.IsRunning() {
+			phases = append(phases, phase.String())
+		}
+	}
+	return sortedUniqueStrings(phases)
+}
+
+func goPostSuccessPhaseNames() []string {
+	var phases []string
+	for _, phase := range allPhases() {
+		if phase.IsPostSuccess() {
+			phases = append(phases, phase.String())
+		}
+	}
+	return sortedUniqueStrings(phases)
+}
+
+func allPhases() []migration.Phase {
+	return []migration.Phase{
+		migration.UNKNOWN,
+		migration.NONE,
+		migration.QUIESCE,
+		migration.IMPORT,
+		migration.VALIDATION,
+		migration.SUCCESS,
+		migration.LOGTRANSFER,
+		migration.REAP,
+		migration.REAPFAILED,
+		migration.DONE,
+		migration.ABORT,
+		migration.ABORTDONE,
+	}
+}
+
+func allPhaseNames() []string {
+	names := make([]string, 0, len(allPhases()))
+	for _, phase := range allPhases() {
+		names = append(names, phase.String())
+	}
+	return sortedUniqueStrings(names)
+}
+
+func longestTransitionPath(start string, transitions map[string][]string) (int, error) {
+	memo := make(map[string]int)
+	visiting := make(map[string]struct{})
+
+	var dfs func(string) (int, error)
+	dfs = func(phase string) (int, error) {
+		if depth, exists := memo[phase]; exists {
+			return depth, nil
+		}
+		if _, exists := visiting[phase]; exists {
+			return 0, fmt.Errorf("cycle detected at phase %q", phase)
+		}
+		visiting[phase] = struct{}{}
+		defer delete(visiting, phase)
+
+		targets := transitions[phase]
+		if len(targets) == 0 {
+			return 0, nil
+		}
+
+		maxDepth := 0
+		for _, target := range targets {
+			depth, err := dfs(target)
+			if err != nil {
+				return 0, err
+			}
+			depth++
+			if depth > maxDepth {
+				maxDepth = depth
+			}
+		}
+
+		memo[phase] = maxDepth
+		return maxDepth, nil
+	}
+
+	return dfs(start)
+}
+
+func sortedUniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+
+	unique := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		unique[value] = struct{}{}
+	}
+
+	result := make([]string, 0, len(unique))
+	for value := range unique {
+		result = append(result, value)
+	}
+	slices.Sort(result)
+	return result
+}
+
+type tlaConfig struct {
+	specification string
+	invariants    []string
+	properties    []string
+}

--- a/core/migration/tla/ImportClaimPhases.cfg
+++ b/core/migration/tla/ImportClaimPhases.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeInvariant
+    StepBoundInvariant
+
+PROPERTIES
+    TransitionSafety
+    ActivatingNeverAborts
+    AbortingNeverActivates
+    TerminalStability
+    EventuallyTerminal

--- a/core/migration/tla/ImportClaimPhases.tla
+++ b/core/migration/tla/ImportClaimPhases.tla
@@ -1,0 +1,93 @@
+---- MODULE ImportClaimPhases ----
+\* Copyright 2026 Canonical Ltd.
+\* Licensed under the AGPLv3, see LICENCE file for details.
+
+\* Model of the target-side import-claim protocol. The claim is created at
+\* "importing" (the first target-side write) and is destroyed ("deleted") once
+\* activation or abort cleanup finalises. The key safety property is the
+\* "activation point of no return": there is no activating -> aborting edge
+\* (and, symmetrically, no aborting -> activating).
+
+EXTENDS Naturals
+
+\* "deleted" models the absence of the claim row (model UUID free again); it is
+\* the terminal node of the protocol.
+Phases == {"importing", "activating", "aborting", "deleted"}
+
+InitialPhase == "importing"
+
+AllowedNext ==
+    [p \in Phases |->
+        CASE p = "importing"  -> {"activating", "aborting"}
+          [] p = "activating" -> {"deleted"}   \* never -> aborting (point of no return)
+          [] p = "aborting"   -> {"deleted"}   \* never -> activating
+          [] OTHER -> {}
+    ]
+
+CanTransition(from, to) == to \in AllowedNext[from]
+
+TerminalPhases == {p \in Phases : AllowedNext[p] = {}}
+
+\* Longest valid path from InitialPhase has 2 transitions:
+\* importing -> activating -> deleted (and importing -> aborting -> deleted).
+MaxTransitions == 2
+
+VARIABLES phase, steps
+
+vars == <<phase, steps>>
+
+Init ==
+    /\ phase = InitialPhase
+    /\ steps = 0
+
+Advance ==
+    /\ phase \notin TerminalPhases
+    /\ \E next \in AllowedNext[phase]:
+        /\ phase' = next
+        /\ steps' = steps + 1
+
+StayTerminal ==
+    /\ phase \in TerminalPhases
+    /\ UNCHANGED vars
+
+Next == Advance \/ StayTerminal
+
+\* WF_vars(Advance) assumes a driver (master worker / reconciler / operator)
+\* keeps acting. It deliberately abstracts away the crash-without-recovery of an
+\* "importing" claim, whose recovery is an out-of-band operator/reconciler path
+\* rather than a phase transition.
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(Advance)
+
+TypeInvariant ==
+    /\ phase \in Phases
+    /\ steps \in Nat
+
+StepBoundInvariant == steps <= MaxTransitions
+
+ASSUME AllowedTransitionsMatchDesign ==
+    /\ AllowedNext["importing"] = {"activating", "aborting"}
+    /\ AllowedNext["activating"] = {"deleted"}
+    /\ AllowedNext["aborting"] = {"deleted"}
+    /\ AllowedNext["deleted"] = {}
+
+TransitionAction ==
+    (phase' = phase) \/ CanTransition(phase, phase')
+
+TransitionSafety == [][TransitionAction]_vars
+
+\* The activation point of no return: once activation has started, abort cleanup
+\* can never take over.
+ActivatingNeverAborts == [][ (phase = "activating") => (phase' # "aborting") ]_vars
+
+\* Symmetrically, once abort cleanup has started, activation can never take over.
+AbortingNeverActivates == [][ (phase = "aborting") => (phase' # "activating") ]_vars
+
+\* Once the claim is deleted it stays deleted (terminal node is absorbing).
+TerminalStability == [][ (phase \in TerminalPhases) => (phase' = phase) ]_vars
+
+EventuallyTerminal == <> (phase \in TerminalPhases)
+
+=============================================================================

--- a/core/migration/tla/MigrationTransitionPhases.cfg
+++ b/core/migration/tla/MigrationTransitionPhases.cfg
@@ -1,0 +1,10 @@
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeInvariant
+    StepBoundInvariant
+
+PROPERTIES
+    TransitionSafety
+    TerminalStability
+    EventuallyTerminal

--- a/core/migration/tla/MigrationTransitionPhases.tla
+++ b/core/migration/tla/MigrationTransitionPhases.tla
@@ -1,0 +1,112 @@
+---- MODULE MigrationTransitionPhases ----
+\* Copyright 2026 Canonical Ltd.
+\* Licensed under the AGPLv3, see LICENCE file for details.
+
+EXTENDS Naturals
+
+\* Model of core/migration/phase.go validTransitions.
+\*
+\* UNKNOWN and NONE are code-only sentinels ("uninitialised field" and "no
+\* migration has ever been attempted"). They are terminal per IsTerminal() and
+\* are included here so the Go drift test can compare the spec against the full
+\* phase enum verbatim, but the lifecycle begins at QUIESCE so they are
+\* unreachable in any behaviour.
+Phases == {"UNKNOWN", "NONE", "QUIESCE", "IMPORT",
+           "VALIDATION", "SUCCESS", "LOGTRANSFER", "REAP",
+           "REAPFAILED", "DONE", "ABORT", "ABORTDONE"}
+
+InitialPhase == "QUIESCE"
+
+\* Transition relation matching validTransitions in phase.go.
+AllowedNext ==
+    [p \in Phases |->
+        CASE p = "QUIESCE"           -> {"IMPORT", "ABORT"}
+          [] p = "IMPORT"            -> {"VALIDATION", "ABORT"}
+          [] p = "VALIDATION"        -> {"SUCCESS", "ABORT"}
+          [] p = "SUCCESS"           -> {"LOGTRANSFER"}
+          [] p = "LOGTRANSFER"       -> {"REAP"}
+          [] p = "REAP"              -> {"DONE", "REAPFAILED"}
+          [] p = "ABORT"             -> {"ABORTDONE"}
+          [] OTHER -> {}
+    ]
+
+CanTransition(from, to) == to \in AllowedNext[from]
+
+TerminalPhases == {p \in Phases : AllowedNext[p] = {}}
+
+\* IsRunning() in phase.go.
+RunningPhases == {"QUIESCE", "IMPORT", "VALIDATION", "SUCCESS"}
+
+\* IsPostSuccess() in phase.go.
+PostSuccessPhases == {"LOGTRANSFER", "REAP", "REAPFAILED", "DONE"}
+
+\* Longest valid path from InitialPhase has 6 transitions:
+\* QUIESCE -> IMPORT -> VALIDATION -> SUCCESS -> LOGTRANSFER -> REAP -> DONE
+MaxTransitions == 6
+
+VARIABLES phase, steps
+
+vars == <<phase, steps>>
+
+Init ==
+    /\ phase = InitialPhase
+    /\ steps = 0
+
+Advance ==
+    /\ phase \notin TerminalPhases
+    /\ \E next \in AllowedNext[phase]:
+        /\ phase' = next
+        /\ steps' = steps + 1
+
+StayTerminal ==
+    /\ phase \in TerminalPhases
+    /\ UNCHANGED vars
+
+Next == Advance \/ StayTerminal
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(Advance)
+
+TypeInvariant ==
+    /\ phase \in Phases
+    /\ steps \in Nat
+
+ASSUME TerminalPhasesMatchGo ==
+    TerminalPhases = {"UNKNOWN", "NONE", "REAPFAILED", "DONE", "ABORTDONE"}
+
+ASSUME RunningPhasesMatchGo ==
+    RunningPhases = {"QUIESCE", "IMPORT", "VALIDATION", "SUCCESS"}
+
+ASSUME PostSuccessPhasesMatchGo ==
+    PostSuccessPhases = {"LOGTRANSFER", "REAP", "REAPFAILED", "DONE"}
+
+ASSUME AllowedTransitionsMatchGo ==
+    /\ AllowedNext["QUIESCE"] = {"IMPORT", "ABORT"}
+    /\ AllowedNext["IMPORT"] = {"VALIDATION", "ABORT"}
+    /\ AllowedNext["VALIDATION"] = {"SUCCESS", "ABORT"}
+    /\ AllowedNext["SUCCESS"] = {"LOGTRANSFER"}
+    /\ AllowedNext["LOGTRANSFER"] = {"REAP"}
+    /\ AllowedNext["REAP"] = {"DONE", "REAPFAILED"}
+    /\ AllowedNext["ABORT"] = {"ABORTDONE"}
+    /\ AllowedNext["DONE"] = {}
+    /\ AllowedNext["REAPFAILED"] = {}
+    /\ AllowedNext["ABORTDONE"] = {}
+    /\ AllowedNext["UNKNOWN"] = {}
+    /\ AllowedNext["NONE"] = {}
+
+StepBoundInvariant == steps <= MaxTransitions
+
+TransitionAction ==
+    (phase' = phase) \/ CanTransition(phase, phase')
+
+TransitionSafety == [][TransitionAction]_vars
+
+\* The property this suite exists to prove: once the migration reaches a terminal
+\* phase it never leaves it (terminal nodes are absorbing).
+TerminalStability == [][ (phase \in TerminalPhases) => (phase' = phase) ]_vars
+
+EventuallyTerminal == <> (phase \in TerminalPhases)
+
+=============================================================================

--- a/tests/suites/tla/task.sh
+++ b/tests/suites/tla/task.sh
@@ -115,6 +115,18 @@ run_objectstore_transition_phases() {
 		"core/objectstore/tla/ObjectStoreTransitionPhases.cfg"
 }
 
+run_migration_transition_phases() {
+	run_tla_model \
+		"core/migration/tla/MigrationTransitionPhases.tla" \
+		"core/migration/tla/MigrationTransitionPhases.cfg"
+}
+
+run_migration_import_claim_phases() {
+	run_tla_model \
+		"core/migration/tla/ImportClaimPhases.tla" \
+		"core/migration/tla/ImportClaimPhases.cfg"
+}
+
 test_tla() {
 	if [ "$(skip 'test_tla')" ]; then
 		echo "==> TEST SKIPPED: tla checks"
@@ -131,5 +143,7 @@ test_tla() {
 
 		run "run_prepare_tla_tools"
 		run "run_objectstore_transition_phases"
+		run "run_migration_transition_phases"
+		run "run_migration_import_claim_phases"
 	)
 }


### PR DESCRIPTION
~_Note: This PR duplicates a lot of code from https://github.com/juju/juju/pull/22530, so it should land first._~

Adds a formal verification suite for the model migration state machine.

  Two TLA+ specifications are introduced — one for each state machine
  involved in a migration:

  - **`core/migration/tla/MigrationTransitionPhases.tla`** models the
    source-side migration phases (`core/migration/phase.go`). TLC
    exhaustively checks that every execution eventually terminates, that
    every step is a legal transition, and that once the machine enters a
    terminal phase (DONE, REAPFAILED, ABORTDONE, UNKNOWN, NONE) it never
    leaves it.

  - **`core/migration/tla/ImportClaimPhases.tla`** models the target-side
    import-claim protocol (four phases: `importing` → `activating`/
    `aborting` → `deleted`). TLC proves the "activation point of no
    return": there is no `activating → aborting` edge, and no
    `aborting → activating` edge. Both paths end at `deleted` and can
    never be re-entered.

  A Go drift test (`core/migration/phase_tla_test.go`) parses the
  migration spec and checks every constant — phase set, initial phase,
  transition map, terminal/running/post-success classifiers, longest
  path — against the Go source of truth. If anyone edits
  `validTransitions` in `phase.go` without updating the spec,
  `go test ./core/migration/` fails.

## QA steps

```
$ cd tests && ./main.sh tla
```