### PR TITLE
fix: catch mongo session Copy() panics and return an error

### DIFF
--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -372,19 +372,24 @@ func (s *serverSuite) TestClosesStateFromPool(c *gc.C) {
 func assertStateBecomesClosed(c *gc.C, st *state.State) {
 	// This is gross but I can't see any other way to check for
 	// closedness outside the state package.
-	checkModel := func() {
-		attempt := utils.AttemptStrategy{
-			Total: coretesting.LongWait,
-			Delay: coretesting.ShortWait,
-		}
-		for a := attempt.Start(); a.Next(); {
-			// This will panic once the state is closed.
-			_, _ = st.Model()
-		}
-		// If we got here then st is still open.
-		st.Close()
+	attempt := utils.AttemptStrategy{
+		Total: coretesting.LongWait,
+		Delay: coretesting.ShortWait,
 	}
-	c.Assert(checkModel, gc.PanicMatches, "Session already closed")
+	var err error
+	for a := attempt.Start(); a.Next(); {
+		// This will error once the state is closed.
+		_, err = st.Model()
+		if err != nil {
+			break
+		}
+	}
+	if err == nil {
+		// If we got here then st is still open.
+		_ = st.Close()
+		return
+	}
+	c.Assert(err, gc.ErrorMatches, ".* Session already closed.*")
 }
 
 func (s *serverSuite) checkAPIHandlerTeardown(c *gc.C, srvSt, st *state.State) {

--- a/mongo/collections.go
+++ b/mongo/collections.go
@@ -4,18 +4,54 @@
 package mongo
 
 import (
+	"strings"
 	"time"
 
+	"github.com/juju/errors"
 	"github.com/juju/mgo/v3"
 )
 
 // CollectionFromName returns a named collection on the specified database,
 // initialised with a new session. Also returned is a close function which
 // must be called when the collection is no longer required.
-func CollectionFromName(db *mgo.Database, coll string) (Collection, func()) {
-	session := db.Session.Copy()
+func CollectionFromName(db *mgo.Database, coll string) (collection Collection, closer func(), err error) {
+	session, err := CopySession(db.Session)
+	if err != nil {
+		return nil, nil, errors.Annotatef(err, "copying session for collection %q", coll)
+	}
+
 	newColl := db.C(coll).With(session)
-	return WrapCollection(newColl), session.Close
+	return WrapCollection(newColl), session.Close, nil
+}
+
+const sessionAlreadyClosed = "Session already closed"
+
+// CopySession returns a copied mgo session and converts any closed session
+// panic into an error.
+func CopySession(session *mgo.Session) (_ *mgo.Session, err error) {
+	if session == nil {
+		return nil, errors.New("mongo session is nil")
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if !isClosedSessionPanic(recovered) {
+				panic(recovered)
+			}
+			err = errors.Errorf("copying session failed: %v", recovered)
+		}
+	}()
+	return session.Copy(), nil
+}
+
+func isClosedSessionPanic(recovered interface{}) bool {
+	switch r := recovered.(type) {
+	case string:
+		return r == sessionAlreadyClosed
+	case error:
+		return strings.Contains(r.Error(), sessionAlreadyClosed)
+	default:
+		return false
+	}
 }
 
 // Collection imperfectly insulates clients from the capacity to write to

--- a/mongo/oplog.go
+++ b/mongo/oplog.go
@@ -109,14 +109,17 @@ type oplogSession struct {
 //     and o (object).
 //
 // The returned session should be `Close`d when it's no longer needed.
-func NewOplogSession(collection *mgo.Collection, query bson.D) *oplogSession {
+func NewOplogSession(collection *mgo.Collection, query bson.D) (*oplogSession, error) {
 	// Use a fresh session for the tailer.
-	session := collection.Database.Session.Copy()
+	session, err := CopySession(collection.Database.Session)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return &oplogSession{
 		session:    session,
 		collection: collection.With(session),
 		query:      query,
-	}
+	}, nil
 }
 
 const oplogTailTimeout = time.Second

--- a/mongo/oplog_test.go
+++ b/mongo/oplog_test.go
@@ -32,11 +32,13 @@ func (s *oplogSuite) TestWithRealOplog(c *gc.C) {
 	// Watch for oplog entries for the "bar" collection in the "foo"
 	// DB.
 	oplog := mongo.GetOplog(session)
+	oplogSession, err := mongo.NewOplogSession(
+		oplog,
+		bson.D{{"ns", "foo.bar"}},
+	)
+	c.Assert(err, jc.ErrorIsNil)
 	tailer := mongo.NewOplogTailer(
-		mongo.NewOplogSession(
-			oplog,
-			bson.D{{"ns", "foo.bar"}},
-		),
+		oplogSession,
 		time.Now().Add(-time.Minute),
 	)
 	defer tailer.Stop()
@@ -69,7 +71,7 @@ func (s *oplogSuite) TestWithRealOplog(c *gc.C) {
 	assertOplog("i", bson.D{{"_id", "thing"}}, nil)
 
 	// Update foo.bar and see the update reported.
-	err := coll.UpdateId("thing", bson.M{"$set": bson.M{"blah": 42}})
+	err = coll.UpdateId("thing", bson.M{"$set": bson.M{"blah": 42}})
 	c.Assert(err, jc.ErrorIsNil)
 	assertOplog("u", bson.D{{"$set", bson.D{{"blah", 42}}}}, bson.D{{"_id", "thing"}})
 
@@ -91,7 +93,9 @@ func (s *oplogSuite) TestHonoursInitialTs(c *gc.C) {
 		)
 	}
 
-	tailer := mongo.NewOplogTailer(mongo.NewOplogSession(oplog, nil), t)
+	oplogSession, err := mongo.NewOplogSession(oplog, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	tailer := mongo.NewOplogTailer(oplogSession, t)
 	defer tailer.Stop()
 
 	for offset := 0; offset <= 1; offset++ {
@@ -116,11 +120,13 @@ func (s *oplogSuite) TestStops(c *gc.C) {
 	oplog := s.makeFakeOplog(c, session)
 	s.insertDoc(c, session, oplog, &mongo.OplogDoc{Timestamp: 1})
 
-	tailer := mongo.NewOplogTailer(mongo.NewOplogSession(oplog, nil), time.Time{})
+	oplogSession, err := mongo.NewOplogSession(oplog, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	tailer := mongo.NewOplogTailer(oplogSession, time.Time{})
 	defer tailer.Stop()
 	s.getNextOplog(c, tailer)
 
-	err := tailer.Stop()
+	err = tailer.Stop()
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.assertStopped(c, tailer)
@@ -275,9 +281,10 @@ func (s *oplogSuite) makeFakeOplog(c *gc.C, session *mgo.Session) *mgo.Collectio
 }
 
 func (s *oplogSuite) insertDoc(c *gc.C, srcSession *mgo.Session, coll *mgo.Collection, doc interface{}) {
-	session := srcSession.Copy()
+	session, err := mongo.CopySession(srcSession)
+	c.Assert(err, jc.ErrorIsNil)
 	defer session.Close()
-	err := coll.With(session).Insert(doc)
+	err = coll.With(session).Insert(doc)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/scripts/juju-list-blobstore/main.go
+++ b/scripts/juju-list-blobstore/main.go
@@ -1031,7 +1031,8 @@ func (b *BlobStoreChecker) checkUnreferencedChunks() {
 	if *chunkTimeout == 0 {
 		return
 	}
-	session := b.session.Copy()
+	session, err := mongo.CopySession(b.session)
+	checkErr(err, "copying session")
 	defer session.Close()
 	// Bump the default socket timeout since this usually must be paged from disk.
 	session.SetSocketTimeout(time.Duration(*chunkTimeout) * time.Minute)

--- a/state/action.go
+++ b/state/action.go
@@ -166,11 +166,14 @@ type action struct {
 
 // Refresh the contents of the action.
 func (a *action) Refresh() error {
-	actions, closer := a.st.db().GetCollection(actionsC)
+	actions, closer, err := a.st.db().GetCollection(actionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	id := a.Id()
 	doc := actionDoc{}
-	err := actions.FindId(id).One(&doc)
+	err = actions.FindId(id).One(&doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("action %q", id)
 	}
@@ -622,11 +625,14 @@ var ensureActionMarker = ensureSuffixFn(actionMarker)
 func (m *Model) Action(id string) (Action, error) {
 	actionLogger.Tracef("Action() %q", id)
 	st := m.st
-	actions, closer := st.db().GetCollection(actionsC)
+	actions, closer, err := st.db().GetCollection(actionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := actionDoc{}
-	err := actions.FindId(id).One(&doc)
+	err = actions.FindId(id).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("action %q", id)
 	}
@@ -640,12 +646,15 @@ func (m *Model) Action(id string) (Action, error) {
 // AllActions returns all Actions.
 func (m *Model) AllActions() ([]Action, error) {
 	actionLogger.Tracef("AllActions()")
-	actions, closer := m.st.db().GetCollection(actionsC)
+	actions, closer, err := m.st.db().GetCollection(actionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	results := []Action{}
 	docs := []actionDoc{}
-	err := actions.Find(nil).All(&docs)
+	err = actions.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get all actions")
 	}
@@ -665,7 +674,10 @@ func (m *Model) FindActionsByName(name string) ([]Action, error) {
 	var results []Action
 	var doc actionDoc
 
-	actions, closer := m.st.db().GetCollection(actionsC)
+	actions, closer, err := m.st.db().GetCollection(actionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	iter := actions.Find(bson.D{{"name", name}}).Iter()
@@ -762,7 +774,10 @@ func (st *State) matchingActionsByReceiverId(id string) ([]Action, error) {
 	var doc actionDoc
 	var actions []Action
 
-	actionsCollection, closer := st.db().GetCollection(actionsC)
+	actionsCollection, closer, err := st.db().GetCollection(actionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	iter := actionsCollection.Find(bson.D{{"receiver", id}}).Iter()
@@ -807,7 +822,10 @@ func (st *State) matchingActionsByReceiverAndStatus(tag names.Tag, statusConditi
 	var doc actionDoc
 	var actions []Action
 
-	actionsCollection, closer := st.db().GetCollection(actionsC)
+	actionsCollection, closer, err := st.db().GetCollection(actionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	sel := append(bson.D{{"receiver", tag.Id()}}, statusCondition...)
@@ -828,9 +846,12 @@ func PruneOperations(stop <-chan struct{}, st *State, maxHistoryTime time.Durati
 		{{"operation", ""}},
 		{{"operation", bson.D{{"$exists", false}}}},
 	}}}
-	coll, closer := st.db().GetRawCollection(actionsC)
+	coll, closer, err := st.db().GetRawCollection(actionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
-	err := pruneCollection(stop, st, maxHistoryTime, maxHistoryMB, coll, "completed", hasNoOperation, GoTime)
+	err = pruneCollection(stop, st, maxHistoryTime, maxHistoryMB, coll, "completed", hasNoOperation, GoTime)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -839,13 +860,19 @@ func PruneOperations(stop <-chan struct{}, st *State, maxHistoryTime time.Durati
 	// the actions collection is where the disk space goes, we approximate the
 	// number of operations to delete to achieve a given size deduction based on
 	// the average ratio of number of operations to tasks.
-	operationsColl, closer := st.db().GetRawCollection(operationsC)
+	operationsColl, closer, err := st.db().GetRawCollection(operationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	operationsCount, err := operationsColl.Count()
 	if err != nil {
 		return errors.Annotate(err, "retrieving operations collection count")
 	}
-	actionsColl, closer := st.db().GetRawCollection(actionsC)
+	actionsColl, closer, err := st.db().GetRawCollection(actionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	actionsCount, err := actionsColl.Count()
 	if err != nil {

--- a/state/address.go
+++ b/state/address.go
@@ -35,9 +35,12 @@ func (st *State) controllerAddresses() ([]string, error) {
 		return nil, errors.Trace(err)
 	}
 	if model.ModelTag() == cinfo.ModelTag {
-		machines, closer = st.db().GetCollection(machinesC)
+		machines, closer, err = st.db().GetCollection(machinesC)
 	} else {
-		machines, closer = st.db().GetCollectionFor(cinfo.ModelTag.Id(), machinesC)
+		machines, closer, err = st.db().GetCollectionFor(cinfo.ModelTag.Id(), machinesC)
+	}
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 	defer closer()
 
@@ -107,7 +110,10 @@ type apiHostPortsDoc struct {
 //
 // Each server is represented by one element in the top level slice.
 func (st *State) SetAPIHostPorts(newHostPorts []network.SpaceHostPorts) error {
-	controllers, closer := st.db().GetCollection(controllersC)
+	controllers, closer, err := st.db().GetCollection(controllersC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -344,9 +350,12 @@ func (st *State) apiHostPortsForCAAS(public bool) (addresses []network.SpaceHost
 // identified by the input key.
 func (st *State) apiHostPortsForKey(key string) ([]network.SpaceHostPorts, error) {
 	var doc apiHostPortsDoc
-	controllers, closer := st.db().GetCollection(controllersC)
+	controllers, closer, err := st.db().GetCollection(controllersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
-	err := controllers.Find(bson.D{{"_id", key}}).One(&doc)
+	err = controllers.Find(bson.D{{"_id", key}}).One(&doc)
 	if err != nil {
 		return nil, err
 	}

--- a/state/address_internal_test.go
+++ b/state/address_internal_test.go
@@ -95,7 +95,8 @@ func (s *GetOpsForHostPortsSuite) TestGetOpsForHostPortsChangeWithSpaces(c *gc.C
 		return result
 	}
 
-	controllers, closer := s.state.db().GetCollection(controllersC)
+	controllers, closer, err := s.state.db().GetCollection(controllersC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	ops, err := s.state.getOpsForHostPortsChange(controllers, apiHostPortsKey, addressSlice())

--- a/state/allwatcher.go
+++ b/state/allwatcher.go
@@ -1766,7 +1766,10 @@ func (b *allWatcherBacking) Changed(store multiwatcher.Store, change watcher.Cha
 	// Update the state in the context to be the valid one from the state pool.
 	ctx.state = st.State
 
-	col, closer := st.db().GetCollection(c.name)
+	col, closer, err := st.db().GetCollection(c.name)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	err = col.FindId(id).One(doc)
@@ -1811,7 +1814,10 @@ func (b *allWatcherBacking) getState(modelUUID string) (*PooledState, error) {
 
 func loadAllWatcherEntities(st *State, loadOrder []string, collectionByName map[string]allWatcherStateCollection, store multiwatcher.Store) error {
 	// Use a single new MongoDB connection for all the work here.
-	db, closer := st.newDB()
+	db, closer, err := st.newDB()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	start := st.clock().Now()
 	defer func() {
@@ -1847,7 +1853,10 @@ func loadAllWatcherEntities(st *State, loadOrder []string, collectionByName map[
 }
 
 func loadOneWatcherEntity(ctx *allWatcherContext, db Database, modelUUID string, docType reflect.Type, name string) error {
-	col, closer := db.GetCollection(name)
+	col, closer, err := db.GetCollection(name)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	infoSlicePtr := reflect.New(reflect.SliceOf(docType))
 
@@ -1931,7 +1940,10 @@ func (ctx *allWatcherContext) loadSubsidiaryCollections() error {
 }
 
 func (ctx *allWatcherContext) loadSettings() error {
-	col, closer := ctx.state.db().GetCollection(settingsC)
+	col, closer, err := ctx.state.db().GetCollection(settingsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []settingsDoc
@@ -1949,7 +1961,10 @@ func (ctx *allWatcherContext) loadSettings() error {
 }
 
 func (ctx *allWatcherContext) loadAnnotations() error {
-	col, closer := ctx.state.db().GetCollection(annotationsC)
+	col, closer, err := ctx.state.db().GetCollection(annotationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []annotatorDoc
@@ -1967,7 +1982,10 @@ func (ctx *allWatcherContext) loadAnnotations() error {
 }
 
 func (ctx *allWatcherContext) loadStatuses() error {
-	col, closer := ctx.state.db().GetCollection(statusesC)
+	col, closer, err := ctx.state.db().GetCollection(statusesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []statusDocWithID
@@ -1984,7 +2002,10 @@ func (ctx *allWatcherContext) loadStatuses() error {
 }
 
 func (ctx *allWatcherContext) loadInstanceData() error {
-	col, closer := ctx.state.db().GetCollection(instanceDataC)
+	col, closer, err := ctx.state.db().GetCollection(instanceDataC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []instanceData
@@ -2024,7 +2045,10 @@ func (ctx *allWatcherContext) loadOpenedPortRanges() error {
 }
 
 func (ctx *allWatcherContext) loadPermissions() error {
-	col, closer := ctx.state.db().GetCollection(permissionsC)
+	col, closer, err := ctx.state.db().GetCollection(permissionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []backingPermission
@@ -2050,7 +2074,10 @@ func (ctx *allWatcherContext) loadPermissions() error {
 }
 
 func (ctx *allWatcherContext) loadConstraints() error {
-	col, closer := ctx.state.db().GetCollection(constraintsC)
+	col, closer, err := ctx.state.db().GetCollection(constraintsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []constraintsDoc
@@ -2081,11 +2108,14 @@ func (ctx *allWatcherContext) getAnnotations(key string) map[string]string {
 		return ctx.annotations[gKey]
 	}
 
-	annotations, closer := ctx.state.db().GetCollection(annotationsC)
+	annotations, closer, err := ctx.state.db().GetCollection(annotationsC)
+	if err != nil {
+		return nil
+	}
 	defer closer()
 
 	var doc annotatorDoc
-	err := annotations.FindId(gKey).One(&doc)
+	err = annotations.FindId(gKey).One(&doc)
 	if err != nil {
 		// We really don't care what the error is. Anything substantial
 		// will be caught by other queries.

--- a/state/annotations.go
+++ b/state/annotations.go
@@ -54,7 +54,10 @@ func (m *Model) SetAnnotations(entity GlobalEntity, annotations map[string]strin
 	// annotations in the meantime, we consider that worthy of an error
 	// (will be fixed when new entities can never share names with old ones).
 	buildTxn := func(attempt int) ([]txn.Op, error) {
-		annotations, closer := m.st.db().GetCollection(annotationsC)
+		annotations, closer, err := m.st.db().GetCollection(annotationsC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer closer()
 		if count, err := annotations.FindId(entity.globalKey()).Count(); err != nil {
 			return nil, err
@@ -73,9 +76,12 @@ func (m *Model) SetAnnotations(entity GlobalEntity, annotations map[string]strin
 // Annotations returns all the annotations corresponding to an entity.
 func (m *Model) Annotations(entity GlobalEntity) (map[string]string, error) {
 	doc := new(annotatorDoc)
-	annotations, closer := m.st.db().GetCollection(annotationsC)
+	annotations, closer, err := m.st.db().GetCollection(annotationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
-	err := annotations.FindId(entity.globalKey()).One(doc)
+	err = annotations.FindId(entity.globalKey()).One(doc)
 	if err == mgo.ErrNotFound {
 		// Returning an empty map if there are no annotations.
 		return make(map[string]string), nil

--- a/state/application.go
+++ b/state/application.go
@@ -2176,10 +2176,13 @@ func (a *Application) String() string {
 // state. It returns an error that satisfies errors.IsNotFound if the
 // application has been removed.
 func (a *Application) Refresh() error {
-	applications, closer := a.st.db().GetCollection(applicationsC)
+	applications, closer, err := a.st.db().GetCollection(applicationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
-	err := applications.FindId(a.doc.DocID).One(&a.doc)
+	err = applications.FindId(a.doc.DocID).One(&a.doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("application %q", a)
 	}
@@ -2729,7 +2732,10 @@ func applicationOffersRefCountKey(appName string) string {
 // incApplicationOffersRefOp returns a txn.Op that increments the reference
 // count for an application offer.
 func incApplicationOffersRefOp(mb modelBackend, appName string) (txn.Op, error) {
-	refcounts, closer := mb.db().GetCollection(refcountsC)
+	refcounts, closer, err := mb.db().GetCollection(refcountsC)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
 	defer closer()
 	offerRefCountKey := applicationOffersRefCountKey(appName)
 	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, offerRefCountKey, 1)
@@ -2740,7 +2746,10 @@ func incApplicationOffersRefOp(mb modelBackend, appName string) (txn.Op, error) 
 // count for an application offer, starting at the count supplied. Used in
 // model migration, where offers are created in bulk.
 func newApplicationOffersRefOp(mb modelBackend, appName string, startCount int) (txn.Op, error) {
-	refcounts, closer := mb.db().GetCollection(refcountsC)
+	refcounts, closer, err := mb.db().GetCollection(refcountsC)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
 	defer closer()
 	offerRefCountKey := applicationOffersRefCountKey(appName)
 	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, offerRefCountKey, startCount)
@@ -2750,7 +2759,10 @@ func newApplicationOffersRefOp(mb modelBackend, appName string, startCount int) 
 // countApplicationOffersRefOp returns the number of offers for an application,
 // along with a txn.Op that ensures that that does not change.
 func countApplicationOffersRefOp(mb modelBackend, appName string) (txn.Op, int, error) {
-	refcounts, closer := mb.db().GetCollection(refcountsC)
+	refcounts, closer, err := mb.db().GetCollection(refcountsC)
+	if err != nil {
+		return txn.Op{}, 0, errors.Trace(err)
+	}
 	defer closer()
 	key := applicationOffersRefCountKey(appName)
 	return nsRefcounts.CurrentOp(refcounts, key)
@@ -2759,7 +2771,10 @@ func countApplicationOffersRefOp(mb modelBackend, appName string) (txn.Op, int, 
 // decApplicationOffersRefOp returns a txn.Op that decrements the reference
 // count for an application offer.
 func decApplicationOffersRefOp(mb modelBackend, appName string) (txn.Op, error) {
-	refcounts, closer := mb.db().GetCollection(refcountsC)
+	refcounts, closer, err := mb.db().GetCollection(refcountsC)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
 	defer closer()
 	offerRefCountKey := applicationOffersRefCountKey(appName)
 	decRefOp, _, err := nsRefcounts.DyingDecRefOp(refcounts, offerRefCountKey)
@@ -3152,7 +3167,10 @@ func (a *Application) AllUnits() (units []*Unit, err error) {
 }
 
 func allUnits(st *State, application string) (units []*Unit, err error) {
-	unitsCollection, closer := st.db().GetCollection(unitsC)
+	unitsCollection, closer, err := st.db().GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	docs := []unitDoc{}
@@ -3232,11 +3250,14 @@ func (a *Application) GetUnitAttachmentInfos() ([]UnitAttachmentInfo, error) {
 }
 
 func getStorageAttachmentDocs(db Database, fields interface{}, query interface{}) ([]storageAttachmentDoc, error) {
-	coll, cleanup := db.GetCollection(storageAttachmentsC)
+	coll, cleanup, err := db.GetCollection(storageAttachmentsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var docs []storageAttachmentDoc
-	err := coll.Find(query).Select(fields).All(&docs)
+	err = coll.Find(query).Select(fields).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "querying storageattachments")
 	}
@@ -3252,7 +3273,10 @@ func (a *Application) Relations() (relations []*Relation, err error) {
 // There must be 1 or 2 supplied names, of the form <application>[:<endpoint>]
 func matchingRelations(st *State, names ...string) (relations []*Relation, err error) {
 	defer errors.DeferredAnnotatef(&err, "can't get relations matching %q", strings.Join(names, " "))
-	relationsCollection, closer := st.db().GetCollection(relationsC)
+	relationsCollection, closer, err := st.db().GetCollection(relationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var conditions []bson.D
@@ -3898,13 +3922,16 @@ func (a *Application) StatusHistory(filter status.StatusHistoryFilter) ([]status
 // UnitStatuses returns a map of unit names to their Status results (workload
 // status).
 func (a *Application) UnitStatuses() (map[string]status.StatusInfo, error) {
-	col, closer := a.st.db().GetRawCollection(statusesC)
+	col, closer, err := a.st.db().GetRawCollection(statusesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	// Agent status is u#unit-name
 	// Workload status is u#unit-name#charm
 	selector := fmt.Sprintf("^%s:u#%s/\\d+(#charm)?$", a.st.ModelUUID(), a.doc.Name)
 	var docs []statusDocWithID
-	err := col.Find(bson.M{"_id": bson.M{"$regex": selector}}).All(&docs)
+	err = col.Find(bson.M{"_id": bson.M{"$regex": selector}}).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -4291,13 +4318,16 @@ func (a *Application) CharmPendingToBeDownloaded() bool {
 }
 
 func appUnitNames(st *State, appName string) ([]string, error) {
-	unitsCollection, closer := st.db().GetCollection(unitsC)
+	unitsCollection, closer, err := st.db().GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []struct {
 		Name string `bson:"name"`
 	}
-	err := unitsCollection.Find(bson.D{{"application", appName}}).Select(bson.D{{"name", 1}}).All(&docs)
+	err = unitsCollection.Find(bson.D{{"application", appName}}).Select(bson.D{{"name", 1}}).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/application_ports.go
+++ b/state/application_ports.go
@@ -138,10 +138,13 @@ func (p *applicationPortRanges) Remove() error {
 
 // Refresh refreshes the port document from state.
 func (p *applicationPortRanges) Refresh() error {
-	openedPorts, closer := p.st.db().GetCollection(openedPortsC)
+	openedPorts, closer, err := p.st.db().GetCollection(openedPortsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
-	err := openedPorts.FindId(p.doc.DocID).One(&p.doc)
+	err = openedPorts.FindId(p.doc.DocID).One(&p.doc)
 	if err == mgo.ErrNotFound {
 		p.docExists = false
 		return errors.NotFoundf("open port ranges for application %q", p.ApplicationName())
@@ -516,7 +519,10 @@ func removeApplicationPortsForUnitOps(st *State, unit *Unit) ([]txn.Op, error) {
 // applicationPortRanges instance with the docExists flag set to false will be
 // returned instead.
 func getApplicationPortRanges(st *State, appName string) (*applicationPortRanges, error) {
-	openedPorts, closer := st.db().GetCollection(openedPortsC)
+	openedPorts, closer, err := st.db().GetCollection(openedPortsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	docID := st.docID(applicationGlobalKey(appName))
@@ -574,7 +580,10 @@ func getOpenedApplicationPortRangesForAllApplications(st *State) ([]*application
 	for _, app := range apps {
 		appNames = append(appNames, app.Name())
 	}
-	openedPorts, closer := st.db().GetCollection(openedPortsC)
+	openedPorts, closer, err := st.db().GetCollection(openedPortsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	docs := []applicationPortRangesDoc{}
 	err = openedPorts.Find(bson.D{{"application-name", bson.D{{"$in", appNames}}}}).All(&docs)

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -85,11 +85,14 @@ func ApplicationOfferEndpoint(offer crossmodel.ApplicationOffer, relationName st
 }
 
 func (s *applicationOffers) offerQuery(query bson.D) (*applicationOfferDoc, error) {
-	applicationOffersCollection, closer := s.st.db().GetCollection(applicationOffersC)
+	applicationOffersCollection, closer, err := s.st.db().GetCollection(applicationOffersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc applicationOfferDoc
-	err := applicationOffersCollection.Find(query).One(&doc)
+	err = applicationOffersCollection.Find(query).One(&doc)
 	return &doc, err
 }
 
@@ -127,11 +130,14 @@ func (s *applicationOffers) ApplicationOfferForUUID(offerUUID string) (*crossmod
 
 // AllApplicationOffers returns all application offers in the model.
 func (s *applicationOffers) AllApplicationOffers() (offers []*crossmodel.ApplicationOffer, _ error) {
-	applicationOffersCollection, closer := s.st.db().GetCollection(applicationOffersC)
+	applicationOffersCollection, closer, err := s.st.db().GetCollection(applicationOffersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []applicationOfferDoc
-	err := applicationOffersCollection.Find(bson.D{}).All(&docs)
+	err = applicationOffersCollection.Find(bson.D{}).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting application offer documents")
 	}
@@ -450,7 +456,10 @@ func (op *RemoveOfferOperation) internalRemove(offer *crossmodel.ApplicationOffe
 
 // applicationOffersDocs returns the offer docs for the given application
 func applicationOffersDocs(st *State, application string) ([]applicationOfferDoc, error) {
-	applicationOffersCollection, closer := st.db().GetCollection(applicationOffersC)
+	applicationOffersCollection, closer, err := st.db().GetCollection(applicationOffersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	query := bson.D{{"application-name", application}}
 	var docs []applicationOfferDoc
@@ -772,7 +781,10 @@ func (s *applicationOffers) makeFilterTerm(filterTerm crossmodel.ApplicationOffe
 
 // ListOffers returns the application offers matching any one of the filter terms.
 func (s *applicationOffers) ListOffers(filters ...crossmodel.ApplicationOfferFilter) ([]crossmodel.ApplicationOffer, error) {
-	applicationOffersCollection, closer := s.st.db().GetCollection(applicationOffersC)
+	applicationOffersCollection, closer, err := s.st.db().GetCollection(applicationOffersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var offerDocs []applicationOfferDoc

--- a/state/autocertcache.go
+++ b/state/autocertcache.go
@@ -30,9 +30,12 @@ type autocertCacheDoc struct {
 
 // Put implements autocert.Cache.Put.
 func (cache autocertCache) Put(ctx context.Context, name string, data []byte) error {
-	coll, closeColl := cache.coll()
+	coll, closeColl, err := cache.coll()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closeColl()
-	_, err := coll.UpsertId(name, autocertCacheDoc{
+	_, err = coll.UpsertId(name, autocertCacheDoc{
 		Name: name,
 		Data: data,
 	})
@@ -44,10 +47,13 @@ func (cache autocertCache) Put(ctx context.Context, name string, data []byte) er
 
 // Get implements autocert.Cache.Get.
 func (cache autocertCache) Get(ctx context.Context, name string) ([]byte, error) {
-	coll, closeColl := cache.coll()
+	coll, closeColl, err := cache.coll()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closeColl()
 	var doc autocertCacheDoc
-	err := coll.FindId(name).One(&doc)
+	err = coll.FindId(name).One(&doc)
 	if err == nil {
 		return doc.Data, nil
 	}
@@ -59,16 +65,22 @@ func (cache autocertCache) Get(ctx context.Context, name string) ([]byte, error)
 
 // Delete implements autocert.Cache.Delete.
 func (cache autocertCache) Delete(ctx context.Context, name string) error {
-	coll, closeColl := cache.coll()
+	coll, closeColl, err := cache.coll()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closeColl()
-	err := coll.RemoveId(name)
+	err = coll.RemoveId(name)
 	if err == nil || errors.Cause(err) == mgo.ErrNotFound {
 		return nil
 	}
 	return errors.Annotatef(err, "cannot delete autocert key %q", name)
 }
 
-func (cache autocertCache) coll() (mongo.WriteCollection, func()) {
-	coll, closer := cache.st.db().GetCollection(autocertCacheC)
-	return coll.Writeable(), closer
+func (cache autocertCache) coll() (mongo.WriteCollection, func(), error) {
+	coll, closer, err := cache.st.db().GetCollection(autocertCacheC)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return coll.Writeable(), closer, nil
 }

--- a/state/bakerystorage.go
+++ b/state/bakerystorage.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/juju/errors"
 
 	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/state/bakerystorage"
@@ -18,8 +19,12 @@ import (
 // will expire items at the specified time.
 func (st *State) NewBakeryStorage() (bakerystorage.ExpirableStorage, error) {
 	return bakerystorage.New(bakerystorage.Config{
-		GetCollection: func() (mongo.Collection, func()) {
-			return st.db().GetCollection(bakeryStorageItemsC)
+		GetCollection: func() (mongo.Collection, func(), error) {
+			coll, closer, err := st.db().GetCollection(bakeryStorageItemsC)
+			if err != nil {
+				return nil, nil, errors.Annotate(err, "getting bakery storage collection")
+			}
+			return coll, closer, nil
 		},
 		GetStorage: func(rootKeys *bakerystorage.RootKeys, coll mongo.Collection, expireAfter time.Duration) bakery.RootKeyStore {
 			return rootKeys.NewStore(coll.Writeable().Underlying(), bakerystorage.Policy{
@@ -31,8 +36,12 @@ func (st *State) NewBakeryStorage() (bakerystorage.ExpirableStorage, error) {
 
 // NewBakeryConfig returns a new bakerystorage.BakeryConfig instance.
 func (st *State) NewBakeryConfig() bakerystorage.BakeryConfig {
-	collectionGetter := func(collection string) (mongo.Collection, func()) {
-		return st.db().GetCollection(collection)
+	collectionGetter := func(collection string) (mongo.Collection, func(), error) {
+		coll, closer, err := st.db().GetCollection(collection)
+		if err != nil {
+			return nil, nil, errors.Annotatef(err, "getting bakery config collection %q", collection)
+		}
+		return coll, closer, nil
 	}
 	return bakerystorage.NewBakeryConfig(controllersC, collectionGetter)
 }

--- a/state/bakerystorage/config.go
+++ b/state/bakerystorage/config.go
@@ -22,7 +22,7 @@ const (
 	bakeryConfigKey = "bakeryConfig"
 )
 
-type collectionGetterFunc func(name string) (mongo.Collection, func())
+type collectionGetterFunc func(name string) (mongo.Collection, func(), error)
 
 // BakeryConfig defines methods used to access bakery configuration.
 type BakeryConfig interface {
@@ -156,9 +156,12 @@ func (b *bakeryConfig) deserialiseKey(data, label string) (*bakery.KeyPair, erro
 
 func (b *bakeryConfig) bakeryConfigDoc() (*bakeryConfigDoc, error) {
 	var doc bakeryConfigDoc
-	controllers, closer := b.collectionGetter(b.collection)
+	controllers, closer, err := b.collectionGetter(b.collection)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
-	err := controllers.FindId(bakeryConfigKey).One(&doc)
+	err = controllers.FindId(bakeryConfigKey).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("bakery config")
 	}

--- a/state/bakerystorage/config_test.go
+++ b/state/bakerystorage/config_test.go
@@ -20,7 +20,7 @@ type ConfigSuite struct {
 	jujutesting.BaseSuite
 	testing.Stub
 
-	collectionGetter func(name string) (mongo.Collection, func())
+	collectionGetter func(name string) (mongo.Collection, func(), error)
 	collection       mockCollection
 	closeCollection  func()
 
@@ -47,10 +47,10 @@ func (s *ConfigSuite) SetUpTest(c *gc.C) {
 		s.AddCall("Close")
 		s.PopNoErr()
 	}
-	s.collectionGetter = func(collection string) (mongo.Collection, func()) {
+	s.collectionGetter = func(collection string) (mongo.Collection, func(), error) {
 		s.AddCall("GetCollection", collection)
 		s.PopNoErr()
-		return &s.collection, s.closeCollection
+		return &s.collection, s.closeCollection, nil
 	}
 }
 

--- a/state/bakerystorage/interface.go
+++ b/state/bakerystorage/interface.go
@@ -16,7 +16,7 @@ import (
 type Config struct {
 	// GetCollection returns a mongo.Collection and a function that
 	// will close any associated resources.
-	GetCollection func() (collection mongo.Collection, closer func())
+	GetCollection func() (collection mongo.Collection, closer func(), err error)
 
 	// GetStorage returns a bakery.Storage and a function that will close
 	// any associated resources.

--- a/state/bakerystorage/rootkeys_test.go
+++ b/state/bakerystorage/rootkeys_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
 	"github.com/juju/mgo/v3"
 	mgotesting "github.com/juju/mgo/v3/testing"
+	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/testing"
 )
 
@@ -517,8 +519,10 @@ func (s *RootKeySuite) TestLegacy(c *gc.C) {
 func (s *RootKeySuite) TestUsesSessionFromContext(c *gc.C) {
 	coll := s.testColl(c)
 
-	s1 := coll.Database.Session.Copy()
-	s2 := coll.Database.Session.Copy()
+	s1, err := mongo.CopySession(coll.Database.Session)
+	c.Assert(err, jc.ErrorIsNil)
+	s2, err := mongo.CopySession(coll.Database.Session)
+	c.Assert(err, jc.ErrorIsNil)
 	s.AddCleanup(func(c *gc.C) {
 		s2.Close()
 	})
@@ -530,7 +534,7 @@ func (s *RootKeySuite) TestUsesSessionFromContext(c *gc.C) {
 	s1.Close()
 
 	ctx := ContextWithMgoSession(context.Background(), s2)
-	_, _, err := store.RootKey(ctx)
+	_, _, err = store.RootKey(ctx)
 	c.Assert(err, gc.Equals, nil)
 }
 

--- a/state/bakerystorage/storage.go
+++ b/state/bakerystorage/storage.go
@@ -51,19 +51,28 @@ func (s *storage) ExpireAfter(expireAfter time.Duration) ExpirableStorage {
 
 // RootKey implements Storage.RootKey
 func (s *storage) RootKey(ctx context.Context) ([]byte, []byte, error) {
-	storage, closer := s.getStorage()
+	storage, closer, err := s.getStorage()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	defer closer()
 	return storage.RootKey(ctx)
 }
 
-func (s *storage) getStorage() (bakery.RootKeyStore, func()) {
-	coll, closer := s.config.GetCollection()
-	return s.config.GetStorage(s.rootKeys, coll, s.expireAfter), closer
+func (s *storage) getStorage() (bakery.RootKeyStore, func(), error) {
+	coll, closer, err := s.config.GetCollection()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return s.config.GetStorage(s.rootKeys, coll, s.expireAfter), closer, nil
 }
 
 // Get implements Storage.Get
 func (s *storage) Get(ctx context.Context, id []byte) ([]byte, error) {
-	storage, closer := s.getStorage()
+	storage, closer, err := s.getStorage()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	i, err := storage.Get(ctx, id)
 	if err != nil {
@@ -78,11 +87,14 @@ func (s *storage) Get(ctx context.Context, id []byte) ([]byte, error) {
 // legacyGet is attempted as the id we're looking for was created in a previous
 // version of Juju while using v1 versions of the macaroon-bakery.
 func (s *storage) legacyGet(location []byte) ([]byte, error) {
-	coll, closer := s.config.GetCollection()
+	coll, closer, err := s.config.GetCollection()
+	if err != nil {
+		return nil, errors.Annotate(err, "cannot get collection")
+	}
 	defer closer()
 
 	var i storageDoc
-	err := coll.FindId(string(location)).One(&i)
+	err = coll.FindId(string(location)).One(&i)
 	if err != nil {
 		if err == mgo.ErrNotFound {
 			return nil, bakery.ErrNotFound

--- a/state/bakerystorage/storage_test.go
+++ b/state/bakerystorage/storage_test.go
@@ -55,10 +55,10 @@ func (s *StorageSuite) SetUpTest(c *gc.C) {
 	}
 	s.memStorage = bakery.NewMemRootKeyStore()
 	s.config = Config{
-		GetCollection: func() (mongo.Collection, func()) {
+		GetCollection: func() (mongo.Collection, func(), error) {
 			s.AddCall("GetCollection")
 			s.PopNoErr()
-			return &s.collection, s.closeCollection
+			return &s.collection, s.closeCollection, nil
 		},
 		GetStorage: func(rootKeys *RootKeys, coll mongo.Collection, expireAfter time.Duration) bakery.RootKeyStore {
 			s.AddCall("GetStorage", coll, expireAfter)
@@ -218,8 +218,10 @@ func (s *BakeryStorageSuite) TearDownSuite(c *gc.C) {
 
 func (s *BakeryStorageSuite) initService(c *gc.C, enableExpiry bool) {
 	store, err := New(Config{
-		GetCollection: func() (mongo.Collection, func()) {
-			return mongo.CollectionFromName(s.db, s.coll.Name)
+		GetCollection: func() (mongo.Collection, func(), error) {
+			coll, closer, err := mongo.CollectionFromName(s.db, s.coll.Name)
+			c.Assert(err, jc.ErrorIsNil)
+			return coll, closer, nil
 		},
 		GetStorage: func(rootKeys *RootKeys, coll mongo.Collection, expireAfter time.Duration) (storage bakery.RootKeyStore) {
 			return rootKeys.NewStore(coll.Writeable().Underlying(), Policy{

--- a/state/binarystorage.go
+++ b/state/binarystorage.go
@@ -17,15 +17,22 @@ var binarystorageNew = binarystorage.New
 // ToolsStorage returns a new binarystorage.StorageCloser that stores tools
 // metadata in the "juju" database "toolsmetadata" collection.
 func (st *State) ToolsStorage() (binarystorage.StorageCloser, error) {
-	modelStorage := newBinaryStorageCloser(st.database, toolsmetadataC, st.ModelUUID())
+	modelStorage, err := newBinaryStorageCloser(st.database, toolsmetadataC, st.ModelUUID())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	if st.IsController() {
 		return modelStorage, nil
 	}
 	// This is a hosted model. Hosted models have their own tools
 	// catalogue, which we combine with the controller's.
-	controllerStorage := newBinaryStorageCloser(
+	controllerStorage, err := newBinaryStorageCloser(
 		st.database, toolsmetadataC, st.ControllerModelUUID(),
 	)
+	if err != nil {
+		modelStorage.Close()
+		return nil, errors.Trace(err)
+	}
 	storage, err := binarystorage.NewLayeredStorage(modelStorage, controllerStorage)
 	if err != nil {
 		modelStorage.Close()
@@ -38,17 +45,29 @@ func (st *State) ToolsStorage() (binarystorage.StorageCloser, error) {
 	}}, nil
 }
 
-func newBinaryStorageCloser(db Database, collectionName, uuid string) binarystorage.StorageCloser {
-	db, closer1 := db.CopyForModel(uuid)
-	metadataCollection, closer2 := db.GetCollection(collectionName)
-	txnRunner, closer3 := db.TransactionRunner()
+func newBinaryStorageCloser(db Database, collectionName, uuid string) (binarystorage.StorageCloser, error) {
+	db, closer1, err := db.CopyForModel(uuid)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	metadataCollection, closer2, err := db.GetCollection(collectionName)
+	if err != nil {
+		closer1()
+		return nil, errors.Trace(err)
+	}
+	txnRunner, closer3, err := db.TransactionRunner()
+	if err != nil {
+		closer2()
+		closer1()
+		return nil, errors.Trace(err)
+	}
 	closer := func() {
 		closer3()
 		closer2()
 		closer1()
 	}
 	storage := newBinaryStorage(uuid, metadataCollection, txnRunner)
-	return &storageCloser{storage, closer}
+	return &storageCloser{storage, closer}, nil
 }
 
 func newBinaryStorage(uuid string, metadataCollection mongo.Collection, txnRunner jujutxn.Runner) binarystorage.Storage {

--- a/state/binarystorage/binarystorage_test.go
+++ b/state/binarystorage/binarystorage_test.go
@@ -49,7 +49,9 @@ func (s *binaryStorageSuite) SetUpTest(c *gc.C) {
 	catalogue := s.Session.DB("catalogue")
 	rs := blobstore.NewGridFS("blobstore", "blobstore", catalogue.Session)
 	var closer func()
-	s.metadataCollection, closer = mongo.CollectionFromName(catalogue, "binarymetadata")
+	var err error
+	s.metadataCollection, closer, err = mongo.CollectionFromName(catalogue, "binarymetadata")
+	c.Assert(err, jc.ErrorIsNil)
 	s.addCleanup(func(*gc.C) { closer() })
 	s.managedStorage = blobstore.NewManagedStorage(s.metadataCollection.Writeable().Underlying().Database, rs)
 	s.txnRunner = jujutxn.NewRunner(jujutxn.RunnerParams{

--- a/state/block.go
+++ b/state/block.go
@@ -182,11 +182,14 @@ func (st *State) GetBlockForType(t BlockType) (Block, bool, error) {
 }
 
 func getBlockForType(mb modelBackend, t BlockType) (Block, bool, error) {
-	all, closer := mb.db().GetCollection(blocksC)
+	all, closer, err := mb.db().GetCollection(blocksC)
+	if err != nil {
+		return nil, false, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := blockDoc{}
-	err := all.Find(bson.D{{"type", t}}).One(&doc)
+	err = all.Find(bson.D{{"type", t}}).One(&doc)
 
 	switch err {
 	case nil:
@@ -200,11 +203,14 @@ func getBlockForType(mb modelBackend, t BlockType) (Block, bool, error) {
 
 // AllBlocks returns all blocks in the model.
 func (st *State) AllBlocks() ([]Block, error) {
-	blocksCollection, closer := st.db().GetCollection(blocksC)
+	blocksCollection, closer, err := st.db().GetCollection(blocksC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var bdocs []blockDoc
-	err := blocksCollection.Find(nil).All(&bdocs)
+	err = blocksCollection.Find(nil).All(&bdocs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get all blocks")
 	}
@@ -218,11 +224,14 @@ func (st *State) AllBlocks() ([]Block, error) {
 // AllBlocksForController returns all blocks in any models on
 // the controller.
 func (st *State) AllBlocksForController() ([]Block, error) {
-	blocksCollection, closer := st.db().GetRawCollection(blocksC)
+	blocksCollection, closer, err := st.db().GetRawCollection(blocksC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var bdocs []blockDoc
-	err := blocksCollection.Find(nil).All(&bdocs)
+	err = blocksCollection.Find(nil).All(&bdocs)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get all blocks")
 	}

--- a/state/blockdevices.go
+++ b/state/blockdevices.go
@@ -59,11 +59,14 @@ func (sb *storageBackend) BlockDevices(machine names.MachineTag) ([]BlockDeviceI
 }
 
 func getBlockDevices(db Database, machineId string) ([]BlockDeviceInfo, error) {
-	coll, cleanup := db.GetCollection(blockDevicesC)
+	coll, cleanup, err := db.GetCollection(blockDevicesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var d blockDevicesDoc
-	err := coll.FindId(machineId).One(&d)
+	err = coll.FindId(machineId).One(&d)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("block devices not found for machine %q", machineId)
 	} else if err != nil {

--- a/state/charm.go
+++ b/state/charm.go
@@ -293,7 +293,10 @@ func insertPendingCharmOps(mb modelBackend, curl string) ([]txn.Op, error) {
 // insertAnyCharmOps returns the txn operations necessary to insert the supplied
 // charm document.
 func insertAnyCharmOps(mb modelBackend, cdoc *charmDoc) ([]txn.Op, error) {
-	charms, cCloser := mb.db().GetCollection(charmsC)
+	charms, cCloser, err := mb.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cCloser()
 
 	life, err := nsLife.read(charms, cdoc.DocID)
@@ -313,7 +316,10 @@ func insertAnyCharmOps(mb modelBackend, cdoc *charmDoc) ([]txn.Op, error) {
 		Insert: cdoc,
 	}
 
-	refcounts, rCloser := mb.db().GetCollection(refcountsC)
+	refcounts, rCloser, err := mb.db().GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer rCloser()
 
 	charmKey := charmGlobalKey(cdoc.URL)
@@ -330,7 +336,10 @@ func insertAnyCharmOps(mb modelBackend, cdoc *charmDoc) ([]txn.Op, error) {
 // document with the supplied data, so long as the supplied assert still holds
 // true.
 func updateCharmOps(mb modelBackend, info CharmInfo, assert bson.D) ([]txn.Op, error) {
-	charms, closer := mb.db().GetCollection(charmsC)
+	charms, closer, err := mb.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	charmKey := info.ID
@@ -407,7 +416,10 @@ func deleteOldPlaceholderCharmsOps(mb modelBackend, charms mongo.Collection, cur
 		return nil, errors.Trace(err)
 	}
 
-	refcounts, closer := mb.db().GetCollection(refcountsC)
+	refcounts, closer, err := mb.db().GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var ops []txn.Op
@@ -725,7 +737,10 @@ func (c *Charm) IsPlaceholder() bool {
 // AddCharmMetadata method once the server-side bundle expansion work is
 // complete.
 func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
-	charms, closer := st.db().GetCollection(charmsC)
+	charms, closer, err := st.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	if err := jujuversion.CheckJujuMinVersion(info.Charm.Meta().MinJujuVersion, jujuversion.Current); err != nil {
@@ -769,7 +784,10 @@ func (st *State) AddCharm(info CharmInfo) (stch *Charm, err error) {
 
 // AllCharms returns all charms in state.
 func (st *State) AllCharms() ([]*Charm, error) {
-	charmsCollection, closer := st.db().GetCollection(charmsC)
+	charmsCollection, closer, err := st.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var cdoc charmDoc
 	var charms []*Charm
@@ -809,14 +827,17 @@ func (st *State) Charm(curl string) (*Charm, error) {
 func (st *State) findCharm(curl *charm.URL) (*Charm, error) {
 	var cdoc charmDoc
 
-	charms, closer := st.db().GetCollection(charmsC)
+	charms, closer, err := st.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	what := bson.D{
 		{"_id", curl.String()},
 	}
 	what = append(what, nsLife.notDead()...)
-	err := charms.Find(what).One(&cdoc)
+	err = charms.Find(what).One(&cdoc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("charm %q", curl)
 	}
@@ -835,7 +856,10 @@ func (st *State) findCharm(curl *charm.URL) (*Charm, error) {
 func (st *State) CharmFromSha256(bundleSha256 string) (*Charm, error) {
 	var cdoc charmDoc
 
-	charms, closer := st.db().GetCollection(charmsC)
+	charms, closer, err := st.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	findExpr := fmt.Sprintf("^%s", bundleSha256)
@@ -844,7 +868,7 @@ func (st *State) CharmFromSha256(bundleSha256 string) (*Charm, error) {
 		{"placeholder", bson.D{{"$ne", true}}},
 	}
 	what = append(what, nsLife.notDead()...)
-	err := charms.Find(what).One(&cdoc)
+	err = charms.Find(what).One(&cdoc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("charm with sha256 %q", bundleSha256)
 	}
@@ -865,13 +889,16 @@ func (st *State) CharmFromSha256(bundleSha256 string) (*Charm, error) {
 // LatestPlaceholderCharm returns the latest charm described by the
 // given URL but which is not yet deployed.
 func (st *State) LatestPlaceholderCharm(curl *charm.URL) (*Charm, error) {
-	charms, closer := st.db().GetCollection(charmsC)
+	charms, closer, err := st.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	noRevURL := curl.WithRevision(-1)
 	curlRegex := "^" + regexp.QuoteMeta(st.docID(noRevURL.String()))
 	var docs []charmDoc
-	err := charms.Find(bson.D{{"_id", bson.D{{"$regex", curlRegex}}}, {"placeholder", true}}).All(&docs)
+	err = charms.Find(bson.D{{"_id", bson.D{{"$regex", curlRegex}}}, {"placeholder", true}}).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get charm %q", curl)
 	}
@@ -980,7 +1007,10 @@ func (st *State) PrepareCharmUpload(curl string) (*Charm, error) {
 		return nil, errors.Errorf("expected charm URL with revision, got %q", curl)
 	}
 
-	charms, closer := st.db().GetCollection(charmsC)
+	charms, closer, err := st.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var (
@@ -1034,7 +1064,10 @@ func (st *State) AddCharmPlaceholder(curl *charm.URL) (err error) {
 	if curl.Revision < 0 {
 		return errors.Errorf("expected charm URL with revision, got %q", curl)
 	}
-	charms, closer := st.db().GetCollection(charmsC)
+	charms, closer, err := st.db().GetCollection(charmsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -1069,11 +1102,14 @@ func (st *State) AddCharmPlaceholder(curl *charm.URL) (err error) {
 // TODO(achilleas): This call will be removed once the server-side bundle
 // deployment work lands.
 func (st *State) UpdateUploadedCharm(info CharmInfo) (*Charm, error) {
-	charms, closer := st.db().GetCollection(charmsC)
+	charms, closer, err := st.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := &charmDoc{}
-	err := charms.FindId(info.ID).One(&doc)
+	err = charms.FindId(info.ID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("charm %q", info.ID)
 	}
@@ -1162,13 +1198,16 @@ func (st *State) AddCharmMetadata(info CharmInfo) (*Charm, error) {
 // AllCharmURLs returns a slice of strings representing charm.URLs for every
 // charm deployed in this model.
 func (st *State) AllCharmURLs() ([]*string, error) {
-	applications, closer := st.db().GetCollection(charmsC)
+	applications, closer, err := st.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []struct {
 		CharmURL *string `bson:"url"`
 	}
-	err := applications.Find(bson.D{}).All(&docs)
+	err = applications.Find(bson.D{}).All(&docs)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("charms")
 	}

--- a/state/charmref.go
+++ b/state/charmref.go
@@ -14,7 +14,10 @@ var errCharmInUse = errors.New("charm in use")
 // to a charm and its per-application settings and storage constraints
 // documents. It will fail if the charm is not Alive.
 func appCharmIncRefOps(mb modelBackend, appName string, cURL *string, canCreate bool) ([]txn.Op, error) {
-	charms, cCloser := mb.db().GetCollection(charmsC)
+	charms, cCloser, err := mb.db().GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cCloser()
 
 	// If we're migrating. charm document will not be present. But
@@ -31,7 +34,10 @@ func appCharmIncRefOps(mb modelBackend, appName string, cURL *string, canCreate 
 		checkOps = []txn.Op{checkOp}
 	}
 
-	refcounts, rCloser := mb.db().GetCollection(refcountsC)
+	refcounts, rCloser, err := mb.db().GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer rCloser()
 
 	getIncRefOp := nsRefcounts.CreateOrIncRefOp
@@ -69,7 +75,10 @@ func appCharmIncRefOps(mb modelBackend, appName string, cURL *string, canCreate 
 // and will accumulate operational errors encountered in the operation.
 // If the 'force' is not set, any error will be fatal and no operations will be returned.
 func appCharmDecRefOps(st modelBackend, appName string, cURL *string, maybeDoFinal bool, op *ForcedOperation) ([]txn.Op, error) {
-	refcounts, closer := st.db().GetCollection(refcountsC)
+	refcounts, closer, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	fail := func(e error) ([]txn.Op, error) {
@@ -140,7 +149,10 @@ func charmDestroyOps(st modelBackend, curl string) ([]txn.Op, error) {
 		return nil, errors.BadRequestf("curl is empty")
 	}
 	db := st.db()
-	charms, cCloser := db.GetCollection(charmsC)
+	charms, cCloser, err := db.GetCollection(charmsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cCloser()
 
 	charmOp, err := nsLife.destroyOp(charms, curl, nil)
@@ -148,7 +160,10 @@ func charmDestroyOps(st modelBackend, curl string) ([]txn.Op, error) {
 		return nil, errors.Annotate(err, "charm")
 	}
 
-	refcounts, rCloser := db.GetCollection(refcountsC)
+	refcounts, rCloser, err := db.GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer rCloser()
 
 	refcountKey := charmGlobalKey(&curl)

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -127,7 +127,10 @@ type cancelCleanupOpsArg struct {
 }
 
 func (st *State) cancelCleanupOps(args ...cancelCleanupOpsArg) ([]txn.Op, error) {
-	col, closer := st.db().GetCollection(cleanupsC)
+	col, closer, err := st.db().GetCollection(cleanupsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	patterns := make([]bson.D, len(args))
 	for i, arg := range args {
@@ -137,7 +140,7 @@ func (st *State) cancelCleanupOps(args ...cancelCleanupOpsArg) ([]txn.Op, error)
 		}
 	}
 	var docs []cleanupDoc
-	if err := col.Find(bson.D{{Name: "$or", Value: patterns}}).All(&docs); err != nil {
+	if err = col.Find(bson.D{{Name: "$or", Value: patterns}}).All(&docs); err != nil {
 		return nil, errors.Annotate(err, "cannot get cleanups docs")
 	}
 	var ops []txn.Op
@@ -153,7 +156,10 @@ func (st *State) cancelCleanupOps(args ...cancelCleanupOpsArg) ([]txn.Op, error)
 
 // NeedsCleanup returns true if documents previously marked for removal exist.
 func (st *State) NeedsCleanup() (bool, error) {
-	cleanups, closer := st.db().GetCollection(cleanupsC)
+	cleanups, closer, err := st.db().GetCollection(cleanupsC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 	count, err := cleanups.Count()
 	if err != nil {
@@ -170,7 +176,10 @@ type SecretContentDeleter func(uri *secrets.URI, revision int) error
 // of the system.
 func (st *State) Cleanup(secretContentDeleter SecretContentDeleter) (err error) {
 	var doc cleanupDoc
-	cleanups, closer := st.db().GetCollection(cleanupsC)
+	cleanups, closer, err := st.db().GetCollection(cleanupsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	modelUUID := st.ModelUUID()
@@ -306,7 +315,10 @@ func (st *State) cleanupForceDestroyedRelation(prefix string) (err error) {
 		return errors.Annotatef(err, "getting relation %q", prefix)
 	}
 
-	scopes, closer := st.db().GetCollection(relationScopesC)
+	scopes, closer, err := st.db().GetCollection(relationScopesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	sel := bson.M{"_id": bson.M{
@@ -679,7 +691,10 @@ func (st *State) removeApplicationsForDyingModel(args DestroyModelParams, secret
 	// applications added to it. But we do have to remove the applications
 	// themselves via individual transactions, because they could be in any
 	// state at all.
-	applications, closer := st.db().GetCollection(applicationsC)
+	applications, closer, err := st.db().GetCollection(applicationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	// Note(jam): 2019-04-25 This will only try to shut down Alive applications,
 	//  it doesn't cause applications that are Dying to finish progressing to Dead.
@@ -714,7 +729,10 @@ func (st *State) removeRemoteApplicationsForDyingModel(args DestroyModelParams) 
 	// This won't miss remote applications, because a Dying model cannot have
 	// applications added to it. But we do have to remove the applications themselves
 	// via individual transactions, because they could be in any state at all.
-	remoteApps, closer := st.db().GetCollection(remoteApplicationsC)
+	remoteApps, closer, err := st.db().GetCollection(remoteApplicationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	remoteApp := RemoteApplication{st: st}
 	sel := bson.D{{"life", Alive}}
@@ -791,7 +809,10 @@ func (st *State) cleanupUnitsForDyingApplication(applicationname string, cleanup
 	// This won't miss units, because a Dying application cannot have units
 	// added to it. But we do have to remove the units themselves via
 	// individual transactions, because they could be in any state at all.
-	units, closer := st.db().GetCollection(unitsC)
+	units, closer, err := st.db().GetCollection(unitsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	sel := bson.D{{"application", applicationname}}
@@ -1658,7 +1679,10 @@ func (st *State) cleanupAttachmentsForDyingStorage(storageId string, cleanupArgs
 	// have attachments added to it. But we do have to remove the attachments
 	// themselves via individual transactions, because they could be in
 	// any state at all.
-	coll, closer := st.db().GetCollection(storageAttachmentsC)
+	coll, closer, err := st.db().GetCollection(storageAttachmentsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var doc storageAttachmentDoc
@@ -1689,7 +1713,10 @@ func (st *State) cleanupAttachmentsForDyingVolume(volumeId string) (err error) {
 	// attachments added to it. But we do have to remove the attachments
 	// themselves via individual transactions, because they could be in
 	// any state at all.
-	coll, closer := st.db().GetCollection(volumeAttachmentsC)
+	coll, closer, err := st.db().GetCollection(volumeAttachmentsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	sb, err := NewStorageBackend(st)
@@ -1725,7 +1752,10 @@ func (st *State) cleanupAttachmentsForDyingFilesystem(filesystemId string) (err 
 	// attachments added to it. But we do have to remove the attachments
 	// themselves via individual transactions, because they could be in
 	// any state at all.
-	coll, closer := sb.mb.db().GetCollection(filesystemAttachmentsC)
+	coll, closer, err := sb.mb.db().GetCollection(filesystemAttachmentsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var doc filesystemAttachmentDoc

--- a/state/cloud.go
+++ b/state/cloud.go
@@ -126,7 +126,10 @@ func cloudModelRefCountKey(cloudName string) string {
 // incApplicationOffersRefOp returns a txn.Op that increments the reference
 // count for a cloud model.
 func incCloudModelRefOp(mb modelBackend, cloudName string) (txn.Op, error) {
-	refcounts, closer := mb.db().GetCollection(globalRefcountsC)
+	refcounts, closer, err := mb.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
 	defer closer()
 	cloudModelRefCountKey := cloudModelRefCountKey(cloudName)
 	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, cloudModelRefCountKey, 1)
@@ -136,7 +139,10 @@ func incCloudModelRefOp(mb modelBackend, cloudName string) (txn.Op, error) {
 // countCloudModelRefOp returns the number of models for a cloud,
 // along with a txn.Op that ensures that that does not change.
 func countCloudModelRefOp(mb modelBackend, cloudName string) (txn.Op, int, error) {
-	refcounts, closer := mb.db().GetCollection(globalRefcountsC)
+	refcounts, closer, err := mb.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return txn.Op{}, 0, errors.Trace(err)
+	}
 	defer closer()
 	key := cloudModelRefCountKey(cloudName)
 	return nsRefcounts.CurrentOp(refcounts, key)
@@ -145,7 +151,10 @@ func countCloudModelRefOp(mb modelBackend, cloudName string) (txn.Op, int, error
 // decCloudModelRefOp returns a txn.Op that decrements the reference
 // count for a cloud model.
 func decCloudModelRefOp(mb modelBackend, cloudName string) (txn.Op, error) {
-	refcounts, closer := mb.db().GetCollection(globalRefcountsC)
+	refcounts, closer, err := mb.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
 	defer closer()
 	cloudModelRefCountKey := cloudModelRefCountKey(cloudName)
 	decRefOp, _, err := nsRefcounts.DyingDecRefOp(refcounts, cloudModelRefCountKey)
@@ -195,7 +204,10 @@ func (st *State) Clouds() (map[names.CloudTag]cloud.Cloud, error) {
 		return nil, errors.Trace(err)
 	}
 
-	coll, cleanup := st.db().GetCollection(cloudsC)
+	coll, cleanup, err := st.db().GetCollection(cloudsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var doc cloudDoc
@@ -217,7 +229,10 @@ func (st *State) Cloud(name string) (cloud.Cloud, error) {
 		return cloud.Cloud{}, errors.Trace(err)
 	}
 
-	coll, cleanup := st.db().GetCollection(cloudsC)
+	coll, cleanup, err := st.db().GetCollection(cloudsC)
+	if err != nil {
+		return cloud.Cloud{}, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var doc cloudDoc

--- a/state/cloudcontainer.go
+++ b/state/cloudcontainer.go
@@ -81,11 +81,14 @@ func globalCloudContainerKey(name string) string {
 }
 
 func (u *Unit) cloudContainer() (*cloudContainerDoc, error) {
-	coll, closer := u.st.db().GetCollection(cloudContainersC)
+	coll, closer, err := u.st.db().GetCollection(cloudContainersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc cloudContainerDoc
-	err := coll.FindId(u.globalKey()).One(&doc)
+	err = coll.FindId(u.globalKey()).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("cloud container for unit %v", u.Name())
 	}
@@ -141,11 +144,14 @@ func (u *Unit) removeCloudContainerOps() []txn.Op {
 
 // Containers returns the containers for the specified provider ids.
 func (m *CAASModel) Containers(providerIds ...string) ([]CloudContainer, error) {
-	coll, closer := m.st.db().GetCollection(cloudContainersC)
+	coll, closer, err := m.st.db().GetCollection(cloudContainersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var all []cloudContainerDoc
-	err := coll.Find(bson.D{{"provider-id", bson.D{{"$in", providerIds}}}}).All(&all)
+	err = coll.Find(bson.D{{"provider-id", bson.D{{"$in", providerIds}}}}).All(&all)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/cloudcredentials.go
+++ b/state/cloudcredentials.go
@@ -64,11 +64,14 @@ type cloudCredentialDoc struct {
 
 // CloudCredential returns the cloud credential for the given tag.
 func (st *State) CloudCredential(tag names.CloudCredentialTag) (Credential, error) {
-	coll, cleanup := st.db().GetCollection(cloudCredentialsC)
+	coll, cleanup, err := st.db().GetCollection(cloudCredentialsC)
+	if err != nil {
+		return Credential{}, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var doc cloudCredentialDoc
-	err := coll.FindId(cloudCredentialDocID(tag)).One(&doc)
+	err = coll.FindId(cloudCredentialDocID(tag)).One(&doc)
 	if err == mgo.ErrNotFound {
 		return Credential{}, errors.NotFoundf(
 			"cloud credential %q", tag.Id(),
@@ -84,7 +87,10 @@ func (st *State) CloudCredential(tag names.CloudCredentialTag) (Credential, erro
 // CloudCredentials returns the user's cloud credentials for a given cloud,
 // keyed by credential name.
 func (st *State) CloudCredentials(user names.UserTag, cloudName string) (map[string]Credential, error) {
-	coll, cleanup := st.db().GetCollection(cloudCredentialsC)
+	coll, cleanup, err := st.db().GetCollection(cloudCredentialsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	credentials := make(map[string]Credential)
@@ -430,7 +436,10 @@ func (st *State) WatchCredential(cred names.CloudCredentialTag) NotifyWatcher {
 // AllCloudCredentials returns all cloud credentials stored on the controller
 // for a given user.
 func (st *State) AllCloudCredentials(user names.UserTag) ([]Credential, error) {
-	coll, cleanup := st.db().GetCollection(cloudCredentialsC)
+	coll, cleanup, err := st.db().GetCollection(cloudCredentialsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	// There are 2 ways of getting a credential for a user:
@@ -442,7 +451,7 @@ func (st *State) AllCloudCredentials(user names.UserTag) ([]Credential, error) {
 	clause := bson.D{{"owner", user.Id()}}
 
 	var docs []cloudCredentialDoc
-	err := coll.Find(clause).Sort("cloud").All(&docs)
+	err = coll.Find(clause).Sort("cloud").All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting cloud credentials for %q", user.Id())
 	}
@@ -459,7 +468,10 @@ func (st *State) AllCloudCredentials(user names.UserTag) ([]Credential, error) {
 }
 
 func (st *State) modelsWithCredential(tag names.CloudCredentialTag) ([]modelDoc, error) {
-	coll, cleanup := st.db().GetCollection(modelsC)
+	coll, cleanup, err := st.db().GetCollection(modelsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	sel := bson.D{
@@ -468,7 +480,7 @@ func (st *State) modelsWithCredential(tag names.CloudCredentialTag) ([]modelDoc,
 	}
 
 	var docs []modelDoc
-	err := coll.Find(sel).All(&docs)
+	err = coll.Find(sel).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting models that use cloud credential %q", tag.Id())
 	}
@@ -496,7 +508,10 @@ func (st *State) CredentialModels(tag names.CloudCredentialTag) (map[string]stri
 func (st *State) RemoveModelsCredential(tag names.CloudCredentialTag) error {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		logger.Tracef("creating operations to remove models credential, attempt %d", attempt)
-		coll, cleanup := st.db().GetCollection(modelsC)
+		coll, cleanup, err := st.db().GetCollection(modelsC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer cleanup()
 
 		sel := bson.D{

--- a/state/cloudimagemetadata/image.go
+++ b/state/cloudimagemetadata/image.go
@@ -154,7 +154,10 @@ func (s *storage) DeleteMetadata(imageId string) error {
 }
 
 func (s *storage) metadataForImageId(imageId string) ([]imagesMetadataDoc, error) {
-	coll, closer := s.store.GetCollection(s.collection)
+	coll, closer, err := s.store.GetCollection(s.collection)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []imagesMetadataDoc
@@ -166,7 +169,10 @@ func (s *storage) metadataForImageId(imageId string) ([]imagesMetadataDoc, error
 }
 
 func (s *storage) getMetadata(id string) (Metadata, error) {
-	coll, closer := s.store.GetCollection(s.collection)
+	coll, closer, err := s.store.GetCollection(s.collection)
+	if err != nil {
+		return emptyMetadata, errors.Trace(err)
+	}
 	defer closer()
 
 	var old imagesMetadataDoc
@@ -181,12 +187,15 @@ func (s *storage) getMetadata(id string) (Metadata, error) {
 
 // AllCloudImageMetadata returns all cloud image metadata in the model.
 func (s *storage) AllCloudImageMetadata() ([]Metadata, error) {
-	coll, closer := s.store.GetCollection(s.collection)
+	coll, closer, err := s.store.GetCollection(s.collection)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	results := []Metadata{}
 	docs := []imagesMetadataDoc{}
-	err := coll.Find(nil).All(&docs)
+	err = coll.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get all image metadata")
 	}
@@ -328,7 +337,10 @@ func validateMetadata(m *imagesMetadataDoc) error {
 // FindMetadata implements Storage.FindMetadata.
 // Results are sorted by date created and grouped by source.
 func (s *storage) FindMetadata(criteria MetadataFilter) (map[string][]Metadata, error) {
-	coll, closer := s.store.GetCollection(s.collection)
+	coll, closer, err := s.store.GetCollection(s.collection)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	logger.Debugf("searching for image metadata %#v", criteria)
@@ -420,7 +432,10 @@ type MetadataFilter struct {
 
 // SupportedArchitectures implements Storage.SupportedArchitectures.
 func (s *storage) SupportedArchitectures(criteria MetadataFilter) ([]string, error) {
-	coll, closer := s.store.GetCollection(s.collection)
+	coll, closer, err := s.store.GetCollection(s.collection)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var arches []string

--- a/state/cloudimagemetadata/image_test.go
+++ b/state/cloudimagemetadata/image_test.go
@@ -106,7 +106,8 @@ func (s *cloudImageMetadataSuite) TestSaveMetadataExpiry(c *gc.C) {
 
 	err := s.storage.SaveMetadata(metadata)
 	c.Assert(err, jc.ErrorIsNil)
-	coll, closer := s.access.GetCollection(collectionName)
+	coll, closer, err := s.access.GetCollection(collectionName)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	var all []bson.M
@@ -608,8 +609,12 @@ func NewTestMongo(database *mgo.Database) *TestMongo {
 	}
 }
 
-func (m *TestMongo) GetCollection(name string) (mongo.Collection, func()) {
-	return mongo.CollectionFromName(m.database, name)
+func (m *TestMongo) GetCollection(name string) (mongo.Collection, func(), error) {
+	coll, closer, err := mongo.CollectionFromName(m.database, name)
+	if err != nil {
+		return nil, nil, err
+	}
+	return coll, closer, nil
 }
 
 func (m *TestMongo) RunTransaction(getTxn jujutxn.TransactionSource) error {

--- a/state/cloudimagemetadata/interface.go
+++ b/state/cloudimagemetadata/interface.go
@@ -86,5 +86,5 @@ type DataStore interface {
 	RunTransaction(jujutxn.TransactionSource) error
 
 	// GetCollection retrieves desired collection from this data source.
-	GetCollection(name string) (collection mongo.Collection, closer func())
+	GetCollection(name string) (collection mongo.Collection, closer func(), err error)
 }

--- a/state/cloudservice.go
+++ b/state/cloudservice.go
@@ -86,11 +86,14 @@ func (c *CloudService) DesiredScaleProtected() bool {
 }
 
 func (c *CloudService) cloudServiceDoc() (*cloudServiceDoc, error) {
-	coll, closer := c.st.db().GetCollection(cloudServicesC)
+	coll, closer, err := c.st.db().GetCollection(cloudServicesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc cloudServiceDoc
-	err := coll.FindId(c.doc.DocID).One(&doc)
+	err = coll.FindId(c.doc.DocID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("cloud service %v", c.Id())
 	}

--- a/state/clouduser.go
+++ b/state/clouduser.go
@@ -115,7 +115,10 @@ func (st *State) CloudsForUser(user names.UserTag, isSuperuser bool) ([]CloudInf
 		return nil, errors.Trace(err)
 	}
 
-	clouds, closer := st.db().GetCollection(cloudsC)
+	clouds, closer, err := st.db().GetCollection(cloudsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var cloudQuery mongo.Query
@@ -153,7 +156,10 @@ func (st *State) CloudsForUser(user names.UserTag, isSuperuser bool) ([]CloudInf
 func (st *State) cloudNamesForUser(user names.UserTag) ([]string, error) {
 	// Start by looking up cloud names that the user has access to, and then load only the records that are
 	// included in that set
-	permissions, permCloser := st.db().GetRawCollection(permissionsC)
+	permissions, permCloser, err := st.db().GetRawCollection(permissionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer permCloser()
 
 	findExpr := fmt.Sprintf("^.*#%s$", userGlobalKey(user.Id()))
@@ -190,7 +196,10 @@ func (st *State) fillInCloudUserAccess(user names.UserTag, cloudInfo []CloudInfo
 		indexByName[info.Name] = i
 	}
 
-	perms, closer := st.db().GetCollection(permissionsC)
+	perms, closer, err := st.db().GetCollection(permissionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	query := perms.Find(bson.M{"_id": bson.M{"$in": permissionIds}}).Batch(100)
 	iter := query.Iter()

--- a/state/constraints.go
+++ b/state/constraints.go
@@ -119,10 +119,13 @@ func (c *Constraints) ChangeSpaceNameOps(from, to string) []txn.Op {
 
 // AllConstraints returns all constraints in the collection.
 func (st *State) AllConstraints() ([]*Constraints, error) {
-	constraintsCollection, closer := st.db().GetCollection(constraintsC)
+	constraintsCollection, closer, err := st.db().GetCollection(constraintsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var docs []constraintsDoc
-	err := constraintsCollection.Find(nil).All(&docs)
+	err = constraintsCollection.Find(nil).All(&docs)
 
 	cons := make([]*Constraints, len(docs))
 	for i, doc := range docs {
@@ -134,7 +137,10 @@ func (st *State) AllConstraints() ([]*Constraints, error) {
 // ConstraintsBySpaceName returns all Constraints that include a positive
 // or negative space constraint for the input space name.
 func (st *State) ConstraintsBySpaceName(spaceName string) ([]*Constraints, error) {
-	constraintsCollection, closer := st.db().GetCollection(constraintsC)
+	constraintsCollection, closer, err := st.db().GetCollection(constraintsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []constraintsDoc
@@ -142,7 +148,7 @@ func (st *State) ConstraintsBySpaceName(spaceName string) ([]*Constraints, error
 		{{"spaces", spaceName}},
 		{{"spaces", "^" + spaceName}},
 	}}}
-	err := constraintsCollection.Find(query).All(&docs)
+	err = constraintsCollection.Find(query).All(&docs)
 
 	cons := make([]*Constraints, len(docs))
 	for i, doc := range docs {
@@ -178,7 +184,10 @@ func removeConstraintsOp(id string) txn.Op {
 }
 
 func readConstraints(mb modelBackend, id string) (constraints.Value, error) {
-	constraintsCollection, closer := mb.db().GetCollection(constraintsC)
+	constraintsCollection, closer, err := mb.db().GetCollection(constraintsC)
+	if err != nil {
+		return constraints.Value{}, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc constraintsDoc
@@ -201,11 +210,14 @@ func writeConstraints(mb modelBackend, id string, cons constraints.Value) error 
 // AllConstraints retrieves all the constraints in the model
 // and provides a way to query based on machine or application.
 func (m *Model) AllConstraints() (*ModelConstraints, error) {
-	coll, closer := m.st.db().GetCollection(constraintsC)
+	coll, closer, err := m.st.db().GetCollection(constraintsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []constraintsDoc
-	err := coll.Find(nil).All(&docs)
+	err = coll.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get all constraints for model")
 	}

--- a/state/controller.go
+++ b/state/controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/names/v5"
 
 	jujucontroller "github.com/juju/juju/controller"
+	"github.com/juju/juju/mongo"
 )
 
 const (
@@ -239,7 +240,10 @@ type ControllerInfo struct {
 // ControllerInfo returns information about
 // the currently configured controller machines.
 func (st *State) ControllerInfo() (*ControllerInfo, error) {
-	session := st.session.Copy()
+	session, err := mongo.CopySession(st.session)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer session.Close()
 	return readRawControllerInfo(session)
 }
@@ -281,11 +285,14 @@ type stateServingInfo struct {
 
 // StateServingInfo returns information for running a controller machine
 func (st *State) StateServingInfo() (jujucontroller.StateServingInfo, error) {
-	controllers, closer := st.db().GetCollection(controllersC)
+	controllers, closer, err := st.db().GetCollection(controllersC)
+	if err != nil {
+		return jujucontroller.StateServingInfo{}, errors.Trace(err)
+	}
 	defer closer()
 
 	var info stateServingInfo
-	err := controllers.Find(bson.D{{"_id", stateServingInfoKey}}).One(&info)
+	err = controllers.Find(bson.D{{"_id", stateServingInfoKey}}).One(&info)
 	if err != nil {
 		return jujucontroller.StateServingInfo{}, errors.Trace(err)
 	}
@@ -349,11 +356,14 @@ type sshServerHostKeyDoc struct {
 // during the controller bootstrap process via bootstrap-state and is currently
 // a FIXED value.
 func (st *State) SSHServerHostKey() (string, error) {
-	controllers, closer := st.db().GetCollection(controllersC)
+	controllers, closer, err := st.db().GetCollection(controllersC)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
 	defer closer()
 
 	var keyDoc sshServerHostKeyDoc
-	err := controllers.Find(bson.D{{"_id", sshServerHostKeyDocId}}).One(&keyDoc)
+	err = controllers.Find(bson.D{{"_id", sshServerHostKeyDocId}}).One(&keyDoc)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/state/controlleruser.go
+++ b/state/controlleruser.go
@@ -35,11 +35,14 @@ func (st *State) setControllerAccess(access permission.Access, userGlobalKey str
 // controllerUser a model userAccessDoc.
 func (st *State) controllerUser(user names.UserTag) (userAccessDoc, error) {
 	controllerUser := userAccessDoc{}
-	controllerUsers, closer := st.db().GetCollection(controllerUsersC)
+	controllerUsers, closer, err := st.db().GetCollection(controllerUsersC)
+	if err != nil {
+		return userAccessDoc{}, errors.Trace(err)
+	}
 	defer closer()
 
 	username := strings.ToLower(user.Id())
-	err := controllerUsers.FindId(username).One(&controllerUser)
+	err = controllerUsers.FindId(username).One(&controllerUser)
 	if err == mgo.ErrNotFound {
 		return userAccessDoc{}, errors.NotFoundf("controller user %q", user.Id())
 	}

--- a/state/database.go
+++ b/state/database.go
@@ -42,18 +42,18 @@ type Database interface {
 	// GetCollection and TransactionRunner results from the resulting Database
 	// will all share a session; this does not absolve you of responsibility
 	// for calling those collections' closers.
-	Copy() (Database, SessionCloser)
+	Copy() (Database, SessionCloser, error)
 
 	// CopyRaw returns a matching Database with its own session, and the
 	// session, which must be closed when the Database is no longer needed.
-	CopyRaw() (Database, *mgo.Session)
+	CopyRaw() (Database, *mgo.Session, error)
 
 	// CopyForModel returns a matching Database with its own session and
 	// its own modelUUID and a func that must be called when the Database is no
 	// longer needed.
 	//
 	// Same warnings apply for CopyForModel than for Copy.
-	CopyForModel(modelUUID string) (Database, SessionCloser)
+	CopyForModel(modelUUID string) (Database, SessionCloser, error)
 
 	// GetCollection returns the named Collection, and a func that must be
 	// called when the Collection is no longer needed. The returned Collection
@@ -63,17 +63,17 @@ type Database interface {
 	// If the schema specifies model-filtering for the named collection,
 	// the returned collection will automatically filter queries; for details,
 	// see modelStateCollection.
-	GetCollection(name string) (mongo.Collection, SessionCloser)
+	GetCollection(name string) (mongo.Collection, SessionCloser, error)
 
 	// GetCollectionFor returns the named collection, scoped for the
 	// model specified. As for GetCollection, a closer is also returned.
-	GetCollectionFor(modelUUID, name string) (mongo.Collection, SessionCloser)
+	GetCollectionFor(modelUUID, name string) (mongo.Collection, SessionCloser, error)
 
 	// GetRawCollection returns the named mgo Collection. As no
 	// automatic model filtering is performed by the returned
 	// collection it should be rarely used. GetCollection() should be
 	// used in almost all cases.
-	GetRawCollection(name string) (*mgo.Collection, SessionCloser)
+	GetRawCollection(name string) (*mgo.Collection, SessionCloser, error)
 
 	// TransactionRunner returns a runner responsible for making changes to
 	// the database, and a func that must be called when the runner is no longer
@@ -84,7 +84,7 @@ type Database interface {
 	// collections; it will automatically rewrite operations that reference
 	// non-global collections; and it will ensure that non-global documents can
 	// only be inserted while the corresponding model is still Alive.
-	TransactionRunner() (jujutxn.Runner, SessionCloser)
+	TransactionRunner() (jujutxn.Runner, SessionCloser, error)
 
 	// RunTransaction is a convenience method for running a single
 	// transaction.
@@ -130,7 +130,10 @@ var ErrChangeComplete = errors.New("change complete")
 // Apply runs the supplied Change against the supplied Database. If it
 // returns no error, the change succeeded.
 func Apply(db Database, change Change) error {
-	db, dbCloser := db.Copy()
+	db, dbCloser, err := db.Copy()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer dbCloser()
 
 	buildTxn := func(int) ([]txn.Op, error) {
@@ -144,7 +147,10 @@ func Apply(db Database, change Change) error {
 		return ops, nil
 	}
 
-	runner, tCloser := db.TransactionRunner()
+	runner, tCloser, err := db.TransactionRunner()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer tCloser()
 	if err := runner.Run(buildTxn); err != nil {
 		return errors.Trace(err)
@@ -276,8 +282,11 @@ type database struct {
 // after an mgo/txn transaction is run.
 type RunTransactionObserverFunc func(dbName, modelUUID string, attempt int, duration time.Duration, ops []txn.Op, err error)
 
-func (db *database) copySession(modelUUID string) (*database, *mgo.Session) {
-	session := db.raw.Session.Copy()
+func (db *database) copySession(modelUUID string) (*database, *mgo.Session, error) {
+	session, err := mongo.CopySession(db.raw.Session)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	return &database{
 		raw:            db.raw.With(session),
 		schema:         db.schema,
@@ -286,7 +295,7 @@ func (db *database) copySession(modelUUID string) (*database, *mgo.Session) {
 		ownSession:     true,
 		clock:          db.clock,
 		maxTxnAttempts: db.maxTxnAttempts,
-	}, session
+	}, session, nil
 }
 
 func (db *database) setTracker(tracker *queryTracker) {
@@ -296,24 +305,34 @@ func (db *database) setTracker(tracker *queryTracker) {
 }
 
 // Copy is part of the Database interface.
-func (db *database) Copy() (Database, SessionCloser) {
-	result, session := db.copySession(db.modelUUID)
-	return result, session.Close
+func (db *database) Copy() (Database, SessionCloser, error) {
+	result, session, err := db.copySession(db.modelUUID)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return result, session.Close, nil
 }
 
 // CopyRaw is part of the Database interface.
-func (db *database) CopyRaw() (Database, *mgo.Session) {
-	return db.copySession(db.modelUUID)
+func (db *database) CopyRaw() (Database, *mgo.Session, error) {
+	result, session, err := db.copySession(db.modelUUID)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return result, session, nil
 }
 
 // CopyForModel is part of the Database interface.
-func (db *database) CopyForModel(modelUUID string) (Database, SessionCloser) {
-	result, session := db.copySession(modelUUID)
-	return result, session.Close
+func (db *database) CopyForModel(modelUUID string) (Database, SessionCloser, error) {
+	result, session, err := db.copySession(modelUUID)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return result, session.Close, nil
 }
 
 // GetCollection is part of the Database interface.
-func (db *database) GetCollection(name string) (collection mongo.Collection, closer SessionCloser) {
+func (db *database) GetCollection(name string) (collection mongo.Collection, closer SessionCloser, err error) {
 	info, found := db.schema[name]
 	if !found {
 		logger.Errorf("using unknown collection %q", name)
@@ -327,7 +346,10 @@ func (db *database) GetCollection(name string) (collection mongo.Collection, clo
 		collection = mongo.WrapCollection(db.raw.C(name))
 		closer = dontCloseAnything
 	} else {
-		collection, closer = mongo.CollectionFromName(db.raw, name)
+		collection, closer, err = mongo.CollectionFromName(db.raw, name)
+		if err != nil {
+			return nil, nil, errors.Annotatef(err, "cannot get collection %q", name)
+		}
 	}
 
 	// Apply model filtering.
@@ -347,33 +369,50 @@ func (db *database) GetCollection(name string) (collection mongo.Collection, clo
 		// interface a bit to drop Writeable in this situation, but it's
 		// not convenient yet.
 	}
-	return collection, closer
+	return collection, closer, nil
 }
 
 // GetCollectionFor is part of the Database interface.
-func (db *database) GetCollectionFor(modelUUID, name string) (mongo.Collection, SessionCloser) {
-	newDb, dbcloser := db.CopyForModel(modelUUID)
-	collection, closer := newDb.GetCollection(name)
+func (db *database) GetCollectionFor(modelUUID, name string) (mongo.Collection, SessionCloser, error) {
+	newDb, dbcloser, err := db.CopyForModel(modelUUID)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	collection, closer, err := newDb.GetCollection(name)
+	if err != nil {
+		dbcloser()
+		return nil, nil, errors.Trace(err)
+	}
 	return collection, func() {
 		closer()
 		dbcloser()
-	}
+	}, nil
 }
 
 // GetRawCollection is part of the Database interface.
-func (db *database) GetRawCollection(name string) (*mgo.Collection, SessionCloser) {
-	collection, closer := db.GetCollection(name)
-	return collection.Writeable().Underlying(), closer
+func (db *database) GetRawCollection(name string) (*mgo.Collection, SessionCloser, error) {
+	collection, closer, err := db.GetCollection(name)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return collection.Writeable().Underlying(), closer, nil
 }
 
 // TransactionRunner is part of the Database interface.
-func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCloser) {
+func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCloser, err error) {
 	runner = db.runner
 	closer = dontCloseAnything
 	if runner == nil {
 		raw := db.raw
 		if !db.ownSession {
-			session := raw.Session.Copy()
+			session, err := mongo.CopySession(raw.Session)
+			if err != nil {
+				return nil, nil, errors.Annotatef(
+					err,
+					"cannot copy transaction runner session for model %q",
+					db.modelUUID,
+				)
+			}
 			raw = raw.With(session)
 			closer = session.Close
 		}
@@ -412,28 +451,40 @@ func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCl
 		rawRunner: runner,
 		modelUUID: db.modelUUID,
 		schema:    db.schema,
-	}, closer
+	}, closer, nil
 }
 
 // RunTransaction is part of the Database interface.
 func (db *database) RunTransaction(ops []txn.Op) error {
-	runner, closer := db.TransactionRunner()
+	runner, closer, err := db.TransactionRunner()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	return runner.RunTransaction(&jujutxn.Transaction{Ops: ops})
 }
 
 // RunTransactionFor is part of the Database interface.
 func (db *database) RunTransactionFor(modelUUID string, ops []txn.Op) error {
-	newDB, dbcloser := db.CopyForModel(modelUUID)
+	newDB, dbcloser, err := db.CopyForModel(modelUUID)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer dbcloser()
-	runner, closer := newDB.TransactionRunner()
+	runner, closer, err := newDB.TransactionRunner()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	return runner.RunTransaction(&jujutxn.Transaction{Ops: ops})
 }
 
 // RunRawTransaction is part of the Database interface.
 func (db *database) RunRawTransaction(ops []txn.Op) error {
-	runner, closer := db.TransactionRunner()
+	runner, closer, err := db.TransactionRunner()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	if multiRunner, ok := runner.(*multiModelRunner); ok {
 		runner = multiRunner.rawRunner
@@ -443,14 +494,20 @@ func (db *database) RunRawTransaction(ops []txn.Op) error {
 
 // Run is part of the Database interface.
 func (db *database) Run(transactions jujutxn.TransactionSource) error {
-	runner, closer := db.TransactionRunner()
+	runner, closer, err := db.TransactionRunner()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	return runner.Run(transactions)
 }
 
 // RunRaw is part of the Database interface.
 func (db *database) RunRaw(transactions jujutxn.TransactionSource) error {
-	runner, closer := db.TransactionRunner()
+	runner, closer, err := db.TransactionRunner()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	if multiRunner, ok := runner.(*multiModelRunner); ok {
 		runner = multiRunner.rawRunner

--- a/state/devices.go
+++ b/state/devices.go
@@ -97,11 +97,14 @@ func (db *deviceBackend) DeviceConstraints(id string) (map[string]DeviceConstrai
 }
 
 func readDeviceConstraints(mb modelBackend, id string) (map[string]DeviceConstraints, error) {
-	coll, closer := mb.db().GetCollection(deviceConstraintsC)
+	coll, closer, err := mb.db().GetCollection(deviceConstraintsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc deviceConstraintsDoc
-	err := coll.FindId(id).One(&doc)
+	err = coll.FindId(id).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("device constraints for %q", id)
 	}

--- a/state/docker_resource.go
+++ b/state/docker_resource.go
@@ -130,11 +130,14 @@ func (dr *dockerMetadataStorage) Get(resourceID string) (io.ReadCloser, int64, e
 }
 
 func (dr *dockerMetadataStorage) get(resourceID string) (*dockerMetadataDoc, error) {
-	coll, closer := dr.st.db().GetCollection(dockerResourcesC)
+	coll, closer, err := dr.st.db().GetCollection(dockerResourcesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc dockerMetadataDoc
-	err := coll.FindId(resourceID).One(&doc)
+	err = coll.FindId(resourceID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("Docker resource with ID: %s", resourceID)
 	}

--- a/state/dump.go
+++ b/state/dump.go
@@ -31,7 +31,10 @@ func (st *State) DumpAll() (map[string]interface{}, error) {
 }
 
 func getModelDoc(mb modelBackend) (map[string]interface{}, error) {
-	coll, closer := mb.db().GetCollection(modelsC)
+	coll, closer, err := mb.db().GetCollection(modelsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc map[string]interface{}
@@ -43,7 +46,10 @@ func getModelDoc(mb modelBackend) (map[string]interface{}, error) {
 }
 
 func getAllModelDocs(mb modelBackend, collectionName string) ([]map[string]interface{}, error) {
-	coll, closer := mb.db().GetCollection(collectionName)
+	coll, closer, err := mb.db().GetCollection(collectionName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var (

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -40,7 +40,10 @@ func isController(mdoc *machineDoc) bool {
 var errControllerNotAllowed = errors.New("controller jobs specified but not allowed")
 
 func (st *State) getVotingControllerCount() (int, error) {
-	controllerNodesColl, closer := st.db().GetCollection(controllerNodesC)
+	controllerNodesColl, closer, err := st.db().GetCollection(controllerNodesC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
 	return controllerNodesColl.Find(bson.M{"wants-vote": true}).Count()
@@ -423,12 +426,15 @@ func convertControllerOps(m *Machine) []txn.Op {
 }
 
 func (st *State) getControllerNodeDoc(id string) (*controllerNodeDoc, error) {
-	controllerNodesColl, closer := st.db().GetCollection(controllerNodesC)
+	controllerNodesColl, closer, err := st.db().GetCollection(controllerNodesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	cdoc := &controllerNodeDoc{}
 	docId := st.docID(id)
-	err := controllerNodesColl.FindId(docId).One(cdoc)
+	err = controllerNodesColl.FindId(docId).One(cdoc)
 
 	switch err {
 	case nil:
@@ -489,14 +495,17 @@ func (st *State) ControllerIds() ([]string, error) {
 // This method is only used when preparing for upgrades since 2.6
 // or earlier used "machineids".
 func (st *State) SafeControllerIds() ([]string, error) {
-	session := st.session.Copy()
+	session, err := mongo.CopySession(st.session)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer session.Close()
 
 	db := session.DB(jujuDB)
 	controllers := db.C(controllersC)
 
 	var info bson.M
-	err := controllers.Find(bson.D{{"_id", modelGlobalKey}}).One(&info)
+	err = controllers.Find(bson.D{{"_id", modelGlobalKey}}).One(&info)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("controllers document")
 	}
@@ -592,11 +601,14 @@ func (st *State) HAPrimaryMachine() (names.MachineTag, error) {
 
 // ControllerNodes returns all the controller nodes.
 func (st *State) ControllerNodes() ([]*controllerNode, error) {
-	controllerNodesColl, closer := st.db().GetCollection(controllerNodesC)
+	controllerNodesColl, closer, err := st.db().GetCollection(controllerNodesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []controllerNodeDoc
-	err := controllerNodesColl.Find(nil).All(&docs)
+	err = controllerNodesColl.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/endpoint_bindings.go
+++ b/state/endpoint_bindings.go
@@ -391,11 +391,14 @@ func readEndpointBindings(st *State, key string) (map[string]string, int64, erro
 // readEndpointBindingsDoc returns the endpoint bindings document for the
 // specified key.
 func readEndpointBindingsDoc(st *State, key string) (*endpointBindingsDoc, error) {
-	endpointBindings, closer := st.db().GetCollection(endpointBindingsC)
+	endpointBindings, closer, err := st.db().GetCollection(endpointBindingsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc endpointBindingsDoc
-	err := endpointBindings.FindId(key).One(&doc)
+	err = endpointBindings.FindId(key).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("endpoint bindings for %q", key)
 	}

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -174,7 +174,10 @@ func SetPolicy(st *State, p Policy) Policy {
 }
 
 func CloudModelRefCount(st *State, cloudName string) (int, error) {
-	refcounts, closer := st.db().GetCollection(globalRefcountsC)
+	refcounts, closer, err := st.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
 	key := cloudModelRefCountKey(cloudName)
@@ -182,7 +185,10 @@ func CloudModelRefCount(st *State, cloudName string) (int, error) {
 }
 
 func ApplicationSettingsRefCount(st *State, appName string, curl *string) (int, error) {
-	refcounts, closer := st.db().GetCollection(refcountsC)
+	refcounts, closer, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
 	key := applicationCharmConfigKey(appName, curl)
@@ -190,7 +196,10 @@ func ApplicationSettingsRefCount(st *State, appName string, curl *string) (int, 
 }
 
 func ApplicationOffersRefCount(st *State, appName string) (int, error) {
-	refcounts, closer := st.db().GetCollection(refcountsC)
+	refcounts, closer, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
 	key := applicationOffersRefCountKey(appName)
@@ -198,7 +207,10 @@ func ApplicationOffersRefCount(st *State, appName string) (int, error) {
 }
 
 func ControllerRefCount(st *State, controllerUUID string) (int, error) {
-	refcounts, closer := st.db().GetCollection(globalRefcountsC)
+	refcounts, closer, err := st.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
 	key := externalControllerRefCountKey(controllerUUID)
@@ -206,7 +218,10 @@ func ControllerRefCount(st *State, controllerUUID string) (int, error) {
 }
 
 func IncSecretConsumerRefCount(st *State, uri *secrets.URI, inc int) error {
-	refCountCollection, ccloser := st.db().GetCollection(refcountsC)
+	refCountCollection, ccloser, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer ccloser()
 	incOp, err := nsRefcounts.CreateOrIncRefOp(refCountCollection, uri.ID, inc)
 	if err != nil {
@@ -216,7 +231,10 @@ func IncSecretConsumerRefCount(st *State, uri *secrets.URI, inc int) error {
 }
 
 func SecretBackendRefCount(st *State, backendID string) (int, error) {
-	refcounts, closer := st.db().GetCollection(globalRefcountsC)
+	refcounts, closer, err := st.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
 	key := secretBackendRefCountKey(backendID)
@@ -493,9 +511,12 @@ func TxnRevno(st *State, collName string, id interface{}) (int64, error) {
 	var doc struct {
 		TxnRevno int64 `bson:"txn-revno"`
 	}
-	coll, closer := st.db().GetCollection(collName)
+	coll, closer, err := st.db().GetCollection(collName)
+	if err != nil {
+		return 0, err
+	}
 	defer closer()
-	err := coll.FindId(id).One(&doc)
+	err = coll.FindId(id).One(&doc)
 	if err != nil {
 		return 0, err
 	}
@@ -505,7 +526,10 @@ func TxnRevno(st *State, collName string, id interface{}) (int64, error) {
 // MinUnitsRevno returns the Revno of the minUnits document
 // associated with the given application name.
 func MinUnitsRevno(st *State, applicationname string) (int, error) {
-	minUnitsCollection, closer := st.db().GetCollection(minUnitsC)
+	minUnitsCollection, closer, err := st.db().GetCollection(minUnitsC)
+	if err != nil {
+		return 0, err
+	}
 	defer closer()
 	var doc minUnitsDoc
 	if err := minUnitsCollection.FindId(applicationname).One(&doc); err != nil {
@@ -544,7 +568,10 @@ func WatcherMakeIdFilter(st *State, marker string, receivers ...ActionReceiver) 
 }
 
 func GetAllUpgradeInfos(st *State) ([]*UpgradeInfo, error) {
-	upgradeInfos, closer := st.db().GetCollection(upgradeInfoC)
+	upgradeInfos, closer, err := st.db().GetCollection(upgradeInfoC)
+	if err != nil {
+		return nil, err
+	}
 	defer closer()
 
 	var out []*UpgradeInfo
@@ -565,11 +592,14 @@ func UserModelNameIndex(username, modelName string) string {
 }
 
 func (m *Model) UniqueIndexExists() bool {
-	coll, closer := m.st.db().GetCollection(usermodelnameC)
+	coll, closer, err := m.st.db().GetCollection(usermodelnameC)
+	if err != nil {
+		return false
+	}
 	defer closer()
 
 	var doc bson.M
-	err := coll.FindId(m.uniqueIndexID()).One(&doc)
+	err = coll.FindId(m.uniqueIndexID()).One(&doc)
 
 	return err == nil
 }
@@ -591,11 +621,19 @@ func GetUnitModelUUID(unit *Unit) string {
 }
 
 func GetCollection(mb modelBackend, name string) (mongo.Collection, func()) {
-	return mb.db().GetCollection(name)
+	coll, closer, err := mb.db().GetCollection(name)
+	if err != nil {
+		panic(err)
+	}
+	return coll, closer
 }
 
 func GetRawCollection(mb modelBackend, name string) (*mgo.Collection, func()) {
-	return mb.db().GetRawCollection(name)
+	coll, closer, err := mb.db().GetRawCollection(name)
+	if err != nil {
+		panic(err)
+	}
+	return coll, closer
 }
 
 func HasRawAccess(collectionName string) bool {
@@ -625,7 +663,10 @@ func SequenceWithMin(st *State, name string, minVal int) (int, error) {
 }
 
 func SequenceEnsure(st *State, name string, nextVal int) error {
-	sequences, closer := st.db().GetRawCollection(sequenceC)
+	sequences, closer, err := st.db().GetRawCollection(sequenceC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	updater := newDbSeqUpdater(sequences, st.ModelUUID(), name)
 	return updater.ensure(nextVal)
@@ -825,10 +866,11 @@ func RemoveRelationStatus(c *gc.C, rel *Relation) {
 
 func RemoveUnitRelations(c *gc.C, rel *Relation) {
 	st := rel.st
-	scopes, closer := st.db().GetCollection(relationScopesC)
+	scopes, closer, err := st.db().GetCollection(relationScopesC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 	scopesW := scopes.Writeable()
-	_, err := scopesW.RemoveAll(nil)
+	_, err = scopesW.RemoveAll(nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -842,7 +884,8 @@ func PrimeUnitStatusHistory(
 ) {
 	globalKey := unit.globalKey()
 
-	history, closer := unit.st.db().GetCollection(statusesHistoryC)
+	history, closer, err := unit.st.db().GetCollection(statusesHistoryC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 	historyW := history.Writeable()
 
@@ -877,7 +920,7 @@ func PrimeUnitStatusHistory(
 		return statusSetOps(unit.st.db(), doc, globalKey)
 	}
 
-	err := unit.st.db().Run(buildTxn)
+	err = unit.st.db().Run(buildTxn)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -886,9 +929,11 @@ func PrimeUnitStatusHistory(
 // approximate size of the entry and limit the number of entries that
 // must be generated for size related tests.
 func PrimeOperations(c *gc.C, age time.Time, unit *Unit, count, actionsPerOperation int) {
-	operationsCollection, closer := unit.st.db().GetCollection(operationsC)
+	operationsCollection, closer, err := unit.st.db().GetCollection(operationsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
-	actionCollection, closer := unit.st.db().GetCollection(actionsC)
+	actionCollection, closer, err := unit.st.db().GetCollection(actionsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	operationsCollectionWriter := operationsCollection.Writeable()
@@ -924,7 +969,7 @@ func PrimeOperations(c *gc.C, age time.Time, unit *Unit, count, actionsPerOperat
 		}
 	}
 
-	err := operationsCollectionWriter.Insert(operationDocs...)
+	err = operationsCollectionWriter.Insert(operationDocs...)
 	c.Assert(err, jc.ErrorIsNil)
 	err = actionCollectionWriter.Insert(actionDocs...)
 	c.Assert(err, jc.ErrorIsNil)
@@ -932,7 +977,8 @@ func PrimeOperations(c *gc.C, age time.Time, unit *Unit, count, actionsPerOperat
 
 // PrimeLegacyActions creates actions without a parent operation.
 func PrimeLegacyActions(c *gc.C, age time.Time, unit *Unit, count int) {
-	actionCollection, closer := unit.st.db().GetCollection(actionsC)
+	actionCollection, closer, err := unit.st.db().GetCollection(actionsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	actionCollectionWriter := actionCollection.Writeable()
@@ -955,7 +1001,7 @@ func PrimeLegacyActions(c *gc.C, age time.Time, unit *Unit, count int) {
 		})
 	}
 
-	err := actionCollectionWriter.Insert(actionDocs...)
+	err = actionCollectionWriter.Insert(actionDocs...)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, id := range ids {
 		err = actionCollectionWriter.UpdateId(id, bson.D{{"$unset", bson.M{"operation": 1}}})
@@ -1011,9 +1057,10 @@ func IsBlobStored(c *gc.C, st *State, storagePath string) bool {
 // of a given kind scheduled.
 func AssertNoCleanupsWithKind(c *gc.C, st *State, kind cleanupKind) {
 	var docs []cleanupDoc
-	cleanups, closer := st.db().GetCollection(cleanupsC)
+	cleanups, closer, err := st.db().GetCollection(cleanupsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
-	err := cleanups.Find(nil).All(&docs)
+	err = cleanups.Find(nil).All(&docs)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, doc := range docs {
 		if doc.Kind == kind {
@@ -1026,9 +1073,10 @@ func AssertNoCleanupsWithKind(c *gc.C, st *State, kind cleanupKind) {
 // one cleanup of a given kind scheduled.
 func AssertCleanupsWithKind(c *gc.C, st *State, kind cleanupKind) {
 	var docs []cleanupDoc
-	cleanups, closer := st.db().GetCollection(cleanupsC)
+	cleanups, closer, err := st.db().GetCollection(cleanupsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
-	err := cleanups.Find(nil).All(&docs)
+	err = cleanups.Find(nil).All(&docs)
 	c.Assert(err, jc.ErrorIsNil)
 	for _, doc := range docs {
 		if doc.Kind == kind {
@@ -1041,9 +1089,10 @@ func AssertCleanupsWithKind(c *gc.C, st *State, kind cleanupKind) {
 // AssertNoCleanups checks that there are no cleanups scheduled.
 func AssertNoCleanups(c *gc.C, st *State) {
 	var docs []cleanupDoc
-	cleanups, closer := st.db().GetCollection(cleanupsC)
+	cleanups, closer, err := st.db().GetCollection(cleanupsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
-	err := cleanups.Find(nil).All(&docs)
+	err = cleanups.Find(nil).All(&docs)
 	c.Assert(err, jc.ErrorIsNil)
 	if len(docs) > 0 {
 		c.Fatalf("unexpected cleanups: %+v", docs)
@@ -1162,21 +1211,23 @@ func ApplicationPortOps(st *State, a description.Application) ([]txn.Op, error) 
 }
 
 func GetSecretNextRotateTime(c *gc.C, st *State, id string) time.Time {
-	secretRotateCollection, closer := st.db().GetCollection(secretRotateC)
+	secretRotateCollection, closer, err := st.db().GetCollection(secretRotateC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	var doc secretRotationDoc
-	err := secretRotateCollection.FindId(id).One(&doc)
+	err = secretRotateCollection.FindId(id).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	return doc.NextRotateTime.UTC()
 }
 
 func GetSecretBackendNextRotateInfo(c *gc.C, st *State, id string) (string, time.Time) {
-	secretBackendRotateCollection, closer := st.db().GetCollection(secretBackendsRotateC)
+	secretBackendRotateCollection, closer, err := st.db().GetCollection(secretBackendsRotateC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	var doc secretBackendRotationDoc
-	err := secretBackendRotateCollection.FindId(id).One(&doc)
+	err = secretBackendRotateCollection.FindId(id).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	return doc.Name, doc.NextRotateTime.UTC()
 }
@@ -1272,11 +1323,14 @@ func GetCollectionCappedInfo(coll *mgo.Collection) (bool, int, error) {
 }
 
 func (m *Model) AllActionIDsHasActionNotifications() ([]string, error) {
-	actionNotifications, closer := m.st.db().GetCollection(actionNotificationsC)
+	actionNotifications, closer, err := m.st.db().GetCollection(actionNotificationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	docs := []actionNotificationDoc{}
-	err := actionNotifications.Find(nil).All(&docs)
+	err = actionNotifications.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get all actions")
 	}

--- a/state/externalcontroller.go
+++ b/state/externalcontroller.go
@@ -221,11 +221,14 @@ func (ec *externalControllers) Controller(controllerUUID string) (ExternalContro
 }
 
 func (ec *externalControllers) controller(controllerUUID string) (*externalControllerDoc, error) {
-	coll, closer := ec.st.db().GetCollection(externalControllersC)
+	coll, closer, err := ec.st.db().GetCollection(externalControllersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc externalControllerDoc
-	err := coll.FindId(controllerUUID).One(&doc)
+	err = coll.FindId(controllerUUID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("external controller with UUID %v", controllerUUID)
 	}
@@ -273,11 +276,14 @@ func (st *State) ExternalControllerForModel(modelUUID string) (*externalControll
 }
 
 func (st *State) externalControllerDocsForModels(modelUUIDs ...string) ([]externalControllerDoc, error) {
-	coll, closer := st.db().GetCollection(externalControllersC)
+	coll, closer, err := st.db().GetCollection(externalControllersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []externalControllerDoc
-	err := coll.Find(bson.M{"models": bson.M{"$in": modelUUIDs}}).All(&docs)
+	err = coll.Find(bson.M{"models": bson.M{"$in": modelUUIDs}}).All(&docs)
 	return docs, errors.Trace(err)
 }
 
@@ -321,7 +327,10 @@ func externalControllerRefCountKey(controllerUUID string) string {
 // incExternalControllersRefOp returns a txn.Op that increments the reference
 // count for an external controller. These ref counts are controller wide.
 func incExternalControllersRefOp(mb modelBackend, controllerUUID string) (txn.Op, error) {
-	refcounts, closer := mb.db().GetCollection(globalRefcountsC)
+	refcounts, closer, err := mb.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
 	defer closer()
 	refCountKey := externalControllerRefCountKey(controllerUUID)
 	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, refCountKey, 1)
@@ -331,7 +340,10 @@ func incExternalControllersRefOp(mb modelBackend, controllerUUID string) (txn.Op
 // decExternalControllersRefOp returns a txn.Op that decrements the reference
 // count for an external controller. These ref counts are controller wide.
 func decExternalControllersRefOp(mb modelBackend, controllerUUID string) (txn.Op, bool, error) {
-	refcounts, closer := mb.db().GetCollection(globalRefcountsC)
+	refcounts, closer, err := mb.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return txn.Op{}, false, errors.Trace(err)
+	}
 	defer closer()
 	refCountKey := externalControllerRefCountKey(controllerUUID)
 	decRefOp, isFinal, err := nsRefcounts.DyingDecRefOp(refcounts, refCountKey)

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -397,11 +397,14 @@ func getFilesystemDocByTag(db Database, tag names.FilesystemTag) (filesystemDoc,
 }
 
 func getFilesystemDoc(db Database, query bson.D, description string) (filesystemDoc, error) {
-	coll, cleanup := db.GetCollection(filesystemsC)
+	coll, cleanup, err := db.GetCollection(filesystemsC)
+	if err != nil {
+		return filesystemDoc{}, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var doc filesystemDoc
-	err := coll.Find(query).One(&doc)
+	err = coll.Find(query).One(&doc)
 	if err == mgo.ErrNotFound {
 		return doc, errors.NotFoundf(description)
 	} else if err != nil {
@@ -414,11 +417,14 @@ func getFilesystemDoc(db Database, query bson.D, description string) (filesystem
 }
 
 func getFilesystemDocs(db Database, query interface{}) ([]filesystemDoc, error) {
-	coll, cleanup := db.GetCollection(filesystemsC)
+	coll, cleanup, err := db.GetCollection(filesystemsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var docs []filesystemDoc
-	err := coll.Find(query).All(&docs)
+	err = coll.Find(query).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -433,11 +439,14 @@ func getFilesystemDocs(db Database, query interface{}) ([]filesystemDoc, error) 
 // FilesystemAttachment returns the FilesystemAttachment corresponding to
 // the specified filesystem and machine.
 func (sb *storageBackend) FilesystemAttachment(host names.Tag, filesystem names.FilesystemTag) (FilesystemAttachment, error) {
-	coll, cleanup := sb.mb.db().GetCollection(filesystemAttachmentsC)
+	coll, cleanup, err := sb.mb.db().GetCollection(filesystemAttachmentsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var att filesystemAttachment
-	err := coll.FindId(filesystemAttachmentId(host.Id(), filesystem.Id())).One(&att.doc)
+	err = coll.FindId(filesystemAttachmentId(host.Id(), filesystem.Id())).One(&att.doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("filesystem %q on %q", filesystem.Id(), names.ReadableString(host))
 	} else if err != nil {
@@ -477,11 +486,14 @@ func (sb *storageBackend) UnitFilesystemAttachments(unit names.UnitTag) ([]Files
 }
 
 func (sb *storageBackend) filesystemAttachments(query bson.D) ([]FilesystemAttachment, error) {
-	coll, cleanup := sb.mb.db().GetCollection(filesystemAttachmentsC)
+	coll, cleanup, err := sb.mb.db().GetCollection(filesystemAttachmentsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var docs []filesystemAttachmentDoc
-	err := coll.Find(query).All(&docs)
+	err = coll.Find(query).All(&docs)
 	if err == mgo.ErrNotFound {
 		return nil, nil
 	} else if err != nil {

--- a/state/life.go
+++ b/state/life.go
@@ -88,7 +88,10 @@ type AgentLiving interface {
 }
 
 func isAlive(mb modelBackend, collName string, id interface{}) (bool, error) {
-	coll, closer := mb.db().GetCollection(collName)
+	coll, closer, err := mb.db().GetCollection(collName)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 	return isAliveWithSession(coll, id)
 }
@@ -98,7 +101,10 @@ func isAliveWithSession(coll mongo.Collection, id interface{}) (bool, error) {
 }
 
 func isNotDead(mb modelBackend, collName string, id interface{}) (bool, error) {
-	coll, closer := mb.db().GetCollection(collName)
+	coll, closer, err := mb.db().GetCollection(collName)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 	return isNotDeadWithSession(coll, id)
 }
@@ -108,7 +114,10 @@ func isNotDeadWithSession(coll mongo.Collection, id interface{}) (bool, error) {
 }
 
 func isDying(mb modelBackend, collName string, id interface{}) (bool, error) {
-	coll, closer := mb.db().GetCollection(collName)
+	coll, closer, err := mb.db().GetCollection(collName)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 	return isDyingWithSession(coll, id)
 }

--- a/state/linklayerdevices.go
+++ b/state/linklayerdevices.go
@@ -331,7 +331,10 @@ func (dev *LinkLayerDevice) Remove() (err error) {
 }
 
 func (dev *LinkLayerDevice) childCount() (int, error) {
-	col, closer := dev.st.db().GetCollection(linkLayerDevicesC)
+	col, closer, err := dev.st.db().GetCollection(linkLayerDevicesC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
 	children, err := col.Find(bson.M{"$or": []bson.M{
@@ -361,7 +364,10 @@ func (dev *LinkLayerDevice) errNoOperationsIfMissing() error {
 
 // AllLinkLayerDevices returns all link layer devices in the model.
 func (st *State) AllLinkLayerDevices() (devices []*LinkLayerDevice, err error) {
-	devicesCollection, closer := st.db().GetCollection(linkLayerDevicesC)
+	devicesCollection, closer, err := st.db().GetCollection(linkLayerDevicesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var sDocs []linkLayerDeviceDoc
@@ -376,11 +382,14 @@ func (st *State) AllLinkLayerDevices() (devices []*LinkLayerDevice, err error) {
 }
 
 func (st *State) LinkLayerDevice(id string) (*LinkLayerDevice, error) {
-	linkLayerDevices, closer := st.db().GetCollection(linkLayerDevicesC)
+	linkLayerDevices, closer, err := st.db().GetCollection(linkLayerDevicesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc linkLayerDeviceDoc
-	err := linkLayerDevices.FindId(id).One(&doc)
+	err = linkLayerDevices.FindId(id).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("device with ID %q", id)
 	} else if err != nil {
@@ -633,13 +642,16 @@ func (dev *LinkLayerDevice) mtuForChild() (uint, error) {
 		return dev.MTU(), nil
 	}
 
-	linkLayerDevs, closer := dev.st.db().GetCollection(linkLayerDevicesC)
+	linkLayerDevs, closer, err := dev.st.db().GetCollection(linkLayerDevicesC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
 	var resultDoc struct {
 		MTU uint `bson:"mtu"`
 	}
-	err := linkLayerDevs.Find(bson.D{
+	err = linkLayerDevs.Find(bson.D{
 		{"machine-id", dev.doc.MachineID},
 		{"parent-name", dev.doc.Name},
 		{"type", network.VXLANDevice},

--- a/state/linklayerdevices_ipaddresses.go
+++ b/state/linklayerdevices_ipaddresses.go
@@ -498,7 +498,10 @@ func (st *State) removeMatchingIPAddressesDocOps(findQuery bson.D) ([]txn.Op, er
 }
 
 func (st *State) forEachIPAddressDoc(findQuery bson.D, callbackFunc func(resultDoc *ipAddressDoc)) error {
-	addresses, closer := st.db().GetCollection(ipAddressesC)
+	addresses, closer, err := st.db().GetCollection(ipAddressesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	query := addresses.Find(findQuery)
@@ -514,7 +517,10 @@ func (st *State) forEachIPAddressDoc(findQuery bson.D, callbackFunc func(resultD
 
 // AllIPAddresses returns all ip addresses in the model.
 func (st *State) AllIPAddresses() (addresses []*Address, err error) {
-	addressesCollection, closer := st.db().GetCollection(ipAddressesC)
+	addressesCollection, closer, err := st.db().GetCollection(ipAddressesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []ipAddressDoc

--- a/state/logs.go
+++ b/state/logs.go
@@ -658,7 +658,11 @@ func (t *logTailer) tailOplog() error {
 	)
 
 	minOplogTs := t.lastTime.Add(-oplogOverlap)
-	oplogTailer := mongo.NewOplogTailer(mongo.NewOplogSession(t.opLog, oplogSel), minOplogTs)
+	oplogSession, err := mongo.NewOplogSession(t.opLog, oplogSel)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	oplogTailer := mongo.NewOplogTailer(oplogSession, minOplogTs)
 	defer func() { _ = oplogTailer.Stop() }()
 
 	logger.Infof("LogTailer starting oplog tailing: recent id count=%d, lastTime=%s, minOplogTs=%s",

--- a/state/machine.go
+++ b/state/machine.go
@@ -281,11 +281,14 @@ func (m *Machine) HardwareCharacteristics() (*instance.HardwareCharacteristics, 
 }
 
 func getInstanceData(st *State, id string) (instanceData, error) {
-	instanceDataCollection, closer := st.db().GetCollection(instanceDataC)
+	instanceDataCollection, closer, err := st.db().GetCollection(instanceDataC)
+	if err != nil {
+		return instanceData{}, errors.Trace(err)
+	}
 	defer closer()
 
 	var instData instanceData
-	err := instanceDataCollection.FindId(id).One(&instData)
+	err = instanceDataCollection.FindId(id).One(&instData)
 	if err == mgo.ErrNotFound {
 		return instanceData{}, errors.NotFoundf("instance data for machine %v", id)
 	}
@@ -309,11 +312,14 @@ func removeInstanceDataOp(globalKey string) txn.Op {
 // and provides a way to query hardware characteristics and
 // charm profiles by machine.
 func (m *Model) AllInstanceData() (*ModelInstanceData, error) {
-	coll, closer := m.st.db().GetCollection(instanceDataC)
+	coll, closer, err := m.st.db().GetCollection(instanceDataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []instanceData
-	err := coll.Find(nil).All(&docs)
+	err = coll.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get all instance data for model")
 	}
@@ -686,11 +692,14 @@ func (m *Machine) EnsureDead() error {
 // Containers returns the container ids belonging to a parent machine.
 // TODO(wallyworld): move this method to a service
 func (m *Machine) Containers() ([]string, error) {
-	containerRefs, closer := m.st.db().GetCollection(containerRefsC)
+	containerRefs, closer, err := m.st.db().GetCollection(containerRefsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var mc machineContainers
-	err := containerRefs.FindId(m.doc.DocID).One(&mc)
+	err = containerRefs.FindId(m.doc.DocID).One(&mc)
 	if err == nil {
 		return mc.Children, nil
 	}
@@ -1306,7 +1315,10 @@ func (m *Machine) ApplicationNames() ([]string, error) {
 // Units returns all the units that have been assigned to the machine.
 func (m *Machine) Units() (units []*Unit, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot get units assigned to machine %v", m)
-	unitsCollection, closer := m.st.db().GetCollection(unitsC)
+	unitsCollection, closer, err := m.st.db().GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	pudocs := []unitDoc{}
@@ -1348,7 +1360,10 @@ func (m *Machine) SetProvisioned(
 		return fmt.Errorf("instance id and nonce cannot be empty")
 	}
 
-	coll, closer := m.st.db().GetCollection(instanceDataC)
+	coll, closer, err := m.st.db().GetCollection(instanceDataC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	count, err := coll.Find(bson.D{{"instanceid", id}}).Count()
 	if err != nil {
@@ -2284,14 +2299,17 @@ func (op *UpdateMachineOperation) Done(err error) error {
 }
 
 func (st *State) GetManualMachineArches() (set.Strings, error) {
-	instanceDataCollection, closer := st.db().GetCollection(instanceDataC)
+	instanceDataCollection, closer, err := st.db().GetCollection(instanceDataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var archDocs []struct {
 		Arch string `bson:"arch"`
 	}
 
-	err := instanceDataCollection.Find(bson.M{
+	err = instanceDataCollection.Find(bson.M{
 		"instanceid": bson.M{
 			"$regex": "^" + manualMachinePrefix,
 		},

--- a/state/machine_linklayerdevices.go
+++ b/state/machine_linklayerdevices.go
@@ -46,7 +46,10 @@ func (m *Machine) AllLinkLayerDevices() ([]*LinkLayerDevice, error) {
 func (m *Machine) forEachLinkLayerDeviceDoc(
 	docFieldsToSelect bson.D, callbackFunc func(resultDoc *linkLayerDeviceDoc),
 ) error {
-	linkLayerDevices, closer := m.st.db().GetCollection(linkLayerDevicesC)
+	linkLayerDevices, closer, err := m.st.db().GetCollection(linkLayerDevicesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	query := linkLayerDevices.Find(bson.D{{"machine-id", m.doc.Id}})
@@ -249,7 +252,10 @@ func (st *State) allProviderIDsForLinkLayerDevices() (set.Strings, error) {
 }
 
 func (st *State) allProviderIDsForEntity(entityName string) (set.Strings, error) {
-	idCollection, closer := st.db().GetCollection(providerIDsC)
+	idCollection, closer, err := st.db().GetCollection(providerIDsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	allProviderIDs := set.NewStrings()
@@ -347,7 +353,10 @@ func (m *Machine) assertAliveOp() txn.Op {
 }
 
 func (m *Machine) setDevicesFromDocsOps(newDocs []linkLayerDeviceDoc) ([]txn.Op, error) {
-	devices, closer := m.st.db().GetCollection(linkLayerDevicesC)
+	devices, closer, err := m.st.db().GetCollection(linkLayerDevicesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var ops []txn.Op
@@ -670,7 +679,10 @@ func (m *Machine) verifySubnetAlive(subnet *Subnet) error {
 }
 
 func (m *Machine) setDevicesAddressesFromDocsOps(newDocs []ipAddressDoc) ([]txn.Op, error) {
-	addresses, closer := m.st.db().GetCollection(ipAddressesC)
+	addresses, closer, err := m.st.db().GetCollection(ipAddressesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	providerIDAddrs := make(map[string]string)

--- a/state/machine_ports.go
+++ b/state/machine_ports.go
@@ -101,10 +101,13 @@ func (p *machinePortRanges) Changes() ModelOperation {
 
 // Refresh refreshes the port document from state.
 func (p *machinePortRanges) Refresh() error {
-	openedPorts, closer := p.st.db().GetCollection(openedPortsC)
+	openedPorts, closer, err := p.st.db().GetCollection(openedPortsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
-	err := openedPorts.FindId(p.doc.DocID).One(&p.doc)
+	err = openedPorts.FindId(p.doc.DocID).One(&p.doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("open port ranges for machine %q", p.MachineID())
 	} else if err != nil {
@@ -251,7 +254,10 @@ func getOpenedPortRangesForAllMachines(st *State) ([]*machinePortRanges, error) 
 	for _, m := range machines {
 		machineIDs = append(machineIDs, m.Id())
 	}
-	openedPorts, closer := st.db().GetCollection(openedPortsC)
+	openedPorts, closer, err := st.db().GetCollection(openedPortsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	docs := []machinePortRangesDoc{}
@@ -281,7 +287,10 @@ func getOpenedMachinePortRanges(st *State, machineID string) (*machinePortRanges
 	}
 	machineExists := err == nil
 
-	openedPorts, closer := st.db().GetCollection(openedPortsC)
+	openedPorts, closer, err := st.db().GetCollection(openedPortsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc machinePortRangesDoc

--- a/state/machine_upgradeseries.go
+++ b/state/machine_upgradeseries.go
@@ -363,11 +363,14 @@ func removeUpgradeSeriesLockTxnOps(machineDocId string) []txn.Op {
 }
 
 func (m *Machine) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, error) {
-	coll, closer := m.st.db().GetCollection(machineUpgradeSeriesLocksC)
+	coll, closer, err := m.st.db().GetCollection(machineUpgradeSeriesLocksC)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
 	defer closer()
 
 	var lock upgradeSeriesLockDoc
-	err := coll.FindId(m.Id()).One(&lock)
+	err = coll.FindId(m.Id()).One(&lock)
 	if err == mgo.ErrNotFound {
 		return "", errors.NotFoundf("upgrade series lock for machine %q", m.Id())
 	}
@@ -604,11 +607,14 @@ func (m *Machine) getUpgradeSeriesLock() (*upgradeSeriesLockDoc, error) {
 }
 
 func (st *State) getUpgradeSeriesLock(machineID string) (*upgradeSeriesLockDoc, error) {
-	coll, closer := st.db().GetCollection(machineUpgradeSeriesLocksC)
+	coll, closer, err := st.db().GetCollection(machineUpgradeSeriesLocksC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var lock upgradeSeriesLockDoc
-	err := coll.FindId(machineID).One(&lock)
+	err = coll.FindId(machineID).One(&lock)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("upgrade lock for machine %q", machineID)
 	}
@@ -643,7 +649,10 @@ func setMachineUpgradeSeriesTxnOps(
 // upgradeSeriesMachineIds returns the IDs of all machines
 // currently locked for series-upgrade.
 func (st *State) upgradeSeriesMachineIds() ([]string, error) {
-	coll, closer := st.db().GetCollection(machineUpgradeSeriesLocksC)
+	coll, closer, err := st.db().GetCollection(machineUpgradeSeriesLocksC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var locks []struct {

--- a/state/machineremovals.go
+++ b/state/machineremovals.go
@@ -45,7 +45,10 @@ func (m *Machine) MarkForRemoval() (err error) {
 	buildTxn := func(attempt int) ([]txn.Op, error) {
 		// Check if it has already been marked first.
 		// If so, we just do nothing and return success.
-		col, close := m.st.db().GetCollection(machineRemovalsC)
+		col, close, err := m.st.db().GetCollection(machineRemovalsC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer close()
 
 		remCount, err := col.FindId(m.globalKey()).Count()
@@ -73,11 +76,14 @@ func (m *Machine) MarkForRemoval() (err error) {
 // AllMachineRemovals returns (the ids of) all of the machines that
 // need to be removed but need provider-level cleanup.
 func (st *State) AllMachineRemovals() ([]string, error) {
-	removals, close := st.db().GetCollection(machineRemovalsC)
+	removals, close, err := st.db().GetCollection(machineRemovalsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer close()
 
 	var docs []machineRemovalDoc
-	err := removals.Find(nil).All(&docs)
+	err = removals.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -89,11 +95,14 @@ func (st *State) AllMachineRemovals() ([]string, error) {
 }
 
 func (st *State) allMachinesMatching(query bson.D) ([]*Machine, error) {
-	machines, close := st.db().GetCollection(machinesC)
+	machines, close, err := st.db().GetCollection(machinesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer close()
 
 	var docs []machineDoc
-	err := machines.Find(query).All(&docs)
+	err = machines.Find(query).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -319,7 +319,10 @@ func (e *exporter) sequences() error {
 }
 
 func (e *exporter) readBlocks() (map[string]string, error) {
-	blocks, closer := e.st.db().GetCollection(blocksC)
+	blocks, closer, err := e.st.db().GetCollection(blocksC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []blockDoc
@@ -451,7 +454,10 @@ func (e *exporter) loadOpenedPortRangesForApplication() (map[string]*application
 }
 
 func (e *exporter) loadMachineInstanceData() (map[string]instanceData, error) {
-	instanceDataCollection, closer := e.st.db().GetCollection(instanceDataC)
+	instanceDataCollection, closer, err := e.st.db().GetCollection(instanceDataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var instData []instanceData
@@ -467,7 +473,10 @@ func (e *exporter) loadMachineInstanceData() (map[string]instanceData, error) {
 }
 
 func (e *exporter) loadMachineBlockDevices() (map[string][]BlockDeviceInfo, error) {
-	coll, closer := e.st.db().GetCollection(blockDevicesC)
+	coll, closer, err := e.st.db().GetCollection(blockDevicesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var deviceData []blockDevicesDoc
@@ -767,7 +776,10 @@ func (e *exporter) applications(leaders map[string]string) error {
 }
 
 func (e *exporter) readAllStorageConstraints() error {
-	coll, closer := e.st.db().GetCollection(storageConstraintsC)
+	coll, closer, err := e.st.db().GetCollection(storageConstraintsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	storageConstraints := make(map[string]storageConstraintsDoc)
@@ -2024,11 +2036,14 @@ func (e *exporter) virtualHostKeys() error {
 }
 
 func (e *exporter) readAllRelationScopes() (set.Strings, error) {
-	relationScopes, closer := e.st.db().GetCollection(relationScopesC)
+	relationScopes, closer, err := e.st.db().GetCollection(relationScopesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []relationScopeDoc
-	err := relationScopes.Find(nil).All(&docs)
+	err = relationScopes.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get all relation scopes")
 	}
@@ -2042,11 +2057,14 @@ func (e *exporter) readAllRelationScopes() (set.Strings, error) {
 }
 
 func (e *exporter) readAllUnits() (map[string][]*Unit, error) {
-	unitsCollection, closer := e.st.db().GetCollection(unitsC)
+	unitsCollection, closer, err := e.st.db().GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []unitDoc
-	err := unitsCollection.Find(nil).Sort("name").All(&docs)
+	err = unitsCollection.Find(nil).Sort("name").All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get all units")
 	}
@@ -2060,11 +2078,14 @@ func (e *exporter) readAllUnits() (map[string][]*Unit, error) {
 }
 
 func (e *exporter) readAllEndpointBindings() (map[string]bindingsMap, error) {
-	bindings, closer := e.st.db().GetCollection(endpointBindingsC)
+	bindings, closer, err := e.st.db().GetCollection(endpointBindingsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []endpointBindingsDoc
-	err := bindings.Find(nil).All(&docs)
+	err = bindings.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get all application endpoint bindings")
 	}
@@ -2077,11 +2098,14 @@ func (e *exporter) readAllEndpointBindings() (map[string]bindingsMap, error) {
 }
 
 func (e *exporter) readAllPodSpecs() (map[string]string, error) {
-	specs, closer := e.st.db().GetCollection(podSpecsC)
+	specs, closer, err := e.st.db().GetCollection(podSpecsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []containerSpecDoc
-	err := specs.Find(nil).All(&docs)
+	err = specs.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get all pod spec docs")
 	}
@@ -2094,11 +2118,14 @@ func (e *exporter) readAllPodSpecs() (map[string]string, error) {
 }
 
 func (e *exporter) readAllCloudServices() (map[string]*cloudServiceDoc, error) {
-	cloudServices, closer := e.st.db().GetCollection(cloudServicesC)
+	cloudServices, closer, err := e.st.db().GetCollection(cloudServicesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []cloudServiceDoc
-	err := cloudServices.Find(nil).All(&docs)
+	err = cloudServices.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get all cloud service docs")
 	}
@@ -2119,11 +2146,14 @@ func (e *exporter) cloudService(doc *cloudServiceDoc) *description.CloudServiceA
 }
 
 func (e *exporter) readAllCloudContainers() (map[string]*cloudContainerDoc, error) {
-	cloudContainers, closer := e.st.db().GetCollection(cloudContainersC)
+	cloudContainers, closer, err := e.st.db().GetCollection(cloudContainersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []cloudContainerDoc
-	err := cloudContainers.Find(nil).All(&docs)
+	err = cloudContainers.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get all cloud container docs")
 	}
@@ -2148,7 +2178,10 @@ func (e *exporter) cloudContainer(doc *cloudContainerDoc) *description.CloudCont
 }
 
 func (e *exporter) readLastConnectionTimes() (map[string]time.Time, error) {
-	lastConnections, closer := e.st.db().GetCollection(modelUserLastConnectionC)
+	lastConnections, closer, err := e.st.db().GetCollection(modelUserLastConnectionC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []modelUserLastConnectionDoc
@@ -2169,7 +2202,10 @@ func (e *exporter) readAllAnnotations() error {
 		return nil
 	}
 
-	annotations, closer := e.st.db().GetCollection(annotationsC)
+	annotations, closer, err := e.st.db().GetCollection(annotationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []annotatorDoc
@@ -2185,14 +2221,17 @@ func (e *exporter) readAllAnnotations() error {
 }
 
 func (e *exporter) readAllConstraints() error {
-	constraintsCollection, closer := e.st.db().GetCollection(constraintsC)
+	constraintsCollection, closer, err := e.st.db().GetCollection(constraintsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	// Since the constraintsDoc doesn't include any global key or _id
 	// fields, we can't just deserialize the entire collection into a slice
 	// of docs, so we get them all out with bson maps.
 	var docs []bson.M
-	err := constraintsCollection.Find(nil).All(&docs)
+	err = constraintsCollection.Find(nil).All(&docs)
 	if err != nil {
 		return errors.Annotate(err, "failed to read constraints collection")
 	}
@@ -2272,7 +2311,10 @@ func (e *exporter) readAllSettings() error {
 		return nil
 	}
 
-	settings, closer := e.st.db().GetCollection(settingsC)
+	settings, closer, err := e.st.db().GetCollection(settingsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []settingsDoc
@@ -2288,11 +2330,14 @@ func (e *exporter) readAllSettings() error {
 }
 
 func (e *exporter) readAllStatuses() error {
-	statuses, closer := e.st.db().GetCollection(statusesC)
+	statuses, closer, err := e.st.db().GetCollection(statusesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []bson.M
-	err := statuses.Find(nil).All(&docs)
+	err = statuses.Find(nil).All(&docs)
 	if err != nil {
 		return errors.Annotate(err, "failed to read status collection")
 	}
@@ -2312,7 +2357,10 @@ func (e *exporter) readAllStatuses() error {
 }
 
 func (e *exporter) readAllStatusHistory() error {
-	statuses, closer := e.st.db().GetCollection(statusesHistoryC)
+	statuses, closer, err := e.st.db().GetCollection(statusesHistoryC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	count := 0
@@ -2632,7 +2680,10 @@ func (e *exporter) storage() error {
 }
 
 func (e *exporter) volumes() error {
-	coll, closer := e.st.db().GetCollection(volumesC)
+	coll, closer, err := e.st.db().GetCollection(volumesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	attachments, err := e.readVolumeAttachments()
@@ -2764,7 +2815,10 @@ func (e *exporter) addVolume(vol *volume, volAttachments []volumeAttachmentDoc, 
 }
 
 func (e *exporter) readVolumeAttachments() (map[string][]volumeAttachmentDoc, error) {
-	coll, closer := e.st.db().GetCollection(volumeAttachmentsC)
+	coll, closer, err := e.st.db().GetCollection(volumeAttachmentsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	result := make(map[string][]volumeAttachmentDoc)
@@ -2784,7 +2838,10 @@ func (e *exporter) readVolumeAttachments() (map[string][]volumeAttachmentDoc, er
 }
 
 func (e *exporter) readVolumeAttachmentPlans() (map[string][]volumeAttachmentPlanDoc, error) {
-	coll, closer := e.st.db().GetCollection(volumeAttachmentPlanC)
+	coll, closer, err := e.st.db().GetCollection(volumeAttachmentPlanC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	result := make(map[string][]volumeAttachmentPlanDoc)
@@ -2804,7 +2861,10 @@ func (e *exporter) readVolumeAttachmentPlans() (map[string][]volumeAttachmentPla
 }
 
 func (e *exporter) filesystems() error {
-	coll, closer := e.st.db().GetCollection(filesystemsC)
+	coll, closer, err := e.st.db().GetCollection(filesystemsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	attachments, err := e.readFilesystemAttachments()
@@ -2886,7 +2946,10 @@ func (e *exporter) addFilesystem(fs *filesystem, fsAttachments []filesystemAttac
 }
 
 func (e *exporter) readFilesystemAttachments() (map[string][]filesystemAttachmentDoc, error) {
-	coll, closer := e.st.db().GetCollection(filesystemAttachmentsC)
+	coll, closer, err := e.st.db().GetCollection(filesystemAttachmentsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	result := make(map[string][]filesystemAttachmentDoc)
@@ -2910,7 +2973,10 @@ func (e *exporter) storageInstances() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	coll, closer := e.st.db().GetCollection(storageInstancesC)
+	coll, closer, err := e.st.db().GetCollection(storageInstancesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	attachments, err := e.readStorageAttachments()
@@ -2951,7 +3017,10 @@ func (e *exporter) addStorage(instance *storageInstance, attachments []names.Uni
 }
 
 func (e *exporter) readStorageAttachments() (map[string][]names.UnitTag, error) {
-	coll, closer := e.st.db().GetCollection(storageAttachmentsC)
+	coll, closer, err := e.st.db().GetCollection(storageAttachmentsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	result := make(map[string][]names.UnitTag)

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -396,7 +396,10 @@ func (i *importer) sequences() error {
 		return nil
 	}
 
-	sequences, closer := i.st.db().GetCollection(sequenceC)
+	sequences, closer, err := i.st.db().GetCollection(sequenceC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	if err := sequences.Writeable().Insert(docs...); err != nil {
@@ -895,11 +898,14 @@ func (i *importer) applications() error {
 }
 
 func (i *importer) loadUnits() error {
-	unitsCollection, closer := i.st.db().GetCollection(unitsC)
+	unitsCollection, closer, err := i.st.db().GetCollection(unitsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	docs := []unitDoc{}
-	err := unitsCollection.Find(nil).All(&docs)
+	err = unitsCollection.Find(nil).All(&docs)
 	if err != nil {
 		return errors.Annotate(err, "cannot get all units")
 	}
@@ -2289,7 +2295,10 @@ func (i *importer) importStatusHistory(globalKey string, history []description.S
 		return nil
 	}
 
-	statusHistory, closer := i.st.db().GetCollection(statusesHistoryC)
+	statusHistory, closer, err := i.st.db().GetCollection(statusesHistoryC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	if err := statusHistory.Writeable().Insert(docs...); err != nil {
@@ -2410,7 +2419,10 @@ func (i *importer) addStorageInstance(storage description.Storage) error {
 	})
 
 	if owner != nil {
-		refcounts, closer := i.st.db().GetCollection(refcountsC)
+		refcounts, closer, err := i.st.db().GetCollection(refcountsC)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		defer closer()
 		storageRefcountKey := entityStorageRefcountKey(owner, storage.Name())
 		incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, storageRefcountKey, 1)

--- a/state/migration_import_tasks.go
+++ b/state/migration_import_tasks.go
@@ -464,11 +464,14 @@ func (s *applicationOffersStateShim) OfferUUID(offerName string) (string, bool) 
 }
 
 func (a applicationOffersStateShim) OfferUUIDForApp(appName string) (string, error) {
-	applicationOffersCollection, closer := a.st.db().GetCollection(applicationOffersC)
+	applicationOffersCollection, closer, err := a.st.db().GetCollection(applicationOffersC)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
 	defer closer()
 
 	var doc applicationOfferDoc
-	err := applicationOffersCollection.Find(bson.D{{"application-name", appName}}).One(&doc)
+	err = applicationOffersCollection.Find(bson.D{{"application-name", appName}}).One(&doc)
 	if err == mgo.ErrNotFound {
 		return "", errors.NotFoundf("offer for app %q", appName)
 	}

--- a/state/minimumunits.go
+++ b/state/minimumunits.go
@@ -100,10 +100,13 @@ func setMinUnitsOps(app *Application, minUnits int) []txn.Op {
 
 // doesMinUnitsExits checks if the minUnits doc exists in the database.
 func doesMinUnitsExist(st *State, appName string) (bool, error) {
-	minUnits, closer := st.db().GetCollection(minUnitsC)
+	minUnits, closer, err := st.db().GetCollection(minUnitsC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 	var result bson.D
-	err := minUnits.FindId(appName).Select(bson.M{"_id": 1}).One(&result)
+	err = minUnits.FindId(appName).Select(bson.M{"_id": 1}).One(&result)
 	if err == nil {
 		return true, nil
 	} else if err == mgo.ErrNotFound {
@@ -201,7 +204,10 @@ func (a *Application) EnsureMinUnits() (err error) {
 
 // aliveUnitsCount returns the number a alive units for the application.
 func aliveUnitsCount(app *Application) (int, error) {
-	units, closer := app.st.db().GetCollection(unitsC)
+	units, closer, err := app.st.db().GetCollection(unitsC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
 	query := bson.D{{"application", app.doc.Name}, {"life", Alive}}

--- a/state/mocks/database_mock.go
+++ b/state/mocks/database_mock.go
@@ -12,12 +12,13 @@ package mocks
 import (
 	reflect "reflect"
 
-	mongo "github.com/juju/juju/mongo"
-	state "github.com/juju/juju/state"
 	mgo "github.com/juju/mgo/v3"
 	txn "github.com/juju/mgo/v3/txn"
 	txn0 "github.com/juju/txn/v3"
 	gomock "go.uber.org/mock/gomock"
+
+	mongo "github.com/juju/juju/mongo"
+	state "github.com/juju/juju/state"
 )
 
 // MockDatabase is a mock of Database interface.
@@ -44,12 +45,13 @@ func (m *MockDatabase) EXPECT() *MockDatabaseMockRecorder {
 }
 
 // Copy mocks base method.
-func (m *MockDatabase) Copy() (state.Database, state.SessionCloser) {
+func (m *MockDatabase) Copy() (state.Database, state.SessionCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Copy")
 	ret0, _ := ret[0].(state.Database)
 	ret1, _ := ret[1].(state.SessionCloser)
-	return ret0, ret1
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Copy indicates an expected call of Copy.
@@ -59,12 +61,13 @@ func (mr *MockDatabaseMockRecorder) Copy() *gomock.Call {
 }
 
 // CopyForModel mocks base method.
-func (m *MockDatabase) CopyForModel(arg0 string) (state.Database, state.SessionCloser) {
+func (m *MockDatabase) CopyForModel(arg0 string) (state.Database, state.SessionCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyForModel", arg0)
 	ret0, _ := ret[0].(state.Database)
 	ret1, _ := ret[1].(state.SessionCloser)
-	return ret0, ret1
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // CopyForModel indicates an expected call of CopyForModel.
@@ -74,12 +77,13 @@ func (mr *MockDatabaseMockRecorder) CopyForModel(arg0 any) *gomock.Call {
 }
 
 // CopyRaw mocks base method.
-func (m *MockDatabase) CopyRaw() (state.Database, *mgo.Session) {
+func (m *MockDatabase) CopyRaw() (state.Database, *mgo.Session, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyRaw")
 	ret0, _ := ret[0].(state.Database)
 	ret1, _ := ret[1].(*mgo.Session)
-	return ret0, ret1
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // CopyRaw indicates an expected call of CopyRaw.
@@ -89,12 +93,13 @@ func (mr *MockDatabaseMockRecorder) CopyRaw() *gomock.Call {
 }
 
 // GetCollection mocks base method.
-func (m *MockDatabase) GetCollection(arg0 string) (mongo.Collection, state.SessionCloser) {
+func (m *MockDatabase) GetCollection(arg0 string) (mongo.Collection, state.SessionCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCollection", arg0)
 	ret0, _ := ret[0].(mongo.Collection)
 	ret1, _ := ret[1].(state.SessionCloser)
-	return ret0, ret1
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetCollection indicates an expected call of GetCollection.
@@ -104,12 +109,13 @@ func (mr *MockDatabaseMockRecorder) GetCollection(arg0 any) *gomock.Call {
 }
 
 // GetCollectionFor mocks base method.
-func (m *MockDatabase) GetCollectionFor(arg0, arg1 string) (mongo.Collection, state.SessionCloser) {
+func (m *MockDatabase) GetCollectionFor(arg0, arg1 string) (mongo.Collection, state.SessionCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCollectionFor", arg0, arg1)
 	ret0, _ := ret[0].(mongo.Collection)
 	ret1, _ := ret[1].(state.SessionCloser)
-	return ret0, ret1
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetCollectionFor indicates an expected call of GetCollectionFor.
@@ -119,12 +125,13 @@ func (mr *MockDatabaseMockRecorder) GetCollectionFor(arg0, arg1 any) *gomock.Cal
 }
 
 // GetRawCollection mocks base method.
-func (m *MockDatabase) GetRawCollection(arg0 string) (*mgo.Collection, state.SessionCloser) {
+func (m *MockDatabase) GetRawCollection(arg0 string) (*mgo.Collection, state.SessionCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRawCollection", arg0)
 	ret0, _ := ret[0].(*mgo.Collection)
 	ret1, _ := ret[1].(state.SessionCloser)
-	return ret0, ret1
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetRawCollection indicates an expected call of GetRawCollection.
@@ -218,12 +225,13 @@ func (mr *MockDatabaseMockRecorder) Schema() *gomock.Call {
 }
 
 // TransactionRunner mocks base method.
-func (m *MockDatabase) TransactionRunner() (txn0.Runner, state.SessionCloser) {
+func (m *MockDatabase) TransactionRunner() (txn0.Runner, state.SessionCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransactionRunner")
 	ret0, _ := ret[0].(txn0.Runner)
 	ret1, _ := ret[1].(state.SessionCloser)
-	return ret0, ret1
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // TransactionRunner indicates an expected call of TransactionRunner.

--- a/state/mocks/database_mock.go
+++ b/state/mocks/database_mock.go
@@ -12,13 +12,12 @@ package mocks
 import (
 	reflect "reflect"
 
+	mongo "github.com/juju/juju/mongo"
+	state "github.com/juju/juju/state"
 	mgo "github.com/juju/mgo/v3"
 	txn "github.com/juju/mgo/v3/txn"
 	txn0 "github.com/juju/txn/v3"
 	gomock "go.uber.org/mock/gomock"
-
-	mongo "github.com/juju/juju/mongo"
-	state "github.com/juju/juju/state"
 )
 
 // MockDatabase is a mock of Database interface.

--- a/state/model.go
+++ b/state/model.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/mongo"
 	"github.com/juju/juju/mongo/utils"
 	stateerrors "github.com/juju/juju/state/errors"
 	"github.com/juju/juju/storage"
@@ -227,11 +228,14 @@ func (st *State) AllModelUUIDsIncludingDead() ([]string, error) {
 
 // filteredModelUUIDs returns all model uuids that match the filter.
 func (st *State) filteredModelUUIDs(filter bson.D) ([]string, error) {
-	models, closer := st.db().GetCollection(modelsC)
+	models, closer, err := st.db().GetCollection(modelsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []bson.M
-	err := models.Find(filter).Sort("name", "owner").Select(bson.M{"_id": 1}).All(&docs)
+	err = models.Find(filter).Sort("name", "owner").Select(bson.M{"_id": 1}).All(&docs)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +248,10 @@ func (st *State) filteredModelUUIDs(filter bson.D) ([]string, error) {
 
 // ModelExists returns true if a model with the supplied UUID exists.
 func (st *State) ModelExists(uuid string) (bool, error) {
-	models, closer := st.db().GetCollection(modelsC)
+	models, closer, err := st.db().GetCollection(modelsC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 
 	count, err := models.FindId(uuid).Count()
@@ -380,7 +387,10 @@ func (ctlr *Controller) NewModel(args ModelArgs) (_ *Model, _ *State, err error)
 	prereqOps = append(prereqOps, assertCloudCredentialOp)
 
 	uuid := args.Config.UUID()
-	session := st.session.Copy()
+	session, err := mongo.CopySession(st.session)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	newSt, err := newState(
 		st.controllerTag,
 		names.NewModelTag(uuid),
@@ -430,7 +440,10 @@ func (ctlr *Controller) NewModel(args ModelArgs) (_ *Model, _ *State, err error)
 		// the same "owner" and "name" in the collection. If the txn is
 		// aborted, check if it is due to the unique key restriction.
 		name := args.Config.Name()
-		models, closer := st.db().GetCollection(modelsC)
+		models, closer, countErr := st.db().GetCollection(modelsC)
+		if countErr != nil {
+			return nil, nil, errors.Trace(countErr)
+		}
 		defer closer()
 		modelCount, countErr := models.Find(bson.D{
 			{"owner", owner.Id()},
@@ -910,9 +923,12 @@ func (m *Model) Refresh() error {
 }
 
 func (m *Model) refresh(uuid string) error {
-	models, closer := m.st.db().GetCollection(modelsC)
+	models, closer, err := m.st.db().GetCollection(modelsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
-	err := models.FindId(uuid).One(&m.doc)
+	err = models.FindId(uuid).One(&m.doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("model %q", uuid)
 	}
@@ -921,11 +937,14 @@ func (m *Model) refresh(uuid string) error {
 
 // AllUnits returns all units for a model, for all applications.
 func (m *Model) AllUnits() ([]*Unit, error) {
-	coll, closer := m.st.db().GetCollection(unitsC)
+	coll, closer, err := m.st.db().GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	docs := []unitDoc{}
-	err := coll.Find(nil).All(&docs)
+	err = coll.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get all units for model")
 	}
@@ -983,19 +1002,28 @@ func (m *Model) Metrics() (ModelMetrics, error) {
 }
 
 func (m *Model) applicationCount() (int, error) {
-	coll, closer := m.st.db().GetCollection(applicationsC)
+	coll, closer, err := m.st.db().GetCollection(applicationsC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 	return coll.Find(isAliveDoc).Count()
 }
 
 func (m *Model) machineCount() (int, error) {
-	coll, closer := m.st.db().GetCollection(machinesC)
+	coll, closer, err := m.st.db().GetCollection(machinesC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 	return coll.Find(isAliveDoc).Count()
 }
 
 func (m *Model) unitCount() (int, error) {
-	coll, closer := m.st.db().GetCollection(unitsC)
+	coll, closer, err := m.st.db().GetCollection(unitsC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 	return coll.Find(isAliveDoc).Count()
 }
@@ -1003,11 +1031,14 @@ func (m *Model) unitCount() (int, error) {
 // AllEndpointBindings returns all endpoint->space bindings
 // keyed by application name.
 func (m *Model) AllEndpointBindings() (map[string]*Bindings, error) {
-	endpointBindings, closer := m.st.db().GetCollection(endpointBindingsC)
+	endpointBindings, closer, err := m.st.db().GetCollection(endpointBindingsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []endpointBindingsDoc
-	err := endpointBindings.Find(nil).All(&docs)
+	err = endpointBindings.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get endpoint bindings")
 	}
@@ -1065,11 +1096,14 @@ func (st *State) AllEndpointBindingsSpaceNames() (set.Strings, error) {
 
 // Users returns a slice of all users for this model.
 func (m *Model) Users() ([]permission.UserAccess, error) {
-	coll, closer := m.st.db().GetCollection(modelUsersC)
+	coll, closer, err := m.st.db().GetCollection(modelUsersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var userDocs []userAccessDoc
-	err := coll.Find(nil).All(&userDocs)
+	err = coll.Find(nil).All(&userDocs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1432,7 +1466,10 @@ func (m *Model) destroyOps(
 
 // getEntityRefs reads the current model entity refs document for the model.
 func (m *Model) getEntityRefs() (*modelEntityRefsDoc, error) {
-	modelEntityRefs, closer := m.st.db().GetCollection(modelEntityRefsC)
+	modelEntityRefs, closer, err := m.st.db().GetCollection(modelEntityRefsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc modelEntityRefsDoc
@@ -1735,7 +1772,10 @@ func HostedModelCountOp(amount int) txn.Op {
 
 func hostedModelCount(st *State) (int, error) {
 	var doc hostedModelCountDoc
-	controllers, closer := st.db().GetCollection(controllersC)
+	controllers, closer, err := st.db().GetCollection(controllersC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
 	if err := controllers.Find(bson.D{{"_id", hostedModelCountKey}}).One(&doc); err != nil {

--- a/state/modelcredential.go
+++ b/state/modelcredential.go
@@ -158,7 +158,10 @@ func (m *Model) WatchModelCredential() NotifyWatcher {
 			return false
 		}
 
-		models, closer := m.st.db().GetCollection(modelsC)
+		models, closer, err := m.st.db().GetCollection(modelsC)
+		if err != nil {
+			return false
+		}
 		defer closer()
 
 		var doc *modelDoc

--- a/state/modelgeneration.go
+++ b/state/modelgeneration.go
@@ -559,7 +559,10 @@ func (g *Generation) CheckNotComplete() error {
 
 // Refresh refreshes the contents of the generation from the underlying state.
 func (g *Generation) Refresh() error {
-	col, closer := g.st.db().GetCollection(generationsC)
+	col, closer, err := g.st.db().GetCollection(generationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var doc generationDoc
@@ -707,7 +710,10 @@ func (m *Model) Branches() ([]*Generation, error) {
 
 // Branches returns all "in-flight" branches.
 func (st *State) Branches() ([]*Generation, error) {
-	col, closer := st.db().GetCollection(generationsC)
+	col, closer, err := st.db().GetCollection(generationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []generationDoc
@@ -724,7 +730,10 @@ func (st *State) Branches() ([]*Generation, error) {
 
 // CommittedBranches returns all committed branches.
 func (st *State) CommittedBranches() ([]*Generation, error) {
-	col, closer := st.db().GetCollection(generationsC)
+	col, closer, err := st.db().GetCollection(generationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []generationDoc
@@ -793,11 +802,14 @@ func (st *State) CommittedBranch(id int) (*Generation, error) {
 }
 
 func (st *State) getBranchDoc(name string) (*generationDoc, error) {
-	col, closer := st.db().GetCollection(generationsC)
+	col, closer, err := st.db().GetCollection(generationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := &generationDoc{}
-	err := col.Find(bson.M{
+	err = col.Find(bson.M{
 		"name":      name,
 		"completed": 0,
 	}).One(doc)
@@ -815,11 +827,14 @@ func (st *State) getBranchDoc(name string) (*generationDoc, error) {
 }
 
 func (st *State) getCommittedBranchDoc(id int) (*generationDoc, error) {
-	col, closer := st.db().GetCollection(generationsC)
+	col, closer, err := st.db().GetCollection(generationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := &generationDoc{}
-	err := col.Find(bson.M{
+	err = col.Find(bson.M{
 		"generation-id": id,
 	}).One(doc)
 
@@ -879,13 +894,16 @@ type branchesCleanupChange struct{}
 
 // Prepare is part of the Change interface.
 func (change branchesCleanupChange) Prepare(db Database) ([]txn.Op, error) {
-	generations, closer := db.GetCollection(generationsC)
+	generations, closer, err := db.GetCollection(generationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []struct {
 		DocID string `bson:"_id"`
 	}
-	err := generations.Find(nil).Select(bson.D{{"_id", 1}}).All(&docs)
+	err = generations.Find(nil).Select(bson.D{{"_id", 1}}).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -467,10 +467,13 @@ func (mig *modelMigration) SubmitMinionReport(tag names.Tag, phase migration.Pha
 	}}
 	err = mig.st.db().RunTransaction(ops)
 	if errors.Cause(err) == txn.ErrAborted {
-		coll, closer := mig.st.db().GetCollection(migrationsMinionSyncC)
+		coll, closer, err := mig.st.db().GetCollection(migrationsMinionSyncC)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		defer closer()
 		var existingDoc modelMigMinionSyncDoc
-		err := coll.FindId(docID).Select(bson.M{"success": 1}).One(&existingDoc)
+		err = coll.FindId(docID).Select(bson.M{"success": 1}).One(&existingDoc)
 		if err != nil {
 			return errors.Annotate(err, "checking existing report")
 		}
@@ -497,7 +500,10 @@ func (mig *modelMigration) MinionReports() (*MinionReports, error) {
 		return nil, errors.Annotate(err, "retrieving phase")
 	}
 
-	coll, closer := mig.st.db().GetCollection(migrationsMinionSyncC)
+	coll, closer, err := mig.st.db().GetCollection(migrationsMinionSyncC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	query := coll.Find(bson.M{"_id": bson.M{
 		"$regex": "^" + mig.minionReportId(phase, ".+"),
@@ -624,10 +630,13 @@ func (mig *modelMigration) loadAgentTags(collName, fieldName string, convert fun
 	// During migrations we know that nothing there are no machines or
 	// units being provisioned or destroyed so a simple query of the
 	// collections will do.
-	coll, closer := mig.st.db().GetCollection(collName)
+	coll, closer, err := mig.st.db().GetCollection(collName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var docs []bson.M
-	err := coll.Find(nil).Select(bson.M{fieldName: 1}).All(&docs)
+	err = coll.Find(nil).Select(bson.M{fieldName: 1}).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -647,17 +656,23 @@ func (mig *modelMigration) loadAgentTags(collName, fieldName string, convert fun
 func (mig *modelMigration) Refresh() error {
 	// Only the status document is updated. The modelMigDoc is static
 	// after creation.
-	statusColl, closer := mig.st.db().GetCollection(migrationsStatusC)
+	statusColl, closer, err := mig.st.db().GetCollection(migrationsStatusC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	var statusDoc modelMigStatusDoc
-	err := statusColl.FindId(mig.doc.Id).One(&statusDoc)
+	err = statusColl.FindId(mig.doc.Id).One(&statusDoc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("migration status")
 	} else if err != nil {
 		return errors.Annotate(err, "migration status lookup failed")
 	}
 
-	statusMessageColl, closer := mig.st.db().GetCollection(migrationsStatusMessageC)
+	statusMessageColl, closer, err := mig.st.db().GetCollection(migrationsStatusMessageC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	var statusMessageDoc modelMigStatusMessageDoc
 	err = statusMessageColl.FindId(mig.doc.Id).One(&statusMessageDoc)
@@ -940,7 +955,10 @@ func (st *State) CompletedMigrationForModel(modelUUID string) (ModelMigration, e
 // latestMigration returns the most recent ModelMigration for a model
 // (if any).
 func (st *State) latestMigration(modelUUID string) (ModelMigration, migration.Phase, error) {
-	migColl, closer := st.db().GetCollection(migrationsC)
+	migColl, closer, err := st.db().GetCollection(migrationsC)
+	if err != nil {
+		return nil, migration.UNKNOWN, errors.Trace(err)
+	}
 	defer closer()
 	query := migColl.Find(bson.M{"model-uuid": modelUUID})
 	query = query.Sort("-attempt").Limit(1)
@@ -961,7 +979,10 @@ func (st *State) latestMigration(modelUUID string) (ModelMigration, migration.Ph
 // Migration retrieves a specific ModelMigration by its id. See also
 // LatestMigration and LatestCompletedMigration.
 func (st *State) Migration(id string) (ModelMigration, error) {
-	migColl, closer := st.db().GetCollection(migrationsC)
+	migColl, closer, err := st.db().GetCollection(migrationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	mig, err := st.migrationFromQuery(migColl.FindId(id))
 	if err != nil {
@@ -979,7 +1000,10 @@ func (st *State) migrationFromQuery(query mongo.Query) (ModelMigration, error) {
 		return nil, errors.Annotate(err, "migration lookup failed")
 	}
 
-	statusColl, closer := st.db().GetCollection(migrationsStatusC)
+	statusColl, closer, err := st.db().GetCollection(migrationsStatusC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var statusDoc modelMigStatusDoc
 	err = statusColl.FindId(doc.Id).One(&statusDoc)
@@ -989,7 +1013,10 @@ func (st *State) migrationFromQuery(query mongo.Query) (ModelMigration, error) {
 		return nil, errors.Annotate(err, "migration status lookup failed")
 	}
 
-	statusMessageColl, closer := st.db().GetCollection(migrationsStatusMessageC)
+	statusMessageColl, closer, err := st.db().GetCollection(migrationsStatusMessageC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var statusMessageDoc modelMigStatusMessageDoc
 	err = statusMessageColl.FindId(doc.Id).One(&statusMessageDoc)
@@ -1017,7 +1044,10 @@ func (st *State) IsMigrationActive() (bool, error) {
 // the model with the given UUID. The State provided need not be for
 // the model in question.
 func IsMigrationActive(st *State, modelUUID string) (bool, error) {
-	active, closer := st.db().GetCollection(migrationsActiveC)
+	active, closer, err := st.db().GetCollection(migrationsActiveC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 	n, err := active.FindId(modelUUID).Count()
 	if err != nil {

--- a/state/modelsummaries.go
+++ b/state/modelsummaries.go
@@ -124,7 +124,10 @@ func newProcessorFromModelDocs(st *State, modelDocs []modelDoc, user names.UserT
 
 func (p *modelSummaryProcessor) fillInFromConfig() error {
 	// We use the raw settings because we are reading across model UUIDs
-	rawSettings, closer := p.st.database.GetRawCollection(settingsC)
+	rawSettings, closer, err := p.st.database.GetRawCollection(settingsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	settingIds := make([]string, len(p.modelUUIDs))
@@ -169,7 +172,10 @@ func (p *modelSummaryProcessor) fillInFromConfig() error {
 
 func (p *modelSummaryProcessor) fillInFromStatus() error {
 	// We use the raw statuses because otherwise it filters by model-uuid
-	rawStatus, closer := p.st.database.GetRawCollection(statusesC)
+	rawStatus, closer, err := p.st.database.GetRawCollection(statusesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	statusIds := make([]string, len(p.modelUUIDs))
 	for i, uuid := range p.modelUUIDs {
@@ -201,7 +207,10 @@ func (p *modelSummaryProcessor) fillInFromStatus() error {
 
 func (p *modelSummaryProcessor) fillInPermissions(permissionIds []string) error {
 	// permissionsC is a global collection, so can be accessed from any state
-	perms, closer := p.st.db().GetCollection(permissionsC)
+	perms, closer, err := p.st.db().GetCollection(permissionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	query := perms.Find(bson.M{"_id": bson.M{"$in": permissionIds}})
 	iter := query.Iter()
@@ -235,7 +244,10 @@ func (p *modelSummaryProcessor) fillInPermissions(permissionIds []string) error 
 }
 
 func (p *modelSummaryProcessor) fillInMachineSummary() error {
-	machines, closer := p.st.db().GetRawCollection(machinesC)
+	machines, closer, err := p.st.db().GetRawCollection(machinesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	query := machines.Find(bson.M{
 		"model-uuid": bson.M{"$in": p.modelUUIDs},
@@ -267,7 +279,10 @@ func (p *modelSummaryProcessor) fillInMachineSummary() error {
 	if err := iter.Close(); err != nil {
 		return errors.Trace(err)
 	}
-	instances, closer2 := p.st.db().GetRawCollection(instanceDataC)
+	instances, closer2, err := p.st.db().GetRawCollection(instanceDataC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer2()
 	query = instances.Find(bson.M{"_id": bson.M{"$in": machineIds}})
 	query.Select(bson.M{"cpucores": 1, "model-uuid": 1})
@@ -291,7 +306,10 @@ func (p *modelSummaryProcessor) fillInMachineSummary() error {
 }
 
 func (p *modelSummaryProcessor) fillInApplicationSummary() error {
-	units, closer := p.st.db().GetRawCollection(unitsC)
+	units, closer, err := p.st.db().GetRawCollection(unitsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	query := units.Find(bson.M{
 		"model-uuid": bson.M{"$in": p.modelUUIDs},
@@ -324,7 +342,10 @@ func (p *modelSummaryProcessor) fillInMigration() error {
 	// It might be possible to do it differently with an aggregation and $first queries.
 	// $first appears to have been available since Mongo 2.4.
 	// Migrations is a global collection so can be accessed from any State
-	migrations, closer := p.st.db().GetCollection(migrationsC)
+	migrations, closer, err := p.st.db().GetCollection(migrationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	pipe := migrations.Pipe([]bson.M{
 		{"$match": bson.M{"model-uuid": bson.M{"$in": p.modelUUIDs}}},
@@ -369,7 +390,10 @@ func (p *modelSummaryProcessor) fillInMigration() error {
 		return errors.Trace(err)
 	}
 	// Now look up the status documents and join them together
-	migStatus, closer2 := p.st.db().GetCollection(migrationsStatusC)
+	migStatus, closer2, err := p.st.db().GetCollection(migrationsStatusC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer2()
 	query := migStatus.Find(bson.M{"_id": bson.M{"$in": docIds}})
 	query.Batch(100)
@@ -407,7 +431,10 @@ func (p *modelSummaryProcessor) fillInMigration() error {
 	}
 	// Now look up the status message documents and join them together with
 	// the migration documents.
-	migStatusMessage, closer3 := p.st.db().GetCollection(migrationsStatusMessageC)
+	migStatusMessage, closer3, err := p.st.db().GetCollection(migrationsStatusMessageC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer3()
 	query = migStatusMessage.Find(bson.M{"_id": bson.M{"$in": docIds}})
 	query.Batch(100)
@@ -462,7 +489,10 @@ func (p *modelSummaryProcessor) fillInLastAccess() error {
 	for i, modelUUID := range p.modelUUIDs {
 		lastAccessIds[i] = modelUUID + suffix
 	}
-	lastConnections, closer := p.st.db().GetRawCollection(modelUserLastConnectionC)
+	lastConnections, closer, err := p.st.db().GetRawCollection(modelUserLastConnectionC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	query := lastConnections.Find(bson.M{"_id": bson.M{"$in": lastAccessIds}})
 	query.Select(bson.M{"_id": 1, "model-uuid": 1, "last-connection": 1})
@@ -520,7 +550,10 @@ func (p *modelSummaryProcessor) substituteModelStatusForInvalidCredentials(crede
 		ids = append(ids, cloudCredentialDocID(tag))
 	}
 	// cloudCredentialsC is a global collection, so can be accessed from any state
-	perms, closer := p.st.db().GetCollection(cloudCredentialsC)
+	perms, closer, err := p.st.db().GetCollection(cloudCredentialsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	query := perms.Find(bson.M{"_id": bson.M{"$in": ids}})
 	iter := query.Iter()

--- a/state/modeluser.go
+++ b/state/modeluser.go
@@ -46,12 +46,15 @@ func (st *State) setModelAccess(access permission.Access, userGlobalKey, modelUU
 // LastModelConnection returns when this User last connected through the API
 // in UTC. The resulting time will be nil if the user has never logged in.
 func (m *Model) LastModelConnection(user names.UserTag) (time.Time, error) {
-	lastConnections, closer := m.st.db().GetRawCollection(modelUserLastConnectionC)
+	lastConnections, closer, err := m.st.db().GetRawCollection(modelUserLastConnectionC)
+	if err != nil {
+		return time.Time{}, errors.Trace(err)
+	}
 	defer closer()
 
 	username := user.Id()
 	var lastConn modelUserLastConnectionDoc
-	err := lastConnections.FindId(m.st.docID(username)).Select(bson.D{{"last-connection", 1}}).One(&lastConn)
+	err = lastConnections.FindId(m.st.docID(username)).Select(bson.D{{"last-connection", 1}}).One(&lastConn)
 	if err != nil {
 		if err == mgo.ErrNotFound {
 			err = errors.Wrap(err, newNeverConnectedError(username))
@@ -68,7 +71,10 @@ func (m *Model) UpdateLastModelConnection(user names.UserTag) error {
 }
 
 func (m *Model) updateLastModelConnection(user names.UserTag, when time.Time) error {
-	lastConnections, closer := m.st.db().GetCollection(modelUserLastConnectionC)
+	lastConnections, closer, err := m.st.db().GetCollection(modelUserLastConnectionC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	lastConnectionsW := lastConnections.Writeable()
@@ -84,18 +90,21 @@ func (m *Model) updateLastModelConnection(user names.UserTag, when time.Time) er
 		UserName:       user.Id(),
 		LastConnection: when,
 	}
-	_, err := lastConnectionsW.UpsertId(lastConn.ID, lastConn)
+	_, err = lastConnectionsW.UpsertId(lastConn.ID, lastConn)
 	return errors.Trace(err)
 }
 
 // ModelUser a model userAccessDoc.
 func (st *State) modelUser(modelUUID string, user names.UserTag) (userAccessDoc, error) {
 	modelUser := userAccessDoc{}
-	modelUsers, closer := st.db().GetCollectionFor(modelUUID, modelUsersC)
+	modelUsers, closer, err := st.db().GetCollectionFor(modelUUID, modelUsersC)
+	if err != nil {
+		return userAccessDoc{}, errors.Trace(err)
+	}
 	defer closer()
 
 	username := strings.ToLower(user.Id())
-	err := modelUsers.FindId(username).One(&modelUser)
+	err = modelUsers.FindId(username).One(&modelUser)
 	if err == mgo.ErrNotFound {
 		return userAccessDoc{}, errors.NotFoundf("model user %q", username)
 	}
@@ -209,7 +218,10 @@ func (st *State) ModelSummariesForUser(user names.UserTag, isSuperuser bool) ([]
 // This includes the name and UUID, as well as the last time the user connected to that model.
 func (st *State) modelQueryForUser(user names.UserTag, isSuperuser bool) (mongo.Query, SessionCloser, error) {
 	var modelQuery mongo.Query
-	models, closer := st.db().GetCollection(modelsC)
+	models, closer, err := st.db().GetCollection(modelsC)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	if isSuperuser {
 		// Fast path, we just return all the models that aren't Importing
 		modelQuery = models.Find(bson.M{"migration-mode": bson.M{"$ne": MigrationModeImporting}})
@@ -219,7 +231,11 @@ func (st *State) modelQueryForUser(user names.UserTag, isSuperuser bool) (mongo.
 		var modelUUID struct {
 			UUID string `bson:"object-uuid"`
 		}
-		modelUsers, userCloser := st.db().GetRawCollection(modelUsersC)
+		modelUsers, userCloser, err := st.db().GetRawCollection(modelUsersC)
+		if err != nil {
+			closer()
+			return nil, nil, errors.Trace(err)
+		}
 		defer userCloser()
 		query := modelUsers.Find(bson.D{{"user", user.Id()}})
 		query.Select(bson.M{"object-uuid": 1, "_id": 0})
@@ -269,7 +285,10 @@ func (st *State) ModelBasicInfoForUser(user names.UserTag, isSuperuser bool) ([]
 	for i, acc := range accessInfo {
 		connDocIds[i] = acc.UUID + ":" + username
 	}
-	lastConnections, closer2 := st.db().GetRawCollection(modelUserLastConnectionC)
+	lastConnections, closer2, err := st.db().GetRawCollection(modelUserLastConnectionC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer2()
 	query := lastConnections.Find(bson.M{"_id": bson.M{"$in": connDocIds}})
 	query.Select(bson.M{"last-connection": 1, "_id": 0, "model-uuid": 1})
@@ -315,11 +334,14 @@ func (st *State) ModelUUIDsForUser(user names.UserTag) ([]string, error) {
 		// the models that a particular user can see is to look through the
 		// model user collection. A raw collection is required to support
 		// queries across multiple models.
-		modelUsers, userCloser := st.db().GetRawCollection(modelUsersC)
+		modelUsers, userCloser, err := st.db().GetRawCollection(modelUsersC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer userCloser()
 
 		var userSlice []userAccessDoc
-		err := modelUsers.Find(bson.D{{"user", user.Id()}}).Select(bson.D{{"object-uuid", 1}, {"_id", 1}}).All(&userSlice)
+		err = modelUsers.Find(bson.D{{"user", user.Id()}}).Select(bson.D{{"object-uuid", 1}, {"_id", 1}}).All(&userSlice)
 		if err != nil {
 			return nil, err
 		}
@@ -328,7 +350,10 @@ func (st *State) ModelUUIDsForUser(user names.UserTag) ([]string, error) {
 		}
 	}
 
-	modelsColl, close := st.db().GetCollection(modelsC)
+	modelsColl, close, err := st.db().GetCollection(modelsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer close()
 	query := modelsColl.Find(bson.M{
 		"_id":            bson.M{"$in": modelUUIDs},

--- a/state/mongo.go
+++ b/state/mongo.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"github.com/juju/errors"
 	jujutxn "github.com/juju/txn/v3"
 
 	"github.com/juju/juju/mongo"
@@ -16,8 +17,12 @@ type environMongo struct {
 }
 
 // GetCollection is part of the lease.Mongo interface.
-func (m *environMongo) GetCollection(name string) (mongo.Collection, func()) {
-	return m.state.db().GetCollection(name)
+func (m *environMongo) GetCollection(name string) (mongo.Collection, func(), error) {
+	coll, closer, err := m.state.db().GetCollection(name)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	return coll, closer, nil
 }
 
 // RunTransaction is part of the lease.Mongo interface.

--- a/state/offerconnections.go
+++ b/state/offerconnections.go
@@ -180,7 +180,10 @@ func (st *State) OfferConnectionsForUser(username string) ([]*OfferConnection, e
 
 // offerConnections returns the offer connections for the input condition
 func (st *State) offerConnections(condition bson.D) ([]*OfferConnection, error) {
-	offerConnectionCollection, closer := st.db().GetCollection(offerConnectionsC)
+	offerConnectionCollection, closer, err := st.db().GetCollection(offerConnectionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var connDocs []offerConnectionDoc
@@ -197,11 +200,14 @@ func (st *State) offerConnections(condition bson.D) ([]*OfferConnection, error) 
 
 // OfferConnectionForRelation returns the offer connection for the specified relation.
 func (st *State) OfferConnectionForRelation(relationKey string) (*OfferConnection, error) {
-	offerConnectionCollection, closer := st.db().GetCollection(offerConnectionsC)
+	offerConnectionCollection, closer, err := st.db().GetCollection(offerConnectionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var connDoc offerConnectionDoc
-	err := offerConnectionCollection.Find(bson.D{{"relation-key", relationKey}}).One(&connDoc)
+	err = offerConnectionCollection.Find(bson.D{{"relation-key", relationKey}}).One(&connDoc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("offer connection for relation %q", relationKey)
 	}

--- a/state/operation.go
+++ b/state/operation.go
@@ -296,17 +296,23 @@ func (m *Model) Operation(id string) (Operation, error) {
 // OperationWithActions returns an OperationInfo by Id.
 func (m *Model) OperationWithActions(id string) (*OperationInfo, error) {
 	// First gather the matching actions and record the parent operation ids we need.
-	actionsCollection, aCloser := m.st.db().GetCollection(actionsC)
+	actionsCollection, aCloser, err := m.st.db().GetCollection(actionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer aCloser()
 
 	var actions []actionDoc
-	err := actionsCollection.Find(bson.D{{"operation", id}}).
+	err = actionsCollection.Find(bson.D{{"operation", id}}).
 		Sort("_id").All(&actions)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	operationCollection, oCloser := m.st.db().GetCollection(operationsC)
+	operationCollection, oCloser, err := m.st.db().GetCollection(operationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer oCloser()
 
 	var docs []operationDoc
@@ -331,13 +337,19 @@ func (m *Model) OperationWithActions(id string) (*OperationInfo, error) {
 }
 
 func (st *State) getOperationDoc(id string) (*operationDoc, []ActionStatus, error) {
-	operations, closer := st.db().GetCollection(operationsC)
+	operations, closer, err := st.db().GetCollection(operationsC)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	defer closer()
-	actions, closer := st.db().GetCollection(actionsC)
+	actions, closer, err := st.db().GetCollection(actionsC)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := operationDoc{}
-	err := operations.FindId(id).One(&doc)
+	err = operations.FindId(id).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, nil, errors.NotFoundf("operation %q", id)
 	}
@@ -358,12 +370,15 @@ func (st *State) getOperationDoc(id string) (*operationDoc, []ActionStatus, erro
 
 // AllOperations returns all Operations.
 func (m *Model) AllOperations() ([]Operation, error) {
-	operations, closer := m.st.db().GetCollection(operationsC)
+	operations, closer, err := m.st.db().GetCollection(operationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	results := []Operation{}
 	docs := []operationDoc{}
-	err := operations.Find(nil).All(&docs)
+	err = operations.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get all operations")
 	}
@@ -391,7 +406,10 @@ func (m *Model) ListOperations(
 	offset, limit int,
 ) ([]OperationInfo, bool, error) {
 	// First gather the matching actions and record the parent operation ids we need.
-	actionsCollection, closer := m.st.db().GetCollection(actionsC)
+	actionsCollection, closer, err := m.st.db().GetCollection(actionsC)
+	if err != nil {
+		return nil, false, errors.Trace(err)
+	}
 	defer closer()
 
 	var receiverIDs []string
@@ -407,7 +425,7 @@ func (m *Model) ListOperations(
 	}
 	actionsQuery := append(receiverTerm, namesTerm...)
 	var actions []actionDoc
-	err := actionsCollection.Find(actionsQuery).
+	err = actionsCollection.Find(actionsQuery).
 		// For now we'll limit what we return to the caller as action results
 		// can be large and show-task can be used to get more detail as needed.
 		Select(bson.D{
@@ -440,7 +458,10 @@ func (m *Model) ListOperations(
 	}
 	operationsQuery := append(idsTerm, statusTerm...)
 
-	operationCollection, closer := m.st.db().GetCollection(operationsC)
+	operationCollection, closer, err := m.st.db().GetCollection(operationsC)
+	if err != nil {
+		return nil, false, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []operationDoc

--- a/state/package_test.go
+++ b/state/package_test.go
@@ -6,6 +6,7 @@ package state
 import (
 	"testing"
 
+	"github.com/juju/errors"
 	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/mgo/v3/txn"
 	jc "github.com/juju/testing/checkers"
@@ -109,7 +110,10 @@ func MustCloseUnitPortRanges(c *gc.C, st *State, machine *Machine, unitName, end
 }
 
 func (st *State) ReadBackendRefCount(backendID string) (int, error) {
-	refCountCollection, ccloser := st.db().GetCollection(globalRefcountsC)
+	refCountCollection, ccloser, err := st.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer ccloser()
 
 	key := secretBackendRefCountKey(backendID)
@@ -117,10 +121,11 @@ func (st *State) ReadBackendRefCount(backendID string) (int, error) {
 }
 
 func (st *State) IsSecretRevisionObsolete(c *gc.C, uri *secrets.URI, rev int) bool {
-	col, closer := st.db().GetCollection(secretRevisionsC)
+	col, closer, err := st.db().GetCollection(secretRevisionsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 	var doc secretRevisionDoc
-	err := col.FindId(secretRevisionKey(uri, rev)).One(&doc)
+	err = col.FindId(secretRevisionKey(uri, rev)).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	return doc.Obsolete
 }

--- a/state/payloads.go
+++ b/state/payloads.go
@@ -25,7 +25,10 @@ type ModelPayloads struct {
 
 // ListAll builds the list of payload information that is registered in state.
 func (mp ModelPayloads) ListAll() ([]payloads.FullPayloadInfo, error) {
-	coll, closer := mp.db.GetCollection(payloadsC)
+	coll, closer, err := mp.db.GetCollection(payloadsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []payloadDoc
@@ -74,7 +77,10 @@ func (up UnitPayloads) List(names ...string) ([]payloads.Result, error) {
 		}
 	}
 
-	coll, closer := up.db.GetCollection(payloadsC)
+	coll, closer, err := up.db.GetCollection(payloadsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var docs []payloadDoc
 	if err := coll.Find(sel).All(&docs); err != nil {
@@ -168,7 +174,10 @@ type payloadTrackChange struct {
 // Prepare is part of the Change interface.
 func (change payloadTrackChange) Prepare(db Database) ([]txn.Op, error) {
 	unit := change.Doc.UnitID
-	units, uCloser := db.GetCollection(unitsC)
+	units, uCloser, err := db.GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer uCloser()
 	unitOp, err := nsLife.notDeadOp(units, unit)
 	if errors.Cause(err) == errDeadOrGone {
@@ -177,7 +186,10 @@ func (change payloadTrackChange) Prepare(db Database) ([]txn.Op, error) {
 		return nil, errors.Trace(err)
 	}
 
-	payloads, pCloser := db.GetCollection(payloadsC)
+	payloads, pCloser, err := db.GetCollection(payloadsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer pCloser()
 	payloadOp, err := nsPayloads.trackOp(payloads, change.Doc)
 	if err != nil {
@@ -197,7 +209,10 @@ type payloadSetStatusChange struct {
 // Prepare is part of the Change interface.
 func (change payloadSetStatusChange) Prepare(db Database) ([]txn.Op, error) {
 	docID := nsPayloads.docID(change.Unit, change.Name)
-	payloadColl, closer := db.GetCollection(payloadsC)
+	payloadColl, closer, err := db.GetCollection(payloadsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	op, err := nsPayloads.setStatusOp(payloadColl, docID, change.Status)
@@ -218,7 +233,10 @@ type payloadUntrackChange struct {
 // Prepare is part of the Change interface.
 func (change payloadUntrackChange) Prepare(db Database) ([]txn.Op, error) {
 	docID := nsPayloads.docID(change.Unit, change.Name)
-	payloads, closer := db.GetCollection(payloadsC)
+	payloads, closer, err := db.GetCollection(payloadsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	op, err := nsPayloads.untrackOp(payloads, docID)
@@ -237,7 +255,10 @@ type payloadCleanupChange struct {
 
 // Prepare is part of the Change interface.
 func (change payloadCleanupChange) Prepare(db Database) ([]txn.Op, error) {
-	payloads, closer := db.GetCollection(payloadsC)
+	payloads, closer, err := db.GetCollection(payloadsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	sel := nsPayloads.forUnit(change.Unit)
@@ -245,7 +266,7 @@ func (change payloadCleanupChange) Prepare(db Database) ([]txn.Op, error) {
 	var docs []struct {
 		DocID string `bson:"_id"`
 	}
-	err := payloads.Find(sel).Select(fields).All(&docs)
+	err = payloads.Find(sel).Select(fields).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	} else if len(docs) == 0 {

--- a/state/podspec.go
+++ b/state/podspec.go
@@ -78,9 +78,12 @@ func (m *CAASModel) podInfo(appTag names.ApplicationTag) (*containerSpecDoc, err
 }
 
 func readPodInfo(db Database, appName string, doc interface{}) error {
-	coll, cleanup := db.GetCollection(podSpecsC)
+	coll, cleanup, err := db.GetCollection(podSpecsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer cleanup()
-	if err := coll.FindId(applicationGlobalKey(appName)).One(doc); err != nil {
+	if err = coll.FindId(applicationGlobalKey(appName)).One(doc); err != nil {
 		if err == mgo.ErrNotFound {
 			return errors.NotFoundf("k8s spec for application %s", appName)
 		}

--- a/state/pool.go
+++ b/state/pool.go
@@ -153,7 +153,10 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 		hub:        pubsub.NewSimpleHub(nil),
 	}
 
-	session := args.MongoSession.Copy()
+	session, err := mongo.CopySession(args.MongoSession)
+	if err != nil {
+		return nil, errors.Annotate(err, "copying mongo session for state pool")
+	}
 	st, err := open(
 		args.ControllerTag,
 		args.ControllerModelTag,
@@ -198,7 +201,10 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 		RestartDelay: time.Second,
 		Clock:        args.Clock,
 	})
-	pool.txnWatcherSession = args.MongoSession.Copy()
+	pool.txnWatcherSession, err = mongo.CopySession(args.MongoSession)
+	if err != nil {
+		return nil, errors.Annotate(err, "copying mongo session for txn watcher")
+	}
 	if err = pool.watcherRunner.StartWorker(txnLogWorker, func() (worker.Worker, error) {
 		return watcher.NewTxnWatcher(
 			watcher.TxnWatcherConfig{
@@ -295,7 +301,10 @@ func (p *StatePool) Get(modelUUID string) (*PooledState, error) {
 
 func (p *StatePool) openState(modelUUID string) (*State, error) {
 	modelTag := names.NewModelTag(modelUUID)
-	session := p.systemState.session.Copy()
+	session, err := mongo.CopySession(p.systemState.session)
+	if err != nil {
+		return nil, errors.Annotate(err, "copying model state session")
+	}
 	newSt, err := newState(
 		p.systemState.controllerTag,
 		modelTag, p.systemState.controllerModelTag,

--- a/state/pool.go
+++ b/state/pool.go
@@ -203,6 +203,10 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 	})
 	pool.txnWatcherSession, err = mongo.CopySession(args.MongoSession)
 	if err != nil {
+		if stopErr := st.stopWorkers(); stopErr != nil {
+			logger.Errorf("stopping state workers for model %s: %v", args.ControllerModelTag.Id(), stopErr)
+		}
+		st.workers = nil
 		return nil, errors.Annotate(err, "copying mongo session for txn watcher")
 	}
 	if err = pool.watcherRunner.StartWorker(txnLogWorker, func() (worker.Worker, error) {
@@ -218,6 +222,10 @@ func OpenStatePool(args OpenParams) (_ *StatePool, err error) {
 			})
 	}); err != nil {
 		pool.txnWatcherSession.Close()
+		if stopErr := st.stopWorkers(); stopErr != nil {
+			logger.Errorf("stopping state workers for model %s: %v", args.ControllerModelTag.Id(), stopErr)
+		}
+		st.workers = nil
 		return nil, errors.Trace(err)
 	}
 	return pool, nil

--- a/state/reboot.go
+++ b/state/reboot.go
@@ -81,7 +81,10 @@ func removeRebootDocOp(st *State, machineId string) txn.Op {
 }
 
 func (m *Machine) clearFlag() error {
-	reboot, closer := m.st.db().GetCollection(rebootC)
+	reboot, closer, err := m.st.db().GetCollection(rebootC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	docID := m.doc.DocID
@@ -112,7 +115,10 @@ func (m *Machine) SetRebootFlag(flag bool) error {
 
 // GetRebootFlag returns the reboot flag for this machine.
 func (m *Machine) GetRebootFlag() (bool, error) {
-	rebootCol, closer := m.st.db().GetCollection(rebootC)
+	rebootCol, closer, err := m.st.db().GetCollection(rebootC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 
 	count, err := rebootCol.FindId(m.doc.DocID).Count()
@@ -138,7 +144,10 @@ func (m *Machine) machinesToCareAboutRebootsFor() []string {
 // If we are a container, and our parent needs to reboot, this should return:
 // ShouldShutdown
 func (m *Machine) ShouldRebootOrShutdown() (RebootAction, error) {
-	rebootCol, closer := m.st.db().GetCollection(rebootC)
+	rebootCol, closer, err := m.st.db().GetCollection(rebootC)
+	if err != nil {
+		return ShouldDoNothing, errors.Trace(err)
+	}
 	defer closer()
 
 	machines := m.machinesToCareAboutRebootsFor()

--- a/state/relation.go
+++ b/state/relation.go
@@ -92,11 +92,14 @@ func (r *Relation) SuspendedReason() string {
 // state. It returns an error that satisfies errors.IsNotFound if the
 // relation has been removed.
 func (r *Relation) Refresh() error {
-	relations, closer := r.st.db().GetCollection(relationsC)
+	relations, closer, err := r.st.db().GetCollection(relationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	doc := relationDoc{}
-	err := relations.FindId(r.doc.DocID).One(&doc)
+	err = relations.FindId(r.doc.DocID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("relation %v", r)
 	}
@@ -395,7 +398,10 @@ func (r *Relation) destroyOps(ignoreApplication string, op *ForcedOperation) (op
 			return nil, false, errAlreadyDying
 		}
 	}
-	scopes, closer := r.st.db().GetCollection(relationScopesC)
+	scopes, closer, err := r.st.db().GetCollection(relationScopesC)
+	if err != nil {
+		return nil, false, errors.Trace(err)
+	}
 	defer closer()
 	sel := bson.M{"_id": bson.M{
 		"$regex": fmt.Sprintf("^%s#", r.st.docID(r.globalScope())),
@@ -538,7 +544,10 @@ func (r *Relation) removeLocalEndpointOps(ep Endpoint, departingUnitName string,
 		// This application may require immediate removal.
 		// Check if the application is Dying, and if so, queue up a potential
 		// cleanup in case this was the last reference.
-		applications, closer := r.st.db().GetCollection(applicationsC)
+		applications, closer, err := r.st.db().GetCollection(applicationsC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer closer()
 
 		asserts = append(hasRelation)
@@ -575,7 +584,10 @@ func (r *Relation) removeRemoteEndpointOps(ep Endpoint, unitDying bool) ([]txn.O
 	} else {
 		// The remote application may require immediate removal if all relations are being
 		// removed and it's either dying or on the offering side as a consumer proxy.
-		applications, closer := r.st.db().GetCollection(remoteApplicationsC)
+		applications, closer, err := r.st.db().GetCollection(remoteApplicationsC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer closer()
 
 		app := &RemoteApplication{st: r.st}
@@ -693,7 +705,10 @@ func (r *Relation) AllRemoteUnits(appName string) ([]*RelationUnit, error) {
 		return nil, errors.Trace(err)
 	}
 
-	relationScopes, closer := r.st.db().GetCollection(relationScopesC)
+	relationScopes, closer, err := r.st.db().GetCollection(relationScopesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	ep, err := r.Endpoint(appName)
@@ -788,13 +803,16 @@ type relationSettingsCleanupChange struct {
 
 // Prepare is part of the Change interface.
 func (change relationSettingsCleanupChange) Prepare(db Database) ([]txn.Op, error) {
-	settings, closer := db.GetCollection(settingsC)
+	settings, closer, err := db.GetCollection(settingsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	sel := bson.D{{"_id", bson.D{{"$regex", "^" + change.Prefix}}}}
 	var docs []struct {
 		DocID string `bson:"_id"`
 	}
-	err := settings.Find(sel).Select(bson.D{{"_id", 1}}).All(&docs)
+	err = settings.Find(sel).Select(bson.D{{"_id", 1}}).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/state/relationnetworks.go
+++ b/state/relationnetworks.go
@@ -95,7 +95,10 @@ func NewRelationNetworks(st *State) *rootRelationNetworksState {
 
 // AllRelationNetworks returns all the relation networks for the model.
 func (rin *rootRelationNetworksState) AllRelationNetworks() ([]RelationNetworks, error) {
-	relationNetworksCollection, closer := rin.st.db().GetCollection(relationNetworksC)
+	relationNetworksCollection, closer, err := rin.st.db().GetCollection(relationNetworksC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []relationNetworksDoc
@@ -213,11 +216,14 @@ func (rin *relationNetworksState) Save(relationKey string, adminOverride bool, c
 
 // Networks returns the networks for the specified relation.
 func (rin *relationNetworksState) Networks(relationKey string) (RelationNetworks, error) {
-	coll, closer := rin.st.db().GetCollection(relationNetworksC)
+	coll, closer, err := rin.st.db().GetCollection(relationNetworksC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc relationNetworksDoc
-	err := coll.FindId(relationNetworkDocID(relationKey, rin.direction, relationNetworkAdmin)).One(&doc)
+	err = coll.FindId(relationNetworkDocID(relationKey, rin.direction, relationNetworkAdmin)).One(&doc)
 	if err == mgo.ErrNotFound {
 		err = coll.FindId(relationNetworkDocID(relationKey, rin.direction, relationNetworkDefault)).One(&doc)
 	}

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -72,9 +72,15 @@ func (ru *RelationUnit) UnitName() string {
 // intervention; the relation will not be able to become Dead until all units
 // have departed its scopes.
 func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
-	db, dbCloser := ru.st.newDB()
+	db, dbCloser, err := ru.st.newDB()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer dbCloser()
-	relationScopes, rsCloser := db.GetCollection(relationScopesC)
+	relationScopes, rsCloser, err := db.GetCollection(relationScopesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer rsCloser()
 	ruKey := ru.key()
 	relationDocID := ru.relation.doc.DocID
@@ -99,7 +105,10 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 			// unit: this could fail due to the subordinate applications not being Alive,
 			// but this case will always be caught by the check for the relation's
 			// life (because a relation cannot be Alive if its applications are not).)
-			relations, rCloser := db.GetCollection(relationsC)
+			relations, rCloser, err := db.GetCollection(relationsC)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 			defer rCloser()
 			if alive, err := isAliveWithSession(relations, relationDocID); err != nil {
 				return nil, errors.Trace(err)
@@ -107,7 +116,10 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 				return nil, errors.Annotate(stateerrors.ErrCannotEnterScope, prefix+"relation is no longer alive")
 			}
 			if ru.isLocalUnit {
-				units, uCloser := db.GetCollection(unitsC)
+				units, uCloser, err := db.GetCollection(unitsC)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
 				defer uCloser()
 				if alive, err := isAliveWithSession(units, ru.unitName); err != nil {
 					return nil, errors.Trace(err)
@@ -170,7 +182,10 @@ func (ru *RelationUnit) EnterScope(settings map[string]interface{}) error {
 		//   exist; or completely overwrite them if they do. This must happen
 		//   before we create the scope doc, because the existence of a scope doc
 		//   is considered to be a guarantee of the existence of a settings doc.
-		settingsColl, sCloser := db.GetCollection(settingsC)
+		settingsColl, sCloser, err := db.GetCollection(settingsC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer sCloser()
 		if count, err := settingsColl.FindId(ruKey).Count(); err != nil {
 			return nil, errors.Trace(err)
@@ -238,7 +253,10 @@ func (ru *RelationUnit) counterpartApplicationSettingsKeys() []string {
 // exists and is Alive, its name will be returned as well; if one exists
 // but is not Alive, ErrCannotEnterScopeYet is returned.
 func (ru *RelationUnit) subordinateOps() ([]txn.Op, string, error) {
-	units, closer := ru.st.db().GetCollection(unitsC)
+	units, closer, err := ru.st.db().GetCollection(unitsC)
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
 	defer closer()
 
 	if !ru.isPrincipal || ru.endpoint.Scope != charm.ScopeContainer {
@@ -297,7 +315,10 @@ func (ru *RelationUnit) subordinateOps() ([]txn.Op, string, error) {
 // but does not *actually* leave the scope, to avoid triggering relation
 // cleanup.
 func (ru *RelationUnit) PrepareLeaveScope() error {
-	relationScopes, closer := ru.st.db().GetCollection(relationScopesC)
+	relationScopes, closer, err := ru.st.db().GetCollection(relationScopesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	key := ru.key()
@@ -420,7 +441,10 @@ func (ru *RelationUnit) leaveScopeForcedOps(existingOperation *ForcedOperation) 
 // and will accumulate all operational errors encountered in the operation.
 // If the 'force' is not set, any error will be fatal and no operations will be applied.
 func (op *LeaveScopeOperation) internalLeaveScope() ([]txn.Op, error) {
-	relationScopes, closer := op.ru.st.db().GetCollection(relationScopesC)
+	relationScopes, closer, err := op.ru.st.db().GetCollection(relationScopesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	key := op.ru.key()
@@ -559,7 +583,10 @@ func (ru *RelationUnit) Joined() (bool, error) {
 // inScope returns whether a scope document exists satisfying the supplied
 // selector.
 func (ru *RelationUnit) inScope(sel bson.D) (bool, error) {
-	relationScopes, closer := ru.st.db().GetCollection(relationScopesC)
+	relationScopes, closer, err := ru.st.db().GetCollection(relationScopesC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 
 	sel = append(sel, bson.D{{"_id", ru.key()}}...)

--- a/state/remoteapplication.go
+++ b/state/remoteapplication.go
@@ -831,10 +831,13 @@ func (a *RemoteApplication) String() string {
 // state. It returns an error that satisfies errors.IsNotFound if the
 // application has been removed.
 func (a *RemoteApplication) Refresh() error {
-	applications, closer := a.st.db().GetCollection(remoteApplicationsC)
+	applications, closer, err := a.st.db().GetCollection(remoteApplicationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
-	err := applications.FindId(a.doc.DocID).One(&a.doc)
+	err = applications.FindId(a.doc.DocID).One(&a.doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("saas application %q", a)
 	}
@@ -1138,7 +1141,10 @@ func (st *State) RemoteApplication(name string) (_ *RemoteApplication, err error
 		return nil, errors.NotValidf("saas application name %q", name)
 	}
 
-	applications, closer := st.db().GetCollection(remoteApplicationsC)
+	applications, closer, err := st.db().GetCollection(remoteApplicationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	appDoc := &remoteApplicationDoc{}
@@ -1154,7 +1160,10 @@ func (st *State) RemoteApplication(name string) (_ *RemoteApplication, err error
 
 // AllRemoteApplications returns all the remote applications used by the model.
 func (st *State) AllRemoteApplications() (applications []*RemoteApplication, err error) {
-	applicationsCollection, closer := st.db().GetCollection(remoteApplicationsC)
+	applicationsCollection, closer, err := st.db().GetCollection(remoteApplicationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	appDocs := []remoteApplicationDoc{}

--- a/state/remoteentities.go
+++ b/state/remoteentities.go
@@ -63,7 +63,10 @@ func (st *State) RemoteEntities() *RemoteEntities {
 
 // AllRemoteEntities returns all the remote entities for the model.
 func (st *State) AllRemoteEntities() ([]RemoteEntity, error) {
-	remoteEntitiesCollection, closer := st.db().GetCollection(remoteEntitiesC)
+	remoteEntitiesCollection, closer, err := st.db().GetCollection(remoteEntitiesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []remoteEntityDoc
@@ -221,11 +224,14 @@ func (r *RemoteEntities) removeRemoteEntityOps(entity names.Tag) []txn.Op {
 // GetToken returns the token associated with the entity with the given tag
 // and model.
 func (r *RemoteEntities) GetToken(entity names.Tag) (string, error) {
-	remoteEntities, closer := r.st.db().GetCollection(remoteEntitiesC)
+	remoteEntities, closer, err := r.st.db().GetCollection(remoteEntitiesC)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
 	defer closer()
 
 	var doc remoteEntityDoc
-	err := remoteEntities.FindId(entity.String()).One(&doc)
+	err = remoteEntities.FindId(entity.String()).One(&doc)
 	if err == mgo.ErrNotFound {
 		return "", errors.NotFoundf("token for %s", names.ReadableString(entity))
 	}
@@ -236,11 +242,14 @@ func (r *RemoteEntities) GetToken(entity names.Tag) (string, error) {
 }
 
 func (r *RemoteEntities) remoteEntityDoc(entity names.Tag) (remoteEntityDoc, error) {
-	remoteEntities, closer := r.st.db().GetCollection(remoteEntitiesC)
+	remoteEntities, closer, err := r.st.db().GetCollection(remoteEntitiesC)
+	if err != nil {
+		return remoteEntityDoc{}, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc remoteEntityDoc
-	err := remoteEntities.FindId(entity.String()).One(&doc)
+	err = remoteEntities.FindId(entity.String()).One(&doc)
 	return doc, err
 }
 
@@ -303,11 +312,14 @@ func (r *RemoteEntities) SaveMacaroon(entity names.Tag, mac *macaroon.Macaroon) 
 
 // GetRemoteEntity returns the tag of the entity associated with the given token.
 func (r *RemoteEntities) GetRemoteEntity(token string) (names.Tag, error) {
-	remoteEntities, closer := r.st.db().GetCollection(remoteEntitiesC)
+	remoteEntities, closer, err := r.st.db().GetCollection(remoteEntitiesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc remoteEntityDoc
-	err := remoteEntities.Find(bson.D{
+	err = remoteEntities.Find(bson.D{
 		{"token", token},
 	}).One(&doc)
 	if err == mgo.ErrNotFound {

--- a/state/resources.go
+++ b/state/resources.go
@@ -357,10 +357,13 @@ type resourcePersistence struct {
 
 // One gets the identified document from the collection.
 func (sp *resourcePersistence) one(collName, id string, doc interface{}) error {
-	coll, closeColl := sp.st.db().GetCollection(collName)
+	coll, closeColl, err := sp.st.db().GetCollection(collName)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closeColl()
 
-	err := coll.FindId(id).One(doc)
+	err = coll.FindId(id).One(doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf(id)
 	}
@@ -372,7 +375,10 @@ func (sp *resourcePersistence) one(collName, id string, doc interface{}) error {
 
 // All gets all documents from the collection matching the query.
 func (p *resourcePersistence) all(collName string, query, docs interface{}) error {
-	coll, closeColl := p.st.db().GetCollection(collName)
+	coll, closeColl, err := p.st.db().GetCollection(collName)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closeColl()
 
 	if err := coll.Find(query).All(docs); err != nil {

--- a/state/secretbackends.go
+++ b/state/secretbackends.go
@@ -160,7 +160,10 @@ func (s *secretBackendsStorage) toSecretBackend(doc *secretBackendDoc) *secrets.
 }
 
 func (st *State) checkBackendExists(ID string) error {
-	secretBackendCollection, closer := st.db().GetCollection(secretBackendsC)
+	secretBackendCollection, closer, err := st.db().GetCollection(secretBackendsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	n, err := secretBackendCollection.FindId(ID).Count()
 	if err != nil {
@@ -174,11 +177,14 @@ func (st *State) checkBackendExists(ID string) error {
 
 // UpdateSecretBackend updates a new secret backend.
 func (s *secretBackendsStorage) UpdateSecretBackend(p UpdateSecretBackendParams) error {
-	secretBackendsColl, closer := s.st.db().GetCollection(secretBackendsC)
+	secretBackendsColl, closer, err := s.st.db().GetCollection(secretBackendsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretBackendDoc
-	err := secretBackendsColl.FindId(p.ID).One(&doc)
+	err = secretBackendsColl.FindId(p.ID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("secret backend %q", p.ID)
 	}
@@ -254,11 +260,14 @@ func (s *secretBackendsStorage) UpdateSecretBackend(p UpdateSecretBackendParams)
 
 // GetSecretBackend gets the named secret backend.
 func (s *secretBackendsStorage) GetSecretBackend(name string) (*secrets.SecretBackend, error) {
-	secretBackendsColl, closer := s.st.db().GetCollection(secretBackendsC)
+	secretBackendsColl, closer, err := s.st.db().GetCollection(secretBackendsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretBackendDoc
-	err := secretBackendsColl.Find(bson.D{{"name", name}}).One(&doc)
+	err = secretBackendsColl.Find(bson.D{{"name", name}}).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("secret backend %q", name)
 	}
@@ -270,11 +279,14 @@ func (s *secretBackendsStorage) GetSecretBackend(name string) (*secrets.SecretBa
 
 // GetSecretBackendByID gets the secret backend with the given ID.
 func (s *secretBackendsStorage) GetSecretBackendByID(ID string) (*secrets.SecretBackend, error) {
-	secretBackendsColl, closer := s.st.db().GetCollection(secretBackendsC)
+	secretBackendsColl, closer, err := s.st.db().GetCollection(secretBackendsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretBackendDoc
-	err := secretBackendsColl.FindId(ID).One(&doc)
+	err = secretBackendsColl.FindId(ID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("secret backend %q", ID)
 	}
@@ -286,11 +298,14 @@ func (s *secretBackendsStorage) GetSecretBackendByID(ID string) (*secrets.Secret
 
 // ListSecretBackends lists the secret backends.
 func (s *secretBackendsStorage) ListSecretBackends() ([]*secrets.SecretBackend, error) {
-	secretBackendCollection, closer := s.st.db().GetCollection(secretBackendsC)
+	secretBackendCollection, closer, err := s.st.db().GetCollection(secretBackendsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []secretBackendDoc
-	err := secretBackendCollection.Find(nil).All(&docs)
+	err = secretBackendCollection.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -333,7 +348,10 @@ func secretBackendRefCountKey(backendID string) string {
 }
 
 func (st *State) isSecretBackendInUse(backendID string) (bool, error) {
-	refCountCollection, ccloser := st.db().GetCollection(globalRefcountsC)
+	refCountCollection, ccloser, err := st.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer ccloser()
 	_, count, err := nsRefcounts.CurrentOp(refCountCollection, secretBackendRefCountKey(backendID))
 	if err != nil {
@@ -352,7 +370,10 @@ func (st *State) removeBackendRefCountOp(backendID string, force bool) ([]txn.Op
 		return []txn.Op{op}, nil
 	}
 
-	refCountCollection, ccloser := st.db().GetCollection(globalRefcountsC)
+	refCountCollection, ccloser, err := st.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer ccloser()
 
 	_, count, err := nsRefcounts.CurrentOp(refCountCollection, secretBackendRefCountKey(backendID))
@@ -370,7 +391,10 @@ func (st *State) createSecretBackendRefCountOp(backendID string) ([]txn.Op, erro
 	if secrets.IsInternalSecretBackendID(backendID) {
 		return nil, nil
 	}
-	refCountCollection, ccloser := st.db().GetCollection(globalRefcountsC)
+	refCountCollection, ccloser, err := st.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer ccloser()
 	op, err := nsRefcounts.StrictCreateOp(refCountCollection, secretBackendRefCountKey(backendID), 0)
 	if err != nil {
@@ -383,7 +407,10 @@ func (st *State) decSecretBackendRefCountOp(backendID string) ([]txn.Op, error) 
 	if secrets.IsInternalSecretBackendID(backendID) {
 		return nil, nil
 	}
-	refCountCollection, ccloser := st.db().GetCollection(globalRefcountsC)
+	refCountCollection, ccloser, err := st.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer ccloser()
 
 	op, err := nsRefcounts.AliveDecRefOp(refCountCollection, secretBackendRefCountKey(backendID))
@@ -399,7 +426,10 @@ func (st *State) incBackendRevisionCountOps(backendID string, count int) ([]txn.
 	if secrets.IsInternalSecretBackendID(backendID) {
 		return nil, nil
 	}
-	refCountCollection, ccloser := st.db().GetCollection(globalRefcountsC)
+	refCountCollection, ccloser, err := st.db().GetCollection(globalRefcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer ccloser()
 
 	key := secretBackendRefCountKey(backendID)
@@ -432,11 +462,14 @@ func (s *secretBackendsStorage) tokenRotationOps(ID string, name *string, nextRo
 			Remove: true,
 		}}, nil
 	}
-	secretBackendRotateCollection, closer := s.st.db().GetCollection(secretBackendsRotateC)
+	secretBackendRotateCollection, closer, err := s.st.db().GetCollection(secretBackendsRotateC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretBackendRotationDoc
-	err := secretBackendRotateCollection.FindId(ID).One(&doc)
+	err = secretBackendRotateCollection.FindId(ID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return []txn.Op{{
 			C:      secretBackendsRotateC,
@@ -471,7 +504,10 @@ func (s *secretBackendsStorage) tokenRotationOps(ID string, name *string, nextRo
 // SecretBackendRotated records that the given secret backend token was rotated and
 // sets the next rotate time.
 func (s *secretBackendsStorage) SecretBackendRotated(ID string, next time.Time) error {
-	secretBadckendRotateCollection, closer := s.st.db().GetCollection(secretBackendsRotateC)
+	secretBadckendRotateCollection, closer, err := s.st.db().GetCollection(secretBackendsRotateC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -553,7 +589,10 @@ func (w *secretBackendRotationWatcher) initial() ([]corewatcher.SecretBackendRot
 	var details []corewatcher.SecretBackendRotateChange
 
 	var doc secretBackendRotationDoc
-	secretBackendRotateCollection, closer := w.db.GetCollection(secretBackendsRotateC)
+	secretBackendRotateCollection, closer, err := w.db.GetCollection(secretBackendsRotateC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	iter := secretBackendRotateCollection.Find(nil).Iter()
@@ -580,9 +619,12 @@ func (w *secretBackendRotationWatcher) merge(details []corewatcher.SecretBackend
 	doc := secretBackendRotationDoc{}
 	if change.Revno >= 0 {
 		// Record added or updated.
-		secretBackendRotateColl, closer := w.db.GetCollection(secretBackendsRotateC)
+		secretBackendRotateColl, closer, err := w.db.GetCollection(secretBackendsRotateC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer closer()
-		err := secretBackendRotateColl.FindId(change.Id).One(&doc)
+		err = secretBackendRotateColl.FindId(change.Id).One(&doc)
 		if err != nil && err != mgo.ErrNotFound {
 			return nil, errors.Trace(err)
 		}

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -372,7 +372,10 @@ func (s *secretsStore) ReserveSecret(uri *secrets.URI, owner names.Tag) error {
 			"cannot reserve secret for owner %q which is not alive", owner)
 	}
 
-	secretMetadataCollection, closer := s.st.db().GetCollection(secretMetadataC)
+	secretMetadataCollection, closer, err := s.st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	metadata := struct {
 		DocID string `bson:"_id"`
@@ -454,7 +457,10 @@ func (s *secretsStore) ListReservedSecrets(
 		wantTags = append(wantTags, v.String())
 	}
 
-	secretReservationColl, closer := s.st.db().GetCollection(secretReservationsC)
+	secretReservationColl, closer, err := s.st.db().GetCollection(secretReservationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	res := secretReservationColl.Find(bson.M{
@@ -479,9 +485,12 @@ func (s *secretsStore) ListReservedSecrets(
 // if it is found, otherwise it returns an [errors.NotFound].
 func (s *secretsStore) getSecretReservation(uri *secrets.URI) (secretReservationDoc, error) {
 	var doc secretReservationDoc
-	secretReservationColl, closer := s.st.db().GetCollection(secretReservationsC)
+	secretReservationColl, closer, err := s.st.db().GetCollection(secretReservationsC)
+	if err != nil {
+		return secretReservationDoc{}, errors.Trace(err)
+	}
 	defer closer()
-	err := secretReservationColl.FindId(uri.ID).One(&doc)
+	err = secretReservationColl.FindId(uri.ID).One(&doc)
 	if errors.Is(err, mgo.ErrNotFound) {
 		return secretReservationDoc{}, errors.NotFound
 	} else if err != nil {
@@ -517,7 +526,10 @@ func (op *removeSecretReservationsModelOp) Done(err error) error {
 // removeSecretReservationOps returns the mongo operations to remove all secret
 // reservations for the given owner.
 func (st *State) removeSecretReservationOps(owner names.Tag) ([]txn.Op, error) {
-	secretReservationColl, closer := st.db().GetCollection(secretReservationsC)
+	secretReservationColl, closer, err := st.db().GetCollection(secretReservationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var ops []txn.Op
@@ -659,7 +671,10 @@ func (s *secretsStore) CreateSecret(uri *secrets.URI, p CreateSecretParams) (*se
 }
 
 func (st *State) checkExists(uri *secrets.URI) error {
-	secretMetadataCollection, closer := st.db().GetCollection(secretMetadataC)
+	secretMetadataCollection, closer, err := st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	n, err := secretMetadataCollection.FindId(uri.ID).Count()
 	if err != nil {
@@ -682,7 +697,10 @@ func (s *secretsStore) UpdateSecret(uri *secrets.URI, p UpdateSecretParams) (*se
 		return nil, errors.Trace(err)
 	}
 
-	secretMetadataCollection, closer := s.st.db().GetCollection(secretMetadataC)
+	secretMetadataCollection, closer, err := s.st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	// Pre-process the expire time update.
@@ -824,11 +842,14 @@ func (s *secretsStore) UpdateSecret(uri *secrets.URI, p UpdateSecretParams) (*se
 }
 
 func (st *State) nextRotateTime(docID string) (*time.Time, error) {
-	secretRotateCollection, closer := st.db().GetCollection(secretRotateC)
+	secretRotateCollection, closer, err := st.db().GetCollection(secretRotateC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var rotateDoc secretRotationDoc
-	err := secretRotateCollection.FindId(docID).One(&rotateDoc)
+	err = secretRotateCollection.FindId(docID).One(&rotateDoc)
 	if err == mgo.ErrNotFound {
 		return nil, nil
 	}
@@ -883,7 +904,10 @@ func (st *State) deleteSecrets(uris []*secrets.URI, revisions ...int) (external 
 	if len(uris) == 0 || len(uris) > 1 && len(revisions) > 0 {
 		return nil, errors.Errorf("PROGRAMMING ERROR: invalid secret deletion args uris=%v, revisions=%v", uris, revisions)
 	}
-	db, session := st.db().CopyRaw()
+	db, session, err := st.db().CopyRaw()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer session.Close()
 	err = session.StartTransaction()
 	if err != nil {
@@ -904,11 +928,14 @@ func (st *State) deleteSecrets(uris []*secrets.URI, revisions ...int) (external 
 	if len(revisions) > 0 {
 		uri := uris[0]
 
-		secretRevisionsCollection, closer := db.GetCollection(secretRevisionsC)
+		secretRevisionsCollection, closer, err := db.GetCollection(secretRevisionsC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer closer()
 
 		var savedRevisionDocs []secretRevisionDoc
-		err := secretRevisionsCollection.Find(bson.D{{"_id",
+		err = secretRevisionsCollection.Find(bson.D{{"_id",
 			bson.D{{"$regex", st.localSecretURIRegex(uri, "/")}}}}).Select(
 			bson.D{{"revision", 1}, {"value-reference", 1}}).All(&savedRevisionDocs)
 		if err != nil {
@@ -940,7 +967,10 @@ func (st *State) deleteSecrets(uris []*secrets.URI, revisions ...int) (external 
 			}
 			// Decrement the count of secret revisions stored in the external backends.
 			// This allows backends without stored revisions to be removed without using force.
-			globalRefCountsCollection, closer := db.GetCollection(globalRefcountsC)
+			globalRefCountsCollection, closer, err := db.GetCollection(globalRefcountsC)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
 			defer closer()
 			for backendID, count := range externalRevisionCounts {
 				if secrets.IsInternalSecretBackendID(backendID) {
@@ -973,14 +1003,20 @@ func (st *State) deleteSecrets(uris []*secrets.URI, revisions ...int) (external 
 }
 
 func (st *State) deleteOne(db Database, uri *secrets.URI) (external []secrets.ValueRef, _ error) {
-	secretMetadataCollection, closer := db.GetCollection(secretMetadataC)
+	secretMetadataCollection, closer, err := db.GetCollection(secretMetadataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
-	secretRevisionsCollection, closer := db.GetCollection(secretRevisionsC)
+	secretRevisionsCollection, closer, err := db.GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var md secretMetadataDoc
-	err := secretMetadataCollection.FindId(uri.ID).One(&md)
+	err = secretMetadataCollection.FindId(uri.ID).One(&md)
 	if err == mgo.ErrNotFound {
 		return nil, nil
 	}
@@ -994,7 +1030,10 @@ func (st *State) deleteOne(db Database, uri *secrets.URI) (external []secrets.Va
 		return nil, errors.Annotatef(err, "deleting revisions for %s", uri.String())
 	}
 
-	secretRotateCollection, closer := db.GetCollection(secretRotateC)
+	secretRotateCollection, closer, err := db.GetCollection(secretRotateC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	_, err = secretRotateCollection.Writeable().RemoveAll(bson.D{{
 		"_id", uri.ID,
@@ -1027,7 +1066,10 @@ func (st *State) deleteOne(db Database, uri *secrets.URI) (external []secrets.Va
 		return nil, errors.Annotatef(err, "deleting revisions for %s", uri.String())
 	}
 
-	secretPermissionsCollection, closer := db.GetCollection(secretPermissionsC)
+	secretPermissionsCollection, closer, err := db.GetCollection(secretPermissionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	_, err = secretPermissionsCollection.Writeable().RemoveAll(bson.D{{
 		"_id", bson.D{{"$regex", st.localSecretURIRegex(uri, "#")}},
@@ -1043,7 +1085,10 @@ func (st *State) deleteOne(db Database, uri *secrets.URI) (external []secrets.Va
 		return nil, errors.Trace(err)
 	}
 
-	refCountsCollection, closer := db.GetCollection(refcountsC)
+	refCountsCollection, closer, err := db.GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	_, err = refCountsCollection.Writeable().RemoveAll(bson.D{{
 		"_id", fmt.Sprintf("%s#%s", uri.ID, "consumer"),
@@ -1054,7 +1099,10 @@ func (st *State) deleteOne(db Database, uri *secrets.URI) (external []secrets.Va
 
 	// Decrement the count of secret revisions stored in the external backends.
 	// This allows backends without stored revisions to be removed without using force.
-	globalRefCountsCollection, closer := db.GetCollection(globalRefcountsC)
+	globalRefCountsCollection, closer, err := db.GetCollection(globalRefcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	for backendID, count := range externalRevisionCounts {
 		if secrets.IsInternalSecretBackendID(backendID) {
@@ -1091,12 +1139,15 @@ func (s *secretsStore) getSecretValue(uri *secrets.URI, revision int, checkExist
 			return nil, nil, errors.Trace(err)
 		}
 	}
-	secretValuesCollection, closer := s.st.db().GetCollection(secretRevisionsC)
+	secretValuesCollection, closer, err := s.st.db().GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretRevisionDoc
 	key := secretRevisionKey(uri, revision)
-	err := secretValuesCollection.FindId(key).One(&doc)
+	err = secretValuesCollection.FindId(key).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, nil, errors.NotFoundf("secret revision %q", key)
 	}
@@ -1123,11 +1174,14 @@ func (s *secretsStore) ChangeSecretBackend(arg ChangeSecretBackendParams) error 
 		return errors.Trace(err)
 	}
 
-	secretRevisionsCollection, closer := s.st.db().GetCollection(secretRevisionsC)
+	secretRevisionsCollection, closer, err := s.st.db().GetCollection(secretRevisionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	var doc secretRevisionDoc
 	key := secretRevisionKey(arg.URI, arg.Revision)
-	err := secretRevisionsCollection.FindId(key).One(&doc)
+	err = secretRevisionsCollection.FindId(key).One(&doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("secret revision %q", key)
 	}
@@ -1176,7 +1230,10 @@ func (s *secretsStore) ChangeSecretBackend(arg ChangeSecretBackendParams) error 
 
 // SecretGrants returns the list of access information of the secret for the specified role.
 func (s *secretsStore) SecretGrants(uri *secrets.URI, role secrets.SecretRole) ([]secrets.AccessInfo, error) {
-	secretPermissionsCollection, closer := s.st.db().GetCollection(secretPermissionsC)
+	secretPermissionsCollection, closer, err := s.st.db().GetCollection(secretPermissionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	if err := s.st.checkExists(uri); err != nil {
@@ -1184,7 +1241,7 @@ func (s *secretsStore) SecretGrants(uri *secrets.URI, role secrets.SecretRole) (
 	}
 
 	var docs []secretPermissionDoc
-	err := secretPermissionsCollection.Find(
+	err = secretPermissionsCollection.Find(
 		bson.M{
 			"_id": bson.M{
 				"$regex": s.st.localSecretURIRegex(uri, "#"),
@@ -1212,11 +1269,14 @@ func (s *secretsStore) GetSecret(uri *secrets.URI) (*secrets.SecretMetadata, err
 		return nil, errors.NewNotValid(nil, "empty URI")
 	}
 
-	secretMetadataCollection, closer := s.st.db().GetCollection(secretMetadataC)
+	secretMetadataCollection, closer, err := s.st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretMetadataDoc
-	err := secretMetadataCollection.FindId(uri.ID).One(&doc)
+	err = secretMetadataCollection.FindId(uri.ID).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("secret %q", uri.String())
 	}
@@ -1236,7 +1296,10 @@ func secretOwnerTerm(owners []string) bson.DocElem {
 
 // ListSecrets list the secrets using the specified filter.
 func (s *secretsStore) ListSecrets(filter SecretsFilter) ([]*secrets.SecretMetadata, error) {
-	secretMetadataCollection, closer := s.st.db().GetCollection(secretMetadataC)
+	secretMetadataCollection, closer, err := s.st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []secretMetadataDoc
@@ -1316,7 +1379,10 @@ func (s *secretsStore) ListSecrets(filter SecretsFilter) ([]*secrets.SecretMetad
 func (s *secretsStore) GetOwnedSecretMetadataByLabelAsUnit(
 	unit names.UnitTag, label string,
 ) (*secrets.SecretMetadataOwnerIdent, error) {
-	c, closer := s.st.db().GetCollection(secretMetadataC)
+	c, closer, err := s.st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	appName, _ := names.UnitApplication(unit.Id())
@@ -1330,7 +1396,7 @@ func (s *secretsStore) GetOwnedSecretMetadataByLabelAsUnit(
 	}
 
 	var doc secretMetadataDoc
-	err := c.Find(q).Select(bson.D{
+	err = c.Find(q).Select(bson.D{
 		{"owner-tag", 1},
 	}).One(&doc)
 	if errors.Is(err, mgo.ErrNotFound) {
@@ -1359,7 +1425,10 @@ func (s *secretsStore) GetOwnedSecretMetadataByLabelAsUnit(
 func (s *secretsStore) GetOwnedSecretMetadataByLabelAsApp(
 	app names.ApplicationTag, label string,
 ) (*secrets.SecretMetadataOwnerIdent, error) {
-	c, closer := s.st.db().GetCollection(secretMetadataC)
+	c, closer, err := s.st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	q := bson.D{
@@ -1368,7 +1437,7 @@ func (s *secretsStore) GetOwnedSecretMetadataByLabelAsApp(
 	}
 
 	var doc secretMetadataDoc
-	err := c.Find(q).Select(bson.D{
+	err = c.Find(q).Select(bson.D{
 		{"_id", 1},
 	}).One(&doc)
 	if errors.Is(err, mgo.ErrNotFound) {
@@ -1397,7 +1466,10 @@ func (s *secretsStore) GetOwnedSecretMetadataByLabelAsApp(
 func (s *secretsStore) GetOwnedSecretMetadataAsUnit(
 	unit names.UnitTag, uri *secrets.URI,
 ) (*secrets.SecretMetadataOwnerIdent, error) {
-	c, closer := s.st.db().GetCollection(secretMetadataC)
+	c, closer, err := s.st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	appName, _ := names.UnitApplication(unit.Id())
@@ -1411,7 +1483,7 @@ func (s *secretsStore) GetOwnedSecretMetadataAsUnit(
 	}
 
 	var doc secretMetadataDoc
-	err := c.Find(q).Select(bson.D{
+	err = c.Find(q).Select(bson.D{
 		{"owner-tag", 1},
 		{"label", 1},
 	}).One(&doc)
@@ -1437,7 +1509,10 @@ func (s *secretsStore) GetOwnedSecretMetadataAsUnit(
 func (s *secretsStore) GetOwnedSecretMetadataAsApp(
 	app names.ApplicationTag, uri *secrets.URI,
 ) (*secrets.SecretMetadataOwnerIdent, error) {
-	c, closer := s.st.db().GetCollection(secretMetadataC)
+	c, closer, err := s.st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	q := bson.D{
@@ -1446,7 +1521,7 @@ func (s *secretsStore) GetOwnedSecretMetadataAsApp(
 	}
 
 	var doc secretMetadataDoc
-	err := c.Find(q).Select(bson.D{
+	err = c.Find(q).Select(bson.D{
 		{"label", 1},
 	}).One(&doc)
 	if errors.Is(err, mgo.ErrNotFound) {
@@ -1470,7 +1545,10 @@ func (s *secretsStore) GetOwnedSecretMetadataAsApp(
 func (s *secretsStore) GetOwnedSecretRevisionsAsUnit(
 	unit names.UnitTag,
 ) (map[secrets.URI][]int, error) {
-	c, closer := s.st.db().GetCollection(secretRevisionsC)
+	c, closer, err := s.st.db().GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	q := bson.D{
@@ -1478,7 +1556,7 @@ func (s *secretsStore) GetOwnedSecretRevisionsAsUnit(
 	}
 
 	var docs []secretRevisionDoc
-	err := c.Find(q).Select(bson.D{
+	err = c.Find(q).Select(bson.D{
 		{"_id", 1},
 	}).All(&docs)
 	if err != nil {
@@ -1506,7 +1584,10 @@ func (s *secretsStore) GetOwnedSecretRevisionsAsUnit(
 func (s *secretsStore) GetOwnedSecretRevisionsByIDAsUnit(
 	unit names.UnitTag, uri *secrets.URI,
 ) ([]int, error) {
-	c, closer := s.st.db().GetCollection(secretRevisionsC)
+	c, closer, err := s.st.db().GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	q := bson.D{
@@ -1515,7 +1596,7 @@ func (s *secretsStore) GetOwnedSecretRevisionsByIDAsUnit(
 	}
 
 	var docs []secretRevisionDoc
-	err := c.Find(q).Select(bson.D{
+	err = c.Find(q).Select(bson.D{
 		{"revision", 1},
 	}).All(&docs)
 	if err != nil {
@@ -1539,7 +1620,10 @@ func (s *secretsStore) GetOwnedSecretRevisionsByIDAsUnit(
 func (s *secretsStore) GetOwnedSecretRevisionsByIDAsLeaderUnit(
 	unit names.UnitTag, uri *secrets.URI,
 ) ([]int, error) {
-	c, closer := s.st.db().GetCollection(secretRevisionsC)
+	c, closer, err := s.st.db().GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	appName, _ := names.UnitApplication(unit.Id())
@@ -1553,7 +1637,7 @@ func (s *secretsStore) GetOwnedSecretRevisionsByIDAsLeaderUnit(
 	}
 
 	var docs []secretRevisionDoc
-	err := c.Find(q).Select(bson.D{
+	err = c.Find(q).Select(bson.D{
 		{"revision", 1},
 	}).All(&docs)
 	if err != nil {
@@ -1574,10 +1658,13 @@ func (s *secretsStore) GetOwnedSecretRevisionsByIDAsLeaderUnit(
 // allModelRevisions uses a raw collection to load secret revisions for all models.
 func (s *secretsStore) allModelRevisions() ([]secretRevisionDoc, error) {
 	var docs []secretRevisionDoc
-	secretRevisionCollection, closer := s.st.db().GetRawCollection(secretRevisionsC)
+	secretRevisionCollection, closer, err := s.st.db().GetRawCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
-	err := secretRevisionCollection.Find(nil).Select(bson.D{{"_id", 1}, {"value-reference", 1}}).All(&docs)
+	err = secretRevisionCollection.Find(nil).Select(bson.D{{"_id", 1}, {"value-reference", 1}}).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1587,10 +1674,13 @@ func (s *secretsStore) allModelRevisions() ([]secretRevisionDoc, error) {
 // modelRevisions uses a warpped collection to load secret revisions for the current model.
 func (s *secretsStore) modelRevisions() ([]secretRevisionDoc, error) {
 	var docs []secretRevisionDoc
-	secretRevisionCollection, closer := s.st.db().GetCollection(secretRevisionsC)
+	secretRevisionCollection, closer, err := s.st.db().GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
-	err := secretRevisionCollection.Find(nil).Select(bson.D{{"_id", 1}, {"value-reference", 1}}).All(&docs)
+	err = secretRevisionCollection.Find(nil).Select(bson.D{{"_id", 1}, {"value-reference", 1}}).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1636,10 +1726,13 @@ func (s *secretsStore) ListModelSecrets(all bool) (map[string]set.Strings, error
 }
 
 func (s *secretsStore) listConsumedSecrets(consumers []string) ([]string, error) {
-	secretPermissionsCollection, closer := s.st.db().GetCollection(secretPermissionsC)
+	secretPermissionsCollection, closer, err := s.st.db().GetCollection(secretPermissionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var docs []secretPermissionDoc
-	err := secretPermissionsCollection.Find(bson.M{
+	err = secretPermissionsCollection.Find(bson.M{
 		"subject-tag": bson.M{
 			"$in": consumers,
 		},
@@ -1658,12 +1751,15 @@ func (s *secretsStore) listConsumedSecrets(consumers []string) ([]string, error)
 
 // allSecretPermissions is used for model export.
 func (s *secretsStore) allSecretPermissions() ([]secretPermissionDoc, error) {
-	secretPermissionCollection, closer := s.st.db().GetCollection(secretPermissionsC)
+	secretPermissionCollection, closer, err := s.st.db().GetCollection(secretPermissionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []secretPermissionDoc
 
-	err := secretPermissionCollection.Find(nil).All(&docs)
+	err = secretPermissionCollection.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1707,7 +1803,10 @@ func (s *secretsStore) GetSecretRevision(uri *secrets.URI, revision int) (*secre
 }
 
 func (s *secretsStore) listSecretRevisionDocs(uri *secrets.URI, revision *int) ([]secretRevisionDoc, error) {
-	secretRevisionCollection, closer := s.st.db().GetCollection(secretRevisionsC)
+	secretRevisionCollection, closer, err := s.st.db().GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var (
@@ -1720,7 +1819,7 @@ func (s *secretsStore) listSecretRevisionDocs(uri *secrets.URI, revision *int) (
 	} else {
 		q = bson.D{{"_id", secretRevisionKey(uri, *revision)}}
 	}
-	err := secretRevisionCollection.Find(q).Sort("_id").All(&docs)
+	err = secretRevisionCollection.Find(q).Sort("_id").All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1733,7 +1832,10 @@ func (s *secretsStore) listSecretRevisions(uri *secrets.URI, revision *int) ([]*
 		return nil, errors.Trace(err)
 	}
 
-	secretBackendsColl, closer := s.st.db().GetCollection(secretBackendsC)
+	secretBackendsColl, closer, err := s.st.db().GetCollection(secretBackendsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	backendNames := make(map[string]string)
@@ -1777,12 +1879,15 @@ func (s *secretsStore) listSecretRevisions(uri *secrets.URI, revision *int) ([]*
 
 // allSecretRevisions is used for model export.
 func (s *secretsStore) allSecretRevisions() ([]secretRevisionDoc, error) {
-	secretRevisionCollection, closer := s.st.db().GetCollection(secretRevisionsC)
+	secretRevisionCollection, closer, err := s.st.db().GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []secretRevisionDoc
 
-	err := secretRevisionCollection.Find(nil).All(&docs)
+	err = secretRevisionCollection.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1820,7 +1925,10 @@ func splitSecretConsumerKey(key string) (string, string) {
 // checkConsumerCountOps returns txn ops to ensure that no new secrets consumers
 // are added whilst a txn is in progress.
 func (st *State) checkConsumerCountOps(uri *secrets.URI, inc int) ([]txn.Op, error) {
-	refCountCollection, ccloser := st.db().GetCollection(refcountsC)
+	refCountCollection, ccloser, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer ccloser()
 
 	key := fmt.Sprintf("%s#consumer", uri.ID)
@@ -1900,7 +2008,10 @@ func (st *State) uniqueSecretConsumerLabelOps(consumerTag names.Tag, label strin
 // as is used in the secret metadata of any application owned secret.
 // The check is done when creating a new application owned secret, or saving a consumer record.
 func (st *State) uniqueSecretLabelBaseOps(tag names.Tag, label string) (ops []txn.Op, _ error) {
-	col, close := st.db().GetCollection(refcountsC)
+	col, close, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer close()
 
 	var (
@@ -1952,7 +2063,10 @@ func (st *State) uniqueSecretLabelBaseOps(tag names.Tag, label string) (ops []tx
 }
 
 func (st *State) uniqueSecretLabelOpsRaw(tag names.Tag, label, role string, keyGenerator func(names.Tag, string) string, assertionOnly bool) ([]txn.Op, error) {
-	refCountCollection, ccloser := st.db().GetCollection(refcountsC)
+	refCountCollection, ccloser, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer ccloser()
 
 	key := keyGenerator(tag, label)
@@ -1975,7 +2089,10 @@ func (st *State) uniqueSecretLabelOpsRaw(tag names.Tag, label, role string, keyG
 }
 
 func (st *State) removeOwnerSecretLabelOps(ownerTag names.Tag, label string) ([]txn.Op, error) {
-	refCountCollection, ccloser := st.db().GetCollection(refcountsC)
+	refCountCollection, ccloser, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer ccloser()
 
 	key := secretOwnerLabelKey(ownerTag, label)
@@ -2006,7 +2123,10 @@ func (st *State) removeConsumerSecretLabelsOps(consumerTag names.Tag) ([]txn.Op,
 }
 
 func (st *State) removeSecretLabelOps(tag names.Tag, keyGenerator func(names.Tag, string) string) ([]txn.Op, error) {
-	refCountsCollection, closer := st.db().GetCollection(refcountsC)
+	refCountsCollection, closer, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var (
@@ -2030,11 +2150,14 @@ func (st *State) removeSecretLabelOps(tag names.Tag, keyGenerator func(names.Tag
 
 // GetURIByConsumerLabel gets the secret URI for the specified secret consumer label.
 func (st *State) GetURIByConsumerLabel(label string, consumer names.Tag) (*secrets.URI, error) {
-	secretConsumersCollection, closer := st.db().GetCollection(secretConsumersC)
+	secretConsumersCollection, closer, err := st.db().GetCollection(secretConsumersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretConsumerDoc
-	err := secretConsumersCollection.Find(bson.M{
+	err = secretConsumersCollection.Find(bson.M{
 		"consumer-tag": consumer.String(), "label": label,
 	}).Select(bson.D{{"_id", 1}}).One(&doc)
 	if err == mgo.ErrNotFound {
@@ -2062,11 +2185,14 @@ func (st *State) GetSecretConsumer(uri *secrets.URI, consumer names.Tag) (*secre
 		}
 	}
 
-	secretConsumersCollection, closer := st.db().GetCollection(secretConsumersC)
+	secretConsumersCollection, closer, err := st.db().GetCollection(secretConsumersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	key := st.secretConsumerKey(uri, consumer.String())
 	var doc secretConsumerDoc
-	err := secretConsumersCollection.FindId(key).One(&doc)
+	err = secretConsumersCollection.FindId(key).One(&doc)
 	if errors.Cause(err) == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("consumer %q metadata for secret %q", consumer, uri.String())
 	}
@@ -2103,12 +2229,15 @@ func (st *State) GetSecretRemoteConsumer(uri *secrets.URI, consumer names.Tag) (
 		return nil, errors.Trace(err)
 	}
 
-	secretConsumersCollection, closer := st.db().GetCollection(secretRemoteConsumersC)
+	secretConsumersCollection, closer, err := st.db().GetCollection(secretRemoteConsumersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	key := st.secretConsumerKey(uri, consumer.String())
 	var doc secretRemoteConsumerDoc
-	err := secretConsumersCollection.FindId(key).One(&doc)
+	err = secretConsumersCollection.FindId(key).One(&doc)
 	if errors.Cause(err) == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("consumer %q metadata for secret %q", consumer, uri.String())
 	}
@@ -2124,11 +2253,14 @@ func (st *State) GetSecretRemoteConsumer(uri *secrets.URI, consumer names.Tag) (
 }
 
 func (st *State) removeSecretConsumerInfo(uri *secrets.URI) error {
-	secretConsumersCollection, closer := st.db().GetCollection(secretConsumersC)
+	secretConsumersCollection, closer, err := st.db().GetCollection(secretConsumersC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []secretConsumerDoc
-	err := secretConsumersCollection.Find(
+	err = secretConsumersCollection.Find(
 		bson.D{
 			{
 				Name: "$and", Value: []bson.D{
@@ -2141,8 +2273,11 @@ func (st *State) removeSecretConsumerInfo(uri *secrets.URI) error {
 	if err != nil && errors.Cause(err) != mgo.ErrNotFound {
 		return errors.Trace(err)
 	}
-	refCountsCollection, closer := st.db().GetCollection(refcountsC)
-	defer closer()
+	refCountsCollection, closer2, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer closer2()
 	for _, doc := range docs {
 		consumer, _ := names.ParseTag(doc.ConsumerTag)
 		key := secretConsumerLabelKey(consumer, doc.Label)
@@ -2164,10 +2299,13 @@ func (st *State) removeSecretConsumerInfo(uri *secrets.URI) error {
 }
 
 func (st *State) removeSecretRemoteConsumerInfo(uri *secrets.URI) error {
-	secretConsumersCollection, closer := st.db().GetCollection(secretRemoteConsumersC)
+	secretConsumersCollection, closer, err := st.db().GetCollection(secretRemoteConsumersC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
-	_, err := secretConsumersCollection.Writeable().RemoveAll(bson.D{{
+	_, err = secretConsumersCollection.Writeable().RemoveAll(bson.D{{
 		"_id", bson.D{{"$regex", st.localSecretURIRegex(uri, "#")}},
 	}})
 	if err != nil {
@@ -2178,18 +2316,24 @@ func (st *State) removeSecretRemoteConsumerInfo(uri *secrets.URI) error {
 
 // RemoveSecretConsumer removes secret references for the specified consumer.
 func (st *State) RemoveSecretConsumer(consumer names.Tag) error {
-	secretConsumersCollection, closer := st.db().GetCollection(secretConsumersC)
+	secretConsumersCollection, closer, err := st.db().GetCollection(secretConsumersC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []secretConsumerDoc
-	err := secretConsumersCollection.Find(
+	err = secretConsumersCollection.Find(
 		bson.D{{"consumer-tag", consumer.String()}},
 	).Select(bson.D{{"_id", 1}, {"label", 1}}).All(&docs)
 	if err != nil && errors.Cause(err) != mgo.ErrNotFound {
 		return errors.Trace(err)
 	}
-	refCountsCollection, closer := st.db().GetCollection(refcountsC)
-	defer closer()
+	refCountsCollection, closer2, err := st.db().GetCollection(refcountsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer closer2()
 	for _, doc := range docs {
 		key := secretConsumerLabelKey(consumer, doc.Label)
 		_, err = refCountsCollection.Writeable().RemoveAll(bson.D{{
@@ -2211,12 +2355,15 @@ func (st *State) RemoveSecretConsumer(consumer names.Tag) error {
 // removeRemoteSecretConsumer removes secret consumer info for the specified
 // remote application and also any of its units.
 func (st *State) removeRemoteSecretConsumer(appName string) error {
-	secretConsumersCollection, closer := st.db().GetCollection(secretRemoteConsumersC)
+	secretConsumersCollection, closer, err := st.db().GetCollection(secretRemoteConsumersC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	match := fmt.Sprintf("(unit|application)-%s(\\/\\d)?", appName)
 	q := bson.D{{"consumer-tag", bson.D{{"$regex", match}}}}
-	_, err := secretConsumersCollection.Writeable().RemoveAll(q)
+	_, err = secretConsumersCollection.Writeable().RemoveAll(q)
 	return err
 }
 
@@ -2256,10 +2403,16 @@ func (st *State) UpdateSecretConsumerOperation(uri *secrets.URI, latestRevision 
 // SaveSecretConsumer saves or updates secret consumer metadata.
 func (st *State) SaveSecretConsumer(uri *secrets.URI, consumer names.Tag, metadata *secrets.SecretConsumerMetadata) error {
 	key := st.secretConsumerKey(uri, consumer.String())
-	secretConsumersCollection, closer := st.db().GetCollection(secretConsumersC)
+	secretConsumersCollection, closer, err := st.db().GetCollection(secretConsumersC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
-	secretMetadataCollection, closer := st.db().GetCollection(secretMetadataC)
-	defer closer()
+	secretMetadataCollection, closer2, err := st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer closer2()
 
 	// Cross model secrets do not exist in this model.
 	localSecret := uri.IsLocal(st.ModelUUID())
@@ -2365,10 +2518,16 @@ func (st *State) SaveSecretConsumer(uri *secrets.URI, consumer names.Tag, metada
 // for a cross model consumer.
 func (st *State) SaveSecretRemoteConsumer(uri *secrets.URI, consumer names.Tag, metadata *secrets.SecretConsumerMetadata) error {
 	key := st.secretConsumerKey(uri, consumer.String())
-	secretConsumersCollection, closer := st.db().GetCollection(secretRemoteConsumersC)
+	secretConsumersCollection, closer, err := st.db().GetCollection(secretRemoteConsumersC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
-	secretMetadataCollection, closer := st.db().GetCollection(secretMetadataC)
-	defer closer()
+	secretMetadataCollection, closer2, err := st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer closer2()
 
 	var doc secretRemoteConsumerDoc
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -2441,7 +2600,10 @@ func (st *State) SaveSecretRemoteConsumer(uri *secrets.URI, consumer names.Tag, 
 // secretUpdateConsumersOps updates the latest secret revision number
 // on all consumers. This triggers the secrets change watcher.
 func (st *State) secretUpdateConsumersOps(coll string, uri *secrets.URI, newRevision int) ([]txn.Op, error) {
-	secretConsumersCollection, closer := st.db().GetCollection(coll)
+	secretConsumersCollection, closer, err := st.db().GetCollection(coll)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var (
@@ -2472,12 +2634,15 @@ const (
 
 // allLocalSecretConsumers is used for model export.
 func (s *secretsStore) allLocalSecretConsumers() ([]secretConsumerDoc, error) {
-	secretConsumerCollection, closer := s.st.db().GetCollection(secretConsumersC)
+	secretConsumerCollection, closer, err := s.st.db().GetCollection(secretConsumersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []secretConsumerDoc
 
-	err := secretConsumerCollection.Find(bson.D{{"_id", bson.D{{"$regex", idSnippet}}}}).All(&docs)
+	err = secretConsumerCollection.Find(bson.D{{"_id", bson.D{{"$regex", idSnippet}}}}).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -2486,13 +2651,16 @@ func (s *secretsStore) allLocalSecretConsumers() ([]secretConsumerDoc, error) {
 
 // allRemoteSecretConsumers is used for model export.
 func (s *secretsStore) allRemoteSecretConsumers() ([]secretConsumerDoc, error) {
-	secretConsumerCollection, closer := s.st.db().GetCollection(secretConsumersC)
+	secretConsumerCollection, closer, err := s.st.db().GetCollection(secretConsumersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []secretConsumerDoc
 
 	q := fmt.Sprintf(`%s/%s`, uuidSnippet, idSnippet)
-	err := secretConsumerCollection.Find(bson.D{{"_id", bson.D{{"$regex", q}}}}).All(&docs)
+	err = secretConsumerCollection.Find(bson.D{{"_id", bson.D{{"$regex", q}}}}).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -2501,12 +2669,15 @@ func (s *secretsStore) allRemoteSecretConsumers() ([]secretConsumerDoc, error) {
 
 // allSecretRemoteConsumers is used for model export.
 func (s *secretsStore) allSecretRemoteConsumers() ([]secretRemoteConsumerDoc, error) {
-	secretRemoteConsumerCollection, closer := s.st.db().GetCollection(secretRemoteConsumersC)
+	secretRemoteConsumerCollection, closer, err := s.st.db().GetCollection(secretRemoteConsumersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []secretRemoteConsumerDoc
 
-	err := secretRemoteConsumerCollection.Find(nil).All(&docs)
+	err = secretRemoteConsumerCollection.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -2570,7 +2741,10 @@ func (w *consumedSecretsWatcher) Changes() <-chan []string {
 
 func (w *consumedSecretsWatcher) initial() ([]string, error) {
 	var doc secretConsumerDoc
-	secretConsumersCollection, closer := w.db.GetCollection(w.coll)
+	secretConsumersCollection, closer, err := w.db.GetCollection(w.coll)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var ids []string
@@ -2611,10 +2785,13 @@ func (w *consumedSecretsWatcher) merge(currentChanges []string, change watcher.C
 
 	// Record added or updated.
 	var doc secretConsumerDoc
-	secretConsumerColl, closer := w.db.GetCollection(w.coll)
+	secretConsumerColl, closer, err := w.db.GetCollection(w.coll)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
-	err := secretConsumerColl.FindId(change.Id).Select(bson.D{{"latest-revision", 1}}).One(&doc)
+	err = secretConsumerColl.FindId(change.Id).Select(bson.D{{"latest-revision", 1}}).One(&doc)
 	if err != nil && err != mgo.ErrNotFound {
 		return nil, errors.Trace(err)
 	}
@@ -2737,11 +2914,14 @@ func newObsoleteSecretsWatcher(st modelBackend, owners []string, filter func(str
 	obsoleteRevisionsWatcher := newCollectionWatcher(st, colWCfg{
 		col: secretRevisionsC,
 		filter: func(key interface{}) bool {
-			secretRevisionsCollection, closer := st.db().GetCollection(secretRevisionsC)
+			secretRevisionsCollection, closer, err := st.db().GetCollection(secretRevisionsC)
+			if err != nil {
+				return false
+			}
 			defer closer()
 
 			var doc secretRevisionDoc
-			err := secretRevisionsCollection.Find(bson.D{{"_id", key}, secretOwnerTerm(owners)}).Select(
+			err = secretRevisionsCollection.Find(bson.D{{"_id", key}, secretOwnerTerm(owners)}).Select(
 				bson.D{{"obsolete", 1}},
 			).One(&doc)
 			if err != nil {
@@ -2790,7 +2970,10 @@ func (w *obsoleteSecretsWatcher) Changes() <-chan []string {
 
 func (w *obsoleteSecretsWatcher) initial() error {
 	var doc secretMetadataDoc
-	secretMetadataCollection, closer := w.db.GetCollection(secretMetadataC)
+	secretMetadataCollection, closer, err := w.db.GetCollection(secretMetadataC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	iter := secretMetadataCollection.Find(bson.D{secretOwnerTerm(w.owners)}).Iter()
@@ -2838,9 +3021,12 @@ func (w *obsoleteSecretsWatcher) mergedOwnedChanges(currentChanges []string, cha
 	var doc secretMetadataDoc
 	// Record added or updated - we don't emit an event but
 	// record that we know about it.
-	secretMetadataColl, closer := w.db.GetCollection(secretMetadataC)
+	secretMetadataColl, closer, err := w.db.GetCollection(secretMetadataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
-	err := secretMetadataColl.Find(bson.D{{"_id", change.Id}, secretOwnerTerm(w.owners)}).One(&doc)
+	err = secretMetadataColl.Find(bson.D{{"_id", change.Id}, secretOwnerTerm(w.owners)}).One(&doc)
 	if err != nil && err != mgo.ErrNotFound {
 		return nil, errors.Trace(err)
 	}
@@ -2974,7 +3160,10 @@ func (w *deletedSecretsWatcher) Changes() <-chan []string {
 
 func (w *deletedSecretsWatcher) initial() error {
 	var doc secretMetadataDoc
-	secretRevisionCollection, closer := w.db.GetCollection(secretRevisionsC)
+	secretRevisionCollection, closer, err := w.db.GetCollection(secretRevisionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	iter := secretRevisionCollection.Find(bson.D{secretOwnerTerm(w.owners)}).Select(bson.D{{"_id", 1}}).Iter()
@@ -3021,7 +3210,10 @@ func (w *deletedSecretsWatcher) mergedOwnedChanges(currentChanges []string, chan
 	var doc secretRevisionDoc
 	// Record added or updated - we don't emit an event but
 	// record that we know about it.
-	secretRevisionsColl, closer := w.db.GetCollection(secretRevisionsC)
+	secretRevisionsColl, closer, err := w.db.GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	relevantURI := false
 	iter := secretRevisionsColl.Find(bson.D{{"_id",
@@ -3070,7 +3262,10 @@ func (w *deletedSecretsWatcher) mergeRevisionChanges(currentChanges []string, ch
 
 	// Record added or updated - we don't emit an event but
 	// record that we know about it.
-	secretRevisionsColl, closer := w.db.GetCollection(secretRevisionsC)
+	secretRevisionsColl, closer, err := w.db.GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	n, err := secretRevisionsColl.Find(bson.D{{"_id", fmt.Sprintf("%s/%d", uriStr, rev)},
 		secretOwnerTerm(w.owners)}).Count()
@@ -3192,7 +3387,10 @@ func (st *State) markObsoleteRevisionOps(uri *secrets.URI, exceptForConsumer str
 // and which have not yet been marked as orphaned, excluding the specified consumer and/or revision.
 // The result includes the current latest revision, for the specified secret
 func (st *State) getNewlyOrphanedSecretRevisions(uri *secrets.URI, exceptForConsumer string, exceptForRev ...int) ([]int, error) {
-	secretRevisionCollection, closer := st.db().GetCollection(secretRevisionsC)
+	secretRevisionCollection, closer, err := st.db().GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	q := bson.D{
@@ -3226,7 +3424,10 @@ func (st *State) getNewlyOrphanedSecretRevisions(uri *secrets.URI, exceptForCons
 }
 
 func (st *State) getInUseSecretRevisions(collName string, uri *secrets.URI, exceptForConsumer string) (set.Ints, error) {
-	secretConsumersCollection, closer := st.db().GetCollection(collName)
+	secretConsumersCollection, closer, err := st.db().GetCollection(collName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	pipe := secretConsumersCollection.Pipe([]bson.M{
@@ -3259,7 +3460,7 @@ func (st *State) getInUseSecretRevisions(collName string, uri *secrets.URI, exce
 		},
 	})
 	var usedRevisions []map[string]int
-	err := pipe.All(&usedRevisions)
+	err = pipe.All(&usedRevisions)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -3332,7 +3533,10 @@ func (st *State) findSecretEntity(tag names.Tag) (entity Lifer, collName, docID 
 }
 
 func (st *State) referencedSecrets(ref names.Tag, attr string) ([]*secrets.URI, error) {
-	secretMetadataCollection, closer := st.db().GetCollection(secretMetadataC)
+	secretMetadataCollection, closer, err := st.db().GetCollection(secretMetadataC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var (
@@ -3412,7 +3616,10 @@ func (st *State) GrantSecretAccess(uri *secrets.URI, p SecretAccessParams) (err 
 
 	key := st.secretConsumerKey(uri, p.Subject.String())
 
-	secretPermissionsCollection, closer := st.db().GetCollection(secretPermissionsC)
+	secretPermissionsCollection, closer, err := st.db().GetCollection(secretPermissionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretPermissionDoc
@@ -3458,7 +3665,10 @@ func (st *State) GrantSecretAccess(uri *secrets.URI, p SecretAccessParams) (err 
 func (st *State) RevokeSecretAccess(uri *secrets.URI, p SecretAccessParams) error {
 	key := st.secretConsumerKey(uri, p.Subject.String())
 
-	secretPermissionsCollection, closer := st.db().GetCollection(secretPermissionsC)
+	secretPermissionsCollection, closer, err := st.db().GetCollection(secretPermissionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretPermissionDoc
@@ -3469,7 +3679,7 @@ func (st *State) RevokeSecretAccess(uri *secrets.URI, p SecretAccessParams) erro
 			}
 			return nil, errors.Trace(err)
 		}
-		err := secretPermissionsCollection.FindId(key).One(&doc)
+		err = secretPermissionsCollection.FindId(key).One(&doc)
 		if err == mgo.ErrNotFound {
 			return nil, jujutxn.ErrNoOperations
 		} else if err != nil {
@@ -3491,7 +3701,10 @@ func (st *State) RevokeSecretAccess(uri *secrets.URI, p SecretAccessParams) erro
 func (st *State) SecretAccess(uri *secrets.URI, subject names.Tag) (secrets.SecretRole, error) {
 	key := st.secretConsumerKey(uri, subject.String())
 
-	secretPermissionsCollection, closer := st.db().GetCollection(secretPermissionsC)
+	secretPermissionsCollection, closer, err := st.db().GetCollection(secretPermissionsC)
+	if err != nil {
+		return secrets.RoleNone, errors.Trace(err)
+	}
 	defer closer()
 
 	if err := st.checkExists(uri); err != nil {
@@ -3499,7 +3712,7 @@ func (st *State) SecretAccess(uri *secrets.URI, subject names.Tag) (secrets.Secr
 	}
 
 	var doc secretPermissionDoc
-	err := secretPermissionsCollection.FindId(key).One(&doc)
+	err = secretPermissionsCollection.FindId(key).One(&doc)
 	if err == mgo.ErrNotFound {
 		return secrets.RoleNone, nil
 	}
@@ -3513,7 +3726,10 @@ func (st *State) SecretAccess(uri *secrets.URI, subject names.Tag) (secrets.Secr
 func (st *State) SecretAccessScope(uri *secrets.URI, subject names.Tag) (names.Tag, error) {
 	key := st.secretConsumerKey(uri, subject.String())
 
-	secretPermissionsCollection, closer := st.db().GetCollection(secretPermissionsC)
+	secretPermissionsCollection, closer, err := st.db().GetCollection(secretPermissionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	if err := st.checkExists(uri); err != nil {
@@ -3521,7 +3737,7 @@ func (st *State) SecretAccessScope(uri *secrets.URI, subject names.Tag) (names.T
 	}
 
 	var doc secretPermissionDoc
-	err := secretPermissionsCollection.FindId(key).One(&doc)
+	err = secretPermissionsCollection.FindId(key).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("secret access for consumer %q", subject)
 	}
@@ -3532,7 +3748,10 @@ func (st *State) SecretAccessScope(uri *secrets.URI, subject names.Tag) (names.T
 }
 
 func (st *State) removeScopedSecretPermissionOps(scope names.Tag) ([]txn.Op, error) {
-	secretPermissionsCollection, closer := st.db().GetCollection(secretPermissionsC)
+	secretPermissionsCollection, closer, err := st.db().GetCollection(secretPermissionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var (
@@ -3551,7 +3770,10 @@ func (st *State) removeScopedSecretPermissionOps(scope names.Tag) ([]txn.Op, err
 }
 
 func (st *State) removeConsumerSecretPermissionOps(consumer names.Tag) ([]txn.Op, error) {
-	secretPermissionsCollection, closer := st.db().GetCollection(secretPermissionsC)
+	secretPermissionsCollection, closer, err := st.db().GetCollection(secretPermissionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var (
@@ -3591,11 +3813,14 @@ func (s *secretsStore) secretRotationOps(uri *secrets.URI, owner string, rotateP
 	if nextRotateTime == nil {
 		return nil, errors.New("must specify a secret rotate time")
 	}
-	secretRotateCollection, closer := s.st.db().GetCollection(secretRotateC)
+	secretRotateCollection, closer, err := s.st.db().GetCollection(secretRotateC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretRotationDoc
-	err := secretRotateCollection.FindId(secretKey).One(&doc)
+	err = secretRotateCollection.FindId(secretKey).One(&doc)
 	if err == mgo.ErrNotFound {
 		return []txn.Op{{
 			C:      secretRotateC,
@@ -3626,7 +3851,10 @@ func (s *secretsStore) secretRotationOps(uri *secrets.URI, owner string, rotateP
 
 // SecretRotated records when the given secret was rotated.
 func (st *State) SecretRotated(uri *secrets.URI, next time.Time) error {
-	secretRotateCollection, closer := st.db().GetCollection(secretRotateC)
+	secretRotateCollection, closer, err := st.db().GetCollection(secretRotateC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	secretKey := uri.ID
@@ -3717,7 +3945,10 @@ func (w *secretsRotationWatcher) initial() ([]corewatcher.SecretTriggerChange, e
 	var details []corewatcher.SecretTriggerChange
 
 	var doc secretRotationDoc
-	secretRotateCollection, closer := w.db.GetCollection(secretRotateC)
+	secretRotateCollection, closer, err := w.db.GetCollection(secretRotateC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	iter := secretRotateCollection.Find(bson.D{secretOwnerTerm(w.owners)}).Iter()
@@ -3747,9 +3978,12 @@ func (w *secretsRotationWatcher) merge(details []corewatcher.SecretTriggerChange
 	doc := secretRotationDoc{}
 	if change.Revno >= 0 {
 		// Record added or updated.
-		secretsRotationColl, closer := w.db.GetCollection(secretRotateC)
+		secretsRotationColl, closer, err := w.db.GetCollection(secretRotateC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer closer()
-		err := secretsRotationColl.Find(bson.D{{"_id", change.Id}, secretOwnerTerm(w.owners)}).One(&doc)
+		err = secretsRotationColl.Find(bson.D{{"_id", change.Id}, secretOwnerTerm(w.owners)}).One(&doc)
 		if err != nil && err != mgo.ErrNotFound {
 			return nil, errors.Trace(err)
 		}
@@ -3874,7 +4108,10 @@ func (w *secretsExpiryWatcher) initial() ([]corewatcher.SecretTriggerChange, err
 	var details []corewatcher.SecretTriggerChange
 
 	var doc secretRevisionDoc
-	secretRevisionCollection, closer := w.db.GetCollection(secretRevisionsC)
+	secretRevisionCollection, closer, err := w.db.GetCollection(secretRevisionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	iter := secretRevisionCollection.Find(bson.D{secretOwnerTerm(w.owners)}).Iter()
@@ -3910,9 +4147,12 @@ func (w *secretsExpiryWatcher) merge(details []corewatcher.SecretTriggerChange, 
 
 	doc := secretRevisionDoc{}
 	if change.Revno >= 0 {
-		secretRevisionCollection, closer := w.db.GetCollection(secretRevisionsC)
+		secretRevisionCollection, closer, err := w.db.GetCollection(secretRevisionsC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer closer()
-		err := secretRevisionCollection.Find(bson.D{{"_id", change.Id}, secretOwnerTerm(w.owners)}).One(&doc)
+		err = secretRevisionCollection.Find(bson.D{{"_id", change.Id}, secretOwnerTerm(w.owners)}).One(&doc)
 		if err != nil && err != mgo.ErrNotFound {
 			return nil, errors.Trace(err)
 		}
@@ -4031,7 +4271,10 @@ func (s *secretsStore) CreateSecretBackendIssuedToken(
 			"creating secret backend issued token failed due to missing values",
 		)
 	}
-	tokenColl, closer := s.st.db().GetCollection(secretBackendIssuedTokensC)
+	tokenColl, closer, err := s.st.db().GetCollection(secretBackendIssuedTokensC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	check := func() (string, string, *secretIssuedTokenDoc, error) {
@@ -4111,7 +4354,7 @@ func (s *secretsStore) CreateSecretBackendIssuedToken(
 		})
 		return ops, nil
 	}
-	err := s.st.db().Run(buildTxn)
+	err = s.st.db().Run(buildTxn)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -4147,11 +4390,14 @@ type SecretBackendIssuedToken struct {
 // NextSecretBackendIssuedTokenExpiry returns the time of the next secret
 // backend issued token expiry.
 func (s *secretsStore) NextSecretBackendIssuedTokenExpiry() (time.Time, error) {
-	collection, closer := s.st.db().GetCollection(secretBackendIssuedTokensC)
+	collection, closer, err := s.st.db().GetCollection(secretBackendIssuedTokensC)
+	if err != nil {
+		return time.Time{}, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc secretIssuedTokenDoc
-	err := collection.Find(nil).Sort("expire-time").One(&doc)
+	err = collection.Find(nil).Sort("expire-time").One(&doc)
 	if errors.Is(err, mgo.ErrNotFound) {
 		return time.Time{}, nil
 	} else if err != nil {
@@ -4189,7 +4435,10 @@ func (s *secretsStore) ListSecretBackendIssuedTokenUntilForConsumer(
 func (s *secretsStore) listSecretBackendIssuedTokenUntil(
 	query any,
 ) ([]SecretBackendIssuedToken, error) {
-	collection, closer := s.st.db().GetCollection(secretBackendIssuedTokensC)
+	collection, closer, err := s.st.db().GetCollection(secretBackendIssuedTokensC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	iter := collection.Find(query).Sort("expire-time").Iter()
@@ -4253,7 +4502,7 @@ func (s *secretsStore) WatchSecretBackendIssuedTokenExpiry() StringsWatcher {
 // tokens as an RFC3339 timestamp string.
 type secretBackendIssuedTokenExpiryWatcher struct {
 	commonWatcher
-	coll func() (mongo.Collection, func())
+	coll func() (mongo.Collection, func(), error)
 	out  chan []string
 }
 
@@ -4283,10 +4532,13 @@ func (w *secretBackendIssuedTokenExpiryWatcher) Changes() <-chan []string {
 // initial returns the initial changes for the expiry watcher. Each string is an
 // RFC3339 encoded timestamp.
 func (w *secretBackendIssuedTokenExpiryWatcher) initial() ([]string, error) {
-	coll, closer := w.coll()
+	coll, closer, err := w.coll()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var expireTimes []time.Time
-	err := coll.Find(nil).Distinct("expire-time", &expireTimes)
+	err = coll.Find(nil).Distinct("expire-time", &expireTimes)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -4310,7 +4562,10 @@ func (w *secretBackendIssuedTokenExpiryWatcher) loop() error {
 		return errors.Trace(err)
 	}
 
-	coll, closer := w.coll()
+	coll, closer, err := w.coll()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	// out is not-nil when a notification should be sent, it is set to the

--- a/state/sequence.go
+++ b/state/sequence.go
@@ -21,7 +21,10 @@ type sequenceDoc struct {
 // sequence safely increments a database backed sequence, returning
 // the next value.
 func sequence(mb modelBackend, name string) (int, error) {
-	sequences, closer := mb.db().GetCollection(sequenceC)
+	sequences, closer, err := mb.db().GetCollection(sequenceC)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
 	defer closer()
 	query := sequences.FindId(name)
 	inc := mgo.Change{
@@ -35,7 +38,7 @@ func sequence(mb modelBackend, name string) (int, error) {
 		Upsert: true,
 	}
 	result := &sequenceDoc{}
-	_, err := query.Apply(inc, result)
+	_, err = query.Apply(inc, result)
 	if err != nil {
 		return -1, fmt.Errorf("cannot increment %q sequence number: %v", name, err)
 	}
@@ -43,9 +46,12 @@ func sequence(mb modelBackend, name string) (int, error) {
 }
 
 func resetSequence(mb modelBackend, name string) error {
-	sequences, closer := mb.db().GetCollection(sequenceC)
+	sequences, closer, err := mb.db().GetCollection(sequenceC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
-	err := sequences.Writeable().RemoveId(name)
+	err = sequences.Writeable().RemoveId(name)
 	if err != nil && errors.Cause(err) != mgo.ErrNotFound {
 		return errors.Annotatef(err, "can not reset sequence for %q", name)
 	}
@@ -65,7 +71,10 @@ func resetSequence(mb modelBackend, name string) error {
 // `sequence` is more efficient than `sequenceWithMin` and should be
 // preferred if there is no minimum value requirement.
 func sequenceWithMin(mb modelBackend, name string, minVal int) (int, error) {
-	sequences, closer := mb.db().GetRawCollection(sequenceC)
+	sequences, closer, err := mb.db().GetRawCollection(sequenceC)
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
 	defer closer()
 	updater := newDbSeqUpdater(sequences, mb.ModelUUID(), name)
 	return updateSeqWithMin(updater, minVal)
@@ -96,7 +105,10 @@ type seqUpdater interface {
 
 // Sequences returns the model's sequence names and their next values.
 func (st *State) Sequences() (map[string]int, error) {
-	sequences, closer := st.db().GetCollection(sequenceC)
+	sequences, closer, err := st.db().GetCollection(sequenceC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []sequenceDoc

--- a/state/settings.go
+++ b/state/settings.go
@@ -258,10 +258,13 @@ func (s *Settings) Read() error {
 // readSettingsDoc reads the settings doc with the given key.
 func readSettingsDoc(db Database, collection, key string) (*settingsDoc, error) {
 	var doc settingsDoc
-	col, closer := db.GetCollection(collection)
+	col, closer, err := db.GetCollection(collection)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
-	err := col.FindId(key).One(&doc)
+	err = col.FindId(key).One(&doc)
 	if err == mgo.ErrNotFound {
 		err = errors.NotFoundf("settings")
 	}
@@ -273,10 +276,13 @@ func readSettingsDocVersion(db Database, collection, key string) (int64, error) 
 	var doc struct {
 		Version int64 `bson:"version"`
 	}
-	col, closer := db.GetCollection(collection)
+	col, closer, err := db.GetCollection(collection)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 
-	err := col.FindId(key).Select(bson.M{"version": 1}).One(&doc)
+	err = col.FindId(key).Select(bson.M{"version": 1}).One(&doc)
 	if err == mgo.ErrNotFound {
 		err = errors.NotFoundf("settings %s", key)
 	}
@@ -377,7 +383,10 @@ func replaceSettings(db Database, collection, key string, values map[string]inte
 
 // listSettings returns all the settings with the specified key prefix.
 func listSettings(backend modelBackend, collection, keyPrefix string) (map[string]map[string]interface{}, error) {
-	col, closer := backend.db().GetRawCollection(collection)
+	col, closer, err := backend.db().GetRawCollection(collection)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var matchingSettings []settingsDoc

--- a/state/settings_test.go
+++ b/state/settings_test.go
@@ -89,7 +89,8 @@ func (s *SettingsSuite) TestUpdateWithWrite(c *gc.C) {
 	var mgoData struct {
 		Settings settingsMap
 	}
-	settings, closer := s.state.db().GetCollection(settingsC)
+	settings, closer, err := s.state.db().GetCollection(settingsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
@@ -175,7 +176,8 @@ func (s *SettingsSuite) TestSetItem(c *gc.C) {
 	var mgoData struct {
 		Settings settingsMap
 	}
-	settings, closer := s.state.db().GetCollection(settingsC)
+	settings, closer, err := s.state.db().GetCollection(settingsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
@@ -203,7 +205,8 @@ func (s *SettingsSuite) TestSetItemEscape(c *gc.C) {
 	var mgoData struct {
 		Settings map[string]interface{}
 	}
-	settings, closer := s.state.db().GetCollection(settingsC)
+	settings, closer, err := s.state.db().GetCollection(settingsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
@@ -268,7 +271,8 @@ func (s *SettingsSuite) TestReplaceSettingsEscape(c *gc.C) {
 	var mgoData struct {
 		Settings map[string]interface{}
 	}
-	settings, closer := s.state.db().GetCollection(settingsC)
+	settings, closer, err := s.state.db().GetCollection(settingsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
@@ -289,7 +293,8 @@ func (s *SettingsSuite) TestCreateSettingsEscape(c *gc.C) {
 	var mgoData struct {
 		Settings map[string]interface{}
 	}
-	settings, closer := s.state.db().GetCollection(settingsC)
+	settings, closer, err := s.state.db().GetCollection(settingsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	err = settings.FindId(s.key).One(&mgoData)
@@ -448,7 +453,8 @@ func (s *SettingsSuite) TestMultipleWritesAreStable(c *gc.C) {
 	var mgoData struct {
 		Settings map[string]interface{}
 	}
-	settings, closer := s.state.db().GetCollection(settingsC)
+	settings, closer, err := s.state.db().GetCollection(settingsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)
@@ -557,7 +563,8 @@ func (s *SettingsSuite) TestReplaceSettings(c *gc.C) {
 	var mgoData struct {
 		Settings settingsMap
 	}
-	settings, closer := s.state.db().GetCollection(settingsC)
+	settings, closer, err := s.state.db().GetCollection(settingsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 	err = settings.FindId(s.key).One(&mgoData)
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/spaces.go
+++ b/state/spaces.go
@@ -243,11 +243,14 @@ func (st *State) addSpaceTxnOps(id, name string, providerId network.Id, isPublic
 // An error is returned if the space does not exist or if there was a problem
 // accessing its information.
 func (st *State) Space(id string) (*Space, error) {
-	spaces, closer := st.db().GetCollection(spacesC)
+	spaces, closer, err := st.db().GetCollection(spacesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc spaceDoc
-	err := spaces.Find(bson.M{"spaceid": id}).One(&doc)
+	err = spaces.Find(bson.M{"spaceid": id}).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("space id %q", id)
 	}
@@ -261,11 +264,14 @@ func (st *State) Space(id string) (*Space, error) {
 // An error is returned if the space does not exist or if there was a problem
 // accessing its information.
 func (st *State) SpaceByName(name string) (*Space, error) {
-	spaces, closer := st.db().GetCollection(spacesC)
+	spaces, closer, err := st.db().GetCollection(spacesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc spaceDoc
-	err := spaces.Find(bson.M{"name": name}).One(&doc)
+	err = spaces.Find(bson.M{"name": name}).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("space %q", name)
 	}
@@ -298,11 +304,14 @@ func (st *State) AllSpaceInfos() (network.SpaceInfos, error) {
 
 // AllSpaces returns all spaces for the model.
 func (st *State) AllSpaces() ([]*Space, error) {
-	spacesCollection, closer := st.db().GetCollection(spacesC)
+	spacesCollection, closer, err := st.db().GetCollection(spacesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []spaceDoc
-	err := spacesCollection.Find(nil).All(&docs)
+	err = spacesCollection.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get all spaces")
 	}
@@ -368,11 +377,14 @@ func (s *Space) Remove() (err error) {
 // returns an error that satisfies errors.IsNotFound if the Space has been
 // removed.
 func (s *Space) Refresh() error {
-	spaces, closer := s.st.db().GetCollection(spacesC)
+	spaces, closer, err := s.st.db().GetCollection(spacesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var doc spaceDoc
-	err := spaces.FindId(s.doc.Id).One(&doc)
+	err = spaces.FindId(s.doc.Id).One(&doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("space %q", s)
 	} else if err != nil {

--- a/state/sshconnrequests.go
+++ b/state/sshconnrequests.go
@@ -134,11 +134,14 @@ func (st *State) RemoveSSHConnRequest(arg SSHConnRequestRemoveArg) error {
 
 // GetSSHConnRequest returns a ssh connection request by its document ID.
 func (st *State) GetSSHConnRequest(docID string) (SSHConnRequest, error) {
-	vhkeys, closer := st.db().GetCollection(sshConnRequestsC)
+	vhkeys, closer, err := st.db().GetCollection(sshConnRequestsC)
+	if err != nil {
+		return SSHConnRequest{}, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := sshConnRequestDoc{}
-	err := vhkeys.FindId(st.docID(docID)).One(&doc)
+	err = vhkeys.FindId(st.docID(docID)).One(&doc)
 	if err == mgo.ErrNotFound {
 		return SSHConnRequest{}, errors.NotFoundf("sshreqconn key %q", docID)
 	}

--- a/state/sshhostkeys.go
+++ b/state/sshhostkeys.go
@@ -35,11 +35,14 @@ type sshHostKeysDoc struct {
 // NOTE: Currently only machines are supported. This can be
 // generalised to take other tag types later, if and when we need it.
 func (st *State) GetSSHHostKeys(tag names.MachineTag) (SSHHostKeys, error) {
-	coll, closer := st.db().GetCollection(sshHostKeysC)
+	coll, closer, err := st.db().GetCollection(sshHostKeysC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc sshHostKeysDoc
-	err := coll.FindId(machineGlobalKey(tag.Id())).One(&doc)
+	err = coll.FindId(machineGlobalKey(tag.Id())).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("keys")
 	} else if err != nil {
@@ -70,7 +73,10 @@ func keysEqual(a, b []string) bool {
 //
 // See the note for GetSSHHostKeys regarding supported entities.
 func (st *State) SetSSHHostKeys(tag names.MachineTag, keys SSHHostKeys) error {
-	coll, closer := st.db().GetCollection(sshHostKeysC)
+	coll, closer, err := st.db().GetCollection(sshHostKeysC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	id := machineGlobalKey(tag.Id())
 	doc := sshHostKeysDoc{

--- a/state/state.go
+++ b/state/state.go
@@ -81,7 +81,10 @@ type State struct {
 }
 
 func (st *State) newStateNoWorkers(modelUUID string) (*State, error) {
-	session := st.session.Copy()
+	session, err := mongo.CopySession(st.session)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	newSt, err := newState(
 		st.controllerTag,
 		names.NewModelTag(modelUUID),
@@ -142,10 +145,13 @@ func (st *State) ControllerModelTag() names.ModelTag {
 
 // ControllerOwner returns the owner of the controller model.
 func (st *State) ControllerOwner() (names.UserTag, error) {
-	models, closer := st.db().GetCollection(modelsC)
+	models, closer, err := st.db().GetCollection(modelsC)
+	if err != nil {
+		return names.UserTag{}, errors.Trace(err)
+	}
 	defer closer()
 	var doc map[string]string
-	err := models.FindId(st.ControllerModelUUID()).Select(bson.M{"owner": 1}).One(&doc)
+	err = models.FindId(st.ControllerModelUUID()).Select(bson.M{"owner": 1}).One(&doc)
 	if err != nil {
 		return names.UserTag{}, errors.Annotate(err, "loading controller model")
 	}
@@ -238,7 +244,10 @@ func (st *State) RemoveExportingModelDocs() error {
 }
 
 func cleanupSecretBackendRefCountAfterModelMigrationDone(st *State) error {
-	col, closer := st.db().GetCollection(secretRevisionsC)
+	col, closer, err := st.db().GetCollection(secretRevisionsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	pipe := col.Pipe([]bson.M{
 		{
@@ -380,7 +389,10 @@ func (st *State) removeAllModelPermissions() error {
 	}
 	permOps = append(permOps, ops...)
 
-	applicationOffersCollection, closer := st.db().GetCollection(applicationOffersC)
+	applicationOffersCollection, closer, err := st.db().GetCollection(applicationOffersC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var offerDocs []applicationOfferDoc
@@ -405,9 +417,12 @@ func (st *State) removeAllModelPermissions() error {
 // removeAllInCollectionRaw removes all the documents from the given
 // named collection.
 func (st *State) removeAllInCollectionRaw(name string) error {
-	coll, closer := st.db().GetCollection(name)
+	coll, closer, err := st.db().GetCollection(name)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
-	_, err := coll.Writeable().RemoveAll(nil)
+	_, err = coll.Writeable().RemoveAll(nil)
 	return errors.Trace(err)
 }
 
@@ -420,11 +435,14 @@ func (st *State) removeAllInCollectionOps(name string) ([]txn.Op, error) {
 // removeInCollectionOps generates operations to remove all documents
 // from the named collection matching a specific selector.
 func (st *State) removeInCollectionOps(name string, sel interface{}) ([]txn.Op, error) {
-	coll, closer := st.db().GetCollection(name)
+	coll, closer, err := st.db().GetCollection(name)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var ids []bson.M
-	err := coll.Find(sel).Select(bson.D{{"_id", 1}}).All(&ids)
+	err = coll.Find(sel).Select(bson.D{{"_id", 1}}).All(&ids)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -487,7 +505,10 @@ func (st *State) EnsureModelRemoved() error {
 		}
 
 		if err := func(name string, info CollectionInfo) error {
-			coll, closer := st.db().GetCollection(name)
+			coll, closer, err := st.db().GetCollection(name)
+			if err != nil {
+				return errors.Trace(err)
+			}
 			defer closer()
 
 			n, err := coll.Find(nil).Count()
@@ -523,7 +544,7 @@ func (st *State) EnsureModelRemoved() error {
 // a closer function for the session. This is useful where you need to work
 // with various collections in a single session, so don't want to call
 // getCollection multiple times.
-func (st *State) newDB() (Database, func()) {
+func (st *State) newDB() (Database, func(), error) {
 	return st.database.Copy()
 }
 
@@ -587,7 +608,10 @@ func (st *State) checkCanUpgradeIAAS(currentVersion, newVersion string) error {
 	}}}
 	var agentTags []string
 	for _, name := range []string{machinesC, unitsC} {
-		collection, closer := st.db().GetCollection(name)
+		collection, closer, err := st.db().GetCollection(name)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		defer closer()
 		var doc struct {
 			DocID string `bson:"_id"`
@@ -740,7 +764,10 @@ func (st *State) allMachines(machinesCollection mongo.Collection) ([]*Machine, e
 // AllMachines returns all machines in the model
 // ordered by id.
 func (st *State) AllMachines() ([]*Machine, error) {
-	machinesCollection, closer := st.db().GetCollection(machinesC)
+	machinesCollection, closer, err := st.db().GetCollection(machinesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	return st.allMachines(machinesCollection)
 }
@@ -748,7 +775,10 @@ func (st *State) AllMachines() ([]*Machine, error) {
 // MachineCountForBase counts the machines for the provided bases in the model.
 // The bases must all be for the one os.
 func (st *State) MachineCountForBase(base ...Base) (map[string]int, error) {
-	machinesCollection, closer := st.db().GetCollection(machinesC)
+	machinesCollection, closer, err := st.db().GetCollection(machinesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var (
@@ -764,7 +794,7 @@ func (st *State) MachineCountForBase(base ...Base) (map[string]int, error) {
 	}
 
 	var docs []machineDoc
-	err := machinesCollection.Find(bson.D{
+	err = machinesCollection.Find(bson.D{
 		{"base.channel", bson.D{{"$in", channels}}},
 		{"base.os", os},
 	}).Select(bson.M{"base": 1}).All(&docs)
@@ -839,10 +869,12 @@ func (st *State) Machine(id string) (*Machine, error) {
 }
 
 func (st *State) getMachineDoc(id string) (*machineDoc, error) {
-	machinesCollection, closer := st.db().GetCollection(machinesC)
+	machinesCollection, closer, err := st.db().GetCollection(machinesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
-	var err error
 	mdoc := &machineDoc{}
 	err = machinesCollection.FindId(id).One(mdoc)
 
@@ -1663,7 +1695,10 @@ func (st *State) AllUnitAssignments() ([]UnitAssignment, error) {
 }
 
 func (st *State) unitAssignments(query bson.D) ([]UnitAssignment, error) {
-	col, closer := st.db().GetCollection(assignUnitC)
+	col, closer, err := st.db().GetCollection(assignUnitC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []assignUnitDoc
@@ -1889,7 +1924,10 @@ func (st *State) addMachineWithPlacement(unit *Unit, data *placementData) (*Mach
 
 // Application returns an application state by name.
 func (st *State) Application(name string) (_ *Application, err error) {
-	applications, closer := st.db().GetCollection(applicationsC)
+	applications, closer, err := st.db().GetCollection(applicationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	if !names.IsValidApplication(name) {
@@ -1908,7 +1946,10 @@ func (st *State) Application(name string) (_ *Application, err error) {
 
 // AllApplications returns all deployed applications in the model.
 func (st *State) AllApplications() (applications []*Application, err error) {
-	applicationsCollection, closer := st.db().GetCollection(applicationsC)
+	applicationsCollection, closer, err := st.db().GetCollection(applicationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	sdocs := []applicationDoc{}
@@ -2357,11 +2398,14 @@ func (st *State) EndpointsRelation(endpoints ...Endpoint) (*Relation, error) {
 // KeyRelation returns the existing relation with the given key (which can
 // be derived unambiguously from the relation's endpoints).
 func (st *State) KeyRelation(key string) (*Relation, error) {
-	relations, closer := st.db().GetCollection(relationsC)
+	relations, closer, err := st.db().GetCollection(relationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := relationDoc{}
-	err := relations.FindId(key).One(&doc)
+	err = relations.FindId(key).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("relation %q", key)
 	}
@@ -2373,11 +2417,14 @@ func (st *State) KeyRelation(key string) (*Relation, error) {
 
 // Relation returns the existing relation with the given id.
 func (st *State) Relation(id int) (*Relation, error) {
-	relations, closer := st.db().GetCollection(relationsC)
+	relations, closer, err := st.db().GetCollection(relationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := relationDoc{}
-	err := relations.Find(bson.D{{"id", id}}).One(&doc)
+	err = relations.Find(bson.D{{"id", id}}).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("relation %d", id)
 	}
@@ -2389,7 +2436,10 @@ func (st *State) Relation(id int) (*Relation, error) {
 
 // AllRelations returns all relations in the model ordered by id.
 func (st *State) AllRelations() (relations []*Relation, err error) {
-	relationsCollection, closer := st.db().GetCollection(relationsC)
+	relationsCollection, closer, err := st.db().GetCollection(relationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	docs := relationDocSlice{}
@@ -2407,7 +2457,10 @@ func (st *State) AllRelations() (relations []*Relation, err error) {
 // AliveRelationKeys returns the relation keys of all live relations in
 // the model.  Used in charmhub metrics collection.
 func (st *State) AliveRelationKeys() []string {
-	relationsCollection, closer := st.db().GetCollection(relationsC)
+	relationsCollection, closer, err := st.db().GetCollection(relationsC)
+	if err != nil {
+		return nil
+	}
 	defer closer()
 	var doc struct {
 		Key string `bson:"key"`
@@ -2445,11 +2498,14 @@ func (st *State) Unit(name string) (*Unit, error) {
 	if !names.IsValidUnit(name) {
 		return nil, errors.Errorf("%q is not a valid unit name", name)
 	}
-	units, closer := st.db().GetCollection(unitsC)
+	units, closer, err := st.db().GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := unitDoc{}
-	err := units.FindId(name).One(&doc)
+	err = units.FindId(name).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("unit %q", name)
 	}
@@ -2495,7 +2551,10 @@ func (st *State) UnitsInError() ([]*Unit, error) {
 	}
 
 	// Query the units with the names of units in error.
-	units, closer := st.db().GetCollection(unitsC)
+	units, closer, err := st.db().GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []unitDoc
@@ -2576,12 +2635,15 @@ func (st *State) networkEntityGlobalKeyRemoveOp(globalKey string, providerId cor
 }
 
 func (st *State) networkEntityGlobalKeyExists(globalKey string, providerId corenetwork.Id) (bool, error) {
-	col, closer := st.db().GetCollection(providerIDsC)
+	col, closer, err := st.db().GetCollection(providerIDsC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 
 	key := st.networkEntityGlobalKey(globalKey, providerId)
 	var doc providerIdDoc
-	err := col.FindId(key).One(&doc)
+	err = col.FindId(key).One(&doc)
 
 	switch err {
 	case nil:
@@ -2628,10 +2690,13 @@ func (st *State) SLACredential() ([]byte, error) {
 // It is not exported as it is currently
 // only used during upgrades.
 func (st *State) allUnits() ([]*Unit, error) {
-	unitsCollection, closer := st.db().GetCollection(unitsC)
+	unitsCollection, closer, err := st.db().GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var udocs []unitDoc
-	err := unitsCollection.Find(nil).All(&udocs)
+	err = unitsCollection.Find(nil).All(&udocs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get all units")
 	}

--- a/state/status.go
+++ b/state/status.go
@@ -34,11 +34,14 @@ type ModelStatus struct {
 // LoadModelStatus retrieves all the status documents for the model
 // at once. Used to primarily speed up status.
 func (m *Model) LoadModelStatus() (*ModelStatus, error) {
-	statuses, closer := m.st.db().GetCollection(statusesC)
+	statuses, closer, err := m.st.db().GetCollection(statusesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []statusDocWithID
-	err := statuses.Find(nil).All(&docs)
+	err = statuses.Find(nil).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to read status collection")
 	}
@@ -242,7 +245,10 @@ func unixNanoToTime(i int64) *time.Time {
 // is not found, a NotFoundError referencing badge will be returned.
 func getStatus(db Database, globalKey, badge string) (_ status.StatusInfo, err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot get status")
-	statuses, closer := db.GetCollection(statusesC)
+	statuses, closer, err := db.GetCollection(statusesC)
+	if err != nil {
+		return status.StatusInfo{}, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc statusDoc
@@ -257,7 +263,10 @@ func getStatus(db Database, globalKey, badge string) (_ status.StatusInfo, err e
 }
 
 func getEntityKeysForStatus(mb modelBackend, keyType string, status status.Status) ([]string, error) {
-	statuses, closer := mb.db().GetCollection(statusesC)
+	statuses, closer, err := mb.db().GetCollection(statusesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var ids []bson.M
@@ -265,7 +274,7 @@ func getEntityKeysForStatus(mb modelBackend, keyType string, status status.Statu
 		{"_id", bson.D{{"$regex", fmt.Sprintf(".+\\:%s#.+", keyType)}}},
 		{"status", status},
 	}
-	err := statuses.Find(query).Select(bson.D{{"_id", 1}}).All(&ids)
+	err = statuses.Find(query).Select(bson.D{{"_id", 1}}).All(&ids)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -435,7 +444,10 @@ func probablyUpdateStatusHistory(db Database, globalKey string, doc statusDoc) (
 		Updated:    doc.Updated,
 		GlobalKey:  globalKey,
 	}
-	history, closer := db.GetCollection(statusesHistoryC)
+	history, closer, err := db.GetCollection(statusesHistoryC)
+	if err != nil {
+		return false, err
+	}
 	defer closer()
 
 	exists, currentID := statusHistoryExists(db, historyDoc)
@@ -455,7 +467,7 @@ func probablyUpdateStatusHistory(db Database, globalKey string, doc statusDoc) (
 	}
 
 	historyW := history.Writeable()
-	err := historyW.Insert(historyDoc)
+	err = historyW.Insert(historyDoc)
 	if err != nil {
 		logger.Errorf("failed to write status history: %v", err)
 		return false, err
@@ -466,13 +478,16 @@ func probablyUpdateStatusHistory(db Database, globalKey string, doc statusDoc) (
 func statusHistoryExists(db Database, historyDoc *historicalStatusDoc) (bool, bson.ObjectId) {
 	// Find the current value to see if it is worthwhile adding the new
 	// status value.
-	history, closer := db.GetCollection(statusesHistoryC)
+	history, closer, err := db.GetCollection(statusesHistoryC)
+	if err != nil {
+		return false, ""
+	}
 	defer closer()
 
 	var latest []recordedHistoricalStatusDoc
 	query := history.Find(bson.D{{globalKeyField, historyDoc.GlobalKey}})
 	query = query.Sort("-updated").Limit(1)
-	err := query.All(&latest)
+	err = query.All(&latest)
 	if err == nil && len(latest) == 1 {
 		current := latest[0]
 		// Short circuit the writing to the DB if the status, message,
@@ -511,7 +526,10 @@ func eraseStatusHistory(stop <-chan struct{}, mb modelBackend, globalKey string)
 	// recording. This method would then become a single
 	// Remove operation.
 
-	history, closer := mb.db().GetCollection(statusesHistoryC)
+	history, closer, err := mb.db().GetCollection(statusesHistoryC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	iter := history.Find(bson.D{{
@@ -585,7 +603,10 @@ func statusHistory(args *statusHistoryArgs) ([]status.StatusInfo, error) {
 	if err := args.filter.Validate(); err != nil {
 		return nil, errors.Annotate(err, "validating arguments")
 	}
-	statusHistory, closer := args.db.GetCollection(statusesHistoryC)
+	statusHistory, closer, err := args.db.GetCollection(statusesHistoryC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var results []status.StatusInfo
@@ -608,9 +629,12 @@ func statusHistory(args *statusHistoryArgs) ([]status.StatusInfo, error) {
 
 // PruneStatusHistory prunes the status history collection.
 func PruneStatusHistory(stop <-chan struct{}, st *State, maxHistoryTime time.Duration, maxHistoryMB int) error {
-	coll, closer := st.db().GetRawCollection(statusesHistoryC)
+	coll, closer, err := st.db().GetRawCollection(statusesHistoryC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
-	err := pruneCollection(stop, st, maxHistoryTime, maxHistoryMB, coll, "updated", nil, NanoSeconds)
+	err = pruneCollection(stop, st, maxHistoryTime, maxHistoryMB, coll, "updated", nil, NanoSeconds)
 	return errors.Trace(err)
 }

--- a/state/storage.go
+++ b/state/storage.go
@@ -280,11 +280,14 @@ func (sb *storageBackend) StorageInstance(tag names.StorageTag) (StorageInstance
 }
 
 func (sb *storageBackend) storageInstance(tag names.StorageTag) (*storageInstance, error) {
-	storageInstances, cleanup := sb.mb.db().GetCollection(storageInstancesC)
+	storageInstances, cleanup, err := sb.mb.db().GetCollection(storageInstancesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	s := storageInstance{sb: sb}
-	err := storageInstances.FindId(tag.Id()).One(&s.doc)
+	err = storageInstances.FindId(tag.Id()).One(&s.doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("storage instance %q", tag.Id())
 	} else if err != nil {
@@ -309,7 +312,10 @@ func (sb *storageBackend) AllStorageInstances() ([]StorageInstance, error) {
 
 // RemoveStoragePool removes a pool only if its not currently in use
 func (sb *storageBackend) RemoveStoragePool(poolName string) error {
-	storageCollection, closer := sb.mb.db().GetCollection(storageInstancesC)
+	storageCollection, closer, err := sb.mb.db().GetCollection(storageInstancesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	// TODO: Improve the data model to have a count of in use pools so we can
@@ -347,7 +353,10 @@ func (sb *storageBackend) RemoveStoragePool(poolName string) error {
 }
 
 func (sb *storageBackend) storageInstances(query bson.D) (storageInstances []*storageInstance, err error) {
-	storageCollection, closer := sb.mb.db().GetCollection(storageInstancesC)
+	storageCollection, closer, err := sb.mb.db().GetCollection(storageInstancesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	sdocs := []storageInstanceDoc{}
@@ -696,7 +705,10 @@ func validateStorageCountChange(
 // should be called when creating a shared storage instance, or when
 // attaching a non-shared storage instance to a unit.
 func increfEntityStorageOp(mb modelBackend, owner names.Tag, storageName string, n int) (txn.Op, error) {
-	refcounts, closer := mb.db().GetCollection(refcountsC)
+	refcounts, closer, err := mb.db().GetCollection(refcountsC)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
 	defer closer()
 	storageRefcountKey := entityStorageRefcountKey(owner, storageName)
 	incRefOp, err := nsRefcounts.CreateOrIncRefOp(refcounts, storageRefcountKey, n)
@@ -708,7 +720,10 @@ func increfEntityStorageOp(mb modelBackend, owner names.Tag, storageName string,
 // should be called when removing a shared storage instance, or when
 // detaching a non-shared storage instance from a unit.
 func decrefEntityStorageOp(mb modelBackend, owner names.Tag, storageName string) (txn.Op, error) {
-	refcounts, closer := mb.db().GetCollection(refcountsC)
+	refcounts, closer, err := mb.db().GetCollection(refcountsC)
+	if err != nil {
+		return txn.Op{}, errors.Trace(err)
+	}
 	defer closer()
 	storageRefcountKey := entityStorageRefcountKey(owner, storageName)
 	decRefOp, _, err := nsRefcounts.DyingDecRefOp(refcounts, storageRefcountKey)
@@ -977,7 +992,10 @@ func (sb *storageBackend) UnitStorageAttachments(unit names.UnitTag) ([]StorageA
 }
 
 func (sb *storageBackend) storageAttachments(query bson.D) ([]StorageAttachment, error) {
-	coll, closer := sb.mb.db().GetCollection(storageAttachmentsC)
+	coll, closer, err := sb.mb.db().GetCollection(storageAttachmentsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []storageAttachmentDoc
@@ -1001,10 +1019,13 @@ func (sb *storageBackend) StorageAttachment(storage names.StorageTag, unit names
 }
 
 func (sb *storageBackend) storageAttachment(storage names.StorageTag, unit names.UnitTag) (*storageAttachment, error) {
-	coll, closer := sb.mb.db().GetCollection(storageAttachmentsC)
+	coll, closer, err := sb.mb.db().GetCollection(storageAttachmentsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var s storageAttachment
-	err := coll.FindId(storageAttachmentId(unit.Id(), storage.Id())).One(&s.doc)
+	err = coll.FindId(storageAttachmentId(unit.Id(), storage.Id())).One(&s.doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("storage attachment %s:%s", storage.Id(), unit.Id())
 	} else if err != nil {
@@ -1644,11 +1665,14 @@ func (sb *storageBackend) detachStorageAttachmentOps(si *storageInstance, unitTa
 // removeStorageInstancesOps returns the transaction operations to remove all
 // storage instances owned by the specified entity.
 func removeStorageInstancesOps(im *storageBackend, owner names.Tag, force bool) ([]txn.Op, error) {
-	coll, closer := im.mb.db().GetCollection(storageInstancesC)
+	coll, closer, err := im.mb.db().GetCollection(storageInstancesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []storageInstanceDoc
-	err := coll.Find(bson.D{{"owner", owner.String()}}).Select(bson.D{{"id", true}}).All(&docs)
+	err = coll.Find(bson.D{{"owner", owner.String()}}).Select(bson.D{{"id", true}}).All(&docs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot get storage instances for %s", owner)
 	}
@@ -1733,11 +1757,14 @@ func removeStorageConstraintsOp(key string) txn.Op {
 }
 
 func readStorageConstraints(mb modelBackend, key string) (map[string]StorageConstraints, error) {
-	coll, closer := mb.db().GetCollection(storageConstraintsC)
+	coll, closer, err := mb.db().GetCollection(storageConstraintsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc storageConstraintsDoc
-	err := coll.FindId(key).One(&doc)
+	err = coll.FindId(key).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("storage constraints for %q", key)
 	}
@@ -2296,7 +2323,10 @@ func (sb *storageBackend) addUnitStorageOps(
 }
 
 func (sb *storageBackend) countEntityStorageInstances(owner names.Tag, name string) (txn.Op, int, error) {
-	refcounts, closer := sb.mb.db().GetCollection(refcountsC)
+	refcounts, closer, err := sb.mb.db().GetCollection(refcountsC)
+	if err != nil {
+		return txn.Op{}, 0, errors.Trace(err)
+	}
 	defer closer()
 	key := entityStorageRefcountKey(owner, name)
 	return nsRefcounts.CurrentOp(refcounts, key)

--- a/state/storage/storage.go
+++ b/state/storage/storage.go
@@ -7,7 +7,10 @@ import (
 	"io"
 
 	"github.com/juju/blobstore/v3"
+	"github.com/juju/errors"
 	"github.com/juju/mgo/v3"
+
+	"github.com/juju/juju/mongo"
 )
 
 const (
@@ -51,15 +54,21 @@ type stateStorage struct {
 	session   *mgo.Session
 }
 
-func (s stateStorage) blobstore() (*mgo.Session, blobstore.ManagedStorage) {
-	session := s.session.Copy()
+func (s stateStorage) blobstore() (*mgo.Session, blobstore.ManagedStorage, error) {
+	session, err := mongo.CopySession(s.session)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
 	rs := blobstore.NewGridFS(blobstoreDB, blobstoreDB, session)
 	db := session.DB(metadataDB)
-	return session, blobstore.NewManagedStorage(db, rs)
+	return session, blobstore.NewManagedStorage(db, rs), nil
 }
 
 func (s stateStorage) Get(path string) (r io.ReadCloser, length int64, err error) {
-	session, ms := s.blobstore()
+	session, ms, err := s.blobstore()
+	if err != nil {
+		return nil, -1, errors.Trace(err)
+	}
 	r, length, err = ms.GetForBucket(s.modelUUID, path)
 	if err != nil {
 		session.Close()
@@ -69,19 +78,28 @@ func (s stateStorage) Get(path string) (r io.ReadCloser, length int64, err error
 }
 
 func (s stateStorage) Put(path string, r io.Reader, length int64) error {
-	session, ms := s.blobstore()
+	session, ms, err := s.blobstore()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer session.Close()
 	return ms.PutForBucket(s.modelUUID, path, r, length)
 }
 
 func (s stateStorage) PutAndCheckHash(path string, r io.Reader, length int64, hash string) error {
-	session, ms := s.blobstore()
+	session, ms, err := s.blobstore()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer session.Close()
 	return ms.PutForBucketAndCheckHash(s.modelUUID, path, r, length, hash)
 }
 
 func (s stateStorage) Remove(path string) error {
-	session, ms := s.blobstore()
+	session, ms, err := s.blobstore()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer session.Close()
 	return ms.RemoveForBucket(s.modelUUID, path)
 }

--- a/state/subnets.go
+++ b/state/subnets.go
@@ -205,10 +205,13 @@ func (s *Subnet) ProviderNetworkId() network.Id {
 // state. It an error that satisfies errors.IsNotFound if the SubnetByCIDR has
 // been removed.
 func (s *Subnet) Refresh() error {
-	subnets, closer := s.st.db().GetCollection(subnetsC)
+	subnets, closer, err := s.st.db().GetCollection(subnetsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
-	err := subnets.FindId(s.doc.DocID).One(&s.doc)
+	err = subnets.FindId(s.doc.DocID).One(&s.doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("subnet %q", s)
 	}
@@ -223,19 +226,23 @@ func (s *Subnet) Refresh() error {
 
 func (s *Subnet) setSpace(subnets mongo.Collection) error {
 	s.spaceID = s.doc.SpaceID
+	var err error
 	if s.doc.FanLocalUnderlay == "" {
 		return nil
 	}
 	if subnets == nil {
 		// Some callers have the mongo subnet collection already; some do not.
 		var closer SessionCloser
-		subnets, closer = s.st.db().GetCollection(subnetsC)
+		subnets, closer, err = s.st.db().GetCollection(subnetsC)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		defer closer()
 	}
 	overlayDoc := &subnetDoc{}
 	// TODO: (hml) 2019-08-06
 	// Rethink the bson logic once multiple subnets can have the same cidr.
-	err := subnets.Find(bson.M{"cidr": s.doc.FanLocalUnderlay}).One(overlayDoc)
+	err = subnets.Find(bson.M{"cidr": s.doc.FanLocalUnderlay}).One(overlayDoc)
 	if err == mgo.ErrNotFound {
 		logger.Errorf("unable to update spaceID for subnet %q %q: underlay network %q: %s",
 			s.doc.ID, s.doc.CIDR, s.doc.FanLocalUnderlay, err.Error())
@@ -484,7 +491,10 @@ func (st *State) addSubnetOps(id string, args network.SubnetInfo) (subnetDoc, []
 }
 
 func (st *State) uniqueSubnet(cidr, providerID string) (bool, error) {
-	subnets, closer := st.db().GetCollection(subnetsC)
+	subnets, closer, err := st.db().GetCollection(subnetsC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 
 	pID := bson.D{{"providerid", providerID}}
@@ -550,11 +560,14 @@ func (st *State) SubnetsByCIDR(cidr string) ([]*Subnet, error) {
 }
 
 func (st *State) subnets(exp bson.M) ([]*Subnet, error) {
-	col, closer := st.db().GetCollection(subnetsC)
+	col, closer, err := st.db().GetCollection(subnetsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []subnetDoc
-	err := col.Find(exp).All(&docs)
+	err = col.Find(exp).All(&docs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -574,7 +587,10 @@ func (st *State) subnets(exp bson.M) ([]*Subnet, error) {
 
 // AllSubnets returns all known subnets in the model.
 func (st *State) AllSubnets() (subnets []*Subnet, err error) {
-	subnetsCollection, closer := st.db().GetCollection(subnetsC)
+	subnetsCollection, closer, err := st.db().GetCollection(subnetsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var docs []subnetDoc

--- a/state/txns.go
+++ b/state/txns.go
@@ -16,13 +16,16 @@ import (
 )
 
 func readTxnRevno(db Database, collectionName string, id interface{}) (int64, error) {
-	collection, closer := db.GetCollection(collectionName)
+	collection, closer, err := db.GetCollection(collectionName)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
 	defer closer()
 	query := collection.FindId(id).Select(bson.D{{"txn-revno", 1}})
 	var result struct {
 		TxnRevno int64 `bson:"txn-revno"`
 	}
-	err := query.One(&result)
+	err = query.One(&result)
 	return result.TxnRevno, errors.Trace(err)
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -1354,10 +1354,13 @@ func (u *Unit) AvailabilityZone() (string, error) {
 // state. It an error that satisfies errors.IsNotFound if the unit has
 // been removed.
 func (u *Unit) Refresh() error {
-	units, closer := u.st.db().GetCollection(unitsC)
+	units, closer, err := u.st.db().GetCollection(unitsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
-	err := units.FindId(u.doc.DocID).One(&u.doc)
+	err = units.FindId(u.doc.DocID).One(&u.doc)
 	if err == mgo.ErrNotFound {
 		return errors.NotFoundf("unit %q", u)
 	}
@@ -1534,11 +1537,20 @@ func (u *Unit) SetCharmURL(curl string) error {
 		return errors.Errorf("cannot set empty charm url")
 	}
 
-	db, dbCloser := u.st.newDB()
+	db, dbCloser, err := u.st.newDB()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer dbCloser()
-	units, uCloser := db.GetCollection(unitsC)
+	units, uCloser, err := db.GetCollection(unitsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer uCloser()
-	charms, cCloser := db.GetCollection(charmsC)
+	charms, cCloser, err := db.GetCollection(charmsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer cCloser()
 
 	buildTxn := func(attempt int) ([]txn.Op, error) {
@@ -1600,7 +1612,7 @@ func (u *Unit) SetCharmURL(curl string) error {
 		}
 		return ops, nil
 	}
-	err := u.st.db().Run(buildTxn)
+	err = u.st.db().Run(buildTxn)
 	if err == nil {
 		u.doc.CharmURL = &curl
 	}
@@ -2119,7 +2131,10 @@ func (u *Unit) AssignToNewMachineOrContainer() (err error) {
 	if err != nil {
 		return err
 	}
-	machinesCollection, closer := u.st.db().GetCollection(machinesC)
+	machinesCollection, closer, err := u.st.db().GetCollection(machinesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	var host machineDoc
 	if err := machinesCollection.Find(query).One(&host); err == mgo.ErrNotFound {
@@ -2496,7 +2511,10 @@ var hasNoContainersTerm = bson.DocElem{
 // findCleanMachineQuery returns a Mongo query to find clean (and maybe empty)
 // machines with characteristics matching the specified constraints.
 func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value) (bson.D, error) {
-	db, dbCloser := u.st.newDB()
+	db, dbCloser, err := u.st.newDB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer dbCloser()
 
 	// Select all machines that can accept principal units and are clean.
@@ -2504,10 +2522,13 @@ func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value)
 	// If we need empty machines, first build up a list of machine ids which
 	// have containers so we can exclude those.
 	if requireEmpty {
-		containerRefsCollection, cCloser := db.GetCollection(containerRefsC)
+		containerRefsCollection, cCloser, err := db.GetCollection(containerRefsC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer cCloser()
 
-		err := containerRefsCollection.Find(bson.D{hasContainerTerm}).All(&containerRefs)
+		err = containerRefsCollection.Find(bson.D{hasContainerTerm}).All(&containerRefs)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -2597,11 +2618,14 @@ func (u *Unit) findCleanMachineQuery(requireEmpty bool, cons *constraints.Value)
 		suitableTerms = append(suitableTerms, bson.DocElem{"imageid", *cons.ImageID})
 	}
 	if len(suitableTerms) > 0 {
-		instanceDataCollection, iCloser := db.GetCollection(instanceDataC)
+		instanceDataCollection, iCloser, err := db.GetCollection(instanceDataC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer iCloser()
 
 		var suitableInstanceData []instanceData
-		err := instanceDataCollection.Find(suitableTerms).Select(bson.M{"_id": 1}).All(&suitableInstanceData)
+		err = instanceDataCollection.Find(suitableTerms).Select(bson.M{"_id": 1}).All(&suitableInstanceData)
 		if err != nil {
 			return nil, err
 		}
@@ -2691,7 +2715,10 @@ func (u *Unit) assignToCleanMaybeEmptyMachineOps(requireEmpty bool) (_ *Machine,
 	// instances for those that are provisioned. Instances
 	// will be distributed across in preference to
 	// unprovisioned machines.
-	machinesCollection, closer := u.st.db().GetCollection(machinesC)
+	machinesCollection, closer, err := u.st.db().GetCollection(machinesC)
+	if err != nil {
+		return failure(errors.Trace(err))
+	}
 	defer closer()
 	var mdocs []*machineDoc
 	if err := machinesCollection.Find(query).All(&mdocs); err != nil {
@@ -3076,7 +3103,10 @@ func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) 
 		return "", "", errors.Trace(err)
 	}
 
-	coll, closer := u.st.db().GetCollection(machineUpgradeSeriesLocksC)
+	coll, closer, err := u.st.db().GetCollection(machineUpgradeSeriesLocksC)
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
 	defer closer()
 
 	var lock upgradeSeriesLockDoc

--- a/state/unit_ops.go
+++ b/state/unit_ops.go
@@ -44,7 +44,10 @@ func (op *unitSetStateOperation) buildTxn(attempt int) ([]txn.Op, error) {
 		return nil, errors.Annotatef(errors.NotFoundf("unit %s", op.u.Name()), "cannot persist state for unit %q", op.u)
 	}
 
-	coll, closer := op.u.st.db().GetCollection(unitStatesC)
+	coll, closer, err := op.u.st.db().GetCollection(unitStatesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	// The state of a unit can only be updated if it is currently alive.

--- a/state/unitstate.go
+++ b/state/unitstate.go
@@ -243,7 +243,10 @@ func (u *Unit) State() (*UnitState, error) {
 		return us, errors.NotFoundf("unit %s", u.Name())
 	}
 
-	coll, closer := u.st.db().GetCollection(unitStatesC)
+	coll, closer, err := u.st.db().GetCollection(unitStatesC)
+	if err != nil {
+		return us, errors.Trace(err)
+	}
 	defer closer()
 
 	var stDoc unitStateDoc

--- a/state/upgrade.go
+++ b/state/upgrade.go
@@ -167,7 +167,10 @@ func (info *UpgradeInfo) getProvisionedControllers() ([]string, error) {
 	}
 
 	// Extract current and provisioned controllers.
-	instanceData, closer := info.st.db().GetRawCollection(instanceDataC)
+	instanceData, closer, err := info.st.db().GetRawCollection(instanceDataC)
+	if err != nil {
+		return provisioned, errors.Trace(err)
+	}
 	defer closer()
 
 	query := bson.D{
@@ -370,7 +373,10 @@ func (st *State) EnsureUpgradeInfo(
 }
 
 func (st *State) isMachineProvisioned(machineId string) (bool, error) {
-	instanceData, closer := st.db().GetRawCollection(instanceDataC)
+	instanceData, closer, err := st.db().GetRawCollection(instanceDataC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 
 	for _, id := range []string{st.docID(machineId), machineId} {
@@ -547,7 +553,10 @@ func (st *State) AbortCurrentUpgrade() error {
 
 func currentUpgradeInfoDoc(st *State) (*upgradeInfoDoc, error) {
 	var doc upgradeInfoDoc
-	upgradeInfo, closer := st.db().GetCollection(upgradeInfoC)
+	upgradeInfo, closer, err := st.db().GetCollection(upgradeInfoC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	if err := upgradeInfo.FindId(currentUpgradeId).One(&doc); err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("current upgrade info")

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -38,7 +38,10 @@ func runForAllModelStates(pool *StatePool, runner func(st *State) error) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	models, closer := st.db().GetCollection(modelsC)
+	models, closer, err := st.db().GetCollection(modelsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var modelDocs []bson.M
@@ -75,7 +78,10 @@ func applyToAllModelSettings(st *State, change func(*settingsDoc) (bool, error))
 		return errors.Trace(err)
 	}
 
-	coll, closer := st.db().GetRawCollection(settingsC)
+	coll, closer, err := st.db().GetRawCollection(settingsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var ids []string
@@ -118,7 +124,10 @@ func AddVirtualHostKeys(pool *StatePool) error {
 		return errors.Trace(err)
 	}
 
-	virtualHostKeysCollection, vhkCloser := st.db().GetRawCollection(virtualHostKeysC)
+	virtualHostKeysCollection, vhkCloser, err := st.db().GetRawCollection(virtualHostKeysC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer vhkCloser()
 	virtualHostKeys := []virtualHostKeyDoc{}
 	err = virtualHostKeysCollection.Find(nil).All(&virtualHostKeys)
@@ -131,7 +140,10 @@ func AddVirtualHostKeys(pool *StatePool) error {
 		hostKeyMap[virtualHostKey.DocId] = struct{}{}
 	}
 
-	machinesCollection, machineCloser := st.db().GetRawCollection(machinesC)
+	machinesCollection, machineCloser, err := st.db().GetRawCollection(machinesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer machineCloser()
 	mdocs := machineDocSlice{}
 	err = machinesCollection.Find(nil).All(&mdocs)
@@ -230,7 +242,10 @@ func SplitMigrationStatusMessages(pool *StatePool) error {
 		return errors.Trace(err)
 	}
 
-	migStatus, closer := st.db().GetCollection(migrationsStatusC)
+	migStatus, closer, err := st.db().GetCollection(migrationsStatusC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	iter := migStatus.Find(nil).Iter()
@@ -279,7 +294,10 @@ func OpenControllerAPIPort(pool *StatePool) error {
 	}
 	apiPort := controllerCfg.APIPort()
 
-	unitsColl, closer := st.db().GetRawCollection(unitsC)
+	unitsColl, closer, err := st.db().GetRawCollection(unitsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var controllerUnits []unitDoc
@@ -331,7 +349,10 @@ func ExposeControllerApplication(pool *StatePool) error {
 		return errors.Trace(err)
 	}
 
-	appsColl, closer := st.db().GetCollection(applicationsC)
+	appsColl, closer, err := st.db().GetCollection(applicationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	var appData bson.M
 	err = appsColl.Find(bson.M{"_id": controllerAppName}).Select(bson.M{"exposed": 1}).One(&appData)
@@ -386,7 +407,10 @@ func PopulateApplicationStorageUniqueID(
 			return nil
 		}
 
-		applicationsColl, closer := st.db().GetCollection(applicationsC)
+		applicationsColl, closer, err := st.db().GetCollection(applicationsC)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		defer closer()
 
 		// Fetch the list of applications with an empty storage unique ID.
@@ -448,7 +472,10 @@ func ConvertScalingToCurrentOperationEnumField(pool *StatePool) error {
 			return nil
 		}
 
-		applicationsColl, closer := st.db().GetCollection(applicationsC)
+		applicationsColl, closer, err := st.db().GetCollection(applicationsC)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		defer closer()
 
 		query := bson.M{"provisioning-state.scaling": bson.M{"$exists": true}}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -124,17 +124,19 @@ func (s *upgradesSuite) TestUpgradeAddVirtualHostKeys(c *gc.C) {
 		_ = k8sModel.Close()
 	}()
 
-	machinesColl, machinesCloser := s.state.db().GetRawCollection(machinesC)
+	machinesColl, machinesCloser, err := s.state.db().GetRawCollection(machinesC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer machinesCloser()
 
-	err := machinesColl.Insert(bson.M{
+	err = machinesColl.Insert(bson.M{
 		"_id":        ensureModelUUID(machineModel.ModelUUID(), "1"),
 		"machineid":  "1",
 		"model-uuid": machineModel.ModelUUID(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	unitsColl, unitsCloser := s.state.db().GetRawCollection(unitsC)
+	unitsColl, unitsCloser, err := s.state.db().GetRawCollection(unitsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer unitsCloser()
 
 	// The first unit is on a machine model and the second on a k8s model.
@@ -152,7 +154,8 @@ func (s *upgradesSuite) TestUpgradeAddVirtualHostKeys(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	virtualHostKeysColl, vhkCloser := s.state.db().GetRawCollection(virtualHostKeysC)
+	virtualHostKeysColl, vhkCloser, err := s.state.db().GetRawCollection(virtualHostKeysC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer vhkCloser()
 
 	// The hostkey values below are ignored by the checker but must still exist for deepEquals to work.
@@ -182,13 +185,15 @@ func (s *upgradesSuite) TestSplitMigrationStatusMessages(c *gc.C) {
 	model := s.makeModel(c, "m", coretesting.Attrs{}, ModelArgs{Type: ModelTypeIAAS})
 	defer func() { _ = model.Close() }()
 
-	migStatus, closer := s.state.db().GetRawCollection(migrationsStatusC)
+	migStatus, closer, err := s.state.db().GetRawCollection(migrationsStatusC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
-	migStatusMessage, closer2 := s.state.db().GetRawCollection(migrationsStatusMessageC)
+	migStatusMessage, closer2, err := s.state.db().GetRawCollection(migrationsStatusMessageC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer2()
 
-	err := migStatus.Insert(bson.M{
+	err = migStatus.Insert(bson.M{
 		"_id":                ensureModelUUID(model.ModelUUID(), "0"),
 		"start-time":         "1742996705546941797",
 		"success-time":       "1742996716038789910",
@@ -249,7 +254,8 @@ func (s *upgradesSuite) TestOpenControllerAPIPort(c *gc.C) {
 	err = s.state.ApplyOperation(pcp.Changes())
 	c.Assert(err, jc.ErrorIsNil)
 
-	openPorts, closer := s.state.db().GetRawCollection(openedPortsC)
+	openPorts, closer, err := s.state.db().GetRawCollection(openedPortsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	s.assertUpgradedData(c, OpenControllerAPIPort, nil,
@@ -289,11 +295,12 @@ func (s *upgradesSuite) TestOpenControllerAPIPort(c *gc.C) {
 func (s *upgradesSuite) TestExposeControllerApplication(c *gc.C) {
 	AddTestingApplication(c, s.state, "controller", AddTestingCharm(c, s.state, "wordpress"))
 
-	appsColl, closer := s.state.db().GetRawCollection(applicationsC)
+	appsColl, closer, err := s.state.db().GetRawCollection(applicationsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	var appData bson.M
-	err := appsColl.Find(bson.M{"_id": s.state.docID(controllerAppName)}).One(&appData)
+	err = appsColl.Find(bson.M{"_id": s.state.docID(controllerAppName)}).One(&appData)
 	c.Assert(err, jc.ErrorIsNil)
 	exposed, ok := appData["exposed"].(bool)
 	c.Assert(ok, jc.IsTrue)
@@ -319,7 +326,8 @@ func (s *upgradesSuite) TestPopulateApplicationStorageUniqueID(c *gc.C) {
 		_ = state2.Close()
 	}()
 
-	appColl1, closer := state1.db().GetRawCollection(applicationsC)
+	appColl1, closer, err := state1.db().GetRawCollection(applicationsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	model1, err := state1.Model()
@@ -353,7 +361,8 @@ func (s *upgradesSuite) TestPopulateApplicationStorageUniqueID(c *gc.C) {
 	model2, err := state2.Model()
 	c.Assert(err, gc.IsNil)
 
-	appColl2, closer := state2.db().GetRawCollection(applicationsC)
+	appColl2, closer, err := state2.db().GetRawCollection(applicationsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	err = appColl2.Insert(bson.M{
@@ -471,7 +480,8 @@ func (s *upgradesSuite) TestConvertScalingToCurrentOperationEnumField(c *gc.C) {
 	}()
 
 	// Insert apps to model1 (CAAS model)
-	appColl1, closer := state1.db().GetRawCollection(applicationsC)
+	appColl1, closer, err := state1.db().GetRawCollection(applicationsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	model1, err := state1.Model()
@@ -532,7 +542,8 @@ func (s *upgradesSuite) TestConvertScalingToCurrentOperationEnumField(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	appColl2, closer := state2.db().GetRawCollection(applicationsC)
+	appColl2, closer, err := state2.db().GetRawCollection(applicationsC)
+	c.Assert(err, jc.ErrorIsNil)
 	defer closer()
 
 	// Insert apps to model2 (IAAS model)

--- a/state/user.go
+++ b/state/user.go
@@ -39,11 +39,13 @@ func userIDFromGlobalKey(key string) string {
 func (st *State) checkUserExists(name string) (bool, error) {
 	lowercaseName := strings.ToLower(name)
 
-	users, closer := st.db().GetCollection(usersC)
+	users, closer, err := st.db().GetCollection(usersC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 
 	var count int
-	var err error
 	if count, err = users.FindId(lowercaseName).Count(); err != nil {
 		return false, err
 	}
@@ -336,11 +338,14 @@ func createInitialUserOps(controllerUUID string, user names.UserTag, password, s
 // getUser fetches information about the user with the
 // given name into the provided userDoc.
 func (st *State) getUser(name string, udoc *userDoc) error {
-	users, closer := st.db().GetCollection(usersC)
+	users, closer, err := st.db().GetCollection(usersC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	name = strings.ToLower(name)
-	err := users.Find(bson.D{{"_id", name}}).One(udoc)
+	err = users.Find(bson.D{{"_id", name}}).One(udoc)
 	if err == mgo.ErrNotFound {
 		err = errors.NotFoundf("user %q", name)
 	}
@@ -375,7 +380,10 @@ func (st *State) User(tag names.UserTag) (*User, error) {
 func (st *State) AllUsers(includeDeactivated bool) ([]*User, error) {
 	var result []*User
 
-	users, closer := st.db().GetCollection(usersC)
+	users, closer, err := st.db().GetCollection(usersC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var query bson.D
@@ -496,11 +504,14 @@ func (u *User) UserTag() names.UserTag {
 // normal case, the LastLogin is the last time that the user connected through
 // the API server.
 func (u *User) LastLogin() (time.Time, error) {
-	lastLogins, closer := u.st.db().GetRawCollection(userLastLoginC)
+	lastLogins, closer, err := u.st.db().GetRawCollection(userLastLoginC)
+	if err != nil {
+		return time.Time{}, errors.Trace(err)
+	}
 	defer closer()
 
 	var lastLogin userLastLoginDoc
-	err := lastLogins.FindId(u.doc.DocID).Select(bson.D{{"last-login", 1}}).One(&lastLogin)
+	err = lastLogins.FindId(u.doc.DocID).Select(bson.D{{"last-login", 1}}).One(&lastLogin)
 	if err != nil {
 		if err == mgo.ErrNotFound {
 			err = errors.Wrap(err, newNeverLoggedInError(u.UserTag().Name()))
@@ -517,7 +528,10 @@ func (u *User) UpdateLastLogin() (err error) {
 	if err := u.ensureNotDeleted(); err != nil {
 		return errors.Annotate(err, "cannot update last login")
 	}
-	lastLogins, closer := u.st.db().GetCollection(userLastLoginC)
+	lastLogins, closer, err := u.st.db().GetCollection(userLastLoginC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	lastLoginsW := lastLogins.Writeable()

--- a/state/userpermission.go
+++ b/state/userpermission.go
@@ -42,11 +42,14 @@ func accessToString(a permission.Access) string {
 // userPermission returns a Permission for the given Subject and User.
 func (st *State) userPermission(objectGlobalKey, subjectGlobalKey string) (*userPermission, error) {
 	result := &userPermission{}
-	permissions, closer := st.db().GetCollection(permissionsC)
+	permissions, closer, err := st.db().GetCollection(permissionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	id := permissionID(objectGlobalKey, subjectGlobalKey)
-	err := permissions.FindId(id).One(&result.doc)
+	err = permissions.FindId(id).One(&result.doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("user permission for %q on %q", subjectGlobalKey, objectGlobalKey)
 	}
@@ -55,7 +58,10 @@ func (st *State) userPermission(objectGlobalKey, subjectGlobalKey string) (*user
 
 // usersPermissions returns all permissions for a given object.
 func (st *State) usersPermissions(objectGlobalKey string) ([]*userPermission, error) {
-	permissions, closer := st.db().GetCollection(permissionsC)
+	permissions, closer, err := st.db().GetCollection(permissionsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	var matchingPermissions []permissionDoc

--- a/state/virtualhostkeys.go
+++ b/state/virtualhostkeys.go
@@ -106,11 +106,14 @@ func (st *State) UnitVirtualHostKey(unitID string) (*VirtualHostKey, error) {
 }
 
 func (st *State) virtualHostKey(id string) (*VirtualHostKey, error) {
-	vhkeys, closer := st.db().GetCollection(virtualHostKeysC)
+	vhkeys, closer, err := st.db().GetCollection(virtualHostKeysC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	doc := virtualHostKeyDoc{}
-	err := vhkeys.FindId(st.docID(id)).One(&doc)
+	err = vhkeys.FindId(st.docID(id)).One(&doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("virtual host key %q", id)
 	}
@@ -125,10 +128,13 @@ func (st *State) virtualHostKey(id string) (*VirtualHostKey, error) {
 // AllVirtualHostKeys returns all virtual host keys.
 func (st *State) AllVirtualHostKeys() ([]*VirtualHostKey, error) {
 	var vhkDocs []virtualHostKeyDoc
-	virtualHostKeysCollection, closer := st.db().GetCollection(virtualHostKeysC)
+	virtualHostKeysCollection, closer, err := st.db().GetCollection(virtualHostKeysC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
-	err := virtualHostKeysCollection.Find(nil).All(&vhkDocs)
+	err = virtualHostKeysCollection.Find(nil).All(&vhkDocs)
 	if err != nil {
 		return nil, errors.Annotatef(err, "getting all virtual host keys")
 	}

--- a/state/volume.go
+++ b/state/volume.go
@@ -430,11 +430,14 @@ func getVolumeDoc(db Database, query bson.D, description string) (volumeDoc, err
 }
 
 func getVolumeDocs(db Database, query interface{}) ([]volumeDoc, error) {
-	coll, cleanup := db.GetCollection(volumesC)
+	coll, cleanup, err := db.GetCollection(volumesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var docs []volumeDoc
-	err := coll.Find(query).All(&docs)
+	err = coll.Find(query).All(&docs)
 	if err != nil {
 		return nil, errors.Annotate(err, "querying volumes")
 	}
@@ -471,11 +474,14 @@ func (sb *storageBackend) StorageInstanceVolume(tag names.StorageTag) (Volume, e
 // VolumeAttachment returns the VolumeAttachment corresponding to
 // the specified volume and machine.
 func (sb *storageBackend) VolumeAttachment(host names.Tag, volume names.VolumeTag) (VolumeAttachment, error) {
-	coll, cleanup := sb.mb.db().GetCollection(volumeAttachmentsC)
+	coll, cleanup, err := sb.mb.db().GetCollection(volumeAttachmentsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var att volumeAttachment
-	err := coll.FindId(volumeAttachmentId(host.Id(), volume.Id())).One(&att.doc)
+	err = coll.FindId(volumeAttachmentId(host.Id(), volume.Id())).One(&att.doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("volume %q on %q", volume.Id(), names.ReadableString(host))
 	} else if err != nil {
@@ -485,11 +491,14 @@ func (sb *storageBackend) VolumeAttachment(host names.Tag, volume names.VolumeTa
 }
 
 func (sb *storageBackend) VolumeAttachmentPlan(host names.Tag, volume names.VolumeTag) (VolumeAttachmentPlan, error) {
-	coll, cleanup := sb.mb.db().GetCollection(volumeAttachmentPlanC)
+	coll, cleanup, err := sb.mb.db().GetCollection(volumeAttachmentPlanC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var att volumeAttachmentPlan
-	err := coll.FindId(volumeAttachmentId(host.Id(), volume.Id())).One(&att.doc)
+	err = coll.FindId(volumeAttachmentId(host.Id(), volume.Id())).One(&att.doc)
 	if err == mgo.ErrNotFound {
 		return nil, errors.NotFoundf("volume attachment plan %q on host %q", volume.Id(), host.Id())
 	} else if err != nil {
@@ -529,11 +538,14 @@ func (sb *storageBackend) VolumeAttachments(volume names.VolumeTag) ([]VolumeAtt
 }
 
 func (sb *storageBackend) volumeAttachments(query bson.D) ([]VolumeAttachment, error) {
-	coll, cleanup := sb.mb.db().GetCollection(volumeAttachmentsC)
+	coll, cleanup, err := sb.mb.db().GetCollection(volumeAttachmentsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var docs []volumeAttachmentDoc
-	err := coll.Find(query).All(&docs)
+	err = coll.Find(query).All(&docs)
 	if err == mgo.ErrNotFound {
 		return nil, nil
 	} else if err != nil {
@@ -566,11 +578,14 @@ func (sb *storageBackend) VolumeAttachmentPlans(volume names.VolumeTag) ([]Volum
 }
 
 func (sb *storageBackend) volumeAttachmentPlans(query bson.D) ([]VolumeAttachmentPlan, error) {
-	coll, cleanup := sb.mb.db().GetCollection(volumeAttachmentPlanC)
+	coll, cleanup, err := sb.mb.db().GetCollection(volumeAttachmentPlanC)
+	if err != nil {
+		return []VolumeAttachmentPlan{}, errors.Trace(err)
+	}
 	defer cleanup()
 
 	var docs []volumeAttachmentPlanDoc
-	err := coll.Find(query).All(&docs)
+	err = coll.Find(query).All(&docs)
 	if err == mgo.ErrNotFound {
 		return []VolumeAttachmentPlan{}, nil
 	} else if err != nil {

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -183,7 +183,7 @@ type lifecycleWatcher struct {
 
 	// coll is a function returning the mongo.Collection holding all
 	// interesting entities
-	coll     func() (mongo.Collection, func())
+	coll     func() (mongo.Collection, func(), error)
 	collName string
 
 	// members is used to select the initial set of interesting entities.
@@ -197,8 +197,8 @@ type lifecycleWatcher struct {
 	life map[string]Life
 }
 
-func collFactory(db Database, collName string) func() (mongo.Collection, func()) {
-	return func() (mongo.Collection, func()) {
+func collFactory(db Database, collName string) func() (mongo.Collection, func(), error) {
+	return func() (mongo.Collection, func(), error) {
 		return db.GetCollection(collName)
 	}
 }
@@ -472,7 +472,10 @@ func (a *Application) WatchScale() NotifyWatcher {
 		if k != a.doc.Name {
 			return false
 		}
-		applications, closer := a.st.db().GetCollection(applicationsC)
+		applications, closer, err := a.st.db().GetCollection(applicationsC)
+		if err != nil {
+			return false
+		}
 		defer closer()
 
 		var scaleField = bson.D{{"scale", 1}}
@@ -668,7 +671,10 @@ func (w *modelMachineStartTimeWatcher) loop() error {
 }
 
 func (w *modelMachineStartTimeWatcher) initialMachineSet() (set.Strings, error) {
-	coll, closer := w.db.GetCollection(machinesC)
+	coll, closer, err := w.db.GetCollection(machinesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	// Select the fields we need from documents that are not referring to
@@ -690,7 +696,10 @@ func (w *modelMachineStartTimeWatcher) initialMachineSet() (set.Strings, error) 
 }
 
 func (w *modelMachineStartTimeWatcher) processChanges(pendingDocs set.Strings) (set.Strings, error) {
-	coll, closer := w.db.GetCollection(machinesC)
+	coll, closer, err := w.db.GetCollection(machinesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	// Select the fields we need from the changed documents that are not
@@ -813,7 +822,10 @@ func (w *lifecycleWatcher) Changes() <-chan []string {
 }
 
 func (w *lifecycleWatcher) initial() (set.Strings, error) {
-	coll, closer := w.coll()
+	coll, closer, err := w.coll()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	ids := make(set.Strings)
@@ -835,7 +847,10 @@ func (w *lifecycleWatcher) initial() (set.Strings, error) {
 }
 
 func (w *lifecycleWatcher) merge(ids set.Strings, updates map[interface{}]bool) error {
-	coll, closer := w.coll()
+	coll, closer, err := w.coll()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	// Separate ids into those thought to exist and those known to be removed.
@@ -975,7 +990,10 @@ func (st *State) WatchMinUnits() StringsWatcher {
 func (w *minUnitsWatcher) initial() (set.Strings, error) {
 	applicationnames := make(set.Strings)
 	var doc minUnitsDoc
-	newMinUnits, closer := w.db.GetCollection(minUnitsC)
+	newMinUnits, closer, err := w.db.GetCollection(minUnitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	iter := newMinUnits.Find(nil).Iter()
@@ -994,7 +1012,10 @@ func (w *minUnitsWatcher) merge(applicationnames set.Strings, change watcher.Cha
 		return nil
 	}
 	doc := minUnitsDoc{}
-	newMinUnits, closer := w.db.GetCollection(minUnitsC)
+	newMinUnits, closer, err := w.db.GetCollection(minUnitsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 	if err := newMinUnits.FindId(change.Id).One(&doc); err != nil {
 		return err
@@ -1131,7 +1152,10 @@ func (w *RelationScopeWatcher) Changes() <-chan *RelationScopeChange {
 
 // initialInfo returns an uncommitted scopeInfo with the current set of units.
 func (w *RelationScopeWatcher) initialInfo() (info *scopeInfo, err error) {
-	relationScopes, closer := w.db.GetCollection(relationScopesC)
+	relationScopes, closer, err := w.db.GetCollection(relationScopesC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	docs := []relationScopeDoc{}
@@ -1161,7 +1185,10 @@ func (w *RelationScopeWatcher) initialInfo() (info *scopeInfo, err error) {
 // document to be read, and whether it's treated as added or removed depends
 // on the value of the document's Departing field.
 func (w *RelationScopeWatcher) mergeChanges(info *scopeInfo, ids map[interface{}]bool) error {
-	relationScopes, closer := w.db.GetCollection(relationScopesC)
+	relationScopes, closer, err := w.db.GetCollection(relationScopesC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	var existIds []string
@@ -1577,7 +1604,10 @@ type relationLifeSuspendedDoc struct {
 var relationLifeSuspendedFields = bson.D{{"_id", 1}, {"life", 1}, {"suspended", 1}}
 
 func (w *relationLifeSuspendedWatcher) initial() (set.Strings, error) {
-	coll, closer := w.db.GetCollection(relationsC)
+	coll, closer, err := w.db.GetCollection(relationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	ids := make(set.Strings)
@@ -1599,7 +1629,10 @@ func (w *relationLifeSuspendedWatcher) initial() (set.Strings, error) {
 }
 
 func (w *relationLifeSuspendedWatcher) merge(ids set.Strings, updates map[interface{}]bool) error {
-	coll, closer := w.db.GetCollection(relationsC)
+	coll, closer, err := w.db.GetCollection(relationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	// Separate ids into those thought to exist and those known to be removed.
@@ -1790,8 +1823,11 @@ func (w *unitsWatcher) watchUnits(names, changes []string) ([]string, error) {
 		return nil, errors.Trace(err)
 	}
 	logger.Tracef("watching %q ids: %q", unitsC, ids)
-	newUnits, closer := w.db.GetCollection(unitsC)
-	err := newUnits.Find(bson.M{"_id": bson.M{"$in": names}}).Select(lifeWatchFields).All(&docs)
+	newUnits, closer, err := w.db.GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	err = newUnits.Find(bson.M{"_id": bson.M{"$in": names}}).Select(lifeWatchFields).All(&docs)
 	closer()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1881,8 +1917,11 @@ func (w *unitsWatcher) update(changes []string) ([]string, error) {
 func (w *unitsWatcher) merge(changes []string, name string) ([]string, error) {
 	logger.Tracef("merging change for %q %q", unitsC, name)
 	var doc lifeWatchDoc
-	units, closer := w.db.GetCollection(unitsC)
-	err := units.FindId(name).Select(lifeWatchFields).One(&doc)
+	units, closer, err := w.db.GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	err = units.FindId(name).Select(lifeWatchFields).One(&doc)
 	closer()
 	gone := false
 	if err == mgo.ErrNotFound {
@@ -2264,7 +2303,10 @@ func newDocumentFieldWatcher(
 }
 
 func (w *documentFieldWatcher) initial() error {
-	col, closer := w.db.GetCollection(w.collection)
+	col, closer, err := w.db.GetCollection(w.collection)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	field := w.initialKnown
@@ -2289,7 +2331,10 @@ func (w *documentFieldWatcher) merge(change watcher.Change) (bool, error) {
 		}
 		return false, nil
 	}
-	col, closer := w.db.GetCollection(w.collection)
+	col, closer, err := w.db.GetCollection(w.collection)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 
 	// check the field before adding it to the known value
@@ -2546,7 +2591,11 @@ func (w *machineUnitsWatcher) watchNewUnits(unitNames, pending []string, unitCol
 
 	if unitColl == nil {
 		var closer SessionCloser
-		unitColl, closer = w.db.GetCollection(unitsC)
+		var err error
+		unitColl, closer, err = w.db.GetCollection(unitsC)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		defer closer()
 	}
 	var doc unitDoc
@@ -2610,7 +2659,10 @@ func (w *machineUnitsWatcher) removeWatchedUnit(unitName string, doc unitDoc, pe
 // use watchNewUnits if you have a new object
 func (w *machineUnitsWatcher) merge(pending []string, unitName string) (new []string, err error) {
 	doc := unitDoc{}
-	newUnits, closer := w.db.GetCollection(unitsC)
+	newUnits, closer, err := w.db.GetCollection(unitsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	err = newUnits.FindId(unitName).One(&doc)
 	if err != nil && err != mgo.ErrNotFound {
@@ -2770,7 +2822,7 @@ func (st *State) WatchActionLogs(actionId string) StringsWatcher {
 // actionLogsWatcher reports new action progress messages.
 type actionLogsWatcher struct {
 	commonWatcher
-	coll func() (mongo.Collection, func())
+	coll func() (mongo.Collection, func(), error)
 	out  chan []string
 
 	actionId string
@@ -2802,10 +2854,13 @@ func (w *actionLogsWatcher) messages() ([]string, error) {
 	type messagesDoc struct {
 		Messages []ActionMessage `bson:"messages"`
 	}
-	coll, closer := w.coll()
+	coll, closer, err := w.coll()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	var doc messagesDoc
-	err := coll.FindId(w.backend.docID(w.actionId)).Select(bson.D{{"messages", 1}}).One(&doc)
+	err = coll.FindId(w.backend.docID(w.actionId)).Select(bson.D{{"messages", 1}}).One(&doc)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -3016,7 +3071,10 @@ func (w *collectionWatcher) initial() ([]string, error) {
 	var doc struct {
 		DocId string `bson:"_id"`
 	}
-	coll, closer := w.db.GetCollection(w.col)
+	coll, closer, err := w.db.GetCollection(w.col)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	iter := coll.Find(nil).Iter()
 	for iter.Next(&doc) {
@@ -3217,7 +3275,10 @@ func (w *actionNotificationWatcher) loop() error {
 func (w *actionNotificationWatcher) initial() ([]string, error) {
 	var ids []string
 	var doc actionNotificationDoc
-	coll, closer := w.db.GetCollection(actionNotificationsC)
+	coll, closer, err := w.db.GetCollection(actionNotificationsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	iter := coll.Find(nil).Iter()
 	for iter.Next(&doc) {
@@ -3252,7 +3313,10 @@ func (w *actionNotificationWatcher) filterPendingAndMergeIds(changes *[]string, 
 		}
 	}
 
-	coll, closer := w.db.GetCollection(actionNotificationsC)
+	coll, closer, err := w.db.GetCollection(actionNotificationsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	defer closer()
 
 	// query for all documents that match the ids who
@@ -3387,7 +3451,10 @@ func (w *openedPortsWatcher) Changes() <-chan []string {
 }
 
 func (w *openedPortsWatcher) initial() (set.Strings, error) {
-	ports, closer := w.db.GetCollection(openedPortsC)
+	ports, closer, err := w.db.GetCollection(openedPortsC)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 
 	portDocs := set.NewStrings()
@@ -3452,7 +3519,10 @@ func (w *openedPortsWatcher) merge(ids set.Strings, change watcher.Change) error
 		ids.Add(localID)
 		return nil
 	}
-	openedPorts, closer := w.db.GetCollection(openedPortsC)
+	openedPorts, closer, err := w.db.GetCollection(openedPortsC)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	currentRevno, err := getTxnRevno(openedPorts, id)
 	closer()
 	if err != nil {
@@ -3708,7 +3778,10 @@ func (st *State) WatchRemoteRelations() StringsWatcher {
 		}
 
 		// Gather the remote app names.
-		remoteApps, closer := st.db().GetCollection(remoteApplicationsC)
+		remoteApps, closer, err := st.db().GetCollection(remoteApplicationsC)
+		if err != nil {
+			return false
+		}
 		defer closer()
 
 		type remoteAppDoc struct {
@@ -3727,7 +3800,10 @@ func (st *State) WatchRemoteRelations() StringsWatcher {
 		}
 
 		// Run a query to pickup any relations to those remote apps.
-		relations, closer := st.db().GetCollection(relationsC)
+		relations, closer, err := st.db().GetCollection(relationsC)
+		if err != nil {
+			return false
+		}
 		defer closer()
 
 		query := bson.D{
@@ -3841,7 +3917,10 @@ func (w *relationNetworksWatcher) Changes() <-chan []string {
 }
 
 func (w *relationNetworksWatcher) loadCIDRs() (bool, error) {
-	coll, closer := w.db.GetCollection(relationNetworksC)
+	coll, closer, err := w.db.GetCollection(relationNetworksC)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 	defer closer()
 
 	var doc struct {
@@ -3849,7 +3928,7 @@ func (w *relationNetworksWatcher) loadCIDRs() (bool, error) {
 		Id       string   `bson:"_id"`
 		CIDRs    []string `bson:"cidrs"`
 	}
-	err := coll.FindId(relationNetworkDocID(w.key, w.direction, relationNetworkAdmin)).One(&doc)
+	err = coll.FindId(relationNetworkDocID(w.key, w.direction, relationNetworkAdmin)).One(&doc)
 	if err == mgo.ErrNotFound {
 		err = coll.FindId(relationNetworkDocID(w.key, w.direction, relationNetworkDefault)).One(&doc)
 	}
@@ -3923,7 +4002,7 @@ func (w *relationNetworksWatcher) loop() error {
 // external controller references.
 type externalControllersWatcher struct {
 	commonWatcher
-	coll func() (mongo.Collection, func())
+	coll func() (mongo.Collection, func(), error)
 	out  chan []string
 }
 
@@ -3952,7 +4031,10 @@ func (w *externalControllersWatcher) initial() (set.Strings, error) {
 	type idDoc struct {
 		Id string `bson:"_id"`
 	}
-	coll, closer := w.coll()
+	coll, closer, err := w.coll()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	defer closer()
 	changes := make(set.Strings)
 	iter := coll.Find(nil).Select(bson.D{{"_id", 1}}).Iter()
@@ -4111,7 +4193,10 @@ func newSettingsHashWatcher(st *State, localID string) StringsWatcher {
 }
 
 func hashSettings(db Database, id string, name string) (string, error) {
-	settings, closer := db.GetCollection(settingsC)
+	settings, closer, err := db.GetCollection(settingsC)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
 	defer closer()
 	var doc settingsDoc
 	if err := settings.FindId(id).One(&doc); err == mgo.ErrNotFound {

--- a/state/watcher_profilecharm_test.go
+++ b/state/watcher_profilecharm_test.go
@@ -189,7 +189,7 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) workerForScenario(c *gc.
 
 func (s *instanceCharmProfileWatcherCompatibilitySuite) expectInitialCollectionInstanceField(url string) func() {
 	return func() {
-		s.database.EXPECT().GetCollection("applications").Return(s.collection, noop)
+		s.database.EXPECT().GetCollection("applications").Return(s.collection, noop, nil)
 		s.collection.EXPECT().Find(bson.D{{"_id", "1"}}).Return(s.query)
 		s.query.EXPECT().One(gomock.Any()).SetArg(0, state.ApplicationDoc{
 			CharmURL: &url,
@@ -214,7 +214,7 @@ func (s *instanceCharmProfileWatcherCompatibilitySuite) expectLoopCollectionFilt
 
 func (s *instanceCharmProfileWatcherCompatibilitySuite) expectMergeCollectionInstanceField(url string) func() {
 	return func() {
-		s.database.EXPECT().GetCollection("applications").Return(s.collection, noop)
+		s.database.EXPECT().GetCollection("applications").Return(s.collection, noop, nil)
 		s.collection.EXPECT().Find(bson.D{{"_id", "1"}}).Return(s.query)
 		s.query.EXPECT().One(gomock.Any()).SetArg(0, state.ApplicationDoc{
 			CharmURL: &url,


### PR DESCRIPTION
The mgo library panics if a session Copy() is done and the session is already closed. Rather than allowing that panic to escape, we introduce a CopySession helper which catches the panic and returns an error instead.

Call sites which were calling a raw session.Copy() instead use the helper. This required some churn because various GetCollection() type methods needed an error added to their return values.

The panics are a symptom of a separate issue in Juju where sessions are being prematurely closed.That will be addressed in another PR. For now, we just want to not panic in production code.

## QA steps

unit tests and smoke tests

## Links

**Issue:** Fixes #22706.

**Jira card:** [JUJU-10064](https://warthogs.atlassian.net/browse/JUJU-10064)


[JUJU-10064]: https://warthogs.atlassian.net/browse/JUJU-10064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ