### PR TITLE
chore: replace agent dependency in controller manifolds

### DIFF
--- a/cmd/jujuagentd/agent/agent_test.go
+++ b/cmd/jujuagentd/agent/agent_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/cmd"
 	"github.com/juju/juju/cmd/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/internal/agent/agentconf"
@@ -227,6 +228,28 @@ func (s *machineControllerStartupValueProviderSuite) TestControllerStartupValues
 	c.Check(values.ControllerPrivateKey, tc.Equals, "key-two")
 }
 
+func (s *machineControllerStartupValueProviderSuite) TestBootstrapStartupValuesAllowMissingControllerData(c *tc.C) {
+	apiPort, password := bootstrapStartupValues(&fakeMachineConfig{
+		controllerInfoFound: false,
+		apiInfoFound:        false,
+	})
+
+	c.Check(apiPort, tc.Equals, 0)
+	c.Check(password, tc.Equals, "")
+}
+
+func (s *machineControllerStartupValueProviderSuite) TestBootstrapStartupValuesReadCurrentAgentConfig(c *tc.C) {
+	apiPort, password := bootstrapStartupValues(&fakeMachineConfig{
+		controllerInfoFound: true,
+		controllerAgentInfo: controller.ControllerAgentInfo{APIPort: 17070},
+		apiInfoFound:        true,
+		apiInfo:             &api.Info{Password: "secret"},
+	})
+
+	c.Check(apiPort, tc.Equals, 17070)
+	c.Check(password, tc.Equals, "secret")
+}
+
 type fakeMachineAgentConfigWriter struct {
 	agentconf.AgentConf
 	config agent.Config
@@ -247,6 +270,9 @@ type fakeMachineConfig struct {
 	dqlitePort            int
 	tag                   names.Tag
 	controllerAgentInfo   controller.ControllerAgentInfo
+	controllerInfoFound   bool
+	apiInfo               *api.Info
+	apiInfoFound          bool
 }
 
 func (f *fakeMachineConfig) DataDir() string {
@@ -278,7 +304,20 @@ func (f *fakeMachineConfig) DqlitePort() (int, bool) {
 }
 
 func (f *fakeMachineConfig) ControllerAgentInfo() (controller.ControllerAgentInfo, bool) {
+	if !f.controllerInfoFound && f.controllerAgentInfo == (controller.ControllerAgentInfo{}) {
+		return controller.ControllerAgentInfo{}, false
+	}
 	return f.controllerAgentInfo, true
+}
+
+func (f *fakeMachineConfig) APIInfo() (*api.Info, bool) {
+	if !f.apiInfoFound && f.apiInfo == nil {
+		return nil, false
+	}
+	if f.apiInfo != nil {
+		return f.apiInfo, true
+	}
+	return &api.Info{Password: "password"}, true
 }
 
 func (f *fakeMachineConfig) Value(key string) string {

--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -624,6 +624,7 @@ func (a *MachineAgent) makeEngineCreator(
 		c := clock.WallClock
 		flightRecorder := workerflightrecorder.New(flightrecorder.NewRecorder(c), "", internallogger.GetLogger("juju.flightrecorder"))
 		startupValueProvider := machineControllerStartupValueProvider{agent: a}
+		bootstrapAPIPort, bootstrapAgentPassword := bootstrapStartupValues(agentConfig)
 
 		manifoldsCfg := machine.ManifoldsConfig{
 			PreviousAgentVersion:              previousAgentVersion,
@@ -636,6 +637,9 @@ func (a *MachineAgent) makeEngineCreator(
 			StartupValueProvider:              startupValueProvider,
 			ConfigChangeSocketPath:            path.Join(agentConfig.DataDir(), "configchange.socket"),
 			ControlSocketPath:                 path.Join(agentConfig.DataDir(), "control.socket"),
+			DataDir:                           agentConfig.DataDir(),
+			APIPort:                           bootstrapAPIPort,
+			AgentPassword:                     bootstrapAgentPassword,
 			Agent:                             agent.APIHostPortsSetter{Agent: a},
 			RootDir:                           a.rootDir,
 			AgentConfigChanged:                a.configChangedVal,
@@ -713,6 +717,20 @@ func (a *MachineAgent) makeEngineCreator(
 		}
 		return eng, nil
 	}
+}
+
+func bootstrapStartupValues(config agent.Config) (int, string) {
+	var apiPort int
+	if servingInfo, ok := config.ControllerAgentInfo(); ok {
+		apiPort = servingInfo.APIPort
+	}
+
+	var password string
+	if apiInfo, ok := config.APIInfo(); ok {
+		password = apiInfo.Password
+	}
+
+	return apiPort, password
 }
 
 func (a *MachineAgent) executeRebootOrShutdown(action params.RebootAction) error {

--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -143,6 +143,19 @@ func (p machineControllerStartupValueProvider) ObjectStoreRootDir() (string, err
 	return p.agent.CurrentConfig().DataDir(), nil
 }
 
+// APIInfo returns the current API connection details from agent config. This
+// is used by the API server worker to determine whether to start up or not,
+// and if it does start up, what API info to use to connect to the controller.
+// It is called each time the worker starts so that bounced workers do not keep
+// stale values.
+func (p machineControllerStartupValueProvider) APIInfo() (*api.Info, error) {
+	info, ok := p.agent.CurrentConfig().APIInfo()
+	if !ok {
+		return nil, errors.NotFoundf("API info")
+	}
+	return info, nil
+}
+
 type (
 	// The following allows the upgrade steps to be overridden by brittle
 	// integration tests.
@@ -228,7 +241,6 @@ type machineAgentCommand struct {
 // Init is called by the cmd system to initialize the structure for
 // running.
 func (a *machineAgentCommand) Init(args []string) error {
-
 	if a.machineId == "" && a.controllerId == "" {
 		return errors.New("either machine-id or controller-id must be set")
 	}
@@ -257,7 +269,7 @@ func (a *machineAgentCommand) Init(args []string) error {
 		return errors.Errorf("cannot read agent configuration: %v", err)
 	}
 	config := a.currentConfig.CurrentConfig()
-	if err := os.MkdirAll(config.LogDir(), 0644); err != nil {
+	if err := os.MkdirAll(config.LogDir(), 0o644); err != nil {
 		logger.Warningf(context.TODO(), "cannot create log dir: %v", err)
 	}
 	a.isCaas = config.Value(agent.ProviderType) == k8sconstants.CAASProviderType
@@ -609,22 +621,19 @@ func (a *MachineAgent) makeEngineCreator(
 			handle("/metrics/", promhttp.HandlerFor(a.prometheusRegistry, promhttp.HandlerOpts{}))
 		}
 
-		clock := clock.WallClock
-		flightRecorder := workerflightrecorder.New(flightrecorder.NewRecorder(clock), "", internallogger.GetLogger("juju.flightrecorder"))
+		c := clock.WallClock
+		flightRecorder := workerflightrecorder.New(flightrecorder.NewRecorder(c), "", internallogger.GetLogger("juju.flightrecorder"))
 		startupValueProvider := machineControllerStartupValueProvider{agent: a}
 
 		manifoldsCfg := machine.ManifoldsConfig{
 			PreviousAgentVersion:              previousAgentVersion,
 			AgentName:                         agentName,
 			ControllerID:                      agentConfig.Tag().Id(),
-			ObjectStoreRootDirReader:          startupValueProvider,
 			ControllerUUID:                    agentConfig.Controller().Id(),
 			ControllerModelUUID:               agentConfig.Model().Id(),
-			ControllerStartupValues:           startupValueProvider,
 			ControllerAgentTag:                agentConfig.Tag(),
 			LogDir:                            agentConfig.LogDir(),
-			CertReader:                        startupValueProvider,
-			APIServerLocalConfigReader:        startupValueProvider,
+			StartupValueProvider:              startupValueProvider,
 			ConfigChangeSocketPath:            path.Join(agentConfig.DataDir(), "configchange.socket"),
 			ControlSocketPath:                 path.Join(agentConfig.DataDir(), "control.socket"),
 			Agent:                             agent.APIHostPortsSetter{Agent: a},
@@ -640,7 +649,7 @@ func (a *MachineAgent) makeEngineCreator(
 			UpgradeSteps:                      a.upgradeSteps,
 			LogSink:                           logSink,
 			NewDeployContext:                  deployer.NewNestedContext,
-			Clock:                             clock,
+			Clock:                             c,
 			FlightRecorder:                    flightRecorder,
 			ValidateMigration:                 a.validateMigration,
 			PrometheusRegisterer:              a.prometheusRegistry,
@@ -687,7 +696,7 @@ func (a *MachineAgent) makeEngineCreator(
 			PrometheusGatherer: a.prometheusRegistry,
 			FlightRecorder:     flightRecorder,
 			WorkerFunc:         introspection.NewWorker,
-			Clock:              clock,
+			Clock:              c,
 			Logger:             logger.Child("introspection"),
 		}); err != nil {
 			// If the introspection worker failed to start, we just log error
@@ -935,7 +944,7 @@ func (a *MachineAgent) createSymlink(target, link string) error {
 		}
 	}
 
-	if err := os.MkdirAll(filepath.Dir(fullLink), os.FileMode(0755)); err != nil {
+	if err := os.MkdirAll(filepath.Dir(fullLink), os.FileMode(0o755)); err != nil {
 		return err
 	}
 	return symlink.New(target, fullLink)

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -140,6 +140,13 @@ type ManifoldsConfig struct {
 	// through the agent manifold.
 	ControllerID string
 
+	// StartupValueProvider is used by workers that need to read values from the
+	// agent config at startup, e.g. to get the API server certificate for the
+	// apiservercertwatcher manifold. This is used instead of the agent manifold
+	// to avoid unnecessary coupling and to allow these workers to be started
+	// before the agent manifold.
+	StartupValueProvider ControllerStartupValueProvider
+
 	// ControllerUUID is the controller entity UUID. It is sourced from
 	// agentConfig.Controller().Id() in makeEngineCreator and passed
 	// directly to the lease-manager manifold instead of being looked
@@ -158,13 +165,6 @@ type ManifoldsConfig struct {
 	// LogDir is the controller process log directory for workers in this change
 	// area that still take a fixed local path.
 	LogDir string
-
-	// StartupValueProvider is used by workers that need to read values from the
-	// agent config at startup, e.g. to get the API server certificate for the
-	// apiservercertwatcher manifold. This is used instead of the agent manifold
-	// to avoid unnecessary coupling and to allow these workers to be started
-	// before the agent manifold.
-	StartupValueProvider ControllerStartupValueProvider
 
 	// ConfigChangeSocketPath is the path to the config-change reload socket.
 	ConfigChangeSocketPath string
@@ -228,7 +228,8 @@ type ManifoldsConfig struct {
 	// worker to perform the upgrade steps.
 	UpgradeSteps upgrades.UpgradeStepsFunc
 
-	// LogSink defines an interface for writing log records to a log sink.
+	// LogSink defines an interface for writing log records to a log
+	// sink.
 	LogSink corelogger.LogSink
 
 	// NewDeployContext gives the tests the opportunity to create a
@@ -589,7 +590,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		controllerTraceName: trace.ControllerManifold(trace.ControllerManifoldConfig{
-			AgentName:         agentName,
+			Tag:               agentConfig.Tag(),
 			TraceServicesName: traceServicesName,
 			Clock:             config.Clock,
 			Logger:            internallogger.GetLogger("juju.worker.trace"),

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -172,6 +172,15 @@ type ManifoldsConfig struct {
 	// ControlSocketPath is the path to the local controller control socket.
 	ControlSocketPath string
 
+	// DataDir is the agent data directory used by bootstrap.
+	DataDir string
+
+	// APIPort is the controller API port advertised during bootstrap.
+	APIPort int
+
+	// AgentPassword is the agent password used during bootstrap finalization.
+	AgentPassword string
+
 	// Agent contains the agent that will be wrapped and made available to
 	// its dependencies via a dependency.Engine.
 	Agent coreagent.Agent
@@ -1032,12 +1041,14 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	manifolds := dependency.Manifolds{
 		// Bootstrap worker is responsible for setting up the initial machine.
 		bootstrapName: ifDatabaseUpgradeComplete(bootstrap.Manifold(bootstrap.ManifoldConfig{
-			AgentName:               agentName,
 			ObjectStoreName:         objectStoreFacadeName,
 			DomainServicesName:      domainServicesName,
 			HTTPClientName:          httpClientName,
 			BootstrapGateName:       isBootstrapGateName,
 			ProviderFactoryName:     providerTrackerName,
+			DataDir:                 config.DataDir,
+			APIPort:                 config.APIPort,
+			AgentPassword:           config.AgentPassword,
 			RequiresBootstrap:       bootstrap.RequiresBootstrap,
 			PopulateControllerCharm: bootstrap.PopulateIAASControllerCharm,
 			StatusHistory:           domain.NewStatusHistory(internallogger.GetLogger("juju.services"), config.Clock),
@@ -1266,12 +1277,14 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	return mergeManifolds(config, dependency.Manifolds{
 		// Bootstrap worker is responsible for setting up the initial machine.
 		bootstrapName: ifDatabaseUpgradeComplete(bootstrap.Manifold(bootstrap.ManifoldConfig{
-			AgentName:               agentName,
 			ObjectStoreName:         objectStoreFacadeName,
 			DomainServicesName:      domainServicesName,
 			HTTPClientName:          httpClientName,
 			BootstrapGateName:       isBootstrapGateName,
 			ProviderFactoryName:     providerTrackerName,
+			DataDir:                 config.DataDir,
+			APIPort:                 config.APIPort,
+			AgentPassword:           config.AgentPassword,
 			RequiresBootstrap:       bootstrap.RequiresBootstrap,
 			PopulateControllerCharm: bootstrap.PopulateCAASControllerCharm,
 			StatusHistory:           domain.NewStatusHistory(internallogger.GetLogger("juju.services"), config.Clock),

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -128,7 +128,6 @@ import (
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.
 type ManifoldsConfig struct {
-
 	// AgentName is the name of the machine agent, like "machine-12".
 	// This will never change during the execution of an agent, and
 	// is used to provide this as config into a worker rather than
@@ -140,10 +139,6 @@ type ManifoldsConfig struct {
 	// that now take direct identity values instead of looking them up
 	// through the agent manifold.
 	ControllerID string
-
-	// ObjectStoreRootDirReader returns the current local filesystem root used by
-	// object-store workers.
-	ObjectStoreRootDirReader objectstore.RootDirReader
 
 	// ControllerUUID is the controller entity UUID. It is sourced from
 	// agentConfig.Controller().Id() in makeEngineCreator and passed
@@ -157,13 +152,6 @@ type ManifoldsConfig struct {
 	// up from agent config at worker start.
 	ControllerModelUUID string
 
-	// ControllerStartupValues provides the controller-local startup values
-	// needed by dbaccessor from agent config.
-	ControllerStartupValues dbaccessor.ControllerStartupValuesProvider
-
-	// CertReader returns the current controller certificate material.
-	CertReader apiservercertwatcher.CertReader
-
 	// ControllerAgentTag is the tag used for controller-agent log records.
 	ControllerAgentTag names.Tag
 
@@ -171,8 +159,12 @@ type ManifoldsConfig struct {
 	// area that still take a fixed local path.
 	LogDir string
 
-	// APIServerLocalConfigReader returns the current API-server local values.
-	APIServerLocalConfigReader apiserver.LocalConfigReader
+	// StartupValueProvider is used by workers that need to read values from the
+	// agent config at startup, e.g. to get the API server certificate for the
+	// apiservercertwatcher manifold. This is used instead of the agent manifold
+	// to avoid unnecessary coupling and to allow these workers to be started
+	// before the agent manifold.
+	StartupValueProvider ControllerStartupValueProvider
 
 	// ConfigChangeSocketPath is the path to the config-change reload socket.
 	ConfigChangeSocketPath string
@@ -328,7 +320,6 @@ type ManifoldsConfig struct {
 //
 // Thou Shalt Not Use String Literals In This Function. Or Else.
 func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
-
 	// connectFilter exists:
 	//  1) to let us retry api connections immediately on password change,
 	//     rather than causing the dependency engine to wait for a while;
@@ -438,7 +429,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// and offers the result to other manifolds. This is only
 		// run by state servers.
 		certificateWatcherName: ifController(apiservercertwatcher.Manifold(apiservercertwatcher.ManifoldConfig{
-			CertReader: config.CertReader,
+			CertReader: config.StartupValueProvider,
 		})),
 
 		// The api caller is a thin concurrent wrapper around a connection
@@ -644,7 +635,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AuthenticatorName:      httpServerArgsName,
 			Clock:                  clock.WallClock,
 			ControllerTag:          config.ControllerAgentTag,
-			LocalConfigReader:      config.APIServerLocalConfigReader,
+			LocalConfigReader:      config.StartupValueProvider,
 			LogSinkName:            logSinkName,
 			MuxName:                httpServerArgsName,
 			LeaseManagerName:       leaseManagerName,
@@ -843,7 +834,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			S3ClientName:                    objectStoreS3CallerName,
 			ObjectStoreName:                 objectStoreName,
 			ObjectStoreServicesName:         objectStoreServicesName,
-			RootDirReader:                   config.ObjectStoreRootDirReader,
+			RootDirReader:                   config.StartupValueProvider,
 			FortressName:                    objectStoreFortressName,
 			GetControllerService:            objectstoredrainer.GetControllerService,
 			GeObjectStoreServices:           objectstoredrainer.GeObjectStoreServicesGetter,
@@ -864,7 +855,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			LeaseManagerName:           leaseManagerName,
 			S3ClientName:               objectStoreS3CallerName,
 			APIRemoteCallerName:        apiRemoteCallerName,
-			RootDirReader:              config.ObjectStoreRootDirReader,
+			RootDirReader:              config.StartupValueProvider,
 			ControllerNodeID:           config.ControllerID,
 			Clock:                      config.Clock,
 			Logger:                     internallogger.GetLogger("juju.worker.objectstore"),
@@ -940,7 +931,8 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 				switch namespace {
 				case corehttp.CharmhubPurpose:
 					logger := internallogger.GetLogger("juju.charmhub", corelogger.CHARMHUB)
-					opts = append(opts,
+					opts = append(
+						opts,
 						internalhttp.WithLogger(logger),
 						internalhttp.WithRequestRetrier(charmhub.DefaultRetryPolicy()),
 					)
@@ -972,8 +964,9 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 
 		apiRemoteCallerName: ifController(apiremotecaller.Manifold(apiremotecaller.ManifoldConfig{
-			AgentName:               agentName,
 			ObjectStoreServicesName: objectStoreServicesName,
+			APIInfo:                 config.StartupValueProvider,
+			Origin:                  agentConfig.Tag(),
 			Clock:                   config.Clock,
 			Logger:                  internallogger.GetLogger("juju.worker.apiremotecaller"),
 			NewWorker:               apiremotecaller.NewWorker,
@@ -1110,7 +1103,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
 			QueryLoggerName:           queryLoggerName,
 			ControllerAgentConfigName: controllerAgentConfigName,
-			ControllerStartupValues:   config.ControllerStartupValues,
+			ControllerStartupValues:   config.StartupValueProvider,
 			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
 			PrometheusRegisterer:      config.PrometheusRegisterer,
 			NewApp:                    dbaccessor.NewApp,
@@ -1345,7 +1338,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
 			QueryLoggerName:           queryLoggerName,
 			ControllerAgentConfigName: controllerAgentConfigName,
-			ControllerStartupValues:   config.ControllerStartupValues,
+			ControllerStartupValues:   config.StartupValueProvider,
 			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
 			PrometheusRegisterer:      config.PrometheusRegisterer,
 			NewApp:                    dbaccessor.NewApp,
@@ -1446,6 +1439,17 @@ var ifControllerAgentConfigNeededAndReady = engine.Housing{
 		controllerAgentConfigReadyFlagName,
 	},
 }.Decorate
+
+// ControllerStartupValueProvider is the set of methods required to provide
+// startup values to controller-only workers. This is implemented by the
+// config.StartupValueProvider, which is passed to the manifolds in the config.
+type ControllerStartupValueProvider interface {
+	objectstore.RootDirReader
+	dbaccessor.ControllerStartupValuesProvider
+	apiservercertwatcher.CertReader
+	apiserver.LocalConfigReader
+	apiremotecaller.APIInfoProvider
+}
 
 const (
 	agentName              = "agent"

--- a/cmd/jujuagentd/agent/machine/manifolds_test.go
+++ b/cmd/jujuagentd/agent/machine/manifolds_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agenttest"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/cmd/jujuagentd/agent/machine"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
@@ -3109,6 +3110,15 @@ func (mc *mockConfig) StateServingInfo() (controller.ControllerAgentInfo, bool) 
 
 func (mc *mockConfig) ControllerAgentInfo() (controller.ControllerAgentInfo, bool) {
 	return mc.ssi, mc.ssiSet
+}
+
+func (mc *mockConfig) APIInfo() (*api.Info, bool) {
+	return &api.Info{
+		Addrs:    []string{"0.1.2.3:1234"},
+		CACert:   "mock-ca-cert",
+		Tag:      mc.Tag(),
+		Password: "mock-password",
+	}, true
 }
 
 func (mc *mockConfig) SetStateServingInfo(info controller.ControllerAgentInfo) {

--- a/cmd/jujud/agent/controller.go
+++ b/cmd/jujud/agent/controller.go
@@ -512,6 +512,14 @@ func (a *ControllerAgent) makeEngineCreator(
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		servingInfo, ok := agentConfig.ControllerAgentInfo()
+		if !ok {
+			return nil, errors.NotFoundf("controller agent info")
+		}
+		apiInfo, ok := agentConfig.APIInfo()
+		if !ok {
+			return nil, errors.NotFoundf("API info")
+		}
 		startupValueProvider := controllerStartupValueProvider{
 			agent:                 a,
 			controllerRuntimePath: controllerRuntimeConfigPath,
@@ -537,6 +545,9 @@ func (a *ControllerAgent) makeEngineCreator(
 			ControlSocketPath: path.Join(
 				controllerRuntimeConfig.DataDir, "control.socket",
 			),
+			DataDir:                           agentConfig.DataDir(),
+			APIPort:                           servingInfo.APIPort,
+			AgentPassword:                     apiInfo.Password,
 			RootDir:                           a.rootDir,
 			BootstrapLock:                     a.bootstrapLock,
 			ControllerUpgradeLock:             a.controllerUpgradeLock,

--- a/cmd/jujud/agent/controller.go
+++ b/cmd/jujud/agent/controller.go
@@ -529,6 +529,7 @@ func (a *ControllerAgent) makeEngineCreator(
 			ControllerUUID:       controllerRuntimeConfig.ControllerUUID,
 			ControllerModelUUID:  controllerRuntimeConfig.ControllerModelUUID,
 			ControllerAgentTag:   a.agentTag,
+			ControllerTag:        names.NewControllerTag(controllerRuntimeConfig.ControllerUUID),
 			LogDir:               controllerRuntimeConfig.LogDir,
 			ConfigChangeSocketPath: path.Join(
 				controllerRuntimeConfig.DataDir, "configchange.socket",
@@ -536,9 +537,7 @@ func (a *ControllerAgent) makeEngineCreator(
 			ControlSocketPath: path.Join(
 				controllerRuntimeConfig.DataDir, "control.socket",
 			),
-			Agent:                             agent.APIHostPortsSetter{Agent: a},
 			RootDir:                           a.rootDir,
-			AgentConfigChanged:                a.configChangedVal,
 			BootstrapLock:                     a.bootstrapLock,
 			ControllerUpgradeLock:             a.controllerUpgradeLock,
 			UpgradeDBLock:                     a.upgradeDBLock,

--- a/cmd/jujud/agent/controller.go
+++ b/cmd/jujud/agent/controller.go
@@ -28,6 +28,7 @@ import (
 	agentconfig "github.com/juju/juju/agent/config"
 	agentengine "github.com/juju/juju/agent/engine"
 	agenterrors "github.com/juju/juju/agent/errors"
+	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
 	coreapiserver "github.com/juju/juju/apiserver"
 	jujucmd "github.com/juju/juju/cmd"
@@ -129,6 +130,20 @@ func (p controllerStartupValueProvider) ObjectStoreRootDir() (string, error) {
 		return "", errors.Trace(err)
 	}
 	return cfg.DataDir, nil
+}
+
+// APIInfo returns the current API connection info from runtime.conf.
+func (p controllerStartupValueProvider) APIInfo() (*api.Info, error) {
+	cfg, err := p.readRuntimeConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &api.Info{
+		Addrs:          cfg.APIAddresses,
+		CACert:         cfg.CACert,
+		ControllerUUID: cfg.ControllerUUID,
+		Tag:            p.agent.agentTag,
+	}, nil
 }
 
 // LoggingOverride returns the current persisted logging override.
@@ -507,17 +522,14 @@ func (a *ControllerAgent) makeEngineCreator(
 		)
 
 		manifoldsCfg := agentcontroller.ManifoldsConfig{
-			PreviousAgentVersion:       previousAgentVersion,
-			AgentName:                  agentName,
-			ControllerID:               a.agentTag.Id(),
-			ObjectStoreRootDirReader:   startupValueProvider,
-			ControllerUUID:             controllerRuntimeConfig.ControllerUUID,
-			ControllerModelUUID:        controllerRuntimeConfig.ControllerModelUUID,
-			ControllerStartupValues:    startupValueProvider,
-			ControllerAgentTag:         a.agentTag,
-			LogDir:                     controllerRuntimeConfig.LogDir,
-			CertReader:                 startupValueProvider,
-			APIServerLocalConfigReader: startupValueProvider,
+			PreviousAgentVersion: previousAgentVersion,
+			AgentName:            agentName,
+			ControllerID:         a.agentTag.Id(),
+			StartupValueProvider: startupValueProvider,
+			ControllerUUID:       controllerRuntimeConfig.ControllerUUID,
+			ControllerModelUUID:  controllerRuntimeConfig.ControllerModelUUID,
+			ControllerAgentTag:   a.agentTag,
+			LogDir:               controllerRuntimeConfig.LogDir,
 			ConfigChangeSocketPath: path.Join(
 				controllerRuntimeConfig.DataDir, "configchange.socket",
 			),
@@ -550,8 +562,6 @@ func (a *ControllerAgent) makeEngineCreator(
 			SetupLogging:                      agentconf.SetupAgentLogging,
 			DependencyEngineMetrics:           metrics,
 			NewEnvironFunc:                    newEnvirons,
-			LoggingOverrideReader:             startupValueProvider,
-			SystemIdentityReader:              startupValueProvider,
 		}
 		manifolds := agentcontroller.IAASManifolds(manifoldsCfg)
 		if agentConfig.Value(agent.ProviderType) == k8sconstants.CAASProviderType {

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -73,7 +73,6 @@ import (
 	leasemanager "github.com/juju/juju/internal/worker/lease"
 	"github.com/juju/juju/internal/worker/leaseexpiry"
 	"github.com/juju/juju/internal/worker/logsink"
-	"github.com/juju/juju/internal/worker/migrationflag"
 	"github.com/juju/juju/internal/worker/migrationminion"
 	"github.com/juju/juju/internal/worker/modelworkermanager"
 	"github.com/juju/juju/internal/worker/objectstore"
@@ -114,9 +113,9 @@ type ManifoldsConfig struct {
 	// the lookup.
 	ControllerID string
 
-	// ObjectStoreRootDirReader returns the current local filesystem root used by
-	// object-store workers.
-	ObjectStoreRootDirReader objectstore.RootDirReader
+	// StartupValueProvider is used to read values from the controller runtime
+	// config file, which is passed to the manifolds in the config.
+	StartupValueProvider ControllerStartupValueProvider
 
 	// ControllerUUID is the controller entity UUID. It is sourced from
 	// agentConfig.Controller().Id() in makeEngineCreator and passed
@@ -130,22 +129,12 @@ type ManifoldsConfig struct {
 	// up from agent config at worker start.
 	ControllerModelUUID string
 
-	// ControllerStartupValues provides the controller-local startup values
-	// needed by dbaccessor.
-	ControllerStartupValues dbaccessor.ControllerStartupValuesProvider
-
-	// CertReader returns the current controller certificate material.
-	CertReader apiservercertwatcher.CertReader
-
 	// ControllerAgentTag is the tag used for controller-agent log records.
 	ControllerAgentTag names.Tag
 
 	// LogDir is the controller process log directory for workers in this change
 	// area that still take a fixed local path.
 	LogDir string
-
-	// APIServerLocalConfigReader returns the current API-server local values.
-	APIServerLocalConfigReader apiserver.LocalConfigReader
 
 	// ConfigChangeSocketPath is the path to the config-change reload socket.
 	ConfigChangeSocketPath string
@@ -270,12 +259,6 @@ type ManifoldsConfig struct {
 	// NewEnvironFunc is a function that opens a provider
 	// "environment" (typically environs.New).
 	NewEnvironFunc func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.Environ, error)
-
-	// LoggingOverrideReader returns the current persisted logging override.
-	LoggingOverrideReader controllerlogger.LoggingOverrideReader
-
-	// SystemIdentityReader returns the current system identity values.
-	SystemIdentityReader identityfilewriter.SystemIdentityReader
 }
 
 // commonManifolds returns the shared controller manifolds.
@@ -362,7 +345,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// certificate in the agent config for changes, and parses and
 		// offers the result to other manifolds.
 		certificateWatcherName: apiservercertwatcher.Manifold(apiservercertwatcher.ManifoldConfig{
-			CertReader: config.CertReader,
+			CertReader: config.StartupValueProvider,
 		}),
 
 		// The api caller is a thin concurrent wrapper around a connection
@@ -389,8 +372,8 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The upgrade-database worker runs soon after the controller
 		// agent starts and runs any steps required to upgrade the
 		// database to the current version.
-		upgradeDatabaseName: upgradedatabase.Manifold(upgradedatabase.ManifoldConfig{
-			AgentName:           agentName,
+		upgradeDatabaseName: disabledManifold(upgradedatabase.Manifold(upgradedatabase.ManifoldConfig{
+			// AgentName:           agentName,
 			UpgradeDBGateName:   upgradeDatabaseGateName,
 			UpgradeServicesName: upgradeDomainServicesName,
 			DBAccessorName:      dbAccessorName,
@@ -398,7 +381,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:              internallogger.GetLogger("juju.worker.upgradedatabase"),
 			Clock:               config.Clock,
 			UpgradeSteps:        upgradedatabase.UpgradeSteps,
-		}),
+		})),
 
 		// The upgrade services worker provides domain services for
 		// upgrading the controller. This worker MUST never take on a
@@ -435,15 +418,20 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// a mechanism for running other workers so they can't
 		// accidentally interfere with a migration in progress.
 		migrationFortressName: fortress.Manifold(),
-		migrationInactiveFlagName: migrationflag.Manifold(migrationflag.ManifoldConfig{
-			APICallerName: apiCallerName,
-			Check:         migrationflag.IsTerminal,
-			NewFacade:     migrationflag.NewFacade,
-			NewWorker:     migrationflag.NewWorker,
-		}),
-		migrationMinionName: ifControllerUpgradeComplete(migrationminion.Manifold(migrationminion.ManifoldConfig{
-			AgentName:         agentName,
-			APICallerName:     apiCallerName,
+		// migration-inactive-flag is out of scope for Phase 1;
+		// migration is never active in the standalone controller,
+		// so this unconditionally reports "inactive". Replace
+		// with migrationflag.Manifold when controller migration
+		// is implemented.
+		migrationInactiveFlagName: dependency.Manifold{
+			Start: func(_ context.Context, _ dependency.Getter) (worker.Worker, error) {
+				return engine.NewStaticFlagWorker(true), nil
+			},
+			Output: engine.FlagOutput,
+		},
+		migrationMinionName: ifControllerUpgradeComplete(disabledManifold(migrationminion.Manifold(migrationminion.ManifoldConfig{
+			// AgentName:         agentName,
+			// APICallerName:     apiCallerName,
 			FortressName:      migrationFortressName,
 			Clock:             config.Clock,
 			APIOpen:           api.Open,
@@ -451,7 +439,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewFacade:         migrationminion.NewFacade,
 			NewWorker:         migrationminion.NewWorker,
 			Logger:            internallogger.GetLogger("juju.worker.migrationminion", corelogger.MIGRATION),
-		})),
+		}))),
 
 		// The primary controller flag manifold will attempt to claim
 		// responsibility for running certain workers that must not be
@@ -473,12 +461,12 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			LoggerContext:         internallogger.DefaultContext(),
 			Logger:                internallogger.GetLogger("juju.worker.logger"),
 			Tag:                   agentTag,
-			LoggingOverrideReader: config.LoggingOverrideReader,
+			LoggingOverrideReader: config.StartupValueProvider,
 			UpdateAgentFunc:       config.UpdateLoggerConfig,
 		})),
 
 		identityFileWriterName: ifNotMigrating(identityfilewriter.Manifold(identityfilewriter.ManifoldConfig{
-			SystemIdentityReader: config.SystemIdentityReader,
+			SystemIdentityReader: config.StartupValueProvider,
 			NewWorker:            identityfilewriter.NewWorker,
 		})),
 
@@ -528,7 +516,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			AuthenticatorName:      httpServerArgsName,
 			Clock:                  clock.WallClock,
 			ControllerTag:          config.ControllerAgentTag,
-			LocalConfigReader:      config.APIServerLocalConfigReader,
+			LocalConfigReader:      config.StartupValueProvider,
 			LogSinkName:            logSinkName,
 			MuxName:                httpServerArgsName,
 			LeaseManagerName:       leaseManagerName,
@@ -704,7 +692,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			S3ClientName:                    objectStoreS3CallerName,
 			ObjectStoreName:                 objectStoreName,
 			ObjectStoreServicesName:         objectStoreServicesName,
-			RootDirReader:                   config.ObjectStoreRootDirReader,
+			RootDirReader:                   config.StartupValueProvider,
 			FortressName:                    objectStoreFortressName,
 			GetControllerService:            objectstoredrainer.GetControllerService,
 			GeObjectStoreServices:           objectstoredrainer.GeObjectStoreServicesGetter,
@@ -725,7 +713,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			LeaseManagerName:           leaseManagerName,
 			S3ClientName:               objectStoreS3CallerName,
 			APIRemoteCallerName:        apiRemoteCallerName,
-			RootDirReader:              config.ObjectStoreRootDirReader,
+			RootDirReader:              config.StartupValueProvider,
 			ControllerNodeID:           config.ControllerID,
 			Clock:                      config.Clock,
 			Logger:                     internallogger.GetLogger("juju.worker.objectstore"),
@@ -799,7 +787,8 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 				switch namespace {
 				case corehttp.CharmhubPurpose:
 					logger := internallogger.GetLogger("juju.charmhub", corelogger.CHARMHUB)
-					opts = append(opts,
+					opts = append(
+						opts,
 						internalhttp.WithLogger(logger),
 						internalhttp.WithRequestRetrier(charmhub.DefaultRetryPolicy()),
 					)
@@ -831,8 +820,9 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 
 		apiRemoteCallerName: apiremotecaller.Manifold(apiremotecaller.ManifoldConfig{
-			AgentName:               agentName,
 			ObjectStoreServicesName: objectStoreServicesName,
+			APIInfo:                 config.StartupValueProvider,
+			Origin:                  config.ControllerAgentTag,
 			Clock:                   config.Clock,
 			Logger:                  internallogger.GetLogger("juju.worker.apiremotecaller"),
 			NewWorker:               apiremotecaller.NewWorker,
@@ -915,23 +905,23 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// type recognised by the controller agent, causing other workers
 		// to be stopped and the agent to be restarted running the new
 		// tools.
-		upgraderName: ifControllerUpgradeComplete(upgrader.Manifold(upgrader.ManifoldConfig{
-			AgentName:            agentName,
-			APICallerName:        apiCallerName,
+		upgraderName: ifControllerUpgradeComplete(disabledManifold(upgrader.Manifold(upgrader.ManifoldConfig{
+			// AgentName:            agentName,
+			// APICallerName:        apiCallerName,
 			UpgradeStepsGateName: upgradeStepsGateName,
 			UpgradeCheckGateName: upgradeCheckGateName,
 			PreviousAgentVersion: config.PreviousAgentVersion,
 			Logger:               internallogger.GetLogger("juju.worker.upgrader"),
 			Clock:                config.Clock,
-		})),
+		}))),
 
 		// The upgradestepscontroller worker runs soon after the
 		// controller agent starts and runs any steps required to
 		// upgrade to the running jujud version. Once upgrade steps have
 		// run, the upgradesteps gate is unlocked and the worker exits.
-		upgradeControllerStepsName: ifControllerUpgradeComplete(upgradestepscontroller.Manifold(upgradestepscontroller.ManifoldConfig{
-			AgentName:            agentName,
-			APICallerName:        apiCallerName,
+		upgradeControllerStepsName: ifControllerUpgradeComplete(disabledManifold(upgradestepscontroller.Manifold(upgradestepscontroller.ManifoldConfig{
+			// AgentName:            agentName,
+			// APICallerName:        apiCallerName,
 			DomainServicesName:   domainServicesName,
 			UpgradeStepsGateName: upgradeStepsGateName,
 			PreUpgradeSteps:      config.PreUpgradeSteps(model.IAAS),
@@ -941,7 +931,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			GetUpgradeService:    upgradestepscontroller.GetUpgradeService,
 			Logger:               internallogger.GetLogger("juju.worker.upgradestepscontroller"),
 			Clock:                config.Clock,
-		})),
+		}))),
 	})
 }
 
@@ -963,19 +953,19 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		dbAccessorName: dbaccessor.Manifold(NewCAASDBAccessorManifoldConfig(config)),
 
-		upgraderName: ifControllerUpgradeComplete(upgrader.Manifold(upgrader.ManifoldConfig{
-			AgentName:            agentName,
-			APICallerName:        apiCallerName,
+		upgraderName: ifControllerUpgradeComplete(disabledManifold(upgrader.Manifold(upgrader.ManifoldConfig{
+			// AgentName:            agentName,
+			// APICallerName:        apiCallerName,
 			UpgradeStepsGateName: upgradeStepsGateName,
 			UpgradeCheckGateName: upgradeCheckGateName,
 			PreviousAgentVersion: config.PreviousAgentVersion,
 			Logger:               internallogger.GetLogger("juju.worker.upgrader"),
 			Clock:                config.Clock,
-		})),
+		}))),
 
-		upgradeControllerStepsName: ifControllerUpgradeComplete(upgradestepscontroller.Manifold(upgradestepscontroller.ManifoldConfig{
-			AgentName:            agentName,
-			APICallerName:        apiCallerName,
+		upgradeControllerStepsName: ifControllerUpgradeComplete(disabledManifold(upgradestepscontroller.Manifold(upgradestepscontroller.ManifoldConfig{
+			// AgentName:            agentName,
+			// APICallerName:        apiCallerName,
 			DomainServicesName:   domainServicesName,
 			UpgradeStepsGateName: upgradeStepsGateName,
 			PreUpgradeSteps:      config.PreUpgradeSteps(model.IAAS),
@@ -985,7 +975,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			GetUpgradeService:    upgradestepscontroller.GetUpgradeService,
 			Logger:               internallogger.GetLogger("juju.worker.upgradestepscontroller"),
 			Clock:                config.Clock,
-		})),
+		}))),
 	})
 }
 
@@ -1066,7 +1056,7 @@ func NewIAASDBAccessorManifoldConfig(config ManifoldsConfig) dbaccessor.Manifold
 	return dbaccessor.ManifoldConfig{
 		QueryLoggerName:           queryLoggerName,
 		ControllerAgentConfigName: controllerAgentConfigName,
-		ControllerStartupValues:   config.ControllerStartupValues,
+		ControllerStartupValues:   config.StartupValueProvider,
 		Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
 		PrometheusRegisterer:      config.PrometheusRegisterer,
 		NewApp:                    dbaccessor.NewApp,
@@ -1081,7 +1071,7 @@ func NewCAASDBAccessorManifoldConfig(config ManifoldsConfig) dbaccessor.Manifold
 	return dbaccessor.ManifoldConfig{
 		QueryLoggerName:           queryLoggerName,
 		ControllerAgentConfigName: controllerAgentConfigName,
-		ControllerStartupValues:   config.ControllerStartupValues,
+		ControllerStartupValues:   config.StartupValueProvider,
 		Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
 		PrometheusRegisterer:      config.PrometheusRegisterer,
 		NewApp:                    dbaccessor.NewApp,
@@ -1103,6 +1093,17 @@ func clockManifold(clk clock.Clock) dependency.Manifold {
 			return engine.NewValueWorker(clk)
 		},
 		Output: engine.ValueWorkerOutput,
+	}
+}
+
+func disabledManifold(manifold dependency.Manifold) dependency.Manifold {
+	return dependency.Manifold{
+		Start: func(_ context.Context, _ dependency.Getter) (worker.Worker, error) {
+			return jworker.NewSimpleWorker(func(ctx context.Context) error {
+				<-ctx.Done()
+				return nil
+			}), nil
+		},
 	}
 }
 
@@ -1146,6 +1147,19 @@ var ifDatabaseUpgradeComplete = engine.Housing{
 		upgradeDatabaseFlagName,
 	},
 }.Decorate
+
+// ControllerStartupValueProvider is the set of methods required to provide
+// startup values to controller-only workers. This is implemented by the
+// config.StartupValueProvider, which is passed to the manifolds in the config.
+type ControllerStartupValueProvider interface {
+	objectstore.RootDirReader
+	dbaccessor.ControllerStartupValuesProvider
+	apiservercertwatcher.CertReader
+	apiserver.LocalConfigReader
+	apiremotecaller.APIInfoProvider
+	controllerlogger.LoggingOverrideReader
+	identityfilewriter.SystemIdentityReader
+}
 
 const (
 	agentName              = "agent"

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -143,6 +143,16 @@ type ManifoldsConfig struct {
 	// ControlSocketPath is the path to the local controller control socket.
 	ControlSocketPath string
 
+	// DataDir is the controller agent data directory used by bootstrap.
+	DataDir string
+
+	// APIPort is the controller API port advertised during bootstrap.
+	APIPort int
+
+	// AgentPassword is the controller agent password used during bootstrap
+	// finalization.
+	AgentPassword string
+
 	// RootDir is the root directory that any worker that needs to
 	// access local filesystems should use as a base. In actual use it
 	// will be "" but it may be overridden in tests.
@@ -316,6 +326,8 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The upgrade-database worker runs soon after the controller
 		// agent starts and runs any steps required to upgrade the
 		// database to the current version.
+		// TODO: remove disabledManifold wrapper once upgrade-database manifold is
+		// reworked for standalone controller.
 		upgradeDatabaseName: disabledManifold(upgradedatabase.Manifold(upgradedatabase.ManifoldConfig{
 			// AgentName:           agentName,
 			UpgradeDBGateName:   upgradeDatabaseGateName,
@@ -362,17 +374,21 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// a mechanism for running other workers so they can't
 		// accidentally interfere with a migration in progress.
 		migrationFortressName: fortress.Manifold(),
-		// migration-inactive-flag is out of scope for Phase 1;
-		// migration is never active in the standalone controller,
-		// so this unconditionally reports "inactive". Replace
-		// with migrationflag.Manifold when controller migration
-		// is implemented.
+
+		// migration-inactive-flag is out of scope for Phase 1; migration is never
+		// active in the standalone controller, so this unconditionally reports
+		// "inactive".
+		// TODO: replace with migrationflag.Manifold when controller migration is
+		// implemented.
 		migrationInactiveFlagName: dependency.Manifold{
 			Start: func(_ context.Context, _ dependency.Getter) (worker.Worker, error) {
 				return engine.NewStaticFlagWorker(true), nil
 			},
 			Output: engine.FlagOutput,
 		},
+
+		// TODO: remove disabledManifold wrapper once migration-minion manifold is
+		// reworked for standalone controller.
 		migrationMinionName: ifControllerUpgradeComplete(disabledManifold(migrationminion.Manifold(migrationminion.ManifoldConfig{
 			// AgentName:         agentName,
 			// APICallerName:     apiCallerName,
@@ -859,6 +875,8 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// type recognised by the controller agent, causing other workers
 		// to be stopped and the agent to be restarted running the new
 		// tools.
+		// TODO: remove disabledManifold wrapper once upgrader manifold is reworked
+		// for standalone controller.
 		upgraderName: ifControllerUpgradeComplete(disabledManifold(upgrader.Manifold(upgrader.ManifoldConfig{
 			// AgentName:            agentName,
 			// APICallerName:        apiCallerName,
@@ -873,6 +891,8 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// controller agent starts and runs any steps required to
 		// upgrade to the running jujud version. Once upgrade steps have
 		// run, the upgradesteps gate is unlocked and the worker exits.
+		// TODO: remove disabledManifold wrapper once upgrade-steps controller
+		// manifold is reworked for standalone controller.
 		upgradeControllerStepsName: ifControllerUpgradeComplete(disabledManifold(upgradestepscontroller.Manifold(upgradestepscontroller.ManifoldConfig{
 			// AgentName:            agentName,
 			// APICallerName:        apiCallerName,
@@ -905,6 +925,8 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		dbAccessorName: dbaccessor.Manifold(NewCAASDBAccessorManifoldConfig(config)),
 
+		// TODO: remove disabledManifold wrapper once upgrader manifold is reworked
+		// for standalone controller.
 		upgraderName: ifControllerUpgradeComplete(disabledManifold(upgrader.Manifold(upgrader.ManifoldConfig{
 			// AgentName:            agentName,
 			// APICallerName:        apiCallerName,
@@ -914,7 +936,8 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:               internallogger.GetLogger("juju.worker.upgrader"),
 			Clock:                config.Clock,
 		}))),
-
+		// TODO: remove disabledManifold wrapper once upgrade-steps controller
+		// manifold is reworked for standalone controller.
 		upgradeControllerStepsName: ifControllerUpgradeComplete(disabledManifold(upgradestepscontroller.Manifold(upgradestepscontroller.ManifoldConfig{
 			// AgentName:            agentName,
 			// APICallerName:        apiCallerName,
@@ -934,12 +957,14 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 // NewIAASBootstrapManifoldConfig returns the IAAS-specific bootstrap config.
 func NewIAASBootstrapManifoldConfig(config ManifoldsConfig) bootstrap.ManifoldConfig {
 	return bootstrap.ManifoldConfig{
-		AgentName:                    agentName,
 		ObjectStoreName:              objectStoreFacadeName,
 		DomainServicesName:           domainServicesName,
 		HTTPClientName:               httpClientName,
 		BootstrapGateName:            isBootstrapGateName,
 		ProviderFactoryName:          providerTrackerName,
+		DataDir:                      config.DataDir,
+		APIPort:                      config.APIPort,
+		AgentPassword:                config.AgentPassword,
 		RequiresBootstrap:            bootstrap.RequiresBootstrap,
 		PopulateControllerCharm:      bootstrap.PopulateIAASControllerCharm,
 		StatusHistory:                domain.NewStatusHistory(internallogger.GetLogger("juju.services"), config.Clock),
@@ -956,12 +981,14 @@ func NewIAASBootstrapManifoldConfig(config ManifoldsConfig) bootstrap.ManifoldCo
 // NewCAASBootstrapManifoldConfig returns the CAAS-specific bootstrap config.
 func NewCAASBootstrapManifoldConfig(config ManifoldsConfig) bootstrap.ManifoldConfig {
 	return bootstrap.ManifoldConfig{
-		AgentName:                    agentName,
 		ObjectStoreName:              objectStoreFacadeName,
 		DomainServicesName:           domainServicesName,
 		HTTPClientName:               httpClientName,
 		BootstrapGateName:            isBootstrapGateName,
 		ProviderFactoryName:          providerTrackerName,
+		DataDir:                      config.DataDir,
+		APIPort:                      config.APIPort,
+		AgentPassword:                config.AgentPassword,
 		RequiresBootstrap:            bootstrap.RequiresBootstrap,
 		PopulateControllerCharm:      bootstrap.PopulateCAASControllerCharm,
 		StatusHistory:                domain.NewStatusHistory(internallogger.GetLogger("juju.services"), config.Clock),
@@ -1011,9 +1038,13 @@ func mergeManifolds(config ManifoldsConfig, manifolds dependency.Manifolds) depe
 	return result
 }
 
-// disabledManifold helps keeping the manifolds that are out-of-scope in this
-// file so that they're not forgotten. Those manifolds will be reworked in
-// next phases of the standalone controller project.
+// disabledManifold wraps an existing manifold definition so that its call site
+// and configuration are preserved in the source while the manifold itself is
+// replaced with a no-op worker. This keeps the wiring visible and makes it
+// easy to re-enable manifolds once their dependencies (e.g. agent, api-caller)
+// are reworked in a later phase of the standalone controller project. Remove
+// disabledManifold and unwrap the call sites when each manifold is brought
+// back in scope.
 func disabledManifold(_ dependency.Manifold) dependency.Manifold {
 	return dependency.Manifold{
 		Start: func(_ context.Context, _ dependency.Getter) (worker.Worker, error) {
@@ -1080,7 +1111,6 @@ type ControllerStartupValueProvider interface {
 }
 
 const (
-	agentName          = "agent"
 	terminationName    = "termination-signal-handler"
 	flightRecorderName = "flight-recorder"
 

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
-	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,7 +27,6 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/semversion"
-	coretrace "github.com/juju/juju/core/trace"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/environs"
 	internalbootstrap "github.com/juju/juju/internal/bootstrap"
@@ -40,11 +38,8 @@ import (
 	"github.com/juju/juju/internal/upgrades"
 	"github.com/juju/juju/internal/upgradesteps"
 	jworker "github.com/juju/juju/internal/worker"
-	"github.com/juju/juju/internal/worker/agent"
-	"github.com/juju/juju/internal/worker/agentconfigupdater"
 	"github.com/juju/juju/internal/worker/apiaddresssetter"
 	"github.com/juju/juju/internal/worker/apicaller"
-	"github.com/juju/juju/internal/worker/apiconfigwatcher"
 	"github.com/juju/juju/internal/worker/apiremotecaller"
 	"github.com/juju/juju/internal/worker/apiremoterelationcaller"
 	"github.com/juju/juju/internal/worker/apiserver"
@@ -89,6 +84,7 @@ import (
 	"github.com/juju/juju/internal/worker/storageregistry"
 	"github.com/juju/juju/internal/worker/terminationworker"
 	"github.com/juju/juju/internal/worker/trace"
+	"github.com/juju/juju/internal/worker/traceservices"
 	"github.com/juju/juju/internal/worker/undertaker"
 	"github.com/juju/juju/internal/worker/upgradedatabase"
 	"github.com/juju/juju/internal/worker/upgrader"
@@ -132,6 +128,11 @@ type ManifoldsConfig struct {
 	// ControllerAgentTag is the tag used for controller-agent log records.
 	ControllerAgentTag names.Tag
 
+	// ControllerTag is the tag identifying the controller entity
+	// (e.g. controller-UUID). It is passed directly to manifolds that
+	// require it instead of being looked up from the agent config.
+	ControllerTag names.ControllerTag
+
 	// LogDir is the controller process log directory for workers in this change
 	// area that still take a fixed local path.
 	LogDir string
@@ -141,14 +142,6 @@ type ManifoldsConfig struct {
 
 	// ControlSocketPath is the path to the local controller control socket.
 	ControlSocketPath string
-
-	// Agent contains the agent that will be wrapped and made available
-	// to its dependencies via a dependency.Engine.
-	Agent coreagent.Agent
-
-	// AgentConfigChanged is set whenever the controller agent's config
-	// is updated.
-	AgentConfigChanged *voyeur.Value
 
 	// RootDir is the root directory that any worker that needs to
 	// access local filesystems should use as a base. In actual use it
@@ -228,8 +221,8 @@ type ManifoldsConfig struct {
 	// for controller administration rights.
 	ControllerLeaseDuration time.Duration
 
-	// TransactionPruneInterval defines how frequently mgo/txn
-	// transactions are pruned from the database.
+	// TransactionPruneInterval defines how frequently mgo/txn transactions
+	// are pruned from the database.
 	TransactionPruneInterval time.Duration
 
 	// RegisterIntrospectionHTTPHandlers is a function that calls the
@@ -263,21 +256,6 @@ type ManifoldsConfig struct {
 
 // commonManifolds returns the shared controller manifolds.
 func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
-	// connectFilter exists:
-	//  1) to let us retry api connections immediately on password change,
-	//     rather than causing the dependency engine to wait for a while;
-	//  2) to decide how to deal with fatal, non-recoverable errors
-	//     e.g. apicaller.ErrConnectImpossible.
-	connectFilter := func(err error) error {
-		cause := errors.Cause(err)
-		if errors.Is(cause, apicaller.ErrConnectImpossible) {
-			return jworker.ErrTerminateAgent
-		} else if errors.Is(cause, apicaller.ErrChangedPassword) {
-			return dependency.ErrBounce
-		}
-		return err
-	}
-
 	newExternalControllerWatcherClient := func(ctx context.Context, apiInfo *api.Info) (
 		externalcontrollerupdater.ExternalControllerWatcherClientCloser, string, error,
 	) {
@@ -288,16 +266,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		return crosscontroller.NewClient(conn), conn.IPAddr(), nil
 	}
 
-	agentConfig := config.Agent.CurrentConfig()
-	agentTag := agentConfig.Tag()
-	controllerTag := agentConfig.Controller()
-
 	return dependency.Manifolds{
-		// The agent manifold references the enclosing agent, and is the
-		// foundation stone on which most other manifolds ultimately
-		// depend.
-		agentName: agent.Manifold(config.Agent),
-
 		// Bootstrap gate/flag manifolds coordinate workers that should
 		// not do anything until the bootstrap worker is done.
 		isBootstrapGateName: gate.ManifoldEx(config.BootstrapLock),
@@ -317,10 +286,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// in.
 		terminationName: terminationworker.Manifold(),
 
-		// clock is retained because several manifolds (http-server-args,
-		// api-server, lease-expiry, lease-manager) reference it by name.
-		clockName: clockManifold(config.Clock),
-
 		flightRecorderName: workerflightrecorder.Manifold(config.FlightRecorder),
 
 		// Controller agent config manifold watches the controller agent
@@ -332,32 +297,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			SocketName:        config.ConfigChangeSocketPath,
 		}),
 
-		// The api-config-watcher manifold monitors the API server
-		// addresses in the agent config and bounces when they change.
-		// It's required as part of model migrations.
-		apiConfigWatcherName: apiconfigwatcher.Manifold(apiconfigwatcher.ManifoldConfig{
-			AgentName:          agentName,
-			AgentConfigChanged: config.AgentConfigChanged,
-			Logger:             internallogger.GetLogger("juju.worker.apiconfigwatcher"),
-		}),
-
 		// The certificate-watcher manifold monitors the API server
 		// certificate in the agent config for changes, and parses and
 		// offers the result to other manifolds.
 		certificateWatcherName: apiservercertwatcher.Manifold(apiservercertwatcher.ManifoldConfig{
 			CertReader: config.StartupValueProvider,
-		}),
-
-		// The api caller is a thin concurrent wrapper around a connection
-		// to some API server. It's used by many other manifolds, which
-		// all select their own desired facades.
-		apiCallerName: apicaller.Manifold(apicaller.ManifoldConfig{
-			AgentName:            agentName,
-			APIConfigWatcherName: apiConfigWatcherName,
-			APIOpen:              api.Open,
-			NewConnection:        apicaller.ScaryConnect,
-			Filter:               connectFilter,
-			Logger:               internallogger.GetLogger("juju.worker.apicaller"),
 		}),
 
 		// The upgrade database gate/flag coordinate workers that should
@@ -449,8 +393,8 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			LeaseManagerName: leaseManagerName,
 			Clock:            clock.WallClock,
 			Duration:         config.ControllerLeaseDuration,
-			Claimant:         agentTag,
-			Entity:           controllerTag,
+			Claimant:         config.ControllerAgentTag,
+			Entity:           config.ControllerTag,
 			NewWorker:        singular.NewFlagWorker,
 		}),
 
@@ -460,7 +404,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			DomainServicesName:    domainServicesName,
 			LoggerContext:         internallogger.DefaultContext(),
 			Logger:                internallogger.GetLogger("juju.worker.logger"),
-			Tag:                   agentTag,
+			Tag:                   config.ControllerAgentTag,
 			LoggingOverrideReader: config.StartupValueProvider,
 			UpdateAgentFunc:       config.UpdateLoggerConfig,
 		})),
@@ -478,12 +422,20 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			},
 		))),
 
-		traceName: trace.Manifold(trace.ManifoldConfig{
-			AgentName:       agentName,
-			Clock:           config.Clock,
-			Logger:          internallogger.GetLogger("juju.worker.trace"),
-			NewTracerWorker: trace.NewTracerWorker,
-			Kind:            coretrace.KindController,
+		traceServicesName: traceservices.Manifold(traceservices.ManifoldConfig{
+			ChangeStreamName: changeStreamName,
+			Logger:           internallogger.GetLogger("juju.worker.traceservices"),
+			NewWorker:        traceservices.NewWorker,
+			NewTraceServices: traceservices.NewTraceServices,
+		}),
+
+		controllerTraceName: trace.ControllerManifold(trace.ControllerManifoldConfig{
+			Tag:               config.ControllerAgentTag,
+			TraceServicesName: traceServicesName,
+			Clock:             config.Clock,
+			Logger:            internallogger.GetLogger("juju.worker.trace"),
+			GetTracingService: trace.GetTracingService,
+			NewTracerWorker:   trace.NewTracerWorker,
 		}),
 
 		httpServerArgsName: ifBootstrapComplete(httpserverargs.Manifold(httpserverargs.ManifoldConfig{
@@ -523,7 +475,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			UpgradeGateName:        upgradeStepsGateName,
 			AuditConfigUpdaterName: auditConfigUpdaterName,
 			HTTPClientName:         httpClientName,
-			TraceName:              traceName,
+			TraceName:              controllerTraceName,
 			ObjectStoreName:        objectStoreFacadeName,
 			JWTParserName:          jwtParserName,
 			WatcherRegistryName:    watcherRegistryName,
@@ -629,7 +581,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// expiry time in the past.
 		leaseExpiryName: ifPrimaryController(leaseexpiry.Manifold(leaseexpiry.ManifoldConfig{
 			DBAccessorName: dbAccessorName,
-			TraceName:      traceName,
+			TraceName:      controllerTraceName,
 			Clock:          config.Clock,
 			Logger:         internallogger.GetLogger("juju.worker.leaseexpiry"),
 			NewWorker:      leaseexpiry.NewWorker,
@@ -640,7 +592,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// Dqlite database.
 		leaseManagerName: leasemanager.Manifold(leasemanager.ManifoldConfig{
 			DBAccessorName:       dbAccessorName,
-			TraceName:            traceName,
+			TraceName:            controllerTraceName,
 			ControllerUUID:       config.ControllerUUID,
 			ControllerModelUUID:  config.ControllerModelUUID,
 			Clock:                config.Clock,
@@ -708,7 +660,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 
 		objectStoreName: ifDatabaseUpgradeComplete(objectstore.Manifold(objectstore.ManifoldConfig{
-			TraceName:                  traceName,
+			TraceName:                  controllerTraceName,
 			ObjectStoreServicesName:    objectStoreServicesName,
 			LeaseManagerName:           leaseManagerName,
 			S3ClientName:               objectStoreS3CallerName,
@@ -753,9 +705,13 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		// Provider tracker manifold is not dependent on the
-		// ifDatabaseUpgradeComplete gate. The provider tracker data must
-		// not change between patch/build versions and should be available
-		// to all workers from the start.
+		// ifDatabaseUpgradeComplete gate. The provider tracker data must not
+		// change between patch/build versions and should be available to all
+		// workers from the start. This includes the controller and read-only
+		// model data that the provider tracker worker is responsible for.
+		//
+		// Migration away to a major/minor version is the correct way to move
+		// a model for upgrade scenarios.
 		providerTrackerName: providertracker.MultiTrackerManifold(providertracker.ManifoldConfig{
 			ProviderServiceFactoriesName: providerDomainServicesName,
 			LogSinkName:                  logSinkName,
@@ -887,8 +843,6 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// controller.
 		bootstrapName: ifDatabaseUpgradeComplete(bootstrap.Manifold(NewIAASBootstrapManifoldConfig(config))),
 
-		agentConfigUpdaterName: ifNotMigrating(agentconfigupdater.Manifold(NewIAASAgentConfigUpdaterManifoldConfig())),
-
 		certificateUpdaterName: ifFullyUpgraded(certupdater.Manifold(certupdater.ManifoldConfig{
 			AuthorityName:               certificateWatcherName,
 			DomainServicesName:          domainServicesName,
@@ -940,8 +894,6 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	return mergeManifolds(config, dependency.Manifolds{
 		bootstrapName: ifDatabaseUpgradeComplete(bootstrap.Manifold(NewCAASBootstrapManifoldConfig(config))),
-
-		agentConfigUpdaterName: ifNotMigrating(agentconfigupdater.Manifold(NewCAASAgentConfigUpdaterManifoldConfig())),
 
 		certificateUpdaterName: ifFullyUpgraded(certupdater.Manifold(certupdater.ManifoldConfig{
 			AuthorityName:               certificateWatcherName,
@@ -1023,34 +975,6 @@ func NewCAASBootstrapManifoldConfig(config ManifoldsConfig) bootstrap.ManifoldCo
 	}
 }
 
-// NewIAASAgentConfigUpdaterManifoldConfig returns the IAAS agent-config updater
-// config.
-func NewIAASAgentConfigUpdaterManifoldConfig() agentconfigupdater.ManifoldConfig {
-	return agentconfigupdater.ManifoldConfig{
-		AgentName:                     agentName,
-		APICallerName:                 apiCallerName,
-		DomainServicesName:            domainServicesName,
-		TraceName:                     traceName,
-		GetControllerDomainServicesFn: agentconfigupdater.GetControllerDomainServices,
-		IsControllerAgentFn:           agentconfigupdater.IAASIsControllerAgent,
-		Logger:                        internallogger.GetLogger("juju.worker.agentconfigupdater"),
-	}
-}
-
-// NewCAASAgentConfigUpdaterManifoldConfig returns the CAAS agent-config updater
-// config.
-func NewCAASAgentConfigUpdaterManifoldConfig() agentconfigupdater.ManifoldConfig {
-	return agentconfigupdater.ManifoldConfig{
-		AgentName:                     agentName,
-		APICallerName:                 apiCallerName,
-		DomainServicesName:            domainServicesName,
-		TraceName:                     traceName,
-		GetControllerDomainServicesFn: agentconfigupdater.GetControllerDomainServices,
-		IsControllerAgentFn:           agentconfigupdater.CAASIsControllerAgent,
-		Logger:                        internallogger.GetLogger("juju.worker.agentconfigupdater"),
-	}
-}
-
 // NewIAASDBAccessorManifoldConfig returns the IAAS-specific db-accessor config.
 func NewIAASDBAccessorManifoldConfig(config ManifoldsConfig) dbaccessor.ManifoldConfig {
 	return dbaccessor.ManifoldConfig{
@@ -1087,16 +1011,10 @@ func mergeManifolds(config ManifoldsConfig, manifolds dependency.Manifolds) depe
 	return result
 }
 
-func clockManifold(clk clock.Clock) dependency.Manifold {
-	return dependency.Manifold{
-		Start: func(_ context.Context, _ dependency.Getter) (worker.Worker, error) {
-			return engine.NewValueWorker(clk)
-		},
-		Output: engine.ValueWorkerOutput,
-	}
-}
-
-func disabledManifold(manifold dependency.Manifold) dependency.Manifold {
+// disabledManifold helps keeping the manifolds that are out-of-scope in this
+// file so that they're not forgotten. Those manifolds will be reworked in
+// next phases of the standalone controller project.
+func disabledManifold(_ dependency.Manifold) dependency.Manifold {
 	return dependency.Manifold{
 		Start: func(_ context.Context, _ dependency.Getter) (worker.Worker, error) {
 			return jworker.NewSimpleWorker(func(ctx context.Context) error {
@@ -1162,13 +1080,9 @@ type ControllerStartupValueProvider interface {
 }
 
 const (
-	agentName              = "agent"
-	agentConfigUpdaterName = "agent-config-updater"
-	terminationName        = "termination-signal-handler"
-	apiCallerName          = "api-caller"
-	apiConfigWatcherName   = "api-config-watcher"
-	clockName              = "clock"
-	flightRecorderName     = "flight-recorder"
+	agentName          = "agent"
+	terminationName    = "termination-signal-handler"
+	flightRecorderName = "flight-recorder"
 
 	bootstrapName       = "bootstrap"
 	isBootstrapGateName = "is-bootstrap-gate"
@@ -1232,7 +1146,8 @@ const (
 	secretBackendRotateName            = "secret-backend-rotate"
 	sshServerName                      = "ssh-server"
 	storageRegistryName                = "storage-registry"
-	traceName                          = "trace"
+	controllerTraceName                = "controller-trace"
+	traceServicesName                  = "trace-services"
 	undertakerName                     = "undertaker"
 	watcherRegistryName                = "watcher-registry"
 )

--- a/cmd/jujud/agent/controller/manifolds_test.go
+++ b/cmd/jujud/agent/controller/manifolds_test.go
@@ -729,7 +729,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	},
 
 	"bootstrap": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",

--- a/cmd/jujud/agent/controller/manifolds_test.go
+++ b/cmd/jujud/agent/controller/manifolds_test.go
@@ -10,20 +10,15 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/dependency"
 	"github.com/juju/worker/v5/workertest"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agenttest"
 	agentcontroller "github.com/juju/juju/cmd/jujud/agent/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/upgrades"
-	jworker "github.com/juju/juju/internal/worker"
-	"github.com/juju/juju/internal/worker/agentconfigupdater"
-	"github.com/juju/juju/internal/worker/apicaller"
 	"github.com/juju/juju/internal/worker/bootstrap"
 	"github.com/juju/juju/internal/worker/dbaccessor"
 	"github.com/juju/juju/internal/worker/gate"
@@ -43,8 +38,8 @@ func (s *ManifoldsSuite) SetUpTest(c *tc.C) {
 
 func (s *ManifoldsSuite) TestStartFuncs(c *tc.C) {
 	manifolds := agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-		Agent:           &mockAgent{},
 		PreUpgradeSteps: preUpgradeSteps,
+		ControllerTag:   testing.ControllerTag,
 	})
 	for name, manifold := range manifolds {
 		c.Logf("checking %q manifold", name)
@@ -52,8 +47,8 @@ func (s *ManifoldsSuite) TestStartFuncs(c *tc.C) {
 	}
 
 	manifolds = agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
-		Agent:           &mockAgent{},
 		PreUpgradeSteps: preUpgradeSteps,
+		ControllerTag:   testing.ControllerTag,
 	})
 	for name, manifold := range manifolds {
 		c.Logf("checking CAAS %q manifold", name)
@@ -63,8 +58,8 @@ func (s *ManifoldsSuite) TestStartFuncs(c *tc.C) {
 
 func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 	manifolds := agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-		Agent:           &mockAgent{},
 		PreUpgradeSteps: preUpgradeSteps,
+		ControllerTag:   testing.ControllerTag,
 	})
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {
@@ -72,11 +67,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 	}
 	sort.Strings(keys)
 	c.Assert(keys, tc.SameContents, []string{
-		"agent",
-		"agent-config-updater",
 		"api-address-setter",
-		"api-caller",
-		"api-config-watcher",
 		"api-remote-caller",
 		"api-remote-relation-caller",
 		"api-server",
@@ -86,12 +77,12 @@ func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 		"certificate-watcher",
 		"change-stream",
 		"change-stream-pruner",
-		"clock",
-		"controller-upgrade-flag",
-		"controller-upgrade-gate",
 		"control-socket",
 		"controller-agent-config",
 		"controller-presence",
+		"controller-trace",
+		"controller-upgrade-flag",
+		"controller-upgrade-gate",
 		"db-accessor",
 		"domain-services",
 		"external-controller-updater",
@@ -126,7 +117,7 @@ func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 		"ssh-server",
 		"storage-registry",
 		"termination-signal-handler",
-		"trace",
+		"trace-services",
 		"undertaker",
 		"upgrade-check-flag",
 		"upgrade-check-gate",
@@ -144,8 +135,8 @@ func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 
 func (*ManifoldsSuite) TestMigrationInfrastructureStaysActive(c *tc.C) {
 	manifolds := agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-		Agent:           &mockAgent{},
 		PreUpgradeSteps: preUpgradeSteps,
+		ControllerTag:   testing.ControllerTag,
 	})
 	manifold, ok := manifolds["migration-fortress"]
 	c.Assert(ok, tc.IsTrue)
@@ -159,10 +150,7 @@ func (s *ManifoldsSuite) TestMigrationGuardsUsed(c *tc.C) {
 	// All manifolds that do NOT require both migration-fortress and
 	// migration-inactive-flag as direct Inputs are listed here.
 	exempt := set.NewStrings(
-		"agent",
 		"api-address-setter",
-		"api-caller",
-		"api-config-watcher",
 		"api-remote-caller",
 		"api-remote-relation-caller",
 		"api-server",
@@ -172,7 +160,6 @@ func (s *ManifoldsSuite) TestMigrationGuardsUsed(c *tc.C) {
 		"certificate-watcher",
 		"change-stream",
 		"change-stream-pruner",
-		"clock",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
 		"control-socket",
@@ -208,7 +195,8 @@ func (s *ManifoldsSuite) TestMigrationGuardsUsed(c *tc.C) {
 		"ssh-server",
 		"storage-registry",
 		"termination-signal-handler",
-		"trace",
+		"trace-services",
+		"controller-trace",
 		"undertaker",
 		"upgrade-check-flag",
 		"upgrade-check-gate",
@@ -223,8 +211,8 @@ func (s *ManifoldsSuite) TestMigrationGuardsUsed(c *tc.C) {
 		"watcher-registry",
 	)
 	manifolds := agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-		Agent:           &mockAgent{},
 		PreUpgradeSteps: preUpgradeSteps,
+		ControllerTag:   testing.ControllerTag,
 	})
 	for name, manifold := range manifolds {
 		c.Logf("%s", name)
@@ -239,8 +227,8 @@ func (*ManifoldsSuite) TestObjectStoreDoesNotUseDomainServices(c *tc.C) {
 	// The object-store is a dependency of domain-services; no circular
 	// dependency is permitted.
 	manifolds := agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-		Agent:           &mockAgent{},
 		PreUpgradeSteps: preUpgradeSteps,
+		ControllerTag:   testing.ControllerTag,
 	})
 
 	manifold := manifolds["object-store"]
@@ -254,8 +242,8 @@ func (*ManifoldsSuite) TestProviderTrackerDoesNotUseDomainServices(c *tc.C) {
 	// The provider-tracker is a dependency of domain-services; no circular
 	// dependency is permitted.
 	manifolds := agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-		Agent:           &mockAgent{},
 		PreUpgradeSteps: preUpgradeSteps,
+		ControllerTag:   testing.ControllerTag,
 	})
 
 	manifold := manifolds["provider-tracker"]
@@ -263,24 +251,6 @@ func (*ManifoldsSuite) TestProviderTrackerDoesNotUseDomainServices(c *tc.C) {
 
 	dependencies := agenttest.ManifoldDependencies(manifolds, manifold)
 	c.Check(dependencies.Contains("domain-services"), tc.IsFalse)
-}
-
-func (*ManifoldsSuite) TestAPICallerNonRecoverableErrorHandling(c *tc.C) {
-	ag := &mockAgent{
-		conf: mockConfig{
-			dataPath: c.MkDir(),
-		},
-	}
-	manifolds := agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-		Agent:           ag,
-		PreUpgradeSteps: preUpgradeSteps,
-	})
-
-	c.Assert(manifolds["api-caller"], tc.Not(tc.IsNil))
-	apiCallerManifold := manifolds["api-caller"]
-
-	err := apiCallerManifold.Filter(apicaller.ErrConnectImpossible)
-	c.Assert(err, tc.Equals, jworker.ErrTerminateAgent)
 }
 
 func checkContains(c *tc.C, names []string, seek string) {
@@ -300,8 +270,8 @@ func checkNotContains(c *tc.C, names []string, seek string) {
 func (*ManifoldsSuite) TestControllerUpgradeGate(c *tc.C) {
 	controllerUpgradeLock := gate.NewLock()
 	manifolds := agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-		Agent:                 &mockAgent{},
 		PreUpgradeSteps:       preUpgradeSteps,
+		ControllerTag:         testing.ControllerTag,
 		ControllerUpgradeLock: controllerUpgradeLock,
 	})
 	assertGate(c, manifolds["controller-upgrade-gate"], controllerUpgradeLock)
@@ -311,8 +281,8 @@ func (*ManifoldsSuite) TestUpgradeGates(c *tc.C) {
 	upgradeStepsLock := gate.NewLock()
 	upgradeCheckLock := gate.NewLock()
 	manifolds := agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-		Agent:            &mockAgent{},
 		PreUpgradeSteps:  preUpgradeSteps,
+		ControllerTag:    testing.ControllerTag,
 		UpgradeStepsLock: upgradeStepsLock,
 		UpgradeCheckLock: upgradeCheckLock,
 	})
@@ -326,11 +296,10 @@ func (*ManifoldsSuite) TestChangeStreamDirectInputs(c *tc.C) {
 	// db-accessor and file-notify-watcher appear in its direct Inputs.
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{},
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			ControllerTag:   testing.ControllerTag,
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 	} {
@@ -347,11 +316,10 @@ func (*ManifoldsSuite) TestChangeStreamDirectInputs(c *tc.C) {
 func (*ManifoldsSuite) TestControllerOnlyWorkerDirectInputs(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{},
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			ControllerTag:   testing.ControllerTag,
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 	} {
@@ -429,18 +397,17 @@ func (*ManifoldsSuite) TestControllerOnlyWorkerDirectInputs(c *tc.C) {
 func (*ManifoldsSuite) TestObjectStoreDirectInputs(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{},
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			ControllerTag:   testing.ControllerTag,
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 	} {
 		manifold, ok := manifolds["object-store"]
 		c.Assert(ok, tc.IsTrue)
 		c.Check(manifold.Inputs, tc.SameContents, []string{
-			"trace",
+			"controller-trace",
 			"object-store-services",
 			"lease-manager",
 			"object-store-s3-caller",
@@ -455,11 +422,10 @@ func (*ManifoldsSuite) TestObjectStoreDirectInputs(c *tc.C) {
 func (*ManifoldsSuite) TestObjectStoreServicesDirectInputs(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{},
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			ControllerTag:   testing.ControllerTag,
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 	} {
@@ -474,11 +440,10 @@ func (*ManifoldsSuite) TestObjectStoreServicesDirectInputs(c *tc.C) {
 func (*ManifoldsSuite) TestObjectStoreDrainerDirectInputs(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{},
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			ControllerTag:   testing.ControllerTag,
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 	} {
@@ -498,11 +463,10 @@ func (*ManifoldsSuite) TestObjectStoreDrainerDirectInputs(c *tc.C) {
 func (*ManifoldsSuite) TestLeaseExpiryDirectInputs(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{},
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			ControllerTag:   testing.ControllerTag,
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 	} {
@@ -510,7 +474,7 @@ func (*ManifoldsSuite) TestLeaseExpiryDirectInputs(c *tc.C) {
 		c.Assert(ok, tc.IsTrue)
 		c.Check(manifold.Inputs, tc.SameContents, []string{
 			"db-accessor",
-			"trace",
+			"controller-trace",
 			"is-primary-controller-flag",
 		})
 		checkNotContains(c, manifold.Inputs, "clock")
@@ -520,11 +484,10 @@ func (*ManifoldsSuite) TestLeaseExpiryDirectInputs(c *tc.C) {
 func (*ManifoldsSuite) TestLeaseManagerDirectInputs(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{},
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			ControllerTag:   testing.ControllerTag,
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 	} {
@@ -532,7 +495,7 @@ func (*ManifoldsSuite) TestLeaseManagerDirectInputs(c *tc.C) {
 		c.Assert(ok, tc.IsTrue)
 		c.Check(manifold.Inputs, tc.SameContents, []string{
 			"db-accessor",
-			"trace",
+			"controller-trace",
 		})
 		checkNotContains(c, manifold.Inputs, "agent")
 		checkNotContains(c, manifold.Inputs, "clock")
@@ -542,11 +505,10 @@ func (*ManifoldsSuite) TestLeaseManagerDirectInputs(c *tc.C) {
 func (*ManifoldsSuite) TestOutOfScopeWorkersUseControllerUpgradeGate(c *tc.C) {
 	for _, manifolds := range []dependency.Manifolds{
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{},
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
+			ControllerTag:   testing.ControllerTag,
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 	} {
@@ -577,26 +539,9 @@ func (*ManifoldsSuite) TestOutOfScopeWorkersUseControllerUpgradeGate(c *tc.C) {
 	}
 }
 
-func (*ManifoldsSuite) TestAgentConfigUpdaterUsesMigrationHousingInBothVariants(c *tc.C) {
-	for _, manifolds := range []dependency.Manifolds{
-		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{},
-			PreUpgradeSteps: preUpgradeSteps,
-		}),
-		agentcontroller.CAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
-			PreUpgradeSteps: preUpgradeSteps,
-		}),
-	} {
-		manifold := manifolds["agent-config-updater"]
-		checkContains(c, manifold.Inputs, "migration-fortress")
-		checkContains(c, manifold.Inputs, "migration-inactive-flag")
-	}
-}
-
 func (*ManifoldsSuite) TestBootstrapManifoldConfigUsesProviderSpecificHelpers(c *tc.C) {
 	manifoldsCfg := agentcontroller.ManifoldsConfig{
-		Agent: &mockAgent{},
+		ControllerTag: testing.ControllerTag,
 	}
 	iaasCfg := agentcontroller.NewIAASBootstrapManifoldConfig(manifoldsCfg)
 	caasCfg := agentcontroller.NewCAASBootstrapManifoldConfig(manifoldsCfg)
@@ -615,17 +560,9 @@ func (*ManifoldsSuite) TestBootstrapManifoldConfigUsesProviderSpecificHelpers(c 
 	c.Check(reflect.ValueOf(caasCfg.AgentFinalizer).Pointer(), tc.Equals, reflect.ValueOf(bootstrap.CAASAgentFinalizer).Pointer())
 }
 
-func (*ManifoldsSuite) TestAgentConfigUpdaterManifoldConfigUsesProviderSpecificControllerChecks(c *tc.C) {
-	iaasCfg := agentcontroller.NewIAASAgentConfigUpdaterManifoldConfig()
-	caasCfg := agentcontroller.NewCAASAgentConfigUpdaterManifoldConfig()
-
-	c.Check(reflect.ValueOf(iaasCfg.IsControllerAgentFn).Pointer(), tc.Equals, reflect.ValueOf(agentconfigupdater.IAASIsControllerAgent).Pointer())
-	c.Check(reflect.ValueOf(caasCfg.IsControllerAgentFn).Pointer(), tc.Equals, reflect.ValueOf(agentconfigupdater.CAASIsControllerAgent).Pointer())
-}
-
 func (*ManifoldsSuite) TestDBAccessorManifoldConfigUsesProviderSpecificNodeManagers(c *tc.C) {
 	manifoldsCfg := agentcontroller.ManifoldsConfig{
-		Agent: &mockAgent{},
+		ControllerTag: testing.ControllerTag,
 	}
 	iaasCfg := agentcontroller.NewIAASDBAccessorManifoldConfig(manifoldsCfg)
 	caasCfg := agentcontroller.NewCAASDBAccessorManifoldConfig(manifoldsCfg)
@@ -662,7 +599,6 @@ func (s *ManifoldsSuite) TestManifoldsDependencies(c *tc.C) {
 	agenttest.AssertManifoldsDependencies(
 		c,
 		agentcontroller.IAASManifolds(agentcontroller.ManifoldsConfig{
-			Agent:           &mockAgent{},
 			PreUpgradeSteps: preUpgradeSteps,
 		}),
 		expectedControllerManifoldsWithDependencies,
@@ -670,42 +606,11 @@ func (s *ManifoldsSuite) TestManifoldsDependencies(c *tc.C) {
 }
 
 var expectedControllerManifoldsWithDependencies = map[string][]string{
-	"agent": {},
-
-	"agent-config-updater": {
-		"agent",
-		"api-caller",
-		"api-config-watcher",
-		"api-remote-caller",
-		"change-stream",
-		"controller-agent-config",
-		"db-accessor",
-		"domain-services",
-		"file-notify-watcher",
-		"http-client",
-		"lease-manager",
-		"log-sink",
-		"migration-fortress",
-		"migration-inactive-flag",
-		"object-store",
-		"object-store-facade",
-		"object-store-fortress",
-		"object-store-s3-caller",
-		"object-store-services",
-		"provider-services",
-		"provider-tracker",
-		"query-logger",
-		"storage-registry",
-		"trace",
-		"upgrade-database-flag",
-		"upgrade-database-gate",
-	},
-
 	"api-address-setter": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -722,14 +627,10 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
-
-	"api-caller": {"agent", "api-config-watcher"},
-
-	"api-config-watcher": {"agent"},
 
 	"api-remote-caller": {
 		"change-stream",
@@ -741,10 +642,10 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	},
 
 	"api-remote-relation-caller": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
 		"db-accessor",
@@ -762,17 +663,17 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
 
 	"api-server": {
-		"agent",
 		"api-remote-caller",
 		"audit-config-updater",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
 		"db-accessor",
@@ -795,7 +696,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 		"upgrade-steps-gate",
@@ -803,10 +704,10 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	},
 
 	"audit-config-updater": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -822,7 +723,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
@@ -832,6 +733,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -848,17 +750,17 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
 
 	"certificate-updater": {
-		"agent",
 		"api-remote-caller",
 		"certificate-watcher",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
 		"db-accessor",
@@ -876,7 +778,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-check-flag",
 		"upgrade-check-gate",
 		"upgrade-database-flag",
@@ -895,10 +797,10 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	},
 
 	"change-stream-pruner": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -915,22 +817,16 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
 
-	"clock": {},
-
-	"controller-upgrade-flag": {"controller-upgrade-gate"},
-
-	"controller-upgrade-gate": {},
-
 	"control-socket": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -946,7 +842,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
@@ -954,10 +850,10 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	"controller-agent-config": {},
 
 	"controller-presence": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -973,10 +869,23 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
+
+	"controller-trace": {
+		"change-stream",
+		"controller-agent-config",
+		"db-accessor",
+		"file-notify-watcher",
+		"query-logger",
+		"trace-services",
+	},
+
+	"controller-upgrade-flag": {"controller-upgrade-gate"},
+
+	"controller-upgrade-gate": {},
 
 	"db-accessor": {
 		"controller-agent-config",
@@ -984,10 +893,10 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	},
 
 	"domain-services": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"file-notify-watcher",
 		"http-client",
@@ -1002,16 +911,16 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
 
 	"external-controller-updater": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -1030,7 +939,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
@@ -1042,13 +951,13 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	"http-client": {},
 
 	"http-server": {
-		"agent",
 		"api-remote-caller",
 		"api-server",
 		"audit-config-updater",
 		"certificate-watcher",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
 		"db-accessor",
@@ -1071,7 +980,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 		"upgrade-steps-gate",
@@ -1079,10 +988,10 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	},
 
 	"http-server-args": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -1100,7 +1009,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
@@ -1110,19 +1019,21 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	"is-bootstrap-gate": {},
 
 	"is-primary-controller-flag": {
-		"agent",
+		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
+		"file-notify-watcher",
 		"lease-manager",
 		"query-logger",
-		"trace",
+		"trace-services",
 	},
 
 	"jwt-parser": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -1138,36 +1049,40 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
 
 	"lease-expiry": {
-		"agent",
+		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
+		"file-notify-watcher",
 		"is-primary-controller-flag",
 		"lease-manager",
 		"query-logger",
-		"trace",
+		"trace-services",
 	},
 
 	"lease-manager": {
-		"agent",
+		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
+		"file-notify-watcher",
 		"query-logger",
-		"trace",
+		"trace-services",
 	},
 
 	"log-sink": {},
 
 	"logging-controller-config-updater": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -1185,7 +1100,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
@@ -1200,12 +1115,12 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	},
 
 	"model-worker-manager": {
-		"agent",
 		"api-remote-caller",
 		"api-remote-relation-caller",
 		"certificate-watcher",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
 		"db-accessor",
@@ -1223,7 +1138,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-check-flag",
 		"upgrade-check-gate",
 		"upgrade-database-flag",
@@ -1235,10 +1150,10 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	"object-store-fortress": {},
 
 	"object-store-facade": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"file-notify-watcher",
 		"http-client",
@@ -1248,16 +1163,16 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"object-store-s3-caller",
 		"object-store-services",
 		"query-logger",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
 
 	"object-store-drainer": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"file-notify-watcher",
 		"http-client",
@@ -1267,16 +1182,16 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"object-store-s3-caller",
 		"object-store-services",
 		"query-logger",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
 
 	"object-store": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"file-notify-watcher",
 		"http-client",
@@ -1284,7 +1199,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"object-store-s3-caller",
 		"object-store-services",
 		"query-logger",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
@@ -1330,10 +1245,10 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	"query-logger": {},
 
 	"secret-backend-rotate": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -1352,7 +1267,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
@@ -1363,10 +1278,10 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	},
 
 	"ssh-server": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -1382,7 +1297,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
@@ -1400,13 +1315,19 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 
 	"termination-signal-handler": {},
 
-	"trace": {"agent"},
+	"trace-services": {
+		"change-stream",
+		"controller-agent-config",
+		"db-accessor",
+		"file-notify-watcher",
+		"query-logger",
+	},
 
 	"undertaker": {
-		"agent",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
+		"controller-trace",
 		"db-accessor",
 		"domain-services",
 		"file-notify-watcher",
@@ -1422,7 +1343,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 		"provider-tracker",
 		"query-logger",
 		"storage-registry",
-		"trace",
+		"trace-services",
 		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
@@ -1462,51 +1383,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	},
 
 	"watcher-registry": {},
-}
-
-type mockAgent struct {
-	agent.Agent
-	conf mockConfig
-}
-
-func (ma *mockAgent) CurrentConfig() agent.Config {
-	return &ma.conf
-}
-
-func (ma *mockAgent) ChangeConfig(f agent.ConfigMutator) error {
-	return f(&ma.conf)
-}
-
-type mockConfig struct {
-	agent.ConfigSetter
-	tag      names.Tag
-	dataPath string
-}
-
-func (mc *mockConfig) Tag() names.Tag {
-	if mc.tag == nil {
-		return names.NewMachineTag("99")
-	}
-	return mc.tag
-}
-
-func (mc *mockConfig) Controller() names.ControllerTag {
-	return testing.ControllerTag
-}
-
-func (mc *mockConfig) LogDir() string {
-	return "log-dir"
-}
-
-func (mc *mockConfig) DataDir() string {
-	if mc.dataPath != "" {
-		return mc.dataPath
-	}
-	return "data-dir"
-}
-
-func (mc *mockConfig) LoggingConfig() string {
-	return ""
 }
 
 func preUpgradeSteps(model.ModelType) upgrades.PreUpgradeStepsFunc { return nil }

--- a/cmd/jujud/agent/controller/manifolds_test.go
+++ b/cmd/jujud/agent/controller/manifolds_test.go
@@ -415,6 +415,14 @@ func (*ManifoldsSuite) TestControllerOnlyWorkerDirectInputs(c *tc.C) {
 		})
 		checkNotContains(c, externalControllerUpdaterManifold.Inputs, "api-caller")
 		checkNotContains(c, externalControllerUpdaterManifold.Inputs, "agent")
+
+		apiRemoteCallerManifold, ok := manifolds["api-remote-caller"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(apiRemoteCallerManifold.Inputs, tc.SameContents, []string{
+			"object-store-services",
+		})
+		checkNotContains(c, apiRemoteCallerManifold.Inputs, "agent")
+		checkNotContains(c, apiRemoteCallerManifold.Inputs, "api-caller")
 	}
 }
 
@@ -724,7 +732,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	"api-config-watcher": {"agent"},
 
 	"api-remote-caller": {
-		"agent",
 		"change-stream",
 		"controller-agent-config",
 		"db-accessor",
@@ -1002,8 +1009,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 
 	"external-controller-updater": {
 		"agent",
-		"api-caller",
-		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
@@ -1160,8 +1165,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 
 	"logging-controller-config-updater": {
 		"agent",
-		"api-caller",
-		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
@@ -1189,19 +1192,11 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 
 	"migration-fortress": {},
 
-	"migration-inactive-flag": {
-		"agent",
-		"api-caller",
-		"api-config-watcher",
-	},
+	"migration-inactive-flag": {},
 
 	"migration-minion": {
-		"agent",
-		"api-caller",
-		"api-config-watcher",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
-		"migration-fortress",
 	},
 
 	"model-worker-manager": {
@@ -1336,8 +1331,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 
 	"secret-backend-rotate": {
 		"agent",
-		"api-caller",
-		"api-config-watcher",
 		"api-remote-caller",
 		"change-stream",
 		"controller-agent-config",
@@ -1365,9 +1358,6 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	},
 
 	"ssh-identity-writer": {
-		"agent",
-		"api-caller",
-		"api-config-watcher",
 		"migration-fortress",
 		"migration-inactive-flag",
 	},
@@ -1445,18 +1435,7 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 
 	"upgrade-database-gate": {},
 
-	"upgrade-database-runner": {
-		"agent",
-		"change-stream",
-		"controller-agent-config",
-		"controller-upgrade-flag",
-		"controller-upgrade-gate",
-		"db-accessor",
-		"file-notify-watcher",
-		"query-logger",
-		"upgrade-database-gate",
-		"upgrade-services",
-	},
+	"upgrade-database-runner": {},
 
 	"upgrade-services": {
 		"change-stream",
@@ -1473,43 +1452,13 @@ var expectedControllerManifoldsWithDependencies = map[string][]string{
 	"upgrade-steps-gate": {"controller-upgrade-flag", "controller-upgrade-gate"},
 
 	"upgrade-controller-steps-runner": {
-		"agent",
-		"api-caller",
-		"api-config-watcher",
-		"api-remote-caller",
-		"change-stream",
-		"controller-agent-config",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
-		"db-accessor",
-		"domain-services",
-		"file-notify-watcher",
-		"http-client",
-		"lease-manager",
-		"log-sink",
-		"object-store",
-		"object-store-facade",
-		"object-store-fortress",
-		"object-store-s3-caller",
-		"object-store-services",
-		"provider-services",
-		"provider-tracker",
-		"query-logger",
-		"storage-registry",
-		"trace",
-		"upgrade-database-flag",
-		"upgrade-database-gate",
-		"upgrade-steps-gate",
 	},
 
 	"upgrader": {
-		"agent",
-		"api-caller",
-		"api-config-watcher",
 		"controller-upgrade-flag",
 		"controller-upgrade-gate",
-		"upgrade-check-gate",
-		"upgrade-steps-gate",
 	},
 
 	"watcher-registry": {},

--- a/internal/cloudconfig/userdatacfg.go
+++ b/internal/cloudconfig/userdatacfg.go
@@ -519,6 +519,7 @@ func (w *userdataConfig) configureBootstrap() error {
 		SystemIdentity:         w.icfg.Bootstrap.ControllerAgentInfo.SystemIdentity,
 		LogSinkRateLimitBurst:  logSinkBurst,
 		LogSinkRateLimitRefill: logSinkRefill,
+		APIAddresses:           w.icfg.APIInfo.Addrs,
 	}
 	runtimeCfgContent, err := controllerruntimeconfig.RenderControllerRuntimeConfig(runtimeCfg)
 	if err != nil {

--- a/internal/controllerruntimeconfig/config.go
+++ b/internal/controllerruntimeconfig/config.go
@@ -95,6 +95,11 @@ type ControllerRuntimeConfig struct {
 	// through once the initial burst is depleted. A zero value means use
 	// the default from apiserver.DefaultLogSinkConfig().
 	LogSinkRateLimitRefill time.Duration `yaml:"log-sink-rate-limit-refill,omitempty"`
+
+	// APIAddresses holds the API server addresses that the controller
+	// uses to connect to other controllers. These are written at
+	// bootstrap time and used by the api-remote-caller worker.
+	APIAddresses []string `yaml:"api-addresses,omitempty"`
 }
 
 // Validate returns an error if any required field is missing or invalid.

--- a/internal/controllerruntimeconfig/config.go
+++ b/internal/controllerruntimeconfig/config.go
@@ -96,9 +96,9 @@ type ControllerRuntimeConfig struct {
 	// the default from apiserver.DefaultLogSinkConfig().
 	LogSinkRateLimitRefill time.Duration `yaml:"log-sink-rate-limit-refill,omitempty"`
 
-	// APIAddresses holds the API server addresses that the controller
-	// uses to connect to other controllers. These are written at
-	// bootstrap time and used by the api-remote-caller worker.
+	// APIAddresses holds the API server addresses that the controller uses to
+	// connect to other controllers. These are written at bootstrap time and used
+	// by the api-remote-caller worker.
 	APIAddresses []string `yaml:"api-addresses,omitempty"`
 }
 
@@ -140,6 +140,11 @@ func (cfg ControllerRuntimeConfig) Validate() error {
 	if cfg.ControllerPrivateKey == "" {
 		return errors.NotValidf("empty controller-private-key")
 	}
+	for i, addr := range cfg.APIAddresses {
+		if addr == "" {
+			return errors.NotValidf("empty api-address at index %d", i)
+		}
+	}
 	return nil
 }
 
@@ -175,11 +180,11 @@ func WriteControllerRuntimeConfig(path string, cfg ControllerRuntimeConfig) erro
 	if err != nil {
 		return errors.Annotate(err, "marshalling controller runtime config")
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return errors.Annotatef(err,
 			"creating parent directory for controller runtime config %q", path)
 	}
-	if err := utils.AtomicWriteFile(path, data, 0600); err != nil {
+	if err := utils.AtomicWriteFile(path, data, 0o600); err != nil {
 		return errors.Annotatef(err,
 			"writing controller runtime config %q", path)
 	}

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -741,6 +741,7 @@ func (c *controllerStack) ensureControllerConfigmapAgentConf(ctx context.Context
 		SystemIdentity:         c.pcfg.Bootstrap.ControllerAgentInfo.SystemIdentity,
 		LogSinkRateLimitBurst:  logSinkBurst,
 		LogSinkRateLimitRefill: logSinkRefill,
+		APIAddresses:           c.pcfg.APIInfo.Addrs,
 	}
 	runtimeCfgContent, err := controllerruntimeconfig.RenderControllerRuntimeConfig(runtimeCfg)
 	if err != nil {

--- a/internal/worker/apiremotecaller/manifold.go
+++ b/internal/worker/apiremotecaller/manifold.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/names/v6"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 
-	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/services"
@@ -46,11 +46,27 @@ type Subscription interface {
 	Close()
 }
 
+// APIInfoProvider returns the current API connection details. It is
+// called each time the worker starts so that bounced workers do not
+// keep stale values.
+type APIInfoProvider interface {
+	APIInfo() (*api.Info, error)
+}
+
 // ManifoldConfig defines the names of the manifolds on which a Manifold will
 // depend.
 type ManifoldConfig struct {
-	AgentName               string
 	ObjectStoreServicesName string
+
+	// APIInfo returns the current API connection details. It is called
+	// each time the worker starts so that bounced workers do not keep
+	// stale values.
+	APIInfo APIInfoProvider
+
+	// Origin is the tag identifying the calling controller. It is
+	// passed directly because it never changes during the lifetime
+	// of the agent.
+	Origin names.Tag
 
 	Clock  clock.Clock
 	Logger logger.Logger
@@ -58,10 +74,12 @@ type ManifoldConfig struct {
 	NewWorker func(WorkerConfig) (worker.Worker, error)
 }
 
-// Validate validates the manifold configuration.
 func (config ManifoldConfig) Validate() error {
-	if config.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
+	if config.APIInfo == nil {
+		return errors.NotValidf("missing APIInfo")
+	}
+	if config.Origin == nil {
+		return errors.NotValidf("missing Origin")
 	}
 	if config.ObjectStoreServicesName == "" {
 		return errors.NotValidf("empty ObjectStoreServicesName")
@@ -78,12 +96,9 @@ func (config ManifoldConfig) Validate() error {
 	return nil
 }
 
-// Manifold returns a dependency manifold that runs an API remote caller worker,
-// using the resource names defined in the supplied config.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
 			config.ObjectStoreServicesName,
 		},
 		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
@@ -91,27 +106,24 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			var agent coreagent.Agent
-			if err := getter.Get(config.AgentName, &agent); err != nil {
-				return nil, err
-			}
-
-			agentConfig := agent.CurrentConfig()
-			apiInfo, ready := agentConfig.APIInfo()
-			if !ready {
-				return nil, dependency.ErrMissing
-			}
-
 			var services services.ControllerObjectStoreServices
 			if err := getter.Get(config.ObjectStoreServicesName, &services); err != nil {
 				return nil, errors.Trace(err)
+			}
+
+			apiInfo, err := config.APIInfo.APIInfo()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if apiInfo == nil {
+				return nil, errors.NotValidf("APIInfo provider returned nil")
 			}
 
 			cfg := WorkerConfig{
 				ControllerNodeService: services.ControllerNode(),
 				APIInfo:               apiInfo,
 				APIOpener:             api.Open,
-				Origin:                agentConfig.Tag(),
+				Origin:                config.Origin,
 				NewRemote:             NewRemoteServer,
 				Logger:                config.Logger,
 				Clock:                 config.Clock,

--- a/internal/worker/apiremotecaller/manifold_test.go
+++ b/internal/worker/apiremotecaller/manifold_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/juju/clock"
+	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
@@ -14,7 +15,6 @@ import (
 	dt "github.com/juju/worker/v5/dependency/testing"
 	"go.uber.org/goleak"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	controllernodeservice "github.com/juju/juju/domain/controllernode/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -36,8 +36,9 @@ func TestManifoldSuite(t *testing.T) {
 func (s *ManifoldSuite) SetUpTest(c *tc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.config = ManifoldConfig{
-		AgentName:               "agent",
 		ObjectStoreServicesName: "object-store-services",
+		APIInfo:                 &stubAPIInfoProvider{info: &api.Info{CACert: "cert", Tag: names.NewControllerAgentTag("0")}},
+		Origin:                  names.NewControllerAgentTag("0"),
 		Clock:                   clock.WallClock,
 		Logger:                  loggertesting.WrapCheckLog(c),
 		NewWorker: func(wc WorkerConfig) (worker.Worker, error) {
@@ -47,28 +48,25 @@ func (s *ManifoldSuite) SetUpTest(c *tc.C) {
 }
 
 func (s *ManifoldSuite) TestInputs(c *tc.C) {
-	c.Check(s.manifold().Inputs, tc.DeepEquals, []string{"agent", "object-store-services"})
+	c.Check(s.manifold().Inputs, tc.DeepEquals, []string{"object-store-services"})
 }
 
-func (s *ManifoldSuite) TestAgentMissing(c *tc.C) {
-	getter := dt.StubGetter(map[string]any{
-		"agent": dependency.ErrMissing,
-	})
+func (s *ManifoldSuite) TestValidateRequiresAPIInfo(c *tc.C) {
+	config := s.config
+	config.APIInfo = nil
+	c.Check(config.Validate(), tc.ErrorIs, errors.NotValid)
 
-	worker, err := s.manifold().Start(c.Context(), getter)
-	c.Assert(err, tc.ErrorIs, dependency.ErrMissing)
-	c.Check(worker, tc.IsNil)
+	config.APIInfo = &stubAPIInfoProvider{info: &api.Info{CACert: "cert"}}
+	c.Check(config.Validate(), tc.ErrorIsNil)
 }
 
-func (s *ManifoldSuite) TestAgentAPIInfoNotReady(c *tc.C) {
-	getter := dt.StubGetter(map[string]any{
-		"agent":                 &fakeAgent{missingAPIinfo: true},
-		"object-store-services": objectStoreServices{},
-	})
+func (s *ManifoldSuite) TestValidateRequiresOrigin(c *tc.C) {
+	config := s.config
+	config.Origin = nil
+	c.Check(config.Validate(), tc.ErrorIs, errors.NotValid)
 
-	worker, err := s.manifold().Start(c.Context(), getter)
-	c.Assert(err, tc.ErrorIs, dependency.ErrMissing)
-	c.Check(worker, tc.IsNil)
+	config.Origin = names.NewControllerAgentTag("0")
+	c.Check(config.Validate(), tc.ErrorIsNil)
 }
 
 func (s *ManifoldSuite) TestNewWorkerArgs(c *tc.C) {
@@ -81,7 +79,6 @@ func (s *ManifoldSuite) TestNewWorkerArgs(c *tc.C) {
 	}
 
 	getter := dt.StubGetter(map[string]any{
-		"agent":                 &fakeAgent{tag: names.NewMachineTag("42")},
 		"object-store-services": objectStoreServices{},
 	})
 
@@ -89,10 +86,10 @@ func (s *ManifoldSuite) TestNewWorkerArgs(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(worker, tc.NotNil)
 
-	c.Check(config.Origin, tc.Equals, names.NewMachineTag("42"))
+	c.Check(config.Origin, tc.Equals, names.NewControllerAgentTag("0"))
 	c.Check(config.Clock, tc.Equals, clock)
 	c.Check(config.ControllerNodeService, tc.DeepEquals, &controllernodeservice.WatchableService{})
-	c.Check(config.APIInfo.CACert, tc.Equals, "fake as")
+	c.Check(config.APIInfo.CACert, tc.Equals, "cert")
 	c.Check(config.NewRemote, tc.NotNil)
 }
 
@@ -112,34 +109,11 @@ type fakeWorker struct {
 	worker.Worker
 }
 
-type fakeAgent struct {
-	agent.Agent
-
-	tag            names.Tag
-	missingAPIinfo bool
+type stubAPIInfoProvider struct {
+	info *api.Info
+	err  error
 }
 
-type fakeConfig struct {
-	agent.Config
-
-	tag            names.Tag
-	missingAPIinfo bool
-}
-
-func (f *fakeAgent) CurrentConfig() agent.Config {
-	return &fakeConfig{tag: f.tag, missingAPIinfo: f.missingAPIinfo}
-}
-
-func (f *fakeConfig) APIInfo() (*api.Info, bool) {
-	if f.missingAPIinfo {
-		return nil, false
-	}
-	return &api.Info{
-		CACert: "fake as",
-		Tag:    f.tag,
-	}, true
-}
-
-func (f *fakeConfig) Tag() names.Tag {
-	return f.tag
+func (p *stubAPIInfoProvider) APIInfo() (*api.Info, error) {
+	return p.info, p.err
 }

--- a/internal/worker/bootstrap/manifold.go
+++ b/internal/worker/bootstrap/manifold.go
@@ -55,7 +55,7 @@ type BootstrapAddressFinderGetter func(providerFactory providertracker.ProviderF
 
 // AgentFinalizerFunc is the function that is used to finalize the agent
 // during bootstrap.
-type AgentFinalizerFunc func(context.Context, AgentPasswordService, MachineService, instancecfg.StateInitializationParams, agent.Config) error
+type AgentFinalizerFunc func(context.Context, AgentPasswordService, MachineService, instancecfg.StateInitializationParams, string) error
 
 // ControllerUnitPasswordFunc is the function that is used to get the
 // controller unit password.
@@ -81,12 +81,20 @@ type StatusHistory interface {
 
 // ManifoldConfig defines the configuration for the trace manifold.
 type ManifoldConfig struct {
-	AgentName           string
 	ObjectStoreName     string
 	BootstrapGateName   string
 	DomainServicesName  string
 	HTTPClientName      string
 	ProviderFactoryName string
+	// DataDir is the local agent data directory used to read bootstrap params
+	// and seed artifacts during bootstrap.
+	DataDir string
+	// APIPort is the controller API port written into the initial API host-port
+	// records once bootstrap completes.
+	APIPort int
+	// AgentPassword is the bootstrap agent password used by the finalizer to
+	// seed the initial machine or controller-node password in state.
+	AgentPassword string
 
 	AgentBinaryUploader          AgentBinaryBootstrapFunc
 	ControllerCharmDeployer      ControllerCharmDeployerFunc
@@ -103,9 +111,6 @@ type ManifoldConfig struct {
 
 // Validate validates the manifold configuration.
 func (cfg ManifoldConfig) Validate() error {
-	if cfg.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
-	}
 	if cfg.ObjectStoreName == "" {
 		return errors.NotValidf("empty ObjectStoreName")
 	}
@@ -120,6 +125,15 @@ func (cfg ManifoldConfig) Validate() error {
 	}
 	if cfg.ProviderFactoryName == "" {
 		return errors.NotValidf("empty ProviderFactoryName")
+	}
+	if cfg.DataDir == "" {
+		return errors.NotValidf("empty DataDir")
+	}
+	if cfg.APIPort == 0 {
+		return errors.NotValidf("missing APIPort")
+	}
+	if cfg.AgentPassword == "" {
+		return errors.NotValidf("missing AgentPassword")
 	}
 
 	if cfg.AgentBinaryUploader == nil {
@@ -159,7 +173,6 @@ func (cfg ManifoldConfig) Validate() error {
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
 			config.ObjectStoreName,
 			config.BootstrapGateName,
 			config.DomainServicesName,
@@ -174,11 +187,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			var bootstrapUnlocker gate.Unlocker
 			if err := getter.Get(config.BootstrapGateName, &bootstrapUnlocker); err != nil {
 				return nil, errors.Trace(err)
-			}
-
-			var a agent.Agent
-			if err := getter.Get(config.AgentName, &a); err != nil {
-				return nil, err
 			}
 
 			var controllerDomainServices services.ControllerDomainServices
@@ -247,7 +255,6 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			applicationService := controllerModelDomainServices.Application()
 
 			w, err := NewWorker(WorkerConfig{
-				Agent:                      a,
 				ObjectStoreGetter:          objectStoreGetter,
 				ControllerAgentBinaryStore: controllerDomainServices.ControllerAgentBinaryStore(),
 				ControllerConfigService:    controllerDomainServices.ControllerConfig(),
@@ -266,10 +273,13 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				NetworkService:             controllerModelDomainServices.Network(),
 				BakeryConfigService:        controllerDomainServices.Macaroon(),
 				BootstrapUnlocker:          bootstrapUnlocker,
+				DataDir:                    config.DataDir,
+				APIPort:                    config.APIPort,
 				AgentBinaryUploader:        config.AgentBinaryUploader,
 				ControllerCharmDeployer:    config.ControllerCharmDeployer,
 				PopulateControllerCharm:    config.PopulateControllerCharm,
 				AgentFinalizer:             config.AgentFinalizer,
+				AgentPassword:              config.AgentPassword,
 				CharmhubHTTPClient:         charmhubHTTPClient,
 				UnitPassword:               unitPassword,
 				ServiceManagerGetter:       serviceManagerGetter,
@@ -315,7 +325,7 @@ func IAASAgentFinalizer(
 	agentPasswordService AgentPasswordService,
 	machineService MachineService,
 	bootstrapParams instancecfg.StateInitializationParams,
-	agentConfig agent.Config,
+	agentPassword string,
 ) error {
 	// Set machine cloud instance data for the bootstrap machine.
 	bootstrapMachineUUID, err := machineService.GetMachineUUID(ctx, machine.Name(agent.BootstrapControllerId))
@@ -323,15 +333,8 @@ func IAASAgentFinalizer(
 		return errors.Trace(err)
 	}
 
-	apiInfo, ok := agentConfig.APIInfo()
-	if !ok {
-		// If this is missing, we cannot set the machine password or set the
-		// machine as provisioned.
-		return errors.Errorf("agent config is missing APIInfo for %q", agent.BootstrapControllerId)
-	}
-
 	// Set the machine password for the bootstrap controller.
-	if err := agentPasswordService.SetMachinePassword(ctx, machine.Name(agent.BootstrapControllerId), apiInfo.Password); err != nil {
+	if err := agentPasswordService.SetMachinePassword(ctx, machine.Name(agent.BootstrapControllerId), agentPassword); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -357,16 +360,10 @@ func CAASAgentFinalizer(
 	agentPasswordService AgentPasswordService,
 	machineService MachineService,
 	bootstrapParams instancecfg.StateInitializationParams,
-	agentConfig agent.Config,
+	agentPassword string,
 ) error {
-	apiInfo, ok := agentConfig.APIInfo()
-	if !ok {
-		// If this is missing, we cannot set the controller node password.
-		return errors.Errorf("agent config is missing APIInfo for %q", agent.BootstrapControllerId)
-	}
-
 	// Set the controller node password.
-	if err := agentPasswordService.SetControllerNodePassword(ctx, agent.BootstrapControllerId, apiInfo.Password); err != nil {
+	if err := agentPasswordService.SetControllerNodePassword(ctx, agent.BootstrapControllerId, agentPassword); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/internal/worker/bootstrap/manifold_test.go
+++ b/internal/worker/bootstrap/manifold_test.go
@@ -14,7 +14,6 @@ import (
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"go.uber.org/goleak"
 
-	agent "github.com/juju/juju/agent"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/providertracker"
@@ -38,7 +37,7 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIsNil)
 
 	cfg = s.getConfig()
-	cfg.AgentName = ""
+	cfg.DataDir = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
@@ -55,6 +54,14 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 
 	cfg = s.getConfig()
 	cfg.HTTPClientName = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.APIPort = 0
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.AgentPassword = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
@@ -95,12 +102,14 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
-		AgentName:           "agent",
 		ObjectStoreName:     "object-store",
 		BootstrapGateName:   "bootstrap-gate",
 		DomainServicesName:  "domain-services",
 		ProviderFactoryName: "provider-factory",
 		HTTPClientName:      "http-client",
+		DataDir:             s.dataDir,
+		APIPort:             42,
+		AgentPassword:       "password",
 		Logger:              s.logger,
 		Clock:               clock.WallClock,
 		AgentBinaryUploader: func(context.Context, string, AgentBinaryStore, objectstore.ObjectStore, logger.Logger) (func(), error) {
@@ -121,7 +130,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		RequiresBootstrap: func(context.Context, FlagService) (bool, error) {
 			return false, nil
 		},
-		AgentFinalizer: func(ctx context.Context, aps AgentPasswordService, ms MachineService, sip instancecfg.StateInitializationParams, c agent.Config) error {
+		AgentFinalizer: func(ctx context.Context, aps AgentPasswordService, ms MachineService, sip instancecfg.StateInitializationParams, password string) error {
 			return nil
 		},
 		StatusHistory: s.statusHistory,
@@ -130,7 +139,6 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 
 func (s *manifoldSuite) newGetter() dependency.Getter {
 	resources := map[string]any{
-		"agent":           s.agent,
 		"object-store":    s.objectStoreGetter,
 		"bootstrap-gate":  s.bootstrapUnlocker,
 		"http-client":     s.httpClientGetter,
@@ -140,7 +148,6 @@ func (s *manifoldSuite) newGetter() dependency.Getter {
 }
 
 var expectedInputs = []string{
-	"agent",
 	"object-store",
 	"bootstrap-gate",
 	"domain-services",
@@ -156,7 +163,6 @@ func (s *manifoldSuite) TestStartAlreadyBootstrapped(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectGateUnlock()
-	s.expectAgentConfig()
 
 	_, err := Manifold(s.getConfig()).Start(c.Context(), s.newGetter())
 	c.Assert(err, tc.ErrorIs, dependency.ErrUninstall)

--- a/internal/worker/bootstrap/package_test.go
+++ b/internal/worker/bootstrap/package_test.go
@@ -6,21 +6,18 @@ package bootstrap
 import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/clock"
-	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/domain"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
-	"github.com/juju/juju/internal/uuid"
 )
 
 //go:generate go run github.com/canonical/gomock/mockgen -package bootstrap -destination addressfinder_mock_test.go github.com/juju/juju/environs InstanceLister
 //go:generate go run github.com/canonical/gomock/mockgen -package bootstrap -destination providertracker_mock_test.go github.com/juju/juju/core/providertracker ProviderFactory
 //go:generate go run github.com/canonical/gomock/mockgen -package bootstrap -destination caas_broker_mock_test.go github.com/juju/juju/caas ServiceManager
 //go:generate go run github.com/canonical/gomock/mockgen -package bootstrap -destination instance_mock_test.go github.com/juju/juju/environs/instances Instance
-//go:generate go run github.com/canonical/gomock/mockgen -package bootstrap -destination agent_mock_test.go github.com/juju/juju/agent Agent,Config
 //go:generate go run github.com/canonical/gomock/mockgen -package bootstrap -destination objectstore_mock_test.go github.com/juju/juju/core/objectstore ObjectStore
 //go:generate go run github.com/canonical/gomock/mockgen -package bootstrap -destination storage_mock_test.go github.com/juju/juju/core/storage StorageRegistryGetter
 //go:generate go run github.com/canonical/gomock/mockgen -package bootstrap -destination lock_mock_test.go github.com/juju/juju/internal/worker/gate Unlocker
@@ -33,8 +30,6 @@ type baseSuite struct {
 
 	dataDir string
 
-	agent                      *MockAgent
-	agentConfig                *MockConfig
 	controllerAgentBinaryStore *MockAgentBinaryStore
 	objectStore                *MockObjectStore
 	objectStoreGetter          *MockObjectStoreGetter
@@ -66,8 +61,6 @@ func (s *baseSuite) setupMocks(c *tc.C) *gomock.Controller {
 
 	s.dataDir = c.MkDir()
 
-	s.agent = NewMockAgent(ctrl)
-	s.agentConfig = NewMockConfig(ctrl)
 	s.controllerAgentBinaryStore = NewMockAgentBinaryStore(ctrl)
 	s.objectStore = NewMockObjectStore(ctrl)
 	s.objectStoreGetter = NewMockObjectStoreGetter(ctrl)
@@ -94,8 +87,6 @@ func (s *baseSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.statusHistory = domain.NewStatusHistory(s.logger, clock.WallClock)
 
 	c.Cleanup(func() {
-		s.agent = nil
-		s.agentConfig = nil
 		s.controllerAgentBinaryStore = nil
 		s.objectStore = nil
 		s.objectStoreGetter = nil
@@ -128,11 +119,4 @@ func (s *baseSuite) setupMocks(c *tc.C) *gomock.Controller {
 func (s *baseSuite) expectGateUnlock() {
 	s.bootstrapUnlocker.EXPECT().Unlock()
 	s.domainServices.EXPECT().Flag().AnyTimes()
-}
-
-func (s *baseSuite) expectAgentConfig() {
-	s.agentConfig.EXPECT().DataDir().Return(s.dataDir).AnyTimes()
-	s.agentConfig.EXPECT().Controller().Return(names.NewControllerTag(uuid.MustNewUUID().String())).AnyTimes()
-	s.agentConfig.EXPECT().Model().Return(names.NewModelTag("test-model")).AnyTimes()
-	s.agent.EXPECT().CurrentConfig().Return(s.agentConfig).AnyTimes()
 }

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/tomb.v2"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/flags"
 	"github.com/juju/juju/core/logger"
@@ -47,7 +46,6 @@ const (
 // WorkerConfig encapsulates the configuration options for the
 // bootstrap worker.
 type WorkerConfig struct {
-	Agent                      agent.Agent
 	ObjectStoreGetter          ObjectStoreGetter
 	ControllerAgentBinaryStore AgentBinaryStore
 	ControllerConfigService    ControllerConfigService
@@ -67,10 +65,13 @@ type WorkerConfig struct {
 	BakeryConfigService        BakeryConfigService
 	BootstrapAddressFinder     BootstrapAddressFinderFunc
 	BootstrapUnlocker          gate.Unlocker
+	DataDir                    string
+	APIPort                    int
 	AgentBinaryUploader        AgentBinaryBootstrapFunc
 	ControllerCharmDeployer    ControllerCharmDeployerFunc
 	PopulateControllerCharm    PopulateControllerCharmFunc
 	AgentFinalizer             AgentFinalizerFunc
+	AgentPassword              string
 	CharmhubHTTPClient         HTTPClient
 	UnitPassword               string
 	ServiceManagerGetter       ServiceManagerGetterFunc
@@ -81,9 +82,6 @@ type WorkerConfig struct {
 
 // Validate ensures that the config values are valid.
 func (c *WorkerConfig) Validate() error {
-	if c.Agent == nil {
-		return errors.NotValidf("nil Agent")
-	}
 	if c.ObjectStoreGetter == nil {
 		return errors.NotValidf("nil ObjectStoreGetter")
 	}
@@ -123,6 +121,12 @@ func (c *WorkerConfig) Validate() error {
 	if c.BootstrapUnlocker == nil {
 		return errors.NotValidf("nil BootstrapUnlocker")
 	}
+	if c.DataDir == "" {
+		return errors.NotValidf("missing DataDir")
+	}
+	if c.APIPort == 0 {
+		return errors.NotValidf("missing APIPort")
+	}
 	if c.AgentBinaryUploader == nil {
 		return errors.NotValidf("nil AgentBinaryUploader")
 	}
@@ -146,6 +150,9 @@ func (c *WorkerConfig) Validate() error {
 	}
 	if c.AgentFinalizer == nil {
 		return errors.NotValidf("nil AgentFinalizer")
+	}
+	if c.AgentPassword == "" {
+		return errors.NotValidf("missing AgentPassword")
 	}
 	if c.StatusHistory == nil {
 		return errors.NotValidf("nil StatusHistory")
@@ -219,8 +226,7 @@ func (w *bootstrapWorker) loop() error {
 		return errors.Annotatef(err, "inserting initial users")
 	}
 
-	agentConfig := w.cfg.Agent.CurrentConfig()
-	dataDir := agentConfig.DataDir()
+	dataDir := w.cfg.DataDir
 
 	// Seed the agent binary to the object store.
 	cleanup, err := w.seedAgentBinary(ctx, dataDir)
@@ -250,11 +256,6 @@ func (w *bootstrapWorker) loop() error {
 		return errors.Trace(err)
 	}
 
-	servingInfo, ok := agentConfig.ControllerAgentInfo()
-	if !ok {
-		return errors.Errorf("state serving information not available")
-	}
-
 	// Load spaces from the underlying substrate.
 	if err := w.cfg.NetworkService.ReloadSpaces(ctx); err != nil {
 		if !errors.Is(err, errors.NotSupported) {
@@ -276,13 +277,13 @@ func (w *bootstrapWorker) loop() error {
 
 	// Finialize the agent by either setting the machine as provisioned
 	// or by setting the controller node password.
-	if err := w.cfg.AgentFinalizer(ctx, w.cfg.AgentPasswordService, w.cfg.MachineService, bootstrapParams, agentConfig); err != nil {
+	if err := w.cfg.AgentFinalizer(ctx, w.cfg.AgentPasswordService, w.cfg.MachineService, bootstrapParams, w.cfg.AgentPassword); err != nil {
 		return errors.Annotatef(err, "finalizing agent")
 	}
 
 	// Convert the provider addresses that we got from the bootstrap instance
 	// to space ID decorated addresses.
-	if err := w.initAPIHostPorts(ctx, controllerConfig, bootstrapAddresses, servingInfo.APIPort); err != nil {
+	if err := w.initAPIHostPorts(ctx, controllerConfig, bootstrapAddresses, w.cfg.APIPort); err != nil {
 		w.logger.Errorf(ctx, "unable to set API host ports %v:%w", bootstrapAddresses, err)
 		return errors.Trace(err)
 	}

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/worker/v5/workertest"
 	"go.uber.org/goleak"
 
-	agent "github.com/juju/juju/agent"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/flags"
@@ -71,10 +70,8 @@ func (s *workerSuite) TestKilled(c *tc.C) {
 	s.expectUser(c)
 	s.expectAuthorizedKeys()
 	s.expectControllerConfig()
-	s.expectAgentConfig()
 	s.expectObjectStoreGetter(2)
 	s.expectBootstrapFlagSet()
-	s.expectControllerAgentInfo()
 	s.expectReloadSpaces()
 	s.expectSeedDefaultStoragePools()
 	s.expectInitialiseBakeryConfig(nil)
@@ -98,11 +95,9 @@ func (s *workerSuite) TestReloadSpacesBeforeControllerCharm(c *tc.C) {
 	s.expectUser(c)
 	s.expectAuthorizedKeys()
 	s.expectControllerConfig()
-	s.expectAgentConfig()
 	s.expectObjectStoreGetter(2)
 	s.expectBootstrapFlagSet()
 	s.expectSetAPIHostPorts()
-	s.expectControllerAgentInfo()
 	s.expectSeedDefaultStoragePools()
 	controllerCharmDeployerFunc := s.expectReloadSpacesWithFunc(c)
 	s.expectInitialiseBakeryConfig(nil)
@@ -344,9 +339,10 @@ func (s *workerSuite) newWorker(c *tc.C) worker.Worker {
 
 func (s *workerSuite) newWorkerWithFunc(c *tc.C, controllerCharmDeployerFunc ControllerCharmDeployerFunc) worker.Worker {
 	w, err := newWorker(WorkerConfig{
-		Agent:                      s.agent,
 		ObjectStoreGetter:          s.objectStoreGetter,
 		BootstrapUnlocker:          s.bootstrapUnlocker,
+		DataDir:                    s.dataDir,
+		APIPort:                    42,
 		CharmhubHTTPClient:         s.httpClient,
 		ControllerAgentBinaryStore: s.controllerAgentBinaryStore,
 		UserService:                s.userService,
@@ -371,10 +367,11 @@ func (s *workerSuite) newWorkerWithFunc(c *tc.C, controllerCharmDeployerFunc Con
 			return func() {}, nil
 		},
 		ControllerCharmDeployer: controllerCharmDeployerFunc,
+		AgentPassword:           "password",
 		BootstrapAddressFinder: func(context.Context, instance.Id) (network.ProviderAddresses, error) {
 			return nil, nil
 		},
-		AgentFinalizer: func(ctx context.Context, aps AgentPasswordService, ms MachineService, sip instancecfg.StateInitializationParams, c agent.Config) error {
+		AgentFinalizer: func(ctx context.Context, aps AgentPasswordService, ms MachineService, sip instancecfg.StateInitializationParams, password string) error {
 			return nil
 		},
 		StatusHistory: s.statusHistory,
@@ -433,12 +430,6 @@ func (s *workerSuite) expectUser(c *tc.C) {
 
 func (s *workerSuite) expectAuthorizedKeys() {
 	s.keyManagerService.EXPECT().AddPublicKeysForUser(gomock.Any(), s.adminUserID, []string{}).Return(nil)
-}
-
-func (s *workerSuite) expectControllerAgentInfo() {
-	s.agentConfig.EXPECT().ControllerAgentInfo().Return(controller.ControllerAgentInfo{
-		APIPort: 42,
-	}, true)
 }
 
 func (s *workerSuite) expectReloadSpaces() {

--- a/internal/worker/changestream/manifold_test.go
+++ b/internal/worker/changestream/manifold_test.go
@@ -6,13 +6,13 @@ package changestream
 import (
 	"testing"
 
+	"github.com/canonical/gomock/gomock"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
 	"go.uber.org/goleak"
-	gomock "go.uber.org/mock/gomock"
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"

--- a/internal/worker/trace/manifold_linux.go
+++ b/internal/worker/trace/manifold_linux.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/names/v6"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/logger"
 	coretrace "github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/watcher"
@@ -29,7 +29,7 @@ type GetTracingServiceFunc func(getter dependency.Getter, name string) (TracingS
 // ControllerManifoldConfig defines the configuration for the controller
 // trace manifold.
 type ControllerManifoldConfig struct {
-	AgentName         string
+	Tag               names.Tag
 	TraceServicesName string
 	Clock             clock.Clock
 	Logger            logger.Logger
@@ -39,8 +39,8 @@ type ControllerManifoldConfig struct {
 
 // Validate validates the controller manifold configuration.
 func (cfg ControllerManifoldConfig) Validate() error {
-	if cfg.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
+	if cfg.Tag == nil {
+		return errors.NotValidf("nil Tag")
 	}
 	if cfg.TraceServicesName == "" {
 		return errors.NotValidf("empty TraceServicesName")
@@ -65,7 +65,6 @@ func (cfg ControllerManifoldConfig) Validate() error {
 func ControllerManifold(config ControllerManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
 			config.TraceServicesName,
 		},
 		Output: tracerOutput,
@@ -73,12 +72,6 @@ func ControllerManifold(config ControllerManifoldConfig) dependency.Manifold {
 			if err := config.Validate(); err != nil {
 				return nil, errors.Trace(err)
 			}
-
-			var a agent.Agent
-			if err := getter.Get(config.AgentName, &a); err != nil {
-				return nil, err
-			}
-			currentConfig := a.CurrentConfig()
 
 			tracingService, err := config.GetTracingService(getter, config.TraceServicesName)
 			if err != nil {
@@ -91,7 +84,7 @@ func ControllerManifold(config ControllerManifoldConfig) dependency.Manifold {
 				Clock:                 config.Clock,
 				Logger:                config.Logger,
 				NewTracerWorker:       config.NewTracerWorker,
-				Tag:                   currentConfig.Tag(),
+				Tag:                   config.Tag,
 				Kind:                  coretrace.KindController,
 				SampleRatio:           defaultOpenTelemetrySampleRatio,
 				TailSamplingThreshold: defaultOpenTelemetryTailSamplingThreshold,

--- a/internal/worker/trace/manifold_other.go
+++ b/internal/worker/trace/manifold_other.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/names/v6"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 
@@ -27,7 +28,7 @@ type GetTracingServiceFunc func(getter dependency.Getter, name string) (TracingS
 // ControllerManifoldConfig defines the configuration for the controller
 // trace manifold.
 type ControllerManifoldConfig struct {
-	AgentName         string
+	Tag               names.Tag
 	TraceServicesName string
 	Clock             clock.Clock
 	Logger            logger.Logger
@@ -37,8 +38,8 @@ type ControllerManifoldConfig struct {
 
 // Validate validates the controller manifold configuration.
 func (cfg ControllerManifoldConfig) Validate() error {
-	if cfg.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
+	if cfg.Tag == nil {
+		return errors.NotValidf("nil Tag")
 	}
 	if cfg.TraceServicesName == "" {
 		return errors.NotValidf("empty TraceServicesName")
@@ -63,7 +64,6 @@ func (cfg ControllerManifoldConfig) Validate() error {
 func ControllerManifold(config ControllerManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
 			config.TraceServicesName,
 		},
 		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {

--- a/scripts/engine-dag/main.go
+++ b/scripts/engine-dag/main.go
@@ -239,12 +239,10 @@ func getManifolds(useModel bool, modelType string, agent string) dependency.Mani
 		switch modelType {
 		case "iaas":
 			return jjudcontroller.IAASManifolds(jjudcontroller.ManifoldsConfig{
-				Agent:           &mockAgent{},
 				PreUpgradeSteps: preUpgradeSteps,
 			})
 		case "caas":
 			return jjudcontroller.CAASManifolds(jjudcontroller.ManifoldsConfig{
-				Agent:           &mockAgent{conf: mockConfig{tag: names.NewControllerAgentTag("0")}},
 				PreUpgradeSteps: preUpgradeSteps,
 			})
 		default:


### PR DESCRIPTION

### Disabled upgrade manifolds

The `agent`, `api-caller`, and `api-config-watcher` manifolds have been removed
from the controller dependency engine. All manifolds that previously depended
on them are either reworked to receive their values through config or wrapped
in `disabledManifold`, which preserves the call site and configuration while
running a no-op worker. This affects:

- **upgrader** — disabled in both IAAS and CAAS variants
- **upgrade-steps-controller** — disabled in both IAAS and CAAS variants
- **upgrade-database** — disabled
- **migration-minion** — disabled
- **agent-config-updater** — removed entirely
- **migration-inactive-flag** — replaced with a static flag that
  unconditionally reports "inactive", since migration is never active in the
  standalone controller

Each `disabledManifold` call site carries a TODO to unwrap it when the manifold is reworked for the standalone controller.

### Trace worker

The controller-trace manifold no longer depends on the agent manifold. The
controller tag is now passed directly via the config's `Tag` field. The
manifold is split into two: `trace-services` (provides the tracing service) and
`controller-trace` (creates the tracer worker for the controller), breaking the
previous single `trace` manifold into a separate service layer.

### Bootstrap worker

The bootstrap worker no longer takes an `agent.Agent` dependency. Instead,
`DataDir`, `APIPort`, and `AgentPassword` are passed explicitly through the
manifold config. The `AgentFinalizerFunc` signature is simplified to accept a
password string instead of an `agent.Config`, removing the need for the
finalizer to extract API info from the agent config.

### API remote caller

The `api-remote-caller` manifold no longer depends on the agent manifold. It
receives an `APIInfoProvider` interface and an `Origin` tag directly in its
config, making it usable without a running agent.

### Startup value consolidation

Several previously separate provider interfaces (`ObjectStoreRootDirReader`,
`CertReader`, `APIServerLocalConfigReader`, `ControllerStartupValues`,
`LoggingOverrideReader`, `SystemIdentityReader`) are consolidated into a single
`ControllerStartupValueProvider` interface, implemented by the existing startup
value provider in both the controller and machine agents. `APIAddresses` is
added to the controller runtime config so it can be read at startup without the
agent.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


```sh
❯ juju bootstrap lxd src --build-agent
❯ juju add-model m
❯ juju deploy ubuntu
Deployed "ubuntu" from charm-hub charm "ubuntu", revision 26 in channel latest/stable on ubuntu@24.04/stable

❯ jst
Model  Controller  Cloud/Region  Version      Timestamp
m      src         lxd/default   4.1-beta2.1  16:46:52+02:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  24.04    active      1  ubuntu  latest/stable   26  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.159.202.148

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.148  juju-37c0c7-0  ubuntu@24.04  tuxedo  Running

❯ jst -m controller
Model       Controller  Cloud/Region  Version      Timestamp
controller  src         lxd/default   4.1-beta2.1  16:46:54+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.159.202.109  17022,17070/tcp

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.109  juju-1fcd0d-0  ubuntu@24.04  tuxedo  Running

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer
```


## Documentation changes


## Links

**Jira card:** [JUJU-9719](https://warthogs.atlassian.net/browse/JUJU-9719)


[JUJU-9719]: https://warthogs.atlassian.net/browse/JUJU-9719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ