### PR TITLE
fix: use errors.Is to detect reboot/shutdown sentinels in machine agent

### DIFF
--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -505,11 +505,11 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 	// At this point, all workers will have been configured to start
 	close(a.workersStarted)
 	err = a.runner.Wait()
-	switch errors.Cause(err) {
-	case internalworker.ErrRebootMachine:
+	switch {
+	case errors.Is(err, internalworker.ErrRebootMachine):
 		logger.Infof(ctx, "Caught reboot error")
 		err = a.executeRebootOrShutdown(params.ShouldReboot)
-	case internalworker.ErrShutdownMachine:
+	case errors.Is(err, internalworker.ErrShutdownMachine):
 		logger.Infof(ctx, "Caught shutdown error")
 		err = a.executeRebootOrShutdown(params.ShouldShutdown)
 	}

--- a/cmd/jujud-controller/agent/machine_test.go
+++ b/cmd/jujud-controller/agent/machine_test.go
@@ -6,7 +6,11 @@ package agent
 import (
 	"testing"
 
+	jujuerrors "github.com/juju/errors"
 	"github.com/juju/tc"
+
+	internalerrors "github.com/juju/juju/internal/errors"
+	internalworker "github.com/juju/juju/internal/worker"
 )
 
 type MachineSuite struct {
@@ -55,4 +59,68 @@ func (s *MachineSuite) TestIntegrationStub(c *tc.C) {
 - Test model workers respect the singular responsibility flag, by claiming the lease for the model and checking that
   the correct set of workers are started.
 `)
+}
+
+// rebootDispatchSuite tests the error-dispatch logic in MachineAgent.Run that
+// decides whether to call executeRebootOrShutdown. The switch uses errors.Is
+// which correctly traverses Unwrap() chains; the regression was that the old
+// errors.Cause()-based switch silently dropped the reboot when the error was
+// wrapped by internal/errors.Capture (as it is when it travels through
+// core/watcher.NotifyWorker).
+type rebootDispatchSuite struct{}
+
+func TestRebootDispatchSuite(t *testing.T) {
+	tc.Run(t, &rebootDispatchSuite{})
+}
+
+// TestRebootMachineIdentifiedWhenBare confirms that a bare ErrRebootMachine
+// matches the errors.Is check used in the Run() switch.
+func (s *rebootDispatchSuite) TestRebootMachineIdentifiedWhenBare(c *tc.C) {
+	err := internalworker.ErrRebootMachine
+	c.Check(isRebootError(err), tc.IsTrue)
+	c.Check(isShutdownError(err), tc.IsFalse)
+}
+
+// TestShutdownMachineIdentifiedWhenBare confirms that a bare ErrShutdownMachine
+// matches the errors.Is check used in the Run() switch.
+func (s *rebootDispatchSuite) TestShutdownMachineIdentifiedWhenBare(c *tc.C) {
+	err := internalworker.ErrShutdownMachine
+	c.Check(isShutdownError(err), tc.IsTrue)
+	c.Check(isRebootError(err), tc.IsFalse)
+}
+
+// TestRebootMachineIdentifiedWhenCaptured is the regression test: when
+// ErrRebootMachine has been wrapped by internal/errors.Capture (as happens
+// when it travels through core/watcher.NotifyWorker), errors.Is must still
+// identify it.  The old errors.Cause()-based switch did not traverse Unwrap()
+// chains and therefore missed the wrapped sentinel, causing the reboot to be
+// silently dropped.
+func (s *rebootDispatchSuite) TestRebootMachineIdentifiedWhenCaptured(c *tc.C) {
+	wrapped := internalerrors.Capture(internalworker.ErrRebootMachine)
+	c.Check(isRebootError(wrapped), tc.IsTrue)
+}
+
+// TestShutdownMachineIdentifiedWhenCaptured mirrors the above for
+// ErrShutdownMachine.
+func (s *rebootDispatchSuite) TestShutdownMachineIdentifiedWhenCaptured(c *tc.C) {
+	wrapped := internalerrors.Capture(internalworker.ErrShutdownMachine)
+	c.Check(isShutdownError(wrapped), tc.IsTrue)
+}
+
+// TestOtherErrorNotMisidentified ensures that an unrelated error is not
+// dispatched to either reboot or shutdown.
+func (s *rebootDispatchSuite) TestOtherErrorNotMisidentified(c *tc.C) {
+	wrapped := internalerrors.Capture(internalworker.ErrTerminateAgent)
+	c.Check(isRebootError(wrapped), tc.IsFalse)
+	c.Check(isShutdownError(wrapped), tc.IsFalse)
+}
+
+// isRebootError mirrors the first case of the switch in MachineAgent.Run.
+func isRebootError(err error) bool {
+	return jujuerrors.Is(err, internalworker.ErrRebootMachine)
+}
+
+// isShutdownError mirrors the second case of the switch in MachineAgent.Run.
+func isShutdownError(err error) bool {
+	return jujuerrors.Is(err, internalworker.ErrShutdownMachine)
 }

--- a/cmd/jujud-controller/util/util.go
+++ b/cmd/jujud-controller/util/util.go
@@ -15,15 +15,18 @@ import (
 
 // AgentDone processes the error returned by an exiting agent.
 func AgentDone(logger logger.Logger, err error) error {
-	err = errors.Cause(err)
-	switch err {
-	case jworker.ErrTerminateAgent, jworker.ErrRebootMachine, jworker.ErrShutdownMachine:
+	switch {
+	case errors.Is(err, jworker.ErrTerminateAgent),
+		errors.Is(err, jworker.ErrRebootMachine),
+		errors.Is(err, jworker.ErrShutdownMachine):
 		// These errors are swallowed here because we want to exit
 		// the agent process without error, to avoid the init system
 		// restarting us.
 		err = nil
 	}
-	if ug, ok := err.(*agenterrors.UpgradeReadyError); ok {
+
+	var ug *agenterrors.UpgradeReadyError
+	if errors.As(err, &ug) {
 		if err := ug.ChangeAgentTools(logger); err != nil {
 			// Return and let the init system deal with the restart.
 			err = errors.Annotate(err, "cannot change agent binaries")
@@ -31,7 +34,7 @@ func AgentDone(logger logger.Logger, err error) error {
 			return err
 		}
 	}
-	if err == jworker.ErrRestartAgent {
+	if errors.Is(err, jworker.ErrRestartAgent) {
 		logger.Warningf(context.TODO(), "agent restarting")
 	}
 	return err

--- a/cmd/jujud-controller/util/util_test.go
+++ b/cmd/jujud-controller/util/util_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package util_test
+
+import (
+	"testing"
+
+	jujuerrors "github.com/juju/errors"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/cmd/jujud-controller/util"
+	internalerrors "github.com/juju/juju/internal/errors"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	jworker "github.com/juju/juju/internal/worker"
+)
+
+func TestAgentDoneSuite(t *testing.T) {
+	tc.Run(t, &agentDoneSuite{})
+}
+
+type agentDoneSuite struct{}
+
+// TestAgentDoneNilError verifies that a nil error passes through unchanged.
+func (s *agentDoneSuite) TestAgentDoneNilError(c *tc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+	err := util.AgentDone(logger, nil)
+	c.Check(err, tc.ErrorIsNil)
+}
+
+// TestAgentDoneTerminateAgent verifies that a bare ErrTerminateAgent is
+// swallowed so the init system does not restart the agent.
+func (s *agentDoneSuite) TestAgentDoneTerminateAgent(c *tc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+	err := util.AgentDone(logger, jworker.ErrTerminateAgent)
+	c.Check(err, tc.ErrorIsNil)
+}
+
+// TestAgentDoneRebootMachine verifies that a bare ErrRebootMachine is
+// swallowed so the init system does not restart the agent.
+func (s *agentDoneSuite) TestAgentDoneRebootMachine(c *tc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+	err := util.AgentDone(logger, jworker.ErrRebootMachine)
+	c.Check(err, tc.ErrorIsNil)
+}
+
+// TestAgentDoneShutdownMachine verifies that a bare ErrShutdownMachine is
+// swallowed so the init system does not restart the agent.
+func (s *agentDoneSuite) TestAgentDoneShutdownMachine(c *tc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+	err := util.AgentDone(logger, jworker.ErrShutdownMachine)
+	c.Check(err, tc.ErrorIsNil)
+}
+
+// TestAgentDoneRebootMachineCaptured is the regression test for the original
+// bug: when ErrRebootMachine is wrapped by internal/errors.Capture (as it is
+// when it travels through core/watcher.NotifyWorker), the old
+// errors.Cause()-based switch failed to recognise it and the agent exited
+// without executing the reboot. The fix uses errors.Is(), which correctly
+// traverses Unwrap() chains produced by Capture.
+func (s *agentDoneSuite) TestAgentDoneRebootMachineCaptured(c *tc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+	wrapped := internalerrors.Capture(jworker.ErrRebootMachine)
+	err := util.AgentDone(logger, wrapped)
+	c.Check(err, tc.ErrorIsNil)
+}
+
+// TestAgentDoneShutdownMachineCaptured mirrors the above for ErrShutdownMachine.
+func (s *agentDoneSuite) TestAgentDoneShutdownMachineCaptured(c *tc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+	wrapped := internalerrors.Capture(jworker.ErrShutdownMachine)
+	err := util.AgentDone(logger, wrapped)
+	c.Check(err, tc.ErrorIsNil)
+}
+
+// TestAgentDoneTerminateAgentCaptured mirrors the above for ErrTerminateAgent.
+func (s *agentDoneSuite) TestAgentDoneTerminateAgentCaptured(c *tc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+	wrapped := internalerrors.Capture(jworker.ErrTerminateAgent)
+	err := util.AgentDone(logger, wrapped)
+	c.Check(err, tc.ErrorIsNil)
+}
+
+// TestAgentDoneRebootMachineTraced verifies that an ErrRebootMachine annotated
+// via juju/errors.Trace is also swallowed correctly.
+func (s *agentDoneSuite) TestAgentDoneRebootMachineTraced(c *tc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+	wrapped := jujuerrors.Trace(jworker.ErrRebootMachine)
+	err := util.AgentDone(logger, wrapped)
+	c.Check(err, tc.ErrorIsNil)
+}
+
+// TestAgentDoneUnknownErrorPassesThrough verifies that unrelated errors are
+// returned unchanged by AgentDone.
+func (s *agentDoneSuite) TestAgentDoneUnknownErrorPassesThrough(c *tc.C) {
+	logger := loggertesting.WrapCheckLog(c)
+	sentinel := jujuerrors.New("some unexpected error")
+	err := util.AgentDone(logger, sentinel)
+	c.Check(err, tc.ErrorIs, sentinel)
+}

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -18,10 +18,9 @@ run_start_hook_fires_after_reboot() {
 	# fire for the initial charm deployment
 	echo "[+] ensuring that implicit start hook does not fire after initial deployment"
 	logs=$(juju debug-log --include-module juju.worker.uniter --replay --no-tail | grep -n "reboot detected" || true)
-	echo "$logs" | sed 's/^/    | /g'
+	echo "${logs//#/    | }"
 	if [ -n "$logs" ]; then
-		# shellcheck disable=SC2046
-		echo $(red "Uniter incorrectly assumed a reboot occurred after initial charm deployment")
+		red "Uniter incorrectly assumed a reboot occurred after initial charm deployment"
 		exit 1
 	fi
 
@@ -33,10 +32,9 @@ run_start_hook_fires_after_reboot() {
 	echo
 	wait_for "$charm" "$(charm_rev "$charm" 22)"
 	logs=$(juju debug-log --include-module juju.worker.uniter --replay --no-tail | grep -n "reboot detected" || true)
-	echo "$logs" | sed 's/^/    | /g'
+	echo "${logs//#/    | }"
 	if [ -n "$logs" ]; then
-		# shellcheck disable=SC2046
-		echo $(red "Uniter incorrectly assumed a reboot occurred after restarting the agent")
+		red "Uniter incorrectly assumed a reboot occurred after restarting the agent"
 		exit 1
 	fi
 	sleep 1
@@ -48,10 +46,9 @@ run_start_hook_fires_after_reboot() {
 	sleep 1
 	wait_for "$charm" "$(charm_rev "$charm" 23)"
 	logs=$(juju debug-log --include-module juju.worker.uniter --replay --no-tail | grep -n "reboot detected" || true)
-	echo "$logs" | sed 's/^/    | /g'
+	echo "${logs//#/    | }"
 	if [ -n "$logs" ]; then
-		# shellcheck disable=SC2046
-		echo $(red "Uniter incorrectly assumed a reboot occurred after restarting the agent")
+		red "Uniter incorrectly assumed a reboot occurred after restarting the agent"
 		exit 1
 	fi
 
@@ -60,15 +57,45 @@ run_start_hook_fires_after_reboot() {
 
 	# Trigger a reboot and verify that the implicit start hook fires
 	echo "[+] ensuring that implicit start hook fires after a machine reboot"
+
+	# Record machine uptime before reboot to verify the machine
+	# actually reboots (not just agent restart).
+	uptime_before=$(juju ssh juju-qa-test/0 -- cat /proc/uptime 2>/dev/null | awk '{print int($1)}' || true)
+	echo "   | machine uptime before reboot: ${uptime_before}s"
+
 	juju ssh juju-qa-test/0 'sudo reboot now' || true
 	sleep 1
 	wait_for "$charm" "$(idle_condition "$charm")"
 	echo
 	logs=$(juju debug-log --include-module juju.worker.uniter --replay --no-tail | grep -n "reboot detected" || true)
-	echo "$logs" | sed 's/^/    | /g'
+	echo "${logs//#/    | }"
 	if [ -z "$logs" ]; then
-		# shellcheck disable=SC2046
-		echo $(red "Uniter did not fire start hook after the machine rebooted")
+		red "Uniter did not fire start hook after the machine rebooted"
+		exit 1
+	fi
+
+	# Verify that the machine actually rebooted by checking that uptime
+	# decreased. This catches the failure mode where AgentDone() does not
+	# swallow the sentinel error, causing systemd to restart the agent
+	# instead of the machine rebooting.
+	echo "[+] verifying that the machine actually rebooted (uptime decreased)"
+	uptime_after=$(juju ssh juju-qa-test/0 -- cat /proc/uptime 2>/dev/null | awk '{print int($1)}' || true)
+	echo "   | uptime before: ${uptime_before}s, after: ${uptime_after}s"
+	if [ -z "$uptime_before" ] || [ -z "$uptime_after" ] || [ "$uptime_after" -ge "$uptime_before" ]; then
+		red "Machine uptime did not decrease after reboot; machine may not have actually rebooted"
+		exit 1
+	fi
+
+	# Verify that the machine agent executed the reboot via
+	# executeRebootOrShutdown. This directly tests the code path fixed
+	# in the errors.Cause -> errors.Is change: the machine agent must
+	# recognise ErrRebootMachine through the Unwrap chain and dispatch
+	# to executeRebootOrShutdown.
+	echo "[+] verifying that the machine agent executed the reboot"
+	machine_log=$(juju ssh juju-qa-test/0 -- sudo grep -E "Caught reboot error|Executing reboot" /var/log/juju/machine-0.log 2>/dev/null || true)
+	echo "$machine_log//#/    | }"
+	if [ -z "$machine_log" ]; then
+		red "Machine agent did not log reboot execution in machine-0.log"
 		exit 1
 	fi
 
@@ -97,8 +124,7 @@ run_reboot_monitor_state_cleanup() {
 	num_files=$(juju ssh juju-qa-test/0 'ls -1 /var/run/juju/reboot-monitor/ | wc -l' 2>/dev/null | tr -d "[:space:]")
 	echo "   | number of monitor state files: ${num_files}"
 	if [ "$num_files" != "2" ]; then
-		# shellcheck disable=SC2046
-		echo $(red "Expected 2 reboot monitor state files to be created; got ${num_files}")
+		red "Expected 2 reboot monitor state files to be created; got ${num_files}"
 		exit 1
 	fi
 
@@ -108,11 +134,10 @@ run_reboot_monitor_state_cleanup() {
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	wait_for_subordinate_count "juju-qa-test"
-	num_files=$(juju ssh juju-qa-test/0 'ls -1 /var/run/juju/reboot-monitor/ | wc -l' 2>/dev/null | tr -d "[:space:]")
+	num_files=$(juju ssh   juju-qa-test/0 'ls -1 /var/run/juju/reboot-monitor/ | wc -l' 2>/dev/null | tr -d "[:space:]")
 	echo "   | number of monitor state files: ${num_files}"
 	if [ "$num_files" != "1" ]; then
-		# shellcheck disable=SC2046
-		echo $(red "Expected one remaining reboot monitor state file after subordinate removal; got ${num_files}")
+		red "Expected one remaining reboot monitor state file after subordinate removal; got ${num_files}"
 		exit 1
 	fi
 


### PR DESCRIPTION
The machine agent's Run() method and AgentDone() both used
juju/errors.Cause() to unwrap the error before comparing it against the
sentinels. Because Cause() only walks the Cause() interface chain and
ignores Unwrap(), the frameTracer was returned as-is and the comparison
failed silently. As a result:

- executeRebootOrShutdown() was never called, so the OS-level
  reboot/shutdown command was never executed.
- AgentDone() did not swallow the error, causing the agent to exit with
  a non-zero status and be restarted by systemd rather than rebooting.
- On the fresh start the reboot worker found noop (the flag had already
  been cleared before returning ErrRebootMachine) and did nothing.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Bootstrap:

```sh
juju bootstrap lxd src --build-agent
juju add-model m
juju add-ssh-key -m m "$(cat $JUJU_DATA/ssh/juju_id_ed25519.pub)"
```

Create charm for testing:

```sh
❯ mkdir -p testcharms/rebooter/hooks

❯ cat << EOF > testcharms/rebooter/charmcraft.yaml
type: charm
name: rebooter
summary: Reproducer for dropped juju-reboot on Juju 4
description: Calls juju-reboot from config-changed.
base: ubuntu@24.04
build-base: ubuntu@24.04
platforms:
  amd64:
parts:
  rebooter:
    plugin: dump
    source: .
config:
  options:
    reboot-trigger:
      type: string
      default: ""
      description: Set to any value to ask the hook to queue a reboot.
EOF

❯ cat << EOF > testcharms/rebooter/hooks/start
#!/bin/bash
status-set active ""
EOF

❯ cat << EOF > testcharms/rebooter/hooks/install
#!/bin/bash
exit 0
EOF

❯ cat << EOF > testcharms/rebooter/hooks/config-changed
#!/bin/bash
set -eux
TRIGGER=\$(config-get reboot-trigger)
MARKER=/var/local/rebooter.marker
status-set active "trigger=\$TRIGGER marker=\$([ -e \$MARKER ] && echo yes || echo no)" || true
[ -z "\$TRIGGER" ] && exit 0
[ -e "\$MARKER" ] && exit 0           # post-reboot run early-exits
sudo touch "\$MARKER"
juju-log "Calling juju-reboot (queued)"
juju-reboot                          # queued; should fire at end of hook
EOF

❯ chmod +x testcharms/rebooter/hooks/install
❯ chmod +x testcharms/rebooter/hooks/start
❯ chmod +x testcharms/rebooter/hooks/config-changed

❯ cd testcharms/rebooter/
❯ charmcraft pack --use-lxd
Packed rebooter_amd64.charm

```


Trigger reboot:

```sh
❯ juju deploy ./rebooter_amd64.charm rebooter
Located local charm "rebooter", revision 0
Deploying "rebooter" from local charm "rebooter", revision 0 on ubuntu@24.04/stable

❯ jst
Model  Controller  Cloud/Region  Version   Timestamp
m      src         lxd/default   4.0.12.1  18:01:29+02:00

App       Version  Status  Scale  Charm     Channel  Rev  Exposed  Message
rebooter           active      1  rebooter             0  no

Unit         Workload  Agent  Machine  Public address  Ports  Message
rebooter/0*  active    idle   0        10.159.202.17

Machine  State    Address        Inst id        Base          AZ      Message
0        started  10.159.202.17  juju-6a429b-0  ubuntu@24.04  tuxedo  Running

❯ sudo lxc info juju-6a429b-0 | grep -iE 'created|status|pid'
Status: RUNNING
PID: 223883
Created: 2026/06/22 18:01 CEST

❯ ps -o pid,etimes,lstart,cmd -p 223883
    PID ELAPSED                  STARTED CMD
 223883      99 Mon Jun 22 18:01:07 2026 /sbin/init

❯ sudo lxc exec juju-6a429b-0 -- ls -la /var/local/rebooter.marker
ls: cannot access '/var/local/rebooter.marker': No such file or directory

❯ juju ssh rebooter/0 -- grep machine.go /var/log/juju/machine-0.log
Connection to 10.159.202.17 closed.

❯ juju config rebooter reboot-trigger=please

```

Verify reboot:

```sh
❯ sudo lxc info juju-6a429b-0 | grep -iE 'created|status|pid'
Status: RUNNING
PID: 247691
Created: 2026/06/22 18:01 CEST

❯ ps -o pid,etimes,lstart,cmd -p 247691
    PID ELAPSED                  STARTED CMD
 247691      25 Mon Jun 22 18:04:07 2026 /sbin/init

❯ juju ssh rebooter/0 -- grep machine.go /var/log/juju/machine-0.log
2026-06-22 16:03:49 INFO juju.cmd.jujud machine.go:510 Caught reboot error
2026-06-22 16:03:49 INFO juju.cmd.jujud machine.go:638 Reboot: Executing reboot
Connection to 10.159.202.17 closed.

❯ sudo lxc exec juju-6a429b-0 -- ls -la /var/local/rebooter.marker
-rw-r--r-- 1 root staff 0 Jun 22 16:03 /var/local/rebooter.marker
```

## Documentation changes


## Links

**Issue:** Fixes #22639

**Jira card:** [JUJU-10007](https://warthogs.atlassian.net/browse/JUJU-10007)


[JUJU-10007]: https://warthogs.atlassian.net/browse/JUJU-10007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ