### PR TITLE
ci: don't run upgrade test from beta versions

### DIFF
--- a/.github/workflows/context-tests.yml
+++ b/.github/workflows/context-tests.yml
@@ -182,7 +182,7 @@ jobs:
   upgrade:
     needs: [changed-files]
     name: Upgrade
-    if: github.event.pull_request.draft == false && github.base_ref != 'main' && needs.changed-files.outputs.check-upgrade == 'true' && github.event_name != 'merge_group'
+    if: github.event.pull_request.draft == false && needs.changed-files.outputs.check-upgrade == 'true' && github.event_name != 'merge_group'
     uses: ./.github/workflows/upgrade.yml
 
   ddl:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -20,7 +20,21 @@ jobs:
           version=$(grep -r "const version =" core/version/version.go | sed -r 's/^const version = \"(.*)\"$/\1/')
           majmin=$(echo $version | awk -F'[.-]' '{print $1 "." $2}')
           snap info juju > snap-info.txt
-          channel=$(awk -F':' -v ver=$majmin 'NR == 1, /channels/ {next} {gsub(/ /, "", $1); gsub(/ /, "", $2); if (!match($1,ver)) next; if ($2 == "--") next; print $1; exit}' snap-info.txt)
+          # Find the first snap channel matching the major.minor version,
+          # skipping empty channels and any channels with beta versions.
+          # Upgrading from beta is not supported.
+          channel=$(awk -F':' -v ver=$majmin '
+            NR == 1, /channels/ { next }
+            {
+              gsub(/ /, "", $1)
+              gsub(/ /, "", $2)
+              if (!match($1, ver)) next
+              if ($2 == "--") next
+              if ($1 ~ /beta/) next
+              if ($2 ~ /beta/) next
+              print $1
+              exit
+            }' snap-info.txt)
           echo "version=$version" >> $GITHUB_OUTPUT 
           echo "channel=$channel" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The upgrade smoke tests were failing because they attempted to upgrade from
beta versions (e.g., 4.1-beta1 → 4.1-beta2), which is not supported.

**Changes:**

- Added filtering to the snap channel selection to skip beta channels and any
channel with a beta version string. If no stable/candidate channel exists, the
upgrade job is skipped automatically.
- Removed `github.base_ref != 'main'` condition so the upgrade job runs on PRs
targeting main.
