### PR TITLE
fix: remove stale Dqlite nodes when topology changes

### DIFF
--- a/database/client/dqlite_other.go
+++ b/database/client/dqlite_other.go
@@ -42,6 +42,16 @@ func (c *Client) Leader(ctx context.Context) (*dqlite.NodeInfo, error) {
 	return nil, nil
 }
 
+// Remove removes a node from the cluster.
+func (c *Client) Remove(context.Context, uint64) error {
+	return nil
+}
+
+// Close closes the client.
+func (c *Client) Close() error {
+	return nil
+}
+
 // FindLeader returns no leader and no error, as dqlite is not available.
 func FindLeader(ctx context.Context, store NodeStore, opts ...Option) (*Client, error) {
 	return nil, nil

--- a/database/dqlite/dqlite_linux.go
+++ b/database/dqlite/dqlite_linux.go
@@ -5,7 +5,10 @@
 
 package dqlite
 
-import "github.com/canonical/go-dqlite/v3"
+import (
+	"github.com/canonical/go-dqlite/v3"
+	"github.com/canonical/go-dqlite/v3/client"
+)
 
 const (
 	// Enabled is true if dqlite is enabled.
@@ -14,6 +17,18 @@ const (
 
 // NodeInfo holds information about a single server.
 type NodeInfo = dqlite.NodeInfo
+
+// NodeRole identifies the role of a node within the Dqlite cluster.
+type NodeRole = client.NodeRole
+
+const (
+	// Voter is a full voting member of the cluster.
+	Voter = client.Voter
+	// StandBy is a non-voting member that can be promoted.
+	StandBy = client.StandBy
+	// Spare is a non-voting spare member.
+	Spare = client.Spare
+)
 
 // ReconfigureMembership can be used to recover a cluster whose majority of
 // nodes have died, and therefore has become unavailable.

--- a/database/dqlite/dqlite_other.go
+++ b/database/dqlite/dqlite_other.go
@@ -12,6 +12,15 @@ const (
 
 type NodeRole int
 
+const (
+	// Voter is a full voting member of the cluster.
+	Voter NodeRole = iota
+	// StandBy is a non-voting member that can be promoted.
+	StandBy
+	// Spare is a non-voting spare member.
+	Spare
+)
+
 func (NodeRole) String() string {
 	return ""
 }

--- a/internal/worker/dbaccessor/package_mock_test.go
+++ b/internal/worker/dbaccessor/package_mock_test.go
@@ -645,6 +645,20 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockClient) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockClientMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockClient)(nil).Close))
+}
+
 // Cluster mocks base method.
 func (m *MockClient) Cluster(arg0 context.Context) ([]dqlite.NodeInfo, error) {
 	m.ctrl.T.Helper()
@@ -673,4 +687,18 @@ func (m *MockClient) Leader(arg0 context.Context) (*dqlite.NodeInfo, error) {
 func (mr *MockClientMockRecorder) Leader(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Leader", reflect.TypeOf((*MockClient)(nil).Leader), arg0)
+}
+
+// Remove mocks base method.
+func (m *MockClient) Remove(arg0 context.Context, arg1 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Remove", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Remove indicates an expected call of Remove.
+func (mr *MockClientMockRecorder) Remove(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockClient)(nil).Remove), arg0, arg1)
 }

--- a/internal/worker/dbaccessor/shim.go
+++ b/internal/worker/dbaccessor/shim.go
@@ -20,6 +20,10 @@ type Client interface {
 	Cluster(context.Context) ([]dqlite.NodeInfo, error)
 	// Leader returns information about the current leader, if any.
 	Leader(ctx context.Context) (*dqlite.NodeInfo, error)
+	// Remove a node from the cluster.
+	Remove(ctx context.Context, id uint64) error
+	// Close releases resources for the dqlite client connection.
+	Close() error
 }
 
 // DBApp describes methods of a Dqlite database application,

--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -320,6 +320,7 @@ func (w *dbWorker) Report() map[string]any {
 		leaderID   uint64
 	)
 	if client, err := w.dbApp.Client(ctx); err == nil {
+		defer func() { _ = client.Close() }()
 		if nodeInfo, err := client.Leader(ctx); err == nil {
 			leaderID = nodeInfo.ID
 			leader = nodeInfo.Address
@@ -477,6 +478,7 @@ func (w *dbWorker) startDqliteNode(options ...app.Option) error {
 	w.cfg.Logger.Infof("serving Dqlite application (ID: %v)", w.dbApp.ID())
 
 	if c, err := w.dbApp.Client(ctx); err == nil {
+		defer func() { _ = c.Close() }()
 		if info, err := c.Cluster(ctx); err == nil {
 			w.cfg.Logger.Infof("current cluster: %#v", info)
 		}
@@ -625,11 +627,14 @@ func (w *dbWorker) processAPIServerChange(apiDetails apiserver.Details) error {
 		}
 
 		// If we are an existing, previously clustered node,
-		// and the node is running, we have nothing to do.
+		// and the node is running, the only thing left to reconcile is
+		// whether any nodes have been removed from the controller and so
+		// need to be removed from the Dqlite cluster.
 		w.mu.RLock()
 		running := w.dbApp != nil
 		w.mu.RUnlock()
 		if running {
+			w.removeStaleClusterNodes(ctx, apiDetails)
 			return nil
 		}
 
@@ -655,6 +660,87 @@ func (w *dbWorker) processAPIServerChange(apiDetails apiserver.Details) error {
 	// Otherwise this is a node added by enabling HA,
 	// and we need to join to an existing cluster.
 	return errors.Trace(w.joinNodeToCluster(apiDetails))
+}
+
+// removeStaleClusterNodes removes nodes from the Dqlite cluster that are no
+// longer represented in the latest API server details.
+func (w *dbWorker) removeStaleClusterNodes(ctx context.Context, apiDetails apiserver.Details) {
+	desiredHosts := make(map[string]struct{}, len(apiDetails.Servers))
+	for _, server := range apiDetails.Servers {
+		if host, _, err := net.SplitHostPort(server.InternalAddress); err == nil {
+			desiredHosts[host] = struct{}{}
+		}
+		// InternalAddress can be empty during topology transitions even for
+		// live nodes, so we utilize Addresses of servers as well to decide
+		// whether we have stale nodes in the cluster or not.
+		for _, hostPort := range server.Addresses {
+			if host, _, err := net.SplitHostPort(hostPort); err == nil {
+				desiredHosts[host] = struct{}{}
+			}
+		}
+	}
+
+	if len(desiredHosts) == 0 {
+		w.cfg.Logger.Warningf("skipping stale Dqlite node removal: no valid API server addresses available")
+		return
+	}
+
+	w.mu.RLock()
+	dbApp := w.dbApp
+	w.mu.RUnlock()
+	if dbApp == nil {
+		return
+	}
+
+	client, err := dbApp.Client(ctx)
+	if err != nil {
+		w.cfg.Logger.Warningf("cannot get Dqlite client: %v", err)
+		return
+	}
+	defer func() { _ = client.Close() }()
+
+	// Only the leader can reconfigure cluster membership.
+	leader, err := client.Leader(ctx)
+	if err != nil {
+		w.cfg.Logger.Warningf("cannot determine Dqlite cluster leader: %v", err)
+		return
+	}
+	if leader == nil || leader.ID != dbApp.ID() {
+		return
+	}
+
+	cluster, err := client.Cluster(ctx)
+	if err != nil {
+		w.cfg.Logger.Warningf("cannot retrieve Dqlite cluster details: %v", err)
+		return
+	}
+
+	localID := dbApp.ID()
+	for _, node := range cluster {
+		if node.ID == localID {
+			continue
+		}
+
+		host, _, err := net.SplitHostPort(node.Address)
+		if err != nil {
+			w.cfg.Logger.Warningf("skipping stale-node check for malformed Dqlite address %q", node.Address)
+			continue
+		}
+
+		if _, ok := desiredHosts[host]; ok {
+			continue
+		}
+
+		if node.Role != dqlite.Spare {
+			w.cfg.Logger.Debugf("not removing stale Dqlite node %d (%s): role is not spare", node.ID, node.Address)
+			continue
+		}
+
+		if err := client.Remove(ctx, node.ID); err != nil {
+			w.cfg.Logger.Warningf("cannot remove stale Dqlite node %d (%s) from cluster: %v", node.ID, node.Address, err)
+			continue
+		}
+	}
 }
 
 // rebindAddress stops the current node, reconfigures the cluster so that

--- a/internal/worker/dbaccessor/worker_test.go
+++ b/internal/worker/dbaccessor/worker_test.go
@@ -147,6 +147,7 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 	mgrExp.IsLoopbackPreferred().Return(false).Times(3)
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
+	s.client.EXPECT().Close().Return(nil).Times(2)
 
 	s.expectNodeStartupAndShutdown()
 	s.dbApp.EXPECT().Handover(gomock.Any()).Return(nil)
@@ -214,7 +215,6 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *gc.C) {
 	c.Assert(report, MapHasKeys, []string{
 		"leader",
 		"leader-id",
-		"leader-role",
 	})
 
 	workertest.CleanKill(c, w)
@@ -243,6 +243,7 @@ func (s *workerSuite) TestWorkerStartupExistingNode(c *gc.C) {
 	mgrExp.WithTracingOption().Return(nil)
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
+	s.client.EXPECT().Close().Return(nil).Times(1)
 
 	s.expectNodeStartupAndShutdown()
 	s.dbApp.EXPECT().Handover(gomock.Any()).Return(nil)
@@ -253,6 +254,235 @@ func (s *workerSuite) TestWorkerStartupExistingNode(c *gc.C) {
 	defer workertest.DirtyKill(c, w)
 
 	ensureStartup(c, w.(*dbWorker))
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) TestWorkerStartupExistingNodeRemovesStaleMembers(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectAnyLogs()
+	s.expectClock()
+	s.expectTrackedDBKill()
+
+	mgrExp := s.nodeManager.EXPECT()
+	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
+	mgrExp.IsExistingNode().Return(true, nil).Times(2)
+	mgrExp.IsLoopbackBound(gomock.Any()).Return(false, nil).Times(3)
+	mgrExp.IsLoopbackPreferred().Return(false).Times(2)
+	mgrExp.WithLogFuncOption().Return(nil)
+	mgrExp.WithTLSOption().Return(nil, nil)
+	mgrExp.WithTracingOption().Return(nil)
+
+	s.client.EXPECT().Cluster(gomock.Any()).Return([]dqlite.NodeInfo{
+		{ID: 666, Address: "10.6.6.6:1234"},
+		{ID: 777, Address: "10.6.6.7:1234", Role: dqlite.Spare},
+	}, nil).MinTimes(2)
+	// This node is the leader, so it is allowed to perform the removal.
+	s.client.EXPECT().Leader(gomock.Any()).Return(&dqlite.NodeInfo{
+		ID:      666,
+		Address: "10.6.6.6:1234",
+	}, nil)
+	// Peer 777 exists in the current Dqlite cluster with role Spare and should be
+	// removed once API details indicate it is no longer part of controller topology.
+	s.client.EXPECT().Remove(gomock.Any(), uint64(777)).Return(nil)
+	s.client.EXPECT().Close().Return(nil).Times(2)
+
+	s.expectNodeStartupAndShutdown()
+	s.dbApp.EXPECT().ID().Return(uint64(666)).AnyTimes()
+	s.dbApp.EXPECT().Handover(gomock.Any()).Return(nil)
+
+	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
+
+	w := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+	dbw := w.(*dbWorker)
+
+	ensureStartup(c, dbw)
+
+	// Simulate topology change where only the local controller remains.
+	select {
+	case dbw.apiServerChanges <- apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {ID: "0", InternalAddress: "10.6.6.6:1234"},
+		},
+	}: // nothing to do, the changes were accepted
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for cluster change to be processed")
+	}
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) TestWorkerStartupExistingNodeDoesNotRemoveWhenAddressKnown(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectAnyLogs()
+	s.expectClock()
+	s.expectTrackedDBKill()
+
+	mgrExp := s.nodeManager.EXPECT()
+	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
+	mgrExp.IsExistingNode().Return(true, nil).Times(2)
+	mgrExp.IsLoopbackBound(gomock.Any()).Return(false, nil).Times(3)
+	mgrExp.IsLoopbackPreferred().Return(false).Times(2)
+	mgrExp.WithLogFuncOption().Return(nil)
+	mgrExp.WithTLSOption().Return(nil, nil)
+	mgrExp.WithTracingOption().Return(nil)
+
+	s.client.EXPECT().Cluster(gomock.Any()).Return([]dqlite.NodeInfo{
+		{ID: 666, Address: "10.6.6.6:1234"},
+		{ID: 777, Address: "10.6.6.7:1234", Role: dqlite.Spare},
+	}, nil).MinTimes(2)
+	// This node is the leader, so it is allowed to perform the removal.
+	s.client.EXPECT().Leader(gomock.Any()).Return(&dqlite.NodeInfo{
+		ID:      666,
+		Address: "10.6.6.6:1234",
+	}, nil)
+	// Intentionally no Remove expectation: if Remove is called, gomock will fail
+	// this test. This asserts we keep peer 777 when its address is still known.
+	s.client.EXPECT().Close().Return(nil).Times(2)
+
+	s.expectNodeStartupAndShutdown()
+	s.dbApp.EXPECT().ID().Return(uint64(666)).AnyTimes()
+	s.dbApp.EXPECT().Handover(gomock.Any()).Return(nil)
+
+	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
+
+	w := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+	dbw := w.(*dbWorker)
+
+	ensureStartup(c, dbw)
+
+	// Node 1 has no InternalAddress but is still discoverable via
+	// Addresses; this must not be treated as a stale node.
+	select {
+	case dbw.apiServerChanges <- apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {ID: "0", InternalAddress: "10.6.6.6:1234", Addresses: []string{"10.6.6.6:1234"}},
+			"1": {ID: "1", Addresses: []string{"10.6.6.7:1234"}},
+		},
+	}: // nothing to do, the changes were accepted
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for cluster change to be processed")
+	}
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) TestWorkerStartupExistingNodeDoesNotRemoveWhenNewNodeJoins(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectAnyLogs()
+	s.expectClock()
+	s.expectTrackedDBKill()
+
+	mgrExp := s.nodeManager.EXPECT()
+	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
+	mgrExp.IsExistingNode().Return(true, nil).Times(2)
+	mgrExp.IsLoopbackBound(gomock.Any()).Return(false, nil).Times(3)
+	mgrExp.IsLoopbackPreferred().Return(false).Times(2)
+	mgrExp.WithLogFuncOption().Return(nil)
+	mgrExp.WithTLSOption().Return(nil, nil)
+	mgrExp.WithTracingOption().Return(nil)
+
+	s.client.EXPECT().Cluster(gomock.Any()).Return([]dqlite.NodeInfo{
+		{ID: 666, Address: "10.6.6.6:1234"},
+		{ID: 777, Address: "10.6.6.7:1234", Role: dqlite.Spare},
+	}, nil).MinTimes(2)
+	// This node is the leader, so it is allowed to perform removals.
+	s.client.EXPECT().Leader(gomock.Any()).Return(&dqlite.NodeInfo{
+		ID:      666,
+		Address: "10.6.6.6:1234",
+	}, nil)
+	// Intentionally no Remove expectation: when node 888 joins,
+	// existing node 777 is still part of topology and must not be removed.
+	s.client.EXPECT().Close().Return(nil).Times(2)
+
+	s.expectNodeStartupAndShutdown()
+	s.dbApp.EXPECT().ID().Return(uint64(666)).AnyTimes()
+	s.dbApp.EXPECT().Handover(gomock.Any()).Return(nil)
+
+	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
+
+	w := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+	dbw := w.(*dbWorker)
+
+	ensureStartup(c, dbw)
+
+	// Simulate topology change where a new node 888 joins and existing
+	// members remain present.
+	select {
+	case dbw.apiServerChanges <- apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {ID: "0", InternalAddress: "10.6.6.6:1234"},
+			"1": {ID: "1", InternalAddress: "10.6.6.7:1234"},
+			"2": {ID: "2", InternalAddress: "10.6.6.8:1234"},
+		},
+	}: // nothing to do, the changes were accepted
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for cluster change to be processed")
+	}
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) TestWorkerStartupExistingNodeDoesNotRemoveNonSpareNode(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectAnyLogs()
+	s.expectClock()
+	s.expectTrackedDBKill()
+
+	mgrExp := s.nodeManager.EXPECT()
+	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
+	mgrExp.IsExistingNode().Return(true, nil).Times(2)
+	mgrExp.IsLoopbackBound(gomock.Any()).Return(false, nil).Times(3)
+	mgrExp.IsLoopbackPreferred().Return(false).Times(2)
+	mgrExp.WithLogFuncOption().Return(nil)
+	mgrExp.WithTLSOption().Return(nil, nil)
+	mgrExp.WithTracingOption().Return(nil)
+
+	// Peer 777 is still a voter as far as Dqlite is concerned.
+	s.client.EXPECT().Cluster(gomock.Any()).Return([]dqlite.NodeInfo{
+		{ID: 666, Address: "10.6.6.6:1234"},
+		{ID: 777, Address: "10.6.6.7:1234", Role: dqlite.Voter},
+	}, nil).MinTimes(2)
+	// This node is the leader, so it is allowed to perform removals.
+	s.client.EXPECT().Leader(gomock.Any()).Return(&dqlite.NodeInfo{
+		ID:      666,
+		Address: "10.6.6.6:1234",
+	}, nil)
+	// Intentionally no Remove expectation: although 777 is absent from the
+	// topology, it is not a spare, so Dqlite still treats it as a legitimate
+	// participant and we must not remove it.
+	s.client.EXPECT().Close().Return(nil).Times(2)
+
+	s.expectNodeStartupAndShutdown()
+	s.dbApp.EXPECT().ID().Return(uint64(666)).AnyTimes()
+	s.dbApp.EXPECT().Handover(gomock.Any()).Return(nil)
+
+	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
+
+	w := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+	dbw := w.(*dbWorker)
+
+	ensureStartup(c, dbw)
+
+	// Simulate topology change where only the local controller remains, so
+	// node 777 is stale, but is still a voter.
+	select {
+	case dbw.apiServerChanges <- apiserver.Details{
+		Servers: map[string]apiserver.APIServer{
+			"0": {ID: "0", InternalAddress: "10.6.6.6:1234"},
+		},
+	}: // nothing to do, the changes were accepted
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for cluster change to be processed")
+	}
 
 	workertest.CleanKill(c, w)
 }
@@ -279,6 +509,7 @@ func (s *workerSuite) TestWorkerStartupExistingNodeWithLoopbackPreferred(c *gc.C
 	mgrExp.WithTracingOption().Return(nil)
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
+	s.client.EXPECT().Close().Return(nil).Times(1)
 
 	s.expectNodeStartupAndShutdown()
 
@@ -314,6 +545,7 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeSingleServerNoRebind(c *gc
 	mgrExp.WithTracingOption().Return(nil)
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
+	s.client.EXPECT().Close().Return(nil).Times(1)
 
 	s.expectNodeStartupAndShutdown()
 
@@ -383,23 +615,21 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigure(c *gc.C) {
 		{
 			ID:      3297041220608546238,
 			Address: "127.0.0.1:17666",
-			Role:    0,
 		},
 	}, nil)
 	mgrExp.SetClusterServers(gomock.Any(), []dqlite.NodeInfo{
 		{
 			ID:      3297041220608546238,
 			Address: "10.6.6.6:17666",
-			Role:    0,
 		},
 	}).Return(nil)
 	mgrExp.SetNodeInfo(dqlite.NodeInfo{
 		ID:      3297041220608546238,
 		Address: "10.6.6.6:17666",
-		Role:    0,
 	}).Return(nil)
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
+	s.client.EXPECT().Close().Return(nil)
 
 	// Although the shut-down check for IsLoopbackBound returns false,
 	// this call to shut-down is actually run before reconfiguring the node.
@@ -457,6 +687,7 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigureWithLoopbac
 	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
+	s.client.EXPECT().Close().Return(nil)
 
 	w := s.newWorker(c)
 	defer workertest.DirtyKill(c, w)
@@ -508,6 +739,7 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigureWithLoopbac
 	s.hub.EXPECT().Subscribe(apiserver.DetailsTopic, gomock.Any()).Return(func() {}, nil)
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
+	s.client.EXPECT().Close().Return(nil)
 
 	w := s.newWorker(c)
 	defer workertest.DirtyKill(c, w)


### PR DESCRIPTION
When a Dqlite cluster member is decommissioned (e.g. during HA teardown or
machine removal), the node should be explicitly removed from the cluster.yaml to
maintain consistency between the Juju controller topology and the underlying
Dqlite cluster membership.

This change adds logic to removeStaleClusterNodes() which:
- Compares current Dqlite cluster members (via Client.Cluster()) against
  the latest API server topology (from apiDetails)
- Identifies nodes that are no longer in the new topology by matching on
  host addresses
- Calls Client.Remove() to gracefully remove stale members
- Gracefully handles malformed addresses and transient topology updates

The implementation also uses both InternalAddress and Addresses fields to
match peers, preventing accidental removal of nodes with incomplete
InternalAddress data during topology transitions.

Two regression tests are added:
- TestWorkerStartupExistingNodeRemovesStaleMembers: verifies removal of
  genuinely stale nodes
- TestWorkerStartupExistingNodeDoesNotRemoveWhenAddressKnown: ensures
  nodes are not removed if still present in Addresses, even with empty
  InternalAddress

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju bootstrap lxd
juju enable-ha -n 3
juju remove-machine -m controller 1 --force
juju ssh -m controller 0 -- sudo cat /var/lib/juju/dqlite/cluster.yaml
juju enable-ha -n 3
```

## Links

**Issue:** Fixes #22668.

**Jira card:** [JUJU-10036](https://warthogs.atlassian.net/browse/JUJU-10036)


[JUJU-10036]: https://warthogs.atlassian.net/browse/JUJU-10036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ