### PR TITLE
chore: remove api-caller dependency from model manifolds

### DIFF
--- a/apiserver/facades/controller/caasmodeloperator/service.go
+++ b/apiserver/facades/controller/caasmodeloperator/service.go
@@ -35,6 +35,8 @@ type AgentPasswordService interface {
 
 // ControllerService provides access to controller agent serving information.
 type ControllerService interface {
+	// GetControllerAgentInfo returns the controller agent information
+	// including the controller ID and API addresses.
 	GetControllerAgentInfo(ctx context.Context) (controller.ControllerAgentInfo, error)
 }
 

--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -868,6 +868,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 		NewMigrationMaster:            migrationmaster.NewWorker,
 		OperationPrunerInterval:       24 * time.Hour,
 		DomainServices:                cfg.DomainServices,
+		DomainServicesGetter:          cfg.DomainServicesGetter,
 		ProviderServicesGetter:        cfg.ProviderServicesGetter,
 		LeaseManager:                  cfg.LeaseManager,
 		HTTPClientGetter:              cfg.HTTPClientGetter,

--- a/cmd/jujuagentd/agent/model/manifolds.go
+++ b/cmd/jujuagentd/agent/model/manifolds.go
@@ -381,10 +381,9 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		secretsPrunerName: ifNotMigrating(secretspruner.Manifold(secretspruner.ManifoldConfig{
-			APICallerName:        apiCallerName,
-			Logger:               config.LoggingContext.GetLogger("juju.worker.secretspruner"),
-			NewUserSecretsFacade: secretspruner.NewUserSecretsFacade,
-			NewWorker:            secretspruner.NewWorker,
+			DomainServicesName: domainServicesName,
+			Logger:             config.LoggingContext.GetLogger("juju.worker.secretspruner"),
+			NewWorker:          secretspruner.NewWorker,
 		})),
 		// The userSecretsDrainWorker is the worker that drains the user secrets
 		// from the inactive backend to the current active backend.

--- a/cmd/jujuagentd/agent/model/manifolds.go
+++ b/cmd/jujuagentd/agent/model/manifolds.go
@@ -362,7 +362,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}))),
 
 		storageProvisionerName: ifNotMigrating(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
-			APICallerName:       apiCallerName,
+			DomainServicesName:  domainServicesName,
 			Clock:               config.Clock,
 			Logger:              config.LoggingContext.GetLogger("juju.worker.modelstorageprovisioner"),
 			StorageRegistryName: providerTrackerName,

--- a/cmd/jujuagentd/agent/model/manifolds.go
+++ b/cmd/jujuagentd/agent/model/manifolds.go
@@ -121,6 +121,9 @@ type ManifoldsConfig struct {
 	// DomainServices is used to access the domain services.
 	DomainServices services.DomainServices
 
+	// DomainServicesGetter is used to access domain services for other models.
+	DomainServicesGetter services.DomainServicesGetter
+
 	// LeaseManager is used to manage the lease for the model.
 	LeaseManager lease.Manager
 
@@ -277,13 +280,13 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:     migrationflag.NewWorker,
 		})),
 		migrationMasterName: ifNotDead(migrationmaster.Manifold(migrationmaster.ManifoldConfig{
-			APICallerName:      apiCallerName,
-			DomainServicesName: domainServicesName,
-			FortressName:       migrationFortressName,
-			ModelUUID:          config.ModelUUID,
-			Clock:              config.Clock,
-			NewFacade:          migrationmaster.NewFacade,
-			NewWorker:          config.NewMigrationMaster,
+			DomainServicesName:   domainServicesName,
+			DomainServicesGetter: config.DomainServicesGetter,
+			FortressName:         migrationFortressName,
+			ModelUUID:            config.ModelUUID,
+			LogDir:               config.LogDir,
+			Clock:                config.Clock,
+			NewWorker:            config.NewMigrationMaster,
 		})),
 
 		// Everything else should be wrapped in ifResponsible,

--- a/cmd/jujuagentd/agent/model/manifolds_test.go
+++ b/cmd/jujuagentd/agent/model/manifolds_test.go
@@ -548,6 +548,10 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 
 	"log-sink": {},
 
+	"domain-services": {},
+
+	"http-client": {},
+
 	"migration-fortress": {
 		"domain-services",
 		"is-responsible-flag",
@@ -613,10 +617,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"migration-inactive-flag",
 		"not-dead-flag",
 	},
-
-	"domain-services": {},
-
-	"http-client": {},
 
 	"storage-provisioner": {
 		"agent",

--- a/cmd/jujuagentd/agent/model/manifolds_test.go
+++ b/cmd/jujuagentd/agent/model/manifolds_test.go
@@ -335,8 +335,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"migration-master": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -569,8 +567,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"migration-master": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",

--- a/cmd/jujud/agent/controller.go
+++ b/cmd/jujud/agent/controller.go
@@ -694,6 +694,7 @@ func (a *ControllerAgent) startModelWorkers(
 		NewMigrationMaster:            migrationmaster.NewWorker,
 		OperationPrunerInterval:       24 * time.Hour,
 		DomainServices:                cfg.DomainServices,
+		DomainServicesGetter:          cfg.DomainServicesGetter,
 		ProviderServicesGetter:        cfg.ProviderServicesGetter,
 		LeaseManager:                  cfg.LeaseManager,
 		HTTPClientGetter:              cfg.HTTPClientGetter,

--- a/cmd/jujud/agent/controller/manifolds.go
+++ b/cmd/jujud/agent/controller/manifolds.go
@@ -392,13 +392,14 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		migrationMinionName: ifControllerUpgradeComplete(disabledManifold(migrationminion.Manifold(migrationminion.ManifoldConfig{
 			// AgentName:         agentName,
 			// APICallerName:     apiCallerName,
-			FortressName:      migrationFortressName,
-			Clock:             config.Clock,
-			APIOpen:           api.Open,
-			ValidateMigration: config.ValidateMigration,
-			NewFacade:         migrationminion.NewFacade,
-			NewWorker:         migrationminion.NewWorker,
-			Logger:            internallogger.GetLogger("juju.worker.migrationminion", corelogger.MIGRATION),
+			FortressName:          migrationFortressName,
+			Clock:                 config.Clock,
+			APIOpen:               api.Open,
+			ValidateMigration:     config.ValidateMigration,
+			NewWorker:             migrationminion.NewWorker,
+			Logger:                internallogger.GetLogger("juju.worker.migrationminion", corelogger.MIGRATION),
+			SendReport:            migrationminion.SendReport,
+			FetchTargetLokiConfig: migrationminion.FetchTargetLokiConfig,
 		}))),
 
 		// The primary controller flag manifold will attempt to claim

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -372,7 +372,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}))),
 
 		storageProvisionerName: ifNotMigrating(storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
-			APICallerName:       apiCallerName,
+			DomainServicesName:  domainServicesName,
 			Clock:               config.Clock,
 			Logger:              config.LoggingContext.GetLogger("juju.worker.modelstorageprovisioner"),
 			StorageRegistryName: providerTrackerName,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -140,6 +140,15 @@ type ManifoldsConfig struct {
 	UpdateLoggerConfig   func(string) error
 }
 
+// StartupValueProvider provides information from the runtime.conf to workers
+// in the controller application. It supplies startup configuration values for
+// the model operator and logging override reader.
+//
+// Using an interface rather than passing values directly ensures that workers
+// read the current configuration when they are bounced (restarted). If values
+// were passed directly, workers would retain stale configuration after a bounce
+// until the agent itself is restarted. This interface combines all configuration
+// interfaces required by all workers into a single provider.
 type StartupValueProvider interface {
 	caasmodeloperator.ConfigProvider
 	controllerlogger.LoggingOverrideReader
@@ -250,11 +259,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 		// This flag runs on all models, and
 		// indicates if model's cloud credential is valid.
-		validCredentialFlagName: credentialvalidator.Manifold(credentialvalidator.ManifoldConfig{
-			APICallerName: apiCallerName,
-			NewFacade:     credentialvalidator.NewFacade,
-			NewWorker:     credentialvalidator.NewWorker,
-			Logger:        config.LoggingContext.GetLogger("juju.worker.credentialvalidator"),
+		validCredentialFlagName: credentialvalidator.ModelManifold(credentialvalidator.ModelManifoldConfig{
+			DomainServicesName: domainServicesName,
+			ModelUUID:          config.ModelUUID,
+			NewWorker:          credentialvalidator.NewWorker,
+			Logger:             config.LoggingContext.GetLogger("juju.worker.credentialvalidator"),
 		}),
 
 		// The migration workers collaborate to run migrations;

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -391,10 +391,9 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 
 		secretsPrunerName: ifNotMigrating(secretspruner.Manifold(secretspruner.ManifoldConfig{
-			APICallerName:        apiCallerName,
-			Logger:               config.LoggingContext.GetLogger("juju.worker.secretspruner"),
-			NewUserSecretsFacade: secretspruner.NewUserSecretsFacade,
-			NewWorker:            secretspruner.NewWorker,
+			DomainServicesName: domainServicesName,
+			Logger:             config.LoggingContext.GetLogger("juju.worker.secretspruner"),
+			NewWorker:          secretspruner.NewWorker,
 		})),
 		// The userSecretsDrainWorker is the worker that drains the user secrets
 		// from the inactive backend to the current active backend.

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -280,11 +280,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// the model is not dead, and not upgrading; this frees
 		// their dependencies from model-lifetime/upgrade concerns.
 		migrationFortressName: ifNotDead(fortress.Manifold()),
-		migrationInactiveFlagName: ifNotDead(migrationflag.Manifold(migrationflag.ManifoldConfig{
-			APICallerName: apiCallerName,
-			Check:         migrationflag.IsTerminal,
-			NewFacade:     migrationflag.NewFacade,
-			NewWorker:     migrationflag.NewWorker,
+		migrationInactiveFlagName: ifNotDead(migrationflag.ModelManifold(migrationflag.ModelManifoldConfig{
+			DomainServicesName: domainServicesName,
+			ModelUUID:          config.ModelUUID,
+			Check:              migrationflag.IsTerminal,
+			NewWorker:          migrationflag.NewWorker,
 		})),
 		migrationMasterName: ifNotDead(migrationmaster.Manifold(migrationmaster.ManifoldConfig{
 			APICallerName:      apiCallerName,

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -397,12 +397,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		})),
 		// The userSecretsDrainWorker is the worker that drains the user secrets
 		// from the inactive backend to the current active backend.
-		userSecretsDrainWorker: ifNotMigrating(secretsdrainworker.Manifold(secretsdrainworker.ManifoldConfig{
-			APICallerName:         apiCallerName,
-			Logger:                config.LoggingContext.GetLogger("juju.worker.usersecretsdrainworker"),
-			NewSecretsDrainFacade: secretsdrainworker.NewUserSecretsDrainFacade,
-			NewWorker:             secretsdrainworker.NewWorker,
-			NewBackendsClient:     secretsdrainworker.NewUserSecretBackendsClient,
+		userSecretsDrainWorker: ifNotMigrating(secretsdrainworker.ModelManifold(secretsdrainworker.ModelManifoldConfig{
+			DomainServicesName: domainServicesName,
+			ModelUUID:          config.ModelUUID,
+			Logger:             config.LoggingContext.GetLogger("juju.worker.usersecretsdrainworker"),
+			NewWorker:          secretsdrainworker.NewWorker,
 		})),
 
 		// the operationPruner is the worker that prune operation based on their

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -120,6 +120,9 @@ type ManifoldsConfig struct {
 	// DomainServices is used to access the domain services.
 	DomainServices services.DomainServices
 
+	// DomainServicesGetter is used to access domain services for other models.
+	DomainServicesGetter services.DomainServicesGetter
+
 	// LeaseManager is used to manage the lease for the model.
 	LeaseManager lease.Manager
 
@@ -287,13 +290,13 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:          migrationflag.NewWorker,
 		})),
 		migrationMasterName: ifNotDead(migrationmaster.Manifold(migrationmaster.ManifoldConfig{
-			APICallerName:      apiCallerName,
-			DomainServicesName: domainServicesName,
-			FortressName:       migrationFortressName,
-			ModelUUID:          config.ModelUUID,
-			Clock:              config.Clock,
-			NewFacade:          migrationmaster.NewFacade,
-			NewWorker:          config.NewMigrationMaster,
+			DomainServicesName:   domainServicesName,
+			DomainServicesGetter: config.DomainServicesGetter,
+			FortressName:         migrationFortressName,
+			ModelUUID:            config.ModelUUID,
+			LogDir:               config.LogDir,
+			Clock:                config.Clock,
+			NewWorker:            config.NewMigrationMaster,
 		})),
 
 		// Everything else should be wrapped in ifResponsible,

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -323,8 +323,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"migration-master": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -534,8 +532,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"migration-master": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -367,8 +367,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"storage-provisioner": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -580,8 +578,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"storage-provisioner": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -210,8 +210,7 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	"api-config-watcher": {"agent"},
 
 	"provider-tracker": {
-		"agent",
-		"api-caller",
+		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
 		"log-sink",
@@ -222,6 +221,7 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	"caas-model-config-manager": {
 		"agent",
 		"api-caller",
+		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
 		"log-sink",
@@ -403,7 +403,7 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 
 	"http-client": {},
 
-	"valid-credential-flag": {"agent", "api-caller"},
+	"valid-credential-flag": {"domain-services"},
 }
 
 var expectedIAASModelManifoldsWithDependencies = map[string][]string{
@@ -492,8 +492,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"provider-tracker": {
-		"agent",
-		"api-caller",
+		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
 		"log-sink",
@@ -633,7 +632,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"valid-credential-flag",
 	},
 
-	"valid-credential-flag": {"agent", "api-caller"},
+	"valid-credential-flag": {"domain-services"},
 }
 
 func testManifoldsConfig() model.ManifoldsConfig {

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -180,7 +180,6 @@ func (s *ManifoldsSuite) TestCAASManifold(c *tc.C) {
 var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 
 	"secrets-pruner": {
-		"agent",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -190,8 +189,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"user-secrets-drain-worker": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -394,7 +391,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 
 	"secrets-pruner": {
-		"agent",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -404,8 +400,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"user-secrets-drain-worker": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -181,7 +181,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 
 	"secrets-pruner": {
 		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -396,7 +395,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 
 	"secrets-pruner": {
 		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",

--- a/cmd/jujud/agent/model/manifolds_test.go
+++ b/cmd/jujud/agent/model/manifolds_test.go
@@ -231,8 +231,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"caas-firewaller": {
-		"agent",
-		"api-caller",
 		"clock",
 		"domain-services",
 		"is-responsible-flag",
@@ -289,8 +287,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"change-stream-pruner": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -306,8 +302,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	"lease-manager": {},
 
 	"logging-config-updater": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -326,8 +320,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"migration-inactive-flag": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -349,8 +341,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"operation-pruner": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -362,8 +352,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	"provider-service-factories": {},
 
 	"remote-relation-consumer": {
-		"agent",
-		"api-caller",
 		"api-remote-relation-caller",
 		"domain-services",
 		"is-responsible-flag",
@@ -374,8 +362,6 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"removal": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -433,8 +419,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	"agent": {},
 
 	"agent-binary-fetcher": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -464,8 +448,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"change-stream-pruner": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -516,8 +498,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"instance-poller": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -535,8 +515,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	"lease-manager": {},
 
 	"logging-config-updater": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -547,6 +525,10 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 
 	"log-sink": {},
 
+	"domain-services": {},
+
+	"http-client": {},
+
 	"migration-fortress": {
 		"domain-services",
 		"is-responsible-flag",
@@ -555,8 +537,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"migration-inactive-flag": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -578,8 +558,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"operation-pruner": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -591,8 +569,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	"provider-service-factories": {},
 
 	"remote-relation-consumer": {
-		"agent",
-		"api-caller",
 		"api-remote-relation-caller",
 		"domain-services",
 		"is-responsible-flag",
@@ -603,8 +579,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"removal": {
-		"agent",
-		"api-caller",
 		"domain-services",
 		"is-responsible-flag",
 		"lease-manager",
@@ -612,10 +586,6 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"migration-inactive-flag",
 		"not-dead-flag",
 	},
-
-	"domain-services": {},
-
-	"http-client": {},
 
 	"storage-provisioner": {
 		"agent",

--- a/internal/worker/credentialvalidator/manifold.go
+++ b/internal/worker/credentialvalidator/manifold.go
@@ -13,6 +13,12 @@ import (
 	"github.com/juju/juju/agent/engine"
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/watcher"
+	credentialerrors "github.com/juju/juju/domain/credential/errors"
+	credentialservice "github.com/juju/juju/domain/credential/service"
+	modelservice "github.com/juju/juju/domain/model/service"
+	"github.com/juju/juju/internal/services"
 )
 
 // ManifoldConfig holds the dependencies and configuration for a
@@ -82,4 +88,97 @@ func filterErrors(err error) error {
 		return dependency.ErrBounce
 	}
 	return err
+}
+
+// ModelManifoldConfig holds the dependencies and configuration for a
+// model-only Worker manifold backed by local domain services instead of
+// an API caller.
+type ModelManifoldConfig struct {
+	DomainServicesName string
+	ModelUUID          string
+
+	NewWorker func(context.Context, Config) (worker.Worker, error)
+	Logger    logger.Logger
+}
+
+// Validate is called by start to check for bad configuration.
+func (config ModelManifoldConfig) Validate() error {
+	if config.DomainServicesName == "" {
+		return errors.NotValidf("empty DomainServicesName")
+	}
+	if config.ModelUUID == "" {
+		return errors.NotValidf("empty ModelUUID")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	return nil
+}
+
+// start is a StartFunc for a model-only Worker manifold.
+func (config ModelManifoldConfig) start(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var domainServices services.DomainServices
+	if err := getter.Get(config.DomainServicesName, &domainServices); err != nil {
+		return nil, errors.Trace(err)
+	}
+	facade := &modelCredentialFacade{
+		credSvc:   domainServices.Credential(),
+		modelSvc:  domainServices.Model(),
+		modelUUID: model.UUID(config.ModelUUID),
+	}
+	w, err := config.NewWorker(ctx, Config{
+		Facade: facade,
+		Logger: config.Logger,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// ModelManifold packages a Worker for use in a dependency.Engine. It reads
+// credential status through local domain services rather than an API caller.
+func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{config.DomainServicesName},
+		Start:  config.start,
+		Output: engine.FlagOutput,
+		Filter: filterErrors,
+	}
+}
+
+// modelCredentialFacade is a local facade adapter that satisfies the Facade
+// interface by reading from domain services directly.
+type modelCredentialFacade struct {
+	credSvc   *credentialservice.WatchableService
+	modelSvc  *modelservice.WatchableService
+	modelUUID model.UUID
+}
+
+// ModelCredential is part of the Facade interface.
+func (f *modelCredentialFacade) ModelCredential(ctx context.Context) (base.StoredCredential, bool, error) {
+	key, valid, err := f.credSvc.GetModelCredentialStatus(ctx, f.modelUUID)
+	if errors.Is(err, credentialerrors.ModelCredentialNotSet) {
+		// Some clouds do not require a credential. Treat as valid with no
+		// credential set, matching the API facade behaviour.
+		return base.StoredCredential{Valid: true}, false, nil
+	}
+	if err != nil {
+		return base.StoredCredential{}, false, errors.Trace(err)
+	}
+	return base.StoredCredential{
+		CloudCredential: key.String(),
+		Valid:           valid,
+	}, true, nil
+}
+
+// WatchModelCredential is part of the Facade interface.
+func (f *modelCredentialFacade) WatchModelCredential(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return f.modelSvc.WatchModelCloudCredential(ctx, f.modelUUID)
 }

--- a/internal/worker/credentialvalidator/manifold_test.go
+++ b/internal/worker/credentialvalidator/manifold_test.go
@@ -155,3 +155,123 @@ func (*ManifoldSuite) TestStartSuccess(c *tc.C) {
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(w, tc.Equals, expectWorker)
 }
+
+func (*ManifoldSuite) TestModelManifoldInputs(c *tc.C) {
+	manifold := credentialvalidator.ModelManifold(validModelManifoldConfig(c))
+	c.Check(manifold.Inputs, tc.DeepEquals, []string{"domain-services"})
+}
+
+func (*ManifoldSuite) TestModelManifoldOutputBadWorker(c *tc.C) {
+	manifold := credentialvalidator.ModelManifold(credentialvalidator.ModelManifoldConfig{})
+	in := &struct{ worker.Worker }{}
+	var out engine.Flag
+	err := manifold.Output(in, &out)
+	c.Check(err, tc.ErrorMatches, "expected in to implement Flag; got a .*")
+}
+
+func (*ManifoldSuite) TestModelManifoldFilterNil(c *tc.C) {
+	manifold := credentialvalidator.ModelManifold(credentialvalidator.ModelManifoldConfig{})
+	err := manifold.Filter(nil)
+	c.Check(err, tc.ErrorIsNil)
+}
+
+func (*ManifoldSuite) TestModelManifoldFilterErrChanged(c *tc.C) {
+	manifold := credentialvalidator.ModelManifold(credentialvalidator.ModelManifoldConfig{})
+	err := manifold.Filter(credentialvalidator.ErrValidityChanged)
+	c.Check(err, tc.Equals, dependency.ErrBounce)
+}
+
+func (*ManifoldSuite) TestModelManifoldFilterErrModelCredentialChanged(c *tc.C) {
+	manifold := credentialvalidator.ModelManifold(credentialvalidator.ModelManifoldConfig{})
+	err := manifold.Filter(credentialvalidator.ErrModelCredentialChanged)
+	c.Check(err, tc.Equals, dependency.ErrBounce)
+}
+
+func (*ManifoldSuite) TestModelManifoldFilterOther(c *tc.C) {
+	manifold := credentialvalidator.ModelManifold(credentialvalidator.ModelManifoldConfig{})
+	expect := errors.New("whatever")
+	actual := manifold.Filter(expect)
+	c.Check(actual, tc.Equals, expect)
+}
+
+func (*ManifoldSuite) TestModelManifoldStartMissingDomainServicesName(c *tc.C) {
+	config := validModelManifoldConfig(c)
+	config.DomainServicesName = ""
+	checkModelManifoldNotValid(c, config, "empty DomainServicesName not valid")
+}
+
+func (*ManifoldSuite) TestModelManifoldStartMissingModelUUID(c *tc.C) {
+	config := validModelManifoldConfig(c)
+	config.ModelUUID = ""
+	checkModelManifoldNotValid(c, config, "empty ModelUUID not valid")
+}
+
+func (*ManifoldSuite) TestModelManifoldStartMissingNewWorker(c *tc.C) {
+	config := validModelManifoldConfig(c)
+	config.NewWorker = nil
+	checkModelManifoldNotValid(c, config, "nil NewWorker not valid")
+}
+
+func (*ManifoldSuite) TestModelManifoldStartMissingLogger(c *tc.C) {
+	config := validModelManifoldConfig(c)
+	config.Logger = nil
+	checkModelManifoldNotValid(c, config, "nil Logger not valid")
+}
+
+func (*ManifoldSuite) TestModelManifoldStartMissingDomainServices(c *tc.C) {
+	getter := dt.StubGetter(map[string]any{
+		"domain-services": dependency.ErrMissing,
+	})
+	manifold := credentialvalidator.ModelManifold(validModelManifoldConfig(c))
+
+	w, err := manifold.Start(c.Context(), getter)
+	c.Check(w, tc.IsNil)
+	c.Check(errors.Cause(err), tc.Equals, dependency.ErrMissing)
+}
+
+func (*ManifoldSuite) TestModelManifoldStartNewWorkerError(c *tc.C) {
+	getter := dt.StubGetter(map[string]any{
+		"domain-services": &stubDomainServices{},
+	})
+	config := validModelManifoldConfig(c)
+	config.NewWorker = func(_ context.Context, workerConfig credentialvalidator.Config) (worker.Worker, error) {
+		c.Check(workerConfig.Facade, tc.NotNil)
+		return nil, errors.New("snerk")
+	}
+	manifold := credentialvalidator.ModelManifold(config)
+
+	w, err := manifold.Start(c.Context(), getter)
+	c.Check(w, tc.IsNil)
+	c.Check(err, tc.ErrorMatches, "snerk")
+}
+
+func (*ManifoldSuite) TestModelManifoldStartSuccess(c *tc.C) {
+	getter := dt.StubGetter(map[string]any{
+		"domain-services": &stubDomainServices{},
+	})
+	expectWorker := &struct{ worker.Worker }{}
+	config := validModelManifoldConfig(c)
+	config.NewWorker = func(context.Context, credentialvalidator.Config) (worker.Worker, error) {
+		return expectWorker, nil
+	}
+	manifold := credentialvalidator.ModelManifold(config)
+
+	w, err := manifold.Start(c.Context(), getter)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(w, tc.Equals, expectWorker)
+}
+
+func (*ManifoldSuite) TestModelManifoldStartDoesNotRequestAPICaller(c *tc.C) {
+	getter := dt.StubGetter(map[string]any{
+		"domain-services": &stubDomainServices{},
+	})
+	config := validModelManifoldConfig(c)
+	config.NewWorker = func(_ context.Context, workerConfig credentialvalidator.Config) (worker.Worker, error) {
+		c.Check(workerConfig.Facade, tc.NotNil)
+		return &struct{ worker.Worker }{}, nil
+	}
+	manifold := credentialvalidator.ModelManifold(config)
+
+	_, err := manifold.Start(c.Context(), getter)
+	c.Check(err, tc.ErrorIsNil)
+}

--- a/internal/worker/credentialvalidator/util_test.go
+++ b/internal/worker/credentialvalidator/util_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
+	credentialservice "github.com/juju/juju/domain/credential/service"
+	modelservice "github.com/juju/juju/domain/model/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/testhelpers"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/credentialvalidator"
@@ -118,4 +121,38 @@ type stubCaller struct {
 // ModelTag is part of the base.APICaller interface.
 func (*stubCaller) ModelTag() (names.ModelTag, bool) {
 	return coretesting.ModelTag, true
+}
+
+// stubDomainServices is a minimal stub that satisfies services.DomainServices
+// for tests that only need Credential() and Model() methods.
+type stubDomainServices struct {
+	services.ControllerDomainServices
+	services.ModelDomainServices
+}
+
+func (s *stubDomainServices) Credential() *credentialservice.WatchableService {
+	return nil
+}
+
+func (s *stubDomainServices) Model() *modelservice.WatchableService {
+	return nil
+}
+
+// validModelManifoldConfig returns a minimal ModelManifoldConfig stuffed with
+// dummy objects that will explode when used.
+func validModelManifoldConfig(c *tc.C) credentialvalidator.ModelManifoldConfig {
+	return credentialvalidator.ModelManifoldConfig{
+		DomainServicesName: "domain-services",
+		ModelUUID:          "mock-model-uuid",
+		NewWorker:          panicWorker,
+		Logger:             loggertesting.WrapCheckLog(c),
+	}
+}
+
+// checkModelManifoldNotValid checks that the supplied ModelManifoldConfig
+// creates a manifold that cannot be started.
+func checkModelManifoldNotValid(c *tc.C, config credentialvalidator.ModelManifoldConfig, expect string) {
+	err := config.Validate()
+	c.Check(err, tc.ErrorMatches, expect)
+	c.Check(err, tc.ErrorIs, errors.NotValid)
 }

--- a/internal/worker/migrationflag/manifold_linux.go
+++ b/internal/worker/migrationflag/manifold_linux.go
@@ -1,0 +1,102 @@
+//go:build dqlite
+
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationflag
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/dependency"
+
+	"github.com/juju/juju/agent/engine"
+	"github.com/juju/juju/core/migration"
+	"github.com/juju/juju/core/watcher"
+	modelmigrationservice "github.com/juju/juju/domain/modelmigration/service"
+	"github.com/juju/juju/internal/services"
+)
+
+// ModelManifoldConfig holds the dependencies and configuration for a
+// model-only Worker manifold backed by local domain services instead of
+// an API caller.
+type ModelManifoldConfig struct {
+	DomainServicesName string
+	ModelUUID          string
+	Check              Predicate
+
+	NewWorker func(context.Context, Config) (worker.Worker, error)
+}
+
+// validate is called by start to check for bad configuration.
+func (config ModelManifoldConfig) validate() error {
+	if config.DomainServicesName == "" {
+		return errors.NotValidf("empty DomainServicesName")
+	}
+	if config.ModelUUID == "" {
+		return errors.NotValidf("empty ModelUUID")
+	}
+	if config.Check == nil {
+		return errors.NotValidf("nil Check")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+// start is a StartFunc for a model-only Worker manifold.
+func (config ModelManifoldConfig) start(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
+	if err := config.validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	var domainServices services.DomainServices
+	if err := getter.Get(config.DomainServicesName, &domainServices); err != nil {
+		return nil, errors.Trace(err)
+	}
+	facade := &domainServicesFacade{
+		migrationSvc: domainServices.ModelMigration(),
+	}
+	w, err := config.NewWorker(ctx, Config{
+		Facade: facade,
+		Model:  config.ModelUUID,
+		Check:  config.Check,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// ModelManifold packages a Worker for use in a dependency.Engine. It
+// reads migration phase through local domain services rather than an API caller.
+func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{config.DomainServicesName},
+		Start:  config.start,
+		Output: engine.FlagOutput,
+		Filter: bounceErrChanged,
+	}
+}
+
+// domainServicesFacade is a local facade adapter that satisfies the Facade
+// interface by reading from domain services directly.
+type domainServicesFacade struct {
+	migrationSvc *modelmigrationservice.Service
+}
+
+// Phase is part of the Facade interface.
+func (f *domainServicesFacade) Phase(ctx context.Context, _ string) (migration.Phase, error) {
+	mig, err := f.migrationSvc.Migration(ctx)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	return mig.Phase, nil
+}
+
+// Watch is part of the Facade interface.
+func (f *domainServicesFacade) Watch(ctx context.Context, _ string) (watcher.NotifyWatcher, error) {
+	return f.migrationSvc.WatchMigrationPhase(ctx)
+}

--- a/internal/worker/migrationflag/manifold_linux_test.go
+++ b/internal/worker/migrationflag/manifold_linux_test.go
@@ -1,0 +1,92 @@
+//go:build dqlite
+
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationflag_test
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/tc"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/dependency"
+	dt "github.com/juju/worker/v5/dependency/testing"
+
+	"github.com/juju/juju/agent/engine"
+	"github.com/juju/juju/internal/worker/migrationflag"
+)
+
+func (*ManifoldSuite) TestModelManifoldInputs(c *tc.C) {
+	manifold := migrationflag.ModelManifold(validModelManifoldConfig())
+	c.Check(manifold.Inputs, tc.DeepEquals, []string{"domain-services"})
+}
+
+func (*ManifoldSuite) TestModelManifoldOutputBadWorker(c *tc.C) {
+	manifold := migrationflag.ModelManifold(migrationflag.ModelManifoldConfig{})
+	in := &struct{ worker.Worker }{}
+	var out engine.Flag
+	err := manifold.Output(in, &out)
+	c.Check(err, tc.ErrorMatches, "expected in to implement Flag; got a .*")
+}
+
+func (*ManifoldSuite) TestModelManifoldFilterErrChanged(c *tc.C) {
+	manifold := migrationflag.ModelManifold(migrationflag.ModelManifoldConfig{})
+	err := manifold.Filter(migrationflag.ErrChanged)
+	c.Check(err, tc.Equals, dependency.ErrBounce)
+}
+
+func (*ManifoldSuite) TestModelManifoldStartMissingDomainServicesName(c *tc.C) {
+	config := validModelManifoldConfig()
+	config.DomainServicesName = ""
+	checkModelManifoldNotValid(c, config, "empty DomainServicesName not valid")
+}
+
+func (*ManifoldSuite) TestModelManifoldStartMissingModelUUID(c *tc.C) {
+	config := validModelManifoldConfig()
+	config.ModelUUID = ""
+	checkModelManifoldNotValid(c, config, "empty ModelUUID not valid")
+}
+
+func (*ManifoldSuite) TestModelManifoldStartMissingCheck(c *tc.C) {
+	config := validModelManifoldConfig()
+	config.Check = nil
+	checkModelManifoldNotValid(c, config, "nil Check not valid")
+}
+
+func (*ManifoldSuite) TestModelManifoldStartMissingNewWorker(c *tc.C) {
+	config := validModelManifoldConfig()
+	config.NewWorker = nil
+	checkModelManifoldNotValid(c, config, "nil NewWorker not valid")
+}
+
+func (*ManifoldSuite) TestModelManifoldStartMissingDomainServices(c *tc.C) {
+	getter := dt.StubGetter(map[string]any{
+		"domain-services": dependency.ErrMissing,
+	})
+	manifold := migrationflag.ModelManifold(validModelManifoldConfig())
+
+	worker, err := manifold.Start(c.Context(), getter)
+	c.Check(worker, tc.IsNil)
+	c.Check(errors.Cause(err), tc.Equals, dependency.ErrMissing)
+}
+
+func (*ManifoldSuite) TestModelManifoldStartSuccess(c *tc.C) {
+	getter := dt.StubGetter(map[string]any{
+		"domain-services": &stubDomainServices{},
+	})
+	expectWorker := &struct{ worker.Worker }{}
+	config := validModelManifoldConfig()
+	config.NewWorker = func(ctx context.Context, workerConfig migrationflag.Config) (worker.Worker, error) {
+		c.Check(workerConfig.Model, tc.Equals, validUUID)
+		c.Check(workerConfig.Facade, tc.NotNil)
+		c.Check(workerConfig.Check, tc.NotNil)
+		return expectWorker, nil
+	}
+	manifold := migrationflag.ModelManifold(config)
+
+	worker, err := manifold.Start(c.Context(), getter)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(worker, tc.Equals, expectWorker)
+}

--- a/internal/worker/migrationflag/manifold_other.go
+++ b/internal/worker/migrationflag/manifold_other.go
@@ -1,0 +1,97 @@
+//go:build !dqlite
+
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationflag
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/dependency"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/agent/engine"
+)
+
+// ModelManifoldConfig holds the dependencies and configuration for a
+// model-only Worker manifold backed by local domain services instead of
+// an API caller.
+type ModelManifoldConfig struct {
+	DomainServicesName string
+	ModelUUID          string
+	Check              Predicate
+
+	NewWorker func(context.Context, Config) (worker.Worker, error)
+}
+
+// validate is called by start to check for bad configuration.
+func (config ModelManifoldConfig) validate() error {
+	if config.DomainServicesName == "" {
+		return errors.NotValidf("empty DomainServicesName")
+	}
+	if config.ModelUUID == "" {
+		return errors.NotValidf("empty ModelUUID")
+	}
+	if config.Check == nil {
+		return errors.NotValidf("nil Check")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+// ModelManifold packages a Worker for use in a dependency.Engine. It
+// reads migration phase through local domain services rather than an API caller.
+func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{config.DomainServicesName},
+		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
+			if err := config.validate(); err != nil {
+				return nil, errors.Trace(err)
+			}
+			return newNoopWorker(), nil
+		},
+		Output: engine.FlagOutput,
+		Filter: bounceErrChanged,
+	}
+}
+
+// NoopWorker ensures that we get a functioning worker even if we're not using
+// it.
+type noopWorker struct {
+	tomb tomb.Tomb
+}
+
+// NewNoopWorker worker creates a worker that doesn't perform any new work on
+// the context. Though it will manage the lifecycle of the worker.
+func newNoopWorker() *noopWorker {
+	// Set this up, so we only ever hand out a singular tracer and span per
+	// worker.
+	w := &noopWorker{}
+
+	w.tomb.Go(func() error {
+		<-w.tomb.Dying()
+		return tomb.ErrDying
+	})
+
+	return w
+}
+
+// Check ensures noopWorker satisfies the Output requirement of the Manifold.
+func (w *noopWorker) Check() bool {
+	return true
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *noopWorker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *noopWorker) Wait() error {
+	return w.tomb.Wait()
+}

--- a/internal/worker/migrationflag/manifold_test.go
+++ b/internal/worker/migrationflag/manifold_test.go
@@ -106,8 +106,8 @@ func (*ManifoldSuite) TestStartMissingAPICaller(c *tc.C) {
 	})
 	manifold := migrationflag.Manifold(validManifoldConfig())
 
-	worker, err := manifold.Start(c.Context(), getter)
-	c.Check(worker, tc.IsNil)
+	w, err := manifold.Start(c.Context(), getter)
+	c.Check(w, tc.IsNil)
 	c.Check(errors.Cause(err), tc.Equals, dependency.ErrMissing)
 }
 
@@ -123,8 +123,8 @@ func (*ManifoldSuite) TestStartNewFacadeError(c *tc.C) {
 	}
 	manifold := migrationflag.Manifold(config)
 
-	worker, err := manifold.Start(c.Context(), getter)
-	c.Check(worker, tc.IsNil)
+	w, err := manifold.Start(c.Context(), getter)
+	c.Check(w, tc.IsNil)
 	c.Check(err, tc.ErrorMatches, "bort")
 }
 
@@ -145,8 +145,8 @@ func (*ManifoldSuite) TestStartNewWorkerError(c *tc.C) {
 	}
 	manifold := migrationflag.Manifold(config)
 
-	worker, err := manifold.Start(c.Context(), getter)
-	c.Check(worker, tc.IsNil)
+	w, err := manifold.Start(c.Context(), getter)
+	c.Check(w, tc.IsNil)
 	c.Check(err, tc.ErrorMatches, "snerk")
 }
 
@@ -164,7 +164,7 @@ func (*ManifoldSuite) TestStartSuccess(c *tc.C) {
 	}
 	manifold := migrationflag.Manifold(config)
 
-	worker, err := manifold.Start(c.Context(), getter)
+	w, err := manifold.Start(c.Context(), getter)
 	c.Check(err, tc.ErrorIsNil)
-	c.Check(worker, tc.Equals, expectWorker)
+	c.Check(w, tc.Equals, expectWorker)
 }

--- a/internal/worker/migrationflag/util_model_test.go
+++ b/internal/worker/migrationflag/util_model_test.go
@@ -1,0 +1,48 @@
+//go:build dqlite
+
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migrationflag_test
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/tc"
+	dt "github.com/juju/worker/v5/dependency/testing"
+
+	modelmigrationservice "github.com/juju/juju/domain/modelmigration/service"
+	"github.com/juju/juju/internal/services"
+	"github.com/juju/juju/internal/worker/migrationflag"
+)
+
+// stubDomainServices is a minimal stub that satisfies services.DomainServices
+// for tests that only need ModelMigration().
+type stubDomainServices struct {
+	services.ControllerDomainServices
+	services.ModelDomainServices
+}
+
+func (s *stubDomainServices) ModelMigration() *modelmigrationservice.Service {
+	return nil
+}
+
+// validModelManifoldConfig returns a minimal ModelManifoldConfig
+// stuffed with dummy objects that will explode when used.
+func validModelManifoldConfig() migrationflag.ModelManifoldConfig {
+	return migrationflag.ModelManifoldConfig{
+		DomainServicesName: "domain-services",
+		ModelUUID:          validUUID,
+		Check:              panicCheck,
+		NewWorker:          panicWorker,
+	}
+}
+
+// checkModelManifoldNotValid checks that the supplied
+// ModelManifoldConfig creates a manifold that cannot be started.
+func checkModelManifoldNotValid(c *tc.C, config migrationflag.ModelManifoldConfig, expect string) {
+	manifold := migrationflag.ModelManifold(config)
+	worker, err := manifold.Start(c.Context(), dt.StubGetter(nil))
+	c.Check(worker, tc.IsNil)
+	c.Check(err, tc.ErrorMatches, expect)
+	c.Check(err, tc.ErrorIs, errors.NotValid)
+}

--- a/internal/worker/migrationmaster/manifold.go
+++ b/internal/worker/migrationmaster/manifold.go
@@ -4,7 +4,11 @@
 package migrationmaster
 
 import (
+	"bufio"
 	"context"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -12,7 +16,10 @@ import (
 	"github.com/juju/worker/v5/dependency"
 
 	"github.com/juju/juju/api"
-	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/api/common"
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/model"
+	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/worker/fortress"
@@ -21,24 +28,40 @@ import (
 // ManifoldConfig defines the names of the manifolds on which a
 // Worker manifold will depend.
 type ManifoldConfig struct {
-	APICallerName      string
+	// DomainServicesName is the name of the domain-services manifold
+	// used to access per-model services for the migrating model.
 	DomainServicesName string
-	FortressName       string
+
+	// DomainServicesGetter provides access to domain services for any
+	// model by UUID. It is used to resolve controller-model services
+	// needed for source prechecks.
+	DomainServicesGetter services.DomainServicesGetter
+
+	// FortressName is the name of the fortress manifold that guards
+	// model operations during migration.
+	FortressName string
+
 	// ModelUUID is the UUID of the model being migrated.
 	ModelUUID string
 
-	Clock     clock.Clock
-	NewFacade func(base.APICaller) (Facade, error)
+	// LogDir is the path to the controller's log directory. The log
+	// transfer collaborator reads logsink.log from this directory.
+	LogDir string
+
+	// Clock supplies timing services to the worker.
+	Clock clock.Clock
+
+	// NewWorker is called to create a new migrationmaster worker.
 	NewWorker func(Config) (worker.Worker, error)
 }
 
 // Validate is called by start to check for bad configuration.
 func (config ManifoldConfig) Validate() error {
-	if config.APICallerName == "" {
-		return errors.NotValidf("empty APICallerName")
-	}
 	if config.DomainServicesName == "" {
 		return errors.NotValidf("empty DomainServicesName")
+	}
+	if config.DomainServicesGetter == nil {
+		return errors.NotValidf("nil DomainServicesGetter")
 	}
 	if config.FortressName == "" {
 		return errors.NotValidf("empty FortressName")
@@ -46,8 +69,8 @@ func (config ManifoldConfig) Validate() error {
 	if config.ModelUUID == "" {
 		return errors.NotValidf("empty ModelUUID")
 	}
-	if config.NewFacade == nil {
-		return errors.NotValidf("nil NewFacade")
+	if config.LogDir == "" {
+		return errors.NotValidf("empty LogDir")
 	}
 	if config.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
@@ -59,15 +82,11 @@ func (config ManifoldConfig) Validate() error {
 }
 
 // start is a StartFunc for a Worker manifold.
-func (config ManifoldConfig) start(context context.Context, getter dependency.Getter) (worker.Worker, error) {
+func (config ManifoldConfig) start(_ context.Context, getter dependency.Getter) (worker.Worker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	var apiConn api.Connection
-	if err := getter.Get(config.APICallerName, &apiConn); err != nil {
-		return nil, errors.Trace(err)
-	}
 	var domainServices services.DomainServices
 	if err := getter.Get(config.DomainServicesName, &domainServices); err != nil {
 		return nil, errors.Trace(err)
@@ -76,13 +95,87 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 	if err := getter.Get(config.FortressName, &guard); err != nil {
 		return nil, errors.Trace(err)
 	}
-	facade, err := config.NewFacade(apiConn)
+
+	modelUUID := model.UUID(config.ModelUUID)
+	controllerModelUUID, err := domainServices.Controller().ControllerModelUUID(context.Background())
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(err, "resolving controller model UUID")
 	}
+
+	sourcePrecheck := func(precheckCtx context.Context) error {
+		return migration.SourcePrecheck(
+			precheckCtx,
+			modelUUID,
+			controllerModelUUID,
+			domainServices.Model(),
+			func(getterCtx context.Context, uuid model.UUID) (migration.ModelMigrationService, error) {
+				svc, err := config.DomainServicesGetter.ServicesForModel(getterCtx, uuid)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				return svc.ModelMigration(), nil
+			},
+			func(getterCtx context.Context, uuid model.UUID) (migration.CredentialService, error) {
+				svc, err := config.DomainServicesGetter.ServicesForModel(getterCtx, uuid)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				return svc.Credential(), nil
+			},
+			func(getterCtx context.Context, uuid model.UUID) (migration.UpgradeService, error) {
+				svc, err := config.DomainServicesGetter.ServicesForModel(getterCtx, uuid)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				return svc.Upgrade(), nil
+			},
+			func(getterCtx context.Context, uuid model.UUID) (migration.ApplicationService, error) {
+				svc, err := config.DomainServicesGetter.ServicesForModel(getterCtx, uuid)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				return svc.Application(), nil
+			},
+			func(getterCtx context.Context, uuid model.UUID) (migration.RelationService, error) {
+				svc, err := config.DomainServicesGetter.ServicesForModel(getterCtx, uuid)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				return svc.Relation(), nil
+			},
+			func(getterCtx context.Context, uuid model.UUID) (migration.StatusService, error) {
+				svc, err := config.DomainServicesGetter.ServicesForModel(getterCtx, uuid)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				return svc.Status(), nil
+			},
+			func(getterCtx context.Context, uuid model.UUID) (migration.ModelAgentService, error) {
+				svc, err := config.DomainServicesGetter.ServicesForModel(getterCtx, uuid)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				return svc.Agent(), nil
+			},
+			func(getterCtx context.Context, uuid model.UUID) (migration.MachineService, error) {
+				svc, err := config.DomainServicesGetter.ServicesForModel(getterCtx, uuid)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				return svc.Machine(), nil
+			},
+		)
+	}
+
+	lgr := internallogger.GetLogger("juju.worker.migrationmaster.manifold", logger.MIGRATION)
+
+	streamModelLog := func(logCtx context.Context, start time.Time) (<-chan common.LogMessage, error) {
+		logPath := filepath.Join(config.LogDir, "logsink.log")
+		return streamLogsFromFile(logCtx, lgr, logPath, config.ModelUUID, start)
+	}
+
 	w, err := config.NewWorker(Config{
 		ModelUUID:               config.ModelUUID,
-		Facade:                  facade,
 		CharmService:            domainServices.Application(),
 		ModelMigrationService:   domainServices.ModelMigration(),
 		ExportService:           domainServices.Export(),
@@ -95,6 +188,8 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		AgentBinaryStore:        domainServices.AgentBinaryStore(),
 		LoggingService:          domainServices.Logging(),
 		Clock:                   config.Clock,
+		SourcePrecheck:          sourcePrecheck,
+		StreamModelLog:          streamModelLog,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -103,12 +198,12 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 }
 
 func errorFilter(err error) error {
-	switch errors.Cause(err) {
-	case ErrMigrated:
+	switch err := errors.Cause(err); {
+	case errors.Is(err, ErrMigrated):
 		// If the model has migrated, the migrationmaster should no
 		// longer be running.
 		return dependency.ErrUninstall
-	case ErrInactive:
+	case errors.Is(err, ErrInactive):
 		// If the migration is no longer active, restart the
 		// migrationmaster immediately so it can wait for the next
 		// attempt.
@@ -122,11 +217,70 @@ func errorFilter(err error) error {
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.APICallerName,
 			config.DomainServicesName,
 			config.FortressName,
 		},
 		Start:  config.start,
 		Filter: errorFilter,
 	}
+}
+
+const (
+	// logScanBufSize is the initial buffer size for the log scanner.
+	logScanBufSize = 64 * 1024
+
+	// logScanMaxTokenSize is the maximum allowed line size for the log
+	// scanner. Lines exceeding this size will cause the scanner to stop
+	// with bufio.ErrTooLong.
+	logScanMaxTokenSize = 1024 * 1024
+)
+
+// streamLogsFromFile reads log messages from the local logsink.log file,
+// filters by model UUID, and emits them on a channel.
+func streamLogsFromFile(ctx context.Context, lgr logger.Logger, logPath, modelUUID string, start time.Time) (<-chan common.LogMessage, error) {
+	f, err := os.Open(logPath)
+	if err != nil {
+		return nil, errors.Annotate(err, "opening log file")
+	}
+
+	ch := make(chan common.LogMessage)
+	go func() {
+		defer close(ch)
+		defer func(f *os.File) {
+			_ = f.Close()
+		}(f)
+
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, logScanBufSize), logScanMaxTokenSize)
+		for scanner.Scan() {
+			var record logger.LogRecord
+			if err := record.UnmarshalJSON(scanner.Bytes()); err != nil {
+				continue
+			}
+			if record.ModelUUID != modelUUID {
+				continue
+			}
+			if !record.Time.After(start) {
+				continue
+			}
+			select {
+			case ch <- common.LogMessage{
+				ModelUUID: record.ModelUUID,
+				Entity:    record.Entity,
+				Timestamp: record.Time,
+				Severity:  record.Level.String(),
+				Module:    record.Module,
+				Location:  record.Location,
+				Message:   record.Message,
+				Labels:    record.Labels,
+			}:
+			case <-ctx.Done():
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			lgr.Errorf(ctx, "error reading log file %s: %v", logPath, err)
+		}
+	}()
+	return ch, nil
 }

--- a/internal/worker/migrationmaster/manifoldconfig_test.go
+++ b/internal/worker/migrationmaster/manifoldconfig_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
 
-	"github.com/juju/juju/api/base"
+	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/worker/migrationmaster"
 )
@@ -32,13 +32,13 @@ func (s *ManifoldConfigSuite) SetUpTest(c *tc.C) {
 
 func (s *ManifoldConfigSuite) validConfig() migrationmaster.ManifoldConfig {
 	return migrationmaster.ManifoldConfig{
-		APICallerName:      "api-caller",
-		DomainServicesName: "domain-services",
-		FortressName:       "fortress",
-		ModelUUID:          "model-uuid",
-		Clock:              struct{ clock.Clock }{},
-		NewFacade:          func(base.APICaller) (migrationmaster.Facade, error) { return nil, nil },
-		NewWorker:          func(migrationmaster.Config) (worker.Worker, error) { return nil, nil },
+		DomainServicesName:   "domain-services",
+		DomainServicesGetter: struct{ services.DomainServicesGetter }{},
+		FortressName:         "fortress",
+		ModelUUID:            "model-uuid",
+		LogDir:               "/tmp/logs",
+		Clock:                struct{ clock.Clock }{},
+		NewWorker:            func(migrationmaster.Config) (worker.Worker, error) { return nil, nil },
 	}
 }
 
@@ -51,14 +51,14 @@ func (s *ManifoldConfigSuite) TestMissingModelUUID(c *tc.C) {
 	s.checkNotValid(c, "empty ModelUUID not valid")
 }
 
-func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *tc.C) {
-	s.config.APICallerName = ""
-	s.checkNotValid(c, "empty APICallerName not valid")
-}
-
 func (s *ManifoldConfigSuite) TestMissingDomainServicesName(c *tc.C) {
 	s.config.DomainServicesName = ""
 	s.checkNotValid(c, "empty DomainServicesName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingDomainServicesGetter(c *tc.C) {
+	s.config.DomainServicesGetter = nil
+	s.checkNotValid(c, "nil DomainServicesGetter not valid")
 }
 
 func (s *ManifoldConfigSuite) TestMissingFortressName(c *tc.C) {
@@ -66,14 +66,14 @@ func (s *ManifoldConfigSuite) TestMissingFortressName(c *tc.C) {
 	s.checkNotValid(c, "empty FortressName not valid")
 }
 
+func (s *ManifoldConfigSuite) TestMissingLogDir(c *tc.C) {
+	s.config.LogDir = ""
+	s.checkNotValid(c, "empty LogDir not valid")
+}
+
 func (s *ManifoldConfigSuite) TestMissingClock(c *tc.C) {
 	s.config.Clock = nil
 	s.checkNotValid(c, "nil Clock not valid")
-}
-
-func (s *ManifoldConfigSuite) TestMissingNewFacade(c *tc.C) {
-	s.config.NewFacade = nil
-	s.checkNotValid(c, "nil NewFacade not valid")
 }
 
 func (s *ManifoldConfigSuite) TestMissingNewWorker(c *tc.C) {

--- a/internal/worker/migrationmaster/shim.go
+++ b/internal/worker/migrationmaster/shim.go
@@ -6,23 +6,13 @@ package migrationmaster
 import (
 	"github.com/juju/errors"
 	"github.com/juju/worker/v5"
-
-	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/controller/migrationmaster"
-	"github.com/juju/juju/api/watcher"
 )
-
-// NewFacade attempts to create a new facade for the migration master
-func NewFacade(apiCaller base.APICaller) (Facade, error) {
-	facade := migrationmaster.NewClient(apiCaller, watcher.NewNotifyWatcher)
-	return facade, nil
-}
 
 // NewWorker creates a new Worker from the config supplied.
 func NewWorker(config Config) (worker.Worker, error) {
-	worker, err := New(config)
+	w, err := New(config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return worker, nil
+	return w, nil
 }

--- a/internal/worker/migrationmaster/validate_test.go
+++ b/internal/worker/migrationmaster/validate_test.go
@@ -6,12 +6,14 @@ package migrationmaster_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/api"
+	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/testhelpers"
@@ -45,10 +47,16 @@ func (*ValidateSuite) TestMissingGuard(c *tc.C) {
 	checkNotValid(c, config, "nil Guard not valid")
 }
 
-func (*ValidateSuite) TestMissingFacade(c *tc.C) {
+func (*ValidateSuite) TestMissingSourcePrecheck(c *tc.C) {
 	config := validConfig()
-	config.Facade = nil
-	checkNotValid(c, config, "nil Facade not valid")
+	config.SourcePrecheck = nil
+	checkNotValid(c, config, "nil SourcePrecheck not valid")
+}
+
+func (*ValidateSuite) TestMissingStreamModelLog(c *tc.C) {
+	config := validConfig()
+	config.StreamModelLog = nil
+	checkNotValid(c, config, "nil StreamModelLog not valid")
 }
 
 func (*ValidateSuite) TestMissingAPIOpen(c *tc.C) {
@@ -121,7 +129,6 @@ func validConfig() migrationmaster.Config {
 	return migrationmaster.Config{
 		ModelUUID:      coretesting.ModelTag.Id(),
 		Guard:          struct{ fortress.Guard }{},
-		Facade:         struct{ migrationmaster.Facade }{},
 		APIOpen:        func(context.Context, *api.Info, api.DialOpts) (api.Connection, error) { return nil, nil },
 		UploadBinaries: func(context.Context, migration.UploadBinariesConfig, logger.Logger) error { return nil },
 		CharmService:   struct{ migrationmaster.CharmService }{},
@@ -141,6 +148,10 @@ func validConfig() migrationmaster.Config {
 		AgentBinaryStore: struct{ migration.AgentBinaryStore }{},
 		LoggingService:   struct{ migrationmaster.LoggingService }{},
 		Clock:            struct{ clock.Clock }{},
+		SourcePrecheck:   func(context.Context) error { return nil },
+		StreamModelLog: func(context.Context, time.Time) (<-chan common.LogMessage, error) {
+			return nil, nil
+		},
 	}
 }
 

--- a/internal/worker/migrationmaster/worker.go
+++ b/internal/worker/migrationmaster/worker.go
@@ -63,24 +63,6 @@ var (
 // to the newly-migrated model.
 const progressUpdateInterval = 30 * time.Second
 
-// Facade exposes the controller facade functionality the Worker still needs.
-// These are the operations shared with remote callers; everything that is
-// worker-private is reached directly through the domain services instead.
-type Facade interface {
-	// Prechecks performs pre-migration checks on the model and
-	// (source) controller.
-	Prechecks(context.Context) error
-
-	// OpenResource downloads a single resource for an application.
-	OpenResource(context.Context, string, string) (io.ReadCloser, error)
-
-	// StreamModelLog takes a starting time and returns a channel that
-	// will yield the logs on or after that time - these are the logs
-	// that need to be transferred to the target after the migration
-	// is successful.
-	StreamModelLog(context.Context, time.Time) (<-chan common.LogMessage, error)
-}
-
 type CharmService interface {
 	// GetCharmArchive returns a ReadCloser stream for the charm archive for a given
 	// charm id, along with the hash of the charm archive. Clients can use the hash
@@ -157,11 +139,19 @@ type ModelAgentService interface {
 	) (map[machine.Name]coreagentbinary.Metadata, map[unit.Name]coreagentbinary.Metadata, error)
 }
 
-// ResourceService lists the model resources that need binary transfer.
+// ResourceService lists the model resources that need binary transfer
+// and opens resource content for download.
 type ResourceService interface {
 	// ListAllModelResources returns the application and unit resources to
 	// export for all applications in the model.
 	ListAllModelResources(context.Context) ([]resource.Resource, error)
+
+	// GetResourceUUIDByApplicationAndResourceName returns the UUID of the
+	// resource identified by application and resource name.
+	GetResourceUUIDByApplicationAndResourceName(ctx context.Context, appName, resName string) (resource.UUID, error)
+
+	// OpenResource returns the details of and a reader for the resource.
+	OpenResource(ctx context.Context, resourceUUID resource.UUID) (resource.Resource, io.ReadCloser, error)
 }
 
 // AgentBinaryStore provides an interface for interacting with the stored agent
@@ -185,7 +175,6 @@ type LoggingService interface {
 // Config defines the operation of a Worker.
 type Config struct {
 	ModelUUID               string
-	Facade                  Facade
 	CharmService            CharmService
 	ModelMigrationService   ModelMigrationService
 	ExportService           ExportService
@@ -198,15 +187,20 @@ type Config struct {
 	AgentBinaryStore        AgentBinaryStore
 	LoggingService          LoggingService
 	Clock                   clock.Clock
+
+	// SourcePrecheck runs source-side migration prechecks using local
+	// domain services instead of an API facade.
+	SourcePrecheck func(context.Context) error
+
+	// StreamModelLog returns a channel that yields log messages on or
+	// after the given time from the local logsink.log file.
+	StreamModelLog func(context.Context, time.Time) (<-chan common.LogMessage, error)
 }
 
 // Validate returns an error if config cannot drive a Worker.
 func (config Config) Validate() error {
 	if !names.IsValidModel(config.ModelUUID) {
 		return errors.NotValidf("model UUID %q", config.ModelUUID)
-	}
-	if config.Facade == nil {
-		return errors.NotValidf("nil Facade")
 	}
 	if config.CharmService == nil {
 		return errors.NotValidf("nil CharmService")
@@ -243,6 +237,12 @@ func (config Config) Validate() error {
 	}
 	if config.Clock == nil {
 		return errors.NotValidf("nil Clock")
+	}
+	if config.SourcePrecheck == nil {
+		return errors.NotValidf("nil SourcePrecheck")
+	}
+	if config.StreamModelLog == nil {
+		return errors.NotValidf("nil StreamModelLog")
 	}
 	return nil
 }
@@ -447,7 +447,7 @@ func checkTargetSupportsEnvelope(targetClient *migrationtarget.Client) error {
 
 func (w *Worker) prechecks(ctx context.Context, status coremigration.MigrationStatus) error {
 	w.setInfoStatus(ctx, "performing source prechecks")
-	if err := w.config.Facade.Prechecks(ctx); err != nil {
+	if err := w.config.SourcePrecheck(ctx); err != nil {
 		return errors.Annotate(err, "source prechecks failed")
 	}
 
@@ -569,7 +569,7 @@ func (w *Worker) transferModel(ctx context.Context, status coremigration.Migrati
 		ToolsUploader:    wrapper,
 
 		Resources:          model.resources,
-		ResourceDownloader: w.config.Facade,
+		ResourceDownloader: &resourceDownloaderShim{svc: w.config.ResourceService},
 		ResourceUploader:   wrapper,
 	}, w.logger)
 	if err != nil {
@@ -732,7 +732,7 @@ func (w *Worker) transferLogs(ctx context.Context, targetInfo coremigration.Targ
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
-	logSource, err := w.config.Facade.StreamModelLog(ctx, latestLogTime)
+	logSource, err := w.config.StreamModelLog(ctx, latestLogTime)
 	if err != nil {
 		return errors.Annotate(err, "opening source log stream")
 	}
@@ -1062,4 +1062,23 @@ func (w *Worker) openAPIConnForModel(ctx context.Context, targetInfo coremigrati
 
 func modelHasMigrated(phase coremigration.Phase) bool {
 	return phase == coremigration.DONE || phase == coremigration.REAPFAILED
+}
+
+// resourceDownloaderShim implements migration.ResourceDownloader by
+// resolving the resource UUID from the application/name pair and opening
+// the resource content through the domain service directly.
+type resourceDownloaderShim struct {
+	svc ResourceService
+}
+
+func (a *resourceDownloaderShim) OpenResource(ctx context.Context, appName, resName string) (io.ReadCloser, error) {
+	uuid, err := a.svc.GetResourceUUIDByApplicationAndResourceName(ctx, appName, resName)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	_, reader, err := a.svc.OpenResource(ctx, uuid)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return reader, nil
 }

--- a/internal/worker/migrationmaster/worker_test.go
+++ b/internal/worker/migrationmaster/worker_test.go
@@ -5,10 +5,12 @@ package migrationmaster_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/textproto"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -231,7 +233,6 @@ func (s *Suite) SetUpTest(c *tc.C) {
 	// tweak parts of this as needed.
 	s.config = migrationmaster.Config{
 		ModelUUID:               modelUUID,
-		Facade:                  s.facade,
 		CharmService:            s.charmService,
 		ModelMigrationService:   s.modelMigrationService,
 		ExportService:           s.exportService,
@@ -244,6 +245,8 @@ func (s *Suite) SetUpTest(c *tc.C) {
 		AgentBinaryStore:        fakeAgentBinaryStore,
 		LoggingService:          s.loggingService,
 		Clock:                   s.clock,
+		SourcePrecheck:          s.facade.Prechecks,
+		StreamModelLog:          s.facade.StreamModelLog,
 	}
 }
 
@@ -1388,6 +1391,13 @@ func assertExpectedCallArgs(c *tc.C, stub *testhelpers.Stub, expectedCalls []tes
 			continue
 		}
 
+		if call.FuncName == "UploadBinaries" {
+			mc := tc.NewMultiChecker()
+			mc.AddExpr(`_[5]`, tc.NotNil)
+			c.Assert(stubCall.Args[:5], mc, call.Args[:5], tc.Commentf("call %s", call.FuncName))
+			continue
+		}
+
 		c.Assert(stubCall, tc.DeepEquals, call, tc.Commentf("call %s", call.FuncName))
 	}
 }
@@ -1427,8 +1437,6 @@ func newStubMasterFacade(stub *testhelpers.Stub) *stubMasterFacade {
 }
 
 type stubMasterFacade struct {
-	migrationmaster.Facade
-
 	stub *testhelpers.Stub
 
 	prechecksErr error
@@ -1622,6 +1630,16 @@ type stubResourceService struct {
 func (s *stubResourceService) ListAllModelResources(ctx context.Context) ([]coreresource.Resource, error) {
 	s.stub.AddCall("resourceService.ListAllModelResources")
 	return s.resources, nil
+}
+
+func (s *stubResourceService) GetResourceUUIDByApplicationAndResourceName(ctx context.Context, appName, resName string) (coreresource.UUID, error) {
+	s.stub.AddCall("resourceService.GetResourceUUIDByApplicationAndResourceName", appName, resName)
+	return coreresource.UUID(""), nil
+}
+
+func (s *stubResourceService) OpenResource(ctx context.Context, resourceUUID coreresource.UUID) (coreresource.Resource, io.ReadCloser, error) {
+	s.stub.AddCall("resourceService.OpenResource", resourceUUID)
+	return coreresource.Resource{}, io.NopCloser(strings.NewReader("")), nil
 }
 
 type stubCharmService struct {

--- a/internal/worker/modelworkermanager/modelworkermanager.go
+++ b/internal/worker/modelworkermanager/modelworkermanager.go
@@ -65,6 +65,7 @@ type NewModelConfig struct {
 	ControllerConfig              controller.Config
 	ProviderServicesGetter        ProviderServicesGetter
 	DomainServices                services.DomainServices
+	DomainServicesGetter          services.DomainServicesGetter
 	LeaseManager                  lease.Manager
 	HTTPClientGetter              http.HTTPClientGetter
 	APIRemoteRelationClientGetter apiremoterelationcaller.APIRemoteCallerGetter
@@ -276,6 +277,7 @@ func (m *modelWorkerManager) newWorkerFuncFromConfig(ctx context.Context, cfg Ne
 	cfg.LeaseManager = m.config.LeaseManager
 	cfg.HTTPClientGetter = m.config.HTTPClientGetter
 	cfg.APIRemoteRelationClientGetter = m.config.APIRemoteRelationClientGetter
+	cfg.DomainServicesGetter = m.config.DomainServicesGetter
 
 	// We don't want to get this in the start worker function because it
 	// won't change. Hammering the domainservices getter to get the services

--- a/internal/worker/secretsdrainworker/manifold.go
+++ b/internal/worker/secretsdrainworker/manifold.go
@@ -88,7 +88,7 @@ func (cfg ManifoldConfig) Validate() error {
 }
 
 // start is a StartFunc for a Worker manifold.
-func (cfg ManifoldConfig) start(context context.Context, getter dependency.Getter) (worker.Worker, error) {
+func (cfg ManifoldConfig) start(_ context.Context, getter dependency.Getter) (worker.Worker, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -112,7 +112,7 @@ func (cfg ManifoldConfig) start(context context.Context, getter dependency.Gette
 		return leadershipTracker
 	}
 
-	worker, err := cfg.NewWorker(Config{
+	w, err := cfg.NewWorker(Config{
 		SecretsDrainFacade: cfg.NewSecretsDrainFacade(apiCaller),
 		Logger:             cfg.Logger,
 		SecretsBackendGetter: func() (jujusecrets.BackendsClient, error) {
@@ -123,7 +123,7 @@ func (cfg ManifoldConfig) start(context context.Context, getter dependency.Gette
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return worker, nil
+	return w, nil
 }
 
 type passThroughLeadershipTracker struct{}

--- a/internal/worker/secretsdrainworker/manifold_linux.go
+++ b/internal/worker/secretsdrainworker/manifold_linux.go
@@ -1,0 +1,273 @@
+//go:build dqlite
+
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretsdrainworker
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/dependency"
+
+	"github.com/juju/juju/api/common/secretsdrain"
+	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/model"
+	coresecrets "github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/secret"
+	secretservice "github.com/juju/juju/domain/secret/service"
+	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
+	jujusecrets "github.com/juju/juju/internal/secrets"
+	"github.com/juju/juju/internal/secrets/provider"
+	"github.com/juju/juju/internal/services"
+)
+
+// ModelManifoldConfig holds the dependencies and configuration for a
+// model-only Worker manifold backed by local domain services instead of
+// an API caller.
+type ModelManifoldConfig struct {
+	DomainServicesName string
+	ModelUUID          string
+	Logger             logger.Logger
+
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+// Validate is called by start to check for bad configuration.
+func (cfg ModelManifoldConfig) Validate() error {
+	if cfg.DomainServicesName == "" {
+		return errors.NotValidf("empty DomainServicesName")
+	}
+	if cfg.ModelUUID == "" {
+		return errors.NotValidf("empty ModelUUID")
+	}
+	if cfg.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if cfg.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+// start is a StartFunc for a model-only Worker manifold.
+func (cfg ModelManifoldConfig) start(context context.Context, getter dependency.Getter) (worker.Worker, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var domainServices services.DomainServices
+	if err := getter.Get(cfg.DomainServicesName, &domainServices); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	secretSvc := domainServices.Secret()
+	backendSvc := domainServices.SecretBackend()
+	modelUUID := model.UUID(cfg.ModelUUID)
+
+	facade := &modelSecretsDrainFacade{
+		secretSvc:  secretSvc,
+		backendSvc: backendSvc,
+		modelUUID:  modelUUID,
+	}
+
+	backendGetter := func() (jujusecrets.BackendsClient, error) {
+		api := &localJujuAPIClient{
+			secretSvc:  secretSvc,
+			backendSvc: backendSvc,
+			modelUUID:  modelUUID,
+		}
+		return jujusecrets.NewClient(api)
+	}
+
+	w, err := cfg.NewWorker(Config{
+		SecretsDrainFacade:   facade,
+		Logger:               cfg.Logger,
+		SecretsBackendGetter: backendGetter,
+		LeadershipTrackerFunc: func() leadership.ChangeTracker {
+			return passThroughLeadershipTracker{}
+		},
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}
+
+// ModelManifold packages a Worker for use in a dependency.Engine. It reads
+// secret drain data through local domain services rather than an API caller.
+func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{config.DomainServicesName},
+		Start:  config.start,
+	}
+}
+
+// modelSecretsDrainFacade satisfies the SecretsDrainFacade interface by
+// reading from domain services directly.
+type modelSecretsDrainFacade struct {
+	secretSvc  secretService
+	backendSvc secretBackendService
+	modelUUID  model.UUID
+}
+
+// secretService is the subset of the domain secret service needed by the
+// model drain facade adapter.
+type secretService interface {
+	ListUserSecretsToDrain(context.Context) ([]*coresecrets.SecretMetadataForDrain, error)
+	ChangeSecretBackend(context.Context, *coresecrets.URI, int, secretservice.ChangeSecretBackendParams) error
+	GetSecretValue(context.Context, *coresecrets.URI, int, secret.SecretAccessor) (coresecrets.SecretValue, *coresecrets.ValueRef, error)
+	ListGrantedSecretsForBackend(context.Context, string, coresecrets.SecretRole, ...secret.SecretAccessor) ([]*coresecrets.SecretRevisionRef, error)
+}
+
+// secretBackendService is the subset of the domain secret backend service
+// needed by the model drain facade adapter.
+type secretBackendService interface {
+	GetRevisionsToDrain(context.Context, model.UUID, []coresecrets.SecretExternalRevision) ([]secretbackendservice.RevisionInfo, error)
+	WatchModelSecretBackendChanged(context.Context, model.UUID) (watcher.NotifyWatcher, error)
+	DrainBackendConfigInfo(context.Context, secretbackendservice.DrainBackendConfigParams) (*provider.ModelBackendConfigInfo, error)
+	BackendConfigInfo(context.Context, secretbackendservice.BackendConfigParams) (*provider.ModelBackendConfigInfo, error)
+}
+
+// GetSecretsToDrain is part of the SecretsDrainFacade interface.
+func (f *modelSecretsDrainFacade) GetSecretsToDrain(ctx context.Context) ([]coresecrets.SecretMetadataForDrain, error) {
+	secrets, err := f.secretSvc.ListUserSecretsToDrain(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var result []coresecrets.SecretMetadataForDrain
+	for _, info := range secrets {
+		revisions, err := f.backendSvc.GetRevisionsToDrain(ctx, f.modelUUID, info.Revisions)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		var extRevs []coresecrets.SecretExternalRevision
+		for _, r := range revisions {
+			extRevs = append(extRevs, coresecrets.SecretExternalRevision{
+				Revision: r.Revision,
+				ValueRef: r.ValueRef,
+			})
+		}
+		if len(extRevs) == 0 {
+			continue
+		}
+		result = append(result, coresecrets.SecretMetadataForDrain{
+			URI:       info.URI,
+			Revisions: extRevs,
+		})
+	}
+	return result, nil
+}
+
+// ChangeSecretBackend is part of the SecretsDrainFacade interface.
+func (f *modelSecretsDrainFacade) ChangeSecretBackend(ctx context.Context, args []secretsdrain.ChangeSecretBackendArg) (secretsdrain.ChangeSecretBackendResult, error) {
+	result := secretsdrain.ChangeSecretBackendResult{
+		Results: make([]error, len(args)),
+	}
+	accessor := secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
+		ID:   f.modelUUID.String(),
+	}
+	for i, arg := range args {
+		err := f.secretSvc.ChangeSecretBackend(ctx, arg.URI, arg.Revision, secretservice.ChangeSecretBackendParams{
+			Accessor: accessor,
+			ValueRef: arg.ValueRef,
+			Data:     arg.Data,
+		})
+		result.Results[i] = err
+	}
+	return result, nil
+}
+
+// WatchSecretBackendChanged is part of the SecretsDrainFacade interface.
+func (f *modelSecretsDrainFacade) WatchSecretBackendChanged(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return f.backendSvc.WatchModelSecretBackendChanged(ctx, f.modelUUID)
+}
+
+// localJujuAPIClient is a local implementation of the jujusecrets.JujuAPIClient
+// interface that reads from domain services directly instead of making API calls.
+type localJujuAPIClient struct {
+	secretSvc  secretService
+	backendSvc secretBackendService
+	modelUUID  model.UUID
+}
+
+// GetBackendConfigForDrain returns the backend config for the drain worker.
+func (c *localJujuAPIClient) GetBackendConfigForDrain(ctx context.Context, backendID *string) (*provider.ModelBackendConfig, string, error) {
+	var bid string
+	if backendID != nil {
+		bid = *backendID
+	}
+	accessor := secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
+		ID:   c.modelUUID.String(),
+	}
+	info, err := c.backendSvc.DrainBackendConfigInfo(ctx, secretbackendservice.DrainBackendConfigParams{
+		GrantedSecretsGetter: c.secretSvc.ListGrantedSecretsForBackend,
+		Accessor:             accessor,
+		ModelUUID:            c.modelUUID,
+		BackendID:            bid,
+	})
+	if err != nil {
+		return nil, "", errors.Trace(err)
+	}
+	want := info.ActiveID
+	if backendID != nil {
+		want = *backendID
+	}
+	cfg, ok := info.Configs[want]
+	if !ok {
+		return nil, "", errors.Errorf("secret backend %q missing from config", want)
+	}
+	return &cfg, info.ActiveID, nil
+}
+
+// GetRevisionContentInfo returns the content of a secret revision.
+func (c *localJujuAPIClient) GetRevisionContentInfo(ctx context.Context, uri *coresecrets.URI, revision int, _ bool) (*jujusecrets.ContentParams, *provider.ModelBackendConfig, bool, error) {
+	accessor := secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
+		ID:   c.modelUUID.String(),
+	}
+	val, valueRef, err := c.secretSvc.GetSecretValue(ctx, uri, revision, accessor)
+	if err != nil {
+		return nil, nil, false, errors.Trace(err)
+	}
+	content := &jujusecrets.ContentParams{SecretValue: val, ValueRef: valueRef}
+	if content.ValueRef == nil {
+		return content, nil, false, nil
+	}
+	backendID := content.ValueRef.BackendID
+	cfg, _, err := c.GetBackendConfigForDrain(ctx, &backendID)
+	if err != nil {
+		return nil, nil, false, errors.Trace(err)
+	}
+	return content, cfg, false, nil
+}
+
+// GetSecretBackendConfig returns the backend config for reading secrets.
+func (c *localJujuAPIClient) GetSecretBackendConfig(ctx context.Context, backendID *string) (*provider.ModelBackendConfigInfo, error) {
+	var bids []string
+	if backendID != nil {
+		bids = []string{*backendID}
+	}
+	accessor := secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
+		ID:   c.modelUUID.String(),
+	}
+	return c.backendSvc.BackendConfigInfo(ctx, secretbackendservice.BackendConfigParams{
+		GrantedSecretsGetter: c.secretSvc.ListGrantedSecretsForBackend,
+		Accessor:             accessor,
+		ModelUUID:            c.modelUUID,
+		BackendIDs:           bids,
+		SameController:       true,
+	})
+}
+
+// GetContentInfo returns info about the content of a secret.
+func (c *localJujuAPIClient) GetContentInfo(ctx context.Context, uri *coresecrets.URI, _ string, _, _ bool) (*jujusecrets.ContentParams, *provider.ModelBackendConfig, bool, error) {
+	return c.GetRevisionContentInfo(ctx, uri, 0, false)
+}

--- a/internal/worker/secretsdrainworker/manifold_linux_test.go
+++ b/internal/worker/secretsdrainworker/manifold_linux_test.go
@@ -1,0 +1,116 @@
+//go:build dqlite
+
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretsdrainworker_test
+
+import (
+	"testing"
+
+	"github.com/juju/errors"
+	"github.com/juju/tc"
+	"github.com/juju/worker/v5"
+	dt "github.com/juju/worker/v5/dependency/testing"
+
+	secretservice "github.com/juju/juju/domain/secret/service"
+	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/services"
+	"github.com/juju/juju/internal/testhelpers"
+	"github.com/juju/juju/internal/worker/secretsdrainworker"
+)
+
+type ModelManifoldSuite struct {
+	testhelpers.IsolationSuite
+	config secretsdrainworker.ModelManifoldConfig
+}
+
+func TestModelManifoldSuite(t *testing.T) {
+	tc.Run(t, &ModelManifoldSuite{})
+}
+
+func (s *ModelManifoldSuite) SetUpTest(c *tc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.config = s.validModelConfig(c)
+}
+
+func (s *ModelManifoldSuite) validModelConfig(c *tc.C) secretsdrainworker.ModelManifoldConfig {
+	return secretsdrainworker.ModelManifoldConfig{
+		DomainServicesName: "domain-services",
+		ModelUUID:          "mock-model-uuid",
+		Logger:             loggertesting.WrapCheckLog(c),
+		NewWorker: func(config secretsdrainworker.Config) (worker.Worker, error) {
+			return nil, nil
+		},
+	}
+}
+
+func (s *ModelManifoldSuite) TestValid(c *tc.C) {
+	c.Check(s.config.Validate(), tc.ErrorIsNil)
+}
+
+func (s *ModelManifoldSuite) TestMissingDomainServicesName(c *tc.C) {
+	s.config.DomainServicesName = ""
+	s.checkNotValid(c, "empty DomainServicesName not valid")
+}
+
+func (s *ModelManifoldSuite) TestMissingModelUUID(c *tc.C) {
+	s.config.ModelUUID = ""
+	s.checkNotValid(c, "empty ModelUUID not valid")
+}
+
+func (s *ModelManifoldSuite) TestMissingLogger(c *tc.C) {
+	s.config.Logger = nil
+	s.checkNotValid(c, "nil Logger not valid")
+}
+
+func (s *ModelManifoldSuite) TestMissingNewWorker(c *tc.C) {
+	s.config.NewWorker = nil
+	s.checkNotValid(c, "nil NewWorker not valid")
+}
+
+func (s *ModelManifoldSuite) checkNotValid(c *tc.C, expect string) {
+	err := s.config.Validate()
+	c.Check(err, tc.ErrorMatches, expect)
+	c.Check(err, tc.ErrorIs, errors.NotValid)
+}
+
+func (s *ModelManifoldSuite) TestInputs(c *tc.C) {
+	manifold := secretsdrainworker.ModelManifold(s.config)
+	c.Check(manifold.Inputs, tc.DeepEquals, []string{"domain-services"})
+}
+
+func (s *ModelManifoldSuite) TestStart(c *tc.C) {
+	called := false
+	s.config.NewWorker = func(config secretsdrainworker.Config) (worker.Worker, error) {
+		called = true
+		c.Check(config.SecretsDrainFacade, tc.NotNil)
+		c.Check(config.Logger, tc.NotNil)
+		c.Check(config.SecretsBackendGetter, tc.NotNil)
+		c.Check(config.LeadershipTrackerFunc, tc.NotNil)
+		return nil, nil
+	}
+	manifold := secretsdrainworker.ModelManifold(s.config)
+	w, err := manifold.Start(c.Context(), dt.StubGetter(map[string]any{
+		"domain-services": &stubDomainServices{},
+	}))
+	c.Assert(w, tc.IsNil)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(called, tc.IsTrue)
+}
+
+// stubDomainServices is a minimal stub that satisfies services.DomainServices
+// for tests that only need Secret() and SecretBackend() methods.
+type stubDomainServices struct {
+	services.ControllerDomainServices
+	services.ModelDomainServices
+}
+
+func (s *stubDomainServices) Secret() *secretservice.WatchableService {
+	return nil
+}
+
+func (s *stubDomainServices) SecretBackend() *secretbackendservice.WatchableService {
+	return nil
+}

--- a/internal/worker/secretsdrainworker/manifold_other.go
+++ b/internal/worker/secretsdrainworker/manifold_other.go
@@ -1,0 +1,90 @@
+//go:build !dqlite
+
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package secretsdrainworker
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/dependency"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/core/logger"
+)
+
+// ModelManifoldConfig holds the dependencies and configuration for a
+// model-only Worker manifold backed by local domain services instead of
+// an API caller.
+type ModelManifoldConfig struct {
+	DomainServicesName string
+	ModelUUID          string
+	Logger             logger.Logger
+
+	NewWorker func(Config) (worker.Worker, error)
+}
+
+// Validate is called by start to check for bad configuration.
+func (cfg ModelManifoldConfig) validate() error {
+	if cfg.DomainServicesName == "" {
+		return errors.NotValidf("empty DomainServicesName")
+	}
+	if cfg.ModelUUID == "" {
+		return errors.NotValidf("empty ModelUUID")
+	}
+	if cfg.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	if cfg.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	return nil
+}
+
+// ModelManifold packages a Worker for use in a dependency.Engine. It reads
+// secret drain data through local domain services rather than an API caller.
+func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{config.DomainServicesName},
+		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
+			if err := config.validate(); err != nil {
+				return nil, errors.Trace(err)
+			}
+			return newNoopWorker(), nil
+		},
+	}
+}
+
+// NoopWorker ensures that we get a functioning tracer even if we're not using
+// it.
+type noopWorker struct {
+	tomb tomb.Tomb
+}
+
+// NewNoopWorker worker creates a worker that doesn't perform any new work on
+// the context. Though it will manage the lifecycle of the worker.
+func newNoopWorker() *noopWorker {
+	// Set this up, so we only ever hand out a singular tracer and span per
+	// worker.
+	w := &noopWorker{}
+
+	w.tomb.Go(func() error {
+		<-w.tomb.Dying()
+		return tomb.ErrDying
+	})
+
+	return w
+}
+
+// Kill is part of the worker.Worker interface.
+func (w *noopWorker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (w *noopWorker) Wait() error {
+	return w.tomb.Wait()
+}

--- a/internal/worker/secretspruner/manifold.go
+++ b/internal/worker/secretspruner/manifold.go
@@ -10,30 +10,24 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 
-	"github.com/juju/juju/api/base"
-	"github.com/juju/juju/api/controller/usersecrets"
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/internal/services"
 )
 
 // ManifoldConfig describes the resources used by the secretspruner worker.
 type ManifoldConfig struct {
-	APICallerName string
-	Logger        logger.Logger
+	DomainServicesName string
+	Logger             logger.Logger
 
-	NewUserSecretsFacade func(base.APICaller) SecretsFacade
-	NewWorker            func(Config) (worker.Worker, error)
-}
-
-// NewUserSecretsFacade returns a new SecretsFacade.
-func NewUserSecretsFacade(caller base.APICaller) SecretsFacade {
-	return usersecrets.NewClient(caller)
+	NewWorker func(Config) (worker.Worker, error)
 }
 
 // Manifold returns a Manifold that encapsulates the secretspruner worker.
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.APICallerName,
+			config.DomainServicesName,
 		},
 		Start: config.start,
 	}
@@ -41,14 +35,11 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 
 // Validate is called by start to check for bad configuration.
 func (cfg ManifoldConfig) Validate() error {
-	if cfg.APICallerName == "" {
-		return errors.NotValidf("empty APICallerName")
+	if cfg.DomainServicesName == "" {
+		return errors.NotValidf("empty DomainServicesName")
 	}
 	if cfg.Logger == nil {
 		return errors.NotValidf("nil Logger")
-	}
-	if cfg.NewUserSecretsFacade == nil {
-		return errors.NotValidf("nil NewUserSecretsFacade")
 	}
 	if cfg.NewWorker == nil {
 		return errors.NotValidf("nil NewWorker")
@@ -62,17 +53,44 @@ func (cfg ManifoldConfig) start(context context.Context, getter dependency.Gette
 		return nil, errors.Trace(err)
 	}
 
-	var apiCaller base.APICaller
-	if err := getter.Get(cfg.APICallerName, &apiCaller); err != nil {
+	var domainServices services.DomainServices
+	if err := getter.Get(cfg.DomainServicesName, &domainServices); err != nil {
 		return nil, errors.Trace(err)
 	}
 
+	facade := &secretServiceAdapter{
+		secretSvc: domainServices.Secret(),
+	}
+
 	worker, err := cfg.NewWorker(Config{
-		SecretsFacade: cfg.NewUserSecretsFacade(apiCaller),
+		SecretsFacade: facade,
 		Logger:        cfg.Logger,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return worker, nil
+}
+
+// secretServiceAdapter satisfies the SecretsFacade interface by reading
+// from the domain secret service directly.
+type secretServiceAdapter struct {
+	secretSvc secretService
+}
+
+// secretService is the subset of the domain secret service needed by the
+// secrets-pruner facade adapter.
+type secretService interface {
+	WatchObsoleteUserSecretsToPrune(context.Context) (watcher.NotifyWatcher, error)
+	DeleteObsoleteUserSecretRevisions(context.Context) error
+}
+
+// WatchRevisionsToPrune is part of the SecretsFacade interface.
+func (a *secretServiceAdapter) WatchRevisionsToPrune(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return a.secretSvc.WatchObsoleteUserSecretsToPrune(ctx)
+}
+
+// DeleteObsoleteUserSecretRevisions is part of the SecretsFacade interface.
+func (a *secretServiceAdapter) DeleteObsoleteUserSecretRevisions(ctx context.Context) error {
+	return a.secretSvc.DeleteObsoleteUserSecretRevisions(ctx)
 }

--- a/internal/worker/secretspruner/manifold_test.go
+++ b/internal/worker/secretspruner/manifold_test.go
@@ -6,17 +6,15 @@ package secretspruner_test
 import (
 	"testing"
 
-	"github.com/canonical/gomock/gomock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
 
-	"github.com/juju/juju/api/base"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/worker/secretspruner"
-	"github.com/juju/juju/internal/worker/secretspruner/mocks"
 )
 
 type manifoldSuite struct {
@@ -35,12 +33,11 @@ func (s *manifoldSuite) SetUpTest(c *tc.C) {
 
 func (s *manifoldSuite) validConfig(c *tc.C) secretspruner.ManifoldConfig {
 	return secretspruner.ManifoldConfig{
-		APICallerName: "api-caller",
-		Logger:        loggertesting.WrapCheckLog(c),
+		DomainServicesName: "domain-services",
+		Logger:             loggertesting.WrapCheckLog(c),
 		NewWorker: func(config secretspruner.Config) (worker.Worker, error) {
 			return nil, nil
 		},
-		NewUserSecretsFacade: func(base.APICaller) secretspruner.SecretsFacade { return nil },
 	}
 }
 
@@ -48,23 +45,19 @@ func (s *manifoldSuite) TestValid(c *tc.C) {
 	c.Check(s.config.Validate(), tc.ErrorIsNil)
 }
 
-func (s *manifoldSuite) TestMissingAPICallerName(c *tc.C) {
-	s.config.APICallerName = ""
-	s.checkNotValid(c, "empty APICallerName not valid")
+func (s *manifoldSuite) TestMissingDomainServicesName(c *tc.C) {
+	s.config.DomainServicesName = ""
+	s.checkNotValid(c, "empty DomainServicesName not valid")
 }
 
 func (s *manifoldSuite) TestMissingLogger(c *tc.C) {
 	s.config.Logger = nil
 	s.checkNotValid(c, "nil Logger not valid")
 }
+
 func (s *manifoldSuite) TestMissingNewWorker(c *tc.C) {
 	s.config.NewWorker = nil
 	s.checkNotValid(c, "nil NewWorker not valid")
-}
-
-func (s *manifoldSuite) TestMissingNewFacade(c *tc.C) {
-	s.config.NewUserSecretsFacade = nil
-	s.checkNotValid(c, "nil NewUserSecretsFacade not valid")
 }
 
 func (s *manifoldSuite) checkNotValid(c *tc.C, expect string) {
@@ -73,36 +66,17 @@ func (s *manifoldSuite) checkNotValid(c *tc.C, expect string) {
 	c.Check(err, tc.ErrorIs, errors.NotValid)
 }
 
-func (s *manifoldSuite) TestStart(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	facade := mocks.NewMockSecretsFacade(ctrl)
-	s.config.NewUserSecretsFacade = func(base.APICaller) secretspruner.SecretsFacade {
-		return facade
-	}
-
-	called := false
-	s.config.NewWorker = func(config secretspruner.Config) (worker.Worker, error) {
-		called = true
-		mc := tc.NewMultiChecker()
-		mc.AddExpr(`_.Logger`, tc.NotNil)
-		c.Check(config, mc, secretspruner.Config{SecretsFacade: facade})
-		return nil, nil
-	}
-	manifold := secretspruner.Manifold(s.config)
-	w, err := manifold.Start(c.Context(), dt.StubGetter(map[string]any{
-		"api-caller": struct{ base.APICaller }{&mockAPICaller{}},
-	}))
-	c.Assert(w, tc.IsNil)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(called, tc.IsTrue)
+func (s *manifoldSuite) TestInputs(c *tc.C) {
+	m := secretspruner.Manifold(s.config)
+	c.Check(m.Inputs, tc.DeepEquals, []string{"domain-services"})
 }
 
-type mockAPICaller struct {
-	base.APICaller
-}
-
-func (*mockAPICaller) BestFacadeVersion(facade string) int {
-	return 1
+func (s *manifoldSuite) TestStartMissingDomainServices(c *tc.C) {
+	getter := dt.StubGetter(map[string]any{
+		"domain-services": dependency.ErrMissing,
+	})
+	m := secretspruner.Manifold(s.config)
+	w, err := m.Start(c.Context(), getter)
+	c.Check(w, tc.IsNil)
+	c.Check(err, tc.ErrorIs, dependency.ErrMissing)
 }

--- a/internal/worker/storageprovisioner/localadapter.go
+++ b/internal/worker/storageprovisioner/localadapter.go
@@ -1,0 +1,1430 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/names/v6"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/catacomb"
+
+	coreblockdevice "github.com/juju/juju/core/blockdevice"
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/core/watcher"
+	domainblockdevice "github.com/juju/juju/domain/blockdevice"
+	domainlife "github.com/juju/juju/domain/life"
+	domainstorage "github.com/juju/juju/domain/storage"
+	"github.com/juju/juju/domain/storageprovisioning"
+	storageprovisioningerrors "github.com/juju/juju/domain/storageprovisioning/errors"
+	internalerrors "github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/rpc/params"
+)
+
+// storageProvisioningService is the subset of the domain storage provisioning
+// service needed by the model storage adapters.
+type storageProvisioningService interface {
+	// Volume operations
+	GetVolumeUUIDForID(ctx context.Context, volumeID string) (domainstorage.VolumeUUID, error)
+	GetVolumeByID(ctx context.Context, volumeID string) (storageprovisioning.Volume, error)
+	GetVolumeLife(ctx context.Context, uuid domainstorage.VolumeUUID) (domainlife.Life, error)
+	GetVolumeParams(ctx context.Context, uuid domainstorage.VolumeUUID) (storageprovisioning.VolumeParams, error)
+	GetVolumeRemovalParams(ctx context.Context, uuid domainstorage.VolumeUUID) (storageprovisioning.VolumeRemovalParams, error)
+	SetVolumeProvisionedInfo(ctx context.Context, volumeID string, info storageprovisioning.VolumeProvisionedInfo) error
+
+	// Filesystem operations
+	GetFilesystemUUIDForID(ctx context.Context, filesystemID string) (domainstorage.FilesystemUUID, error)
+	GetFilesystemForID(ctx context.Context, filesystemID string) (storageprovisioning.Filesystem, error)
+	GetFilesystemLife(ctx context.Context, uuid domainstorage.FilesystemUUID) (domainlife.Life, error)
+	GetFilesystemParams(ctx context.Context, uuid domainstorage.FilesystemUUID) (storageprovisioning.FilesystemParams, error)
+	GetFilesystemRemovalParams(ctx context.Context, uuid domainstorage.FilesystemUUID) (storageprovisioning.FilesystemRemovalParams, error)
+	SetFilesystemProvisionedInfo(ctx context.Context, filesystemID string, info storageprovisioning.FilesystemProvisionedInfo) error
+
+	// Volume attachment operations
+	GetVolumeAttachmentUUIDForVolumeIDMachine(ctx context.Context, volumeID string, machineUUID machine.UUID) (domainstorage.VolumeAttachmentUUID, error)
+	GetVolumeAttachment(ctx context.Context, uuid domainstorage.VolumeAttachmentUUID) (storageprovisioning.VolumeAttachment, error)
+	GetVolumeAttachmentLife(ctx context.Context, uuid domainstorage.VolumeAttachmentUUID) (domainlife.Life, error)
+	GetVolumeAttachmentParams(ctx context.Context, uuid domainstorage.VolumeAttachmentUUID) (storageprovisioning.VolumeAttachmentParams, error)
+	SetVolumeAttachmentProvisionedInfo(ctx context.Context, uuid domainstorage.VolumeAttachmentUUID, info storageprovisioning.VolumeAttachmentProvisionedInfo) error
+
+	// Filesystem attachment operations
+	GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx context.Context, filesystemID string, machineUUID machine.UUID) (domainstorage.FilesystemAttachmentUUID, error)
+	GetFilesystemAttachmentForMachine(ctx context.Context, filesystemID string, machineUUID machine.UUID) (storageprovisioning.FilesystemAttachment, error)
+	GetFilesystemAttachmentLife(ctx context.Context, uuid domainstorage.FilesystemAttachmentUUID) (domainlife.Life, error)
+	GetFilesystemAttachmentParams(ctx context.Context, uuid domainstorage.FilesystemAttachmentUUID) (storageprovisioning.FilesystemAttachmentParams, error)
+	SetFilesystemAttachmentProvisionedInfoForMachine(ctx context.Context, filesystemID string, machineUUID machine.UUID, info storageprovisioning.FilesystemAttachmentProvisionedInfo) error
+
+	// Attachment ID lookups
+	GetVolumeAttachmentIDs(ctx context.Context, volumeAttachmentUUIDs []string) (map[string]storageprovisioning.VolumeAttachmentID, error)
+	GetFilesystemAttachmentIDs(ctx context.Context, filesystemAttachmentUUIDs []string) (map[string]storageprovisioning.FilesystemAttachmentID, error)
+
+	// Block device for volume attachment
+	GetBlockDeviceForVolumeAttachment(ctx context.Context, uuid domainstorage.VolumeAttachmentUUID) (domainblockdevice.BlockDeviceUUID, error)
+
+	// Model resource tags
+	GetStorageResourceTagsForModel(ctx context.Context) (map[string]string, error)
+
+	// Watchers (model-scoped)
+	WatchModelProvisionedVolumes(ctx context.Context) (watcher.StringsWatcher, error)
+	WatchModelProvisionedFilesystems(ctx context.Context) (watcher.StringsWatcher, error)
+	WatchModelProvisionedVolumeAttachments(ctx context.Context) (watcher.StringsWatcher, error)
+	WatchModelProvisionedFilesystemAttachments(ctx context.Context) (watcher.StringsWatcher, error)
+
+	// Watchers (machine-scoped)
+	WatchMachineProvisionedVolumes(ctx context.Context, machineUUID machine.UUID) (watcher.StringsWatcher, error)
+	WatchMachineProvisionedFilesystems(ctx context.Context, machineUUID machine.UUID) (watcher.StringsWatcher, error)
+	WatchMachineProvisionedVolumeAttachments(ctx context.Context, machineUUID machine.UUID) (watcher.StringsWatcher, error)
+	WatchMachineProvisionedFilesystemAttachments(ctx context.Context, machineUUID machine.UUID) (watcher.StringsWatcher, error)
+	WatchVolumeAttachmentPlans(ctx context.Context, machineUUID machine.UUID) (watcher.StringsWatcher, error)
+
+	// Volume attachment plans
+	GetVolumeAttachmentPlanUUIDForVolumeIDMachine(ctx context.Context, volumeID string, machineUUID machine.UUID) (domainstorage.VolumeAttachmentPlanUUID, error)
+	GetVolumeAttachmentPlan(ctx context.Context, uuid domainstorage.VolumeAttachmentPlanUUID) (storageprovisioning.VolumeAttachmentPlan, error)
+	CreateVolumeAttachmentPlan(ctx context.Context, attachmentUUID domainstorage.VolumeAttachmentUUID, deviceType domainstorage.VolumeDeviceType, attrs map[string]string) (domainstorage.VolumeAttachmentPlanUUID, error)
+	SetVolumeAttachmentPlanProvisionedInfo(ctx context.Context, uuid domainstorage.VolumeAttachmentPlanUUID, info storageprovisioning.VolumeAttachmentPlanProvisionedInfo) error
+	SetVolumeAttachmentPlanProvisionedBlockDevice(ctx context.Context, uuid domainstorage.VolumeAttachmentPlanUUID, blockDeviceUUID domainblockdevice.BlockDeviceUUID) error
+}
+
+// machineService is the subset of the domain machine service needed by the
+// model storage adapters.
+type machineService interface {
+	GetMachineUUID(ctx context.Context, machineName machine.Name) (machine.UUID, error)
+	GetInstanceID(ctx context.Context, machineUUID machine.UUID) (instance.Id, error)
+	WatchMachineCloudInstances(ctx context.Context, machineUUID machine.UUID) (watcher.NotifyWatcher, error)
+}
+
+// removalService is the subset of the domain removal service needed by the
+// model storage adapters.
+type removalService interface {
+	RemoveDeadVolume(ctx context.Context, uuid domainstorage.VolumeUUID) error
+	RemoveDeadFilesystem(ctx context.Context, uuid domainstorage.FilesystemUUID) error
+	MarkVolumeAttachmentAsDead(ctx context.Context, uuid domainstorage.VolumeAttachmentUUID) error
+	MarkFilesystemAttachmentAsDead(ctx context.Context, uuid domainstorage.FilesystemAttachmentUUID) error
+	MarkVolumeAttachmentPlanAsDead(ctx context.Context, uuid domainstorage.VolumeAttachmentPlanUUID) error
+}
+
+// storageStatusService is the subset of the domain status service needed by
+// the model storage adapters.
+type storageStatusService interface {
+	SetVolumeStatus(ctx context.Context, volumeID string, sInfo status.StatusInfo) error
+	SetFilesystemStatus(ctx context.Context, filesystemID string, sInfo status.StatusInfo) error
+}
+
+// blockDeviceService is the subset of the domain block device service needed
+// by the model storage adapters.
+type blockDeviceService interface {
+	WatchBlockDevicesForMachine(ctx context.Context, machineUUID machine.UUID) (watcher.NotifyWatcher, error)
+	GetBlockDevice(ctx context.Context, uuid domainblockdevice.BlockDeviceUUID) (coreblockdevice.BlockDevice, error)
+	MatchOrCreateBlockDevice(ctx context.Context, machineUUID machine.UUID, device coreblockdevice.BlockDevice) (domainblockdevice.BlockDeviceUUID, error)
+}
+
+// modelStorageAdapter implements VolumeAccessor, FilesystemAccessor,
+// LifecycleManager, MachineAccessor, and StatusSetter by reading from
+// domain services directly instead of through an API facade.
+type modelStorageAdapter struct {
+	storageSvc     storageProvisioningService
+	machineSvc     machineService
+	removalSvc     removalService
+	statusSvc      storageStatusService
+	blockDeviceSvc blockDeviceService
+}
+
+// VolumeAccessor implementation
+
+func (a *modelStorageAdapter) WatchBlockDevices(ctx context.Context, m names.MachineTag) (watcher.NotifyWatcher, error) {
+	machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(m.Id()))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return a.blockDeviceSvc.WatchBlockDevicesForMachine(ctx, machineUUID)
+}
+
+func (a *modelStorageAdapter) WatchVolumes(ctx context.Context, scope names.Tag) (watcher.StringsWatcher, error) {
+	switch scope := scope.(type) {
+	case names.ModelTag:
+		return a.storageSvc.WatchModelProvisionedVolumes(ctx)
+	case names.MachineTag:
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(scope.Id()))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return a.storageSvc.WatchMachineProvisionedVolumes(ctx, machineUUID)
+	default:
+		return nil, internalerrors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
+	}
+}
+
+func (a *modelStorageAdapter) WatchVolumeAttachments(ctx context.Context, scope names.Tag) (watcher.MachineStorageIDsWatcher, error) {
+	var sourceWatcher watcher.StringsWatcher
+	switch scope := scope.(type) {
+	case names.ModelTag:
+		w, err := a.storageSvc.WatchModelProvisionedVolumeAttachments(ctx)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		sourceWatcher = w
+	case names.MachineTag:
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(scope.Id()))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		w, err := a.storageSvc.WatchMachineProvisionedVolumeAttachments(ctx, machineUUID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		sourceWatcher = w
+	default:
+		return nil, internalerrors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
+	}
+	return newAttachmentIDWatcher(sourceWatcher, func(ctx context.Context, ids ...string) ([]watcher.MachineStorageID, error) {
+		attachmentIDs, err := a.storageSvc.GetVolumeAttachmentIDs(ctx, ids)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		var out []watcher.MachineStorageID
+		for _, id := range attachmentIDs {
+			if id.MachineName == nil && id.UnitName == nil {
+				continue
+			}
+			msid := watcher.MachineStorageID{
+				AttachmentTag: names.NewVolumeTag(id.VolumeID).String(),
+			}
+			if id.MachineName != nil {
+				msid.MachineTag = names.NewMachineTag(id.MachineName.String()).String()
+			} else if id.UnitName != nil {
+				msid.MachineTag = names.NewUnitTag(id.UnitName.String()).String()
+			}
+			out = append(out, msid)
+		}
+		return out, nil
+	})
+}
+
+func (a *modelStorageAdapter) WatchVolumeAttachmentPlans(ctx context.Context, scope names.Tag) (watcher.MachineStorageIDsWatcher, error) {
+	switch scope := scope.(type) {
+	case names.MachineTag:
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(scope.Id()))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		w, err := a.storageSvc.WatchVolumeAttachmentPlans(ctx, machineUUID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return newAttachmentIDWatcher(w, func(ctx context.Context, ids ...string) ([]watcher.MachineStorageID, error) {
+			attachmentIDs, err := a.storageSvc.GetVolumeAttachmentIDs(ctx, ids)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			var out []watcher.MachineStorageID
+			for _, id := range attachmentIDs {
+				if id.MachineName == nil && id.UnitName == nil {
+					continue
+				}
+				msid := watcher.MachineStorageID{
+					AttachmentTag: names.NewVolumeTag(id.VolumeID).String(),
+				}
+				if id.MachineName != nil {
+					msid.MachineTag = names.NewMachineTag(id.MachineName.String()).String()
+				} else if id.UnitName != nil {
+					msid.MachineTag = names.NewUnitTag(id.UnitName.String()).String()
+				}
+				out = append(out, msid)
+			}
+			return out, nil
+		})
+	default:
+		return nil, internalerrors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
+	}
+}
+
+func (a *modelStorageAdapter) Volumes(ctx context.Context, tags []names.VolumeTag) ([]params.VolumeResult, error) {
+	results := make([]params.VolumeResult, len(tags))
+	for i, tag := range tags {
+		vol, err := a.storageSvc.GetVolumeByID(ctx, tag.Id())
+		if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		if vol.SizeMiB == 0 {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume %q is not provisioned", tag.Id()).Error(), Code: params.CodeNotProvisioned}
+			continue
+		}
+		results[i].Result = params.Volume{
+			VolumeTag: tag.String(),
+			Info: params.VolumeInfo{
+				ProviderId: vol.ProviderID,
+				HardwareId: vol.HardwareID,
+				WWN:        vol.WWN,
+				Persistent: vol.Persistent,
+				SizeMiB:    vol.SizeMiB,
+			},
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) VolumeBlockDevices(ctx context.Context, ids []params.MachineStorageId) ([]params.BlockDeviceResult, error) {
+	results := make([]params.BlockDeviceResult, len(ids))
+	for i, id := range ids {
+		volumeTag, err := names.ParseVolumeTag(id.AttachmentTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineTag, err := names.ParseMachineTag(id.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		attachmentUUID, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		blockDevUUID, err := a.storageSvc.GetBlockDeviceForVolumeAttachment(ctx, attachmentUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		bd, err := a.blockDeviceSvc.GetBlockDevice(ctx, blockDevUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		results[i].Result = params.BlockDevice{
+			DeviceName:  bd.DeviceName,
+			DeviceLinks: bd.DeviceLinks,
+			Label:       bd.FilesystemLabel,
+			UUID:        bd.FilesystemUUID,
+			HardwareId:  bd.HardwareId,
+			WWN:         bd.WWN,
+			BusAddress:  bd.BusAddress,
+			SizeMiB:     bd.SizeMiB,
+			InUse:       bd.InUse,
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) VolumeAttachments(ctx context.Context, ids []params.MachineStorageId) ([]params.VolumeAttachmentResult, error) {
+	results := make([]params.VolumeAttachmentResult, len(ids))
+	for i, id := range ids {
+		volumeTag, err := names.ParseVolumeTag(id.AttachmentTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineTag, err := names.ParseMachineTag(id.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		attachmentUUID, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		va, err := a.storageSvc.GetVolumeAttachment(ctx, attachmentUUID)
+		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume attachment %q on %q not found", volumeTag.Id(), machineTag.Id()).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		if va.BlockDeviceName == "" && len(va.BlockDeviceLinks) == 0 {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume %q is not provisioned", volumeTag.Id()).Error(), Code: params.CodeNotProvisioned}
+			continue
+		}
+		results[i].Result = params.VolumeAttachment{
+			VolumeTag:  volumeTag.String(),
+			MachineTag: machineTag.String(),
+			Info: params.VolumeAttachmentInfo{
+				DeviceName: va.BlockDeviceName,
+				DeviceLink: domainblockdevice.IDLink(va.BlockDeviceLinks),
+				BusAddress: va.BlockDeviceBusAddress,
+				ReadOnly:   va.ReadOnly,
+			},
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) VolumeAttachmentPlans(ctx context.Context, ids []params.MachineStorageId) ([]params.VolumeAttachmentPlanResult, error) {
+	results := make([]params.VolumeAttachmentPlanResult, len(ids))
+	for i, id := range ids {
+		volumeTag, err := names.ParseVolumeTag(id.AttachmentTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineTag, err := names.ParseMachineTag(id.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		planUUID, err := a.storageSvc.GetVolumeAttachmentPlanUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		plan, err := a.storageSvc.GetVolumeAttachmentPlan(ctx, planUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		results[i].Result = params.VolumeAttachmentPlan{
+			VolumeTag:  volumeTag.String(),
+			MachineTag: machineTag.String(),
+			PlanInfo: params.VolumeAttachmentPlanInfo{
+				DeviceType:       plan.DeviceType.String(),
+				DeviceAttributes: plan.DeviceAttributes,
+			},
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) VolumeParams(ctx context.Context, tags []names.VolumeTag) ([]params.VolumeParamsResult, error) {
+	results := make([]params.VolumeParamsResult, len(tags))
+	volModelTags, err := a.storageSvc.GetStorageResourceTagsForModel(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for i, tag := range tags {
+		uuid, err := a.storageSvc.GetVolumeUUIDForID(ctx, tag.Id())
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		volParams, err := a.storageSvc.GetVolumeParams(ctx, uuid)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		rval := params.VolumeParams{
+			Attributes: make(map[string]any, len(volParams.Attributes)),
+			VolumeTag:  tag.String(),
+			Provider:   volParams.Provider,
+			SizeMiB:    volParams.SizeMiB,
+			Tags:       volModelTags,
+		}
+		for k, v := range volParams.Attributes {
+			rval.Attributes[k] = v
+		}
+		if volParams.VolumeAttachmentUUID != nil {
+			vaParams, err := a.storageSvc.GetVolumeAttachmentParams(ctx, *volParams.VolumeAttachmentUUID)
+			if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+				// No attachment params yet.
+			} else if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			} else {
+				rval.Attachment = &params.VolumeAttachmentParams{
+					VolumeTag:  tag.String(),
+					InstanceId: vaParams.MachineInstanceID,
+					Provider:   vaParams.Provider,
+					ProviderId: vaParams.ProviderID,
+					ReadOnly:   vaParams.ReadOnly,
+				}
+				if vaParams.Machine != nil {
+					rval.Attachment.MachineTag = names.NewMachineTag(vaParams.Machine.String()).String()
+				}
+			}
+		}
+		results[i].Result = rval
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) RemoveVolumeParams(ctx context.Context, tags []names.VolumeTag) ([]params.RemoveVolumeParamsResult, error) {
+	results := make([]params.RemoveVolumeParamsResult, len(tags))
+	for i, tag := range tags {
+		uuid, err := a.storageSvc.GetVolumeUUIDForID(ctx, tag.Id())
+		if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		rp, err := a.storageSvc.GetVolumeRemovalParams(ctx, uuid)
+		if errors.Is(err, storageprovisioningerrors.VolumeNotDead) {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume %q is not yet dead", tag.Id()).Error()}
+			continue
+		}
+		if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		results[i].Result = params.RemoveVolumeParams{
+			Provider:   rp.Provider,
+			ProviderId: rp.ProviderID,
+			Destroy:    rp.Obliterate,
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) VolumeAttachmentParams(ctx context.Context, ids []params.MachineStorageId) ([]params.VolumeAttachmentParamsResult, error) {
+	results := make([]params.VolumeAttachmentParamsResult, len(ids))
+	for i, id := range ids {
+		machineTag, err := names.ParseMachineTag(id.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		volumeTag, err := names.ParseVolumeTag(id.AttachmentTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		attachmentUUID, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		vaParams, err := a.storageSvc.GetVolumeAttachmentParams(ctx, attachmentUUID)
+		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume attachment %q on %q not found", volumeTag.Id(), machineTag.Id()).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		results[i].Result = params.VolumeAttachmentParams{
+			VolumeTag:  volumeTag.String(),
+			MachineTag: machineTag.String(),
+			InstanceId: vaParams.MachineInstanceID,
+			Provider:   vaParams.Provider,
+			ProviderId: vaParams.ProviderID,
+			ReadOnly:   vaParams.ReadOnly,
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) SetVolumeInfo(ctx context.Context, vols []params.Volume) ([]params.ErrorResult, error) {
+	results := make([]params.ErrorResult, len(vols))
+	for i, vol := range vols {
+		volumeTag, err := names.ParseVolumeTag(vol.VolumeTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		info := storageprovisioning.VolumeProvisionedInfo{
+			ProviderID: vol.Info.ProviderId,
+			SizeMiB:    vol.Info.SizeMiB,
+			HardwareID: vol.Info.HardwareId,
+			WWN:        vol.Info.WWN,
+			Persistent: vol.Info.Persistent,
+		}
+		err = a.storageSvc.SetVolumeProvisionedInfo(ctx, volumeTag.Id(), info)
+		if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume %q not found", volumeTag.Id()).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) SetVolumeAttachmentInfo(ctx context.Context, vas []params.VolumeAttachment) ([]params.ErrorResult, error) {
+	results := make([]params.ErrorResult, len(vas))
+	for i, va := range vas {
+		machineTag, err := names.ParseMachineTag(va.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		volumeTag, err := names.ParseVolumeTag(va.VolumeTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		attachmentUUID, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume attachment %q on %q not found", volumeTag.Id(), machineUUID).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("volume %q not found for attachment on %q", volumeTag.Id(), machineUUID).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		info := storageprovisioning.VolumeAttachmentProvisionedInfo{
+			ReadOnly: va.Info.ReadOnly,
+		}
+		if va.Info.DeviceName != "" || va.Info.DeviceLink != "" || va.Info.BusAddress != "" {
+			device := coreblockdevice.BlockDevice{
+				DeviceName: va.Info.DeviceName,
+				BusAddress: va.Info.BusAddress,
+			}
+			if va.Info.DeviceLink != "" {
+				device.DeviceLinks = []string{va.Info.DeviceLink}
+			}
+			blockDevUUID, err := a.blockDeviceSvc.MatchOrCreateBlockDevice(ctx, machineUUID, device)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			info.BlockDeviceUUID = &blockDevUUID
+		}
+		err = a.storageSvc.SetVolumeAttachmentProvisionedInfo(ctx, attachmentUUID, info)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) CreateVolumeAttachmentPlans(ctx context.Context, plans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
+	results := make([]params.ErrorResult, len(plans))
+	for i, plan := range plans {
+		machineTag, err := names.ParseMachineTag(plan.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		volumeTag, err := names.ParseVolumeTag(plan.VolumeTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		attachmentUUID, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		var deviceType domainstorage.VolumeDeviceType
+		switch plan.PlanInfo.DeviceType {
+		case "local":
+			deviceType = domainstorage.VolumeDeviceTypeLocal
+		case "iscsi":
+			deviceType = domainstorage.VolumeDeviceTypeISCSI
+		}
+		_, err = a.storageSvc.CreateVolumeAttachmentPlan(ctx, attachmentUUID, deviceType, plan.PlanInfo.DeviceAttributes)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) RemoveVolumeAttachmentPlan(ctx context.Context, ids []params.MachineStorageId) ([]params.ErrorResult, error) {
+	results := make([]params.ErrorResult, len(ids))
+	for i, id := range ids {
+		volumeTag, err := names.ParseVolumeTag(id.AttachmentTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineTag, err := names.ParseMachineTag(id.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		planUUID, err := a.storageSvc.GetVolumeAttachmentPlanUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		err = a.removalSvc.MarkVolumeAttachmentPlanAsDead(ctx, planUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) SetVolumeAttachmentPlanBlockInfo(ctx context.Context, plans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
+	results := make([]params.ErrorResult, len(plans))
+	for i, plan := range plans {
+		machineTag, err := names.ParseMachineTag(plan.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		volumeTag, err := names.ParseVolumeTag(plan.VolumeTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		planUUID, err := a.storageSvc.GetVolumeAttachmentPlanUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		device := coreblockdevice.BlockDevice{
+			DeviceName: plan.BlockDevice.DeviceName,
+			BusAddress: plan.BlockDevice.BusAddress,
+		}
+		if len(plan.BlockDevice.DeviceLinks) > 0 {
+			device.DeviceLinks = plan.BlockDevice.DeviceLinks
+		}
+		blockDevUUID, err := a.blockDeviceSvc.MatchOrCreateBlockDevice(ctx, machineUUID, device)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		err = a.storageSvc.SetVolumeAttachmentPlanProvisionedBlockDevice(ctx, planUUID, blockDevUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+		}
+	}
+	return results, nil
+}
+
+// FilesystemAccessor implementation
+
+func (a *modelStorageAdapter) WatchFilesystems(ctx context.Context, scope names.Tag) (watcher.StringsWatcher, error) {
+	switch scope := scope.(type) {
+	case names.ModelTag:
+		return a.storageSvc.WatchModelProvisionedFilesystems(ctx)
+	case names.MachineTag:
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(scope.Id()))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return a.storageSvc.WatchMachineProvisionedFilesystems(ctx, machineUUID)
+	default:
+		return nil, internalerrors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
+	}
+}
+
+func (a *modelStorageAdapter) WatchFilesystemAttachments(ctx context.Context, scope names.Tag) (watcher.MachineStorageIDsWatcher, error) {
+	var sourceWatcher watcher.StringsWatcher
+	switch scope := scope.(type) {
+	case names.ModelTag:
+		w, err := a.storageSvc.WatchModelProvisionedFilesystemAttachments(ctx)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		sourceWatcher = w
+	case names.MachineTag:
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(scope.Id()))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		w, err := a.storageSvc.WatchMachineProvisionedFilesystemAttachments(ctx, machineUUID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		sourceWatcher = w
+	default:
+		return nil, internalerrors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
+	}
+	return newAttachmentIDWatcher(sourceWatcher, func(ctx context.Context, ids ...string) ([]watcher.MachineStorageID, error) {
+		attachmentIDs, err := a.storageSvc.GetFilesystemAttachmentIDs(ctx, ids)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		var out []watcher.MachineStorageID
+		for _, id := range attachmentIDs {
+			if id.MachineName == nil && id.UnitName == nil {
+				continue
+			}
+			msid := watcher.MachineStorageID{
+				AttachmentTag: names.NewFilesystemTag(id.FilesystemID).String(),
+			}
+			if id.MachineName != nil {
+				msid.MachineTag = names.NewMachineTag(id.MachineName.String()).String()
+			} else if id.UnitName != nil {
+				msid.MachineTag = names.NewUnitTag(id.UnitName.String()).String()
+			}
+			out = append(out, msid)
+		}
+		return out, nil
+	})
+}
+
+func (a *modelStorageAdapter) Filesystems(ctx context.Context, tags []names.FilesystemTag) ([]params.FilesystemResult, error) {
+	results := make([]params.FilesystemResult, len(tags))
+	for i, tag := range tags {
+		fs, err := a.storageSvc.GetFilesystemForID(ctx, tag.Id())
+		if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		if fs.SizeMiB == 0 {
+			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q is not provisioned", tag.Id()).Error(), Code: params.CodeNotProvisioned}
+			continue
+		}
+		result := params.Filesystem{
+			FilesystemTag: tag.String(),
+			Info: params.FilesystemInfo{
+				ProviderId: fs.ProviderID,
+				SizeMiB:    fs.SizeMiB,
+			},
+		}
+		if fs.BackingVolume != nil {
+			result.VolumeTag = names.NewVolumeTag(fs.BackingVolume.VolumeID).String()
+		}
+		results[i].Result = result
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) FilesystemAttachments(ctx context.Context, ids []params.MachineStorageId) ([]params.FilesystemAttachmentResult, error) {
+	results := make([]params.FilesystemAttachmentResult, len(ids))
+	for i, id := range ids {
+		filesystemTag, err := names.ParseFilesystemTag(id.AttachmentTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		hostTag, err := names.ParseTag(id.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		var fsAttachment storageprovisioning.FilesystemAttachment
+		switch tag := hostTag.(type) {
+		case names.MachineTag:
+			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(tag.Id()))
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			fsAttachment, err = a.storageSvc.GetFilesystemAttachmentForMachine(ctx, filesystemTag.Id(), machineUUID)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+		default:
+			results[i].Error = &params.Error{Message: errors.Errorf("unsupported host tag %T", hostTag).Error()}
+			continue
+		}
+		if fsAttachment.MountPoint == "" {
+			results[i].Error = &params.Error{Message: errors.Errorf("filesystem attachment %q on %q is not provisioned", filesystemTag.Id(), hostTag.String()).Error(), Code: params.CodeNotProvisioned}
+			continue
+		}
+		results[i].Result = params.FilesystemAttachment{
+			FilesystemTag: filesystemTag.String(),
+			MachineTag:    hostTag.String(),
+			Info: params.FilesystemAttachmentInfo{
+				MountPoint: fsAttachment.MountPoint,
+				ReadOnly:   fsAttachment.ReadOnly,
+			},
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) FilesystemParams(ctx context.Context, tags []names.FilesystemTag) ([]params.FilesystemParamsResultV5, error) {
+	results := make([]params.FilesystemParamsResultV5, len(tags))
+	fsModelTags, err := a.storageSvc.GetStorageResourceTagsForModel(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for i, tag := range tags {
+		uuid, err := a.storageSvc.GetFilesystemUUIDForID(ctx, tag.Id())
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		fsParams, err := a.storageSvc.GetFilesystemParams(ctx, uuid)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		rval := params.FilesystemParamsV5{
+			Attributes:    make(map[string]any, len(fsParams.Attributes)),
+			FilesystemTag: tag.String(),
+			Provider:      fsParams.Provider,
+			ProviderId:    fsParams.ProviderID,
+			SizeMiB:       fsParams.SizeMiB,
+			Tags:          fsModelTags,
+		}
+		for k, v := range fsParams.Attributes {
+			rval.Attributes[k] = v
+		}
+		if fsParams.BackingVolume != nil {
+			rval.VolumeTag = names.NewVolumeTag(fsParams.BackingVolume.VolumeID).String()
+		}
+		results[i].Result = rval
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) RemoveFilesystemParams(ctx context.Context, tags []names.FilesystemTag) ([]params.RemoveFilesystemParamsResult, error) {
+	results := make([]params.RemoveFilesystemParamsResult, len(tags))
+	for i, tag := range tags {
+		uuid, err := a.storageSvc.GetFilesystemUUIDForID(ctx, tag.Id())
+		if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		rp, err := a.storageSvc.GetFilesystemRemovalParams(ctx, uuid)
+		if errors.Is(err, storageprovisioningerrors.FilesystemNotDead) {
+			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q is not yet dead", tag.Id()).Error()}
+			continue
+		}
+		if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		results[i].Result = params.RemoveFilesystemParams{
+			Provider:   rp.Provider,
+			ProviderId: rp.ProviderID,
+			Destroy:    rp.Obliterate,
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) FilesystemAttachmentParams(ctx context.Context, ids []params.MachineStorageId) ([]params.FilesystemAttachmentParamsResultV5, error) {
+	results := make([]params.FilesystemAttachmentParamsResultV5, len(ids))
+	for i, id := range ids {
+		hostTag, err := names.ParseTag(id.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		filesystemTag, err := names.ParseFilesystemTag(id.AttachmentTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		var attachmentUUID domainstorage.FilesystemAttachmentUUID
+		switch tag := hostTag.(type) {
+		case names.MachineTag:
+			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(tag.Id()))
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			attachmentUUID, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx, filesystemTag.Id(), machineUUID)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+		default:
+			results[i].Error = &params.Error{Message: errors.Errorf("unsupported host tag %T", hostTag).Error()}
+			continue
+		}
+		fsParams, err := a.storageSvc.GetFilesystemAttachmentParams(ctx, attachmentUUID)
+		if errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("filesystem attachment for %q on %q not found", filesystemTag, hostTag).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		instanceID := fsParams.MachineInstanceID
+		if instanceID == "" {
+			instanceID = fsParams.CAASInstanceID
+		}
+		results[i].Result = params.FilesystemAttachmentParamsV5{
+			FilesystemTag: filesystemTag.String(),
+			MachineTag:    hostTag.String(),
+			InstanceId:    instanceID,
+			Provider:      fsParams.Provider,
+			ReadOnly:      fsParams.CharmStorageReadOnly,
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) SetFilesystemInfo(ctx context.Context, fss []params.Filesystem) ([]params.ErrorResult, error) {
+	results := make([]params.ErrorResult, len(fss))
+	for i, fs := range fss {
+		filesystemTag, err := names.ParseFilesystemTag(fs.FilesystemTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		info := storageprovisioning.FilesystemProvisionedInfo{
+			ProviderID: fs.Info.ProviderId,
+			SizeMiB:    fs.Info.SizeMiB,
+		}
+		err = a.storageSvc.SetFilesystemProvisionedInfo(ctx, filesystemTag.Id(), info)
+		if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q not found", filesystemTag.Id()).Error(), Code: params.CodeNotFound}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) SetFilesystemAttachmentInfo(ctx context.Context, fas []params.FilesystemAttachment) ([]params.ErrorResult, error) {
+	results := make([]params.ErrorResult, len(fas))
+	for i, fa := range fas {
+		hostTag, err := names.ParseTag(fa.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		filesystemTag, err := names.ParseFilesystemTag(fa.FilesystemTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		info := storageprovisioning.FilesystemAttachmentProvisionedInfo{
+			MountPoint: fa.Info.MountPoint,
+			ReadOnly:   fa.Info.ReadOnly,
+		}
+		switch tag := hostTag.(type) {
+		case names.MachineTag:
+			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(tag.Id()))
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			err = a.storageSvc.SetFilesystemAttachmentProvisionedInfoForMachine(ctx, filesystemTag.Id(), machineUUID, info)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+			}
+		default:
+			results[i].Error = &params.Error{Message: errors.Errorf("unsupported host tag %T", hostTag).Error()}
+		}
+	}
+	return results, nil
+}
+
+// LifecycleManager implementation
+
+func (a *modelStorageAdapter) Life(ctx context.Context, tags []names.Tag) ([]params.LifeResult, error) {
+	results := make([]params.LifeResult, len(tags))
+	for i, tag := range tags {
+		var l domainlife.Life
+		var err error
+		switch tag := tag.(type) {
+		case names.VolumeTag:
+			uuid, e := a.storageSvc.GetVolumeUUIDForID(ctx, tag.Id())
+			if e != nil {
+				err = e
+				break
+			}
+			l, err = a.storageSvc.GetVolumeLife(ctx, uuid)
+		case names.FilesystemTag:
+			uuid, e := a.storageSvc.GetFilesystemUUIDForID(ctx, tag.Id())
+			if e != nil {
+				err = e
+				break
+			}
+			l, err = a.storageSvc.GetFilesystemLife(ctx, uuid)
+		default:
+			results[i].Error = &params.Error{Message: errors.Errorf("invalid tag %q, expected volume or filesystem", tag).Error()}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		val, err := l.Value()
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		results[i].Life = val
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) Remove(ctx context.Context, tags []names.Tag) ([]params.ErrorResult, error) {
+	results := make([]params.ErrorResult, len(tags))
+	for i, tag := range tags {
+		var err error
+		switch tag := tag.(type) {
+		case names.VolumeTag:
+			uuid, e := a.storageSvc.GetVolumeUUIDForID(ctx, tag.Id())
+			if errors.Is(e, storageprovisioningerrors.VolumeNotFound) {
+				continue
+			}
+			if e != nil {
+				err = e
+				break
+			}
+			err = a.removalSvc.RemoveDeadVolume(ctx, uuid)
+			if errors.Is(err, storageprovisioningerrors.VolumeNotDead) {
+				err = errors.Errorf("volume %q is not yet dead", tag.Id())
+			} else if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+				err = nil
+			}
+		case names.FilesystemTag:
+			uuid, e := a.storageSvc.GetFilesystemUUIDForID(ctx, tag.Id())
+			if errors.Is(e, storageprovisioningerrors.FilesystemNotFound) {
+				continue
+			}
+			if e != nil {
+				err = e
+				break
+			}
+			err = a.removalSvc.RemoveDeadFilesystem(ctx, uuid)
+			if errors.Is(err, storageprovisioningerrors.FilesystemNotDead) {
+				err = errors.Errorf("filesystem %q is not yet dead", tag.Id())
+			} else if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+				err = nil
+			}
+		default:
+			results[i].Error = &params.Error{Message: errors.Errorf("tag %q invalid", tag).Error()}
+			continue
+		}
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+		}
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) AttachmentLife(ctx context.Context, ids []params.MachineStorageId) ([]params.LifeResult, error) {
+	results := make([]params.LifeResult, len(ids))
+	for i, id := range ids {
+		hostTag, err := names.ParseTag(id.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		attachmentTag, err := names.ParseTag(id.AttachmentTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		var l domainlife.Life
+		switch tag := attachmentTag.(type) {
+		case names.VolumeTag:
+			machineTag, ok := hostTag.(names.MachineTag)
+			if !ok {
+				results[i].Error = &params.Error{Message: "volume attachments only supported on machines"}
+				continue
+			}
+			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			uuid, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, tag.Id(), machineUUID)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			l, err = a.storageSvc.GetVolumeAttachmentLife(ctx, uuid)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+		case names.FilesystemTag:
+			machineTag, ok := hostTag.(names.MachineTag)
+			if !ok {
+				results[i].Error = &params.Error{Message: "filesystem attachments only supported on machines"}
+				continue
+			}
+			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			uuid, err := a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx, tag.Id(), machineUUID)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			l, err = a.storageSvc.GetFilesystemAttachmentLife(ctx, uuid)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+		default:
+			results[i].Error = &params.Error{Message: errors.Errorf("attachment tag %q is not valid", attachmentTag).Error()}
+			continue
+		}
+		val, err := l.Value()
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		results[i].Life = val
+	}
+	return results, nil
+}
+
+func (a *modelStorageAdapter) RemoveAttachments(ctx context.Context, ids []params.MachineStorageId) ([]params.ErrorResult, error) {
+	results := make([]params.ErrorResult, len(ids))
+	for i, id := range ids {
+		hostTag, err := names.ParseTag(id.MachineTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		attachmentTag, err := names.ParseTag(id.AttachmentTag)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		switch tag := attachmentTag.(type) {
+		case names.VolumeTag:
+			machineTag, ok := hostTag.(names.MachineTag)
+			if !ok {
+				results[i].Error = &params.Error{Message: "volume attachments only supported on machines"}
+				continue
+			}
+			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			uuid, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, tag.Id(), machineUUID)
+			if errors.Is(err, coreerrors.NotFound) {
+				continue
+			}
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			err = a.removalSvc.MarkVolumeAttachmentAsDead(ctx, uuid)
+			if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+				continue
+			}
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+			}
+		case names.FilesystemTag:
+			machineTag, ok := hostTag.(names.MachineTag)
+			if !ok {
+				results[i].Error = &params.Error{Message: "filesystem attachments only supported on machines"}
+				continue
+			}
+			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			uuid, err := a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx, tag.Id(), machineUUID)
+			if errors.Is(err, coreerrors.NotFound) {
+				continue
+			}
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			err = a.removalSvc.MarkFilesystemAttachmentAsDead(ctx, uuid)
+			if errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound) {
+				continue
+			}
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+			}
+		default:
+			results[i].Error = &params.Error{Message: errors.Errorf("tag %q on host %q invalid", id.AttachmentTag, id.MachineTag).Error()}
+		}
+	}
+	return results, nil
+}
+
+// MachineAccessor implementation
+
+func (a *modelStorageAdapter) WatchMachine(ctx context.Context, m names.MachineTag) (watcher.NotifyWatcher, error) {
+	machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(m.Id()))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return a.machineSvc.WatchMachineCloudInstances(ctx, machineUUID)
+}
+
+func (a *modelStorageAdapter) InstanceIds(ctx context.Context, tags []names.MachineTag) ([]params.StringResult, error) {
+	results := make([]params.StringResult, len(tags))
+	for i, tag := range tags {
+		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(tag.Id()))
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		instanceId, err := a.machineSvc.GetInstanceID(ctx, machineUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		results[i].Result = string(instanceId)
+	}
+	return results, nil
+}
+
+// StatusSetter implementation
+
+func (a *modelStorageAdapter) SetStatus(ctx context.Context, args []params.EntityStatusArgs) error {
+	for _, arg := range args {
+		tag, err := names.ParseTag(arg.Tag)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		sInfo := status.StatusInfo{
+			Status:  status.Status(arg.Status),
+			Message: arg.Info,
+			Data:    arg.Data,
+		}
+		switch tag := tag.(type) {
+		case names.VolumeTag:
+			if err := a.statusSvc.SetVolumeStatus(ctx, tag.Id(), sInfo); err != nil {
+				return errors.Trace(err)
+			}
+		case names.FilesystemTag:
+			if err := a.statusSvc.SetFilesystemStatus(ctx, tag.Id(), sInfo); err != nil {
+				return errors.Trace(err)
+			}
+		default:
+			return errors.Errorf("invalid tag %q, expected volume or filesystem", tag)
+		}
+	}
+	return nil
+}
+
+// newAttachmentIDWatcher creates a MachineStorageIDsWatcher that wraps a
+// StringsWatcher and maps domain UUID strings to MachineStorageID values.
+func newAttachmentIDWatcher(
+	source watcher.StringsWatcher,
+	mapper func(context.Context, ...string) ([]watcher.MachineStorageID, error),
+) (watcher.MachineStorageIDsWatcher, error) {
+	w := &attachmentIDWatcher{
+		source: source,
+		mapper: mapper,
+		out:    make(chan []watcher.MachineStorageID, 1),
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Name: "attachment-watcher",
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{source},
+	})
+	return w, internalerrors.Capture(err)
+}
+
+type attachmentIDWatcher struct {
+	catacomb catacomb.Catacomb
+	source   watcher.StringsWatcher
+	mapper   func(context.Context, ...string) ([]watcher.MachineStorageID, error)
+	out      chan []watcher.MachineStorageID
+}
+
+func (w *attachmentIDWatcher) loop() error {
+	defer close(w.out)
+	var (
+		changes []watcher.MachineStorageID
+		out     chan []watcher.MachineStorageID
+		initial = true
+	)
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case events, ok := <-w.source.Changes():
+			if !ok {
+				return errors.Errorf("source watcher closed")
+			}
+			if !initial && len(events) == 0 {
+				continue
+			}
+			results, err := w.mapper(w.catacomb.Context(context.Background()), events...)
+			if err != nil {
+				return errors.Errorf("processing changes: %v", err)
+			}
+			if !initial && len(results) == 0 {
+				continue
+			}
+			if changes == nil {
+				changes = results
+			} else {
+				changes = append(changes, results...)
+			}
+			out = w.out
+		case out <- changes:
+			changes = nil
+			out = nil
+			initial = false
+		}
+	}
+}
+
+func (w *attachmentIDWatcher) Changes() <-chan []watcher.MachineStorageID {
+	return w.out
+}
+
+func (w *attachmentIDWatcher) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+func (w *attachmentIDWatcher) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *attachmentIDWatcher) Err() error {
+	return w.catacomb.Err()
+}

--- a/internal/worker/storageprovisioner/localadapter.go
+++ b/internal/worker/storageprovisioner/localadapter.go
@@ -16,9 +16,12 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/status"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	domainblockdevice "github.com/juju/juju/domain/blockdevice"
 	domainlife "github.com/juju/juju/domain/life"
+	removalerrors "github.com/juju/juju/domain/removal/errors"
 	domainstorage "github.com/juju/juju/domain/storage"
 	"github.com/juju/juju/domain/storageprovisioning"
 	storageprovisioningerrors "github.com/juju/juju/domain/storageprovisioning/errors"
@@ -54,10 +57,13 @@ type storageProvisioningService interface {
 
 	// Filesystem attachment operations
 	GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx context.Context, filesystemID string, machineUUID machine.UUID) (domainstorage.FilesystemAttachmentUUID, error)
+	GetFilesystemAttachmentUUIDForFilesystemIDUnit(ctx context.Context, filesystemID string, unitUUID coreunit.UUID) (domainstorage.FilesystemAttachmentUUID, error)
 	GetFilesystemAttachmentForMachine(ctx context.Context, filesystemID string, machineUUID machine.UUID) (storageprovisioning.FilesystemAttachment, error)
+	GetFilesystemAttachmentForUnit(ctx context.Context, filesystemID string, unitUUID coreunit.UUID) (storageprovisioning.FilesystemAttachment, error)
 	GetFilesystemAttachmentLife(ctx context.Context, uuid domainstorage.FilesystemAttachmentUUID) (domainlife.Life, error)
 	GetFilesystemAttachmentParams(ctx context.Context, uuid domainstorage.FilesystemAttachmentUUID) (storageprovisioning.FilesystemAttachmentParams, error)
 	SetFilesystemAttachmentProvisionedInfoForMachine(ctx context.Context, filesystemID string, machineUUID machine.UUID, info storageprovisioning.FilesystemAttachmentProvisionedInfo) error
+	SetFilesystemAttachmentProvisionedInfoForUnit(ctx context.Context, filesystemID string, unitUUID coreunit.UUID, info storageprovisioning.FilesystemAttachmentProvisionedInfo) error
 
 	// Attachment ID lookups
 	GetVolumeAttachmentIDs(ctx context.Context, volumeAttachmentUUIDs []string) (map[string]storageprovisioning.VolumeAttachmentID, error)
@@ -98,6 +104,12 @@ type machineService interface {
 	WatchMachineCloudInstances(ctx context.Context, machineUUID machine.UUID) (watcher.NotifyWatcher, error)
 }
 
+// applicationService is the subset of the domain application service needed
+// by the model storage adapters.
+type applicationService interface {
+	GetUnitUUID(ctx context.Context, unitName coreunit.Name) (coreunit.UUID, error)
+}
+
 // removalService is the subset of the domain removal service needed by the
 // model storage adapters.
 type removalService interface {
@@ -129,6 +141,7 @@ type blockDeviceService interface {
 type modelStorageAdapter struct {
 	storageSvc     storageProvisioningService
 	machineSvc     machineService
+	appSvc         applicationService
 	removalSvc     removalService
 	statusSvc      storageStatusService
 	blockDeviceSvc blockDeviceService
@@ -216,25 +229,19 @@ func (a *modelStorageAdapter) WatchVolumeAttachmentPlans(ctx context.Context, sc
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		return newAttachmentIDWatcher(w, func(ctx context.Context, ids ...string) ([]watcher.MachineStorageID, error) {
-			attachmentIDs, err := a.storageSvc.GetVolumeAttachmentIDs(ctx, ids)
-			if err != nil {
-				return nil, errors.Trace(err)
+		return newAttachmentIDWatcher(w, func(ctx context.Context, volumeIDs ...string) ([]watcher.MachineStorageID, error) {
+			if len(volumeIDs) == 0 {
+				return nil, nil
 			}
-			var out []watcher.MachineStorageID
-			for _, id := range attachmentIDs {
-				if id.MachineName == nil && id.UnitName == nil {
+			out := make([]watcher.MachineStorageID, 0, len(volumeIDs))
+			for _, volumeID := range volumeIDs {
+				if !names.IsValidVolume(volumeID) {
 					continue
 				}
-				msid := watcher.MachineStorageID{
-					AttachmentTag: names.NewVolumeTag(id.VolumeID).String(),
-				}
-				if id.MachineName != nil {
-					msid.MachineTag = names.NewMachineTag(id.MachineName.String()).String()
-				} else if id.UnitName != nil {
-					msid.MachineTag = names.NewUnitTag(id.UnitName.String()).String()
-				}
-				out = append(out, msid)
+				out = append(out, watcher.MachineStorageID{
+					MachineTag:    scope.String(),
+					AttachmentTag: names.NewVolumeTag(volumeID).String(),
+				})
 			}
 			return out, nil
 		})
@@ -306,16 +313,44 @@ func (a *modelStorageAdapter) VolumeBlockDevices(ctx context.Context, ids []para
 			results[i].Error = &params.Error{Message: err.Error()}
 			continue
 		}
+		if bd.DeviceName == "" || len(bd.DeviceLinks) == 0 {
+			results[i].Error = &params.Error{
+				Message: errors.Errorf(
+					"volume attachment %q on machine %q is not provisioned",
+					volumeTag.Id(), machineTag.Id(),
+				).Error(),
+				Code: params.CodeNotProvisioned,
+			}
+			continue
+		}
+		var provenance params.BlockDeviceProvenance
+		switch bd.Provenance {
+		case coreblockdevice.ProviderProvenance:
+			provenance = params.BlockDeviceProvenanceProvider
+		case coreblockdevice.MachineProvenance:
+			provenance = params.BlockDeviceProvenanceMachine
+		default:
+			results[i].Error = &params.Error{
+				Message: errors.Errorf(
+					"unexpected provenance value: %v", bd.Provenance,
+				).Error(),
+			}
+			continue
+		}
 		results[i].Result = params.BlockDevice{
-			DeviceName:  bd.DeviceName,
-			DeviceLinks: bd.DeviceLinks,
-			Label:       bd.FilesystemLabel,
-			UUID:        bd.FilesystemUUID,
-			HardwareId:  bd.HardwareId,
-			WWN:         bd.WWN,
-			BusAddress:  bd.BusAddress,
-			SizeMiB:     bd.SizeMiB,
-			InUse:       bd.InUse,
+			DeviceName:     bd.DeviceName,
+			DeviceLinks:    bd.DeviceLinks,
+			Label:          bd.FilesystemLabel,
+			UUID:           bd.FilesystemUUID,
+			HardwareId:     bd.HardwareId,
+			WWN:            bd.WWN,
+			BusAddress:     bd.BusAddress,
+			SizeMiB:        bd.SizeMiB,
+			FilesystemType: bd.FilesystemType,
+			InUse:          bd.InUse,
+			MountPoint:     bd.MountPoint,
+			SerialId:       bd.SerialId,
+			Provenance:     provenance,
 		}
 	}
 	return results, nil
@@ -353,7 +388,7 @@ func (a *modelStorageAdapter) VolumeAttachments(ctx context.Context, ids []param
 			results[i].Error = &params.Error{Message: err.Error()}
 			continue
 		}
-		if va.BlockDeviceName == "" && len(va.BlockDeviceLinks) == 0 {
+		if va.BlockDeviceName == "" || len(va.BlockDeviceLinks) == 0 {
 			results[i].Error = &params.Error{Message: errors.Errorf("volume %q is not provisioned", volumeTag.Id()).Error(), Code: params.CodeNotProvisioned}
 			continue
 		}
@@ -399,9 +434,15 @@ func (a *modelStorageAdapter) VolumeAttachmentPlans(ctx context.Context, ids []p
 			results[i].Error = &params.Error{Message: err.Error()}
 			continue
 		}
+		planLife, err := plan.Life.Value()
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
 		results[i].Result = params.VolumeAttachmentPlan{
 			VolumeTag:  volumeTag.String(),
 			MachineTag: machineTag.String(),
+			Life:       planLife,
 			PlanInfo: params.VolumeAttachmentPlanInfo{
 				DeviceType:       plan.DeviceType.String(),
 				DeviceAttributes: plan.DeviceAttributes,
@@ -549,6 +590,10 @@ func (a *modelStorageAdapter) SetVolumeInfo(ctx context.Context, vols []params.V
 			results[i].Error = &params.Error{Message: err.Error()}
 			continue
 		}
+		if vol.Info.Pool != "" {
+			results[i].Error = &params.Error{Message: "pool field must not be set"}
+			continue
+		}
 		info := storageprovisioning.VolumeProvisionedInfo{
 			ProviderID: vol.Info.ProviderId,
 			SizeMiB:    vol.Info.SizeMiB,
@@ -618,7 +663,41 @@ func (a *modelStorageAdapter) SetVolumeAttachmentInfo(ctx context.Context, vas [
 			info.BlockDeviceUUID = &blockDevUUID
 		}
 		err = a.storageSvc.SetVolumeAttachmentProvisionedInfo(ctx, attachmentUUID, info)
+		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf(
+				"volume attachment for machine %q and volume %q not found",
+				machineTag.Id(), volumeTag.Id(),
+			).Error(), Code: params.CodeNotFound}
+			continue
+		}
 		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		if va.Info.PlanInfo == nil {
+			continue
+		}
+		planUUID, err := a.storageSvc.GetVolumeAttachmentPlanUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		if err != nil {
+			results[i].Error = &params.Error{Message: err.Error()}
+			continue
+		}
+		planInfo := storageprovisioning.VolumeAttachmentPlanProvisionedInfo{
+			DeviceAttributes: va.Info.PlanInfo.DeviceAttributes,
+		}
+		switch va.Info.PlanInfo.DeviceType {
+		case "local":
+			planInfo.DeviceType = domainstorage.VolumeDeviceTypeLocal
+		case "iscsi":
+			planInfo.DeviceType = domainstorage.VolumeDeviceTypeISCSI
+		}
+		err = a.storageSvc.SetVolumeAttachmentPlanProvisionedInfo(ctx, planUUID, planInfo)
+		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentPlanNotFound) {
+			results[i].Error = &params.Error{Message: errors.Errorf(
+				"volume attachment plan for machine %q and volume %q not found",
+				machineTag.Id(), volumeTag.Id(),
+			).Error(), Code: params.CodeNotFound}
+		} else if err != nil {
 			results[i].Error = &params.Error{Message: err.Error()}
 		}
 	}
@@ -650,13 +729,23 @@ func (a *modelStorageAdapter) CreateVolumeAttachmentPlans(ctx context.Context, p
 		}
 		var deviceType domainstorage.VolumeDeviceType
 		switch plan.PlanInfo.DeviceType {
-		case "local":
-			deviceType = domainstorage.VolumeDeviceTypeLocal
 		case "iscsi":
 			deviceType = domainstorage.VolumeDeviceTypeISCSI
+		case "local":
+			deviceType = domainstorage.VolumeDeviceTypeLocal
+		default:
+			results[i].Error = &params.Error{
+				Message: errors.Errorf(
+					"plan device type %q not valid", plan.PlanInfo.DeviceType,
+				).Error(),
+				Code: params.CodeNotValid,
+			}
+			continue
 		}
 		_, err = a.storageSvc.CreateVolumeAttachmentPlan(ctx, attachmentUUID, deviceType, plan.PlanInfo.DeviceAttributes)
-		if err != nil {
+		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentPlanAlreadyExists) {
+			continue
+		} else if err != nil {
 			results[i].Error = &params.Error{Message: err.Error()}
 		}
 	}
@@ -717,12 +806,25 @@ func (a *modelStorageAdapter) SetVolumeAttachmentPlanBlockInfo(ctx context.Conte
 			results[i].Error = &params.Error{Message: err.Error()}
 			continue
 		}
-		device := coreblockdevice.BlockDevice{
-			DeviceName: plan.BlockDevice.DeviceName,
-			BusAddress: plan.BlockDevice.BusAddress,
+		if plan.BlockDevice == nil {
+			continue
 		}
-		if len(plan.BlockDevice.DeviceLinks) > 0 {
-			device.DeviceLinks = plan.BlockDevice.DeviceLinks
+		device := coreblockdevice.BlockDevice{
+			DeviceName:      plan.BlockDevice.DeviceName,
+			DeviceLinks:     plan.BlockDevice.DeviceLinks,
+			FilesystemLabel: plan.BlockDevice.Label,
+			FilesystemUUID:  plan.BlockDevice.UUID,
+			HardwareId:      plan.BlockDevice.HardwareId,
+			WWN:             plan.BlockDevice.WWN,
+			BusAddress:      plan.BlockDevice.BusAddress,
+			SizeMiB:         plan.BlockDevice.SizeMiB,
+			FilesystemType:  plan.BlockDevice.FilesystemType,
+			InUse:           plan.BlockDevice.InUse,
+			MountPoint:      plan.BlockDevice.MountPoint,
+			SerialId:        plan.BlockDevice.SerialId,
+		}
+		if domainblockdevice.IsEmpty(device) {
+			continue
 		}
 		blockDevUUID, err := a.blockDeviceSvc.MatchOrCreateBlockDevice(ctx, machineUUID, device)
 		if err != nil {
@@ -857,8 +959,19 @@ func (a *modelStorageAdapter) FilesystemAttachments(ctx context.Context, ids []p
 				results[i].Error = &params.Error{Message: err.Error()}
 				continue
 			}
+		case names.UnitTag:
+			unitUUID, err := a.getUnitUUID(ctx, tag)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			fsAttachment, err = a.storageSvc.GetFilesystemAttachmentForUnit(ctx, filesystemTag.Id(), unitUUID)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
 		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("unsupported host tag %T", hostTag).Error()}
+			results[i].Error = &params.Error{Message: errors.Errorf("filesystem attachment host tag %q not valid", hostTag.String()).Error(), Code: params.CodeNotValid}
 			continue
 		}
 		if fsAttachment.MountPoint == "" {
@@ -1009,6 +1122,10 @@ func (a *modelStorageAdapter) SetFilesystemInfo(ctx context.Context, fss []param
 			results[i].Error = &params.Error{Message: err.Error()}
 			continue
 		}
+		if fs.Info.Pool != "" {
+			results[i].Error = &params.Error{Message: "pool field must not be set"}
+			continue
+		}
 		info := storageprovisioning.FilesystemProvisionedInfo{
 			ProviderID: fs.Info.ProviderId,
 			SizeMiB:    fs.Info.SizeMiB,
@@ -1053,11 +1170,39 @@ func (a *modelStorageAdapter) SetFilesystemAttachmentInfo(ctx context.Context, f
 			if err != nil {
 				results[i].Error = &params.Error{Message: err.Error()}
 			}
+		case names.UnitTag:
+			unitUUID, err := a.getUnitUUID(ctx, tag)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+				continue
+			}
+			err = a.storageSvc.SetFilesystemAttachmentProvisionedInfoForUnit(ctx, filesystemTag.Id(), unitUUID, info)
+			if err != nil {
+				results[i].Error = &params.Error{Message: err.Error()}
+			}
 		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("unsupported host tag %T", hostTag).Error()}
+			results[i].Error = &params.Error{Message: errors.Errorf("filesystem attachment host tag %q not valid", hostTag.String()).Error(), Code: params.CodeNotValid}
 		}
 	}
 	return results, nil
+}
+
+func (a *modelStorageAdapter) getUnitUUID(ctx context.Context, tag names.UnitTag) (coreunit.UUID, error) {
+	unitName, err := coreunit.NewName(tag.Id())
+	if errors.Is(err, coreunit.InvalidUnitName) {
+		return "", errors.Errorf("invalid unit name %q", tag.Id())
+	} else if err != nil {
+		return "", errors.Trace(err)
+	}
+	unitUUID, err := a.appSvc.GetUnitUUID(ctx, unitName)
+	if errors.Is(err, coreunit.InvalidUnitName) {
+		return "", errors.Errorf("invalid unit name %q", unitName)
+	} else if errors.Is(err, applicationerrors.UnitNotFound) {
+		return "", errors.Errorf("unit %q not found", unitName)
+	} else if err != nil {
+		return "", errors.Errorf("getting unit %q UUID: %v", unitName, err)
+	}
+	return unitUUID, nil
 }
 
 // LifecycleManager implementation
@@ -1070,20 +1215,34 @@ func (a *modelStorageAdapter) Life(ctx context.Context, tags []names.Tag) ([]par
 		switch tag := tag.(type) {
 		case names.VolumeTag:
 			uuid, e := a.storageSvc.GetVolumeUUIDForID(ctx, tag.Id())
-			if e != nil {
-				err = e
-				break
+			if errors.Is(e, storageprovisioningerrors.VolumeNotFound) {
+				results[i].Error = &params.Error{Message: errors.Errorf("volume not found for id %q", tag.Id()).Error(), Code: params.CodeNotFound}
+				continue
+			} else if e != nil {
+				results[i].Error = &params.Error{Message: e.Error()}
+				continue
 			}
 			l, err = a.storageSvc.GetVolumeLife(ctx, uuid)
+			if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+				results[i].Error = &params.Error{Message: errors.Errorf("volume not found for id %q", tag.Id()).Error(), Code: params.CodeNotFound}
+				continue
+			}
 		case names.FilesystemTag:
 			uuid, e := a.storageSvc.GetFilesystemUUIDForID(ctx, tag.Id())
-			if e != nil {
-				err = e
-				break
+			if errors.Is(e, storageprovisioningerrors.FilesystemNotFound) {
+				results[i].Error = &params.Error{Message: errors.Errorf("filesystem not found for id %q", tag.Id()).Error(), Code: params.CodeNotFound}
+				continue
+			} else if e != nil {
+				results[i].Error = &params.Error{Message: e.Error()}
+				continue
 			}
 			l, err = a.storageSvc.GetFilesystemLife(ctx, uuid)
+			if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+				results[i].Error = &params.Error{Message: errors.Errorf("filesystem not found for id %q", tag.Id()).Error(), Code: params.CodeNotFound}
+				continue
+			}
 		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("invalid tag %q, expected volume or filesystem", tag).Error()}
+			results[i].Error = &params.Error{Message: errors.Errorf("invalid tag %q, expected volume or filesystem", tag).Error(), Code: params.CodeNotValid}
 			continue
 		}
 		if err != nil {
@@ -1183,22 +1342,35 @@ func (a *modelStorageAdapter) AttachmentLife(ctx context.Context, ids []params.M
 				continue
 			}
 		case names.FilesystemTag:
-			machineTag, ok := hostTag.(names.MachineTag)
-			if !ok {
-				results[i].Error = &params.Error{Message: "filesystem attachments only supported on machines"}
+			var fsUUID domainstorage.FilesystemAttachmentUUID
+			switch host := hostTag.(type) {
+			case names.MachineTag:
+				machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(host.Id()))
+				if err != nil {
+					results[i].Error = &params.Error{Message: err.Error()}
+					continue
+				}
+				fsUUID, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx, tag.Id(), machineUUID)
+				if err != nil {
+					results[i].Error = &params.Error{Message: err.Error()}
+					continue
+				}
+			case names.UnitTag:
+				unitUUID, err := a.getUnitUUID(ctx, host)
+				if err != nil {
+					results[i].Error = &params.Error{Message: err.Error()}
+					continue
+				}
+				fsUUID, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDUnit(ctx, tag.Id(), unitUUID)
+				if err != nil {
+					results[i].Error = &params.Error{Message: err.Error()}
+					continue
+				}
+			default:
+				results[i].Error = &params.Error{Message: errors.Errorf("attachment tag %q is not valid", attachmentTag).Error(), Code: params.CodeNotValid}
 				continue
 			}
-			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
-				continue
-			}
-			uuid, err := a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx, tag.Id(), machineUUID)
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
-				continue
-			}
-			l, err = a.storageSvc.GetFilesystemAttachmentLife(ctx, uuid)
+			l, err = a.storageSvc.GetFilesystemAttachmentLife(ctx, fsUUID)
 			if err != nil {
 				results[i].Error = &params.Error{Message: err.Error()}
 				continue
@@ -1234,7 +1406,7 @@ func (a *modelStorageAdapter) RemoveAttachments(ctx context.Context, ids []param
 		case names.VolumeTag:
 			machineTag, ok := hostTag.(names.MachineTag)
 			if !ok {
-				results[i].Error = &params.Error{Message: "volume attachments only supported on machines"}
+				results[i].Error = &params.Error{Message: errors.Errorf("tag %q on host %q invalid", id.AttachmentTag, id.MachineTag).Error(), Code: params.CodeNotValid}
 				continue
 			}
 			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
@@ -1251,40 +1423,58 @@ func (a *modelStorageAdapter) RemoveAttachments(ctx context.Context, ids []param
 				continue
 			}
 			err = a.removalSvc.MarkVolumeAttachmentAsDead(ctx, uuid)
-			if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+			if errors.Is(err, removalerrors.EntityStillAlive) {
+				results[i].Error = &params.Error{Message: errors.Errorf("volume %q attachment to machine %q is still alive", tag.Id(), machineTag.Id()).Error()}
+			} else if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
 				continue
-			}
-			if err != nil {
+			} else if err != nil {
 				results[i].Error = &params.Error{Message: err.Error()}
 			}
 		case names.FilesystemTag:
-			machineTag, ok := hostTag.(names.MachineTag)
-			if !ok {
-				results[i].Error = &params.Error{Message: "filesystem attachments only supported on machines"}
+			var fsUUID domainstorage.FilesystemAttachmentUUID
+			switch host := hostTag.(type) {
+			case names.MachineTag:
+				machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(host.Id()))
+				if err != nil {
+					results[i].Error = &params.Error{Message: err.Error()}
+					continue
+				}
+				fsUUID, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx, tag.Id(), machineUUID)
+				if errors.Is(err, coreerrors.NotFound) {
+					continue
+				}
+				if err != nil {
+					results[i].Error = &params.Error{Message: err.Error()}
+					continue
+				}
+			case names.UnitTag:
+				unitUUID, err := a.getUnitUUID(ctx, host)
+				if err != nil {
+					results[i].Error = &params.Error{Message: err.Error()}
+					continue
+				}
+				fsUUID, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDUnit(ctx, tag.Id(), unitUUID)
+				if errors.Is(err, coreerrors.NotFound) {
+					continue
+				}
+				if err != nil {
+					results[i].Error = &params.Error{Message: err.Error()}
+					continue
+				}
+			default:
+				results[i].Error = &params.Error{Message: errors.Errorf("tag %q on host %q invalid", id.AttachmentTag, id.MachineTag).Error(), Code: params.CodeNotValid}
 				continue
 			}
-			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+			err = a.removalSvc.MarkFilesystemAttachmentAsDead(ctx, fsUUID)
+			if errors.Is(err, removalerrors.EntityStillAlive) {
+				results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q attachment to %s %q is still alive", tag.Id(), hostTag.Kind(), hostTag.Id()).Error()}
+			} else if errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound) {
 				continue
-			}
-			uuid, err := a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx, tag.Id(), machineUUID)
-			if errors.Is(err, coreerrors.NotFound) {
-				continue
-			}
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
-				continue
-			}
-			err = a.removalSvc.MarkFilesystemAttachmentAsDead(ctx, uuid)
-			if errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound) {
-				continue
-			}
-			if err != nil {
+			} else if err != nil {
 				results[i].Error = &params.Error{Message: err.Error()}
 			}
 		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("tag %q on host %q invalid", id.AttachmentTag, id.MachineTag).Error()}
+			results[i].Error = &params.Error{Message: errors.Errorf("tag %q on host %q invalid", id.AttachmentTag, id.MachineTag).Error(), Code: params.CodeNotValid}
 		}
 	}
 	return results, nil

--- a/internal/worker/storageprovisioner/localadapter.go
+++ b/internal/worker/storageprovisioner/localadapter.go
@@ -6,7 +6,8 @@ package storageprovisioner
 import (
 	"context"
 
-	"github.com/juju/errors"
+	"github.com/juju/clock"
+	jujuerrors "github.com/juju/errors"
 	"github.com/juju/names/v6"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/catacomb"
@@ -20,12 +21,16 @@ import (
 	"github.com/juju/juju/core/watcher"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	domainblockdevice "github.com/juju/juju/domain/blockdevice"
+	blockdeviceerrors "github.com/juju/juju/domain/blockdevice/errors"
 	domainlife "github.com/juju/juju/domain/life"
+	machineerrors "github.com/juju/juju/domain/machine/errors"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	domainstorage "github.com/juju/juju/domain/storage"
+	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/domain/storageprovisioning"
 	storageprovisioningerrors "github.com/juju/juju/domain/storageprovisioning/errors"
-	internalerrors "github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -138,6 +143,15 @@ type blockDeviceService interface {
 // modelStorageAdapter implements VolumeAccessor, FilesystemAccessor,
 // LifecycleManager, MachineAccessor, and StatusSetter by reading from
 // domain services directly instead of through an API facade.
+//
+// Error handling and message wording in this adapter mirrors the server-side
+// facade implementation at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+//
+// so that the storage provisioner worker observes the same error codes
+// (params.CodeNotFound, params.CodeNotProvisioned, etc.) and message
+// strings it would have received over the RPC API.
 type modelStorageAdapter struct {
 	storageSvc     storageProvisioningService
 	machineSvc     machineService
@@ -145,14 +159,249 @@ type modelStorageAdapter struct {
 	removalSvc     removalService
 	statusSvc      storageStatusService
 	blockDeviceSvc blockDeviceService
+	clock          clock.Clock
+}
+
+// errPerm mirrors apiservererrors.ErrPerm used by the facade for permission
+// denied errors. The facade converts VolumeNotFound/FilesystemNotFound to
+// ErrPerm in VolumeParams/FilesystemParams to avoid leaking entity
+// existence to unauthorized callers. See facade:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+//	(VolumeParams ~line 1611, FilesystemParams ~line 1811)
+var errPerm = jujuerrors.ConstError("permission denied")
+
+// errPermResult is the *params.Error form of errPerm, matching the
+// CodeUnauthorized code that apiservererrors.ServerError assigns to
+// apiservererrors.ErrPerm.
+var errPermResult = &params.Error{
+	Message: "permission denied",
+	Code:    params.CodeUnauthorized,
+}
+
+// serverError converts a Go error into a *params.Error, mapping error
+// codes in the same way as apiservererrors.ServerError used by the facade
+// at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go
+//
+// Only the error code categories used by the storage provisioner facade
+// are handled; all other errors receive an empty code (CodeUnknown),
+// matching the default branch of apiservererrors.ServerError.
+func serverError(err error) *params.Error {
+	if err == nil {
+		return nil
+	}
+	code := ""
+	switch {
+	case errors.Is(err, errPerm):
+		code = params.CodeUnauthorized
+	case errors.Is(err, coreerrors.NotFound):
+		code = params.CodeNotFound
+	case errors.Is(err, coreerrors.NotProvisioned):
+		code = params.CodeNotProvisioned
+	case errors.Is(err, coreerrors.NotValid):
+		code = params.CodeNotValid
+	case errors.Is(err, coreerrors.NotImplemented):
+		code = params.CodeNotImplemented
+	case errors.Is(err, coreerrors.NotSupported):
+		code = params.CodeNotSupported
+	}
+	return &params.Error{
+		Message: err.Error(),
+		Code:    code,
+	}
+}
+
+// getMachineUUID translates a machine tag into a machine UUID, mapping
+// MachineNotFound to CodeNotFound. Mirrors facade helper getMachineUUID at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:3117
+func (a *modelStorageAdapter) getMachineUUID(
+	ctx context.Context, machineTag names.MachineTag,
+) (machine.UUID, error) {
+	machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+	if errors.Is(err, machineerrors.MachineNotFound) {
+		return "", errors.Errorf(
+			"machine %q not found", machineTag.Id(),
+		).Add(coreerrors.NotFound)
+	} else if err != nil {
+		return "", errors.Capture(err)
+	}
+	return machineUUID, nil
+}
+
+// getVolumeAttachmentUUID translates a volume tag + machine UUID into a
+// volume attachment UUID, mapping domain sentinels to CodeNotFound.
+// Mirrors facade helper getVolumeAttachmentUUID at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2743
+func (a *modelStorageAdapter) getVolumeAttachmentUUID(
+	ctx context.Context, volTag names.VolumeTag, machineUUID machine.UUID,
+) (domainstorage.VolumeAttachmentUUID, error) {
+	rval, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(
+		ctx, volTag.Id(), machineUUID,
+	)
+	if errors.Is(err, machineerrors.MachineNotFound) {
+		return "", errors.Errorf(
+			"machine %q not found", machineUUID,
+		).Add(coreerrors.NotFound)
+	} else if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+		return "", errors.Errorf(
+			"volume attachment %q on %q not found", volTag.Id(), machineUUID,
+		).Add(coreerrors.NotFound)
+	} else if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+		return "", errors.Errorf(
+			"volume %q not found for attachment on %q", volTag.Id(), machineUUID,
+		).Add(coreerrors.NotFound)
+	} else if err != nil {
+		return "", errors.Errorf(
+			"getting volume attachment uuid for %q on %q: %w",
+			volTag.Id(), machineUUID, err,
+		)
+	}
+	return rval, nil
+}
+
+// getVolumeAttachmentPlanUUID translates a volume tag + machine UUID into a
+// volume attachment plan UUID, mapping domain sentinels to CodeNotFound.
+// Mirrors facade helper getVolumeAttachmentPlanUUID at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:1027
+func (a *modelStorageAdapter) getVolumeAttachmentPlanUUID(
+	ctx context.Context, volumeTag names.VolumeTag, machineUUID machine.UUID,
+) (domainstorage.VolumeAttachmentPlanUUID, error) {
+	vapUUID, err := a.storageSvc.GetVolumeAttachmentPlanUUIDForVolumeIDMachine(
+		ctx, volumeTag.Id(), machineUUID,
+	)
+	if errors.Is(err, storageprovisioningerrors.VolumeAttachmentPlanNotFound) {
+		return "", errors.Errorf(
+			"volume attachment plan %q on machine %q not found",
+			volumeTag.Id(), machineUUID,
+		).Add(coreerrors.NotFound)
+	} else if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+		return "", errors.Errorf(
+			"volume %q not found", volumeTag.Id(),
+		).Add(coreerrors.NotFound)
+	} else if errors.Is(err, machineerrors.MachineNotFound) {
+		return "", errors.Errorf(
+			"machine %q not found", machineUUID,
+		).Add(coreerrors.NotFound)
+	} else if err != nil {
+		return "", errors.Errorf(
+			"getting volume attachment plan %q on machine %q: %v",
+			volumeTag.Id(), machineUUID, err,
+		)
+	}
+	return vapUUID, nil
+}
+
+// getFilesystemAttachmentUUID translates a filesystem tag + host tag into a
+// filesystem attachment UUID, mapping domain sentinels to CodeNotFound.
+// Mirrors facade helper getFilesystemAttachmentUUID at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2680
+func (a *modelStorageAdapter) getFilesystemAttachmentUUID(
+	ctx context.Context, fsTag names.FilesystemTag, hostTag names.Tag,
+) (domainstorage.FilesystemAttachmentUUID, error) {
+	errHandler := func(err error) error {
+		switch {
+		case errors.Is(err, applicationerrors.UnitNotFound):
+			return errors.Errorf(
+				"unit %q not found", hostTag.Id(),
+			).Add(coreerrors.NotFound)
+		case errors.Is(err, machineerrors.MachineNotFound):
+			return errors.Errorf(
+				"machine %q not found", hostTag.Id(),
+			).Add(coreerrors.NotFound)
+		case errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound):
+			return errors.Errorf(
+				"filesystem attachment %q on %q not found", fsTag.Id(), hostTag.Id(),
+			).Add(coreerrors.NotFound)
+		case errors.Is(err, storageprovisioningerrors.FilesystemNotFound):
+			return errors.Errorf(
+				"filesystem %q not found for attachment on %q", fsTag.Id(), hostTag.Id(),
+			).Add(coreerrors.NotFound)
+		case err != nil:
+			return errors.Errorf(
+				"getting filesystem attachment UUID for %q on %q: %w",
+				fsTag.Id(), hostTag.Id(), err,
+			)
+		}
+		return nil
+	}
+
+	var rval domainstorage.FilesystemAttachmentUUID
+	switch tag := hostTag.(type) {
+	case names.MachineTag:
+		machineUUID, err := a.getMachineUUID(ctx, tag)
+		if err != nil {
+			return "", errors.Capture(err)
+		}
+		rval, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(
+			ctx, fsTag.Id(), machineUUID,
+		)
+		if err != nil {
+			return "", errHandler(err)
+		}
+	case names.UnitTag:
+		unitUUID, err := a.getUnitUUID(ctx, tag)
+		if err != nil {
+			return "", errors.Capture(err)
+		}
+		rval, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDUnit(
+			ctx, fsTag.Id(), unitUUID,
+		)
+		if err != nil {
+			return "", errHandler(err)
+		}
+	default:
+		return "", errors.Errorf(
+			"filesystem attachment host tag %q is not a valid", hostTag.String(),
+		).Add(coreerrors.NotValid)
+	}
+
+	return rval, nil
+}
+
+// getUnitUUID translates a unit tag into a unit UUID, mapping domain
+// sentinels to CodeNotFound and CodeNotValid. Mirrors facade helper
+// getUnitUUID at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2629
+func (a *modelStorageAdapter) getUnitUUID(
+	ctx context.Context, tag names.UnitTag,
+) (coreunit.UUID, error) {
+	unitName, err := coreunit.NewName(tag.Id())
+	if errors.Is(err, coreunit.InvalidUnitName) {
+		return "", errors.Errorf(
+			"invalid unit name %q", tag.Id(),
+		).Add(coreerrors.NotValid)
+	} else if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	unitUUID, err := a.appSvc.GetUnitUUID(ctx, unitName)
+	if errors.Is(err, coreunit.InvalidUnitName) {
+		return "", errors.Errorf(
+			"invalid unit name %q", unitName,
+		).Add(coreerrors.NotValid)
+	} else if errors.Is(err, applicationerrors.UnitNotFound) {
+		return "", errors.Errorf(
+			"unit %q not found", unitName,
+		).Add(coreerrors.NotFound)
+	} else if err != nil {
+		return "", errors.Errorf("getting unit %q UUID: %w", unitName, err)
+	}
+	return unitUUID, nil
 }
 
 // VolumeAccessor implementation
 
 func (a *modelStorageAdapter) WatchBlockDevices(ctx context.Context, m names.MachineTag) (watcher.NotifyWatcher, error) {
-	machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(m.Id()))
+	machineUUID, err := a.getMachineUUID(ctx, m)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, jujuerrors.Trace(err)
 	}
 	return a.blockDeviceSvc.WatchBlockDevicesForMachine(ctx, machineUUID)
 }
@@ -162,13 +411,13 @@ func (a *modelStorageAdapter) WatchVolumes(ctx context.Context, scope names.Tag)
 	case names.ModelTag:
 		return a.storageSvc.WatchModelProvisionedVolumes(ctx)
 	case names.MachineTag:
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(scope.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, scope)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		return a.storageSvc.WatchMachineProvisionedVolumes(ctx, machineUUID)
 	default:
-		return nil, internalerrors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
+		return nil, errors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
 	}
 }
 
@@ -178,26 +427,26 @@ func (a *modelStorageAdapter) WatchVolumeAttachments(ctx context.Context, scope 
 	case names.ModelTag:
 		w, err := a.storageSvc.WatchModelProvisionedVolumeAttachments(ctx)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		sourceWatcher = w
 	case names.MachineTag:
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(scope.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, scope)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		w, err := a.storageSvc.WatchMachineProvisionedVolumeAttachments(ctx, machineUUID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		sourceWatcher = w
 	default:
-		return nil, internalerrors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
+		return nil, errors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
 	}
 	return newAttachmentIDWatcher(sourceWatcher, func(ctx context.Context, ids ...string) ([]watcher.MachineStorageID, error) {
 		attachmentIDs, err := a.storageSvc.GetVolumeAttachmentIDs(ctx, ids)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		var out []watcher.MachineStorageID
 		for _, id := range attachmentIDs {
@@ -221,13 +470,13 @@ func (a *modelStorageAdapter) WatchVolumeAttachments(ctx context.Context, scope 
 func (a *modelStorageAdapter) WatchVolumeAttachmentPlans(ctx context.Context, scope names.Tag) (watcher.MachineStorageIDsWatcher, error) {
 	switch scope := scope.(type) {
 	case names.MachineTag:
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(scope.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, scope)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		w, err := a.storageSvc.WatchVolumeAttachmentPlans(ctx, machineUUID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		return newAttachmentIDWatcher(w, func(ctx context.Context, volumeIDs ...string) ([]watcher.MachineStorageID, error) {
 			if len(volumeIDs) == 0 {
@@ -246,24 +495,34 @@ func (a *modelStorageAdapter) WatchVolumeAttachmentPlans(ctx context.Context, sc
 			return out, nil
 		})
 	default:
-		return nil, internalerrors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
+		return nil, errors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
 	}
 }
 
+// Volumes returns details of volumes with the specified tags.
+// Mirrors facade Volumes at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:884
 func (a *modelStorageAdapter) Volumes(ctx context.Context, tags []names.VolumeTag) ([]params.VolumeResult, error) {
 	results := make([]params.VolumeResult, len(tags))
 	for i, tag := range tags {
 		vol, err := a.storageSvc.GetVolumeByID(ctx, tag.Id())
 		if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"volume %q not found", tag.Id(),
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"getting volume %q: %v", tag.Id(), err,
+			))
 			continue
 		}
 		if vol.SizeMiB == 0 {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume %q is not provisioned", tag.Id()).Error(), Code: params.CodeNotProvisioned}
+			results[i].Error = serverError(errors.Errorf(
+				"volume %q is not provisioned", tag.Id(),
+			).Add(coreerrors.NotProvisioned))
 			continue
 		}
 		results[i].Result = params.Volume{
@@ -280,47 +539,100 @@ func (a *modelStorageAdapter) Volumes(ctx context.Context, tags []names.VolumeTa
 	return results, nil
 }
 
+// VolumeBlockDevices returns details of block devices corresponding to the
+// specified volume attachment IDs.
+// Mirrors facade VolumeBlockDevices at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:1265
 func (a *modelStorageAdapter) VolumeBlockDevices(ctx context.Context, ids []params.MachineStorageId) ([]params.BlockDeviceResult, error) {
 	results := make([]params.BlockDeviceResult, len(ids))
 	for i, id := range ids {
 		volumeTag, err := names.ParseVolumeTag(id.AttachmentTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"volume tag %q invalid", id.AttachmentTag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		machineTag, err := names.ParseMachineTag(id.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"machine tag %q invalid", id.MachineTag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, machineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
-		attachmentUUID, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		// GetVolumeAttachmentUUIDForVolumeIDMachine error mapping mirrors
+		// facade lines ~1296-1314.
+		va, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment %q on machine %q not found",
+				volumeTag.Id(), machineTag.Id(),
+			).Add(coreerrors.NotFound))
+			continue
+		} else if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+			results[i].Error = serverError(errors.Errorf(
+				"volume %q not found", volumeTag.Id(),
+			).Add(coreerrors.NotFound))
+			continue
+		} else if errors.Is(err, machineerrors.MachineNotFound) {
+			results[i].Error = serverError(errors.Errorf(
+				"machine %q not found", machineTag.Id(),
+			).Add(coreerrors.NotFound))
+			continue
+		} else if err != nil {
+			results[i].Error = serverError(errors.Errorf(
+				"getting volume attachment %q on machine %q: %v",
+				volumeTag.Id(), machineTag.Id(), err,
+			))
 			continue
 		}
-		blockDevUUID, err := a.storageSvc.GetBlockDeviceForVolumeAttachment(ctx, attachmentUUID)
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		// GetBlockDeviceForVolumeAttachment error mapping mirrors facade
+		// lines ~1318-1333.
+		bdUUID, err := a.storageSvc.GetBlockDeviceForVolumeAttachment(ctx, va)
+		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentWithoutBlockDevice) {
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment %q on machine %q is not provisioned",
+				volumeTag.Id(), machineTag.Id(),
+			).Add(coreerrors.NotProvisioned))
+			continue
+		} else if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment %q on machine %q not found",
+				volumeTag.Id(), machineTag.Id(),
+			).Add(coreerrors.NotFound))
+			continue
+		} else if err != nil {
+			results[i].Error = serverError(errors.Errorf(
+				"getting volume attachment %q on machine %q: %v",
+				volumeTag.Id(), machineTag.Id(), err,
+			))
 			continue
 		}
-		bd, err := a.blockDeviceSvc.GetBlockDevice(ctx, blockDevUUID)
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		// GetBlockDevice error mapping mirrors facade lines ~1336-1345.
+		bd, err := a.blockDeviceSvc.GetBlockDevice(ctx, bdUUID)
+		if errors.Is(err, blockdeviceerrors.BlockDeviceNotFound) {
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment %q on machine %q is not provisioned",
+				volumeTag.Id(), machineTag.Id(),
+			).Add(coreerrors.NotProvisioned))
+			continue
+		} else if err != nil {
+			results[i].Error = serverError(errors.Errorf(
+				"getting block device %q: %v", bdUUID, err,
+			))
 			continue
 		}
 		if bd.DeviceName == "" || len(bd.DeviceLinks) == 0 {
-			results[i].Error = &params.Error{
-				Message: errors.Errorf(
-					"volume attachment %q on machine %q is not provisioned",
-					volumeTag.Id(), machineTag.Id(),
-				).Error(),
-				Code: params.CodeNotProvisioned,
-			}
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment %q on machine %q is not provisioned",
+				volumeTag.Id(), machineTag.Id(),
+			).Add(coreerrors.NotProvisioned))
 			continue
 		}
 		var provenance params.BlockDeviceProvenance
@@ -330,11 +642,9 @@ func (a *modelStorageAdapter) VolumeBlockDevices(ctx context.Context, ids []para
 		case coreblockdevice.MachineProvenance:
 			provenance = params.BlockDeviceProvenanceMachine
 		default:
-			results[i].Error = &params.Error{
-				Message: errors.Errorf(
-					"unexpected provenance value: %v", bd.Provenance,
-				).Error(),
-			}
+			results[i].Error = serverError(errors.Errorf(
+				"unexpected provenance value: %v", bd.Provenance,
+			).Add(coreerrors.NotImplemented))
 			continue
 		}
 		results[i].Result = params.BlockDevice{
@@ -356,40 +666,55 @@ func (a *modelStorageAdapter) VolumeBlockDevices(ctx context.Context, ids []para
 	return results, nil
 }
 
+// VolumeAttachments returns details of volume attachments with the specified
+// IDs. Mirrors facade VolumeAttachments/volumeAttachments at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:1166
 func (a *modelStorageAdapter) VolumeAttachments(ctx context.Context, ids []params.MachineStorageId) ([]params.VolumeAttachmentResult, error) {
 	results := make([]params.VolumeAttachmentResult, len(ids))
 	for i, id := range ids {
 		volumeTag, err := names.ParseVolumeTag(id.AttachmentTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.New(
+				"volume tag invalid",
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		machineTag, err := names.ParseMachineTag(id.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.New(
+				"machine tag invalid",
+			).Add(coreerrors.NotValid))
 			continue
 		}
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, machineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
-		attachmentUUID, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		uuid, err := a.getVolumeAttachmentUUID(ctx, volumeTag, machineUUID)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
-		va, err := a.storageSvc.GetVolumeAttachment(ctx, attachmentUUID)
+		va, err := a.storageSvc.GetVolumeAttachment(ctx, uuid)
 		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume attachment %q on %q not found", volumeTag.Id(), machineTag.Id()).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment %q on machine %q not found",
+				volumeTag.Id(), machineTag.Id(),
+			).Add(coreerrors.NotFound))
 			continue
-		}
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		} else if err != nil {
+			results[i].Error = serverError(errors.Errorf(
+				"getting volume attachment %q on machine %q: %v",
+				volumeTag.Id(), machineTag.Id(), err,
+			))
 			continue
 		}
 		if va.BlockDeviceName == "" || len(va.BlockDeviceLinks) == 0 {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume %q is not provisioned", volumeTag.Id()).Error(), Code: params.CodeNotProvisioned}
+			results[i].Error = serverError(errors.Errorf(
+				"volume %q is not provisioned", volumeTag.Id(),
+			).Add(coreerrors.NotProvisioned))
 			continue
 		}
 		results[i].Result = params.VolumeAttachment{
@@ -406,37 +731,70 @@ func (a *modelStorageAdapter) VolumeAttachments(ctx context.Context, ids []param
 	return results, nil
 }
 
+// VolumeAttachmentPlans returns details of volume attachment plans with the
+// specified IDs. Mirrors facade VolumeAttachmentPlans/volumeAttachmentPlan at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:1059
 func (a *modelStorageAdapter) VolumeAttachmentPlans(ctx context.Context, ids []params.MachineStorageId) ([]params.VolumeAttachmentPlanResult, error) {
 	results := make([]params.VolumeAttachmentPlanResult, len(ids))
 	for i, id := range ids {
 		volumeTag, err := names.ParseVolumeTag(id.AttachmentTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.New(
+				"volume tag invalid",
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		machineTag, err := names.ParseMachineTag(id.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.New(
+				"machine tag invalid",
+			).Add(coreerrors.NotValid))
 			continue
 		}
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, machineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
-		planUUID, err := a.storageSvc.GetVolumeAttachmentPlanUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		planUUID, err := a.getVolumeAttachmentPlanUUID(ctx, volumeTag, machineUUID)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		plan, err := a.storageSvc.GetVolumeAttachmentPlan(ctx, planUUID)
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentPlanNotFound) {
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment plan %q on machine %q not found",
+				volumeTag.Id(), machineTag.Id(),
+			).Add(coreerrors.NotFound))
+			continue
+		} else if err != nil {
+			results[i].Error = serverError(errors.Errorf(
+				"getting volume attachment plan %q on machine %q: %v",
+				volumeTag.Id(), machineTag.Id(), err,
+			))
 			continue
 		}
 		planLife, err := plan.Life.Value()
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"getting volume attachment plan %q life: %w",
+				planUUID, err,
+			))
+			continue
+		}
+		// Device type conversion and error mirrors facade lines ~1142-1152.
+		var deviceType storage.DeviceType
+		switch plan.DeviceType {
+		case domainstorage.VolumeDeviceTypeISCSI:
+			deviceType = storage.DeviceTypeISCSI
+		case domainstorage.VolumeDeviceTypeLocal:
+			deviceType = storage.DeviceTypeLocal
+		default:
+			results[i].Error = serverError(errors.Errorf(
+				"unknown device type %q", plan.DeviceType,
+			))
 			continue
 		}
 		results[i].Result = params.VolumeAttachmentPlan{
@@ -444,7 +802,7 @@ func (a *modelStorageAdapter) VolumeAttachmentPlans(ctx context.Context, ids []p
 			MachineTag: machineTag.String(),
 			Life:       planLife,
 			PlanInfo: params.VolumeAttachmentPlanInfo{
-				DeviceType:       plan.DeviceType.String(),
+				DeviceType:       deviceType.String(),
 				DeviceAttributes: plan.DeviceAttributes,
 			},
 		}
@@ -452,21 +810,31 @@ func (a *modelStorageAdapter) VolumeAttachmentPlans(ctx context.Context, ids []p
 	return results, nil
 }
 
+// VolumeParams returns the parameters for creating the volumes with the
+// specified tags. Mirrors facade VolumeParams at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:1527
 func (a *modelStorageAdapter) VolumeParams(ctx context.Context, tags []names.VolumeTag) ([]params.VolumeParamsResult, error) {
 	results := make([]params.VolumeParamsResult, len(tags))
 	volModelTags, err := a.storageSvc.GetStorageResourceTagsForModel(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, jujuerrors.Trace(err)
 	}
 	for i, tag := range tags {
 		uuid, err := a.storageSvc.GetVolumeUUIDForID(ctx, tag.Id())
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			// Facade converts VolumeNotFound to ErrPerm (~line 1611)
+			// to avoid leaking entity existence.
+			if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+				results[i].Error = errPermResult
+			} else {
+				results[i].Error = serverError(err)
+			}
 			continue
 		}
 		volParams, err := a.storageSvc.GetVolumeParams(ctx, uuid)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		rval := params.VolumeParams{
@@ -482,9 +850,10 @@ func (a *modelStorageAdapter) VolumeParams(ctx context.Context, tags []names.Vol
 		if volParams.VolumeAttachmentUUID != nil {
 			vaParams, err := a.storageSvc.GetVolumeAttachmentParams(ctx, *volParams.VolumeAttachmentUUID)
 			if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
-				// No attachment params yet.
+				// No attachment params yet — return rval without attachment,
+				// matching facade line ~1586.
 			} else if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 				continue
 			} else {
 				rval.Attachment = &params.VolumeAttachmentParams{
@@ -504,29 +873,39 @@ func (a *modelStorageAdapter) VolumeParams(ctx context.Context, tags []names.Vol
 	return results, nil
 }
 
+// RemoveVolumeParams returns the parameters for destroying or releasing the
+// volumes with the specified tags. Mirrors facade RemoveVolumeParams at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:1627
 func (a *modelStorageAdapter) RemoveVolumeParams(ctx context.Context, tags []names.VolumeTag) ([]params.RemoveVolumeParamsResult, error) {
 	results := make([]params.RemoveVolumeParamsResult, len(tags))
 	for i, tag := range tags {
 		uuid, err := a.storageSvc.GetVolumeUUIDForID(ctx, tag.Id())
 		if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"volume %q not found", tag.Id(),
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		rp, err := a.storageSvc.GetVolumeRemovalParams(ctx, uuid)
 		if errors.Is(err, storageprovisioningerrors.VolumeNotDead) {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume %q is not yet dead", tag.Id()).Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"volume %q is not yet dead", tag.Id(),
+			))
 			continue
 		}
 		if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"volume %q not found", tag.Id(),
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		results[i].Result = params.RemoveVolumeParams{
@@ -538,60 +917,76 @@ func (a *modelStorageAdapter) RemoveVolumeParams(ctx context.Context, tags []nam
 	return results, nil
 }
 
+// VolumeAttachmentParams returns the parameters for creating the volume
+// attachments with the specified IDs. Mirrors facade VolumeAttachmentParams at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:1899
 func (a *modelStorageAdapter) VolumeAttachmentParams(ctx context.Context, ids []params.MachineStorageId) ([]params.VolumeAttachmentParamsResult, error) {
 	results := make([]params.VolumeAttachmentParamsResult, len(ids))
 	for i, id := range ids {
 		machineTag, err := names.ParseMachineTag(id.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing machine tag: %w", err,
+			))
 			continue
 		}
 		volumeTag, err := names.ParseVolumeTag(id.AttachmentTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing volume tag: %w", err,
+			))
 			continue
 		}
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, machineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
-		attachmentUUID, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		attachmentUUID, err := a.getVolumeAttachmentUUID(ctx, volumeTag, machineUUID)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
-		vaParams, err := a.storageSvc.GetVolumeAttachmentParams(ctx, attachmentUUID)
+		volParams, err := a.storageSvc.GetVolumeAttachmentParams(ctx, attachmentUUID)
 		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume attachment %q on %q not found", volumeTag.Id(), machineTag.Id()).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment for volume %q and host %q not found",
+				volumeTag, machineTag,
+			).Add(coreerrors.NotFound))
 			continue
-		}
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		} else if err != nil {
+			results[i].Error = serverError(err)
 			continue
 		}
 		results[i].Result = params.VolumeAttachmentParams{
 			VolumeTag:  volumeTag.String(),
 			MachineTag: machineTag.String(),
-			InstanceId: vaParams.MachineInstanceID,
-			Provider:   vaParams.Provider,
-			ProviderId: vaParams.ProviderID,
-			ReadOnly:   vaParams.ReadOnly,
+			InstanceId: volParams.MachineInstanceID,
+			Provider:   volParams.Provider,
+			ProviderId: volParams.ProviderID,
+			ReadOnly:   volParams.ReadOnly,
 		}
 	}
 	return results, nil
 }
 
+// SetVolumeInfo records the details of newly provisioned volumes.
+// Mirrors facade SetVolumeInfo at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2137
 func (a *modelStorageAdapter) SetVolumeInfo(ctx context.Context, vols []params.Volume) ([]params.ErrorResult, error) {
 	results := make([]params.ErrorResult, len(vols))
 	for i, vol := range vols {
 		volumeTag, err := names.ParseVolumeTag(vol.VolumeTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing volume tag %q: %w", vol.VolumeTag, err,
+			))
 			continue
 		}
 		if vol.Info.Pool != "" {
-			results[i].Error = &params.Error{Message: "pool field must not be set"}
+			results[i].Error = serverError(errors.New("pool field must not be set"))
 			continue
 		}
 		info := storageprovisioning.VolumeProvisionedInfo{
@@ -603,45 +998,63 @@ func (a *modelStorageAdapter) SetVolumeInfo(ctx context.Context, vols []params.V
 		}
 		err = a.storageSvc.SetVolumeProvisionedInfo(ctx, volumeTag.Id(), info)
 		if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume %q not found", volumeTag.Id()).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"volume %q not found", volumeTag.Id(),
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 		}
 	}
 	return results, nil
 }
 
+// SetVolumeAttachmentInfo records the details of newly provisioned volume
+// attachments. Mirrors facade SetVolumeAttachmentInfo/setVolumeAttachmentInfo at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2414
 func (a *modelStorageAdapter) SetVolumeAttachmentInfo(ctx context.Context, vas []params.VolumeAttachment) ([]params.ErrorResult, error) {
 	results := make([]params.ErrorResult, len(vas))
 	for i, va := range vas {
 		machineTag, err := names.ParseMachineTag(va.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing machine tag: %w", err,
+			))
 			continue
 		}
 		volumeTag, err := names.ParseVolumeTag(va.VolumeTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing volume tag: %w", err,
+			))
 			continue
 		}
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, machineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
+		// GetVolumeAttachmentUUIDForVolumeIDMachine error mapping mirrors
+		// facade setVolumeAttachmentInfo ~lines 2462-2476.
 		attachmentUUID, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
 		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume attachment %q on %q not found", volumeTag.Id(), machineUUID).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment %q on %q not found",
+				volumeTag.Id(), machineUUID,
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("volume %q not found for attachment on %q", volumeTag.Id(), machineUUID).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"volume %q not found for attachment on %q",
+				volumeTag.Id(), machineUUID,
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		info := storageprovisioning.VolumeAttachmentProvisionedInfo{
@@ -656,154 +1069,210 @@ func (a *modelStorageAdapter) SetVolumeAttachmentInfo(ctx context.Context, vas [
 				device.DeviceLinks = []string{va.Info.DeviceLink}
 			}
 			blockDevUUID, err := a.blockDeviceSvc.MatchOrCreateBlockDevice(ctx, machineUUID, device)
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+			if errors.Is(err, machineerrors.MachineNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"machine %q not found", machineTag.Id(),
+				).Add(coreerrors.NotFound))
+				continue
+			} else if err != nil {
+				results[i].Error = serverError(err)
 				continue
 			}
 			info.BlockDeviceUUID = &blockDevUUID
 		}
 		err = a.storageSvc.SetVolumeAttachmentProvisionedInfo(ctx, attachmentUUID, info)
 		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf(
+			results[i].Error = serverError(errors.Errorf(
 				"volume attachment for machine %q and volume %q not found",
 				machineTag.Id(), volumeTag.Id(),
-			).Error(), Code: params.CodeNotFound}
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		if va.Info.PlanInfo == nil {
 			continue
 		}
-		planUUID, err := a.storageSvc.GetVolumeAttachmentPlanUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		planUUID, err := a.getVolumeAttachmentPlanUUID(ctx, volumeTag, machineUUID)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		planInfo := storageprovisioning.VolumeAttachmentPlanProvisionedInfo{
 			DeviceAttributes: va.Info.PlanInfo.DeviceAttributes,
 		}
 		switch va.Info.PlanInfo.DeviceType {
-		case "local":
+		case storage.DeviceTypeLocal.String():
 			planInfo.DeviceType = domainstorage.VolumeDeviceTypeLocal
-		case "iscsi":
+		case storage.DeviceTypeISCSI.String():
 			planInfo.DeviceType = domainstorage.VolumeDeviceTypeISCSI
 		}
 		err = a.storageSvc.SetVolumeAttachmentPlanProvisionedInfo(ctx, planUUID, planInfo)
 		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentPlanNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf(
+			results[i].Error = serverError(errors.Errorf(
 				"volume attachment plan for machine %q and volume %q not found",
 				machineTag.Id(), volumeTag.Id(),
-			).Error(), Code: params.CodeNotFound}
+			).Add(coreerrors.NotFound))
 		} else if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			// Wrap with context, matching facade line ~2543.
+			results[i].Error = serverError(errors.Errorf(
+				"setting volume attachment plan info: %w", err,
+			))
 		}
 	}
 	return results, nil
 }
 
+// CreateVolumeAttachmentPlans creates volume attachment plans.
+// Mirrors facade CreateVolumeAttachmentPlans/createVolumeAttachmentPlan at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2227
 func (a *modelStorageAdapter) CreateVolumeAttachmentPlans(ctx context.Context, plans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
 	results := make([]params.ErrorResult, len(plans))
 	for i, plan := range plans {
 		machineTag, err := names.ParseMachineTag(plan.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing machine tag: %w", err,
+			))
 			continue
 		}
 		volumeTag, err := names.ParseVolumeTag(plan.VolumeTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing volume tag: %w", err,
+			))
 			continue
 		}
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
-			continue
-		}
-		attachmentUUID, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		// Reject block device field, matching facade line ~2250.
+		if plan.BlockDevice != nil {
+			results[i].Error = serverError(errors.New(
+				"block device field must not be set",
+			))
 			continue
 		}
 		var deviceType domainstorage.VolumeDeviceType
 		switch plan.PlanInfo.DeviceType {
-		case "iscsi":
+		case storage.DeviceTypeISCSI.String():
 			deviceType = domainstorage.VolumeDeviceTypeISCSI
-		case "local":
+		case storage.DeviceTypeLocal.String():
 			deviceType = domainstorage.VolumeDeviceTypeLocal
 		default:
-			results[i].Error = &params.Error{
-				Message: errors.Errorf(
-					"plan device type %q not valid", plan.PlanInfo.DeviceType,
-				).Error(),
-				Code: params.CodeNotValid,
-			}
+			results[i].Error = serverError(errors.Errorf(
+				"plan device type %q not valid", plan.PlanInfo.DeviceType,
+			).Add(coreerrors.NotValid))
+			continue
+		}
+		machineUUID, err := a.getMachineUUID(ctx, machineTag)
+		if err != nil {
+			results[i].Error = serverError(err)
+			continue
+		}
+		attachmentUUID, err := a.getVolumeAttachmentUUID(ctx, volumeTag, machineUUID)
+		if err != nil {
+			results[i].Error = serverError(err)
 			continue
 		}
 		_, err = a.storageSvc.CreateVolumeAttachmentPlan(ctx, attachmentUUID, deviceType, plan.PlanInfo.DeviceAttributes)
 		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentPlanAlreadyExists) {
 			continue
+		} else if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment for machine %q and volume %q not found",
+				machineTag.Id(), volumeTag.Id(),
+			).Add(coreerrors.NotFound))
 		} else if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 		}
 	}
 	return results, nil
 }
 
+// RemoveVolumeAttachmentPlan removes volume attachment plans.
+// Mirrors facade RemoveVolumeAttachmentPlan/removeVolumeAttachmentPlan at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:745
 func (a *modelStorageAdapter) RemoveVolumeAttachmentPlan(ctx context.Context, ids []params.MachineStorageId) ([]params.ErrorResult, error) {
 	results := make([]params.ErrorResult, len(ids))
 	for i, id := range ids {
 		volumeTag, err := names.ParseVolumeTag(id.AttachmentTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"volume tag %q invalid", id.AttachmentTag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		machineTag, err := names.ParseMachineTag(id.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"machine tag %q invalid", id.MachineTag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, machineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
-		planUUID, err := a.storageSvc.GetVolumeAttachmentPlanUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		// Plan UUID lookup: NotFound is treated as success (already removed),
+		// matching facade line ~793.
+		planUUID, err := a.getVolumeAttachmentPlanUUID(ctx, volumeTag, machineUUID)
+		if errors.Is(err, coreerrors.NotFound) {
+			continue
+		} else if err != nil {
+			results[i].Error = serverError(err)
 			continue
 		}
+		// MarkVolumeAttachmentPlanAsDead error mapping mirrors facade
+		// lines ~800-809.
 		err = a.removalSvc.MarkVolumeAttachmentPlanAsDead(ctx, planUUID)
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		if errors.Is(err, removalerrors.EntityStillAlive) {
+			results[i].Error = serverError(errors.Errorf(
+				"volume %q attachment plan for machine %q is still alive",
+				volumeTag.Id(), machineTag.Id(),
+			))
+		} else if errors.Is(err, storageprovisioningerrors.VolumeAttachmentPlanNotFound) {
+			// Already removed — treat as success, matching facade line ~806.
+			continue
+		} else if err != nil {
+			results[i].Error = serverError(err)
 		}
 	}
 	return results, nil
 }
 
+// SetVolumeAttachmentPlanBlockInfo records block device info for volume
+// attachment plans. Mirrors facade
+// SetVolumeAttachmentPlanBlockInfo/setVolumeAttachmentPlanBlockInfo at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2312
 func (a *modelStorageAdapter) SetVolumeAttachmentPlanBlockInfo(ctx context.Context, plans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
 	results := make([]params.ErrorResult, len(plans))
 	for i, plan := range plans {
 		machineTag, err := names.ParseMachineTag(plan.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing machine tag: %w", err,
+			))
 			continue
 		}
 		volumeTag, err := names.ParseVolumeTag(plan.VolumeTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing volume tag: %w", err,
+			))
 			continue
 		}
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, machineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
-		planUUID, err := a.storageSvc.GetVolumeAttachmentPlanUUIDForVolumeIDMachine(ctx, volumeTag.Id(), machineUUID)
+		planUUID, err := a.getVolumeAttachmentPlanUUID(ctx, volumeTag, machineUUID)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		if plan.BlockDevice == nil {
@@ -826,14 +1295,28 @@ func (a *modelStorageAdapter) SetVolumeAttachmentPlanBlockInfo(ctx context.Conte
 		if domainblockdevice.IsEmpty(device) {
 			continue
 		}
+		// MatchOrCreateBlockDevice MachineNotFound mapping mirrors facade
+		// line ~2390.
 		blockDevUUID, err := a.blockDeviceSvc.MatchOrCreateBlockDevice(ctx, machineUUID, device)
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		if errors.Is(err, machineerrors.MachineNotFound) {
+			results[i].Error = serverError(errors.Errorf(
+				"machine %q not found", machineTag.Id(),
+			).Add(coreerrors.NotFound))
+			continue
+		} else if err != nil {
+			results[i].Error = serverError(err)
 			continue
 		}
+		// SetVolumeAttachmentPlanProvisionedBlockDevice PlanNotFound mapping
+		// mirrors facade line ~2400.
 		err = a.storageSvc.SetVolumeAttachmentPlanProvisionedBlockDevice(ctx, planUUID, blockDevUUID)
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		if errors.Is(err, storageprovisioningerrors.VolumeAttachmentPlanNotFound) {
+			results[i].Error = serverError(errors.Errorf(
+				"volume attachment plan for machine %q and volume %q not found",
+				machineTag.Id(), volumeTag.Id(),
+			).Add(coreerrors.NotFound))
+		} else if err != nil {
+			results[i].Error = serverError(err)
 		}
 	}
 	return results, nil
@@ -846,13 +1329,13 @@ func (a *modelStorageAdapter) WatchFilesystems(ctx context.Context, scope names.
 	case names.ModelTag:
 		return a.storageSvc.WatchModelProvisionedFilesystems(ctx)
 	case names.MachineTag:
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(scope.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, scope)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		return a.storageSvc.WatchMachineProvisionedFilesystems(ctx, machineUUID)
 	default:
-		return nil, internalerrors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
+		return nil, errors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
 	}
 }
 
@@ -862,26 +1345,26 @@ func (a *modelStorageAdapter) WatchFilesystemAttachments(ctx context.Context, sc
 	case names.ModelTag:
 		w, err := a.storageSvc.WatchModelProvisionedFilesystemAttachments(ctx)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		sourceWatcher = w
 	case names.MachineTag:
-		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(scope.Id()))
+		machineUUID, err := a.getMachineUUID(ctx, scope)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		w, err := a.storageSvc.WatchMachineProvisionedFilesystemAttachments(ctx, machineUUID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		sourceWatcher = w
 	default:
-		return nil, internalerrors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
+		return nil, errors.Errorf("unsupported scope %T", scope).Add(coreerrors.NotSupported)
 	}
 	return newAttachmentIDWatcher(sourceWatcher, func(ctx context.Context, ids ...string) ([]watcher.MachineStorageID, error) {
 		attachmentIDs, err := a.storageSvc.GetFilesystemAttachmentIDs(ctx, ids)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, jujuerrors.Trace(err)
 		}
 		var out []watcher.MachineStorageID
 		for _, id := range attachmentIDs {
@@ -902,20 +1385,30 @@ func (a *modelStorageAdapter) WatchFilesystemAttachments(ctx context.Context, sc
 	})
 }
 
+// Filesystems returns details of filesystems with the specified tags.
+// Mirrors facade Filesystems at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:951
 func (a *modelStorageAdapter) Filesystems(ctx context.Context, tags []names.FilesystemTag) ([]params.FilesystemResult, error) {
 	results := make([]params.FilesystemResult, len(tags))
 	for i, tag := range tags {
 		fs, err := a.storageSvc.GetFilesystemForID(ctx, tag.Id())
 		if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem %q not found", tag.Id(),
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"getting filesystem %q: %v", tag.Id(), err,
+			))
 			continue
 		}
 		if fs.SizeMiB == 0 {
-			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q is not provisioned", tag.Id()).Error(), Code: params.CodeNotProvisioned}
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem %q is not provisioned", tag.Id(),
+			).Add(coreerrors.NotProvisioned))
 			continue
 		}
 		result := params.Filesystem{
@@ -926,6 +1419,14 @@ func (a *modelStorageAdapter) Filesystems(ctx context.Context, tags []names.File
 			},
 		}
 		if fs.BackingVolume != nil {
+			// Validate backing volume ID, matching facade lines ~994-998.
+			if !names.IsValidVolume(fs.BackingVolume.VolumeID) {
+				results[i].Error = serverError(errors.Errorf(
+					"invalid volume ID %q for filesystem %q",
+					fs.BackingVolume.VolumeID, tag.Id(),
+				).Add(coreerrors.NotValid))
+				continue
+			}
 			result.VolumeTag = names.NewVolumeTag(fs.BackingVolume.VolumeID).String()
 		}
 		results[i].Result = result
@@ -933,49 +1434,104 @@ func (a *modelStorageAdapter) Filesystems(ctx context.Context, tags []names.File
 	return results, nil
 }
 
+// FilesystemAttachments returns details of filesystem attachments with the
+// specified IDs. Mirrors facade FilesystemAttachments at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:1421
 func (a *modelStorageAdapter) FilesystemAttachments(ctx context.Context, ids []params.MachineStorageId) ([]params.FilesystemAttachmentResult, error) {
 	results := make([]params.FilesystemAttachmentResult, len(ids))
 	for i, id := range ids {
 		filesystemTag, err := names.ParseFilesystemTag(id.AttachmentTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing filesystem tag %q: %w", id.AttachmentTag, err,
+			))
 			continue
 		}
 		hostTag, err := names.ParseTag(id.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing host tag %q: %w", id.MachineTag, err,
+			))
 			continue
 		}
 		var fsAttachment storageprovisioning.FilesystemAttachment
 		switch tag := hostTag.(type) {
 		case names.MachineTag:
-			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(tag.Id()))
+			machineUUID, err := a.getMachineUUID(ctx, tag)
 			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 				continue
 			}
 			fsAttachment, err = a.storageSvc.GetFilesystemAttachmentForMachine(ctx, filesystemTag.Id(), machineUUID)
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+			// Error mapping mirrors facade lines ~1473-1491.
+			if errors.Is(err, machineerrors.MachineNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"machine %q not found", hostTag.Id(),
+				).Add(coreerrors.NotFound))
+				continue
+			} else if errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"filesystem attachment %q on %q not found",
+					filesystemTag.Id(), hostTag.Id(),
+				).Add(coreerrors.NotFound))
+				continue
+			} else if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"filesystem %q not found for attachment on %q",
+					filesystemTag.Id(), hostTag.Id(),
+				).Add(coreerrors.NotFound))
+				continue
+			} else if err != nil {
+				results[i].Error = serverError(errors.Errorf(
+					"getting filesystem attachment for %q on %q: %w",
+					filesystemTag.Id(), hostTag.Id(), err,
+				))
 				continue
 			}
 		case names.UnitTag:
 			unitUUID, err := a.getUnitUUID(ctx, tag)
 			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 				continue
 			}
 			fsAttachment, err = a.storageSvc.GetFilesystemAttachmentForUnit(ctx, filesystemTag.Id(), unitUUID)
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+			// Error mapping mirrors facade lines ~1473-1491.
+			if errors.Is(err, applicationerrors.UnitNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"unit %q not found", hostTag.Id(),
+				).Add(coreerrors.NotFound))
+				continue
+			} else if errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"filesystem attachment %q on %q not found",
+					filesystemTag.Id(), hostTag.Id(),
+				).Add(coreerrors.NotFound))
+				continue
+			} else if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"filesystem %q not found for attachment on %q",
+					filesystemTag.Id(), hostTag.Id(),
+				).Add(coreerrors.NotFound))
+				continue
+			} else if err != nil {
+				results[i].Error = serverError(errors.Errorf(
+					"getting filesystem attachment for %q on %q: %w",
+					filesystemTag.Id(), hostTag.Id(), err,
+				))
 				continue
 			}
 		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("filesystem attachment host tag %q not valid", hostTag.String()).Error(), Code: params.CodeNotValid}
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem attachment host tag %q", hostTag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		if fsAttachment.MountPoint == "" {
-			results[i].Error = &params.Error{Message: errors.Errorf("filesystem attachment %q on %q is not provisioned", filesystemTag.Id(), hostTag.String()).Error(), Code: params.CodeNotProvisioned}
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem attachment %q on %q is not provisioned",
+				filesystemTag.Id(), hostTag.String(),
+			).Add(coreerrors.NotProvisioned))
 			continue
 		}
 		results[i].Result = params.FilesystemAttachment{
@@ -990,21 +1546,31 @@ func (a *modelStorageAdapter) FilesystemAttachments(ctx context.Context, ids []p
 	return results, nil
 }
 
+// FilesystemParams returns the parameters for creating the filesystems with
+// the specified tags. Mirrors facade FilesystemParams at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:1742
 func (a *modelStorageAdapter) FilesystemParams(ctx context.Context, tags []names.FilesystemTag) ([]params.FilesystemParamsResultV5, error) {
 	results := make([]params.FilesystemParamsResultV5, len(tags))
 	fsModelTags, err := a.storageSvc.GetStorageResourceTagsForModel(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, jujuerrors.Trace(err)
 	}
 	for i, tag := range tags {
 		uuid, err := a.storageSvc.GetFilesystemUUIDForID(ctx, tag.Id())
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			// Facade converts FilesystemNotFound to ErrPerm (~line 1811)
+			// to avoid leaking entity existence.
+			if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+				results[i].Error = errPermResult
+			} else {
+				results[i].Error = serverError(err)
+			}
 			continue
 		}
 		fsParams, err := a.storageSvc.GetFilesystemParams(ctx, uuid)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		rval := params.FilesystemParamsV5{
@@ -1026,29 +1592,40 @@ func (a *modelStorageAdapter) FilesystemParams(ctx context.Context, tags []names
 	return results, nil
 }
 
+// RemoveFilesystemParams returns the parameters for destroying or releasing
+// the filesystems with the specified tags. Mirrors facade
+// RemoveFilesystemParams at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:1827
 func (a *modelStorageAdapter) RemoveFilesystemParams(ctx context.Context, tags []names.FilesystemTag) ([]params.RemoveFilesystemParamsResult, error) {
 	results := make([]params.RemoveFilesystemParamsResult, len(tags))
 	for i, tag := range tags {
 		uuid, err := a.storageSvc.GetFilesystemUUIDForID(ctx, tag.Id())
 		if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem %q not found", tag.Id(),
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		rp, err := a.storageSvc.GetFilesystemRemovalParams(ctx, uuid)
 		if errors.Is(err, storageprovisioningerrors.FilesystemNotDead) {
-			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q is not yet dead", tag.Id()).Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem %q is not yet dead", tag.Id(),
+			))
 			continue
 		}
 		if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q not found", tag.Id()).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem %q not found", tag.Id(),
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		results[i].Result = params.RemoveFilesystemParams{
@@ -1060,70 +1637,88 @@ func (a *modelStorageAdapter) RemoveFilesystemParams(ctx context.Context, tags [
 	return results, nil
 }
 
+// FilesystemAttachmentParams returns the parameters for creating the
+// filesystem attachments with the specified IDs. Mirrors facade
+// FilesystemAttachmentParams/filesystemAttachmentParams at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2048
 func (a *modelStorageAdapter) FilesystemAttachmentParams(ctx context.Context, ids []params.MachineStorageId) ([]params.FilesystemAttachmentParamsResultV5, error) {
 	results := make([]params.FilesystemAttachmentParamsResultV5, len(ids))
 	for i, id := range ids {
 		hostTag, err := names.ParseTag(id.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
+			continue
+		}
+		if hostTag.Kind() != names.MachineTagKind && hostTag.Kind() != names.UnitTagKind {
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem attachment host tag %q not valid", hostTag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		filesystemTag, err := names.ParseFilesystemTag(id.AttachmentTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
-		var attachmentUUID domainstorage.FilesystemAttachmentUUID
-		switch tag := hostTag.(type) {
-		case names.MachineTag:
-			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(tag.Id()))
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
-				continue
-			}
-			attachmentUUID, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx, filesystemTag.Id(), machineUUID)
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
-				continue
-			}
-		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("unsupported host tag %T", hostTag).Error()}
+		// Use getFilesystemAttachmentUUID helper which handles both
+		// MachineTag and UnitTag hosts, matching facade
+		// getFilesystemAttachmentUUID at line ~2680.
+		attachmentUUID, err := a.getFilesystemAttachmentUUID(ctx, filesystemTag, hostTag)
+		if err != nil {
+			results[i].Error = serverError(err)
 			continue
 		}
 		fsParams, err := a.storageSvc.GetFilesystemAttachmentParams(ctx, attachmentUUID)
 		if errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("filesystem attachment for %q on %q not found", filesystemTag, hostTag).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem attachment for filesystem %q and host %q not found",
+				filesystemTag, hostTag,
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
+		// Instance ID selection mirrors facade V6 selector at line ~2054:
+		// prefer MachineInstanceID, fall back to CAASInstanceID.
 		instanceID := fsParams.MachineInstanceID
 		if instanceID == "" {
 			instanceID = fsParams.CAASInstanceID
 		}
 		results[i].Result = params.FilesystemAttachmentParamsV5{
-			FilesystemTag: filesystemTag.String(),
-			MachineTag:    hostTag.String(),
-			InstanceId:    instanceID,
-			Provider:      fsParams.Provider,
-			ReadOnly:      fsParams.CharmStorageReadOnly,
+			FilesystemTag:        filesystemTag.String(),
+			MachineTag:           hostTag.String(),
+			InstanceId:           instanceID,
+			Provider:             fsParams.Provider,
+			FilesystemProviderId: fsParams.FilesystemProviderID,
+			// AttachmentProviderId is *string, matching V5/V6 struct fields
+			// populated by the facade at line ~2118.
+			AttachmentProviderId: fsParams.FilesystemAttachmentProviderID,
+			MountPoint:           fsParams.MountPoint,
+			ReadOnly:             fsParams.CharmStorageReadOnly,
 		}
 	}
 	return results, nil
 }
 
+// SetFilesystemInfo records the details of newly provisioned filesystems.
+// Mirrors facade SetFilesystemInfo at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2184
 func (a *modelStorageAdapter) SetFilesystemInfo(ctx context.Context, fss []params.Filesystem) ([]params.ErrorResult, error) {
 	results := make([]params.ErrorResult, len(fss))
 	for i, fs := range fss {
 		filesystemTag, err := names.ParseFilesystemTag(fs.FilesystemTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing filesystem tag %q: %w", fs.FilesystemTag, err,
+			))
 			continue
 		}
 		if fs.Info.Pool != "" {
-			results[i].Error = &params.Error{Message: "pool field must not be set"}
+			results[i].Error = serverError(errors.New("pool field must not be set"))
 			continue
 		}
 		info := storageprovisioning.FilesystemProvisionedInfo{
@@ -1132,27 +1727,37 @@ func (a *modelStorageAdapter) SetFilesystemInfo(ctx context.Context, fss []param
 		}
 		err = a.storageSvc.SetFilesystemProvisionedInfo(ctx, filesystemTag.Id(), info)
 		if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
-			results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q not found", filesystemTag.Id()).Error(), Code: params.CodeNotFound}
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem %q not found", filesystemTag.Id(),
+			).Add(coreerrors.NotFound))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 		}
 	}
 	return results, nil
 }
 
+// SetFilesystemAttachmentInfo records the details of newly provisioned
+// filesystem attachments. Mirrors facade SetFilesystemAttachmentInfo at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2550
 func (a *modelStorageAdapter) SetFilesystemAttachmentInfo(ctx context.Context, fas []params.FilesystemAttachment) ([]params.ErrorResult, error) {
 	results := make([]params.ErrorResult, len(fas))
 	for i, fa := range fas {
 		hostTag, err := names.ParseTag(fa.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing host tag %q: %w", fa.MachineTag, err,
+			))
 			continue
 		}
 		filesystemTag, err := names.ParseFilesystemTag(fa.FilesystemTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"parsing filesystem tag %q: %w", fa.FilesystemTag, err,
+			))
 			continue
 		}
 		info := storageprovisioning.FilesystemAttachmentProvisionedInfo{
@@ -1161,52 +1766,51 @@ func (a *modelStorageAdapter) SetFilesystemAttachmentInfo(ctx context.Context, f
 		}
 		switch tag := hostTag.(type) {
 		case names.MachineTag:
-			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(tag.Id()))
+			machineUUID, err := a.getMachineUUID(ctx, tag)
 			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 				continue
 			}
 			err = a.storageSvc.SetFilesystemAttachmentProvisionedInfoForMachine(ctx, filesystemTag.Id(), machineUUID, info)
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+			// FilesystemNotFound mapping mirrors facade line ~2613.
+			if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"filesystem %q not found", filesystemTag.Id(),
+				).Add(coreerrors.NotFound))
+			} else if err != nil {
+				results[i].Error = serverError(err)
 			}
 		case names.UnitTag:
 			unitUUID, err := a.getUnitUUID(ctx, tag)
 			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 				continue
 			}
 			err = a.storageSvc.SetFilesystemAttachmentProvisionedInfoForUnit(ctx, filesystemTag.Id(), unitUUID, info)
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+			// FilesystemNotFound mapping mirrors facade line ~2613.
+			if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"filesystem %q not found", filesystemTag.Id(),
+				).Add(coreerrors.NotFound))
+			} else if err != nil {
+				results[i].Error = serverError(err)
 			}
 		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("filesystem attachment host tag %q not valid", hostTag.String()).Error(), Code: params.CodeNotValid}
+			// Invalid host tag message mirrors facade line ~2610.
+			results[i].Error = serverError(errors.Errorf(
+				"filesystem attachment host tag %q not found", tag,
+			).Add(coreerrors.NotValid))
 		}
 	}
 	return results, nil
 }
 
-func (a *modelStorageAdapter) getUnitUUID(ctx context.Context, tag names.UnitTag) (coreunit.UUID, error) {
-	unitName, err := coreunit.NewName(tag.Id())
-	if errors.Is(err, coreunit.InvalidUnitName) {
-		return "", errors.Errorf("invalid unit name %q", tag.Id())
-	} else if err != nil {
-		return "", errors.Trace(err)
-	}
-	unitUUID, err := a.appSvc.GetUnitUUID(ctx, unitName)
-	if errors.Is(err, coreunit.InvalidUnitName) {
-		return "", errors.Errorf("invalid unit name %q", unitName)
-	} else if errors.Is(err, applicationerrors.UnitNotFound) {
-		return "", errors.Errorf("unit %q not found", unitName)
-	} else if err != nil {
-		return "", errors.Errorf("getting unit %q UUID: %v", unitName, err)
-	}
-	return unitUUID, nil
-}
-
 // LifecycleManager implementation
 
+// Life returns the lifecycle state of the specified entities.
+// Mirrors facade Life/lifeForVolume/lifeForFilesystem at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:238
 func (a *modelStorageAdapter) Life(ctx context.Context, tags []names.Tag) ([]params.LifeResult, error) {
 	results := make([]params.LifeResult, len(tags))
 	for i, tag := range tags {
@@ -1216,42 +1820,58 @@ func (a *modelStorageAdapter) Life(ctx context.Context, tags []names.Tag) ([]par
 		case names.VolumeTag:
 			uuid, e := a.storageSvc.GetVolumeUUIDForID(ctx, tag.Id())
 			if errors.Is(e, storageprovisioningerrors.VolumeNotFound) {
-				results[i].Error = &params.Error{Message: errors.Errorf("volume not found for id %q", tag.Id()).Error(), Code: params.CodeNotFound}
+				results[i].Error = serverError(errors.Errorf(
+					"volume not found for id %q", tag.Id(),
+				).Add(coreerrors.NotFound))
 				continue
 			} else if e != nil {
-				results[i].Error = &params.Error{Message: e.Error()}
+				results[i].Error = serverError(errors.Errorf(
+					"getting volume UUID for id %q: %v", tag.Id(), e,
+				))
 				continue
 			}
 			l, err = a.storageSvc.GetVolumeLife(ctx, uuid)
 			if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
-				results[i].Error = &params.Error{Message: errors.Errorf("volume not found for id %q", tag.Id()).Error(), Code: params.CodeNotFound}
+				results[i].Error = serverError(errors.Errorf(
+					"volume not found for id %q", tag.Id(),
+				).Add(coreerrors.NotFound))
 				continue
 			}
 		case names.FilesystemTag:
 			uuid, e := a.storageSvc.GetFilesystemUUIDForID(ctx, tag.Id())
 			if errors.Is(e, storageprovisioningerrors.FilesystemNotFound) {
-				results[i].Error = &params.Error{Message: errors.Errorf("filesystem not found for id %q", tag.Id()).Error(), Code: params.CodeNotFound}
+				results[i].Error = serverError(errors.Errorf(
+					"filesystem not found for id %q", tag.Id(),
+				).Add(coreerrors.NotFound))
 				continue
 			} else if e != nil {
-				results[i].Error = &params.Error{Message: e.Error()}
+				results[i].Error = serverError(errors.Errorf(
+					"getting filesystem UUID for id %q: %v", tag.Id(), e,
+				))
 				continue
 			}
 			l, err = a.storageSvc.GetFilesystemLife(ctx, uuid)
 			if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
-				results[i].Error = &params.Error{Message: errors.Errorf("filesystem not found for id %q", tag.Id()).Error(), Code: params.CodeNotFound}
+				results[i].Error = serverError(errors.Errorf(
+					"filesystem not found for id %q", tag.Id(),
+				).Add(coreerrors.NotFound))
 				continue
 			}
 		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("invalid tag %q, expected volume or filesystem", tag).Error(), Code: params.CodeNotValid}
+			results[i].Error = serverError(errors.Errorf(
+				"invalid tag %q, expected volume or filesystem", tag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"getting volume UUID for id %q: %v", tag, err,
+			))
 			continue
 		}
 		val, err := l.Value()
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		results[i].Life = val
@@ -1259,6 +1879,10 @@ func (a *modelStorageAdapter) Life(ctx context.Context, tags []names.Tag) ([]par
 	return results, nil
 }
 
+// Remove removes volumes and filesystems from state.
+// Mirrors facade Remove/removeVolume/removeFilesystem at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2852
 func (a *modelStorageAdapter) Remove(ctx context.Context, tags []names.Tag) ([]params.ErrorResult, error) {
 	results := make([]params.ErrorResult, len(tags))
 	for i, tag := range tags {
@@ -1267,6 +1891,7 @@ func (a *modelStorageAdapter) Remove(ctx context.Context, tags []names.Tag) ([]p
 		case names.VolumeTag:
 			uuid, e := a.storageSvc.GetVolumeUUIDForID(ctx, tag.Id())
 			if errors.Is(e, storageprovisioningerrors.VolumeNotFound) {
+				// Already removed, matching facade line ~2900.
 				continue
 			}
 			if e != nil {
@@ -1277,11 +1902,13 @@ func (a *modelStorageAdapter) Remove(ctx context.Context, tags []names.Tag) ([]p
 			if errors.Is(err, storageprovisioningerrors.VolumeNotDead) {
 				err = errors.Errorf("volume %q is not yet dead", tag.Id())
 			} else if errors.Is(err, storageprovisioningerrors.VolumeNotFound) {
+				// Already removed, matching facade line ~2912.
 				err = nil
 			}
 		case names.FilesystemTag:
 			uuid, e := a.storageSvc.GetFilesystemUUIDForID(ctx, tag.Id())
 			if errors.Is(e, storageprovisioningerrors.FilesystemNotFound) {
+				// Already removed, matching facade line ~2929.
 				continue
 			}
 			if e != nil {
@@ -1292,96 +1919,110 @@ func (a *modelStorageAdapter) Remove(ctx context.Context, tags []names.Tag) ([]p
 			if errors.Is(err, storageprovisioningerrors.FilesystemNotDead) {
 				err = errors.Errorf("filesystem %q is not yet dead", tag.Id())
 			} else if errors.Is(err, storageprovisioningerrors.FilesystemNotFound) {
+				// Already removed, matching facade line ~2942.
 				err = nil
 			}
 		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("tag %q invalid", tag).Error()}
+			// Invalid tag with NotValid code, matching facade line ~2876.
+			results[i].Error = serverError(errors.Errorf(
+				"tag %q invalid", tag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 		}
 	}
 	return results, nil
 }
 
+// AttachmentLife returns the lifecycle state of the specified machine/entity
+// attachments. Mirrors facade AttachmentLife/volumeAttachmentLife/
+// filesystemAttachmentLife at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2808
 func (a *modelStorageAdapter) AttachmentLife(ctx context.Context, ids []params.MachineStorageId) ([]params.LifeResult, error) {
 	results := make([]params.LifeResult, len(ids))
 	for i, id := range ids {
 		hostTag, err := names.ParseTag(id.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		attachmentTag, err := names.ParseTag(id.AttachmentTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		var l domainlife.Life
 		switch tag := attachmentTag.(type) {
 		case names.VolumeTag:
+			// Volume attachments only supported on machines, matching
+			// facade volumeAttachmentLife line ~2775.
 			machineTag, ok := hostTag.(names.MachineTag)
 			if !ok {
-				results[i].Error = &params.Error{Message: "volume attachments only supported on machines"}
+				results[i].Error = serverError(errors.New(
+					"volume attachments only supported on machines",
+				).Add(coreerrors.NotImplemented))
 				continue
 			}
-			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+			machineUUID, err := a.getMachineUUID(ctx, machineTag)
 			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 				continue
 			}
-			uuid, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, tag.Id(), machineUUID)
+			uuid, err := a.getVolumeAttachmentUUID(ctx, tag, machineUUID)
 			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 				continue
 			}
 			l, err = a.storageSvc.GetVolumeAttachmentLife(ctx, uuid)
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+			if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"volume attachment %q on %q not found",
+					tag.Id(), hostTag.Id(),
+				).Add(coreerrors.NotFound))
+				continue
+			} else if err != nil {
+				results[i].Error = serverError(errors.Errorf(
+					"getting volume attachment life for %q on %q: %w",
+					tag.Id(), hostTag.Id(), err,
+				))
 				continue
 			}
 		case names.FilesystemTag:
-			var fsUUID domainstorage.FilesystemAttachmentUUID
-			switch host := hostTag.(type) {
-			case names.MachineTag:
-				machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(host.Id()))
-				if err != nil {
-					results[i].Error = &params.Error{Message: err.Error()}
-					continue
-				}
-				fsUUID, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx, tag.Id(), machineUUID)
-				if err != nil {
-					results[i].Error = &params.Error{Message: err.Error()}
-					continue
-				}
-			case names.UnitTag:
-				unitUUID, err := a.getUnitUUID(ctx, host)
-				if err != nil {
-					results[i].Error = &params.Error{Message: err.Error()}
-					continue
-				}
-				fsUUID, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDUnit(ctx, tag.Id(), unitUUID)
-				if err != nil {
-					results[i].Error = &params.Error{Message: err.Error()}
-					continue
-				}
-			default:
-				results[i].Error = &params.Error{Message: errors.Errorf("attachment tag %q is not valid", attachmentTag).Error(), Code: params.CodeNotValid}
+			// Use getFilesystemAttachmentUUID helper for both machine
+			// and unit hosts, matching facade filesystemAttachmentLife.
+			fsUUID, err := a.getFilesystemAttachmentUUID(ctx, tag, hostTag)
+			if err != nil {
+				results[i].Error = serverError(err)
 				continue
 			}
 			l, err = a.storageSvc.GetFilesystemAttachmentLife(ctx, fsUUID)
-			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+			if errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound) {
+				results[i].Error = serverError(errors.Errorf(
+					"filesystem attachment %q on %q not found",
+					tag.Id(), hostTag.Id(),
+				).Add(coreerrors.NotFound))
+				continue
+			} else if err != nil {
+				results[i].Error = serverError(errors.Errorf(
+					"getting filesystem attachment life for %q on %q: %w",
+					tag.Id(), hostTag.Id(), err,
+				))
 				continue
 			}
 		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("attachment tag %q is not valid", attachmentTag).Error()}
+			// Invalid attachment tag with NotValid code, matching facade
+			// line ~2836.
+			results[i].Error = serverError(errors.Errorf(
+				"attachment tag %q is not a valid", attachmentTag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		val, err := l.Value()
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		results[i].Life = val
@@ -1389,92 +2030,96 @@ func (a *modelStorageAdapter) AttachmentLife(ctx context.Context, ids []params.M
 	return results, nil
 }
 
+// RemoveAttachments removes the specified machine/entity attachments from
+// state. Mirrors facade RemoveAttachment/removeVolumeAttachment/
+// removeFilesystemAttachment at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:2953
 func (a *modelStorageAdapter) RemoveAttachments(ctx context.Context, ids []params.MachineStorageId) ([]params.ErrorResult, error) {
 	results := make([]params.ErrorResult, len(ids))
 	for i, id := range ids {
 		hostTag, err := names.ParseTag(id.MachineTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"tag %q invalid", id.MachineTag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		attachmentTag, err := names.ParseTag(id.AttachmentTag)
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(errors.Errorf(
+				"tag %q invalid", id.AttachmentTag,
+			).Add(coreerrors.NotValid))
 			continue
 		}
 		switch tag := attachmentTag.(type) {
 		case names.VolumeTag:
 			machineTag, ok := hostTag.(names.MachineTag)
 			if !ok {
-				results[i].Error = &params.Error{Message: errors.Errorf("tag %q on host %q invalid", id.AttachmentTag, id.MachineTag).Error(), Code: params.CodeNotValid}
+				results[i].Error = serverError(errors.Errorf(
+					"tag %q on host %q invalid", id.AttachmentTag, id.MachineTag,
+				).Add(coreerrors.NotValid))
 				continue
 			}
-			machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(machineTag.Id()))
+			machineUUID, err := a.getMachineUUID(ctx, machineTag)
 			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 				continue
 			}
-			uuid, err := a.storageSvc.GetVolumeAttachmentUUIDForVolumeIDMachine(ctx, tag.Id(), machineUUID)
+			// getVolumeAttachmentUUID maps domain sentinels to CodeNotFound.
+			// coreerrors.NotFound is treated as success (already removed),
+			// matching facade line ~3011.
+			uuid, err := a.getVolumeAttachmentUUID(ctx, tag, machineUUID)
 			if errors.Is(err, coreerrors.NotFound) {
 				continue
 			}
 			if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 				continue
 			}
+			// MarkVolumeAttachmentAsDead error mapping mirrors facade
+			// lines ~3018-3027.
 			err = a.removalSvc.MarkVolumeAttachmentAsDead(ctx, uuid)
 			if errors.Is(err, removalerrors.EntityStillAlive) {
-				results[i].Error = &params.Error{Message: errors.Errorf("volume %q attachment to machine %q is still alive", tag.Id(), machineTag.Id()).Error()}
+				results[i].Error = serverError(errors.Errorf(
+					"volume %q attachment to machine %q is still alive",
+					tag.Id(), machineTag.Id(),
+				))
 			} else if errors.Is(err, storageprovisioningerrors.VolumeAttachmentNotFound) {
 				continue
 			} else if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 			}
 		case names.FilesystemTag:
-			var fsUUID domainstorage.FilesystemAttachmentUUID
-			switch host := hostTag.(type) {
-			case names.MachineTag:
-				machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(host.Id()))
-				if err != nil {
-					results[i].Error = &params.Error{Message: err.Error()}
-					continue
-				}
-				fsUUID, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDMachine(ctx, tag.Id(), machineUUID)
-				if errors.Is(err, coreerrors.NotFound) {
-					continue
-				}
-				if err != nil {
-					results[i].Error = &params.Error{Message: err.Error()}
-					continue
-				}
-			case names.UnitTag:
-				unitUUID, err := a.getUnitUUID(ctx, host)
-				if err != nil {
-					results[i].Error = &params.Error{Message: err.Error()}
-					continue
-				}
-				fsUUID, err = a.storageSvc.GetFilesystemAttachmentUUIDForFilesystemIDUnit(ctx, tag.Id(), unitUUID)
-				if errors.Is(err, coreerrors.NotFound) {
-					continue
-				}
-				if err != nil {
-					results[i].Error = &params.Error{Message: err.Error()}
-					continue
-				}
-			default:
-				results[i].Error = &params.Error{Message: errors.Errorf("tag %q on host %q invalid", id.AttachmentTag, id.MachineTag).Error(), Code: params.CodeNotValid}
+			// getFilesystemAttachmentUUID handles both machine and unit
+			// hosts, mapping domain sentinels to CodeNotFound.
+			// coreerrors.NotFound is treated as success (already removed),
+			// matching facade line ~3038.
+			fsUUID, err := a.getFilesystemAttachmentUUID(ctx, tag, hostTag)
+			if errors.Is(err, coreerrors.NotFound) {
 				continue
 			}
+			if err != nil {
+				results[i].Error = serverError(err)
+				continue
+			}
+			// MarkFilesystemAttachmentAsDead error mapping mirrors facade
+			// lines ~3045-3054.
 			err = a.removalSvc.MarkFilesystemAttachmentAsDead(ctx, fsUUID)
 			if errors.Is(err, removalerrors.EntityStillAlive) {
-				results[i].Error = &params.Error{Message: errors.Errorf("filesystem %q attachment to %s %q is still alive", tag.Id(), hostTag.Kind(), hostTag.Id()).Error()}
+				results[i].Error = serverError(errors.Errorf(
+					"filesystem %q attachment to %s %q is still alive",
+					tag.Id(), hostTag.Kind(), hostTag.Id(),
+				))
 			} else if errors.Is(err, storageprovisioningerrors.FilesystemAttachmentNotFound) {
 				continue
 			} else if err != nil {
-				results[i].Error = &params.Error{Message: err.Error()}
+				results[i].Error = serverError(err)
 			}
 		default:
-			results[i].Error = &params.Error{Message: errors.Errorf("tag %q on host %q invalid", id.AttachmentTag, id.MachineTag).Error(), Code: params.CodeNotValid}
+			results[i].Error = serverError(errors.Errorf(
+				"tag %q on host %q invalid", id.AttachmentTag, id.MachineTag,
+			).Add(coreerrors.NotValid))
 		}
 	}
 	return results, nil
@@ -1483,24 +2128,36 @@ func (a *modelStorageAdapter) RemoveAttachments(ctx context.Context, ids []param
 // MachineAccessor implementation
 
 func (a *modelStorageAdapter) WatchMachine(ctx context.Context, m names.MachineTag) (watcher.NotifyWatcher, error) {
-	machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(m.Id()))
+	machineUUID, err := a.getMachineUUID(ctx, m)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, jujuerrors.Trace(err)
 	}
 	return a.machineSvc.WatchMachineCloudInstances(ctx, machineUUID)
 }
 
+// InstanceIds returns the provider specific instance ID for each machine,
+// or a CodeNotProvisioned error if not set. Mirrors facade InstanceIdGetter
+// at:
+//
+//	apiserver/common/instanceidgetter.go:50
 func (a *modelStorageAdapter) InstanceIds(ctx context.Context, tags []names.MachineTag) ([]params.StringResult, error) {
 	results := make([]params.StringResult, len(tags))
 	for i, tag := range tags {
 		machineUUID, err := a.machineSvc.GetMachineUUID(ctx, machine.Name(tag.Id()))
+		if errors.Is(err, machineerrors.MachineNotFound) {
+			results[i].Error = serverError(jujuerrors.NotFoundf("machine %s", tag.Id()))
+			continue
+		}
 		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+			results[i].Error = serverError(err)
 			continue
 		}
 		instanceId, err := a.machineSvc.GetInstanceID(ctx, machineUUID)
-		if err != nil {
-			results[i].Error = &params.Error{Message: err.Error()}
+		if errors.Is(err, machineerrors.NotProvisioned) {
+			results[i].Error = serverError(jujuerrors.NotProvisionedf("machine %s", tag.Id()))
+			continue
+		} else if err != nil {
+			results[i].Error = serverError(err)
 			continue
 		}
 		results[i].Result = string(instanceId)
@@ -1510,31 +2167,63 @@ func (a *modelStorageAdapter) InstanceIds(ctx context.Context, tags []names.Mach
 
 // StatusSetter implementation
 
+// SetStatus sets the status of each given storage artefact. Mirrors facade
+// SetStatus at:
+//
+//	apiserver/facades/agent/storageprovisioner/storageprovisioner.go:3059
+//
+// Unlike the previous localadapter implementation which returned on the
+// first error, this now processes all entities and combines errors,
+// matching the facade's per-item ErrorResults + API client Combine().
 func (a *modelStorageAdapter) SetStatus(ctx context.Context, args []params.EntityStatusArgs) error {
-	for _, arg := range args {
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args)),
+	}
+	if len(args) == 0 {
+		return nil
+	}
+	// Set Since timestamp using clock, matching facade line ~3085.
+	now := a.clock.Now()
+	for i, arg := range args {
 		tag, err := names.ParseTag(arg.Tag)
 		if err != nil {
-			return errors.Trace(err)
+			result.Results[i].Error = serverError(err)
+			continue
 		}
 		sInfo := status.StatusInfo{
 			Status:  status.Status(arg.Status),
 			Message: arg.Info,
 			Data:    arg.Data,
+			Since:   &now,
 		}
+		var statusErr error
 		switch tag := tag.(type) {
-		case names.VolumeTag:
-			if err := a.statusSvc.SetVolumeStatus(ctx, tag.Id(), sInfo); err != nil {
-				return errors.Trace(err)
-			}
 		case names.FilesystemTag:
-			if err := a.statusSvc.SetFilesystemStatus(ctx, tag.Id(), sInfo); err != nil {
-				return errors.Trace(err)
+			statusErr = a.statusSvc.SetFilesystemStatus(ctx, tag.Id(), sInfo)
+			// Map FilesystemNotFound to CodeNotFound, matching facade
+			// line ~3091.
+			if errors.Is(statusErr, storageerrors.FilesystemNotFound) {
+				statusErr = errors.Errorf(
+					"filesystem %q not found", tag.Id(),
+				).Add(coreerrors.NotFound)
+			}
+		case names.VolumeTag:
+			statusErr = a.statusSvc.SetVolumeStatus(ctx, tag.Id(), sInfo)
+			// Map VolumeNotFound to CodeNotFound, matching facade
+			// line ~3098.
+			if errors.Is(statusErr, storageerrors.VolumeNotFound) {
+				statusErr = errors.Errorf(
+					"volume %q not found", tag.Id(),
+				).Add(coreerrors.NotFound)
 			}
 		default:
-			return errors.Errorf("invalid tag %q, expected volume or filesystem", tag)
+			// Non-volume/non-filesystem tags get ErrPerm, matching
+			// facade line ~3104.
+			statusErr = errPerm
 		}
+		result.Results[i].Error = serverError(statusErr)
 	}
-	return nil
+	return result.Combine()
 }
 
 // newAttachmentIDWatcher creates a MachineStorageIDsWatcher that wraps a
@@ -1554,7 +2243,7 @@ func newAttachmentIDWatcher(
 		Work: w.loop,
 		Init: []worker.Worker{source},
 	})
-	return w, internalerrors.Capture(err)
+	return w, errors.Capture(err)
 }
 
 type attachmentIDWatcher struct {

--- a/internal/worker/storageprovisioner/manifold_model.go
+++ b/internal/worker/storageprovisioner/manifold_model.go
@@ -70,6 +70,7 @@ func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
 			adapter := &modelStorageAdapter{
 				storageSvc:     domainServices.StorageProvisioning(),
 				machineSvc:     domainServices.Machine(),
+				appSvc:         domainServices.Application(),
 				removalSvc:     domainServices.Removal(),
 				statusSvc:      domainServices.Status(),
 				blockDeviceSvc: domainServices.BlockDevice(),

--- a/internal/worker/storageprovisioner/manifold_model.go
+++ b/internal/worker/storageprovisioner/manifold_model.go
@@ -74,6 +74,7 @@ func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
 				removalSvc:     domainServices.Removal(),
 				statusSvc:      domainServices.Status(),
 				blockDeviceSvc: domainServices.BlockDevice(),
+				clock:          config.Clock,
 			}
 
 			w, err := config.NewWorker(Config{

--- a/internal/worker/storageprovisioner/manifold_model.go
+++ b/internal/worker/storageprovisioner/manifold_model.go
@@ -12,15 +12,14 @@ import (
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 
-	"github.com/juju/juju/api/agent/storageprovisioner"
-	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/storage"
 )
 
 // ModelManifoldConfig defines a storage provisioner's configuration and dependencies.
 type ModelManifoldConfig struct {
-	APICallerName       string
+	DomainServicesName  string
 	StorageRegistryName string
 
 	Clock      clock.Clock
@@ -30,14 +29,37 @@ type ModelManifoldConfig struct {
 	Logger     logger.Logger
 }
 
+// Validate returns an error if the config cannot be relied upon to start a worker.
+func (config ModelManifoldConfig) Validate() error {
+	if config.DomainServicesName == "" {
+		return errors.NotValidf("empty DomainServicesName")
+	}
+	if config.StorageRegistryName == "" {
+		return errors.NotValidf("empty StorageRegistryName")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if config.NewWorker == nil {
+		return errors.NotValidf("nil NewWorker")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	return nil
+}
+
 // ModelManifold returns a dependency.Manifold that runs a storage provisioner.
 func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
-		Inputs: []string{config.APICallerName, config.StorageRegistryName},
+		Inputs: []string{config.DomainServicesName, config.StorageRegistryName},
 		Start: func(context context.Context, getter dependency.Getter) (worker.Worker, error) {
+			if err := config.Validate(); err != nil {
+				return nil, errors.Trace(err)
+			}
 
-			var apiCaller base.APICaller
-			if err := getter.Get(config.APICallerName, &apiCaller); err != nil {
+			var domainServices services.DomainServices
+			if err := getter.Get(config.DomainServicesName, &domainServices); err != nil {
 				return nil, errors.Trace(err)
 			}
 			var registry storage.ProviderRegistry
@@ -45,21 +67,24 @@ func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			api, err := storageprovisioner.NewClient(apiCaller)
-			if err != nil {
-				return nil, errors.Trace(err)
+			adapter := &modelStorageAdapter{
+				storageSvc:     domainServices.StorageProvisioning(),
+				machineSvc:     domainServices.Machine(),
+				removalSvc:     domainServices.Removal(),
+				statusSvc:      domainServices.Status(),
+				blockDeviceSvc: domainServices.BlockDevice(),
 			}
 
 			w, err := config.NewWorker(Config{
 				Model:       config.Model,
 				Scope:       config.Model,
 				StorageDir:  config.StorageDir,
-				Volumes:     api,
-				Filesystems: api,
-				Life:        api,
+				Volumes:     adapter,
+				Filesystems: adapter,
+				Life:        adapter,
 				Registry:    registry,
-				Machines:    api,
-				Status:      api,
+				Machines:    adapter,
+				Status:      adapter,
 				Clock:       config.Clock,
 				Logger:      config.Logger,
 			})

--- a/internal/worker/storageprovisioner/manifold_model_test.go
+++ b/internal/worker/storageprovisioner/manifold_model_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
+	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
 
-	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/environs"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/testhelpers"
 	"github.com/juju/juju/internal/worker/storageprovisioner"
 )
@@ -28,37 +30,47 @@ func TestManifoldSuite(t *testing.T) {
 
 func (s *ManifoldSuite) TestManifold(c *tc.C) {
 	manifold := storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
-		APICallerName:       "grenouille",
+		DomainServicesName:  "domain-services",
 		StorageRegistryName: "environ",
 	})
-	c.Check(manifold.Inputs, tc.DeepEquals, []string{"grenouille", "environ"})
+	c.Check(manifold.Inputs, tc.DeepEquals, []string{"domain-services", "environ"})
 	c.Check(manifold.Output, tc.IsNil)
 	c.Check(manifold.Start, tc.NotNil)
 	// ...Start is *not* well-tested, in common with many manifold configs.
 }
 
-func (s *ManifoldSuite) TestMissingAPICaller(c *tc.C) {
+func (s *ManifoldSuite) TestMissingDomainServices(c *tc.C) {
 	manifold := storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
-		APICallerName:       "api-caller",
+		DomainServicesName:  "domain-services",
 		StorageRegistryName: "environ",
+		Clock:               struct{ clock.Clock }{},
+		Logger:              loggertesting.WrapCheckLog(c),
+		NewWorker:           func(storageprovisioner.Config) (worker.Worker, error) { return nil, nil },
 	})
 	_, err := manifold.Start(c.Context(), dt.StubGetter(map[string]any{
-		"api-caller": dependency.ErrMissing,
-		"clock":      struct{ clock.Clock }{},
-		"environ":    struct{ environs.Environ }{},
+		"domain-services": dependency.ErrMissing,
+		"environ":         struct{ environs.Environ }{},
 	}))
 	c.Check(errors.Cause(err), tc.Equals, dependency.ErrMissing)
 }
 
 func (s *ManifoldSuite) TestMissingEnviron(c *tc.C) {
 	manifold := storageprovisioner.ModelManifold(storageprovisioner.ModelManifoldConfig{
-		APICallerName:       "api-caller",
+		DomainServicesName:  "domain-services",
 		StorageRegistryName: "environ",
+		Clock:               struct{ clock.Clock }{},
+		Logger:              loggertesting.WrapCheckLog(c),
+		NewWorker:           func(storageprovisioner.Config) (worker.Worker, error) { return nil, nil },
 	})
 	_, err := manifold.Start(c.Context(), dt.StubGetter(map[string]any{
-		"api-caller": struct{ base.APICaller }{},
-		"clock":      struct{ clock.Clock }{},
-		"environ":    dependency.ErrMissing,
+		"domain-services": &stubDomainServices{},
+		"environ":         dependency.ErrMissing,
 	}))
 	c.Check(errors.Cause(err), tc.Equals, dependency.ErrMissing)
+}
+
+// stubDomainServices is a minimal stub that satisfies services.DomainServices.
+type stubDomainServices struct {
+	services.ControllerDomainServices
+	services.ModelDomainServices
 }


### PR DESCRIPTION
Remove the `api-caller` dependency from six model-manifold workers, replacing
loopback API calls with direct domain-service access. This is part of the
standalone controller initiative (JUJU-9694) which moves model workers that
already run inside the controller process off API calls and onto local domain
services.

### Affected workers

| Worker                      | Package               | Approach                                                                                                                                                                                                                                         |
| --------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `valid-credential-flag`     | `credentialvalidator` | New `ModelManifold` backed by `domainServices.Credential()` and `domainServices.Model()`; legacy API-backed `Manifold` kept for machine-agent consumers                                                                                          |
| `migration-inactive-flag`   | `migrationflag`       | New `ModelManifold` backed by `domainServices.ModelMigration()`; legacy API-backed `Manifold` kept for machine, unit, and deployer consumers                                                                                                     |
| `migration-master`          | `migrationmaster`     | `Facade` interface removed entirely; source prechecks replaced with `migration.SourcePrecheck` via `DomainServicesGetter`, resource downloads replaced with domain-service lookups, log transfer replaced with direct `logsink.log` file reading |
| `storage-provisioner`       | `storageprovisioner`  | `ModelManifold` switched from `storageprovisioner.NewClient(apiCaller)` to a local `modelStorageAdapter` over `domainServices.StorageProvisioning()`, `Machine()`, `Removal()`, `Status()`, and `BlockDevice()`; `MachineManifold` unchanged     |
| `secrets-pruner`            | `secretspruner`       | Switched from `usersecrets.NewClient(apiCaller)` to a local adapter over `domainServices.Secret()`                                                                                                                                               |
| `user-secrets-drain-worker` | `secretsdrainworker`  | New `ModelManifold` backed by `domainServices.Secret()` and `domainServices.SecretBackend()`; legacy API-backed `Manifold` kept for unit charm-secret drain                                                                                      |

### Key changes

- **Model manifold wiring** (`cmd/jujud/agent/model/manifolds.go`,
  `cmd/jujuagentd/agent/model/manifolds.go`): all six target workers switched
  from `APICallerName` to `DomainServicesName`.
- **`DomainServicesGetter` threading**: added to `ManifoldsConfig` and threaded
  through `modelworkermanager.NewModelConfig` so the migration-master can
  resolve controller-model services for source prechecks.
- **`controller/manifolds.go`**: wires `SendReport` and `FetchTargetLokiConfig`
  for `migrationminion` (required fields that were previously missing).
- **Storage provisioner adapter** (`localadapter.go`): new ~1400-line file
  implementing `VolumeAccessor`, `FilesystemAccessor`, `LifecycleManager`,
  `MachineAccessor`, and `StatusSetter` over domain services.
- **Build-tagged manifold variants**: `migrationflag` and `secretsdrainworker`
  each gain `manifold_linux.go` (dqlite) and `manifold_other.go` (!dqlite)
  files for the new model-only constructors.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ juju bootstrap lxd src --build-agent
Creating Juju controller "src" on lxd/default
Building local Juju agent binary version 4.1-beta2 for amd64
To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
Launching controller instance(s) on lxd/default...
 - juju-a233ab-0 (arch=amd64)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.159.202.250:22
Connected to 10.159.202.250
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.159.202.250 to verify accessibility...

Bootstrap complete, controller "src" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

❯ jst -m controller
Model       Controller  Cloud/Region  Version      Timestamp
controller  src         lxd/default   4.1-beta2.1  15:28:09+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.159.202.250  17022,17070/tcp

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.250  juju-a233ab-0  ubuntu@24.04  tuxedo  Running

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer

❯ juju add-model m
Added 'm' model on lxd/default with credential 'lxd' for user 'admin'
To use "juju ssh", "juju scp" and "juju debug-hooks" ssh public keys need to be added to the model with "juju add-ssh-key"

❯ juju deploy ubuntu-lite
Deployed "ubuntu-lite" from charm-hub charm "ubuntu-lite", revision 4 in channel latest/stable on ubuntu@24.04/stable

❯ jst
Model  Controller  Cloud/Region  Version      Timestamp
m      src         lxd/default   4.1-beta2.1  15:29:07+02:00

App          Version  Status  Scale  Charm        Channel        Rev  Exposed  Message
ubuntu-lite  24.04    active      1  ubuntu-lite  latest/stable    4  no

Unit            Workload  Agent  Machine  Public address  Ports  Message
ubuntu-lite/0*  active    idle   0        10.159.202.198

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.198  juju-e13d61-0  ubuntu@24.04  tuxedo  Running

```

## Documentation changes


## Links

**Jira card:** [JUJU-9730](https://warthogs.atlassian.net/browse/JUJU-9730)


[JUJU-9730]: https://warthogs.atlassian.net/browse/JUJU-9730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ