### PR TITLE
perf(add-model): add-model in lxd

### DIFF
--- a/internal/provider/lxd/environ_network.go
+++ b/internal/provider/lxd/environ_network.go
@@ -32,11 +32,8 @@ func (e *environ) Subnets(ctx context.Context, subnetIDs []network.Id) ([]networ
 		return nil, errors.Annotate(err, "retrieving lxd availability zones")
 	}
 
-	networks, err := srv.GetNetworks()
+	networkStates, err := providerNetworkStates(srv)
 	if err != nil {
-		if isErrMissingAPIExtension(err, "network") {
-			return nil, errors.NewNotSupported(nil, `subnet discovery requires the "network" extension to be enabled on the lxd server`)
-		}
 		return nil, errors.Trace(err)
 	}
 
@@ -52,18 +49,10 @@ func (e *environ) Subnets(ctx context.Context, subnetIDs []network.Id) ([]networ
 		subnets       []network.SubnetInfo
 		uniqueSubnets = set.NewStrings()
 	)
-	for _, networkDetails := range networks {
-		if networkDetails.Type != "bridge" {
+	for _, networkDetails := range networkStates {
+		state := networkDetails.state
+		if state.Bridge == nil {
 			continue
-		}
-
-		networkName := networkDetails.Name
-		state, err := srv.GetNetworkState(networkName)
-		if err != nil {
-			if isErrMissingAPIExtension(err, "network_state") {
-				return nil, errors.Errorf("network_state extension unsupported; upgrade to a newer version of LXD")
-			}
-			return nil, errors.Annotatef(err, "querying lxd server for state of network %q", networkName)
 		}
 
 		// We are only interested in networks that are up.
@@ -90,11 +79,42 @@ func (e *environ) Subnets(ctx context.Context, subnetIDs []network.Id) ([]networ
 			}
 
 			uniqueSubnets.Add(cidr)
-			subnets = append(subnets, makeSubnetInfo(cidr, networkName, availabilityZones))
+			subnets = append(subnets, makeSubnetInfo(cidr, networkDetails.name, availabilityZones))
 		}
 	}
 
 	return subnets, nil
+}
+
+type providerNetworkState struct {
+	name  string
+	state *lxdapi.NetworkState
+}
+
+func providerNetworkStates(srv Server) ([]providerNetworkState, error) {
+	networkNames, err := srv.GetNetworkNames()
+	if err != nil {
+		if isErrMissingAPIExtension(err, "network") {
+			return nil, errors.NewNotSupported(nil, `subnet discovery requires the "network" extension to be enabled on the lxd server`)
+		}
+		return nil, errors.Trace(err)
+	}
+
+	networkStates := make([]providerNetworkState, 0, len(networkNames))
+	for _, networkName := range networkNames {
+		state, err := srv.GetNetworkState(networkName)
+		if err != nil {
+			if isErrMissingAPIExtension(err, "network_state") {
+				return nil, errors.Errorf("network_state extension unsupported; upgrade to a newer version of LXD")
+			}
+			return nil, errors.Annotatef(err, "querying lxd server for state of network %q", networkName)
+		}
+		if state == nil {
+			return nil, errors.Errorf("network state %q not found", networkName)
+		}
+		networkStates = append(networkStates, providerNetworkState{name: networkName, state: state})
+	}
+	return networkStates, nil
 }
 
 func makeSubnetInfo(cidr, networkName string, availabilityZones network.AvailabilityZones) network.SubnetInfo {

--- a/internal/provider/lxd/environ_network_test.go
+++ b/internal/provider/lxd/environ_network_test.go
@@ -45,28 +45,16 @@ func (s *environNetSuite) TestSubnetsForClustered(c *tc.C) {
 		},
 	}, nil)
 
-	srv.EXPECT().GetNetworks().Return([]lxdapi.Network{
-		{
-			Name: "ovs-system",
-			Type: "bridge",
-		},
-		{
-			Name: "lxdbr0",
-			Type: "bridge",
-		},
-		// This should be filtered, as it is not a bridge.
-		{
-			Name: "phys-nic-0",
-			Type: "physical",
-		},
-	}, nil)
+	srv.EXPECT().GetNetworkNames().Return([]string{"ovs-system", "lxdbr0", "phys-nic-0"}, nil)
 	srv.EXPECT().GetNetworkState("ovs-system").Return(&lxdapi.NetworkState{
-		Type:  "broadcast",
-		State: "down", // should be filtered out because it's down
+		Type:   "broadcast",
+		State:  "down", // should be filtered out because it's down
+		Bridge: &lxdapi.NetworkStateBridge{},
 	}, nil)
 	srv.EXPECT().GetNetworkState("lxdbr0").Return(&lxdapi.NetworkState{
-		Type:  "broadcast",
-		State: "up",
+		Type:   "broadcast",
+		State:  "up",
+		Bridge: &lxdapi.NetworkStateBridge{},
 		Addresses: []lxdapi.NetworkStateAddress{
 			{
 				Family:  "inet",
@@ -87,6 +75,11 @@ func (s *environNetSuite) TestSubnetsForClustered(c *tc.C) {
 				Scope:   "link", // ignored because it has link scope
 			},
 		},
+	}, nil)
+	// This should be filtered, as it is not a bridge.
+	srv.EXPECT().GetNetworkState("phys-nic-0").Return(&lxdapi.NetworkState{
+		Type:  "broadcast",
+		State: "up",
 	}, nil)
 
 	invalidator := lxd.NewMockCredentialInvalidator(ctrl)
@@ -119,13 +112,11 @@ func (s *environNetSuite) TestSubnetsForSubnetFiltering(c *tc.C) {
 	defer ctrl.Finish()
 
 	srv := lxd.NewMockServer(ctrl)
-	srv.EXPECT().GetNetworks().Return([]lxdapi.Network{{
-		Name: "lxdbr0",
-		Type: "bridge",
-	}}, nil)
+	srv.EXPECT().GetNetworkNames().Return([]string{"lxdbr0"}, nil)
 	srv.EXPECT().GetNetworkState("lxdbr0").Return(&lxdapi.NetworkState{
-		Type:  "broadcast",
-		State: "up",
+		Type:   "broadcast",
+		State:  "up",
+		Bridge: &lxdapi.NetworkStateBridge{},
 		Addresses: []lxdapi.NetworkStateAddress{
 			{
 				Family:  "inet",

--- a/internal/provider/lxd/package_mock_test.go
+++ b/internal/provider/lxd/package_mock_test.go
@@ -54,6 +54,7 @@ type MockServerMockRecorder struct {
 	getInstanceExpects                  []*gomock.Call1_3[string, *api.Instance, string, error]
 	getInstanceStateExpects             []*gomock.Call1_3[string, *api.InstanceState, string, error]
 	getNICsFromProfileExpects           []*gomock.Call1_2[string, map[string]map[string]string, error]
+	getNetworkNamesExpects              []*gomock.Call0_2[[]string, error]
 	getNetworkStateExpects              []*gomock.Call1_2[string, *api.NetworkState, error]
 	getNetworksExpects                  []*gomock.Call0_2[[]api.Network, error]
 	getProfileExpects                   []*gomock.Call1_3[string, *api.Profile, string, error]
@@ -493,6 +494,24 @@ func (mr *MockServerMockRecorder) GetNICsFromProfile(profName any) *MockServerGe
 
 // MockServerGetNICsFromProfileCall is the typed call wrapper for GetNICsFromProfile.
 type MockServerGetNICsFromProfileCall = gomock.Call1_2[string, map[string]map[string]string, error]
+
+// GetNetworkNames mocks base method.
+func (m *MockServer) GetNetworkNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_2(&m.recorder.getNetworkNamesExpects, m.ctrl, m, "GetNetworkNames")
+}
+
+// GetNetworkNames indicates an expected call of GetNetworkNames.
+func (mr *MockServerMockRecorder) GetNetworkNames() *MockServerGetNetworkNamesCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_2[[]string, error](mr.mock.ctrl.T, mr.mock, "GetNetworkNames")
+	mr.getNetworkNamesExpects = append(mr.getNetworkNamesExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockServerGetNetworkNamesCall is the typed call wrapper for GetNetworkNames.
+type MockServerGetNetworkNamesCall = gomock.Call0_2[[]string, error]
 
 // GetNetworkState mocks base method.
 func (m *MockServer) GetNetworkState(name string) (*api.NetworkState, error) {

--- a/internal/provider/lxd/server.go
+++ b/internal/provider/lxd/server.go
@@ -83,6 +83,7 @@ type Server interface {
 	Name() string
 	HasExtension(extension string) (exists bool)
 	GetNetworks() ([]lxdapi.Network, error)
+	GetNetworkNames() ([]string, error)
 	GetNetworkState(name string) (*lxdapi.NetworkState, error)
 	GetInstance(name string) (*lxdapi.Instance, string, error)
 	GetInstanceState(name string) (*lxdapi.InstanceState, string, error)

--- a/internal/provider/lxd/testing_test.go
+++ b/internal/provider/lxd/testing_test.go
@@ -709,6 +709,10 @@ func (*StubClient) HasExtension(_ string) bool {
 	panic("this stub is deprecated; use mocks instead")
 }
 
+func (conn *StubClient) GetNetworkNames() ([]string, error) {
+	panic("this stub is deprecated; use mocks instead")
+}
+
 func (conn *StubClient) GetNetworks() ([]api.Network, error) {
 	panic("this stub is deprecated; use mocks instead")
 }


### PR DESCRIPTION
# Description

Remove expensive GetNetworks() in favor of GetNetworkNames(). During my tracing effort I've seen ReloadSpaces taking around ~800ms, it seems we didn't need it, and we just need the name to get the state. Now it takes <100ms.

The only thing i could think of if that filtering for bridge networks in `Networks` and in `NetworkState` is any different. From my searching there would be a difference if LXD returns a bridge network but omits the sub-struct in state, so the new code would skip it.

You can check using curl the filtering based on not-null bridge options seems to be proper:
```
#!/bin/bash

sock=/var/snap/lxd/common/lxd/unix.socket

old=$(mktemp)
new=$(mktemp)
trap 'rm -f "$old" "$new"' EXIT

# Old Juju/LXD path: /networks?recursion=1, filter api.Network.Type == "bridge"
curl -s --unix-socket "$sock" \
  'http://unix.socket/1.0/networks?recursion=1' |
  jq -r '.metadata[] | select(.type == "bridge") | .name' |
  sort > "$old"

# New path: /networks names, then /networks/<name>/state, filter state.bridge != null
curl -s --unix-socket "$sock" \
  'http://unix.socket/1.0/networks' |
  jq -r '.metadata[] | split("/")[-1]' |
  while read -r name; do
    curl -s --unix-socket "$sock" \
      "http://unix.socket/1.0/networks/${name}/state" |
      jq -r --arg name "$name" 'select(.metadata.bridge != null) | $name'
  done |
  sort > "$new"

echo "old bridge networks:"
cat "$old"

echo
echo "new bridge networks:"
cat "$new"

echo
if diff -u "$old" "$new"; then
  echo "MATCH: old type==bridge and new state.bridge filters agree"
else
  echo "DIFFER: filters do not agree"
fi
```

# QA

Before:
```
[4:11:17] ➜  jimm git:(enable-tracing) ✗ time juju add-model a
Added 'a' model on localhost/localhost with credential 'localhost' for user 'admin'
To use "juju ssh", "juju scp" and "juju debug-hooks" ssh public keys need to be added to the model with "juju add-ssh-key"
juju add-model a  0.02s user 0.02s system 3% cpu 1.342 total
```

After: 
```
[4:07:48] ➜  jimm git:(enable-tracing) ✗ time juju add-model a             
Added 'a' model on localhost/localhost with credential 'localhost' for user 'admin'
To use "juju ssh", "juju scp" and "juju debug-hooks" ssh public keys need to be added to the model with "juju add-ssh-key"
juju add-model a  0.03s user 0.02s system 7% cpu 0.609 total
```
