### PR TITLE
feat: add migration target V8 facade

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -76,7 +76,7 @@ var facadeVersions = facades.FacadeVersions{
 	"MigrationMaster":              {4, 5},
 	"MigrationMinion":              {1},
 	"MigrationStatusWatcher":       {1},
-	"MigrationTarget":              {4, 5, 6, 7},
+	"MigrationTarget":              {4, 5, 6, 7, 8},
 	"ModelConfig":                  {3, 4},
 	"ModelManager":                 {9, 10, 11},
 	"ModelSummaryWatcher":          {1},

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/crossmodel"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/facades"
 	"github.com/juju/juju/core/life"
 	corelogger "github.com/juju/juju/core/logger"
@@ -601,4 +602,80 @@ func (api *API) CACert(ctx context.Context) (params.BytesResult, error) {
 	}
 	caCert, _ := cfg.CACert()
 	return params.BytesResult{Result: []byte(caCert)}, nil
+}
+
+// APIV8 implements the MigrationTarget v8 facade: typed-envelope
+// (params.SerializedModelV2) prechecks and import. It embeds the v7 API for
+// the methods that are unchanged (Abort, Activate, AdoptResources, etc.) and
+// shadows Prechecks and Import with the v8 envelope signatures — the inverse
+// of the legacy.go adapter pattern, because Go cannot overload method names
+// by parameter type.
+//
+// The v8 methods are envelope-validating no-op shells for now, registered so
+// that the new-path migrationmaster worker can be exercised end to end while
+// the rest of the v8 pipeline is developed: the runtime schema guard, payload
+// version/decode guards, full prechecks and the real import path (durable
+// claim, controller-fact application and the V2 model-DB import) land in
+// follow-up work. The real import path must land before a 4.1 release ships.
+type APIV8 struct {
+	*API
+}
+
+// NewAPIV8 returns a new MigrationTarget v8 facade wrapping the given v7 API.
+func NewAPIV8(api *API) (*APIV8, error) {
+	return &APIV8{API: api}, nil
+}
+
+// Prechecks ensures that the target controller is ready to accept the model
+// described by the v8 envelope. Only envelope identity validation is
+// implemented so far; the rest of the routine is a no-op shell.
+func (api *APIV8) Prechecks(ctx context.Context, envelope params.SerializedModelV2) error {
+	if err := validateEnvelopeModelInfo(envelope.ModelInfo); err != nil {
+		return errors.Capture(err)
+	}
+
+	// TODO(modelmigration): run the runtime schema guard, payload
+	// version/decode guards and the static/environmental v8 prechecks.
+	api.logger.Warningf(ctx,
+		"MigrationTarget v8 Prechecks for model %q is a no-op shell; the v8 precheck routine is not implemented yet",
+		envelope.ModelInfo.UUID)
+	return nil
+}
+
+// Import accepts a v8 model migration envelope. Only envelope identity
+// validation is implemented so far; the import itself is a no-op shell that
+// reports success WITHOUT importing anything, so the source-side migration
+// worker can be exercised against this facade during development.
+func (api *APIV8) Import(ctx context.Context, envelope params.SerializedModelV2) error {
+	if err := validateEnvelopeModelInfo(envelope.ModelInfo); err != nil {
+		return errors.Capture(err)
+	}
+
+	// TODO(modelmigration): run the pre-write guards (runtime schema guard,
+	// payload version/decode), then implement the v8 import path: durable
+	// model_migration_import claim, target-local model bootstrap,
+	// controller-fact application and the V2 model-DB import. This must land
+	// before a 4.1 release ships.
+	api.logger.Warningf(ctx,
+		"MigrationTarget v8 Import for model %q is a no-op shell; the model was NOT imported",
+		envelope.ModelInfo.UUID)
+	return nil
+}
+
+// validateEnvelopeModelInfo validates the bootstrap identity fields of the v8
+// envelope.
+func validateEnvelopeModelInfo(info params.SerializedModelInfo) error {
+	if err := coremodel.UUID(info.UUID).Validate(); err != nil {
+		return errors.Errorf("model UUID %q %w", info.UUID, coreerrors.NotValid)
+	}
+	if info.Name == "" {
+		return errors.Errorf("empty model name %w", coreerrors.NotValid)
+	}
+	if info.Qualifier == "" {
+		return errors.Errorf("empty model qualifier %w", coreerrors.NotValid)
+	}
+	if info.SourceMigrationUUID == "" {
+		return errors.Errorf("empty source migration UUID %w", coreerrors.NotValid)
+	}
+	return nil
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/crossmodel"
-	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/facades"
 	"github.com/juju/juju/core/life"
 	corelogger "github.com/juju/juju/core/logger"
@@ -611,12 +610,9 @@ func (api *API) CACert(ctx context.Context) (params.BytesResult, error) {
 // of the legacy.go adapter pattern, because Go cannot overload method names
 // by parameter type.
 //
-// The v8 methods are envelope-validating no-op shells for now, registered so
-// that the new-path migrationmaster worker can be exercised end to end while
-// the rest of the v8 pipeline is developed: the runtime schema guard, payload
-// version/decode guards, full prechecks and the real import path (durable
-// claim, controller-fact application and the V2 model-DB import) land in
-// follow-up work. The real import path must land before a 4.1 release ships.
+// Both methods are no-op shells so the migrationmaster worker can be exercised
+// end to end while the rest of the v8 pipeline is developed. The real import
+// path must land before a 4.1 release ships.
 type APIV8 struct {
 	*API
 }
@@ -626,56 +622,16 @@ func NewAPIV8(api *API) (*APIV8, error) {
 	return &APIV8{API: api}, nil
 }
 
-// Prechecks ensures that the target controller is ready to accept the model
-// described by the v8 envelope. Only envelope identity validation is
-// implemented so far; the rest of the routine is a no-op shell.
-func (api *APIV8) Prechecks(ctx context.Context, envelope params.SerializedModelV2) error {
-	if err := validateEnvelopeModelInfo(envelope.ModelInfo); err != nil {
-		return errors.Capture(err)
-	}
-
-	// TODO(modelmigration): run the runtime schema guard, payload
-	// version/decode guards and the static/environmental v8 prechecks.
-	api.logger.Warningf(ctx,
-		"MigrationTarget v8 Prechecks for model %q is a no-op shell; the v8 precheck routine is not implemented yet",
-		envelope.ModelInfo.UUID)
+// Prechecks is a no-op shell for v8 envelope prechecks.
+//
+// TODO(modelmigration): implement v8 prechecks before a 4.1 release ships.
+func (api *APIV8) Prechecks(_ context.Context, _ params.SerializedModelV2) error {
 	return nil
 }
 
-// Import accepts a v8 model migration envelope. Only envelope identity
-// validation is implemented so far; the import itself is a no-op shell that
-// reports success WITHOUT importing anything, so the source-side migration
-// worker can be exercised against this facade during development.
-func (api *APIV8) Import(ctx context.Context, envelope params.SerializedModelV2) error {
-	if err := validateEnvelopeModelInfo(envelope.ModelInfo); err != nil {
-		return errors.Capture(err)
-	}
-
-	// TODO(modelmigration): run the pre-write guards (runtime schema guard,
-	// payload version/decode), then implement the v8 import path: durable
-	// model_migration_import claim, target-local model bootstrap,
-	// controller-fact application and the V2 model-DB import. This must land
-	// before a 4.1 release ships.
-	api.logger.Warningf(ctx,
-		"MigrationTarget v8 Import for model %q is a no-op shell; the model was NOT imported",
-		envelope.ModelInfo.UUID)
-	return nil
-}
-
-// validateEnvelopeModelInfo validates the bootstrap identity fields of the v8
-// envelope.
-func validateEnvelopeModelInfo(info params.SerializedModelInfo) error {
-	if err := coremodel.UUID(info.UUID).Validate(); err != nil {
-		return errors.Errorf("model UUID %q %w", info.UUID, coreerrors.NotValid)
-	}
-	if info.Name == "" {
-		return errors.Errorf("empty model name %w", coreerrors.NotValid)
-	}
-	if info.Qualifier == "" {
-		return errors.Errorf("empty model qualifier %w", coreerrors.NotValid)
-	}
-	if info.SourceMigrationUUID == "" {
-		return errors.Errorf("empty source migration UUID %w", coreerrors.NotValid)
-	}
+// Import is a no-op shell for v8 envelope import.
+//
+// TODO(modelmigration): implement v8 import path before a 4.1 release ships.
+func (api *APIV8) Import(_ context.Context, _ params.SerializedModelV2) error {
 	return nil
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationtarget_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/canonical/gomock/gomock"
+	"github.com/juju/names/v6"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/apiserver"
+	"github.com/juju/juju/apiserver/facade/facadetest"
+	"github.com/juju/juju/apiserver/facades/controller/migrationtarget"
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/core/facades"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/semversion"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/uuid"
+	"github.com/juju/juju/rpc/params"
+)
+
+type v8Suite struct {
+	authorizer *apiservertesting.FakeAuthorizer
+
+	cloudService              *MockCloudService
+	controllerConfigService   *MockControllerConfigService
+	externalControllerService *MockExternalControllerService
+	modelService              *MockModelService
+	upgradeService            *MockUpgradeService
+	statusService             *MockStatusService
+	machineService            *MockMachineService
+	modelImporter             *MockModelImporter
+	modelMigrationService     *MockModelMigrationService
+	agentService              *MockModelAgentService
+	removalService            *MockRemovalService
+
+	modelUUID string
+
+	facadeContext facadetest.ModelContext
+}
+
+func TestV8Suite(t *testing.T) {
+	tc.Run(t, &v8Suite{})
+}
+
+func (s *v8Suite) setupMocks(c *tc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+
+	s.cloudService = NewMockCloudService(ctrl)
+	s.controllerConfigService = NewMockControllerConfigService(ctrl)
+	s.externalControllerService = NewMockExternalControllerService(ctrl)
+	s.modelService = NewMockModelService(ctrl)
+	s.upgradeService = NewMockUpgradeService(ctrl)
+	s.statusService = NewMockStatusService(ctrl)
+	s.machineService = NewMockMachineService(ctrl)
+	s.modelImporter = NewMockModelImporter(ctrl)
+	s.modelMigrationService = NewMockModelMigrationService(ctrl)
+	s.agentService = NewMockModelAgentService(ctrl)
+	s.removalService = NewMockRemovalService(ctrl)
+
+	s.modelUUID = uuid.MustNewUUID().String()
+
+	s.authorizer = &apiservertesting.FakeAuthorizer{
+		Tag:      names.NewUserTag("fred"),
+		AdminTag: names.NewUserTag("fred"),
+	}
+	s.facadeContext = facadetest.ModelContext{
+		Auth_:          s.authorizer,
+		ModelImporter_: s.modelImporter,
+	}
+
+	return ctrl
+}
+
+func (s *v8Suite) mustNewAPIV8(c *tc.C) *migrationtarget.APIV8 {
+	api, err := migrationtarget.NewAPI(
+		&s.facadeContext,
+		s.authorizer,
+		s.cloudService,
+		s.controllerConfigService,
+		s.externalControllerService,
+		s.modelService,
+		s.upgradeService,
+		s.statusService,
+		s.machineService,
+		func(context.Context, model.UUID) (migrationtarget.ModelAgentService, error) {
+			return s.agentService, nil
+		},
+		func(context.Context, model.UUID) (migrationtarget.ModelMigrationService, error) {
+			return s.modelMigrationService, nil
+		},
+		func(context.Context, model.UUID) (migrationtarget.RemovalService, error) {
+			return s.removalService, nil
+		},
+		facades.FacadeVersions{},
+		c.MkDir(),
+		loggertesting.WrapCheckLog(c),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	apiV8, err := migrationtarget.NewAPIV8(api)
+	c.Assert(err, tc.ErrorIsNil)
+	return apiV8
+}
+
+func (s *v8Suite) makeEnvelope() params.SerializedModelV2 {
+	return params.SerializedModelV2{
+		PayloadVersion: semversion.MustParse("4.0.6"),
+		ModelInfo: params.SerializedModelInfo{
+			UUID:                s.modelUUID,
+			Name:                "some-model",
+			Qualifier:           "prod",
+			Type:                "iaas",
+			Cloud:               "my-cloud",
+			CloudRegion:         "my-region",
+			Life:                "alive",
+			SourceMigrationUUID: uuid.MustNewUUID().String(),
+		},
+	}
+}
+
+// TestPrechecksInvalidModelInfo verifies the envelope identity validation:
+// bad model UUID, empty name, empty qualifier and empty source migration
+// UUID are all rejected before any service call.
+func (s *v8Suite) TestPrechecksInvalidModelInfo(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	api := s.mustNewAPIV8(c)
+
+	valid := s.makeEnvelope()
+
+	envelope := valid
+	envelope.ModelInfo.UUID = "not-a-uuid"
+	err := api.Prechecks(c.Context(), envelope)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+	c.Assert(err, tc.ErrorMatches, `model UUID "not-a-uuid" not valid`)
+
+	envelope = valid
+	envelope.ModelInfo.Name = ""
+	err = api.Prechecks(c.Context(), envelope)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+	c.Assert(err, tc.ErrorMatches, `empty model name not valid`)
+
+	envelope = valid
+	envelope.ModelInfo.Qualifier = ""
+	err = api.Prechecks(c.Context(), envelope)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+	c.Assert(err, tc.ErrorMatches, `empty model qualifier not valid`)
+
+	envelope = valid
+	envelope.ModelInfo.SourceMigrationUUID = ""
+	err = api.Prechecks(c.Context(), envelope)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+	c.Assert(err, tc.ErrorMatches, `empty source migration UUID not valid`)
+}
+
+// TestPrechecksNoOpSuccess verifies the v8 Prechecks shell accepts a valid
+// envelope and reports success without calling any service: the real precheck
+// routine is not implemented yet.
+func (s *v8Suite) TestPrechecksNoOpSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := s.mustNewAPIV8(c).Prechecks(c.Context(), s.makeEnvelope())
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestImportNoOpSuccess verifies the v8 Import shell accepts a valid envelope
+// and reports success without importing anything: the real import path is not
+// implemented yet, and no service is called.
+func (s *v8Suite) TestImportNoOpSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := s.mustNewAPIV8(c).Import(c.Context(), s.makeEnvelope())
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestV8Registered asserts MigrationTarget v8 is advertised alongside the
+// legacy versions so the new-path source worker can negotiate it.
+func (s *v8Suite) TestV8Registered(c *tc.C) {
+	for _, description := range apiserver.AllFacades().List() {
+		if description.Name != "MigrationTarget" {
+			continue
+		}
+		c.Assert(description.Versions, tc.DeepEquals, []int{4, 5, 6, 7, 8})
+		return
+	}
+	c.Fatal("MigrationTarget facade not registered at all")
+}

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/controller/migrationtarget"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/facades"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/semversion"
@@ -124,43 +123,8 @@ func (s *v8Suite) makeEnvelope() params.SerializedModelV2 {
 	}
 }
 
-// TestPrechecksInvalidModelInfo verifies the envelope identity validation:
-// bad model UUID, empty name, empty qualifier and empty source migration
-// UUID are all rejected before any service call.
-func (s *v8Suite) TestPrechecksInvalidModelInfo(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-	api := s.mustNewAPIV8(c)
-
-	valid := s.makeEnvelope()
-
-	envelope := valid
-	envelope.ModelInfo.UUID = "not-a-uuid"
-	err := api.Prechecks(c.Context(), envelope)
-	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
-	c.Assert(err, tc.ErrorMatches, `model UUID "not-a-uuid" not valid`)
-
-	envelope = valid
-	envelope.ModelInfo.Name = ""
-	err = api.Prechecks(c.Context(), envelope)
-	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
-	c.Assert(err, tc.ErrorMatches, `empty model name not valid`)
-
-	envelope = valid
-	envelope.ModelInfo.Qualifier = ""
-	err = api.Prechecks(c.Context(), envelope)
-	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
-	c.Assert(err, tc.ErrorMatches, `empty model qualifier not valid`)
-
-	envelope = valid
-	envelope.ModelInfo.SourceMigrationUUID = ""
-	err = api.Prechecks(c.Context(), envelope)
-	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
-	c.Assert(err, tc.ErrorMatches, `empty source migration UUID not valid`)
-}
-
-// TestPrechecksNoOpSuccess verifies the v8 Prechecks shell accepts a valid
-// envelope and reports success without calling any service: the real precheck
-// routine is not implemented yet.
+// TestPrechecksNoOpSuccess verifies that v8 Prechecks accepts any envelope
+// and returns success: the real precheck routine is not implemented yet.
 func (s *v8Suite) TestPrechecksNoOpSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -168,9 +132,9 @@ func (s *v8Suite) TestPrechecksNoOpSuccess(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-// TestImportNoOpSuccess verifies the v8 Import shell accepts a valid envelope
-// and reports success without importing anything: the real import path is not
-// implemented yet, and no service is called.
+// TestImportNoOpSuccess verifies that v8 Import accepts any envelope and
+// returns success without importing anything: the real import path is not
+// implemented yet.
 func (s *v8Suite) TestImportNoOpSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/apiserver/facades/controller/migrationtarget/register.go
+++ b/apiserver/facades/controller/migrationtarget/register.go
@@ -51,7 +51,32 @@ func Register(requiredMigrationFacadeVersions facades.FacadeVersions) func(regis
 			}
 			return api, nil
 		}, reflect.TypeFor[*API]())
+		// v8 takes the typed params.SerializedModelV2 envelope for both
+		// Prechecks and Import. The methods are envelope-validating no-op
+		// shells for now (see APIV8); the real v8 import path must land
+		// before a 4.1 release ships.
+		registry.MustRegisterForMultiModel("MigrationTarget", 8, func(stdCtx context.Context, ctx facade.MultiModelContext) (facade.Facade, error) {
+			api, err := makeFacadeV8(stdCtx, ctx, requiredMigrationFacadeVersions)
+			if err != nil {
+				return nil, errors.Errorf("making migration target version 8: %w", err)
+			}
+			return api, nil
+		}, reflect.TypeFor[*APIV8]())
 	}
+}
+
+// makeFacadeV8 is responsible for constructing the migration target v8 facade
+// and its dependencies.
+func makeFacadeV8(
+	stdCtx context.Context,
+	ctx facade.MultiModelContext,
+	facadeVersions facades.FacadeVersions,
+) (*APIV8, error) {
+	api, err := makeFacade(stdCtx, ctx, facadeVersions)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return NewAPIV8(api)
 }
 
 func makeFacadeV4(

--- a/rpc/params/migration.go
+++ b/rpc/params/migration.go
@@ -122,13 +122,6 @@ type SerializedModelResource struct {
 	Username       string    `json:"username,omitempty"`
 }
 
-// SerializedModelV2PayloadLimit is the default maximum size, in bytes, of the
-// model-DB YAML payload carried in [SerializedModelV2.Payload]. It is validated
-// by the source before RPC and by the target's v8 Prechecks/Import before the
-// YAML is decoded. It bounds the model-DB payload only, not the API websocket
-// frame or the binary-transfer HTTP endpoints.
-const SerializedModelV2PayloadLimit = 200 * 1024 * 1024 // 200 MiB
-
 // SerializedModelV2 is the wire envelope for the new (v8) model-migration
 // import/precheck path. Controller-scoped facts ride as typed semantic fields;
 // only the model-DB content is a serialized YAML payload that flows through the
@@ -145,8 +138,7 @@ type SerializedModelV2 struct {
 	// Payload is the YAML-encoded concrete generated
 	// domain/export/types/vX_Y_Z.ModelExport at PayloadVersion. It is the only
 	// field the transformer chain walks. The domain/export.ModelExport wrapper
-	// is NOT serialized into this field. Its size is validated against
-	// SerializedModelV2PayloadLimit before decode.
+	// is NOT serialized into this field.
 	Payload []byte `json:"payload"`
 
 	// ModelInfo carries the bootstrap identity for the migrating model. It is


### PR DESCRIPTION
  Adds the MigrationTarget version 8 facade, which is the entry point on the receiving (target) controller
  for the new Juju 4.x model migration path.

  The key difference between v8 and the previous versions (v4–v7) is the wire format. Older versions send
  a legacy SerializedModel blob alongside a MigrationModelInfo struct. v8 takes a single
  params.SerializedModelV2 envelope that groups all the context the target controller needs — cloud,
  credentials, users, secret backend, external controllers — alongside a YAML payload of the model's
  database state.

  Both Prechecks and Import in v8 are intentional no-op shells at this stage. They check that the
  envelope's basic identity fields are well-formed (UUID, name, qualifier, source migration UUID), then
  return success. Each logs a clear warning that it is a no-op. Import in particular logs that it imported
  nothing.

  v8 is fully registered and advertised to clients in this PR. This is necessary so the migrationmaster
  worker can be exercised end-to-end: without v8 in facade negotiation the worker hard-errors during phase
  negotiation and you cannot test any part of the migration flow. With this PR you can drive the worker
  through QUIESCE → IMPORT (succeeds from the facade's perspective) → ACTIVATE (fails cleanly, no model
  was imported — expected).


## QA steps

Not fully wired yet.

## Links



<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9900](https://warthogs.atlassian.net/browse/JUJU-9900)


[JUJU-9900]: https://warthogs.atlassian.net/browse/JUJU-9900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ