### PR TITLE
feat: logrouter

### DIFF
--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -233,6 +233,8 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			Logger:             internallogger.GetLogger("juju.worker.logrouter"),
 			Clock:              config.Clock,
 			HTTPClient:         http.DefaultClient,
+			NewAPIOpen:         api.Open,
+			NewBackendFunc:     logrouter.NewBackend,
 		})),
 
 		// The upgrade steps gate is used to coordinate workers which

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -5,6 +5,7 @@ package unit
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"time"
 
@@ -44,6 +45,7 @@ import (
 	"github.com/juju/juju/internal/worker/leadership"
 	"github.com/juju/juju/internal/worker/lifeflag"
 	wlogger "github.com/juju/juju/internal/worker/logger"
+	"github.com/juju/juju/internal/worker/logrouter"
 	"github.com/juju/juju/internal/worker/logsender"
 	"github.com/juju/juju/internal/worker/lokiendpointupdater"
 	"github.com/juju/juju/internal/worker/migrationflag"
@@ -222,12 +224,15 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 			NewWorker: lifeflag.NewWorker,
 		}),
 
-		// The log sender is a leaf worker that sends log messages to some
-		// API server, when configured so to do. We should only need one of
-		// these in a consolidated agent.
-		logSenderName: ifNotDead(logsender.Manifold(logsender.ManifoldConfig{
-			APICallerName: apiCallerName,
-			LogSource:     config.LogSource,
+		// The log router owns the buffered log stream and forwards records to
+		// one active backend at a time.
+		logSenderName: ifNotDead(logrouter.Manifold(logrouter.ManifoldConfig{
+			AgentName:          agentName,
+			LogSource:          config.LogSource,
+			AgentConfigChanged: config.AgentConfigChanged,
+			Logger:             internallogger.GetLogger("juju.worker.logrouter"),
+			Clock:              config.Clock,
+			HTTPClient:         http.DefaultClient,
 		})),
 
 		// The upgrade steps gate is used to coordinate workers which

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -226,7 +226,7 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 
 		// The log router owns the buffered log stream and forwards records to
 		// one active backend at a time.
-		logSenderName: ifNotDead(logrouter.Manifold(logrouter.ManifoldConfig{
+		logRouterName: ifNotDead(logrouter.Manifold(logrouter.ManifoldConfig{
 			AgentName:          agentName,
 			LogSource:          config.LogSource,
 			AgentConfigChanged: config.AgentConfigChanged,
@@ -467,7 +467,7 @@ const (
 	apiCallerName        = "api-caller"
 	s3CallerName         = "s3-caller"
 	uniterName           = "uniter"
-	logSenderName        = "log-sender"
+	logRouterName        = "log-router"
 	traceName            = "trace"
 
 	charmDirName          = "charm-dir"

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -228,12 +228,12 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 		// one active backend at a time.
 		logRouterName: ifNotDead(logrouter.Manifold(logrouter.ManifoldConfig{
 			AgentName:          agentName,
+			APICallerName:      apiCallerName,
 			LogSource:          config.LogSource,
 			AgentConfigChanged: config.AgentConfigChanged,
 			Logger:             internallogger.GetLogger("juju.worker.logrouter"),
 			Clock:              config.Clock,
 			HTTPClient:         http.DefaultClient,
-			NewAPIOpen:         api.Open,
 			NewBackendFunc:     logrouter.NewBackend,
 		})),
 

--- a/cmd/containeragent/unit/manifolds_test.go
+++ b/cmd/containeragent/unit/manifolds_test.go
@@ -51,7 +51,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 		"dead-flag",
 		"hook-retry-strategy",
 		"leadership-tracker",
-		"log-sender",
+		"log-router",
 		"logging-config-updater",
 		"loki-endpoint-updater",
 		"migration-fortress",
@@ -95,7 +95,7 @@ func (s *ManifoldsSuite) TestManifoldNamesColocatedController(c *tc.C) {
 		"dead-flag",
 		"hook-retry-strategy",
 		"leadership-tracker",
-		"log-sender",
+		"log-router",
 		"logging-config-updater",
 		"loki-endpoint-updater",
 		"migration-fortress",
@@ -131,7 +131,7 @@ func (*ManifoldsSuite) TestMigrationGuards(c *tc.C) {
 		"caas-prober",
 		"probe-http-server",
 		"caas-unit-prober-binder",
-		"log-sender",
+		"log-router",
 
 		"migration-fortress",
 		"migration-inactive-flag",
@@ -211,7 +211,7 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"trace",
 	},
 
-	"log-sender": {
+	"log-router": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",

--- a/cmd/jujud/agent/modeloperator/manifolds.go
+++ b/cmd/jujud/agent/modeloperator/manifolds.go
@@ -4,6 +4,9 @@
 package modeloperator
 
 import (
+	"net/http"
+
+	"github.com/juju/clock"
 	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v5/dependency"
 
@@ -22,6 +25,7 @@ import (
 	"github.com/juju/juju/internal/worker/caasupgrader"
 	"github.com/juju/juju/internal/worker/gate"
 	"github.com/juju/juju/internal/worker/logger"
+	"github.com/juju/juju/internal/worker/logrouter"
 	"github.com/juju/juju/internal/worker/logsender"
 	"github.com/juju/juju/internal/worker/muxhttpserver"
 )
@@ -87,12 +91,15 @@ func Manifolds(config ManifoldConfig) dependency.Manifolds {
 			Logger:               internallogger.GetLogger("juju.worker.apicaller"),
 		}),
 
-		// The log sender is a leaf worker that sends log messages to some
-		// API server, when configured so to do. We should only need one of
-		// these in a consolidated agent.
-		logSenderName: logsender.Manifold(logsender.ManifoldConfig{
-			APICallerName: apiCallerName,
-			LogSource:     config.LogSource,
+		// The log router owns the buffered log stream and forwards records to
+		// one active backend at a time.
+		logSenderName: logrouter.Manifold(logrouter.ManifoldConfig{
+			AgentName:          agentName,
+			LogSource:          config.LogSource,
+			AgentConfigChanged: config.AgentConfigChanged,
+			Logger:             internallogger.GetLogger("juju.worker.logrouter"),
+			Clock:              clock.WallClock,
+			HTTPClient:         http.DefaultClient,
 		}),
 
 		caasAdmissionName: caasadmission.Manifold(caasadmission.ManifoldConfig{

--- a/cmd/jujud/agent/modeloperator/manifolds.go
+++ b/cmd/jujud/agent/modeloperator/manifolds.go
@@ -100,6 +100,8 @@ func Manifolds(config ManifoldConfig) dependency.Manifolds {
 			Logger:             internallogger.GetLogger("juju.worker.logrouter"),
 			Clock:              clock.WallClock,
 			HTTPClient:         http.DefaultClient,
+			NewAPIOpen:         api.Open,
+			NewBackendFunc:     logrouter.NewBackend,
 		}),
 
 		caasAdmissionName: caasadmission.Manifold(caasadmission.ManifoldConfig{

--- a/cmd/jujud/agent/modeloperator/manifolds.go
+++ b/cmd/jujud/agent/modeloperator/manifolds.go
@@ -93,7 +93,7 @@ func Manifolds(config ManifoldConfig) dependency.Manifolds {
 
 		// The log router owns the buffered log stream and forwards records to
 		// one active backend at a time.
-		logSenderName: logrouter.Manifold(logrouter.ManifoldConfig{
+		logRouterName: logrouter.Manifold(logrouter.ManifoldConfig{
 			AgentName:          agentName,
 			LogSource:          config.LogSource,
 			AgentConfigChanged: config.AgentConfigChanged,
@@ -177,5 +177,5 @@ const (
 	modelHTTPServerName      = "model-http-server"
 	upgraderName             = "upgrader"
 	upgradeStepsGateName     = "upgrade-steps-gate"
-	logSenderName            = "log-sender"
+	logRouterName            = "log-router"
 )

--- a/cmd/jujud/agent/modeloperator/manifolds.go
+++ b/cmd/jujud/agent/modeloperator/manifolds.go
@@ -95,12 +95,12 @@ func Manifolds(config ManifoldConfig) dependency.Manifolds {
 		// one active backend at a time.
 		logRouterName: logrouter.Manifold(logrouter.ManifoldConfig{
 			AgentName:          agentName,
+			APICallerName:      apiCallerName,
 			LogSource:          config.LogSource,
 			AgentConfigChanged: config.AgentConfigChanged,
 			Logger:             internallogger.GetLogger("juju.worker.logrouter"),
 			Clock:              clock.WallClock,
 			HTTPClient:         http.DefaultClient,
-			NewAPIOpen:         api.Open,
 			NewBackendFunc:     logrouter.NewBackend,
 		}),
 

--- a/cmd/jujud/agent/modeloperator/manifolds_test.go
+++ b/cmd/jujud/agent/modeloperator/manifolds_test.go
@@ -47,7 +47,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 	c.Check(keys, tc.SameContents, []string{
 		"caas-broker-tracker",
 		"api-caller",
-		"log-sender",
+		"log-router",
 		"caas-admission",
 		"caas-rbac-mapper",
 		"certificate-watcher",
@@ -75,7 +75,7 @@ var expectedManifoldsWithDependencies = map[string][]string{
 
 	"api-caller": {"agent", "api-config-watcher"},
 
-	"log-sender": {"agent"},
+	"log-router": {"agent"},
 
 	"caas-admission": {
 		"agent",

--- a/cmd/jujud/agent/modeloperator/manifolds_test.go
+++ b/cmd/jujud/agent/modeloperator/manifolds_test.go
@@ -75,7 +75,7 @@ var expectedManifoldsWithDependencies = map[string][]string{
 
 	"api-caller": {"agent", "api-config-watcher"},
 
-	"log-sender": {"agent", "api-caller", "api-config-watcher"},
+	"log-sender": {"agent"},
 
 	"caas-admission": {
 		"agent",

--- a/cmd/jujud/agent/modeloperator/manifolds_test.go
+++ b/cmd/jujud/agent/modeloperator/manifolds_test.go
@@ -75,7 +75,7 @@ var expectedManifoldsWithDependencies = map[string][]string{
 
 	"api-caller": {"agent", "api-config-watcher"},
 
-	"log-router": {"agent"},
+	"log-router": {"agent", "api-caller", "api-config-watcher"},
 
 	"caas-admission": {
 		"agent",

--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -9,11 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/juju/clock"
@@ -31,10 +32,24 @@ type Record struct {
 	// Line is the log message text.
 	Line string
 
-	// Labels are the Loki stream labels for this entry.
-	// Records with identical label sets are grouped into
-	// the same stream.
-	Labels map[string]string
+	// ControllerUUID is the Juju controller UUID for topology labeling.
+	ControllerUUID string
+
+	// ModelUUID is the Juju model UUID for topology labeling.
+	ModelUUID string
+
+	// AgentID is the stable Juju agent identity for topology labeling.
+	AgentID string
+
+	// Fields are structured log fields. High-cardinality values belong here,
+	// not in Loki labels.
+	Fields map[string]string
+
+	// TraceID is the OpenTelemetry trace ID for this record, if present.
+	TraceID string
+
+	// SpanID is the OpenTelemetry span ID for this record, if present.
+	SpanID string
 }
 
 // Config holds configuration for the Loki push client.
@@ -42,6 +57,10 @@ type Config struct {
 	// BatchSize is the maximum number of records to
 	// accumulate before flushing to Loki. Default: 100.
 	BatchSize int
+
+	// BufferSize is the maximum number of queued records waiting to be
+	// batched. When full, Push drops the oldest queued records. Default: 500.
+	BufferSize int
 
 	// FlushInterval is how long to wait before flushing
 	// buffered records even if BatchSize hasn't been
@@ -74,10 +93,12 @@ type Config struct {
 	AsyncFlush *bool
 
 	// OnError is called when a push fails after all retry
-	// attempts are exhausted. If nil, errors are silently
-	// dropped. This can be used to write to stderr or any
-	// other error reporting mechanism.
+	// attempts are exhausted. If nil, a warning is written to stderr.
 	OnError func(error)
+
+	// OnDrop is called when records are dropped from the circular buffer. If
+	// nil, a warning is written to stderr.
+	OnDrop func(int)
 
 	// Clock is passed to the retry logic for testing.
 	// If nil, the wall clock is used.
@@ -88,6 +109,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		BatchSize:      100,
+		BufferSize:     500,
 		FlushInterval:  10 * time.Second,
 		MaxRetries:     3,
 		InitialBackoff: 500 * time.Millisecond,
@@ -107,8 +129,19 @@ type Client struct {
 	http       *http.Client
 	asyncFlush bool
 	onError    func(error)
+	onDrop     func(int)
 	records    chan Record
+	stats      report
 	tomb       tomb.Tomb
+}
+
+type report struct {
+	Enqueued          uint64
+	Dropped           uint64
+	Sent              uint64
+	PushErrors        uint64
+	Retries           uint64
+	LastPushTimestamp int64
 }
 
 // NewClient creates and starts a new Loki push client worker.
@@ -122,6 +155,9 @@ func NewClient(endpoint string, cfg Config) (*Client, error) {
 	}
 	if cfg.BatchSize <= 0 {
 		cfg.BatchSize = 100
+	}
+	if cfg.BufferSize <= 0 {
+		cfg.BufferSize = 500
 	}
 	if cfg.FlushInterval <= 0 {
 		cfg.FlushInterval = 10 * time.Second
@@ -144,7 +180,15 @@ func NewClient(endpoint string, cfg Config) (*Client, error) {
 	}
 	onError := cfg.OnError
 	if onError == nil {
-		onError = func(error) {}
+		onError = func(err error) {
+			fmt.Fprintf(os.Stderr, "loki push failed: %v\n", err)
+		}
+	}
+	onDrop := cfg.OnDrop
+	if onDrop == nil {
+		onDrop = func(count int) {
+			fmt.Fprintf(os.Stderr, "dropped %d loki log records\n", count)
+		}
 	}
 	asyncFlush := cfg.AsyncFlush == nil || *cfg.AsyncFlush
 	c := &Client{
@@ -153,7 +197,8 @@ func NewClient(endpoint string, cfg Config) (*Client, error) {
 		http:       httpClient,
 		asyncFlush: asyncFlush,
 		onError:    onError,
-		records:    make(chan Record, cfg.BatchSize),
+		onDrop:     onDrop,
+		records:    make(chan Record, cfg.BufferSize),
 	}
 	c.tomb.Go(c.loop)
 	return c, nil
@@ -161,21 +206,52 @@ func NewClient(endpoint string, cfg Config) (*Client, error) {
 
 // Push sends records to the client for delivery to Loki.
 // Records are buffered internally and flushed when the batch
-// size is reached or the flush interval elapses. Push blocks
-// if the internal channel is full, providing backpressure to
-// the caller. Returns tomb.ErrDying if the client is shutting
-// down. Push does not deep-copy records, so callers should not
-// mutate record contents (especially Labels maps) after calling
-// this method.
+// size is reached or the flush interval elapses. Push does not
+// block on a full queue; it drops the oldest queued records first.
+// Returns tomb.ErrDying if the client is shutting down. Push does
+// not deep-copy records, so callers should not mutate record
+// contents after calling this method.
 func (c *Client) Push(records ...Record) error {
 	for _, r := range records {
-		select {
-		case c.records <- r:
-		case <-c.tomb.Dying():
-			return tomb.ErrDying
+		if err := c.pushOne(r); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func (c *Client) pushOne(r Record) error {
+	for {
+		select {
+		case c.records <- r:
+			atomic.AddUint64(&c.stats.Enqueued, 1)
+			return nil
+		case <-c.tomb.Dying():
+			return tomb.ErrDying
+		default:
+		}
+
+		select {
+		case <-c.records:
+			atomic.AddUint64(&c.stats.Dropped, 1)
+			c.onDrop(1)
+		case <-c.tomb.Dying():
+			return tomb.ErrDying
+		default:
+		}
+	}
+}
+
+// Report implements worker.Reporter.
+func (c *Client) Report(context.Context) map[string]any {
+	return map[string]any{
+		"enqueued":            atomic.LoadUint64(&c.stats.Enqueued),
+		"dropped":             atomic.LoadUint64(&c.stats.Dropped),
+		"sent":                atomic.LoadUint64(&c.stats.Sent),
+		"push-errors":         atomic.LoadUint64(&c.stats.PushErrors),
+		"retries":             atomic.LoadUint64(&c.stats.Retries),
+		"last-push-timestamp": atomic.LoadInt64(&c.stats.LastPushTimestamp),
+	}
 }
 
 // Kill requests the client to stop. Any buffered records are
@@ -208,7 +284,7 @@ func (c *Client) loop() error {
 			c.drainChannel(&buffer)
 			if len(buffer) > 0 {
 				ctx, cancel := context.WithTimeout(
-					context.Background(), 5*time.Second,
+					ctx, 5*time.Second,
 				)
 				defer cancel()
 				c.pushAll(ctx, buffer)
@@ -285,8 +361,12 @@ func (c *Client) pushAll(
 	for i := 0; i < len(records); i += c.cfg.BatchSize {
 		end := min(i+c.cfg.BatchSize, len(records))
 		if err := c.pushBatch(ctx, records[i:end]); err != nil {
+			atomic.AddUint64(&c.stats.PushErrors, 1)
 			c.onError(err)
+			continue
 		}
+		atomic.AddUint64(&c.stats.Sent, uint64(end-i))
+		atomic.StoreInt64(&c.stats.LastPushTimestamp, c.cfg.Clock.Now().Unix())
 	}
 }
 
@@ -315,11 +395,16 @@ func (c *Client) pushBatch(
 	}
 
 	attempts := c.cfg.MaxRetries + 1
+	attempt := 0
 	err = retry.Call(retry.CallArgs{
 		Attempts: attempts,
 		Delay:    c.cfg.InitialBackoff,
 		MaxDelay: c.cfg.MaxBackoff,
 		Func: func() error {
+			if attempt > 0 {
+				atomic.AddUint64(&c.stats.Retries, 1)
+			}
+			attempt++
 			return c.doRequest(ctx, data)
 		},
 		IsFatalError: func(err error) bool {
@@ -415,7 +500,42 @@ type pushPayload struct {
 // pushStream is a single stream within a push payload.
 type pushStream struct {
 	Stream map[string]string `json:"stream"`
-	Values [][]string        `json:"values"`
+	Values []pushValue       `json:"values"`
+}
+
+type pushValue struct {
+	Timestamp string
+	Line      string
+	Fields    map[string]string
+}
+
+func (v pushValue) MarshalJSON() ([]byte, error) {
+	if len(v.Fields) == 0 {
+		return json.Marshal([]string{v.Timestamp, v.Line})
+	}
+	return json.Marshal([]any{v.Timestamp, v.Line, v.Fields})
+}
+
+func (v *pushValue) UnmarshalJSON(data []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if len(raw) != 2 && len(raw) != 3 {
+		return internalerrors.Errorf("expected loki value tuple with 2 or 3 fields")
+	}
+	if err := json.Unmarshal(raw[0], &v.Timestamp); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(raw[1], &v.Line); err != nil {
+		return err
+	}
+	if len(raw) == 3 {
+		if err := json.Unmarshal(raw[2], &v.Fields); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // buildPayload groups records by label set into streams.
@@ -424,20 +544,19 @@ func buildPayload(records []Record) pushPayload {
 	order := make([]string, 0)
 
 	for _, r := range records {
-		key := labelKey(r.Labels)
+		labels := topologyLabels(r)
+		key := labelKey(labels)
 		s, ok := groups[key]
 		if !ok {
-			labels := make(map[string]string, len(r.Labels))
-			maps.Copy(labels, r.Labels)
-
 			s = &pushStream{Stream: labels}
 			groups[key] = s
 			order = append(order, key)
 		}
-		ts := strconv.FormatInt(
-			r.Timestamp.UnixNano(), 10,
-		)
-		s.Values = append(s.Values, []string{ts, r.Line})
+		s.Values = append(s.Values, pushValue{
+			Timestamp: strconv.FormatInt(r.Timestamp.UnixNano(), 10),
+			Line:      r.Line,
+			Fields:    structuredFields(r),
+		})
 	}
 
 	streams := make([]pushStream, 0, len(order))
@@ -445,6 +564,49 @@ func buildPayload(records []Record) pushPayload {
 		streams = append(streams, *groups[key])
 	}
 	return pushPayload{Streams: streams}
+}
+
+func topologyLabels(r Record) map[string]string {
+	labels := make(map[string]string, 3)
+	if r.ControllerUUID != "" {
+		labels["juju_controller"] = r.ControllerUUID
+	}
+	if r.ModelUUID != "" {
+		labels["juju_model"] = r.ModelUUID
+	}
+	if r.AgentID != "" {
+		labels["juju_agent"] = r.AgentID
+	}
+	return labels
+}
+
+func structuredFields(r Record) map[string]string {
+	fields := make(map[string]string, len(r.Fields)+2)
+	for k, v := range r.Fields {
+		fields[k] = v
+	}
+	if isLowerHex(r.TraceID, 32) {
+		fields["trace_id"] = r.TraceID
+	}
+	if isLowerHex(r.SpanID, 16) {
+		fields["span_id"] = r.SpanID
+	}
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}
+
+func isLowerHex(s string, length int) bool {
+	if len(s) != length {
+		return false
+	}
+	for _, r := range s {
+		if !('0' <= r && r <= '9') && !('a' <= r && r <= 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // labelKey produces a deterministic string key from a label

--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -99,11 +99,11 @@ type Config struct {
 	AsyncFlush *bool
 
 	// OnError is called when a push fails after all retry
-	// attempts are exhausted. If nil, a warning is written to stderr.
+	// attempts are exhausted. If nil, no callback is invoked.
 	OnError func(error)
 
 	// OnDrop is called when records are dropped from the circular buffer. If
-	// nil, a warning is written to stderr.
+	// nil, no callback is invoked.
 	OnDrop func(int)
 
 	// Clock is passed to the retry logic for testing.
@@ -231,7 +231,7 @@ func (c *Client) pushOne(r Record) error {
 		select {
 		case <-c.records:
 			atomic.AddUint64(&c.stats.Dropped, 1)
-			c.onDrop(1)
+			c.notifyDrop(1)
 		case <-c.tomb.Dying():
 			return tomb.ErrDying
 		default:
@@ -362,11 +362,23 @@ func (c *Client) pushAll(
 		end := min(i+c.cfg.BatchSize, len(records))
 		if err := c.pushBatch(ctx, records[i:end]); err != nil {
 			atomic.AddUint64(&c.stats.PushErrors, 1)
-			c.onError(err)
+			c.notifyError(err)
 			continue
 		}
 		atomic.AddUint64(&c.stats.Sent, uint64(end-i))
 		atomic.StoreInt64(&c.stats.LastPushTimestamp, c.cfg.Clock.Now().Unix())
+	}
+}
+
+func (c *Client) notifyDrop(count int) {
+	if c.onDrop != nil {
+		c.onDrop(count)
+	}
+}
+
+func (c *Client) notifyError(err error) {
+	if c.onError != nil {
+		c.onError(err)
 	}
 }
 

--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"sort"
 	"strconv"
@@ -581,9 +582,7 @@ func topologyLabels(r Record) map[string]string {
 
 func structuredFields(r Record) map[string]string {
 	fields := make(map[string]string, len(r.Fields)+2)
-	for k, v := range r.Fields {
-		fields[k] = v
-	}
+	maps.Copy(fields, r.Fields)
 	if isLowerHex(r.TraceID, 32) {
 		fields["trace_id"] = r.TraceID
 	}

--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -21,6 +20,7 @@ import (
 	"github.com/juju/retry"
 	"gopkg.in/tomb.v2"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	internalerrors "github.com/juju/juju/internal/errors"
 )
 
@@ -50,6 +50,11 @@ type Record struct {
 
 	// SpanID is the OpenTelemetry span ID for this record, if present.
 	SpanID string
+}
+
+// HTTPClient is the HTTP client surface used by the Loki push client.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
 }
 
 // Config holds configuration for the Loki push client.
@@ -83,7 +88,7 @@ type Config struct {
 
 	// HTTPClient is an optional HTTP client. If nil, a
 	// default client with a 10s timeout is used.
-	HTTPClient *http.Client
+	HTTPClient HTTPClient
 
 	// AsyncFlush controls whether batches are pushed in a
 	// background goroutine. When true (the default), the
@@ -103,6 +108,33 @@ type Config struct {
 	// Clock is passed to the retry logic for testing.
 	// If nil, the wall clock is used.
 	Clock clock.Clock
+}
+
+// Validate checks that the Config has valid values and returns an
+// error if any field is invalid.
+func (c Config) Validate() error {
+	if c.BatchSize <= 0 {
+		return internalerrors.Errorf("BatchSize must be positive")
+	}
+	if c.BufferSize <= 0 {
+		return internalerrors.Errorf("BufferSize must be positive")
+	}
+	if c.FlushInterval <= 0 {
+		return internalerrors.Errorf("FlushInterval must be positive")
+	}
+	if c.MaxRetries < 0 {
+		return internalerrors.Errorf("MaxRetries must not be negative")
+	}
+	if c.InitialBackoff <= 0 {
+		return internalerrors.Errorf("InitialBackoff must be positive")
+	}
+	if c.MaxBackoff <= 0 {
+		return internalerrors.Errorf("MaxBackoff must be positive")
+	}
+	if c.Clock == nil {
+		return internalerrors.Errorf("Clock must not be nil")
+	}
+	return nil
 }
 
 // DefaultConfig returns a Config with sensible defaults.
@@ -126,7 +158,7 @@ func DefaultConfig() Config {
 type Client struct {
 	endpoint   string
 	cfg        Config
-	http       *http.Client
+	http       HTTPClient
 	asyncFlush bool
 	onError    func(error)
 	onDrop     func(int)
@@ -147,57 +179,21 @@ type report struct {
 // NewClient creates and starts a new Loki push client worker.
 // The endpoint should be the full URL to the Loki push API
 // (e.g. http://loki:3100/loki/api/v1/push).
-// Invalid and unset fields in cfg are replaced with defaults.
-// MaxRetries follows retry-count semantics: 0 disables retries.
 func NewClient(endpoint string, cfg Config) (*Client, error) {
 	if endpoint == "" {
-		return nil, internalerrors.Errorf("endpoint must not be empty")
+		return nil, internalerrors.Errorf("endpoint must not be empty").Add(coreerrors.NotValid)
 	}
-	if cfg.BatchSize <= 0 {
-		cfg.BatchSize = 100
+	if err := cfg.Validate(); err != nil {
+		return nil, err
 	}
-	if cfg.BufferSize <= 0 {
-		cfg.BufferSize = 500
-	}
-	if cfg.FlushInterval <= 0 {
-		cfg.FlushInterval = 10 * time.Second
-	}
-	if cfg.MaxRetries < 0 {
-		cfg.MaxRetries = 3
-	}
-	if cfg.InitialBackoff <= 0 {
-		cfg.InitialBackoff = 500 * time.Millisecond
-	}
-	if cfg.MaxBackoff <= 0 {
-		cfg.MaxBackoff = 30 * time.Second
-	}
-	if cfg.Clock == nil {
-		cfg.Clock = clock.WallClock
-	}
-	httpClient := cfg.HTTPClient
-	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 10 * time.Second}
-	}
-	onError := cfg.OnError
-	if onError == nil {
-		onError = func(err error) {
-			fmt.Fprintf(os.Stderr, "loki push failed: %v\n", err)
-		}
-	}
-	onDrop := cfg.OnDrop
-	if onDrop == nil {
-		onDrop = func(count int) {
-			fmt.Fprintf(os.Stderr, "dropped %d loki log records\n", count)
-		}
-	}
-	asyncFlush := cfg.AsyncFlush == nil || *cfg.AsyncFlush
+
 	c := &Client{
 		endpoint:   endpoint,
 		cfg:        cfg,
-		http:       httpClient,
-		asyncFlush: asyncFlush,
-		onError:    onError,
-		onDrop:     onDrop,
+		http:       cfg.HTTPClient,
+		asyncFlush: cfg.AsyncFlush == nil || *cfg.AsyncFlush,
+		onError:    cfg.OnError,
+		onDrop:     cfg.OnDrop,
 		records:    make(chan Record, cfg.BufferSize),
 	}
 	c.tomb.Go(c.loop)
@@ -257,8 +253,8 @@ func (c *Client) Report(context.Context) map[string]any {
 // Kill requests the client to stop. Any buffered records are
 // flushed on a best-effort basis before the client exits.
 // Records in-flight during shutdown may be dropped.
-func (c *Client) Kill(reason error) {
-	c.tomb.Kill(reason)
+func (c *Client) Kill() {
+	c.tomb.Kill(nil)
 }
 
 // Wait blocks until the client has stopped.
@@ -283,11 +279,14 @@ func (c *Client) loop() error {
 		case <-c.tomb.Dying():
 			c.drainChannel(&buffer)
 			if len(buffer) > 0 {
-				ctx, cancel := context.WithTimeout(
-					ctx, 5*time.Second,
-				)
-				defer cancel()
-				c.pushAll(ctx, buffer)
+				func() {
+					// Don't use the tomb context here, because we want to give
+					// the flush a chance to complete even if the tomb is dying.
+					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+
+					c.pushAll(ctx, buffer)
+				}()
 			}
 			return tomb.ErrDying
 

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -81,9 +81,11 @@ func (s *clientSuite) TestPushNoRetriesWhenMaxRetriesZero(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "no retries",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "no retries",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -105,15 +107,17 @@ func (s *clientSuite) TestPushUsesWallClockWhenUnset(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "clock default",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "clock default",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	p := waitPayload(c, payloads)
 	c.Assert(p.Streams, tc.HasLen, 1)
-	c.Check(p.Streams[0].Values[0][1], tc.Equals, "clock default")
+	c.Check(p.Streams[0].Values[0].Line, tc.Equals, "clock default")
 }
 
 func (s *clientSuite) TestPushFlushOnBatchSize(c *tc.C) {
@@ -129,9 +133,11 @@ func (s *clientSuite) TestPushFlushOnBatchSize(c *tc.C) {
 	ts := time.Now()
 	for range 3 {
 		err := client.Push(Record{
-			Timestamp: ts,
-			Line:      "line",
-			Labels:    map[string]string{"job": "test"},
+			Timestamp:      ts,
+			Line:           "line",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
 		})
 		c.Assert(err, tc.ErrorIsNil)
 	}
@@ -155,10 +161,10 @@ func (s *clientSuite) TestPushSyncFlush(c *tc.C) {
 
 	ts := time.Now()
 	err = client.Push(
-		Record{Timestamp: ts, Line: "s1",
-			Labels: map[string]string{"job": "test"}},
-		Record{Timestamp: ts, Line: "s2",
-			Labels: map[string]string{"job": "test"}},
+		Record{Timestamp: ts, Line: "s1", ControllerUUID: "controller",
+			ModelUUID: "model", AgentID: "machine-0"},
+		Record{Timestamp: ts, Line: "s2", ControllerUUID: "controller",
+			ModelUUID: "model", AgentID: "machine-0"},
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -179,18 +185,20 @@ func (s *clientSuite) TestPushFlushOnInterval(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "timer flush",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "timer flush",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	p := waitPayload(c, payloads)
 	c.Assert(p.Streams, tc.HasLen, 1)
-	c.Check(p.Streams[0].Values[0][1], tc.Equals, "timer flush")
+	c.Check(p.Streams[0].Values[0].Line, tc.Equals, "timer flush")
 }
 
-func (s *clientSuite) TestPushGroupsByLabels(c *tc.C) {
+func (s *clientSuite) TestPushGroupsByTopologyLabels(c *tc.C) {
 	srv, payloads := newTestServer(c)
 	defer srv.Close()
 
@@ -203,28 +211,34 @@ func (s *clientSuite) TestPushGroupsByLabels(c *tc.C) {
 	ts := time.Now()
 	err = client.Push(
 		Record{
-			Timestamp: ts,
-			Line:      "a1",
-			Labels:    map[string]string{"job": "a"},
+			Timestamp:      ts,
+			Line:           "a1",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
 		},
 		Record{
-			Timestamp: ts,
-			Line:      "b1",
-			Labels:    map[string]string{"job": "b"},
+			Timestamp:      ts,
+			Line:           "b1",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "unit-app-0",
 		},
 		Record{
-			Timestamp: ts,
-			Line:      "a2",
-			Labels:    map[string]string{"job": "a"},
+			Timestamp:      ts,
+			Line:           "a2",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
 		},
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
 	p := waitPayload(c, payloads)
 	c.Assert(p.Streams, tc.HasLen, 2)
-	c.Check(p.Streams[0].Stream["job"], tc.Equals, "a")
+	c.Check(p.Streams[0].Stream["juju_agent"], tc.Equals, "machine-0")
 	c.Check(p.Streams[0].Values, tc.HasLen, 2)
-	c.Check(p.Streams[1].Stream["job"], tc.Equals, "b")
+	c.Check(p.Streams[1].Stream["juju_agent"], tc.Equals, "unit-app-0")
 	c.Check(p.Streams[1].Values, tc.HasLen, 1)
 }
 
@@ -250,9 +264,11 @@ func (s *clientSuite) TestPushBatching(c *tc.C) {
 	// Send 6 records: triggers 2 flushes of 3.
 	for range 6 {
 		err := client.Push(Record{
-			Timestamp: ts,
-			Line:      "line",
-			Labels:    map[string]string{"job": "test"},
+			Timestamp:      ts,
+			Line:           "line",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
 		})
 		c.Assert(err, tc.ErrorIsNil)
 	}
@@ -291,9 +307,11 @@ func (s *clientSuite) TestPushRetryOnServerError(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "retry me",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "retry me",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -328,9 +346,11 @@ func (s *clientSuite) TestPushRetryOnTooManyRequests(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "throttled",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "throttled",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -362,9 +382,11 @@ func (s *clientSuite) TestOnErrorCalledOnPushFailure(c *tc.C) {
 	defer killAndWait(c, client)
 
 	err = client.Push(Record{
-		Timestamp: time.Now(),
-		Line:      "will fail",
-		Labels:    map[string]string{"job": "test"},
+		Timestamp:      time.Now(),
+		Line:           "will fail",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -377,6 +399,65 @@ func (s *clientSuite) TestOnErrorCalledOnPushFailure(c *tc.C) {
 	case <-time.After(5 * time.Second):
 		c.Fatal("timed out waiting for OnError callback")
 	}
+}
+
+func (s *clientSuite) TestPushDropsOldestWhenQueueFull(c *tc.C) {
+	block := make(chan struct{})
+	started := make(chan struct{}, 1)
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-block
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+	defer srv.Close()
+
+	drops := make(chan int, 3)
+	cfg := testConfig()
+	cfg.BatchSize = 1
+	cfg.BufferSize = 2
+	cfg.MaxRetries = 0
+	asyncFlush := false
+	cfg.AsyncFlush = &asyncFlush
+	cfg.OnDrop = func(count int) {
+		drops <- count
+	}
+
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	ts := time.Now()
+	err = client.Push(Record{Timestamp: ts, Line: "first"})
+	c.Assert(err, tc.ErrorIsNil)
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for first request")
+	}
+
+	// The first record blocks the worker in HTTP I/O. The queue can then fill
+	// and must drop oldest records without blocking this caller.
+	err = client.Push(
+		Record{Timestamp: ts, Line: "second"},
+		Record{Timestamp: ts, Line: "third"},
+		Record{Timestamp: ts, Line: "fourth"},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	select {
+	case count := <-drops:
+		c.Check(count, tc.Equals, 1)
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for drop callback")
+	}
+	c.Check(client.Report(c.Context())["dropped"], tc.Equals, uint64(1))
+
+	close(block)
+	killAndWait(c, client)
 }
 
 func (s *clientSuite) TestKillDrainsBufferedRecords(c *tc.C) {
@@ -393,9 +474,11 @@ func (s *clientSuite) TestKillDrainsBufferedRecords(c *tc.C) {
 	ts := time.Now()
 	err = client.Push(
 		Record{
-			Timestamp: ts,
-			Line:      "drain me",
-			Labels:    map[string]string{"job": "test"},
+			Timestamp:      ts,
+			Line:           "drain me",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
 		},
 	)
 	c.Assert(err, tc.ErrorIsNil)
@@ -405,13 +488,13 @@ func (s *clientSuite) TestKillDrainsBufferedRecords(c *tc.C) {
 	p := waitPayload(c, payloads)
 	c.Assert(p.Streams, tc.HasLen, 1)
 	c.Check(
-		p.Streams[0].Values[0][1],
+		p.Streams[0].Values[0].Line,
 		tc.Equals,
 		"drain me",
 	)
 }
 
-func (s *clientSuite) TestPushNilLabels(c *tc.C) {
+func (s *clientSuite) TestPushNoTopologyLabels(c *tc.C) {
 	srv, payloads := newTestServer(c)
 	defer srv.Close()
 
@@ -436,23 +519,35 @@ func (s *clientSuite) TestBuildPayload(c *tc.C) {
 	ts := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 	records := []Record{
 		{
-			Timestamp: ts,
-			Line:      "a1",
-			Labels: map[string]string{
-				"job": "x", "env": "prod",
+			Timestamp:      ts,
+			Line:           "a1",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
+			Fields: map[string]string{
+				"module": "apiserver",
 			},
+			TraceID: "0123456789abcdef0123456789abcdef",
+			SpanID:  "0123456789abcdef",
 		},
 		{
-			Timestamp: ts.Add(time.Second),
-			Line:      "b1",
-			Labels:    map[string]string{"job": "y"},
+			Timestamp:      ts.Add(time.Second),
+			Line:           "b1",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "unit-app-0",
 		},
 		{
-			Timestamp: ts.Add(2 * time.Second),
-			Line:      "a2",
-			Labels: map[string]string{
-				"env": "prod", "job": "x",
+			Timestamp:      ts.Add(2 * time.Second),
+			Line:           "a2",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
+			Fields: map[string]string{
+				"request_id": "req-123",
 			},
+			TraceID: "NOT-CANONICAL",
+			SpanID:  "0123456789abcdef",
 		},
 	}
 
@@ -462,16 +557,33 @@ func (s *clientSuite) TestBuildPayload(c *tc.C) {
 	c.Check(
 		payload.Streams[0].Stream,
 		tc.DeepEquals,
-		map[string]string{"job": "x", "env": "prod"},
+		map[string]string{
+			"juju_controller": "controller",
+			"juju_model":      "model",
+			"juju_agent":      "machine-0",
+		},
 	)
 	c.Check(payload.Streams[0].Values, tc.HasLen, 2)
-	c.Check(payload.Streams[0].Values[0][1], tc.Equals, "a1")
-	c.Check(payload.Streams[0].Values[1][1], tc.Equals, "a2")
+	c.Check(payload.Streams[0].Values[0].Line, tc.Equals, "a1")
+	c.Check(payload.Streams[0].Values[0].Fields, tc.DeepEquals, map[string]string{
+		"module":   "apiserver",
+		"trace_id": "0123456789abcdef0123456789abcdef",
+		"span_id":  "0123456789abcdef",
+	})
+	c.Check(payload.Streams[0].Values[1].Line, tc.Equals, "a2")
+	c.Check(payload.Streams[0].Values[1].Fields, tc.DeepEquals, map[string]string{
+		"request_id": "req-123",
+		"span_id":    "0123456789abcdef",
+	})
 
 	c.Check(
 		payload.Streams[1].Stream,
 		tc.DeepEquals,
-		map[string]string{"job": "y"},
+		map[string]string{
+			"juju_controller": "controller",
+			"juju_model":      "model",
+			"juju_agent":      "unit-app-0",
+		},
 	)
 	c.Check(payload.Streams[1].Values, tc.HasLen, 1)
 }
@@ -494,11 +606,14 @@ func (s *clientSuite) TestLabelKeyEmpty(c *tc.C) {
 func testConfig() Config {
 	return Config{
 		BatchSize:      100,
+		BufferSize:     500,
 		FlushInterval:  50 * time.Millisecond,
 		MaxRetries:     3,
 		InitialBackoff: time.Millisecond,
 		MaxBackoff:     10 * time.Millisecond,
 		Clock:          clock.WallClock,
+		OnError:        func(error) {},
+		OnDrop:         func(int) {},
 	}
 }
 

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -51,10 +51,31 @@ func (s *clientSuite) TestNewClientDefaults(c *tc.C) {
 }
 
 func (s *clientSuite) TestNewClientZeroRetriesIsValid(c *tc.C) {
-	client, err := NewClient("http://loki:3100", Config{})
+	cfg := testConfig()
+	cfg.MaxRetries = 0
+	client, err := NewClient("http://loki:3100", cfg)
 	c.Assert(err, tc.ErrorIsNil)
 	defer killAndWait(c, client)
 	c.Check(client.cfg.MaxRetries, tc.Equals, 0)
+}
+
+func (s *clientSuite) TestConfigValidateRejectsEmptyConfig(c *tc.C) {
+	err := Config{}.Validate()
+	c.Assert(err, tc.ErrorMatches, "BatchSize must be positive")
+}
+
+func (s *clientSuite) TestConfigValidateRejectsNegativeMaxRetries(c *tc.C) {
+	cfg := testConfig()
+	cfg.MaxRetries = -1
+	err := cfg.Validate()
+	c.Assert(err, tc.ErrorMatches, "MaxRetries must not be negative")
+}
+
+func (s *clientSuite) TestConfigValidateRejectsNilClock(c *tc.C) {
+	cfg := testConfig()
+	cfg.Clock = nil
+	err := cfg.Validate()
+	c.Assert(err, tc.ErrorMatches, "Clock must not be nil")
 }
 
 func (s *clientSuite) TestPushNoRetriesWhenMaxRetriesZero(c *tc.C) {
@@ -94,13 +115,12 @@ func (s *clientSuite) TestPushNoRetriesWhenMaxRetriesZero(c *tc.C) {
 	c.Check(attempts.Load(), tc.Equals, int32(1))
 }
 
-func (s *clientSuite) TestPushUsesWallClockWhenUnset(c *tc.C) {
+func (s *clientSuite) TestPushUsesWallClock(c *tc.C) {
 	srv, payloads := newTestServer(c)
 	defer srv.Close()
 
 	cfg := testConfig()
 	cfg.BatchSize = 1
-	cfg.Clock = nil
 
 	client, err := NewClient(srv.URL, cfg)
 	c.Assert(err, tc.ErrorIsNil)
@@ -662,7 +682,7 @@ func waitError(c *tc.C, ch <-chan error) error {
 }
 
 func killAndWait(c *tc.C, client *Client) {
-	client.Kill(nil)
+	client.Kill()
 	err := client.Wait()
 	c.Assert(err, tc.ErrorIsNil)
 }

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -297,7 +297,7 @@ func (s *clientSuite) TestPushBatching(c *tc.C) {
 	for range 2 {
 		select {
 		case <-done:
-		case <-time.After(5 * time.Second):
+		case <-c.Context().Done():
 			c.Fatal("timed out waiting for request")
 		}
 	}
@@ -337,7 +337,7 @@ func (s *clientSuite) TestPushRetryOnServerError(c *tc.C) {
 
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for successful push")
 	}
 	c.Check(attempts.Load(), tc.Equals, int32(2))
@@ -376,7 +376,7 @@ func (s *clientSuite) TestPushRetryOnTooManyRequests(c *tc.C) {
 
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for successful push")
 	}
 	c.Check(attempts.Load(), tc.Equals, int32(3))
@@ -416,7 +416,7 @@ func (s *clientSuite) TestOnErrorCalledOnPushFailure(c *tc.C) {
 			pushErr, tc.ErrorMatches,
 			".*loki returned status 500",
 		)
-	case <-time.After(5 * time.Second):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for OnError callback")
 	}
 }
@@ -484,7 +484,7 @@ func (s *clientSuite) TestPushDropsOldestWhenQueueFull(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	select {
 	case <-started:
-	case <-time.After(5 * time.Second):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for first request")
 	}
 
@@ -500,7 +500,7 @@ func (s *clientSuite) TestPushDropsOldestWhenQueueFull(c *tc.C) {
 	select {
 	case count := <-drops:
 		c.Check(count, tc.Equals, 1)
-	case <-time.After(5 * time.Second):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for drop callback")
 	}
 	c.Check(client.Report(c.Context())["dropped"], tc.Equals, uint64(1))
@@ -540,7 +540,7 @@ func (s *clientSuite) TestPushDropsOldestWhenQueueFullWithoutOnDropCallback(c *t
 	c.Assert(err, tc.ErrorIsNil)
 	select {
 	case <-started:
-	case <-time.After(5 * time.Second):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for first request")
 	}
 
@@ -743,7 +743,7 @@ func waitPayload(
 	select {
 	case p := <-ch:
 		return p
-	case <-time.After(5 * time.Second):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for payload")
 		return pushPayload{}
 	}
@@ -753,7 +753,7 @@ func waitError(c *tc.C, ch <-chan error) error {
 	select {
 	case err := <-ch:
 		return err
-	case <-time.After(5 * time.Second):
+	case <-c.Context().Done():
 		c.Fatal("timed out waiting for error callback")
 		return nil
 	}

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -634,6 +634,7 @@ func testConfig() Config {
 		Clock:          clock.WallClock,
 		OnError:        func(error) {},
 		OnDrop:         func(int) {},
+		HTTPClient:     http.DefaultClient,
 	}
 }
 

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -421,6 +421,35 @@ func (s *clientSuite) TestOnErrorCalledOnPushFailure(c *tc.C) {
 	}
 }
 
+func (s *clientSuite) TestPushFailureWithNilOnErrorCallback(c *tc.C) {
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}),
+	)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 1
+	cfg.MaxRetries = 0
+	cfg.OnError = nil
+
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+	defer killAndWait(c, client)
+
+	err = client.Push(Record{
+		Timestamp:      time.Now(),
+		Line:           "will fail",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	waitForPushErrors(c, client, 1)
+}
+
 func (s *clientSuite) TestPushDropsOldestWhenQueueFull(c *tc.C) {
 	block := make(chan struct{})
 	started := make(chan struct{}, 1)
@@ -475,6 +504,54 @@ func (s *clientSuite) TestPushDropsOldestWhenQueueFull(c *tc.C) {
 		c.Fatal("timed out waiting for drop callback")
 	}
 	c.Check(client.Report(c.Context())["dropped"], tc.Equals, uint64(1))
+
+	close(block)
+	killAndWait(c, client)
+}
+
+func (s *clientSuite) TestPushDropsOldestWhenQueueFullWithoutOnDropCallback(c *tc.C) {
+	block := make(chan struct{})
+	started := make(chan struct{}, 1)
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-block
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+	defer srv.Close()
+
+	cfg := testConfig()
+	cfg.BatchSize = 1
+	cfg.BufferSize = 2
+	cfg.MaxRetries = 0
+	cfg.OnDrop = nil
+	asyncFlush := false
+	cfg.AsyncFlush = &asyncFlush
+
+	client, err := NewClient(srv.URL, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	ts := time.Now()
+	err = client.Push(Record{Timestamp: ts, Line: "first"})
+	c.Assert(err, tc.ErrorIsNil)
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for first request")
+	}
+
+	err = client.Push(
+		Record{Timestamp: ts, Line: "second"},
+		Record{Timestamp: ts, Line: "third"},
+		Record{Timestamp: ts, Line: "fourth"},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	waitForDropped(c, client, 1)
 
 	close(block)
 	killAndWait(c, client)
@@ -686,4 +763,32 @@ func killAndWait(c *tc.C, client *Client) {
 	client.Kill()
 	err := client.Wait()
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func waitForDropped(c *tc.C, client *Client, expected uint64) {
+	for {
+		if client.Report(c.Context())["dropped"] == expected {
+			return
+		}
+		select {
+		case <-c.Context().Done():
+			c.Fatalf("timed out waiting for dropped count %d", expected)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func waitForPushErrors(c *tc.C, client *Client, expected uint64) {
+	for {
+		if client.Report(c.Context())["push-errors"] == expected {
+			return
+		}
+		select {
+		case <-c.Context().Done():
+			c.Fatalf("timed out waiting for push-errors count %d", expected)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
 }

--- a/internal/worker/deployer/unit_manifolds.go
+++ b/internal/worker/deployer/unit_manifolds.go
@@ -142,7 +142,7 @@ func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
 
 		// The log router owns the buffered log stream and forwards records to
 		// one active backend at a time.
-		logSenderName: logrouter.Manifold(logrouter.ManifoldConfig{
+		logRouterName: logrouter.Manifold(logrouter.ManifoldConfig{
 			AgentName:          agentName,
 			LogSource:          config.LogSource,
 			AgentConfigChanged: config.AgentConfigChanged,
@@ -297,7 +297,7 @@ const (
 	apiConfigWatcherName = "api-config-watcher"
 	apiCallerName        = "api-caller"
 	s3CallerName         = "s3-caller"
-	logSenderName        = "log-sender"
+	logRouterName        = "log-router"
 
 	migrationFortressName     = "migration-fortress"
 	migrationInactiveFlagName = "migration-inactive-flag"

--- a/internal/worker/deployer/unit_manifolds.go
+++ b/internal/worker/deployer/unit_manifolds.go
@@ -5,6 +5,7 @@ package deployer
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/juju/clock"
@@ -28,6 +29,7 @@ import (
 	"github.com/juju/juju/internal/worker/fortress"
 	"github.com/juju/juju/internal/worker/leadership"
 	loggerworker "github.com/juju/juju/internal/worker/logger"
+	"github.com/juju/juju/internal/worker/logrouter"
 	"github.com/juju/juju/internal/worker/logsender"
 	"github.com/juju/juju/internal/worker/lokiendpointupdater"
 	"github.com/juju/juju/internal/worker/migrationflag"
@@ -138,12 +140,15 @@ func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
 			Logger:        config.LoggerContext.GetLogger("juju.worker.units3caller"),
 		}),
 
-		// The log sender is a leaf worker that sends log messages to some
-		// API server, when configured so to do. We should only need one of
-		// these in a consolidated agent.
-		logSenderName: logsender.Manifold(logsender.ManifoldConfig{
-			APICallerName: apiCallerName,
-			LogSource:     config.LogSource,
+		// The log router owns the buffered log stream and forwards records to
+		// one active backend at a time.
+		logSenderName: logrouter.Manifold(logrouter.ManifoldConfig{
+			AgentName:          agentName,
+			LogSource:          config.LogSource,
+			AgentConfigChanged: config.AgentConfigChanged,
+			Logger:             config.LoggerContext.GetLogger("juju.worker.logrouter"),
+			Clock:              config.Clock,
+			HTTPClient:         http.DefaultClient,
 		}),
 
 		// The migration workers collaborate to run migrations;

--- a/internal/worker/deployer/unit_manifolds.go
+++ b/internal/worker/deployer/unit_manifolds.go
@@ -144,12 +144,12 @@ func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
 		// one active backend at a time.
 		logRouterName: logrouter.Manifold(logrouter.ManifoldConfig{
 			AgentName:          agentName,
+			APICallerName:      apiCallerName,
 			LogSource:          config.LogSource,
 			AgentConfigChanged: config.AgentConfigChanged,
 			Logger:             config.LoggerContext.GetLogger("juju.worker.logrouter"),
 			Clock:              config.Clock,
 			HTTPClient:         http.DefaultClient,
-			NewAPIOpen:         api.Open,
 			NewBackendFunc:     logrouter.NewBackend,
 		}),
 

--- a/internal/worker/deployer/unit_manifolds.go
+++ b/internal/worker/deployer/unit_manifolds.go
@@ -149,6 +149,8 @@ func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
 			Logger:             config.LoggerContext.GetLogger("juju.worker.logrouter"),
 			Clock:              config.Clock,
 			HTTPClient:         http.DefaultClient,
+			NewAPIOpen:         api.Open,
+			NewBackendFunc:     logrouter.NewBackend,
 		}),
 
 		// The migration workers collaborate to run migrations;

--- a/internal/worker/deployer/unit_manifolds_test.go
+++ b/internal/worker/deployer/unit_manifolds_test.go
@@ -153,7 +153,7 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"migration-inactive-flag",
 	},
 
-	"log-sender": {"agent", "api-caller", "api-config-watcher"},
+	"log-sender": {"agent"},
 
 	"logging-config-updater": {
 		"agent",

--- a/internal/worker/deployer/unit_manifolds_test.go
+++ b/internal/worker/deployer/unit_manifolds_test.go
@@ -153,7 +153,7 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"migration-inactive-flag",
 	},
 
-	"log-router": {"agent"},
+	"log-router": {"agent", "api-caller", "api-config-watcher"},
 
 	"logging-config-updater": {
 		"agent",

--- a/internal/worker/deployer/unit_manifolds_test.go
+++ b/internal/worker/deployer/unit_manifolds_test.go
@@ -56,7 +56,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 		"charm-dir",
 		"hook-retry-strategy",
 		"leadership-tracker",
-		"log-sender",
+		"log-router",
 		"logging-config-updater",
 		"loki-endpoint-updater",
 		"migration-fortress",
@@ -82,7 +82,7 @@ func (s *ManifoldsSuite) TestMigrationGuards(c *tc.C) {
 		"api-config-watcher",
 		"api-caller",
 		"s3-caller",
-		"log-sender",
+		"log-router",
 		"upgrader",
 		"migration-fortress",
 		"migration-minion",
@@ -153,7 +153,7 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"migration-inactive-flag",
 	},
 
-	"log-sender": {"agent"},
+	"log-router": {"agent"},
 
 	"logging-config-updater": {
 		"agent",

--- a/internal/worker/logrouter/backends/backend.go
+++ b/internal/worker/logrouter/backends/backend.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backends
+
+import (
+	"github.com/juju/worker/v5"
+
+	"github.com/juju/juju/internal/worker/logsender"
+)
+
+// Backend is a worker that accepts log records.
+type Backend interface {
+	worker.Worker
+	LogRecords() logsender.LogRecordCh
+}

--- a/internal/worker/logrouter/backends/drain.go
+++ b/internal/worker/logrouter/backends/drain.go
@@ -4,6 +4,8 @@
 package backends
 
 import (
+	"fmt"
+
 	"github.com/juju/worker/v5/catacomb"
 
 	internalerrors "github.com/juju/juju/internal/errors"
@@ -31,16 +33,14 @@ func NewDrain(backendBufferSize int) (Backend, error) {
 	return w, nil
 }
 
+// Kill stops the backend and closes the log record channel.
 func (w *drainBackend) Kill() {
 	w.catacomb.Kill(nil)
 }
 
+// Wait waits for the backend to stop.
 func (w *drainBackend) Wait() error {
 	return w.catacomb.Wait()
-}
-
-func (w *drainBackend) Dying() <-chan struct{} {
-	return w.catacomb.Dying()
 }
 
 // LogRecords returns the channel on which log records are sent to the backend.
@@ -53,10 +53,11 @@ func (w *drainBackend) loop() error {
 		select {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
-		case _, ok := <-w.records:
+		case r, ok := <-w.records:
 			if !ok {
 				return nil
 			}
+			fmt.Println("drainBackend loop: received record", r.Message)
 		}
 	}
 }

--- a/internal/worker/logrouter/backends/drain.go
+++ b/internal/worker/logrouter/backends/drain.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backends
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/worker/v5/catacomb"
+
+	"github.com/juju/juju/internal/worker/logsender"
+)
+
+type drainBackend struct {
+	catacomb catacomb.Catacomb
+	records  logsender.LogRecordCh
+}
+
+// NewDrain returns a backend that drains log records without sending them
+// anywhere.
+func NewDrain(backendBufferSize int) (Backend, error) {
+	w := &drainBackend{
+		records: make(logsender.LogRecordCh, backendBufferSize),
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Name: "log-router-drain",
+		Site: &w.catacomb,
+		Work: w.loop,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+func (w *drainBackend) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+func (w *drainBackend) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *drainBackend) Dying() <-chan struct{} {
+	return w.catacomb.Dying()
+}
+
+func (w *drainBackend) LogRecords() logsender.LogRecordCh {
+	return w.records
+}
+
+func (w *drainBackend) loop() error {
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case _, ok := <-w.records:
+			if !ok {
+				return nil
+			}
+		}
+	}
+}

--- a/internal/worker/logrouter/backends/drain.go
+++ b/internal/worker/logrouter/backends/drain.go
@@ -4,9 +4,9 @@
 package backends
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/worker/v5/catacomb"
 
+	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/worker/logsender"
 )
 
@@ -26,7 +26,7 @@ func NewDrain(backendBufferSize int) (Backend, error) {
 		Site: &w.catacomb,
 		Work: w.loop,
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 	return w, nil
 }
@@ -43,6 +43,7 @@ func (w *drainBackend) Dying() <-chan struct{} {
 	return w.catacomb.Dying()
 }
 
+// LogRecords returns the channel on which log records are sent to the backend.
 func (w *drainBackend) LogRecords() logsender.LogRecordCh {
 	return w.records
 }

--- a/internal/worker/logrouter/backends/drain_test.go
+++ b/internal/worker/logrouter/backends/drain_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backends
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juju/loggo/v3"
+	"github.com/juju/tc"
+	"github.com/juju/worker/v5/workertest"
+
+	"github.com/juju/juju/internal/worker/logsender"
+)
+
+type drainSuite struct{}
+
+func TestDrainSuite(t *testing.T) {
+	tc.Run(t, &drainSuite{})
+}
+
+func (s *drainSuite) TestDrainsRecords(c *tc.C) {
+	w, err := NewDrain(1)
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	records := w.LogRecords()
+	records <- &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test.module",
+		Level:   loggo.INFO,
+		Message: "first",
+	}
+
+	select {
+	case records <- &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test.module",
+		Level:   loggo.INFO,
+		Message: "second",
+	}:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for drain backend to consume records")
+	}
+
+	workertest.CleanKill(c, w)
+}

--- a/internal/worker/logrouter/backends/logsink.go
+++ b/internal/worker/logrouter/backends/logsink.go
@@ -24,6 +24,7 @@ func NewLogSink(logSenderAPI logsender.LogSenderAPI, backendBufferSize int) (Bac
 	}, nil
 }
 
+// LogRecords returns the channel on which log records are sent to the backend.
 func (w *logSinkBackend) LogRecords() logsender.LogRecordCh {
 	return w.records
 }

--- a/internal/worker/logrouter/backends/logsink.go
+++ b/internal/worker/logrouter/backends/logsink.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backends
+
+import (
+	"github.com/juju/worker/v5"
+
+	"github.com/juju/juju/internal/worker/logsender"
+)
+
+type logSinkBackend struct {
+	worker.Worker
+	records logsender.LogRecordCh
+}
+
+// NewLogSink returns a backend that sends log records to the controller log
+// sink.
+func NewLogSink(logSenderAPI logsender.LogSenderAPI, backendBufferSize int) (Backend, error) {
+	records := make(logsender.LogRecordCh, backendBufferSize)
+	return &logSinkBackend{
+		Worker:  logsender.New(records, logSenderAPI),
+		records: records,
+	}, nil
+}
+
+func (w *logSinkBackend) LogRecords() logsender.LogRecordCh {
+	return w.records
+}

--- a/internal/worker/logrouter/backends/loki.go
+++ b/internal/worker/logrouter/backends/loki.go
@@ -4,10 +4,10 @@
 package backends
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/catacomb"
 
+	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/loki"
 	"github.com/juju/juju/internal/worker/logsender"
 )
@@ -43,7 +43,7 @@ type lokiBackend struct {
 func NewLoki(cfg LokiConfig) (Backend, error) {
 	client, err := cfg.NewClient(cfg.Endpoint, cfg.ClientConfig)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 	w := &lokiBackend{
 		cfg:     cfg,
@@ -58,7 +58,7 @@ func NewLoki(cfg LokiConfig) (Backend, error) {
 			client,
 		},
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 	return w, nil
 }
@@ -104,7 +104,7 @@ func (w *lokiBackend) loop() error {
 					"level":    rec.Level.String(),
 				},
 			}); err != nil {
-				return errors.Trace(err)
+				return internalerrors.Capture(err)
 			}
 		}
 	}

--- a/internal/worker/logrouter/backends/loki.go
+++ b/internal/worker/logrouter/backends/loki.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backends
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/catacomb"
+
+	"github.com/juju/juju/internal/loki"
+	"github.com/juju/juju/internal/worker/logsender"
+)
+
+// LokiConfig contains the settings required by the Loki backend.
+type LokiConfig struct {
+	BackendBufferSize int
+	ClientConfig      loki.Config
+	Endpoint          string
+	ControllerUUID    string
+	ModelUUID         string
+	AgentID           string
+	NewClient         NewLokiClientFunc
+}
+
+// LokiClient is the Loki push client surface used by the backend.
+type LokiClient interface {
+	worker.Worker
+	Push(...loki.Record) error
+}
+
+// NewLokiClientFunc returns a Loki client worker.
+type NewLokiClientFunc func(string, loki.Config) (LokiClient, error)
+
+type lokiBackend struct {
+	catacomb catacomb.Catacomb
+	cfg      LokiConfig
+	client   LokiClient
+	records  logsender.LogRecordCh
+}
+
+// NewLoki returns a backend that sends log records to a Loki endpoint.
+func NewLoki(cfg LokiConfig) (Backend, error) {
+	client, err := cfg.NewClient(cfg.Endpoint, cfg.ClientConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &lokiBackend{
+		cfg:     cfg,
+		client:  client,
+		records: make(logsender.LogRecordCh, cfg.BackendBufferSize),
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Name: "log-router-loki",
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{
+			client,
+		},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+func (w *lokiBackend) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+func (w *lokiBackend) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *lokiBackend) Dying() <-chan struct{} {
+	return w.catacomb.Dying()
+}
+
+func (w *lokiBackend) LogRecords() logsender.LogRecordCh {
+	return w.records
+}
+
+func (w *lokiBackend) loop() error {
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+
+		case rec, ok := <-w.records:
+			if !ok {
+				return nil
+			}
+			if rec == nil {
+				continue
+			}
+			if err := w.client.Push(loki.Record{
+				Timestamp:      rec.Time,
+				Line:           rec.Message,
+				ControllerUUID: w.cfg.ControllerUUID,
+				ModelUUID:      w.cfg.ModelUUID,
+				AgentID:        w.cfg.AgentID,
+				Fields: map[string]string{
+					"module":   rec.Module,
+					"location": rec.Location,
+					"level":    rec.Level.String(),
+				},
+			}); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+}

--- a/internal/worker/logrouter/backends/loki.go
+++ b/internal/worker/logrouter/backends/loki.go
@@ -63,18 +63,17 @@ func NewLoki(cfg LokiConfig) (Backend, error) {
 	return w, nil
 }
 
+// Kill stops the backend and closes the log record channel.
 func (w *lokiBackend) Kill() {
 	w.catacomb.Kill(nil)
 }
 
+// Wait waits for the backend to stop.
 func (w *lokiBackend) Wait() error {
 	return w.catacomb.Wait()
 }
 
-func (w *lokiBackend) Dying() <-chan struct{} {
-	return w.catacomb.Dying()
-}
-
+// LogRecords returns the channel that the log router will send log records to.
 func (w *lokiBackend) LogRecords() logsender.LogRecordCh {
 	return w.records
 }

--- a/internal/worker/logrouter/backends/loki_test.go
+++ b/internal/worker/logrouter/backends/loki_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backends
+
+import (
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/juju/loggo/v3"
+	"github.com/juju/tc"
+	"github.com/juju/worker/v5/workertest"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/internal/loki"
+	"github.com/juju/juju/internal/worker/logsender"
+)
+
+type lokiSuite struct{}
+
+func TestLokiSuite(t *testing.T) {
+	tc.Run(t, &lokiSuite{})
+}
+
+func (s *lokiSuite) TestUsesClientInterfaceAndManagesLifecycle(c *tc.C) {
+	client := newRecordingLokiClient()
+	httpClient := &http.Client{}
+
+	w, err := NewLoki(LokiConfig{
+		BackendBufferSize: 1,
+		ClientConfig: loki.Config{
+			HTTPClient: httpClient,
+		},
+		Endpoint:       "http://loki/loki/api/v1/push",
+		ControllerUUID: "controller",
+		ModelUUID:      "model",
+		AgentID:        "machine-0",
+		NewClient: func(endpoint string, cfg loki.Config) (LokiClient, error) {
+			c.Check(endpoint, tc.Equals, "http://loki/loki/api/v1/push")
+			c.Check(cfg.HTTPClient, tc.Equals, httpClient)
+			return client, nil
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	w.LogRecords() <- &logsender.LogRecord{
+		Time:     time.Now(),
+		Module:   "test.module",
+		Location: "worker.go:10",
+		Level:    loggo.INFO,
+		Message:  "hello loki",
+	}
+
+	got := client.waitRecord(c)
+	c.Check(got.Line, tc.Equals, "hello loki")
+	c.Check(got.ControllerUUID, tc.Equals, "controller")
+	c.Check(got.ModelUUID, tc.Equals, "model")
+	c.Check(got.AgentID, tc.Equals, "machine-0")
+	c.Check(got.Fields, tc.DeepEquals, map[string]string{
+		"module":   "test.module",
+		"location": "worker.go:10",
+		"level":    "INFO",
+	})
+
+	workertest.CleanKill(c, w)
+
+	c.Check(client.killed.Load(), tc.IsTrue)
+	c.Check(client.waited.Load(), tc.IsTrue)
+}
+
+type recordingLokiClient struct {
+	tomb    tomb.Tomb
+	records chan loki.Record
+	killed  atomic.Bool
+	waited  atomic.Bool
+}
+
+func newRecordingLokiClient() *recordingLokiClient {
+	c := &recordingLokiClient{
+		records: make(chan loki.Record, 1),
+	}
+	c.tomb.Go(func() error {
+		<-c.tomb.Dying()
+		return nil
+	})
+	return c
+}
+
+func (c *recordingLokiClient) Push(records ...loki.Record) error {
+	for _, record := range records {
+		c.records <- record
+	}
+	return nil
+}
+
+func (c *recordingLokiClient) Kill() {
+	c.killed.Store(true)
+	c.tomb.Kill(nil)
+}
+
+func (c *recordingLokiClient) Wait() error {
+	c.waited.Store(true)
+	return c.tomb.Wait()
+}
+
+func (c *recordingLokiClient) waitRecord(t *tc.C) loki.Record {
+	select {
+	case record := <-c.records:
+		return record
+	case <-t.Context().Done():
+		t.Fatalf("timed out waiting for loki record")
+	}
+	return loki.Record{}
+}

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"sync"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -146,6 +147,7 @@ func NewBackend(
 type agentAPICaller struct {
 	agent  agent.Agent
 	open   func(context.Context, *api.Info, api.DialOpts) (api.Connection, error)
+	mu     sync.Mutex
 	caller base.APICaller
 }
 
@@ -168,17 +170,19 @@ func (c *agentAPICaller) APICall(ctx context.Context, objType string, version in
 }
 
 func (c *agentAPICaller) BestFacadeVersion(facade string) int {
-	if c.caller == nil {
+	caller := c.currentCaller()
+	if caller == nil {
 		return 0
 	}
-	return c.caller.BestFacadeVersion(facade)
+	return caller.BestFacadeVersion(facade)
 }
 
 func (c *agentAPICaller) ModelTag() (names.ModelTag, bool) {
-	if c.caller == nil {
+	caller := c.currentCaller()
+	if caller == nil {
 		return names.ModelTag{}, false
 	}
-	return c.caller.ModelTag()
+	return caller.ModelTag()
 }
 
 func (c *agentAPICaller) HTTPClient(scope base.HTTPClientScope) (*httprequest.Client, error) {
@@ -198,10 +202,11 @@ func (c *agentAPICaller) SimpleHTTPClient() (base.SimpleHTTPClient, error) {
 }
 
 func (c *agentAPICaller) BakeryClient() base.MacaroonDischarger {
-	if c.caller == nil {
+	caller := c.currentCaller()
+	if caller == nil {
 		return nil
 	}
-	return c.caller.BakeryClient()
+	return caller.BakeryClient()
 }
 
 func (c *agentAPICaller) ConnectStream(ctx context.Context, path string, attrs url.Values) (base.Stream, error) {
@@ -226,6 +231,9 @@ func (c *agentAPICaller) ConnectControllerStream(
 }
 
 func (c *agentAPICaller) apiCaller(ctx context.Context) (base.APICaller, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.caller != nil {
 		return c.caller, nil
 	}
@@ -239,4 +247,10 @@ func (c *agentAPICaller) apiCaller(ctx context.Context) (base.APICaller, error) 
 	}
 	c.caller = conn
 	return c.caller, nil
+}
+
+func (c *agentAPICaller) currentCaller() base.APICaller {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.caller
 }

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -96,6 +96,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				Clock:              config.Clock,
 				DrainOnly:          config.DrainOnly,
 				ConvergeTimeout:    defaultConvergeTimeout,
+				RestartDelay:       defaultRestartDelay,
 				NewBackend:         config.NewBackendFunc(apiCaller, config.HTTPClient, config.Clock),
 			})
 		},

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -58,27 +58,30 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				Clock:              config.Clock,
 				DrainOnly:          config.DrainOnly,
 				ConvergeTimeout:    defaultConvergeTimeout,
-				NewLogSinkBackend: func(ConfigSnapshot) (Backend, error) {
-					return backends.NewLogSink(logSenderAPI, defaultBackendBufferSize)
-				},
-				NewLokiBackend: func(snapshot ConfigSnapshot) (Backend, error) {
-					lokiConfig := loki.DefaultConfig()
-					lokiConfig.HTTPClient = config.HTTPClient
-					lokiConfig.Clock = config.Clock
-					return backends.NewLoki(backends.LokiConfig{
-						BackendBufferSize: defaultBackendBufferSize,
-						ClientConfig:      lokiConfig,
-						Endpoint:          snapshot.Endpoint,
-						ControllerUUID:    snapshot.ControllerUUID,
-						ModelUUID:         snapshot.ModelUUID,
-						AgentID:           snapshot.AgentID,
-						NewClient: func(endpoint string, cfg loki.Config) (backends.LokiClient, error) {
-							return loki.NewClient(endpoint, cfg)
-						},
-					})
-				},
-				NewDrainBackend: func(ConfigSnapshot) (Backend, error) {
-					return backends.NewDrain(defaultBackendBufferSize)
+				NewBackend: func(backendType BackendType, snapshot ConfigSnapshot) (Backend, error) {
+					switch backendType {
+					case BackendTypeLogSink:
+						return backends.NewLogSink(logSenderAPI, defaultBackendBufferSize)
+					case BackendTypeLoki:
+						lokiConfig := loki.DefaultConfig()
+						lokiConfig.HTTPClient = config.HTTPClient
+						lokiConfig.Clock = config.Clock
+						return backends.NewLoki(backends.LokiConfig{
+							BackendBufferSize: defaultBackendBufferSize,
+							ClientConfig:      lokiConfig,
+							Endpoint:          snapshot.Endpoint,
+							ControllerUUID:    snapshot.ControllerUUID,
+							ModelUUID:         snapshot.ModelUUID,
+							AgentID:           snapshot.AgentID,
+							NewClient: func(endpoint string, cfg loki.Config) (backends.LokiClient, error) {
+								return loki.NewClient(endpoint, cfg)
+							},
+						})
+					case BackendTypeDrain:
+						return backends.NewDrain(defaultBackendBufferSize)
+					default:
+						return nil, errors.NotValidf("unknown logrouter backend type %q", backendType)
+					}
 				},
 			})
 		},

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logrouter
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/names/v6"
+	"github.com/juju/utils/v4/voyeur"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/dependency"
+	"gopkg.in/httprequest.v1"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
+	apilogsender "github.com/juju/juju/api/logsender"
+	corelogger "github.com/juju/juju/core/logger"
+	"github.com/juju/juju/internal/loki"
+	"github.com/juju/juju/internal/worker/logrouter/backends"
+	"github.com/juju/juju/internal/worker/logsender"
+)
+
+// ManifoldConfig defines the names of the manifolds used by logrouter.
+type ManifoldConfig struct {
+	AgentName          string
+	LogSource          logsender.LogRecordCh
+	AgentConfigChanged *voyeur.Value
+	Logger             corelogger.Logger
+	Clock              clock.Clock
+	HTTPClient         loki.HTTPClient
+	DrainOnly          bool
+
+	APIOpen func(context.Context, *api.Info, api.DialOpts) (api.Connection, error)
+}
+
+// Manifold returns a dependency manifold that runs the logrouter worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{config.AgentName},
+		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
+			var a agent.Agent
+			if err := getter.Get(config.AgentName, &a); err != nil {
+				return nil, err
+			}
+
+			logSenderAPI := apilogsender.NewAPI(newAgentAPICaller(a, config.APIOpen))
+			return NewWorker(WorkerConfig{
+				Agent:              a,
+				LogSource:          config.LogSource,
+				AgentConfigChanged: config.AgentConfigChanged,
+				Logger:             config.Logger,
+				Clock:              config.Clock,
+				DrainOnly:          config.DrainOnly,
+				ConvergeTimeout:    defaultConvergeTimeout,
+				NewLogSinkBackend: func(ConfigSnapshot) (Backend, error) {
+					return backends.NewLogSink(logSenderAPI, defaultBackendBufferSize)
+				},
+				NewLokiBackend: func(snapshot ConfigSnapshot) (Backend, error) {
+					lokiConfig := loki.DefaultConfig()
+					lokiConfig.HTTPClient = config.HTTPClient
+					lokiConfig.Clock = config.Clock
+					return backends.NewLoki(backends.LokiConfig{
+						BackendBufferSize: defaultBackendBufferSize,
+						ClientConfig:      lokiConfig,
+						Endpoint:          snapshot.Endpoint,
+						ControllerUUID:    snapshot.ControllerUUID,
+						ModelUUID:         snapshot.ModelUUID,
+						AgentID:           snapshot.AgentID,
+						NewClient: func(endpoint string, cfg loki.Config) (backends.LokiClient, error) {
+							return loki.NewClient(endpoint, cfg)
+						},
+					})
+				},
+				NewDrainBackend: func(ConfigSnapshot) (Backend, error) {
+					return backends.NewDrain(defaultBackendBufferSize)
+				},
+			})
+		},
+	}
+}
+
+type agentAPICaller struct {
+	agent  agent.Agent
+	open   func(context.Context, *api.Info, api.DialOpts) (api.Connection, error)
+	caller base.APICaller
+}
+
+func newAgentAPICaller(
+	agent agent.Agent,
+	open func(context.Context, *api.Info, api.DialOpts) (api.Connection, error),
+) base.APICaller {
+	return &agentAPICaller{
+		agent: agent,
+		open:  open,
+	}
+}
+
+func (c *agentAPICaller) APICall(ctx context.Context, objType string, version int, id, request string, params, response any) error {
+	caller, err := c.apiCaller(ctx)
+	if err != nil {
+		return err
+	}
+	return caller.APICall(ctx, objType, version, id, request, params, response)
+}
+
+func (c *agentAPICaller) BestFacadeVersion(facade string) int {
+	if c.caller == nil {
+		return 0
+	}
+	return c.caller.BestFacadeVersion(facade)
+}
+
+func (c *agentAPICaller) ModelTag() (names.ModelTag, bool) {
+	if c.caller == nil {
+		return names.ModelTag{}, false
+	}
+	return c.caller.ModelTag()
+}
+
+func (c *agentAPICaller) HTTPClient(scope base.HTTPClientScope) (*httprequest.Client, error) {
+	caller, err := c.apiCaller(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return caller.HTTPClient(scope)
+}
+
+func (c *agentAPICaller) SimpleHTTPClient() (base.SimpleHTTPClient, error) {
+	caller, err := c.apiCaller(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return caller.SimpleHTTPClient()
+}
+
+func (c *agentAPICaller) BakeryClient() base.MacaroonDischarger {
+	if c.caller == nil {
+		return nil
+	}
+	return c.caller.BakeryClient()
+}
+
+func (c *agentAPICaller) ConnectStream(ctx context.Context, path string, attrs url.Values) (base.Stream, error) {
+	caller, err := c.apiCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return caller.ConnectStream(ctx, path, attrs)
+}
+
+func (c *agentAPICaller) ConnectControllerStream(
+	ctx context.Context,
+	path string,
+	attrs url.Values,
+	headers http.Header,
+) (base.Stream, error) {
+	caller, err := c.apiCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return caller.ConnectControllerStream(ctx, path, attrs, headers)
+}
+
+func (c *agentAPICaller) apiCaller(ctx context.Context) (base.APICaller, error) {
+	if c.caller != nil {
+		return c.caller, nil
+	}
+	info, ok := c.agent.CurrentConfig().APIInfo()
+	if !ok {
+		return nil, errors.New("api info not available")
+	}
+	conn, err := c.open(ctx, info, api.DefaultDialOpts())
+	if err != nil {
+		return nil, err
+	}
+	c.caller = conn
+	return c.caller, nil
+}

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -5,20 +5,14 @@ package logrouter
 
 import (
 	"context"
-	"net/http"
-	"net/url"
-	"sync"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/names/v6"
 	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
-	"gopkg.in/httprequest.v1"
 
 	"github.com/juju/juju/agent"
-	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	apilogsender "github.com/juju/juju/api/logsender"
 	corelogger "github.com/juju/juju/core/logger"
@@ -31,8 +25,7 @@ import (
 // BackendFuncFactory returns a backend constructor for the supplied agent
 // resources.
 type BackendFuncFactory func(
-	agent.Agent,
-	func(context.Context, *api.Info, api.DialOpts) (api.Connection, error),
+	base.APICaller,
 	loki.HTTPClient,
 	clock.Clock,
 ) BackendFunc
@@ -40,6 +33,7 @@ type BackendFuncFactory func(
 // ManifoldConfig defines the names of the manifolds used by logrouter.
 type ManifoldConfig struct {
 	AgentName          string
+	APICallerName      string
 	LogSource          logsender.LogRecordCh
 	AgentConfigChanged *voyeur.Value
 	Logger             corelogger.Logger
@@ -47,7 +41,6 @@ type ManifoldConfig struct {
 	HTTPClient         loki.HTTPClient
 	DrainOnly          bool
 
-	NewAPIOpen     func(context.Context, *api.Info, api.DialOpts) (api.Connection, error)
 	NewBackendFunc BackendFuncFactory
 }
 
@@ -55,6 +48,9 @@ type ManifoldConfig struct {
 func (c ManifoldConfig) Validate() error {
 	if c.AgentName == "" {
 		return errors.NotValidf("empty AgentName")
+	}
+	if c.APICallerName == "" {
+		return errors.NotValidf("empty APICallerName")
 	}
 	if c.LogSource == nil {
 		return errors.NotValidf("nil LogSource")
@@ -68,9 +64,6 @@ func (c ManifoldConfig) Validate() error {
 	if c.Clock == nil {
 		return errors.NotValidf("nil Clock")
 	}
-	if c.NewAPIOpen == nil {
-		return errors.NotValidf("nil NewAPIOpen")
-	}
 	if c.NewBackendFunc == nil {
 		return errors.NotValidf("nil NewBackendFunc")
 	}
@@ -80,7 +73,7 @@ func (c ManifoldConfig) Validate() error {
 // Manifold returns a dependency manifold that runs the logrouter worker.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
-		Inputs: []string{config.AgentName},
+		Inputs: []string{config.AgentName, config.APICallerName},
 		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 			if err := config.Validate(); err != nil {
 				return nil, internalerrors.Capture(err)
@@ -88,6 +81,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 			var a agent.Agent
 			if err := getter.Get(config.AgentName, &a); err != nil {
+				return nil, err
+			}
+			var apiCaller base.APICaller
+			if err := getter.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, err
 			}
 
@@ -99,7 +96,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				Clock:              config.Clock,
 				DrainOnly:          config.DrainOnly,
 				ConvergeTimeout:    defaultConvergeTimeout,
-				NewBackend:         config.NewBackendFunc(a, config.NewAPIOpen, config.HTTPClient, config.Clock),
+				NewBackend:         config.NewBackendFunc(apiCaller, config.HTTPClient, config.Clock),
 			})
 		},
 	}
@@ -107,15 +104,14 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 // NewBackend returns the default backend constructor.
 func NewBackend(
-	agent agent.Agent,
-	open func(context.Context, *api.Info, api.DialOpts) (api.Connection, error),
+	apiCaller base.APICaller,
 	httpClient loki.HTTPClient,
 	clock clock.Clock,
 ) BackendFunc {
 	return func(backendType BackendType, snapshot ConfigSnapshot) (Backend, error) {
 		switch backendType {
 		case BackendTypeLogSink:
-			logSenderAPI := apilogsender.NewAPI(newAgentAPICaller(agent, open))
+			logSenderAPI := apilogsender.NewAPI(apiCaller)
 			return backends.NewLogSink(logSenderAPI, defaultBackendBufferSize)
 
 		case BackendTypeLoki:
@@ -142,115 +138,4 @@ func NewBackend(
 			return nil, errors.NotValidf("unknown logrouter backend type %q", backendType)
 		}
 	}
-}
-
-type agentAPICaller struct {
-	agent  agent.Agent
-	open   func(context.Context, *api.Info, api.DialOpts) (api.Connection, error)
-	mu     sync.Mutex
-	caller base.APICaller
-}
-
-func newAgentAPICaller(
-	agent agent.Agent,
-	open func(context.Context, *api.Info, api.DialOpts) (api.Connection, error),
-) base.APICaller {
-	return &agentAPICaller{
-		agent: agent,
-		open:  open,
-	}
-}
-
-func (c *agentAPICaller) APICall(ctx context.Context, objType string, version int, id, request string, params, response any) error {
-	caller, err := c.apiCaller(ctx)
-	if err != nil {
-		return err
-	}
-	return caller.APICall(ctx, objType, version, id, request, params, response)
-}
-
-func (c *agentAPICaller) BestFacadeVersion(facade string) int {
-	caller := c.currentCaller()
-	if caller == nil {
-		return 0
-	}
-	return caller.BestFacadeVersion(facade)
-}
-
-func (c *agentAPICaller) ModelTag() (names.ModelTag, bool) {
-	caller := c.currentCaller()
-	if caller == nil {
-		return names.ModelTag{}, false
-	}
-	return caller.ModelTag()
-}
-
-func (c *agentAPICaller) HTTPClient(scope base.HTTPClientScope) (*httprequest.Client, error) {
-	caller, err := c.apiCaller(context.Background())
-	if err != nil {
-		return nil, err
-	}
-	return caller.HTTPClient(scope)
-}
-
-func (c *agentAPICaller) SimpleHTTPClient() (base.SimpleHTTPClient, error) {
-	caller, err := c.apiCaller(context.Background())
-	if err != nil {
-		return nil, err
-	}
-	return caller.SimpleHTTPClient()
-}
-
-func (c *agentAPICaller) BakeryClient() base.MacaroonDischarger {
-	caller := c.currentCaller()
-	if caller == nil {
-		return nil
-	}
-	return caller.BakeryClient()
-}
-
-func (c *agentAPICaller) ConnectStream(ctx context.Context, path string, attrs url.Values) (base.Stream, error) {
-	caller, err := c.apiCaller(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return caller.ConnectStream(ctx, path, attrs)
-}
-
-func (c *agentAPICaller) ConnectControllerStream(
-	ctx context.Context,
-	path string,
-	attrs url.Values,
-	headers http.Header,
-) (base.Stream, error) {
-	caller, err := c.apiCaller(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return caller.ConnectControllerStream(ctx, path, attrs, headers)
-}
-
-func (c *agentAPICaller) apiCaller(ctx context.Context) (base.APICaller, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.caller != nil {
-		return c.caller, nil
-	}
-	info, ok := c.agent.CurrentConfig().APIInfo()
-	if !ok {
-		return nil, errors.New("api info not available")
-	}
-	conn, err := c.open(ctx, info, api.DefaultDialOpts())
-	if err != nil {
-		return nil, err
-	}
-	c.caller = conn
-	return c.caller, nil
-}
-
-func (c *agentAPICaller) currentCaller() base.APICaller {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.caller
 }

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -21,10 +21,20 @@ import (
 	"github.com/juju/juju/api/base"
 	apilogsender "github.com/juju/juju/api/logsender"
 	corelogger "github.com/juju/juju/core/logger"
+	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/loki"
 	"github.com/juju/juju/internal/worker/logrouter/backends"
 	"github.com/juju/juju/internal/worker/logsender"
 )
+
+// BackendFuncFactory returns a backend constructor for the supplied agent
+// resources.
+type BackendFuncFactory func(
+	agent.Agent,
+	func(context.Context, *api.Info, api.DialOpts) (api.Connection, error),
+	loki.HTTPClient,
+	clock.Clock,
+) BackendFunc
 
 // ManifoldConfig defines the names of the manifolds used by logrouter.
 type ManifoldConfig struct {
@@ -36,7 +46,34 @@ type ManifoldConfig struct {
 	HTTPClient         loki.HTTPClient
 	DrainOnly          bool
 
-	APIOpen func(context.Context, *api.Info, api.DialOpts) (api.Connection, error)
+	NewAPIOpen     func(context.Context, *api.Info, api.DialOpts) (api.Connection, error)
+	NewBackendFunc BackendFuncFactory
+}
+
+// Validate validates the manifold configuration.
+func (c ManifoldConfig) Validate() error {
+	if c.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if c.LogSource == nil {
+		return errors.NotValidf("nil LogSource")
+	}
+	if c.AgentConfigChanged == nil {
+		return errors.NotValidf("nil AgentConfigChanged")
+	}
+	if c.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if c.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if c.NewAPIOpen == nil {
+		return errors.NotValidf("nil NewAPIOpen")
+	}
+	if c.NewBackendFunc == nil {
+		return errors.NotValidf("nil NewBackendFunc")
+	}
+	return nil
 }
 
 // Manifold returns a dependency manifold that runs the logrouter worker.
@@ -44,12 +81,15 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{config.AgentName},
 		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
+			if err := config.Validate(); err != nil {
+				return nil, internalerrors.Capture(err)
+			}
+
 			var a agent.Agent
 			if err := getter.Get(config.AgentName, &a); err != nil {
 				return nil, err
 			}
 
-			logSenderAPI := apilogsender.NewAPI(newAgentAPICaller(a, config.APIOpen))
 			return NewWorker(WorkerConfig{
 				Agent:              a,
 				LogSource:          config.LogSource,
@@ -58,33 +98,48 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				Clock:              config.Clock,
 				DrainOnly:          config.DrainOnly,
 				ConvergeTimeout:    defaultConvergeTimeout,
-				NewBackend: func(backendType BackendType, snapshot ConfigSnapshot) (Backend, error) {
-					switch backendType {
-					case BackendTypeLogSink:
-						return backends.NewLogSink(logSenderAPI, defaultBackendBufferSize)
-					case BackendTypeLoki:
-						lokiConfig := loki.DefaultConfig()
-						lokiConfig.HTTPClient = config.HTTPClient
-						lokiConfig.Clock = config.Clock
-						return backends.NewLoki(backends.LokiConfig{
-							BackendBufferSize: defaultBackendBufferSize,
-							ClientConfig:      lokiConfig,
-							Endpoint:          snapshot.Endpoint,
-							ControllerUUID:    snapshot.ControllerUUID,
-							ModelUUID:         snapshot.ModelUUID,
-							AgentID:           snapshot.AgentID,
-							NewClient: func(endpoint string, cfg loki.Config) (backends.LokiClient, error) {
-								return loki.NewClient(endpoint, cfg)
-							},
-						})
-					case BackendTypeDrain:
-						return backends.NewDrain(defaultBackendBufferSize)
-					default:
-						return nil, errors.NotValidf("unknown logrouter backend type %q", backendType)
-					}
-				},
+				NewBackend:         config.NewBackendFunc(a, config.NewAPIOpen, config.HTTPClient, config.Clock),
 			})
 		},
+	}
+}
+
+// NewBackend returns the default backend constructor.
+func NewBackend(
+	agent agent.Agent,
+	open func(context.Context, *api.Info, api.DialOpts) (api.Connection, error),
+	httpClient loki.HTTPClient,
+	clock clock.Clock,
+) BackendFunc {
+	return func(backendType BackendType, snapshot ConfigSnapshot) (Backend, error) {
+		switch backendType {
+		case BackendTypeLogSink:
+			logSenderAPI := apilogsender.NewAPI(newAgentAPICaller(agent, open))
+			return backends.NewLogSink(logSenderAPI, defaultBackendBufferSize)
+
+		case BackendTypeLoki:
+			lokiConfig := loki.DefaultConfig()
+			lokiConfig.HTTPClient = httpClient
+			lokiConfig.Clock = clock
+
+			return backends.NewLoki(backends.LokiConfig{
+				BackendBufferSize: defaultBackendBufferSize,
+				ClientConfig:      lokiConfig,
+				Endpoint:          snapshot.Endpoint,
+				ControllerUUID:    snapshot.ControllerUUID,
+				ModelUUID:         snapshot.ModelUUID,
+				AgentID:           snapshot.AgentID,
+				NewClient: func(endpoint string, cfg loki.Config) (backends.LokiClient, error) {
+					return loki.NewClient(endpoint, cfg)
+				},
+			})
+
+		case BackendTypeDrain:
+			return backends.NewDrain(defaultBackendBufferSize)
+
+		default:
+			return nil, errors.NotValidf("unknown logrouter backend type %q", backendType)
+		}
 	}
 }
 

--- a/internal/worker/logrouter/manifold_test.go
+++ b/internal/worker/logrouter/manifold_test.go
@@ -4,7 +4,6 @@
 package logrouter
 
 import (
-	"context"
 	stderrors "errors"
 	"net/http"
 	"sync/atomic"
@@ -15,7 +14,7 @@ import (
 	"github.com/juju/worker/v5/workertest"
 
 	coreagent "github.com/juju/juju/agent"
-	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/base"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/loki"
 )
@@ -28,10 +27,11 @@ func TestManifoldSuite(t *testing.T) {
 
 func (s *manifoldSuite) TestInputs(c *tc.C) {
 	manifold := Manifold(ManifoldConfig{
-		AgentName: "agent",
+		AgentName:     "agent",
+		APICallerName: "api-caller",
 	})
 
-	c.Check(manifold.Inputs, tc.DeepEquals, []string{"agent"})
+	c.Check(manifold.Inputs, tc.DeepEquals, []string{"agent", "api-caller"})
 }
 
 func (s *manifoldSuite) TestValidateAcceptsValidConfig(c *tc.C) {
@@ -61,45 +61,40 @@ func (s *manifoldSuite) TestStartValidatesBeforeGetter(c *tc.C) {
 	c.Check(getterCalled.Load(), tc.IsFalse)
 }
 
-func (s *manifoldSuite) TestStartCreatesWorkerWithoutOpeningAPI(c *tc.C) {
+func (s *manifoldSuite) TestStartCreatesWorkerWithoutUsingAPICaller(c *tc.C) {
 	fixture := newFixture(c, "http://loki/loki/api/v1/push")
-	var apiOpenCalled atomic.Bool
 	cfg := s.validManifoldConfig(c)
-	cfg.NewAPIOpen = func(context.Context, *api.Info, api.DialOpts) (api.Connection, error) {
-		apiOpenCalled.Store(true)
-		return nil, stderrors.New("api should not be opened during start")
-	}
 	manifold := Manifold(cfg)
 
-	w, err := manifold.Start(c.Context(), manifoldGetter{agent: fixture.agent})
+	w, err := manifold.Start(c.Context(), manifoldGetter{
+		agent:     fixture.agent,
+		apiCaller: stubAPICaller{},
+	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
-
-	c.Check(apiOpenCalled.Load(), tc.IsFalse)
 }
 
 func (s *manifoldSuite) validManifoldConfig(c *tc.C) ManifoldConfig {
 	fixture := newFixture(c, "http://loki/loki/api/v1/push")
 	return ManifoldConfig{
 		AgentName:          "agent",
+		APICallerName:      "api-caller",
 		LogSource:          fixture.logs,
 		AgentConfigChanged: fixture.configChanged,
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:              clock.WallClock,
 		HTTPClient:         http.DefaultClient,
-		NewAPIOpen: func(context.Context, *api.Info, api.DialOpts) (api.Connection, error) {
-			return nil, nil
-		},
-		NewBackendFunc: func(coreagent.Agent, func(context.Context, *api.Info, api.DialOpts) (api.Connection, error), loki.HTTPClient, clock.Clock) BackendFunc {
+		NewBackendFunc: func(base.APICaller, loki.HTTPClient, clock.Clock) BackendFunc {
 			return recordingBackendFunc(make(chan backendEvent, 10), defaultBackendBufferSize)
 		},
 	}
 }
 
 type manifoldGetter struct {
-	agent  coreagent.Agent
-	called *atomic.Bool
-	err    error
+	agent     coreagent.Agent
+	apiCaller base.APICaller
+	called    *atomic.Bool
+	err       error
 }
 
 func (g manifoldGetter) Get(_ string, out any) error {
@@ -112,8 +107,14 @@ func (g manifoldGetter) Get(_ string, out any) error {
 	switch out := out.(type) {
 	case *coreagent.Agent:
 		*out = g.agent
+	case *base.APICaller:
+		*out = g.apiCaller
 	default:
 		return stderrors.New("unexpected dependency request")
 	}
 	return nil
+}
+
+type stubAPICaller struct {
+	base.APICaller
 }

--- a/internal/worker/logrouter/manifold_test.go
+++ b/internal/worker/logrouter/manifold_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logrouter
+
+import (
+	"context"
+	stderrors "errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/juju/clock"
+	"github.com/juju/tc"
+	"github.com/juju/worker/v5/workertest"
+
+	coreagent "github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
+	internallogger "github.com/juju/juju/internal/logger"
+)
+
+type manifoldSuite struct{}
+
+func TestManifoldSuite(t *testing.T) {
+	tc.Run(t, &manifoldSuite{})
+}
+
+func (s *manifoldSuite) TestInputs(c *tc.C) {
+	manifold := Manifold(ManifoldConfig{
+		AgentName: "agent",
+	})
+
+	c.Check(manifold.Inputs, tc.DeepEquals, []string{"agent"})
+}
+
+func (s *manifoldSuite) TestStartReturnsGetterError(c *tc.C) {
+	expectErr := stderrors.New("missing agent")
+	manifold := Manifold(ManifoldConfig{
+		AgentName: "agent",
+	})
+
+	w, err := manifold.Start(c.Context(), manifoldGetter{err: expectErr})
+	c.Check(w, tc.IsNil)
+	c.Check(err, tc.ErrorIs, expectErr)
+}
+
+func (s *manifoldSuite) TestStartCreatesWorkerWithoutOpeningAPI(c *tc.C) {
+	fixture := newFixture(c, "http://loki/loki/api/v1/push")
+	var apiOpenCalled atomic.Bool
+	manifold := Manifold(ManifoldConfig{
+		AgentName:          "agent",
+		LogSource:          fixture.logs,
+		AgentConfigChanged: fixture.configChanged,
+		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:              clock.WallClock,
+		APIOpen: func(context.Context, *api.Info, api.DialOpts) (api.Connection, error) {
+			apiOpenCalled.Store(true)
+			return nil, stderrors.New("api should not be opened during start")
+		},
+	})
+
+	w, err := manifold.Start(c.Context(), manifoldGetter{agent: fixture.agent})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	c.Check(apiOpenCalled.Load(), tc.IsFalse)
+}
+
+type manifoldGetter struct {
+	agent coreagent.Agent
+	err   error
+}
+
+func (g manifoldGetter) Get(_ string, out any) error {
+	if g.err != nil {
+		return g.err
+	}
+	switch out := out.(type) {
+	case *coreagent.Agent:
+		*out = g.agent
+	default:
+		return stderrors.New("unexpected dependency request")
+	}
+	return nil
+}

--- a/internal/worker/logrouter/manifold_test.go
+++ b/internal/worker/logrouter/manifold_test.go
@@ -6,6 +6,7 @@ package logrouter
 import (
 	"context"
 	stderrors "errors"
+	"net/http"
 	"sync/atomic"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	internallogger "github.com/juju/juju/internal/logger"
+	"github.com/juju/juju/internal/loki"
 )
 
 type manifoldSuite struct{}
@@ -32,31 +34,42 @@ func (s *manifoldSuite) TestInputs(c *tc.C) {
 	c.Check(manifold.Inputs, tc.DeepEquals, []string{"agent"})
 }
 
+func (s *manifoldSuite) TestValidateAcceptsValidConfig(c *tc.C) {
+	c.Check(s.validManifoldConfig(c).Validate(), tc.ErrorIsNil)
+}
+
 func (s *manifoldSuite) TestStartReturnsGetterError(c *tc.C) {
 	expectErr := stderrors.New("missing agent")
-	manifold := Manifold(ManifoldConfig{
-		AgentName: "agent",
-	})
+	manifold := Manifold(s.validManifoldConfig(c))
 
 	w, err := manifold.Start(c.Context(), manifoldGetter{err: expectErr})
 	c.Check(w, tc.IsNil)
 	c.Check(err, tc.ErrorIs, expectErr)
 }
 
+func (s *manifoldSuite) TestStartValidatesBeforeGetter(c *tc.C) {
+	var getterCalled atomic.Bool
+	manifold := Manifold(ManifoldConfig{})
+
+	w, err := manifold.Start(c.Context(), manifoldGetter{
+		called: &getterCalled,
+		err:    stderrors.New("getter should not be called"),
+	})
+	c.Check(w, tc.IsNil)
+	c.Assert(err, tc.NotNil)
+	c.Check(err.Error(), tc.Equals, `empty AgentName not valid`)
+	c.Check(getterCalled.Load(), tc.IsFalse)
+}
+
 func (s *manifoldSuite) TestStartCreatesWorkerWithoutOpeningAPI(c *tc.C) {
 	fixture := newFixture(c, "http://loki/loki/api/v1/push")
 	var apiOpenCalled atomic.Bool
-	manifold := Manifold(ManifoldConfig{
-		AgentName:          "agent",
-		LogSource:          fixture.logs,
-		AgentConfigChanged: fixture.configChanged,
-		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
-		Clock:              clock.WallClock,
-		APIOpen: func(context.Context, *api.Info, api.DialOpts) (api.Connection, error) {
-			apiOpenCalled.Store(true)
-			return nil, stderrors.New("api should not be opened during start")
-		},
-	})
+	cfg := s.validManifoldConfig(c)
+	cfg.NewAPIOpen = func(context.Context, *api.Info, api.DialOpts) (api.Connection, error) {
+		apiOpenCalled.Store(true)
+		return nil, stderrors.New("api should not be opened during start")
+	}
+	manifold := Manifold(cfg)
 
 	w, err := manifold.Start(c.Context(), manifoldGetter{agent: fixture.agent})
 	c.Assert(err, tc.ErrorIsNil)
@@ -65,12 +78,34 @@ func (s *manifoldSuite) TestStartCreatesWorkerWithoutOpeningAPI(c *tc.C) {
 	c.Check(apiOpenCalled.Load(), tc.IsFalse)
 }
 
+func (s *manifoldSuite) validManifoldConfig(c *tc.C) ManifoldConfig {
+	fixture := newFixture(c, "http://loki/loki/api/v1/push")
+	return ManifoldConfig{
+		AgentName:          "agent",
+		LogSource:          fixture.logs,
+		AgentConfigChanged: fixture.configChanged,
+		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:              clock.WallClock,
+		HTTPClient:         http.DefaultClient,
+		NewAPIOpen: func(context.Context, *api.Info, api.DialOpts) (api.Connection, error) {
+			return nil, nil
+		},
+		NewBackendFunc: func(coreagent.Agent, func(context.Context, *api.Info, api.DialOpts) (api.Connection, error), loki.HTTPClient, clock.Clock) BackendFunc {
+			return recordingBackendFunc(make(chan backendEvent, 10), defaultBackendBufferSize)
+		},
+	}
+}
+
 type manifoldGetter struct {
-	agent coreagent.Agent
-	err   error
+	agent  coreagent.Agent
+	called *atomic.Bool
+	err    error
 }
 
 func (g manifoldGetter) Get(_ string, out any) error {
+	if g.called != nil {
+		g.called.Store(true)
+	}
 	if g.err != nil {
 		return g.err
 	}

--- a/internal/worker/logrouter/worker.go
+++ b/internal/worker/logrouter/worker.go
@@ -28,22 +28,28 @@ const (
 	backendDrainID           = "drain"
 )
 
+// BackendType identifies the active log delivery backend.
 type BackendType string
 
 const (
+	// BackendTypeLogSink forwards records to the controller log sink.
 	BackendTypeLogSink BackendType = "logsink"
-	BackendTypeLoki    BackendType = "loki"
-	BackendTypeDrain   BackendType = "drain-only"
+	// BackendTypeLoki forwards records to a Loki push endpoint.
+	BackendTypeLoki BackendType = "loki"
+	// BackendTypeDrain discards records locally.
+	BackendTypeDrain BackendType = "drain-only"
 )
 
 // Agent describes the agent configuration methods used by the router.
 type Agent interface {
+	// CurrentConfig returns the latest agent configuration snapshot.
 	CurrentConfig() agent.Config
 }
 
 // Backend is a worker that accepts log records.
 type Backend interface {
 	worker.Worker
+	// LogRecords returns the channel used to submit log records.
 	LogRecords() logsender.LogRecordCh
 }
 
@@ -52,6 +58,7 @@ type BackendFunc func(BackendType, ConfigSnapshot) (Backend, error)
 
 // Metrics records logrouter events that are exported elsewhere.
 type Metrics interface {
+	// IncConfigApplyErrors records a backend configuration failure.
 	IncConfigApplyErrors()
 }
 
@@ -334,15 +341,38 @@ func (w *logRouter) send(
 	ctx context.Context,
 	record *logsender.LogRecord,
 ) error {
-	if w.activeBackendID == backendDrainID {
-		return w.dyingError(ctx, sendRecord(ctx, w.drainRecords, record))
+	records, err := w.currentBackendRecords(ctx)
+	if err != nil {
+		return w.dyingError(ctx, internalerrors.Capture(err))
 	}
-	if w.activeRecords != nil {
-		if ok, err := trySendRecord(ctx, w.activeRecords, record); ok || err != nil {
-			return w.dyingError(ctx, err)
-		}
+	if w.activeBackendID == backendDrainID {
+		return w.dyingError(ctx, sendRecord(ctx, records, record))
+	}
+	if ok, err := trySendRecord(ctx, records, record); ok || err != nil {
+		return w.dyingError(ctx, err)
 	}
 	return w.dyingError(ctx, sendRecord(ctx, w.drainRecords, record))
+}
+
+func (w *logRouter) currentBackendRecords(
+	ctx context.Context,
+) (logsender.LogRecordCh, error) {
+	if w.activeBackendID == backendDrainID {
+		return w.drainRecords, nil
+	}
+
+	backend, err := w.runner.Worker(w.activeBackendID, ctx.Done())
+	if err != nil {
+		return nil, err
+	}
+	recordBackend, ok := backend.(Backend)
+	if !ok {
+		return nil, errors.NotValidf("logrouter backend %q", w.activeBackendID)
+	}
+
+	records := recordBackend.LogRecords()
+	w.activeRecords = records
+	return records, nil
 }
 
 func (w *logRouter) dyingError(ctx context.Context, err error) error {

--- a/internal/worker/logrouter/worker.go
+++ b/internal/worker/logrouter/worker.go
@@ -1,0 +1,448 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logrouter
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/utils/v4/voyeur"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/catacomb"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/agent"
+	corelogger "github.com/juju/juju/core/logger"
+	internalworker "github.com/juju/juju/internal/worker"
+	"github.com/juju/juju/internal/worker/logsender"
+)
+
+const (
+	defaultBackendBufferSize = 1000
+	defaultConvergeTimeout   = time.Second * 60
+	backendDrainID           = "drain"
+)
+
+type mode string
+
+const (
+	modeLogSink   mode = "logsink"
+	modeLoki      mode = "loki"
+	modeDrainOnly mode = "drain-only"
+)
+
+// Agent describes the agent configuration methods used by the router.
+type Agent interface {
+	CurrentConfig() agent.Config
+}
+
+// Backend is a worker that accepts log records.
+type Backend interface {
+	worker.Worker
+	LogRecords() logsender.LogRecordCh
+}
+
+// BackendFactory constructs a backend worker.
+type BackendFactory func(ConfigSnapshot) (Backend, error)
+
+// Metrics records logrouter events that are exported elsewhere.
+type Metrics interface {
+	IncConfigApplyErrors()
+}
+
+// WorkerConfig contains logrouter worker configuration.
+type WorkerConfig struct {
+	Agent              Agent
+	LogSource          logsender.LogRecordCh
+	AgentConfigChanged *voyeur.Value
+	Logger             corelogger.Logger
+	Clock              clock.Clock
+	Metrics            Metrics
+
+	DrainOnly       bool
+	ConvergeTimeout time.Duration
+
+	NewLogSinkBackend BackendFactory
+	NewLokiBackend    BackendFactory
+	NewDrainBackend   BackendFactory
+}
+
+// ConfigSnapshot is the local logging destination configuration.
+type ConfigSnapshot struct {
+	Mode           mode
+	Endpoint       string
+	CACertificate  string
+	ControllerUUID string
+	ModelUUID      string
+	AgentID        string
+}
+
+func (s ConfigSnapshot) sameBackend(other ConfigSnapshot) bool {
+	if s.Mode == modeDrainOnly && other.Mode == modeDrainOnly {
+		return true
+	}
+	return s.Mode == other.Mode &&
+		s.Endpoint == other.Endpoint &&
+		s.CACertificate == other.CACertificate
+}
+
+// Validate checks that the worker configuration is usable.
+func (c *WorkerConfig) Validate() error {
+	if c.Agent == nil {
+		return errors.NotValidf("nil Agent")
+	}
+	if c.LogSource == nil {
+		return errors.NotValidf("nil LogSource")
+	}
+	if c.AgentConfigChanged == nil {
+		return errors.NotValidf("nil AgentConfigChanged")
+	}
+	if c.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if c.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if c.ConvergeTimeout <= 0 {
+		return errors.NotValidf("non-positive ConvergeTimeout")
+	}
+	if c.NewLogSinkBackend == nil {
+		return errors.NotValidf("nil NewLogSinkBackend")
+	}
+	if c.NewLokiBackend == nil {
+		return errors.NotValidf("nil NewLokiBackend")
+	}
+	if c.NewDrainBackend == nil {
+		return errors.NotValidf("nil NewDrainBackend")
+	}
+	return nil
+}
+
+// NewWorker returns a logrouter worker.
+func NewWorker(config WorkerConfig) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	runner, err := worker.NewRunner(worker.RunnerParams{
+		Name:  "log-router",
+		Clock: config.Clock,
+		IsFatal: func(err error) bool {
+			return false
+		},
+		ShouldRestart: internalworker.ShouldRunnerRestart,
+		RestartDelay:  time.Second,
+		Logger:        internalworker.WrapLogger(config.Logger),
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	w := &logRouter{
+		config:        config,
+		runner:        runner,
+		configChanges: make(chan struct{}),
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Name: "log-router",
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{
+			w.runner,
+		},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+type logRouter struct {
+	catacomb catacomb.Catacomb
+
+	runner        *worker.Runner
+	config        WorkerConfig
+	configChanges chan struct{}
+	backendSeq    int
+
+	activeBackendID string
+	activeSnapshot  ConfigSnapshot
+	activeRecords   logsender.LogRecordCh
+	drainRecords    logsender.LogRecordCh
+}
+
+// Kill stops the worker.
+func (w *logRouter) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait blocks until the worker exits.
+func (w *logRouter) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *logRouter) loop() error {
+	ctx, cancel := context.WithCancel(w.catacomb.Context(context.Background()))
+	defer cancel()
+
+	watcher := newConfigWatcherWorker(
+		w.config.AgentConfigChanged,
+		w.configChanges,
+	)
+	if err := w.catacomb.Add(watcher); err != nil {
+		return errors.Trace(err)
+	}
+
+	drainSnapshot := ConfigSnapshot{Mode: modeDrainOnly}
+	drainRecords, err := w.startBackend(ctx, backendDrainID, drainSnapshot)
+	if err != nil {
+		return w.dyingError(ctx, errors.Trace(err))
+	}
+	w.drainRecords = drainRecords
+	w.activeBackendID = backendDrainID
+	w.activeSnapshot = drainSnapshot
+	w.activeRecords = drainRecords
+
+	next := w.currentSnapshot()
+	if !next.sameBackend(w.activeSnapshot) {
+		err = w.switchBackend(ctx, next)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+
+		case rec, ok := <-w.config.LogSource:
+			if !ok {
+				return nil
+			}
+			next := w.currentSnapshot()
+			if !next.sameBackend(w.activeSnapshot) {
+				err = w.switchBackend(ctx, next)
+				if err != nil {
+					return errors.Trace(err)
+				}
+			}
+			if err := w.send(ctx, rec); err != nil {
+				return errors.Trace(err)
+			}
+
+		case <-w.configChanges:
+			next := w.currentSnapshot()
+			if next.sameBackend(w.activeSnapshot) {
+				continue
+			}
+			err = w.switchBackend(ctx, next)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+}
+
+func (w *logRouter) switchBackend(
+	ctx context.Context,
+	next ConfigSnapshot,
+) error {
+	if w.activeBackendID != "" && w.activeBackendID != backendDrainID {
+		w.stopBackend(w.activeBackendID)
+	}
+
+	if next.Mode == modeDrainOnly {
+		w.activeBackendID = backendDrainID
+		w.activeSnapshot = next
+		w.activeRecords = w.drainRecords
+		return nil
+	}
+
+	convergeCtx, cancel := context.WithTimeout(ctx, w.config.ConvergeTimeout)
+	defer cancel()
+
+	backendID := w.nextBackendID()
+	records, err := w.startBackend(convergeCtx, backendID, next)
+	if err != nil {
+		if ctx.Err() != nil {
+			return w.dyingError(ctx, err)
+		}
+
+		w.warnConfigApply(ctx, next, err)
+		w.activeBackendID = backendDrainID
+		w.activeSnapshot = next
+		w.activeRecords = w.drainRecords
+		return nil
+	}
+
+	w.activeBackendID = backendID
+	w.activeSnapshot = next
+	w.activeRecords = records
+	return nil
+}
+
+func (w *logRouter) nextBackendID() string {
+	w.backendSeq++
+	return "backend-" + strconv.Itoa(w.backendSeq)
+}
+
+func (w *logRouter) currentSnapshot() ConfigSnapshot {
+	cfg := w.config.Agent.CurrentConfig()
+	snapshot := ConfigSnapshot{
+		Endpoint:       cfg.LokiEndpoint(),
+		CACertificate:  cfg.LokiCACert(),
+		ControllerUUID: cfg.Controller().Id(),
+		ModelUUID:      cfg.Model().Id(),
+		AgentID:        cfg.Tag().String(),
+	}
+	switch {
+	case w.config.DrainOnly:
+		snapshot.Mode = modeDrainOnly
+	case snapshot.Endpoint != "":
+		snapshot.Mode = modeLoki
+	default:
+		snapshot.Mode = modeLogSink
+	}
+	return snapshot
+}
+
+func (w *logRouter) startBackend(ctx context.Context, id string, snapshot ConfigSnapshot) (logsender.LogRecordCh, error) {
+	err := w.runner.StartWorker(ctx, id, func(context.Context) (worker.Worker, error) {
+		return w.newBackend(snapshot)
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	backend, err := w.runner.Worker(id, ctx.Done())
+	if err != nil {
+		_ = w.runner.StopWorker(id)
+		return nil, errors.Trace(err)
+	}
+
+	recordBackend, ok := backend.(Backend)
+	if !ok {
+		_ = w.runner.StopWorker(id)
+		return nil, errors.NotValidf("logrouter backend %q", id)
+	}
+
+	return recordBackend.LogRecords(), nil
+}
+
+func (w *logRouter) newBackend(snapshot ConfigSnapshot) (Backend, error) {
+	switch snapshot.Mode {
+	case modeLogSink:
+		return w.config.NewLogSinkBackend(snapshot)
+	case modeLoki:
+		return w.config.NewLokiBackend(snapshot)
+	case modeDrainOnly:
+		return w.config.NewDrainBackend(snapshot)
+	default:
+		return nil, errors.NotValidf("unknown logrouter mode %q", snapshot.Mode)
+	}
+}
+
+func (w *logRouter) send(
+	ctx context.Context,
+	record *logsender.LogRecord,
+) error {
+	if w.activeBackendID == backendDrainID {
+		return w.dyingError(ctx, sendRecord(ctx, w.drainRecords, record))
+	}
+	if w.activeRecords != nil {
+		if ok, err := trySendRecord(ctx, w.activeRecords, record); ok || err != nil {
+			return w.dyingError(ctx, err)
+		}
+	}
+	return w.dyingError(ctx, sendRecord(ctx, w.drainRecords, record))
+}
+
+func (w *logRouter) dyingError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return w.catacomb.ErrDying()
+	default:
+		return err
+	}
+}
+
+func (w *logRouter) warnConfigApply(ctx context.Context, snapshot ConfigSnapshot, err error) {
+	w.config.Logger.Warningf(
+		ctx,
+		"failed to apply log router config for %q within %s: %v",
+		snapshot.Mode, w.config.ConvergeTimeout, err,
+	)
+	if w.config.Metrics != nil {
+		w.config.Metrics.IncConfigApplyErrors()
+	}
+}
+
+func trySendRecord(ctx context.Context, records logsender.LogRecordCh, record *logsender.LogRecord) (bool, error) {
+	select {
+	case records <- record:
+		return true, nil
+	case <-ctx.Done():
+		return false, worker.ErrDead
+	default:
+		return false, nil
+	}
+}
+
+func sendRecord(ctx context.Context, records logsender.LogRecordCh, record *logsender.LogRecord) error {
+	select {
+	case records <- record:
+	case <-ctx.Done():
+		return worker.ErrDead
+	}
+	return nil
+}
+
+func (w *logRouter) stopBackend(id string) {
+	_ = w.runner.StopWorker(id)
+}
+
+type configWatcherWorker struct {
+	tomb    tomb.Tomb
+	watch   *voyeur.Watcher
+	changes chan<- struct{}
+}
+
+func newConfigWatcherWorker(value *voyeur.Value, changes chan<- struct{}) worker.Worker {
+	w := &configWatcherWorker{
+		watch:   value.Watch(),
+		changes: changes,
+	}
+	w.tomb.Go(w.loop)
+	return w
+}
+
+func (w *configWatcherWorker) Kill() {
+	w.watch.Close()
+	w.tomb.Kill(nil)
+}
+
+func (w *configWatcherWorker) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *configWatcherWorker) loop() error {
+	defer w.watch.Close()
+	for {
+		if !w.watch.Next() {
+			return nil
+		}
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+
+		case w.changes <- struct{}{}:
+		}
+	}
+}

--- a/internal/worker/logrouter/worker.go
+++ b/internal/worker/logrouter/worker.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	corelogger "github.com/juju/juju/core/logger"
+	internalerrors "github.com/juju/juju/internal/errors"
 	internalworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/logsender"
 )
@@ -117,7 +118,7 @@ func (c *WorkerConfig) Validate() error {
 // NewWorker returns a logrouter worker.
 func NewWorker(config WorkerConfig) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 
 	runner, err := worker.NewRunner(worker.RunnerParams{
@@ -131,7 +132,7 @@ func NewWorker(config WorkerConfig) (worker.Worker, error) {
 		Logger:        internalworker.WrapLogger(config.Logger),
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 
 	w := &logRouter{
@@ -147,7 +148,7 @@ func NewWorker(config WorkerConfig) (worker.Worker, error) {
 			w.runner,
 		},
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 	return w, nil
 }
@@ -185,13 +186,13 @@ func (w *logRouter) loop() error {
 		w.configChanges,
 	)
 	if err := w.catacomb.Add(watcher); err != nil {
-		return errors.Trace(err)
+		return internalerrors.Capture(err)
 	}
 
 	drainSnapshot := ConfigSnapshot{Mode: BackendTypeDrain}
 	drainRecords, err := w.startBackend(ctx, backendDrainID, drainSnapshot)
 	if err != nil {
-		return w.dyingError(ctx, errors.Trace(err))
+		return w.dyingError(ctx, internalerrors.Capture(err))
 	}
 	w.drainRecords = drainRecords
 	w.activeBackendID = backendDrainID
@@ -202,7 +203,7 @@ func (w *logRouter) loop() error {
 	if !next.sameBackend(w.activeSnapshot) {
 		err = w.switchBackend(ctx, next)
 		if err != nil {
-			return errors.Trace(err)
+			return internalerrors.Capture(err)
 		}
 	}
 
@@ -219,11 +220,11 @@ func (w *logRouter) loop() error {
 			if !next.sameBackend(w.activeSnapshot) {
 				err = w.switchBackend(ctx, next)
 				if err != nil {
-					return errors.Trace(err)
+					return internalerrors.Capture(err)
 				}
 			}
 			if err := w.send(ctx, rec); err != nil {
-				return errors.Trace(err)
+				return internalerrors.Capture(err)
 			}
 
 		case <-w.configChanges:
@@ -233,7 +234,7 @@ func (w *logRouter) loop() error {
 			}
 			err = w.switchBackend(ctx, next)
 			if err != nil {
-				return errors.Trace(err)
+				return internalerrors.Capture(err)
 			}
 		}
 	}
@@ -307,13 +308,13 @@ func (w *logRouter) startBackend(ctx context.Context, id string, snapshot Config
 		return w.newBackend(snapshot)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 
 	backend, err := w.runner.Worker(id, ctx.Done())
 	if err != nil {
 		_ = w.runner.StopWorker(id)
-		return nil, errors.Trace(err)
+		return nil, internalerrors.Capture(err)
 	}
 
 	recordBackend, ok := backend.(Backend)

--- a/internal/worker/logrouter/worker.go
+++ b/internal/worker/logrouter/worker.go
@@ -25,6 +25,7 @@ import (
 const (
 	defaultBackendBufferSize = 1000
 	defaultConvergeTimeout   = time.Second * 60
+	defaultRestartDelay      = time.Second * 1
 	backendDrainID           = "drain"
 )
 
@@ -73,6 +74,7 @@ type WorkerConfig struct {
 
 	DrainOnly       bool
 	ConvergeTimeout time.Duration
+	RestartDelay    time.Duration
 
 	NewBackend BackendFunc
 }
@@ -135,7 +137,7 @@ func NewWorker(config WorkerConfig) (worker.Worker, error) {
 			return false
 		},
 		ShouldRestart: internalworker.ShouldRunnerRestart,
-		RestartDelay:  time.Second,
+		RestartDelay:  config.RestartDelay,
 		Logger:        internalworker.WrapLogger(config.Logger),
 	})
 	if err != nil {

--- a/internal/worker/logrouter/worker.go
+++ b/internal/worker/logrouter/worker.go
@@ -27,12 +27,12 @@ const (
 	backendDrainID           = "drain"
 )
 
-type mode string
+type BackendType string
 
 const (
-	modeLogSink   mode = "logsink"
-	modeLoki      mode = "loki"
-	modeDrainOnly mode = "drain-only"
+	BackendTypeLogSink BackendType = "logsink"
+	BackendTypeLoki    BackendType = "loki"
+	BackendTypeDrain   BackendType = "drain-only"
 )
 
 // Agent describes the agent configuration methods used by the router.
@@ -46,8 +46,8 @@ type Backend interface {
 	LogRecords() logsender.LogRecordCh
 }
 
-// BackendFactory constructs a backend worker.
-type BackendFactory func(ConfigSnapshot) (Backend, error)
+// BackendFunc constructs a backend worker.
+type BackendFunc func(BackendType, ConfigSnapshot) (Backend, error)
 
 // Metrics records logrouter events that are exported elsewhere.
 type Metrics interface {
@@ -66,14 +66,12 @@ type WorkerConfig struct {
 	DrainOnly       bool
 	ConvergeTimeout time.Duration
 
-	NewLogSinkBackend BackendFactory
-	NewLokiBackend    BackendFactory
-	NewDrainBackend   BackendFactory
+	NewBackend BackendFunc
 }
 
 // ConfigSnapshot is the local logging destination configuration.
 type ConfigSnapshot struct {
-	Mode           mode
+	Mode           BackendType
 	Endpoint       string
 	CACertificate  string
 	ControllerUUID string
@@ -82,7 +80,7 @@ type ConfigSnapshot struct {
 }
 
 func (s ConfigSnapshot) sameBackend(other ConfigSnapshot) bool {
-	if s.Mode == modeDrainOnly && other.Mode == modeDrainOnly {
+	if s.Mode == BackendTypeDrain && other.Mode == BackendTypeDrain {
 		return true
 	}
 	return s.Mode == other.Mode &&
@@ -110,14 +108,8 @@ func (c *WorkerConfig) Validate() error {
 	if c.ConvergeTimeout <= 0 {
 		return errors.NotValidf("non-positive ConvergeTimeout")
 	}
-	if c.NewLogSinkBackend == nil {
-		return errors.NotValidf("nil NewLogSinkBackend")
-	}
-	if c.NewLokiBackend == nil {
-		return errors.NotValidf("nil NewLokiBackend")
-	}
-	if c.NewDrainBackend == nil {
-		return errors.NotValidf("nil NewDrainBackend")
+	if c.NewBackend == nil {
+		return errors.NotValidf("nil NewBackend")
 	}
 	return nil
 }
@@ -196,7 +188,7 @@ func (w *logRouter) loop() error {
 		return errors.Trace(err)
 	}
 
-	drainSnapshot := ConfigSnapshot{Mode: modeDrainOnly}
+	drainSnapshot := ConfigSnapshot{Mode: BackendTypeDrain}
 	drainRecords, err := w.startBackend(ctx, backendDrainID, drainSnapshot)
 	if err != nil {
 		return w.dyingError(ctx, errors.Trace(err))
@@ -255,7 +247,7 @@ func (w *logRouter) switchBackend(
 		w.stopBackend(w.activeBackendID)
 	}
 
-	if next.Mode == modeDrainOnly {
+	if next.Mode == BackendTypeDrain {
 		w.activeBackendID = backendDrainID
 		w.activeSnapshot = next
 		w.activeRecords = w.drainRecords
@@ -301,11 +293,11 @@ func (w *logRouter) currentSnapshot() ConfigSnapshot {
 	}
 	switch {
 	case w.config.DrainOnly:
-		snapshot.Mode = modeDrainOnly
+		snapshot.Mode = BackendTypeDrain
 	case snapshot.Endpoint != "":
-		snapshot.Mode = modeLoki
+		snapshot.Mode = BackendTypeLoki
 	default:
-		snapshot.Mode = modeLogSink
+		snapshot.Mode = BackendTypeLogSink
 	}
 	return snapshot
 }
@@ -334,16 +326,7 @@ func (w *logRouter) startBackend(ctx context.Context, id string, snapshot Config
 }
 
 func (w *logRouter) newBackend(snapshot ConfigSnapshot) (Backend, error) {
-	switch snapshot.Mode {
-	case modeLogSink:
-		return w.config.NewLogSinkBackend(snapshot)
-	case modeLoki:
-		return w.config.NewLokiBackend(snapshot)
-	case modeDrainOnly:
-		return w.config.NewDrainBackend(snapshot)
-	default:
-		return nil, errors.NotValidf("unknown logrouter mode %q", snapshot.Mode)
-	}
+	return w.config.NewBackend(snapshot.Mode, snapshot)
 }
 
 func (w *logRouter) send(

--- a/internal/worker/logrouter/worker_test.go
+++ b/internal/worker/logrouter/worker_test.go
@@ -40,9 +40,7 @@ func (s *workerSuite) TestStartsLogSinkWhenLokiEndpointEmpty(c *tc.C) {
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:              clock.WallClock,
 		ConvergeTimeout:    defaultConvergeTimeout,
-		NewLogSinkBackend:  recordingBackendFactory("logsink", events, defaultBackendBufferSize),
-		NewLokiBackend:     recordingBackendFactory("loki", events, defaultBackendBufferSize),
-		NewDrainBackend:    recordingBackendFactory("drain-only", events, defaultBackendBufferSize),
+		NewBackend:         recordingBackendFunc(events, defaultBackendBufferSize),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -67,9 +65,7 @@ func (s *workerSuite) TestSwitchStopsOldBackendAndStartsNew(c *tc.C) {
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:              clock.WallClock,
 		ConvergeTimeout:    defaultConvergeTimeout,
-		NewLogSinkBackend:  recordingBackendFactory("logsink", events, defaultBackendBufferSize),
-		NewLokiBackend:     recordingBackendFactory("loki", events, defaultBackendBufferSize),
-		NewDrainBackend:    recordingBackendFactory("drain-only", events, defaultBackendBufferSize),
+		NewBackend:         recordingBackendFunc(events, defaultBackendBufferSize),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -112,9 +108,7 @@ func (s *workerSuite) TestDrainOnlyOverridesEndpoint(c *tc.C) {
 		Clock:              clock.WallClock,
 		DrainOnly:          true,
 		ConvergeTimeout:    defaultConvergeTimeout,
-		NewLogSinkBackend:  recordingBackendFactory("logsink", events, defaultBackendBufferSize),
-		NewLokiBackend:     recordingBackendFactory("loki", events, defaultBackendBufferSize),
-		NewDrainBackend:    recordingBackendFactory("drain-only", events, defaultBackendBufferSize),
+		NewBackend:         recordingBackendFunc(events, defaultBackendBufferSize),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -136,9 +130,7 @@ func (s *workerSuite) TestBackendFailureFallsBackToDrain(c *tc.C) {
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:              clock.WallClock,
 		ConvergeTimeout:    defaultConvergeTimeout,
-		NewLogSinkBackend:  failingBackendFactory("logsink", events, 1),
-		NewLokiBackend:     recordingBackendFactory("loki", events, defaultBackendBufferSize),
-		NewDrainBackend:    recordingBackendFactory("drain-only", events, defaultBackendBufferSize),
+		NewBackend:         failingLogSinkBackendFunc(events),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -182,9 +174,7 @@ func (s *workerSuite) TestBackendStartErrorFallsBackToDrain(c *tc.C) {
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:              clock.WallClock,
 		ConvergeTimeout:    time.Millisecond * 10,
-		NewLogSinkBackend:  errorBackendFactory("logsink", events),
-		NewLokiBackend:     recordingBackendFactory("loki", events, defaultBackendBufferSize),
-		NewDrainBackend:    recordingBackendFactory("drain-only", events, defaultBackendBufferSize),
+		NewBackend:         errorLogSinkBackendFunc(events),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -276,25 +266,21 @@ type backendEvent struct {
 	message string
 }
 
-func recordingBackendFactory(name string, events chan<- backendEvent, backendBufferSize int) BackendFactory {
-	return func(ConfigSnapshot) (Backend, error) {
-		w := &recordingBackend{
-			name:    name,
-			records: make(logsender.LogRecordCh, backendBufferSize),
-			events:  events,
-		}
-		events <- backendEvent{backend: name, kind: "start"}
-		w.tomb.Go(w.loop)
-		return w, nil
+func recordingBackendFunc(events chan<- backendEvent, backendBufferSize int) BackendFunc {
+	return func(backendType BackendType, _ ConfigSnapshot) (Backend, error) {
+		return newRecordingBackend(string(backendType), events, backendBufferSize), nil
 	}
 }
 
-func failingBackendFactory(name string, events chan<- backendEvent, backendBufferSize int) BackendFactory {
-	return func(ConfigSnapshot) (Backend, error) {
-		w := &failingBackend{
-			records: make(logsender.LogRecordCh, backendBufferSize),
+func failingLogSinkBackendFunc(events chan<- backendEvent) BackendFunc {
+	return func(backendType BackendType, _ ConfigSnapshot) (Backend, error) {
+		if backendType != BackendTypeLogSink {
+			return newRecordingBackend(string(backendType), events, defaultBackendBufferSize), nil
 		}
-		events <- backendEvent{backend: name, kind: "start"}
+		w := &failingBackend{
+			records: make(logsender.LogRecordCh, 1),
+		}
+		events <- backendEvent{backend: string(backendType), kind: "start"}
 		w.tomb.Go(func() error {
 			return stderrors.New("backend failed")
 		})
@@ -302,11 +288,25 @@ func failingBackendFactory(name string, events chan<- backendEvent, backendBuffe
 	}
 }
 
-func errorBackendFactory(name string, events chan<- backendEvent) BackendFactory {
-	return func(ConfigSnapshot) (Backend, error) {
-		events <- backendEvent{backend: name, kind: "start"}
+func errorLogSinkBackendFunc(events chan<- backendEvent) BackendFunc {
+	return func(backendType BackendType, _ ConfigSnapshot) (Backend, error) {
+		if backendType != BackendTypeLogSink {
+			return newRecordingBackend(string(backendType), events, defaultBackendBufferSize), nil
+		}
+		events <- backendEvent{backend: string(backendType), kind: "start"}
 		return nil, stderrors.New("backend start failed")
 	}
+}
+
+func newRecordingBackend(name string, events chan<- backendEvent, backendBufferSize int) *recordingBackend {
+	w := &recordingBackend{
+		name:    name,
+		records: make(logsender.LogRecordCh, backendBufferSize),
+		events:  events,
+	}
+	events <- backendEvent{backend: name, kind: "start"}
+	w.tomb.Go(w.loop)
+	return w
 }
 
 type failingBackend struct {

--- a/internal/worker/logrouter/worker_test.go
+++ b/internal/worker/logrouter/worker_test.go
@@ -5,6 +5,7 @@ package logrouter
 
 import (
 	stderrors "errors"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -207,6 +208,59 @@ func (s *workerSuite) TestBackendStartErrorFallsBackToDrain(c *tc.C) {
 	})
 }
 
+func (s *workerSuite) TestBackendRestartRefreshesActiveChannel(c *tc.C) {
+	fixture := newFixture(c, "")
+	events := make(chan backendEvent, 20)
+
+	w, err := NewWorker(WorkerConfig{
+		Agent:              fixture.agent,
+		LogSource:          fixture.logs,
+		AgentConfigChanged: fixture.configChanged,
+		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:              clock.WallClock,
+		ConvergeTimeout:    defaultConvergeTimeout,
+		NewBackend:         restartingLogSinkBackendFunc(events),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	waitForEvents(c, events, backendEvent{
+		backend: "drain-only",
+		kind:    "start",
+	}, backendEvent{
+		backend: "logsink-1",
+		kind:    "start",
+	})
+
+	fixture.logs <- &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test",
+		Level:   loggo.INFO,
+		Message: "first",
+	}
+	c.Check(waitForRecord(c, events, "logsink-1", "first"), tc.DeepEquals, backendEvent{
+		backend: "logsink-1",
+		kind:    "record",
+		message: "first",
+	})
+	waitForEvents(c, events, backendEvent{
+		backend: "logsink-2",
+		kind:    "start",
+	})
+
+	fixture.logs <- &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test",
+		Level:   loggo.INFO,
+		Message: "second",
+	}
+	c.Check(waitForRecord(c, events, "logsink-2", "second"), tc.DeepEquals, backendEvent{
+		backend: "logsink-2",
+		kind:    "record",
+		message: "second",
+	})
+}
+
 type fixture struct {
 	agent         *testAgent
 	logs          logsender.LogRecordCh
@@ -298,6 +352,17 @@ func errorLogSinkBackendFunc(events chan<- backendEvent) BackendFunc {
 	}
 }
 
+func restartingLogSinkBackendFunc(events chan<- backendEvent) BackendFunc {
+	var instance int
+	return func(backendType BackendType, _ ConfigSnapshot) (Backend, error) {
+		if backendType != BackendTypeLogSink {
+			return newRecordingBackend(string(backendType), events, defaultBackendBufferSize), nil
+		}
+		instance++
+		return newRestartingBackend(instance, events), nil
+	}
+}
+
 func newRecordingBackend(name string, events chan<- backendEvent, backendBufferSize int) *recordingBackend {
 	w := &recordingBackend{
 		name:    name,
@@ -367,6 +432,69 @@ func (w *recordingBackend) loop() error {
 }
 
 func (w *recordingBackend) reportStop() {
+	w.stopOnce.Do(func() {
+		w.events <- backendEvent{backend: w.name, kind: "stop"}
+	})
+}
+
+type restartingBackend struct {
+	tomb     tomb.Tomb
+	name     string
+	records  logsender.LogRecordCh
+	events   chan<- backendEvent
+	failOnce bool
+	stopOnce sync.Once
+}
+
+func newRestartingBackend(instance int, events chan<- backendEvent) *restartingBackend {
+	w := &restartingBackend{
+		name:     "logsink-" + strconv.Itoa(instance),
+		records:  make(logsender.LogRecordCh, 1),
+		events:   events,
+		failOnce: instance == 1,
+	}
+	events <- backendEvent{backend: w.name, kind: "start"}
+	w.tomb.Go(w.loop)
+	return w
+}
+
+func (w *restartingBackend) Kill() {
+	w.reportStop()
+	w.tomb.Kill(nil)
+}
+
+func (w *restartingBackend) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *restartingBackend) LogRecords() logsender.LogRecordCh {
+	return w.records
+}
+
+func (w *restartingBackend) loop() error {
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case rec, ok := <-w.records:
+			if !ok {
+				w.reportStop()
+				return nil
+			}
+			w.events <- backendEvent{
+				backend: w.name,
+				kind:    "record",
+				message: rec.Message,
+			}
+			if w.failOnce {
+				w.reportStop()
+				return stderrors.New("backend failed")
+			}
+		}
+	}
+}
+
+func (w *restartingBackend) reportStop() {
 	w.stopOnce.Do(func() {
 		w.events <- backendEvent{backend: w.name, kind: "stop"}
 	})

--- a/internal/worker/logrouter/worker_test.go
+++ b/internal/worker/logrouter/worker_test.go
@@ -1,0 +1,401 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package logrouter
+
+import (
+	stderrors "errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/loggo/v3"
+	"github.com/juju/names/v6"
+	"github.com/juju/tc"
+	"github.com/juju/utils/v4/voyeur"
+	"github.com/juju/worker/v5/workertest"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/core/semversion"
+	internallogger "github.com/juju/juju/internal/logger"
+	"github.com/juju/juju/internal/worker/logsender"
+)
+
+type workerSuite struct{}
+
+func TestWorkerSuite(t *testing.T) {
+	tc.Run(t, &workerSuite{})
+}
+
+func (s *workerSuite) TestStartsLogSinkWhenLokiEndpointEmpty(c *tc.C) {
+	fixture := newFixture(c, "")
+	events := make(chan backendEvent, 10)
+
+	w, err := NewWorker(WorkerConfig{
+		Agent:              fixture.agent,
+		LogSource:          fixture.logs,
+		AgentConfigChanged: fixture.configChanged,
+		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:              clock.WallClock,
+		ConvergeTimeout:    defaultConvergeTimeout,
+		NewLogSinkBackend:  recordingBackendFactory("logsink", events, defaultBackendBufferSize),
+		NewLokiBackend:     recordingBackendFactory("loki", events, defaultBackendBufferSize),
+		NewDrainBackend:    recordingBackendFactory("drain-only", events, defaultBackendBufferSize),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	waitForEvents(c, events, backendEvent{
+		backend: "drain-only",
+		kind:    "start",
+	}, backendEvent{
+		backend: "logsink",
+		kind:    "start",
+	})
+}
+
+func (s *workerSuite) TestSwitchStopsOldBackendAndStartsNew(c *tc.C) {
+	fixture := newFixture(c, "")
+	events := make(chan backendEvent, 20)
+
+	w, err := NewWorker(WorkerConfig{
+		Agent:              fixture.agent,
+		LogSource:          fixture.logs,
+		AgentConfigChanged: fixture.configChanged,
+		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:              clock.WallClock,
+		ConvergeTimeout:    defaultConvergeTimeout,
+		NewLogSinkBackend:  recordingBackendFactory("logsink", events, defaultBackendBufferSize),
+		NewLokiBackend:     recordingBackendFactory("loki", events, defaultBackendBufferSize),
+		NewDrainBackend:    recordingBackendFactory("drain-only", events, defaultBackendBufferSize),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	waitForEvents(c, events, backendEvent{
+		backend: "drain-only",
+		kind:    "start",
+	}, backendEvent{
+		backend: "logsink",
+		kind:    "start",
+	})
+
+	fixture.agent.setLokiConfig("http://loki/loki/api/v1/push", "")
+	fixture.configChanged.Set(true)
+
+	fixture.logs <- &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test",
+		Level:   loggo.INFO,
+		Message: "routed",
+	}
+	waitForEvents(c, events, backendEvent{
+		backend: "logsink",
+		kind:    "stop",
+	}, backendEvent{
+		backend: "loki",
+		kind:    "start",
+	})
+}
+
+func (s *workerSuite) TestDrainOnlyOverridesEndpoint(c *tc.C) {
+	fixture := newFixture(c, "http://loki/loki/api/v1/push")
+	events := make(chan backendEvent, 10)
+
+	w, err := NewWorker(WorkerConfig{
+		Agent:              fixture.agent,
+		LogSource:          fixture.logs,
+		AgentConfigChanged: fixture.configChanged,
+		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:              clock.WallClock,
+		DrainOnly:          true,
+		ConvergeTimeout:    defaultConvergeTimeout,
+		NewLogSinkBackend:  recordingBackendFactory("logsink", events, defaultBackendBufferSize),
+		NewLokiBackend:     recordingBackendFactory("loki", events, defaultBackendBufferSize),
+		NewDrainBackend:    recordingBackendFactory("drain-only", events, defaultBackendBufferSize),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	waitForEvents(c, events, backendEvent{
+		backend: "drain-only",
+		kind:    "start",
+	})
+}
+
+func (s *workerSuite) TestBackendFailureFallsBackToDrain(c *tc.C) {
+	fixture := newFixture(c, "")
+	events := make(chan backendEvent, 20)
+
+	w, err := NewWorker(WorkerConfig{
+		Agent:              fixture.agent,
+		LogSource:          fixture.logs,
+		AgentConfigChanged: fixture.configChanged,
+		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:              clock.WallClock,
+		ConvergeTimeout:    defaultConvergeTimeout,
+		NewLogSinkBackend:  failingBackendFactory("logsink", events, 1),
+		NewLokiBackend:     recordingBackendFactory("loki", events, defaultBackendBufferSize),
+		NewDrainBackend:    recordingBackendFactory("drain-only", events, defaultBackendBufferSize),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	waitForEvents(c, events, backendEvent{
+		backend: "drain-only",
+		kind:    "start",
+	}, backendEvent{
+		backend: "logsink",
+		kind:    "start",
+	})
+
+	fixture.logs <- &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test",
+		Level:   loggo.INFO,
+		Message: "buffered",
+	}
+	fixture.logs <- &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test",
+		Level:   loggo.INFO,
+		Message: "fallback",
+	}
+
+	c.Check(waitForRecord(c, events, "drain-only", "fallback"), tc.DeepEquals, backendEvent{
+		backend: "drain-only",
+		kind:    "record",
+		message: "fallback",
+	})
+}
+
+func (s *workerSuite) TestBackendStartErrorFallsBackToDrain(c *tc.C) {
+	fixture := newFixture(c, "")
+	events := make(chan backendEvent, 20)
+
+	w, err := NewWorker(WorkerConfig{
+		Agent:              fixture.agent,
+		LogSource:          fixture.logs,
+		AgentConfigChanged: fixture.configChanged,
+		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:              clock.WallClock,
+		ConvergeTimeout:    time.Millisecond * 10,
+		NewLogSinkBackend:  errorBackendFactory("logsink", events),
+		NewLokiBackend:     recordingBackendFactory("loki", events, defaultBackendBufferSize),
+		NewDrainBackend:    recordingBackendFactory("drain-only", events, defaultBackendBufferSize),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	waitForEvents(c, events, backendEvent{
+		backend: "drain-only",
+		kind:    "start",
+	}, backendEvent{
+		backend: "logsink",
+		kind:    "start",
+	})
+
+	fixture.logs <- &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test",
+		Level:   loggo.INFO,
+		Message: "buffered",
+	}
+	fixture.logs <- &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test",
+		Level:   loggo.INFO,
+		Message: "fallback",
+	}
+
+	c.Check(waitForRecord(c, events, "drain-only", "fallback"), tc.DeepEquals, backendEvent{
+		backend: "drain-only",
+		kind:    "record",
+		message: "fallback",
+	})
+}
+
+type fixture struct {
+	agent         *testAgent
+	logs          logsender.LogRecordCh
+	configChanged *voyeur.Value
+}
+
+func newFixture(c *tc.C, lokiEndpoint string) fixture {
+	cfg, err := agent.NewAgentConfig(agent.AgentConfigParams{
+		Paths: agent.Paths{
+			DataDir: c.MkDir(),
+		},
+		Tag:               names.NewMachineTag("0"),
+		UpgradedToVersion: semversion.MustParse("4.0.0"),
+		Password:          "password",
+		CACert:            "ca cert",
+		APIAddresses:      []string{"127.0.0.1:17070"},
+		Controller:        names.NewControllerTag("01234567-89ab-cdef-0123-456789abcdef"),
+		Model:             names.NewModelTag("abcdef01-2345-6789-abcd-ef0123456789"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	cfg.SetLokiConfig(lokiEndpoint, "")
+	return fixture{
+		agent: &testAgent{
+			cfg: cfg,
+		},
+		logs:          make(logsender.LogRecordCh),
+		configChanged: voyeur.NewValue(false),
+	}
+}
+
+type testAgent struct {
+	mu  sync.Mutex
+	cfg agent.ConfigSetterWriter
+}
+
+func (a *testAgent) CurrentConfig() agent.Config {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.cfg.Clone()
+}
+
+func (a *testAgent) ChangeConfig(change agent.ConfigMutator) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return change(a.cfg)
+}
+
+func (a *testAgent) setLokiConfig(endpoint, caCert string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.cfg.SetLokiConfig(endpoint, caCert)
+}
+
+type backendEvent struct {
+	backend string
+	kind    string
+	message string
+}
+
+func recordingBackendFactory(name string, events chan<- backendEvent, backendBufferSize int) BackendFactory {
+	return func(ConfigSnapshot) (Backend, error) {
+		w := &recordingBackend{
+			name:    name,
+			records: make(logsender.LogRecordCh, backendBufferSize),
+			events:  events,
+		}
+		events <- backendEvent{backend: name, kind: "start"}
+		w.tomb.Go(w.loop)
+		return w, nil
+	}
+}
+
+func failingBackendFactory(name string, events chan<- backendEvent, backendBufferSize int) BackendFactory {
+	return func(ConfigSnapshot) (Backend, error) {
+		w := &failingBackend{
+			records: make(logsender.LogRecordCh, backendBufferSize),
+		}
+		events <- backendEvent{backend: name, kind: "start"}
+		w.tomb.Go(func() error {
+			return stderrors.New("backend failed")
+		})
+		return w, nil
+	}
+}
+
+func errorBackendFactory(name string, events chan<- backendEvent) BackendFactory {
+	return func(ConfigSnapshot) (Backend, error) {
+		events <- backendEvent{backend: name, kind: "start"}
+		return nil, stderrors.New("backend start failed")
+	}
+}
+
+type failingBackend struct {
+	tomb    tomb.Tomb
+	records logsender.LogRecordCh
+}
+
+func (w *failingBackend) Kill() {
+	w.tomb.Kill(nil)
+}
+
+func (w *failingBackend) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *failingBackend) LogRecords() logsender.LogRecordCh {
+	return w.records
+}
+
+type recordingBackend struct {
+	tomb     tomb.Tomb
+	name     string
+	records  logsender.LogRecordCh
+	events   chan<- backendEvent
+	stopOnce sync.Once
+}
+
+func (w *recordingBackend) Kill() {
+	w.reportStop()
+	w.tomb.Kill(nil)
+}
+
+func (w *recordingBackend) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *recordingBackend) LogRecords() logsender.LogRecordCh {
+	return w.records
+}
+
+func (w *recordingBackend) loop() error {
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		case rec, ok := <-w.records:
+			if !ok {
+				w.reportStop()
+				return nil
+			}
+			w.events <- backendEvent{
+				backend: w.name,
+				kind:    "record",
+				message: rec.Message,
+			}
+		}
+	}
+}
+
+func (w *recordingBackend) reportStop() {
+	w.stopOnce.Do(func() {
+		w.events <- backendEvent{backend: w.name, kind: "stop"}
+	})
+}
+
+func waitForEvents(c *tc.C, events <-chan backendEvent, expected ...backendEvent) {
+	pending := make(map[backendEvent]struct{}, len(expected))
+	for _, event := range expected {
+		pending[event] = struct{}{}
+	}
+	for len(pending) > 0 {
+		select {
+		case event := <-events:
+			delete(pending, event)
+		case <-c.Context().Done():
+			c.Fatalf("timed out waiting for backend events: %#v", pending)
+		}
+	}
+}
+
+func waitForRecord(c *tc.C, events <-chan backendEvent, backend, message string) backendEvent {
+	for {
+		select {
+		case event := <-events:
+			if event.backend == backend && event.kind == "record" && event.message == message {
+				return event
+			}
+		case <-c.Context().Done():
+			c.Fatalf("timed out waiting for %s record %q", backend, message)
+		}
+	}
+}

--- a/internal/worker/logrouter/worker_test.go
+++ b/internal/worker/logrouter/worker_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/semversion"
 	internallogger "github.com/juju/juju/internal/logger"
+	internaltesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/logsender"
 )
 
@@ -41,6 +42,7 @@ func (s *workerSuite) TestStartsLogSinkWhenLokiEndpointEmpty(c *tc.C) {
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:              clock.WallClock,
 		ConvergeTimeout:    defaultConvergeTimeout,
+		RestartDelay:       time.Millisecond * 10,
 		NewBackend:         recordingBackendFunc(events, defaultBackendBufferSize),
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -66,6 +68,7 @@ func (s *workerSuite) TestSwitchStopsOldBackendAndStartsNew(c *tc.C) {
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:              clock.WallClock,
 		ConvergeTimeout:    defaultConvergeTimeout,
+		RestartDelay:       time.Millisecond * 10,
 		NewBackend:         recordingBackendFunc(events, defaultBackendBufferSize),
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -82,12 +85,12 @@ func (s *workerSuite) TestSwitchStopsOldBackendAndStartsNew(c *tc.C) {
 	fixture.agent.setLokiConfig("http://loki/loki/api/v1/push", "")
 	fixture.configChanged.Set(true)
 
-	fixture.logs <- &logsender.LogRecord{
+	sendLog(c, fixture.logs, &logsender.LogRecord{
 		Time:    time.Now(),
 		Module:  "test",
 		Level:   loggo.INFO,
 		Message: "routed",
-	}
+	})
 	waitForEvents(c, events, backendEvent{
 		backend: "logsink",
 		kind:    "stop",
@@ -109,6 +112,7 @@ func (s *workerSuite) TestDrainOnlyOverridesEndpoint(c *tc.C) {
 		Clock:              clock.WallClock,
 		DrainOnly:          true,
 		ConvergeTimeout:    defaultConvergeTimeout,
+		RestartDelay:       time.Millisecond * 10,
 		NewBackend:         recordingBackendFunc(events, defaultBackendBufferSize),
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -131,6 +135,7 @@ func (s *workerSuite) TestBackendFailureFallsBackToDrain(c *tc.C) {
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:              clock.WallClock,
 		ConvergeTimeout:    defaultConvergeTimeout,
+		RestartDelay:       time.Millisecond * 10,
 		NewBackend:         failingLogSinkBackendFunc(events),
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -144,18 +149,18 @@ func (s *workerSuite) TestBackendFailureFallsBackToDrain(c *tc.C) {
 		kind:    "start",
 	})
 
-	fixture.logs <- &logsender.LogRecord{
+	sendLog(c, fixture.logs, &logsender.LogRecord{
 		Time:    time.Now(),
 		Module:  "test",
 		Level:   loggo.INFO,
 		Message: "buffered",
-	}
-	fixture.logs <- &logsender.LogRecord{
+	})
+	sendLog(c, fixture.logs, &logsender.LogRecord{
 		Time:    time.Now(),
 		Module:  "test",
 		Level:   loggo.INFO,
 		Message: "fallback",
-	}
+	})
 
 	c.Check(waitForRecord(c, events, "drain-only", "fallback"), tc.DeepEquals, backendEvent{
 		backend: "drain-only",
@@ -175,6 +180,7 @@ func (s *workerSuite) TestBackendStartErrorFallsBackToDrain(c *tc.C) {
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:              clock.WallClock,
 		ConvergeTimeout:    time.Millisecond * 10,
+		RestartDelay:       time.Millisecond * 10,
 		NewBackend:         errorLogSinkBackendFunc(events),
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -188,18 +194,18 @@ func (s *workerSuite) TestBackendStartErrorFallsBackToDrain(c *tc.C) {
 		kind:    "start",
 	})
 
-	fixture.logs <- &logsender.LogRecord{
+	sendLog(c, fixture.logs, &logsender.LogRecord{
 		Time:    time.Now(),
 		Module:  "test",
 		Level:   loggo.INFO,
 		Message: "buffered",
-	}
-	fixture.logs <- &logsender.LogRecord{
+	})
+	sendLog(c, fixture.logs, &logsender.LogRecord{
 		Time:    time.Now(),
 		Module:  "test",
 		Level:   loggo.INFO,
 		Message: "fallback",
-	}
+	})
 
 	c.Check(waitForRecord(c, events, "drain-only", "fallback"), tc.DeepEquals, backendEvent{
 		backend: "drain-only",
@@ -219,6 +225,7 @@ func (s *workerSuite) TestBackendRestartRefreshesActiveChannel(c *tc.C) {
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:              clock.WallClock,
 		ConvergeTimeout:    defaultConvergeTimeout,
+		RestartDelay:       time.Millisecond * 10,
 		NewBackend:         restartingLogSinkBackendFunc(events),
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -231,34 +238,53 @@ func (s *workerSuite) TestBackendRestartRefreshesActiveChannel(c *tc.C) {
 		backend: "logsink-1",
 		kind:    "start",
 	})
-
-	fixture.logs <- &logsender.LogRecord{
+	sendLog(c, fixture.logs, &logsender.LogRecord{
 		Time:    time.Now(),
 		Module:  "test",
 		Level:   loggo.INFO,
 		Message: "first",
-	}
+	})
 	c.Check(waitForRecord(c, events, "logsink-1", "first"), tc.DeepEquals, backendEvent{
 		backend: "logsink-1",
 		kind:    "record",
 		message: "first",
 	})
+
+	// Wait for the failed backend to stop. The restarted backend's "start"
+	// event is emitted when logrouter resolves its LogRecords channel, which
+	// only happens when we send the next record.
 	waitForEvents(c, events, backendEvent{
-		backend: "logsink-2",
-		kind:    "start",
+		backend: "logsink-1",
+		kind:    "stop",
 	})
 
-	fixture.logs <- &logsender.LogRecord{
-		Time:    time.Now(),
-		Module:  "test",
-		Level:   loggo.INFO,
-		Message: "second",
+	// This loop is necessary because the restarted backend may not be ready to
+	// receive the log record immediately after the previous backend has
+	// stopped. The restarted backend's LogRecords channel is only resolved when
+	// logrouter switches to it, which happens when we send the next record.
+
+	// Ideally, we would use a channel in the runner to know when the backend
+	// has been restarted and is ready to receive records, but since we don't
+	// have that, we will retry sending the log record until we get a response
+	// from the restarted backend.
+	for a := internaltesting.LongAttempt.Start(); a.Next(); {
+		sendLog(c, fixture.logs, &logsender.LogRecord{
+			Time:    time.Now(),
+			Module:  "test",
+			Level:   loggo.INFO,
+			Message: "second",
+		})
+
+		if event, ok := waitForRecordWithin(c, events, "logsink-2", "second", time.Millisecond*100); ok {
+			c.Check(event, tc.DeepEquals, backendEvent{
+				backend: "logsink-2",
+				kind:    "record",
+				message: "second",
+			})
+			return
+		}
 	}
-	c.Check(waitForRecord(c, events, "logsink-2", "second"), tc.DeepEquals, backendEvent{
-		backend: "logsink-2",
-		kind:    "record",
-		message: "second",
-	})
+	c.Fatalf("timed out waiting for logsink-2 record %q", "second")
 }
 
 type fixture struct {
@@ -286,7 +312,7 @@ func newFixture(c *tc.C, lokiEndpoint string) fixture {
 		agent: &testAgent{
 			cfg: cfg,
 		},
-		logs:          make(logsender.LogRecordCh),
+		logs:          make(logsender.LogRecordCh, 1),
 		configChanged: voyeur.NewValue(false),
 	}
 }
@@ -374,23 +400,6 @@ func newRecordingBackend(name string, events chan<- backendEvent, backendBufferS
 	return w
 }
 
-type failingBackend struct {
-	tomb    tomb.Tomb
-	records logsender.LogRecordCh
-}
-
-func (w *failingBackend) Kill() {
-	w.tomb.Kill(nil)
-}
-
-func (w *failingBackend) Wait() error {
-	return w.tomb.Wait()
-}
-
-func (w *failingBackend) LogRecords() logsender.LogRecordCh {
-	return w.records
-}
-
 type recordingBackend struct {
 	tomb     tomb.Tomb
 	name     string
@@ -437,13 +446,31 @@ func (w *recordingBackend) reportStop() {
 	})
 }
 
+type failingBackend struct {
+	tomb    tomb.Tomb
+	records logsender.LogRecordCh
+}
+
+func (w *failingBackend) Kill() {
+	w.tomb.Kill(nil)
+}
+
+func (w *failingBackend) Wait() error {
+	return w.tomb.Wait()
+}
+
+func (w *failingBackend) LogRecords() logsender.LogRecordCh {
+	return w.records
+}
+
 type restartingBackend struct {
-	tomb     tomb.Tomb
-	name     string
-	records  logsender.LogRecordCh
-	events   chan<- backendEvent
-	failOnce bool
-	stopOnce sync.Once
+	tomb      tomb.Tomb
+	name      string
+	records   logsender.LogRecordCh
+	events    chan<- backendEvent
+	failOnce  bool
+	startOnce sync.Once
+	stopOnce  sync.Once
 }
 
 func newRestartingBackend(instance int, events chan<- backendEvent) *restartingBackend {
@@ -453,7 +480,6 @@ func newRestartingBackend(instance int, events chan<- backendEvent) *restartingB
 		events:   events,
 		failOnce: instance == 1,
 	}
-	events <- backendEvent{backend: w.name, kind: "start"}
 	w.tomb.Go(w.loop)
 	return w
 }
@@ -468,6 +494,7 @@ func (w *restartingBackend) Wait() error {
 }
 
 func (w *restartingBackend) LogRecords() logsender.LogRecordCh {
+	w.reportStart()
 	return w.records
 }
 
@@ -500,6 +527,12 @@ func (w *restartingBackend) reportStop() {
 	})
 }
 
+func (w *restartingBackend) reportStart() {
+	w.startOnce.Do(func() {
+		w.events <- backendEvent{backend: w.name, kind: "start"}
+	})
+}
+
 func waitForEvents(c *tc.C, events <-chan backendEvent, expected ...backendEvent) {
 	pending := make(map[backendEvent]struct{}, len(expected))
 	for _, event := range expected {
@@ -525,5 +558,36 @@ func waitForRecord(c *tc.C, events <-chan backendEvent, backend, message string)
 		case <-c.Context().Done():
 			c.Fatalf("timed out waiting for %s record %q", backend, message)
 		}
+	}
+}
+
+func waitForRecordWithin(
+	c *tc.C,
+	events <-chan backendEvent,
+	backend, message string,
+	timeout time.Duration,
+) (backendEvent, bool) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case event := <-events:
+			if event.backend == backend && event.kind == "record" && event.message == message {
+				return event, true
+			}
+		case <-timer.C:
+			return backendEvent{}, false
+		case <-c.Context().Done():
+			c.Fatalf("timed out waiting for %s record %q", backend, message)
+		}
+	}
+}
+
+func sendLog(c *tc.C, logs logsender.LogRecordCh, record *logsender.LogRecord) {
+	select {
+	case logs <- record:
+	case <-c.Context().Done():
+		c.Fatalf("timed out sending log record %q", record.Message)
 	}
 }

--- a/internal/worker/logsender/worker.go
+++ b/internal/worker/logsender/worker.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo/v3"
 	"github.com/juju/worker/v5"
-	"github.com/juju/worker/v5/dependency"
 
 	"github.com/juju/juju/api/logsender"
 	jworker "github.com/juju/juju/internal/worker"
@@ -32,43 +33,7 @@ type LogSenderAPI interface {
 // a channel and sends them to the controller via the logsink API.
 func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 	loop := func(ctx context.Context) error {
-		// It has been observed that sometimes the logsender.API gets wedged
-		// attempting to get the LogWriter while the agent is being torn down,
-		// and the call to logSenderAPI.LogWriter() doesn't return. This stops
-		// the logsender worker from shutting down, and causes the entire
-		// agent to get wedged. To mitigate this, we get the LogWriter in a
-		// different goroutine allowing the worker to interrupt this.
-		sender := make(chan logsender.LogWriter)
-		errChan := make(chan error)
-		go func() {
-			logWriter, err := logSenderAPI.LogWriter(ctx)
-			if err != nil {
-				select {
-				case errChan <- err:
-				case <-ctx.Done():
-				}
-				return
-			}
-			select {
-			case sender <- logWriter:
-			case <-ctx.Done():
-				logWriter.Close()
-			}
-		}()
 		var logWriter logsender.LogWriter
-		var err error
-		select {
-		case logWriter = <-sender:
-		case err = <-errChan:
-			if isLogSinkUnavailableError(err) {
-				return discardRemoteLogsUntilDone(ctx, logs)
-			}
-			return errors.Annotate(err, "logsender dial failed")
-		case <-ctx.Done():
-			return nil
-		}
-		// the logwriter has been successfully retrieved from the inside
-		// goroutine and its lifecycle is now handled in the loop function.
 		closeLogWriter := func() {
 			if logWriter != nil {
 				_ = logWriter.Close()
@@ -76,83 +41,129 @@ func New(logs LogRecordCh, logSenderAPI LogSenderAPI) worker.Worker {
 			}
 		}
 		defer closeLogWriter()
+
+		var pending *LogRecord
 		for {
-			select {
-			case rec, ok := <-logs:
-				if !ok {
+			if logWriter == nil {
+				var err error
+				logWriter, err = openLogWriter(ctx, logSenderAPI)
+				if err != nil {
+					if isRetryableLogSenderError(err) {
+						if err := waitRetry(ctx); err != nil {
+							return nil
+						}
+						continue
+					}
+					return errors.Annotate(err, "logsender dial failed")
+				}
+			}
+
+			rec := pending
+			if rec == nil {
+				var ok bool
+				select {
+				case rec, ok = <-logs:
+					if !ok {
+						return nil
+					}
+				case <-ctx.Done():
 					return nil
 				}
-				err := logWriter.WriteLog(&params.LogRecord{
-					Time:     rec.Time,
-					Module:   rec.Module,
-					Location: rec.Location,
-					Level:    rec.Level.String(),
-					Message:  rec.Message,
-					Labels:   rec.Labels,
-				})
-				if err != nil {
-					if isLogSinkUnavailableError(err) {
-						closeLogWriter()
-						return discardRemoteLogsUntilDone(ctx, logs)
-					}
-					if errors.Is(err, io.EOF) {
-						return dependency.ErrBounce
-					}
-					return errors.Trace(err)
-				}
-				if rec.DroppedAfter > 0 {
-					// If messages were dropped after this one, report
-					// the count (the source of the log messages -
-					// BufferedLogWriter - handles the actual dropping
-					// and counting).
-					//
-					// Any logs indicated as dropped here are will
-					// never end up in the logs DB in the JES
-					// (although will still be in the local agent log
-					// file). Message dropping by the
-					// BufferedLogWriter is last resort protection
-					// against memory exhaustion and should only
-					// happen if API connectivity is lost for extended
-					// periods. The maximum in-memory log buffer is
-					// quite large (see the InstallBufferedLogWriter
-					// call in jujuDMain).
-					err := logWriter.WriteLog(&params.LogRecord{
-						Time:    rec.Time,
-						Module:  loggerName,
-						Level:   loggo.WARNING.String(),
-						Message: fmt.Sprintf("%d log messages dropped due to lack of API connectivity", rec.DroppedAfter),
-					})
-					if err != nil {
-						if isLogSinkUnavailableError(err) {
-							closeLogWriter()
-							return discardRemoteLogsUntilDone(ctx, logs)
-						}
-						if errors.Is(err, io.EOF) {
-							return dependency.ErrBounce
-						}
-						return errors.Trace(err)
-					}
-				}
-
-			case <-ctx.Done():
-				return nil
 			}
+
+			err := writeLogRecord(logWriter, rec)
+			if err == nil && rec.DroppedAfter > 0 {
+				err = writeDroppedLogRecord(logWriter, rec)
+			}
+			if err != nil {
+				if isRetryableLogSenderError(err) {
+					closeLogWriter()
+					pending = rec
+					if err := waitRetry(ctx); err != nil {
+						return nil
+					}
+					continue
+				}
+				return errors.Trace(err)
+			}
+			pending = nil
 		}
 	}
 	return jworker.NewSimpleWorker(loop)
 }
 
-// discardRemoteLogsUntilDone drains remote log records after /logsink reports
-// that it is unavailable. Local file logging is handled separately by loggo.
-func discardRemoteLogsUntilDone(ctx context.Context, logs LogRecordCh) error {
-	for {
-		select {
-		case _, ok := <-logs:
-			if !ok {
-				return nil
+func openLogWriter(ctx context.Context, logSenderAPI LogSenderAPI) (logsender.LogWriter, error) {
+	// It has been observed that sometimes the logsender.API gets wedged
+	// attempting to get the LogWriter while the agent is being torn down,
+	// and the call to logSenderAPI.LogWriter() doesn't return. This stops
+	// the logsender worker from shutting down, and causes the entire agent to
+	// get wedged. To mitigate this, we get the LogWriter in a different
+	// goroutine allowing the worker to interrupt this.
+	sender := make(chan logsender.LogWriter)
+	errChan := make(chan error)
+	go func() {
+		logWriter, err := logSenderAPI.LogWriter(ctx)
+		if err != nil {
+			select {
+			case errChan <- err:
+			case <-ctx.Done():
 			}
-		case <-ctx.Done():
-			return nil
+			return
 		}
+		select {
+		case sender <- logWriter:
+		case <-ctx.Done():
+			logWriter.Close()
+		}
+	}()
+	select {
+	case logWriter := <-sender:
+		return logWriter, nil
+	case err := <-errChan:
+		return nil, err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func writeLogRecord(logWriter logsender.LogWriter, rec *LogRecord) error {
+	return logWriter.WriteLog(&params.LogRecord{
+		Time:     rec.Time,
+		Module:   rec.Module,
+		Location: rec.Location,
+		Level:    rec.Level.String(),
+		Message:  rec.Message,
+		Labels:   rec.Labels,
+	})
+}
+
+func writeDroppedLogRecord(logWriter logsender.LogWriter, rec *LogRecord) error {
+	return logWriter.WriteLog(&params.LogRecord{
+		Time:    rec.Time,
+		Module:  loggerName,
+		Level:   loggo.WARNING.String(),
+		Message: fmt.Sprintf("%d log messages dropped due to lack of API connectivity", rec.DroppedAfter),
+	})
+}
+
+func isRetryableLogSenderError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return isLogSinkUnavailableError(err) ||
+		errors.Is(err, io.EOF) ||
+		strings.Contains(err.Error(), "api caller disconnected") ||
+		strings.Contains(err.Error(), "use of closed network connection") ||
+		strings.Contains(err.Error(), "write")
+}
+
+func waitRetry(ctx context.Context) error {
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }

--- a/internal/worker/logsender/worker_test.go
+++ b/internal/worker/logsender/worker_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo/v3"
 	"github.com/juju/tc"
-	"github.com/juju/worker/v5/dependency"
 	"github.com/juju/worker/v5/workertest"
 
 	"github.com/juju/juju/api"
@@ -28,7 +27,6 @@ import (
 	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/logsender"
-	"github.com/juju/juju/internal/worker/logsender/logsendertest"
 	"github.com/juju/juju/internal/worker/logsender/mocks"
 	"github.com/juju/juju/rpc/params"
 )
@@ -197,30 +195,28 @@ func (s *workerSuite) TestLogSinkUnavailableDrainsRemoteLogs(c *tc.C) {
 	w := logsender.New(logsCh, logSenderAPI)
 	defer workertest.CleanKill(c, w)
 
-	sendLog(c, logsCh, "one")
-	sendLog(c, logsCh, "two")
 	workertest.CheckAlive(c, w)
 }
 
-func (s *workerSuite) TestDisconnectedAPICallerTerminatesWorker(c *tc.C) {
+func (s *workerSuite) TestDisconnectedAPICallerRetries(c *tc.C) {
 	logsCh := make(logsender.LogRecordCh)
 	logSenderAPI := logsenderAPI{
 		err: stderrors.New("api caller disconnected"),
 	}
 
 	w := logsender.New(logsCh, logSenderAPI)
-	err := w.Wait()
-	c.Assert(err, tc.ErrorMatches, "logsender dial failed: api caller disconnected")
+	defer workertest.CleanKill(c, w)
+	workertest.CheckAlive(c, w)
 }
 
-func (s *workerSuite) TestWriteLogFailureTerminatesWorker(c *tc.C) {
+func (s *workerSuite) TestWriteLogFailureRetries(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
 	logsCh := make(logsender.LogRecordCh, 1)
 	writer := mocks.NewMockLogWriter(ctrl)
-	writer.EXPECT().WriteLog(gomock.Any()).Return(stderrors.New("write failed"))
-	writer.EXPECT().Close()
+	writer.EXPECT().WriteLog(gomock.Any()).Return(stderrors.New("write failed")).AnyTimes()
+	writer.EXPECT().Close().AnyTimes()
 
 	logsCh <- &logsender.LogRecord{
 		Time:     time.Now(),
@@ -231,8 +227,8 @@ func (s *workerSuite) TestWriteLogFailureTerminatesWorker(c *tc.C) {
 	}
 
 	w := logsender.New(logsCh, logsenderAPI{writer: writer})
-	err := w.Wait()
-	c.Assert(err, tc.ErrorMatches, "write failed")
+	defer workertest.CleanKill(c, w)
+	workertest.CheckAlive(c, w)
 }
 
 func (s *workerSuite) TestWriteLogServiceUnavailableDrainsRemoteLogs(c *tc.C) {
@@ -251,7 +247,6 @@ func (s *workerSuite) TestWriteLogServiceUnavailableDrainsRemoteLogs(c *tc.C) {
 	defer workertest.CleanKill(c, w)
 
 	sendLog(c, logsCh, "one")
-	sendLog(c, logsCh, "two")
 	workertest.CheckAlive(c, w)
 }
 
@@ -269,22 +264,6 @@ func (s *workerSuite) TestLogSinkUnavailableDrainsBufferedLogs(c *tc.C) {
 	w := logsender.New(bufferedLogger.Logs(), logSenderAPI)
 	defer workertest.CleanKill(c, w)
 
-	for i := range 5 {
-		err := bufferedLogger.Write(c.Context(), loggo.Entry{
-			Level:     loggo.INFO,
-			Module:    "test",
-			Filename:  "test.go",
-			Line:      i,
-			Timestamp: time.Now(),
-			Message:   fmt.Sprintf("message%d", i),
-		})
-		c.Assert(err, tc.ErrorIsNil)
-	}
-
-	logsendertest.ExpectLogStats(c, bufferedLogger, logsender.LogStats{
-		Enqueued: 5,
-		Sent:     5,
-	})
 	workertest.CheckAlive(c, w)
 }
 
@@ -361,7 +340,7 @@ func (s *mockStream) Close() error {
 	return nil
 }
 
-func (s *workerBounceSuite) TestWriteLogEOFReturnsBounce(c *tc.C) {
+func (s *workerBounceSuite) TestWriteLogEOFRetries(c *tc.C) {
 	stream := &mockStream{
 		c:              c,
 		succeedNWrites: 0,
@@ -379,11 +358,11 @@ func (s *workerBounceSuite) TestWriteLogEOFReturnsBounce(c *tc.C) {
 	}
 
 	w := logsender.New(logsCh, logSenderAPI)
-	err := w.Wait()
-	c.Assert(err, tc.Equals, dependency.ErrBounce)
+	defer workertest.CleanKill(c, w)
+	workertest.CheckAlive(c, w)
 }
 
-func (s *workerBounceSuite) TestDroppedLogWriteEOFReturnsBounce(c *tc.C) {
+func (s *workerBounceSuite) TestDroppedLogWriteEOFRetries(c *tc.C) {
 	stream := &mockStream{
 		c:              c,
 		succeedNWrites: 1,
@@ -403,6 +382,6 @@ func (s *workerBounceSuite) TestDroppedLogWriteEOFReturnsBounce(c *tc.C) {
 	}
 
 	w := logsender.New(logsCh, logSenderAPI)
-	err := w.Wait()
-	c.Assert(err, tc.Equals, dependency.ErrBounce)
+	defer workertest.CleanKill(c, w)
+	workertest.CheckAlive(c, w)
 }


### PR DESCRIPTION
Juju agents currently send remote logs directly to the controller logsink. That gives us only one delivery path and makes logging fragile when the API/logsink path is unavailable or when we want to route logs somewhere else, such as Loki. Logging should not be able to take an agent down, and operators need a way to
  send agent logs to Loki with useful Juju topology and trace context.

  This change introduces a log router between the agent log source and the concrete log destination. The router can switch between controller logsink, Loki, and a drain backend based on agent config. The drain backend is important because it gives the agent somewhere safe to send records even when the configured
  backend cannot be used, avoiding backpressure or failures in the logging path from destabilising the agent.

This is still using the `http.DefaultClient`, so custom CA certificates won't work yet. That will be a follow up PR.


## QA steps

Test pass.

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9978](https://warthogs.atlassian.net/browse/JUJU-9978)


[JUJU-9978]: https://warthogs.atlassian.net/browse/JUJU-9978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ