### PR TITLE
refactor: remove dbrepl agent dependencies

### DIFF
--- a/cmd/jujuagentd/agent/dbrepl.go
+++ b/cmd/jujuagentd/agent/dbrepl.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -294,13 +295,21 @@ func (a *replMachineAgent) makeEngineCreator(
 			return nil, err
 		}
 
+		agentConfig := a.CurrentConfig()
+		info, _ := agentConfig.ControllerAgentInfo()
+
 		manifoldsCfg := dbrepl.ManifoldsConfig{
-			Agent:               agent.APIHostPortsSetter{Agent: a},
-			AgentConfigChanged:  a.configChangedVal,
 			NewDBReplWorkerFunc: a.newDBReplWorkerFunc,
 			ControllerUnlocker:  a.controllerUnlocker,
 			ControllerID:        a.Tag().Id(),
-			Clock:               clock.WallClock,
+			ConfigChangeSocketPath: filepath.Join(
+				agentConfig.DataDir(), "configchange.socket",
+			),
+			DataDir:              agentConfig.DataDir(),
+			CACert:               agentConfig.CACert(),
+			ControllerCert:       info.Cert,
+			ControllerPrivateKey: info.PrivateKey,
+			Clock:                clock.WallClock,
 
 			Stdout: stdout,
 			Stderr: stderr,

--- a/cmd/jujuagentd/agent/dbrepl/manifolds.go
+++ b/cmd/jujuagentd/agent/dbrepl/manifolds.go
@@ -6,46 +6,45 @@ package dbrepl
 import (
 	"io"
 	"maps"
-	"path"
 
 	"github.com/juju/clock"
-	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v5/dependency"
 
-	coreagent "github.com/juju/juju/agent"
-	"github.com/juju/juju/agent/engine"
-	"github.com/juju/juju/cmd/jujuagentd/util"
 	internallogger "github.com/juju/juju/internal/logger"
-	"github.com/juju/juju/internal/worker/agent"
 	"github.com/juju/juju/internal/worker/controlleragentconfig"
 	"github.com/juju/juju/internal/worker/dbrepl"
 	"github.com/juju/juju/internal/worker/dbreplaccessor"
 	"github.com/juju/juju/internal/worker/gate"
-	"github.com/juju/juju/internal/worker/stateconfigwatcher"
 	"github.com/juju/juju/internal/worker/terminationworker"
 )
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.
 type ManifoldsConfig struct {
-	// Agent contains the agent that will be wrapped and made available to
-	// its dependencies via a dependency.Engine.
-	Agent coreagent.Agent
-
-	// AgentConfigChanged is set whenever the machine agent's config
-	// is updated.
-	AgentConfigChanged *voyeur.Value
-
 	// NewDBReplWorkerFunc returns a tracked db worker.
 	NewDBReplWorkerFunc dbreplaccessor.NewDBReplWorkerFunc
 
-	// ControllerUnlocker is passed to allow the controller agent config
-	// manifold to unlock the controller agent config ready lock when the
-	// controller agent config is ready. This isn't strictly required for
-	// the db-repl, but it is a dependency.
-	ControllerUnlocker gate.Lock
-
 	// ControllerID is the numeric ID of the controller.
 	ControllerID string
+
+	// ConfigChangeSocketPath is the controller config-change socket path.
+	ConfigChangeSocketPath string
+
+	// DataDir is the controller agent data directory.
+	DataDir string
+
+	// CACert is the controller CA certificate.
+	CACert string
+
+	// ControllerCert is the controller API certificate.
+	ControllerCert string
+
+	// ControllerPrivateKey is the controller API private key.
+	ControllerPrivateKey string
+
+	// ControllerUnlocker is passed to allow the controller agent config manifold
+	// to unlock the controller agent config ready lock when the controller agent
+	// config is ready.
+	ControllerUnlocker gate.Unlocker
 
 	// Clock supplies timekeeping services to various workers.
 	Clock clock.Clock
@@ -60,18 +59,11 @@ type ManifoldsConfig struct {
 	Stdin io.Reader
 }
 
-// commonManifolds returns a set of co-configured manifolds covering the
-// various responsibilities of a machine agent.
-//
-// Thou Shalt Not Use String Literals In This Function. Or Else.
+// commonManifolds returns manifolds shared between IAAS and CAAS controller
+// REPL engines.  The controller binary is always a controller, so no
+// ifController gating is required.
 func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
-	agentConfig := config.Agent.CurrentConfig()
-
-	manifolds := dependency.Manifolds{
-		// The agent manifold references the enclosing agent, and is the
-		// foundation stone on which most other manifolds ultimately depend.
-		agentName: agent.Manifold(config.Agent),
-
+	return dependency.Manifolds{
 		// The termination worker returns ErrTerminateAgent if a
 		// termination signal is received by the process it's running
 		// in. It has no inputs and its only output is the error it
@@ -81,94 +73,74 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// with this code.
 		terminationName: terminationworker.Manifold(),
 
-		// Each machine agent has a flag manifold/worker which
-		// reports whether or not the agent is a controller.
-		isControllerFlagName: util.IsControllerFlagManifold(stateConfigWatcherName, true),
+		// Controller agent config manifold watches the controller agent config
+		// socket and bounces if it changes.
+		controllerAgentConfigName: controlleragentconfig.Manifold(
+			controlleragentconfig.ManifoldConfig{
+				ControllerID:      config.ControllerID,
+				Logger:            internallogger.GetLogger("juju.worker.controlleragentconfig"),
+				NewSocketListener: controlleragentconfig.NewSocketListener,
+				SocketName:        config.ConfigChangeSocketPath,
+				ReadyUnlocker:     config.ControllerUnlocker,
+			},
+		),
 
-		// The stateconfigwatcher manifold watches the machine agent's
-		// configuration and reports if state serving info is
-		// present. It will bounce itself if state serving info is
-		// added or removed. It is intended as a dependency just for
-		// the state manifold.
-		stateConfigWatcherName: stateconfigwatcher.Manifold(stateconfigwatcher.ManifoldConfig{
-			AgentName:          agentName,
-			AgentConfigChanged: config.AgentConfigChanged,
-		}),
-
-		// Controller agent config manifold watches the controller
-		// agent config and bounces if it changes.
-		controllerAgentConfigName: ifController(controlleragentconfig.Manifold(controlleragentconfig.ManifoldConfig{
-			ControllerID:      config.ControllerID,
-			Logger:            internallogger.GetLogger("juju.worker.controlleragentconfig"),
-			NewSocketListener: controlleragentconfig.NewSocketListener,
-			SocketName:        path.Join(agentConfig.DataDir(), "configchange.socket"),
-			ReadyUnlocker:     config.ControllerUnlocker,
-		})),
-
-		// The db-repl manifold is responsible for managing the
-		// database REPL worker.
-		dbReplName: ifController(dbrepl.Manifold(dbrepl.ManifoldConfig{
+		// The db-repl manifold drives the interactive REPL worker.
+		dbReplName: dbrepl.Manifold(dbrepl.ManifoldConfig{
 			DBReplAccessorName: dbReplAccessorName,
 			Logger:             internallogger.GetLogger("juju.worker.dbrepl"),
 			Stdout:             config.Stdout,
 			Stderr:             config.Stderr,
 			Stdin:              config.Stdin,
-		})),
+		}),
 	}
-
-	return manifolds
 }
 
-// IAASManifolds returns a set of co-configured manifolds covering the
-// various responsibilities of a IAAS machine agent.
+// IAASManifolds returns manifolds for an IAAS controller REPL engine.
 func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	return mergeManifolds(config, dependency.Manifolds{
-		dbReplAccessorName: ifController(dbreplaccessor.Manifold(dbreplaccessor.ManifoldConfig{
-			AgentName:       agentName,
-			Clock:           config.Clock,
-			Logger:          internallogger.GetLogger("juju.worker.dbreplaccessor"),
-			NewApp:          dbreplaccessor.NewApp,
-			NewDBReplWorker: config.NewDBReplWorkerFunc,
-			NewNodeManager:  dbreplaccessor.IAASNodeManager,
-		})),
+		dbReplAccessorName: dbreplaccessor.Manifold(dbreplaccessor.ManifoldConfig{
+			DataDir:              config.DataDir,
+			CACert:               config.CACert,
+			ControllerCert:       config.ControllerCert,
+			ControllerPrivateKey: config.ControllerPrivateKey,
+			Clock:                config.Clock,
+			Logger:               internallogger.GetLogger("juju.worker.dbreplaccessor"),
+			NewApp:               dbreplaccessor.NewApp,
+			NewDBReplWorker:      config.NewDBReplWorkerFunc,
+			NewNodeManager:       dbreplaccessor.IAASNodeManager,
+		}),
 	})
 }
 
-// CAASManifolds returns a set of co-configured manifolds covering the
-// various responsibilities of a CAAS machine agent.
+// CAASManifolds returns manifolds for a CAAS controller REPL engine.
 func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	return mergeManifolds(config, dependency.Manifolds{
-		dbReplAccessorName: ifController(dbreplaccessor.Manifold(dbreplaccessor.ManifoldConfig{
-			AgentName:       agentName,
-			Clock:           config.Clock,
-			Logger:          internallogger.GetLogger("juju.worker.dbreplaccessor"),
-			NewApp:          dbreplaccessor.NewApp,
-			NewDBReplWorker: config.NewDBReplWorkerFunc,
-			NewNodeManager:  dbreplaccessor.CAASNodeManager,
-		})),
+		dbReplAccessorName: dbreplaccessor.Manifold(dbreplaccessor.ManifoldConfig{
+			DataDir:              config.DataDir,
+			CACert:               config.CACert,
+			ControllerCert:       config.ControllerCert,
+			ControllerPrivateKey: config.ControllerPrivateKey,
+			Clock:                config.Clock,
+			Logger:               internallogger.GetLogger("juju.worker.dbreplaccessor"),
+			NewApp:               dbreplaccessor.NewApp,
+			NewDBReplWorker:      config.NewDBReplWorkerFunc,
+			NewNodeManager:       dbreplaccessor.CAASNodeManager,
+		}),
 	})
 }
 
-func mergeManifolds(config ManifoldsConfig, manifolds dependency.Manifolds) dependency.Manifolds {
+func mergeManifolds(
+	config ManifoldsConfig, manifolds dependency.Manifolds,
+) dependency.Manifolds {
 	result := commonManifolds(config)
 	maps.Copy(result, manifolds)
 	return result
 }
 
-var ifController = engine.Housing{
-	Flags: []string{
-		isControllerFlagName,
-	},
-}.Decorate
-
 const (
-	agentName              = "agent"
-	terminationName        = "termination-signal-handler"
-	stateConfigWatcherName = "state-config-watcher"
-
-	isControllerFlagName      = "is-controller-flag"
 	controllerAgentConfigName = "controller-agent-config"
-
-	dbReplName         = "db-repl"
-	dbReplAccessorName = "db-repl-accessor"
+	dbReplAccessorName        = "db-repl-accessor"
+	dbReplName                = "db-repl"
+	terminationName           = "termination-signal-handler"
 )

--- a/cmd/jujuagentd/agent/dbrepl/manifolds_test.go
+++ b/cmd/jujuagentd/agent/dbrepl/manifolds_test.go
@@ -4,20 +4,15 @@
 package dbrepl_test
 
 import (
-	"slices"
 	"sort"
 	stdtesting "testing"
 
-	"github.com/juju/collections/set"
-	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/dependency"
 
-	"github.com/juju/juju/agent"
-	"github.com/juju/juju/agent/agenttest"
 	"github.com/juju/juju/cmd/jujuagentd/agent/dbrepl"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/internal/testing"
+	"github.com/juju/juju/internal/worker/gate"
 )
 
 type ManifoldsSuite struct {
@@ -33,15 +28,11 @@ func (s *ManifoldsSuite) SetUpTest(c *tc.C) {
 }
 
 func (s *ManifoldsSuite) TestStartFuncsIAAS(c *tc.C) {
-	s.assertStartFuncs(c, dbrepl.IAASManifolds(dbrepl.ManifoldsConfig{
-		Agent: &mockAgent{},
-	}))
+	s.assertStartFuncs(c, dbrepl.IAASManifolds(newManifoldsConfig()))
 }
 
 func (s *ManifoldsSuite) TestStartFuncsCAAS(c *tc.C) {
-	s.assertStartFuncs(c, dbrepl.CAASManifolds(dbrepl.ManifoldsConfig{
-		Agent: &mockAgent{},
-	}))
+	s.assertStartFuncs(c, dbrepl.CAASManifolds(newManifoldsConfig()))
 }
 
 func (*ManifoldsSuite) assertStartFuncs(c *tc.C, manifolds dependency.Manifolds) {
@@ -53,16 +44,11 @@ func (*ManifoldsSuite) assertStartFuncs(c *tc.C, manifolds dependency.Manifolds)
 
 func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *tc.C) {
 	s.assertManifoldNames(c,
-		dbrepl.IAASManifolds(dbrepl.ManifoldsConfig{
-			Agent: &mockAgent{},
-		}),
+		dbrepl.IAASManifolds(newManifoldsConfig()),
 		[]string{
-			"agent",
 			"controller-agent-config",
 			"db-repl-accessor",
 			"db-repl",
-			"is-controller-flag",
-			"state-config-watcher",
 			"termination-signal-handler",
 		},
 	)
@@ -70,16 +56,11 @@ func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *tc.C) {
 
 func (s *ManifoldsSuite) TestManifoldNamesCAAS(c *tc.C) {
 	s.assertManifoldNames(c,
-		dbrepl.CAASManifolds(dbrepl.ManifoldsConfig{
-			Agent: &mockAgent{},
-		}),
+		dbrepl.CAASManifolds(newManifoldsConfig()),
 		[]string{
-			"agent",
 			"controller-agent-config",
 			"db-repl-accessor",
 			"db-repl",
-			"is-controller-flag",
-			"state-config-watcher",
 			"termination-signal-handler",
 		},
 	)
@@ -94,183 +75,44 @@ func (*ManifoldsSuite) assertManifoldNames(c *tc.C, manifolds dependency.Manifol
 	c.Assert(keys, tc.SameContents, expectedKeys)
 }
 
-func (*ManifoldsSuite) TestSingularGuardsUsed(c *tc.C) {
-	manifolds := dbrepl.IAASManifolds(dbrepl.ManifoldsConfig{
-		Agent: &mockAgent{},
-	})
-
-	// Explicitly guarded by ifController.
-	controllerWorkers := set.NewStrings(
-		"controller-agent-config",
-		"db-repl",
-		"db-repl-accessor",
-	)
-
-	// Explicitly guarded by ifPrimaryController.
-	primaryControllerWorkers := set.NewStrings()
-
-	dbUpgradedWorkers := set.NewStrings()
-
-	for name, manifold := range manifolds {
-		c.Logf("%s", name)
-		switch {
-		case controllerWorkers.Contains(name):
-			checkContains(c, manifold.Inputs, "is-controller-flag")
-			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
-		case primaryControllerWorkers.Contains(name):
-			checkNotContains(c, manifold.Inputs, "is-controller-flag")
-			checkContains(c, manifold.Inputs, "is-primary-controller-flag")
-		case dbUpgradedWorkers.Contains(name):
-			checkNotContains(c, manifold.Inputs, "is-controller-flag")
-			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
-			checkContains(c, manifold.Inputs, "upgrade-database-flag")
-		default:
-			checkNotContains(c, manifold.Inputs, "is-controller-flag")
-			checkNotContains(c, manifold.Inputs, "is-primary-controller-flag")
-		}
-	}
-}
-
-func checkContains(c *tc.C, names []string, seek string) {
-	if slices.Contains(names, seek) {
-		return
-	}
-	c.Errorf("%q not found in %v", seek, names)
-}
-
-func checkNotContains(c *tc.C, names []string, seek string) {
-	if slices.Contains(names, seek) {
-		c.Errorf("%q found in %v", seek, names)
-		return
-	}
-}
-
 func (s *ManifoldsSuite) TestManifoldsDependenciesIAAS(c *tc.C) {
-	agenttest.AssertManifoldsDependencies(c,
-		dbrepl.IAASManifolds(dbrepl.ManifoldsConfig{
-			Agent: &mockAgent{},
-		}),
-		expectedMachineManifoldsWithDependenciesIAAS,
-	)
+	manifolds := dbrepl.IAASManifolds(newManifoldsConfig())
+	for name, expected := range expectedManifoldsWithDependencies {
+		manifold, ok := manifolds[name]
+		c.Assert(ok, tc.IsTrue, tc.Commentf("manifold %q not found", name))
+		c.Check(manifold.Inputs, tc.SameContents, expected, tc.Commentf("manifold %q", name))
+	}
 }
 
 func (s *ManifoldsSuite) TestManifoldsDependenciesCAAS(c *tc.C) {
-	agenttest.AssertManifoldsDependencies(c,
-		dbrepl.CAASManifolds(dbrepl.ManifoldsConfig{
-			Agent: &mockAgent{},
-		}),
-		expectedMachineManifoldsWithDependenciesCAAS,
-	)
+	manifolds := dbrepl.CAASManifolds(newManifoldsConfig())
+	for name, expected := range expectedManifoldsWithDependencies {
+		manifold, ok := manifolds[name]
+		c.Assert(ok, tc.IsTrue, tc.Commentf("manifold %q not found", name))
+		c.Check(manifold.Inputs, tc.SameContents, expected, tc.Commentf("manifold %q", name))
+	}
 }
 
-var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
+var expectedManifoldsWithDependencies = map[string][]string{
+	"controller-agent-config": {},
 
-	"agent": {},
+	"db-repl": {"db-repl-accessor"},
 
-	"controller-agent-config": {
-		"agent",
-		"is-controller-flag",
-		"state-config-watcher",
-	},
-
-	"db-repl": {
-		"agent",
-		"db-repl-accessor",
-		"is-controller-flag",
-		"state-config-watcher",
-	},
-
-	"db-repl-accessor": {
-		"agent",
-		"is-controller-flag",
-		"state-config-watcher",
-	},
-
-	"is-controller-flag": {"agent", "state-config-watcher"},
-
-	"state-config-watcher": {"agent"},
+	"db-repl-accessor": {},
 
 	"termination-signal-handler": {},
 }
 
-var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
-
-	"agent": {},
-
-	"controller-agent-config": {
-		"agent",
-		"is-controller-flag",
-		"state-config-watcher",
-	},
-
-	"db-repl": {
-		"agent",
-		"db-repl-accessor",
-		"is-controller-flag",
-		"state-config-watcher",
-	},
-
-	"db-repl-accessor": {
-		"agent",
-		"is-controller-flag",
-		"state-config-watcher",
-	},
-
-	"is-controller-flag": {"agent", "state-config-watcher"},
-
-	"state-config-watcher": {"agent"},
-
-	"termination-signal-handler": {},
-}
-
-type mockAgent struct {
-	agent.Agent
-	conf mockConfig
-}
-
-func (ma *mockAgent) CurrentConfig() agent.Config {
-	return &ma.conf
-}
-
-func (ma *mockAgent) ChangeConfig(f agent.ConfigMutator) error {
-	return f(&ma.conf)
-}
-
-type mockConfig struct {
-	agent.ConfigSetter
-	tag      names.Tag
-	ssiSet   bool
-	ssi      controller.ControllerAgentInfo
-	dataPath string
-}
-
-func (mc *mockConfig) Tag() names.Tag {
-	if mc.tag == nil {
-		return names.NewMachineTag("99")
+func newManifoldsConfig() dbrepl.ManifoldsConfig {
+	unlocker := gate.NewLock()
+	unlocker.Unlock()
+	return dbrepl.ManifoldsConfig{
+		ControllerUnlocker:     unlocker,
+		ControllerID:           testing.ControllerTag.Id(),
+		ConfigChangeSocketPath: "data-dir/configchange.socket",
+		DataDir:                "data-dir",
+		CACert:                 "ca-cert",
+		ControllerCert:         "controller-cert",
+		ControllerPrivateKey:   "controller-private-key",
 	}
-	return mc.tag
-}
-
-func (mc *mockConfig) Controller() names.ControllerTag {
-	return testing.ControllerTag
-}
-
-func (mc *mockConfig) StateServingInfo() (controller.ControllerAgentInfo, bool) {
-	return mc.ssi, mc.ssiSet
-}
-
-func (mc *mockConfig) SetStateServingInfo(info controller.ControllerAgentInfo) {
-	mc.ssiSet = true
-	mc.ssi = info
-}
-
-func (mc *mockConfig) LogDir() string {
-	return "log-dir"
-}
-
-func (mc *mockConfig) DataDir() string {
-	if mc.dataPath != "" {
-		return mc.dataPath
-	}
-	return "data-dir"
 }

--- a/cmd/jujud/agent/dbrepl.go
+++ b/cmd/jujud/agent/dbrepl.go
@@ -8,30 +8,28 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	"github.com/juju/loggo/v3"
 	"github.com/juju/names/v6"
-	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 
-	"github.com/juju/juju/agent"
-	agentconfig "github.com/juju/juju/agent/config"
 	agentengine "github.com/juju/juju/agent/engine"
 	agenterrors "github.com/juju/juju/agent/errors"
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/cmd"
-	"github.com/juju/juju/cmd/internal/agent/agentconf"
 	"github.com/juju/juju/cmd/jujud/agent/dbrepl"
 	cmdutil "github.com/juju/juju/cmd/jujud/util"
+	"github.com/juju/juju/internal/controllerruntimeconfig"
 	internaldependency "github.com/juju/juju/internal/dependency"
 	internallogger "github.com/juju/juju/internal/logger"
-	k8sconstants "github.com/juju/juju/internal/provider/kubernetes/constants"
 	internalworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/dbreplaccessor"
+	"github.com/juju/juju/internal/worker/gate"
 )
 
 // NewDBReplAgentCommand creates a Command that handles parsing
@@ -41,13 +39,11 @@ func NewDBReplAgentCommand(
 	ctx *cmd.Context,
 	replControllerAgentFactory dbReplControllerAgentFactoryFnType,
 	agentInitializer AgentInitializer,
-	configFetcher agentconfig.AgentConfigWriter,
 ) cmd.Command {
 	return &dbReplAgentCommand{
 		ctx:                        ctx,
 		replControllerAgentFactory: replControllerAgentFactory,
 		agentInitializer:           agentInitializer,
-		currentConfig:              configFetcher,
 	}
 }
 
@@ -56,12 +52,11 @@ type dbReplAgentCommand struct {
 
 	// This group of arguments is required.
 	agentInitializer           AgentInitializer
-	currentConfig              agentconfig.AgentConfigWriter
 	replControllerAgentFactory dbReplControllerAgentFactoryFnType
 	ctx                        *cmd.Context
 
-	isCaas   bool
-	agentTag names.Tag
+	runtimeConfig controllerruntimeconfig.ControllerRuntimeConfig
+	agentTag      names.Tag
 
 	// The following are set via command-line flags.
 	controllerId string
@@ -87,14 +82,17 @@ func (a *dbReplAgentCommand) Init(args []string) error {
 	_, _ = loggo.RemoveWriter("logfile")
 
 	a.agentTag = names.NewControllerAgentTag(a.controllerId)
-	if err := agentconfig.ReadAgentConfig(a.currentConfig, a.agentTag.Id()); err != nil {
-		return errors.Errorf("cannot read agent configuration: %v", err)
+	runtimeConfigPath := controllerruntimeconfig.ConfigPath(filepath.Join(
+		a.agentInitializer.DataDir(), "agents", "controller-"+a.agentTag.Id(),
+	))
+	runtimeConfig, err := controllerruntimeconfig.ReadControllerRuntimeConfig(runtimeConfigPath)
+	if err != nil {
+		return errors.Annotate(err, "cannot read controller runtime configuration")
 	}
-	config := a.currentConfig.CurrentConfig()
-	if err := os.MkdirAll(config.LogDir(), 0644); err != nil {
+	a.runtimeConfig = runtimeConfig
+	if err := os.MkdirAll(runtimeConfig.LogDir, 0644); err != nil {
 		logger.Warningf(context.TODO(), "cannot create log dir: %v", err)
 	}
-	a.isCaas = config.Value(agent.ProviderType) == k8sconstants.CAASProviderType
 
 	return nil
 }
@@ -106,7 +104,7 @@ func (a *dbReplAgentCommand) Run(c *cmd.Context) error {
 		fmt.Fprint(os.Stderr, replWarningHeader)
 	}
 
-	controllerAgent, err := a.replControllerAgentFactory(a.agentTag, a.isCaas)
+	controllerAgent, err := a.replControllerAgentFactory(a.agentTag, a.runtimeConfig)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -139,15 +137,14 @@ state of the system. Be careful!
 Type '.help' for help.
 `
 
-type dbReplControllerAgentFactoryFnType func(names.Tag, bool) (*replControllerAgent, error)
+type dbReplControllerAgentFactoryFnType func(names.Tag, controllerruntimeconfig.ControllerRuntimeConfig) (*replControllerAgent, error)
 
 // DBReplControllerAgentFactoryFn returns a function which instantiates a
 // replControllerAgent given a controller agent tag.
 func DBReplControllerAgentFactoryFn(
-	agentConfWriter agentconfig.AgentConfigWriter,
 	newDBReplWorkerFunc dbreplaccessor.NewDBReplWorkerFunc,
 ) dbReplControllerAgentFactoryFnType {
-	return func(agentTag names.Tag, isCaasAgent bool) (*replControllerAgent, error) {
+	return func(agentTag names.Tag, runtimeConfig controllerruntimeconfig.ControllerRuntimeConfig) (*replControllerAgent, error) {
 		runner, err := worker.NewRunner(worker.RunnerParams{
 			Name:          "repl",
 			IsFatal:       agenterrors.IsFatal,
@@ -160,10 +157,9 @@ func DBReplControllerAgentFactoryFn(
 		}
 		return NewREPLControllerAgent(
 			agentTag,
-			agentConfWriter,
 			runner,
 			newDBReplWorkerFunc,
-			isCaasAgent,
+			runtimeConfig,
 		)
 	}
 }
@@ -171,19 +167,16 @@ func DBReplControllerAgentFactoryFn(
 // NewREPLControllerAgent instantiates a new replControllerAgent.
 func NewREPLControllerAgent(
 	agentTag names.Tag,
-	agentConfWriter agentconfig.AgentConfigWriter,
 	runner *worker.Runner,
 	newDBReplWorkerFunc dbreplaccessor.NewDBReplWorkerFunc,
-	isCaasAgent bool,
+	runtimeConfig controllerruntimeconfig.ControllerRuntimeConfig,
 ) (*replControllerAgent, error) {
 	a := &replControllerAgent{
 		agentTag:            agentTag,
-		AgentConfigWriter:   agentConfWriter,
-		configChangedVal:    voyeur.NewValue(true),
 		dead:                make(chan struct{}),
 		runner:              runner,
 		newDBReplWorkerFunc: newDBReplWorkerFunc,
-		isCaasAgent:         isCaasAgent,
+		runtimeConfig:       runtimeConfig,
 	}
 	return a, nil
 }
@@ -192,17 +185,15 @@ func NewREPLControllerAgent(
 // manifolds required to provide an interactive Dqlite REPL.  It does
 // not participate in the controller's normal dependency engine.
 type replControllerAgent struct {
-	agentconfig.AgentConfigWriter
-
-	dead             chan struct{}
-	errReason        error
-	agentTag         names.Tag
-	runner           *worker.Runner
-	configChangedVal *voyeur.Value
+	dead      chan struct{}
+	errReason error
+	agentTag  names.Tag
+	runner    *worker.Runner
 
 	newDBReplWorkerFunc dbreplaccessor.NewDBReplWorkerFunc
 
-	isCaasAgent bool
+	runtimeConfig      controllerruntimeconfig.ControllerRuntimeConfig
+	controllerUnlocker gate.Unlocker
 }
 
 // Wait waits for the repl controller agent to finish.
@@ -228,24 +219,13 @@ func (a *replControllerAgent) Tag() names.Tag {
 	return a.agentTag
 }
 
-// ChangeConfig updates the agent's configuration and notifies
-// listeners of the change.
-func (a *replControllerAgent) ChangeConfig(mutate agent.ConfigMutator) error {
-	err := a.AgentConfigWriter.ChangeConfig(mutate)
-	a.configChangedVal.Set(true)
-	return errors.Trace(err)
-}
-
 // Run runs a repl controller agent.
 func (a *replControllerAgent) Run(ctx *cmd.Context) (err error) {
 	defer a.Done(err)
 
-	if err := a.ReadConfig(a.Tag().String()); err != nil {
-		return errors.Errorf("cannot read agent configuration: %v", err)
-	}
-
-	agentConfig := a.CurrentConfig()
-	agentconf.SetupAgentLogging(internallogger.DefaultContext(), agentConfig)
+	controllerUnlocker := gate.NewLock()
+	controllerUnlocker.Unlock()
+	a.controllerUnlocker = controllerUnlocker
 
 	createEngine := a.makeEngineCreator(ctx.Stdout, ctx.Stderr, ctx.Stdin)
 	_ = a.runner.StartWorker(ctx, "engine", createEngine)
@@ -271,18 +251,24 @@ func (a *replControllerAgent) makeEngineCreator(
 		}
 
 		manifoldsCfg := dbrepl.ManifoldsConfig{
-			Agent:               agent.APIHostPortsSetter{Agent: a},
-			AgentConfigChanged:  a.configChangedVal,
 			NewDBReplWorkerFunc: a.newDBReplWorkerFunc,
 			ControllerID:        a.Tag().Id(),
-			Clock:               clock.WallClock,
-			Stdout:              stdout,
-			Stderr:              stderr,
-			Stdin:               stdin,
+			ControllerUnlocker:  a.controllerUnlocker,
+			ConfigChangeSocketPath: filepath.Join(
+				a.runtimeConfig.DataDir, "configchange.socket",
+			),
+			DataDir:              a.runtimeConfig.DataDir,
+			CACert:               a.runtimeConfig.CACert,
+			ControllerCert:       a.runtimeConfig.ControllerCert,
+			ControllerPrivateKey: a.runtimeConfig.ControllerPrivateKey,
+			Clock:                clock.WallClock,
+			Stdout:               stdout,
+			Stderr:               stderr,
+			Stdin:                stdin,
 		}
 
 		var manifolds dependency.Manifolds
-		if a.isCaasAgent {
+		if a.runtimeConfig.LoopbackPreferred {
 			manifolds = dbrepl.CAASManifolds(manifoldsCfg)
 		} else {
 			manifolds = dbrepl.IAASManifolds(manifoldsCfg)

--- a/cmd/jujud/agent/dbrepl/manifolds.go
+++ b/cmd/jujud/agent/dbrepl/manifolds.go
@@ -6,36 +6,45 @@ package dbrepl
 import (
 	"io"
 	"maps"
-	"path"
 
 	"github.com/juju/clock"
-	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v5/dependency"
 
-	coreagent "github.com/juju/juju/agent"
 	internallogger "github.com/juju/juju/internal/logger"
-	"github.com/juju/juju/internal/worker/agent"
 	"github.com/juju/juju/internal/worker/controlleragentconfig"
 	"github.com/juju/juju/internal/worker/dbrepl"
 	"github.com/juju/juju/internal/worker/dbreplaccessor"
+	"github.com/juju/juju/internal/worker/gate"
 	"github.com/juju/juju/internal/worker/terminationworker"
 )
 
 // ManifoldsConfig allows specialisation of the result of Manifolds.
 type ManifoldsConfig struct {
-	// Agent contains the agent that will be wrapped and made available to
-	// its dependencies via a dependency.Engine.
-	Agent coreagent.Agent
-
-	// AgentConfigChanged is set whenever the controller agent's config
-	// is updated.
-	AgentConfigChanged *voyeur.Value
-
 	// NewDBReplWorkerFunc returns a tracked db worker.
 	NewDBReplWorkerFunc dbreplaccessor.NewDBReplWorkerFunc
 
 	// ControllerID is the numeric ID of the controller.
 	ControllerID string
+
+	// ConfigChangeSocketPath is the controller config-change socket path.
+	ConfigChangeSocketPath string
+
+	// DataDir is the controller agent data directory.
+	DataDir string
+
+	// CACert is the controller CA certificate.
+	CACert string
+
+	// ControllerCert is the controller API certificate.
+	ControllerCert string
+
+	// ControllerPrivateKey is the controller API private key.
+	ControllerPrivateKey string
+
+	// ControllerUnlocker is passed to allow the controller agent config manifold
+	// to unlock the controller agent config ready lock when the controller agent
+	// config is ready.
+	ControllerUnlocker gate.Unlocker
 
 	// Clock supplies timekeeping services to various workers.
 	Clock clock.Clock
@@ -54,28 +63,20 @@ type ManifoldsConfig struct {
 // controller REPL engines.  The controller binary is always a
 // controller, so no ifController gating is required.
 func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
-	agentConfig := config.Agent.CurrentConfig()
-
 	return dependency.Manifolds{
-		// The agent manifold references the enclosing agent, and is the
-		// foundation stone on which most other manifolds ultimately
-		// depend.
-		agentName: agent.Manifold(config.Agent),
-
 		// The termination worker returns ErrTerminateAgent if a
 		// termination signal is received by the process it's running in.
 		terminationName: terminationworker.Manifold(),
 
-		// Controller agent config manifold watches the controller agent
-		// config socket and bounces if it changes.
+		// Controller agent config manifold watches the controller agent config
+		// socket and bounces if it changes.
 		controllerAgentConfigName: controlleragentconfig.Manifold(
 			controlleragentconfig.ManifoldConfig{
 				ControllerID:      config.ControllerID,
 				Logger:            internallogger.GetLogger("juju.worker.controlleragentconfig"),
 				NewSocketListener: controlleragentconfig.NewSocketListener,
-				SocketName: path.Join(
-					agentConfig.DataDir(), "configchange.socket",
-				),
+				SocketName:        config.ConfigChangeSocketPath,
+				ReadyUnlocker:     config.ControllerUnlocker,
 			},
 		),
 
@@ -94,12 +95,15 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	return mergeManifolds(config, dependency.Manifolds{
 		dbReplAccessorName: dbreplaccessor.Manifold(dbreplaccessor.ManifoldConfig{
-			AgentName:       agentName,
-			Clock:           config.Clock,
-			Logger:          internallogger.GetLogger("juju.worker.dbreplaccessor"),
-			NewApp:          dbreplaccessor.NewApp,
-			NewDBReplWorker: config.NewDBReplWorkerFunc,
-			NewNodeManager:  dbreplaccessor.IAASNodeManager,
+			DataDir:              config.DataDir,
+			CACert:               config.CACert,
+			ControllerCert:       config.ControllerCert,
+			ControllerPrivateKey: config.ControllerPrivateKey,
+			Clock:                config.Clock,
+			Logger:               internallogger.GetLogger("juju.worker.dbreplaccessor"),
+			NewApp:               dbreplaccessor.NewApp,
+			NewDBReplWorker:      config.NewDBReplWorkerFunc,
+			NewNodeManager:       dbreplaccessor.IAASNodeManager,
 		}),
 	})
 }
@@ -108,12 +112,15 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 	return mergeManifolds(config, dependency.Manifolds{
 		dbReplAccessorName: dbreplaccessor.Manifold(dbreplaccessor.ManifoldConfig{
-			AgentName:       agentName,
-			Clock:           config.Clock,
-			Logger:          internallogger.GetLogger("juju.worker.dbreplaccessor"),
-			NewApp:          dbreplaccessor.NewApp,
-			NewDBReplWorker: config.NewDBReplWorkerFunc,
-			NewNodeManager:  dbreplaccessor.CAASNodeManager,
+			DataDir:              config.DataDir,
+			CACert:               config.CACert,
+			ControllerCert:       config.ControllerCert,
+			ControllerPrivateKey: config.ControllerPrivateKey,
+			Clock:                config.Clock,
+			Logger:               internallogger.GetLogger("juju.worker.dbreplaccessor"),
+			NewApp:               dbreplaccessor.NewApp,
+			NewDBReplWorker:      config.NewDBReplWorkerFunc,
+			NewNodeManager:       dbreplaccessor.CAASNodeManager,
 		}),
 	})
 }
@@ -127,11 +134,8 @@ func mergeManifolds(
 }
 
 const (
-	agentName       = "agent"
-	terminationName = "termination-signal-handler"
-
 	controllerAgentConfigName = "controller-agent-config"
-
-	dbReplName         = "db-repl"
-	dbReplAccessorName = "db-repl-accessor"
+	dbReplAccessorName        = "db-repl-accessor"
+	dbReplName                = "db-repl"
+	terminationName           = "termination-signal-handler"
 )

--- a/cmd/jujud/agent/dbrepl/manifolds_test.go
+++ b/cmd/jujud/agent/dbrepl/manifolds_test.go
@@ -8,14 +8,11 @@ import (
 	"sort"
 	stdtesting "testing"
 
-	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/dependency"
 
-	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agenttest"
 	"github.com/juju/juju/cmd/jujud/agent/dbrepl"
-	"github.com/juju/juju/controller"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -32,15 +29,11 @@ func (s *ManifoldsSuite) SetUpTest(c *tc.C) {
 }
 
 func (s *ManifoldsSuite) TestStartFuncsIAAS(c *tc.C) {
-	s.assertStartFuncs(c, dbrepl.IAASManifolds(dbrepl.ManifoldsConfig{
-		Agent: &mockAgent{},
-	}))
+	s.assertStartFuncs(c, dbrepl.IAASManifolds(newManifoldsConfig()))
 }
 
 func (s *ManifoldsSuite) TestStartFuncsCAAS(c *tc.C) {
-	s.assertStartFuncs(c, dbrepl.CAASManifolds(dbrepl.ManifoldsConfig{
-		Agent: &mockAgent{},
-	}))
+	s.assertStartFuncs(c, dbrepl.CAASManifolds(newManifoldsConfig()))
 }
 
 func (*ManifoldsSuite) assertStartFuncs(c *tc.C, manifolds dependency.Manifolds) {
@@ -52,11 +45,8 @@ func (*ManifoldsSuite) assertStartFuncs(c *tc.C, manifolds dependency.Manifolds)
 
 func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *tc.C) {
 	s.assertManifoldNames(c,
-		dbrepl.IAASManifolds(dbrepl.ManifoldsConfig{
-			Agent: &mockAgent{},
-		}),
+		dbrepl.IAASManifolds(newManifoldsConfig()),
 		[]string{
-			"agent",
 			"controller-agent-config",
 			"db-repl-accessor",
 			"db-repl",
@@ -67,11 +57,8 @@ func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *tc.C) {
 
 func (s *ManifoldsSuite) TestManifoldNamesCAAS(c *tc.C) {
 	s.assertManifoldNames(c,
-		dbrepl.CAASManifolds(dbrepl.ManifoldsConfig{
-			Agent: &mockAgent{},
-		}),
+		dbrepl.CAASManifolds(newManifoldsConfig()),
 		[]string{
-			"agent",
 			"controller-agent-config",
 			"db-repl-accessor",
 			"db-repl",
@@ -94,7 +81,12 @@ func (*ManifoldsSuite) TestNoControllerFlagGuards(c *tc.C) {
 	// should reference the removed is-controller-flag or
 	// state-config-watcher workers.
 	manifolds := dbrepl.IAASManifolds(dbrepl.ManifoldsConfig{
-		Agent: &mockAgent{},
+		ControllerID:           "99",
+		ConfigChangeSocketPath: "data-dir/configchange.socket",
+		DataDir:                "data-dir",
+		CACert:                 "ca-cert",
+		ControllerCert:         "controller-cert",
+		ControllerPrivateKey:   "controller-private-key",
 	})
 
 	for name, manifold := range manifolds {
@@ -113,106 +105,49 @@ func checkNotContains(c *tc.C, names []string, seek string) {
 
 func (s *ManifoldsSuite) TestManifoldsDependenciesIAAS(c *tc.C) {
 	agenttest.AssertManifoldsDependencies(c,
-		dbrepl.IAASManifolds(dbrepl.ManifoldsConfig{
-			Agent: &mockAgent{},
-		}),
+		dbrepl.IAASManifolds(newManifoldsConfig()),
 		expectedMachineManifoldsWithDependenciesIAAS,
 	)
 }
 
 func (s *ManifoldsSuite) TestManifoldsDependenciesCAAS(c *tc.C) {
 	agenttest.AssertManifoldsDependencies(c,
-		dbrepl.CAASManifolds(dbrepl.ManifoldsConfig{
-			Agent: &mockAgent{},
-		}),
+		dbrepl.CAASManifolds(newManifoldsConfig()),
 		expectedMachineManifoldsWithDependenciesCAAS,
 	)
 }
 
 var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
-
-	"agent": {},
-
 	"controller-agent-config": {},
 
 	"db-repl": {
-		"agent",
 		"db-repl-accessor",
 	},
 
-	"db-repl-accessor": {
-		"agent",
-	},
+	"db-repl-accessor": {},
 
 	"termination-signal-handler": {},
 }
 
 var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
-
-	"agent": {},
-
 	"controller-agent-config": {},
 
 	"db-repl": {
-		"agent",
 		"db-repl-accessor",
 	},
 
-	"db-repl-accessor": {
-		"agent",
-	},
+	"db-repl-accessor": {},
 
 	"termination-signal-handler": {},
 }
 
-type mockAgent struct {
-	agent.Agent
-	conf mockConfig
-}
-
-func (ma *mockAgent) CurrentConfig() agent.Config {
-	return &ma.conf
-}
-
-func (ma *mockAgent) ChangeConfig(f agent.ConfigMutator) error {
-	return f(&ma.conf)
-}
-
-type mockConfig struct {
-	agent.ConfigSetter
-	tag      names.Tag
-	ssiSet   bool
-	ssi      controller.ControllerAgentInfo
-	dataPath string
-}
-
-func (mc *mockConfig) Tag() names.Tag {
-	if mc.tag == nil {
-		return names.NewMachineTag("99")
+func newManifoldsConfig() dbrepl.ManifoldsConfig {
+	return dbrepl.ManifoldsConfig{
+		ControllerID:           "99",
+		ConfigChangeSocketPath: "data-dir/configchange.socket",
+		DataDir:                "data-dir",
+		CACert:                 "ca-cert",
+		ControllerCert:         "controller-cert",
+		ControllerPrivateKey:   "controller-private-key",
 	}
-	return mc.tag
-}
-
-func (mc *mockConfig) Controller() names.ControllerTag {
-	return testing.ControllerTag
-}
-
-func (mc *mockConfig) StateServingInfo() (controller.ControllerAgentInfo, bool) {
-	return mc.ssi, mc.ssiSet
-}
-
-func (mc *mockConfig) SetStateServingInfo(info controller.ControllerAgentInfo) {
-	mc.ssiSet = true
-	mc.ssi = info
-}
-
-func (mc *mockConfig) LogDir() string {
-	return "log-dir"
-}
-
-func (mc *mockConfig) DataDir() string {
-	if mc.dataPath != "" {
-		return mc.dataPath
-	}
-	return "data-dir"
 }

--- a/cmd/jujud/run.go
+++ b/cmd/jujud/run.go
@@ -280,10 +280,9 @@ func jujuDMain(args []string, ctx *cmd.Context) (code int, err error) {
 	jujud.Register(agentcmd.NewControllerAgentCommand(ctx, controllerAgentFactory, agentConf, agentConf))
 
 	dbReplControllerAgentFactory := agentcmd.DBReplControllerAgentFactoryFn(
-		agentConf,
 		dbreplaccessor.NewTrackedDBWorker,
 	)
-	jujud.Register(agentcmd.NewDBReplAgentCommand(ctx, dbReplControllerAgentFactory, agentConf, agentConf))
+	jujud.Register(agentcmd.NewDBReplAgentCommand(ctx, dbReplControllerAgentFactory, agentConf))
 
 	safeModeControllerAgentFactory := agentcmd.SafeModeControllerAgentFactoryFn(
 		agentConf,

--- a/internal/cloudconfig/userdatacfg.go
+++ b/internal/cloudconfig/userdatacfg.go
@@ -508,6 +508,7 @@ func (w *userdataConfig) configureBootstrap() error {
 		ControllerUUID:         w.icfg.ControllerTag.Id(),
 		ControllerModelUUID:    w.icfg.APIInfo.ModelTag.Id(),
 		DataDir:                w.icfg.DataDir,
+		LoopbackPreferred:      false,
 		LogDir:                 w.icfg.LogDir,
 		QueryTracingEnabled:    w.icfg.ControllerConfig.QueryTracingEnabled(),
 		QueryTracingThreshold:  w.icfg.ControllerConfig.QueryTracingThreshold(),

--- a/internal/controllerruntimeconfig/config.go
+++ b/internal/controllerruntimeconfig/config.go
@@ -48,6 +48,11 @@ type ControllerRuntimeConfig struct {
 	// DataDir is the Dqlite data directory root.
 	DataDir string `yaml:"data-dir"`
 
+	// LoopbackPreferred controls whether Dqlite should prefer the loopback
+	// address instead of the cloud-local TLS-terminated address. This is true
+	// for CAAS controllers.
+	LoopbackPreferred bool `yaml:"loopback-preferred,omitempty"`
+
 	// LogDir is the controller process log directory.
 	LogDir string `yaml:"log-dir"`
 

--- a/internal/controllerruntimeconfig/config_test.go
+++ b/internal/controllerruntimeconfig/config_test.go
@@ -31,6 +31,7 @@ func validConfig() controllerruntimeconfig.ControllerRuntimeConfig {
 		ControllerUUID:        "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		ControllerModelUUID:   "feedface-dead-beef-cafe-c0ffee000000",
 		DataDir:               "/var/lib/juju",
+		LoopbackPreferred:     false,
 		LogDir:                "/var/log/juju",
 		QueryTracingEnabled:   true,
 		QueryTracingThreshold: time.Second,
@@ -203,6 +204,22 @@ func (s *configSuite) TestWriteAndReadRoundTrip_SystemIdentity(c *tc.C) {
 	c.Check(got.SystemIdentity, tc.Equals, cfg.SystemIdentity)
 }
 
+// TestWriteAndReadRoundTrip_LoopbackPreferred ensures the loopback preference
+// is preserved in the write/read round trip.
+func (s *configSuite) TestWriteAndReadRoundTrip_LoopbackPreferred(c *tc.C) {
+	dir := c.MkDir()
+	path := filepath.Join(dir, controllerruntimeconfig.Filename)
+	cfg := validConfig()
+	cfg.LoopbackPreferred = true
+
+	err := controllerruntimeconfig.WriteControllerRuntimeConfig(path, cfg)
+	c.Assert(err, tc.ErrorIsNil)
+
+	got, err := controllerruntimeconfig.ReadControllerRuntimeConfig(path)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got.LoopbackPreferred, tc.IsTrue)
+}
+
 // TestWriteAndReadRoundTrip_EmptySystemIdentityOmitted ensures that an empty
 // SystemIdentity is not written to the YAML output, allowing existing runtime
 // config files without the field to read back cleanly.
@@ -230,6 +247,7 @@ func (s *configSuite) TestWriteAndReadRoundTrip_AllNodeManagerFields(c *tc.C) {
 		ControllerUUID:        "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		ControllerModelUUID:   "feedface-dead-beef-cafe-c0ffee000000",
 		DataDir:               "/var/lib/juju",
+		LoopbackPreferred:     true,
 		LogDir:                "/var/log/juju",
 		DqlitePort:            0, // default
 		QueryTracingEnabled:   true,
@@ -250,6 +268,7 @@ func (s *configSuite) TestWriteAndReadRoundTrip_AllNodeManagerFields(c *tc.C) {
 	c.Check(got.ControllerUUID, tc.Equals, cfg.ControllerUUID)
 	c.Check(got.ControllerModelUUID, tc.Equals, cfg.ControllerModelUUID)
 	c.Check(got.DataDir, tc.Equals, cfg.DataDir)
+	c.Check(got.LoopbackPreferred, tc.Equals, cfg.LoopbackPreferred)
 	c.Check(got.LogDir, tc.Equals, cfg.LogDir)
 	c.Check(got.CACert, tc.Equals, cfg.CACert)
 	c.Check(got.CAPrivateKey, tc.Equals, cfg.CAPrivateKey)

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -730,6 +730,7 @@ func (c *controllerStack) ensureControllerConfigmapAgentConf(ctx context.Context
 		ControllerUUID:         c.pcfg.ControllerTag.Id(),
 		ControllerModelUUID:    c.pcfg.APIInfo.ModelTag.Id(),
 		DataDir:                c.pcfg.DataDir,
+		LoopbackPreferred:      true,
 		LogDir:                 c.pcfg.LogDir,
 		QueryTracingEnabled:    c.pcfg.Controller.QueryTracingEnabled(),
 		QueryTracingThreshold:  c.pcfg.Controller.QueryTracingThreshold(),

--- a/internal/provider/kubernetes/export_test.go
+++ b/internal/provider/kubernetes/export_test.go
@@ -72,6 +72,7 @@ func (cs *controllerStack) GetControllerRuntimeConfigContent(c *tc.C) string {
 		ControllerUUID:        cs.pcfg.ControllerTag.Id(),
 		ControllerModelUUID:   cs.pcfg.APIInfo.ModelTag.Id(),
 		DataDir:               cs.pcfg.DataDir,
+		LoopbackPreferred:     true,
 		LogDir:                cs.pcfg.LogDir,
 		QueryTracingEnabled:   cs.pcfg.Controller.QueryTracingEnabled(),
 		QueryTracingThreshold: cs.pcfg.Controller.QueryTracingThreshold(),

--- a/internal/worker/dbreplaccessor/manifold.go
+++ b/internal/worker/dbreplaccessor/manifold.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 
-	"github.com/juju/juju/agent"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/database"
@@ -45,17 +44,29 @@ type NewNodeManagerFunc func(database.NodeManagerConfig, logger.Logger, coredata
 // - The names of other manifolds on which the DB accessor depends.
 // - Other dependencies from ManifoldsConfig required by the worker.
 type ManifoldConfig struct {
-	AgentName       string
-	Clock           clock.Clock
-	Logger          logger.Logger
-	NewApp          NewAppFunc
-	NewDBReplWorker NewDBReplWorkerFunc
-	NewNodeManager  NewNodeManagerFunc
+	DataDir              string
+	CACert               string
+	ControllerCert       string
+	ControllerPrivateKey string
+	Clock                clock.Clock
+	Logger               logger.Logger
+	NewApp               NewAppFunc
+	NewDBReplWorker      NewDBReplWorkerFunc
+	NewNodeManager       NewNodeManagerFunc
 }
 
 func (cfg ManifoldConfig) Validate() error {
-	if cfg.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
+	if cfg.DataDir == "" {
+		return errors.NotValidf("empty DataDir")
+	}
+	if cfg.CACert == "" {
+		return errors.NotValidf("empty CACert")
+	}
+	if cfg.ControllerCert == "" {
+		return errors.NotValidf("empty ControllerCert")
+	}
+	if cfg.ControllerPrivateKey == "" {
+		return errors.NotValidf("empty ControllerPrivateKey")
 	}
 	if cfg.Clock == nil {
 		return errors.NotValidf("nil Clock")
@@ -79,27 +90,17 @@ func (cfg ManifoldConfig) Validate() error {
 // worker, using the resource names defined in the supplied config.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
-		Inputs: []string{
-			config.AgentName,
-		},
 		Output: dbAccessorOutput,
 		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 			if err := config.Validate(); err != nil {
 				return nil, errors.Trace(err)
 			}
 
-			var thisAgent agent.Agent
-			if err := getter.Get(config.AgentName, &thisAgent); err != nil {
-				return nil, err
-			}
-			agentConfig := thisAgent.CurrentConfig()
-
-			info, _ := agentConfig.ControllerAgentInfo()
 			nodeManagerCfg := database.NodeManagerConfig{
-				DataDir:              agentConfig.DataDir(),
-				CACert:               agentConfig.CACert(),
-				ControllerCert:       info.Cert,
-				ControllerPrivateKey: info.PrivateKey,
+				DataDir:              config.DataDir,
+				CACert:               config.CACert,
+				ControllerCert:       config.ControllerCert,
+				ControllerPrivateKey: config.ControllerPrivateKey,
 			}
 
 			cfg := WorkerConfig{

--- a/internal/worker/dbreplaccessor/manifold_test.go
+++ b/internal/worker/dbreplaccessor/manifold_test.go
@@ -31,7 +31,19 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	cfg := s.getConfig()
 	c.Check(cfg.Validate(), tc.ErrorIsNil)
 
-	cfg.AgentName = ""
+	cfg.DataDir = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.CACert = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.ControllerCert = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.ControllerPrivateKey = ""
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
@@ -57,9 +69,12 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
-		AgentName: "agent",
-		Clock:     s.clock,
-		Logger:    s.logger,
+		DataDir:              "data-dir",
+		CACert:               "ca-cert",
+		ControllerCert:       "controller-cert",
+		ControllerPrivateKey: "controller-private-key",
+		Clock:                s.clock,
+		Logger:               s.logger,
 		NewApp: func(string) (DBApp, error) {
 			return s.dbApp, nil
 		},


### PR DESCRIPTION
Removes the `agent.Agent` dependency from the `dbreplaccessor` manifold and
propagates the change through both the `jujud` and `jujuagentd` db-repl engine
wiring. The db-repl is a standalone CLI subcommand that only runs on controller
agents, so it never needed the full agent manifold, `state-config-watcher`, or
`ifController` gating inherited from the machine agent manifolds.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


Test with microk8s:

```sh
❯ juju bootstrap microk8s mk8stest

❯ jst -m controller
Model       Controller  Cloud/Region        Version    Timestamp
controller  mk8stest    microk8s/localhost  4.1-beta2  11:55:20+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Address         Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  10.152.183.216  no

Unit           Workload  Agent  Address      Ports            Message
controller/0*  active    idle   10.1.180.85  17022,17070/tcp

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer

❯ juju ssh -m controller 0
juju@controller-0:/var/lib/juju$ juju_db_repl

Running DB REPL.
----------------

This is a DB REPL (Read-Eval-Print Loop) environment.

You can run arbitrary code here, including code that can modify the
state of the system. Be careful!

Type '.help' for help.
repl (controller)> 
```

Test with LXD:

```sh
❯ juju bootstrap lxd src --build-agent

❯ jst -m controller
Model       Controller  Cloud/Region  Version      Timestamp
controller  src         lxd/default   4.1-beta2.1  11:56:14+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.159.202.169  17022,17070/tcp

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.169  juju-109778-0  ubuntu@24.04  tuxedo  Running

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer

❯ juju ssh -m controller 0
ubuntu@juju-109778-0:~$ juju_db_repl

Running DB REPL.
----------------

This is a DB REPL (Read-Eval-Print Loop) environment.

You can run arbitrary code here, including code that can modify the
state of the system. Be careful!

Type '.help' for help.
repl (controller)>
```

## Documentation changes


## Links

**Jira card:** [JUJU-9723](https://warthogs.atlassian.net/browse/JUJU-9723)


[JUJU-9723]: https://warthogs.atlassian.net/browse/JUJU-9723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ