### PR TITLE
(2.9) perf(status): optimize full status lookups

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -21,7 +21,11 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          sudo snap install snapcraft --classic
+          action=$(snap info snapcraft | grep -q "installed" || echo "install")
+          if [ "$action" == "" ]; then
+              action="refresh"
+          fi
+          sudo snap $action snapcraft --channel 8.x --classic
           echo "/snap/bin" >> $GITHUB_PATH
 
       - name: Checkout

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -286,7 +286,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 		fetchNetworkInterfaces(c.api.stateAccessor, context.spaceInfos); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch IP addresses and link layer devices")
 	}
-	if context.relations, context.relationsById, err = fetchRelations(c.api.stateAccessor); err != nil {
+	if context.relations, context.relationsById, err = context.fetchRelations(c.api.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch relations")
 	}
 	if len(context.allAppsUnitsCharmBindings.applications) > 0 {
@@ -300,7 +300,7 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	context.branches = fetchBranches(c.api.modelCache)
 
 	logger.Tracef("Applications: %v", context.allAppsUnitsCharmBindings.applications)
-	logger.Tracef("Remote applications: %v", context.consumerRemoteApplications)
+	logger.Tracef("Remote applications: %v", context.consumerRemoteApplicationsWithURL())
 	logger.Tracef("Offers: %v", context.offers)
 	logger.Tracef("Relations: %v", context.relations)
 
@@ -604,7 +604,7 @@ type statusContext struct {
 	// linkLayerDevices: machine id -> list of linkLayerDevices
 	linkLayerDevices map[string][]*state.LinkLayerDevice
 
-	// remote applications: application name -> application
+	// consumerRemoteApplications: application name -> remote application
 	consumerRemoteApplications map[string]*state.RemoteApplication
 
 	// opened ports by machine.
@@ -890,7 +890,8 @@ func fetchAllApplicationsAndUnits(st Backend, model *state.Model, spaceInfos net
 	}, nil
 }
 
-// fetchConsumerRemoteApplications returns a map from application name to remote application.
+// fetchConsumerRemoteApplications returns all remote applications keyed by
+// application name, including consumer proxies without offer URLs.
 func fetchConsumerRemoteApplications(st Backend) (map[string]*state.RemoteApplication, error) {
 	appMap := make(map[string]*state.RemoteApplication)
 	applications, err := st.AllRemoteApplications()
@@ -898,9 +899,6 @@ func fetchConsumerRemoteApplications(st Backend) (map[string]*state.RemoteApplic
 		return nil, err
 	}
 	for _, a := range applications {
-		if _, ok := a.URL(); !ok {
-			continue
-		}
 		appMap[a.Name()] = a
 	}
 	return appMap, nil
@@ -952,7 +950,7 @@ func fetchOffers(st Backend, applications map[string]*state.Application) (map[st
 // to have the relations for each application. Reading them once here
 // avoids the repeated DB hits to retrieve the relations for each
 // application that used to happen in processApplicationRelations().
-func fetchRelations(st Backend) (map[string][]*state.Relation, map[int]*state.Relation, error) {
+func (context *statusContext) fetchRelations(st Backend) (map[string][]*state.Relation, map[int]*state.Relation, error) {
 	relations, err := st.AllRelations()
 	if err != nil {
 		return nil, nil, err
@@ -965,13 +963,11 @@ func fetchRelations(st Backend) (map[string][]*state.Relation, map[int]*state.Re
 		// on the offering side, exclude it here.
 		isRemote := false
 		for _, ep := range relation.Endpoints() {
-			if app, err := st.RemoteApplication(ep.ApplicationName); err == nil {
+			if app, ok := context.consumerRemoteApplications[ep.ApplicationName]; ok {
 				if app.IsConsumerProxy() {
 					isRemote = true
 					break
 				}
-			} else if !errors.IsNotFound(err) {
-				return nil, nil, err
 			}
 		}
 		if isRemote {
@@ -1195,7 +1191,7 @@ func (context *statusContext) processRelations() []params.RelationStatus {
 			Scope:     string(scope),
 			Endpoints: eps,
 		}
-		rStatus, err := relation.Status()
+		rStatus, err := context.status.Relation(relation.Id())
 		populateStatusFromStatusInfoAndErr(&relStatus.Status, rStatus, err)
 		out = append(out, relStatus)
 	}
@@ -1434,10 +1430,23 @@ func (context *statusContext) mapExposedEndpointsFromState(exposedEndpoints map[
 
 func (context *statusContext) processRemoteApplications() map[string]params.RemoteApplicationStatus {
 	applicationsMap := make(map[string]params.RemoteApplicationStatus)
-	for _, app := range context.consumerRemoteApplications {
+	for _, app := range context.consumerRemoteApplicationsWithURL() {
 		applicationsMap[app.Name()] = context.processRemoteApplication(app)
 	}
 	return applicationsMap
+}
+
+// consumerRemoteApplicationsWithURL returns the subset of remote applications
+// displayed by status. Relation processing uses all consumer remote applications.
+func (context *statusContext) consumerRemoteApplicationsWithURL() map[string]*state.RemoteApplication {
+	applications := make(map[string]*state.RemoteApplication)
+	for _, app := range context.consumerRemoteApplications {
+		if _, ok := app.URL(); !ok {
+			continue
+		}
+		applications[app.Name()] = app
+	}
+	return applications
 }
 
 func (context *statusContext) processRemoteApplication(application *state.RemoteApplication) (status params.RemoteApplicationStatus) {
@@ -1463,7 +1472,7 @@ func (context *statusContext) processRemoteApplication(application *state.Remote
 		status.Err = apiservererrors.ServerError(err)
 		return
 	}
-	applicationStatus, err := application.Status()
+	applicationStatus, err := context.status.RemoteApplication(application.Name())
 	populateStatusFromStatusInfoAndErr(&status.Status, applicationStatus, err)
 	return status
 }

--- a/state/status.go
+++ b/state/status.go
@@ -76,6 +76,16 @@ func (m *ModelStatus) Model() (status.StatusInfo, error) {
 	return m.getStatus(m.model.globalKey(), "model")
 }
 
+// Relation returns the status of the relation.
+func (m *ModelStatus) Relation(id int) (status.StatusInfo, error) {
+	return m.getStatus(relationGlobalScope(id), "relation")
+}
+
+// RemoteApplication returns the status of the remote application.
+func (m *ModelStatus) RemoteApplication(appName string) (status.StatusInfo, error) {
+	return m.getStatus(remoteApplicationGlobalKey(appName), fmt.Sprintf("saas application %q", appName))
+}
+
 // MachineAgent returns the status of the machine agent.
 func (m *ModelStatus) MachineAgent(machineID string) (status.StatusInfo, error) {
 	return m.getStatus(machineGlobalKey(machineID), "machine")

--- a/state/status_model_test.go
+++ b/state/status_model_test.go
@@ -4,6 +4,7 @@
 package state_test
 
 import (
+	"github.com/juju/charm/v8"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -163,6 +164,58 @@ func (s *ModelStatusSuite) TestModelStatusForModel(c *gc.C) {
 	mInfo, err := s.model.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, mInfo)
+}
+
+func (s *ModelStatusSuite) TestRelationStatus(c *gc.C) {
+	relation := s.factory.MakeRelation(c, nil)
+	err := relation.SetStatus(status.StatusInfo{
+		Status:  status.Suspended,
+		Message: "for a while",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msStatus, err := ms.Relation(relation.Id())
+	c.Assert(err, jc.ErrorIsNil)
+	relStatus, err := relation.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(msStatus, jc.DeepEquals, relStatus)
+}
+
+func (s *ModelStatusSuite) TestRemoteApplicationStatus(c *gc.C) {
+	application, err := s.st.AddRemoteApplication(state.AddRemoteApplicationParams{
+		Name:        "hosted-mysql",
+		OfferUUID:   "offer-uuid",
+		URL:         "fred/prod.mysql",
+		SourceModel: s.model.ModelTag(),
+		Endpoints: []charm.Relation{{
+			Interface: "mysql",
+			Name:      "db",
+			Role:      charm.RoleProvider,
+			Scope:     charm.ScopeGlobal,
+		}},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	now := testing.ZeroTime()
+	err = application.SetStatus(status.StatusInfo{
+		Status:  status.Active,
+		Message: "ready",
+		Since:   &now,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	ms, err := s.model.LoadModelStatus()
+	c.Assert(err, jc.ErrorIsNil)
+
+	msStatus, err := ms.RemoteApplication(application.Name())
+	c.Assert(err, jc.ErrorIsNil)
+	appStatus, err := application.Status()
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(msStatus, jc.DeepEquals, appStatus)
 }
 
 func (s *ModelStatusSuite) TestMachineStatus(c *gc.C) {


### PR DESCRIPTION
`juju status` is slow on models with many applications, units and relations.
`FullStatus` already loads a full `ModelStatus` snapshot once per call, but relation and remote-application status were still fetched with one database query per entity, and remote (consumer-proxy) detection issued one `RemoteApplication` query per relation endpoint. On a model with ~107 applications/units and ~2500 relation rows this added time to every `juju status`.

This change serves those remaining status values from the snapshot that `FullStatus` already loads, and detects remote applications from a preloaded map instead of per-endpoint queries.

Before this commit:
- relation status: `relation.Status()` — one DB query per relation
- saas/remote application status: `application(*RemoteApplication).Status()` — one query per remote application
- relation remote-end detection: `st.RemoteApplication(ep.ApplicationName)` — one query per relation endpoint

After this commit:
- relation status: `context.status.Relation(relation.Id())` — snapshot lookup
- saas/remote application status: `context.status.RemoteApplication(application.Name())` — snapshot lookup
- relation remote-end detection: `context.consumerRemoteApplications[ep.ApplicationName]` — preloaded map lookup

Two accessors are added to `state.ModelStatus` (`Relation`, `RemoteApplication`).
They use the same global status keys as the matching `Status()` methods, so the returned values and the not-found handling are unchanged.
The URL filter that used to live in the remote-application fetch is moved to a `consumerRemoteApplicationsWithURL()` helper used only on the display path, so relation detection still sees consumer proxies that have no offer URL.

Scope difference from the 3.6 change: the 3.6 commit also moved application status and CAAS operator status to the snapshot.
2.9 already serves those from the in-memory model cache (`context.cachedModel.Application(...).DisplayStatus()`), not from per-entity database queries, so moving them to the snapshot would change the displayed value (derived display status to raw global-key status) without removing any query.
Only the relation and remote-application paths are backported, and only the `Relation` and `RemoteApplication` accessors are added.

This extends the model-status snapshot approach introduced in #7766, which covered only machine and unit statuses.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~Integration tests~ — behaviour-preserving; covered by unit tests and the existing full-status tests
- [ ] ~doc.go added or updated in changed packages~ — no package responsibilities changed

## QA steps

Correctness (output must be identical with and without the patch):

1. Bootstrap a controller and add a model.
2. Deploy a relation-heavy model: many applications with relations between them.
   Include at least one cross-model relation / SaaS offer consumed in the model so the remote-application and consumer-proxy code paths are exercised.
3. Compare `juju status` and `juju status --relations` before and after the patch. Relation and SaaS/offer statuses must be populated identically.

Performance (synthetic model: 107 applications, 107 units, 1 machine; `juju status --relations` printed ~2500 relation rows; 2.9.61 controller on an OpenStack cloud).
Times are wall-clock for repeated runs, measured with a single fixed client; 
only the controller agent was swapped (unpatched 2.9.61.1 to patched 2.9.61.2).

The synthetic model carries many more relations than applications because it uses a local test charm with multiple named compatible endpoints.
The application and unit names are synthetic and exist only to create a dense endpoint/relation topology.
All units are co-located on one machine, so the test stresses the controller status read path without needing many machines or real workloads.

`juju status`

| metric  | before      | after       |
|---------|-------------|-------------|
| samples | 10          | 10          |
| mean    | 1.87 s      | 0.71 s      |
| median  | 1.88 s      | 0.71 s      |
| min–max | 1.73–1.98 s | 0.59–0.77 s |

mean 2.6x faster (62% lower); median 2.6x faster (62% lower).

`juju status --relations`

| metric  | before      | after       |
|---------|-------------|-------------|
| samples | 10          | 10          |
| mean    | 1.89 s      | 0.77 s      |
| median  | 1.92 s      | 0.76 s      |
| min–max | 1.76–1.97 s | 0.67–0.87 s |

mean 2.45x faster (59% lower); median 2.5x faster (60% lower).

The absolute numbers are not comparable to the 3.6 baseline in #22686 (3.42 s).
All three runs use the same cloud (myopenstack/RegionOne) and the same controller flavor (m1.medium-2c, 4 GB / 2 vCPU), but they differ in juju version (3.6.23 vs 2.9.61) and controller-instance state, and the controller load at measurement time was not isolated.
Only the within-version before/after comparison measures the patch: same controller, same model, only the agent binary swapped (unpatched 2.9.61.1 to patched 2.9.61.2).
The gain comes from removing the per-relation status query and the per-endpoint remote-application lookup, which scale with relation count.

## Documentation changes

None. `juju status` output, CLI flags and the client API are unchanged.

## Links

- ~Launchpad bug~ — none for this change
- ~Jira card~ — none for this change
- Forward port: #22686 (3.6)