### PR TITLE
feat: prevent 4.0 -> 4.0 migrations

### DIFF
--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -829,8 +829,10 @@ func (c *ControllerAPI) runMigrationPrechecks(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// Check target controller.
-	modelInfo, srcUserList, err := makeModelInfo(ctx,
+	// Check target controller. We only need the source user list here; the
+	// model info that used to feed the legacy target precheck is no longer sent
+	// (target prechecks now run in the migrationmaster worker via the envelope).
+	_, srcUserList, err := makeModelInfo(ctx,
 		c.controllerConfigService, c.modelService, modelAgentService, c.store, model)
 	if err != nil {
 		return errors.Trace(err)
@@ -869,8 +871,15 @@ func (c *ControllerAPI) runMigrationPrechecks(
 		}
 	}
 
-	err = client.Prechecks(ctx, modelInfo)
-	return errors.Annotate(err, "target prechecks failed")
+	// The full envelope-based target prechecks run in the migrationmaster
+	// worker during QUIESCE (it owns the SerializedModelV2 envelope assembly).
+	// Here we only reject early, at "juju migrate" time, when the target is too
+	// old to accept the new migration envelope at all (for example a 4.0 target
+	// targeted by a 4.0 source).
+	return errors.Annotate(
+		migration.CheckTargetSupportsEnvelope(client.BestFacadeVersion()),
+		"target prechecks failed",
+	)
 }
 
 // userList encapsulates information about the users who have been granted

--- a/internal/migration/precheck.go
+++ b/internal/migration/precheck.go
@@ -27,6 +27,25 @@ import (
 	"github.com/juju/juju/internal/upgrades/upgradevalidation"
 )
 
+// MinTargetEnvelopeFacadeVersion is the first migrationtarget facade version
+// able to accept the SerializedModelV2 envelope used by the model migration
+// path. It lands in Juju 4.1; 4.0 targets only advertise up to v7.
+const MinTargetEnvelopeFacadeVersion = 8
+
+// CheckTargetSupportsEnvelope hard-errors when the target controller does not
+// advertise a migrationtarget facade new enough to accept the SerializedModelV2
+// envelope. There is no fallback to a legacy path for the new migration path, so
+// a too-old target (for example a 4.0 controller targeted by a 4.0 source) is
+// rejected with a clear, actionable error.
+func CheckTargetSupportsEnvelope(bestFacadeVersion int) error {
+	if bestFacadeVersion < MinTargetEnvelopeFacadeVersion {
+		return errors.New("target controller does not support the model " +
+			"migration format; upgrade the target controller to " +
+			"Juju 4.1 or later")
+	}
+	return nil
+}
+
 // SourcePrecheck checks the state of the source controller to make
 // sure that the preconditions for model migration are met. The
 // backend provided must be for the model to be migrated.

--- a/internal/migration/precheck_test.go
+++ b/internal/migration/precheck_test.go
@@ -1020,3 +1020,24 @@ func (s *TargetPrecheckSuite) TestUUIDAlreadyExistsButImporting(c *tc.C) {
 	err := s.runPrecheck(c)
 	c.Assert(err, tc.ErrorIsNil)
 }
+
+func TestCheckTargetSupportsEnvelope(t *stdtesting.T) {
+	tc.Run(t, &checkTargetSupportsEnvelopeSuite{})
+}
+
+type checkTargetSupportsEnvelopeSuite struct{}
+
+func (s *checkTargetSupportsEnvelopeSuite) TestTargetNotRecentEnough(c *tc.C) {
+	// A target advertising a facade older than the envelope version (for
+	// example a 4.0 controller, which tops out at v7) is rejected with a
+	// clear, actionable error rather than a cryptic deserialize failure.
+	err := migration.CheckTargetSupportsEnvelope(migration.MinTargetEnvelopeFacadeVersion - 1)
+	c.Assert(err, tc.ErrorMatches,
+		"target controller does not support the model migration format; "+
+			"upgrade the target controller to Juju 4.1 or later")
+}
+
+func (s *checkTargetSupportsEnvelopeSuite) TestTargetSupported(c *tc.C) {
+	err := migration.CheckTargetSupportsEnvelope(migration.MinTargetEnvelopeFacadeVersion)
+	c.Assert(err, tc.ErrorIsNil)
+}

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -423,22 +423,13 @@ func (w *Worker) doQUIESCE(ctx context.Context, status coremigration.MigrationSt
 	return coremigration.IMPORT, nil
 }
 
-// incompatibleTargetMessage is the hard error reported when the source is on
-// the new SerializedModelV2 migration path but the target controller does not
-// expose the v8 migrationtarget facade that accepts it.
-var incompatibleTargetMessage = `
-target controller does not support the model migration envelope format;
-upgrade the target controller to Juju 4.1 or later
-`[1:]
-
 // checkTargetSupportsEnvelope hard-errors when the target controller does not
-// advertise migrationtarget v8, the first version able to accept the
-// SerializedModelV2 envelope. There is no fallback to a legacy path.
+// advertise the migrationtarget facade version able to accept the
+// SerializedModelV2 envelope. There is no fallback to a legacy path. The guard
+// is shared with the synchronous InitiateMigration precheck so both fail with
+// the same message.
 func checkTargetSupportsEnvelope(targetClient *migrationtarget.Client) error {
-	if targetClient.BestFacadeVersion() < 8 {
-		return errors.New(incompatibleTargetMessage)
-	}
-	return nil
+	return migration.CheckTargetSupportsEnvelope(targetClient.BestFacadeVersion())
 }
 
 func (w *Worker) prechecks(ctx context.Context, status coremigration.MigrationStatus) error {

--- a/internal/worker/migrationmaster/worker_test.go
+++ b/internal/worker/migrationmaster/worker_test.go
@@ -413,7 +413,7 @@ func (s *Suite) TestIncompatibleTarget(c *tc.C) {
 	))
 	lastMessages := s.modelMigrationService.statuses[len(s.modelMigrationService.statuses)-2:]
 	c.Assert(lastMessages[0], tc.Matches,
-		"(?s)target controller does not support the model migration envelope format.*")
+		"(?s)target controller does not support the model migration format.*")
 }
 
 func (s *Suite) TestMigrationResume(c *tc.C) {


### PR DESCRIPTION
Up until now we've been implementing new methods on the modelmigration domain and wiring some of them on the migration master worker; but we have never prevented a 4.0 source try to migrate to a 4.0 target.

This patch prevents 4.0 to 4.0 migrations by explicitly failing during prechecks with a bespoke error.


## QA steps

Bootstrap two 4.0 controllers, add a (empty) model on the source and then attempt a migration:
```
$ juju bootstrap lxd tgt --build-agent
$ juju bootstrap lxd src --build-agent
$ juju add-model m
$ juju migrate m tgt
juju migrate m tgt
ERROR target prechecks failed: target controller does not support the model migration envelope format; upgrade the target controller to Juju 4.1 or later
```

## Links


<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9900](https://warthogs.atlassian.net/browse/JUJU-9900)


[JUJU-9900]: https://warthogs.atlassian.net/browse/JUJU-9900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ