### PR TITLE
Juju pr22651 followup

### DIFF
--- a/apiserver/facades/agent/uniter/secret_mocks_test.go
+++ b/apiserver/facades/agent/uniter/secret_mocks_test.go
@@ -34,7 +34,6 @@ type MockSecretServiceMockRecorder struct {
 	getSecretValueExpects          []*gomock.Call4_3[context.Context, *secrets.URI, int, secret.SecretAccessor, secrets.SecretValue, *secrets.ValueRef, error]
 	resolveGrantParamsExpects      []*gomock.Call2_1[context.Context, []secret.SecretAccessParams, []secret.GrantResult]
 	resolveRevokeParamsExpects     []*gomock.Call2_1[context.Context, []secret.SecretAccessParams, []secret.RevokeResult]
-	updateCharmSecretExpects       []*gomock.Call3_1[context.Context, *secrets.URI, secret.UpdateCharmSecretParams, error]
 }
 
 // NewMockSecretService creates a new mock instance.
@@ -156,21 +155,3 @@ func (mr *MockSecretServiceMockRecorder) ResolveRevokeParams(ctx, params any) *M
 
 // MockSecretServiceResolveRevokeParamsCall is the typed call wrapper for ResolveRevokeParams.
 type MockSecretServiceResolveRevokeParamsCall = gomock.Call2_1[context.Context, []secret.SecretAccessParams, []secret.RevokeResult]
-
-// UpdateCharmSecret mocks base method.
-func (m *MockSecretService) UpdateCharmSecret(arg0 context.Context, arg1 *secrets.URI, arg2 secret.UpdateCharmSecretParams) error {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch3_1(&m.recorder.updateCharmSecretExpects, m.ctrl, m, "UpdateCharmSecret", arg0, arg1, arg2)
-}
-
-// UpdateCharmSecret indicates an expected call of UpdateCharmSecret.
-func (mr *MockSecretServiceMockRecorder) UpdateCharmSecret(arg0, arg1, arg2 any) *MockSecretServiceUpdateCharmSecretCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall3_1[context.Context, *secrets.URI, secret.UpdateCharmSecretParams, error](mr.mock.ctrl.T, mr.mock, "UpdateCharmSecret", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
-	mr.updateCharmSecretExpects = append(mr.updateCharmSecretExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockSecretServiceUpdateCharmSecretCall is the typed call wrapper for UpdateCharmSecret.
-type MockSecretServiceUpdateCharmSecretCall = gomock.Call3_1[context.Context, *secrets.URI, secret.UpdateCharmSecretParams, error]

--- a/apiserver/facades/agent/uniter/secrets.go
+++ b/apiserver/facades/agent/uniter/secrets.go
@@ -129,6 +129,69 @@ func fromUpsertParams(p params.UpsertSecretArg, accessor secret.SecretAccessor) 
 	}
 }
 
+// prepareSecretCreates validates and converts a list of create args from the
+// wire format into domain types ready for CommitHookChanges. Per-entry
+// validation errors are collected; only structural URI parse errors cause
+// an immediate abort.
+func (u *UniterAPI) prepareSecretCreates(
+	ctx context.Context, creates []params.CreateSecretArg,
+) ([]unitstate.CreateSecretArg, error) {
+	authTag := u.auth.GetAuthTag()
+	secretCreates := make([]unitstate.CreateSecretArg, 0, len(creates))
+	var createErrs []error
+	for _, createArg := range creates {
+		if len(createArg.Content.Data) == 0 && createArg.Content.ValueRef == nil {
+			createErrs = append(createErrs, errors.NotValidf("empty secret value"))
+			continue
+		}
+		secretOwner, err := names.ParseTag(createArg.OwnerTag)
+		if err != nil {
+			createErrs = append(createErrs, err)
+			continue
+		}
+		if !isSameApplication(authTag, secretOwner) {
+			createErrs = append(createErrs, apiServerErrors.ErrPerm)
+			continue
+		}
+
+		createParams := secret.CreateCharmSecretParams{
+			Version: secrets.Version,
+			UpdateCharmSecretParams: fromUpsertParams(createArg.UpsertSecretArg, secret.SecretAccessor{
+				Kind: secret.UnitAccessor,
+				ID:   authTag.Id(),
+			}),
+		}
+		switch kind := secretOwner.Kind(); kind {
+		case names.UnitTagKind:
+			createParams.CharmOwner = secret.CharmSecretOwner{Kind: secret.UnitCharmSecretOwner, ID: secretOwner.Id()}
+		case names.ApplicationTagKind:
+			createParams.CharmOwner = secret.CharmSecretOwner{Kind: secret.ApplicationCharmSecretOwner, ID: secretOwner.Id()}
+		default:
+			createErrs = append(createErrs, errors.NotValidf("secret owner kind %q", kind))
+			continue
+		}
+		var uri *coresecrets.URI
+		if createArg.URI != nil {
+			uri, err = coresecrets.ParseURI(*createArg.URI)
+			if err != nil {
+				createErrs = append(createErrs, err)
+				continue
+			}
+		} else {
+			uri = coresecrets.NewURI()
+		}
+		secretCreates = append(secretCreates, unitstate.CreateSecretArg{
+			CreateCharmSecretParams: createParams,
+			URI:                     uri,
+		})
+	}
+	if len(createErrs) > 0 {
+		return nil, internalerrors.Errorf(
+			"creating secrets: %w", internalerrors.Join(createErrs...))
+	}
+	return secretCreates, nil
+}
+
 // isSameApplication returns true if the authenticated entity and the specified entity are in the same application.
 func isSameApplication(authTag names.Tag, tag names.Tag) bool {
 	return appFromTag(authTag) == appFromTag(tag)

--- a/apiserver/facades/agent/uniter/secrets.go
+++ b/apiserver/facades/agent/uniter/secrets.go
@@ -27,10 +27,6 @@ type SecretService interface {
 	// parameters and associates it with a given URI.
 	CreateCharmSecret(context.Context, *coresecrets.URI, secret.CreateCharmSecretParams) error
 
-	// UpdateCharmSecret updates an existing charm secret with the provided
-	// parameters and returns an error if the operation fails.
-	UpdateCharmSecret(context.Context, *coresecrets.URI, secret.UpdateCharmSecretParams) error
-
 	// GetSecretValue retrieves the value and reference of a secret for a
 	// specified URI and revision, using a secret accessor.
 	GetSecretValue(context.Context, *coresecrets.URI, int, secret.SecretAccessor) (coresecrets.SecretValue, *coresecrets.ValueRef, error)

--- a/apiserver/facades/agent/uniter/secrets.go
+++ b/apiserver/facades/agent/uniter/secrets.go
@@ -22,8 +22,17 @@ import (
 
 // SecretService provides core secrets operations.
 type SecretService interface {
+
+	// CreateCharmSecret creates a new charm secret with the specified
+	// parameters and associates it with a given URI.
 	CreateCharmSecret(context.Context, *coresecrets.URI, secret.CreateCharmSecretParams) error
+
+	// UpdateCharmSecret updates an existing charm secret with the provided
+	// parameters and returns an error if the operation fails.
 	UpdateCharmSecret(context.Context, *coresecrets.URI, secret.UpdateCharmSecretParams) error
+
+	// GetSecretValue retrieves the value and reference of a secret for a
+	// specified URI and revision, using a secret accessor.
 	GetSecretValue(context.Context, *coresecrets.URI, int, secret.SecretAccessor) (coresecrets.SecretValue, *coresecrets.ValueRef, error)
 
 	// CheckSecretManageAccess verifies the unit has RoleManage access on

--- a/apiserver/facades/agent/uniter/secrets_test.go
+++ b/apiserver/facades/agent/uniter/secrets_test.go
@@ -170,17 +170,94 @@ func (s *UniterSecretsSuite) TestCreateCharmSecretDuplicateLabel(c *tc.C) {
 	})
 }
 
-// --- prepareSecretUpdates tests ---
+// --- prepareSecretCreates tests ---
 
-func (s *UniterSecretsSuite) TestPrepareSecretUpdatesInvalidURI(c *tc.C) {
+func (s *UniterSecretsSuite) TestPrepareSecretCreatesEmptyValue(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	unitName := unittesting.GenNewName(c, "mariadb/0")
-	_, err := s.facade.prepareSecretUpdates(c.Context(), unitName, []params.UpdateSecretArg{{
-		URI: "not-a-valid-uri-%%%",
+	_, err := s.facade.prepareSecretCreates(c.Context(), []params.CreateSecretArg{{
+		OwnerTag:        "unit-mariadb/0",
+		UpsertSecretArg: params.UpsertSecretArg{},
 	}})
-	c.Assert(err, tc.ErrorMatches, `.*invalid URL escape.*`)
+	c.Assert(err, tc.ErrorMatches, `creating secrets: .*empty secret value.*`)
 }
+
+func (s *UniterSecretsSuite) TestPrepareSecretCreatesPermissionDenied(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	_, err := s.facade.prepareSecretCreates(c.Context(), []params.CreateSecretArg{{
+		OwnerTag: "application-mysql",
+		UpsertSecretArg: params.UpsertSecretArg{
+			Content: params.SecretContentParams{Data: map[string]string{"foo": "bar"}},
+		},
+	}})
+	c.Assert(err, tc.ErrorMatches, `creating secrets: .*permission denied.*`)
+}
+
+func (s *UniterSecretsSuite) TestPrepareSecretCreatesUnitOwned(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	result, err := s.facade.prepareSecretCreates(c.Context(), []params.CreateSecretArg{{
+		OwnerTag: "unit-mariadb/0",
+		UpsertSecretArg: params.UpsertSecretArg{
+			RotatePolicy: new(coresecrets.RotateDaily),
+			Description:  new("my secret"),
+			Label:        new("foobar"),
+			Content:      params.SecretContentParams{Data: data, Checksum: "checksum"},
+		},
+	}})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.HasLen, 1)
+	c.Check(result[0].URI, tc.Not(tc.IsNil))
+	c.Check(result[0].Data, tc.DeepEquals, coresecrets.SecretData(data))
+	c.Check(result[0].Checksum, tc.Equals, "checksum")
+	c.Check(result[0].CharmOwner.Kind, tc.Equals, secret.UnitCharmSecretOwner)
+	c.Check(result[0].CharmOwner.ID, tc.Equals, "mariadb/0")
+	c.Check(result[0].Accessor.Kind, tc.Equals, secret.UnitAccessor)
+	c.Check(result[0].Accessor.ID, tc.Equals, "mariadb/0")
+	c.Check(*result[0].RotatePolicy, tc.Equals, coresecrets.RotateDaily)
+}
+
+func (s *UniterSecretsSuite) TestPrepareSecretCreatesAppOwned(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	data := map[string]string{"foo": "bar"}
+	result, err := s.facade.prepareSecretCreates(c.Context(), []params.CreateSecretArg{{
+		OwnerTag: "application-mariadb",
+		UpsertSecretArg: params.UpsertSecretArg{
+			Content: params.SecretContentParams{Data: data},
+		},
+	}})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.HasLen, 1)
+	c.Check(result[0].URI, tc.Not(tc.IsNil))
+	c.Check(result[0].Data, tc.DeepEquals, coresecrets.SecretData(data))
+	c.Check(result[0].CharmOwner.Kind, tc.Equals, secret.ApplicationCharmSecretOwner)
+	c.Check(result[0].CharmOwner.ID, tc.Equals, "mariadb")
+	c.Check(result[0].Accessor.Kind, tc.Equals, secret.UnitAccessor)
+	c.Check(result[0].Accessor.ID, tc.Equals, "mariadb/0")
+}
+
+func (s *UniterSecretsSuite) TestPrepareSecretCreatesWithCustomURI(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uri := coresecrets.NewURI()
+	data := map[string]string{"foo": "bar"}
+	result, err := s.facade.prepareSecretCreates(c.Context(), []params.CreateSecretArg{{
+		OwnerTag: "unit-mariadb/0",
+		URI:      new(uri.String()),
+		UpsertSecretArg: params.UpsertSecretArg{
+			Content: params.SecretContentParams{Data: data},
+		},
+	}})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.HasLen, 1)
+	c.Check(result[0].URI.String(), tc.Equals, uri.String())
+	c.Check(result[0].Data, tc.DeepEquals, coresecrets.SecretData(data))
+}
+
+// --- prepareSecretUpdates tests ---
 
 func (s *UniterSecretsSuite) TestPrepareSecretUpdatesNotFoundSkipped(c *tc.C) {
 	defer s.setupMocks(c).Finish()

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2987,23 +2987,12 @@ func (u *UniterAPI) commitHookChangesForOneUnit(
 	}
 	arg.AddStorage = preparedStorageAdds
 
-	// TODO - do in txn once we have support for that
 	if len(changes.SecretCreates) > 0 {
-		result, err := u.createSecrets(ctx, params.CreateSecretArgs{Args: changes.SecretCreates})
-		if err == nil {
-			var errorStrings []string
-			for _, r := range result.Results {
-				if r.Error != nil {
-					errorStrings = append(errorStrings, r.Error.Error())
-				}
-			}
-			if errorStrings != nil {
-				err = errors.New(strings.Join(errorStrings, "\n"))
-			}
-		}
+		secretCreates, err := u.prepareSecretCreates(ctx, changes.SecretCreates)
 		if err != nil {
-			return errors.Annotate(err, "creating secrets")
+			return apiservererrors.ServerError(err)
 		}
+		arg.SecretCreates = secretCreates
 	}
 	// Convert secret updates to domain types, filtering out any the unit
 	// does not have manage access on.

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/juju/juju/domain/unitstate"
 	internalerrors "github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/secrets"
 	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/rpc/params"
 )
@@ -3740,6 +3741,109 @@ func (s *commitHookChangesSuite) TestCommitHookChangesUpdateSecrets(c *tc.C) {
 		},
 	)
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *commitHookChangesSuite) TestCommitHookChangesCreateSecretsUnitOwned(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName, _ := coreunit.NewName("wordpress/0")
+	unitTag := names.NewUnitTag(unitName.String())
+
+	data := map[string]string{"foo": "bar"}
+
+	s.unitStateService.EXPECT().CommitHookChanges(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, arg unitstate.CommitHookChangesArg) error {
+			c.Check(arg.UnitName, tc.Equals, unitName)
+			c.Assert(len(arg.SecretCreates), tc.Equals, 1)
+			c.Check(arg.SecretCreates[0].URI, tc.Not(tc.IsNil))
+			c.Check(arg.SecretCreates[0].Version, tc.Equals, secrets.Version)
+			c.Check(arg.SecretCreates[0].CharmOwner.Kind, tc.Equals, domainsecret.UnitCharmSecretOwner)
+			c.Check(arg.SecretCreates[0].CharmOwner.ID, tc.Equals, "wordpress/0")
+			c.Check(arg.SecretCreates[0].Data, tc.DeepEquals, coresecrets.SecretData(data))
+			return nil
+		})
+
+	err := s.uniter.commitHookChangesForOneUnit(c.Context(), unitTag,
+		params.CommitHookChangesArg{
+			Tag: unitTag.String(),
+			SecretCreates: []params.CreateSecretArg{{
+				OwnerTag: "unit-wordpress/0",
+				UpsertSecretArg: params.UpsertSecretArg{
+					Content: params.SecretContentParams{Data: data},
+				},
+			}},
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *commitHookChangesSuite) TestCommitHookChangesCreateSecretsAppOwned(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName, _ := coreunit.NewName("wordpress/0")
+	unitTag := names.NewUnitTag(unitName.String())
+
+	data := map[string]string{"foo": "bar"}
+
+	s.unitStateService.EXPECT().CommitHookChanges(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, arg unitstate.CommitHookChangesArg) error {
+			c.Check(arg.UnitName, tc.Equals, unitName)
+			c.Assert(len(arg.SecretCreates), tc.Equals, 1)
+			c.Check(arg.SecretCreates[0].CharmOwner.Kind, tc.Equals, domainsecret.ApplicationCharmSecretOwner)
+			c.Check(arg.SecretCreates[0].CharmOwner.ID, tc.Equals, "wordpress")
+			return nil
+		})
+
+	err := s.uniter.commitHookChangesForOneUnit(c.Context(), unitTag,
+		params.CommitHookChangesArg{
+			Tag: unitTag.String(),
+			SecretCreates: []params.CreateSecretArg{{
+				OwnerTag: "application-wordpress",
+				UpsertSecretArg: params.UpsertSecretArg{
+					Content: params.SecretContentParams{Data: data},
+				},
+			}},
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *commitHookChangesSuite) TestCommitHookChangesCreateSecretsPermissionDenied(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName, _ := coreunit.NewName("wordpress/0")
+	unitTag := names.NewUnitTag(unitName.String())
+
+	err := s.uniter.commitHookChangesForOneUnit(c.Context(), unitTag,
+		params.CommitHookChangesArg{
+			Tag: unitTag.String(),
+			SecretCreates: []params.CreateSecretArg{{
+				OwnerTag: "application-mysql",
+				UpsertSecretArg: params.UpsertSecretArg{
+					Content: params.SecretContentParams{Data: map[string]string{"foo": "bar"}},
+				},
+			}},
+		},
+	)
+	c.Assert(err, tc.ErrorMatches, `creating secrets: .*permission denied.*`)
+}
+
+func (s *commitHookChangesSuite) TestCommitHookChangesCreateSecretsEmptyValue(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName, _ := coreunit.NewName("wordpress/0")
+	unitTag := names.NewUnitTag(unitName.String())
+
+	err := s.uniter.commitHookChangesForOneUnit(c.Context(), unitTag,
+		params.CommitHookChangesArg{
+			Tag: unitTag.String(),
+			SecretCreates: []params.CreateSecretArg{{
+				OwnerTag:        "unit-wordpress/0",
+				UpsertSecretArg: params.UpsertSecretArg{},
+			}},
+		},
+	)
+	c.Assert(err, tc.ErrorMatches, `creating secrets: .*empty secret value.*`)
 }
 
 func (s *commitHookChangesSuite) TestCommitHookChangesOpenPortFail(c *tc.C) {

--- a/domain/unitstate/internal/types.go
+++ b/domain/unitstate/internal/types.go
@@ -191,6 +191,11 @@ type UpdateSecretArg struct {
 	// RotatePolicy is the new rotation policy (nil if unchanged).
 	RotatePolicy *domainsecret.RotatePolicy
 
+	// NextRotateTime is the computed next rotation time (nil if no change to
+	// the rotation schedule is needed). When the policy changes to
+	// RotateNever, the state layer deletes the secret_rotation row instead.
+	NextRotateTime *time.Time
+
 	// ExpireTime is the expiry time (nil if unchanged).
 	ExpireTime *time.Time
 

--- a/domain/unitstate/internal/types.go
+++ b/domain/unitstate/internal/types.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/relation"
 	"github.com/juju/juju/domain/life"
-	"github.com/juju/juju/domain/secret"
+	domainsecret "github.com/juju/juju/domain/secret"
 	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/internal/errors"
 )
@@ -46,6 +46,9 @@ type CommitHookUnitInfo struct {
 	// MachineUUID is the UUID of the unit's machine, if the unit is
 	// machine-backed.
 	MachineUUID *string
+
+	// ApplicationUUID is the UUID of the unit's application.
+	ApplicationUUID string
 }
 
 // CommitHookChangesArg contains data needed to commit a hook change
@@ -80,8 +83,9 @@ type CommitHookChangesArg struct {
 	// hook transaction.
 	AddStorage []unitstate.PreparedStorageAdd
 
-	// SecretCreates contains charm secrets to create.
-	SecretCreates []unitstate.CreateSecretArg
+	// SecretCreates contains pre-computed charm secrets to create inside
+	// the transaction.
+	SecretCreates []CreateSecretArg
 
 	// TrackLatestSecrets is a slice of URIs for which the latest revision should
 	// be tracked.
@@ -112,6 +116,30 @@ type DeleteSecretArg struct {
 	ArgJSON *string
 }
 
+// CreateSecretArg holds a pre-computed secret creation request ready for the
+// state layer. All values are resolved and computed outside the transaction.
+type CreateSecretArg struct {
+	// SecretID is the short ID stored in the database (from URI.ID).
+	SecretID string
+
+	// Version is the secret version (typically 1).
+	Version int
+
+	// OwnerKind indicates whether the secret is owned by an application
+	// or a unit.
+	OwnerKind domainsecret.CharmSecretOwnerKind
+
+	// OwnerUUID is the resolved application UUID or unit UUID of the owner.
+	OwnerUUID string
+
+	// Label is the optional secret label.
+	Label string
+
+	// Params contains the pre-computed parameters for creating the secret
+	// (timestamps, revision ID, data, value ref, rotate policy, etc.).
+	Params domainsecret.UpsertSecretParams
+}
+
 // secretDeletionArg is the JSON payload stored in the removal table's arg
 // column when scheduling a charm-secret deletion with specific revisions.
 type secretDeletionArg struct {
@@ -128,16 +156,16 @@ type GrantSecretArg struct {
 	SubjectUUID string
 
 	// SubjectTypeID is the type of the subject entity.
-	SubjectTypeID secret.GrantSubjectType
+	SubjectTypeID domainsecret.GrantSubjectType
 
 	// ScopeUUID is the resolved UUID of the access scope entity.
 	ScopeUUID string
 
 	// ScopeTypeID is the type of the scope entity.
-	ScopeTypeID secret.GrantScopeType
+	ScopeTypeID domainsecret.GrantScopeType
 
 	// RoleID is the role being granted.
-	RoleID secret.Role
+	RoleID domainsecret.Role
 }
 
 // RevokeSecretArg holds a pre-resolved secret revoke request ready for the
@@ -150,7 +178,7 @@ type RevokeSecretArg struct {
 	SubjectUUID string
 
 	// SubjectTypeID is the type of the subject entity.
-	SubjectTypeID secret.GrantSubjectType
+	SubjectTypeID domainsecret.GrantSubjectType
 }
 
 // UpdateSecretArg holds a pre-resolved secret update request ready for the
@@ -161,7 +189,7 @@ type UpdateSecretArg struct {
 	SecretID string
 
 	// RotatePolicy is the new rotation policy (nil if unchanged).
-	RotatePolicy *secret.RotatePolicy
+	RotatePolicy *domainsecret.RotatePolicy
 
 	// ExpireTime is the expiry time (nil if unchanged).
 	ExpireTime *time.Time
@@ -189,12 +217,13 @@ type UpdateSecretArg struct {
 	RevisionUUID string
 
 	// OwnerKind indicates whether the secret is owned by application or unit.
-	OwnerKind secret.CharmSecretOwnerKind
+	OwnerKind domainsecret.CharmSecretOwnerKind
 }
 
 // TransformCommitHookChangesArg takes a domain package CommitHookChangesArg
 // struct and return an internal package CommitHookChangesArg struct. Does not
-// include RelationSettings.
+// include RelationSettings. SecretCreates and SecretUpdates are handled
+// separately by the service layer's pre-computation step.
 func TransformCommitHookChangesArg(
 	in unitstate.CommitHookChangesArg, unitInfo CommitHookUnitInfo,
 ) (CommitHookChangesArg, error) {
@@ -220,7 +249,7 @@ func TransformCommitHookChangesArg(
 		OpenPorts:          in.OpenPorts,
 		ClosePorts:         in.ClosePorts,
 		CharmState:         in.CharmState,
-		SecretCreates:      in.SecretCreates,
+		SecretCreates:      nil, // will be populated outside this function
 		TrackLatestSecrets: in.TrackLatestSecrets,
 		SecretUpdates:      nil, // will be populated outside this function
 		SecretGrants:       secretGrants,

--- a/domain/unitstate/service/commithook.go
+++ b/domain/unitstate/service/commithook.go
@@ -131,7 +131,7 @@ func (s *LeadershipService) prepareSecretCreates(
 	ctx context.Context,
 	creates []unitstate.CreateSecretArg,
 	unitInfo internal.CommitHookUnitInfo,
-) (result []internal.CreateSecretArg, rollbacks []func() error, err error) {
+) (_ []internal.CreateSecretArg, _ []func() error, err error) {
 	if len(creates) == 0 {
 		return nil, nil, nil
 	}
@@ -142,7 +142,8 @@ func (s *LeadershipService) prepareSecretCreates(
 	}
 
 	now := s.clock.Now()
-	result = make([]internal.CreateSecretArg, 0, len(creates))
+	result := make([]internal.CreateSecretArg, 0, len(creates))
+	rollbacks := make([]func() error, 0, len(creates))
 	defer func() {
 		if err != nil {
 			s.rollbackAll(ctx, rollbacks)
@@ -221,7 +222,7 @@ func (s *LeadershipService) prepareSecretCreates(
 func (s *LeadershipService) prepareSecretUpdates(
 	ctx context.Context,
 	updates []unitstate.UpdateSecretArg,
-) (result []internal.UpdateSecretArg, rollbacks []func() error, err error) {
+) (_ []internal.UpdateSecretArg, _ []func() error, err error) {
 	if len(updates) == 0 {
 		return nil, nil, nil
 	}
@@ -231,7 +232,8 @@ func (s *LeadershipService) prepareSecretUpdates(
 		return nil, nil, errors.Errorf("getting model uuid: %w", err)
 	}
 
-	result = make([]internal.UpdateSecretArg, 0, len(updates))
+	result := make([]internal.UpdateSecretArg, 0, len(updates))
+	rollbacks := make([]func() error, 0, len(updates))
 	// Roll back accumulated backend references on any error during
 	// preparation. Failures are logged, not propagated — see rollbackAll.
 	defer func() {

--- a/domain/unitstate/service/commithook.go
+++ b/domain/unitstate/service/commithook.go
@@ -12,7 +12,7 @@ import (
 
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/relation"
-	"github.com/juju/juju/core/secrets"
+	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/trace"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
@@ -70,6 +70,15 @@ func (s *LeadershipService) CommitHookChanges(ctx context.Context, arg unitstate
 			s.rollbackAll(ctx, rollbacks)
 		}
 	}()
+
+	// Pre-compute secret creates outside the transaction.
+	secretCreates, createRollbacks, err := s.prepareSecretCreates(ctx, arg.SecretCreates, unitInfo)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	rollbacks = append(rollbacks, createRollbacks...)
+
+	// Pre-compute secret updates outside the transaction.
 	secretUpdates, updateRollbacks, err := s.prepareSecretUpdates(ctx, arg.SecretUpdates)
 	if err != nil {
 		return errors.Capture(err)
@@ -81,6 +90,7 @@ func (s *LeadershipService) CommitHookChanges(ctx context.Context, arg unitstate
 		return errors.Capture(err)
 	}
 	newArgs.RelationSettings = relationSettings
+	newArgs.SecretCreates = secretCreates
 	newArgs.SecretUpdates = secretUpdates
 
 	withCaveat, err := s.getManagementCaveat(arg)
@@ -112,6 +122,97 @@ func (s *LeadershipService) getManagementCaveat(
 	return func(ctx context.Context, fn func(context.Context) error) error {
 		return fn(ctx)
 	}, nil
+}
+
+// prepareSecretCreates pre-computes all data needed for secret creation
+// outside the main transaction: generates revision UUIDs, timestamps, resolves
+// owner UUIDs, and calls AddSecretBackendReference on the controller DB.
+func (s *LeadershipService) prepareSecretCreates(
+	ctx context.Context,
+	creates []unitstate.CreateSecretArg,
+	unitInfo internal.CommitHookUnitInfo,
+) (result []internal.CreateSecretArg, rollbacks []func() error, err error) {
+	if len(creates) == 0 {
+		return nil, nil, nil
+	}
+
+	modelID, err := s.st.GetModelUUID(ctx)
+	if err != nil {
+		return nil, nil, errors.Errorf("getting model uuid: %w", err)
+	}
+
+	now := s.clock.Now()
+	result = make([]internal.CreateSecretArg, 0, len(creates))
+	defer func() {
+		if err != nil {
+			s.rollbackAll(ctx, rollbacks)
+		}
+	}()
+
+	for i, create := range creates {
+		revisionID, err := s.uuidGenerator()
+		if err != nil {
+			return nil, nil, errors.Errorf("generating revision UUID for create[%d]: %w", i, err)
+		}
+
+		p := domainsecret.UpsertSecretParams{
+			Description:  create.Description,
+			Label:        create.Label,
+			ValueRef:     create.ValueRef,
+			Checksum:     create.Checksum,
+			CreateTime:   now,
+			UpdateTime:   now,
+			RevisionUUID: new(revisionID.String()),
+		}
+
+		if len(create.Data) > 0 {
+			p.Data = make(coresecrets.SecretData)
+			maps.Copy(p.Data, create.Data)
+		}
+
+		rotatePolicy := domainsecret.MarshallRotatePolicy(create.RotatePolicy)
+		p.RotatePolicy = &rotatePolicy
+		if create.RotatePolicy != nil && create.RotatePolicy.WillRotate() {
+			p.NextRotateTime = create.RotatePolicy.NextRotateTime(now)
+		}
+		p.ExpireTime = create.ExpireTime
+
+		// Resolve owner UUID.
+		ownerKind := create.CharmOwner.Kind
+		var ownerUUID string
+		switch ownerKind {
+		case domainsecret.ApplicationCharmSecretOwner:
+			ownerUUID = unitInfo.ApplicationUUID
+		case domainsecret.UnitCharmSecretOwner:
+			ownerUUID = unitInfo.UnitUUID
+		default:
+			return nil, nil, errors.Errorf("unexpected owner kind %q for create[%d]", ownerKind, i)
+		}
+
+		// Add backend reference (controller DB, outside model txn).
+		rollBack, err := s.secretBackendState.AddSecretBackendReference(
+			ctx, p.ValueRef, coremodel.UUID(modelID), revisionID.String(), create.URI.ID)
+		if err != nil {
+			return nil, nil, errors.Errorf("adding backend reference for create[%d]: %w", i, err)
+		}
+		rollbacks = append(rollbacks, rollBack)
+
+		var label string
+		if create.Label != nil {
+			label = *create.Label
+		}
+
+		result = append(result, internal.CreateSecretArg{
+			SecretID:  create.URI.ID,
+			Version:   create.Version,
+			OwnerKind: ownerKind,
+			OwnerUUID: ownerUUID,
+			Label:     label,
+			Params:    p,
+		})
+	}
+
+	return result, rollbacks, nil
 }
 
 // prepareSecretUpdates pre-computes all data needed for secret updates
@@ -180,9 +281,9 @@ func (s *LeadershipService) prepareSecretUpdates(
 			}
 			arg.RevisionUUID = revisionID.String()
 
-			var valueRef *secrets.ValueRef
+			var valueRef *coresecrets.ValueRef
 			if arg.ValueRefBackendID != "" {
-				valueRef = &secrets.ValueRef{
+				valueRef = &coresecrets.ValueRef{
 					BackendID:  arg.ValueRefBackendID,
 					RevisionID: arg.ValueRefRevisionID,
 				}

--- a/domain/unitstate/service/commithook.go
+++ b/domain/unitstate/service/commithook.go
@@ -17,6 +17,7 @@ import (
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
 	domainsecret "github.com/juju/juju/domain/secret"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/domain/unitstate/internal"
 	"github.com/juju/juju/internal/errors"
@@ -252,6 +253,24 @@ func (s *LeadershipService) prepareSecretUpdates(
 		if update.RotatePolicy != nil {
 			p := domainsecret.MarshallRotatePolicy(update.RotatePolicy)
 			arg.RotatePolicy = &p
+
+			if update.RotatePolicy.WillRotate() {
+				currentPolicy, err := s.st.GetSecretRotatePolicy(ctx, update.URI.ID)
+				if errors.Is(err, secreterrors.SecretNotFound) {
+					// SecretNotFound is expected when the secret is being created
+					// in this same transaction or was concurrently deleted. In both
+					// cases, we treat it as having RotateNever policy. This ensures
+					// NextRotateTime is computed when updating to a policy that
+					// rotates, implementing "last update wins" semantics. Transaction
+					// isolation at the database layer handles actual concurrent deletes.
+					currentPolicy = coresecrets.RotateNever
+				} else if err != nil {
+					return nil, nil, errors.Errorf("getting rotate policy for update[%d]: %w", i, err)
+				}
+				if update.RotatePolicy.LessThan(currentPolicy) {
+					arg.NextRotateTime = update.RotatePolicy.NextRotateTime(s.clock.Now())
+				}
+			}
 		}
 		if update.ExpireTime != nil {
 			arg.ExpireTime = update.ExpireTime

--- a/domain/unitstate/service/commithook_test.go
+++ b/domain/unitstate/service/commithook_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/juju/clock/testclock"
 	"github.com/juju/tc"
 
+	coreapplication "github.com/juju/juju/core/application"
 	model "github.com/juju/juju/core/model"
 	corerelation "github.com/juju/juju/core/relation"
 	corerelationtesting "github.com/juju/juju/core/relation/testing"
 	coresecrets "github.com/juju/juju/core/secrets"
 	coreunit "github.com/juju/juju/core/unit"
 	unittesting "github.com/juju/juju/core/unit/testing"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/life"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
 	"github.com/juju/juju/domain/secret"
 	"github.com/juju/juju/domain/unitstate"
@@ -494,6 +497,266 @@ func (s *commitHookSuite) TestParseForSetAndUnsetSettingsNilSettings(c *tc.C) {
 	// Assert
 	c.Check(obtainedSettings, tc.DeepEquals, unitstate.Settings(nil))
 	c.Check(obtainedKeys, tc.DeepEquals, []string{"key1"})
+}
+
+func (s *commitHookSuite) TestCommitHookChangesCreateAppSecretRequiresLeadership(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{
+		UnitUUID:        unitUUID.String(),
+		ApplicationUUID: appUUID.String(),
+	}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetModelUUID(gomock.Any()).Return("model-uuid", nil)
+	s.secretBackend.EXPECT().AddSecretBackendReference(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(func() error { return nil }, nil)
+	s.leadershipEnsurer.EXPECT().WithLeader(gomock.Any(), "test", "test/0", gomock.Any()).Return(nil)
+
+	uri := coresecrets.NewURI()
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretCreates: []unitstate.CreateSecretArg{{
+			CreateCharmSecretParams: secret.CreateCharmSecretParams{
+				Version: 1,
+				CharmOwner: secret.CharmSecretOwner{
+					Kind: secret.ApplicationCharmSecretOwner,
+					ID:   "test",
+				},
+				UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+					Data:     map[string]string{"key": "val"},
+					Checksum: "checksum",
+				},
+			},
+			URI: uri,
+		}},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *commitHookSuite) TestCommitHookChangesCreateUnitSecretNoLeadership(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{
+		UnitUUID: unitUUID.String(),
+	}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetModelUUID(gomock.Any()).Return("model-uuid", nil)
+	s.secretBackend.EXPECT().AddSecretBackendReference(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(func() error { return nil }, nil)
+	s.st.EXPECT().CommitHookChanges(gomock.Any(), gomock.Any()).Return(nil)
+
+	uri := coresecrets.NewURI()
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretCreates: []unitstate.CreateSecretArg{{
+			CreateCharmSecretParams: secret.CreateCharmSecretParams{
+				Version: 1,
+				CharmOwner: secret.CharmSecretOwner{
+					Kind: secret.UnitCharmSecretOwner,
+					ID:   "test/0",
+				},
+				UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+					Data:     map[string]string{"key": "val"},
+					Checksum: "checksum",
+				},
+			},
+			URI: uri,
+		}},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *commitHookSuite) TestPrepareSecretCreatesUUIDGenerationFailure(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uuidErr := errors.New("uuid boom")
+	s.svc.uuidGenerator = func() (uuid.UUID, error) {
+		return uuid.UUID{}, uuidErr
+	}
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{UnitUUID: unitUUID.String()}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetModelUUID(gomock.Any()).Return("model-uuid", nil)
+
+	uri := coresecrets.NewURI()
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretCreates: []unitstate.CreateSecretArg{{
+			CreateCharmSecretParams: secret.CreateCharmSecretParams{
+				Version: 1,
+				CharmOwner: secret.CharmSecretOwner{
+					Kind: secret.UnitCharmSecretOwner,
+					ID:   "test/0",
+				},
+				UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+					Data:     map[string]string{"key": "val"},
+					Checksum: "checksum",
+				},
+			},
+			URI: uri,
+		}},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorMatches, `generating revision UUID for create\[0\]: uuid boom`)
+}
+
+func (s *commitHookSuite) TestPrepareSecretCreatesBackendRefFailure(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{UnitUUID: unitUUID.String()}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetModelUUID(gomock.Any()).Return("model-uuid", nil)
+	s.secretBackend.EXPECT().AddSecretBackendReference(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil, errors.New("backend boom"))
+
+	uri := coresecrets.NewURI()
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretCreates: []unitstate.CreateSecretArg{{
+			CreateCharmSecretParams: secret.CreateCharmSecretParams{
+				Version: 1,
+				CharmOwner: secret.CharmSecretOwner{
+					Kind: secret.UnitCharmSecretOwner,
+					ID:   "test/0",
+				},
+				UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+					Data:     map[string]string{"key": "val"},
+					Checksum: "checksum",
+				},
+			},
+			URI: uri,
+		}},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Check(err, tc.ErrorMatches, `.*adding backend reference for create\[0\].*`)
+}
+
+func (s *commitHookSuite) TestPrepareSecretCreatesEmpty(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+
+	arg := unitstate.CommitHookChangesArg{
+		UnitName:      unitName,
+		SecretCreates: nil,
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *commitHookSuite) TestCommitHookChangesSecretCreateDeadUnit(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{
+		UnitUUID: unitUUID.String(),
+		UnitLife: life.Dead,
+	}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+
+	uri := coresecrets.NewURI()
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretCreates: []unitstate.CreateSecretArg{{
+			CreateCharmSecretParams: secret.CreateCharmSecretParams{
+				Version: 1,
+				CharmOwner: secret.CharmSecretOwner{
+					Kind: secret.UnitCharmSecretOwner,
+					ID:   "test/0",
+				},
+				UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+					Data:     map[string]string{"key": "val"},
+					Checksum: "checksum",
+				},
+			},
+			URI: uri,
+		}},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorMatches, `.*unit "test/0" is dead.*`)
+	c.Assert(err, tc.ErrorIs, applicationerrors.UnitIsDead)
+}
+
+func (s *commitHookSuite) TestPrepareSecretCreatesPartialRollback(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{UnitUUID: unitUUID.String()}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetModelUUID(gomock.Any()).Return("model-uuid", nil)
+
+	firstRolledBack := false
+	s.secretBackend.EXPECT().AddSecretBackendReference(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(func() error {
+		firstRolledBack = true
+		return nil
+	}, nil)
+	s.secretBackend.EXPECT().AddSecretBackendReference(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil, errors.New("backend boom"))
+
+	uri1 := coresecrets.NewURI()
+	uri2 := coresecrets.NewURI()
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretCreates: []unitstate.CreateSecretArg{
+			{
+				CreateCharmSecretParams: secret.CreateCharmSecretParams{
+					Version: 1,
+					CharmOwner: secret.CharmSecretOwner{
+						Kind: secret.UnitCharmSecretOwner,
+						ID:   "test/0",
+					},
+					UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+						Data:     map[string]string{"a": "1"},
+						Checksum: "checksum-1",
+					},
+				},
+				URI: uri1,
+			},
+			{
+				CreateCharmSecretParams: secret.CreateCharmSecretParams{
+					Version: 1,
+					CharmOwner: secret.CharmSecretOwner{
+						Kind: secret.UnitCharmSecretOwner,
+						ID:   "test/0",
+					},
+					UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+						Data:     map[string]string{"b": "2"},
+						Checksum: "checksum-2",
+					},
+				},
+				URI: uri2,
+			},
+		},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Check(err, tc.ErrorMatches, `.*adding backend reference for create\[1\].*`)
+	c.Check(firstRolledBack, tc.IsTrue)
 }
 
 func (s *commitHookSuite) setupMocks(c *tc.C) *gomock.Controller {

--- a/domain/unitstate/service/commithook_test.go
+++ b/domain/unitstate/service/commithook_test.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/juju/juju/domain/life"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
 	"github.com/juju/juju/domain/secret"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/domain/unitstate/internal"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -500,6 +502,182 @@ func (s *commitHookSuite) TestPrepareSecretUpdatesPartialRollback(c *tc.C) {
 	err := s.svc.CommitHookChanges(c.Context(), arg)
 	c.Check(err, tc.ErrorMatches, `.*adding backend reference for update\[1\].*`)
 	c.Check(firstRolledBack, tc.IsTrue)
+}
+
+func (s *commitHookSuite) TestPrepareSecretUpdatesRotatePolicyMoreFrequent(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{UnitUUID: unitUUID.String()}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetModelUUID(gomock.Any()).Return("model-uuid", nil)
+
+	uri := coresecrets.NewURI()
+
+	// Mock the current policy as RotateDaily (less frequent than RotateHourly).
+	s.st.EXPECT().GetSecretRotatePolicy(gomock.Any(), uri.ID).
+		Return(coresecrets.RotateDaily, nil)
+
+	var captured internal.CommitHookChangesArg
+	s.st.EXPECT().CommitHookChanges(gomock.Any(), gomock.Any()).
+		Do(func(_ context.Context, arg internal.CommitHookChangesArg) {
+			captured = arg
+		}).
+		Return(nil)
+
+	hourly := coresecrets.RotateHourly
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretUpdates: []unitstate.UpdateSecretArg{{
+			URI: uri,
+			UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+				RotatePolicy: &hourly,
+			},
+		}},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(captured.SecretUpdates), tc.Equals, 1)
+	update := captured.SecretUpdates[0]
+	c.Assert(update.NextRotateTime, tc.Not(tc.IsNil))
+	c.Assert(update.RotatePolicy, tc.Not(tc.IsNil))
+	c.Check(*update.RotatePolicy, tc.Equals, secret.RotateHourly)
+	// NextRotateTime should be roughly now + 1 hour.
+	expected := s.clock.Now().Add(time.Hour)
+	c.Check(update.NextRotateTime.UTC().Truncate(time.Second), tc.Equals, expected.UTC().Truncate(time.Second))
+}
+
+func (s *commitHookSuite) TestPrepareSecretUpdatesRotatePolicyToNever(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{UnitUUID: unitUUID.String()}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetModelUUID(gomock.Any()).Return("model-uuid", nil)
+
+	uri := coresecrets.NewURI()
+
+	// GetSecretRotatePolicy must NOT be called because RotateNever.WillRotate() returns false.
+	var captured internal.CommitHookChangesArg
+	s.st.EXPECT().CommitHookChanges(gomock.Any(), gomock.Any()).
+		Do(func(_ context.Context, arg internal.CommitHookChangesArg) {
+			captured = arg
+		}).
+		Return(nil)
+
+	never := coresecrets.RotateNever
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretUpdates: []unitstate.UpdateSecretArg{{
+			URI: uri,
+			UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+				RotatePolicy: &never,
+			},
+		}},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(captured.SecretUpdates), tc.Equals, 1)
+	update := captured.SecretUpdates[0]
+	c.Assert(update.NextRotateTime, tc.IsNil)
+	c.Assert(update.RotatePolicy, tc.Not(tc.IsNil))
+	c.Check(*update.RotatePolicy, tc.Equals, secret.RotateNever)
+}
+
+func (s *commitHookSuite) TestPrepareSecretUpdatesRotatePolicyLessFrequent(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{UnitUUID: unitUUID.String()}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetModelUUID(gomock.Any()).Return("model-uuid", nil)
+
+	uri := coresecrets.NewURI()
+
+	// Mock the current policy as RotateHourly (more frequent than RotateDaily).
+	s.st.EXPECT().GetSecretRotatePolicy(gomock.Any(), uri.ID).
+		Return(coresecrets.RotateHourly, nil)
+
+	var captured internal.CommitHookChangesArg
+	s.st.EXPECT().CommitHookChanges(gomock.Any(), gomock.Any()).
+		Do(func(_ context.Context, arg internal.CommitHookChangesArg) {
+			captured = arg
+		}).
+		Return(nil)
+
+	daily := coresecrets.RotateDaily
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretUpdates: []unitstate.UpdateSecretArg{{
+			URI: uri,
+			UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+				RotatePolicy: &daily,
+			},
+		}},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(captured.SecretUpdates), tc.Equals, 1)
+	update := captured.SecretUpdates[0]
+	// NextRotateTime should be nil because the new policy is less frequent.
+	c.Assert(update.NextRotateTime, tc.IsNil)
+	c.Assert(update.RotatePolicy, tc.Not(tc.IsNil))
+	c.Check(*update.RotatePolicy, tc.Equals, secret.RotateDaily)
+}
+
+func (s *commitHookSuite) TestPrepareSecretUpdatesRotatePolicySecretNotFound(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{UnitUUID: unitUUID.String()}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetModelUUID(gomock.Any()).Return("model-uuid", nil)
+
+	uri := coresecrets.NewURI()
+
+	// Mock GetSecretRotatePolicy to return SecretNotFound, which occurs when
+	// the secret is being created in this transaction or was concurrently deleted.
+	s.st.EXPECT().GetSecretRotatePolicy(gomock.Any(), uri.ID).
+		Return(coresecrets.RotateNever, secreterrors.SecretNotFound)
+
+	var captured internal.CommitHookChangesArg
+	s.st.EXPECT().CommitHookChanges(gomock.Any(), gomock.Any()).
+		Do(func(_ context.Context, arg internal.CommitHookChangesArg) {
+			captured = arg
+		}).
+		Return(nil)
+
+	hourly := coresecrets.RotateHourly
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretUpdates: []unitstate.UpdateSecretArg{{
+			URI: uri,
+			UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+				RotatePolicy: &hourly,
+			},
+		}},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(len(captured.SecretUpdates), tc.Equals, 1)
+	update := captured.SecretUpdates[0]
+	// NextRotateTime should be computed because SecretNotFound is treated as RotateNever.
+	// This implements "last update wins" semantics and handles the case where a secret
+	// is being created in the same transaction or was concurrently deleted.
+	c.Assert(update.NextRotateTime, tc.Not(tc.IsNil))
+	c.Assert(update.RotatePolicy, tc.Not(tc.IsNil))
+	c.Check(*update.RotatePolicy, tc.Equals, secret.RotateHourly)
+	// NextRotateTime should be roughly now + 1 hour.
+	expected := s.clock.Now().Add(time.Hour)
+	c.Check(update.NextRotateTime.UTC().Truncate(time.Second), tc.Equals, expected.UTC().Truncate(time.Second))
 }
 
 func (s *commitHookSuite) TestParseForSetAndUnsetSettings(c *tc.C) {

--- a/domain/unitstate/service/commithook_test.go
+++ b/domain/unitstate/service/commithook_test.go
@@ -455,6 +455,53 @@ func (s *commitHookSuite) TestPrepareSecretUpdatesDifferentChecksumAddsBackendRe
 	c.Check(rollbackCalled, tc.IsFalse)
 }
 
+func (s *commitHookSuite) TestPrepareSecretUpdatesPartialRollback(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unittesting.GenNewName(c, "test/0")
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	unitInfo := internal.CommitHookUnitInfo{UnitUUID: unitUUID.String()}
+	s.st.EXPECT().GetCommitHookUnitInfo(gomock.Any(), unitName.String()).Return(unitInfo, nil)
+	s.st.EXPECT().GetModelUUID(gomock.Any()).Return("model-uuid", nil)
+
+	firstRolledBack := false
+	s.secretBackend.EXPECT().AddSecretBackendReference(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(func() error {
+		firstRolledBack = true
+		return nil
+	}, nil)
+	s.secretBackend.EXPECT().AddSecretBackendReference(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil, errors.New("backend boom"))
+
+	uri1 := coresecrets.NewURI()
+	uri2 := coresecrets.NewURI()
+	arg := unitstate.CommitHookChangesArg{
+		UnitName: unitName,
+		SecretUpdates: []unitstate.UpdateSecretArg{
+			{
+				URI: uri1,
+				UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+					Data:     map[string]string{"a": "1"},
+					Checksum: "checksum-1",
+				},
+			},
+			{
+				URI: uri2,
+				UpdateCharmSecretParams: secret.UpdateCharmSecretParams{
+					Data:     map[string]string{"b": "2"},
+					Checksum: "checksum-2",
+				},
+			},
+		},
+	}
+
+	err := s.svc.CommitHookChanges(c.Context(), arg)
+	c.Check(err, tc.ErrorMatches, `.*adding backend reference for update\[1\].*`)
+	c.Check(firstRolledBack, tc.IsTrue)
+}
+
 func (s *commitHookSuite) TestParseForSetAndUnsetSettings(c *tc.C) {
 	// Arrange
 	input := unitstate.Settings{

--- a/domain/unitstate/service/interface.go
+++ b/domain/unitstate/service/interface.go
@@ -72,12 +72,6 @@ type UnitStateState interface {
 	SetUnitState(context.Context, unitstate.UnitState) error
 }
 
-// ProviderWithNetworking describes the interface needed from providers that
-// support networking capabilities.
-type ProviderWithNetworking interface {
-	environs.Networking
-}
-
 // SecretBackendReferenceMutator describes methods for modifying secret
 // backend references in the controller database.
 type SecretBackendReferenceMutator interface {
@@ -87,4 +81,17 @@ type SecretBackendReferenceMutator interface {
 	AddSecretBackendReference(
 		ctx context.Context, valueRef *secrets.ValueRef, modelID coremodel.UUID, revisionID string, secretID string,
 	) (func() error, error)
+
+	// UpdateSecretBackendReference updates the reference to the secret
+	// backend for the given secret revision. It returns a rollback function
+	// which can be used to revert the changes.
+	UpdateSecretBackendReference(
+		ctx context.Context, valueRef *secrets.ValueRef, modelID coremodel.UUID, revisionID string, secretID string,
+	) (func() error, error)
+}
+
+// ProviderWithNetworking describes the interface needed from providers that
+// support networking capabilities.
+type ProviderWithNetworking interface {
+	environs.Networking
 }

--- a/domain/unitstate/service/interface.go
+++ b/domain/unitstate/service/interface.go
@@ -55,6 +55,11 @@ type CommitHookState interface {
 
 	// GetModelUUID returns the UUID of the model for the unit state domain.
 	GetModelUUID(ctx context.Context) (string, error)
+
+	// GetSecretRotatePolicy returns the current rotate policy for the
+	// secret identified by the given secret ID. If the secret does not
+	// exist, an error satisfying [secreterrors.SecretNotFound] is returned.
+	GetSecretRotatePolicy(ctx context.Context, secretID string) (secrets.RotatePolicy, error)
 }
 
 // UnitStateState defines a persistence layer interface for retrieving

--- a/domain/unitstate/service/secretbackend_mock_test.go
+++ b/domain/unitstate/service/secretbackend_mock_test.go
@@ -26,8 +26,9 @@ type MockSecretBackendReferenceMutator struct {
 
 // MockSecretBackendReferenceMutatorMockRecorder is the mock recorder for MockSecretBackendReferenceMutator.
 type MockSecretBackendReferenceMutatorMockRecorder struct {
-	mock                             *MockSecretBackendReferenceMutator
-	addSecretBackendReferenceExpects []*gomock.Call5_2[context.Context, *secrets.ValueRef, model.UUID, string, string, func() error, error]
+	mock                                *MockSecretBackendReferenceMutator
+	addSecretBackendReferenceExpects    []*gomock.Call5_2[context.Context, *secrets.ValueRef, model.UUID, string, string, func() error, error]
+	updateSecretBackendReferenceExpects []*gomock.Call5_2[context.Context, *secrets.ValueRef, model.UUID, string, string, func() error, error]
 }
 
 // NewMockSecretBackendReferenceMutator creates a new mock instance.
@@ -59,3 +60,21 @@ func (mr *MockSecretBackendReferenceMutatorMockRecorder) AddSecretBackendReferen
 
 // MockSecretBackendReferenceMutatorAddSecretBackendReferenceCall is the typed call wrapper for AddSecretBackendReference.
 type MockSecretBackendReferenceMutatorAddSecretBackendReferenceCall = gomock.Call5_2[context.Context, *secrets.ValueRef, model.UUID, string, string, func() error, error]
+
+// UpdateSecretBackendReference mocks base method.
+func (m *MockSecretBackendReferenceMutator) UpdateSecretBackendReference(ctx context.Context, valueRef *secrets.ValueRef, modelID model.UUID, revisionID, secretID string) (func() error, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch5_2(&m.recorder.updateSecretBackendReferenceExpects, m.ctrl, m, "UpdateSecretBackendReference", ctx, valueRef, modelID, revisionID, secretID)
+}
+
+// UpdateSecretBackendReference indicates an expected call of UpdateSecretBackendReference.
+func (mr *MockSecretBackendReferenceMutatorMockRecorder) UpdateSecretBackendReference(ctx, valueRef, modelID, revisionID, secretID any) *MockSecretBackendReferenceMutatorUpdateSecretBackendReferenceCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall5_2[context.Context, *secrets.ValueRef, model.UUID, string, string, func() error, error](mr.mock.ctrl.T, mr.mock, "UpdateSecretBackendReference", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(valueRef), gomock.EnsureMatcher(modelID), gomock.EnsureMatcher(revisionID), gomock.EnsureMatcher(secretID))
+	mr.updateSecretBackendReferenceExpects = append(mr.updateSecretBackendReferenceExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockSecretBackendReferenceMutatorUpdateSecretBackendReferenceCall is the typed call wrapper for UpdateSecretBackendReference.
+type MockSecretBackendReferenceMutatorUpdateSecretBackendReferenceCall = gomock.Call5_2[context.Context, *secrets.ValueRef, model.UUID, string, string, func() error, error]

--- a/domain/unitstate/service/state_mock_test.go
+++ b/domain/unitstate/service/state_mock_test.go
@@ -14,6 +14,7 @@ import (
 
 	gomock "github.com/canonical/gomock/gomock"
 	relation "github.com/juju/juju/core/relation"
+	secrets "github.com/juju/juju/core/secrets"
 	unitstate "github.com/juju/juju/domain/unitstate"
 	internal "github.com/juju/juju/domain/unitstate/internal"
 )
@@ -33,6 +34,7 @@ type MockStateMockRecorder struct {
 	getModelUUIDExpects                                []*gomock.Call1_2[context.Context, string, error]
 	getPeerRelationUUIDByEndpointIdentifiersExpects    []*gomock.Call2_2[context.Context, relation.EndpointIdentifier, relation.UUID, error]
 	getRegularRelationUUIDByEndpointIdentifiersExpects []*gomock.Call3_2[context.Context, relation.EndpointIdentifier, relation.EndpointIdentifier, relation.UUID, error]
+	getSecretRotatePolicyExpects                       []*gomock.Call2_2[context.Context, string, secrets.RotatePolicy, error]
 	getUnitStateExpects                                []*gomock.Call2_2[context.Context, string, unitstate.RetrievedUnitState, error]
 	setUnitStateExpects                                []*gomock.Call2_1[context.Context, unitstate.UnitState, error]
 }
@@ -138,6 +140,24 @@ func (mr *MockStateMockRecorder) GetRegularRelationUUIDByEndpointIdentifiers(ctx
 
 // MockStateGetRegularRelationUUIDByEndpointIdentifiersCall is the typed call wrapper for GetRegularRelationUUIDByEndpointIdentifiers.
 type MockStateGetRegularRelationUUIDByEndpointIdentifiersCall = gomock.Call3_2[context.Context, relation.EndpointIdentifier, relation.EndpointIdentifier, relation.UUID, error]
+
+// GetSecretRotatePolicy mocks base method.
+func (m *MockState) GetSecretRotatePolicy(ctx context.Context, secretID string) (secrets.RotatePolicy, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_2(&m.recorder.getSecretRotatePolicyExpects, m.ctrl, m, "GetSecretRotatePolicy", ctx, secretID)
+}
+
+// GetSecretRotatePolicy indicates an expected call of GetSecretRotatePolicy.
+func (mr *MockStateMockRecorder) GetSecretRotatePolicy(ctx, secretID any) *MockStateGetSecretRotatePolicyCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_2[context.Context, string, secrets.RotatePolicy, error](mr.mock.ctrl.T, mr.mock, "GetSecretRotatePolicy", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(secretID))
+	mr.getSecretRotatePolicyExpects = append(mr.getSecretRotatePolicyExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockStateGetSecretRotatePolicyCall is the typed call wrapper for GetSecretRotatePolicy.
+type MockStateGetSecretRotatePolicyCall = gomock.Call2_2[context.Context, string, secrets.RotatePolicy, error]
 
 // GetUnitState mocks base method.
 func (m *MockState) GetUnitState(arg0 context.Context, arg1 string) (unitstate.RetrievedUnitState, error) {

--- a/domain/unitstate/state/commithook.go
+++ b/domain/unitstate/state/commithook.go
@@ -257,9 +257,10 @@ SELECT sm.secret_id AS &secretInfo.secret_id,
        sm.auto_prune AS &secretInfo.auto_prune,
        sm.latest_revision_checksum AS &secretInfo.latest_revision_checksum,
        sm.update_time AS &secretInfo.update_time,
-       MAX(sr.revision) AS &secretInfo.latest_revision
+       MAX(sr.revision) AS &secretInfo.latest_revision,
+	   sr.uuid AS &secretInfo.latest_revision_uuid
 FROM   secret_metadata sm
-       LEFT JOIN secret_revision sr ON sr.secret_id = sm.secret_id
+	   JOIN secret_revision sr ON sr.secret_id = sm.secret_id
 WHERE  sm.secret_id = $secretID.secret_id
 GROUP BY sm.secret_id`
 	existingStmt, err := st.Prepare(existingQuery, secretID{}, secretInfo{})
@@ -379,21 +380,6 @@ ON CONFLICT(uuid) DO UPDATE SET update_time=excluded.update_time
 			return errors.Errorf("inserting revision: %w", err)
 		}
 
-		if update.ExpireTime != nil {
-			expStmt, err := st.Prepare(`
-INSERT INTO secret_revision_expire (revision_uuid, expire_time)
-VALUES ($secretRevisionExpire.*)
-ON CONFLICT(revision_uuid) DO UPDATE SET expire_time=excluded.expire_time
-`, secretRevisionExpire{})
-			if err != nil {
-				return errors.Capture(err)
-			}
-			exp := secretRevisionExpire{RevisionUUID: rev.UUID, ExpireTime: *update.ExpireTime}
-			if err := tx.Query(ctx, expStmt, exp).Run(); err != nil {
-				return errors.Errorf("setting revision expiry: %w", err)
-			}
-		}
-
 		if len(update.Data) > 0 {
 			contentStmt, err := st.Prepare(`
 INSERT INTO secret_content (revision_uuid, name, content)
@@ -427,6 +413,30 @@ ON CONFLICT(revision_uuid) DO UPDATE SET backend_uuid=excluded.backend_uuid, rev
 			}
 			if err := tx.Query(ctx, refStmt, ref).Run(); err != nil {
 				return errors.Errorf("setting revision value ref: %w", err)
+			}
+		}
+	}
+
+	// Handle ExpireTime: apply to the new revision if one was created,
+	// otherwise apply to the existing latest revision if it exists.
+	if update.ExpireTime != nil {
+		targetRevisionUUID := update.RevisionUUID
+		if targetRevisionUUID == "" {
+			targetRevisionUUID = info.LatestRevisionUUID
+		}
+
+		if targetRevisionUUID != "" {
+			expStmt, err := st.Prepare(`
+INSERT INTO secret_revision_expire (revision_uuid, expire_time)
+VALUES ($secretRevisionExpire.*)
+ON CONFLICT(revision_uuid) DO UPDATE SET expire_time=excluded.expire_time
+`, secretRevisionExpire{})
+			if err != nil {
+				return errors.Capture(err)
+			}
+			exp := secretRevisionExpire{RevisionUUID: targetRevisionUUID, ExpireTime: *update.ExpireTime}
+			if err := tx.Query(ctx, expStmt, exp).Run(); err != nil {
+				return errors.Errorf("setting revision expiry: %w", err)
 			}
 		}
 	}

--- a/domain/unitstate/state/commithook.go
+++ b/domain/unitstate/state/commithook.go
@@ -312,6 +312,19 @@ ON CONFLICT(secret_id) DO UPDATE SET
 		return errors.Capture(err)
 	}
 
+	// Handle rotation scheduling: delete when policy becomes RotateNever,
+	// insert or update NextRotateTime when switching to a more frequent policy.
+	if update.RotatePolicy != nil && *update.RotatePolicy == domainsecret.RotateNever {
+		if err := st.deleteSecretRotation(ctx, tx, update.SecretID); err != nil {
+			return errors.Errorf("deleting rotation schedule: %w", err)
+		}
+	}
+	if update.NextRotateTime != nil {
+		if err := st.upsertSecretNextRotateTime(ctx, tx, update.SecretID, *update.NextRotateTime); err != nil {
+			return errors.Errorf("updating next rotate time: %w", err)
+		}
+	}
+
 	if update.Label != nil {
 		label := *update.Label
 		switch update.OwnerKind {

--- a/domain/unitstate/state/commithook.go
+++ b/domain/unitstate/state/commithook.go
@@ -15,9 +15,8 @@ import (
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
-	"github.com/juju/juju/domain/secret"
+	domainsecret "github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
-	"github.com/juju/juju/domain/unitstate"
 	unitstateerrors "github.com/juju/juju/domain/unitstate/errors"
 	"github.com/juju/juju/domain/unitstate/internal"
 	"github.com/juju/juju/internal/errors"
@@ -115,7 +114,105 @@ func (st *State) updateCharmState(ctx context.Context, tx *sqlair.TX, unit entit
 	return st.setUnitStateCharm(ctx, tx, unit, *charmState)
 }
 
-func (st *State) createSecrets(ctx context.Context, tx *sqlair.TX, creates []unitstate.CreateSecretArg) error {
+func (st *State) createSecrets(ctx context.Context, tx *sqlair.TX, creates []internal.CreateSecretArg) error {
+	if len(creates) == 0 {
+		return nil
+	}
+
+	for _, arg := range creates {
+		if err := st.createOneSecret(ctx, tx, arg); err != nil {
+			return errors.Errorf("creating secret %q: %w", arg.SecretID, err)
+		}
+	}
+	return nil
+}
+
+// createOneSecret inserts all records for a single charm secret inside the
+// commit-hook transaction: secret, secret_metadata, secret_revision,
+// content/value-ref, expiry, rotation, ownership, and manage permission.
+func (st *State) createOneSecret(ctx context.Context, tx *sqlair.TX, arg internal.CreateSecretArg) error {
+	// 1. Insert into secret table (just the ID).
+	insertSecretStmt, err := st.Prepare(
+		"INSERT INTO secret (id) VALUES ($createSecretID.id)", createSecretID{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if err := tx.Query(ctx, insertSecretStmt, createSecretID{ID: arg.SecretID}).Run(); err != nil {
+		return errors.Errorf("inserting secret: %w", err)
+	}
+
+	// 2. Insert secret_metadata.
+	p := arg.Params
+	md := secretMetadata{
+		ID:      arg.SecretID,
+		Version: arg.Version,
+	}
+	updateSecretMetadataFromParams(p, &md)
+	if err := st.upsertSecretMetadata(ctx, tx, md); err != nil {
+		return errors.Errorf("inserting metadata: %w", err)
+	}
+
+	// 3. Insert secret_revision (revision 1).
+	if p.RevisionUUID == nil {
+		return errors.Errorf("revision UUID must be provided")
+	}
+	rev := secretRevision{
+		UUID:       *p.RevisionUUID,
+		SecretID:   arg.SecretID,
+		Revision:   1,
+		CreateTime: p.UpdateTime.UTC(),
+		UpdateTime: p.UpdateTime.UTC(),
+	}
+	if err := st.upsertSecretRevision(ctx, tx, &rev); err != nil {
+		return errors.Errorf("inserting revision: %w", err)
+	}
+
+	// 4. Insert content or value reference.
+	if len(p.Data) > 0 {
+		if err := st.insertSecretContent(ctx, tx, *p.RevisionUUID, p.Data); err != nil {
+			return errors.Errorf("inserting content: %w", err)
+		}
+	}
+	if p.ValueRef != nil {
+		if err := st.upsertSecretValueRef(ctx, tx, *p.RevisionUUID, p.ValueRef); err != nil {
+			return errors.Errorf("inserting value ref: %w", err)
+		}
+	}
+
+	// 5. Insert expiry if set.
+	if p.ExpireTime != nil {
+		if err := st.upsertSecretRevisionExpiry(ctx, tx, *p.RevisionUUID, *p.ExpireTime); err != nil {
+			return errors.Errorf("inserting revision expiry: %w", err)
+		}
+	}
+
+	// 6. Insert next rotation time if set.
+	if p.NextRotateTime != nil {
+		if err := st.upsertSecretNextRotateTime(ctx, tx, arg.SecretID, *p.NextRotateTime); err != nil {
+			return errors.Errorf("inserting next rotate time: %w", err)
+		}
+	}
+
+	// 7. Set ownership and grant manage permission.
+	switch arg.OwnerKind {
+	case domainsecret.ApplicationCharmSecretOwner:
+		if err := st.setSecretApplicationOwner(ctx, tx, arg.SecretID, arg.OwnerUUID, arg.Label); err != nil {
+			return errors.Errorf("setting application owner: %w", err)
+		}
+		if err := st.grantSecretOwnerManage(ctx, tx, arg.SecretID, arg.OwnerUUID, domainsecret.SubjectApplication); err != nil {
+			return errors.Errorf("granting owner manage: %w", err)
+		}
+	case domainsecret.UnitCharmSecretOwner:
+		if err := st.setSecretUnitOwner(ctx, tx, arg.SecretID, arg.OwnerUUID, arg.Label); err != nil {
+			return errors.Errorf("setting unit owner: %w", err)
+		}
+		if err := st.grantSecretOwnerManage(ctx, tx, arg.SecretID, arg.OwnerUUID, domainsecret.SubjectUnit); err != nil {
+			return errors.Errorf("granting owner manage: %w", err)
+		}
+	default:
+		return errors.Errorf("unexpected secret owner kind %q", arg.OwnerKind)
+	}
+
 	return nil
 }
 
@@ -218,7 +315,7 @@ ON CONFLICT(secret_id) DO UPDATE SET
 	if update.Label != nil {
 		label := *update.Label
 		switch update.OwnerKind {
-		case secret.ApplicationCharmSecretOwner:
+		case domainsecret.ApplicationCharmSecretOwner:
 			ownerStmt, err := st.Prepare(`
 INSERT INTO secret_application_owner (secret_id, application_uuid, label)
 SELECT $secretID.secret_id, owner_uuid, $secretApplicationOwner.label
@@ -232,7 +329,7 @@ ON CONFLICT(secret_id, application_uuid) DO UPDATE SET label=excluded.label
 			if err := tx.Query(ctx, ownerStmt, secretID{ID: update.SecretID}, secretApplicationOwner{Label: label}).Run(); err != nil {
 				return errors.Errorf("updating application secret label: %w", err)
 			}
-		case secret.UnitCharmSecretOwner:
+		case domainsecret.UnitCharmSecretOwner:
 			ownerStmt, err := st.Prepare(`
 INSERT INTO secret_unit_owner (secret_id, unit_uuid, label)
 SELECT $secretID.secret_id, owner_uuid, $secretUnitOwner.label
@@ -428,13 +525,13 @@ ON CONFLICT(secret_id, subject_uuid) DO UPDATE SET
 
 // subjectExists checks whether the subject entity referenced by uuid still
 // exists in the database, dispatching to the appropriate table based on type.
-func (st *State) subjectExists(ctx context.Context, tx *sqlair.TX, uuid string, t secret.GrantSubjectType) (bool, error) {
+func (st *State) subjectExists(ctx context.Context, tx *sqlair.TX, uuid string, t domainsecret.GrantSubjectType) (bool, error) {
 	switch t {
-	case secret.SubjectUnit:
+	case domainsecret.SubjectUnit:
 		return st.unitExists(ctx, tx, uuid)
-	case secret.SubjectApplication:
+	case domainsecret.SubjectApplication:
 		return st.applicationExists(ctx, tx, uuid)
-	case secret.SubjectModel:
+	case domainsecret.SubjectModel:
 		return st.modelExists(ctx, tx, uuid)
 	default:
 		return false, errors.Errorf("unknown subject type %d", t)
@@ -443,15 +540,15 @@ func (st *State) subjectExists(ctx context.Context, tx *sqlair.TX, uuid string, 
 
 // scopeExists checks whether the scope entity referenced by uuid still
 // exists in the database, dispatching to the appropriate table based on type.
-func (st *State) scopeExists(ctx context.Context, tx *sqlair.TX, uuid string, t secret.GrantScopeType) (bool, error) {
+func (st *State) scopeExists(ctx context.Context, tx *sqlair.TX, uuid string, t domainsecret.GrantScopeType) (bool, error) {
 	switch t {
-	case secret.ScopeUnit:
+	case domainsecret.ScopeUnit:
 		return st.unitExists(ctx, tx, uuid)
-	case secret.ScopeApplication:
+	case domainsecret.ScopeApplication:
 		return st.applicationExists(ctx, tx, uuid)
-	case secret.ScopeModel:
+	case domainsecret.ScopeModel:
 		return st.modelExists(ctx, tx, uuid)
-	case secret.ScopeRelation:
+	case domainsecret.ScopeRelation:
 		return st.relationExists(ctx, tx, uuid)
 	default:
 		return false, errors.Errorf("unknown scope type %d", t)
@@ -527,6 +624,10 @@ func (st *State) relationExists(ctx context.Context, tx *sqlair.TX, id string) (
 // deleted; this method logs each such ID at debug level so callers do not
 // need to.
 func (st *State) filterExistingSecrets(ctx context.Context, tx *sqlair.TX, ids secretIDs) (map[string]struct{}, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	stmt, err := st.Prepare(`
 SELECT &secretID.secret_id
 FROM   secret_metadata
@@ -862,6 +963,7 @@ func (st *State) GetCommitHookUnitInfo(ctx context.Context, name string) (intern
 	stmt, err := st.Prepare(`
 SELECT u.uuid AS &commitHookUnitInfo.unit_uuid,
        u.life_id AS &commitHookUnitInfo.unit_life_id,
+       u.application_uuid AS &commitHookUnitInfo.application_uuid,
        m.uuid AS &commitHookUnitInfo.machine_uuid
 FROM   unit u
 LEFT JOIN machine m ON m.net_node_uuid = u.net_node_uuid
@@ -884,8 +986,9 @@ WHERE  u.name = $unitName.name
 	}
 
 	retVal := internal.CommitHookUnitInfo{
-		UnitUUID: result.UnitUUID,
-		UnitLife: life.Life(result.UnitLife),
+		UnitUUID:        result.UnitUUID,
+		UnitLife:        life.Life(result.UnitLife),
+		ApplicationUUID: result.ApplicationUUID,
 	}
 	if result.MachineUUID.Valid {
 		retVal.MachineUUID = &result.MachineUUID.String

--- a/domain/unitstate/state/commithook_test.go
+++ b/domain/unitstate/state/commithook_test.go
@@ -1952,6 +1952,107 @@ func (s *commitHookSuite) TestUpdateSecretsRotatePolicyLessFrequentKeepsExisting
 	c.Check(gotNextRotate.UTC(), tc.Equals, oldNextRotate.UTC())
 }
 
+// TestUpdateSecretsWithExpireTimeOnly verifies that updating a secret with
+// only ExpireTime (no new data, no new value ref) applies the expiry to the
+// existing latest revision. This is Gap 2 from PR#22651 followup.
+func (s *commitHookSuite) TestUpdateSecretsWithExpireTimeOnly(c *tc.C) {
+	ctx := c.Context()
+	secretID := "update-test-expire-only"
+	s.addSecretWithOwner(c, secretID, s.unitUUID, "unit")
+	existingRevUUID := s.addSecretRevision(c, secretID, 1)
+
+	expireTime := time.Now().UTC().Truncate(time.Microsecond).Add(48 * time.Hour)
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretUpdates: []internal.UpdateSecretArg{{
+			SecretID:   secretID,
+			ExpireTime: &expireTime,
+			Checksum:   "checksum-expire-only",
+			OwnerKind:  secret.UnitCharmSecretOwner,
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	// Verify that no new revision was created
+	var revCount int
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT count(*) FROM secret_revision WHERE secret_id = ?",
+			secretID).Scan(&revCount)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(revCount, tc.Equals, 1)
+
+	// Verify that expiry was applied to the existing revision
+	var gotExpire time.Time
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT expire_time FROM secret_revision_expire WHERE revision_uuid = ?",
+			existingRevUUID).Scan(&gotExpire)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotExpire.UTC(), tc.Equals, expireTime.UTC())
+}
+
+// TestUpdateSecretsWithExpireTimeAndNewData verifies that updating a secret
+// with both ExpireTime and new data creates a new revision and applies the
+// expiry to that new revision (regression guard).
+func (s *commitHookSuite) TestUpdateSecretsWithExpireTimeAndNewData(c *tc.C) {
+	ctx := c.Context()
+	secretID := "update-test-expire-with-data"
+	s.addSecretWithOwner(c, secretID, s.unitUUID, "unit")
+	s.addSecretRevision(c, secretID, 1)
+
+	revUUID := tc.Must(c, uuid.NewUUID).String()
+	data := map[string]string{"key1": "newvalue1"}
+	expireTime := time.Now().UTC().Truncate(time.Microsecond).Add(24 * time.Hour)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretUpdates: []internal.UpdateSecretArg{{
+			SecretID:     secretID,
+			Data:         data,
+			ExpireTime:   &expireTime,
+			Checksum:     "checksum-expire-with-data",
+			RevisionUUID: revUUID,
+			OwnerKind:    secret.UnitCharmSecretOwner,
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	// Verify that new revision was created
+	var revCount int
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT count(*) FROM secret_revision WHERE secret_id = ?",
+			secretID).Scan(&revCount)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(revCount, tc.Equals, 2)
+
+	// Verify that expiry was applied to the new revision
+	var gotExpire time.Time
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT expire_time FROM secret_revision_expire WHERE revision_uuid = ?",
+			revUUID).Scan(&gotExpire)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotExpire.UTC(), tc.Equals, expireTime.UTC())
+
+	// Verify data was stored in the new revision
+	var contentCount int
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT count(*) FROM secret_content WHERE revision_uuid = ?",
+			revUUID).Scan(&contentCount)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(contentCount, tc.Equals, 1)
+}
+
 // addSecretWithOwner inserts a secret with an owner row.
 func (s *commitHookSuite) addSecretWithOwner(c *tc.C, secretID, ownerUUID, ownerKind string) {
 	s.query(c, `INSERT INTO secret (id) VALUES (?)`, secretID)

--- a/domain/unitstate/state/commithook_test.go
+++ b/domain/unitstate/state/commithook_test.go
@@ -1821,6 +1821,137 @@ func (s *commitHookSuite) TestUpdateSecretsDifferentChecksumCreatesNewRevision(c
 	c.Check(revCount, tc.Equals, 3)
 }
 
+func (s *commitHookSuite) TestUpdateSecretsRotatePolicyMoreFrequent(c *tc.C) {
+	ctx := c.Context()
+	secretID := "update-test-rotate-freq"
+	s.addSecretWithOwner(c, secretID, s.unitUUID, "unit")
+	s.addSecretRevision(c, secretID, 1)
+
+	oldNextRotate := time.Now().UTC().Truncate(time.Microsecond).Add(24 * time.Hour)
+	s.query(c,
+		"INSERT INTO secret_rotation (secret_id, next_rotation_time) VALUES (?, ?)",
+		secretID, oldNextRotate)
+
+	policy := secret.RotateHourly
+	newNextRotate := time.Now().UTC().Truncate(time.Microsecond).Add(time.Hour)
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretUpdates: []internal.UpdateSecretArg{{
+			SecretID:       secretID,
+			RotatePolicy:   &policy,
+			NextRotateTime: &newNextRotate,
+			Checksum:       "checksum-rotate-freq",
+			OwnerKind:      secret.UnitCharmSecretOwner,
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	var gotPolicyID int
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT rotate_policy_id FROM secret_metadata WHERE secret_id = ?",
+			secretID).Scan(&gotPolicyID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotPolicyID, tc.Equals, int(policy))
+
+	var gotNextRotate time.Time
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT next_rotation_time FROM secret_rotation WHERE secret_id = ?",
+			secretID).Scan(&gotNextRotate)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotNextRotate.UTC(), tc.Equals, newNextRotate.UTC())
+}
+
+func (s *commitHookSuite) TestUpdateSecretsRotatePolicyToNever(c *tc.C) {
+	ctx := c.Context()
+	secretID := "update-test-rotate-never"
+	s.addSecretWithOwner(c, secretID, s.unitUUID, "unit")
+	s.addSecretRevision(c, secretID, 1)
+
+	nextRotate := time.Now().UTC().Truncate(time.Microsecond).Add(time.Hour)
+	s.query(c,
+		"INSERT INTO secret_rotation (secret_id, next_rotation_time) VALUES (?, ?)",
+		secretID, nextRotate)
+
+	policy := secret.RotateNever
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretUpdates: []internal.UpdateSecretArg{{
+			SecretID:     secretID,
+			RotatePolicy: &policy,
+			Checksum:     "checksum-rotate-never",
+			OwnerKind:    secret.UnitCharmSecretOwner,
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	var gotPolicyID int
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT rotate_policy_id FROM secret_metadata WHERE secret_id = ?",
+			secretID).Scan(&gotPolicyID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotPolicyID, tc.Equals, int(policy))
+
+	var rotationCount int
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT count(*) FROM secret_rotation WHERE secret_id = ?",
+			secretID).Scan(&rotationCount)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(rotationCount, tc.Equals, 0)
+}
+
+func (s *commitHookSuite) TestUpdateSecretsRotatePolicyLessFrequentKeepsExistingRotation(c *tc.C) {
+	ctx := c.Context()
+	secretID := "update-test-rotate-less"
+	s.addSecretWithOwner(c, secretID, s.unitUUID, "unit")
+	s.addSecretRevision(c, secretID, 1)
+
+	oldNextRotate := time.Now().UTC().Truncate(time.Microsecond).Add(time.Hour)
+	s.query(c,
+		"INSERT INTO secret_rotation (secret_id, next_rotation_time) VALUES (?, ?)",
+		secretID, oldNextRotate)
+
+	policy := secret.RotateDaily
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretUpdates: []internal.UpdateSecretArg{{
+			SecretID:     secretID,
+			RotatePolicy: &policy,
+			Checksum:     "checksum-rotate-less",
+			OwnerKind:    secret.UnitCharmSecretOwner,
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	var gotPolicyID int
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT rotate_policy_id FROM secret_metadata WHERE secret_id = ?",
+			secretID).Scan(&gotPolicyID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotPolicyID, tc.Equals, int(policy))
+
+	var gotNextRotate time.Time
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT next_rotation_time FROM secret_rotation WHERE secret_id = ?",
+			secretID).Scan(&gotNextRotate)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotNextRotate.UTC(), tc.Equals, oldNextRotate.UTC())
+}
+
 // addSecretWithOwner inserts a secret with an owner row.
 func (s *commitHookSuite) addSecretWithOwner(c *tc.C, secretID, ownerUUID, ownerKind string) {
 	s.query(c, `INSERT INTO secret (id) VALUES (?)`, secretID)

--- a/domain/unitstate/state/commithook_test.go
+++ b/domain/unitstate/state/commithook_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/tc"
@@ -1830,4 +1831,413 @@ func (s *commitHookSuite) addSecretWithOwner(c *tc.C, secretID, ownerUUID, owner
 	case "application":
 		s.query(c, `INSERT INTO secret_application_owner (secret_id, application_uuid) VALUES (?, ?)`, secretID, ownerUUID)
 	}
+}
+
+func (s *commitHookSuite) TestCreateSecretsUnitOwned(c *tc.C) {
+	ctx := c.Context()
+	secretID := "create-test-unit"
+	revUUID := tc.Must(c, uuid.NewUUID).String()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretCreates: []internal.CreateSecretArg{{
+			SecretID:  secretID,
+			Version:   1,
+			OwnerKind: secret.UnitCharmSecretOwner,
+			OwnerUUID: s.unitUUID,
+			Label:     "my-unit-secret",
+			Params: secret.UpsertSecretParams{
+				RevisionUUID: &revUUID,
+				CreateTime:   now,
+				UpdateTime:   now,
+				Data:         coresecrets.SecretData{"key": "val"},
+				Checksum:     "checksum-unit",
+			},
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	var count int
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT count(*) FROM secret WHERE id = ?", secretID).Scan(&count)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 1)
+
+	var label string
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT label FROM secret_unit_owner WHERE secret_id = ?", secretID).Scan(&label)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(label, tc.Equals, "my-unit-secret")
+
+	var roleID int
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT role_id FROM secret_permission WHERE secret_id = ? AND subject_uuid = ?", secretID, s.unitUUID).Scan(&roleID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(roleID, tc.Equals, int(secret.RoleManage))
+}
+
+func (s *commitHookSuite) TestCreateSecretsApplicationOwned(c *tc.C) {
+	ctx := c.Context()
+	secretID := "create-test-app"
+	revUUID := tc.Must(c, uuid.NewUUID).String()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretCreates: []internal.CreateSecretArg{{
+			SecretID:  secretID,
+			Version:   1,
+			OwnerKind: secret.ApplicationCharmSecretOwner,
+			OwnerUUID: s.fakeApplicationUUID1,
+			Label:     "my-app-secret",
+			Params: secret.UpsertSecretParams{
+				RevisionUUID: &revUUID,
+				CreateTime:   now,
+				UpdateTime:   now,
+				Data:         coresecrets.SecretData{"key": "val"},
+				Checksum:     "checksum-app",
+			},
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	var label string
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT label FROM secret_application_owner WHERE secret_id = ?", secretID).Scan(&label)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(label, tc.Equals, "my-app-secret")
+
+	var roleID int
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT role_id FROM secret_permission WHERE secret_id = ? AND subject_uuid = ?", secretID, s.fakeApplicationUUID1).Scan(&roleID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(roleID, tc.Equals, int(secret.RoleManage))
+}
+
+func (s *commitHookSuite) TestCreateSecretsWithRotatePolicy(c *tc.C) {
+	ctx := c.Context()
+	secretID := "create-test-rotate"
+	revUUID := tc.Must(c, uuid.NewUUID).String()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	nextRotate := now.Add(24 * time.Hour)
+
+	policy := secret.RotateDaily
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretCreates: []internal.CreateSecretArg{{
+			SecretID:  secretID,
+			Version:   1,
+			OwnerKind: secret.UnitCharmSecretOwner,
+			OwnerUUID: s.unitUUID,
+			Params: secret.UpsertSecretParams{
+				RevisionUUID:   &revUUID,
+				RotatePolicy:   &policy,
+				NextRotateTime: &nextRotate,
+				CreateTime:     now,
+				UpdateTime:     now,
+				Checksum:       "checksum-rotate",
+			},
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	var gotPolicyID int
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT rotate_policy_id FROM secret_metadata WHERE secret_id = ?", secretID).Scan(&gotPolicyID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotPolicyID, tc.Equals, int(policy))
+
+	var gotNextRotate time.Time
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT next_rotation_time FROM secret_rotation WHERE secret_id = ?", secretID).Scan(&gotNextRotate)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotNextRotate.UTC(), tc.Equals, nextRotate.UTC())
+}
+
+func (s *commitHookSuite) TestCreateSecretsWithExpireTime(c *tc.C) {
+	ctx := c.Context()
+	secretID := "create-test-expire"
+	revUUID := tc.Must(c, uuid.NewUUID).String()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	expireTime := now.Add(48 * time.Hour)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretCreates: []internal.CreateSecretArg{{
+			SecretID:  secretID,
+			Version:   1,
+			OwnerKind: secret.UnitCharmSecretOwner,
+			OwnerUUID: s.unitUUID,
+			Params: secret.UpsertSecretParams{
+				RevisionUUID: &revUUID,
+				ExpireTime:   &expireTime,
+				CreateTime:   now,
+				UpdateTime:   now,
+				Checksum:     "checksum-expire",
+			},
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	var gotExpire time.Time
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT expire_time FROM secret_revision_expire WHERE revision_uuid = ?", revUUID).Scan(&gotExpire)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotExpire.UTC(), tc.Equals, expireTime.UTC())
+}
+
+func (s *commitHookSuite) TestCreateSecretsWithValueRef(c *tc.C) {
+	ctx := c.Context()
+	secretID := "create-test-valref"
+	revUUID := tc.Must(c, uuid.NewUUID).String()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretCreates: []internal.CreateSecretArg{{
+			SecretID:  secretID,
+			Version:   1,
+			OwnerKind: secret.UnitCharmSecretOwner,
+			OwnerUUID: s.unitUUID,
+			Params: secret.UpsertSecretParams{
+				RevisionUUID: &revUUID,
+				CreateTime:   now,
+				UpdateTime:   now,
+				ValueRef: &coresecrets.ValueRef{
+					BackendID:  "backend-uuid",
+					RevisionID: "ext-rev-123",
+				},
+				Checksum: "checksum-valref",
+			},
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	var backendUUID, revisionID string
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT backend_uuid, revision_id FROM secret_value_ref WHERE revision_uuid = ?", revUUID).Scan(&backendUUID, &revisionID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(backendUUID, tc.Equals, "backend-uuid")
+	c.Check(revisionID, tc.Equals, "ext-rev-123")
+}
+
+func (s *commitHookSuite) TestCreateSecretsMultiple(c *tc.C) {
+	ctx := c.Context()
+	revUUID1 := tc.Must(c, uuid.NewUUID).String()
+	revUUID2 := tc.Must(c, uuid.NewUUID).String()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretCreates: []internal.CreateSecretArg{
+			{
+				SecretID:  "create-multi-1",
+				Version:   1,
+				OwnerKind: secret.UnitCharmSecretOwner,
+				OwnerUUID: s.unitUUID,
+				Label:     "secret-one",
+				Params: secret.UpsertSecretParams{
+					RevisionUUID: &revUUID1,
+					CreateTime:   now,
+					UpdateTime:   now,
+					Data:         coresecrets.SecretData{"a": "1"},
+					Checksum:     "checksum-1",
+				},
+			},
+			{
+				SecretID:  "create-multi-2",
+				Version:   1,
+				OwnerKind: secret.ApplicationCharmSecretOwner,
+				OwnerUUID: s.fakeApplicationUUID1,
+				Label:     "secret-two",
+				Params: secret.UpsertSecretParams{
+					RevisionUUID: &revUUID2,
+					CreateTime:   now,
+					UpdateTime:   now,
+					Data:         coresecrets.SecretData{"b": "2"},
+					Checksum:     "checksum-2",
+				},
+			},
+		},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	var count int
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT count(*) FROM secret WHERE id IN ('create-multi-1', 'create-multi-2')").Scan(&count)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 2)
+
+	var label1, label2 string
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		if err := tx.QueryRowContext(ctx, "SELECT label FROM secret_unit_owner WHERE secret_id = ?", "create-multi-1").Scan(&label1); err != nil {
+			return err
+		}
+		return tx.QueryRowContext(ctx, "SELECT label FROM secret_application_owner WHERE secret_id = ?", "create-multi-2").Scan(&label2)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(label1, tc.Equals, "secret-one")
+	c.Check(label2, tc.Equals, "secret-two")
+}
+
+func (s *commitHookSuite) TestCreateSecretsWithLabel(c *tc.C) {
+	ctx := c.Context()
+	secretID := "create-test-label"
+	revUUID := tc.Must(c, uuid.NewUUID).String()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretCreates: []internal.CreateSecretArg{{
+			SecretID:  secretID,
+			Version:   1,
+			OwnerKind: secret.UnitCharmSecretOwner,
+			OwnerUUID: s.unitUUID,
+			Label:     "my-labeled-secret",
+			Params: secret.UpsertSecretParams{
+				RevisionUUID: &revUUID,
+				CreateTime:   now,
+				UpdateTime:   now,
+				Data:         coresecrets.SecretData{"key": "val"},
+				Checksum:     "checksum-label",
+			},
+		}},
+	}
+
+	c.Assert(s.state.CommitHookChanges(ctx, arg), tc.ErrorIsNil)
+
+	var label string
+	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT label FROM secret_unit_owner WHERE secret_id = ?", secretID).Scan(&label)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(label, tc.Equals, "my-labeled-secret")
+}
+
+func (s *commitHookSuite) TestCreateSecretsNoRevisionUUIDFails(c *tc.C) {
+	ctx := c.Context()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretCreates: []internal.CreateSecretArg{{
+			SecretID:  "create-no-revuuid",
+			Version:   1,
+			OwnerKind: secret.UnitCharmSecretOwner,
+			OwnerUUID: s.unitUUID,
+			Params: secret.UpsertSecretParams{
+				CreateTime: now,
+				UpdateTime: now,
+				Checksum:   "checksum",
+			},
+		}},
+	}
+
+	err := s.state.CommitHookChanges(ctx, arg)
+	c.Check(err, tc.ErrorMatches, `.*revision UUID must be provided.*`)
+}
+
+func (s *commitHookSuite) TestCreateSecretIDConflict(c *tc.C) {
+	ctx := c.Context()
+	secretID := "create-test-conflict"
+	revUUID := tc.Must(c, uuid.NewUUID).String()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s.addSecret(c, secretID)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretCreates: []internal.CreateSecretArg{{
+			SecretID:  secretID,
+			Version:   1,
+			OwnerKind: secret.UnitCharmSecretOwner,
+			OwnerUUID: s.unitUUID,
+			Params: secret.UpsertSecretParams{
+				RevisionUUID: &revUUID,
+				CreateTime:   now,
+				UpdateTime:   now,
+				Checksum:     "checksum",
+			},
+		}},
+	}
+
+	err := s.state.CommitHookChanges(ctx, arg)
+	c.Check(err, tc.Not(tc.IsNil))
+	c.Check(err, tc.ErrorMatches, `.*creating secret "create-test-conflict".*`)
+}
+
+func (s *commitHookSuite) TestCreateSecretsRollsBackOnStorageFailure(c *tc.C) {
+	ctx := c.Context()
+	secretID := "create-test-rollback"
+	revUUID := tc.Must(c, uuid.NewUUID).String()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	poolUUID := s.addStoragePool(c, "test-pool", "lxd")
+
+	existingStorageUUID := tc.Must(c, domainstorage.NewStorageInstanceUUID)
+	s.query(c, `
+INSERT INTO storage_instance
+    (uuid, charm_name, storage_name, storage_kind_id, storage_id, life_id,
+     storage_pool_uuid, requested_size_mib)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`, existingStorageUUID.String(), "app", "data",
+		int(domainstorage.StorageKindBlock), "data/0", 0,
+		poolUUID.String(), 1024)
+	s.query(c, `
+INSERT INTO storage_unit_owner (storage_instance_uuid, unit_uuid)
+VALUES (?, ?)
+`, existingStorageUUID.String(), s.unitUUID)
+
+	arg := internal.CommitHookChangesArg{
+		UnitUUID: s.unitUUID,
+		SecretCreates: []internal.CreateSecretArg{{
+			SecretID:  secretID,
+			Version:   1,
+			OwnerKind: secret.UnitCharmSecretOwner,
+			OwnerUUID: s.unitUUID,
+			Params: secret.UpsertSecretParams{
+				RevisionUUID: &revUUID,
+				CreateTime:   now,
+				UpdateTime:   now,
+				Data:         coresecrets.SecretData{"key": "val"},
+				Checksum:     "checksum-rollback",
+			},
+		}},
+		AddStorage: []unitstate.PreparedStorageAdd{{
+			StorageName: "data",
+			Storage: domainstorage.IAASUnitAddStorageArg{
+				UnitAddStorageArg: domainstorage.UnitAddStorageArg{
+					CountLessThanEqual: 0,
+				},
+			},
+		}},
+	}
+
+	err := s.state.CommitHookChanges(ctx, arg)
+	c.Assert(err, tc.ErrorIs, storageerrors.MaxStorageCountPreconditionFailed)
+
+	var secretCount int
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, "SELECT count(*) FROM secret WHERE id = ?", secretID).Scan(&secretCount)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(secretCount, tc.Equals, 0)
 }

--- a/domain/unitstate/state/secrets.go
+++ b/domain/unitstate/state/secrets.go
@@ -201,6 +201,8 @@ func (st *State) grantSecretOwnerManage(ctx context.Context, tx *sqlair.TX, secr
 		perm.ScopeTypeID = domainsecret.ScopeUnit
 	case domainsecret.SubjectApplication:
 		perm.ScopeTypeID = domainsecret.ScopeApplication
+	default:
+		return errors.New("invalid owner type")
 	}
 
 	query := `

--- a/domain/unitstate/state/secrets.go
+++ b/domain/unitstate/state/secrets.go
@@ -11,8 +11,41 @@ import (
 
 	coresecrets "github.com/juju/juju/core/secrets"
 	domainsecret "github.com/juju/juju/domain/secret"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/internal/errors"
 )
+
+// GetSecretRotatePolicy returns the current rotate policy for the
+// secret identified by the given secret UUID. If the secret metadata
+// does not exist, it returns an error satisfying
+// [secreterrors.SecretNotFound].
+func (st *State) GetSecretRotatePolicy(ctx context.Context, secretUUID string) (coresecrets.RotatePolicy, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return coresecrets.RotateNever, errors.Capture(err)
+	}
+
+	stmt, err := st.Prepare(`
+SELECT srp.policy AS &secretRotatePolicyInfo.policy
+FROM   secret_metadata sm
+       JOIN secret_rotate_policy srp ON srp.id = sm.rotate_policy_id
+WHERE  sm.secret_id = $secretID.secret_id`, secretID{}, secretRotatePolicyInfo{})
+	if err != nil {
+		return coresecrets.RotateNever, errors.Capture(err)
+	}
+
+	var info secretRotatePolicyInfo
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, secretID{ID: secretUUID}).Get(&info)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("rotate policy for %q not found", secretUUID).Add(secreterrors.SecretNotFound)
+		}
+		return errors.Capture(err)
+	}); err != nil {
+		return coresecrets.RotateNever, errors.Capture(err)
+	}
+	return coresecrets.RotatePolicy(info.Policy), nil
+}
 
 // updateSecretMetadataFromParams applies non-nil fields from p onto md.
 func updateSecretMetadataFromParams(p domainsecret.UpsertSecretParams, md *secretMetadata) {
@@ -149,6 +182,17 @@ ON CONFLICT(secret_id) DO UPDATE SET
 		SecretID:       secretID,
 		NextRotateTime: next.UTC(),
 	}).Run()
+}
+
+// deleteSecretRotation deletes the secret_rotation row for the given
+// secret. This is used when the rotate policy changes to RotateNever.
+func (st *State) deleteSecretRotation(ctx context.Context, tx *sqlair.TX, secretUUID string) error {
+	query := "DELETE FROM secret_rotation WHERE secret_id = $secretID.secret_id"
+	stmt, err := st.Prepare(query, secretID{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return tx.Query(ctx, stmt, secretID{ID: secretUUID}).Run()
 }
 
 // setSecretApplicationOwner inserts an application ownership record.

--- a/domain/unitstate/state/secrets.go
+++ b/domain/unitstate/state/secrets.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/sqlair"
+
+	coresecrets "github.com/juju/juju/core/secrets"
+	domainsecret "github.com/juju/juju/domain/secret"
+	"github.com/juju/juju/internal/errors"
+)
+
+// updateSecretMetadataFromParams applies non-nil fields from p onto md.
+func updateSecretMetadataFromParams(p domainsecret.UpsertSecretParams, md *secretMetadata) {
+	if p.Description != nil {
+		md.Description = *p.Description
+	}
+	if p.AutoPrune != nil {
+		md.AutoPrune = *p.AutoPrune
+	}
+	if p.RotatePolicy != nil {
+		md.RotatePolicyID = int(*p.RotatePolicy)
+	}
+	if p.Checksum != "" {
+		md.LatestRevisionChecksum = p.Checksum
+	}
+	md.CreateTime = p.CreateTime.UTC()
+	md.UpdateTime = p.UpdateTime.UTC()
+}
+
+// upsertSecretMetadata inserts or updates secret_metadata.
+func (st *State) upsertSecretMetadata(ctx context.Context, tx *sqlair.TX, md secretMetadata) error {
+	query := `
+INSERT INTO secret_metadata (*)
+VALUES ($secretMetadata.*)
+ON CONFLICT(secret_id) DO UPDATE SET
+    version=excluded.version,
+    description=excluded.description,
+    rotate_policy_id=excluded.rotate_policy_id,
+    auto_prune=excluded.auto_prune,
+    latest_revision_checksum=excluded.latest_revision_checksum,
+    update_time=excluded.update_time`
+
+	stmt, err := st.Prepare(query, secretMetadata{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return tx.Query(ctx, stmt, md).Run()
+}
+
+// upsertSecretRevision inserts or updates a secret_revision record.
+func (st *State) upsertSecretRevision(ctx context.Context, tx *sqlair.TX, rev *secretRevision) error {
+	query := `
+INSERT INTO secret_revision (*)
+VALUES ($secretRevision.*)
+ON CONFLICT (uuid) DO UPDATE SET
+    update_time=excluded.update_time`
+
+	stmt, err := st.Prepare(query, secretRevision{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return tx.Query(ctx, stmt, rev).Run()
+}
+
+// insertSecretContent inserts key/value content for a secret revision.
+func (st *State) insertSecretContent(ctx context.Context, tx *sqlair.TX, revUUID string, content coresecrets.SecretData) error {
+	query := `
+INSERT INTO secret_content (revision_uuid, name, content)
+VALUES ($secretContent.revision_uuid, $secretContent.name, $secretContent.content)
+ON CONFLICT(revision_uuid, name) DO UPDATE SET
+    content=excluded.content`
+
+	stmt, err := st.Prepare(query, secretContent{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	for key, value := range content {
+		if err := tx.Query(ctx, stmt, secretContent{
+			RevisionUUID: revUUID,
+			Name:         key,
+			Content:      value,
+		}).Run(); err != nil {
+			return errors.Capture(err)
+		}
+	}
+	return nil
+}
+
+// upsertSecretValueRef inserts or updates a value reference for a secret
+// revision stored in an external backend.
+func (st *State) upsertSecretValueRef(ctx context.Context, tx *sqlair.TX, revUUID string, valueRef *coresecrets.ValueRef) error {
+	query := `
+INSERT INTO secret_value_ref (*)
+VALUES ($secretValueRef.*)
+ON CONFLICT(revision_uuid) DO UPDATE SET
+    backend_uuid=excluded.backend_uuid,
+    revision_id=excluded.revision_id`
+
+	stmt, err := st.Prepare(query, secretValueRef{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return tx.Query(ctx, stmt, secretValueRef{
+		RevisionUUID: revUUID,
+		BackendUUID:  valueRef.BackendID,
+		RevisionID:   valueRef.RevisionID,
+	}).Run()
+}
+
+// upsertSecretRevisionExpiry inserts or updates the expiry for a secret
+// revision.
+func (st *State) upsertSecretRevisionExpiry(ctx context.Context, tx *sqlair.TX, revUUID string, expireTime time.Time) error {
+	query := `
+INSERT INTO secret_revision_expire (*)
+VALUES ($secretRevisionExpire.*)
+ON CONFLICT(revision_uuid) DO UPDATE SET
+    expire_time=excluded.expire_time`
+
+	stmt, err := st.Prepare(query, secretRevisionExpire{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return tx.Query(ctx, stmt, secretRevisionExpire{
+		RevisionUUID: revUUID,
+		ExpireTime:   expireTime.UTC(),
+	}).Run()
+}
+
+// upsertSecretNextRotateTime inserts or updates the next rotation time for a
+// secret.
+func (st *State) upsertSecretNextRotateTime(ctx context.Context, tx *sqlair.TX, secretID string, next time.Time) error {
+	query := `
+INSERT INTO secret_rotation (*)
+VALUES ($secretRotate.*)
+ON CONFLICT(secret_id) DO UPDATE SET
+    next_rotation_time=excluded.next_rotation_time`
+
+	stmt, err := st.Prepare(query, secretRotate{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return tx.Query(ctx, stmt, secretRotate{
+		SecretID:       secretID,
+		NextRotateTime: next.UTC(),
+	}).Run()
+}
+
+// setSecretApplicationOwner inserts an application ownership record.
+func (st *State) setSecretApplicationOwner(ctx context.Context, tx *sqlair.TX, secretID, appUUID, label string) error {
+	query := `
+INSERT INTO secret_application_owner (secret_id, application_uuid, label)
+VALUES ($secretApplicationOwner.*)
+ON CONFLICT(secret_id, application_uuid) DO UPDATE SET label=excluded.label`
+
+	stmt, err := st.Prepare(query, secretApplicationOwner{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return tx.Query(ctx, stmt, secretApplicationOwner{
+		SecretID:        secretID,
+		ApplicationUUID: appUUID,
+		Label:           label,
+	}).Run()
+}
+
+// setSecretUnitOwner inserts a unit ownership record.
+func (st *State) setSecretUnitOwner(ctx context.Context, tx *sqlair.TX, secretID, unitUUID, label string) error {
+	query := `
+INSERT INTO secret_unit_owner (secret_id, unit_uuid, label)
+VALUES ($secretUnitOwner.*)
+ON CONFLICT(secret_id, unit_uuid) DO UPDATE SET label=excluded.label`
+
+	stmt, err := st.Prepare(query, secretUnitOwner{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return tx.Query(ctx, stmt, secretUnitOwner{
+		SecretID: secretID,
+		UnitUUID: unitUUID,
+		Label:    label,
+	}).Run()
+}
+
+// grantSecretOwnerManage grants RoleManage permission to the secret owner.
+func (st *State) grantSecretOwnerManage(ctx context.Context, tx *sqlair.TX, secretID, ownerUUID string, ownerType domainsecret.GrantSubjectType) error {
+	perm := secretPermissionGrant{
+		SecretID:      secretID,
+		RoleID:        domainsecret.RoleManage,
+		SubjectUUID:   ownerUUID,
+		SubjectTypeID: ownerType,
+		ScopeUUID:     ownerUUID,
+	}
+	switch ownerType {
+	case domainsecret.SubjectUnit:
+		perm.ScopeTypeID = domainsecret.ScopeUnit
+	case domainsecret.SubjectApplication:
+		perm.ScopeTypeID = domainsecret.ScopeApplication
+	}
+
+	query := `
+INSERT INTO secret_permission (*)
+VALUES ($secretPermissionGrant.*)
+ON CONFLICT(secret_id, subject_uuid) DO UPDATE SET
+    role_id=excluded.role_id,
+    subject_type_id=excluded.subject_type_id,
+    scope_type_id=excluded.scope_type_id,
+    scope_uuid=excluded.scope_uuid`
+
+	stmt, err := st.Prepare(query, secretPermissionGrant{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return tx.Query(ctx, stmt, perm).Run()
+}

--- a/domain/unitstate/state/types.go
+++ b/domain/unitstate/state/types.go
@@ -339,6 +339,10 @@ type secretInfo struct {
 	LatestRevisionUUID     string    `db:"latest_revision_uuid"`
 }
 
+type secretRotatePolicyInfo struct {
+	Policy string `db:"policy"`
+}
+
 type secretMetadata struct {
 	ID                     string    `db:"secret_id"`
 	Version                int       `db:"version"`

--- a/domain/unitstate/state/types.go
+++ b/domain/unitstate/state/types.go
@@ -50,6 +50,11 @@ type secretID struct {
 	ID string `db:"secret_id"`
 }
 
+// createSecretID is a sqlair wrapper for inserting a secret ID.
+type createSecretID struct {
+	ID string `db:"id"`
+}
+
 // secretIDs is a sqlair slice type for batch IN queries on secret_id.
 type secretIDs []string
 
@@ -266,6 +271,8 @@ type commitHookUnitInfo struct {
 	UnitLife int `db:"unit_life_id"`
 	// MachineUUID identifies the unit's machine if it is assigned to one.
 	MachineUUID sql.NullString `db:"machine_uuid"`
+	// ApplicationUUID is the UUID of the unit's application.
+	ApplicationUUID string `db:"application_uuid"`
 }
 
 // unitStateVal is a type for holding a key/value pair that is
@@ -330,6 +337,22 @@ type secretInfo struct {
 	UpdateTime             time.Time `db:"update_time"`
 	LatestRevision         int       `db:"latest_revision"`
 	LatestRevisionUUID     string    `db:"latest_revision_uuid"`
+}
+
+type secretMetadata struct {
+	ID                     string    `db:"secret_id"`
+	Version                int       `db:"version"`
+	Description            string    `db:"description"`
+	AutoPrune              bool      `db:"auto_prune"`
+	RotatePolicyID         int       `db:"rotate_policy_id"`
+	CreateTime             time.Time `db:"create_time"`
+	UpdateTime             time.Time `db:"update_time"`
+	LatestRevisionChecksum string    `db:"latest_revision_checksum"`
+}
+
+type secretRotate struct {
+	SecretID       string    `db:"secret_id"`
+	NextRotateTime time.Time `db:"next_rotation_time"`
 }
 
 type secretRevision struct {

--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -461,6 +461,39 @@ run_track_latest_revision() {
 	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-get "$secret_uri")" 'val: two'
 }
 
+# run_atomic_secret_create verifies that multiple secret creations through
+# CommitHookChanges (JUJU-9034) commit atomically in a single hook execution.
+# Two secrets created in one hook must both be readable immediately.
+run_atomic_secret_create() {
+	echo
+
+	# Create two secrets in one hook execution. Both must appear in
+	# secret_ids and be readable immediately, proving atomic commit.
+	echo "Checking: multiple secret-add in one hook commits atomically"
+	output=$(juju exec --unit juju-qa-test/0 -- \
+		"secret_uri1=\$(secret-add val=first --label=create-one); echo \$secret_uri1; secret_uri2=\$(secret-add val=second --label=create-two); echo \$secret_uri2")
+
+	secret_uri1=$(echo "$output" | head -1)
+	secret_uri2=$(echo "$output" | tail -1)
+	secret_id1=${secret_uri1##*/}
+	secret_id2=${secret_uri2##*/}
+
+	# Verify both secrets exist and are readable.
+	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-get "$secret_uri1")" 'val: first'
+	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-get "$secret_uri2")" 'val: second'
+	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-info-get "$secret_uri1" --format json | yq ".${secret_id1}.label")" 'create-one'
+	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-info-get "$secret_uri2" --format json | yq ".${secret_id2}.label")" 'create-two'
+
+	# Verify both appear in secret-ids output.
+	secret_ids=$(juju exec --unit juju-qa-test/0 -- secret-ids)
+	check_contains "$secret_ids" "$secret_id1"
+	check_contains "$secret_ids" "$secret_id2"
+
+	echo "Cleaning up atomic create secrets"
+	juju exec --unit juju-qa-test/0 -- secret-remove "$secret_uri1"
+	juju exec --unit juju-qa-test/0 -- secret-remove "$secret_uri2"
+}
+
 # run_atomic_secret_update verifies that a unit-owned secret update applied
 # through CommitHookChanges (JUJU-9962) commits atomically with other hook
 # changes. Secret updates now flow through the CommitHookChanges domain
@@ -599,6 +632,7 @@ test_secrets_hook_commit() {
 		wait_for "dummy-source" "$(idle_condition "dummy-source" 0)"
 		wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0)"
 
+		run_atomic_secret_create
 		run_track_latest_revision
 		run_atomic_secret_update
 		run_atomic_secret_update_grant


### PR DESCRIPTION
Waiting for merge of #22663 

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
