### PR TITLE
fix(uniter): include non-root user notices in pebbleNoticer polling

### DIFF
--- a/internal/worker/uniter/pebblenotices.go
+++ b/internal/worker/uniter/pebblenotices.go
@@ -88,7 +88,7 @@ func (n *pebbleNoticer) run(containerName string) (err error) {
 	for {
 		// Wait up to a timeout for new notices to arrive (also stop when
 		// tomb's context is cancelled).
-		options := &client.NoticesOptions{After: after}
+		options := &client.NoticesOptions{After: after, Users: client.NoticesUsersAll}
 		notices, err := pebbleClient.WaitNotices(ctx, waitTimeout, options)
 
 		// Return early if the worker was killed.

--- a/internal/worker/uniter/pebblenotices_test.go
+++ b/internal/worker/uniter/pebblenotices_test.go
@@ -284,3 +284,29 @@ func (s *pebbleNoticerSuite) TestMultipleContainers(c *gc.C) {
 		})
 	}
 }
+
+// TestNonRootNoticeReceived verifies that custom notices created by non-root
+// workload services (e.g., a database running as a dedicated user) are
+// received by the pebbleNoticer. This requires NoticesUsersAll to be set
+// in the query options; without it, Pebble's API only returns notices
+// matching the caller's UID.
+func (s *pebbleNoticerSuite) TestNonRootNoticeReceived(c *gc.C) {
+	s.setUpWorker(c, []string{"c1"})
+	defer workertest.CleanKill(c, s.worker)
+
+	nonRootUID := uint32(584788) // e.g., postgres user
+	s.clients["c1"].AddNotice(c, &client.Notice{
+		ID:           "1",
+		UserID:       &nonRootUID,
+		Type:         "custom",
+		Key:          "example.com/workload/ready",
+		LastRepeated: time.Now(),
+	})
+	s.waitWorkloadEvent(c, container.WorkloadEvent{
+		Type:         container.CustomNoticeEvent,
+		WorkloadName: "c1",
+		NoticeID:     "1",
+		NoticeType:   "custom",
+		NoticeKey:    "example.com/workload/ready",
+	})
+}

--- a/internal/worker/uniter/pebblepoller_test.go
+++ b/internal/worker/uniter/pebblepoller_test.go
@@ -182,6 +182,9 @@ func noticeMatches(notice *pebbleclient.Notice, opts *pebbleclient.NoticesOption
 	if opts == nil || opts.Types != nil || opts.Keys != nil {
 		panic("not supported")
 	}
+	if opts.Users != pebbleclient.NoticesUsersAll {
+		panic("WaitNotices must use NoticesUsersAll to see notices from all users")
+	}
 	if !opts.After.IsZero() && !notice.LastRepeated.After(opts.After) {
 		return false
 	}

--- a/internal/worker/uniter/pebblepoller_test.go
+++ b/internal/worker/uniter/pebblepoller_test.go
@@ -167,7 +167,11 @@ func (c *fakePebbleClient) WaitNotices(ctx context.Context, serverTimeout time.D
 			if notice.Type == "error" {
 				return nil, errors.New(notice.Key)
 			}
-			if noticeMatches(notice, opts) {
+			match, err := noticeMatches(notice, opts)
+			if err != nil {
+				return nil, err
+			}
+			if match {
 				return []*pebbleclient.Notice{notice}, nil
 			}
 		case <-timeoutCh:
@@ -178,17 +182,17 @@ func (c *fakePebbleClient) WaitNotices(ctx context.Context, serverTimeout time.D
 	}
 }
 
-func noticeMatches(notice *pebbleclient.Notice, opts *pebbleclient.NoticesOptions) bool {
+func noticeMatches(notice *pebbleclient.Notice, opts *pebbleclient.NoticesOptions) (bool, error) {
 	if opts == nil || opts.Types != nil || opts.Keys != nil {
-		panic("not supported")
+		return false, fmt.Errorf("NoticesOptions is nil or has unsupported fields set")
 	}
 	if opts.Users != pebbleclient.NoticesUsersAll {
-		panic("WaitNotices must use NoticesUsersAll to see notices from all users")
+		return false, fmt.Errorf("WaitNotices must use NoticesUsersAll to see notices from all users")
 	}
 	if !opts.After.IsZero() && !notice.LastRepeated.After(opts.After) {
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 // AddChange adds a change for Change to return.


### PR DESCRIPTION
The pebbleNoticer was only seeing notices matching the caller's UID (root/0) because NoticesOptions did not set Users to NoticesUsersAll. This caused custom notices created by non-root workload services (e.g., a database running as a dedicated user) to be silently dropped, preventing charms from receiving pebble-custom-notice events for those workloads.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. Bootstrap a controller and deploy a sidecar charm whose workload runs as a non-root user:
   ```sh
   juju bootstrap k8s test-controller
   juju add-model test-notices
   juju deploy postgresql-k8s --channel 16/edge --trust
   ```

2. Wait for `active/idle`, then send a custom notice as the non-root workload user:
   ```sh
   juju ssh --container postgresql postgresql-k8s/0 \
     "su -s /bin/bash -c \"/charm/bin/pebble notify example.com/test/nonroot\" postgres"
   ```

3. Verify the hook is dispatched:
   ```sh
   juju debug-log --replay --include unit-postgresql-k8s-0 | grep pebble-custom-notice
   ```

**Without the fix:** No hook is dispatched. The notice is silently ignored.
**With the fix:** A `postgresql-pebble-custom-notice` hook execution appears in the log.

## Documentation changes

None.

## Links

**Issue:** Fixes #22683.