### PR TITLE
feat(constraints): validate ip-family constraint per cloud provider

### DIFF
--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"strings"
 
 	"github.com/juju/clock"
 
@@ -142,6 +143,17 @@ func (s *ProviderService) mergeMachineAndModelConstraints(ctx context.Context, c
 	mergedCons, err := validator.Merge(domainconstraints.EncodeConstraints(modelCons), domainconstraints.EncodeConstraints(cons))
 	if err != nil {
 		return constraints.Value{}, errors.Errorf("merging application and model constraints: %w", err)
+	}
+
+	// Validate merged constraints to catch unsupported constraints.
+	unsupported, err := validator.Validate(mergedCons)
+	if err != nil {
+		// Should never happens, constraint are validated in merge
+		return constraints.Value{}, errors.Capture(err)
+	}
+	if len(unsupported) > 0 {
+		s.logger.Warningf(ctx,
+			"unsupported constraints: %v", strings.Join(unsupported, ","))
 	}
 
 	return mergedCons, nil

--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -148,7 +148,7 @@ func (s *ProviderService) mergeMachineAndModelConstraints(ctx context.Context, c
 	// Validate merged constraints to catch unsupported constraints.
 	unsupported, err := validator.Validate(mergedCons)
 	if err != nil {
-		// Should never happens, constraint are validated in merge
+		// Should never happen; constraints are validated during merge.
 		return constraints.Value{}, errors.Capture(err)
 	}
 	if len(unsupported) > 0 {

--- a/domain/machine/service/provider_test.go
+++ b/domain/machine/service/provider_test.go
@@ -16,6 +16,7 @@ import (
 	coreconstraints "github.com/juju/juju/core/constraints"
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/network/ipfamily"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/domain/constraints"
 	"github.com/juju/juju/domain/deployment"
@@ -197,6 +198,60 @@ func (s *providerServiceSuite) TestAddMachineContainer(c *tc.C) {
 	c.Check(*res.ChildMachineName, tc.Equals, machine.Name("0/lxd/0"))
 }
 
+func (s *providerServiceSuite) TestAddMachineUnsupportedConstraintWarns(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	// Use a real validator with ip-family registered as unsupported.
+	// The real validator's Validate will return ip-family in the
+	// unsupported slice, triggering the warn-and-ignore log.
+	realValidator := coreconstraints.NewValidator()
+	realValidator.RegisterUnsupported([]string{"ip-family"})
+
+	s.provider.EXPECT().ConstraintsValidator(gomock.Any()).Return(realValidator, nil)
+	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{}, nil)
+	s.provider.EXPECT().PrecheckInstance(gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().AddMachine(gomock.Any(), gomock.Any()).Return("netNodeUUID", []machine.Name{"name"}, nil)
+	s.expectCreateMachineStatusHistory(c, machine.Name("name"))
+
+	res, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Constraints: constraints.Constraints{
+			IPFamily: new(ipfamily.Dual),
+		},
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(res.MachineName, tc.Equals, machine.Name("name"))
+}
+
+func (s *providerServiceSuite) TestAddMachineVocabError(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	// Use a real validator with ip-family vocabulary restricted to ipv4.
+	// ip-family=dual will cause a vocab error, which should propagate
+	// as a hard error from AddMachine.
+	realValidator := coreconstraints.NewValidator()
+	realValidator.RegisterVocabulary("ip-family", []string{"ipv4"})
+
+	s.provider.EXPECT().ConstraintsValidator(gomock.Any()).Return(realValidator, nil)
+	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{}, nil)
+
+	_, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Constraints: constraints.Constraints{
+			IPFamily: new(ipfamily.Dual),
+		},
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
+	c.Assert(err, tc.ErrorMatches, "(?s).*invalid constraint value.*")
+}
+
 // TestAddMachineError asserts that an error coming from the state layer is
 // preserved, passed over to the service layer to be maintained there.
 func (s *providerServiceSuite) TestAddMachineError(c *tc.C) {
@@ -248,13 +303,14 @@ func (s *providerServiceSuite) TestMergeApplicationAndModelConstraintsConstraint
 	defer ctrl.Finish()
 
 	s.provider.EXPECT().ConstraintsValidator(gomock.Any()).Return(s.validator, nil)
-
 	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{}, modelerrors.ConstraintsNotFound)
 
 	s.validator.EXPECT().Merge(
 		constraints.EncodeConstraints(constraints.Constraints{}),
 		constraints.EncodeConstraints(constraints.Constraints{})).
 		Return(coreconstraints.Value{}, nil)
+	s.validator.EXPECT().Validate(coreconstraints.Value{}).
+		Return(nil, nil)
 
 	_, err := s.service.mergeMachineAndModelConstraints(c.Context(), constraints.Constraints{})
 	c.Assert(err, tc.ErrorIsNil)
@@ -265,7 +321,6 @@ func (s *providerServiceSuite) TestMergeApplicationAndModelConstraintsNotSubordi
 	defer ctrl.Finish()
 
 	s.provider.EXPECT().ConstraintsValidator(gomock.Any()).Return(s.validator, nil)
-
 	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{}, modelerrors.ConstraintsNotFound)
 
 	s.validator.EXPECT().Merge(
@@ -276,6 +331,9 @@ func (s *providerServiceSuite) TestMergeApplicationAndModelConstraintsNotSubordi
 		Return(coreconstraints.Value{
 			Arch: new(arch.AMD64),
 		}, nil)
+	s.validator.EXPECT().Validate(coreconstraints.Value{
+		Arch: new(arch.AMD64),
+	}).Return(nil, nil)
 
 	merged, err := s.service.mergeMachineAndModelConstraints(c.Context(), constraints.Constraints{
 		Arch: new(arch.AMD64),
@@ -289,7 +347,6 @@ func (s *providerServiceSuite) TestMergeApplicationAndModelConstraintsSubordinat
 	defer ctrl.Finish()
 
 	s.provider.EXPECT().ConstraintsValidator(gomock.Any()).Return(s.validator, nil)
-
 	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{
 		RootDiskSource: new("source-disk"),
 		Mem:            new(uint64(42)),
@@ -308,6 +365,11 @@ func (s *providerServiceSuite) TestMergeApplicationAndModelConstraintsSubordinat
 			RootDiskSource: new("source-disk"),
 			Mem:            new(uint64(42)),
 		}, nil)
+	s.validator.EXPECT().Validate(coreconstraints.Value{
+		Arch:           new(arch.AMD64),
+		RootDiskSource: new("source-disk"),
+		Mem:            new(uint64(42)),
+	}).Return(nil, nil)
 
 	merged, err := s.service.mergeMachineAndModelConstraints(c.Context(), constraints.Constraints{
 		Arch: new(arch.AMD64),
@@ -322,7 +384,6 @@ func (s *providerServiceSuite) TestMergeApplicationAndModelConstraintsNotSubordi
 	defer ctrl.Finish()
 
 	s.provider.EXPECT().ConstraintsValidator(gomock.Any()).Return(s.validator, nil)
-
 	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{
 		Mem: new(uint64(42)),
 	}, modelerrors.ConstraintsNotFound)
@@ -338,6 +399,10 @@ func (s *providerServiceSuite) TestMergeApplicationAndModelConstraintsNotSubordi
 			RootDiskSource: new("source-disk"),
 			Mem:            new(uint64(42)),
 		}, nil)
+	s.validator.EXPECT().Validate(coreconstraints.Value{
+		RootDiskSource: new("source-disk"),
+		Mem:            new(uint64(42)),
+	}).Return(nil, nil)
 
 	merged, err := s.service.mergeMachineAndModelConstraints(c.Context(), constraints.Constraints{
 		RootDiskSource: new("source-disk"),

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -292,6 +292,10 @@ func (env *azureEnviron) CreateModelResources(ctx context.Context, args environs
 
 // Bootstrap is part of the Environ interface.
 func (env *azureEnviron) Bootstrap(ctx environs.BootstrapContext, args environs.BootstrapParams) (*environs.BootstrapResult, error) {
+	if err := env.validateIPFamilyConstraint(args.BootstrapConstraints); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	needResourceGroup := env.config.resourceGroupName == ""
 	if needResourceGroup && (args.BootstrapConstraints.HasInstanceRole() || env.cloud.Credential.AuthType() == cloud.ManagedIdentityAuthType) {
 		var instanceRole string
@@ -508,17 +512,24 @@ func (env *azureEnviron) ConstraintsValidator(ctx context.Context) (constraints.
 	return validator, nil
 }
 
-// PrecheckInstance is defined on the environs.InstancePrechecker interface.
-func (env *azureEnviron) PrecheckInstance(ctx context.Context, args environs.PrecheckInstanceParams) error {
-	// Reject ip-family=dual when the load balancer SKU is Basic.
-	// Basic SKU does not support dual-stack public IPs; operators
-	// must use Standard SKU (the default).
-	if args.Constraints.IPFamily != nil &&
-		*args.Constraints.IPFamily == ipfamily.Dual &&
+// validateIPFamilyConstraint rejects ip-family=dual when the load balancer
+// SKU is Basic. Basic SKU does not support dual-stack public IPs; operators
+// must use Standard SKU (the default).
+func (env *azureEnviron) validateIPFamilyConstraint(cons constraints.Value) error {
+	if cons.IPFamily != nil &&
+		*cons.IPFamily == ipfamily.Dual &&
 		env.config.loadBalancerSkuName == string(armnetwork.LoadBalancerSKUNameBasic) {
 		return errors.Errorf(
 			"ip-family=dual requires load-balancer-sku-name=Standard on Azure; " +
 				"Basic SKU is not supported for this configuration")
+	}
+	return nil
+}
+
+// PrecheckInstance is defined on the environs.InstancePrechecker interface.
+func (env *azureEnviron) PrecheckInstance(ctx context.Context, args environs.PrecheckInstanceParams) error {
+	if err := env.validateIPFamilyConstraint(args.Constraints); err != nil {
+		return errors.Trace(err)
 	}
 
 	if _, err := env.findPlacementSubnet(ctx, args.Placement); err != nil {

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -35,6 +35,7 @@ import (
 	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network/ipfamily"
 	"github.com/juju/juju/core/os/ostype"
 	"github.com/juju/juju/core/semversion"
 	jujuversion "github.com/juju/juju/core/version"
@@ -500,11 +501,26 @@ func (env *azureEnviron) ConstraintsValidator(ctx context.Context) (constraints.
 		// in instanceTypes.
 		return errors.NotFoundf("%v %q", constraints.InstanceType, instanceTypeName)
 	})
+	validator.RegisterVocabulary(constraints.IPFamily, []string{
+		string(ipfamily.IPv4),
+		string(ipfamily.Dual),
+	})
 	return validator, nil
 }
 
 // PrecheckInstance is defined on the environs.InstancePrechecker interface.
 func (env *azureEnviron) PrecheckInstance(ctx context.Context, args environs.PrecheckInstanceParams) error {
+	// Reject ip-family=dual when the load balancer SKU is Basic.
+	// Basic SKU does not support dual-stack public IPs; operators
+	// must use Standard SKU (the default).
+	if args.Constraints.IPFamily != nil &&
+		*args.Constraints.IPFamily == ipfamily.Dual &&
+		env.config.loadBalancerSkuName == string(armnetwork.LoadBalancerSKUNameBasic) {
+		return errors.Errorf(
+			"ip-family=dual requires load-balancer-sku-name=Standard on Azure; " +
+				"Basic SKU is not supported for this configuration")
+	}
+
 	if _, err := env.findPlacementSubnet(ctx, args.Placement); err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2150,6 +2150,86 @@ func (s *environSuite) TestPrecheckInstanceIPFamilyIPv4BasicSKUAccepted(c *tc.C)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *environSuite) TestBootstrapIPFamilyDualBasicSKURejected(c *tc.C) {
+	defer envtesting.DisableFinishBootstrap(c)()
+
+	ctx := envtesting.BootstrapTestContext(c)
+	env := prepareForBootstrap(c, ctx, s.provider, s.credentialInvalidator, &s.sender, testing.Attrs{"load-balancer-sku-name": "Basic"})
+
+	// ConstraintsValidator is invoked before Bootstrap and needs the SKU
+	// listing to succeed so that the bootstrap-specific conflict check in
+	// azureEnviron.Bootstrap is reached.
+	s.sender = append(s.sender, s.resourceSKUsSender())
+
+	err := bootstrap.Bootstrap(
+		ctx, env, bootstrap.BootstrapParams{
+			ControllerConfig:     testing.FakeControllerConfig(),
+			AdminSecret:          jujutesting.AdminSecret,
+			CAPrivateKey:         testing.CAKey,
+			BootstrapBase:        corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints: constraints.MustParse("ip-family=dual"),
+			BuildAgentTarball: func(
+				build bool, _ string, _ func(semversion.Number) semversion.Number,
+			) (*sync.BuiltAgent, error) {
+				c.Assert(build, tc.IsFalse)
+				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
+			},
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
+		},
+	)
+	c.Assert(err, tc.ErrorMatches,
+		"ip-family=dual requires load-balancer-sku-name=Standard on Azure; "+
+			"Basic SKU is not supported for this configuration",
+	)
+}
+
+func (s *environSuite) TestBootstrapIPFamilyDualStandardSKUAccepted(c *tc.C) {
+	defer envtesting.DisableFinishBootstrap(c)()
+
+	ctx := envtesting.BootstrapTestContext(c)
+	env := prepareForBootstrap(c, ctx, s.provider, s.credentialInvalidator, &s.sender)
+
+	authorizedKeys := make([]string, 0, len(s.sshPublicKeys))
+	for _, key := range s.sshPublicKeys {
+		authorizedKeys = append(authorizedKeys, *key.KeyData)
+	}
+
+	s.sender = append(s.sender, s.resourceSKUsSender())
+	s.sender = append(s.sender, s.initResourceGroupSenders(resourceGroupName)...)
+	s.sender = append(s.sender, s.startInstanceSendersNoSizes()...)
+	s.requests = nil
+	err := bootstrap.Bootstrap(
+		ctx, env, bootstrap.BootstrapParams{
+			ControllerModelAuthorizedKeys: authorizedKeys,
+			ControllerConfig:              testing.FakeControllerConfig(),
+			AdminSecret:                   jujutesting.AdminSecret,
+			CAPrivateKey:                  testing.CAKey,
+			BootstrapBase:                 corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:          constraints.MustParse("ip-family=dual"),
+			BuildAgentTarball: func(
+				build bool, _ string, _ func(semversion.Number) semversion.Number,
+			) (*sync.BuiltAgent, error) {
+				c.Assert(build, tc.IsFalse)
+				return &sync.BuiltAgent{Dir: c.MkDir()}, nil
+			},
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
+		},
+	)
+
+	if corearch.HostArch() != "amd64" && corearch.HostArch() != "arm64" {
+		// Non amd64/arm64 architectures are not supported for bootstrap.
+		c.Assert(err, tc.ErrorMatches,
+			fmt.Sprintf("model %q of type %s does not support instances running on %q",
+				env.Config().Name(),
+				env.Config().Type(),
+				corearch.HostArch(),
+			),
+		)
+		return
+	}
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *environSuite) TestConstraintsValidatorVocabulary(c *tc.C) {
 	validator := s.constraintsValidator(c)
 	_, err := validator.Validate(constraints.MustParse("arch=s390x"))

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2103,6 +2103,53 @@ func (s *environSuite) TestConstraintsValidatorUnsupported(c *tc.C) {
 	c.Assert(unsupported, tc.SameContents, []string{"tags", "cpu-power", "virt-type"})
 }
 
+func (s *environSuite) TestConstraintsValidatorIPFamilyIPv4(c *tc.C) {
+	validator := s.constraintsValidator(c)
+	_, err := validator.Validate(constraints.MustParse("ip-family=ipv4"))
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *environSuite) TestConstraintsValidatorIPFamilyDual(c *tc.C) {
+	validator := s.constraintsValidator(c)
+	_, err := validator.Validate(constraints.MustParse("ip-family=dual"))
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *environSuite) TestConstraintsValidatorIPFamilyIPv6Rejected(c *tc.C) {
+	validator := s.constraintsValidator(c)
+	_, err := validator.Validate(constraints.MustParse("ip-family=ipv6"))
+	c.Assert(err, tc.ErrorMatches,
+		"invalid constraint value: ip-family=ipv6\nvalid values are: ipv4 dual",
+	)
+}
+
+func (s *environSuite) TestPrecheckInstanceIPFamilyDualBasicSKURejected(c *tc.C) {
+	env := s.openEnviron(c, testing.Attrs{"load-balancer-sku-name": "Basic"})
+	err := env.PrecheckInstance(c.Context(), environs.PrecheckInstanceParams{
+		Constraints: constraints.MustParse("ip-family=dual"),
+	})
+	c.Assert(err, tc.ErrorMatches,
+		"ip-family=dual requires load-balancer-sku-name=Standard on Azure; "+
+			"Basic SKU is not supported for this configuration",
+	)
+}
+
+func (s *environSuite) TestPrecheckInstanceIPFamilyDualStandardSKUAccepted(c *tc.C) {
+	env := s.openEnviron(c)
+	err := env.PrecheckInstance(c.Context(), environs.PrecheckInstanceParams{
+		Constraints: constraints.MustParse("ip-family=dual"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *environSuite) TestPrecheckInstanceIPFamilyIPv4BasicSKUAccepted(c *tc.C) {
+	env := s.openEnviron(c, testing.Attrs{"load-balancer-sku-name": "Basic"})
+	err := env.PrecheckInstance(c.Context(), environs.PrecheckInstanceParams{
+		Constraints: constraints.MustParse("ip-family=ipv4"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *environSuite) TestConstraintsValidatorVocabulary(c *tc.C) {
 	validator := s.constraintsValidator(c)
 	_, err := validator.Validate(constraints.MustParse("arch=s390x"))

--- a/internal/provider/ec2/environ.go
+++ b/internal/provider/ec2/environ.go
@@ -268,6 +268,7 @@ var unsupportedConstraints = []string{
 	// use virt-type in StartInstances
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
+	constraints.IPFamily,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/internal/provider/ec2/local_test.go
+++ b/internal/provider/ec2/local_test.go
@@ -1734,10 +1734,10 @@ func (t *localServerSuite) TestConstraintsValidatorUnsupported(c *tc.C) {
 	env := t.Prepare(c)
 	validator, err := env.ConstraintsValidator(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=lxd")
+	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=lxd ip-family=dual")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(unsupported, tc.SameContents, []string{"tags", "virt-type"})
+	c.Assert(unsupported, tc.SameContents, []string{"tags", "virt-type", "ip-family"})
 }
 
 func (t *localServerSuite) TestConstraintsValidatorVocab(c *tc.C) {

--- a/internal/provider/gce/environ_policy.go
+++ b/internal/provider/gce/environ_policy.go
@@ -49,6 +49,7 @@ var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
 	constraints.ImageID,
+	constraints.IPFamily,
 }
 
 // instanceTypeConstraints defines the fields defined on each of the

--- a/internal/provider/gce/environ_policy_test.go
+++ b/internal/provider/gce/environ_policy_test.go
@@ -351,11 +351,11 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *tc.C) {
 	validator, err := env.ConstraintsValidator(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
-	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
+	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm ip-family=dual")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Assert(unsupported, tc.SameContents, []string{"tags", "virt-type"})
+	c.Assert(unsupported, tc.SameContents, []string{"tags", "virt-type", "ip-family"})
 }
 
 func (s *environPolSuite) TestConstraintsValidatorVocabInstType(c *tc.C) {

--- a/internal/provider/kubernetes/constraints.go
+++ b/internal/provider/kubernetes/constraints.go
@@ -17,6 +17,7 @@ var unsupportedConstraints = []string{
 	constraints.Spaces,
 	constraints.AllocatePublicIP,
 	constraints.ImageID,
+	constraints.IPFamily,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/internal/provider/kubernetes/constraints_test.go
+++ b/internal/provider/kubernetes/constraints_test.go
@@ -65,6 +65,7 @@ func (s *ConstraintsSuite) TestConstraintsValidatorUnsupported(c *tc.C) {
 		"root-disk=10M",
 		"spaces=foo",
 		"container=lxd",
+		"ip-family=dual",
 	}, " "))
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, tc.ErrorIsNil)
@@ -75,6 +76,7 @@ func (s *ConstraintsSuite) TestConstraintsValidatorUnsupported(c *tc.C) {
 		"instance-type",
 		"spaces",
 		"container",
+		"ip-family",
 	}
 	c.Check(unsupported, tc.SameContents, expected)
 }

--- a/internal/provider/lxd/environ_policy.go
+++ b/internal/provider/lxd/environ_policy.go
@@ -31,6 +31,7 @@ var unsupportedConstraints = []string{
 	constraints.Container,
 	constraints.AllocatePublicIP,
 	constraints.ImageID,
+	constraints.IPFamily,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/internal/provider/lxd/environ_policy_test.go
+++ b/internal/provider/lxd/environ_policy_test.go
@@ -185,6 +185,7 @@ func (s *environPolicySuite) TestConstraintsValidatorUnsupported(c *tc.C) {
 		"cores=2",
 		"cpu-power=250",
 		"virt-type=virtual-machine",
+		"ip-family=dual",
 	}, " "))
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, tc.ErrorIsNil)
@@ -192,6 +193,7 @@ func (s *environPolicySuite) TestConstraintsValidatorUnsupported(c *tc.C) {
 	expected := []string{
 		"tags",
 		"cpu-power",
+		"ip-family",
 	}
 	c.Check(unsupported, tc.SameContents, expected)
 }

--- a/internal/provider/maas/constraints.go
+++ b/internal/provider/maas/constraints.go
@@ -20,6 +20,7 @@ var unsupportedConstraints = []string{
 	constraints.InstanceType,
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
+	constraints.IPFamily,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -2655,10 +2655,10 @@ func (suite *maasEnvironSuite) TestConstraintsValidator(c *tc.C) {
 	env := suite.makeEnviron(c, controller)
 	validator, err := env.ConstraintsValidator(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm ip-family=dual")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(unsupported, tc.SameContents, []string{"cpu-power", "instance-type", "virt-type"})
+	c.Assert(unsupported, tc.SameContents, []string{"cpu-power", "instance-type", "virt-type", "ip-family"})
 }
 
 func (suite *maasEnvironSuite) TestConstraintsValidatorWithUnsupportedArch(c *tc.C) {
@@ -2670,10 +2670,10 @@ func (suite *maasEnvironSuite) TestConstraintsValidatorWithUnsupportedArch(c *tc
 	env := suite.makeEnviron(c, controller)
 	validator, err := env.ConstraintsValidator(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 instance-type=foo virt-type=kvm ip-family=dual")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(unsupported, tc.SameContents, []string{"cpu-power", "instance-type", "virt-type"})
+	c.Assert(unsupported, tc.SameContents, []string{"cpu-power", "instance-type", "virt-type", "ip-family"})
 }
 
 func (suite *maasEnvironSuite) TestConstraintsValidatorInvalidCredential(c *tc.C) {

--- a/internal/provider/oci/environ.go
+++ b/internal/provider/oci/environ.go
@@ -316,6 +316,7 @@ var unsupportedConstraints = []string{
 	constraints.VirtType,
 	constraints.Tags,
 	constraints.ImageID,
+	constraints.IPFamily,
 }
 
 // ConstraintsValidator implements environs.Environ.

--- a/internal/provider/oci/environ_test.go
+++ b/internal/provider/oci/environ_test.go
@@ -116,3 +116,14 @@ func (s *environSuite) TestEnsureShapeConfig(c *tc.C) {
 		c.Check(instanceDetails.ShapeConfig, tc.DeepEquals, test.want)
 	}
 }
+
+func (s *environSuite) TestConstraintsValidatorUnsupported(c *tc.C) {
+	var env Environ
+	validator, err := env.ConstraintsValidator(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm ip-family=dual")
+	unsupported, err := validator.Validate(cons)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(unsupported, tc.SameContents, []string{"tags", "virt-type", "ip-family"})
+}

--- a/internal/provider/openstack/local_test.go
+++ b/internal/provider/openstack/local_test.go
@@ -1538,10 +1538,10 @@ func (s *localServerSuite) TestConstraintsValidator(c *tc.C) {
 	env := s.Open(c, c.Context(), s.env.Config())
 	validator, err := env.ConstraintsValidator(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	cons := constraints.MustParse("arch=amd64 cpu-power=10 virt-type=lxd")
+	cons := constraints.MustParse("arch=amd64 cpu-power=10 virt-type=lxd ip-family=dual")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(unsupported, tc.SameContents, []string{"cpu-power"})
+	c.Assert(unsupported, tc.SameContents, []string{"cpu-power", "ip-family"})
 }
 
 func (s *localServerSuite) TestConstraintsValidatorVocab(c *tc.C) {

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -586,6 +586,7 @@ func (e *Environ) neutron() NetworkingNeutron {
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.CpuPower,
+	constraints.IPFamily,
 }
 
 // ConstraintsValidator is defined on the Environs interface.

--- a/internal/provider/vsphere/environ_policy.go
+++ b/internal/provider/vsphere/environ_policy.go
@@ -81,6 +81,7 @@ var unsupportedConstraints = []string{
 	constraints.VirtType,
 	constraints.AllocatePublicIP,
 	constraints.ImageID,
+	constraints.IPFamily,
 }
 
 // ConstraintsValidator returns a Validator value which is used to

--- a/internal/provider/vsphere/environ_policy_test.go
+++ b/internal/provider/vsphere/environ_policy_test.go
@@ -49,11 +49,11 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *tc.C) {
 	validator, err := s.env.ConstraintsValidator(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
-	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm")
+	cons := constraints.MustParse("arch=amd64 tags=foo virt-type=kvm ip-family=dual")
 	unsupported, err := validator.Validate(cons)
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Check(unsupported, tc.SameContents, []string{"tags", "virt-type"})
+	c.Check(unsupported, tc.SameContents, []string{"tags", "virt-type", "ip-family"})
 }
 
 func (s *environPolSuite) TestConstraintsValidatorVocabArch(c *tc.C) {


### PR DESCRIPTION
This PR implements Task 2 of the ip-family implementation plan. It registers
the `ip-family` constraint in every cloud providers ConstraintsValidator:

- **Azure**: `ip-family=ipv4` and `ip-family=dual` accepted via
  `RegisterVocabulary`. `ip-family=ipv6` rejected with the standard
  vocabulary error. A custom validator wrapper rejects
  `ip-family=dual` combined with `load-balancer-sku-name=Basic` and
  directs the user to Standard SKU.
- **All other providers** (EC2, GCE, OpenStack, OCI, MAAS, vSphere, LXD,
  Kubernetes): `ip-family` registered via `RegisterUnsupported`, producing
  a warn-and-ignore behaviour (same pattern as `tags` and `virt-type`).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what youre testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests)~ (integration tests are deferred to Tasks 4 and 7 of the implementation plan)
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451)~ (no new packages added or changed)

## QA steps

> **Note:** Full end-to-end integration tests (bootstrap, model constraints,
> application deploy) are deferred to Tasks 4 and 7 of the implementation
> plan. The unit tests in this PR exercise each providers validator
> directly.

1. **Azure: `ip-family=dual` accepted**

```sh
juju add-machine --constraints "ip-family=dual"
juju deploy juju-qa-test --constraints "ip-family=dual"
```

Expected: no error. The machine provisions with the Standard SKU load
balancer (default), and validation passes.

2. **Azure: `ip-family=ipv6` rejected**

```sh
juju add-machine --constraints "ip-family=ipv6"
juju deploy juju-qa-test nope --constraints "ip-family=ipv6"
```

Expected: both fails with:

```
invalid constraint value: ip-family=ipv6
valid values are: ipv4 dual
```

3. **Azure: `ip-family=dual` + Basic SKU rejected**

```sh
juju add-model test  --config load-balancer-sku-name=Basic
juju add-machine --constraints "ip-family=dual"
juju deploy juju-qa-test nope --constraints "ip-family=dual"
```

Expected: both fails with:

```
ip-family=dual requires load-balancer-sku-name=Standard on Azure; Basic SKU is not supported for this configuration
```

4. **Azure: `ip-family=dual` + Basic SKU rejected at bootstrap**

```sh
juju bootstrap azure test-controller \
    --config load-balancer-sku-name=Basic \
    --bootstrap-constraints "ip-family=dual"
```

Expected: fails with:

```
ip-family=dual requires load-balancer-sku-name=Standard on Azure; Basic SKU is not supported for this configuration
```

No resources (resource group, VM, etc.) should be created.

5. **Azure: `ip-family=dual` accepted at bootstrap**

```sh
juju bootstrap azure test-controller \
    --bootstrap-constraints "ip-family=dual"
```

Expected: no error. The controller provisions with the Standard SKU load
balancer (default), and validation passes.

6. **Non-Azure providers: `ip-family=dual` warn-and-ignore**

```sh
juju add-machine --constraints "ip-family=dual"
juju deploy juju-qa-test nope --constraints "ip-family=ipv4"
```

Expected (on EC2, GCE, LXD, etc.): succeeds with a warning in the controller logs:

```
WARNING: ignoring unsupported constraint: ip-family=dual
```

## Documentation changes

None. User-facing documentation updates are deferred to Task 5 of the
implementation plan.

## Links

**Jira card:** [JUJU-9875](https://warthogs.atlassian.net/browse/JUJU-9875)
**Implementation plan:** [JUJU-9599 implementation plan](https://github.com/juju/juju-agent-specs/blob/main/2610/JUJU-9599/implementation_plan.md)
**Spec:** [JUJU-9599 spec](https://github.com/juju/juju-agent-specs/blob/main/2610/JUJU-9599/spec.md)

[JUJU-9875]: https://warthogs.atlassian.net/browse/JUJU-9875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ