### PR TITLE
feat(migration): exchange admin password for macaroon during prechecks

### DIFF
--- a/api/controller/migrationtarget/client.go
+++ b/api/controller/migrationtarget/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 	"gopkg.in/httprequest.v1"
+	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -284,6 +285,22 @@ func (c *Client) CACert(ctx context.Context) (string, error) {
 		return "", errors.Trace(err)
 	}
 	return string(result.Result), nil
+}
+
+// CreateMigrationMacaroon asks the target controller to mint a directly-
+// presentable 24h login macaroon for the authenticated admin user. The
+// macaroon can be stored in place of the cleartext password so the
+// migrationmaster worker can reconnect to the target without a discharge
+// ceremony.
+func (c *Client) CreateMigrationMacaroon(ctx context.Context) ([]macaroon.Slice, error) {
+	var result params.CreateMigrationMacaroonResult
+	if err := c.caller.FacadeCall(ctx, "CreateMigrationMacaroon", nil, &result); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if result.Macaroon == nil {
+		return nil, errors.New("target returned no migration macaroon")
+	}
+	return []macaroon.Slice{{result.Macaroon}}, nil
 }
 
 // CheckMachines compares the machines in state with the ones reported

--- a/api/controller/migrationtarget/client_test.go
+++ b/api/controller/migrationtarget/client_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"gopkg.in/httprequest.v1"
+	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/api/base"
 	apitesting "github.com/juju/juju/api/base/testing"
@@ -335,6 +336,51 @@ func (s *ClientSuite) TestCACert(c *tc.C) {
 	r, err := client.CACert(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(r, tc.Equals, "foo cert")
+}
+
+func (s *ClientSuite) TestCreateMigrationMacaroon(c *tc.C) {
+	mac, err := macaroon.New([]byte("root-key"), []byte("id"), "loc", macaroon.V2)
+	c.Assert(err, tc.ErrorIsNil)
+
+	call := func(objType string, version int, id, request string, args, response any) error {
+		c.Check(objType, tc.Equals, "MigrationTarget")
+		c.Check(request, tc.Equals, "CreateMigrationMacaroon")
+		c.Check(args, tc.Equals, nil)
+		c.Check(response, tc.FitsTypeOf, (*params.CreateMigrationMacaroonResult)(nil))
+		response.(*params.CreateMigrationMacaroonResult).Macaroon = mac
+		return nil
+	}
+	client := migrationtarget.NewClient(apitesting.APICallerFunc(call))
+
+	result, err := client.CreateMigrationMacaroon(c.Context())
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, []macaroon.Slice{{mac}})
+}
+
+func (s *ClientSuite) TestCreateMigrationMacaroonEmptyResult(c *tc.C) {
+	call := func(objType string, version int, id, request string, args, response any) error {
+		c.Check(response, tc.FitsTypeOf, (*params.CreateMigrationMacaroonResult)(nil))
+		return nil
+	}
+	client := migrationtarget.NewClient(apitesting.APICallerFunc(call))
+
+	result, err := client.CreateMigrationMacaroon(c.Context())
+
+	c.Check(result, tc.IsNil)
+	c.Check(err, tc.ErrorMatches, "target returned no migration macaroon")
+}
+
+func (s *ClientSuite) TestCreateMigrationMacaroonError(c *tc.C) {
+	call := func(objType string, version int, id, request string, args, response any) error {
+		return errors.New("boom")
+	}
+	client := migrationtarget.NewClient(apitesting.APICallerFunc(call))
+
+	result, err := client.CreateMigrationMacaroon(c.Context())
+
+	c.Check(result, tc.IsNil)
+	c.Check(err, tc.ErrorMatches, "boom")
 }
 
 func (s *ClientSuite) AssertModelCall(c *tc.C, stub *testhelpers.Stub, tag names.ModelTag, call string, err error, expectError bool) {

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -871,9 +871,11 @@ func (c *ControllerAPI) runMigrationPrechecks(
 		}
 	}
 
-	if err := migration.HarvestMigrationMacaroon(ctx, targetInfo, client); err != nil {
+	harvested, err := migration.HarvestMigrationMacaroon(ctx, *targetInfo, client)
+	if err != nil {
 		return errors.Trace(err)
 	}
+	*targetInfo = harvested
 
 	// The full envelope-based target prechecks run in the migrationmaster
 	// worker during QUIESCE (it owns the SerializedModelV2 envelope assembly).

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -871,6 +871,10 @@ func (c *ControllerAPI) runMigrationPrechecks(
 		}
 	}
 
+	if err := migration.HarvestMigrationMacaroon(ctx, targetInfo, client); err != nil {
+		return errors.Trace(err)
+	}
+
 	// The full envelope-based target prechecks run in the migrationmaster
 	// worker during QUIESCE (it owns the SerializedModelV2 envelope assembly).
 	// Here we only reject early, at "juju migrate" time, when the target is too

--- a/core/migration/targetinfo.go
+++ b/core/migration/targetinfo.go
@@ -56,6 +56,14 @@ type TargetInfo struct {
 	SkipUserChecks bool
 }
 
+// NeedsPasswordMacaroon reports whether targetInfo has a password that
+// must be exchanged for a migration macaroon before it can be persisted:
+// that is, a password is present and there's no token or macaroon already
+// usable in its place.
+func (info TargetInfo) NeedsPasswordMacaroon() bool {
+	return info.Password != "" && len(info.Macaroons) == 0 && info.Token == ""
+}
+
 // Validate returns an error if the TargetInfo contains bad data. Nil
 // is returned otherwise.
 func (info *TargetInfo) Validate() error {

--- a/core/migration/targetinfo_test.go
+++ b/core/migration/targetinfo_test.go
@@ -132,6 +132,41 @@ func (s *TargetInfoSuite) TestValidation(c *tc.C) {
 	}
 }
 
+func (s *TargetInfoSuite) TestNeedsPasswordMacaroon(c *tc.C) {
+	mac, err := macaroon.New([]byte("secret"), []byte("id"), "location", macaroon.LatestVersion)
+	c.Assert(err, tc.ErrorIsNil)
+
+	tests := []struct {
+		label    string
+		info     migration.TargetInfo
+		expected bool
+	}{{
+		label:    "password and no reusable auth",
+		info:     migration.TargetInfo{Password: "password"},
+		expected: true,
+	}, {
+		label: "password and macaroons",
+		info: migration.TargetInfo{
+			Password:  "password",
+			Macaroons: []macaroon.Slice{{mac}},
+		},
+	}, {
+		label: "password and token",
+		info: migration.TargetInfo{
+			Password: "password",
+			Token:    "jimm-token",
+		},
+	}, {
+		label: "no password",
+		info:  migration.TargetInfo{},
+	}}
+
+	for _, test := range tests {
+		c.Logf("%s", test.label)
+		c.Check(test.info.NeedsPasswordMacaroon(), tc.Equals, test.expected)
+	}
+}
+
 func makeValidTargetInfo(c *tc.C) migration.TargetInfo {
 	mac, err := macaroon.New([]byte("secret"), []byte("id"), "location", macaroon.LatestVersion)
 	c.Assert(err, tc.ErrorIsNil)

--- a/internal/migration/auth.go
+++ b/internal/migration/auth.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"gopkg.in/macaroon.v2"
+
+	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/rpc/params"
+)
+
+// MigrationMacaroonMinter mints a directly-presentable login macaroon on the
+// target controller, in exchange for the credentials already used to open the
+// precheck connection. Satisfied by api/controller/migrationtarget.Client.
+type MigrationMacaroonMinter interface {
+	// CreateMigrationMacaroon asks the target controller to mint a 24h login
+	// macaroon for the user authenticated on the current connection.
+	CreateMigrationMacaroon(ctx context.Context) ([]macaroon.Slice, error)
+}
+
+// HarvestMigrationMacaroon exchanges the admin password in targetInfo for a
+// directly-presentable 24h login macaroon minted by the target controller.
+// On success, targetInfo.Macaroons is populated and targetInfo.Password is
+// cleared so the cleartext credential is never persisted.
+//
+// It is a no-op when a token or macaroons are already present (those flows
+// do not need a password exchange). When the target is too old to support
+// the method, an error is returned — callers must NOT fall back to
+// persisting the cleartext password.
+func HarvestMigrationMacaroon(ctx context.Context, targetInfo *coremigration.TargetInfo, client MigrationMacaroonMinter) error {
+	if targetInfo.Password == "" || len(targetInfo.Macaroons) != 0 || targetInfo.Token != "" {
+		return nil
+	}
+	macs, err := client.CreateMigrationMacaroon(ctx)
+	if err != nil {
+		if params.IsCodeNotImplemented(err) {
+			return errors.New("target controller is too old to support password-authenticated migration; upgrade the target to a version that exposes MigrationTarget v8 or later")
+		}
+		return errors.Annotate(err, "cannot obtain migration macaroon from target")
+	}
+	targetInfo.Macaroons = macs
+	targetInfo.Password = ""
+	return nil
+}

--- a/internal/migration/auth.go
+++ b/internal/migration/auth.go
@@ -23,26 +23,27 @@ type MigrationMacaroonMinter interface {
 }
 
 // HarvestMigrationMacaroon exchanges the admin password in targetInfo for a
-// directly-presentable 24h login macaroon minted by the target controller.
-// On success, targetInfo.Macaroons is populated and targetInfo.Password is
-// cleared so the cleartext credential is never persisted.
+// directly-presentable 24h login macaroon minted by the target controller,
+// returning the updated TargetInfo with Macaroons populated and Password
+// cleared so the cleartext credential is never persisted. The targetInfo
+// argument itself is left unmodified.
 //
 // It is a no-op when a token or macaroons are already present (those flows
 // do not need a password exchange). When the target is too old to support
 // the method, an error is returned — callers must NOT fall back to
 // persisting the cleartext password.
-func HarvestMigrationMacaroon(ctx context.Context, targetInfo *coremigration.TargetInfo, client MigrationMacaroonMinter) error {
-	if targetInfo.Password == "" || len(targetInfo.Macaroons) != 0 || targetInfo.Token != "" {
-		return nil
+func HarvestMigrationMacaroon(ctx context.Context, targetInfo coremigration.TargetInfo, client MigrationMacaroonMinter) (coremigration.TargetInfo, error) {
+	if !targetInfo.NeedsPasswordMacaroon() {
+		return targetInfo, nil
 	}
 	macs, err := client.CreateMigrationMacaroon(ctx)
 	if err != nil {
 		if params.IsCodeNotImplemented(err) {
-			return errors.New("target controller is too old to support password-authenticated migration; upgrade the target to a version that exposes MigrationTarget v8 or later")
+			return targetInfo, errors.New("target controller is too old to support password-authenticated migration; upgrade the target to a version that exposes MigrationTarget v8 or later")
 		}
-		return errors.Annotate(err, "cannot obtain migration macaroon from target")
+		return targetInfo, errors.Annotate(err, "cannot obtain migration macaroon from target")
 	}
 	targetInfo.Macaroons = macs
 	targetInfo.Password = ""
-	return nil
+	return targetInfo, nil
 }

--- a/internal/migration/auth_test.go
+++ b/internal/migration/auth_test.go
@@ -38,35 +38,38 @@ func (s *harvestMigrationMacaroonSuite) TestSuccess(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	minter := &fakeMacaroonMinter{macs: []macaroon.Slice{{m}}}
-	targetInfo := &coremigration.TargetInfo{
+	targetInfo := coremigration.TargetInfo{
 		User:     "admin",
 		Password: "hunter2",
 	}
 
-	err = migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
+	harvested, err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
 
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(minter.called, tc.IsTrue)
-	c.Check(targetInfo.Password, tc.Equals, "")
-	c.Check(targetInfo.Macaroons, tc.DeepEquals, []macaroon.Slice{{m}})
+	c.Check(harvested.Password, tc.Equals, "")
+	c.Check(harvested.Macaroons, tc.DeepEquals, []macaroon.Slice{{m}})
+	// The argument passed in must not be mutated.
+	c.Check(targetInfo.Password, tc.Equals, "hunter2")
+	c.Check(targetInfo.Macaroons, tc.HasLen, 0)
 }
 
 func (s *harvestMigrationMacaroonSuite) TestNotImplemented(c *tc.C) {
 	minter := &fakeMacaroonMinter{
 		err: &params.Error{Code: params.CodeNotImplemented, Message: "not implemented"},
 	}
-	targetInfo := &coremigration.TargetInfo{
+	targetInfo := coremigration.TargetInfo{
 		User:     "admin",
 		Password: "hunter2",
 	}
 
-	err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
+	harvested, err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
 
 	c.Assert(err, tc.Not(tc.ErrorIsNil))
 	c.Check(err, tc.ErrorMatches, ".*target controller is too old.*")
 	// Password must NOT be cleared — the error prevents persistence.
-	c.Check(targetInfo.Password, tc.Equals, "hunter2")
-	c.Check(targetInfo.Macaroons, tc.HasLen, 0)
+	c.Check(harvested.Password, tc.Equals, "hunter2")
+	c.Check(harvested.Macaroons, tc.HasLen, 0)
 }
 
 func (s *harvestMigrationMacaroonSuite) TestSkippedWhenMacaroonsPresent(c *tc.C) {
@@ -75,43 +78,43 @@ func (s *harvestMigrationMacaroonSuite) TestSkippedWhenMacaroonsPresent(c *tc.C)
 
 	minter := &fakeMacaroonMinter{}
 	existing := []macaroon.Slice{{m}}
-	targetInfo := &coremigration.TargetInfo{
+	targetInfo := coremigration.TargetInfo{
 		User:      "admin",
 		Password:  "hunter2",
 		Macaroons: existing,
 	}
 
-	err = migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
+	harvested, err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
 
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(minter.called, tc.IsFalse, tc.Commentf("minter must not be called when macaroons are already present"))
-	c.Check(targetInfo.Password, tc.Equals, "hunter2")
+	c.Check(harvested.Password, tc.Equals, "hunter2")
 }
 
 func (s *harvestMigrationMacaroonSuite) TestSkippedWhenTokenPresent(c *tc.C) {
 	minter := &fakeMacaroonMinter{}
-	targetInfo := &coremigration.TargetInfo{
+	targetInfo := coremigration.TargetInfo{
 		User:     "admin",
 		Password: "hunter2",
 		Token:    "jimm-token",
 	}
 
-	err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
+	harvested, err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
 
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(minter.called, tc.IsFalse, tc.Commentf("minter must not be called when a token is present"))
-	c.Check(targetInfo.Password, tc.Equals, "hunter2")
+	c.Check(harvested.Password, tc.Equals, "hunter2")
 }
 
 func (s *harvestMigrationMacaroonSuite) TestSkippedWhenPasswordEmpty(c *tc.C) {
 	minter := &fakeMacaroonMinter{}
-	targetInfo := &coremigration.TargetInfo{
+	targetInfo := coremigration.TargetInfo{
 		User: "admin",
 	}
 
-	err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
+	harvested, err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
 
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(minter.called, tc.IsFalse, tc.Commentf("minter must not be called when there is no password to exchange"))
-	c.Check(targetInfo.Macaroons, tc.HasLen, 0)
+	c.Check(harvested.Macaroons, tc.HasLen, 0)
 }

--- a/internal/migration/auth_test.go
+++ b/internal/migration/auth_test.go
@@ -46,9 +46,9 @@ func (s *harvestMigrationMacaroonSuite) TestSuccess(c *tc.C) {
 	err = migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
 
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(minter.called, tc.IsTrue)
-	c.Assert(targetInfo.Password, tc.Equals, "")
-	c.Assert(targetInfo.Macaroons, tc.DeepEquals, []macaroon.Slice{{m}})
+	c.Check(minter.called, tc.IsTrue)
+	c.Check(targetInfo.Password, tc.Equals, "")
+	c.Check(targetInfo.Macaroons, tc.DeepEquals, []macaroon.Slice{{m}})
 }
 
 func (s *harvestMigrationMacaroonSuite) TestNotImplemented(c *tc.C) {
@@ -63,10 +63,10 @@ func (s *harvestMigrationMacaroonSuite) TestNotImplemented(c *tc.C) {
 	err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
 
 	c.Assert(err, tc.Not(tc.ErrorIsNil))
-	c.Assert(err, tc.ErrorMatches, ".*target controller is too old.*")
+	c.Check(err, tc.ErrorMatches, ".*target controller is too old.*")
 	// Password must NOT be cleared — the error prevents persistence.
-	c.Assert(targetInfo.Password, tc.Equals, "hunter2")
-	c.Assert(targetInfo.Macaroons, tc.HasLen, 0)
+	c.Check(targetInfo.Password, tc.Equals, "hunter2")
+	c.Check(targetInfo.Macaroons, tc.HasLen, 0)
 }
 
 func (s *harvestMigrationMacaroonSuite) TestSkippedWhenMacaroonsPresent(c *tc.C) {
@@ -84,8 +84,8 @@ func (s *harvestMigrationMacaroonSuite) TestSkippedWhenMacaroonsPresent(c *tc.C)
 	err = migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
 
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(minter.called, tc.IsFalse, tc.Commentf("minter must not be called when macaroons are already present"))
-	c.Assert(targetInfo.Password, tc.Equals, "hunter2")
+	c.Check(minter.called, tc.IsFalse, tc.Commentf("minter must not be called when macaroons are already present"))
+	c.Check(targetInfo.Password, tc.Equals, "hunter2")
 }
 
 func (s *harvestMigrationMacaroonSuite) TestSkippedWhenTokenPresent(c *tc.C) {
@@ -99,6 +99,19 @@ func (s *harvestMigrationMacaroonSuite) TestSkippedWhenTokenPresent(c *tc.C) {
 	err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
 
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(minter.called, tc.IsFalse, tc.Commentf("minter must not be called when a token is present"))
-	c.Assert(targetInfo.Password, tc.Equals, "hunter2")
+	c.Check(minter.called, tc.IsFalse, tc.Commentf("minter must not be called when a token is present"))
+	c.Check(targetInfo.Password, tc.Equals, "hunter2")
+}
+
+func (s *harvestMigrationMacaroonSuite) TestSkippedWhenPasswordEmpty(c *tc.C) {
+	minter := &fakeMacaroonMinter{}
+	targetInfo := &coremigration.TargetInfo{
+		User: "admin",
+	}
+
+	err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(minter.called, tc.IsFalse, tc.Commentf("minter must not be called when there is no password to exchange"))
+	c.Check(targetInfo.Macaroons, tc.HasLen, 0)
 }

--- a/internal/migration/auth_test.go
+++ b/internal/migration/auth_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration_test
+
+import (
+	"context"
+	stdtesting "testing"
+
+	"github.com/juju/tc"
+	"gopkg.in/macaroon.v2"
+
+	coremigration "github.com/juju/juju/core/migration"
+	"github.com/juju/juju/internal/migration"
+	"github.com/juju/juju/rpc/params"
+)
+
+func TestHarvestMigrationMacaroonSuite(t *stdtesting.T) {
+	tc.Run(t, &harvestMigrationMacaroonSuite{})
+}
+
+type harvestMigrationMacaroonSuite struct{}
+
+// fakeMacaroonMinter is a test double for migration.MigrationMacaroonMinter.
+type fakeMacaroonMinter struct {
+	called bool
+	macs   []macaroon.Slice
+	err    error
+}
+
+func (f *fakeMacaroonMinter) CreateMigrationMacaroon(_ context.Context) ([]macaroon.Slice, error) {
+	f.called = true
+	return f.macs, f.err
+}
+
+func (s *harvestMigrationMacaroonSuite) TestSuccess(c *tc.C) {
+	m, err := macaroon.New([]byte("root-key"), []byte("id"), "loc", macaroon.V2)
+	c.Assert(err, tc.ErrorIsNil)
+
+	minter := &fakeMacaroonMinter{macs: []macaroon.Slice{{m}}}
+	targetInfo := &coremigration.TargetInfo{
+		User:     "admin",
+		Password: "hunter2",
+	}
+
+	err = migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(minter.called, tc.IsTrue)
+	c.Assert(targetInfo.Password, tc.Equals, "")
+	c.Assert(targetInfo.Macaroons, tc.DeepEquals, []macaroon.Slice{{m}})
+}
+
+func (s *harvestMigrationMacaroonSuite) TestNotImplemented(c *tc.C) {
+	minter := &fakeMacaroonMinter{
+		err: &params.Error{Code: params.CodeNotImplemented, Message: "not implemented"},
+	}
+	targetInfo := &coremigration.TargetInfo{
+		User:     "admin",
+		Password: "hunter2",
+	}
+
+	err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
+
+	c.Assert(err, tc.Not(tc.ErrorIsNil))
+	c.Assert(err, tc.ErrorMatches, ".*target controller is too old.*")
+	// Password must NOT be cleared — the error prevents persistence.
+	c.Assert(targetInfo.Password, tc.Equals, "hunter2")
+	c.Assert(targetInfo.Macaroons, tc.HasLen, 0)
+}
+
+func (s *harvestMigrationMacaroonSuite) TestSkippedWhenMacaroonsPresent(c *tc.C) {
+	m, err := macaroon.New([]byte("root-key"), []byte("id"), "loc", macaroon.V2)
+	c.Assert(err, tc.ErrorIsNil)
+
+	minter := &fakeMacaroonMinter{}
+	existing := []macaroon.Slice{{m}}
+	targetInfo := &coremigration.TargetInfo{
+		User:      "admin",
+		Password:  "hunter2",
+		Macaroons: existing,
+	}
+
+	err = migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(minter.called, tc.IsFalse, tc.Commentf("minter must not be called when macaroons are already present"))
+	c.Assert(targetInfo.Password, tc.Equals, "hunter2")
+}
+
+func (s *harvestMigrationMacaroonSuite) TestSkippedWhenTokenPresent(c *tc.C) {
+	minter := &fakeMacaroonMinter{}
+	targetInfo := &coremigration.TargetInfo{
+		User:     "admin",
+		Password: "hunter2",
+		Token:    "jimm-token",
+	}
+
+	err := migration.HarvestMigrationMacaroon(c.Context(), targetInfo, minter)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(minter.called, tc.IsFalse, tc.Commentf("minter must not be called when a token is present"))
+	c.Assert(targetInfo.Password, tc.Equals, "hunter2")
+}

--- a/rpc/params/migration.go
+++ b/rpc/params/migration.go
@@ -6,6 +6,8 @@ package params
 import (
 	"time"
 
+	"gopkg.in/macaroon.v2"
+
 	"github.com/juju/juju/core/semversion"
 )
 
@@ -518,4 +520,10 @@ type AdoptResourcesArgs struct {
 	// ensure it looks for the original tags in the correct format for
 	// that version.
 	SourceControllerVersion semversion.Number `json:"source-controller-version"`
+}
+
+// CreateMigrationMacaroonResult holds a reusable login macaroon minted by the
+// target controller for the authenticated user, for migration use only.
+type CreateMigrationMacaroonResult struct {
+	Macaroon *macaroon.Macaroon `json:"macaroon"`
 }


### PR DESCRIPTION
  `juju migrate` stores a `TargetInfo (target address, CA cert, and credentials)` in the source controller's
  database. The migrationmaster worker reads that record and uses it to open authenticated connections to
  the target throughout every migration phase.

  In the 3.x era, the cleartext target admin password lived in that record. PR #22391 deliberately removed
  it: commit 0e90c6e ("tighten model migration auth storage") dropped the target_password column because
  storing clear-text admin passwords in the controller DB is a security liability. That left a gap: the
  worker has no credential to present at the target, so migrations fail immediately with "interaction 
  required but not possible" on the source and "invalid login macaroon" on the target.

  The design agreed in PR #22391: use the password transiently during prechecks
  while a live authenticated connection to the target already exists, exchange it for a reusable macaroon
  over that connection, and persist only the macaroon. This PR implements the source side of that design.



## QA steps

For the QA scenario we need either https://github.com/juju/juju/pull/22674 to land first or to check it out and build a 4.1 client with those changes before bootstrapping the target. 

Bootstrap a target (4.1, patched) and source controller, create a model on the source and attempt to migrate it:
```
$ juju_41 bootstrap lxd tgt
$ juju bootstrap lxd src
$ juju add-model m
$ juju migrate m tgt
```
No errors will be returned at this point, and the migration will effectively begin. We can check that the migrationmaster worker went all the way to `VALIDATION` phase because of this log line (that you should see) on the source controller:  
```
machine-0: 12:29:50 ERROR juju.worker.dependency "migration-master" manifold worker returned unexpected error: cannot check machine discrepancies in imported model "d6a37748-8d6a-4764-8753-26b3baa19460": cannot get provider for model when checking for machine discrepancies in migrated model: provider not found for namespace
```
This means that the source controller can effectively communicate with the target and initiate the migration correctly.

## Links

**Jira card:** [JUJU-9900](https://warthogs.atlassian.net/browse/JUJU-9900)


[JUJU-9900]: https://warthogs.atlassian.net/browse/JUJU-9900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ