### PR TITLE
fix: tag maas vms created by juju and delete only them

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -327,3 +327,5 @@ replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
 replace go.uber.org/mock => go.uber.org/mock v0.4.0
 
 replace go.opencensus.io => github.com/census-instrumentation/opencensus-go v0.24.0
+
+replace github.com/juju/gomaasapi/v2 => github.com/wallyworld/gomaasapi/v2 v2.0.0-20260623034555-b7c9820fd5b7

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0
 	github.com/juju/gojsonschema v1.0.0
-	github.com/juju/gomaasapi/v2 v2.4.0
+	github.com/juju/gomaasapi/v3 v3.0.0
 	github.com/juju/http/v2 v2.0.1
 	github.com/juju/idmclient/v2 v2.0.0
 	github.com/juju/jsonschema v1.0.0
@@ -327,5 +327,3 @@ replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
 replace go.uber.org/mock => go.uber.org/mock v0.4.0
 
 replace go.opencensus.io => github.com/census-instrumentation/opencensus-go v0.24.0
-
-replace github.com/juju/gomaasapi/v2 => github.com/wallyworld/gomaasapi/v2 v2.0.0-20260623034555-b7c9820fd5b7

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,6 @@ github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 h1:huRsqE0iXm
 github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33/go.mod h1:UxUZdlQkjnbl3YoCZT1y5uxmvG2KMwqgffBFccD7qHI=
 github.com/juju/gojsonschema v1.0.0 h1:v0hVxinRWko/SwRYCZ99fBH20Q1JtDqKtplcovXewt0=
 github.com/juju/gojsonschema v1.0.0/go.mod h1:w3BDUH3gGgrcrAyvEbBy3lNb1vmdqG31UMn3njL8oGc=
-github.com/juju/gomaasapi/v2 v2.4.0 h1:fKsAEakrE0csf/KgBLeqjUfoqqTXdKFINKR4ZhD+Kns=
-github.com/juju/gomaasapi/v2 v2.4.0/go.mod h1:BJdYcbOpk1aOjsvgu3qNCty4mMrmtjbSAW4bfxMcf7s=
 github.com/juju/http/v2 v2.0.1 h1:cTt8RHvdVv9uZFmAb/7zQrRitT1bgywEDOf8nLpYd8M=
 github.com/juju/http/v2 v2.0.1/go.mod h1:V9dcD7DkT4xkwWjXpFr1C0ZNq7gG+eN9f+Mi2c7GnCs=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
@@ -777,6 +775,7 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vmware/govmomi v0.34.1 h1:Hqu2Uke2itC+cNoIcFQBLEZvX9wBRTTOP04J7V1fqRw=
 github.com/vmware/govmomi v0.34.1/go.mod h1:qWWT6n9mdCr/T9vySsoUqcI04sSEj4CqHXxtk/Y+Los=
+github.com/wallyworld/gomaasapi/v2 v2.0.0-20260623034555-b7c9820fd5b7/go.mod h1:BJdYcbOpk1aOjsvgu3qNCty4mMrmtjbSAW4bfxMcf7s=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=

--- a/go.sum
+++ b/go.sum
@@ -775,6 +775,7 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vmware/govmomi v0.34.1 h1:Hqu2Uke2itC+cNoIcFQBLEZvX9wBRTTOP04J7V1fqRw=
 github.com/vmware/govmomi v0.34.1/go.mod h1:qWWT6n9mdCr/T9vySsoUqcI04sSEj4CqHXxtk/Y+Los=
+github.com/wallyworld/gomaasapi/v2 v2.0.0-20260623034555-b7c9820fd5b7 h1:maob0YqprE+cjE7AbLZdUWJvoLPmGkBwBpd9Xs6gcn4=
 github.com/wallyworld/gomaasapi/v2 v2.0.0-20260623034555-b7c9820fd5b7/go.mod h1:BJdYcbOpk1aOjsvgu3qNCty4mMrmtjbSAW4bfxMcf7s=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33 h1:huRsqE0iXm
 github.com/juju/gojsonreference v0.0.0-20150204194633-f0d24ac5ee33/go.mod h1:UxUZdlQkjnbl3YoCZT1y5uxmvG2KMwqgffBFccD7qHI=
 github.com/juju/gojsonschema v1.0.0 h1:v0hVxinRWko/SwRYCZ99fBH20Q1JtDqKtplcovXewt0=
 github.com/juju/gojsonschema v1.0.0/go.mod h1:w3BDUH3gGgrcrAyvEbBy3lNb1vmdqG31UMn3njL8oGc=
+github.com/juju/gomaasapi/v3 v3.0.0 h1:sROF9IB+uOZasH7ASgcwL24tzq01ihx9svpj7gaYChk=
+github.com/juju/gomaasapi/v3 v3.0.0/go.mod h1:zBy6EHDnh5wGelPRhPAxPPy7uvTbEfaM/UukbOzR44c=
 github.com/juju/http/v2 v2.0.1 h1:cTt8RHvdVv9uZFmAb/7zQrRitT1bgywEDOf8nLpYd8M=
 github.com/juju/http/v2 v2.0.1/go.mod h1:V9dcD7DkT4xkwWjXpFr1C0ZNq7gG+eN9f+Mi2c7GnCs=
 github.com/juju/httpprof v0.0.0-20141217160036-14bf14c30767/go.mod h1:+MaLYz4PumRkkyHYeXJ2G5g5cIW0sli2bOfpmbaMV/g=
@@ -775,8 +777,6 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/vmware/govmomi v0.34.1 h1:Hqu2Uke2itC+cNoIcFQBLEZvX9wBRTTOP04J7V1fqRw=
 github.com/vmware/govmomi v0.34.1/go.mod h1:qWWT6n9mdCr/T9vySsoUqcI04sSEj4CqHXxtk/Y+Los=
-github.com/wallyworld/gomaasapi/v2 v2.0.0-20260623034555-b7c9820fd5b7 h1:maob0YqprE+cjE7AbLZdUWJvoLPmGkBwBpd9Xs6gcn4=
-github.com/wallyworld/gomaasapi/v2 v2.0.0-20260623034555-b7c9820fd5b7/go.mod h1:BJdYcbOpk1aOjsvgu3qNCty4mMrmtjbSAW4bfxMcf7s=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=

--- a/internal/provider/maas/config_test.go
+++ b/internal/provider/maas/config_test.go
@@ -4,7 +4,7 @@
 package maas
 
 import (
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 

--- a/internal/provider/maas/constraints.go
+++ b/internal/provider/maas/constraints.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"

--- a/internal/provider/maas/constraints_test.go
+++ b/internal/provider/maas/constraints_test.go
@@ -6,7 +6,7 @@ package maas
 import (
 	"net/url"
 
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 

--- a/internal/provider/maas/devices.go
+++ b/internal/provider/maas/devices.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 
 	corenetwork "github.com/juju/juju/core/network"
 )

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -702,12 +702,12 @@ func (env *maasEnviron) composeNode(
 	positiveSpaceIDs set.Strings,
 	volumes []volumeInfo,
 ) (string, error) {
-	pods, err := env.maasController.Pods()
+	vmHosts, err := env.maasController.VmHosts()
 	if err != nil {
 		return "", errors.Annotate(err, "listing pods")
 	}
-	if len(pods) == 0 {
-		return "", errors.New("no pods available to compose machine")
+	if len(vmHosts) == 0 {
+		return "", errors.New("no vm hosts available to compose machine")
 	}
 
 	composeArgs := gomaasapi.ComposeMachineArgs{
@@ -745,18 +745,18 @@ func (env *maasEnviron) composeNode(
 
 	// Use the first pod that can commission the machine.
 	var lastComposeErr error
-	for _, pod := range pods {
-		machine, err := pod.ComposeMachine(composeArgs)
+	for _, vmHost := range vmHosts {
+		machine, err := vmHost.ComposeMachine(composeArgs)
 		if err != nil {
 			if gomaasapi.IsNoMatchError(err) || gomaasapi.IsCannotCompleteError(err) {
 				lastComposeErr = err
-				logger.Debugf("pod %q could not compose machine, trying next pod: %v", pod.Name(), err)
+				logger.Debugf("pod %q could not compose machine, trying next pod: %v", vmHost.Name(), err)
 				continue
 			}
 			return "", errors.Annotate(err, "composing machine")
 		}
 		systemID := machine.SystemID()
-		err = env.markComposedMachine(ctx, systemID)
+		err = machine.SetOwnerData(map[string]string{composedByJujuDataKey: composedByJujuDataVal})
 		if err != nil {
 			if deleteErr := env.maasController.DeleteMachine(systemID); deleteErr != nil {
 				logger.Warningf("failed to delete unmarked composed machine %q: %v", systemID, deleteErr)
@@ -764,7 +764,7 @@ func (env *maasEnviron) composeNode(
 			return "", errors.Annotate(err, "marking composed machine")
 		}
 
-		logger.Infof("composed machine %q in pod %q", systemID, pod.Name())
+		logger.Infof("composed machine %q in pod %q", systemID, vmHost.Name())
 
 		// The composed machine goes through MAAS commissioning before it
 		// reaches "Ready" state. AllocateMachine only works on Ready
@@ -783,27 +783,7 @@ func (env *maasEnviron) composeNode(
 		return "", errors.Annotate(lastComposeErr, "composing machine")
 	}
 
-	return "", errors.New("no pods matched the zone requirement")
-}
-
-// markComposedMachine tags a given virtual machine as being created by Juju.
-func (env *maasEnviron) markComposedMachine(ctx context.ProviderCallContext, systemID string) error {
-	// TODO - in gomaasapi SetOwnerData on the returned machine is a no op
-	//  Once gomaasapi is fixed, we no longer need this helper.
-	machines, err := env.maasController.Machines(gomaasapi.MachinesArgs{SystemIDs: []string{systemID}})
-	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
-		return errors.Trace(err)
-	}
-	if len(machines) == 0 {
-		return errors.NotFoundf("composed machine %q", systemID)
-	}
-	err = machines[0].SetOwnerData(map[string]string{composedByJujuDataKey: composedByJujuDataVal})
-	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
-		return errors.Trace(err)
-	}
-	return nil
+	return "", errors.New("no vm host matched the zone requirement")
 }
 
 // waitForComposedMachineReady polls MAAS until the machine with the given

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -6,6 +6,7 @@ package maas
 import (
 	stdcontext "context"
 	"crypto/tls"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -1227,12 +1228,9 @@ func (env *maasEnviron) StopInstances(ctx context.ProviderCallContext, ids ...in
 		return nil
 	}
 
-	err := env.deleteAnyComposedNodes(ctx, ids)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	err = env.releaseNodes(ctx, ids, true)
-	if err != nil {
+	deleteErr := env.deleteAnyComposedNodes(ctx, ids)
+	releaseErr := env.releaseNodes(ctx, ids, true)
+	if err := stderrors.Join(deleteErr, releaseErr); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -45,6 +45,11 @@ import (
 const (
 	// The version strings indicating the MAAS API version.
 	apiVersion2 = "2.0"
+
+	// composedByJujuDataKey marks machines composed by Juju so cleanup
+	// can distinguish them from pre-existing MAAS pod machines.
+	composedByJujuDataKey = "juju-composed"
+	composedByJujuDataVal = "true"
 )
 
 var defaultShortRetryStrategy = retry.CallArgs{
@@ -751,6 +756,14 @@ func (env *maasEnviron) composeNode(
 			return "", errors.Annotate(err, "composing machine")
 		}
 		systemID := machine.SystemID()
+		err = env.markComposedMachine(ctx, systemID)
+		if err != nil {
+			if deleteErr := env.maasController.DeleteMachine(systemID); deleteErr != nil {
+				logger.Warningf("failed to delete unmarked composed machine %q: %v", systemID, deleteErr)
+			}
+			return "", errors.Annotate(err, "marking composed machine")
+		}
+
 		logger.Infof("composed machine %q in pod %q", systemID, pod.Name())
 
 		// The composed machine goes through MAAS commissioning before it
@@ -771,6 +784,26 @@ func (env *maasEnviron) composeNode(
 	}
 
 	return "", errors.New("no pods matched the zone requirement")
+}
+
+// markComposedMachine tags a given virtual machine as being created by Juju.
+func (env *maasEnviron) markComposedMachine(ctx context.ProviderCallContext, systemID string) error {
+	// TODO - in gomaasapi SetOwnerData on the returned machine is a no op
+	//  Once gomaasapi is fixed, we no longer need this helper.
+	machines, err := env.maasController.Machines(gomaasapi.MachinesArgs{SystemIDs: []string{systemID}})
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return errors.Trace(err)
+	}
+	if len(machines) == 0 {
+		return errors.NotFoundf("composed machine %q", systemID)
+	}
+	err = machines[0].SetOwnerData(map[string]string{composedByJujuDataKey: composedByJujuDataVal})
+	if err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // waitForComposedMachineReady polls MAAS until the machine with the given
@@ -1170,14 +1203,13 @@ func (env *maasEnviron) releaseNodesIndividually(ctx context.ProviderCallContext
 	return errors.Trace(lastErr)
 }
 
-// deleteAnyComposedNodes determines which instance ids are for VMs provisioned
-// by a pod (rather than pre-existing machines) and deletes them.
-// This is necessary to clean up the composed machines after release,
-// as ReleaseMachine only releases the machine but does not delete it from MAAS,
-// and we don't need composed machines to be reused for future allocations.
+// deleteAnyComposedNodes deletes released machines that Juju explicitly composed.
+// This is necessary to clean up composed machines after release because
+// ReleaseMachine does not delete them from MAAS.
 func (env *maasEnviron) deleteAnyComposedNodes(ctx context.ProviderCallContext, ids []instance.Id) error {
 	machines, err := env.maasController.Machines(gomaasapi.MachinesArgs{
 		SystemIDs: instanceIdsToSystemIDs(ids),
+		OwnerData: map[string]string{composedByJujuDataKey: composedByJujuDataVal},
 	})
 	if err != nil {
 		common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx)
@@ -1185,9 +1217,6 @@ func (env *maasEnviron) deleteAnyComposedNodes(ctx context.ProviderCallContext, 
 	}
 	var lastErr error
 	for _, m := range machines {
-		if m.Pod() == nil && m.PowerType() != "virsh" && m.PowerType() != "lxd" {
-			continue
-		}
 		err = env.maasController.DeleteMachine(m.SystemID())
 		if err != nil {
 			lastErr = err

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	"github.com/juju/names/v5"
 	"github.com/juju/retry"
 	"github.com/juju/version/v2"

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -1227,11 +1227,11 @@ func (env *maasEnviron) StopInstances(ctx context.ProviderCallContext, ids ...in
 		return nil
 	}
 
-	err := env.releaseNodes(ctx, ids, true)
+	err := env.deleteAnyComposedNodes(ctx, ids)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = env.deleteAnyComposedNodes(ctx, ids)
+	err = env.releaseNodes(ctx, ids, true)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/provider/maas/environprovider.go
+++ b/internal/provider/maas/environprovider.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 
 	"github.com/juju/errors"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	"github.com/juju/jsonschema"
 	"github.com/juju/loggo"
 

--- a/internal/provider/maas/environprovider_test.go
+++ b/internal/provider/maas/environprovider_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"

--- a/internal/provider/maas/errors.go
+++ b/internal/provider/maas/errors.go
@@ -4,7 +4,7 @@
 package maas
 
 import (
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 
 	"github.com/juju/juju/internal/provider/common"
 )

--- a/internal/provider/maas/errors_test.go
+++ b/internal/provider/maas/errors_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/juju/errors"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 

--- a/internal/provider/maas/instance.go
+++ b/internal/provider/maas/instance.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"

--- a/internal/provider/maas/instance_test.go
+++ b/internal/provider/maas/instance_test.go
@@ -4,7 +4,7 @@
 package maas
 
 import (
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 

--- a/internal/provider/maas/interfaces_test.go
+++ b/internal/provider/maas/interfaces_test.go
@@ -4,7 +4,7 @@
 package maas
 
 import (
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -644,8 +644,7 @@ func (suite *maasEnvironSuite) TestAcquireNodeStorage(c *gc.C) {
 
 func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 	composedMachine := &fakeMachine{Stub: &testing.Stub{}, systemID: "composed-1", hostname: "vm-1", statusName: "Ready"}
-	lookupMachine := &fakeMachine{Stub: &testing.Stub{}, systemID: "composed-1", hostname: "vm-1", statusName: "Ready"}
-	pod := &fakePod{
+	pod := &fakeVmHost{
 		name: "pod-a",
 		zone: fakeZone{name: "mossack"},
 		composeMachineArgsCheck: func(args gomaasapi.ComposeMachineArgs) {
@@ -668,8 +667,8 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 		composeMachine: composedMachine,
 	}
 	controller := &fakeController{
-		Stub: &testing.Stub{},
-		pods: []gomaasapi.Pod{pod},
+		Stub:    &testing.Stub{},
+		vmHosts: []gomaasapi.VmHost{pod},
 		allocateMachineArgsCheck: func(args gomaasapi.AllocateMachineArgs) {
 			c.Assert(args.SystemId, gc.Equals, "composed-1")
 		},
@@ -678,7 +677,7 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 			architecture: arch.HostArch(),
 		},
 		allocateMachineMatches: gomaasapi.ConstraintMatches{Storage: map[string][]gomaasapi.StorageDevice{}},
-		machines:               []gomaasapi.Machine{lookupMachine},
+		machines:               []gomaasapi.Machine{composedMachine},
 	}
 	env := suite.makeEnviron(c, controller)
 
@@ -695,21 +694,20 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(collectDeleteMachineArgs(controller), gc.HasLen, 0)
-	lookupMachine.CheckCallNames(c, "SetOwnerData")
-	ownerDataArg, ok := lookupMachine.Calls()[0].Args[0].(map[string]string)
+	composedMachine.CheckCallNames(c, "SetOwnerData")
+	ownerDataArg, ok := composedMachine.Calls()[0].Args[0].(map[string]string)
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(ownerDataArg, gc.DeepEquals, map[string]string{
 		composedByJujuDataKey: composedByJujuDataVal})
-	c.Assert(composedMachine.Calls(), gc.HasLen, 0)
 }
 
 func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchTriesNextPod(c *gc.C) {
 	composedMachine := &fakeMachine{systemID: "composed-2", hostname: "vm-2", statusName: "Ready"}
 	controller := &fakeController{
 		Stub: &testing.Stub{},
-		pods: []gomaasapi.Pod{
-			&fakePod{name: "pod-a", composeMachineErr: gomaasapi.NewNoMatchError("insufficient resources")},
-			&fakePod{name: "pod-b", composeMachine: composedMachine},
+		vmHosts: []gomaasapi.VmHost{
+			&fakeVmHost{name: "pod-a", composeMachineErr: gomaasapi.NewNoMatchError("insufficient resources")},
+			&fakeVmHost{name: "pod-b", composeMachine: composedMachine},
 		},
 		allocateMachineArgsCheck: func(args gomaasapi.AllocateMachineArgs) {
 			c.Assert(args.SystemId, gc.Equals, "composed-2")
@@ -740,9 +738,9 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchTriesN
 func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchAllPodsFail(c *gc.C) {
 	controller := &fakeController{
 		Stub: &testing.Stub{},
-		pods: []gomaasapi.Pod{
-			&fakePod{name: "pod-a", composeMachineErr: gomaasapi.NewNoMatchError("insufficient resources")},
-			&fakePod{name: "pod-b", composeMachineErr: gomaasapi.NewCannotCompleteError("cannot compose right now")},
+		vmHosts: []gomaasapi.VmHost{
+			&fakeVmHost{name: "pod-a", composeMachineErr: gomaasapi.NewNoMatchError("insufficient resources")},
+			&fakeVmHost{name: "pod-b", composeMachineErr: gomaasapi.NewCannotCompleteError("cannot compose right now")},
 		},
 	}
 	env := suite.makeEnviron(c, controller)
@@ -764,13 +762,13 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchAllPod
 func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchPodsSkipped(c *gc.C) {
 	controller := &fakeController{
 		Stub: &testing.Stub{},
-		pods: []gomaasapi.Pod{
-			&fakePod{
+		vmHosts: []gomaasapi.VmHost{
+			&fakeVmHost{
 				name:              "pod-a",
 				zone:              &fakeZone{name: "mossack"},
 				composeMachineErr: gomaasapi.NewNoMatchError("insufficient resources"),
 			},
-			&fakePod{
+			&fakeVmHost{
 				name:              "pod-b",
 				zone:              &fakeZone{name: "fonseca"},
 				composeMachineErr: gomaasapi.NewCannotCompleteError("no available machines"),
@@ -796,7 +794,7 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineAllocateFailureClean
 	composedMachine := &fakeMachine{systemID: "composed-2", hostname: "vm-2", statusName: "Ready"}
 	controller := &fakeController{
 		Stub:                 &testing.Stub{},
-		pods:                 []gomaasapi.Pod{&fakePod{composeMachine: composedMachine}},
+		vmHosts:              []gomaasapi.VmHost{&fakeVmHost{composeMachine: composedMachine}},
 		machines:             []gomaasapi.Machine{composedMachine},
 		allocateMachineError: errors.New("allocate failed"),
 	}
@@ -825,7 +823,7 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineWaitReadyFailureClea
 	}
 	controller := &fakeController{
 		Stub:     &testing.Stub{},
-		pods:     []gomaasapi.Pod{&fakePod{composeMachine: orphan}},
+		vmHosts:  []gomaasapi.VmHost{&fakeVmHost{composeMachine: orphan}},
 		machines: []gomaasapi.Machine{orphan},
 	}
 	env := suite.makeEnviron(c, controller)

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -382,6 +382,12 @@ func (suite *maasEnvironSuite) TestStopInstancesDeletesComposedNodes(c *gc.C) {
 	err := suite.makeEnviron(c, controller).StopInstances(suite.callCtx, "test1", "test2", "test3")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(collectDeleteMachineArgs(controller), jc.SameContents, []string{"test1", "test2"})
+	controller.CheckCallNames(c,
+		"DeleteMachine",
+		"DeleteMachine",
+		"ReleaseMachines",
+		"GetFile",
+	)
 }
 
 func (suite *maasEnvironSuite) TestStopInstancesDoesNotDeleteNonComposedNodes(c *gc.C) {

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -373,9 +373,10 @@ func (suite *maasEnvironSuite) TestStopInstancesReturnsUnexpectedError(c *gc.C) 
 func (suite *maasEnvironSuite) TestStopInstancesDeletesComposedNodes(c *gc.C) {
 	controller := newFakeControllerWithFiles(&fakeFile{name: coretesting.ModelTag.Id() + "-provider-state"})
 	controller.machines = []gomaasapi.Machine{
-		&fakeMachine{systemID: "test1", pod: &fakePod{}},
-		&fakeMachine{systemID: "test2", powerType: "virsh"},
-		&fakeMachine{systemID: "test3", powerType: "ipmi"},
+		// Simulate MAAS server-side filtering by OwnerData.
+		&fakeMachine{systemID: "test1", ownerData: map[string]string{composedByJujuDataKey: composedByJujuDataVal}},
+		&fakeMachine{systemID: "test2", powerType: "virsh", ownerData: map[string]string{composedByJujuDataKey: composedByJujuDataVal}},
+		&fakeMachine{systemID: "test3", powerType: "virsh"},
 	}
 
 	err := suite.makeEnviron(c, controller).StopInstances(suite.callCtx, "test1", "test2", "test3")
@@ -400,7 +401,7 @@ func (suite *maasEnvironSuite) TestStopInstancesDoesNotDeleteNonComposedNodes(c 
 func (suite *maasEnvironSuite) TestStopInstancesReturnsDeleteComposedNodesError(c *gc.C) {
 	controller := newFakeControllerWithFiles(&fakeFile{name: coretesting.ModelTag.Id() + "-provider-state"})
 	controller.machines = []gomaasapi.Machine{
-		&fakeMachine{systemID: "test1", powerType: "lxd"},
+		&fakeMachine{systemID: "test1", powerType: "lxd", ownerData: map[string]string{composedByJujuDataKey: composedByJujuDataVal}},
 	}
 	controller.deleteMachineError = errors.New("delete failed")
 
@@ -642,7 +643,8 @@ func (suite *maasEnvironSuite) TestAcquireNodeStorage(c *gc.C) {
 }
 
 func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
-	composedMachine := &fakeMachine{systemID: "composed-1", hostname: "vm-1", statusName: "Ready"}
+	composedMachine := &fakeMachine{Stub: &testing.Stub{}, systemID: "composed-1", hostname: "vm-1", statusName: "Ready"}
+	lookupMachine := &fakeMachine{Stub: &testing.Stub{}, systemID: "composed-1", hostname: "vm-1", statusName: "Ready"}
 	pod := &fakePod{
 		name: "pod-a",
 		zone: fakeZone{name: "mossack"},
@@ -676,7 +678,7 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 			architecture: arch.HostArch(),
 		},
 		allocateMachineMatches: gomaasapi.ConstraintMatches{Storage: map[string][]gomaasapi.StorageDevice{}},
-		machines:               []gomaasapi.Machine{composedMachine},
+		machines:               []gomaasapi.Machine{lookupMachine},
 	}
 	env := suite.makeEnviron(c, controller)
 
@@ -693,6 +695,12 @@ func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposes(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(collectDeleteMachineArgs(controller), gc.HasLen, 0)
+	lookupMachine.CheckCallNames(c, "SetOwnerData")
+	ownerDataArg, ok := lookupMachine.Calls()[0].Args[0].(map[string]string)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(ownerDataArg, gc.DeepEquals, map[string]string{
+		composedByJujuDataKey: composedByJujuDataVal})
+	c.Assert(composedMachine.Calls(), gc.HasLen, 0)
 }
 
 func (suite *maasEnvironSuite) TestAcquireNodeVirtualMachineComposeNoMatchTriesNextPod(c *gc.C) {

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -404,16 +404,23 @@ func (suite *maasEnvironSuite) TestStopInstancesDoesNotDeleteNonComposedNodes(c 
 	c.Assert(args[0].SystemIDs, jc.SameContents, []string{"test3"})
 }
 
-func (suite *maasEnvironSuite) TestStopInstancesReturnsDeleteComposedNodesError(c *gc.C) {
+func (suite *maasEnvironSuite) TestStopInstancesReturnsDeleteComposedNodeAndReleaseErrors(c *gc.C) {
 	controller := newFakeControllerWithFiles(&fakeFile{name: coretesting.ModelTag.Id() + "-provider-state"})
 	controller.machines = []gomaasapi.Machine{
 		&fakeMachine{systemID: "test1", powerType: "lxd", ownerData: map[string]string{composedByJujuDataKey: composedByJujuDataVal}},
+		&fakeMachine{systemID: "test2", powerType: "lxd", ownerData: map[string]string{composedByJujuDataKey: composedByJujuDataVal}},
 	}
-	controller.deleteMachineError = errors.New("delete failed")
+	controller.deleteMachineErrors = map[string]error{
+		"test2": errors.New("delete test2 failed"),
+	}
+	controller.SetErrors(errors.New("boom"))
 
-	err := suite.makeEnviron(c, controller).StopInstances(suite.callCtx, "test1")
-	c.Assert(err, gc.ErrorMatches, "deleting composed machines: delete failed")
-	c.Assert(collectDeleteMachineArgs(controller), jc.SameContents, []string{"test1"})
+	err := suite.makeEnviron(c, controller).StopInstances(suite.callCtx, "test1", "test2")
+	c.Assert(err, gc.ErrorMatches, "deleting composed machines: delete test2 failed\ncannot release nodes: boom")
+	c.Assert(collectDeleteMachineArgs(controller), jc.SameContents, []string{"test1", "test2"})
+	args := collectReleaseArgs(controller)
+	c.Assert(args, gc.HasLen, 1)
+	c.Assert(args[0].SystemIDs, jc.SameContents, []string{"test1", "test2"})
 }
 
 func (suite *maasEnvironSuite) TestStartInstanceError(c *gc.C) {

--- a/internal/provider/maas/maas_storage.go
+++ b/internal/provider/maas/maas_storage.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	"github.com/juju/utils/v3"
 
 	"github.com/juju/juju/environs/storage"

--- a/internal/provider/maas/maas_storage_test.go
+++ b/internal/provider/maas/maas_storage_test.go
@@ -8,7 +8,7 @@ import (
 	"io"
 
 	"github.com/juju/errors"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/internal/provider/maas/maas_test.go
+++ b/internal/provider/maas/maas_test.go
@@ -83,8 +83,8 @@ type fakeController struct {
 	spacesError        error
 	staticRoutes       []gomaasapi.StaticRoute
 	staticRoutesError  error
-	pods               []gomaasapi.Pod
-	podsError          error
+	vmHosts            []gomaasapi.VmHost
+	vmHostsError       error
 	deleteMachineError error
 
 	allocateMachine          gomaasapi.Machine
@@ -240,11 +240,11 @@ func (c *fakeController) DeleteMachine(systemID string) error {
 	return c.deleteMachineError
 }
 
-func (c *fakeController) Pods() ([]gomaasapi.Pod, error) {
-	if c.podsError != nil {
-		return nil, c.podsError
+func (c *fakeController) VmHosts() ([]gomaasapi.VmHost, error) {
+	if c.vmHostsError != nil {
+		return nil, c.vmHostsError
 	}
-	return c.pods, nil
+	return c.vmHosts, nil
 }
 
 type fakeBootResource struct {
@@ -275,7 +275,7 @@ type fakeMachine struct {
 	memory        int
 	architecture  string
 	powerType     string
-	pod           gomaasapi.Pod
+	vmHost        gomaasapi.VmHost
 	interfaceSet  []gomaasapi.Interface
 	tags          []string
 	ownerData     map[string]string
@@ -357,8 +357,8 @@ func (m *fakeMachine) PowerType() string {
 	return m.powerType
 }
 
-func (m *fakeMachine) Pod() gomaasapi.Pod {
-	return m.pod
+func (m *fakeMachine) VmHost() gomaasapi.VmHost {
+	return m.vmHost
 }
 
 func (m *fakeMachine) StatusName() string {
@@ -756,8 +756,8 @@ func (*fakeDomain) Name() string {
 	return "maas"
 }
 
-type fakePod struct {
-	gomaasapi.Pod
+type fakeVmHost struct {
+	gomaasapi.VmHost
 
 	id    int
 	name  string
@@ -770,27 +770,27 @@ type fakePod struct {
 	composeMachineArgsCheck func(gomaasapi.ComposeMachineArgs)
 }
 
-func (p *fakePod) ID() int {
+func (p *fakeVmHost) ID() int {
 	return p.id
 }
 
-func (p *fakePod) Name() string {
+func (p *fakeVmHost) Name() string {
 	return p.name
 }
 
-func (p *fakePod) Type() string {
+func (p *fakeVmHost) Type() string {
 	return p.type_
 }
 
-func (p *fakePod) Zone() gomaasapi.Zone {
+func (p *fakeVmHost) Zone() gomaasapi.Zone {
 	return p.zone
 }
 
-func (p *fakePod) Pool() gomaasapi.Pool {
+func (p *fakeVmHost) Pool() gomaasapi.Pool {
 	return p.pool
 }
 
-func (p *fakePod) ComposeMachine(args gomaasapi.ComposeMachineArgs) (gomaasapi.Machine, error) {
+func (p *fakeVmHost) ComposeMachine(args gomaasapi.ComposeMachineArgs) (gomaasapi.Machine, error) {
 	if p.composeMachineArgsCheck != nil {
 		p.composeMachineArgsCheck(args)
 	}

--- a/internal/provider/maas/maas_test.go
+++ b/internal/provider/maas/maas_test.go
@@ -6,7 +6,7 @@ package maas
 import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"

--- a/internal/provider/maas/maas_test.go
+++ b/internal/provider/maas/maas_test.go
@@ -71,21 +71,21 @@ type fakeController struct {
 	gomaasapi.Controller
 	*testing.Stub
 
-	domains            []gomaasapi.Domain
-	bootResources      []gomaasapi.BootResource
-	bootResourcesError error
-	machines           []gomaasapi.Machine
-	machinesError      error
-	machinesArgsCheck  func(gomaasapi.MachinesArgs)
-	zones              []gomaasapi.Zone
-	zonesError         error
-	spaces             []gomaasapi.Space
-	spacesError        error
-	staticRoutes       []gomaasapi.StaticRoute
-	staticRoutesError  error
-	vmHosts            []gomaasapi.VmHost
-	vmHostsError       error
-	deleteMachineError error
+	domains             []gomaasapi.Domain
+	bootResources       []gomaasapi.BootResource
+	bootResourcesError  error
+	machines            []gomaasapi.Machine
+	machinesError       error
+	machinesArgsCheck   func(gomaasapi.MachinesArgs)
+	zones               []gomaasapi.Zone
+	zonesError          error
+	spaces              []gomaasapi.Space
+	spacesError         error
+	staticRoutes        []gomaasapi.StaticRoute
+	staticRoutesError   error
+	vmHosts             []gomaasapi.VmHost
+	vmHostsError        error
+	deleteMachineErrors map[string]error
 
 	allocateMachine          gomaasapi.Machine
 	allocateMachineMatches   gomaasapi.ConstraintMatches
@@ -237,7 +237,7 @@ func (c *fakeController) ReleaseMachines(args gomaasapi.ReleaseMachinesArgs) err
 
 func (c *fakeController) DeleteMachine(systemID string) error {
 	c.MethodCall(c, "DeleteMachine", systemID)
-	return c.deleteMachineError
+	return c.deleteMachineErrors[systemID]
 }
 
 func (c *fakeController) VmHosts() ([]gomaasapi.VmHost, error) {

--- a/internal/provider/maas/maas_test.go
+++ b/internal/provider/maas/maas_test.go
@@ -142,11 +142,24 @@ func (c *fakeController) Machines(args gomaasapi.MachinesArgs) ([]gomaasapi.Mach
 	systemIDs := set.NewStrings(args.SystemIDs...)
 	hostnames := set.NewStrings(args.Hostnames...)
 	for _, machine := range c.machines {
-		if systemIDs.Contains(machine.SystemID()) || hostnames.Contains(machine.Hostname()) {
-			result = append(result, machine)
+		if !systemIDs.Contains(machine.SystemID()) && !hostnames.Contains(machine.Hostname()) {
+			continue
 		}
+		if !ownerDataMatches(machine.OwnerData(), args.OwnerData) {
+			continue
+		}
+		result = append(result, machine)
 	}
 	return result, nil
+}
+
+func ownerDataMatches(ownerData, filter map[string]string) bool {
+	for key, value := range filter {
+		if ownerData[key] != value {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *fakeController) Domains() ([]gomaasapi.Domain, error) {
@@ -265,6 +278,7 @@ type fakeMachine struct {
 	pod           gomaasapi.Pod
 	interfaceSet  []gomaasapi.Interface
 	tags          []string
+	ownerData     map[string]string
 	createDevice  gomaasapi.Device
 	devices       []gomaasapi.Device
 }
@@ -283,8 +297,27 @@ func (m *fakeMachine) Tags() []string {
 }
 
 func (m *fakeMachine) SetOwnerData(data map[string]string) error {
-	m.MethodCall(m, "SetOwnerData", data)
-	return m.NextErr()
+	if m.Stub != nil {
+		m.MethodCall(m, "SetOwnerData", data)
+	}
+	if m.ownerData == nil {
+		m.ownerData = make(map[string]string)
+	}
+	for key, value := range data {
+		m.ownerData[key] = value
+	}
+	if m.Stub != nil {
+		return m.NextErr()
+	}
+	return nil
+}
+
+func (m *fakeMachine) OwnerData() map[string]string {
+	result := make(map[string]string, len(m.ownerData))
+	for key, value := range m.ownerData {
+		result[key] = value
+	}
+	return result
 }
 
 func (m *fakeMachine) CPUCount() int {

--- a/internal/provider/maas/volumes.go
+++ b/internal/provider/maas/volumes.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	"github.com/juju/names/v5"
 	"github.com/juju/schema"
 

--- a/internal/provider/maas/volumes_test.go
+++ b/internal/provider/maas/volumes_test.go
@@ -4,7 +4,7 @@
 package maas
 
 import (
-	"github.com/juju/gomaasapi/v2"
+	"github.com/juju/gomaasapi/v3"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -43,7 +43,7 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersNoTags(c *gc.C) {
 	}, constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vInfo, jc.DeepEquals, []volumeInfo{
-		{"root", 0, nil}, //root disk
+		{"root", 0, nil}, // root disk
 		{"1", 1954, nil},
 	})
 }
@@ -57,7 +57,7 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersWithRootDisk(c *gc.C) {
 	}, cons)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vInfo, jc.DeepEquals, []volumeInfo{
-		{"root", 20, nil}, //root disk
+		{"root", 20, nil}, // root disk
 		{"1", 1954, nil},
 	})
 }
@@ -68,7 +68,7 @@ func (s *volumeSuite) TestBuildMAASVolumeParametersWithTags(c *gc.C) {
 	}, constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vInfo, jc.DeepEquals, []volumeInfo{
-		{"root", 0, nil}, //root disk
+		{"root", 0, nil}, // root disk
 		{"1", 1954, []string{"tag1", "tag2"}},
 	})
 }


### PR DESCRIPTION
Juju gained the ability to compose and deploy VMs rather than allocate existing physical machines. Juju took ownership of the VMs and deleted them when the machine was removed from the model.

For the case where VMs already existing, Juju still assumed it owned them once they were recruited into the Juju model and allocated. This doesn't match expectations. So now an explicit owner data tag is added to VMs composed by Juju and only those are removed.

There's a go mod replace until a new upstream gomaasapi is released.

## QA steps

bootstrap maas and configure the maas controller to use a lxd server as a vm host.
(bug has set up details)

Use the maas CLI to compose a VM
`maas admin vm-host compose 1 cores=2 memory=2048 hostname=vm-1`

juju add-model foo
juju add-machine
juju add-machine --constraints "virt-type=virtual-machine" 

The MAAS UX will show 2 machines being deployed - one will come from the pre-created vm, the other will be new.

Once settled, destroy the model.
The maas vm corresponding to the juju machine with the virt-type constraint will be removed.
The other will go back to ready state.

## Links

**Issue:** Fixes #22691.

**Jira card:** [JUJU-10039](https://warthogs.atlassian.net/browse/JUJU-10039)


[JUJU-10039]: https://warthogs.atlassian.net/browse/JUJU-10039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ