### PR TITLE
fix: handle race with two simultaneous writers

### DIFF
--- a/domain/ssh/service/model/service.go
+++ b/domain/ssh/service/model/service.go
@@ -123,6 +123,16 @@ func (s *Service) ensureMachineVirtualHostKey(ctx context.Context, machineName s
 		return "", errors.Errorf("generating machine virtual SSH host key for %q: %w", machineName, err)
 	}
 	if err := s.state.SetMachineVirtualHostKeyByMachineName(ctx, machineName, domainssh.SSHKeyAlgorithmTypeED25519ID, key); err != nil {
+		if errors.Is(err, coreerrors.AlreadyExists) {
+			key, found, getErr := s.state.GetMachineVirtualHostKeyByMachineName(ctx, machineName)
+			if getErr != nil {
+				return "", errors.Errorf("getting machine virtual SSH host key for %q after concurrent insert: %w", machineName, getErr)
+			}
+			if !found {
+				return "", errors.Errorf("machine virtual SSH host key for %q not found after concurrent insert", machineName)
+			}
+			return key, nil
+		}
 		return "", errors.Errorf("persisting machine virtual SSH host key for %q: %w", machineName, err)
 	}
 	return key, nil
@@ -142,6 +152,16 @@ func (s *Service) ensureUnitVirtualHostKey(ctx context.Context, unitName string)
 		return "", errors.Errorf("generating unit virtual SSH host key for %q: %w", unitName, err)
 	}
 	if err := s.state.SetUnitVirtualHostKeyByUnitName(ctx, unitName, domainssh.SSHKeyAlgorithmTypeED25519ID, key); err != nil {
+		if errors.Is(err, coreerrors.AlreadyExists) {
+			key, found, getErr := s.state.GetUnitVirtualHostKeyByUnitName(ctx, unitName)
+			if getErr != nil {
+				return "", errors.Errorf("getting unit virtual SSH host key for %q after concurrent insert: %w", unitName, getErr)
+			}
+			if !found {
+				return "", errors.Errorf("unit virtual SSH host key for %q not found after concurrent insert", unitName)
+			}
+			return key, nil
+		}
 		return "", errors.Errorf("persisting unit virtual SSH host key for %q: %w", unitName, err)
 	}
 	return key, nil

--- a/domain/ssh/service/model/service.go
+++ b/domain/ssh/service/model/service.go
@@ -110,6 +110,7 @@ func (s *Service) UnitVirtualHostKey(ctx context.Context, unitName coreunit.Name
 }
 
 func (s *Service) ensureMachineVirtualHostKey(ctx context.Context, machineName string) (string, error) {
+	// Fast path: check if the machine virtual host key already exists in state.
 	key, found, err := s.state.GetMachineVirtualHostKeyByMachineName(ctx, machineName)
 	if err != nil {
 		return "", errors.Errorf("getting machine virtual SSH host key for %q: %w", machineName, err)
@@ -118,6 +119,8 @@ func (s *Service) ensureMachineVirtualHostKey(ctx context.Context, machineName s
 		return key, nil
 	}
 
+	// Slow path: generate a new machine virtual host key and persist it in state.
+	// The state method handles cases of concurrent requests for the same machine.
 	key, err = generateHostKey()
 	if err != nil {
 		return "", errors.Errorf("generating machine virtual SSH host key for %q: %w", machineName, err)
@@ -135,6 +138,7 @@ func (s *Service) ensureMachineVirtualHostKey(ctx context.Context, machineName s
 }
 
 func (s *Service) ensureUnitVirtualHostKey(ctx context.Context, unitName string) (string, error) {
+	// Fast path: check if the unit virtual host key already exists in state.
 	key, found, err := s.state.GetUnitVirtualHostKeyByUnitName(ctx, unitName)
 	if err != nil {
 		return "", errors.Errorf("getting unit virtual SSH host key for %q: %w", unitName, err)
@@ -143,6 +147,8 @@ func (s *Service) ensureUnitVirtualHostKey(ctx context.Context, unitName string)
 		return key, nil
 	}
 
+	// Slow path: generate a new unit virtual host key and persist it in state.
+	// The state method handles cases of concurrent requests for the same unit.
 	key, err = generateHostKey()
 	if err != nil {
 		return "", errors.Errorf("generating unit virtual SSH host key for %q: %w", unitName, err)

--- a/domain/ssh/service/model/service.go
+++ b/domain/ssh/service/model/service.go
@@ -122,18 +122,14 @@ func (s *Service) ensureMachineVirtualHostKey(ctx context.Context, machineName s
 	if err != nil {
 		return "", errors.Errorf("generating machine virtual SSH host key for %q: %w", machineName, err)
 	}
-	if err := s.state.SetMachineVirtualHostKeyByMachineName(ctx, machineName, domainssh.SSHKeyAlgorithmTypeED25519ID, key); err != nil {
-		if errors.Is(err, coreerrors.AlreadyExists) {
-			key, found, getErr := s.state.GetMachineVirtualHostKeyByMachineName(ctx, machineName)
-			if getErr != nil {
-				return "", errors.Errorf("getting machine virtual SSH host key for %q after concurrent insert: %w", machineName, getErr)
-			}
-			if !found {
-				return "", errors.Errorf("machine virtual SSH host key for %q not found after concurrent insert", machineName)
-			}
-			return key, nil
-		}
-		return "", errors.Errorf("persisting machine virtual SSH host key for %q: %w", machineName, err)
+	key, err = s.state.EnsureMachineVirtualHostKeyByMachineName(
+		ctx,
+		machineName,
+		domainssh.SSHKeyAlgorithmTypeED25519ID,
+		key,
+	)
+	if err != nil {
+		return "", errors.Errorf("ensuring machine virtual SSH host key for %q: %w", machineName, err)
 	}
 	return key, nil
 }
@@ -151,18 +147,14 @@ func (s *Service) ensureUnitVirtualHostKey(ctx context.Context, unitName string)
 	if err != nil {
 		return "", errors.Errorf("generating unit virtual SSH host key for %q: %w", unitName, err)
 	}
-	if err := s.state.SetUnitVirtualHostKeyByUnitName(ctx, unitName, domainssh.SSHKeyAlgorithmTypeED25519ID, key); err != nil {
-		if errors.Is(err, coreerrors.AlreadyExists) {
-			key, found, getErr := s.state.GetUnitVirtualHostKeyByUnitName(ctx, unitName)
-			if getErr != nil {
-				return "", errors.Errorf("getting unit virtual SSH host key for %q after concurrent insert: %w", unitName, getErr)
-			}
-			if !found {
-				return "", errors.Errorf("unit virtual SSH host key for %q not found after concurrent insert", unitName)
-			}
-			return key, nil
-		}
-		return "", errors.Errorf("persisting unit virtual SSH host key for %q: %w", unitName, err)
+	key, err = s.state.EnsureUnitVirtualHostKeyByUnitName(
+		ctx,
+		unitName,
+		domainssh.SSHKeyAlgorithmTypeED25519ID,
+		key,
+	)
+	if err != nil {
+		return "", errors.Errorf("ensuring unit virtual SSH host key for %q: %w", unitName, err)
 	}
 	return key, nil
 }

--- a/domain/ssh/service/model/service_test.go
+++ b/domain/ssh/service/model/service_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/tc"
 	gossh "golang.org/x/crypto/ssh"
 
-	coreerrors "github.com/juju/juju/core/errors"
 	coremachine "github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	coreunit "github.com/juju/juju/core/unit"
@@ -34,7 +33,7 @@ func (s *serviceSuite) TestMachineVirtualHostKeyGeneratesMissing(c *tc.C) {
 
 	key, err := svc.MachineVirtualHostKey(c.Context(), coremachine.Name("1"))
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(state.machineSetCalls, tc.Equals, 1)
+	c.Check(state.machineEnsureCalls, tc.Equals, 1)
 	c.Check(state.machineKeys["1"], tc.Equals, key)
 	assertPrivateKey(c, key)
 }
@@ -51,8 +50,8 @@ func (s *serviceSuite) TestUnitVirtualHostKeyUsesBackingMachine(c *tc.C) {
 	key, err := svc.UnitVirtualHostKey(c.Context(), coreunit.Name("postgresql/0"))
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(key, tc.Equals, testPrivateKey)
-	c.Check(state.unitSetCalls, tc.Equals, 0)
-	c.Check(state.machineSetCalls, tc.Equals, 0)
+	c.Check(state.unitEnsureCalls, tc.Equals, 0)
+	c.Check(state.machineEnsureCalls, tc.Equals, 0)
 }
 
 func (s *serviceSuite) TestUnitVirtualHostKeyGeneratesMissingForCAAS(c *tc.C) {
@@ -64,7 +63,7 @@ func (s *serviceSuite) TestUnitVirtualHostKeyGeneratesMissingForCAAS(c *tc.C) {
 
 	key, err := svc.UnitVirtualHostKey(c.Context(), coreunit.Name("postgresql/0"))
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(state.unitSetCalls, tc.Equals, 1)
+	c.Check(state.unitEnsureCalls, tc.Equals, 1)
 	c.Check(state.unitKeys["postgresql/0"], tc.Equals, key)
 	assertPrivateKey(c, key)
 }
@@ -73,14 +72,14 @@ func (s *serviceSuite) TestMachineVirtualHostKeyReturnsExistingAfterConcurrentIn
 	modelUUID := coremodel.UUID(testModelUUID)
 	state := newStubModelState()
 	state.machineExists["1"] = true
-	state.machineSetAlreadyExists["1"] = testPrivateKey
+	state.machineEnsureKeys["1"] = testPrivateKey
 
 	svc := modelsshservice.NewService(modelUUID, state)
 
 	key, err := svc.MachineVirtualHostKey(c.Context(), coremachine.Name("1"))
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(key, tc.Equals, testPrivateKey)
-	c.Check(state.machineSetCalls, tc.Equals, 1)
+	c.Check(state.machineEnsureCalls, tc.Equals, 1)
 	c.Check(state.machineKeys["1"], tc.Equals, testPrivateKey)
 }
 
@@ -88,14 +87,14 @@ func (s *serviceSuite) TestUnitVirtualHostKeyReturnsExistingAfterConcurrentInser
 	modelUUID := coremodel.UUID(testModelUUID)
 	state := newStubModelState()
 	state.unitExists["postgresql/0"] = true
-	state.unitSetAlreadyExists["postgresql/0"] = testPrivateKey
+	state.unitEnsureKeys["postgresql/0"] = testPrivateKey
 
 	svc := modelsshservice.NewService(modelUUID, state)
 
 	key, err := svc.UnitVirtualHostKey(c.Context(), coreunit.Name("postgresql/0"))
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(key, tc.Equals, testPrivateKey)
-	c.Check(state.unitSetCalls, tc.Equals, 1)
+	c.Check(state.unitEnsureCalls, tc.Equals, 1)
 	c.Check(state.unitKeys["postgresql/0"], tc.Equals, testPrivateKey)
 }
 
@@ -138,30 +137,30 @@ func (s *serviceSuite) TestVirtualHostKeyErrorsForNestedMachine(c *tc.C) {
 }
 
 type stubModelState struct {
-	machineExists           map[string]bool
-	machineKeys             map[string]string
-	machineAlgos            map[string]int
-	machineSetAlreadyExists map[string]string
-	unitExists              map[string]bool
-	unitKeys                map[string]string
-	unitAlgos               map[string]int
-	unitSetAlreadyExists    map[string]string
-	unitMachines            map[string]string
-	machineSetCalls         int
-	unitSetCalls            int
+	machineExists      map[string]bool
+	machineKeys        map[string]string
+	machineAlgos       map[string]int
+	unitExists         map[string]bool
+	unitKeys           map[string]string
+	unitAlgos          map[string]int
+	unitMachines       map[string]string
+	machineEnsureKeys  map[string]string
+	unitEnsureKeys     map[string]string
+	machineEnsureCalls int
+	unitEnsureCalls    int
 }
 
 func newStubModelState() *stubModelState {
 	return &stubModelState{
-		machineExists:           make(map[string]bool),
-		machineKeys:             make(map[string]string),
-		machineAlgos:            make(map[string]int),
-		machineSetAlreadyExists: make(map[string]string),
-		unitExists:              make(map[string]bool),
-		unitKeys:                make(map[string]string),
-		unitAlgos:               make(map[string]int),
-		unitSetAlreadyExists:    make(map[string]string),
-		unitMachines:            make(map[string]string),
+		machineExists:     make(map[string]bool),
+		machineKeys:       make(map[string]string),
+		machineAlgos:      make(map[string]int),
+		unitExists:        make(map[string]bool),
+		unitKeys:          make(map[string]string),
+		unitAlgos:         make(map[string]int),
+		unitMachines:      make(map[string]string),
+		machineEnsureKeys: make(map[string]string),
+		unitEnsureKeys:    make(map[string]string),
 	}
 }
 
@@ -173,20 +172,20 @@ func (s *stubModelState) GetMachineVirtualHostKeyByMachineName(_ context.Context
 	return key, found, nil
 }
 
-func (s *stubModelState) SetMachineVirtualHostKeyByMachineName(_ context.Context, machineName string, algorithmTypeID int, key string) error {
+func (s *stubModelState) EnsureMachineVirtualHostKeyByMachineName(_ context.Context, machineName string, algorithmTypeID int, key string) (string, error) {
 	if !s.machineExists[machineName] {
-		return errors.Errorf("machine %q not found", machineName)
+		return "", errors.Errorf("machine %q not found", machineName)
 	}
-	if existingKey, ok := s.machineSetAlreadyExists[machineName]; ok {
+	if existingKey, ok := s.machineEnsureKeys[machineName]; ok {
 		s.machineKeys[machineName] = existingKey
-		s.machineSetCalls++
-		delete(s.machineSetAlreadyExists, machineName)
-		return errors.Errorf("machine virtual SSH host key for %q already exists", machineName).Add(coreerrors.AlreadyExists)
+		s.machineEnsureCalls++
+		delete(s.machineEnsureKeys, machineName)
+		return existingKey, nil
 	}
 	s.machineKeys[machineName] = key
 	s.machineAlgos[machineName] = algorithmTypeID
-	s.machineSetCalls++
-	return nil
+	s.machineEnsureCalls++
+	return key, nil
 }
 
 func (s *stubModelState) GetUnitVirtualHostKeyByUnitName(_ context.Context, unitName string) (string, bool, error) {
@@ -197,20 +196,20 @@ func (s *stubModelState) GetUnitVirtualHostKeyByUnitName(_ context.Context, unit
 	return key, found, nil
 }
 
-func (s *stubModelState) SetUnitVirtualHostKeyByUnitName(_ context.Context, unitName string, algorithmTypeID int, key string) error {
+func (s *stubModelState) EnsureUnitVirtualHostKeyByUnitName(_ context.Context, unitName string, algorithmTypeID int, key string) (string, error) {
 	if !s.unitExists[unitName] {
-		return errors.Errorf("unit %q not found", unitName)
+		return "", errors.Errorf("unit %q not found", unitName)
 	}
-	if existingKey, ok := s.unitSetAlreadyExists[unitName]; ok {
+	if existingKey, ok := s.unitEnsureKeys[unitName]; ok {
 		s.unitKeys[unitName] = existingKey
-		s.unitSetCalls++
-		delete(s.unitSetAlreadyExists, unitName)
-		return errors.Errorf("unit virtual SSH host key for %q already exists", unitName).Add(coreerrors.AlreadyExists)
+		s.unitEnsureCalls++
+		delete(s.unitEnsureKeys, unitName)
+		return existingKey, nil
 	}
 	s.unitKeys[unitName] = key
 	s.unitAlgos[unitName] = algorithmTypeID
-	s.unitSetCalls++
-	return nil
+	s.unitEnsureCalls++
+	return key, nil
 }
 
 func (s *stubModelState) GetMachineNameForUnit(_ context.Context, unitName string) (string, bool, error) {

--- a/domain/ssh/service/model/service_test.go
+++ b/domain/ssh/service/model/service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/tc"
 	gossh "golang.org/x/crypto/ssh"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	coremachine "github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	coreunit "github.com/juju/juju/core/unit"
@@ -68,6 +69,36 @@ func (s *serviceSuite) TestUnitVirtualHostKeyGeneratesMissingForCAAS(c *tc.C) {
 	assertPrivateKey(c, key)
 }
 
+func (s *serviceSuite) TestMachineVirtualHostKeyReturnsExistingAfterConcurrentInsert(c *tc.C) {
+	modelUUID := coremodel.UUID(testModelUUID)
+	state := newStubModelState()
+	state.machineExists["1"] = true
+	state.machineSetAlreadyExists["1"] = testPrivateKey
+
+	svc := modelsshservice.NewService(modelUUID, state)
+
+	key, err := svc.MachineVirtualHostKey(c.Context(), coremachine.Name("1"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(key, tc.Equals, testPrivateKey)
+	c.Check(state.machineSetCalls, tc.Equals, 1)
+	c.Check(state.machineKeys["1"], tc.Equals, testPrivateKey)
+}
+
+func (s *serviceSuite) TestUnitVirtualHostKeyReturnsExistingAfterConcurrentInsert(c *tc.C) {
+	modelUUID := coremodel.UUID(testModelUUID)
+	state := newStubModelState()
+	state.unitExists["postgresql/0"] = true
+	state.unitSetAlreadyExists["postgresql/0"] = testPrivateKey
+
+	svc := modelsshservice.NewService(modelUUID, state)
+
+	key, err := svc.UnitVirtualHostKey(c.Context(), coreunit.Name("postgresql/0"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(key, tc.Equals, testPrivateKey)
+	c.Check(state.unitSetCalls, tc.Equals, 1)
+	c.Check(state.unitKeys["postgresql/0"], tc.Equals, testPrivateKey)
+}
+
 func (s *serviceSuite) TestVirtualHostKeyFromMachineInfo(c *tc.C) {
 	modelUUID := coremodel.UUID(testModelUUID)
 	state := newStubModelState()
@@ -107,26 +138,30 @@ func (s *serviceSuite) TestVirtualHostKeyErrorsForNestedMachine(c *tc.C) {
 }
 
 type stubModelState struct {
-	machineExists   map[string]bool
-	machineKeys     map[string]string
-	machineAlgos    map[string]int
-	unitExists      map[string]bool
-	unitKeys        map[string]string
-	unitAlgos       map[string]int
-	unitMachines    map[string]string
-	machineSetCalls int
-	unitSetCalls    int
+	machineExists           map[string]bool
+	machineKeys             map[string]string
+	machineAlgos            map[string]int
+	machineSetAlreadyExists map[string]string
+	unitExists              map[string]bool
+	unitKeys                map[string]string
+	unitAlgos               map[string]int
+	unitSetAlreadyExists    map[string]string
+	unitMachines            map[string]string
+	machineSetCalls         int
+	unitSetCalls            int
 }
 
 func newStubModelState() *stubModelState {
 	return &stubModelState{
-		machineExists: make(map[string]bool),
-		machineKeys:   make(map[string]string),
-		machineAlgos:  make(map[string]int),
-		unitExists:    make(map[string]bool),
-		unitKeys:      make(map[string]string),
-		unitAlgos:     make(map[string]int),
-		unitMachines:  make(map[string]string),
+		machineExists:           make(map[string]bool),
+		machineKeys:             make(map[string]string),
+		machineAlgos:            make(map[string]int),
+		machineSetAlreadyExists: make(map[string]string),
+		unitExists:              make(map[string]bool),
+		unitKeys:                make(map[string]string),
+		unitAlgos:               make(map[string]int),
+		unitSetAlreadyExists:    make(map[string]string),
+		unitMachines:            make(map[string]string),
 	}
 }
 
@@ -141,6 +176,12 @@ func (s *stubModelState) GetMachineVirtualHostKeyByMachineName(_ context.Context
 func (s *stubModelState) SetMachineVirtualHostKeyByMachineName(_ context.Context, machineName string, algorithmTypeID int, key string) error {
 	if !s.machineExists[machineName] {
 		return errors.Errorf("machine %q not found", machineName)
+	}
+	if existingKey, ok := s.machineSetAlreadyExists[machineName]; ok {
+		s.machineKeys[machineName] = existingKey
+		s.machineSetCalls++
+		delete(s.machineSetAlreadyExists, machineName)
+		return errors.Errorf("machine virtual SSH host key for %q already exists", machineName).Add(coreerrors.AlreadyExists)
 	}
 	s.machineKeys[machineName] = key
 	s.machineAlgos[machineName] = algorithmTypeID
@@ -159,6 +200,12 @@ func (s *stubModelState) GetUnitVirtualHostKeyByUnitName(_ context.Context, unit
 func (s *stubModelState) SetUnitVirtualHostKeyByUnitName(_ context.Context, unitName string, algorithmTypeID int, key string) error {
 	if !s.unitExists[unitName] {
 		return errors.Errorf("unit %q not found", unitName)
+	}
+	if existingKey, ok := s.unitSetAlreadyExists[unitName]; ok {
+		s.unitKeys[unitName] = existingKey
+		s.unitSetCalls++
+		delete(s.unitSetAlreadyExists, unitName)
+		return errors.Errorf("unit virtual SSH host key for %q already exists", unitName).Add(coreerrors.AlreadyExists)
 	}
 	s.unitKeys[unitName] = key
 	s.unitAlgos[unitName] = algorithmTypeID

--- a/domain/ssh/service/model/state.go
+++ b/domain/ssh/service/model/state.go
@@ -11,15 +11,17 @@ type State interface {
 	// The boolean indicates whether a key row exists.
 	GetMachineVirtualHostKeyByMachineName(context.Context, string) (string, bool, error)
 
-	// SetMachineVirtualHostKeyByMachineName persists the machine virtual host key.
-	SetMachineVirtualHostKeyByMachineName(context.Context, string, int, string) error
+	// EnsureMachineVirtualHostKeyByMachineName persists the machine virtual host
+	// key when missing, otherwise returns the existing persisted key.
+	EnsureMachineVirtualHostKeyByMachineName(context.Context, string, int, string) (string, error)
 
 	// GetUnitVirtualHostKeyByUnitName returns the unit virtual host key.
 	// The boolean indicates whether a key row exists.
 	GetUnitVirtualHostKeyByUnitName(context.Context, string) (string, bool, error)
 
-	// SetUnitVirtualHostKeyByUnitName persists the unit virtual host key.
-	SetUnitVirtualHostKeyByUnitName(context.Context, string, int, string) error
+	// EnsureUnitVirtualHostKeyByUnitName persists the unit virtual host key when
+	// missing, otherwise returns the existing persisted key.
+	EnsureUnitVirtualHostKeyByUnitName(context.Context, string, int, string) (string, error)
 
 	// GetMachineNameForUnit returns the machine name for an IAAS unit.
 	// The boolean indicates whether the unit is machine backed.

--- a/domain/ssh/state/model/state.go
+++ b/domain/ssh/state/model/state.go
@@ -119,10 +119,10 @@ WHERE machine_uuid = $entityUUID.uuid`, sshPrivateKey{}, entityUUID{})
 		return "", errors.Capture(err)
 	}
 
-	var key sshPrivateKey
+	actualKey := sshKey
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		machineUUID := entityUUID{}
-		key = sshPrivateKey{}
+		txKey := sshPrivateKey{}
 		err := tx.Query(ctx, getMachineUUIDStmt, nameRec).Get(&machineUUID)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf("machine %q %w", machineName, machineerrors.MachineNotFound)
@@ -134,24 +134,24 @@ WHERE machine_uuid = $entityUUID.uuid`, sshPrivateKey{}, entityUUID{})
 		record := machineVirtualSSHHostKey{MachineUUID: machineUUID.UUID, AlgorithmTypeID: algorithmTypeID, SSHKey: sshKey}
 		err = tx.Query(ctx, insertStmt, record).Run()
 		if internaldatabase.IsErrConstraintPrimaryKey(err) || internaldatabase.IsErrConstraintUnique(err) {
-			err = tx.Query(ctx, getKeyStmt, machineUUID).Get(&key)
+			err = tx.Query(ctx, getKeyStmt, machineUUID).Get(&txKey)
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return errors.Errorf("machine virtual SSH host key for %q not found after concurrent insert", machineName)
 			}
 			if err != nil {
 				return errors.Errorf("querying machine virtual SSH host key for %q after concurrent insert: %w", machineName, err)
 			}
+			actualKey = txKey.SSHKey
 			return nil
 		} else if err != nil {
 			return errors.Errorf("persisting machine virtual SSH host key for %q: %w", machineName, err)
 		}
-		key = sshPrivateKey{SSHKey: sshKey}
 		return nil
 	})
 	if err != nil {
 		return "", errors.Capture(err)
 	}
-	return key.SSHKey, nil
+	return actualKey, nil
 }
 
 // GetUnitVirtualHostKeyByUnitName returns the virtual host key stored for the
@@ -247,10 +247,10 @@ WHERE unit_uuid = $entityUUID.uuid`, sshPrivateKey{}, entityUUID{})
 		return "", errors.Capture(err)
 	}
 
-	var key sshPrivateKey
+	actualKey := sshKey
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		unitUUID := entityUUID{}
-		key = sshPrivateKey{}
+		txKey := sshPrivateKey{}
 		err := tx.Query(ctx, getUnitUUIDStmt, nameRec).Get(&unitUUID)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf("unit %q %w", unitName, applicationerrors.UnitNotFound)
@@ -262,24 +262,24 @@ WHERE unit_uuid = $entityUUID.uuid`, sshPrivateKey{}, entityUUID{})
 		record := unitVirtualSSHHostKey{UnitUUID: unitUUID.UUID, AlgorithmTypeID: algorithmTypeID, SSHKey: sshKey}
 		err = tx.Query(ctx, insertStmt, record).Run()
 		if internaldatabase.IsErrConstraintPrimaryKey(err) || internaldatabase.IsErrConstraintUnique(err) {
-			err = tx.Query(ctx, getKeyStmt, unitUUID).Get(&key)
+			err = tx.Query(ctx, getKeyStmt, unitUUID).Get(&txKey)
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return errors.Errorf("unit virtual SSH host key for %q not found after concurrent insert", unitName)
 			}
 			if err != nil {
 				return errors.Errorf("querying unit virtual SSH host key for %q after concurrent insert: %w", unitName, err)
 			}
+			actualKey = txKey.SSHKey
 			return nil
 		} else if err != nil {
 			return errors.Errorf("persisting unit virtual SSH host key for %q: %w", unitName, err)
 		}
-		key = sshPrivateKey{SSHKey: sshKey}
 		return nil
 	})
 	if err != nil {
 		return "", errors.Capture(err)
 	}
-	return key.SSHKey, nil
+	return actualKey, nil
 }
 
 // GetMachineNameForUnit returns the backing machine for a unit when one exists.

--- a/domain/ssh/state/model/state.go
+++ b/domain/ssh/state/model/state.go
@@ -9,7 +9,6 @@ import (
 	"github.com/canonical/sqlair"
 
 	"github.com/juju/juju/core/database"
-	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/domain"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
@@ -85,12 +84,17 @@ WHERE machine_uuid = $entityUUID.uuid`, sshPrivateKey{}, entityUUID{})
 	return key.SSHKey, found, nil
 }
 
-// SetMachineVirtualHostKeyByMachineName persists the virtual host key for the
-// named machine.
-func (st *State) SetMachineVirtualHostKeyByMachineName(ctx context.Context, machineName string, algorithmTypeID int, sshKey string) error {
+// EnsureMachineVirtualHostKeyByMachineName persists the virtual host key for
+// the named machine when it is missing, otherwise returns the existing key.
+func (st *State) EnsureMachineVirtualHostKeyByMachineName(
+	ctx context.Context,
+	machineName string,
+	algorithmTypeID int,
+	sshKey string,
+) (string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
-		return errors.Capture(err)
+		return "", errors.Capture(err)
 	}
 
 	nameRec := entityName{Name: machineName}
@@ -99,17 +103,26 @@ SELECT uuid AS &entityUUID.uuid
 FROM machine
 WHERE name = $entityName.name`, entityUUID{}, entityName{})
 	if err != nil {
-		return errors.Capture(err)
+		return "", errors.Capture(err)
 	}
-	upsertStmt, err := st.Prepare(`
+	insertStmt, err := st.Prepare(`
 INSERT INTO machine_virtual_ssh_host_key (machine_uuid, algorithm_type_id, ssh_key)
 VALUES ($machineVirtualSSHHostKey.*)`, machineVirtualSSHHostKey{})
 	if err != nil {
-		return errors.Capture(err)
+		return "", errors.Capture(err)
+	}
+	getKeyStmt, err := st.Prepare(`
+SELECT ssh_key AS &sshPrivateKey.ssh_key
+FROM machine_virtual_ssh_host_key
+WHERE machine_uuid = $entityUUID.uuid`, sshPrivateKey{}, entityUUID{})
+	if err != nil {
+		return "", errors.Capture(err)
 	}
 
-	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+	var key sshPrivateKey
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		machineUUID := entityUUID{}
+		key = sshPrivateKey{}
 		err := tx.Query(ctx, getMachineUUIDStmt, nameRec).Get(&machineUUID)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf("machine %q %w", machineName, machineerrors.MachineNotFound)
@@ -119,13 +132,26 @@ VALUES ($machineVirtualSSHHostKey.*)`, machineVirtualSSHHostKey{})
 		}
 
 		record := machineVirtualSSHHostKey{MachineUUID: machineUUID.UUID, AlgorithmTypeID: algorithmTypeID, SSHKey: sshKey}
-		if err := tx.Query(ctx, upsertStmt, record).Run(); internaldatabase.IsErrConstraintPrimaryKey(err) || internaldatabase.IsErrConstraintUnique(err) {
-			return errors.Errorf("machine virtual SSH host key for %q already exists", machineName).Add(coreerrors.AlreadyExists)
+		err = tx.Query(ctx, insertStmt, record).Run()
+		if internaldatabase.IsErrConstraintPrimaryKey(err) || internaldatabase.IsErrConstraintUnique(err) {
+			err = tx.Query(ctx, getKeyStmt, machineUUID).Get(&key)
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return errors.Errorf("machine virtual SSH host key for %q not found after concurrent insert", machineName)
+			}
+			if err != nil {
+				return errors.Errorf("querying machine virtual SSH host key for %q after concurrent insert: %w", machineName, err)
+			}
+			return nil
 		} else if err != nil {
 			return errors.Errorf("persisting machine virtual SSH host key for %q: %w", machineName, err)
 		}
+		key = sshPrivateKey{SSHKey: sshKey}
 		return nil
-	}))
+	})
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+	return key.SSHKey, nil
 }
 
 // GetUnitVirtualHostKeyByUnitName returns the virtual host key stored for the
@@ -186,17 +212,17 @@ WHERE unit_uuid = $entityUUID.uuid`, sshPrivateKey{}, entityUUID{})
 	return key.SSHKey, found, nil
 }
 
-// SetUnitVirtualHostKeyByUnitName persists the virtual host key for the named
-// unit.
-func (st *State) SetUnitVirtualHostKeyByUnitName(
+// EnsureUnitVirtualHostKeyByUnitName persists the virtual host key for the
+// named unit when it is missing, otherwise returns the existing key.
+func (st *State) EnsureUnitVirtualHostKeyByUnitName(
 	ctx context.Context,
 	unitName string,
 	algorithmTypeID int,
 	sshKey string,
-) error {
+) (string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
-		return errors.Capture(err)
+		return "", errors.Capture(err)
 	}
 
 	nameRec := entityName{Name: unitName}
@@ -205,17 +231,26 @@ SELECT uuid AS &entityUUID.uuid
 FROM unit
 WHERE name = $entityName.name`, entityUUID{}, entityName{})
 	if err != nil {
-		return errors.Capture(err)
+		return "", errors.Capture(err)
 	}
-	upsertStmt, err := st.Prepare(`
+	insertStmt, err := st.Prepare(`
 INSERT INTO unit_virtual_ssh_host_key (unit_uuid, algorithm_type_id, ssh_key)
 VALUES ($unitVirtualSSHHostKey.*)`, unitVirtualSSHHostKey{})
 	if err != nil {
-		return errors.Capture(err)
+		return "", errors.Capture(err)
+	}
+	getKeyStmt, err := st.Prepare(`
+SELECT ssh_key AS &sshPrivateKey.ssh_key
+FROM unit_virtual_ssh_host_key
+WHERE unit_uuid = $entityUUID.uuid`, sshPrivateKey{}, entityUUID{})
+	if err != nil {
+		return "", errors.Capture(err)
 	}
 
-	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+	var key sshPrivateKey
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		unitUUID := entityUUID{}
+		key = sshPrivateKey{}
 		err := tx.Query(ctx, getUnitUUIDStmt, nameRec).Get(&unitUUID)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Errorf("unit %q %w", unitName, applicationerrors.UnitNotFound)
@@ -225,13 +260,26 @@ VALUES ($unitVirtualSSHHostKey.*)`, unitVirtualSSHHostKey{})
 		}
 
 		record := unitVirtualSSHHostKey{UnitUUID: unitUUID.UUID, AlgorithmTypeID: algorithmTypeID, SSHKey: sshKey}
-		if err := tx.Query(ctx, upsertStmt, record).Run(); internaldatabase.IsErrConstraintPrimaryKey(err) || internaldatabase.IsErrConstraintUnique(err) {
-			return errors.Errorf("unit virtual SSH host key for %q already exists", unitName).Add(coreerrors.AlreadyExists)
+		err = tx.Query(ctx, insertStmt, record).Run()
+		if internaldatabase.IsErrConstraintPrimaryKey(err) || internaldatabase.IsErrConstraintUnique(err) {
+			err = tx.Query(ctx, getKeyStmt, unitUUID).Get(&key)
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return errors.Errorf("unit virtual SSH host key for %q not found after concurrent insert", unitName)
+			}
+			if err != nil {
+				return errors.Errorf("querying unit virtual SSH host key for %q after concurrent insert: %w", unitName, err)
+			}
+			return nil
 		} else if err != nil {
 			return errors.Errorf("persisting unit virtual SSH host key for %q: %w", unitName, err)
 		}
+		key = sshPrivateKey{SSHKey: sshKey}
 		return nil
-	}))
+	})
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+	return key.SSHKey, nil
 }
 
 // GetMachineNameForUnit returns the backing machine for a unit when one exists.

--- a/domain/ssh/state/model/state_test.go
+++ b/domain/ssh/state/model/state_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/tc"
 
 	coredatabase "github.com/juju/juju/core/database"
-	coreerrors "github.com/juju/juju/core/errors"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
@@ -47,12 +46,13 @@ func (s *stateSuite) TestGetMachineVirtualHostKeyMissingMachine(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, machineerrors.MachineNotFound)
 }
 
-func (s *stateSuite) TestSetAndGetMachineVirtualHostKey(c *tc.C) {
+func (s *stateSuite) TestEnsureAndGetMachineVirtualHostKey(c *tc.C) {
 	st := sshmodelstate.NewState(txRunnerFactory(s.ModelTxnRunner()))
 	s.addMachine(c, "1")
 
-	err := st.SetMachineVirtualHostKeyByMachineName(c.Context(), "1", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
+	key, err := st.EnsureMachineVirtualHostKeyByMachineName(c.Context(), "1", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(key, tc.Equals, testPrivateKey)
 
 	key, found, err := st.GetMachineVirtualHostKeyByMachineName(c.Context(), "1")
 	c.Assert(err, tc.ErrorIsNil)
@@ -68,22 +68,25 @@ func (s *stateSuite) TestSetAndGetMachineVirtualHostKey(c *tc.C) {
 	c.Check(algorithmTypeID, tc.Equals, domainssh.SSHKeyAlgorithmTypeED25519ID)
 }
 
-func (s *stateSuite) TestSetMachineVirtualHostKeyMissingMachine(c *tc.C) {
+func (s *stateSuite) TestEnsureMachineVirtualHostKeyMissingMachine(c *tc.C) {
 	st := sshmodelstate.NewState(txRunnerFactory(s.ModelTxnRunner()))
 
-	err := st.SetMachineVirtualHostKeyByMachineName(c.Context(), "99", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
+	key, err := st.EnsureMachineVirtualHostKeyByMachineName(c.Context(), "99", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
+	c.Check(key, tc.Equals, "")
 	c.Assert(err, tc.ErrorIs, machineerrors.MachineNotFound)
 }
 
-func (s *stateSuite) TestSetMachineVirtualHostKeyConflicts(c *tc.C) {
+func (s *stateSuite) TestEnsureMachineVirtualHostKeyReturnsExistingOnConflict(c *tc.C) {
 	st := sshmodelstate.NewState(txRunnerFactory(s.ModelTxnRunner()))
 	s.addMachine(c, "1")
 
-	err := st.SetMachineVirtualHostKeyByMachineName(c.Context(), "1", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
+	key, err := st.EnsureMachineVirtualHostKeyByMachineName(c.Context(), "1", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(key, tc.Equals, testPrivateKey)
 
-	err = st.SetMachineVirtualHostKeyByMachineName(c.Context(), "1", domainssh.SSHKeyAlgorithmTypeRSAID, "different-key")
-	c.Assert(err, tc.ErrorIs, coreerrors.AlreadyExists)
+	key, err = st.EnsureMachineVirtualHostKeyByMachineName(c.Context(), "1", domainssh.SSHKeyAlgorithmTypeRSAID, "different-key")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(key, tc.Equals, testPrivateKey)
 
 	key, found, err := st.GetMachineVirtualHostKeyByMachineName(c.Context(), "1")
 	c.Assert(err, tc.ErrorIsNil)
@@ -100,22 +103,25 @@ func (s *stateSuite) TestGetUnitVirtualHostKeyMissingUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
-func (s *stateSuite) TestSetUnitVirtualHostKeyMissingUnit(c *tc.C) {
+func (s *stateSuite) TestEnsureUnitVirtualHostKeyMissingUnit(c *tc.C) {
 	st := sshmodelstate.NewState(txRunnerFactory(s.ModelTxnRunner()))
 
-	err := st.SetUnitVirtualHostKeyByUnitName(c.Context(), "postgresql/0", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
+	key, err := st.EnsureUnitVirtualHostKeyByUnitName(c.Context(), "postgresql/0", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
+	c.Check(key, tc.Equals, "")
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
-func (s *stateSuite) TestSetUnitVirtualHostKeyConflicts(c *tc.C) {
+func (s *stateSuite) TestEnsureUnitVirtualHostKeyReturnsExistingOnConflict(c *tc.C) {
 	st := sshmodelstate.NewState(txRunnerFactory(s.ModelTxnRunner()))
 	s.addUnit(c, "postgresql/0")
 
-	err := st.SetUnitVirtualHostKeyByUnitName(c.Context(), "postgresql/0", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
+	key, err := st.EnsureUnitVirtualHostKeyByUnitName(c.Context(), "postgresql/0", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(key, tc.Equals, testPrivateKey)
 
-	err = st.SetUnitVirtualHostKeyByUnitName(c.Context(), "postgresql/0", domainssh.SSHKeyAlgorithmTypeRSAID, "different-key")
-	c.Assert(err, tc.ErrorIs, coreerrors.AlreadyExists)
+	key, err = st.EnsureUnitVirtualHostKeyByUnitName(c.Context(), "postgresql/0", domainssh.SSHKeyAlgorithmTypeRSAID, "different-key")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(key, tc.Equals, testPrivateKey)
 
 	key, found, err := st.GetUnitVirtualHostKeyByUnitName(c.Context(), "postgresql/0")
 	c.Assert(err, tc.ErrorIsNil)
@@ -132,12 +138,13 @@ func (s *stateSuite) TestGetMachineNameForUnitMissingUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
-func (s *stateSuite) TestSetAndGetUnitVirtualHostKey(c *tc.C) {
+func (s *stateSuite) TestEnsureAndGetUnitVirtualHostKey(c *tc.C) {
 	st := sshmodelstate.NewState(txRunnerFactory(s.ModelTxnRunner()))
 	s.addUnit(c, "postgresql/0")
 
-	err := st.SetUnitVirtualHostKeyByUnitName(c.Context(), "postgresql/0", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
+	key, err := st.EnsureUnitVirtualHostKeyByUnitName(c.Context(), "postgresql/0", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(key, tc.Equals, testPrivateKey)
 
 	key, found, err := st.GetUnitVirtualHostKeyByUnitName(c.Context(), "postgresql/0")
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/ssh/state/model/state_test.go
+++ b/domain/ssh/state/model/state_test.go
@@ -72,8 +72,8 @@ func (s *stateSuite) TestEnsureMachineVirtualHostKeyMissingMachine(c *tc.C) {
 	st := sshmodelstate.NewState(txRunnerFactory(s.ModelTxnRunner()))
 
 	key, err := st.EnsureMachineVirtualHostKeyByMachineName(c.Context(), "99", domainssh.SSHKeyAlgorithmTypeED25519ID, testPrivateKey)
-	c.Check(key, tc.Equals, "")
 	c.Assert(err, tc.ErrorIs, machineerrors.MachineNotFound)
+	c.Check(key, tc.Equals, "")
 }
 
 func (s *stateSuite) TestEnsureMachineVirtualHostKeyReturnsExistingOnConflict(c *tc.C) {


### PR DESCRIPTION
Resolving a race condition in the SSH virtual host keys logic. If a unit/machine does not already have a key, one will be generated and set. If two routines reach the set logic, one will win and perform the write and the other will obtain an AlreadyExists error, and needs to refetch the key.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
