### PR TITLE
(3.6) perf(status): optimize full status lookups

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -291,7 +291,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 		fetchNetworkInterfaces(c.stateAccessor, context.spaceInfos); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch IP addresses and link layer devices")
 	}
-	if context.relations, context.relationsById, err = fetchRelations(c.stateAccessor); err != nil {
+	if context.relations, context.relationsById, err = context.fetchRelations(c.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch relations")
 	}
 	if len(context.allAppsUnitsCharmBindings.applications) > 0 {
@@ -326,7 +326,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 
 	if logger.IsTraceEnabled() {
 		logger.Tracef("Applications: %v", context.allAppsUnitsCharmBindings.applications)
-		logger.Tracef("Remote applications: %v", context.consumerRemoteApplications)
+		logger.Tracef("Remote applications: %v", context.consumerRemoteApplicationsWithURL())
 		logger.Tracef("Offers: %v", context.offers)
 		logger.Tracef("Leaders: %v", context.leaders)
 		logger.Tracef("Relations: %v", context.relations)
@@ -702,7 +702,7 @@ type statusContext struct {
 	// linkLayerDevices: machine id -> list of linkLayerDevices
 	linkLayerDevices map[string][]*state.LinkLayerDevice
 
-	// remote applications: application name -> application
+	// consumerRemoteApplications: application name -> remote application
 	consumerRemoteApplications map[string]*state.RemoteApplication
 
 	// opened ports by machine.
@@ -997,7 +997,8 @@ func fetchAllApplicationsAndUnits(st Backend, model *state.Model, spaceInfos net
 	}, nil
 }
 
-// fetchConsumerRemoteApplications returns a map from application name to remote application.
+// fetchConsumerRemoteApplications returns all remote applications keyed by
+// application name, including consumer proxies without offer URLs.
 func fetchConsumerRemoteApplications(st Backend) (map[string]*state.RemoteApplication, error) {
 	appMap := make(map[string]*state.RemoteApplication)
 	applications, err := st.AllRemoteApplications()
@@ -1005,9 +1006,6 @@ func fetchConsumerRemoteApplications(st Backend) (map[string]*state.RemoteApplic
 		return nil, err
 	}
 	for _, a := range applications {
-		if _, ok := a.URL(); !ok {
-			continue
-		}
 		appMap[a.Name()] = a
 	}
 	return appMap, nil
@@ -1059,7 +1057,7 @@ func fetchOffers(st Backend, applications map[string]*state.Application) (map[st
 // to have the relations for each application. Reading them once here
 // avoids the repeated DB hits to retrieve the relations for each
 // application that used to happen in processApplicationRelations().
-func fetchRelations(st Backend) (map[string][]*state.Relation, map[int]*state.Relation, error) {
+func (context *statusContext) fetchRelations(st Backend) (map[string][]*state.Relation, map[int]*state.Relation, error) {
 	relations, err := st.AllRelations()
 	if err != nil {
 		return nil, nil, err
@@ -1072,13 +1070,11 @@ func fetchRelations(st Backend) (map[string][]*state.Relation, map[int]*state.Re
 		// on the offering side, exclude it here.
 		isRemote := false
 		for _, ep := range relation.Endpoints() {
-			if app, err := st.RemoteApplication(ep.ApplicationName); err == nil {
+			if app, ok := context.consumerRemoteApplications[ep.ApplicationName]; ok {
 				if app.IsConsumerProxy() {
 					isRemote = true
 					break
 				}
-			} else if !errors.IsNotFound(err) {
-				return nil, nil, err
 			}
 		}
 		if isRemote {
@@ -1298,7 +1294,7 @@ func (context *statusContext) processRelations() []params.RelationStatus {
 			Scope:     string(scope),
 			Endpoints: eps,
 		}
-		rStatus, err := relation.Status()
+		rStatus, err := context.status.Relation(relation.Id())
 		populateStatusFromStatusInfoAndErr(&relStatus.Status, rStatus, err)
 		out = append(out, relStatus)
 	}
@@ -1437,7 +1433,7 @@ func (context *statusContext) processApplication(application *state.Application)
 			units, applicationCharm.URL(), expectWorkload)
 	}
 
-	applicationStatus, err := application.Status()
+	applicationStatus, err := context.status.Application(application.Name())
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		processedStatus.Err = apiservererrors.ServerError(err)
 		return processedStatus
@@ -1464,7 +1460,7 @@ func (context *statusContext) processApplication(application *state.Application)
 	}
 
 	if context.model.Type() == state.ModelTypeCAAS {
-		operatorStatus, err := application.OperatorStatus()
+		operatorStatus, err := context.status.ApplicationOperator(application.Name())
 		if err != nil && !errors.Is(err, errors.NotFound) {
 			processedStatus.Err = apiservererrors.ServerError(err)
 			return processedStatus
@@ -1566,10 +1562,23 @@ func (context *statusContext) mapExposedEndpointsFromState(exposedEndpoints map[
 
 func (context *statusContext) processRemoteApplications() map[string]params.RemoteApplicationStatus {
 	applicationsMap := make(map[string]params.RemoteApplicationStatus)
-	for _, app := range context.consumerRemoteApplications {
+	for _, app := range context.consumerRemoteApplicationsWithURL() {
 		applicationsMap[app.Name()] = context.processRemoteApplication(app)
 	}
 	return applicationsMap
+}
+
+// consumerRemoteApplicationsWithURL returns the subset of remote applications
+// displayed by status. Relation processing uses all consumer remote applications.
+func (context *statusContext) consumerRemoteApplicationsWithURL() map[string]*state.RemoteApplication {
+	applications := make(map[string]*state.RemoteApplication)
+	for _, app := range context.consumerRemoteApplications {
+		if _, ok := app.URL(); !ok {
+			continue
+		}
+		applications[app.Name()] = app
+	}
+	return applications
 }
 
 func (context *statusContext) processRemoteApplication(application *state.RemoteApplication) (status params.RemoteApplicationStatus) {
@@ -1595,7 +1604,7 @@ func (context *statusContext) processRemoteApplication(application *state.Remote
 		status.Err = apiservererrors.ServerError(err)
 		return
 	}
-	applicationStatus, err := application.Status()
+	applicationStatus, err := context.status.RemoteApplication(application.Name())
 	populateStatusFromStatusInfoAndErr(&status.Status, applicationStatus, err)
 	return status
 }

--- a/state/status.go
+++ b/state/status.go
@@ -76,6 +76,26 @@ func (m *ModelStatus) Model() (status.StatusInfo, error) {
 	return m.getStatus(m.model.globalKey(), "model")
 }
 
+// Application returns the status of the application.
+func (m *ModelStatus) Application(appName string) (status.StatusInfo, error) {
+	return m.getStatus(applicationGlobalKey(appName), fmt.Sprintf("application %q", appName))
+}
+
+// ApplicationOperator returns the operator status of the application.
+func (m *ModelStatus) ApplicationOperator(appName string) (status.StatusInfo, error) {
+	return m.getStatus(applicationGlobalOperatorKey(appName), fmt.Sprintf("operator for application %q", appName))
+}
+
+// Relation returns the status of the relation.
+func (m *ModelStatus) Relation(id int) (status.StatusInfo, error) {
+	return m.getStatus(relationGlobalScope(id), "relation")
+}
+
+// RemoteApplication returns the status of the remote application.
+func (m *ModelStatus) RemoteApplication(appName string) (status.StatusInfo, error) {
+	return m.getStatus(remoteApplicationGlobalKey(appName), fmt.Sprintf("saas application %q", appName))
+}
+
 // MachineAgent returns the status of the machine agent.
 func (m *ModelStatus) MachineAgent(machineID string) (status.StatusInfo, error) {
 	return m.getStatus(machineGlobalKey(machineID), "machine")

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"github.com/juju/charm/v12"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -163,6 +164,110 @@ func (s *ModelStatusSuite) TestModelStatusForModel(c *gc.C) {
 	mInfo, err := s.model.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, mInfo)
+}
+
+func (s *ModelStatusSuite) TestApplicationStatus(c *gc.C) {
+	application := s.factory.MakeApplication(c, nil)
+	now := testing.ZeroTime()
+	err := application.SetStatus(status.StatusInfo{
+		Status:  status.Active,
+		Message: "healthy",
+		Since:   &now,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msStatus, err := ms.Application(application.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	appStatus, err := application.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(msStatus, jc.DeepEquals, appStatus)
+}
+
+func (s *ModelStatusSuite) TestApplicationOperatorStatus(c *gc.C) {
+	st := s.factory.MakeModel(c, &factory.ModelParams{
+		Name: "caas-model",
+		Type: state.ModelTypeCAAS,
+	})
+	defer st.Close()
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+	f := factory.NewFactory(st, s.StatePool)
+	ch := f.MakeCharm(c, &factory.CharmParams{Name: "gitlab", Series: "kubernetes"})
+	application := f.MakeApplication(c, &factory.ApplicationParams{Name: "gitlab", Charm: ch})
+
+	now := testing.ZeroTime()
+	err = application.SetOperatorStatus(status.StatusInfo{
+		Status:  status.Error,
+		Message: "broken",
+		Since:   &now,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ms, err := model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msStatus, err := ms.ApplicationOperator(application.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	appStatus, err := application.OperatorStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(msStatus, jc.DeepEquals, appStatus)
+}
+
+func (s *ModelStatusSuite) TestRelationStatus(c *gc.C) {
+	relation := s.factory.MakeRelation(c, nil)
+	err := relation.SetStatus(status.StatusInfo{
+		Status:  status.Suspended,
+		Message: "for a while",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msStatus, err := ms.Relation(relation.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	relStatus, err := relation.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(msStatus, jc.DeepEquals, relStatus)
+}
+
+func (s *ModelStatusSuite) TestRemoteApplicationStatus(c *gc.C) {
+	application, err := s.st.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "hosted-mysql",
+		OfferUUID:   "offer-uuid",
+		URL:         "fred/prod.mysql",
+		SourceModel: s.model.ModelTag(),
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "db",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	now := testing.ZeroTime()
+	err = application.SetStatus(status.StatusInfo{
+		Status:  status.Active,
+		Message: "ready",
+		Since:   &now,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msStatus, err := ms.RemoteApplication(application.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	appStatus, err := application.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(msStatus, jc.DeepEquals, appStatus)
 }
 
 func (s *ModelStatusSuite) TestMachineStatus(c *gc.C) {


### PR DESCRIPTION
`juju status` is slow on models with many applications, units and relations.
`FullStatus` already loads a full `ModelStatus` snapshot once per call, but several status values were still fetched with one database query per entity, and remote (consumer-proxy) detection issued one `RemoteApplication` query per relation endpoint. On a model with ~107 applications/units and ~2500 relation rows this added several seconds to every `juju status`.

This change serves those remaining status values from the snapshot that `FullStatus` already loads, and detects remote applications from a preloaded map instead of per-endpoint queries.

Before this commit:
- application status: `application.Status()` — one DB query per application
- CAAS operator status: `application.OperatorStatus()` — one query per application
- relation status: `relation.Status()` — one query per relation
- saas/remote application status: `application(*RemoteApplication).Status()` — one query per remote application
- relation remote-end detection: `st.RemoteApplication(ep.ApplicationName)` — one query per relation endpoint

After this commit:
- application status: `context.status.Application(application.Name())` — snapshot lookup
- CAAS operator status: `context.status.ApplicationOperator(application.Name())` — snapshot lookup
- relation status: `context.status.Relation(relation.Id())` — snapshot lookup
- saas/remote application status: `context.status.RemoteApplication(application.Name())` — snapshot lookup
- relation remote-end detection: `context.remoteApplications[ep.ApplicationName]` — preloaded map lookup

Four accessors are added to `state.ModelStatus` (`Application`, `ApplicationOperator`, `Relation`, `RemoteApplication`).
They use the same global status keys as the matching `Status()` methods, so the returned values and the not-found handling are unchanged.
The URL filter that used to live in the remote-application fetch is moved to a `remoteApplicationsWithURL()` helper used only on the display path, so relation detection still sees consumer proxies that have no offer URL.

This extends the model-status snapshot approach introduced in #7766, which covered only machine and unit statuses.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~ — behaviour-preserving; covered by unit tests and the existing full-status tests
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~ — no package responsibilities changed

## QA steps

Correctness (output must be identical with and without the patch):

1. Bootstrap a controller and add a model.
2. Deploy a relation-heavy model: many applications with relations between them.
   Include at least one cross-model relation / SaaS offer consumed in the model so the remote-application and consumer-proxy code paths are exercised.
   On a Kubernetes model, also confirm CAAS operator status.
3. Compare `juju status` and `juju status --relations` before and after the patch.
    Application, relation and SaaS/offer statuses must all be populated identically.

Performance (synthetic model: 107 applications, 107 units, 1 machine; `juju status --relations` printed ~2500 relation rows; update-status interval 60m; 3.6.23 controller on an OpenStack cloud).
Times are wall-clock for repeated runs.

The synthetic model could carry many more relations than applications because it used local test charms with multiple named compatible endpoints.
The application and unit names in this model are synthetic and do not represent real workloads; they exist only to create a dense endpoint/relation topology.
Several hub applications were integrated with many leaf applications across those endpoint pairs, and Juju records each integration as a separate relation.
All units were co-located on one machine, so the test stressed the controller/status read path without needing hundreds of machines or real service workloads.

`juju status`

| metric  | before        | after         |
|---------|---------------|---------------|
| samples | 7             | 10            |
| mean    | 3.42 s        | 0.88 s        |
| median  | 3.52 s        | 0.88 s        |
| min–max | 2.77–3.91 s   | 0.77–0.99 s   |

mean 3.9x faster (74% lower); median 4.0x faster (75% lower).

`juju status --relations`

| metric  | before        | after         |
|---------|---------------|---------------|
| samples | 7             | 10            |
| mean    | 3.72 s        | 1.05 s        |
| median  | 3.75 s        | 1.06 s        |
| min–max | 3.46–3.95 s   | 1.00–1.13 s   |

mean and median ~3.5x faster (72% lower).

Read latency stayed low under concurrent `status-set` load (480 set calls, 20 concurrent): `juju status` ran ~1.0 s mean, 1.8 s max, confirming the read path stays fast under write contention.

## Documentation changes

None. `juju status` output, CLI flags and the client API are unchanged.

## Links

- ~Launchpad bug~ — none for this change
- ~Jira card~ — none for this change
