### PR TITLE
ci: add missing Pillow build dependencies to sphinx ci job

### DIFF
--- a/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
@@ -41,13 +41,25 @@ jobs:
           set -ex
           sudo apt -y update
           sudo apt -y install \
-            cargo \
+            cmake \
+            libfreetype6-dev \
+            libharfbuzz-dev \
+            libjpeg8-dev \
+            liblcms2-dev \
+            libopenjp2-7-dev \
             libpython3-dev \
+            libtiff5-dev \
+            libwebp-dev \
+            libxcb1-dev \
             libxml2-dev \
             libxslt1-dev \
             make \
+            ninja-build \
             python3-venv \
-            rustc
+            zlib1g-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+            sh -s -- -y --default-toolchain stable
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Build Sphinx venv
         run: |
@@ -55,5 +67,5 @@ jobs:
           cd docs
           make -f Makefile \
             install \
-            PIPOPTS="--no-binary :all:" \
-            || ( cat .sphinx/venv/pip_install.log && exit 1 )
+            PIPOPTS="--no-binary :all: --only-binary canonical-sphinx" \
+            || ( cat .venv/pip_install.log && exit 1 )


### PR DESCRIPTION
The `docs-sphinx-python-dependency-build-checks` workflow forces building the Sphinx virtual environment entirely from source (`--no-binary :all:`) to document required build packages. This fixes several issues that prevented it from succeeding.

**Changes:**

- Replaced stale `cargo`/`rustc` apt packages with rustup to get a current Rust toolchain (needed by `watchfiles`)
- Added Pillow build dependencies: `libfreetype6-dev`, `libharfbuzz-dev`, `libjpeg8-dev`, `liblcms2-dev`, `libopenjp2-7-dev`, `libtiff5-dev`, `libwebp-dev`, `libxcb1-dev`, `zlib1g-dev`
- Added `cmake` and `ninja-build` — needed to build `pybind11` from source, which Pillow 12.2.0 requires as a build dependency (pip propagates `--no-binary` to isolated build environments)
- Added `--only-binary canonical-sphinx` to allow this pure-Python meta-package to install as a wheel
- Fixed error-log path from `.sphinx/venv/pip_install.log` to `.venv/pip_install.log` to match the Makefile's `DOCS_VENVDIR`

