### PR TITLE
fix(lxd): resolve container NIC bridges from ProviderNetworkId so space subnets are attached again

### DIFF
--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -179,8 +179,8 @@ func (env *environ) getImageSources(ctx context.Context) ([]lxd.ServerSpec, erro
 
 // getContainerSpec builds a container spec from the input container image and
 // start-up parameters.
-// Cloud-init config is generated based on the network devices in the default
-// profile and included in the spec config.
+// Cloud-init config is generated based on the network devices in the applied
+// profiles and included in the spec config.
 func (env *environ) getContainerSpec(
 	ctx context.Context, image lxd.SourcedImage, serverVersion string, args environs.StartInstanceParams,
 ) (lxd.ContainerSpec, error) {
@@ -190,7 +190,7 @@ func (env *environ) getContainerSpec(
 	}
 	cSpec := lxd.ContainerSpec{
 		Name:     hostname,
-		Profiles: []string{"default", env.profileName()},
+		Profiles: env.containerProfileNames(),
 		Image:    image,
 		Config:   make(map[string]string),
 	}
@@ -211,7 +211,7 @@ func (env *environ) getContainerSpec(
 	}
 
 	// Assemble the list of NICs that need to be added to the container.
-	// This includes all NICs from the default profile as well as any
+	// This includes all NICs from the applied profiles as well as any
 	// additional NICs required to satisfy any subnets that were requested
 	// due to space constraints.
 	//
@@ -268,20 +268,26 @@ func (env *environ) getContainerSpec(
 	return cSpec, nil
 }
 
+func (env *environ) containerProfileNames() []string {
+	return []string{"default", env.profileName()}
+}
+
 func (env *environ) assignContainerNICs(ctx context.Context, instStartParams environs.StartInstanceParams) (map[string]map[string]string, error) {
-	// First, include any nics explicitly requested by the default profile.
-	assignedNICs, err := env.server().GetNICsFromProfile("default")
-	if err != nil {
-		return nil, errors.Trace(err)
+	// First, include any NICs explicitly requested by the applied profiles.
+	// Later profiles override earlier profiles, matching LXD profile
+	// precedence.
+	assignedNICs := make(map[string]map[string]string)
+	for _, profileName := range env.containerProfileNames() {
+		profileNICs, err := env.server().GetNICsFromProfile(profileName)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		maps.Copy(assignedNICs, profileNICs)
 	}
 
 	// No additional NICs required.
 	if len(instStartParams.SubnetsToZones) == 0 {
 		return assignedNICs, nil
-	}
-
-	if assignedNICs == nil {
-		assignedNICs = make(map[string]map[string]string)
 	}
 
 	// Map each requested subnet to the LXD network (host bridge) that hosts it.

--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -217,7 +217,7 @@ func (env *environ) getContainerSpec(
 	//
 	// If additional non-eth0 NICs are to be added, we need to ensure that
 	// cloud-init correctly configures them.
-	nics, err := env.assignContainerNICs(args)
+	nics, err := env.assignContainerNICs(ctx, args)
 	if err != nil {
 		return cSpec, errors.Trace(err)
 	}
@@ -268,7 +268,7 @@ func (env *environ) getContainerSpec(
 	return cSpec, nil
 }
 
-func (env *environ) assignContainerNICs(instStartParams environs.StartInstanceParams) (map[string]map[string]string, error) {
+func (env *environ) assignContainerNICs(ctx context.Context, instStartParams environs.StartInstanceParams) (map[string]map[string]string, error) {
 	// First, include any nics explicitly requested by the default profile.
 	assignedNICs, err := env.server().GetNICsFromProfile("default")
 	if err != nil {
@@ -282,6 +282,26 @@ func (env *environ) assignContainerNICs(instStartParams environs.StartInstancePa
 
 	if assignedNICs == nil {
 		assignedNICs = make(map[string]map[string]string)
+	}
+
+	// The subnet provider IDs reported by Subnets() are the subnet CIDRs;
+	// they no longer encode the host bridge name. To attach a NIC to the
+	// correct bridge we need to map each requested subnet back to the LXD
+	// network (host bridge) that hosts it, which is reported as the subnet's
+	// ProviderNetworkId.
+	requestedSubnetIDs := make([]corenetwork.Id, 0)
+	for _, subnetList := range instStartParams.SubnetsToZones {
+		for providerSubnetID := range subnetList {
+			requestedSubnetIDs = append(requestedSubnetIDs, providerSubnetID)
+		}
+	}
+	subnets, err := env.Subnets(ctx, requestedSubnetIDs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	subnetBridges := make(map[corenetwork.Id]string, len(subnets))
+	for _, subnet := range subnets {
+		subnetBridges[subnet.ProviderId] = string(subnet.ProviderNetworkId)
 	}
 
 	// We use two sets to de-dup the required NICs and ensure that each
@@ -299,24 +319,12 @@ func (env *environ) assignContainerNICs(instStartParams environs.StartInstancePa
 	var nextIndex int
 	for _, subnetList := range instStartParams.SubnetsToZones {
 		for providerSubnetID := range subnetList {
-			subnetID := string(providerSubnetID)
-
-			// Sanity check: make sure we are using the correct subnet
-			// naming conventions (subnet-$hostBridgeName-$CIDR).
-			if !strings.HasPrefix(subnetID, "subnet-") {
+			// Recover the host bridge for this subnet. Unknown subnets
+			// (e.g. ones no longer reported by the provider) are skipped.
+			hostBridge, ok := subnetBridges[providerSubnetID]
+			if !ok || hostBridge == "" {
 				continue
 			}
-
-			// Let's be paranoid here and assume that the bridge
-			// name may also contain dashes. So trim the "subnet-"
-			// prefix and anything from the right-most dash to
-			// recover the bridge name.
-			subnetID = strings.TrimPrefix(subnetID, "subnet-")
-			lastDashIndex := strings.LastIndexByte(subnetID, '-')
-			if lastDashIndex == -1 {
-				continue
-			}
-			hostBridge := subnetID[:lastDashIndex]
 
 			// We have already requested a device on this subnet
 			if requestedHostBridges.Contains(hostBridge) {

--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -284,11 +284,9 @@ func (env *environ) assignContainerNICs(ctx context.Context, instStartParams env
 		assignedNICs = make(map[string]map[string]string)
 	}
 
-	// The subnet provider IDs reported by Subnets() are the subnet CIDRs;
-	// they no longer encode the host bridge name. To attach a NIC to the
-	// correct bridge we need to map each requested subnet back to the LXD
-	// network (host bridge) that hosts it, which is reported as the subnet's
-	// ProviderNetworkId.
+	// Map each requested subnet to the LXD network (host bridge) that hosts it.
+	// The subnet's ProviderNetworkId identifies the bridge to attach for a
+	// subnet requested by space constraints.
 	requestedSubnetIDs := make([]corenetwork.Id, 0)
 	for _, subnetList := range instStartParams.SubnetsToZones {
 		for providerSubnetID := range subnetList {
@@ -326,7 +324,10 @@ func (env *environ) assignContainerNICs(ctx context.Context, instStartParams env
 				continue
 			}
 
-			// We have already requested a device on this subnet
+			// A profile or generated device already attaches the container to
+			// the bridge hosting this subnet. Profile NICs are included in
+			// assignedNICs above, so they can satisfy space subnet requirements
+			// without adding a duplicate device.
 			if requestedHostBridges.Contains(hostBridge) {
 				continue
 			}

--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -321,12 +321,16 @@ func (env *environ) assignContainerNICs(ctx context.Context, instStartParams env
 	// Assign any extra NICs required to satisfy the subnet requirements
 	// for this instance.
 	var nextIndex int
+	var unsatisfied []string
 	for _, subnetList := range instStartParams.SubnetsToZones {
 		for providerSubnetID := range subnetList {
-			// Recover the host bridge for this subnet. Unknown subnets
-			// (e.g. ones no longer reported by the provider) are skipped.
+			// Recover the host bridge that hosts this subnet. A subnet with
+			// no host bridge on this LXD host means we cannot provide the
+			// requested connectivity, so we must fail rather than hand back
+			// an under-connected container.
 			hostBridge, ok := subnetBridges[providerSubnetID]
 			if !ok || hostBridge == "" {
+				unsatisfied = append(unsatisfied, string(providerSubnetID))
 				continue
 			}
 
@@ -361,6 +365,12 @@ func (env *environ) assignContainerNICs(ctx context.Context, instStartParams env
 			requestedHostBridges.Add(hostBridge)
 			requestedNICNames.Add(devName)
 		}
+	}
+
+	if len(unsatisfied) > 0 {
+		return nil, errors.Errorf(
+			"cannot satisfy space requirements: no host bridge found for subnet(s) %q",
+			unsatisfied)
 	}
 
 	return assignedNICs, nil

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -294,11 +294,6 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *tc.C) {
 	startArgs := s.GetStartInstanceArgs(c)
 	startArgs.SubnetsToZones = []map[network.Id][]string{
 		{
-			// Unknown subnet, not reported by Subnets(); must be
-			// skipped without exploding.
-			"10.123.0.0/24": {"locutus"},
-		},
-		{
 			"10.42.0.0/24": {"locutus"}, // virbr0
 			"10.0.0.0/24":  {"locutus"}, // ovs-br0
 			// Should be ignored as an applied profile already
@@ -310,6 +305,58 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(res, tc.NotNil)
 	c.Assert(*res.Hardware.AvailabilityZone, tc.DeepEquals, "node01")
+}
+
+func (s *environBrokerSuite) TestStartInstanceUnsatisfiedSubnetReturnsError(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	svr := lxd.NewMockServer(ctrl)
+	invalidator := lxd.NewMockCredentialInvalidator(ctrl)
+
+	defaultNICs := map[string]map[string]string{
+		"eth0": {
+			"name":    "eth0",
+			"type":    "nic",
+			"hwaddr":  "00:00:00:00:00:01",
+			"nictype": "bridged",
+			"parent":  "lxdbr0",
+		},
+	}
+
+	exp := svr.EXPECT()
+	// The failure happens in assignContainerNICs, before the container is
+	// created, so no CreateContainerFromSpec call is expected.
+	gomock.InOrder(
+		exp.HostArch().Return(arch.AMD64),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
+		exp.GetNICsFromProfile("default").Return(defaultNICs, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
+	)
+
+	exp.IsClustered().Return(false)
+	exp.Name().Return("locutus")
+	exp.GetNetworkNames().Return([]string{"lxdbr0"}, nil)
+	exp.GetNetworkState("lxdbr0").Return(&api.NetworkState{
+		Type:      "broadcast",
+		State:     "up",
+		Bridge:    &api.NetworkStateBridge{},
+		Addresses: []api.NetworkStateAddress{{Family: "inet", Address: "10.99.0.1", Netmask: "24", Scope: "global"}},
+	}, nil)
+
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{}, invalidator)
+	startArgs := s.GetStartInstanceArgs(c)
+	startArgs.SubnetsToZones = []map[network.Id][]string{
+		{
+			// No discovered LXD network serves this subnet, so the
+			// requested connectivity cannot be satisfied.
+			"10.250.0.0/24": {"locutus"},
+		},
+	}
+	res, err := env.StartInstance(c.Context(), startArgs)
+	c.Check(err, tc.ErrorMatches, `.*cannot satisfy space requirements: no host bridge found for subnet\(s\).*10.250.0.0/24.*`)
+	c.Assert(res, tc.IsNil)
 }
 
 func (s *environBrokerSuite) TestStartInstanceWithModelProfileSubnetNIC(c *tc.C) {

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -260,24 +260,44 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *tc.C) {
 		exp.HostArch().Return(arch.AMD64),
 	)
 
+	// assignContainerNICs maps the requested subnet provider IDs (CIDRs)
+	// back to the LXD network (host bridge) hosting them via Subnets().
+	exp.IsClustered().Return(false)
+	exp.Name().Return("locutus")
+	exp.GetNetworkNames().Return([]string{"ovs-br0", "virbr0", "lxdbr0"}, nil)
+	exp.GetNetworkState("ovs-br0").Return(&api.NetworkState{
+		Type:      "broadcast",
+		State:     "up",
+		Bridge:    &api.NetworkStateBridge{},
+		Addresses: []api.NetworkStateAddress{{Family: "inet", Address: "10.0.0.1", Netmask: "24", Scope: "global"}},
+	}, nil)
+	exp.GetNetworkState("virbr0").Return(&api.NetworkState{
+		Type:      "broadcast",
+		State:     "up",
+		Bridge:    &api.NetworkStateBridge{},
+		Addresses: []api.NetworkStateAddress{{Family: "inet", Address: "10.42.0.1", Netmask: "24", Scope: "global"}},
+	}, nil)
+	exp.GetNetworkState("lxdbr0").Return(&api.NetworkState{
+		Type:      "broadcast",
+		State:     "up",
+		Bridge:    &api.NetworkStateBridge{},
+		Addresses: []api.NetworkStateAddress{{Family: "inet", Address: "10.99.0.1", Netmask: "24", Scope: "global"}},
+	}, nil)
+
 	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{}, invalidator)
 	startArgs := s.GetStartInstanceArgs(c)
 	startArgs.SubnetsToZones = []map[network.Id][]string{
-		// The following are bogus subnet names that shouldn't
-		// normally be reported by Subnets(). They are only
-		// here to ensure that assignContainerNICs does not
-		// explode if garbage gets passed in.
 		{
-			"bogus-bridge-10.0.0.0/24": {"locutus"},
-			"subnet-bridge":            {"locutus"},
+			// Unknown subnet, not reported by Subnets(); must be
+			// skipped without exploding.
+			"10.123.0.0/24": {"locutus"},
 		},
 		{
-			"subnet-virbr0-10.42.0.0/24": {"locutus"},
-			// Bridge name with dashes
-			"subnet-ovs-br0-10.0.0.0/24": {"locutus"},
+			"10.42.0.0/24": {"locutus"}, // virbr0
+			"10.0.0.0/24":  {"locutus"}, // ovs-br0
 			// Should be ignored as the default profile already
 			// specifies a device bridged to lxdbr0
-			"subnet-lxdbr0-10.99.0.0/24": {"locutus"},
+			"10.99.0.0/24": {"locutus"},
 		},
 	}
 	res, err := env.StartInstance(c.Context(), startArgs)

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/juju/juju/internal/provider/lxd"
 )
 
+const modelProfileName = "juju-model-2d02ee"
+
 type environBrokerSuite struct {
 	lxd.EnvironSuite
 
@@ -85,6 +87,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *tc.C) {
 		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
 			Instance: api.Instance{Location: "node01"},
 		}, nil),
@@ -119,6 +122,7 @@ func (s *environBrokerSuite) TestStartInstanceUseZoneFromServerNameWhenContainer
 		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
 			Instance: api.Instance{Location: "none"},
 		}, nil),
@@ -165,6 +169,7 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *tc.C) {
 		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
 			Instance: api.Instance{Location: "node01"},
 		}, nil),
@@ -254,6 +259,7 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *tc.C) {
 		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(profileNICs, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
 			Instance: api.Instance{Location: "node01"},
 		}, nil),
@@ -295,9 +301,157 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *tc.C) {
 		{
 			"10.42.0.0/24": {"locutus"}, // virbr0
 			"10.0.0.0/24":  {"locutus"}, // ovs-br0
-			// Should be ignored as the default profile already
-			// specifies a device bridged to lxdbr0
+			// Should be ignored as an applied profile already
+			// specifies a device bridged to lxdbr0.
 			"10.99.0.0/24": {"locutus"},
+		},
+	}
+	res, err := env.StartInstance(c.Context(), startArgs)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res, tc.NotNil)
+	c.Assert(*res.Hardware.AvailabilityZone, tc.DeepEquals, "node01")
+}
+
+func (s *environBrokerSuite) TestStartInstanceWithModelProfileSubnetNIC(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	svr := lxd.NewMockServer(ctrl)
+	invalidator := lxd.NewMockCredentialInvalidator(ctrl)
+
+	defaultNICs := map[string]map[string]string{
+		"eth0": {
+			"name":    "eth0",
+			"type":    "nic",
+			"hwaddr":  "00:00:00:00:00:01",
+			"nictype": "bridged",
+			"parent":  "lxdbr0",
+		},
+	}
+	modelNICs := map[string]map[string]string{
+		"eno9": {
+			"name":    "eno9",
+			"type":    "nic",
+			"hwaddr":  "00:00:00:00:00:02",
+			"nictype": "bridged",
+			"parent":  "virbr0",
+		},
+	}
+
+	check := func(spec containerlxd.ContainerSpec) bool {
+		c.Check(spec.Devices, tc.HasLen, 2)
+		c.Check(spec.Devices["eth0"], tc.DeepEquals, defaultNICs["eth0"])
+		c.Check(spec.Devices["eno9"], tc.DeepEquals, modelNICs["eno9"])
+		return spec.Config[containerlxd.NetworkConfigKey] == cloudinit.CloudInitNetworkConfigDisabled
+	}
+
+	exp := svr.EXPECT()
+	gomock.InOrder(
+		exp.HostArch().Return(arch.AMD64),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
+		exp.GetNICsFromProfile("default").Return(defaultNICs, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(modelNICs, nil),
+		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
+			Instance: api.Instance{Location: "node01"},
+		}, nil),
+		exp.HostArch().Return(arch.AMD64),
+	)
+
+	exp.IsClustered().Return(false)
+	exp.Name().Return("locutus")
+	exp.GetNetworkNames().Return([]string{"virbr0"}, nil)
+	exp.GetNetworkState("virbr0").Return(&api.NetworkState{
+		Type:      "broadcast",
+		State:     "up",
+		Bridge:    &api.NetworkStateBridge{},
+		Addresses: []api.NetworkStateAddress{{Family: "inet", Address: "10.42.0.1", Netmask: "24", Scope: "global"}},
+	}, nil)
+
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{}, invalidator)
+	startArgs := s.GetStartInstanceArgs(c)
+	startArgs.SubnetsToZones = []map[network.Id][]string{
+		{
+			"10.42.0.0/24": {"locutus"}, // virbr0
+		},
+	}
+	res, err := env.StartInstance(c.Context(), startArgs)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res, tc.NotNil)
+	c.Assert(*res.Hardware.AvailabilityZone, tc.DeepEquals, "node01")
+}
+
+func (s *environBrokerSuite) TestStartInstanceModelProfileNICOverridesDefaultProfile(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	svr := lxd.NewMockServer(ctrl)
+	invalidator := lxd.NewMockCredentialInvalidator(ctrl)
+
+	defaultNICs := map[string]map[string]string{
+		"eth0": {
+			"name":    "eth0",
+			"type":    "nic",
+			"hwaddr":  "00:00:00:00:00:01",
+			"nictype": "bridged",
+			"parent":  "lxdbr0",
+		},
+	}
+	modelNICs := map[string]map[string]string{
+		"eth0": {
+			"name":    "eth0",
+			"type":    "nic",
+			"hwaddr":  "00:00:00:00:00:02",
+			"nictype": "bridged",
+			"parent":  "virbr0",
+		},
+	}
+
+	check := func(spec containerlxd.ContainerSpec) bool {
+		c.Check(spec.Devices, tc.HasLen, 2)
+		c.Check(spec.Devices["eth0"], tc.DeepEquals, modelNICs["eth0"])
+
+		generatedNIC, ok := spec.Devices["eth1"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(generatedNIC["hwaddr"], tc.HasPrefix, "00:16:3e:")
+		delete(generatedNIC, "hwaddr")
+		c.Check(generatedNIC, tc.DeepEquals, map[string]string{
+			"name":    "eth1",
+			"type":    "nic",
+			"nictype": "bridged",
+			"parent":  "lxdbr0",
+		})
+		return spec.Config[containerlxd.NetworkConfigKey] == cloudinit.CloudInitNetworkConfigDisabled
+	}
+
+	exp := svr.EXPECT()
+	gomock.InOrder(
+		exp.HostArch().Return(arch.AMD64),
+		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
+		exp.ServerVersion().Return("3.10.0"),
+		exp.GetNICsFromProfile("default").Return(defaultNICs, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(modelNICs, nil),
+		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
+			Instance: api.Instance{Location: "node01"},
+		}, nil),
+		exp.HostArch().Return(arch.AMD64),
+	)
+
+	exp.IsClustered().Return(false)
+	exp.Name().Return("locutus")
+	exp.GetNetworkNames().Return([]string{"lxdbr0"}, nil)
+	exp.GetNetworkState("lxdbr0").Return(&api.NetworkState{
+		Type:      "broadcast",
+		State:     "up",
+		Bridge:    &api.NetworkStateBridge{},
+		Addresses: []api.NetworkStateAddress{{Family: "inet", Address: "10.99.0.1", Netmask: "24", Scope: "global"}},
+	}, nil)
+
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{}, invalidator)
+	startArgs := s.GetStartInstanceArgs(c)
+	startArgs.SubnetsToZones = []map[network.Id][]string{
+		{
+			"10.99.0.0/24": {"locutus"}, // lxdbr0
 		},
 	}
 	res, err := env.StartInstance(c.Context(), startArgs)
@@ -351,6 +505,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *tc.C) {
 		sExp.IsClustered().Return(true),
 		sExp.UseTargetServer(gomock.Any(), "node01").Return(jujuTarget, nil),
 		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
+		sExp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
 		sExp.HostArch().Return(arch.AMD64),
 	)
 
@@ -491,6 +646,7 @@ func (s *environBrokerSuite) TestStartInstanceWithZoneConstraintsAvailable(c *tc
 		sExp.IsClustered().Return(true),
 		sExp.UseTargetServer(gomock.Any(), "node01").Return(jujuTarget, nil),
 		sExp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
+		sExp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
 		sExp.HostArch().Return(arch.AMD64),
 	)
 
@@ -590,6 +746,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *tc.C) {
 		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
 			Instance: api.Instance{Location: "node01"},
 		}, nil),
@@ -654,6 +811,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndCustomNICs(c *tc
 		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(nics, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
 			Instance: api.Instance{Location: "node01"},
 		}, nil),
@@ -699,6 +857,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndVirtType(c *tc.C
 	exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeVM, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil)
 	exp.ServerVersion().Return("3.10.0")
 	exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil)
+	exp.GetNICsFromProfile(modelProfileName).Return(nil, nil)
 	exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
 		Instance: api.Instance{Location: "node01"},
 	}, nil)
@@ -739,7 +898,7 @@ func (s *environBrokerSuite) TestStartInstanceWithDefaultProfiles(c *tc.C) {
 		if profiles[0] != "default" {
 			return false
 		}
-		if profiles[1] != "juju-model-2d02ee" {
+		if profiles[1] != modelProfileName {
 			return false
 		}
 		return true
@@ -759,6 +918,7 @@ func (s *environBrokerSuite) TestStartInstanceWithDefaultProfiles(c *tc.C) {
 		).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
 		exp.CreateContainerFromSpec(matchesContainerSpec(check)).Return(&containerlxd.Container{
 			Instance: api.Instance{Location: "node01"},
 		}, nil),
@@ -800,6 +960,7 @@ func (s *environBrokerSuite) TestStartInstanceInvalidCredentials(c *tc.C) {
 		exp.FindImage(gomock.Any(), corebase.MakeDefaultBase("ubuntu", "24.04"), arch.AMD64, instance.InstanceTypeContainer, gomock.Any(), true, gomock.Any()).Return(containerlxd.SourcedImage{}, nil),
 		exp.ServerVersion().Return("3.10.0"),
 		exp.GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
+		exp.GetNICsFromProfile(modelProfileName).Return(nil, nil),
 		exp.CreateContainerFromSpec(gomock.Any()).Return(&containerlxd.Container{}, fmt.Errorf("not authorized")),
 	)
 


### PR DESCRIPTION
Commit f588961dfc intentionally stopped encoding the host bridge name inside the subnet ProviderId (it
  was a contrived, sometimes-wrong value) and made the `ProviderId` just the subnet CIDR, moving the bridge
  name to its proper field, ProviderNetworkId. The part it omitted: the LXD broker still recovered the
  bridge by string-parsing the old subnet-<bridge>-<cidr> format, so it never read the bridge from its new
  location.

  This silently broke container provisioning for spaces:

  1. Subnets() now reports the subnet with ProviderId = "10.170.80.0/24".
  2. The provisioner builds the network topology and hands the broker SubnetsToZones whose keys are those
  ProviderIds — i.e. "10.170.80.0/24".
  3. The broker runs its first gate:
  if !strings.HasPrefix(subnetID, "subnet-") { continue }
  3. "10.170.80.0/24" does not start with "subnet-", so the subnet is silently skipped.
  4. This happens for every space subnet. No extra NICs are ever added.
  5. The container boots with only its default-profile eth0 → a single IP, exactly as the reporter
  observed.

  With only one IP, the binding validation (validateUnitsInSpaces) correctly reports the unit isn't in the
  target space, and the rebind fails.

  The fix is in the broker, which now resolves each requested subnet to its host bridge by looking it up from 
  the provider's `ProviderNetworkId` (via `Subnets()`), instead of parsing the bridge out of the subnet ID. This 
  treats the `ProviderId` as opaque, removes the fragile string-format coupling, and keeps the cleaner data model
  introduced by f588961dfc. Containers once again receive a NIC per space subnet, so endpoint binding
  updates work as they did in 3.6.


## QA steps
Steps taken from https://github.com/juju/juju/issues/22233:

```
lxc network create public-br ipv4.address=10.170.80.1/24 ipv4.nat=true ipv6.address=none ipv6.nat=false
lxc network create management-br ipv4.address=10.150.40.1/24 ipv4.nat=true ipv6.address=none ipv6.nat=false
```
Then we deploy an app with binding:
```
juju add-model tf-test-application-bindings-update
juju add-space public 10.170.80.0/24
juju add-space  management 10.150.40.0/24
juju deploy ubuntu-lite test-app-update --revision 2 --channel stable --constraints "arch=amd64 spaces=management,public" --bind "management"
```
Once the machine becomes active, we should see that the lxd container has now 3 NICs (without this fix it would only have one):
```
lxc info juju-b576ee-0
Name: juju-b576ee-0
Status: RUNNING
Type: container
Architecture: x86_64
PID: 309086
Created: 2026/06/23 14:57 CEST
Last Used: 2026/06/23 14:58 CEST

Resources:
  Processes: 78
  Disk usage:
    root: 0B
  Disk total:
    root: 0B
  CPU usage:
    CPU usage (in seconds): 36
  Memory usage:
    Memory (current): 1.17GiB
  Network usage:
    eth0:
      Type: broadcast
      State: UP
      Host interface: vethe35c1f22
      MAC address: 00:16:3e:b6:05:21
      MTU: 1500
      Bytes received: 192.66MB
      Bytes sent: 1.46MB
      Packets received: 51751
      Packets sent: 18077
      IP addresses:
        inet:  10.134.1.139/24 (global)
        inet6: fe80::216:3eff:feb6:521/64 (link)
    eth1:
      Type: broadcast
      State: UP
      Host interface: veth225aedc9
      MAC address: 00:16:3e:9d:89:c0
      MTU: 1500
      Bytes received: 13.33kB
      Bytes sent: 5.43kB
      Packets received: 79
      Packets sent: 58
      IP addresses:
        inet:  10.150.40.125/24 (global)
        inet6: fe80::216:3eff:fe9d:89c0/64 (link)
    eth2:
      Type: broadcast
      State: UP
      Host interface: veth59a6d392
      MAC address: 00:16:3e:12:5e:8b
      MTU: 1500
      Bytes received: 13.84kB
      Bytes sent: 5.72kB
      Packets received: 82
      Packets sent: 61
      IP addresses:
        inet:  10.170.80.107/24 (global)
        inet6: fe80::216:3eff:fe12:5e8b/64 (link)
    lo:
      Type: loopback
      State: UP
      MTU: 65536
      Bytes received: 7.23kB
      Bytes sent: 7.23kB
      Packets received: 62
      Packets sent: 62
      IP addresses:
        inet:  127.0.0.1/8 (local)
        inet6: ::1/128 (local)
```
and we can therefore do:
```
juju bind test-app-update public
```
which will not fail.
Check the app's bindings:
```
juju show-application test-app-update

test-app-update:
  charm: ubuntu-lite
  base: ubuntu@24.04
  channel: latest/stable
  constraints:
    arch: amd64
    spaces:
    - management
    - public
  principal: true
  exposed: false
  remote: false
  life: alive
  endpoint-bindings:
    "": public
    juju-info: public
    ubuntu: public
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22233.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9669](https://warthogs.atlassian.net/browse/JUJU-9669)


[JUJU-9669]: https://warthogs.atlassian.net/browse/JUJU-9669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ