### PR TITLE
feat: allow nested machines in virtual hostname

### DIFF
--- a/core/virtualhostname/virtualhostname.go
+++ b/core/virtualhostname/virtualhostname.go
@@ -52,7 +52,7 @@ func NewInfoMachineTarget(modelUUID string, machine string) (Info, error) {
 	if err := machineName.Validate(); err != nil {
 		return Info{}, errors.Errorf("invalid machine name %q: %w", machine, err)
 	}
-	return newInfo(MachineTarget, modelUUID, machine, 0, "", "")
+	return newInfo(MachineTarget, modelUUID, machineName, 0, "", "")
 }
 
 // NewInfoUnitTarget returns a new Info struct for a unit target.
@@ -94,7 +94,7 @@ func NewInfoContainerTarget(modelUUID string, unit string, container string) (In
 }
 
 // newInfo returns a new Info struct for the given target.
-func newInfo(target HostnameTarget, modelUUID string, machine string, unitNumber int, applicationName string, container string) (Info, error) {
+func newInfo(target HostnameTarget, modelUUID string, machine coremachine.Name, unitNumber int, applicationName string, container string) (Info, error) {
 	info := Info{}
 	switch target {
 	case MachineTarget:
@@ -126,7 +126,7 @@ func newInfo(target HostnameTarget, modelUUID string, machine string, unitNumber
 type Info struct {
 	target          HostnameTarget
 	modelUUID       coremodel.UUID
-	machine         string
+	machine         coremachine.Name
 	applicationName string
 	unitNumber      int
 	container       string
@@ -150,7 +150,7 @@ func (i Info) ModelUUID() coremodel.UUID {
 }
 
 // Machine returns the machine name.
-func (i Info) Machine() (string, bool) {
+func (i Info) Machine() (coremachine.Name, bool) {
 	return i.machine, i.target == MachineTarget
 }
 
@@ -164,7 +164,7 @@ func (i Info) Target() HostnameTarget {
 func (i Info) String() string {
 	switch i.target {
 	case MachineTarget:
-		return fmt.Sprintf("%s.%s.%s", encodeMachineName(i.machine), i.modelUUID, Domain)
+		return fmt.Sprintf("%s.%s.%s", encodeMachineName(i.machine.String()), i.modelUUID, Domain)
 	case UnitTarget:
 		return fmt.Sprintf("%d.%s.%s.%s", i.unitNumber, i.applicationName, i.modelUUID, Domain)
 	case ContainerTarget:
@@ -290,6 +290,6 @@ func parseMachineHostname(result map[string]string) (Info, error) {
 	return Info{
 		target:    MachineTarget,
 		modelUUID: coremodel.UUID(result["modeluuid"]),
-		machine:   machineName,
+		machine:   coremachine.Name(machineName),
 	}, nil
 }

--- a/core/virtualhostname/virtualhostname.go
+++ b/core/virtualhostname/virtualhostname.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/juju/names/v6"
 
+	coremachine "github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/internal/errors"
 )
@@ -18,6 +20,11 @@ const (
 	// ErrNoMatch indicates that the hostname could not be parsed.
 	ErrNoMatch = errors.ConstError("could not parse hostname")
 	Domain     = "juju.local"
+
+	hostnameLabelPattern = `[a-zA-Z0-9-]+`
+	unitNumberPattern    = `\d+`
+	modelUUIDPattern     = `[0-9a-fA-F-]+`
+	domainPattern        = `[a-zA-Z0-9.-]+`
 )
 
 // HostnameTarget defines what kind of infrastructure the user is targeting.
@@ -41,17 +48,11 @@ func NewInfoMachineTarget(modelUUID string, machine string) (Info, error) {
 	if !names.IsValidModel(modelUUID) {
 		return Info{}, errors.Errorf("invalid model UUID: %q", modelUUID)
 	}
-	if !names.IsValidMachine(machine) {
-		return Info{}, errors.Errorf("invalid machine number: %s", machine)
+	machineName := coremachine.Name(machine)
+	if err := machineName.Validate(); err != nil {
+		return Info{}, errors.Errorf("invalid machine name %q: %w", machine, err)
 	}
-	if names.IsContainerMachine(machine) {
-		return Info{}, errors.Errorf("container machine not supported")
-	}
-	machineNumber, err := strconv.Atoi(machine)
-	if err != nil {
-		return Info{}, errors.Errorf("failed to parse machine number.")
-	}
-	return newInfo(MachineTarget, modelUUID, machineNumber, 0, "", "")
+	return newInfo(MachineTarget, modelUUID, machine, 0, "", "")
 }
 
 // NewInfoUnitTarget returns a new Info struct for a unit target.
@@ -70,7 +71,7 @@ func NewInfoUnitTarget(modelUUID string, unit string) (Info, error) {
 	if err != nil {
 		return Info{}, errors.Capture(err)
 	}
-	return newInfo(UnitTarget, modelUUID, 0, unitNumber, applicationName, "")
+	return newInfo(UnitTarget, modelUUID, "", unitNumber, applicationName, "")
 }
 
 // NewInfoContainerTarget returns a new Info struct for a container target.
@@ -89,11 +90,11 @@ func NewInfoContainerTarget(modelUUID string, unit string, container string) (In
 	if err != nil {
 		return Info{}, errors.Capture(err)
 	}
-	return newInfo(ContainerTarget, modelUUID, 0, unitNumber, applicationName, container)
+	return newInfo(ContainerTarget, modelUUID, "", unitNumber, applicationName, container)
 }
 
 // newInfo returns a new Info struct for the given target.
-func newInfo(target HostnameTarget, modelUUID string, machine int, unitNumber int, applicationName string, container string) (Info, error) {
+func newInfo(target HostnameTarget, modelUUID string, machine string, unitNumber int, applicationName string, container string) (Info, error) {
 	info := Info{}
 	switch target {
 	case MachineTarget:
@@ -125,7 +126,7 @@ func newInfo(target HostnameTarget, modelUUID string, machine int, unitNumber in
 type Info struct {
 	target          HostnameTarget
 	modelUUID       coremodel.UUID
-	machine         int
+	machine         string
 	applicationName string
 	unitNumber      int
 	container       string
@@ -148,8 +149,8 @@ func (i Info) ModelUUID() coremodel.UUID {
 	return i.modelUUID
 }
 
-// Machine returns the machine number.
-func (i Info) Machine() (int, bool) {
+// Machine returns the machine name.
+func (i Info) Machine() (string, bool) {
 	return i.machine, i.target == MachineTarget
 }
 
@@ -163,7 +164,7 @@ func (i Info) Target() HostnameTarget {
 func (i Info) String() string {
 	switch i.target {
 	case MachineTarget:
-		return fmt.Sprintf("%d.%s.%s", i.machine, i.modelUUID, Domain)
+		return fmt.Sprintf("%s.%s.%s", encodeMachineName(i.machine), i.modelUUID, Domain)
 	case UnitTarget:
 		return fmt.Sprintf("%d.%s.%s.%s", i.unitNumber, i.applicationName, i.modelUUID, Domain)
 	case ContainerTarget:
@@ -174,60 +175,121 @@ func (i Info) String() string {
 }
 
 var (
-	// hostnameMatcher parses a hostname of the following formats:
+	// machineHostnameMatcher parses a machine hostname of the following format:
 	// Machine: 1.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
+	// Nested container machine: 1-lxd-0.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
+	machineHostnameMatcher = regexp.MustCompile(
+		`^(?<machine>` + hostnameLabelPattern + `)\.(?<modeluuid>` + modelUUIDPattern + `)\.(?<domain>` + domainPattern + `)$`,
+	)
+
+	// unitHostnameMatcher parses a unit hostname of the following format:
 	// Unit: 1.postgresql.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
+	unitHostnameMatcher = regexp.MustCompile(
+		`^(?<unitnumber>` + unitNumberPattern + `)\.(?<appname>` + hostnameLabelPattern + `)\.(?<modeluuid>` + modelUUIDPattern + `)\.(?<domain>` + domainPattern + `)$`,
+	)
+
+	// containerHostnameMatcher parses a unit container hostname of the following format:
 	// Container: charm.1.postgresql.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
-	// The regular expression doesn't validate the components of the
-	// hostname, it only extracts them for validation separately.
-	// I.e. the extracted UUID may be invalid.
-	hostnameMatcher = regexp.MustCompile(`^(?:(?<containername>[a-zA-Z0-9-]+)\.)?(?<unitnumber>\d+)\.(?:(?<appname>[a-zA-Z0-9-]+)\.)?(?<modeluuid>[0-9a-fA-F-]+)\.(?<domain>[a-zA-Z0-9.-]+)$`)
+	containerHostnameMatcher = regexp.MustCompile(
+		`^(?<containername>` + hostnameLabelPattern + `)\.(?<unitnumber>` + unitNumberPattern + `)\.(?<appname>` + hostnameLabelPattern + `)\.(?<modeluuid>` + modelUUIDPattern + `)\.(?<domain>` + domainPattern + `)$`,
+	)
 )
+
+func encodeMachineName(machineName string) string {
+	return strings.ReplaceAll(machineName, "/", "-")
+}
+
+func decodeMachineName(machineLabel string) (string, error) {
+	machineName := strings.ReplaceAll(machineLabel, "-", "/")
+	if err := coremachine.Name(machineName).Validate(); err != nil {
+		return "", errors.Errorf("invalid machine name %q: %w", machineName, err)
+	}
+	return machineName, nil
+}
+
+func matchSubexpressions(matcher *regexp.Regexp, hostname string) map[string]string {
+	match := matcher.FindStringSubmatch(hostname)
+	if match == nil {
+		return nil
+	}
+	result := make(map[string]string)
+	for i, name := range matcher.SubexpNames() {
+		if i != 0 && name != "" {
+			result[name] = match[i]
+		}
+	}
+	return result
+}
 
 // Parse parses a virtual Juju hostname
 // that references entities like machines, units
 // and containers.
 func Parse(hostname string) (Info, error) {
-	match := hostnameMatcher.FindStringSubmatch(hostname)
-	if match == nil {
-		return Info{}, ErrNoMatch
+	if result := matchSubexpressions(containerHostnameMatcher, hostname); result != nil {
+		return parseContainerHostname(result)
 	}
-	result := make(map[string]string)
-	for i, name := range hostnameMatcher.SubexpNames() {
-		if i != 0 && name != "" {
-			result[name] = match[i]
-		}
+	if result := matchSubexpressions(unitHostnameMatcher, hostname); result != nil {
+		return parseUnitHostname(result)
 	}
+	if result := matchSubexpressions(machineHostnameMatcher, hostname); result != nil {
+		return parseMachineHostname(result)
+	}
+	return Info{}, ErrNoMatch
+}
 
-	// Validate the components where appropriate.
+func parseContainerHostname(result map[string]string) (Info, error) {
 	if !names.IsValidModel(result["modeluuid"]) {
 		return Info{}, errors.Errorf("invalid model UUID: %q", result["modeluuid"])
 	}
-	if result["appname"] != "" && !names.IsValidApplication(result["appname"]) {
+	if !names.IsValidApplication(result["appname"]) {
 		return Info{}, errors.Errorf("invalid application name: %q", result["appname"])
 	}
-	// unit number and machine number come from the same matching group.
 	unitNumber, err := strconv.Atoi(result["unitnumber"])
 	if err != nil {
-		return Info{}, errors.Errorf("failed to parse unit/machine number: %w", err)
+		return Info{}, errors.Errorf("failed to parse unit number: %w", err)
 	}
 
-	res := Info{}
-	appName := result["appname"]
-	res.modelUUID = coremodel.UUID(result["modeluuid"])
-	res.container = result["containername"]
-	if res.container != "" {
-		res.target = ContainerTarget
-		res.unitNumber = unitNumber
-		res.applicationName = appName
-	} else if appName != "" {
-		res.target = UnitTarget
-		res.unitNumber = unitNumber
-		res.applicationName = appName
-	} else {
-		res.target = MachineTarget
-		res.machine = unitNumber
+	return Info{
+		target:          ContainerTarget,
+		modelUUID:       coremodel.UUID(result["modeluuid"]),
+		container:       result["containername"],
+		unitNumber:      unitNumber,
+		applicationName: result["appname"],
+	}, nil
+}
+
+func parseUnitHostname(result map[string]string) (Info, error) {
+	if !names.IsValidModel(result["modeluuid"]) {
+		return Info{}, errors.Errorf("invalid model UUID: %q", result["modeluuid"])
+	}
+	if !names.IsValidApplication(result["appname"]) {
+		return Info{}, errors.Errorf("invalid application name: %q", result["appname"])
+	}
+	unitNumber, err := strconv.Atoi(result["unitnumber"])
+	if err != nil {
+		return Info{}, errors.Errorf("failed to parse unit number: %w", err)
 	}
 
-	return res, nil
+	return Info{
+		target:          UnitTarget,
+		modelUUID:       coremodel.UUID(result["modeluuid"]),
+		unitNumber:      unitNumber,
+		applicationName: result["appname"],
+	}, nil
+}
+
+func parseMachineHostname(result map[string]string) (Info, error) {
+	if !names.IsValidModel(result["modeluuid"]) {
+		return Info{}, errors.Errorf("invalid model UUID: %q", result["modeluuid"])
+	}
+	machineName, err := decodeMachineName(result["machine"])
+	if err != nil {
+		return Info{}, err
+	}
+
+	return Info{
+		target:    MachineTarget,
+		modelUUID: coremodel.UUID(result["modeluuid"]),
+		machine:   machineName,
+	}, nil
 }

--- a/core/virtualhostname/virtualhostname.go
+++ b/core/virtualhostname/virtualhostname.go
@@ -27,6 +27,27 @@ const (
 	domainPattern        = `[a-zA-Z0-9.-]+`
 )
 
+var (
+	// machineHostnameMatcher parses a machine hostname of the following format:
+	// Machine: 1.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
+	// Nested container machine: 1-lxd-0.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
+	machineHostnameMatcher = regexp.MustCompile(
+		`^(?<machine>` + hostnameLabelPattern + `)\.(?<modeluuid>` + modelUUIDPattern + `)\.(?<domain>` + domainPattern + `)$`,
+	)
+
+	// unitHostnameMatcher parses a unit hostname of the following format:
+	// Unit: 1.postgresql.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
+	unitHostnameMatcher = regexp.MustCompile(
+		`^(?<unitnumber>` + unitNumberPattern + `)\.(?<appname>` + hostnameLabelPattern + `)\.(?<modeluuid>` + modelUUIDPattern + `)\.(?<domain>` + domainPattern + `)$`,
+	)
+
+	// containerHostnameMatcher parses a unit container hostname of the following format:
+	// Container: charm.1.postgresql.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
+	containerHostnameMatcher = regexp.MustCompile(
+		`^(?<containername>` + hostnameLabelPattern + `)\.(?<unitnumber>` + unitNumberPattern + `)\.(?<appname>` + hostnameLabelPattern + `)\.(?<modeluuid>` + modelUUIDPattern + `)\.(?<domain>` + domainPattern + `)$`,
+	)
+)
+
 // HostnameTarget defines what kind of infrastructure the user is targeting.
 type HostnameTarget int
 
@@ -173,27 +194,6 @@ func (i Info) String() string {
 		return "unknown"
 	}
 }
-
-var (
-	// machineHostnameMatcher parses a machine hostname of the following format:
-	// Machine: 1.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
-	// Nested container machine: 1-lxd-0.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
-	machineHostnameMatcher = regexp.MustCompile(
-		`^(?<machine>` + hostnameLabelPattern + `)\.(?<modeluuid>` + modelUUIDPattern + `)\.(?<domain>` + domainPattern + `)$`,
-	)
-
-	// unitHostnameMatcher parses a unit hostname of the following format:
-	// Unit: 1.postgresql.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
-	unitHostnameMatcher = regexp.MustCompile(
-		`^(?<unitnumber>` + unitNumberPattern + `)\.(?<appname>` + hostnameLabelPattern + `)\.(?<modeluuid>` + modelUUIDPattern + `)\.(?<domain>` + domainPattern + `)$`,
-	)
-
-	// containerHostnameMatcher parses a unit container hostname of the following format:
-	// Container: charm.1.postgresql.8419cd78-4993-4c3a-928e-c646226beeee.juju.local
-	containerHostnameMatcher = regexp.MustCompile(
-		`^(?<containername>` + hostnameLabelPattern + `)\.(?<unitnumber>` + unitNumberPattern + `)\.(?<appname>` + hostnameLabelPattern + `)\.(?<modeluuid>` + modelUUIDPattern + `)\.(?<domain>` + domainPattern + `)$`,
-	)
-)
 
 func encodeMachineName(machineName string) string {
 	return strings.ReplaceAll(machineName, "/", "-")

--- a/core/virtualhostname/virtualhostname_integration_test.go
+++ b/core/virtualhostname/virtualhostname_integration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/tc"
 
+	coremachine "github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/virtualhostname"
 )
@@ -49,7 +50,7 @@ func (s *HostnameSuite) TestParseUnitHostname(c *tc.C) {
 	c.Check(valid, tc.Equals, false)
 
 	machineName, valid := res.Machine()
-	c.Check(machineName, tc.Equals, "")
+	c.Check(machineName, tc.Equals, coremachine.Name(""))
 	c.Check(valid, tc.Equals, false)
 
 	c.Check(res.Target(), tc.Equals, virtualhostname.UnitTarget)
@@ -67,7 +68,7 @@ func (s *HostnameSuite) TestParseMachineHostname(c *tc.C) {
 	c.Check(valid, tc.Equals, false)
 
 	machineName, valid := res.Machine()
-	c.Check(machineName, tc.Equals, "1")
+	c.Check(machineName, tc.Equals, coremachine.Name("1"))
 	c.Check(valid, tc.Equals, true)
 
 	c.Check(res.Target(), tc.Equals, virtualhostname.MachineTarget)
@@ -85,7 +86,7 @@ func (s *HostnameSuite) TestParseNestedMachineHostname(c *tc.C) {
 	c.Check(valid, tc.Equals, false)
 
 	machineName, valid := res.Machine()
-	c.Check(machineName, tc.Equals, "1/lxd/0")
+	c.Check(machineName, tc.Equals, coremachine.Name("1/lxd/0"))
 	c.Check(valid, tc.Equals, true)
 
 	c.Check(res.Target(), tc.Equals, virtualhostname.MachineTarget)

--- a/core/virtualhostname/virtualhostname_integration_test.go
+++ b/core/virtualhostname/virtualhostname_integration_test.go
@@ -30,8 +30,7 @@ func (s *HostnameSuite) TestParseContainerHostname(c *tc.C) {
 	c.Check(containerName, tc.Equals, "charm")
 	c.Check(valid, tc.Equals, true)
 
-	machineNumber, valid := res.Machine()
-	c.Check(machineNumber, tc.Equals, 0)
+	_, valid = res.Machine()
 	c.Check(valid, tc.Equals, false)
 
 	c.Check(res.Target(), tc.Equals, virtualhostname.ContainerTarget)
@@ -46,12 +45,11 @@ func (s *HostnameSuite) TestParseUnitHostname(c *tc.C) {
 	c.Check(unitName, tc.Equals, "postgresql/1")
 	c.Check(valid, tc.Equals, true)
 
-	containerName, valid := res.Container()
-	c.Check(containerName, tc.Equals, "")
+	_, valid = res.Container()
 	c.Check(valid, tc.Equals, false)
 
-	machineNumber, valid := res.Machine()
-	c.Check(machineNumber, tc.Equals, 0)
+	machineName, valid := res.Machine()
+	c.Check(machineName, tc.Equals, "")
 	c.Check(valid, tc.Equals, false)
 
 	c.Check(res.Target(), tc.Equals, virtualhostname.UnitTarget)
@@ -62,16 +60,32 @@ func (s *HostnameSuite) TestParseMachineHostname(c *tc.C) {
 	res, err := virtualhostname.Parse("1.8419cd78-4993-4c3a-928e-c646226beeee.juju.local")
 	c.Assert(err, tc.IsNil)
 
-	unitName, valid := res.Unit()
-	c.Check(unitName, tc.Equals, "/0")
+	_, valid := res.Unit()
 	c.Check(valid, tc.Equals, false)
 
-	containerName, valid := res.Container()
-	c.Check(containerName, tc.Equals, "")
+	_, valid = res.Container()
 	c.Check(valid, tc.Equals, false)
 
-	machineNumber, valid := res.Machine()
-	c.Check(machineNumber, tc.Equals, 1)
+	machineName, valid := res.Machine()
+	c.Check(machineName, tc.Equals, "1")
+	c.Check(valid, tc.Equals, true)
+
+	c.Check(res.Target(), tc.Equals, virtualhostname.MachineTarget)
+	c.Check(res.ModelUUID(), tc.Equals, coremodel.UUID("8419cd78-4993-4c3a-928e-c646226beeee"))
+}
+
+func (s *HostnameSuite) TestParseNestedMachineHostname(c *tc.C) {
+	res, err := virtualhostname.Parse("1-lxd-0.8419cd78-4993-4c3a-928e-c646226beeee.juju.local")
+	c.Assert(err, tc.IsNil)
+
+	_, valid := res.Unit()
+	c.Check(valid, tc.Equals, false)
+
+	_, valid = res.Container()
+	c.Check(valid, tc.Equals, false)
+
+	machineName, valid := res.Machine()
+	c.Check(machineName, tc.Equals, "1/lxd/0")
 	c.Check(valid, tc.Equals, true)
 
 	c.Check(res.Target(), tc.Equals, virtualhostname.MachineTarget)

--- a/core/virtualhostname/virtualhostname_test.go
+++ b/core/virtualhostname/virtualhostname_test.go
@@ -49,8 +49,16 @@ func (s *HostnameSuite) TestParseHostname(c *tc.C) {
 			desc:     "Machine hostname",
 			hostname: "1.8419cd78-4993-4c3a-928e-c646226beeee.juju.local",
 			result: Info{
-				// Machine and unit are both set and disambiguated by the target type.
-				machine:   1,
+				machine:   "1",
+				modelUUID: coremodel.UUID("8419cd78-4993-4c3a-928e-c646226beeee"),
+				target:    MachineTarget,
+			},
+		},
+		{
+			desc:     "Nested machine hostname",
+			hostname: "1-lxd-0.8419cd78-4993-4c3a-928e-c646226beeee.juju.local",
+			result: Info{
+				machine:   "1/lxd/0",
 				modelUUID: coremodel.UUID("8419cd78-4993-4c3a-928e-c646226beeee"),
 				target:    MachineTarget,
 			},
@@ -84,7 +92,7 @@ func (s *HostnameSuite) TestParseHostname(c *tc.C) {
 		{
 			desc:        "Invalid machine number",
 			hostname:    "1a.8419cd78-4993-4c3a-928e-c646226beeee.juju.local",
-			expectedErr: `could not parse hostname`,
+			expectedErr: `invalid machine name "1a": machine name`,
 		},
 	}
 	for i, tC := range testCases {
@@ -115,7 +123,17 @@ func (s *HostnameSuite) TestNewInfoMachineTarget(c *tc.C) {
 			expected: Info{
 				target:    MachineTarget,
 				modelUUID: coremodel.UUID("8419cd78-4993-4c3a-928e-c646226beeee"),
-				machine:   1,
+				machine:   "1",
+			},
+		},
+		{
+			desc:      "Valid nested machine target",
+			modelUUID: "8419cd78-4993-4c3a-928e-c646226beeee",
+			machine:   "0/lxd/0",
+			expected: Info{
+				target:    MachineTarget,
+				modelUUID: coremodel.UUID("8419cd78-4993-4c3a-928e-c646226beeee"),
+				machine:   "0/lxd/0",
 			},
 		},
 		{
@@ -125,16 +143,10 @@ func (s *HostnameSuite) TestNewInfoMachineTarget(c *tc.C) {
 			expectedErr: ".*invalid model UUID.*",
 		},
 		{
-			desc:        "Invalid machine number",
+			desc:        "Invalid machine name",
 			modelUUID:   "8419cd78-4993-4c3a-928e-c646226beeee",
 			machine:     "-1",
-			expectedErr: "invalid machine number: -1",
-		},
-		{
-			desc:        "Invalid machine number: nested container",
-			modelUUID:   "8419cd78-4993-4c3a-928e-c646226beeee",
-			machine:     "0/lxd/0",
-			expectedErr: "container machine not supported",
+			expectedErr: "invalid machine name \"-1\": .*",
 		},
 	}
 
@@ -247,6 +259,6 @@ func (s *HostnameSuite) TestNewInfoContainerTarget(c *tc.C) {
 }
 
 func (s *HostnameSuite) TestnewInfoInvalidTarget(c *tc.C) {
-	_, err := newInfo(100, "8419cd78-4993-4c3a-928e-c646226beeee", 1, 1, "1", "charm")
+	_, err := newInfo(100, "8419cd78-4993-4c3a-928e-c646226beeee", "1", 1, "1", "charm")
 	c.Assert(err, tc.ErrorMatches, "unknown target: 100")
 }

--- a/core/virtualhostname/virtualhostname_test.go
+++ b/core/virtualhostname/virtualhostname_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/tc"
 
+	coremachine "github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 )
 
@@ -49,7 +50,7 @@ func (s *HostnameSuite) TestParseHostname(c *tc.C) {
 			desc:     "Machine hostname",
 			hostname: "1.8419cd78-4993-4c3a-928e-c646226beeee.juju.local",
 			result: Info{
-				machine:   "1",
+				machine:   coremachine.Name("1"),
 				modelUUID: coremodel.UUID("8419cd78-4993-4c3a-928e-c646226beeee"),
 				target:    MachineTarget,
 			},
@@ -58,7 +59,7 @@ func (s *HostnameSuite) TestParseHostname(c *tc.C) {
 			desc:     "Nested machine hostname",
 			hostname: "1-lxd-0.8419cd78-4993-4c3a-928e-c646226beeee.juju.local",
 			result: Info{
-				machine:   "1/lxd/0",
+				machine:   coremachine.Name("1/lxd/0"),
 				modelUUID: coremodel.UUID("8419cd78-4993-4c3a-928e-c646226beeee"),
 				target:    MachineTarget,
 			},
@@ -123,7 +124,7 @@ func (s *HostnameSuite) TestNewInfoMachineTarget(c *tc.C) {
 			expected: Info{
 				target:    MachineTarget,
 				modelUUID: coremodel.UUID("8419cd78-4993-4c3a-928e-c646226beeee"),
-				machine:   "1",
+				machine:   coremachine.Name("1"),
 			},
 		},
 		{
@@ -133,7 +134,7 @@ func (s *HostnameSuite) TestNewInfoMachineTarget(c *tc.C) {
 			expected: Info{
 				target:    MachineTarget,
 				modelUUID: coremodel.UUID("8419cd78-4993-4c3a-928e-c646226beeee"),
-				machine:   "0/lxd/0",
+				machine:   coremachine.Name("0/lxd/0"),
 			},
 		},
 		{

--- a/domain/ssh/service/model/service.go
+++ b/domain/ssh/service/model/service.go
@@ -5,7 +5,6 @@ package model
 
 import (
 	"context"
-	"strconv"
 
 	coreerrors "github.com/juju/juju/core/errors"
 	coremachine "github.com/juju/juju/core/machine"
@@ -49,12 +48,19 @@ func (s *Service) VirtualHostKey(ctx context.Context, info virtualhostname.Info)
 
 	switch info.Target() {
 	case virtualhostname.MachineTarget:
-		machineNumber, ok := info.Machine()
+		machineName, ok := info.Machine()
 		if !ok {
 			return "", errors.Errorf("missing machine target in virtual hostname")
 		}
-		machineName := coremachine.Name(strconv.Itoa(machineNumber))
-		return s.MachineVirtualHostKey(ctx, machineName)
+		parsedMachineName := coremachine.Name(machineName)
+		if parsedMachineName.IsContainer() {
+			return "", errors.Errorf(
+				"cannot SSH directly to nested machine %q, connect to parent machine %q instead",
+				parsedMachineName,
+				parsedMachineName.Parent(),
+			)
+		}
+		return s.MachineVirtualHostKey(ctx, parsedMachineName)
 	case virtualhostname.UnitTarget, virtualhostname.ContainerTarget:
 		unitName, ok := info.Unit()
 		if !ok {

--- a/domain/ssh/service/model/service.go
+++ b/domain/ssh/service/model/service.go
@@ -52,15 +52,14 @@ func (s *Service) VirtualHostKey(ctx context.Context, info virtualhostname.Info)
 		if !ok {
 			return "", errors.Errorf("missing machine target in virtual hostname")
 		}
-		parsedMachineName := coremachine.Name(machineName)
-		if parsedMachineName.IsContainer() {
+		if machineName.IsContainer() {
 			return "", errors.Errorf(
 				"cannot SSH directly to nested machine %q, connect to parent machine %q instead",
-				parsedMachineName,
-				parsedMachineName.Parent(),
+				machineName,
+				machineName.Parent(),
 			)
 		}
-		return s.MachineVirtualHostKey(ctx, parsedMachineName)
+		return s.MachineVirtualHostKey(ctx, machineName)
 	case virtualhostname.UnitTarget, virtualhostname.ContainerTarget:
 		unitName, ok := info.Unit()
 		if !ok {

--- a/domain/ssh/service/model/service_test.go
+++ b/domain/ssh/service/model/service_test.go
@@ -95,6 +95,17 @@ func (s *serviceSuite) TestVirtualHostKeyErrorsForDifferentModel(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `virtual hostname model UUID .* does not match service model .*`)
 }
 
+func (s *serviceSuite) TestVirtualHostKeyErrorsForNestedMachine(c *tc.C) {
+	modelUUID := coremodel.UUID(testModelUUID)
+	svc := modelsshservice.NewService(modelUUID, newStubModelState())
+
+	info, err := virtualhostname.NewInfoMachineTarget(testModelUUID, "1/lxd/0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = svc.VirtualHostKey(c.Context(), info)
+	c.Assert(err, tc.ErrorMatches, `cannot SSH directly to nested machine "1/lxd/0", connect to parent machine "1" instead`)
+}
+
 type stubModelState struct {
 	machineExists   map[string]bool
 	machineKeys     map[string]string


### PR DESCRIPTION
Prompted by a comment in https://github.com/juju/juju/pull/22647, virtual hostnames are a feature currently only used for the SSH proxy feature. They define a format for strings that encodes information on a model UUID and application/machine/unit/container. Until now the format for a machine did not support nested machines i.e. `1/lxd/0` because the SSH proxy feature would not support SSH to a nested machine. Here, we change the format to accommodate for nested machines but return an error elsewhere once we establish that the user is trying to SSH to a nested machine.

Note that because a hostname cannot contain slashes, the nested machine must be supplied as e.g. `1-lxd-0`. I've checked that the `names` package enforces that the triplet is a number, a set of lowercase chars and another number.

Finally, after decoding the virtual hostname string, we store the machine name as a `coremachine.Name` instead of a string.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
