### PR TITLE
fix: upgrade-controller with --build-agent

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -1029,6 +1029,10 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		handler:         registerHandler,
 		unauthenticated: true,
 	}, {
+		pattern:    "/tools",
+		handler:    modelToolsUploadHandler,
+		authorizer: toolsUploadAuthorizer,
+	}, {
 		pattern:         "/tools/:version",
 		handler:         modelToolsDownloadHandler,
 		unauthenticated: true,

--- a/apiserver/tools_integration_test.go
+++ b/apiserver/tools_integration_test.go
@@ -132,6 +132,24 @@ func (s *toolsWithMacaroonsIntegrationSuite) TestCanPostWithDischargedMacaroon(c
 	c.Assert(checkCount, tc.Equals, 1)
 }
 
+func (s *toolsWithMacaroonsIntegrationSuite) TestCanPostToControllerToolsWithDischargedMacaroon(c *tc.C) {
+	s.MacaroonSuite.AddControllerUser(c, s.userName, permission.SuperuserAccess)
+	checkCount := 0
+	s.DischargerLogin = func() string {
+		checkCount++
+		return s.userName.Name()
+	}
+
+	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
+		Do:     s.doer(), //nolint:bodyclose // Closed below.
+		Method: "POST",
+		URL:    s.URL("/tools", nil).String(),
+	})
+	s.assertJSONErrorResponse(c, resp, http.StatusBadRequest, "expected binaryVersion argument")
+	defer resp.Body.Close()
+	c.Assert(checkCount, tc.Equals, 1)
+}
+
 func (s *toolsWithMacaroonsIntegrationSuite) TestCanPostWithLocalLogin(c *tc.C) {
 	// Create a new local user that we can log in as
 	// using macaroon authentication.


### PR DESCRIPTION
Under #22488 we moved the `modeupgrader` back to controller scope from being model-scoped, but did not have a route for posting the agent binary without a model path.

This adds the route.

## QA steps

Bootstrap, then run `juju upgrade-controller --build-agent`. This will succeed where we were getting a 404 prior.