### PR TITLE
feat: remove logsink writer

### DIFF
--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -244,15 +244,17 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 		// The log router owns the buffered log stream and forwards records to
 		// one active backend at a time.
 		logRouterName: ifNotDead(logrouter.Manifold(logrouter.ManifoldConfig{
-			AgentName:            agentName,
-			APICallerName:        apiCallerName,
-			HTTPClientName:       httpClientName,
-			LogSource:            config.LogSource,
-			AgentConfigChanged:   config.AgentConfigChanged,
-			Logger:               internallogger.GetLogger("juju.worker.logrouter"),
-			Clock:                config.Clock,
-			PrometheusRegisterer: config.PrometheusRegisterer,
-			NewBackendFunc:       logrouter.NewBackend,
+			AgentName:                 agentName,
+			APICallerName:             apiCallerName,
+			HTTPClientName:            httpClientName,
+			LogSource:                 config.LogSource,
+			AgentConfigChanged:        config.AgentConfigChanged,
+			Logger:                    internallogger.GetLogger("juju.worker.logrouter"),
+			Clock:                     config.Clock,
+			PrometheusRegisterer:      config.PrometheusRegisterer,
+			NewBackendFunc:            logrouter.NewBackend,
+			RemoveLegacyLogSinkWriter: func() {},
+			AddLegacyLogSinkWriter:    func() error { return nil },
 		})),
 
 		// The upgrade steps gate is used to coordinate workers which

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -446,7 +446,7 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 	if err != nil {
 		return errors.Annotate(err, "unable to install buffered log writer")
 	}
-	defer bufferedLogger.Close()
+	defer func() { _ = logsender.UninstallBufferedLogWriter() }()
 
 	// Prime the log sink and create the writer.
 	logSink, err := PrimeLogSink(a.CurrentConfig())

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -70,6 +70,7 @@ import (
 	workerflightrecorder "github.com/juju/juju/internal/worker/flightrecorder"
 	"github.com/juju/juju/internal/worker/gate"
 	"github.com/juju/juju/internal/worker/introspection"
+	"github.com/juju/juju/internal/worker/logsender"
 	"github.com/juju/juju/internal/worker/migrationmaster"
 	"github.com/juju/juju/internal/worker/modelworkermanager"
 	"github.com/juju/juju/internal/wrench"
@@ -438,6 +439,15 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 
 	agentconf.SetupAgentLogging(internallogger.DefaultContext(), a.CurrentConfig())
 
+	// Install the buffered log writer on the default loggo context.
+	// This captures log records for the logrouter to forward to the
+	// active backend (LogSink or Loki).
+	bufferedLogger, err := logsender.EnsureBufferedLogWriterOnDefaultContext(1048576)
+	if err != nil {
+		return errors.Annotate(err, "unable to install buffered log writer")
+	}
+	defer bufferedLogger.Close()
+
 	// Prime the log sink and create the writer.
 	logSink, err := PrimeLogSink(a.CurrentConfig())
 	if err != nil {
@@ -445,12 +455,16 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 	}
 	defer logSink.Close()
 
-	// Add the log sink to the default logger context.
-	if err := loggo.DefaultContext().AddWriter("logsink", corelogger.NewTaggedRedirectWriter(
+	// Construct the legacy logsink writer. The logrouter manages its
+	// lifecycle based on the active backend mode.
+	legacyLogSinkWriter := corelogger.NewTaggedRedirectWriter(
 		logSink,
 		a.Tag().String(),
 		a.CurrentConfig().Model().Id(),
-	)); err != nil {
+	)
+
+	// Add the legacy log sink writer to the default logger context.
+	if err := loggo.DefaultContext().AddWriter("logsink", legacyLogSinkWriter); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -496,7 +510,7 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 		a.controllerAgentConfigReadyLock.Unlock()
 	}
 
-	createEngine := a.makeEngineCreator(agentName, agentConfig.UpgradedToVersion(), logSink)
+	createEngine := a.makeEngineCreator(agentName, agentConfig.UpgradedToVersion(), logSink, bufferedLogger, legacyLogSinkWriter)
 	if err := a.createJujudSymlinks(agentConfig.DataDir()); err != nil {
 		return err
 	}
@@ -519,6 +533,8 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 func (a *MachineAgent) makeEngineCreator(
 	agentName string, previousAgentVersion semversion.Number,
 	logSink corelogger.LogSink,
+	bufferedLogger *logsender.BufferedLogWriter,
+	legacyLogSinkWriter loggo.Writer,
 ) func(context.Context) (worker.Worker, error) {
 	return func(ctx context.Context) (worker.Worker, error) {
 		agentConfig := a.CurrentConfig()
@@ -561,6 +577,8 @@ func (a *MachineAgent) makeEngineCreator(
 			PreUpgradeSteps:                   a.preUpgradeSteps,
 			UpgradeSteps:                      a.upgradeSteps,
 			LogSink:                           logSink,
+			LogSource:                         bufferedLogger.Logs(),
+			LegacyLogSinkWriter:               legacyLogSinkWriter,
 			NewDeployContext:                  deployer.NewNestedContext,
 			Clock:                             clock,
 			FlightRecorder:                    flightRecorder,

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/loggo/v3"
 	"github.com/juju/proxy"
 	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v5"
@@ -89,6 +90,8 @@ import (
 	leasemanager "github.com/juju/juju/internal/worker/lease"
 	"github.com/juju/juju/internal/worker/leaseexpiry"
 	"github.com/juju/juju/internal/worker/logger"
+	"github.com/juju/juju/internal/worker/logrouter"
+	"github.com/juju/juju/internal/worker/logsender"
 	"github.com/juju/juju/internal/worker/logsink"
 	"github.com/juju/juju/internal/worker/lokiendpointupdater"
 	"github.com/juju/juju/internal/worker/machineactions"
@@ -193,6 +196,16 @@ type ManifoldsConfig struct {
 
 	// LogSink defines an interface for writing log records to a log sink.
 	LogSink corelogger.LogSink
+
+	// LogSource supplies log records to the logrouter. It is the output
+	// channel of the BufferedLogWriter installed on the default loggo
+	// context.
+	LogSource logsender.LogRecordCh
+
+	// LegacyLogSinkWriter is the TaggedRedirectWriter that writes log
+	// records to the legacy log sink. It is managed by the logrouter
+	// based on the active backend mode.
+	LegacyLogSinkWriter loggo.Writer
 
 	// NewDeployContext gives the tests the opportunity to create a
 	// deployer.Context that can be used for testing.
@@ -531,6 +544,26 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName:      apiCallerName,
 			AgentConfigChanged: config.AgentConfigChanged,
 			Logger:             internallogger.GetLogger("juju.worker.lokiendpointupdater"),
+		})),
+
+		// The log router owns the buffered log stream and forwards records to
+		// one active backend at a time.
+		logRouterName: ifNotMigrating(logrouter.Manifold(logrouter.ManifoldConfig{
+			AgentName:            agentName,
+			APICallerName:        apiCallerName,
+			HTTPClientName:       httpClientName,
+			LogSource:            config.LogSource,
+			AgentConfigChanged:   config.AgentConfigChanged,
+			Logger:               internallogger.GetLogger("juju.worker.logrouter"),
+			Clock:                config.Clock,
+			PrometheusRegisterer: config.PrometheusRegisterer,
+			NewBackendFunc:       logrouter.NewBackend,
+			RemoveLegacyLogSinkWriter: func() {
+				logsender.RemoveLegacyLogSinkWriter()
+			},
+			AddLegacyLogSinkWriter: func() error {
+				return logsender.AddLegacyLogSinkWriter(config.LegacyLogSinkWriter)
+			},
 		})),
 
 		identityFileWriterName: ifNotMigrating(identityfilewriter.Manifold(identityfilewriter.ManifoldConfig{
@@ -1487,6 +1520,7 @@ const (
 	loggingConfigUpdaterName           = "logging-config-updater"
 	lokiEndpointUpdaterName            = "loki-endpoint-updater"
 	logSinkName                        = "log-sink"
+	logRouterName                      = "log-router"
 	lxdContainerProvisioner            = "lxd-container-provisioner"
 	machineActionName                  = "machine-action-runner"
 	machinerName                       = "machiner"

--- a/cmd/jujud/agent/machine/manifolds_test.go
+++ b/cmd/jujud/agent/machine/manifolds_test.go
@@ -110,6 +110,7 @@ func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *tc.C) {
 			"lease-expiry",
 			"lease-manager",
 			"log-sink",
+			"log-router",
 			"logging-config-updater",
 			"loki-endpoint-updater",
 			"lxd-container-provisioner",
@@ -204,6 +205,7 @@ func (s *ManifoldsSuite) TestManifoldNamesCAAS(c *tc.C) {
 			"lease-expiry",
 			"lease-manager",
 			"log-sink",
+			"log-router",
 			"logging-config-updater",
 			"loki-endpoint-updater",
 			"migration-fortress",
@@ -1272,6 +1274,19 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 	},
 
 	"log-sink": {},
+
+	"log-router": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"http-client",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"upgrade-check-flag",
+		"upgrade-check-gate",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+	},
 
 	"machine-action-runner": {
 		"agent",
@@ -2409,6 +2424,19 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 	},
 
 	"log-sink": {},
+
+	"log-router": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"http-client",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"upgrade-check-flag",
+		"upgrade-check-gate",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+	},
 
 	"logging-config-updater": {
 		"agent",

--- a/cmd/jujud/agent/modeloperator/manifolds.go
+++ b/cmd/jujud/agent/modeloperator/manifolds.go
@@ -111,15 +111,17 @@ func Manifolds(config ManifoldConfig) dependency.Manifolds {
 		// The log router owns the buffered log stream and forwards records to
 		// one active backend at a time.
 		logRouterName: logrouter.Manifold(logrouter.ManifoldConfig{
-			AgentName:            agentName,
-			APICallerName:        apiCallerName,
-			HTTPClientName:       httpClientName,
-			LogSource:            config.LogSource,
-			AgentConfigChanged:   config.AgentConfigChanged,
-			Logger:               internallogger.GetLogger("juju.worker.logrouter"),
-			Clock:                clock.WallClock,
-			PrometheusRegisterer: noopPrometheusRegisterer{},
-			NewBackendFunc:       logrouter.NewBackend,
+			AgentName:                 agentName,
+			APICallerName:             apiCallerName,
+			HTTPClientName:            httpClientName,
+			LogSource:                 config.LogSource,
+			AgentConfigChanged:        config.AgentConfigChanged,
+			Logger:                    internallogger.GetLogger("juju.worker.logrouter"),
+			Clock:                     clock.WallClock,
+			PrometheusRegisterer:      noopPrometheusRegisterer{},
+			NewBackendFunc:            logrouter.NewBackend,
+			RemoveLegacyLogSinkWriter: func() {},
+			AddLegacyLogSinkWriter:    func() error { return nil },
 		}),
 
 		caasAdmissionName: caasadmission.Manifold(caasadmission.ManifoldConfig{

--- a/internal/worker/apiremotecaller/remote.go
+++ b/internal/worker/apiremotecaller/remote.go
@@ -139,10 +139,10 @@ func (w *remoteServer) UpdateAddresses(addresses []string) {
 	case w.changes <- addressChange{addresses: addresses, processed: processed}:
 	}
 
-	// Wait for the inner goroutine to acknowledge receipt and cancel
-	// the previous request context. This prevents a race where the
-	// main loop picks up a stale request before the cancellation
-	// has been applied.
+	// Wait for the inner goroutine to acknowledge that the latest request
+	// has been published into the handoff queue. This prevents a race where
+	// a caller observes UpdateAddresses returning before the replacement
+	// request has replaced any stale queued request.
 	select {
 	case <-w.tomb.Dying():
 	case <-processed:
@@ -199,9 +199,9 @@ type report struct {
 
 // addressChange carries address data through the changes channel along
 // with an optional acknowledgment channel. When processed is non-nil,
-// the inner goroutine closes it after cancelling the previous request
-// context, guaranteeing the caller that the prior context is cancelled
-// before UpdateAddresses returns.
+// the inner goroutine closes it after publishing the replacement request,
+// guaranteeing the caller that the latest request has replaced any stale
+// queued request before UpdateAddresses returns.
 type addressChange struct {
 	addresses []string
 	processed chan struct{}
@@ -251,11 +251,6 @@ func (w *remoteServer) loop() error {
 					canceler(newChangeRequestError)
 				}
 
-				// Signal that the previous context has been cancelled.
-				if change.processed != nil {
-					close(change.processed)
-				}
-
 				// Create a new context for the next connection attempt.
 				requestCtx, requestCancel := context.WithCancelCause(ctx)
 				canceler = requestCancel
@@ -274,6 +269,9 @@ func (w *remoteServer) loop() error {
 						requestCancel(context.Canceled)
 						return tomb.ErrDying
 					case requests <- req:
+						if change.processed != nil {
+							close(change.processed)
+						}
 						break enqueue
 					case stale := <-requests:
 						stale.cancel(newChangeRequestError)

--- a/internal/worker/deployer/unit_agent.go
+++ b/internal/worker/deployer/unit_agent.go
@@ -300,6 +300,9 @@ func (a *UnitAgent) initLogging() (logger.LoggerContext, *logsender.BufferedLogW
 		if _, err = loggerContext.RemoveWriter("file"); err != nil {
 			a.logger.Errorf(context.TODO(), "%q remove writer: %s", a.name, err)
 		}
+		if _, err = loggerContext.RemoveWriter("buffered-logs"); err != nil {
+			a.logger.Errorf(context.TODO(), "%q remove buffered-logs writer: %s", a.name, err)
+		}
 		bufferedLogger.Close()
 		if err = ljLogger.Close(); err != nil {
 			a.logger.Errorf(context.TODO(), "%q lumberjack logger close: %s", a.name, err)

--- a/internal/worker/deployer/unit_manifolds.go
+++ b/internal/worker/deployer/unit_manifolds.go
@@ -158,15 +158,17 @@ func UnitManifolds(config UnitManifoldsConfig) dependency.Manifolds {
 		// The log router owns the buffered log stream and forwards records to
 		// one active backend at a time.
 		logRouterName: logrouter.Manifold(logrouter.ManifoldConfig{
-			AgentName:            agentName,
-			APICallerName:        apiCallerName,
-			HTTPClientName:       httpClientName,
-			LogSource:            config.LogSource,
-			AgentConfigChanged:   config.AgentConfigChanged,
-			Logger:               config.LoggerContext.GetLogger("juju.worker.logrouter"),
-			Clock:                config.Clock,
-			PrometheusRegisterer: config.PrometheusRegisterer,
-			NewBackendFunc:       logrouter.NewBackend,
+			AgentName:                 agentName,
+			APICallerName:             apiCallerName,
+			HTTPClientName:            httpClientName,
+			LogSource:                 config.LogSource,
+			AgentConfigChanged:        config.AgentConfigChanged,
+			Logger:                    config.LoggerContext.GetLogger("juju.worker.logrouter"),
+			Clock:                     config.Clock,
+			PrometheusRegisterer:      config.PrometheusRegisterer,
+			NewBackendFunc:            logrouter.NewBackend,
+			RemoveLegacyLogSinkWriter: func() {},
+			AddLegacyLogSinkWriter:    func() error { return nil },
 		}),
 
 		// The migration workers collaborate to run migrations;

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -46,6 +46,14 @@ type ManifoldConfig struct {
 	DrainOnly            bool
 
 	NewBackendFunc BackendFuncFactory
+
+	// RemoveLegacyLogSinkWriter is called when switching to Loki
+	// backend mode. It must be idempotent.
+	RemoveLegacyLogSinkWriter func()
+
+	// AddLegacyLogSinkWriter is called when switching to LogSink
+	// backend mode. It must be idempotent.
+	AddLegacyLogSinkWriter func() error
 }
 
 // Validate validates the manifold configuration.
@@ -73,6 +81,12 @@ func (c ManifoldConfig) Validate() error {
 	}
 	if c.NewBackendFunc == nil {
 		return errors.NotValidf("nil NewBackendFunc")
+	}
+	if c.RemoveLegacyLogSinkWriter == nil {
+		return errors.NotValidf("nil RemoveLegacyLogSinkWriter")
+	}
+	if c.AddLegacyLogSinkWriter == nil {
+		return errors.NotValidf("nil AddLegacyLogSinkWriter")
 	}
 	return nil
 }
@@ -104,15 +118,17 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			return NewWorker(WorkerConfig{
-				Agent:              a,
-				LogSource:          config.LogSource,
-				AgentConfigChanged: config.AgentConfigChanged,
-				Logger:             config.Logger,
-				Clock:              config.Clock,
-				DrainOnly:          config.DrainOnly,
-				ConvergeTimeout:    defaultConvergeTimeout,
-				RestartDelay:       defaultRestartDelay,
-				NewBackend:         config.NewBackendFunc(apiCaller, httpClient, config.Clock, config.PrometheusRegisterer),
+				Agent:                     a,
+				LogSource:                 config.LogSource,
+				AgentConfigChanged:        config.AgentConfigChanged,
+				Logger:                    config.Logger,
+				Clock:                     config.Clock,
+				DrainOnly:                 config.DrainOnly,
+				ConvergeTimeout:           defaultConvergeTimeout,
+				RestartDelay:              defaultRestartDelay,
+				NewBackend:                config.NewBackendFunc(apiCaller, httpClient, config.Clock, config.PrometheusRegisterer),
+				RemoveLegacyLogSinkWriter: config.RemoveLegacyLogSinkWriter,
+				AddLegacyLogSinkWriter:    config.AddLegacyLogSinkWriter,
 			})
 		},
 	}

--- a/internal/worker/logrouter/manifold_test.go
+++ b/internal/worker/logrouter/manifold_test.go
@@ -122,7 +122,25 @@ func (s *manifoldSuite) validManifoldConfig(c *tc.C) ManifoldConfig {
 		NewBackendFunc: func(base.APICaller, loki.HTTPClient, clock.Clock, prometheus.Registerer) BackendFunc {
 			return recordingBackendFunc(make(chan backendEvent, 10), defaultBackendBufferSize)
 		},
+		RemoveLegacyLogSinkWriter: func() {},
+		AddLegacyLogSinkWriter:    func() error { return nil },
 	}
+}
+
+func (s *manifoldSuite) TestValidateRejectsNilRemoveLegacyLogSinkWriter(c *tc.C) {
+	cfg := s.validManifoldConfig(c)
+	cfg.RemoveLegacyLogSinkWriter = nil
+	err := cfg.Validate()
+	c.Assert(err, tc.NotNil)
+	c.Check(err.Error(), tc.Equals, `nil RemoveLegacyLogSinkWriter not valid`)
+}
+
+func (s *manifoldSuite) TestValidateRejectsNilAddLegacyLogSinkWriter(c *tc.C) {
+	cfg := s.validManifoldConfig(c)
+	cfg.AddLegacyLogSinkWriter = nil
+	err := cfg.Validate()
+	c.Assert(err, tc.NotNil)
+	c.Check(err.Error(), tc.Equals, `nil AddLegacyLogSinkWriter not valid`)
 }
 
 type manifoldGetter struct {

--- a/internal/worker/logrouter/worker.go
+++ b/internal/worker/logrouter/worker.go
@@ -77,6 +77,16 @@ type WorkerConfig struct {
 	RestartDelay    time.Duration
 
 	NewBackend BackendFunc
+
+	// RemoveLegacyLogSinkWriter is called when switching to Loki
+	// backend mode. It should remove the legacy "logsink" writer
+	// from the default loggo context. It must be idempotent.
+	RemoveLegacyLogSinkWriter func()
+
+	// AddLegacyLogSinkWriter is called when switching to LogSink
+	// backend mode. It should add the legacy "logsink" writer to
+	// the default loggo context. It must be idempotent.
+	AddLegacyLogSinkWriter func() error
 }
 
 // ConfigSnapshot is the local logging destination configuration.
@@ -220,6 +230,7 @@ func (w *logRouter) loop() error {
 	w.activeRecords = drainRecords
 
 	next := w.currentSnapshot()
+	w.manageLegacyLogSinkWriter(ctx, next)
 	if !next.sameBackend(w.activeSnapshot) {
 		err = w.switchBackend(ctx, next)
 		if err != nil {
@@ -238,6 +249,7 @@ func (w *logRouter) loop() error {
 			}
 			next := w.currentSnapshot()
 			if !next.sameBackend(w.activeSnapshot) {
+				w.manageLegacyLogSinkWriter(ctx, next)
 				err = w.switchBackend(ctx, next)
 				if err != nil {
 					return internalerrors.Capture(err)
@@ -252,6 +264,7 @@ func (w *logRouter) loop() error {
 			if next.sameBackend(w.activeSnapshot) {
 				continue
 			}
+			w.manageLegacyLogSinkWriter(ctx, next)
 			err = w.switchBackend(ctx, next)
 			if err != nil {
 				return internalerrors.Capture(err)
@@ -434,6 +447,21 @@ func sendRecord(ctx context.Context, records logsender.LogRecordCh, record *logs
 
 func (w *logRouter) stopBackend(id string) {
 	_ = w.runner.StopWorker(id)
+}
+
+func (w *logRouter) manageLegacyLogSinkWriter(ctx context.Context, next ConfigSnapshot) {
+	switch next.Mode {
+	case BackendTypeLoki:
+		w.config.RemoveLegacyLogSinkWriter()
+	case BackendTypeLogSink, BackendTypeDrain:
+		if err := w.config.AddLegacyLogSinkWriter(); err != nil {
+			w.config.Logger.Warningf(
+				ctx,
+				"failed to add legacy logsink writer: %v",
+				err,
+			)
+		}
+	}
 }
 
 type configWatcherWorker struct {

--- a/internal/worker/logrouter/worker.go
+++ b/internal/worker/logrouter/worker.go
@@ -230,12 +230,13 @@ func (w *logRouter) loop() error {
 	w.activeRecords = drainRecords
 
 	next := w.currentSnapshot()
-	w.manageLegacyLogSinkWriter(ctx, next)
 	if !next.sameBackend(w.activeSnapshot) {
 		err = w.switchBackend(ctx, next)
 		if err != nil {
 			return internalerrors.Capture(err)
 		}
+	} else {
+		w.manageLegacyLogSinkWriter(ctx, w.activeSnapshot)
 	}
 
 	for {
@@ -249,7 +250,6 @@ func (w *logRouter) loop() error {
 			}
 			next := w.currentSnapshot()
 			if !next.sameBackend(w.activeSnapshot) {
-				w.manageLegacyLogSinkWriter(ctx, next)
 				err = w.switchBackend(ctx, next)
 				if err != nil {
 					return internalerrors.Capture(err)
@@ -264,7 +264,6 @@ func (w *logRouter) loop() error {
 			if next.sameBackend(w.activeSnapshot) {
 				continue
 			}
-			w.manageLegacyLogSinkWriter(ctx, next)
 			err = w.switchBackend(ctx, next)
 			if err != nil {
 				return internalerrors.Capture(err)
@@ -285,6 +284,7 @@ func (w *logRouter) switchBackend(
 		w.activeBackendID = backendDrainID
 		w.activeSnapshot = next
 		w.activeRecords = w.drainRecords
+		w.manageLegacyLogSinkWriter(ctx, next)
 		return nil
 	}
 
@@ -308,6 +308,7 @@ func (w *logRouter) switchBackend(
 	w.activeBackendID = backendID
 	w.activeSnapshot = next
 	w.activeRecords = records
+	w.manageLegacyLogSinkWriter(ctx, next)
 	return nil
 }
 

--- a/internal/worker/logrouter/worker_test.go
+++ b/internal/worker/logrouter/worker_test.go
@@ -36,14 +36,16 @@ func (s *workerSuite) TestStartsLogSinkWhenLokiEndpointEmpty(c *tc.C) {
 	events := make(chan backendEvent, 10)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:              fixture.agent,
-		LogSource:          fixture.logs,
-		AgentConfigChanged: fixture.configChanged,
-		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
-		Clock:              clock.WallClock,
-		ConvergeTimeout:    defaultConvergeTimeout,
-		RestartDelay:       time.Millisecond * 10,
-		NewBackend:         recordingBackendFunc(events, defaultBackendBufferSize),
+		Agent:                     fixture.agent,
+		LogSource:                 fixture.logs,
+		AgentConfigChanged:        fixture.configChanged,
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		ConvergeTimeout:           defaultConvergeTimeout,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                recordingBackendFunc(events, defaultBackendBufferSize),
+		RemoveLegacyLogSinkWriter: func() {},
+		AddLegacyLogSinkWriter:    func() error { return nil },
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -62,14 +64,16 @@ func (s *workerSuite) TestSwitchStopsOldBackendAndStartsNew(c *tc.C) {
 	events := make(chan backendEvent, 20)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:              fixture.agent,
-		LogSource:          fixture.logs,
-		AgentConfigChanged: fixture.configChanged,
-		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
-		Clock:              clock.WallClock,
-		ConvergeTimeout:    defaultConvergeTimeout,
-		RestartDelay:       time.Millisecond * 10,
-		NewBackend:         recordingBackendFunc(events, defaultBackendBufferSize),
+		Agent:                     fixture.agent,
+		LogSource:                 fixture.logs,
+		AgentConfigChanged:        fixture.configChanged,
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		ConvergeTimeout:           defaultConvergeTimeout,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                recordingBackendFunc(events, defaultBackendBufferSize),
+		RemoveLegacyLogSinkWriter: func() {},
+		AddLegacyLogSinkWriter:    func() error { return nil },
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -105,15 +109,17 @@ func (s *workerSuite) TestDrainOnlyOverridesEndpoint(c *tc.C) {
 	events := make(chan backendEvent, 10)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:              fixture.agent,
-		LogSource:          fixture.logs,
-		AgentConfigChanged: fixture.configChanged,
-		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
-		Clock:              clock.WallClock,
-		DrainOnly:          true,
-		ConvergeTimeout:    defaultConvergeTimeout,
-		RestartDelay:       time.Millisecond * 10,
-		NewBackend:         recordingBackendFunc(events, defaultBackendBufferSize),
+		Agent:                     fixture.agent,
+		LogSource:                 fixture.logs,
+		AgentConfigChanged:        fixture.configChanged,
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		DrainOnly:                 true,
+		ConvergeTimeout:           defaultConvergeTimeout,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                recordingBackendFunc(events, defaultBackendBufferSize),
+		RemoveLegacyLogSinkWriter: func() {},
+		AddLegacyLogSinkWriter:    func() error { return nil },
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -129,14 +135,16 @@ func (s *workerSuite) TestBackendFailureFallsBackToDrain(c *tc.C) {
 	events := make(chan backendEvent, 20)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:              fixture.agent,
-		LogSource:          fixture.logs,
-		AgentConfigChanged: fixture.configChanged,
-		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
-		Clock:              clock.WallClock,
-		ConvergeTimeout:    defaultConvergeTimeout,
-		RestartDelay:       time.Millisecond * 10,
-		NewBackend:         failingLogSinkBackendFunc(events),
+		Agent:                     fixture.agent,
+		LogSource:                 fixture.logs,
+		AgentConfigChanged:        fixture.configChanged,
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		ConvergeTimeout:           defaultConvergeTimeout,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                failingLogSinkBackendFunc(events),
+		RemoveLegacyLogSinkWriter: func() {},
+		AddLegacyLogSinkWriter:    func() error { return nil },
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -174,14 +182,16 @@ func (s *workerSuite) TestBackendStartErrorFallsBackToDrain(c *tc.C) {
 	events := make(chan backendEvent, 20)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:              fixture.agent,
-		LogSource:          fixture.logs,
-		AgentConfigChanged: fixture.configChanged,
-		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
-		Clock:              clock.WallClock,
-		ConvergeTimeout:    time.Millisecond * 10,
-		RestartDelay:       time.Millisecond * 10,
-		NewBackend:         errorLogSinkBackendFunc(events),
+		Agent:                     fixture.agent,
+		LogSource:                 fixture.logs,
+		AgentConfigChanged:        fixture.configChanged,
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		ConvergeTimeout:           time.Millisecond * 10,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                errorLogSinkBackendFunc(events),
+		RemoveLegacyLogSinkWriter: func() {},
+		AddLegacyLogSinkWriter:    func() error { return nil },
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -219,14 +229,16 @@ func (s *workerSuite) TestBackendRestartRefreshesActiveChannel(c *tc.C) {
 	events := make(chan backendEvent, 20)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:              fixture.agent,
-		LogSource:          fixture.logs,
-		AgentConfigChanged: fixture.configChanged,
-		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
-		Clock:              clock.WallClock,
-		ConvergeTimeout:    defaultConvergeTimeout,
-		RestartDelay:       time.Millisecond * 10,
-		NewBackend:         restartingLogSinkBackendFunc(events),
+		Agent:                     fixture.agent,
+		LogSource:                 fixture.logs,
+		AgentConfigChanged:        fixture.configChanged,
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		ConvergeTimeout:           defaultConvergeTimeout,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                restartingLogSinkBackendFunc(events),
+		RemoveLegacyLogSinkWriter: func() {},
+		AddLegacyLogSinkWriter:    func() error { return nil },
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -582,6 +594,206 @@ func waitForRecordWithin(
 		case <-c.Context().Done():
 			c.Fatalf("timed out waiting for %s record %q", backend, message)
 		}
+	}
+}
+
+func (s *workerSuite) TestManageLegacyLogSinkWriterOnLokiSwitch(c *tc.C) {
+	fixture := newFixture(c, "")
+	events := make(chan backendEvent, 20)
+
+	addCh := make(chan struct{}, 1)
+	removeCh := make(chan struct{}, 1)
+
+	w, err := NewWorker(WorkerConfig{
+		Agent:                     fixture.agent,
+		LogSource:                 fixture.logs,
+		AgentConfigChanged:        fixture.configChanged,
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		ConvergeTimeout:           defaultConvergeTimeout,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                recordingBackendFunc(events, defaultBackendBufferSize),
+		RemoveLegacyLogSinkWriter: func() { removeCh <- struct{}{} },
+		AddLegacyLogSinkWriter:    func() error { addCh <- struct{}{}; return nil },
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	waitForEvents(c, events, backendEvent{
+		backend: "drain-only",
+		kind:    "start",
+	}, backendEvent{
+		backend: "logsink",
+		kind:    "start",
+	})
+
+	// Drain initial callbacks.
+	drainCh(c, addCh)
+	drainCh(c, removeCh)
+
+	fixture.agent.setLokiConfig("http://loki/loki/api/v1/push", "")
+	fixture.configChanged.Set(true)
+
+	sendLog(c, fixture.logs, &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test",
+		Level:   loggo.INFO,
+		Message: "routed",
+	})
+	waitForEvents(c, events, backendEvent{
+		backend: "logsink",
+		kind:    "stop",
+	}, backendEvent{
+		backend: "loki",
+		kind:    "start",
+	})
+
+	// Switching to Loki should call RemoveLegacyLogSinkWriter, not Add.
+	select {
+	case <-removeCh:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for RemoveLegacyLogSinkWriter callback")
+	}
+	select {
+	case <-addCh:
+		c.Fatal("unexpected AddLegacyLogSinkWriter call on Loki switch")
+	default:
+	}
+}
+
+func (s *workerSuite) TestManageLegacyLogSinkWriterOnLogSinkSwitch(c *tc.C) {
+	fixture := newFixture(c, "")
+	events := make(chan backendEvent, 20)
+
+	addCh := make(chan struct{}, 1)
+	removeCh := make(chan struct{}, 1)
+
+	w, err := NewWorker(WorkerConfig{
+		Agent:                     fixture.agent,
+		LogSource:                 fixture.logs,
+		AgentConfigChanged:        fixture.configChanged,
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		ConvergeTimeout:           defaultConvergeTimeout,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                recordingBackendFunc(events, defaultBackendBufferSize),
+		RemoveLegacyLogSinkWriter: func() { removeCh <- struct{}{} },
+		AddLegacyLogSinkWriter:    func() error { addCh <- struct{}{}; return nil },
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	waitForEvents(c, events, backendEvent{
+		backend: "drain-only",
+		kind:    "start",
+	}, backendEvent{
+		backend: "logsink",
+		kind:    "start",
+	})
+
+	// Drain initial callbacks.
+	drainCh(c, addCh)
+	drainCh(c, removeCh)
+
+	// Switch to Loki first.
+	fixture.agent.setLokiConfig("http://loki/loki/api/v1/push", "")
+	fixture.configChanged.Set(true)
+
+	sendLog(c, fixture.logs, &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test",
+		Level:   loggo.INFO,
+		Message: "routed",
+	})
+	waitForEvents(c, events, backendEvent{
+		backend: "logsink",
+		kind:    "stop",
+	}, backendEvent{
+		backend: "loki",
+		kind:    "start",
+	})
+
+	// Drain Loki switch callbacks.
+	drainCh(c, removeCh)
+
+	// Switch back to LogSink.
+	fixture.agent.setLokiConfig("", "")
+	fixture.configChanged.Set(true)
+
+	sendLog(c, fixture.logs, &logsender.LogRecord{
+		Time:    time.Now(),
+		Module:  "test",
+		Level:   loggo.INFO,
+		Message: "returned",
+	})
+	waitForEvents(c, events, backendEvent{
+		backend: "loki",
+		kind:    "stop",
+	}, backendEvent{
+		backend: "logsink",
+		kind:    "start",
+	})
+
+	// Returning to LogSink should call AddLegacyLogSinkWriter.
+	select {
+	case <-addCh:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for AddLegacyLogSinkWriter callback")
+	}
+	select {
+	case <-removeCh:
+		c.Fatal("unexpected RemoveLegacyLogSinkWriter call on LogSink switch")
+	default:
+	}
+}
+
+func drainCh(c *tc.C, ch <-chan struct{}) {
+	select {
+	case <-ch:
+	case <-c.Context().Done():
+		c.Fatal("timed out draining channel")
+	default:
+	}
+}
+
+func (s *workerSuite) TestManageLegacyLogSinkWriterDrainOnly(c *tc.C) {
+	fixture := newFixture(c, "http://loki/loki/api/v1/push")
+	events := make(chan backendEvent, 10)
+
+	addCh := make(chan struct{}, 1)
+	removeCh := make(chan struct{}, 1)
+
+	w, err := NewWorker(WorkerConfig{
+		Agent:                     fixture.agent,
+		LogSource:                 fixture.logs,
+		AgentConfigChanged:        fixture.configChanged,
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		DrainOnly:                 true,
+		ConvergeTimeout:           defaultConvergeTimeout,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                recordingBackendFunc(events, defaultBackendBufferSize),
+		RemoveLegacyLogSinkWriter: func() { removeCh <- struct{}{} },
+		AddLegacyLogSinkWriter:    func() error { addCh <- struct{}{}; return nil },
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	waitForEvents(c, events, backendEvent{
+		backend: "drain-only",
+		kind:    "start",
+	})
+
+	// In DrainOnly mode, the legacy writer should be present.
+	select {
+	case <-addCh:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for AddLegacyLogSinkWriter callback")
+	}
+	select {
+	case <-removeCh:
+		c.Fatal("unexpected RemoveLegacyLogSinkWriter call in DrainOnly mode")
+	default:
 	}
 }
 

--- a/internal/worker/logrouter/worker_test.go
+++ b/internal/worker/logrouter/worker_test.go
@@ -628,7 +628,11 @@ func (s *workerSuite) TestManageLegacyLogSinkWriterOnLokiSwitch(c *tc.C) {
 	})
 
 	// Drain initial callbacks.
-	drainCh(c, addCh)
+	select {
+	case <-addCh:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for initial AddLegacyLogSinkWriter callback")
+	}
 	drainCh(c, removeCh)
 
 	fixture.agent.setLokiConfig("http://loki/loki/api/v1/push", "")
@@ -692,7 +696,11 @@ func (s *workerSuite) TestManageLegacyLogSinkWriterOnLogSinkSwitch(c *tc.C) {
 	})
 
 	// Drain initial callbacks.
-	drainCh(c, addCh)
+	select {
+	case <-addCh:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for initial AddLegacyLogSinkWriter callback")
+	}
 	drainCh(c, removeCh)
 
 	// Switch to Loki first.
@@ -714,7 +722,11 @@ func (s *workerSuite) TestManageLegacyLogSinkWriterOnLogSinkSwitch(c *tc.C) {
 	})
 
 	// Drain Loki switch callbacks.
-	drainCh(c, removeCh)
+	select {
+	case <-removeCh:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for RemoveLegacyLogSinkWriter callback")
+	}
 
 	// Switch back to LogSink.
 	fixture.agent.setLokiConfig("", "")

--- a/internal/worker/logsender/bufferedlogwriter.go
+++ b/internal/worker/logsender/bufferedlogwriter.go
@@ -73,6 +73,35 @@ func UninstallBufferedLogWriter() error {
 	return nil
 }
 
+const legacyLogSinkWriterName = "logsink"
+
+// EnsureBufferedLogWriterOnDefaultContext installs a BufferedLogWriter on
+// the default loggo context. If a "buffered-logs" writer is already present
+// it is replaced. Returns the writer and any error.
+func EnsureBufferedLogWriterOnDefaultContext(maxLen int) (*BufferedLogWriter, error) {
+	writer := NewBufferedLogWriter(maxLen)
+	_, _ = loggo.DefaultContext().RemoveWriter(writerName)
+	err := loggo.DefaultContext().AddWriter(writerName, writer)
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to set up log buffering")
+	}
+	return writer, nil
+}
+
+// RemoveLegacyLogSinkWriter removes the "logsink" writer from the default
+// loggo context. It is idempotent and returns nil if the writer was not found.
+func RemoveLegacyLogSinkWriter() {
+	_, _ = loggo.DefaultContext().RemoveWriter(legacyLogSinkWriterName)
+}
+
+// AddLegacyLogSinkWriter ensures the "logsink" writer is installed in the
+// default loggo context. If a "logsink" writer is already present it is
+// replaced. Returns any error from installing the writer.
+func AddLegacyLogSinkWriter(writer loggo.Writer) error {
+	_, _ = loggo.DefaultContext().RemoveWriter(legacyLogSinkWriterName)
+	return loggo.DefaultContext().AddWriter(legacyLogSinkWriterName, writer)
+}
+
 // BufferedLogWriter is a loggo.Writer which buffers log messages in
 // memory. These messages are retrieved by reading from the channel
 // returned by the Logs method.

--- a/internal/worker/logsender/bufferedlogwriter_test.go
+++ b/internal/worker/logsender/bufferedlogwriter_test.go
@@ -185,6 +185,84 @@ func (s *bufferedLogWriterSuite) TestUninstallBufferedLogWriter(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "failed to uninstall log buffering: .+")
 }
 
+func (s *bufferedLogWriterSuite) TestEnsureBufferedLogWriterOnDefaultContext(c *tc.C) {
+	w1, err := logsender.EnsureBufferedLogWriterOnDefaultContext(10)
+	c.Assert(err, tc.ErrorIsNil)
+	defer w1.Close()
+
+	// Verify the writer is registered.
+	writer := loggo.DefaultContext().Writer("buffered-logs")
+	c.Assert(writer, tc.NotNil)
+}
+
+func (s *bufferedLogWriterSuite) TestEnsureBufferedLogWriterOnDefaultContextIdempotent(c *tc.C) {
+	w1, err := logsender.EnsureBufferedLogWriterOnDefaultContext(10)
+	c.Assert(err, tc.ErrorIsNil)
+	defer w1.Close()
+
+	// Second call replaces the writer without error.
+	w2, err := logsender.EnsureBufferedLogWriterOnDefaultContext(20)
+	c.Assert(err, tc.ErrorIsNil)
+	defer w2.Close()
+
+	// The writer is still registered.
+	writer := loggo.DefaultContext().Writer("buffered-logs")
+	c.Assert(writer, tc.NotNil)
+}
+
+type recordingWriter struct {
+	writeCalls int
+}
+
+func (w *recordingWriter) Write(_ context.Context, _ loggo.Entry) error {
+	w.writeCalls++
+	return nil
+}
+
+func (s *bufferedLogWriterSuite) TestAddLegacyLogSinkWriter(c *tc.C) {
+	w := &recordingWriter{}
+	err := logsender.AddLegacyLogSinkWriter(w)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Verify the writer is registered.
+	registered := loggo.DefaultContext().Writer("logsink")
+	c.Assert(registered, tc.NotNil)
+}
+
+func (s *bufferedLogWriterSuite) TestAddLegacyLogSinkWriterIdempotent(c *tc.C) {
+	w1 := &recordingWriter{}
+	err := logsender.AddLegacyLogSinkWriter(w1)
+	c.Assert(err, tc.ErrorIsNil)
+
+	w2 := &recordingWriter{}
+	err = logsender.AddLegacyLogSinkWriter(w2)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The writer is still registered.
+	registered := loggo.DefaultContext().Writer("logsink")
+	c.Assert(registered, tc.NotNil)
+}
+
+func (s *bufferedLogWriterSuite) TestRemoveLegacyLogSinkWriter(c *tc.C) {
+	w := &recordingWriter{}
+	err := logsender.AddLegacyLogSinkWriter(w)
+	c.Assert(err, tc.ErrorIsNil)
+
+	logsender.RemoveLegacyLogSinkWriter()
+
+	// Writer should no longer be registered.
+	registered := loggo.DefaultContext().Writer("logsink")
+	c.Assert(registered, tc.IsNil)
+}
+
+func (s *bufferedLogWriterSuite) TestRemoveLegacyLogSinkWriterIdempotent(c *tc.C) {
+	// Removing when not present should not panic.
+	logsender.RemoveLegacyLogSinkWriter()
+
+	// Removing again should still not panic.
+	logsender.RemoveLegacyLogSinkWriter()
+}
+
 func (s *bufferedLogWriterSuite) writeAndReceive(c *tc.C) {
 	now := time.Now()
 	s.writer.Write(


### PR DESCRIPTION
Unit agents and model operators already use BufferedLogWriter → logrouter to route log records. Machine/controller agents were the odd ones out: they wrote directly to the controller via a TaggedRedirectWriter registered on loggo.DefaultContext as "logsink", with no BufferedLogWriter or logrouter in the path.

This meant that in Loki mode, machine/controller log records couldn't be captured and forwarded — they kept going straight to the controller instead of entering the logrouter for routing to Loki.

## QA steps

Ensure that debug-log still works.

```sh
$ juju bootstrap lxd test
$ juju debug-log -m controller --replay
$ juju add-model foo
$ juju deploy juju-qa-test
$ juju debug-log --replay
```

## Links

**Jira card:** [JUJU-9980](https://warthogs.atlassian.net/browse/JUJU-9980)


[JUJU-9980]: https://warthogs.atlassian.net/browse/JUJU-9980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ