### PR TITLE
feat(migration): add CreateMigrationMacaroon to MigrationTarget v8 facade

### DIFF
--- a/apiserver/authentication/macaroon/authenticator.go
+++ b/apiserver/authentication/macaroon/authenticator.go
@@ -26,4 +26,11 @@ type LocalMacaroonAuthenticator interface {
 	// log in without presenting their password for a set amount
 	// of time.
 	CreateLocalLoginMacaroon(context.Context, names.UserTag, bakery.Version) (*macaroon.Macaroon, error)
+
+	// CreateMigrationMacaroon creates a directly-presentable login macaroon for
+	// the given local user. Unlike CreateLocalLoginMacaroon, the result needs no
+	// discharge: it carries a declared-username first-party caveat and is valid
+	// for localLoginExpiryTime (24h). Intended for use by the migrationmaster
+	// worker so that a cleartext admin password never needs to be persisted.
+	CreateMigrationMacaroon(context.Context, names.UserTag, bakery.Version) (*macaroon.Macaroon, error)
 }

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -322,6 +322,27 @@ func CreateLocalLoginMacaroon(
 	}, identchecker.LoginOp)
 }
 
+// CreateMigrationMacaroon creates a macaroon that authenticates the given
+// local user directly at login, without requiring a discharge ceremony. Unlike
+// CreateLocalLoginMacaroon, the macaroon carries a declared-username first-party
+// caveat (no third-party discharge needed) so it can be presented as-is by the
+// migrationmaster worker when reconnecting to the target controller.
+//
+// The minter must be backed by the storage (localUserBakery) oven so that the
+// target's LocalUserAuthenticator can verify it.
+func CreateMigrationMacaroon(
+	ctx context.Context,
+	tag names.UserTag,
+	minter MacaroonMinter,
+	clock clock.Clock,
+	version bakery.Version,
+) (*bakery.Macaroon, error) {
+	return minter.NewMacaroon(ctx, version, []checkers.Caveat{
+		checkers.DeclaredCaveat(usernameKey, tag.Id()),
+		checkers.TimeBeforeCaveat(clock.Now().Add(localLoginExpiryTime)),
+	}, identchecker.LoginOp)
+}
+
 // CheckLocalLoginCaveat parses and checks that the given caveat string is
 // valid for a local login request, and returns the tag of the local user
 // that the caveat asserts is logged in. checkers.ErrCaveatNotRecognized will

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -85,6 +85,10 @@ func (testingAPIRootHandler) CrossModelAuthContext() facade.CrossModelAuthContex
 	return nil
 }
 
+func (testingAPIRootHandler) LocalMacaroonMinter() facade.LocalMacaroonMinter {
+	return nil
+}
+
 func (testingAPIRootHandler) EphemeralProviderFactory() providertracker.EphemeralProviderFactory {
 	return nil
 }

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -25,6 +25,7 @@ import (
 type ModelContext struct {
 	Auth_                  facade.Authorizer
 	CrossModelAuthContext_ facade.CrossModelAuthContext
+	LocalMacaroonMinter_   facade.LocalMacaroonMinter
 	Dispose_               func()
 	WatcherRegistry_       watcherregistry.WatcherRegistry
 	ID_                    string
@@ -66,6 +67,11 @@ func (c ModelContext) Auth() facade.Authorizer {
 // for cross model operations.
 func (c ModelContext) CrossModelAuthContext() facade.CrossModelAuthContext {
 	return c.CrossModelAuthContext_
+}
+
+// LocalMacaroonMinter is part of the facade.ModelContext interface.
+func (c ModelContext) LocalMacaroonMinter() facade.LocalMacaroonMinter {
+	return c.LocalMacaroonMinter_
 }
 
 // Dispose is part of the facade.ModelContext interface.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -104,6 +104,12 @@ type ModelContext interface {
 	// for cross model operations.
 	CrossModelAuthContext() CrossModelAuthContext
 
+	// LocalMacaroonMinter mints directly-presentable login macaroons for
+	// local users. Used by migrationtarget v8 to exchange an admin password
+	// for a reusable macaroon so the migrationmaster worker never has to
+	// store a cleartext password.
+	LocalMacaroonMinter() LocalMacaroonMinter
+
 	// Dispose disposes the context and any resources related to
 	// the API server facade object. Normally the context will not
 	// be disposed until the API connection is closed. This is OK
@@ -290,6 +296,16 @@ type MacaroonAuthenticator interface {
 		mac macaroon.Slice,
 		version bakery.Version,
 	) error
+}
+
+// LocalMacaroonMinter mints directly-presentable login macaroons for local
+// users of this controller. The resulting macaroon is backed by the storage
+// bakery (root key in the DB) so the target's LocalUserAuthenticator can verify
+// it at login without a discharge ceremony.
+type LocalMacaroonMinter interface {
+	// CreateMigrationMacaroon mints a 24h login macaroon for the given local
+	// user that the worker can present directly at login.
+	CreateMigrationMacaroon(ctx context.Context, tag names.UserTag, version bakery.Version) (*macaroon.Macaroon, error)
 }
 
 // CrossModelAuthContext provides methods to create macaroons for cross model

--- a/apiserver/facades/agent/keyupdater/facade_mock_test.go
+++ b/apiserver/facades/agent/keyupdater/facade_mock_test.go
@@ -51,6 +51,7 @@ type MockModelContextMockRecorder struct {
 	leadershipPinnerExpects        []*gomock.Call0_2[leadership.Pinner, error]
 	leadershipReaderExpects        []*gomock.Call0_2[leadership.Reader, error]
 	leadershipRevokerExpects       []*gomock.Call0_2[leadership.Revoker, error]
+	localMacaroonMinterExpects     []*gomock.Call0_1[facade.LocalMacaroonMinter]
 	logDirExpects                  []*gomock.Call0_1[string]
 	loggerExpects                  []*gomock.Call0_1[logger.Logger]
 	machineTagExpects              []*gomock.Call0_1[names.Tag]
@@ -379,6 +380,24 @@ func (mr *MockModelContextMockRecorder) LeadershipRevoker() *MockModelContextLea
 
 // MockModelContextLeadershipRevokerCall is the typed call wrapper for LeadershipRevoker.
 type MockModelContextLeadershipRevokerCall = gomock.Call0_2[leadership.Revoker, error]
+
+// LocalMacaroonMinter mocks base method.
+func (m *MockModelContext) LocalMacaroonMinter() facade.LocalMacaroonMinter {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.localMacaroonMinterExpects, m.ctrl, m, "LocalMacaroonMinter")
+}
+
+// LocalMacaroonMinter indicates an expected call of LocalMacaroonMinter.
+func (mr *MockModelContextMockRecorder) LocalMacaroonMinter() *MockModelContextLocalMacaroonMinterCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[facade.LocalMacaroonMinter](mr.mock.ctrl.T, mr.mock, "LocalMacaroonMinter")
+	mr.localMacaroonMinterExpects = append(mr.localMacaroonMinterExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockModelContextLocalMacaroonMinterCall is the typed call wrapper for LocalMacaroonMinter.
+type MockModelContextLocalMacaroonMinterCall = gomock.Call0_1[facade.LocalMacaroonMinter]
 
 // LogDir mocks base method.
 func (m *MockModelContext) LogDir() string {

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/description/v12"
 	"github.com/juju/names/v6"
 	"github.com/vallerion/rscanner"
@@ -615,11 +616,12 @@ func (api *API) CACert(ctx context.Context) (params.BytesResult, error) {
 // path must land before a 4.1 release ships.
 type APIV8 struct {
 	*API
+	localMacaroonMinter facade.LocalMacaroonMinter
 }
 
 // NewAPIV8 returns a new MigrationTarget v8 facade wrapping the given v7 API.
-func NewAPIV8(api *API) (*APIV8, error) {
-	return &APIV8{API: api}, nil
+func NewAPIV8(api *API, minter facade.LocalMacaroonMinter) (*APIV8, error) {
+	return &APIV8{API: api, localMacaroonMinter: minter}, nil
 }
 
 // Prechecks is a no-op shell for v8 envelope prechecks.
@@ -634,4 +636,19 @@ func (api *APIV8) Prechecks(_ context.Context, _ params.SerializedModelV2) error
 // TODO(modelmigration): implement v8 import path before a 4.1 release ships.
 func (api *APIV8) Import(_ context.Context, _ params.SerializedModelV2) error {
 	return nil
+}
+
+// CreateMigrationMacaroon mints a directly-presentable 24h login macaroon for
+// the authenticated admin so the migrationmaster worker can reconnect to this
+// controller without a discharge ceremony or a stored cleartext password.
+func (api *APIV8) CreateMigrationMacaroon(ctx context.Context) (params.CreateMigrationMacaroonResult, error) {
+	tag, ok := api.authorizer.GetAuthTag().(names.UserTag)
+	if !ok || !tag.IsLocal() {
+		return params.CreateMigrationMacaroonResult{}, apiservererrors.ErrPerm
+	}
+	mac, err := api.localMacaroonMinter.CreateMigrationMacaroon(ctx, tag, bakery.LatestVersion)
+	if err != nil {
+		return params.CreateMigrationMacaroonResult{}, errors.Capture(err)
+	}
+	return params.CreateMigrationMacaroonResult{Macaroon: mac}, nil
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
@@ -102,7 +102,7 @@ func (s *v8Suite) mustNewAPIV8(c *tc.C) *migrationtarget.APIV8 {
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
-	apiV8, err := migrationtarget.NewAPIV8(api)
+	apiV8, err := migrationtarget.NewAPIV8(api, nil)
 	c.Assert(err, tc.ErrorIsNil)
 	return apiV8
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
@@ -5,13 +5,18 @@ package migrationtarget_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/canonical/gomock/gomock"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
+	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/controller/migrationtarget"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -77,6 +82,10 @@ func (s *v8Suite) setupMocks(c *tc.C) *gomock.Controller {
 }
 
 func (s *v8Suite) mustNewAPIV8(c *tc.C) *migrationtarget.APIV8 {
+	return s.mustNewAPIV8WithMinter(c, nil)
+}
+
+func (s *v8Suite) mustNewAPIV8WithMinter(c *tc.C, minter facade.LocalMacaroonMinter) *migrationtarget.APIV8 {
 	api, err := migrationtarget.NewAPI(
 		&s.facadeContext,
 		s.authorizer,
@@ -102,7 +111,7 @@ func (s *v8Suite) mustNewAPIV8(c *tc.C) *migrationtarget.APIV8 {
 	)
 	c.Assert(err, tc.ErrorIsNil)
 
-	apiV8, err := migrationtarget.NewAPIV8(api, nil)
+	apiV8, err := migrationtarget.NewAPIV8(api, minter)
 	c.Assert(err, tc.ErrorIsNil)
 	return apiV8
 }
@@ -142,6 +151,64 @@ func (s *v8Suite) TestImportNoOpSuccess(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestCreateMigrationMacaroonSuccess verifies v8 delegates macaroon minting
+// for the authenticated local user using the latest bakery version.
+func (s *v8Suite) TestCreateMigrationMacaroonSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	mac := newMacaroon(c)
+	minter := &testLocalMacaroonMinter{result: mac}
+	ctx := c.Context()
+
+	result, err := s.mustNewAPIV8WithMinter(c, minter).CreateMigrationMacaroon(ctx)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(result.Macaroon, tc.Equals, mac)
+	c.Check(minter.calls, tc.Equals, 1)
+	c.Check(minter.ctx, tc.Equals, ctx)
+	c.Check(minter.tag, tc.Equals, names.NewUserTag("fred"))
+	c.Check(minter.version, tc.Equals, bakery.LatestVersion)
+}
+
+func (s *v8Suite) TestCreateMigrationMacaroonMinterError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	expectedErr := errors.New("mint failed")
+	minter := &testLocalMacaroonMinter{err: expectedErr}
+
+	result, err := s.mustNewAPIV8WithMinter(c, minter).CreateMigrationMacaroon(c.Context())
+	c.Assert(err, tc.ErrorIs, expectedErr)
+
+	c.Check(result.Macaroon, tc.IsNil)
+	c.Check(minter.calls, tc.Equals, 1)
+}
+
+func (s *v8Suite) TestCreateMigrationMacaroonNonUserPermissionDenied(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.authorizer.Tag = names.NewMachineTag("0")
+	minter := &testLocalMacaroonMinter{}
+
+	result, err := s.mustNewAPIV8WithMinter(c, minter).CreateMigrationMacaroon(c.Context())
+	c.Assert(err, tc.ErrorIs, apiservererrors.ErrPerm)
+
+	c.Check(result.Macaroon, tc.IsNil)
+	c.Check(minter.calls, tc.Equals, 0)
+}
+
+func (s *v8Suite) TestCreateMigrationMacaroonRemoteUserPermissionDenied(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.authorizer.Tag = names.NewUserTag("fred@external")
+	minter := &testLocalMacaroonMinter{}
+
+	result, err := s.mustNewAPIV8WithMinter(c, minter).CreateMigrationMacaroon(c.Context())
+	c.Assert(err, tc.ErrorIs, apiservererrors.ErrPerm)
+
+	c.Check(result.Macaroon, tc.IsNil)
+	c.Check(minter.calls, tc.Equals, 0)
+}
+
 // TestV8Registered asserts MigrationTarget v8 is advertised alongside the
 // legacy versions so the new-path source worker can negotiate it.
 func (s *v8Suite) TestV8Registered(c *tc.C) {
@@ -153,4 +220,36 @@ func (s *v8Suite) TestV8Registered(c *tc.C) {
 		return
 	}
 	c.Fatal("MigrationTarget facade not registered at all")
+}
+
+type testLocalMacaroonMinter struct {
+	result  *macaroon.Macaroon
+	err     error
+	calls   int
+	ctx     context.Context
+	tag     names.UserTag
+	version bakery.Version
+}
+
+func (m *testLocalMacaroonMinter) CreateMigrationMacaroon(
+	ctx context.Context,
+	tag names.UserTag,
+	version bakery.Version,
+) (*macaroon.Macaroon, error) {
+	m.calls++
+	m.ctx = ctx
+	m.tag = tag
+	m.version = version
+	return m.result, m.err
+}
+
+func newMacaroon(c *tc.C) *macaroon.Macaroon {
+	mac, err := macaroon.New(
+		[]byte("root key"),
+		[]byte("id"),
+		"migration target",
+		macaroon.LatestVersion,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	return mac
 }

--- a/apiserver/facades/controller/migrationtarget/register.go
+++ b/apiserver/facades/controller/migrationtarget/register.go
@@ -76,7 +76,7 @@ func makeFacadeV8(
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
-	return NewAPIV8(api)
+	return NewAPIV8(api, ctx.LocalMacaroonMinter())
 }
 
 func makeFacadeV4(

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -118,6 +118,10 @@ type apiHandler struct {
 	// used for cross model operations.
 	crossModelAuthContext facade.CrossModelAuthContext
 
+	// localMacaroonMinter mints directly-presentable login macaroons for
+	// local users; used by the migrationtarget v8 facade.
+	localMacaroonMinter facade.LocalMacaroonMinter
+
 	// ephemeralProviderTracker is used to create providers for operations that
 	// require them.
 	ephemeralProviderTracker providertracker.EphemeralProviderFactory
@@ -167,6 +171,7 @@ func newAPIHandler(
 		connectionID:             connectionID,
 		serverHost:               serverHost,
 		crossModelAuthContext:    crossModelAuthContext,
+		localMacaroonMinter:      srv.localMacaroonAuthenticator,
 		ephemeralProviderTracker: ephemeralProviderTracker,
 	}
 }
@@ -227,6 +232,12 @@ func (r *apiHandler) Authorizer() facade.Authorizer {
 // for cross model operations.
 func (r *apiHandler) CrossModelAuthContext() facade.CrossModelAuthContext {
 	return r.crossModelAuthContext
+}
+
+// LocalMacaroonMinter returns the minter for directly-presentable login
+// macaroons for local users.
+func (r *apiHandler) LocalMacaroonMinter() facade.LocalMacaroonMinter {
+	return r.localMacaroonMinter
 }
 
 // EphemeralProviderFactory returns the ephemeral provider factory.
@@ -405,6 +416,9 @@ type apiRootHandler interface {
 	// CrossModelAuthContext provides methods to create and authorize macaroons
 	// for cross model operations.
 	CrossModelAuthContext() facade.CrossModelAuthContext
+	// LocalMacaroonMinter mints directly-presentable login macaroons for
+	// local users.
+	LocalMacaroonMinter() facade.LocalMacaroonMinter
 	// EphemeralProviderFactory returns the ephemeral provider factory.
 	// Ephemeral providers are not updated when the cloud is updated. They
 	// are single use entities, requiring a provider configuration, for use
@@ -433,6 +447,7 @@ type apiRoot struct {
 	objectCache              map[objectKey]reflect.Value
 	requestRecorder          facade.RequestRecorder
 	crossModelAuthContext    facade.CrossModelAuthContext
+	localMacaroonMinter      facade.LocalMacaroonMinter
 	ephemeralProviderFactory providertracker.EphemeralProviderFactory
 
 	// modelUUID is the UUID of the model that the client is connected to.
@@ -468,6 +483,7 @@ func newAPIRoot(
 		ephemeralProviderFactory: root.EphemeralProviderFactory(),
 		modelUUID:                root.ModelUUID(),
 		crossModelAuthContext:    root.CrossModelAuthContext(),
+		localMacaroonMinter:      root.LocalMacaroonMinter(),
 	}, nil
 }
 
@@ -717,6 +733,11 @@ func (ctx *facadeContext) Auth() facade.Authorizer {
 // for cross model operations.
 func (ctx *facadeContext) CrossModelAuthContext() facade.CrossModelAuthContext {
 	return ctx.r.crossModelAuthContext
+}
+
+// LocalMacaroonMinter is part of the facade.ModelContext interface.
+func (ctx *facadeContext) LocalMacaroonMinter() facade.LocalMacaroonMinter {
+	return ctx.r.localMacaroonMinter
 }
 
 // Dispose is part of the facade.ModelContext interface.

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -156,6 +156,18 @@ func (a *Authenticator) CreateLocalLoginMacaroon(ctx context.Context, tag names.
 	return mac.M(), nil
 }
 
+// CreateMigrationMacaroon is part of the macaroon.LocalMacaroonAuthenticator
+// interface. It mints a directly-presentable 24h login macaroon for the given
+// user so the migrationmaster worker can reconnect to this controller without
+// a discharge ceremony.
+func (a *Authenticator) CreateMigrationMacaroon(ctx context.Context, tag names.UserTag, version bakery.Version) (*macaroon.Macaroon, error) {
+	mac, err := a.authContext.CreateMigrationMacaroon(ctx, tag, version)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return mac.M(), nil
+}
+
 // AddHandlers adds the handlers to the given mux for handling local
 // macaroon logins.
 func (a *Authenticator) AddHandlers(mux *apiserverhttp.Mux) error {

--- a/apiserver/stateauthenticator/context.go
+++ b/apiserver/stateauthenticator/context.go
@@ -191,6 +191,13 @@ func (ctxt *authContext) CreateLocalLoginMacaroon(ctx context.Context, tag names
 	return authentication.CreateLocalLoginMacaroon(ctx, tag, ctxt.localUserThirdPartyBakery.Oven, ctxt.clock, version)
 }
 
+// CreateMigrationMacaroon mints a directly-presentable 24h login macaroon for
+// the given user using the storage bakery, so the target's
+// LocalUserAuthenticator can verify it at worker login without a discharge.
+func (ctxt *authContext) CreateMigrationMacaroon(ctx context.Context, tag names.UserTag, version bakery.Version) (*bakery.Macaroon, error) {
+	return authentication.CreateMigrationMacaroon(ctx, tag, ctxt.localUserBakery, ctxt.clock, version)
+}
+
 // CheckLocalLoginCaveat parses and checks that the given caveat string is
 // valid for a local login request, and returns the tag of the local user
 // that the caveat asserts is logged in. checkers.ErrCaveatNotRecognized will

--- a/rpc/params/migration.go
+++ b/rpc/params/migration.go
@@ -6,6 +6,8 @@ package params
 import (
 	"time"
 
+	"gopkg.in/macaroon.v2"
+
 	"github.com/juju/juju/core/semversion"
 )
 
@@ -518,4 +520,12 @@ type AdoptResourcesArgs struct {
 	// ensure it looks for the original tags in the correct format for
 	// that version.
 	SourceControllerVersion semversion.Number `json:"source-controller-version"`
+}
+
+// CreateMigrationMacaroonResult holds the reusable login macaroon minted by
+// the target controller for the authenticated admin user. The migrationmaster
+// worker presents this macaroon when reconnecting to the target, so that a
+// cleartext admin password never needs to be persisted in the controller DB.
+type CreateMigrationMacaroonResult struct {
+	Macaroon *macaroon.Macaroon `json:"macaroon"`
 }


### PR DESCRIPTION
  When a model migrates from a 4.0 source controller to a 4.1 target, the source needs to store a
  credential for the target so the migrationmaster worker can reconnect across many migration phases. The
  4.x schema does not store cleartext passwords (deliberate decision in PR #22391). Instead, the target
  mints a short-lived login macaroon that the worker can present directly.

  This implements the years-old TODO(axw,mjs) at cmd/juju/commands/migrate.go:256:

  ▎ "add a controller API that returns a macaroon that may be used for the sole purpose of migration"

 #### Why a new method? Why not `CreateLocalLoginMacaroon`?

  `CreateLocalLoginMacaroon` uses the third-party bakery (`localUserThirdPartyBakery`, ephemeral in-memory
  keys). Its macaroons carry a third-party caveat that requires an interactive discharge ceremony — the
  holder must visit the controller's auth endpoint, which times out after 2 minutes and requires user
  interaction. The migrationmaster worker is a non-interactive background process; it cannot discharge.

  `CreateMigrationMacaroon` uses the storage bakery (`localUserBakery`, root keys in DQLite). Its macaroons
  are directly presentable: `LocalUserAuthenticator.authenticateMacaroons()` verifies them against the DB
  root key and reads the username from a `DeclaredCaveat("username", …)` first-party caveat. No third-party
  lookup, no discharge round-trip, no browser required.

_Note: the 24h caveat is a hard-coded TTL, which we could eventually make configurable._

## QA steps

The QA scenario is run on https://github.com/juju/juju/pull/22675 which will need this patch.

## Links

**Jira card:** [JUJU-9900](https://warthogs.atlassian.net/browse/JUJU-9900)


[JUJU-9900]: https://warthogs.atlassian.net/browse/JUJU-9900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ