### PR TITLE
fix: ensure Dqlite clients are closed

### DIFF
--- a/internal/database/client/dqlite_other.go
+++ b/internal/database/client/dqlite_other.go
@@ -27,6 +27,11 @@ func (c *Client) Leader(ctx context.Context) (*dqlite.NodeInfo, error) {
 	return nil, nil
 }
 
+// Close closes the client connection.
+func (c *Client) Close() error {
+	return nil
+}
+
 // FindLeader returns no leader and no error, as dqlite is not available.
 func FindLeader(ctx context.Context, store NodeStore, opts ...Option) (*Client, error) {
 	return nil, nil

--- a/internal/worker/dbaccessor/package_mock_test.go
+++ b/internal/worker/dbaccessor/package_mock_test.go
@@ -595,6 +595,7 @@ type MockClient struct {
 // MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock           *MockClient
+	closeExpects   []*gomock.Call0_1[error]
 	clusterExpects []*gomock.Call1_2[context.Context, []dqlite.NodeInfo, error]
 	leaderExpects  []*gomock.Call1_2[context.Context, *dqlite.NodeInfo, error]
 }
@@ -610,6 +611,24 @@ func NewMockClient(ctrl *gomock.Controller) *MockClient {
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
+
+// Close mocks base method.
+func (m *MockClient) Close() error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.closeExpects, m.ctrl, m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockClientMockRecorder) Close() *MockClientCloseCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[error](mr.mock.ctrl.T, mr.mock, "Close")
+	mr.closeExpects = append(mr.closeExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockClientCloseCall is the typed call wrapper for Close.
+type MockClientCloseCall = gomock.Call0_1[error]
 
 // Cluster mocks base method.
 func (m *MockClient) Cluster(arg0 context.Context) ([]dqlite.NodeInfo, error) {

--- a/internal/worker/dbaccessor/package_test.go
+++ b/internal/worker/dbaccessor/package_test.go
@@ -46,6 +46,7 @@ func (s *baseSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.timer = NewMockTimer(ctrl)
 	s.dbApp = NewMockDBApp(ctrl)
 	s.client = NewMockClient(ctrl)
+	s.client.EXPECT().Close().Return(nil).AnyTimes()
 	s.prometheusRegisterer = NewMockRegisterer(ctrl)
 	s.nodeManager = NewMockNodeManager(ctrl)
 	s.controllerConfigWatcher = NewMockConfigWatcher(ctrl)

--- a/internal/worker/dbaccessor/shim.go
+++ b/internal/worker/dbaccessor/shim.go
@@ -20,6 +20,8 @@ type Client interface {
 	Cluster(context.Context) ([]dqlite.NodeInfo, error)
 	// Leader returns information about the current leader, if any.
 	Leader(ctx context.Context) (*dqlite.NodeInfo, error)
+	// Close the client connection.
+	Close() error
 }
 
 // DBApp describes methods of a Dqlite database application,

--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -407,6 +407,7 @@ func (w *dbWorker) Report(ctx context.Context) map[string]any {
 		leaderID   uint64
 	)
 	if client, err := w.dbApp.Client(ctx); err == nil {
+		defer func() { _ = client.Close() }()
 		if nodeInfo, err := client.Leader(ctx); err == nil {
 			leaderID = nodeInfo.ID
 			leader = nodeInfo.Address
@@ -684,6 +685,7 @@ func (w *dbWorker) startDqliteNode(ctx context.Context, options ...app.Option) e
 	w.cfg.Logger.Infof(ctx, "serving Dqlite application (ID: %v)", w.dbApp.ID())
 
 	if c, err := w.dbApp.Client(ctx); err == nil {
+		defer func() { _ = c.Close() }()
 		if info, err := c.Cluster(ctx); err == nil {
 			w.cfg.Logger.Infof(ctx, "current cluster: %#v", info)
 		}

--- a/internal/worker/dbreplaccessor/worker.go
+++ b/internal/worker/dbreplaccessor/worker.go
@@ -224,6 +224,8 @@ func (w *dbReplWorker) DescribeCluster(ctx context.Context) ([]Node, error) {
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting leader client")
 	}
+	defer func() { _ = client.Close() }()
+
 	nodes, err := client.Cluster(ctx)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting cluster description")

--- a/scripts/dqlite/cmd/main.go
+++ b/scripts/dqlite/cmd/main.go
@@ -240,6 +240,7 @@ func dumpDB(ctx context.Context, db *sql.DB, path, name string) error {
 	if err != nil {
 		return fmt.Errorf("client.New failed %w", err)
 	}
+	defer func() { _ = cli.Close() }()
 
 	files, err := cli.Dump(ctx, name)
 	if err != nil {


### PR DESCRIPTION
Where we are done with a Dqlite client, we should call `Close`, which in turn closes the underlying `net.Conn`.

Such clients are not created frequently, and this has not surfaced as an issue to date. This is simply doing the right thing.