### PR TITLE
fix: network-get returning empty placeholder device

### DIFF
--- a/domain/network/service/unitinfo.go
+++ b/domain/network/service/unitinfo.go
@@ -5,8 +5,6 @@ package service
 
 import (
 	"context"
-	"maps"
-	"slices"
 	"strings"
 
 	"github.com/juju/collections/transform"
@@ -199,31 +197,38 @@ func buildUnitNetworkWithIngressAddresses(
 	ingressAddresses []string,
 	isCaas bool,
 ) domainnetwork.UnitNetwork {
-	byDevice := map[string]domainnetwork.DeviceInfo{}
+	var devices []domainnetwork.DeviceInfo
+	deviceIndex := make(map[string]int)
 	for _, addr := range addresses {
 		// The purpose of the method is to get connectivity information for
 		// the unit. Skip loopback addresses to focus on external connectivity.
 		if addr.IP().IsLoopback() {
 			continue
 		}
-
-		devInfo, ok := byDevice[addr.DeviceName]
-		if !ok {
-			devInfo.Name = addr.DeviceName
-			devInfo.MACAddress = addr.MACAddress
+		// Kubernetes service addresses are valid ingress addresses, but are
+		// not locally bindable by the unit workload.
+		if isCaas && addr.Scope != corenetwork.ScopeMachineLocal {
+			continue
 		}
 
-		if !isCaas || addr.Scope == corenetwork.ScopeMachineLocal {
-			devInfo.Addresses = append(devInfo.Addresses, domainnetwork.AddressInfo{
-				Hostname: addr.Host(),
-				Value:    addr.IP().String(),
-				CIDR:     addr.AddressCIDR(),
+		idx, ok := deviceIndex[addr.DeviceName]
+		if !ok {
+			idx = len(devices)
+			deviceIndex[addr.DeviceName] = idx
+			devices = append(devices, domainnetwork.DeviceInfo{
+				Name:       addr.DeviceName,
+				MACAddress: addr.MACAddress,
 			})
 		}
-		byDevice[addr.DeviceName] = devInfo
+
+		devices[idx].Addresses = append(devices[idx].Addresses, domainnetwork.AddressInfo{
+			Hostname: addr.Host(),
+			Value:    addr.IP().String(),
+			CIDR:     addr.AddressCIDR(),
+		})
 	}
 	return domainnetwork.UnitNetwork{
-		DeviceInfos:      slices.Collect(maps.Values(byDevice)),
+		DeviceInfos:      devices,
 		IngressAddresses: normaliseIngressAddresses(ingressAddresses),
 	}
 }

--- a/domain/network/service/unitinfo_test.go
+++ b/domain/network/service/unitinfo_test.go
@@ -528,21 +528,74 @@ func (s *infoSuite) TestGetUnitEndpointNetworksCaasUsesServiceAddressForIngress(
 	infos, err := service.GetUnitEndpointNetworks(c.Context(), unitName, endpointNames)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(infos, tc.HasLen, 1)
-	c.Check(infos[0].IngressAddresses, tc.DeepEquals, []string{"10.0.0.2"})
+	c.Check(infos[0], tc.DeepEquals, domainnetwork.UnitNetwork{
+		EndpointName: "db",
+		DeviceInfos: []domainnetwork.DeviceInfo{{
+			Name:       "eth0",
+			MACAddress: "aa:bb:cc:dd:ee:ff",
+			Addresses: []domainnetwork.AddressInfo{{
+				Hostname: "10.0.0.1",
+				Value:    "10.0.0.1",
+				CIDR:     "10.0.0.0/24",
+			}},
+		}},
+		IngressAddresses: []string{"10.0.0.2"},
+		EgressSubnets:    []string{"10.0.0.0/24"},
+	})
+}
 
-	devices := transform.SliceToMap(
-		infos[0].DeviceInfos,
-		func(d domainnetwork.DeviceInfo) (string, domainnetwork.DeviceInfo) {
-			return d.Name, d
-		},
-	)
-	c.Assert(devices, tc.HasLen, 2)
-	c.Check(devices["eth0"].Addresses, tc.DeepEquals, []domainnetwork.AddressInfo{{
-		Hostname: "10.0.0.1",
-		Value:    "10.0.0.1",
-		CIDR:     "10.0.0.0/24",
+func (s *infoSuite) TestBuildUnitNetworkPreservesDeviceAndAddressOrder(c *tc.C) {
+	addresses := []networkinternal.UnitAddress{
+		unitAddress("10.0.1.1", "10.0.1.0/24", "eth1",
+			"aa:bb:cc:dd:ee:01", corenetwork.ScopeCloudLocal,
+			corenetwork.EthernetDevice),
+		unitAddress("10.0.0.1", "10.0.0.0/24", "eth0",
+			"aa:bb:cc:dd:ee:00", corenetwork.ScopeCloudLocal,
+			corenetwork.EthernetDevice),
+		unitAddress("10.0.1.2", "10.0.1.0/24", "eth1",
+			"aa:bb:cc:dd:ee:01", corenetwork.ScopeCloudLocal,
+			corenetwork.EthernetDevice),
+	}
+
+	info := buildUnitNetworkWithIngressAddresses(addresses, nil, false)
+
+	c.Check(info.DeviceInfos, tc.DeepEquals, []domainnetwork.DeviceInfo{{
+		Name:       "eth1",
+		MACAddress: "aa:bb:cc:dd:ee:01",
+		Addresses: []domainnetwork.AddressInfo{{
+			Hostname: "10.0.1.1",
+			Value:    "10.0.1.1",
+			CIDR:     "10.0.1.0/24",
+		}, {
+			Hostname: "10.0.1.2",
+			Value:    "10.0.1.2",
+			CIDR:     "10.0.1.0/24",
+		}},
+	}, {
+		Name:       "eth0",
+		MACAddress: "aa:bb:cc:dd:ee:00",
+		Addresses: []domainnetwork.AddressInfo{{
+			Hostname: "10.0.0.1",
+			Value:    "10.0.0.1",
+			CIDR:     "10.0.0.0/24",
+		}},
 	}})
-	c.Check(devices["eth1"].Addresses, tc.HasLen, 0)
+}
+
+func (s *infoSuite) TestBuildUnitNetworkCaasDoesNotEmitEmptyDevices(c *tc.C) {
+	addresses := []networkinternal.UnitAddress{
+		unitAddress("10.0.0.2", "10.0.0.0/24", "service",
+			"aa:bb:cc:dd:ee:02", corenetwork.ScopeCloudLocal,
+			corenetwork.EthernetDevice),
+		unitAddress("127.0.0.1", "127.0.0.0/8", "lo",
+			"00:00:00:00:00:00", corenetwork.ScopeMachineLocal,
+			corenetwork.LoopbackDevice),
+	}
+
+	info := buildUnitNetworkWithIngressAddresses(addresses, []string{"10.0.0.2/24"}, true)
+
+	c.Check(info.DeviceInfos, tc.HasLen, 0)
+	c.Check(info.IngressAddresses, tc.DeepEquals, []string{"10.0.0.2"})
 }
 
 func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedUsesUnitAddresses(c *tc.C) {
@@ -597,6 +650,47 @@ func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedUsesUnitAddresses(c *
 			EgressSubnets:    []string{"192.168.1.0/24"},
 		},
 	})
+}
+
+func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedCaasSkipsServiceAddress(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := coreunit.Name("mysql/0")
+	unitUUID := coreunit.UUID("unit-uuid-123")
+	endpointNames := []string{"db"}
+	addresses := []networkinternal.UnitAddress{
+		unitAddress("10.0.0.2", "10.0.0.0/24", "service",
+			"aa:bb:cc:dd:ee:02", corenetwork.ScopeCloudLocal,
+			corenetwork.EthernetDevice),
+		unitAddress("10.0.0.1", "10.0.0.0/24", "eth0",
+			"aa:bb:cc:dd:ee:01", corenetwork.ScopeMachineLocal,
+			corenetwork.EthernetDevice),
+	}
+
+	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
+	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
+	s.st.EXPECT().GetUnitNetworkInfo(
+		gomock.Any(), unitUUID.String(),
+	).Return(unitNetworkInfo([]string{"10.0.0.2"}, addresses...), nil)
+
+	service := NewProviderService(s.st, s.notSupportedProviderGetter, nil, loggertesting.WrapCheckLog(c))
+	infos, err := service.GetUnitEndpointNetworks(c.Context(), unitName, endpointNames)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(infos, tc.DeepEquals, []domainnetwork.UnitNetwork{{
+		EndpointName: "db",
+		DeviceInfos: []domainnetwork.DeviceInfo{{
+			Name:       "eth0",
+			MACAddress: "aa:bb:cc:dd:ee:01",
+			Addresses: []domainnetwork.AddressInfo{{
+				Hostname: "10.0.0.1",
+				Value:    "10.0.0.1",
+				CIDR:     "10.0.0.0/24",
+			}},
+		}},
+		IngressAddresses: []string{"10.0.0.2"},
+		EgressSubnets:    []string{"10.0.0.0/24"},
+	}})
 }
 
 func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedSortsIngressAddresses(c *tc.C) {

--- a/domain/network/state/unitinfo.go
+++ b/domain/network/state/unitinfo.go
@@ -194,7 +194,8 @@ ORDER BY endpoint_name,
          ingress_is_secondary, /* primary (0) before secondary (1) */
          ingress_origin_id DESC, /* provider (1) before machine (0) */
          address_value,
-         name
+         name,
+         device_uuid
 `, endpointNetworkInfoRow{}, entityUUID{}, endpoints)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -332,7 +333,9 @@ ORDER BY CASE WHEN ingress_address_value IS NULL THEN 1 ELSE 0 END,
          ingress_device_type_id,
          ingress_is_secondary, /* primary (0) before secondary (1) */
          ingress_origin_id DESC, /* provider (1) before machine (0) */
-         address_value
+         address_value,
+         name,
+         device_uuid
 `, unitNetworkInfoRow{}, entityUUID{})
 	if err != nil {
 		return networkinternal.UnitNetworkInfo{}, errors.Capture(err)

--- a/domain/network/state/unitinfo_test.go
+++ b/domain/network/state/unitinfo_test.go
@@ -270,6 +270,81 @@ func (s *infoSuite) TestGetUnitEndpointNetworkInfoCaasUnit(c *tc.C) {
 	}})
 }
 
+func (s *infoSuite) TestUnitNetworkInfoTotallyOrdersTiedDevices(c *tc.C) {
+	podNodeUUID := s.addNetNode(c)
+	serviceNodeUUID := s.addNetNode(c)
+	spaceUUID := s.addSpace(c)
+	subnetUUID := s.addSubnet(c, "10.0.0.0/24", spaceUUID)
+
+	podDeviceUUID := s.addLinkLayerDevice(
+		c, podNodeUUID, "same", "00:11:22:33:44:03", corenetwork.EthernetDevice,
+	)
+	s.query(c, `UPDATE link_layer_device SET uuid = ? WHERE uuid = ?`,
+		"device-b-uuid", podDeviceUUID)
+	podDeviceUUID = "device-b-uuid"
+	podAddressUUID := s.addIPAddressWithSubnetAndScope(
+		c, podDeviceUUID, podNodeUUID, subnetUUID, "10.0.0.1",
+		corenetwork.ScopeCloudLocal,
+	)
+	s.query(c, `UPDATE ip_address SET uuid = ? WHERE uuid = ?`,
+		"address-b-uuid", podAddressUUID)
+
+	alphaDeviceUUID := s.addLinkLayerDevice(
+		c, serviceNodeUUID, "alpha", "00:11:22:33:44:01", corenetwork.EthernetDevice,
+	)
+	s.query(c, `UPDATE link_layer_device SET uuid = ? WHERE uuid = ?`,
+		"device-z-uuid", alphaDeviceUUID)
+	alphaDeviceUUID = "device-z-uuid"
+	alphaAddressUUID := s.addIPAddressWithSubnetAndScope(
+		c, alphaDeviceUUID, serviceNodeUUID, subnetUUID, "10.0.0.1",
+		corenetwork.ScopeCloudLocal,
+	)
+	s.query(c, `UPDATE ip_address SET uuid = ? WHERE uuid = ?`,
+		"address-z-uuid", alphaAddressUUID)
+
+	serviceDeviceUUID := s.addLinkLayerDevice(
+		c, serviceNodeUUID, "same", "00:11:22:33:44:02", corenetwork.EthernetDevice,
+	)
+	s.query(c, `UPDATE link_layer_device SET uuid = ? WHERE uuid = ?`,
+		"device-a-uuid", serviceDeviceUUID)
+	serviceDeviceUUID = "device-a-uuid"
+	serviceAddressUUID := s.addIPAddressWithSubnetAndScope(
+		c, serviceDeviceUUID, serviceNodeUUID, subnetUUID, "10.0.0.1",
+		corenetwork.ScopeCloudLocal,
+	)
+	s.query(c, `UPDATE ip_address SET uuid = ? WHERE uuid = ?`,
+		"address-a-uuid", serviceAddressUUID)
+
+	charmUUID := s.addCharm(c)
+	appUUID := s.addApplication(c, charmUUID, spaceUUID)
+	unitUUID := s.addUnit(c, appUUID, charmUUID, podNodeUUID)
+	s.addK8sService(c, serviceNodeUUID, appUUID)
+	endpointName := "endpoint1"
+	s.addApplicationEndpoint(c, appUUID, charmUUID, endpointName, spaceUUID)
+
+	deviceOrder := func(addresses []networkinternal.UnitAddress) []string {
+		return transform.Slice(addresses, func(address networkinternal.UnitAddress) string {
+			return address.DeviceName + "/" + address.MACAddress
+		})
+	}
+	expectedOrder := []string{
+		"alpha/00:11:22:33:44:01",
+		"same/00:11:22:33:44:02",
+		"same/00:11:22:33:44:03",
+	}
+
+	endpointInfo, err := s.state.GetUnitEndpointNetworkInfo(
+		c.Context(), string(unitUUID), []string{endpointName},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(endpointInfo, tc.HasLen, 1)
+	c.Check(deviceOrder(endpointInfo[0].Addresses), tc.DeepEquals, expectedOrder)
+
+	unitInfo, err := s.state.GetUnitNetworkInfo(c.Context(), string(unitUUID))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(deviceOrder(unitInfo.Addresses), tc.DeepEquals, expectedOrder)
+}
+
 func (s *infoSuite) TestGetUnitEndpointNetworkInfoNoAddresses(c *tc.C) {
 	nodeUUID := s.addNetNode(c)
 	spaceUUID := s.addSpace(c)

--- a/internal/worker/uniter/runner/jujuc/network-get.go
+++ b/internal/worker/uniter/runner/jujuc/network-get.go
@@ -123,11 +123,14 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 	}
 
 	ni, ok := netInfo[c.bindingName]
-	if !ok || len(ni.Info) == 0 {
+	if !ok {
 		return fmt.Errorf("no network config found for binding %q", c.bindingName)
 	}
 	if ni.Error != nil {
 		return errors.Trace(ni.Error)
+	}
+	if len(ni.Info) == 0 && len(ni.IngressAddresses) == 0 && len(ni.EgressSubnets) == 0 {
+		return fmt.Errorf("no network config found for binding %q", c.bindingName)
 	}
 
 	// If no specific attributes were asked for, write everything we know.
@@ -140,10 +143,11 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 		if c.ingressAddress || c.egressSubnets || c.bindAddress {
 			return fmt.Errorf("--primary-address must be the only flag specified")
 		}
-		if len(ni.Info[0].Addresses) == 0 {
-			return fmt.Errorf("no addresses attached to space for binding %q", c.bindingName)
+		address, ok := firstAvailableNetworkAddress(ni.Info)
+		if !ok {
+			return fmt.Errorf("no primary address attached to space for binding %q", c.bindingName)
 		}
-		return c.out.Write(ctx, ni.Info[0].Addresses[0].Address)
+		return c.out.Write(ctx, address)
 	}
 
 	// Write the specific articles requested.
@@ -154,22 +158,36 @@ func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
 	if c.ingressAddress {
 		var ingressAddress string
 		if len(ni.IngressAddresses) == 0 {
-			if len(ni.Info[0].Addresses) == 0 {
-				return fmt.Errorf("no addresses attached to space for binding %q", c.bindingName)
+			address, ok := firstAvailableNetworkAddress(ni.Info)
+			if !ok {
+				return fmt.Errorf("no ingress address attached to space for binding %q", c.bindingName)
 			}
-			ingressAddress = ni.Info[0].Addresses[0].Address
+			ingressAddress = address
 		} else {
 			ingressAddress = ni.IngressAddresses[0]
 		}
 		keyValues[ingressAddressKey] = ingressAddress
 	}
 	if c.bindAddress {
-		keyValues[bindAddressKey] = ni.Info[0].Addresses[0].Address
+		address, ok := firstAvailableNetworkAddress(ni.Info)
+		if !ok {
+			return fmt.Errorf("no bind address attached to space for binding %q", c.bindingName)
+		}
+		keyValues[bindAddressKey] = address
 	}
 	if len(c.keys) == 1 {
 		return c.out.Write(ctx, keyValues[c.keys[0]])
 	}
 	return c.out.Write(ctx, keyValues)
+}
+
+func firstAvailableNetworkAddress(infos []params.NetworkInfo) (string, bool) {
+	for _, info := range infos {
+		if len(info.Addresses) > 0 {
+			return info.Addresses[0].Address, true
+		}
+	}
+	return "", false
 }
 
 // These display types are used for serialising to stdout.

--- a/internal/worker/uniter/runner/jujuc/network-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/network-get_test.go
@@ -114,6 +114,35 @@ func (s *NetworkGetSuite) createCommand(c *tc.C) cmd.Command {
 		IngressAddresses: []string{"100.1.2.3", "100.4.3.2"},
 		EgressSubnets:    []string{"192.168.1.0/8", "10.0.0.0/8"},
 	}
+	presetBindings["empty-first"] = params.NetworkInfoResult{
+		Info: []params.NetworkInfo{
+			{
+				MACAddress:    "00:11:22:33:44:44",
+				InterfaceName: "eth4",
+			},
+			{
+				MACAddress:    "00:11:22:33:44:55",
+				InterfaceName: "eth5",
+				Addresses: []params.InterfaceAddress{{
+					Address: "10.44.1.9",
+					CIDR:    "10.44.1.0/24",
+				}},
+			},
+		},
+	}
+	presetBindings["all-empty"] = params.NetworkInfoResult{
+		Info: []params.NetworkInfo{
+			{InterfaceName: "eth6"},
+			{InterfaceName: "eth7"},
+		},
+	}
+	presetBindings["ingress-egress-only"] = params.NetworkInfoResult{
+		IngressAddresses: []string{"203.0.113.10"},
+		EgressSubnets:    []string{"10.55.0.0/16"},
+	}
+	presetBindings["result-error"] = params.NetworkInfoResult{
+		Error: &params.Error{Message: "network info failed"},
+	}
 
 	hctx.info.NetworkInterface.NetworkInfoResults = presetBindings
 
@@ -157,6 +186,11 @@ func (s *NetworkGetSuite) TestNetworkGet(c *tc.C) {
 		args:    []string{"valid-no-config"},
 		code:    1,
 		out:     `no network config found for binding "valid-no-config"`,
+	}, {
+		summary: "API server error takes precedence over empty network config",
+		args:    []string{"result-error"},
+		code:    1,
+		out:     `network info failed`,
 	}, {
 		summary: "explicitly bound, extra-binding name given with single flag arg",
 		args:    []string{"known-extra", "--ingress-address"},
@@ -238,6 +272,63 @@ bind-addresses:
     address: 10.33.1.8
   macaddress: "00:11:22:33:44:33"
   interfacename: eth3`[1:],
+	}, {
+		summary: "bind address skips an empty first device",
+		args:    []string{"empty-first", "--bind-address"},
+		out:     "10.44.1.9",
+	}, {
+		summary: "primary address skips an empty first device",
+		args:    []string{"empty-first", "--primary-address"},
+		out:     "10.44.1.9",
+	}, {
+		summary: "ingress fallback skips an empty first device",
+		args:    []string{"empty-first", "--ingress-address"},
+		out:     "10.44.1.9",
+	}, {
+		summary: "bind address reports all devices empty",
+		args:    []string{"all-empty", "--bind-address"},
+		code:    1,
+		out:     `no bind address attached to space for binding "all-empty"`,
+	}, {
+		summary: "primary address reports all devices empty",
+		args:    []string{"all-empty", "--primary-address"},
+		code:    1,
+		out:     `no primary address attached to space for binding "all-empty"`,
+	}, {
+		summary: "ingress fallback reports all devices empty",
+		args:    []string{"all-empty", "--ingress-address"},
+		code:    1,
+		out:     `no ingress address attached to space for binding "all-empty"`,
+	}, {
+		summary: "ingress-only result supports ingress flag",
+		args:    []string{"ingress-egress-only", "--ingress-address"},
+		out:     "203.0.113.10",
+	}, {
+		summary: "egress-only result supports egress flag",
+		args:    []string{"ingress-egress-only", "--egress-subnets"},
+		out:     "10.55.0.0/16",
+	}, {
+		summary: "ingress and egress result supports full output without bind devices",
+		args:    []string{"ingress-egress-only"},
+		out: `
+egress-subnets:
+- 10.55.0.0/16
+ingress-addresses:
+- 203.0.113.10`[1:],
+	}, {
+		summary: "ingress and egress result supports JSON output without bind devices",
+		args:    []string{"ingress-egress-only", "--format", "json"},
+		out:     `{"egress-subnets":["10.55.0.0/16"],"ingress-addresses":["203.0.113.10"]}`,
+	}, {
+		summary: "ingress and egress result reports missing bind address",
+		args:    []string{"ingress-egress-only", "--bind-address"},
+		code:    1,
+		out:     `no bind address attached to space for binding "ingress-egress-only"`,
+	}, {
+		summary: "ingress and egress result reports missing primary address",
+		args:    []string{"ingress-egress-only", "--primary-address"},
+		code:    1,
+		out:     `no primary address attached to space for binding "ingress-egress-only"`,
 	}, {
 		summary: "explicit ingress and egress information",
 		args:    []string{"ingress-egress", "--ingress-address", "--bind-address", "--egress-subnets"},


### PR DESCRIPTION
On k8s, the 'network-get' hook tool would return two devices:
- an empty placeholder, corresponding to the application service
- the unit's cloud-container with the pod ip

The empty application service device should not be returned. This is a regression compared with 3.6

Refactor the network service to:
- not return empty devices
- return devices/addresses with a deterministic ordering

Also, make some small defensive changes to network-get in the uniter.

TODO: Fix placeholder lld interface name

Fixes: https://github.com/juju/juju/issues/22616

## QA steps

```
$ juju bootstrap minikube mini
$ juju add-model m
$ juju deploy prometheus-k8s -n2 --trust
$ juju exec --unit prometheus-k8s/0 -- network-get "alertmanager" --format json | jq
{
  "bind-addresses": [
    {
      "mac-address": "",
      "interface-name": "placeholder for \"prometheus-k8s/0\" cloud container",
      "addresses": [
        {
          "hostname": "10.244.0.95",
          "value": "10.244.0.95",
          "cidr": "0.0.0.0/0"
        }
      ]
    }
  ],
  "egress-subnets": [
    "10.102.188.227/32"
  ],
  "ingress-addresses": [
    "10.102.188.227"
  ]
}
```