### PR TITLE
fix(relation): return remote-app units in ApplicationRelationsInfo for non-peer relations

### DIFF
--- a/domain/relation/state/migration.go
+++ b/domain/relation/state/migration.go
@@ -110,28 +110,42 @@ func (st *State) GetApplicationUUIDByName(ctx context.Context, appName string) (
 
 	var id application.UUID
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		app := nameAndUUID{Name: appName}
-		queryApplicationStmt, err := st.Prepare(`
-SELECT uuid AS &nameAndUUID.uuid
-FROM application
-WHERE name = $nameAndUUID.name
-`, app)
+		uuid, err := st.getApplicationUUIDByName(ctx, tx, appName)
 		if err != nil {
 			return errors.Capture(err)
 		}
-		err = tx.Query(ctx, queryApplicationStmt, app).Get(&app)
-		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("getting UUID for application %q not found", appName).
-				Add(applicationerrors.ApplicationNotFound)
-		} else if err != nil {
-			return errors.Errorf("looking up UUID for application %q: %w", appName, err)
-		}
-		id = application.UUID(app.UUID)
+		id = application.UUID(uuid)
 		return nil
 	}); err != nil {
 		return "", errors.Capture(err)
 	}
 	return id, nil
+}
+
+// getApplicationUUIDByName returns the application UUID of the given application
+// within the supplied transaction.
+func (st *State) getApplicationUUIDByName(
+	ctx context.Context,
+	tx *sqlair.TX,
+	appName string,
+) (string, error) {
+	app := nameAndUUID{Name: appName}
+	queryApplicationStmt, err := st.Prepare(`
+SELECT uuid AS &nameAndUUID.uuid
+FROM application
+WHERE name = $nameAndUUID.name
+`, app)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+	err = tx.Query(ctx, queryApplicationStmt, app).Get(&app)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return "", errors.Errorf("getting UUID for application %q not found", appName).
+			Add(applicationerrors.ApplicationNotFound)
+	} else if err != nil {
+		return "", errors.Errorf("looking up UUID for application %q: %w", appName, err)
+	}
+	return app.UUID, nil
 }
 
 // SetRelationApplicationSettings records settings for a specific application

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -353,15 +353,28 @@ func (st *State) ApplicationRelationsInfo(
 			}
 			result.RelationID = rel.ID
 
+			// For peer relations there is a single endpoint and unit data
+			// relates to the local application. For non-peer relations unit
+			// data must represent the counterpart application, so the remote
+			// application is resolved here.
+			unitDataAppUUID := appID.String()
 			if len(eps) == 1 {
 				result.Endpoint = eps[0].EndpointName
 				result.RelatedEndpoint = eps[0].EndpointName
 			} else {
+				var remoteAppName string
 				for _, ep := range eps {
 					if ep.ApplicationName == rel.AppName {
 						result.Endpoint = ep.EndpointName
 					} else {
 						result.RelatedEndpoint = ep.EndpointName
+						remoteAppName = ep.ApplicationName
+					}
+				}
+				if remoteAppName != "" {
+					unitDataAppUUID, err = st.getApplicationUUIDByName(ctx, tx, remoteAppName)
+					if err != nil {
+						return errors.Errorf("getting remote application UUID: %w", err)
 					}
 				}
 			}
@@ -375,7 +388,7 @@ func (st *State) ApplicationRelationsInfo(
 				return s.Key(), s.Value()
 			})
 
-			result.UnitRelationData, err = st.getUnitsRelationData(ctx, tx, rel.UUID, appID.String())
+			result.UnitRelationData, err = st.getUnitsRelationData(ctx, tx, rel.UUID, unitDataAppUUID)
 			if err != nil {
 				return errors.Errorf("getting unit relation data: %w", err)
 			}

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -3802,47 +3802,56 @@ func (s *relationSuite) TestApplicationRelationsInfo(c *tc.C) {
 	unit1 := s.addUnit(c, "three/0", app3, charm3)
 	unit2 := s.addUnit(c, "three/1", app3, charm3)
 
-	// Relate applications 1 and 3. Both of application 3's units
+	// Relate applications 1 and 3. Both of the remote (application 1) units
 	// are in scope and have settings.
 	relID1 := 3
 	relUUID1 := s.addRelationWithID(c, relID1)
-	_ = s.addRelationEndpoint(c, relUUID1, appEndpoint1)
+	relEndpoint1 := s.addRelationEndpoint(c, relUUID1, appEndpoint1)
 	relEndpoint13 := s.addRelationEndpoint(c, relUUID1, appEndpoint3)
-	rel1unit1 := s.addRelationUnit(c, unit1, relEndpoint13)
-	rel1unit2 := s.addRelationUnit(c, unit2, relEndpoint13)
+	app1Unit0 := s.addUnit(c, coreunit.Name(s.fakeApplicationName1+"/0"), s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	app1Unit1 := s.addUnit(c, coreunit.Name(s.fakeApplicationName1+"/1"), s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	rel1unit1 := s.addRelationUnit(c, app1Unit0, relEndpoint1)
+	rel1unit2 := s.addRelationUnit(c, app1Unit1, relEndpoint1)
 	s.addRelationUnitSetting(c, rel1unit1, "foo", "bar")
 	s.addRelationUnitSetting(c, rel1unit2, "foo", "baz")
+	// Add application 3's local units to the relation as well (for symmetry
+	// with a real deployment) but note that for non-peer relations only the
+	// remote application's units are returned.
+	s.addRelationUnit(c, unit1, relEndpoint13)
+	s.addRelationUnit(c, unit2, relEndpoint13)
 	rel13Data := domainrelation.EndpointRelationData{
 		RelationID:      3,
 		Endpoint:        "relation",
 		RelatedEndpoint: "fake-provides",
 		ApplicationData: map[string]string{},
 		UnitRelationData: map[string]domainrelation.RelationData{
-			"three/0": {
+			s.fakeApplicationName1 + "/0": {
 				InScope:  true,
 				UnitData: map[string]string{"foo": "bar"},
 			},
-			"three/1": {
+			s.fakeApplicationName1 + "/1": {
 				InScope:  true,
 				UnitData: map[string]string{"foo": "baz"},
 			},
 		},
 	}
 
-	// Relate applications 2 and 3. Application 3 has settings.
+	// Relate applications 2 and 3. Application 3 has application settings.
 	relID2 := 4
 	relUUID2 := s.addRelationWithID(c, relID2)
 	_ = s.addRelationEndpoint(c, relUUID2, appEndpoint2)
 	relEndpoint23 := s.addRelationEndpoint(c, relUUID2, appEndpoint3)
 	s.addRelationApplicationSetting(c, relEndpoint23, "one", "two")
+	_ = s.addUnit(c, coreunit.Name(s.fakeApplicationName2+"/0"), s.fakeApplicationUUID2, s.fakeCharmUUID2)
+	_ = s.addUnit(c, coreunit.Name(s.fakeApplicationName2+"/1"), s.fakeApplicationUUID2, s.fakeCharmUUID2)
 	rel23Data := domainrelation.EndpointRelationData{
 		RelationID:      4,
 		Endpoint:        "relation",
 		RelatedEndpoint: "fake-provides",
 		ApplicationData: map[string]string{"one": "two"},
 		UnitRelationData: map[string]domainrelation.RelationData{
-			"three/0": {InScope: false},
-			"three/1": {InScope: false},
+			s.fakeApplicationName2 + "/0": {InScope: false},
+			s.fakeApplicationName2 + "/1": {InScope: false},
 		},
 	}
 
@@ -3964,10 +3973,17 @@ func (s *relationSuite) TestApplicationRelationsInfoPeerRelationLast(c *tc.C) {
 
 	relIDRegular := 4
 	relUUIDRegular := s.addRelationWithID(c, relIDRegular)
-	_ = s.addRelationEndpoint(c, relUUIDRegular, appEndpoint1)
+	relEndpoint1 := s.addRelationEndpoint(c, relUUIDRegular, appEndpoint1)
 	relEndpointRegular := s.addRelationEndpoint(c, relUUIDRegular, appEndpoint3)
-	relRegularUnit1 := s.addRelationUnit(c, unit1, relEndpointRegular)
-	relRegularUnit2 := s.addRelationUnit(c, unit2, relEndpointRegular)
+	app1Unit0 := s.addUnit(c, coreunit.Name(s.fakeApplicationName1+"/0"), s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	app1Unit1 := s.addUnit(c, coreunit.Name(s.fakeApplicationName1+"/1"), s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	relRegularUnit1 := s.addRelationUnit(c, app1Unit0, relEndpoint1)
+	relRegularUnit2 := s.addRelationUnit(c, app1Unit1, relEndpoint1)
+	// Add application 3's local units to the relation as well (for symmetry
+	// with a real deployment) but note that for non-peer relations only the
+	// remote application's units are returned.
+	s.addRelationUnit(c, unit1, relEndpointRegular)
+	s.addRelationUnit(c, unit2, relEndpointRegular)
 	s.addRelationUnitSetting(c, relRegularUnit1, "foo", "bar")
 	s.addRelationUnitSetting(c, relRegularUnit2, "foo", "baz")
 	relRegularData := domainrelation.EndpointRelationData{
@@ -3976,11 +3992,11 @@ func (s *relationSuite) TestApplicationRelationsInfoPeerRelationLast(c *tc.C) {
 		RelatedEndpoint: "fake-provides",
 		ApplicationData: map[string]string{},
 		UnitRelationData: map[string]domainrelation.RelationData{
-			"three/0": {
+			s.fakeApplicationName1 + "/0": {
 				InScope:  true,
 				UnitData: map[string]string{"foo": "bar"},
 			},
-			"three/1": {
+			s.fakeApplicationName1 + "/1": {
 				InScope:  true,
 				UnitData: map[string]string{"foo": "baz"},
 			},


### PR DESCRIPTION
## Description

For non-peer relations the state layer was returning the local application's
unit data, causing show-unit to render local-unit instead of related-units.
Now it resolves the counterpart application UUID and fetches that side's
units, which the CLI correctly places under related-units.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] Integration tests
- [ ] doc.go added or updated in changed packages

## QA

```sh
juju deploy grafana-agent-k8s --channel 2/stable --trust
juju deploy prometheus-k8s --channel 2/stable --trust
juju integrate grafana-agent-k8s:grafana-dashboards-consumer prometheus-k8s:grafana-dashboard
```

Verify:
```sh
juju show-unit grafana-agent-k8s/0

grafana-agent-k8s/0:
  workload-version: 0.40.4
  opened-ports: []
  charm: ch:amd64/grafana-agent-k8s-211
  leader: true
  life: alive
  relation-info:
  - relation-id: 2
    endpoint: grafana-dashboards-consumer
    related-endpoint: grafana-dashboard
    application-data: {}
    related-units:    # <------------------ This should appears
      prometheus-k8s/0:
        in-scope: false
        data: {}
  - relation-id: 1
    endpoint: peers
    related-endpoint: peers
    application-data: {}
    local-unit:
      in-scope: true
      data:
        egress-subnets: 10.152.183.118/32
        ingress-address: 10.152.183.118
        private-address: 10.152.183.118
  provider-id: grafana-agent-k8s-0
  address: 10.1.141.205
```

## Links

**Issue:** Fixes #22539
**Jira card:** [JUJU-9916](https://warthogs.atlassian.net/browse/JUJU-9916)

[JUJU-9916]: https://warthogs.atlassian.net/browse/JUJU-9916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ