### PR TITLE
feat: loki insecure skip verify

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -280,6 +280,12 @@ type Config interface {
 	// endpoint.
 	LokiCACert() string
 
+	// LokiInsecureSkipVerify returns whether TLS validation is disabled for
+	// the Loki endpoint. A nil value means the default (verify enabled) is
+	// in effect when connecting to the Loki endpoint, while true/false are
+	// explicit values.
+	LokiInsecureSkipVerify() *bool
+
 	// Value returns the value associated with the key, or an empty string if
 	// the key is not found.
 	Value(key string) string
@@ -377,9 +383,9 @@ type configSetterOnly interface {
 	// SetLoggingConfig sets the logging config value for the agent.
 	SetLoggingConfig(string)
 
-	// SetLokiConfig sets the Loki config values for the agent. The endpoint
-	// and CA certificate are updated together.
-	SetLokiConfig(endpoint, caCert string)
+	// SetLokiConfig sets the Loki config values for the agent. The endpoint,
+	// CA certificate and insecure skip verify flag are updated together.
+	SetLokiConfig(endpoint string, caCert *string, insecureSkipVerify *bool)
 
 	// SetQueryTracingEnabled sets whether query tracing is enabled.
 	SetQueryTracingEnabled(bool)
@@ -485,6 +491,7 @@ type configInternal struct {
 	loggingConfig                      string
 	lokiEndpoint                       string
 	lokiCACert                         string
+	lokiInsecureSkipVerify             *bool
 	values                             map[string]string
 	agentLogfileMaxSizeMB              int
 	agentLogfileMaxBackups             int
@@ -700,6 +707,7 @@ func (c0 *configInternal) Clone() Config {
 		info := *c0.controllerAgentInfo
 		c1.controllerAgentInfo = &info
 	}
+	c1.lokiInsecureSkipVerify = copyBoolPointer(c0.lokiInsecureSkipVerify)
 	return &c1
 }
 
@@ -757,10 +765,31 @@ func (c *configInternal) LokiCACert() string {
 	return c.lokiCACert
 }
 
+// LokiInsecureSkipVerify implements Config.
+func (c *configInternal) LokiInsecureSkipVerify() *bool {
+	return copyBoolPointer(c.lokiInsecureSkipVerify)
+}
+
 // SetLokiConfig implements configSetterOnly.
-func (c *configInternal) SetLokiConfig(endpoint, caCert string) {
+func (c *configInternal) SetLokiConfig(endpoint string, caCert *string, insecureSkipVerify *bool) {
 	c.lokiEndpoint = endpoint
-	c.lokiCACert = caCert
+	if caCert != nil {
+		c.lokiCACert = *caCert
+	} else {
+		c.lokiCACert = ""
+	}
+	c.lokiInsecureSkipVerify = copyBoolPointer(insecureSkipVerify)
+}
+
+// copyBoolPointer preserves the Config snapshot contract: callers must not be
+// able to mutate shared agent config state by holding or editing returned
+// pointers outside ChangeConfig.
+func copyBoolPointer(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
 }
 
 func (c *configInternal) SetOldPassword(oldPassword string) {

--- a/agent/format-2.0.go
+++ b/agent/format-2.0.go
@@ -46,11 +46,12 @@ type format_2_0Serialization struct {
 	APIAddresses []string `yaml:"apiaddresses,omitempty"`
 	APIPassword  string   `yaml:"apipassword,omitempty"`
 
-	OldPassword   string            `yaml:"oldpassword,omitempty"`
-	LoggingConfig string            `yaml:"loggingconfig,omitempty"`
-	LokiEndpoint  string            `yaml:"lokiendpoint,omitempty"`
-	LokiCACert    string            `yaml:"lokicacert,omitempty"`
-	Values        map[string]string `yaml:"values"`
+	OldPassword            string            `yaml:"oldpassword,omitempty"`
+	LoggingConfig          string            `yaml:"loggingconfig,omitempty"`
+	LokiEndpoint           string            `yaml:"lokiendpoint,omitempty"`
+	LokiCACert             string            `yaml:"lokicacert,omitempty"`
+	LokiInsecureSkipVerify *bool             `yaml:"lokiinsecureskipverify,omitempty"`
+	Values                 map[string]string `yaml:"values"`
 
 	AgentLogfileMaxSizeMB  int `yaml:"agent-logfile-max-size"`
 	AgentLogfileMaxBackups int `yaml:"agent-logfile-max-backups"`
@@ -110,18 +111,19 @@ func (formatter_2_0) unmarshal(data []byte) (*configInternal, error) {
 			LogDir:           format.LogDir,
 			MetricsSpoolDir:  format.MetricsSpoolDir,
 		}),
-		jobs:              format.Jobs,
-		upgradedToVersion: *format.UpgradedToVersion,
-		nonce:             format.Nonce,
-		controller:        controllerTag,
-		model:             modelTag,
-		caCert:            format.CACert,
-		statePassword:     format.StatePassword,
-		oldPassword:       format.OldPassword,
-		loggingConfig:     format.LoggingConfig,
-		lokiEndpoint:      format.LokiEndpoint,
-		lokiCACert:        format.LokiCACert,
-		values:            format.Values,
+		jobs:                   format.Jobs,
+		upgradedToVersion:      *format.UpgradedToVersion,
+		nonce:                  format.Nonce,
+		controller:             controllerTag,
+		model:                  modelTag,
+		caCert:                 format.CACert,
+		statePassword:          format.StatePassword,
+		oldPassword:            format.OldPassword,
+		loggingConfig:          format.LoggingConfig,
+		lokiEndpoint:           format.LokiEndpoint,
+		lokiCACert:             format.LokiCACert,
+		lokiInsecureSkipVerify: format.LokiInsecureSkipVerify,
+		values:                 format.Values,
 
 		agentLogfileMaxSizeMB:  format.AgentLogfileMaxSizeMB,
 		agentLogfileMaxBackups: format.AgentLogfileMaxBackups,
@@ -170,22 +172,23 @@ func (formatter_2_0) marshal(config *configInternal) ([]byte, error) {
 	controllerTag := config.controller.String()
 	modelTag := config.model.String()
 	format := &format_2_0Serialization{
-		Tag:               config.tag.String(),
-		DataDir:           config.paths.DataDir,
-		TransientDataDir:  config.paths.TransientDataDir,
-		LogDir:            config.paths.LogDir,
-		MetricsSpoolDir:   config.paths.MetricsSpoolDir,
-		Jobs:              config.jobs,
-		UpgradedToVersion: &config.upgradedToVersion,
-		Nonce:             config.nonce,
-		Controller:        controllerTag,
-		Model:             modelTag,
-		CACert:            config.caCert,
-		OldPassword:       config.oldPassword,
-		LoggingConfig:     config.loggingConfig,
-		LokiEndpoint:      config.lokiEndpoint,
-		LokiCACert:        config.lokiCACert,
-		Values:            config.values,
+		Tag:                    config.tag.String(),
+		DataDir:                config.paths.DataDir,
+		TransientDataDir:       config.paths.TransientDataDir,
+		LogDir:                 config.paths.LogDir,
+		MetricsSpoolDir:        config.paths.MetricsSpoolDir,
+		Jobs:                   config.jobs,
+		UpgradedToVersion:      &config.upgradedToVersion,
+		Nonce:                  config.nonce,
+		Controller:             controllerTag,
+		Model:                  modelTag,
+		CACert:                 config.caCert,
+		OldPassword:            config.oldPassword,
+		LoggingConfig:          config.loggingConfig,
+		LokiEndpoint:           config.lokiEndpoint,
+		LokiCACert:             config.lokiCACert,
+		LokiInsecureSkipVerify: config.lokiInsecureSkipVerify,
+		Values:                 config.values,
 
 		AgentLogfileMaxSizeMB:  config.agentLogfileMaxSizeMB,
 		AgentLogfileMaxBackups: config.agentLogfileMaxBackups,

--- a/agent/format-2.0_whitebox_test.go
+++ b/agent/format-2.0_whitebox_test.go
@@ -62,7 +62,7 @@ func (*format_2_0Suite) TestMarshalUnmarshal(c *tc.C) {
 	config.configFilePath = ""
 
 	config.SetLoggingConfig(loggingConfig)
-	config.SetLokiConfig(lokiEndpoint, lokiCACert)
+	config.SetLokiConfig(lokiEndpoint, &lokiCACert, nil)
 
 	data, err := format_2_0.marshal(config)
 	c.Assert(err, tc.ErrorIsNil)
@@ -73,6 +73,22 @@ func (*format_2_0Suite) TestMarshalUnmarshal(c *tc.C) {
 	c.Check(newConfig.LoggingConfig(), tc.Equals, loggingConfig)
 	c.Check(newConfig.LokiEndpoint(), tc.Equals, lokiEndpoint)
 	c.Check(newConfig.LokiCACert(), tc.Equals, lokiCACert)
+}
+
+func (*format_2_0Suite) TestCloneLokiInsecureSkipVerifyIsolation(c *tc.C) {
+	config := newTestConfig(c)
+	insecureSkipVerify := false
+	config.SetLokiConfig("https://loki.example.com/loki/api/v1/push", nil, &insecureSkipVerify)
+
+	cloned := config.Clone()
+	clonedValue := cloned.LokiInsecureSkipVerify()
+	c.Assert(clonedValue, tc.NotNil)
+
+	*clonedValue = true
+
+	originalValue := config.LokiInsecureSkipVerify()
+	c.Assert(originalValue, tc.NotNil)
+	c.Check(*originalValue, tc.IsFalse)
 }
 
 func (*format_2_0Suite) TestQueryTracing(c *tc.C) {

--- a/api/agent/logger/logger.go
+++ b/api/agent/logger/logger.go
@@ -29,8 +29,9 @@ type Client struct {
 
 // ControllerLokiConfig holds the controller-wide Loki push API configuration.
 type ControllerLokiConfig struct {
-	Endpoint string
-	CACert   string
+	Endpoint           string
+	CACert             string
+	InsecureSkipVerify *bool
 }
 
 // NewClient returns a version of the logger client that provides functionality
@@ -77,8 +78,9 @@ func (c *Client) GetControllerLokiConfig(ctx context.Context, agentTag names.Tag
 		caCert = *result.CACert
 	}
 	return ControllerLokiConfig{
-		Endpoint: result.Endpoint,
-		CACert:   caCert,
+		Endpoint:           result.Endpoint,
+		CACert:             caCert,
+		InsecureSkipVerify: result.InsecureSkipVerify,
 	}, nil
 }
 

--- a/apiserver/facades/agent-schema.json
+++ b/apiserver/facades/agent-schema.json
@@ -3174,6 +3174,9 @@
                         },
                         "error": {
                             "$ref": "#/definitions/Error"
+                        },
+                        "insecure-skip-verify": {
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false,

--- a/apiserver/facades/agent/logger/logger.go
+++ b/apiserver/facades/agent/logger/logger.go
@@ -183,7 +183,10 @@ func (api *LoggerAPIV2) GetControllerLokiConfig(ctx context.Context, arg params.
 		return params.LokiConfigResult{Error: apiservererrors.ServerError(err)}
 	}
 
-	result := params.LokiConfigResult{Endpoint: config.Endpoint}
+	result := params.LokiConfigResult{
+		Endpoint:           config.Endpoint,
+		InsecureSkipVerify: config.InsecureSkipVerify,
+	}
 	if config.CACertificate != "" {
 		result.CACert = &config.CACertificate
 	}

--- a/apiserver/facades/agent/logger/logger_test.go
+++ b/apiserver/facades/agent/logger/logger_test.go
@@ -224,9 +224,11 @@ func (s *loggerSuite) TestGetControllerLokiConfigForAgent(c *tc.C) {
 	defer ctrl.Finish()
 	s.setupAPIV2(c)
 
+	insecureFalse := false
 	s.controllerLokiConfigService.config = logging.LokiConfig{
-		Endpoint:      "https://loki.example.com/loki/api/v1/push",
-		CACertificate: "ca-cert",
+		Endpoint:           "https://loki.example.com/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: &insecureFalse,
 	}
 
 	args := params.Entity{Tag: defaultMachineTag.String()}
@@ -236,6 +238,42 @@ func (s *loggerSuite) TestGetControllerLokiConfigForAgent(c *tc.C) {
 	c.Assert(result.CACert, tc.NotNil)
 	c.Check(*result.CACert, tc.Equals, "ca-cert")
 	c.Check(s.controllerLokiConfigService.getCalls, tc.Equals, 1)
+}
+
+func (s *loggerSuite) TestGetControllerLokiConfigInsecureSkipVerify(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+	s.setupAPIV2(c)
+
+	insecureTrue := true
+	s.controllerLokiConfigService.config = logging.LokiConfig{
+		Endpoint:           "https://loki.example.com/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: &insecureTrue,
+	}
+
+	args := params.Entity{Tag: defaultMachineTag.String()}
+	result := s.loggerV2.GetControllerLokiConfig(c.Context(), args)
+	c.Assert(result.Error, tc.IsNil)
+	c.Check(result.InsecureSkipVerify, tc.NotNil)
+	c.Check(*result.InsecureSkipVerify, tc.Equals, true)
+}
+
+func (s *loggerSuite) TestGetControllerLokiConfigNilInsecureSkipVerify(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+	s.setupAPIV2(c)
+
+	s.controllerLokiConfigService.config = logging.LokiConfig{
+		Endpoint:           "https://loki.example.com/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: nil,
+	}
+
+	args := params.Entity{Tag: defaultMachineTag.String()}
+	result := s.loggerV2.GetControllerLokiConfig(c.Context(), args)
+	c.Assert(result.Error, tc.IsNil)
+	c.Check(result.InsecureSkipVerify, tc.IsNil)
 }
 
 func (s *loggerSuite) TestGetControllerLokiConfigReturnsNotFoundError(c *tc.C) {

--- a/cmd/containeragent/initialize/config.go
+++ b/cmd/containeragent/initialize/config.go
@@ -103,6 +103,10 @@ func (c *configFromEnv) LokiCACert() string {
 	panic("not implemented")
 }
 
+func (c *configFromEnv) LokiInsecureSkipVerify() *bool {
+	panic("not implemented")
+}
+
 func (c *configFromEnv) Value(key string) string {
 	panic("not implemented")
 }

--- a/domain/logging/config.go
+++ b/domain/logging/config.go
@@ -9,4 +9,10 @@ type LokiConfig struct {
 	Endpoint string
 	// CACertificate is the CA certificate used to validate the Loki endpoint.
 	CACertificate string
+	// InsecureSkipVerify controls whether a client verifies the
+	// server's certificate chain and host name. If InsecureSkipVerify
+	// is true, TLS accepts any certificate returned by the server and
+	// any host name in that certificate. This must be pointer so we
+	// can distinguish unset from bool values.
+	InsecureSkipVerify *bool
 }

--- a/domain/logging/service/service.go
+++ b/domain/logging/service/service.go
@@ -83,8 +83,9 @@ func NewWatchableService(st State, wf WatcherFactory) *WatchableService {
 	}
 }
 
-// SetLokiConfig sets the Loki push API endpoint and CA certificate. The
-// endpoint must be non-empty; an error is returned otherwise.
+// SetLokiConfig sets the Loki push API endpoint, CA certificate, and
+// insecure skip verify setting. The endpoint must be non-empty; an error is
+// returned otherwise.
 func (s *Service) SetLokiConfig(ctx context.Context, config logging.LokiConfig) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()

--- a/domain/logging/service/service_test.go
+++ b/domain/logging/service/service_test.go
@@ -54,19 +54,66 @@ func (s *serviceSuite) TestSetLokiConfigInvalidURLReturnsError(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
 }
 
-func (s *serviceSuite) TestSetLokiConfigStateError(c *tc.C) {
+func (s *serviceSuite) TestSetLokiConfigInsecureSkipVerifyTrue(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	boolVal := true
 	config := logging.LokiConfig{
-		Endpoint:      "http://loki:3100/loki/api/v1/push",
-		CACertificate: "ca-cert",
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: &boolVal,
 	}
-	s.st.EXPECT().SetLokiConfig(gomock.Any(), gomock.Any(), config).Return(
-		errors.Errorf("boom"),
-	)
+	s.st.EXPECT().SetLokiConfig(gomock.Any(), gomock.Any(), config).Return(nil)
 
 	err := NewWatchableService(s.st, s.watcherFactory).SetLokiConfig(c.Context(), config)
-	c.Assert(err, tc.ErrorMatches, "boom")
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestSetLokiConfigInsecureSkipVerifyFalse(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	boolVal := false
+	config := logging.LokiConfig{
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: &boolVal,
+	}
+	s.st.EXPECT().SetLokiConfig(gomock.Any(), gomock.Any(), config).Return(nil)
+
+	err := NewWatchableService(s.st, s.watcherFactory).SetLokiConfig(c.Context(), config)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestGetLokiConfigInsecureSkipVerifyTrue(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	boolVal := true
+	s.st.EXPECT().GetLokiConfig(gomock.Any()).Return(logging.LokiConfig{
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: &boolVal,
+	}, nil)
+
+	config, err := NewWatchableService(s.st, s.watcherFactory).GetLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(config.Endpoint, tc.Equals, "http://loki:3100/loki/api/v1/push")
+	c.Check(config.InsecureSkipVerify, tc.NotNil)
+	c.Check(*config.InsecureSkipVerify, tc.Equals, true)
+}
+
+func (s *serviceSuite) TestGetLokiConfigInsecureSkipVerifyNil(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.st.EXPECT().GetLokiConfig(gomock.Any()).Return(logging.LokiConfig{
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: nil,
+	}, nil)
+
+	config, err := NewWatchableService(s.st, s.watcherFactory).GetLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(config.Endpoint, tc.Equals, "http://loki:3100/loki/api/v1/push")
+	c.Check(config.InsecureSkipVerify, tc.IsNil)
 }
 
 func (s *serviceSuite) TestGetLokiConfig(c *tc.C) {

--- a/domain/logging/state/state.go
+++ b/domain/logging/state/state.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/canonical/sqlair"
 
@@ -131,36 +130,4 @@ func (st *State) DeleteLokiConfig(ctx context.Context) error {
 		return errors.Errorf("deleting loki endpoint: %w", err)
 	}
 	return nil
-}
-
-type lokiConfig struct {
-	UUID               string       `db:"uuid"`
-	Endpoint           string       `db:"endpoint"`
-	CACertificate      *string      `db:"ca_cert"`
-	InsecureSkipVerify sql.NullBool `db:"insecure_skip_verify"`
-}
-
-// nsBoolToNil converts a pointer to bool into a nullable sql.NullBool suitable
-// for database storage. A nil input maps to invalid NullBool.
-func nsBoolToNil(b *bool) sql.NullBool {
-	if b == nil {
-		return sql.NullBool{Valid: false}
-	}
-	return sql.NullBool{Valid: true, Bool: *b}
-}
-
-// nsBoolToPtr converts a nullable sql.NullBool into a pointer to bool.
-// An invalid NullBool maps to nil, while True/False map to boolean pointers.
-func nsBoolToPtr(nb sql.NullBool) *bool {
-	if !nb.Valid {
-		return nil
-	}
-	b := nb.Bool
-	return &b
-}
-
-// NamespaceForWatchLokiConfig returns the namespace identifier used for
-// watching Loki config changes.
-func (*State) NamespaceForWatchLokiConfig() string {
-	return "logging_loki_config"
 }

--- a/domain/logging/state/state.go
+++ b/domain/logging/state/state.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/canonical/sqlair"
 
@@ -27,8 +28,8 @@ func NewState(factory database.TxnRunnerFactory) *State {
 	}
 }
 
-// SetLokiConfig sets the Loki push API endpoint and CA certificate. Any
-// previously stored config is replaced.
+// SetLokiConfig sets the Loki push API endpoint, CA certificate, and
+// insecure skip verify setting. Any previously stored config is replaced.
 func (st *State) SetLokiConfig(ctx context.Context, id string, config logging.LokiConfig) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -41,16 +42,18 @@ func (st *State) SetLokiConfig(ctx context.Context, id string, config logging.Lo
 	}
 
 	insertStmt, err := st.Prepare(`
-	INSERT INTO logging_loki_config (uuid, endpoint, ca_cert)
-	VALUES ($lokiConfig.uuid, $lokiConfig.endpoint, $lokiConfig.ca_cert)`, lokiConfig{})
+INSERT INTO logging_loki_config (uuid, endpoint, ca_cert, insecure_skip_verify)
+VALUES ($lokiConfig.uuid, $lokiConfig.endpoint, $lokiConfig.ca_cert, $lokiConfig.insecure_skip_verify)`,
+		lokiConfig{})
 	if err != nil {
 		return errors.Errorf("preparing insert statement: %w", err)
 	}
 
 	dbConfig := lokiConfig{
-		UUID:          id,
-		Endpoint:      config.Endpoint,
-		CACertificate: config.CACertificate,
+		UUID:               id,
+		Endpoint:           config.Endpoint,
+		CACertificate:      &config.CACertificate,
+		InsecureSkipVerify: nsBoolToNil(config.InsecureSkipVerify),
 	}
 
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -67,9 +70,9 @@ func (st *State) SetLokiConfig(ctx context.Context, id string, config logging.Lo
 	return nil
 }
 
-// GetLokiConfig returns the configured Loki push API endpoint and CA
-// certificate. If no endpoint is configured, an error satisfying
-// [loggingerrors.LokiConfigNotFound] is returned.
+// GetLokiConfig returns the configured Loki push API endpoint, CA certificate,
+// and insecure skip verify setting. If no endpoint is configured, an error
+// satisfying [loggingerrors.LokiConfigNotFound] is returned.
 func (st *State) GetLokiConfig(ctx context.Context) (logging.LokiConfig, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -77,7 +80,7 @@ func (st *State) GetLokiConfig(ctx context.Context) (logging.LokiConfig, error) 
 	}
 
 	stmt, err := st.Prepare(`
-SELECT &lokiConfig.endpoint, &lokiConfig.ca_cert FROM logging_loki_config
+SELECT &lokiConfig.* FROM logging_loki_config
 `, lokiConfig{})
 	if err != nil {
 		return logging.LokiConfig{}, errors.Errorf("preparing select statement: %w", err)
@@ -94,9 +97,15 @@ SELECT &lokiConfig.endpoint, &lokiConfig.ca_cert FROM logging_loki_config
 	}); err != nil {
 		return logging.LokiConfig{}, errors.Errorf("getting loki config: %w", err)
 	}
+
+	var caCert string
+	if config.CACertificate != nil {
+		caCert = *config.CACertificate
+	}
 	return logging.LokiConfig{
-		Endpoint:      config.Endpoint,
-		CACertificate: config.CACertificate,
+		Endpoint:           config.Endpoint,
+		CACertificate:      caCert,
+		InsecureSkipVerify: nsBoolToPtr(config.InsecureSkipVerify),
 	}, nil
 }
 
@@ -125,9 +134,29 @@ func (st *State) DeleteLokiConfig(ctx context.Context) error {
 }
 
 type lokiConfig struct {
-	UUID          string `db:"uuid"`
-	Endpoint      string `db:"endpoint"`
-	CACertificate string `db:"ca_cert"`
+	UUID               string       `db:"uuid"`
+	Endpoint           string       `db:"endpoint"`
+	CACertificate      *string      `db:"ca_cert"`
+	InsecureSkipVerify sql.NullBool `db:"insecure_skip_verify"`
+}
+
+// nsBoolToNil converts a pointer to bool into a nullable sql.NullBool suitable
+// for database storage. A nil input maps to invalid NullBool.
+func nsBoolToNil(b *bool) sql.NullBool {
+	if b == nil {
+		return sql.NullBool{Valid: false}
+	}
+	return sql.NullBool{Valid: true, Bool: *b}
+}
+
+// nsBoolToPtr converts a nullable sql.NullBool into a pointer to bool.
+// An invalid NullBool maps to nil, while True/False map to boolean pointers.
+func nsBoolToPtr(nb sql.NullBool) *bool {
+	if !nb.Valid {
+		return nil
+	}
+	b := nb.Bool
+	return &b
 }
 
 // NamespaceForWatchLokiConfig returns the namespace identifier used for

--- a/domain/logging/state/state_test.go
+++ b/domain/logging/state/state_test.go
@@ -36,6 +36,93 @@ func (s *stateSuite) TestSetLokiConfig(c *tc.C) {
 	c.Check(config.CACertificate, tc.Equals, "ca-cert")
 }
 
+func (s *stateSuite) TestSetLokiConfigInsecureSkipVerifyTrue(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	boolVal := true
+	err := st.SetLokiConfig(c.Context(), "some-uuid-1", logging.LokiConfig{
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: &boolVal,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	config, err := st.GetLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(config.Endpoint, tc.Equals, "http://loki:3100/loki/api/v1/push")
+	c.Check(config.CACertificate, tc.Equals, "ca-cert")
+	c.Assert(config.InsecureSkipVerify, tc.NotNil)
+	c.Check(*config.InsecureSkipVerify, tc.Equals, true)
+}
+
+func (s *stateSuite) TestSetLokiConfigInsecureSkipVerifyFalse(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	boolVal := false
+	err := st.SetLokiConfig(c.Context(), "some-uuid-2", logging.LokiConfig{
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: &boolVal,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	config, err := st.GetLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(config.Endpoint, tc.Equals, "http://loki:3100/loki/api/v1/push")
+	c.Check(config.CACertificate, tc.Equals, "ca-cert")
+	c.Assert(config.InsecureSkipVerify, tc.NotNil)
+	c.Check(*config.InsecureSkipVerify, tc.Equals, false)
+}
+
+func (s *stateSuite) TestSetLokiConfigInsecureSkipVerifyNil(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	err := st.SetLokiConfig(c.Context(), "some-uuid-3", logging.LokiConfig{
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: nil,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	config, err := st.GetLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(config.Endpoint, tc.Equals, "http://loki:3100/loki/api/v1/push")
+	c.Check(config.CACertificate, tc.Equals, "ca-cert")
+	c.Assert(config.InsecureSkipVerify, tc.IsNil)
+}
+
+func (s *stateSuite) TestSetLokiConfigReplacesInsecureSkipVerify(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	boolTrue := true
+	err := st.SetLokiConfig(c.Context(), "some-uuid-1", logging.LokiConfig{
+		Endpoint:           "http://old-loki:3100/loki/api/v1/push",
+		CACertificate:      "old-ca",
+		InsecureSkipVerify: &boolTrue,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	boolFalse := false
+	err = st.SetLokiConfig(c.Context(), "some-uuid-2", logging.LokiConfig{
+		Endpoint:           "http://new-loki:3100/loki/api/v1/push",
+		CACertificate:      "new-ca",
+		InsecureSkipVerify: &boolFalse,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	config, err := st.GetLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(config.Endpoint, tc.Equals, "http://new-loki:3100/loki/api/v1/push")
+	c.Check(config.CACertificate, tc.Equals, "new-ca")
+	c.Check(*config.InsecureSkipVerify, tc.Equals, false)
+
+	err = st.DeleteLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = st.GetLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIs, loggingerrors.LokiConfigNotFound)
+}
+
 func (s *stateSuite) TestSetLokiConfigReplacesExisting(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory())
 

--- a/domain/logging/state/types.go
+++ b/domain/logging/state/types.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import "database/sql"
+
+type lokiConfig struct {
+	UUID               string       `db:"uuid"`
+	Endpoint           string       `db:"endpoint"`
+	CACertificate      *string      `db:"ca_cert"`
+	InsecureSkipVerify sql.NullBool `db:"insecure_skip_verify"`
+}
+
+// nsBoolToNil converts a pointer to bool into a nullable sql.NullBool suitable
+// for database storage. A nil input maps to invalid NullBool.
+func nsBoolToNil(b *bool) sql.NullBool {
+	if b == nil {
+		return sql.NullBool{Valid: false}
+	}
+	return sql.NullBool{Valid: true, Bool: *b}
+}
+
+// nsBoolToPtr converts a nullable sql.NullBool into a pointer to bool.
+// An invalid NullBool maps to nil, while True/False map to boolean pointers.
+func nsBoolToPtr(nb sql.NullBool) *bool {
+	if !nb.Valid {
+		return nil
+	}
+	b := nb.Bool
+	return &b
+}
+
+// NamespaceForWatchLokiConfig returns the namespace identifier used for
+// watching Loki config changes.
+func (*State) NamespaceForWatchLokiConfig() string {
+	return "logging_loki_config"
+}

--- a/domain/logging/watcher_test.go
+++ b/domain/logging/watcher_test.go
@@ -108,6 +108,69 @@ func (s *watcherSuite) TestWatchLokiConfigCACertificateUpdate(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
+func (s *watcherSuite) TestWatchLokiConfigInsecureSkipVerifyUpdate(c *tc.C) {
+	svc := s.setupService(c)
+
+	boolTrue := true
+	err := svc.SetLokiConfig(c.Context(), logging.LokiConfig{
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: &boolTrue,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	watcher, err := svc.WatchLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
+
+	// Updating only the InsecureSkipVerify should trigger a change.
+	harness.AddTest(c, func(c *tc.C) {
+		boolFalse := false
+		err := svc.SetLokiConfig(c.Context(), logging.LokiConfig{
+			Endpoint:           "http://loki:3100/loki/api/v1/push",
+			CACertificate:      "ca-cert",
+			InsecureSkipVerify: &boolFalse,
+		})
+		c.Assert(err, tc.ErrorIsNil)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	harness.Run(c, struct{}{})
+}
+
+func (s *watcherSuite) TestWatchLokiConfigInsecureSkipVerifyNilToTrue(c *tc.C) {
+	svc := s.setupService(c)
+
+	err := svc.SetLokiConfig(c.Context(), logging.LokiConfig{
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: nil,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	watcher, err := svc.WatchLokiConfig(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
+
+	// Changing from nil to true should trigger a change.
+	harness.AddTest(c, func(c *tc.C) {
+		boolTrue := true
+		err := svc.SetLokiConfig(c.Context(), logging.LokiConfig{
+			Endpoint:           "http://loki:3100/loki/api/v1/push",
+			CACertificate:      "ca-cert",
+			InsecureSkipVerify: &boolTrue,
+		})
+		c.Assert(err, tc.ErrorIsNil)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	harness.Run(c, struct{}{})
+}
+
 func (s *watcherSuite) TestWatchLokiConfigDelete(c *tc.C) {
 	svc := s.setupService(c)
 

--- a/domain/schema/controller/sql/0027-logging.sql
+++ b/domain/schema/controller/sql/0027-logging.sql
@@ -1,7 +1,8 @@
 CREATE TABLE logging_loki_config (
     uuid TEXT NOT NULL PRIMARY KEY,
     endpoint TEXT NOT NULL,
-    ca_cert TEXT NOT NULL DEFAULT ''
+    ca_cert TEXT NOT NULL DEFAULT '',
+    insecure_skip_verify BOOLEAN NULL
 );
 
 CREATE UNIQUE INDEX idx_singleton_logging_loki_config ON logging_loki_config ((1));

--- a/domain/schema/controller/triggers/logging-triggers.gen.go
+++ b/domain/schema/controller/triggers/logging-triggers.gen.go
@@ -31,7 +31,8 @@ AFTER UPDATE ON logging_loki_config FOR EACH ROW
 WHEN 
 	NEW.uuid != OLD.uuid OR
 	NEW.endpoint != OLD.endpoint OR
-	NEW.ca_cert != OLD.ca_cert
+	NEW.ca_cert != OLD.ca_cert OR
+	(NEW.insecure_skip_verify != OLD.insecure_skip_verify OR (NEW.insecure_skip_verify IS NOT NULL AND OLD.insecure_skip_verify IS NULL) OR (NEW.insecure_skip_verify IS NULL AND OLD.insecure_skip_verify IS NOT NULL))
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));

--- a/internal/upgrade/agent_mock_test.go
+++ b/internal/upgrade/agent_mock_test.go
@@ -110,6 +110,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -429,6 +430,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {

--- a/internal/upgradesteps/agent_mock_test.go
+++ b/internal/upgradesteps/agent_mock_test.go
@@ -111,6 +111,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -430,6 +431,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {
@@ -782,6 +801,7 @@ type MockConfigSetterMockRecorder struct {
 	loggingConfigExpects                         []*gomock.Call0_1[string]
 	lokiCACertExpects                            []*gomock.Call0_1[string]
 	lokiEndpointExpects                          []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects                []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                       []*gomock.Call0_1[string]
 	modelExpects                                 []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                                 []*gomock.Call0_1[string]
@@ -799,7 +819,7 @@ type MockConfigSetterMockRecorder struct {
 	setControllerAgentInfoExpects                []*gomock.Call1_0[controller.ControllerAgentInfo]
 	setDqliteBusyTimeoutExpects                  []*gomock.Call1_0[time.Duration]
 	setLoggingConfigExpects                      []*gomock.Call1_0[string]
-	setLokiConfigExpects                         []*gomock.Call2_0[string, string]
+	setLokiConfigExpects                         []*gomock.Call3_0[string, *string, *bool]
 	setOldPasswordExpects                        []*gomock.Call1_0[string]
 	setOpenTelemetryEnabledExpects               []*gomock.Call1_0[bool]
 	setOpenTelemetryEndpointExpects              []*gomock.Call1_0[string]
@@ -1138,6 +1158,24 @@ func (mr *MockConfigSetterMockRecorder) LokiEndpoint() *MockConfigSetterLokiEndp
 // MockConfigSetterLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigSetterLokiEndpointCall = gomock.Call0_1[string]
 
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfigSetter) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigSetterMockRecorder) LokiInsecureSkipVerify() *MockConfigSetterLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigSetterLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigSetterLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
+
 // MetricsSpoolDir mocks base method.
 func (m *MockConfigSetter) MetricsSpoolDir() string {
 	m.ctrl.T.Helper()
@@ -1445,22 +1483,22 @@ func (mr *MockConfigSetterMockRecorder) SetLoggingConfig(arg0 any) *MockConfigSe
 type MockConfigSetterSetLoggingConfigCall = gomock.Call1_0[string]
 
 // SetLokiConfig mocks base method.
-func (m *MockConfigSetter) SetLokiConfig(endpoint, caCert string) {
+func (m *MockConfigSetter) SetLokiConfig(endpoint string, caCert *string, insecureSkipVerify *bool) {
 	m.ctrl.T.Helper()
-	gomock.Dispatch2_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert)
+	gomock.Dispatch3_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert, insecureSkipVerify)
 }
 
 // SetLokiConfig indicates an expected call of SetLokiConfig.
-func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert any) *MockConfigSetterSetLokiConfigCall {
+func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert, insecureSkipVerify any) *MockConfigSetterSetLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_0[string, string](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert))
+	call := gomock.NewCall3_0[string, *string, *bool](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert), gomock.EnsureMatcher(insecureSkipVerify))
 	mr.setLokiConfigExpects = append(mr.setLokiConfigExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockConfigSetterSetLokiConfigCall is the typed call wrapper for SetLokiConfig.
-type MockConfigSetterSetLokiConfigCall = gomock.Call2_0[string, string]
+type MockConfigSetterSetLokiConfigCall = gomock.Call3_0[string, *string, *bool]
 
 // SetOldPassword mocks base method.
 func (m *MockConfigSetter) SetOldPassword(oldPassword string) {

--- a/internal/worker/auditconfigupdater/agent_mock_test.go
+++ b/internal/worker/auditconfigupdater/agent_mock_test.go
@@ -110,6 +110,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -429,6 +430,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {

--- a/internal/worker/bootstrap/agent_mock_test.go
+++ b/internal/worker/bootstrap/agent_mock_test.go
@@ -110,6 +110,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -429,6 +430,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {

--- a/internal/worker/containerbroker/mocks/agent_mock.go
+++ b/internal/worker/containerbroker/mocks/agent_mock.go
@@ -110,6 +110,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -429,6 +430,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {

--- a/internal/worker/controlsocket/worker.go
+++ b/internal/worker/controlsocket/worker.go
@@ -615,8 +615,9 @@ func (w *Worker) handleRemoveS3Credentials(resp http.ResponseWriter, req *http.R
 }
 
 type lokiEndpointRequest struct {
-	URL           string `json:"url"`
-	CACertificate string `json:"ca_cert"`
+	URL                string `json:"url"`
+	CACertificate      string `json:"ca_cert"`
+	InsecureSkipVerify *bool  `json:"insecure_skip_verify"`
 }
 
 func (w *Worker) handleSetLokiEndpoint(resp http.ResponseWriter, req *http.Request) {
@@ -640,8 +641,9 @@ func (w *Worker) handleSetLokiEndpoint(resp http.ResponseWriter, req *http.Reque
 	}
 
 	if err := w.loggingService.SetLokiConfig(ctx, logging.LokiConfig{
-		Endpoint:      parsedBody.URL,
-		CACertificate: parsedBody.CACertificate,
+		Endpoint:           parsedBody.URL,
+		CACertificate:      parsedBody.CACertificate,
+		InsecureSkipVerify: parsedBody.InsecureSkipVerify,
 	}); internalerrors.Is(err, coreerrors.NotValid) {
 		w.writeErrorResponse(ctx, resp, http.StatusBadRequest, internalerrors.Errorf("invalid loki endpoint: %w", err))
 		return

--- a/internal/worker/controlsocket/worker_test.go
+++ b/internal/worker/controlsocket/worker_test.go
@@ -1172,8 +1172,9 @@ func (s *workerSuite) TestSetLokiEndpoint(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.loggingService.EXPECT().SetLokiConfig(gomock.Any(), logging.LokiConfig{
-		Endpoint:      "http://loki:3100/loki/api/v1/push",
-		CACertificate: "ca-cert",
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: nil,
 	}).Return(nil)
 
 	socket := s.newSocket(c)
@@ -1185,6 +1186,52 @@ func (s *workerSuite) TestSetLokiEndpoint(c *tc.C) {
 		method:     http.MethodPost,
 		endpoint:   "/loki-endpoint",
 		body:       `{"url":"http://loki:3100/loki/api/v1/push","ca_cert":"ca-cert"}`,
+		statusCode: http.StatusOK,
+		response:   ".*updated loki endpoint.*",
+	})
+}
+
+func (s *workerSuite) TestSetLokiEndpointInsecureSkipVerify(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	insecureSkipVerify := true
+	s.loggingService.EXPECT().SetLokiConfig(gomock.Any(), logging.LokiConfig{
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		CACertificate:      "ca-cert",
+		InsecureSkipVerify: &insecureSkipVerify,
+	}).Return(nil)
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/loki-endpoint",
+		body:       `{"url":"http://loki:3100/loki/api/v1/push","ca_cert":"ca-cert","insecure_skip_verify":true}`,
+		statusCode: http.StatusOK,
+		response:   ".*updated loki endpoint.*",
+	})
+}
+
+func (s *workerSuite) TestSetLokiEndpointOmitsInsecureSkipVerify(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.loggingService.EXPECT().SetLokiConfig(gomock.Any(), logging.LokiConfig{
+		Endpoint:           "http://loki:3100/loki/api/v1/push",
+		InsecureSkipVerify: nil,
+	}).Return(nil)
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/loki-endpoint",
+		body:       `{"url":"http://loki:3100/loki/api/v1/push"}`,
 		statusCode: http.StatusOK,
 		response:   ".*updated loki endpoint.*",
 	})

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -133,7 +133,11 @@ func NewBackend(
 
 		case BackendTypeLoki:
 			if updater, ok := httpClient.(corehttp.CACertUpdater); ok {
-				if err := updater.ReplaceCACert(snapshot.CACertificate, false); err != nil {
+				insecureSkipVerify := false
+				if snapshot.InsecureSkipVerify != nil {
+					insecureSkipVerify = *snapshot.InsecureSkipVerify
+				}
+				if err := updater.ReplaceCACert(snapshot.CACertificate, insecureSkipVerify); err != nil {
 					return nil, internalerrors.Capture(err)
 				}
 			}

--- a/internal/worker/logrouter/worker.go
+++ b/internal/worker/logrouter/worker.go
@@ -81,18 +81,29 @@ type WorkerConfig struct {
 
 // ConfigSnapshot is the local logging destination configuration.
 type ConfigSnapshot struct {
-	Mode           BackendType
-	Endpoint       string
-	CACertificate  string
-	ControllerUUID string
-	ModelUUID      string
-	AgentID        string
+	Mode               BackendType
+	Endpoint           string
+	CACertificate      string
+	InsecureSkipVerify *bool
+	ControllerUUID     string
+	ModelUUID          string
+	AgentID            string
 }
 
 func (s ConfigSnapshot) sameBackend(other ConfigSnapshot) bool {
 	if s.Mode == BackendTypeDrain && other.Mode == BackendTypeDrain {
 		return true
 	}
+	if s.InsecureSkipVerify != nil && other.InsecureSkipVerify != nil {
+		if *(s.InsecureSkipVerify) != *(other.InsecureSkipVerify) {
+			return false
+		}
+	} else if s.InsecureSkipVerify == nil || other.InsecureSkipVerify == nil {
+		if s.InsecureSkipVerify != other.InsecureSkipVerify {
+			return false
+		}
+	}
+
 	return s.Mode == other.Mode &&
 		s.Endpoint == other.Endpoint &&
 		s.CACertificate == other.CACertificate
@@ -295,11 +306,12 @@ func (w *logRouter) nextBackendID() string {
 func (w *logRouter) currentSnapshot() ConfigSnapshot {
 	cfg := w.config.Agent.CurrentConfig()
 	snapshot := ConfigSnapshot{
-		Endpoint:       cfg.LokiEndpoint(),
-		CACertificate:  cfg.LokiCACert(),
-		ControllerUUID: cfg.Controller().Id(),
-		ModelUUID:      cfg.Model().Id(),
-		AgentID:        cfg.Tag().String(),
+		Endpoint:           cfg.LokiEndpoint(),
+		CACertificate:      cfg.LokiCACert(),
+		InsecureSkipVerify: cfg.LokiInsecureSkipVerify(),
+		ControllerUUID:     cfg.Controller().Id(),
+		ModelUUID:          cfg.Model().Id(),
+		AgentID:            cfg.Tag().String(),
 	}
 	switch {
 	case w.config.DrainOnly:

--- a/internal/worker/logrouter/worker_test.go
+++ b/internal/worker/logrouter/worker_test.go
@@ -307,7 +307,8 @@ func newFixture(c *tc.C, lokiEndpoint string) fixture {
 		Model:             names.NewModelTag("abcdef01-2345-6789-abcd-ef0123456789"),
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	cfg.SetLokiConfig(lokiEndpoint, "")
+	emptyCACert := ""
+	cfg.SetLokiConfig(lokiEndpoint, &emptyCACert, nil)
 	return fixture{
 		agent: &testAgent{
 			cfg: cfg,
@@ -337,7 +338,7 @@ func (a *testAgent) ChangeConfig(change agent.ConfigMutator) error {
 func (a *testAgent) setLokiConfig(endpoint, caCert string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.cfg.SetLokiConfig(endpoint, caCert)
+	a.cfg.SetLokiConfig(endpoint, &caCert, nil)
 }
 
 type backendEvent struct {

--- a/internal/worker/lokiendpointupdater/worker.go
+++ b/internal/worker/lokiendpointupdater/worker.go
@@ -107,12 +107,17 @@ func (w *lokiEndpointUpdater) update(ctx context.Context) error {
 
 	currentConfig := w.config.Agent.CurrentConfig()
 	if currentConfig.LokiEndpoint() == lokiConfig.Endpoint &&
-		currentConfig.LokiCACert() == lokiConfig.CACert {
+		currentConfig.LokiCACert() == lokiConfig.CACert &&
+		configInsecureEquals(currentConfig.LokiInsecureSkipVerify(), lokiConfig.InsecureSkipVerify) {
 		return nil
 	}
 
+	var caCert *string
+	if lokiConfig.CACert != "" {
+		caCert = &lokiConfig.CACert
+	}
 	err = w.config.Agent.ChangeConfig(func(setter agent.ConfigSetter) error {
-		setter.SetLokiConfig(lokiConfig.Endpoint, lokiConfig.CACert)
+		setter.SetLokiConfig(lokiConfig.Endpoint, caCert, lokiConfig.InsecureSkipVerify)
 		return nil
 	})
 	if err != nil {
@@ -120,4 +125,14 @@ func (w *lokiEndpointUpdater) update(ctx context.Context) error {
 	}
 	w.config.AgentConfigChanged.Set(true)
 	return nil
+}
+
+func configInsecureEquals(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }

--- a/internal/worker/lokiendpointupdater/worker_test.go
+++ b/internal/worker/lokiendpointupdater/worker_test.go
@@ -90,7 +90,7 @@ func (s *workerSuite) TestSetUpPersistsInitialConfigAndStartsWatcher(c *tc.C) {
 }
 
 func (s *workerSuite) TestSetUpDoesNotWriteUnchangedConfig(c *tc.C) {
-	s.agent.config.SetLokiConfig(s.api.config.Endpoint, s.api.config.CACert)
+	s.agent.config.SetLokiConfig(s.api.config.Endpoint, &s.api.config.CACert, s.api.config.InsecureSkipVerify)
 	changeCh := watchConfigChanged(s.configChanged)
 	worker := s.newUpdater(c)
 
@@ -102,7 +102,8 @@ func (s *workerSuite) TestSetUpDoesNotWriteUnchangedConfig(c *tc.C) {
 }
 
 func (s *workerSuite) TestHandlePersistsChangedConfig(c *tc.C) {
-	s.agent.config.SetLokiConfig("https://old-loki.example.com/loki/api/v1/push", "old-ca")
+	oldCACert := "old-ca"
+	s.agent.config.SetLokiConfig("https://old-loki.example.com/loki/api/v1/push", &oldCACert, nil)
 	changeCh := watchConfigChanged(s.configChanged)
 	worker := s.newUpdater(c)
 
@@ -116,7 +117,8 @@ func (s *workerSuite) TestHandlePersistsChangedConfig(c *tc.C) {
 }
 
 func (s *workerSuite) TestHandlePersistsEmptyConfigForLogSinkMode(c *tc.C) {
-	s.agent.config.SetLokiConfig("https://old-loki.example.com/loki/api/v1/push", "old-ca")
+	oldCACert := "old-ca"
+	s.agent.config.SetLokiConfig("https://old-loki.example.com/loki/api/v1/push", &oldCACert, nil)
 	s.api.config = logger.ControllerLokiConfig{}
 	changeCh := watchConfigChanged(s.configChanged)
 	worker := s.newUpdater(c)
@@ -131,7 +133,8 @@ func (s *workerSuite) TestHandlePersistsEmptyConfigForLogSinkMode(c *tc.C) {
 }
 
 func (s *workerSuite) TestHandlePersistsEmptyConfigForLokiConfigNotFound(c *tc.C) {
-	s.agent.config.SetLokiConfig("https://old-loki.example.com/loki/api/v1/push", "old-ca")
+	oldCACert := "old-ca"
+	s.agent.config.SetLokiConfig("https://old-loki.example.com/loki/api/v1/push", &oldCACert, nil)
 	s.api.getErr = &params.Error{
 		Code:    params.CodeNotFound,
 		Message: "loki config not found",

--- a/internal/worker/machineconverter/agent_mock_test.go
+++ b/internal/worker/machineconverter/agent_mock_test.go
@@ -111,6 +111,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -430,6 +431,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {
@@ -782,6 +801,7 @@ type MockConfigSetterMockRecorder struct {
 	loggingConfigExpects                         []*gomock.Call0_1[string]
 	lokiCACertExpects                            []*gomock.Call0_1[string]
 	lokiEndpointExpects                          []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects                []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                       []*gomock.Call0_1[string]
 	modelExpects                                 []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                                 []*gomock.Call0_1[string]
@@ -799,7 +819,7 @@ type MockConfigSetterMockRecorder struct {
 	setControllerAgentInfoExpects                []*gomock.Call1_0[controller.ControllerAgentInfo]
 	setDqliteBusyTimeoutExpects                  []*gomock.Call1_0[time.Duration]
 	setLoggingConfigExpects                      []*gomock.Call1_0[string]
-	setLokiConfigExpects                         []*gomock.Call2_0[string, string]
+	setLokiConfigExpects                         []*gomock.Call3_0[string, *string, *bool]
 	setOldPasswordExpects                        []*gomock.Call1_0[string]
 	setOpenTelemetryEnabledExpects               []*gomock.Call1_0[bool]
 	setOpenTelemetryEndpointExpects              []*gomock.Call1_0[string]
@@ -1138,6 +1158,24 @@ func (mr *MockConfigSetterMockRecorder) LokiEndpoint() *MockConfigSetterLokiEndp
 // MockConfigSetterLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigSetterLokiEndpointCall = gomock.Call0_1[string]
 
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfigSetter) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigSetterMockRecorder) LokiInsecureSkipVerify() *MockConfigSetterLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigSetterLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigSetterLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
+
 // MetricsSpoolDir mocks base method.
 func (m *MockConfigSetter) MetricsSpoolDir() string {
 	m.ctrl.T.Helper()
@@ -1445,22 +1483,22 @@ func (mr *MockConfigSetterMockRecorder) SetLoggingConfig(arg0 any) *MockConfigSe
 type MockConfigSetterSetLoggingConfigCall = gomock.Call1_0[string]
 
 // SetLokiConfig mocks base method.
-func (m *MockConfigSetter) SetLokiConfig(endpoint, caCert string) {
+func (m *MockConfigSetter) SetLokiConfig(endpoint string, caCert *string, insecureSkipVerify *bool) {
 	m.ctrl.T.Helper()
-	gomock.Dispatch2_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert)
+	gomock.Dispatch3_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert, insecureSkipVerify)
 }
 
 // SetLokiConfig indicates an expected call of SetLokiConfig.
-func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert any) *MockConfigSetterSetLokiConfigCall {
+func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert, insecureSkipVerify any) *MockConfigSetterSetLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_0[string, string](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert))
+	call := gomock.NewCall3_0[string, *string, *bool](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert), gomock.EnsureMatcher(insecureSkipVerify))
 	mr.setLokiConfigExpects = append(mr.setLokiConfigExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockConfigSetterSetLokiConfigCall is the typed call wrapper for SetLokiConfig.
-type MockConfigSetterSetLokiConfigCall = gomock.Call2_0[string, string]
+type MockConfigSetterSetLokiConfigCall = gomock.Call3_0[string, *string, *bool]
 
 // SetOldPassword mocks base method.
 func (m *MockConfigSetter) SetOldPassword(oldPassword string) {

--- a/internal/worker/objectstore/agent_mock_test.go
+++ b/internal/worker/objectstore/agent_mock_test.go
@@ -110,6 +110,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -429,6 +430,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {

--- a/internal/worker/objectstoredrainer/agent_mock_test.go
+++ b/internal/worker/objectstoredrainer/agent_mock_test.go
@@ -111,6 +111,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -430,6 +431,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {
@@ -782,6 +801,7 @@ type MockConfigSetterMockRecorder struct {
 	loggingConfigExpects                         []*gomock.Call0_1[string]
 	lokiCACertExpects                            []*gomock.Call0_1[string]
 	lokiEndpointExpects                          []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects                []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                       []*gomock.Call0_1[string]
 	modelExpects                                 []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                                 []*gomock.Call0_1[string]
@@ -799,7 +819,7 @@ type MockConfigSetterMockRecorder struct {
 	setControllerAgentInfoExpects                []*gomock.Call1_0[controller.ControllerAgentInfo]
 	setDqliteBusyTimeoutExpects                  []*gomock.Call1_0[time.Duration]
 	setLoggingConfigExpects                      []*gomock.Call1_0[string]
-	setLokiConfigExpects                         []*gomock.Call2_0[string, string]
+	setLokiConfigExpects                         []*gomock.Call3_0[string, *string, *bool]
 	setOldPasswordExpects                        []*gomock.Call1_0[string]
 	setOpenTelemetryEnabledExpects               []*gomock.Call1_0[bool]
 	setOpenTelemetryEndpointExpects              []*gomock.Call1_0[string]
@@ -1138,6 +1158,24 @@ func (mr *MockConfigSetterMockRecorder) LokiEndpoint() *MockConfigSetterLokiEndp
 // MockConfigSetterLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigSetterLokiEndpointCall = gomock.Call0_1[string]
 
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfigSetter) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigSetterMockRecorder) LokiInsecureSkipVerify() *MockConfigSetterLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigSetterLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigSetterLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
+
 // MetricsSpoolDir mocks base method.
 func (m *MockConfigSetter) MetricsSpoolDir() string {
 	m.ctrl.T.Helper()
@@ -1445,22 +1483,22 @@ func (mr *MockConfigSetterMockRecorder) SetLoggingConfig(arg0 any) *MockConfigSe
 type MockConfigSetterSetLoggingConfigCall = gomock.Call1_0[string]
 
 // SetLokiConfig mocks base method.
-func (m *MockConfigSetter) SetLokiConfig(endpoint, caCert string) {
+func (m *MockConfigSetter) SetLokiConfig(endpoint string, caCert *string, insecureSkipVerify *bool) {
 	m.ctrl.T.Helper()
-	gomock.Dispatch2_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert)
+	gomock.Dispatch3_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert, insecureSkipVerify)
 }
 
 // SetLokiConfig indicates an expected call of SetLokiConfig.
-func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert any) *MockConfigSetterSetLokiConfigCall {
+func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert, insecureSkipVerify any) *MockConfigSetterSetLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_0[string, string](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert))
+	call := gomock.NewCall3_0[string, *string, *bool](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert), gomock.EnsureMatcher(insecureSkipVerify))
 	mr.setLokiConfigExpects = append(mr.setLokiConfigExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockConfigSetterSetLokiConfigCall is the typed call wrapper for SetLokiConfig.
-type MockConfigSetterSetLokiConfigCall = gomock.Call2_0[string, string]
+type MockConfigSetterSetLokiConfigCall = gomock.Call3_0[string, *string, *bool]
 
 // SetOldPassword mocks base method.
 func (m *MockConfigSetter) SetOldPassword(oldPassword string) {

--- a/internal/worker/singular/agent_mock_test.go
+++ b/internal/worker/singular/agent_mock_test.go
@@ -110,6 +110,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -429,6 +430,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {

--- a/internal/worker/trace/agent_mock_test.go
+++ b/internal/worker/trace/agent_mock_test.go
@@ -110,6 +110,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -429,6 +430,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {

--- a/internal/worker/upgradedatabase/agent_mock_test.go
+++ b/internal/worker/upgradedatabase/agent_mock_test.go
@@ -111,6 +111,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -430,6 +431,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {
@@ -782,6 +801,7 @@ type MockConfigSetterMockRecorder struct {
 	loggingConfigExpects                         []*gomock.Call0_1[string]
 	lokiCACertExpects                            []*gomock.Call0_1[string]
 	lokiEndpointExpects                          []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects                []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                       []*gomock.Call0_1[string]
 	modelExpects                                 []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                                 []*gomock.Call0_1[string]
@@ -799,7 +819,7 @@ type MockConfigSetterMockRecorder struct {
 	setControllerAgentInfoExpects                []*gomock.Call1_0[controller.ControllerAgentInfo]
 	setDqliteBusyTimeoutExpects                  []*gomock.Call1_0[time.Duration]
 	setLoggingConfigExpects                      []*gomock.Call1_0[string]
-	setLokiConfigExpects                         []*gomock.Call2_0[string, string]
+	setLokiConfigExpects                         []*gomock.Call3_0[string, *string, *bool]
 	setOldPasswordExpects                        []*gomock.Call1_0[string]
 	setOpenTelemetryEnabledExpects               []*gomock.Call1_0[bool]
 	setOpenTelemetryEndpointExpects              []*gomock.Call1_0[string]
@@ -1138,6 +1158,24 @@ func (mr *MockConfigSetterMockRecorder) LokiEndpoint() *MockConfigSetterLokiEndp
 // MockConfigSetterLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigSetterLokiEndpointCall = gomock.Call0_1[string]
 
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfigSetter) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigSetterMockRecorder) LokiInsecureSkipVerify() *MockConfigSetterLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigSetterLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigSetterLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
+
 // MetricsSpoolDir mocks base method.
 func (m *MockConfigSetter) MetricsSpoolDir() string {
 	m.ctrl.T.Helper()
@@ -1445,22 +1483,22 @@ func (mr *MockConfigSetterMockRecorder) SetLoggingConfig(arg0 any) *MockConfigSe
 type MockConfigSetterSetLoggingConfigCall = gomock.Call1_0[string]
 
 // SetLokiConfig mocks base method.
-func (m *MockConfigSetter) SetLokiConfig(endpoint, caCert string) {
+func (m *MockConfigSetter) SetLokiConfig(endpoint string, caCert *string, insecureSkipVerify *bool) {
 	m.ctrl.T.Helper()
-	gomock.Dispatch2_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert)
+	gomock.Dispatch3_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert, insecureSkipVerify)
 }
 
 // SetLokiConfig indicates an expected call of SetLokiConfig.
-func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert any) *MockConfigSetterSetLokiConfigCall {
+func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert, insecureSkipVerify any) *MockConfigSetterSetLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_0[string, string](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert))
+	call := gomock.NewCall3_0[string, *string, *bool](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert), gomock.EnsureMatcher(insecureSkipVerify))
 	mr.setLokiConfigExpects = append(mr.setLokiConfigExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockConfigSetterSetLokiConfigCall is the typed call wrapper for SetLokiConfig.
-type MockConfigSetterSetLokiConfigCall = gomock.Call2_0[string, string]
+type MockConfigSetterSetLokiConfigCall = gomock.Call3_0[string, *string, *bool]
 
 // SetOldPassword mocks base method.
 func (m *MockConfigSetter) SetOldPassword(oldPassword string) {

--- a/internal/worker/upgradestepsagent/agent_mock_test.go
+++ b/internal/worker/upgradestepsagent/agent_mock_test.go
@@ -111,6 +111,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -430,6 +431,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {
@@ -782,6 +801,7 @@ type MockConfigSetterMockRecorder struct {
 	loggingConfigExpects                         []*gomock.Call0_1[string]
 	lokiCACertExpects                            []*gomock.Call0_1[string]
 	lokiEndpointExpects                          []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects                []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                       []*gomock.Call0_1[string]
 	modelExpects                                 []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                                 []*gomock.Call0_1[string]
@@ -799,7 +819,7 @@ type MockConfigSetterMockRecorder struct {
 	setControllerAgentInfoExpects                []*gomock.Call1_0[controller.ControllerAgentInfo]
 	setDqliteBusyTimeoutExpects                  []*gomock.Call1_0[time.Duration]
 	setLoggingConfigExpects                      []*gomock.Call1_0[string]
-	setLokiConfigExpects                         []*gomock.Call2_0[string, string]
+	setLokiConfigExpects                         []*gomock.Call3_0[string, *string, *bool]
 	setOldPasswordExpects                        []*gomock.Call1_0[string]
 	setOpenTelemetryEnabledExpects               []*gomock.Call1_0[bool]
 	setOpenTelemetryEndpointExpects              []*gomock.Call1_0[string]
@@ -1138,6 +1158,24 @@ func (mr *MockConfigSetterMockRecorder) LokiEndpoint() *MockConfigSetterLokiEndp
 // MockConfigSetterLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigSetterLokiEndpointCall = gomock.Call0_1[string]
 
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfigSetter) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigSetterMockRecorder) LokiInsecureSkipVerify() *MockConfigSetterLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigSetterLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigSetterLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
+
 // MetricsSpoolDir mocks base method.
 func (m *MockConfigSetter) MetricsSpoolDir() string {
 	m.ctrl.T.Helper()
@@ -1445,22 +1483,22 @@ func (mr *MockConfigSetterMockRecorder) SetLoggingConfig(arg0 any) *MockConfigSe
 type MockConfigSetterSetLoggingConfigCall = gomock.Call1_0[string]
 
 // SetLokiConfig mocks base method.
-func (m *MockConfigSetter) SetLokiConfig(endpoint, caCert string) {
+func (m *MockConfigSetter) SetLokiConfig(endpoint string, caCert *string, insecureSkipVerify *bool) {
 	m.ctrl.T.Helper()
-	gomock.Dispatch2_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert)
+	gomock.Dispatch3_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert, insecureSkipVerify)
 }
 
 // SetLokiConfig indicates an expected call of SetLokiConfig.
-func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert any) *MockConfigSetterSetLokiConfigCall {
+func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert, insecureSkipVerify any) *MockConfigSetterSetLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_0[string, string](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert))
+	call := gomock.NewCall3_0[string, *string, *bool](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert), gomock.EnsureMatcher(insecureSkipVerify))
 	mr.setLokiConfigExpects = append(mr.setLokiConfigExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockConfigSetterSetLokiConfigCall is the typed call wrapper for SetLokiConfig.
-type MockConfigSetterSetLokiConfigCall = gomock.Call2_0[string, string]
+type MockConfigSetterSetLokiConfigCall = gomock.Call3_0[string, *string, *bool]
 
 // SetOldPassword mocks base method.
 func (m *MockConfigSetter) SetOldPassword(oldPassword string) {

--- a/internal/worker/upgradestepscontroller/agent_mock_test.go
+++ b/internal/worker/upgradestepscontroller/agent_mock_test.go
@@ -111,6 +111,7 @@ type MockConfigMockRecorder struct {
 	loggingConfigExpects                      []*gomock.Call0_1[string]
 	lokiCACertExpects                         []*gomock.Call0_1[string]
 	lokiEndpointExpects                       []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects             []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                    []*gomock.Call0_1[string]
 	modelExpects                              []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                              []*gomock.Call0_1[string]
@@ -430,6 +431,24 @@ func (mr *MockConfigMockRecorder) LokiEndpoint() *MockConfigLokiEndpointCall {
 
 // MockConfigLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigLokiEndpointCall = gomock.Call0_1[string]
+
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfig) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigMockRecorder) LokiInsecureSkipVerify() *MockConfigLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
 
 // MetricsSpoolDir mocks base method.
 func (m *MockConfig) MetricsSpoolDir() string {
@@ -782,6 +801,7 @@ type MockConfigSetterMockRecorder struct {
 	loggingConfigExpects                         []*gomock.Call0_1[string]
 	lokiCACertExpects                            []*gomock.Call0_1[string]
 	lokiEndpointExpects                          []*gomock.Call0_1[string]
+	lokiInsecureSkipVerifyExpects                []*gomock.Call0_1[*bool]
 	metricsSpoolDirExpects                       []*gomock.Call0_1[string]
 	modelExpects                                 []*gomock.Call0_1[names.ModelTag]
 	nonceExpects                                 []*gomock.Call0_1[string]
@@ -799,7 +819,7 @@ type MockConfigSetterMockRecorder struct {
 	setControllerAgentInfoExpects                []*gomock.Call1_0[controller.ControllerAgentInfo]
 	setDqliteBusyTimeoutExpects                  []*gomock.Call1_0[time.Duration]
 	setLoggingConfigExpects                      []*gomock.Call1_0[string]
-	setLokiConfigExpects                         []*gomock.Call2_0[string, string]
+	setLokiConfigExpects                         []*gomock.Call3_0[string, *string, *bool]
 	setOldPasswordExpects                        []*gomock.Call1_0[string]
 	setOpenTelemetryEnabledExpects               []*gomock.Call1_0[bool]
 	setOpenTelemetryEndpointExpects              []*gomock.Call1_0[string]
@@ -1138,6 +1158,24 @@ func (mr *MockConfigSetterMockRecorder) LokiEndpoint() *MockConfigSetterLokiEndp
 // MockConfigSetterLokiEndpointCall is the typed call wrapper for LokiEndpoint.
 type MockConfigSetterLokiEndpointCall = gomock.Call0_1[string]
 
+// LokiInsecureSkipVerify mocks base method.
+func (m *MockConfigSetter) LokiInsecureSkipVerify() *bool {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.lokiInsecureSkipVerifyExpects, m.ctrl, m, "LokiInsecureSkipVerify")
+}
+
+// LokiInsecureSkipVerify indicates an expected call of LokiInsecureSkipVerify.
+func (mr *MockConfigSetterMockRecorder) LokiInsecureSkipVerify() *MockConfigSetterLokiInsecureSkipVerifyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*bool](mr.mock.ctrl.T, mr.mock, "LokiInsecureSkipVerify")
+	mr.lokiInsecureSkipVerifyExpects = append(mr.lokiInsecureSkipVerifyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockConfigSetterLokiInsecureSkipVerifyCall is the typed call wrapper for LokiInsecureSkipVerify.
+type MockConfigSetterLokiInsecureSkipVerifyCall = gomock.Call0_1[*bool]
+
 // MetricsSpoolDir mocks base method.
 func (m *MockConfigSetter) MetricsSpoolDir() string {
 	m.ctrl.T.Helper()
@@ -1445,22 +1483,22 @@ func (mr *MockConfigSetterMockRecorder) SetLoggingConfig(arg0 any) *MockConfigSe
 type MockConfigSetterSetLoggingConfigCall = gomock.Call1_0[string]
 
 // SetLokiConfig mocks base method.
-func (m *MockConfigSetter) SetLokiConfig(endpoint, caCert string) {
+func (m *MockConfigSetter) SetLokiConfig(endpoint string, caCert *string, insecureSkipVerify *bool) {
 	m.ctrl.T.Helper()
-	gomock.Dispatch2_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert)
+	gomock.Dispatch3_0(&m.recorder.setLokiConfigExpects, m.ctrl, m, "SetLokiConfig", endpoint, caCert, insecureSkipVerify)
 }
 
 // SetLokiConfig indicates an expected call of SetLokiConfig.
-func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert any) *MockConfigSetterSetLokiConfigCall {
+func (mr *MockConfigSetterMockRecorder) SetLokiConfig(endpoint, caCert, insecureSkipVerify any) *MockConfigSetterSetLokiConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_0[string, string](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert))
+	call := gomock.NewCall3_0[string, *string, *bool](mr.mock.ctrl.T, mr.mock, "SetLokiConfig", gomock.EnsureMatcher(endpoint), gomock.EnsureMatcher(caCert), gomock.EnsureMatcher(insecureSkipVerify))
 	mr.setLokiConfigExpects = append(mr.setLokiConfigExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockConfigSetterSetLokiConfigCall is the typed call wrapper for SetLokiConfig.
-type MockConfigSetterSetLokiConfigCall = gomock.Call2_0[string, string]
+type MockConfigSetterSetLokiConfigCall = gomock.Call3_0[string, *string, *bool]
 
 // SetOldPassword mocks base method.
 func (m *MockConfigSetter) SetOldPassword(oldPassword string) {

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -98,9 +98,10 @@ type StringResults struct {
 
 // LokiConfigResult holds a controller Loki configuration or an error.
 type LokiConfigResult struct {
-	Error    *Error  `json:"error,omitempty"`
-	Endpoint string  `json:"endpoint"`
-	CACert   *string `json:"ca-cert,omitempty"`
+	Error              *Error  `json:"error,omitempty"`
+	Endpoint           string  `json:"endpoint"`
+	CACert             *string `json:"ca-cert,omitempty"`
+	InsecureSkipVerify *bool   `json:"insecure-skip-verify,omitempty"`
 }
 
 // MapResult holds a generic map or an error.


### PR DESCRIPTION
It was noted by @hpidcock that the absence of a CA cert doesn't actually indicate that we should skip verification of a certificate. They're orthogonal. This change fixes this, by introducing the ability to set that field independently of the certificate. There will be a follow up patch in the controller charm that will allow you to skip the verification.

Requires https://github.com/juju/juju-controller/pull/118

## QA steps

Ensure that you've got the PR charm packed in the right location https://github.com/juju/juju-controller/pull/118

```sh
$ juju bootstrap lxd src --bootstrap-base=ubuntu@24.04 --controller-charm-path=./juju-controller_ubuntu@24.04-amd64.charm --build-agent
$ juju switch controller
$ juju config controller loki-insecure-skip-verify=true
```

Pack the charm and deploy:

```
$ cd ./testcharms/charms/observability
$ charmcraft pack
$ juju deploy observability
```

Add the relation:

```
$ juju config observability loki-url="http://foo.com"
$ juju integrate controller:loki-push-api observability:loki-push-api
$ juju ssh -m controller 0
$ juju_db_repl
repl (controller)> SELECT * FROM logging_loki_config
uuid                                    endpoint        ca_cert insecure_skip_verify
0f6a774f-7504-4c8e-86c3-5afbffcc663f    http://foo.com          true
```

Remove the relation:

```
$ juju remove-relation controller:loki-push-api observability:loki-push-api
$ juju ssh -m controller 0
$ juju_db_repl
repl (controller)> SELECT * FROM logging_loki_config
uuid    endpoint        ca_cert insecure_skip_verify
```


## Links

It's not quite the following task, but will be part of it for now, as it's just a fix-up to existing code.

**Jira card:** [JUJU-9980](https://warthogs.atlassian.net/browse/JUJU-9980)


[JUJU-9980]: https://warthogs.atlassian.net/browse/JUJU-9980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ