### PR TITLE
fix(snap): add FIDO/U2F security key support for juju ssh

### DIFF
--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -96,6 +96,15 @@ Connect to a mysql unit with an identity not known to juju (ssh option -i):
 
     juju ssh mysql/0 -i ~/.ssh/my_private_key echo hello
 
+Connect to a mysql unit using a FIDO/U2F security key (e.g. YubiKey):
+
+    juju ssh mysql/0 -i ~/.ssh/id_ed25519_sk
+
+When using the Juju snap, the u2f-devices interface must be
+connected to allow access to FIDO/U2F security keys:
+
+    sudo snap connect juju:u2f-devices
+
 **For k8s charms running the workload in a separate pod:**
 
 Connect to a k8s unit targeting the operator pod by default:

--- a/docs/howto/manage-ssh-keys.md
+++ b/docs/howto/manage-ssh-keys.md
@@ -11,6 +11,11 @@ myst:
 See also: {ref}`ssh-key`
 ```
 
+If you've bootstrapped a controller, Juju has automatically created an SSH key
+for you that yon use to SSH into the machines or units provisioned through
+Juju. This document covers the other case where you want to add further SSH
+keys to Juju.
+
 (add-an-ssh-key)=
 ## Add an SSH key
 
@@ -64,6 +69,47 @@ If you want to get more details, or get this information for a different model, 
 ```{ibnote}
 See more: {ref}`command-juju-ssh-keys`
 ```
+
+(use-an-ssh-key)=
+## Use an SSH key
+
+To SSH into a machine using a specific private key, pass OpenSSH's `-i`
+flag between the target and a possible remote command. Because `juju ssh`
+passes any options placed after the target to the underlying OpenSSH client,
+other OpenSSH flags can be used in the same way:
+
+```text
+juju ssh ubuntu/0 -i ~/.ssh/my_private_key
+```
+
+The key's public counterpart must be added to the model first (see
+{ref}`add-an-ssh-key`).
+
+```{ibnote}
+See more: {ref}`command-juju-ssh`
+```
+
+````{dropdown} Example: Use a FIDO/U2F security key (e.g. YubiKey)
+:color: success
+
+To use a FIDO/U2F security key with `juju ssh`, generate an SSH key
+backed by the security key, add the public key to the model, and pass
+the private key with the `-i` option:
+
+```text
+ssh-keygen -t ed25519-sk -f ~/.ssh/id_ed25519_sk
+juju add-ssh-key "$(cat ~/.ssh/id_ed25519_sk.pub)"
+juju ssh ubuntu/0 -i ~/.ssh/id_ed25519_sk
+```
+
+When using the Juju snap, the `u2f-devices` interface must be connected
+to allow access to FIDO/U2F security keys. This interface is not
+auto-connected:
+
+```text
+sudo snap connect juju:u2f-devices
+```
+````
 
 ## Remove an SSH key
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/ssh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/ssh.md
@@ -43,6 +43,15 @@ Connect to a mysql unit with an identity not known to juju (ssh option -i):
 
     juju ssh mysql/0 -i ~/.ssh/my_private_key echo hello
 
+Connect to a mysql unit using a FIDO/U2F security key (e.g. YubiKey):
+
+    juju ssh mysql/0 -i ~/.ssh/id_ed25519_sk
+
+When using the Juju snap, the u2f-devices interface must be
+connected to allow access to FIDO/U2F security keys:
+
+    sudo snap connect juju:u2f-devices
+
 **For k8s charms running the workload in a separate pod:**
 
 Connect to a k8s unit targeting the operator pod by default:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,8 @@ apps:
     environment:
       # Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
       PATH: "$SNAP/bin:$SNAP/usr/bin:$SNAP/opt/jaas/bin:/snap/bin:$PATH"
+      SSH_SK_HELPER: "$SNAP/usr/lib/openssh/ssh-sk-helper"
+      SSH_PKCS11_HELPER: "$SNAP/usr/lib/openssh/ssh-pkcs11-helper"
     command: bin/juju
     plugs:
       - network
@@ -61,6 +63,11 @@ apps:
       - home
       # Needed to that SSO via the web browser can work.
       - desktop
+      # Needed for FIDO/U2F security key support (e.g. YubiKey) with juju ssh.
+      # This interface is not auto-connected; users must run:
+      #   sudo snap connect juju:u2f-devices
+      # We do not want this to be auto-connected.
+      - u2f-devices
     completer: usr/share/bash-completion/completions/juju
   fetch-oci:
     daemon: oneshot


### PR DESCRIPTION
Cherry pick #22661

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps


Bootstrap a controller without ssh keys:

```sh
❯ juju bootstrap lxd repro
❯ juju add-model m
❯ juju deploy ubuntu
❯ rm $JUJU_DATA/ssh/*
❯ juju remove-ssh-key iyigun.cevik@canonical.com

# At this point ssh will not work anymore
❯ juju ssh ubuntu/0
ubuntu@10.159.202.112: Permission denied (publickey).
```


Prepare new key:

```
❯ ssh-keygen -vvv -t ed25519-sk -f ~/.ssh/id_ed25519_sk  -O resident -O verify-required -C "juju-sk-repro"
❯ juju add-ssh-key "$(cat ~/.ssh/id_ed25519_sk.pub)"

❯ juju ssh-keys
Keys used in model: admin/m
SHA256:qJB9S4DxwUmTNzz0VsDihAOfvppN7Yu1GVKPRRQF+94

❯ juju ssh ubuntu/0 -i ~/.ssh/id_ed25519_sk

The programs included with the Ubuntu system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.

To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

ubuntu@juju-af7a03-0:~$
```

## Documentation changes

## Links

**Issue:** Fixes #22497

**Jira card:** [JUJU-9894](https://warthogs.atlassian.net/browse/JUJU-9894)


[JUJU-9894]: https://warthogs.atlassian.net/browse/JUJU-9894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ