### PR TITLE
fix: contain filestorage names within the storage directory

### DIFF
--- a/environs/filestorage/filestorage.go
+++ b/environs/filestorage/filestorage.go
@@ -106,12 +106,12 @@ func (f *fileStorageReader) List(prefix string) ([]string, error) {
 	if isInternalPath(prefix) {
 		return names, nil
 	}
-	prefix = filepath.Join(f.path, prefix)
-	if err := f.ensureWithinRoot(prefix); err != nil {
+	prefix, err := f.fullPath(prefix)
+	if err != nil {
 		return nil, err
 	}
 	dir := filepath.Dir(prefix)
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/environs/filestorage/filestorage.go
+++ b/environs/filestorage/filestorage.go
@@ -43,8 +43,23 @@ func NewFileStorageReader(path string) (reader storage.StorageReader, err error)
 	return &fileStorageReader{p}, nil
 }
 
-func (f *fileStorageReader) fullPath(name string) string {
-	return filepath.Join(f.path, name)
+func (f *fileStorageReader) fullPath(name string) (string, error) {
+	fullpath := filepath.Join(f.path, name)
+	if err := f.ensureWithinRoot(fullpath); err != nil {
+		return "", err
+	}
+	return fullpath, nil
+}
+
+// ensureWithinRoot returns a NotValid error if path is not contained within the
+// storage directory. f.path is absolute and cleaned by NewFileStorageReader, so
+// a prefix check on the cleaned join result is enough to catch ".." components
+// in a name that would otherwise escape the storage directory.
+func (f *fileStorageReader) ensureWithinRoot(path string) error {
+	if path == f.path || strings.HasPrefix(path, f.path+string(os.PathSeparator)) {
+		return nil
+	}
+	return errors.NotValidf("file name %q", path)
 }
 
 // Get implements storage.StorageReader.Get.
@@ -56,7 +71,10 @@ func (f *fileStorageReader) Get(name string) (io.ReadCloser, error) {
 			Err:  os.ErrNotExist,
 		}
 	}
-	filename := f.fullPath(name)
+	filename, err := f.fullPath(name)
+	if err != nil {
+		return nil, err
+	}
 	fi, err := os.Stat(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -89,6 +107,9 @@ func (f *fileStorageReader) List(prefix string) ([]string, error) {
 		return names, nil
 	}
 	prefix = filepath.Join(f.path, prefix)
+	if err := f.ensureWithinRoot(prefix); err != nil {
+		return nil, err
+	}
 	dir := filepath.Dir(prefix)
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -108,7 +129,11 @@ func (f *fileStorageReader) List(prefix string) ([]string, error) {
 
 // URL implements storage.StorageReader.URL.
 func (f *fileStorageReader) URL(name string) (string, error) {
-	return utils.MakeFileURL(filepath.Join(f.path, name)), nil
+	fullpath, err := f.fullPath(name)
+	if err != nil {
+		return "", err
+	}
+	return utils.MakeFileURL(fullpath), nil
 }
 
 // DefaultConsistencyStrategy implements storage.StorageReader.ConsistencyStrategy.
@@ -144,7 +169,10 @@ func (f *fileStorageWriter) Put(name string, r io.Reader, length int64) error {
 			Err:  os.ErrPermission,
 		}
 	}
-	fullpath := f.fullPath(name)
+	fullpath, err := f.fullPath(name)
+	if err != nil {
+		return err
+	}
 	dir := filepath.Dir(fullpath)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
@@ -170,8 +198,11 @@ func (f *fileStorageWriter) Put(name string, r io.Reader, length int64) error {
 }
 
 func (f *fileStorageWriter) Remove(name string) error {
-	fullpath := f.fullPath(name)
-	err := os.Remove(fullpath)
+	fullpath, err := f.fullPath(name)
+	if err != nil {
+		return err
+	}
+	err = os.Remove(fullpath)
 	if os.IsNotExist(err) {
 		err = nil
 	}

--- a/environs/filestorage/filestorage_test.go
+++ b/environs/filestorage/filestorage_test.go
@@ -176,6 +176,60 @@ func (s *filestorageSuite) TestPutRefusesTmp(c *tc.C) {
 	c.Assert(err, tc.Satisfies, os.IsNotExist)
 }
 
+func (s *filestorageSuite) TestRefusesPathTraversal(c *tc.C) {
+	// Create a file in the parent of the storage directory that a "../"
+	// name would resolve to, to prove an escaping name cannot reach it.
+	outside := filepath.Join(filepath.Dir(s.dir), "outside")
+	secret := []byte{6, 7, 8, 9}
+	c.Assert(os.WriteFile(outside, secret, 0644), tc.ErrorIsNil)
+
+	// Names that resolve outside the storage directory: a single level, a
+	// multi-level traversal, and traversal hidden behind a leading segment.
+	for _, name := range []string{"../outside", "../../", "a/../../b"} {
+		c.Logf("name=%q", name)
+
+		_, err := s.reader.Get(name)
+		c.Check(err, tc.ErrorIs, errors.NotValid)
+
+		_, err = s.reader.URL(name)
+		c.Check(err, tc.ErrorIs, errors.NotValid)
+
+		_, err = s.reader.List(name)
+		c.Check(err, tc.ErrorIs, errors.NotValid)
+
+		err = s.writer.Put(name, bytes.NewReader([]byte{1, 2, 3}), 3)
+		c.Check(err, tc.ErrorIs, errors.NotValid)
+
+		err = s.writer.Remove(name)
+		c.Check(err, tc.ErrorIs, errors.NotValid)
+	}
+
+	// The file outside the storage directory is untouched.
+	b, err := os.ReadFile(outside)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(b, tc.DeepEquals, secret)
+}
+
+func (s *filestorageSuite) TestAllowsRootNames(c *tc.C) {
+	// Names that resolve to the storage directory itself ("", ".", "./") stay
+	// within the root, so they must not be rejected as NotValid. Pin that
+	// behaviour so a stricter containment check can't silently start refusing
+	// them.
+	for _, name := range []string{"", ".", "./"} {
+		c.Logf("name=%q", name)
+
+		// URL of the root resolves to the storage directory.
+		url, err := s.reader.URL(name)
+		c.Check(err, tc.ErrorIsNil)
+		c.Check(url, tc.Equals, utils.MakeFileURL(s.dir))
+
+		// Get on the root returns NotFound because it is a directory, not a
+		// NotValid containment error.
+		_, err = s.reader.Get(name)
+		c.Check(err, tc.ErrorIs, errors.NotFound)
+	}
+}
+
 func (s *filestorageSuite) TestRemove(c *tc.C) {
 	expectedpath, _ := s.createFile(c, "test-file")
 	_, file := filepath.Split(expectedpath)

--- a/environs/filestorage/filestorage_test.go
+++ b/environs/filestorage/filestorage_test.go
@@ -177,15 +177,25 @@ func (s *filestorageSuite) TestPutRefusesTmp(c *tc.C) {
 }
 
 func (s *filestorageSuite) TestRefusesPathTraversal(c *tc.C) {
-	// Create a file in the parent of the storage directory that a "../"
-	// name would resolve to, to prove an escaping name cannot reach it.
-	outside := filepath.Join(filepath.Dir(s.dir), "outside")
+	// Each escaping name is paired with a sentinel file planted at the exact
+	// location it resolves to, so a successful escape would read, overwrite or
+	// delete a real file we can detect afterwards. The names cover a single
+	// level, a multi-level traversal, and traversal hidden behind a leading
+	// segment.
+	parent := filepath.Dir(s.dir)
+	grandparent := filepath.Dir(parent)
 	secret := []byte{6, 7, 8, 9}
-	c.Assert(os.WriteFile(outside, secret, 0644), tc.ErrorIsNil)
+	cases := map[string]string{
+		"../outside":        filepath.Join(parent, "outside"),
+		"../../outside":     filepath.Join(grandparent, "outside"),
+		"a/../../outside-b": filepath.Join(parent, "outside-b"),
+	}
+	for name, target := range cases {
+		c.Assert(filepath.Join(s.dir, name), tc.Equals, target)
+		c.Assert(os.WriteFile(target, secret, 0644), tc.ErrorIsNil)
+	}
 
-	// Names that resolve outside the storage directory: a single level, a
-	// multi-level traversal, and traversal hidden behind a leading segment.
-	for _, name := range []string{"../outside", "../../", "a/../../b"} {
+	for name := range cases {
 		c.Logf("name=%q", name)
 
 		_, err := s.reader.Get(name)
@@ -204,13 +214,21 @@ func (s *filestorageSuite) TestRefusesPathTraversal(c *tc.C) {
 		c.Check(err, tc.ErrorIs, errors.NotValid)
 	}
 
-	// The file outside the storage directory is untouched.
-	b, err := os.ReadFile(outside)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(b, tc.DeepEquals, secret)
+	// Every sentinel outside the storage directory is untouched.
+	for _, target := range cases {
+		b, err := os.ReadFile(target)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Assert(b, tc.DeepEquals, secret)
+	}
 }
 
 func (s *filestorageSuite) TestAllowsRootNames(c *tc.C) {
+	// A file at the storage root, plus a decoy planted in the parent directory
+	// that a root List walks over but must not return.
+	s.createFile(c, "root-file")
+	decoy := filepath.Join(filepath.Dir(s.dir), "decoy")
+	c.Assert(os.WriteFile(decoy, []byte{9}, 0644), tc.ErrorIsNil)
+
 	// Names that resolve to the storage directory itself ("", ".", "./") stay
 	// within the root, so they must not be rejected as NotValid. Pin that
 	// behaviour so a stricter containment check can't silently start refusing
@@ -227,6 +245,12 @@ func (s *filestorageSuite) TestAllowsRootNames(c *tc.C) {
 		// NotValid containment error.
 		_, err = s.reader.Get(name)
 		c.Check(err, tc.ErrorIs, errors.NotFound)
+
+		// List of the root walks the storage directory and returns only its
+		// contents, never the parent's, rather than being rejected as NotValid.
+		files, err := s.reader.List(name)
+		c.Check(err, tc.ErrorIsNil)
+		c.Check(files, tc.DeepEquals, []string{"root-file"})
 	}
 }
 


### PR DESCRIPTION
1. fileStorageReader/Writer build the on-disk path with filepath.Join(f.path, name) and only screen out the ".tmp" staging dir, so a name with ".." escapes the storage directory.
2. Get and URL then read outside the root, and Put and Remove write or delete outside it; a product path coming from a simplestreams index is one way such a name reaches these methods.
Added an isWithinRoot containment check shared by Get, Put, Remove, URL and List, so a name that resolves outside the directory is rejected with errors.NotValid.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
go test ./environs/filestorage/ -run TestFilestorageSuite/TestRefusesPathTraversal
```

On the unpatched tree the same test calls `Remove("../outside")` and deletes a file outside the storage directory; after the change every method rejects the escaping name and the outside file is left untouched.
