### PR TITLE
chore: add UUID agent rules for service and state methods

### DIFF
--- a/AGENTS.architecture-rules.md
+++ b/AGENTS.architecture-rules.md
@@ -60,6 +60,12 @@ Respect Juju layering. Never create new cross-layer dependencies.
 - SQL queries must use explicit aliases for tables, CTEs, and projected values;
   use `AS` rather than relying on implicit aliasing.
 - State method arguments should be simple types (`string`, `int`, etc.) or types local to that domain.
+- UUID should be created in the service layer and pushed to the state layer as a string.
+- UUID parameters accepted by service-layer methods should use their typed form
+  (e.g. `coremodel.UUID`) whenever such a type exists, and the service method
+  must validate them (e.g. `modelUUID.Validate()`) before use.
+- State-layer methods must always receive UUIDs as plain `string`; the service
+  converts typed UUIDs at the call boundary.
 - Domain packages should generally avoid `github.com/juju/names`. Prefer
   converting Juju tags to primitive values at API, facade, worker, or command
   boundaries before calling domain services.

--- a/AGENTS.architecture-rules.md
+++ b/AGENTS.architecture-rules.md
@@ -60,7 +60,8 @@ Respect Juju layering. Never create new cross-layer dependencies.
 - SQL queries must use explicit aliases for tables, CTEs, and projected values;
   use `AS` rather than relying on implicit aliasing.
 - State method arguments should be simple types (`string`, `int`, etc.) or types local to that domain.
-- UUID should be created in the service layer and pushed to the state layer as a string.
+- UUIDs for state-persisted entities should be created in the service layer
+  and pushed to the state layer as strings.
 - UUID parameters accepted by service-layer methods should use their typed form
   (e.g. `coremodel.UUID`) whenever such a type exists, and the service method
   must validate them (e.g. `modelUUID.Validate()`) before use.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,6 @@ timeframe.
 
 - Place methods and functions below others that call them.
 - Limit comment line lengths to 80 characters.
-- Generate new UUIDs in the service layer, then pass them into state methods.
-  State should persist supplied UUIDs rather than creating them, so services can
-  return created entity UUIDs directly when needed.
 - When wrapping errors across layers, add identifying context such as
   entity UUIDs once at the highest useful layer. Keep state-layer
   `Errorf` messages generic to avoid repeated identifiers in the final


### PR DESCRIPTION
These rules clarify how UUIDs should be passed to service layer, validated and then passed as string to the state layer.

Basically: 
- Use UUID types whenever available in service method signatures.
- Always validate types UUIDs on the service layer.
- Pass UUIDs as string down to the state layer.