### PR TITLE
fix(snap): add FIDO/U2F security key support for juju ssh

### DIFF
--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -95,6 +95,15 @@ Connect to a mysql unit with an identity not known to juju (ssh option -i):
 
     juju ssh mysql/0 -i ~/.ssh/my_private_key echo hello
 
+Connect to a mysql unit using a FIDO/U2F security key (e.g. YubiKey):
+
+    juju ssh mysql/0 -i ~/.ssh/id_ed25519_sk
+
+When using the Juju snap, the u2f-devices interface must be
+connected to allow access to FIDO/U2F security keys:
+
+    sudo snap connect juju:u2f-devices
+
 **For k8s charms running the workload in a separate pod:**
 
 Connect to a k8s unit targeting the operator pod by default:

--- a/docs/howto/manage-ssh-keys.md
+++ b/docs/howto/manage-ssh-keys.md
@@ -11,6 +11,11 @@ myst:
 See also: {ref}`ssh-key`
 ```
 
+If you've bootstrapped a controller, Juju has automatically created an SSH key
+for you that yon use to SSH into the machines or units provisioned through
+Juju. This document covers the other case where you want to add further SSH
+keys to Juju.
+
 (add-an-ssh-key)=
 ## Add an SSH key
 
@@ -64,6 +69,47 @@ If you want to get more details, or get this information for a different model, 
 ```{ibnote}
 See more: {ref}`command-juju-ssh-keys`
 ```
+
+(use-an-ssh-key)=
+## Use an SSH key
+
+To SSH into a machine using a specific private key, pass OpenSSH's `-i`
+flag between the target and a possible remote command. Because `juju ssh`
+passes any options placed after the target to the underlying OpenSSH client,
+other OpenSSH flags can be used in the same way:
+
+```text
+juju ssh ubuntu/0 -i ~/.ssh/my_private_key
+```
+
+The key's public counterpart must be added to the model first (see
+{ref}`add-an-ssh-key`).
+
+```{ibnote}
+See more: {ref}`command-juju-ssh`
+```
+
+````{dropdown} Example: Use a FIDO/U2F security key (e.g. YubiKey)
+:color: success
+
+To use a FIDO/U2F security key with `juju ssh`, generate an SSH key
+backed by the security key, add the public key to the model, and pass
+the private key with the `-i` option:
+
+```text
+ssh-keygen -t ed25519-sk -f ~/.ssh/id_ed25519_sk
+juju add-ssh-key "$(cat ~/.ssh/id_ed25519_sk.pub)"
+juju ssh ubuntu/0 -i ~/.ssh/id_ed25519_sk
+```
+
+When using the Juju snap, the `u2f-devices` interface must be connected
+to allow access to FIDO/U2F security keys. This interface is not
+auto-connected:
+
+```text
+sudo snap connect juju:u2f-devices
+```
+````
 
 ## Remove an SSH key
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/ssh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/ssh.md
@@ -44,6 +44,15 @@ Connect to a mysql unit with an identity not known to juju (ssh option -i):
 
     juju ssh mysql/0 -i ~/.ssh/my_private_key echo hello
 
+Connect to a mysql unit using a FIDO/U2F security key (e.g. YubiKey):
+
+    juju ssh mysql/0 -i ~/.ssh/id_ed25519_sk
+
+When using the Juju snap, the u2f-devices interface must be
+connected to allow access to FIDO/U2F security keys:
+
+    sudo snap connect juju:u2f-devices
+
 **For k8s charms running the workload in a separate pod:**
 
 Connect to a k8s unit targeting the operator pod by default:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,8 @@ apps:
     environment:
       # Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
       PATH: "$SNAP/bin:$SNAP/usr/bin:$SNAP/opt/jaas/bin:/snap/bin:$PATH"
+      SSH_SK_HELPER: "$SNAP/usr/lib/openssh/ssh-sk-helper"
+      SSH_PKCS11_HELPER: "$SNAP/usr/lib/openssh/ssh-pkcs11-helper"
     command: bin/juju
     plugs:
       - network
@@ -61,6 +63,11 @@ apps:
       - home
       # Needed to that SSO via the web browser can work.
       - desktop
+      # Needed for FIDO/U2F security key support (e.g. YubiKey) with juju ssh.
+      # This interface is not auto-connected; users must run:
+      #   sudo snap connect juju:u2f-devices
+      # We do not want this to be auto-connected.
+      - u2f-devices
     completer: usr/share/bash-completion/completions/juju
   fetch-oci:
     daemon: oneshot


### PR DESCRIPTION

### What didn't work

Using a YubiKey-backed SSH key (`ed25519-sk`) with `juju ssh` inside the confined snap failed with:

```
ssh_sk_sign: failed to find sk
ssh-sk-helper: Signing failed: device not found
sign_and_send_pubkey: signing failed for ED25519-SK: device not found
```

### What was the cause

Two issues in `snap/snapcraft.yaml`:

1. **`SSH_SK_HELPER` / `SSH_PKCS11_HELPER` environment variables were not set.** OpenSSH resolves helper paths by checking `SSH_SK_HELPER` first, then falling back to the compiled-in path (`/usr/lib/openssh/ssh-sk-helper`). The snap bundles these helpers at `$SNAP/usr/lib/openssh/`, but the env var was never set, so `ssh` fell back to the system path — blocked by AppArmor in a strictly confined snap.

2. **No snap interface for FIDO/U2F device access.** The snap had no interface granting access to `/dev/hidraw*` device nodes, which libfido2 (used by `ssh-sk-helper`) needs to communicate with the YubiKey hardware.

### How to use

After installing the snap, connect the U2F interface:

```
sudo snap connect juju:u2f-devices
sudo snap connect juju:ssh-keys
```

Then use your YubiKey-backed key with `juju ssh`:

```
juju ssh ubuntu/0 -i ~/.ssh/id_ed25519_sk
```


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


Build and install new snap:

```sh
❯ snapcraft pack --use-lxd
❯ sudo snap install ./juju_3.6.25_amd64.snap --dangerous
❯ sudo snap connect juju:u2f-devices
❯ sudo snap connect juju:ssh-keys
```

Bootstrap a controller without ssh keys:

```sh
❯ juju bootstrap lxd repro
❯ juju add-model m
❯ juju deploy ubuntu
❯ rm $JUJU_DATA/ssh/*
❯ juju remove-ssh-key iyigun.cevik@canonical.com

# At this point ssh will not work anymore
❯ juju ssh ubuntu/0
ubuntu@10.159.202.180: Permission denied (publickey).
```


Prepare new key:

```
❯ ssh-keygen -vvv -t ed25519-sk -f ~/.ssh/id_ed25519_sk1  -O resident -O verify-required -C "juju-sk-repro"
❯ juju add-ssh-key "$(cat ~/.ssh/id_ed25519_sk.pub)"

❯ juju ssh-keys
Keys used in model: admin/m
53:cd:e8:16:1c:77:67:0c:14:00:aa:0f:3b:d6:6a:36 (juju-sk-repro)

❯ ssh-keygen -K

❯ juju ssh ubuntu/0 -i ~/.ssh/id_ed25519_sk
Enter passphrase for key '/home/iyigun.cevik@canonical.com/.ssh/id_ed25519_sk':
Confirm user presence for key ED25519-SK SHA256:/DzMbh/XsvJsiU6a+lkQxB5farTIQCCNNXbquJDbZPM
User presence confirmed
Welcome to Ubuntu 24.04.4 LTS (GNU/Linux 6.17.0-29-generic x86_64)
```


## Documentation changes


## Links

**Issue:** Fixes #22497

**Jira card:** [JUJU-9894](https://warthogs.atlassian.net/browse/JUJU-9894)


[JUJU-9894]: https://warthogs.atlassian.net/browse/JUJU-9894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ