### PR TITLE
fix: preserve app constraints without model defaults

### DIFF
--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -27,7 +27,6 @@ import (
 	corewatcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
-	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/internal/cloudconfig/podcfg"
 	"github.com/juju/juju/internal/docker"
@@ -435,7 +434,7 @@ func (a *API) provisioningInfo(ctx context.Context, appTag names.ApplicationTag)
 		return nil, errors.Trace(err)
 	}
 	mergedCons, err := a.modelInfoService.ResolveConstraints(ctx, cons)
-	if err != nil && !errors.Is(err, modelerrors.ConstraintsNotFound) {
+	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	resourceTags := tags.ResourceTags(

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -143,12 +143,13 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *tc.C) {
 	modelInfo := model.ModelInfo{
 		UUID: model.UUID(coretesting.ModelTag.Id()),
 	}
+	appCons := constraints.MustParse("mem=2G cpu-power=200")
 	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(modelInfo, nil)
-	s.modelInfoService.EXPECT().ResolveConstraints(gomock.Any(), constraints.Value{}).Return(constraints.Value{}, nil)
+	s.modelInfoService.EXPECT().ResolveConstraints(gomock.Any(), appCons).Return(appCons, nil)
 
 	s.applicationService.EXPECT().GetApplicationScale(gomock.Any(), "gitlab").Return(3, nil)
 	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "gitlab").Return(coreapplication.UUID("deadbeef"), nil)
-	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), coreapplication.UUID("deadbeef")).Return(constraints.Value{}, nil)
+	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), coreapplication.UUID("deadbeef")).Return(appCons, nil)
 	s.applicationService.EXPECT().GetDeviceConstraints(gomock.Any(), "gitlab").Return(map[string]devices.Constraints{}, nil)
 	s.applicationService.EXPECT().GetApplicationCharmOrigin(gomock.Any(), "gitlab").Return(charm.Origin{
 		Platform: charm.Platform{
@@ -175,6 +176,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *tc.C) {
 			},
 			CharmModifiedVersion: 10,
 			Scale:                3,
+			Constraints:          appCons,
 			Trust:                true,
 			Base: params.Base{
 				Name:    "ubuntu",

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -31,6 +31,7 @@ import (
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/removal"
 	envconfig "github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
@@ -184,6 +185,39 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *tc.C) {
 			},
 		}},
 	})
+}
+
+func (s *CAASApplicationProvisionerSuite) TestProvisioningInfoResolveConstraintsError(c *tc.C) {
+	ctrl := s.setupAPI(c)
+	defer ctrl.Finish()
+
+	locator := applicationcharm.CharmLocator{
+		Name:     "gitlab",
+		Source:   applicationcharm.CharmHubSource,
+		Revision: -1,
+	}
+	s.applicationService.EXPECT().GetCharmLocatorByApplicationName(gomock.Any(), "gitlab").Return(locator, nil)
+	s.applicationService.EXPECT().IsCharmAvailable(gomock.Any(), locator).Return(true, nil)
+
+	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(coretesting.FakeControllerConfig(), nil)
+	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(s.fakeModelConfig())
+
+	modelInfo := model.ModelInfo{
+		UUID: model.UUID(coretesting.ModelTag.Id()),
+	}
+	appCons := constraints.MustParse("mem=2G cpu-power=200")
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(modelInfo, nil)
+
+	s.applicationService.EXPECT().GetApplicationUUIDByName(gomock.Any(), "gitlab").Return(coreapplication.UUID("deadbeef"), nil)
+	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), coreapplication.UUID("deadbeef")).Return(appCons, nil)
+	s.applicationService.EXPECT().GetDeviceConstraints(gomock.Any(), "gitlab").Return(map[string]devices.Constraints{}, nil)
+
+	boom := errors.New("boom")
+	s.modelInfoService.EXPECT().ResolveConstraints(gomock.Any(), appCons).Return(constraints.Value{}, boom)
+
+	result, err := s.api.ProvisioningInfo(c.Context(), params.Entities{Entities: []params.Entity{{Tag: "application-gitlab"}}})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results[0].Error, tc.ErrorMatches, "boom")
 }
 
 func (s *CAASApplicationProvisionerSuite) TestProvisioningInfoPendingCharmError(c *tc.C) {

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -924,7 +924,9 @@ func (s *ProviderModelService) ResolveConstraints(
 	defer span.End()
 
 	modelCons, err := s.modelSt.GetModelConstraints(ctx)
-	if err != nil {
+	if errors.Is(err, modelerrors.ConstraintsNotFound) {
+		modelCons = constraints.Constraints{}
+	} else if err != nil {
 		return coreconstraints.Value{}, errors.Errorf(
 			"getting model constraints for model %q: %w", s.modelUUID, err,
 		)

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -1244,6 +1244,24 @@ func (s *providerModelServiceSuite) TestResolveConstraintsWithoutModelConstraint
 	c.Check(result, tc.DeepEquals, appCons)
 }
 
+func (s *providerModelServiceSuite) TestResolveConstraintsModelConstraintsError(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	modelUUID := tc.Must0(c, coremodel.NewUUID)
+	boom := errors.New("db down")
+
+	s.mockModelState.EXPECT().GetModelConstraints(gomock.Any()).Return(
+		constraints.Constraints{}, boom,
+	)
+
+	svc := s.providerService(c, modelUUID)
+	result, err := svc.ResolveConstraints(c.Context(), coreconstraints.MustParse("mem=2G"))
+
+	c.Assert(err, tc.ErrorIs, boom)
+	c.Check(result, tc.DeepEquals, coreconstraints.Value{})
+}
+
 func (s *providerModelServiceSuite) TestResolveConstraintsApplicationOverridesModel(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -1223,6 +1223,51 @@ func (s *providerModelServiceSuite) TestResolveConstraints(c *tc.C) {
 	c.Check(result, tc.DeepEquals, cons)
 }
 
+func (s *providerModelServiceSuite) TestResolveConstraintsWithoutModelConstraints(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	modelUUID := tc.Must0(c, coremodel.NewUUID)
+
+	s.mockModelState.EXPECT().GetModelConstraints(gomock.Any()).Return(
+		constraints.Constraints{}, modelerrors.ConstraintsNotFound,
+	)
+
+	validator := coreconstraints.NewValidator()
+	s.mockProvider.EXPECT().ConstraintsValidator(gomock.Any()).Return(validator, nil)
+
+	svc := s.providerService(c, modelUUID)
+	appCons := coreconstraints.MustParse("mem=2G cpu-power=200")
+	result, err := svc.ResolveConstraints(c.Context(), appCons)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, appCons)
+}
+
+func (s *providerModelServiceSuite) TestResolveConstraintsApplicationOverridesModel(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	modelUUID := tc.Must0(c, coremodel.NewUUID)
+
+	s.mockModelState.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{
+		Arch:     new("amd64"),
+		CpuPower: new(uint64(100)),
+		Mem:      new(uint64(512)),
+	}, nil)
+
+	validator := coreconstraints.NewValidator()
+	s.mockProvider.EXPECT().ConstraintsValidator(gomock.Any()).Return(validator, nil)
+
+	svc := s.providerService(c, modelUUID)
+	result, err := svc.ResolveConstraints(
+		c.Context(), coreconstraints.MustParse("mem=2G"),
+	)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, coreconstraints.MustParse("arch=amd64 mem=2G cpu-power=100"))
+}
+
 func (s *providerModelServiceSuite) TestGetModelRegion(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()

--- a/internal/provider/kubernetes/application/application_test.go
+++ b/internal/provider/kubernetes/application/application_test.go
@@ -3661,47 +3661,41 @@ func (s *applicationSuite) TestLimits(c *tc.C) {
 }
 
 func (s *applicationSuite) TestEnsureUpdatedConstraints(c *tc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
-	s.assertEnsure(
-		c, app, false, constraints.MustParse("mem=1G cpu-power=1000"), true, true, "3.6.8", nil, func() {
-			ps := getPodSpec368()
-			charmResourceMemRequest := corev1.ResourceList{
-				corev1.ResourceMemory: k8sresource.MustParse(constants.CharmMemRequestMi),
-			}
-			charmResourceMemLimit := corev1.ResourceList{
-				corev1.ResourceMemory: k8sresource.MustParse(constants.CharmMemLimitMi),
-			}
+	for _, agentVersion := range []string{"3.6.8", "4.0.11"} {
+		app, _ := s.getApp(c, caas.DeploymentStateful, false)
+		charmResourceMemRequest := corev1.ResourceList{
+			corev1.ResourceMemory: k8sresource.MustParse(constants.CharmMemRequestMi),
+		}
+		charmResourceMemLimit := corev1.ResourceList{
+			corev1.ResourceMemory: k8sresource.MustParse("2Gi"),
+		}
 
-			workloadResourceLimits := corev1.ResourceList{
-				corev1.ResourceCPU:    k8sresource.MustParse("1000m"),
-				corev1.ResourceMemory: k8sresource.MustParse("1024Mi"),
-			}
+		workloadResourceLimits := corev1.ResourceList{
+			corev1.ResourceCPU:    k8sresource.MustParse("200m"),
+			corev1.ResourceMemory: k8sresource.MustParse("2048Mi"),
+		}
 
-			for i, container := range ps.Containers {
-				if container.Name == constants.ApplicationCharmContainer {
-					continue
+		s.assertEnsure(
+			c, app, false, constraints.MustParse("mem=2G cpu-power=200"), true, true, agentVersion, nil, func() {
+				ss, err := s.client.AppsV1().StatefulSets("test").Get(c.Context(), "gitlab", metav1.GetOptions{})
+				c.Assert(err, tc.ErrorIsNil)
+				for _, ctr := range ss.Spec.Template.Spec.Containers {
+					if ctr.Name == constants.ApplicationCharmContainer {
+						c.Check(ctr.Resources.Requests.Memory().Equal(*charmResourceMemRequest.Memory()), tc.IsTrue)
+						c.Check(ctr.Resources.Limits.Memory().Equal(*charmResourceMemLimit.Memory()), tc.IsTrue)
+						continue
+					}
+
+					c.Check(ctr.Resources.Requests.Cpu().Equal(*workloadResourceLimits.Cpu()), tc.IsTrue)
+					c.Check(ctr.Resources.Requests.Memory().Equal(*workloadResourceLimits.Memory()), tc.IsTrue)
+
+					c.Check(ctr.Resources.Limits.Cpu().Equal(*workloadResourceLimits.Cpu()), tc.IsTrue)
+					c.Check(ctr.Resources.Limits.Memory().Equal(*workloadResourceLimits.Memory()), tc.IsTrue)
 				}
-				ps.Containers[i].Resources.Requests = workloadResourceLimits
-				ps.Containers[i].Resources.Limits = workloadResourceLimits
-			}
-			ss, err := s.client.AppsV1().StatefulSets("test").Get(c.Context(), "gitlab", metav1.GetOptions{})
-			c.Assert(err, tc.ErrorIsNil)
-			for _, ctr := range ss.Spec.Template.Spec.Containers {
-				if ctr.Name == constants.ApplicationCharmContainer {
-					c.Assert(ctr.Resources.Requests, tc.DeepEquals, charmResourceMemRequest)
-					c.Assert(ctr.Resources.Limits, tc.DeepEquals, charmResourceMemLimit)
-					continue
-				}
-
-				c.Check(ctr.Resources.Requests.Cpu().Equal(*workloadResourceLimits.Cpu()), tc.IsTrue)
-				c.Check(ctr.Resources.Requests.Memory().Equal(*workloadResourceLimits.Memory()), tc.IsTrue)
-
-				c.Check(ctr.Resources.Requests.Cpu().Equal(*workloadResourceLimits.Cpu()), tc.IsTrue)
-				c.Check(ctr.Resources.Requests.Memory().Equal(*workloadResourceLimits.Memory()), tc.IsTrue)
-			}
-		},
-		nil,
-	)
+			},
+			nil,
+		)
+	}
 }
 
 func (s *applicationSuite) TestDeleteAllCreatedResources(c *tc.C) {

--- a/internal/provider/kubernetes/application/application_test.go
+++ b/internal/provider/kubernetes/application/application_test.go
@@ -3662,39 +3662,43 @@ func (s *applicationSuite) TestLimits(c *tc.C) {
 
 func (s *applicationSuite) TestEnsureUpdatedConstraints(c *tc.C) {
 	for _, agentVersion := range []string{"3.6.8", "4.0.11"} {
-		app, _ := s.getApp(c, caas.DeploymentStateful, false)
-		charmResourceMemRequest := corev1.ResourceList{
-			corev1.ResourceMemory: k8sresource.MustParse(constants.CharmMemRequestMi),
-		}
-		charmResourceMemLimit := corev1.ResourceList{
-			corev1.ResourceMemory: k8sresource.MustParse("2Gi"),
-		}
+		c.Run(agentVersion, func(t *stdtesting.T) {
+			c := &tc.C{T: t}
 
-		workloadResourceLimits := corev1.ResourceList{
-			corev1.ResourceCPU:    k8sresource.MustParse("200m"),
-			corev1.ResourceMemory: k8sresource.MustParse("2048Mi"),
-		}
+			app, _ := s.getApp(c, caas.DeploymentStateful, false)
+			charmResourceMemRequest := corev1.ResourceList{
+				corev1.ResourceMemory: k8sresource.MustParse(constants.CharmMemRequestMi),
+			}
+			charmResourceMemLimit := corev1.ResourceList{
+				corev1.ResourceMemory: k8sresource.MustParse("2Gi"),
+			}
 
-		s.assertEnsure(
-			c, app, false, constraints.MustParse("mem=2G cpu-power=200"), true, true, agentVersion, nil, func() {
-				ss, err := s.client.AppsV1().StatefulSets("test").Get(c.Context(), "gitlab", metav1.GetOptions{})
-				c.Assert(err, tc.ErrorIsNil)
-				for _, ctr := range ss.Spec.Template.Spec.Containers {
-					if ctr.Name == constants.ApplicationCharmContainer {
-						c.Check(ctr.Resources.Requests.Memory().Equal(*charmResourceMemRequest.Memory()), tc.IsTrue)
-						c.Check(ctr.Resources.Limits.Memory().Equal(*charmResourceMemLimit.Memory()), tc.IsTrue)
-						continue
+			workloadResourceLimits := corev1.ResourceList{
+				corev1.ResourceCPU:    k8sresource.MustParse("200m"),
+				corev1.ResourceMemory: k8sresource.MustParse("2048Mi"),
+			}
+
+			s.assertEnsure(
+				c, app, false, constraints.MustParse("mem=2G cpu-power=200"), true, true, agentVersion, nil, func() {
+					ss, err := s.client.AppsV1().StatefulSets("test").Get(c.Context(), "gitlab", metav1.GetOptions{})
+					c.Assert(err, tc.ErrorIsNil)
+					for _, ctr := range ss.Spec.Template.Spec.Containers {
+						if ctr.Name == constants.ApplicationCharmContainer {
+							c.Check(ctr.Resources.Requests.Memory().Equal(*charmResourceMemRequest.Memory()), tc.IsTrue)
+							c.Check(ctr.Resources.Limits.Memory().Equal(*charmResourceMemLimit.Memory()), tc.IsTrue)
+							continue
+						}
+
+						c.Check(ctr.Resources.Requests.Cpu().Equal(*workloadResourceLimits.Cpu()), tc.IsTrue)
+						c.Check(ctr.Resources.Requests.Memory().Equal(*workloadResourceLimits.Memory()), tc.IsTrue)
+
+						c.Check(ctr.Resources.Limits.Cpu().Equal(*workloadResourceLimits.Cpu()), tc.IsTrue)
+						c.Check(ctr.Resources.Limits.Memory().Equal(*workloadResourceLimits.Memory()), tc.IsTrue)
 					}
-
-					c.Check(ctr.Resources.Requests.Cpu().Equal(*workloadResourceLimits.Cpu()), tc.IsTrue)
-					c.Check(ctr.Resources.Requests.Memory().Equal(*workloadResourceLimits.Memory()), tc.IsTrue)
-
-					c.Check(ctr.Resources.Limits.Cpu().Equal(*workloadResourceLimits.Cpu()), tc.IsTrue)
-					c.Check(ctr.Resources.Limits.Memory().Equal(*workloadResourceLimits.Memory()), tc.IsTrue)
-				}
-			},
-			nil,
-		)
+				},
+				nil,
+			)
+		})
 	}
 }
 

--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -26,7 +26,7 @@ test_constraints_common() {
 			run "run_constraints_gce"
 			;;
 		"k8s")
-			echo "==> TEST SKIPPED: constraints - there are no tests for k8s provider"
+			run "run_constraints_k8s"
 			;;
 		*)
 			run "run_constraints_vm"

--- a/tests/suites/constraints/constraints_k8s.sh
+++ b/tests/suites/constraints/constraints_k8s.sh
@@ -1,0 +1,17 @@
+run_constraints_k8s() {
+	name="constraints-k8s"
+
+	file="${TEST_DIR}/constraints-k8s.txt"
+	ensure "${name}" "${file}"
+
+	juju deploy snappass-test --constraints "mem=2G cpu-power=200"
+	wait_for "snappass-test" "$(idle_condition "snappass-test")"
+
+	resources=$(kubectl -n "${name}" get pod snappass-test-0 -o json |
+		yq -r '.spec.containers[] | select(.name != "charm") | .resources')
+
+	check_contains "${resources}" 'cpu: 200m'
+	check_contains "${resources}" 'memory: 2Gi'
+
+	destroy_model "${name}"
+}


### PR DESCRIPTION
This fixes K8s application constraints being dropped when a model has no stored
model constraints.

In the K8s provisioning path, `ResolveConstraints` could return
`ConstraintsNotFound` when no model constraints existed. The facade ignored that
error, but the returned constraints were empty, so app constraints such as
`mem=2G cpu-power=200` never reached the Kubernetes pod spec.

The constraint resolver now treats missing model constraints as empty defaults.
That keeps the intended merge order intact: model defaults are used as fallback,
and application constraints override them.

_Note: also, an integration test was added for flexing this exact path._

## QA steps

Bootstrap and create a model, deploy a sidecar charm with constraints:
```
$ juju bootstrap microk8s c
$ juju add-model m
$ juju deploy snappass-test --constraints "mem=2G cpu-power=200"
```
Once the app is active, check the applied constraints:
```
$ microk8s kubectl -nmfix get pod snappass-test-0 -o jsonpath='{range .spec.containers[*]}{.name}: {.resources}{"\n"}{end}'
charm: {"limits":{"memory":"2Gi"},"requests":{"memory":"64Mi"}}
redis: {"limits":{"cpu":"200m","memory":"2Gi"},"requests":{"cpu":"200m","memory":"2Gi"}}
snappass: {"limits":{"cpu":"200m","memory":"2Gi"},"requests":{"cpu":"200m","memory":"2Gi"}}
```

Also run the integration test:
```
$ cd tests && ./main.sh -c microk8s constraints
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22650.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10035](https://warthogs.atlassian.net/browse/JUJU-10035)


[JUJU-10035]: https://warthogs.atlassian.net/browse/JUJU-10035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ