### PR TITLE
feat(azure): provision dual-stack machines with ip-family=dual

### DIFF
--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"net"
 	"net/url"
 	"slices"
 	"sort"
@@ -555,9 +556,18 @@ func (env *azureEnviron) validateIPFamilyForCreate(
 		if prefix == nil {
 			continue
 		}
-		addrType, err := network.CIDRAddressType(*prefix)
-		if err == nil && addrType == network.IPv6Address {
-			return nil
+		// Parse the CIDR to extract the prefix length and address family.
+		// Azure requires IPv6 subnets to be exactly /64.
+		_, ipNet, err := net.ParseCIDR(*prefix)
+		if err != nil {
+			continue // Skip malformed prefixes
+		}
+		// Check if this is an IPv6 /64 prefix.
+		if ipNet.IP.To4() == nil {
+			ones, _ := ipNet.Mask.Size()
+			if ones == 64 {
+				return nil
+			}
 		}
 	}
 	return errors.Errorf(
@@ -961,10 +971,6 @@ func (env *azureEnviron) createVirtualMachine(
 		if isDualStack {
 			ipv6PIPName := vmName + "-public-ip-ipv6"
 			ipv6PublicIPAddressId = fmt.Sprintf(`[resourceId('Microsoft.Network/publicIPAddresses', '%s')]`, ipv6PIPName)
-			if env.config.loadBalancerSkuName != string(armnetwork.LoadBalancerSKUNameStandard) {
-				logger.Warningf(ctx, "creating IPv6 public IP for %q with load-balancer-sku-name=%q; "+
-					"Standard SKU is recommended for dual-stack, model configuration ignored", vmName, env.config.loadBalancerSkuName)
-			}
 			res = append(res, armtemplates.Resource{
 				APIVersion: networkAPIVersion,
 				Type:       "Microsoft.Network/publicIPAddresses",

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -35,6 +35,7 @@ import (
 	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/ipfamily"
 	"github.com/juju/juju/core/os/ostype"
 	"github.com/juju/juju/core/semversion"
@@ -526,6 +527,44 @@ func (env *azureEnviron) validateIPFamilyConstraint(cons constraints.Value) erro
 	return nil
 }
 
+// validateIPFamilyForCreate validates ip-family constraints for VM creation.
+// It combines the SKU check (defensive — validateIPFamilyConstraint should
+// catch this earlier) with the IPv6 subnet placement check. This is the
+// single validation chokepoint called from createVirtualMachine, which is
+// reached by all three code paths: bootstrap, add-machine, and deploy.
+func (env *azureEnviron) validateIPFamilyForCreate(
+	ctx context.Context, cons constraints.Value, placementSubnet *armnetwork.Subnet,
+) error {
+	if cons.IPFamily == nil || *cons.IPFamily != ipfamily.Dual {
+		return nil
+	}
+	if env.config.loadBalancerSkuName == string(armnetwork.LoadBalancerSKUNameBasic) {
+		return errors.Errorf(
+			"ip-family=dual requires load-balancer-sku-name=Standard on Azure; " +
+				"Basic SKU is not supported for this configuration")
+	}
+	if placementSubnet == nil {
+		return nil
+	}
+	if placementSubnet.Properties == nil {
+		return errors.Errorf(
+			"placement subnet %q does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; "+
+				"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(placementSubnet.Name))
+	}
+	for _, prefix := range placementSubnet.Properties.AddressPrefixes {
+		if prefix == nil {
+			continue
+		}
+		addrType, err := network.CIDRAddressType(*prefix)
+		if err == nil && addrType == network.IPv6Address {
+			return nil
+		}
+	}
+	return errors.Errorf(
+		"placement subnet %q does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; "+
+			"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(placementSubnet.Name))
+}
+
 // PrecheckInstance is defined on the environs.InstancePrechecker interface.
 func (env *azureEnviron) PrecheckInstance(ctx context.Context, args environs.PrecheckInstanceParams) error {
 	if err := env.validateIPFamilyConstraint(args.Constraints); err != nil {
@@ -865,9 +904,36 @@ func (env *azureEnviron) createVirtualMachine(
 		vmDependsOn = append(vmDependsOn, availabilitySetId)
 	}
 
-	placementSubnetID, err := env.findPlacementSubnet(ctx, args.Placement)
-	if err != nil {
-		return environs.ZoneIndependentError(err)
+	// Resolve placement subnet. For dual-stack, also validate IPv6 support
+	// using the same subnet list to avoid duplicate API calls.
+	var placementSubnetID network.Id
+	if args.Placement != "" {
+		allSubnets, subErr := env.allProviderSubnets(ctx)
+		if subErr != nil {
+			return environs.ZoneIndependentError(subErr)
+		}
+		subnetName, subErr := env.parsePlacement(args.Placement)
+		if subErr != nil {
+			return environs.ZoneIndependentError(subErr)
+		}
+		for _, subnet := range allSubnets {
+			if toValue(subnet.Name) != subnetName {
+				continue
+			}
+			placementSubnetID = network.Id(toValue(subnet.ID))
+			if err := env.validateIPFamilyForCreate(ctx, args.Constraints, subnet); err != nil {
+				return environs.ZoneIndependentError(err)
+			}
+			break
+		}
+		if placementSubnetID == "" {
+			return environs.ZoneIndependentError(errors.NotFoundf("subnet %q", subnetName))
+		}
+	} else {
+		// No placement, but still validate SKU for dual-stack.
+		if err := env.validateIPFamilyForCreate(ctx, args.Constraints, nil); err != nil {
+			return environs.ZoneIndependentError(err)
+		}
 	}
 	vnetId, subnetIds, err := env.networkInfoForInstance(ctx, args, bootstrapping, instanceConfig.IsController(), placementSubnetID)
 	if err != nil {
@@ -879,7 +945,10 @@ func (env *azureEnviron) createVirtualMachine(
 		nicDependsOn = append(nicDependsOn, vnetId)
 	}
 
+	isDualStack := args.Constraints.IPFamily != nil && *args.Constraints.IPFamily == ipfamily.Dual
+
 	var publicIPAddressId string
+	var ipv6PublicIPAddressId string
 	if usePublicIP {
 		publicIPAddressName := vmName + "-public-ip"
 		publicIPAddressId = fmt.Sprintf(`[resourceId('Microsoft.Network/publicIPAddresses', '%s')]`, publicIPAddressName)
@@ -900,6 +969,26 @@ func (env *azureEnviron) createVirtualMachine(
 				PublicIPAllocationMethod: new(publicIPAddressAllocationMethod),
 			},
 		})
+		if isDualStack {
+			ipv6PIPName := vmName + "-public-ip-ipv6"
+			ipv6PublicIPAddressId = fmt.Sprintf(`[resourceId('Microsoft.Network/publicIPAddresses', '%s')]`, ipv6PIPName)
+			if env.config.loadBalancerSkuName != string(armnetwork.LoadBalancerSKUNameStandard) {
+				logger.Warningf(ctx, "creating IPv6 public IP for %q with load-balancer-sku-name=%q; "+
+					"Standard SKU is recommended for dual-stack, model configuration ignored", vmName, env.config.loadBalancerSkuName)
+			}
+			res = append(res, armtemplates.Resource{
+				APIVersion: networkAPIVersion,
+				Type:       "Microsoft.Network/publicIPAddresses",
+				Name:       ipv6PIPName,
+				Location:   env.location,
+				Tags:       vmTags,
+				Sku:        &armtemplates.Sku{Name: string(armnetwork.LoadBalancerSKUNameStandard)},
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+					PublicIPAllocationMethod: new(publicIPAddressAllocationMethod),
+				},
+			})
+		}
 	}
 
 	// Create one NIC per subnet. The first one is the primary and has
@@ -928,6 +1017,27 @@ func (env *azureEnviron) createVirtualMachine(
 			Name:       new(ipConfigName),
 			Properties: ipConfig,
 		}}
+
+		// For dual-stack, add an IPv6 IP configuration to the primary NIC.
+		if primary && isDualStack {
+			ipv6Props := &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+				Primary:                   new(false),
+				PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+				PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+				Subnet:                    &armnetwork.Subnet{ID: new(string(subnetID))},
+			}
+			if usePublicIP && ipv6PublicIPAddressId != "" {
+				ipv6Props.PublicIPAddress = &armnetwork.PublicIPAddress{
+					ID: new(ipv6PublicIPAddressId),
+				}
+				nicDependsOn = append(nicDependsOn, ipv6PublicIPAddressId)
+			}
+			ipConfigurations = append(ipConfigurations, &armnetwork.InterfaceIPConfiguration{
+				Name:       new("primary-ipv6"),
+				Properties: ipv6Props,
+			})
+		}
+
 		res = append(res, armtemplates.Resource{
 			APIVersion: networkAPIVersion,
 			Type:       "Microsoft.Network/networkInterfaces",

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -36,7 +36,6 @@ import (
 	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
-	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/ipfamily"
 	"github.com/juju/juju/core/os/ostype"
 	"github.com/juju/juju/core/semversion"
@@ -571,13 +570,13 @@ func hasIPv6Slash64Prefix(prefixes []string) bool {
 
 // validateIPFamilyForResolvedSubnet validates ip-family constraints for VM
 // creation after the subnet has been resolved. It performs the SKU check and,
-// when a placement subnet was provided, verifies that subnet has an IPv6 /64
-// prefix. When no placement subnet is provided (space constraints, default
-// subnet selection), the SKU check alone is sufficient; Azure itself rejects
-// IPv4-only subnets at NIC creation time.
+// when a resolved primary subnet was provided, verifies that subnet has an
+// IPv6 /64 prefix. When no primary subnet is available (Juju-managed VNet
+// at bootstrap or ID resolution miss), the SKU check alone is sufficient;
+// Azure itself rejects IPv4-only subnets at NIC creation time.
 func (env *azureEnviron) validateIPFamilyForResolvedSubnet(
 	ctx context.Context, cons constraints.Value,
-	bootstrapping bool, placementSubnet *armnetwork.Subnet,
+	primarySubnet *armnetwork.Subnet,
 ) error {
 	if cons.IPFamily == nil || *cons.IPFamily != ipfamily.Dual {
 		return nil
@@ -588,30 +587,22 @@ func (env *azureEnviron) validateIPFamilyForResolvedSubnet(
 				"Basic SKU is not supported for this configuration")
 	}
 
-	// Bootstrap with a Juju-managed VNet: the subnet is created by the
-	// ARM template in networkTemplateResources which is always dual-stack.
-	// When a placement subnet was specified, it is an existing subnet
-	// (not ARM-created) and must be validated for IPv6 /64 support.
-	if bootstrapping && env.config.virtualNetworkName == "" && placementSubnet == nil {
+	// When a primary subnet was resolved, verify it has an IPv6 /64 prefix.
+	if primarySubnet == nil {
 		return nil
 	}
-
-	// When a placement subnet was resolved, verify it has an IPv6 /64 prefix.
-	if placementSubnet == nil {
-		return nil
-	}
-	if placementSubnet.Properties == nil {
+	if primarySubnet.Properties == nil {
 		return errors.Errorf(
 			"subnet %q does not support ip-family=dual: no IPv6 /64 prefix found; "+
-				"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(placementSubnet.Name))
+				"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(primarySubnet.Name))
 	}
-	prefixes := subnetAddressPrefixes(placementSubnet.Properties)
+	prefixes := subnetAddressPrefixes(primarySubnet.Properties)
 	if hasIPv6Slash64Prefix(prefixes) {
 		return nil
 	}
 	return errors.Errorf(
 		"subnet %q does not support ip-family=dual: no IPv6 /64 prefix found; "+
-			"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(placementSubnet.Name))
+			"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(primarySubnet.Name))
 }
 
 // PrecheckInstance is defined on the environs.InstancePrechecker interface.
@@ -963,21 +954,13 @@ func (env *azureEnviron) createVirtualMachine(
 	if err != nil {
 		return environs.ZoneIndependentError(err)
 	}
-	var placementSubnetID network.Id
-	if placementSubnet != nil {
-		placementSubnetID = providerSubnetID(placementSubnet)
-	}
-	vnetId, subnetIds, err := env.networkInfoForInstance(ctx, args, bootstrapping, instanceConfig.IsController(), placementSubnetID)
+	vnetId, subnetIds, primarySubnet, err := env.networkInfoForInstance(ctx, args, bootstrapping, instanceConfig.IsController(), placementSubnet)
 	if err != nil {
 		return environs.ZoneIndependentError(err)
 	}
 
-	// Validate ip-family constraints against the resolved subnet(s).
-	// When a placement subnet was resolved, we have its full details and
-	// can verify IPv6 /64 support directly. Otherwise (space constraints,
-	// default subnet selection), the SKU check is sufficient; Azure itself
-	// rejects IPv4-only subnets at NIC creation time.
-	if err := env.validateIPFamilyForResolvedSubnet(ctx, args.Constraints, bootstrapping, placementSubnet); err != nil {
+	// Validate ip-family constraints against the resolved primary subnet.
+	if err := env.validateIPFamilyForResolvedSubnet(ctx, args.Constraints, primarySubnet); err != nil {
 		return environs.ZoneIndependentError(err)
 	}
 	logger.Debugf(ctx, "creating instance using vnet %v, subnets %q", vnetId, subnetIds)

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -528,13 +528,34 @@ func (env *azureEnviron) validateIPFamilyConstraint(cons constraints.Value) erro
 	return nil
 }
 
-// validateIPFamilyForCreate validates ip-family constraints for VM creation.
-// It combines the SKU check (defensive — validateIPFamilyConstraint should
-// catch this earlier) with the IPv6 subnet placement check. This is the
-// single validation chokepoint called from createVirtualMachine, which is
-// reached by all three code paths: bootstrap, add-machine, and deploy.
-func (env *azureEnviron) validateIPFamilyForCreate(
-	ctx context.Context, cons constraints.Value, placementSubnet *armnetwork.Subnet,
+// hasIPv6Slash64Prefix returns true if at least one CIDR in prefixes is an
+// IPv6 address with a /64 prefix length, which is the only IPv6 prefix size
+// Azure accepts for VNet subnets.
+func hasIPv6Slash64Prefix(prefixes []string) bool {
+	for _, prefix := range prefixes {
+		_, ipNet, err := net.ParseCIDR(prefix)
+		if err != nil {
+			continue // Skip malformed prefixes
+		}
+		if ipNet.IP.To4() == nil {
+			ones, _ := ipNet.Mask.Size()
+			if ones == 64 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// validateIPFamilyForResolvedSubnet validates ip-family constraints for VM
+// creation after the subnet has been resolved. It performs the SKU check and,
+// when a placement subnet was provided, verifies that subnet has an IPv6 /64
+// prefix. When no placement subnet is provided (space constraints, default
+// subnet selection), the SKU check alone is sufficient; Azure itself rejects
+// IPv4-only subnets at NIC creation time.
+func (env *azureEnviron) validateIPFamilyForResolvedSubnet(
+	ctx context.Context, cons constraints.Value,
+	bootstrapping bool, placementSubnet *armnetwork.Subnet,
 ) error {
 	if cons.IPFamily == nil || *cons.IPFamily != ipfamily.Dual {
 		return nil
@@ -544,34 +565,33 @@ func (env *azureEnviron) validateIPFamilyForCreate(
 			"ip-family=dual requires load-balancer-sku-name=Standard on Azure; " +
 				"Basic SKU is not supported for this configuration")
 	}
+
+	// Bootstrap with a Juju-managed VNet: the subnet is created by the
+	// ARM template in networkTemplateResources which is always dual-stack.
+	if bootstrapping && env.config.virtualNetworkName == "" {
+		return nil
+	}
+
+	// When a placement subnet was resolved, verify it has an IPv6 /64 prefix.
 	if placementSubnet == nil {
 		return nil
 	}
 	if placementSubnet.Properties == nil {
 		return errors.Errorf(
-			"placement subnet %q does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; "+
+			"subnet %q does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; "+
 				"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(placementSubnet.Name))
 	}
+	var prefixes []string
 	for _, prefix := range placementSubnet.Properties.AddressPrefixes {
-		if prefix == nil {
-			continue
-		}
-		// Parse the CIDR to extract the prefix length and address family.
-		// Azure requires IPv6 subnets to be exactly /64.
-		_, ipNet, err := net.ParseCIDR(*prefix)
-		if err != nil {
-			continue // Skip malformed prefixes
-		}
-		// Check if this is an IPv6 /64 prefix.
-		if ipNet.IP.To4() == nil {
-			ones, _ := ipNet.Mask.Size()
-			if ones == 64 {
-				return nil
-			}
+		if prefix != nil {
+			prefixes = append(prefixes, *prefix)
 		}
 	}
+	if hasIPv6Slash64Prefix(prefixes) {
+		return nil
+	}
 	return errors.Errorf(
-		"placement subnet %q does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; "+
+		"subnet %q does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; "+
 			"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(placementSubnet.Name))
 }
 
@@ -917,25 +937,27 @@ func (env *azureEnviron) createVirtualMachine(
 		vmDependsOn = append(vmDependsOn, availabilitySetId)
 	}
 
-	// Resolve placement subnet and validate IPv6 support.
+	// Resolve placement subnet ID for use in networkInfoForInstance.
 	// findPlacementSubnet returns nil if no placement is specified.
 	placementSubnet, err := env.findPlacementSubnet(ctx, args.Placement)
 	if err != nil {
 		return environs.ZoneIndependentError(err)
 	}
-
-	// Validate ip-family constraints against the placement subnet (if any).
-	if err := env.validateIPFamilyForCreate(ctx, args.Constraints, placementSubnet); err != nil {
-		return environs.ZoneIndependentError(err)
-	}
-
-	// Extract placement subnet ID for use in networkInfoForInstance.
 	var placementSubnetID network.Id
 	if placementSubnet != nil {
 		placementSubnetID = providerSubnetID(placementSubnet)
 	}
 	vnetId, subnetIds, err := env.networkInfoForInstance(ctx, args, bootstrapping, instanceConfig.IsController(), placementSubnetID)
 	if err != nil {
+		return environs.ZoneIndependentError(err)
+	}
+
+	// Validate ip-family constraints against the resolved subnet(s).
+	// When a placement subnet was resolved, we have its full details and
+	// can verify IPv6 /64 support directly. Otherwise (space constraints,
+	// default subnet selection), the SKU check is sufficient; Azure itself
+	// rejects IPv4-only subnets at NIC creation time.
+	if err := env.validateIPFamilyForResolvedSubnet(ctx, args.Constraints, bootstrapping, placementSubnet); err != nil {
 		return environs.ZoneIndependentError(err)
 	}
 	logger.Debugf(ctx, "creating instance using vnet %v, subnets %q", vnetId, subnetIds)

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -528,6 +528,28 @@ func (env *azureEnviron) validateIPFamilyConstraint(cons constraints.Value) erro
 	return nil
 }
 
+// subnetAddressPrefixes returns all CIDR prefixes for a subnet, preferring
+// AddressPrefixes (plural, dual-stack) and falling back to AddressPrefix
+// (singular, legacy single-family subnets).
+func subnetAddressPrefixes(props *armnetwork.SubnetPropertiesFormat) []string {
+	if props == nil {
+		return nil
+	}
+	if len(props.AddressPrefixes) > 0 {
+		var prefixes []string
+		for _, p := range props.AddressPrefixes {
+			if p != nil && *p != "" {
+				prefixes = append(prefixes, *p)
+			}
+		}
+		return prefixes
+	}
+	if props.AddressPrefix != nil && *props.AddressPrefix != "" {
+		return []string{*props.AddressPrefix}
+	}
+	return nil
+}
+
 // hasIPv6Slash64Prefix returns true if at least one CIDR in prefixes is an
 // IPv6 address with a /64 prefix length, which is the only IPv6 prefix size
 // Azure accepts for VNet subnets.
@@ -578,20 +600,15 @@ func (env *azureEnviron) validateIPFamilyForResolvedSubnet(
 	}
 	if placementSubnet.Properties == nil {
 		return errors.Errorf(
-			"subnet %q does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; "+
+			"subnet %q does not support ip-family=dual: no IPv6 /64 prefix found; "+
 				"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(placementSubnet.Name))
 	}
-	var prefixes []string
-	for _, prefix := range placementSubnet.Properties.AddressPrefixes {
-		if prefix != nil {
-			prefixes = append(prefixes, *prefix)
-		}
-	}
+	prefixes := subnetAddressPrefixes(placementSubnet.Properties)
 	if hasIPv6Slash64Prefix(prefixes) {
 		return nil
 	}
 	return errors.Errorf(
-		"subnet %q does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; "+
+		"subnet %q does not support ip-family=dual: no IPv6 /64 prefix found; "+
 			"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(placementSubnet.Name))
 }
 
@@ -601,7 +618,8 @@ func (env *azureEnviron) PrecheckInstance(ctx context.Context, args environs.Pre
 		return errors.Trace(err)
 	}
 
-	// Resolve placement subnet and validate IPv6 support early.
+	// Resolve placement subnet early so a missing-subnet error surfaces
+	// before VM creation. IPv6 validation happens later in createVirtualMachine.
 	_, err := env.findPlacementSubnet(ctx, args.Placement)
 	if err != nil {
 		return errors.Trace(err)

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -971,6 +971,19 @@ func (env *azureEnviron) createVirtualMachine(
 
 	isDualStack := args.Constraints.IPFamily != nil && *args.Constraints.IPFamily == ipfamily.Dual
 
+	// Reject when a space constraint selected the IPv6 variant of a
+	// dual-stack subnet but ip-family is not dual. Provisioning would
+	// silently violate the constraint.
+	if !isDualStack {
+		for _, sel := range subnetIds {
+			if sel.WantIPv6 {
+				return environs.ZoneIndependentError(errors.Errorf(
+					"subnet %q was selected via an IPv6-only space; "+
+						"set ip-family=dual to provision an IPv6 address", sel.ID))
+			}
+		}
+	}
+
 	var publicIPAddressId string
 	var ipv6PublicIPAddressId string
 	if usePublicIP {
@@ -1014,12 +1027,13 @@ func (env *azureEnviron) createVirtualMachine(
 	// Create one NIC per subnet. The first one is the primary and has
 	// the public IP address if so configured.
 	var nics []*armcompute.NetworkInterfaceReference
-	for i, subnetID := range subnetIds {
+	for i, sel := range subnetIds {
 		primary := i == 0
+		subnetID := string(sel.ID)
 		ipConfig := &armnetwork.InterfaceIPConfigurationPropertiesFormat{
 			Primary:                   new(primary),
 			PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
-			Subnet:                    &armnetwork.Subnet{ID: new(string(subnetID))},
+			Subnet:                    &armnetwork.Subnet{ID: new(subnetID)},
 		}
 		if primary && usePublicIP {
 			ipConfig.PublicIPAddress = &armnetwork.PublicIPAddress{
@@ -1044,7 +1058,7 @@ func (env *azureEnviron) createVirtualMachine(
 				Primary:                   new(false),
 				PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
 				PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
-				Subnet:                    &armnetwork.Subnet{ID: new(string(subnetID))},
+				Subnet:                    &armnetwork.Subnet{ID: new(subnetID)},
 			}
 			if usePublicIP && ipv6PublicIPAddressId != "" {
 				ipv6Props.PublicIPAddress = &armnetwork.PublicIPAddress{

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -590,7 +590,9 @@ func (env *azureEnviron) validateIPFamilyForResolvedSubnet(
 
 	// Bootstrap with a Juju-managed VNet: the subnet is created by the
 	// ARM template in networkTemplateResources which is always dual-stack.
-	if bootstrapping && env.config.virtualNetworkName == "" {
+	// When a placement subnet was specified, it is an existing subnet
+	// (not ARM-created) and must be validated for IPv6 /64 support.
+	if bootstrapping && env.config.virtualNetworkName == "" && placementSubnet == nil {
 		return nil
 	}
 

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -571,9 +571,12 @@ func (env *azureEnviron) PrecheckInstance(ctx context.Context, args environs.Pre
 		return errors.Trace(err)
 	}
 
-	if _, err := env.findPlacementSubnet(ctx, args.Placement); err != nil {
+	// Resolve placement subnet and validate IPv6 support early.
+	_, err := env.findPlacementSubnet(ctx, args.Placement)
+	if err != nil {
 		return errors.Trace(err)
 	}
+
 	if !args.Constraints.HasInstanceType() {
 		return nil
 	}
@@ -904,36 +907,22 @@ func (env *azureEnviron) createVirtualMachine(
 		vmDependsOn = append(vmDependsOn, availabilitySetId)
 	}
 
-	// Resolve placement subnet. For dual-stack, also validate IPv6 support
-	// using the same subnet list to avoid duplicate API calls.
+	// Resolve placement subnet and validate IPv6 support.
+	// findPlacementSubnet returns nil if no placement is specified.
+	placementSubnet, err := env.findPlacementSubnet(ctx, args.Placement)
+	if err != nil {
+		return environs.ZoneIndependentError(err)
+	}
+
+	// Validate ip-family constraints against the placement subnet (if any).
+	if err := env.validateIPFamilyForCreate(ctx, args.Constraints, placementSubnet); err != nil {
+		return environs.ZoneIndependentError(err)
+	}
+
+	// Extract placement subnet ID for use in networkInfoForInstance.
 	var placementSubnetID network.Id
-	if args.Placement != "" {
-		allSubnets, subErr := env.allProviderSubnets(ctx)
-		if subErr != nil {
-			return environs.ZoneIndependentError(subErr)
-		}
-		subnetName, subErr := env.parsePlacement(args.Placement)
-		if subErr != nil {
-			return environs.ZoneIndependentError(subErr)
-		}
-		for _, subnet := range allSubnets {
-			if toValue(subnet.Name) != subnetName {
-				continue
-			}
-			placementSubnetID = network.Id(toValue(subnet.ID))
-			if err := env.validateIPFamilyForCreate(ctx, args.Constraints, subnet); err != nil {
-				return environs.ZoneIndependentError(err)
-			}
-			break
-		}
-		if placementSubnetID == "" {
-			return environs.ZoneIndependentError(errors.NotFoundf("subnet %q", subnetName))
-		}
-	} else {
-		// No placement, but still validate SKU for dual-stack.
-		if err := env.validateIPFamilyForCreate(ctx, args.Constraints, nil); err != nil {
-			return environs.ZoneIndependentError(err)
-		}
+	if placementSubnet != nil {
+		placementSubnetID = providerSubnetID(placementSubnet)
 	}
 	vnetId, subnetIds, err := env.networkInfoForInstance(ctx, args, bootstrapping, instanceConfig.IsController(), placementSubnetID)
 	if err != nil {

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -573,7 +573,8 @@ func hasIPv6Slash64Prefix(prefixes []string) bool {
 // when a resolved primary subnet was provided, verifies that subnet has an
 // IPv6 /64 prefix. When no primary subnet is available (Juju-managed VNet
 // at bootstrap or ID resolution miss), the SKU check alone is sufficient;
-// Azure itself rejects IPv4-only subnets at NIC creation time.
+// Azure itself rejects IPv4-only subnets at NIC creation time. Resolution
+// misses are logged upstream by networkInfoForInstance.
 func (env *azureEnviron) validateIPFamilyForResolvedSubnet(
 	ctx context.Context, cons constraints.Value,
 	primarySubnet *armnetwork.Subnet,

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -327,17 +327,17 @@ func (env *azureEnviron) defaultControllerSubnet() network.Id {
 	return network.Id(subnetID)
 }
 
-func (env *azureEnviron) findSubnetID(ctx context.Context, subnetName string) (network.Id, error) {
+func (env *azureEnviron) findSubnet(ctx context.Context, subnetName string) (*azurenetwork.Subnet, error) {
 	subnets, err := env.allProviderSubnets(ctx)
 	if err != nil {
-		return "", env.HandleCredentialError(ctx, err)
+		return nil, env.HandleCredentialError(ctx, err)
 	}
 	for _, subnet := range subnets {
 		if toValue(subnet.Name) == subnetName {
-			return network.Id(toValue(subnet.ID)), nil
+			return subnet, nil
 		}
 	}
-	return "", errors.NotFoundf("subnet %q", subnetName)
+	return nil, errors.NotFoundf("subnet %q", subnetName)
 }
 
 // networkInfoForInstance returns the virtual network and subnet to use
@@ -379,12 +379,12 @@ func (env *azureEnviron) networkInfoForInstance(
 		if controller {
 			defaultSubnetName = controllerSubnetName
 		}
-		defaultSubnetID, err := env.findSubnetID(ctx, defaultSubnetName)
+		defaultSubnet, err := env.findSubnet(ctx, defaultSubnetName)
 		if err != nil && !errors.Is(err, errors.NotFound) {
 			return "", nil, errors.Trace(err)
 		}
 		if err == nil {
-			return vnetID, []network.Id{defaultSubnetID}, nil
+			return vnetID, []network.Id{providerSubnetID(defaultSubnet)}, nil
 		}
 
 		// For deployments without a spaces constraint, there's no subnets to zones mapping.
@@ -479,15 +479,20 @@ func (env *azureEnviron) parsePlacement(placement string) (string, error) {
 	return "", fmt.Errorf("unknown placement directive: %v", placement)
 }
 
-func (env *azureEnviron) findPlacementSubnet(ctx context.Context, placement string) (network.Id, error) {
+// providerSubnetID extracts the network.Id from an Azure subnet resource.
+func providerSubnetID(subnet *azurenetwork.Subnet) network.Id {
+	return network.Id(toValue(toValue(subnet).ID))
+}
+
+func (env *azureEnviron) findPlacementSubnet(ctx context.Context, placement string) (*azurenetwork.Subnet, error) {
 	if placement == "" {
-		return "", nil
+		return nil, nil
 	}
 	subnetName, err := env.parsePlacement(placement)
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	logger.Debugf(ctx, "searching for subnet matching placement directive %q", subnetName)
-	return env.findSubnetID(ctx, subnetName)
+	return env.findSubnet(ctx, subnetName)
 }

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -96,18 +96,7 @@ func (env *azureEnviron) allSubnets(ctx context.Context) ([]network.SubnetInfo, 
 		// Both may be set after PR #22736 (dual-stack VNet templates).
 		// Single-prefix subnets have AddressPrefix set; multi-prefix (dual-stack)
 		// have AddressPrefixes set, and AddressPrefix is nil.
-		var prefixes []string
-		if len(sub.Properties.AddressPrefixes) > 0 {
-			// Use all prefixes from AddressPrefixes (plural).
-			for _, p := range sub.Properties.AddressPrefixes {
-				if p != nil && *p != "" {
-					prefixes = append(prefixes, *p)
-				}
-			}
-		} else if sub.Properties.AddressPrefix != nil && *sub.Properties.AddressPrefix != "" {
-			// Fallback to AddressPrefix (singular) for legacy subnets.
-			prefixes = []string{*sub.Properties.AddressPrefix}
-		}
+		prefixes := subnetAddressPrefixes(sub.Properties)
 
 		if len(prefixes) == 0 {
 			logger.Debugf(ctx, "ignoring subnet %q with empty address prefix", id)

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -472,10 +472,17 @@ func (env *azureEnviron) networkInfoForInstance(
 
 	// Resolve the primary subnet for validation when ip-family=dual.
 	if isDualStack && len(subnetIDs) > 0 && primarySubnet == nil {
-		var err error
-		primarySubnet, err = env.findSubnetByID(ctx, subnetIDs[0].ID)
-		if err != nil && !errors.Is(err, errors.NotFound) {
+		resolved, err := env.findSubnetByID(ctx, subnetIDs[0].ID)
+		switch {
+		case errors.Is(err, errors.NotFound):
+			logger.Warningf(ctx, "primary subnet %q not found while resolving "+
+				"ip-family=dual validation; the IPv6 /64 prefix pre-check will "+
+				"be skipped and Azure will reject the NIC if the subnet lacks IPv6",
+				subnetIDs[0].ID)
+		case err != nil:
 			return "", nil, nil, errors.Trace(err)
+		default:
+			primarySubnet = resolved
 		}
 	}
 
@@ -537,7 +544,7 @@ func (env *azureEnviron) findSubnetByID(ctx context.Context, id network.Id) (*az
 			return subnet, nil
 		}
 	}
-	return nil, nil
+	return nil, errors.NotFoundf("subnet %q", bare)
 }
 
 func (env *azureEnviron) findPlacementSubnet(ctx context.Context, placement string) (*azurenetwork.Subnet, error) {

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network/ipfamily"
 	"github.com/juju/juju/environs"
 )
 
@@ -362,14 +363,21 @@ func (env *azureEnviron) networkInfoForInstance(
 	ctx context.Context,
 	args environs.StartInstanceParams,
 	bootstrapping, controller bool,
-	placementSubnetID network.Id,
-) (vnetID string, subnetIDs []network.Id, _ error) {
+	placementSubnet *azurenetwork.Subnet,
+) (vnetID string, subnetIDs []network.Id, primarySubnet *azurenetwork.Subnet, _ error) {
 
 	vnetRG, vnetName := env.networkInfo(ctx)
 	vnetID = fmt.Sprintf(`[resourceId('Microsoft.Network/virtualNetworks', '%s')]`, vnetName)
 	if vnetRG != "" {
 		vnetID = fmt.Sprintf(`[resourceId('%s', 'Microsoft.Network/virtualNetworks', '%s')]`, vnetRG, vnetName)
 	}
+
+	placementSubnetID := providerSubnetID(placementSubnet)
+	isDualStack := args.Constraints.IPFamily != nil && *args.Constraints.IPFamily == ipfamily.Dual
+	// When a placement subnet was provided, it is the primary by default.
+	// Early returns below may override this, and the space-constraints
+	// fallthrough at the bottom uses it to avoid a redundant lookup.
+	primarySubnet = placementSubnet
 
 	constraints := args.Constraints
 
@@ -380,14 +388,14 @@ func (env *azureEnviron) networkInfoForInstance(
 	if !constraints.HasSpaces() {
 		// Use placement if specified.
 		if placementSubnetID != "" {
-			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{placementSubnetID}), nil
+			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{placementSubnetID}), placementSubnet, nil
 		}
 
 		// When bootstrapping the network doesn't exist yet so just
 		// return the relevant subnet ID and it is created as part of
 		// the bootstrap process.
 		if bootstrapping && env.config.virtualNetworkName == "" {
-			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{env.defaultControllerSubnet()}), nil
+			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{env.defaultControllerSubnet()}), nil, nil
 		}
 
 		// Prefer the legacy default subnet if found.
@@ -397,17 +405,17 @@ func (env *azureEnviron) networkInfoForInstance(
 		}
 		defaultSubnet, err := env.findSubnet(ctx, defaultSubnetName)
 		if err != nil && !errors.Is(err, errors.NotFound) {
-			return "", nil, errors.Trace(err)
+			return "", nil, nil, errors.Trace(err)
 		}
 		if err == nil {
-			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{providerSubnetID(defaultSubnet)}), nil
+			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{providerSubnetID(defaultSubnet)}), defaultSubnet, nil
 		}
 
 		// For deployments without a spaces constraint, there's no subnets to zones mapping.
 		// So get all accessible subnets.
 		allSubnets, err := env.allSubnets(ctx)
 		if err != nil {
-			return "", nil, env.HandleCredentialError(ctx, err)
+			return "", nil, nil, env.HandleCredentialError(ctx, err)
 		}
 		subnetIds := make([]network.Id, len(allSubnets))
 		for i, subnet := range allSubnets {
@@ -420,7 +428,7 @@ func (env *azureEnviron) networkInfoForInstance(
 		// If there is no configured zone, consider all subnet IDs.
 		possibleSubnets, err = env.subnetsForZone(args.SubnetsToZones, args.AvailabilityZone)
 		if err != nil {
-			return "", nil, errors.Trace(err)
+			return "", nil, nil, errors.Trace(err)
 		}
 	}
 
@@ -447,7 +455,7 @@ func (env *azureEnviron) networkInfoForInstance(
 		}
 	}
 	if len(subnetIDForZone) == 0 {
-		return "", nil, errors.NotFoundf("subnet for constraint %q", constraints.String())
+		return "", nil, nil, errors.NotFoundf("subnet for constraint %q", constraints.String())
 	}
 
 	// Put any placement subnet first in the list
@@ -462,11 +470,18 @@ func (env *azureEnviron) networkInfoForInstance(
 		}
 	}
 
-	// Strip :ipv6 suffixes and deduplicate. allSubnets() emits two rows per
-	// dual-stack subnet (one IPv4 with bare ID, one IPv6 with :ipv6 suffix),
-	// but ARM templates expect one subnet ID per NIC. Stripping + deduplicating
-	// ensures that happens.
-	return vnetID, stripAndDeduplicateSubnetIDs(subnetIDs), nil
+	dedupedSubnetIDs := stripAndDeduplicateSubnetIDs(subnetIDs)
+
+	// Resolve the primary subnet for validation when ip-family=dual.
+	if isDualStack && len(dedupedSubnetIDs) > 0 && primarySubnet == nil {
+		var err error
+		primarySubnet, err = env.findSubnetByID(ctx, dedupedSubnetIDs[0])
+		if err != nil && !errors.Is(err, errors.NotFound) {
+			return "", nil, nil, errors.Trace(err)
+		}
+	}
+
+	return vnetID, dedupedSubnetIDs, primarySubnet, nil
 }
 
 func (env *azureEnviron) subnetsForZone(subnetsToZones []map[network.Id][]string, az string) ([][]network.Id, error) {
@@ -508,6 +523,23 @@ func (env *azureEnviron) parsePlacement(placement string) (string, error) {
 // providerSubnetID extracts the network.Id from an Azure subnet resource.
 func providerSubnetID(subnet *azurenetwork.Subnet) network.Id {
 	return network.Id(toValue(toValue(subnet).ID))
+}
+
+// findSubnetByID resolves an Azure subnet ID to its full resource.
+// It strips the :ipv6 suffix before comparison, so it can look up
+// IDs originating from the Juju allSubnets() path.
+func (env *azureEnviron) findSubnetByID(ctx context.Context, id network.Id) (*azurenetwork.Subnet, error) {
+	subnets, err := env.allProviderSubnets(ctx)
+	if err != nil {
+		return nil, env.HandleCredentialError(ctx, err)
+	}
+	bare := network.Id(stripIPFamilySuffix(id.String()))
+	for _, subnet := range subnets {
+		if network.Id(toValue(subnet.ID)) == bare {
+			return subnet, nil
+		}
+	}
+	return nil, nil
 }
 
 func (env *azureEnviron) findPlacementSubnet(ctx context.Context, placement string) (*azurenetwork.Subnet, error) {

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -429,9 +429,13 @@ func (env *azureEnviron) networkInfoForInstance(
 	var subnetIDForZone []network.Id
 	for _, zoneSubnetIDs := range possibleSubnets {
 		// Use placement to select a single subnet if needed.
+		// Strip the :ipv6 suffix before comparing so that a bare
+		// placement ID (e.g. /subnets/foo) matches the suffixed
+		// variant (/subnets/foo:ipv6) emitted by allSubnets().
 		var subnetIDs []network.Id
 		for _, id := range zoneSubnetIDs {
-			if placementSubnetID == "" || placementSubnetID == id {
+			bareID := network.Id(stripIPFamilySuffix(id.String()))
+			if placementSubnetID == "" || placementSubnetID == bareID {
 				subnetIDs = append(subnetIDs, id)
 			}
 		}
@@ -452,7 +456,8 @@ func (env *azureEnviron) networkInfoForInstance(
 		subnetIDs = append(subnetIDs, placementSubnetID)
 	}
 	for _, id := range subnetIDForZone {
-		if id != placementSubnetID {
+		bareID := network.Id(stripIPFamilySuffix(id.String()))
+		if bareID != placementSubnetID {
 			subnetIDs = append(subnetIDs, id)
 		}
 	}

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -91,32 +91,45 @@ func (env *azureEnviron) allSubnets(ctx context.Context) ([]network.SubnetInfo, 
 		if sub.Properties == nil {
 			continue
 		}
-		addressPrefix := sub.Properties.AddressPrefix
-		if addressPrefix == nil || *addressPrefix == "" {
-			for _, prefix := range sub.Properties.AddressPrefixes {
-				if prefix == nil {
-					continue
-				}
-				addrType, err := network.CIDRAddressType(*prefix)
-				// We only care about IPv4 addresses.
-				if err == nil && addrType == network.IPv4Address {
-					addressPrefix = prefix
-					break
-				}
 
+		// Prefer AddressPrefixes (plural) over AddressPrefix (singular).
+		// Both may be set after PR #22736 (dual-stack VNet templates).
+		// Single-prefix subnets have AddressPrefix set; multi-prefix (dual-stack)
+		// have AddressPrefixes set, and AddressPrefix is nil.
+		var prefixes []string
+		if len(sub.Properties.AddressPrefixes) > 0 {
+			// Use all prefixes from AddressPrefixes (plural).
+			for _, p := range sub.Properties.AddressPrefixes {
+				if p != nil && *p != "" {
+					prefixes = append(prefixes, *p)
+				}
 			}
+		} else if sub.Properties.AddressPrefix != nil && *sub.Properties.AddressPrefix != "" {
+			// Fallback to AddressPrefix (singular) for legacy subnets.
+			prefixes = []string{*sub.Properties.AddressPrefix}
 		}
-		// An empty CIDR is no use to us, so guard against it.
-		cidr := toValue(addressPrefix)
-		if cidr == "" {
+
+		if len(prefixes) == 0 {
 			logger.Debugf(ctx, "ignoring subnet %q with empty address prefix", id)
 			continue
 		}
 
-		results = append(results, network.SubnetInfo{
-			CIDR:       cidr,
-			ProviderId: network.Id(id),
-		})
+		// Emit one SubnetInfo per prefix. Use the :ipv6 suffix to distinguish
+		// IPv6 prefixes from IPv4, so that dual-stack subnets appear as two
+		// distinct Juju subnets (one per family).
+		for _, prefix := range prefixes {
+			addrType, err := network.CIDRAddressType(prefix)
+			if err != nil {
+				logger.Debugf(ctx, "invalid CIDR %q in subnet %q: %v; skipping", prefix, id, err)
+				continue
+			}
+
+			isIPv6 := addrType == network.IPv6Address
+			results = append(results, network.SubnetInfo{
+				CIDR:       prefix,
+				ProviderId: subnetProviderIDForFamily(id, isIPv6),
+			})
+		}
 	}
 	return results, nil
 }
@@ -279,11 +292,25 @@ func mapAzureInterfaceList(in []*azurenetwork.Interface, subnetIDToCIDR map[stri
 			)
 			if ipConf.Properties.Subnet != nil && ipConf.Properties.Subnet.ID != nil {
 				subnetID = toValue(ipConf.Properties.Subnet.ID)
-				providerAddrOpts = append(providerAddrOpts, network.WithProviderSubnetID(network.Id(subnetID)))
 
-				if subnetCIDR := subnetIDToCIDR[subnetID]; subnetCIDR != "" {
+				// Determine if this is an IPv6 IP configuration to add the
+				// correct family-suffixed ProviderId and lookup the matching CIDR.
+				isIPv6 := ipConf.Properties.PrivateIPAddressVersion != nil &&
+					toValue(ipConf.Properties.PrivateIPAddressVersion) == azurenetwork.IPVersionIPv6
+
+				// Build the Juju ProviderId suffix convention: bare for IPv4, :ipv6 for IPv6.
+				jujuSubnetID := subnetProviderIDForFamily(subnetID, isIPv6)
+				providerAddrOpts = append(providerAddrOpts, network.WithProviderSubnetID(jujuSubnetID))
+
+				// Look up the CIDR for this family-specific subnet. If we have a dual-stack
+				// subnet, allSubnets() will have created two entries (one bare IPv4, one :ipv6).
+				// If the lookup misses (e.g. legacy IPv4-only model with only bare IDs),
+				// the address is stored without a CIDR tag. This is acceptable for legacy
+				// models; new dual-stack machines will always have matching entries.
+				if subnetCIDR := subnetIDToCIDR[jujuSubnetID.String()]; subnetCIDR != "" {
 					machineAddrOpts = append(machineAddrOpts, network.WithCIDR(subnetCIDR))
 				}
+
 			}
 
 			providerAddr := network.NewMachineAddress(
@@ -364,14 +391,14 @@ func (env *azureEnviron) networkInfoForInstance(
 	if !constraints.HasSpaces() {
 		// Use placement if specified.
 		if placementSubnetID != "" {
-			return vnetID, []network.Id{placementSubnetID}, nil
+			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{placementSubnetID}), nil
 		}
 
 		// When bootstrapping the network doesn't exist yet so just
 		// return the relevant subnet ID and it is created as part of
 		// the bootstrap process.
 		if bootstrapping && env.config.virtualNetworkName == "" {
-			return vnetID, []network.Id{env.defaultControllerSubnet()}, nil
+			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{env.defaultControllerSubnet()}), nil
 		}
 
 		// Prefer the legacy default subnet if found.
@@ -384,7 +411,7 @@ func (env *azureEnviron) networkInfoForInstance(
 			return "", nil, errors.Trace(err)
 		}
 		if err == nil {
-			return vnetID, []network.Id{providerSubnetID(defaultSubnet)}, nil
+			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{providerSubnetID(defaultSubnet)}), nil
 		}
 
 		// For deployments without a spaces constraint, there's no subnets to zones mapping.
@@ -440,7 +467,12 @@ func (env *azureEnviron) networkInfoForInstance(
 			subnetIDs = append(subnetIDs, id)
 		}
 	}
-	return vnetID, subnetIDs, nil
+
+	// Strip :ipv6 suffixes and deduplicate. allSubnets() emits two rows per
+	// dual-stack subnet (one IPv4 with bare ID, one IPv6 with :ipv6 suffix),
+	// but ARM templates expect one subnet ID per NIC. Stripping + deduplicating
+	// ensures that happens.
+	return vnetID, stripAndDeduplicateSubnetIDs(subnetIDs), nil
 }
 
 func (env *azureEnviron) subnetsForZone(subnetsToZones []map[network.Id][]string, az string) ([][]network.Id, error) {
@@ -495,4 +527,45 @@ func (env *azureEnviron) findPlacementSubnet(ctx context.Context, placement stri
 
 	logger.Debugf(ctx, "searching for subnet matching placement directive %q", subnetName)
 	return env.findSubnet(ctx, subnetName)
+}
+
+// subnetProviderIDForFamily builds the Juju provider subnet ID for an Azure subnet,
+// optionally suffixed with the IP family. Bare (no suffix) means IPv4; `:ipv6` suffix
+// means IPv6. The suffix is used only on the read path (allSubnets, NetworkInterfaces);
+// it is stripped before subnet IDs reach ARM templates for provisioning.
+func subnetProviderIDForFamily(azureSubnetID string, isIPv6 bool) network.Id {
+	if isIPv6 {
+		return network.Id(azureSubnetID + ":ipv6")
+	}
+	return network.Id(azureSubnetID)
+}
+
+// stripIPFamilySuffix removes the :ipv4/:ipv6 suffix from a Juju provider subnet ID.
+// Non-suffixed (or otherwise-formatted) input is returned unchanged. The colon is safe
+// within Juju (only appears in suffixes); Azure ARM resource IDs never contain colons.
+func stripIPFamilySuffix(id string) string {
+	if idx := strings.LastIndex(id, ":"); idx != -1 {
+		switch id[idx+1:] {
+		case "ipv4", "ipv6":
+			return id[:idx]
+		}
+	}
+	return id
+}
+
+// stripAndDeduplicateSubnetIDs removes :ipv6 suffixes from subnet IDs and deduplicates them.
+// This ensures that when allSubnets() emits two rows per dual-stack subnet (one for each
+// family), we only pass one bare Azure subnet ID to ARM templates. The order of the first
+// occurrence is preserved.
+func stripAndDeduplicateSubnetIDs(subnetIDs []network.Id) []network.Id {
+	seen := make(map[string]bool)
+	var result []network.Id
+	for _, id := range subnetIDs {
+		bare := stripIPFamilySuffix(id.String())
+		if !seen[bare] {
+			seen[bare] = true
+			result = append(result, network.Id(bare))
+		}
+	}
+	return result
 }

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -364,7 +364,7 @@ func (env *azureEnviron) networkInfoForInstance(
 	args environs.StartInstanceParams,
 	bootstrapping, controller bool,
 	placementSubnet *azurenetwork.Subnet,
-) (vnetID string, subnetIDs []network.Id, primarySubnet *azurenetwork.Subnet, _ error) {
+) (vnetID string, subnetIDs []subnetSelection, primarySubnet *azurenetwork.Subnet, _ error) {
 
 	vnetRG, vnetName := env.networkInfo(ctx)
 	vnetID = fmt.Sprintf(`[resourceId('Microsoft.Network/virtualNetworks', '%s')]`, vnetName)
@@ -388,14 +388,14 @@ func (env *azureEnviron) networkInfoForInstance(
 	if !constraints.HasSpaces() {
 		// Use placement if specified.
 		if placementSubnetID != "" {
-			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{placementSubnetID}), placementSubnet, nil
+			return vnetID, deduplicateSubnets([]network.Id{placementSubnetID}), placementSubnet, nil
 		}
 
 		// When bootstrapping the network doesn't exist yet so just
 		// return the relevant subnet ID and it is created as part of
 		// the bootstrap process.
 		if bootstrapping && env.config.virtualNetworkName == "" {
-			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{env.defaultControllerSubnet()}), nil, nil
+			return vnetID, deduplicateSubnets([]network.Id{env.defaultControllerSubnet()}), nil, nil
 		}
 
 		// Prefer the legacy default subnet if found.
@@ -408,7 +408,7 @@ func (env *azureEnviron) networkInfoForInstance(
 			return "", nil, nil, errors.Trace(err)
 		}
 		if err == nil {
-			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{providerSubnetID(defaultSubnet)}), defaultSubnet, nil
+			return vnetID, deduplicateSubnets([]network.Id{providerSubnetID(defaultSubnet)}), defaultSubnet, nil
 		}
 
 		// For deployments without a spaces constraint, there's no subnets to zones mapping.
@@ -460,28 +460,26 @@ func (env *azureEnviron) networkInfoForInstance(
 
 	// Put any placement subnet first in the list
 	// so it ia allocated to the primary NIC.
+	var rawSubnetIDs []network.Id
 	if placementSubnetID != "" {
-		subnetIDs = append(subnetIDs, placementSubnetID)
+		rawSubnetIDs = append(rawSubnetIDs, placementSubnetID)
 	}
 	for _, id := range subnetIDForZone {
-		bareID := network.Id(stripIPFamilySuffix(id.String()))
-		if bareID != placementSubnetID {
-			subnetIDs = append(subnetIDs, id)
-		}
+		rawSubnetIDs = append(rawSubnetIDs, id)
 	}
 
-	dedupedSubnetIDs := stripAndDeduplicateSubnetIDs(subnetIDs)
+	subnetIDs = deduplicateSubnets(rawSubnetIDs)
 
 	// Resolve the primary subnet for validation when ip-family=dual.
-	if isDualStack && len(dedupedSubnetIDs) > 0 && primarySubnet == nil {
+	if isDualStack && len(subnetIDs) > 0 && primarySubnet == nil {
 		var err error
-		primarySubnet, err = env.findSubnetByID(ctx, dedupedSubnetIDs[0])
+		primarySubnet, err = env.findSubnetByID(ctx, subnetIDs[0].ID)
 		if err != nil && !errors.Is(err, errors.NotFound) {
 			return "", nil, nil, errors.Trace(err)
 		}
 	}
 
-	return vnetID, dedupedSubnetIDs, primarySubnet, nil
+	return vnetID, subnetIDs, primarySubnet, nil
 }
 
 func (env *azureEnviron) subnetsForZone(subnetsToZones []map[network.Id][]string, az string) ([][]network.Id, error) {
@@ -579,19 +577,35 @@ func stripIPFamilySuffix(id string) string {
 	return id
 }
 
-// stripAndDeduplicateSubnetIDs removes :ipv6 suffixes from subnet IDs and deduplicates them.
-// This ensures that when allSubnets() emits two rows per dual-stack subnet (one for each
-// family), we only pass one bare Azure subnet ID to ARM templates. The order of the first
-// occurrence is preserved.
-func stripAndDeduplicateSubnetIDs(subnetIDs []network.Id) []network.Id {
-	seen := make(map[string]bool)
-	var result []network.Id
-	for _, id := range subnetIDs {
+// subnetSelection carries a resolved Azure subnet ID (bare, suitable for ARM
+// templates) and whether the originating Juju provider ID carried the :ipv6
+// suffix — meaning the space constraint selected the IPv6 variant of a
+// dual-stack subnet.
+type subnetSelection struct {
+	ID       network.Id
+	WantIPv6 bool
+}
+
+// deduplicateSubnets removes :ipv6/:ipv4 suffixes from subnet IDs, deduplicates
+// by bare ID, and preserves whether any input variant carried the :ipv6 suffix
+// (wantIPv6). The order of the first occurrence is preserved.
+func deduplicateSubnets(ids []network.Id) []subnetSelection {
+	seen := make(map[string]int)
+	var result []subnetSelection
+	for _, id := range ids {
 		bare := stripIPFamilySuffix(id.String())
-		if !seen[bare] {
-			seen[bare] = true
-			result = append(result, network.Id(bare))
+		wantIPv6 := bare != id.String()
+		if idx, ok := seen[bare]; ok {
+			if wantIPv6 {
+				result[idx].WantIPv6 = true
+			}
+			continue
 		}
+		seen[bare] = len(result)
+		result = append(result, subnetSelection{
+			ID:       network.Id(bare),
+			WantIPv6: wantIPv6,
+		})
 	}
 	return result
 }

--- a/internal/provider/azure/environ_network_test.go
+++ b/internal/provider/azure/environ_network_test.go
@@ -6,6 +6,7 @@ package azure_test
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/juju/errors"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/core/instance"
@@ -799,6 +800,6 @@ func (s *environSuite) TestFindSubnetByIDNotFound(c *tc.C) {
 	}
 
 	res, err := azure.FindSubnetByID(c.Context(), env, "/path/to/subnet1")
-	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(err, tc.ErrorIs, errors.NotFound)
 	c.Assert(res, tc.IsNil)
 }

--- a/internal/provider/azure/environ_network_test.go
+++ b/internal/provider/azure/environ_network_test.go
@@ -716,3 +716,68 @@ func (s *environSuite) TestStripAndDeduplicateSubnetIDs(c *tc.C) {
 		c.Check(got, tc.DeepEquals, test.expected, tc.Commentf("StripAndDeduplicateSubnetIDs(%v)", test.input))
 	}
 }
+
+func (s *environSuite) TestFindSubnetByIDSuccess(c *tc.C) {
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("192.168.0.0/20"),
+		},
+	}, {
+		ID:   new("/path/to/subnet2"),
+		Name: new("subnet2"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{new("10.0.0.0/24"), new("fd00::/64")},
+		},
+	}}
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: subnets,
+		}),
+	}
+
+	res, err := azure.FindSubnetByID(c.Context(), env, "/path/to/subnet2")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res, tc.NotNil)
+	c.Assert(toValue(res.Name), tc.Equals, "subnet2")
+}
+
+func (s *environSuite) TestFindSubnetByIDSuccessSuffix(c *tc.C) {
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{new("192.168.0.0/20"), new("fd00::/64")},
+		},
+	}}
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: subnets,
+		}),
+	}
+
+	// Look up using a Juju-suffixed ID, should still resolve to subnet1.
+	res, err := azure.FindSubnetByID(c.Context(), env, "/path/to/subnet1:ipv6")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res, tc.NotNil)
+	c.Assert(toValue(res.Name), tc.Equals, "subnet1")
+}
+
+func (s *environSuite) TestFindSubnetByIDNotFound(c *tc.C) {
+	env := s.openEnviron(c)
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: []*armnetwork.Subnet{},
+		}),
+	}
+
+	res, err := azure.FindSubnetByID(c.Context(), env, "/path/to/subnet1")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res, tc.IsNil)
+}

--- a/internal/provider/azure/environ_network_test.go
+++ b/internal/provider/azure/environ_network_test.go
@@ -54,6 +54,8 @@ func (s *environSuite) TestSubnetsSuccessNew(c *tc.C) {
 
 	// We wait for common resource creation, then query subnets
 	// in the default virtual network created for every model.
+	// This now tests the case where a subnet has both IPv4 and IPv6 prefixes.
+	// The new behavior is to return two SubnetInfo rows (one per family).
 	s.sender = azuretesting.Senders{
 		makeSender("/deployments/common", s.commonDeployment),
 		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
@@ -81,9 +83,21 @@ func (s *environSuite) TestSubnetsSuccessNew(c *tc.C) {
 	subs, err := netEnv.Subnets(c.Context(), nil)
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Assert(subs, tc.HasLen, 1)
+	// With AddressPrefixes containing both IPv4 and IPv6, we get two entries.
+	c.Assert(subs, tc.HasLen, 2)
+
+	// Sort by CIDR to ensure predictable order.
+	if subs[0].CIDR > subs[1].CIDR {
+		subs[0], subs[1] = subs[1], subs[0]
+	}
+
+	// IPv4 entry: bare ProviderId
 	c.Check(subs[0].ProviderId, tc.Equals, corenetwork.Id("provider-sub-id"))
 	c.Check(subs[0].CIDR, tc.Equals, "10.0.0.0/24")
+
+	// IPv6 entry: :ipv6 suffix
+	c.Check(subs[1].ProviderId, tc.Equals, corenetwork.Id("provider-sub-id:ipv6"))
+	c.Check(subs[1].CIDR, tc.Equals, "fd00:27e8:ed0b::/64")
 }
 
 func (s *environSuite) TestNetworkInterfacesSuccess(c *tc.C) {
@@ -347,4 +361,358 @@ func (s *environSuite) TestNetworkTemplateResourcesNoControllerSubnet(c *tc.C) {
 	c.Assert(vnetProps.Subnets, tc.HasLen, 1)
 	c.Assert(vnetProps.Subnets[0].Properties.AddressPrefixes, tc.HasLen, 2)
 	c.Check(toValue(vnetProps.Subnets[0].Properties.AddressPrefixes[1]), tc.Equals, azure.InternalSubnetIPv6Prefix)
+}
+
+// TestSubnetsDualStackSubnet tests that allSubnets() emits two SubnetInfo rows
+// (one per IP family) for a dual-stack subnet, with the IPv6 one suffixed :ipv6.
+func (s *environSuite) TestSubnetsDualStackSubnet(c *tc.C) {
+	env := s.openEnviron(c)
+
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: []*armnetwork.Subnet{
+				{
+					ID: new("provider-dual-stack-subnet"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefixes: []*string{
+							new("192.168.0.0/20"),
+							new("fd00::/64"),
+						},
+					},
+				},
+			},
+		}),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, tc.IsTrue)
+
+	subs, err := netEnv.Subnets(c.Context(), nil)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Should have two entries: one IPv4, one IPv6.
+	c.Assert(subs, tc.HasLen, 2)
+
+	// Sort by CIDR to ensure predictable order.
+	if subs[0].CIDR > subs[1].CIDR {
+		subs[0], subs[1] = subs[1], subs[0]
+	}
+
+	// IPv4 entry: bare ProviderId.
+	c.Check(subs[0].ProviderId, tc.Equals, corenetwork.Id("provider-dual-stack-subnet"))
+	c.Check(subs[0].CIDR, tc.Equals, "192.168.0.0/20")
+
+	// IPv6 entry: :ipv6 suffix.
+	c.Check(subs[1].ProviderId, tc.Equals, corenetwork.Id("provider-dual-stack-subnet:ipv6"))
+	c.Check(subs[1].CIDR, tc.Equals, "fd00::/64")
+}
+
+// TestSubnetsIPv4OnlySubnet tests regression: IPv4-only subnets still return
+// one entry with bare ProviderId.
+func (s *environSuite) TestSubnetsIPv4OnlySubnet(c *tc.C) {
+	env := s.openEnviron(c)
+
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: []*armnetwork.Subnet{
+				{
+					ID: new("provider-ipv4-only-subnet"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefix: new("10.0.0.0/24"),
+					},
+				},
+			},
+		}),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, tc.IsTrue)
+
+	subs, err := netEnv.Subnets(c.Context(), nil)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Should have one entry (IPv4 only).
+	c.Assert(subs, tc.HasLen, 1)
+	c.Check(subs[0].ProviderId, tc.Equals, corenetwork.Id("provider-ipv4-only-subnet"))
+	c.Check(subs[0].CIDR, tc.Equals, "10.0.0.0/24")
+}
+
+// TestNetworkInterfacesDualStackNIC tests that a NIC with both IPv4 and IPv6
+// IP configurations gets tagged with the correct per-family CIDR and ProviderSubnetID.
+func (s *environSuite) TestNetworkInterfacesDualStackNIC(c *tc.C) {
+	env := s.openEnviron(c)
+
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: []*armnetwork.Subnet{
+				{
+					ID: new("dual-stack-subnet"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefixes: []*string{
+							new("192.168.0.0/20"),
+							new("fd00::/64"),
+						},
+					},
+				},
+			},
+		}),
+		makeSender(".*/networkInterfaces", armnetwork.InterfaceListResult{
+			Value: []*armnetwork.Interface{
+				{
+					ID: new("dual-stack-nic"),
+					Properties: &armnetwork.InterfacePropertiesFormat{
+						Primary: new(true),
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+							{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									PrivateIPAddress:          new("192.168.0.10"),
+									PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+									PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+									Subnet: &armnetwork.Subnet{
+										ID: new("dual-stack-subnet"),
+									},
+									Primary: new(false),
+								},
+							},
+							{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									PrivateIPAddress:          new("fd00::10"),
+									PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+									PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+									Subnet: &armnetwork.Subnet{
+										ID: new("dual-stack-subnet"),
+									},
+									Primary: new(true),
+								},
+							},
+						},
+					},
+					Tags: map[string]*string{
+						"juju-machine-name": new("machine-0"),
+					},
+				},
+			},
+		}),
+		makeSender(".*/publicIPAddresses", armnetwork.PublicIPAddressListResult{}),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, tc.IsTrue)
+
+	res, err := netEnv.NetworkInterfaces(c.Context(), []instance.Id{"machine-0"})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(res, tc.HasLen, 1)
+	c.Assert(res[0], tc.HasLen, 1)
+
+	nic := res[0][0]
+	// IPv6 address should be primary (appear first).
+	c.Assert(nic.Addresses, tc.HasLen, 2)
+
+	// Check IPv6 address: should have :ipv6 suffix and correct CIDR.
+	ipv6Addr := nic.Addresses[0]
+	c.Check(ipv6Addr.Value, tc.Equals, "fd00::10")
+	c.Check(ipv6Addr.CIDR, tc.Equals, "fd00::/64")
+	c.Check(ipv6Addr.ProviderSubnetID, tc.Equals, corenetwork.Id("dual-stack-subnet:ipv6"))
+
+	// Check IPv4 address: bare ProviderSubnetID.
+	ipv4Addr := nic.Addresses[1]
+	c.Check(ipv4Addr.Value, tc.Equals, "192.168.0.10")
+	c.Check(ipv4Addr.CIDR, tc.Equals, "192.168.0.0/20")
+	c.Check(ipv4Addr.ProviderSubnetID, tc.Equals, corenetwork.Id("dual-stack-subnet"))
+}
+
+// TestNetworkInterfacesDualStackNICLegacyModel tests backward compatibility:
+// when allSubnets() returns only bare-ID IPv4 entries (simulating a legacy
+// model with IPv4-only subnets), an IPv6 IP configuration gets no CIDR tag.
+// This is a documented fallback behavior.
+func (s *environSuite) TestNetworkInterfacesDualStackNICLegacyModel(c *tc.C) {
+	env := s.openEnviron(c)
+
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		// Legacy model: only bare IPv4 subnet, no :ipv6 entry.
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: []*armnetwork.Subnet{
+				{
+					ID: new("legacy-subnet"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefix: new("10.0.0.0/24"),
+					},
+				},
+			},
+		}),
+		makeSender(".*/networkInterfaces", armnetwork.InterfaceListResult{
+			Value: []*armnetwork.Interface{
+				{
+					ID: new("legacy-nic"),
+					Properties: &armnetwork.InterfacePropertiesFormat{
+						Primary: new(true),
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+							{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									PrivateIPAddress:          new("10.0.0.10"),
+									PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+									PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+									Subnet: &armnetwork.Subnet{
+										ID: new("legacy-subnet"),
+									},
+									Primary: new(false),
+								},
+							},
+							{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									PrivateIPAddress:          new("fd00::10"),
+									PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+									PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+									Subnet: &armnetwork.Subnet{
+										ID: new("legacy-subnet"),
+									},
+									Primary: new(true),
+								},
+							},
+						},
+					},
+					Tags: map[string]*string{
+						"juju-machine-name": new("machine-0"),
+					},
+				},
+			},
+		}),
+		makeSender(".*/publicIPAddresses", armnetwork.PublicIPAddressListResult{}),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, tc.IsTrue)
+
+	res, err := netEnv.NetworkInterfaces(c.Context(), []instance.Id{"machine-0"})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(res, tc.HasLen, 1)
+	c.Assert(res[0], tc.HasLen, 1)
+
+	nic := res[0][0]
+	c.Assert(nic.Addresses, tc.HasLen, 2)
+
+	// IPv6 address: lookup for :ipv6 suffixed ID misses, so no CIDR tag.
+	ipv6Addr := nic.Addresses[0]
+	c.Check(ipv6Addr.Value, tc.Equals, "fd00::10")
+	c.Check(ipv6Addr.CIDR, tc.Equals, "") // No CIDR tag (legacy fallback).
+	c.Check(ipv6Addr.ProviderSubnetID, tc.Equals, corenetwork.Id("legacy-subnet:ipv6"))
+
+	// IPv4 address: tagged as expected.
+	ipv4Addr := nic.Addresses[1]
+	c.Check(ipv4Addr.Value, tc.Equals, "10.0.0.10")
+	c.Check(ipv4Addr.CIDR, tc.Equals, "10.0.0.0/24")
+	c.Check(ipv4Addr.ProviderSubnetID, tc.Equals, corenetwork.Id("legacy-subnet"))
+}
+
+// TestStripIPFamilySuffix tests the stripIPFamilySuffix helper.
+func (s *environSuite) TestStripIPFamilySuffix(c *tc.C) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "/subscriptions/abc123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet:ipv6",
+			expected: "/subscriptions/abc123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+		},
+		{
+			input:    "/subscriptions/abc123/stuff:ipv4",
+			expected: "/subscriptions/abc123/stuff",
+		},
+		{
+			input:    "/subscriptions/abc123/stuff:other",
+			expected: "/subscriptions/abc123/stuff:other", // :other is not a valid suffix, left alone.
+		},
+		{
+			input:    "plain-id",
+			expected: "plain-id", // No colon, unchanged.
+		},
+		{
+			input:    "",
+			expected: "", // Empty string, unchanged.
+		},
+	}
+
+	for _, test := range testCases {
+		got := azure.StripIPFamilySuffix(test.input)
+		c.Check(got, tc.Equals, test.expected, tc.Commentf("stripIPFamilySuffix(%q)", test.input))
+	}
+}
+
+// TestSubnetProviderIDForFamily tests the subnetProviderIDForFamily helper.
+func (s *environSuite) TestSubnetProviderIDForFamily(c *tc.C) {
+	testCases := []struct {
+		azureID  string
+		isIPv6   bool
+		expected corenetwork.Id
+	}{
+		{
+			azureID:  "/subscriptions/abc/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			isIPv6:   false,
+			expected: corenetwork.Id("/subscriptions/abc/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"),
+		},
+		{
+			azureID:  "/subscriptions/abc/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			isIPv6:   true,
+			expected: corenetwork.Id("/subscriptions/abc/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet:ipv6"),
+		},
+	}
+
+	for _, test := range testCases {
+		got := azure.SubnetProviderIDForFamily(test.azureID, test.isIPv6)
+		c.Check(got, tc.Equals, test.expected, tc.Commentf("SubnetProviderIDForFamily(%q, %v)", test.azureID, test.isIPv6))
+	}
+}
+
+// TestStripAndDeduplicateSubnetIDs tests the stripAndDeduplicateSubnetIDs helper.
+func (s *environSuite) TestStripAndDeduplicateSubnetIDs(c *tc.C) {
+	testCases := []struct {
+		input    []corenetwork.Id
+		expected []corenetwork.Id
+	}{
+		{
+			input: []corenetwork.Id{
+				"subnet-1",
+				"subnet-1:ipv6",
+				"subnet-2",
+			},
+			expected: []corenetwork.Id{
+				"subnet-1",
+				"subnet-2",
+			},
+		},
+		{
+			input: []corenetwork.Id{
+				"subnet-1:ipv6",
+				"subnet-1",
+			},
+			expected: []corenetwork.Id{
+				"subnet-1",
+			},
+		},
+		{
+			input: []corenetwork.Id{
+				"subnet-1",
+				"subnet-2",
+			},
+			expected: []corenetwork.Id{
+				"subnet-1",
+				"subnet-2",
+			},
+		},
+		{
+			input:    []corenetwork.Id{},
+			expected: []corenetwork.Id{},
+		},
+	}
+
+	for _, test := range testCases {
+		got := azure.StripAndDeduplicateSubnetIDs(test.input)
+		c.Check(got, tc.DeepEquals, test.expected, tc.Commentf("StripAndDeduplicateSubnetIDs(%v)", test.input))
+	}
 }

--- a/internal/provider/azure/environ_network_test.go
+++ b/internal/provider/azure/environ_network_test.go
@@ -669,11 +669,18 @@ func (s *environSuite) TestSubnetProviderIDForFamily(c *tc.C) {
 	}
 }
 
-// TestStripAndDeduplicateSubnetIDs tests the stripAndDeduplicateSubnetIDs helper.
-func (s *environSuite) TestStripAndDeduplicateSubnetIDs(c *tc.C) {
+// TestDeduplicateSubnets tests the deduplicateSubnets helper.
+// It verifies that :ipv6-suffixed IDs produce wantIPv6=true,
+// bare IDs produce wantIPv6=false, and duplicates are collapsed
+// with the OR of their wantIPv6 flags.
+func (s *environSuite) TestDeduplicateSubnets(c *tc.C) {
+	type sel struct {
+		id       string
+		wantIPv6 bool
+	}
 	testCases := []struct {
 		input    []corenetwork.Id
-		expected []corenetwork.Id
+		expected []sel
 	}{
 		{
 			input: []corenetwork.Id{
@@ -681,9 +688,9 @@ func (s *environSuite) TestStripAndDeduplicateSubnetIDs(c *tc.C) {
 				"subnet-1:ipv6",
 				"subnet-2",
 			},
-			expected: []corenetwork.Id{
-				"subnet-1",
-				"subnet-2",
+			expected: []sel{
+				{"subnet-1", true},
+				{"subnet-2", false},
 			},
 		},
 		{
@@ -691,8 +698,8 @@ func (s *environSuite) TestStripAndDeduplicateSubnetIDs(c *tc.C) {
 				"subnet-1:ipv6",
 				"subnet-1",
 			},
-			expected: []corenetwork.Id{
-				"subnet-1",
+			expected: []sel{
+				{"subnet-1", true},
 			},
 		},
 		{
@@ -700,20 +707,34 @@ func (s *environSuite) TestStripAndDeduplicateSubnetIDs(c *tc.C) {
 				"subnet-1",
 				"subnet-2",
 			},
-			expected: []corenetwork.Id{
-				"subnet-1",
-				"subnet-2",
+			expected: []sel{
+				{"subnet-1", false},
+				{"subnet-2", false},
 			},
 		},
 		{
 			input:    []corenetwork.Id{},
-			expected: []corenetwork.Id{},
+			expected: []sel{},
+		},
+		{
+			input: []corenetwork.Id{
+				"subnet-1:ipv6",
+				"subnet-2:ipv6",
+			},
+			expected: []sel{
+				{"subnet-1", true},
+				{"subnet-2", true},
+			},
 		},
 	}
 
 	for _, test := range testCases {
-		got := azure.StripAndDeduplicateSubnetIDs(test.input)
-		c.Check(got, tc.DeepEquals, test.expected, tc.Commentf("StripAndDeduplicateSubnetIDs(%v)", test.input))
+		got := azure.DeduplicateSubnets(test.input)
+		want := make([]azure.SubnetSelection, len(test.expected))
+		for i, s := range test.expected {
+			want[i] = azure.SubnetSelection{ID: corenetwork.Id(s.id), WantIPv6: s.wantIPv6}
+		}
+		c.Check(got, tc.DeepEquals, want, tc.Commentf("DeduplicateSubnets(%v)", test.input))
 	}
 }
 

--- a/internal/provider/azure/environ_network_test.go
+++ b/internal/provider/azure/environ_network_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/internal/provider/azure"
 	"github.com/juju/juju/internal/provider/azure/internal/azuretesting"
 )
 
@@ -278,4 +279,72 @@ func (s *environSuite) TestNetworkInterfacesPartialMatch(c *tc.C) {
 	c.Assert(res, tc.HasLen, 2)
 	c.Assert(res[0], tc.HasLen, 1, tc.Commentf("expected to get 1 NIC for machine-0"))
 	c.Assert(res[1], tc.IsNil, tc.Commentf("expected a nil slice for non-matched machines"))
+}
+
+func (s *environSuite) TestNetworkTemplateResourcesDualStack(c *tc.C) {
+	// networkTemplateResources should always produce a dual-stack VNet
+	// and dual-stack subnets, regardless of any constraint.
+	resources, deps := azure.NetworkTemplateResources("westus", s.envTags, []int{17070}, nil)
+
+	// First resource: NSG.
+	c.Assert(resources, tc.HasLen, 2)
+	c.Check(resources[0].Name, tc.Equals, azure.SecurityGroupName)
+
+	// Second resource: VNet.
+	vnet := resources[1]
+	c.Check(vnet.Name, tc.Equals, azure.InternalNetworkName)
+
+	vnetProps, ok := vnet.Properties.(*armnetwork.VirtualNetworkPropertiesFormat)
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(vnetProps.AddressSpace, tc.NotNil)
+
+	// VNet address space must include both IPv4 prefixes and the IPv6 ULA prefix.
+	addrPrefixes := vnetProps.AddressSpace.AddressPrefixes
+	c.Assert(addrPrefixes, tc.HasLen, 3)
+	c.Check(toValue(addrPrefixes[0]), tc.Equals, azure.InternalSubnetPrefix)
+	c.Check(toValue(addrPrefixes[1]), tc.Equals, azure.VnetIPv6Prefix)
+	c.Check(toValue(addrPrefixes[2]), tc.Equals, azure.ControllerSubnetPrefix)
+
+	// Subnets: internal + controller (since apiPorts is non-empty).
+	c.Assert(vnetProps.Subnets, tc.HasLen, 2)
+
+	internalSubnet := vnetProps.Subnets[0]
+	c.Assert(toValue(internalSubnet.Name), tc.Equals, azure.InternalSubnetName)
+	c.Assert(internalSubnet.Properties.AddressPrefixes, tc.HasLen, 2)
+	c.Check(toValue(internalSubnet.Properties.AddressPrefixes[0]), tc.Equals, azure.InternalSubnetPrefix)
+	c.Check(toValue(internalSubnet.Properties.AddressPrefixes[1]), tc.Equals, azure.InternalSubnetIPv6Prefix)
+	// AddressPrefix (singular) should be nil when using AddressPrefixes.
+	c.Check(internalSubnet.Properties.AddressPrefix, tc.IsNil)
+
+	controllerSubnet := vnetProps.Subnets[1]
+	c.Assert(toValue(controllerSubnet.Name), tc.Equals, azure.ControllerSubnetName)
+	c.Assert(controllerSubnet.Properties.AddressPrefixes, tc.HasLen, 2)
+	c.Check(toValue(controllerSubnet.Properties.AddressPrefixes[0]), tc.Equals, azure.ControllerSubnetPrefix)
+	c.Check(toValue(controllerSubnet.Properties.AddressPrefixes[1]), tc.Equals, azure.ControllerSubnetIPv6Prefix)
+
+	// NSG ID is returned as a dependency.
+	c.Assert(deps, tc.HasLen, 1)
+}
+
+func (s *environSuite) TestNetworkTemplateResourcesNoControllerSubnet(c *tc.C) {
+	// When no API ports are given, no controller subnet should be created,
+	// but the VNet and internal subnet should still be dual-stack.
+	resources, _ := azure.NetworkTemplateResources("westus", s.envTags, nil, nil)
+
+	c.Assert(resources, tc.HasLen, 2)
+	vnet := resources[1]
+
+	vnetProps, ok := vnet.Properties.(*armnetwork.VirtualNetworkPropertiesFormat)
+	c.Assert(ok, tc.IsTrue)
+
+	// VNet: internal IPv4 + IPv6 ULA only (no controller prefix).
+	addrPrefixes := vnetProps.AddressSpace.AddressPrefixes
+	c.Assert(addrPrefixes, tc.HasLen, 2)
+	c.Check(toValue(addrPrefixes[0]), tc.Equals, azure.InternalSubnetPrefix)
+	c.Check(toValue(addrPrefixes[1]), tc.Equals, azure.VnetIPv6Prefix)
+
+	// Only one subnet (internal, no controller).
+	c.Assert(vnetProps.Subnets, tc.HasLen, 1)
+	c.Assert(vnetProps.Subnets[0].Properties.AddressPrefixes, tc.HasLen, 2)
+	c.Check(toValue(vnetProps.Subnets[0].Properties.AddressPrefixes[1]), tc.Equals, azure.InternalSubnetIPv6Prefix)
 }

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2407,6 +2407,36 @@ func (s *environSuite) TestStartInstanceIPFamilyDualPlacementIPv4OnlySubnet(c *t
 		`.*placement subnet "subnet2" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
 }
 
+func (s *environSuite) TestStartInstanceIPFamilyDualPlacementNon64IPv6Subnet(c *tc.C) {
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("192.168.0.0/20"),
+		},
+	}, {
+		ID:   new("/path/to/subnet3"),
+		Name: new("subnet3"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{new("10.0.0.0/24"), new("fd00::/56")}, // IPv6 /56, not /64
+		},
+	}}
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets:   subnets,
+	})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Placement = "subnet=subnet3"
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	_, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorMatches,
+		`.*placement subnet "subnet3" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
+}
+
 func (s *environSuite) TestConstraintsValidatorVocabulary(c *tc.C) {
 	validator := s.constraintsValidator(c)
 	_, err := validator.Validate(constraints.MustParse("arch=s390x"))

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2641,6 +2641,121 @@ func (s *environSuite) TestStartInstanceIPFamilyDualSpaceConstraintDualStackSubn
 	})
 }
 
+func (s *environSuite) TestStartInstanceIPv6SpaceConstraintIPv4Family(c *tc.C) {
+	// When a space contains only the :ipv6 variant of a dual-stack subnet
+	// and ip-family=ipv4 is set, the provider must reject the constraint
+	// rather than silently provisioning IPv4-only.
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.IPv4)
+	params.Constraints.Spaces = &[]string{"beta"}
+	params.SubnetsToZones = []map[corenetwork.Id][]string{
+		{"/path/to/subnet1:ipv6": nil},
+	}
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	_, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorMatches,
+		`.*subnet "/path/to/subnet1" was selected via an IPv6-only space; set ip-family=dual to provision an IPv6 address`)
+}
+
+func (s *environSuite) TestStartInstanceIPv6SpaceConstraintDefaultFamily(c *tc.C) {
+	// When a space contains only the :ipv6 variant of a dual-stack subnet
+	// and ip-family is not set (default), the provider must reject the
+	// constraint rather than silently provisioning IPv4-only.
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.Spaces = &[]string{"beta"}
+	params.SubnetsToZones = []map[corenetwork.Id][]string{
+		{"/path/to/subnet1:ipv6": nil},
+	}
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	_, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorMatches,
+		`.*subnet "/path/to/subnet1" was selected via an IPv6-only space; set ip-family=dual to provision an IPv6 address`)
+}
+
+func (s *environSuite) TestStartInstanceIPv6SpaceConstraintPlacement(c *tc.C) {
+	// When placement targets a subnet whose space only has the :ipv6
+	// variant and ip-family is not set, the provider must still detect
+	// the violation. Previously the :ipv6 suffix was silently dropped
+	// at the placement-dedup merge.
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{new("192.168.0.0/20"), new("fd00::/64")},
+		},
+	}}
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets:   subnets,
+	})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.Spaces = &[]string{"beta"}
+	params.SubnetsToZones = []map[corenetwork.Id][]string{
+		{"/path/to/subnet1:ipv6": nil},
+	}
+	params.Placement = "subnet=subnet1"
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	_, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorMatches,
+		`.*subnet "/path/to/subnet1" was selected via an IPv6-only space; set ip-family=dual to provision an IPv6 address`)
+}
+
+func (s *environSuite) TestStartInstanceIPv6SpaceConstraintDualFamily(c *tc.C) {
+	// When ip-family=dual is set and the space contains only the :ipv6
+	// variant, provisioning should succeed with IPv6 on the primary NIC.
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{new("192.168.0.0/20"), new("fd00::/64")},
+		},
+	}}
+	s.sender = azuretesting.Senders{
+		makeSender(".*/skus", armcompute.ResourceSKUsResult{Value: s.skus}),
+		makeSender(".*/Canonical/.*/0001-com-ubuntu-server-jammy/skus", s.ubuntuServerSKUs),
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: subnets,
+		}),
+		makeSender("/deployments/juju-06f00d-0", s.deployment),
+	}
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Constraints.Spaces = &[]string{"beta"}
+	params.SubnetsToZones = []map[corenetwork.Id][]string{
+		{"/path/to/subnet1:ipv6": nil},
+	}
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference:      &jammyImageReferenceGen2,
+		diskSizeGB:          32,
+		osProfile:           &s.linuxOsProfile,
+		instanceType:        "Standard_A1",
+		publicIP:            true,
+		subnets:             []string{"/path/to/subnet1"},
+		hasSpaceConstraints: true,
+		dualStackIPFamily:   true,
+	})
+}
+
 func (s *environSuite) TestConstraintsValidatorVocabulary(c *tc.C) {
 	validator := s.constraintsValidator(c)
 	_, err := validator.Validate(constraints.MustParse("arch=s390x"))

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2272,7 +2272,16 @@ func (s *environSuite) TestBootstrapIPFamilyDualStandardSKUAccepted(c *tc.C) {
 
 func (s *environSuite) TestStartInstanceIPFamilyDual(c *tc.C) {
 	env := s.openEnviron(c)
-	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets: []*armnetwork.Subnet{{
+			ID:   new("/virtualNetworks/juju-internal-network/subnet/juju-internal-subnet"),
+			Name: new("juju-internal-subnet"),
+			Properties: &armnetwork.SubnetPropertiesFormat{
+				AddressPrefixes: []*string{new("192.168.0.0/20"), new("fd00::/64")},
+			},
+		}},
+	})
 	s.requests = nil
 	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
 	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
@@ -2315,7 +2324,16 @@ func (s *environSuite) TestStartInstanceIPFamilyIPv4(c *tc.C) {
 
 func (s *environSuite) TestStartInstanceIPFamilyDualNoPublicIP(c *tc.C) {
 	env := s.openEnviron(c)
-	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets: []*armnetwork.Subnet{{
+			ID:   new("/virtualNetworks/juju-internal-network/subnet/juju-internal-subnet"),
+			Name: new("juju-internal-subnet"),
+			Properties: &armnetwork.SubnetPropertiesFormat{
+				AddressPrefixes: []*string{new("192.168.0.0/20"), new("fd00::/64")},
+			},
+		}},
+	})
 	s.requests = nil
 	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
 	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
@@ -2404,7 +2422,7 @@ func (s *environSuite) TestStartInstanceIPFamilyDualPlacementIPv4OnlySubnet(c *t
 
 	_, err := env.StartInstance(c.Context(), params)
 	c.Assert(err, tc.ErrorMatches,
-		`.*placement subnet "subnet2" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
+		`.*subnet "subnet2" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
 }
 
 func (s *environSuite) TestStartInstanceIPFamilyDualPlacementNon64IPv6Subnet(c *tc.C) {
@@ -2434,7 +2452,73 @@ func (s *environSuite) TestStartInstanceIPFamilyDualPlacementNon64IPv6Subnet(c *
 
 	_, err := env.StartInstance(c.Context(), params)
 	c.Assert(err, tc.ErrorMatches,
-		`.*placement subnet "subnet3" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
+		`.*subnet "subnet3" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDualSpaceConstraintIPv4OnlySubnet(c *tc.C) {
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("192.168.0.0/20"),
+		},
+	}}
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap:           false,
+		hasSpaceConstraints: true,
+		subnets:             subnets,
+	})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Constraints.Spaces = &[]string{"foo"}
+	params.SubnetsToZones = []map[corenetwork.Id][]string{
+		{"/path/to/subnet1": nil},
+	}
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference:      &jammyImageReferenceGen2,
+		diskSizeGB:          32,
+		osProfile:           &s.linuxOsProfile,
+		instanceType:        "Standard_A1",
+		publicIP:            true,
+		subnets:             []string{"/path/to/subnet1"},
+		hasSpaceConstraints: true,
+		dualStackIPFamily:   true,
+	})
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDualLegacyIPv4OnlySubnet(c *tc.C) {
+	// When ip-family=dual is set without placement, the provider proceeds
+	// to create the VM. The Juju-managed VNet template always creates
+	// dual-stack subnets, so this is safe. If the user configured a
+	// virtual-network-name with an IPv4-only subnet, Azure itself rejects
+	// the NIC creation — Juju does not pre-validate this path.
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference:    &jammyImageReferenceGen2,
+		diskSizeGB:        32,
+		osProfile:         &s.linuxOsProfile,
+		instanceType:      "Standard_A1",
+		publicIP:          true,
+		dualStackIPFamily: true,
+	})
 }
 
 func (s *environSuite) TestConstraintsValidatorVocabulary(c *tc.C) {

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2641,6 +2641,36 @@ func (s *environSuite) TestStartInstanceIPFamilyDualSpaceConstraintDualStackSubn
 	})
 }
 
+func (s *environSuite) TestStartInstanceIPFamilyDualSpaceConstraintSubnetResolutionMiss(c *tc.C) {
+	// When ip-family=dual is set with a space constraint and the
+	// selected subnet ID cannot be resolved against Azure's subnets,
+	// the provider should log a warning, skip the IPv6 /64 pre-check,
+	// and proceed — relying on Azure to reject the NIC if the subnet
+	// lacks IPv6.
+	env := s.openEnviron(c)
+	s.sender = azuretesting.Senders{
+		makeSender(".*/skus", armcompute.ResourceSKUsResult{Value: s.skus}),
+		makeSender(".*/Canonical/.*/0001-com-ubuntu-server-jammy/skus", s.ubuntuServerSKUs),
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: []*armnetwork.Subnet{},
+		}),
+		makeSender("/deployments/juju-06f00d-0", s.deployment),
+	}
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Constraints.Spaces = &[]string{"foo"}
+	params.SubnetsToZones = []map[corenetwork.Id][]string{
+		{"/path/to/subnet1": nil},
+	}
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+}
+
 func (s *environSuite) TestStartInstanceIPv6SpaceConstraintIPv4Family(c *tc.C) {
 	// When a space contains only the :ipv6 variant of a dual-stack subnet
 	// and ip-family=ipv4 is set, the provider must reject the constraint

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network/ipfamily"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -1113,6 +1114,7 @@ type assertStartInstanceRequestsParams struct {
 	hasSpaceConstraints    bool
 	managedIdentity        string
 	storageAccountType     *armcompute.StorageAccountType
+	dualStackIPFamily      bool // ip-family=dual: expect IPv6 PIP + IPv6 NIC IP config
 }
 
 func (s *environSuite) assertStartInstanceRequests(
@@ -1186,7 +1188,7 @@ func (s *environSuite) assertStartInstanceRequests(
 	subnets := []*armnetwork.Subnet{{
 		Name: new("juju-internal-subnet"),
 		Properties: &armnetwork.SubnetPropertiesFormat{
-			AddressPrefix: new("192.168.0.0/20"),
+			AddressPrefixes: []*string{new("192.168.0.0/20"), new("fd00::/64")},
 			NetworkSecurityGroup: &armnetwork.SecurityGroup{
 				ID: new(nsgId),
 			},
@@ -1194,7 +1196,7 @@ func (s *environSuite) assertStartInstanceRequests(
 	}, {
 		Name: new("juju-controller-subnet"),
 		Properties: &armnetwork.SubnetPropertiesFormat{
-			AddressPrefix: new("192.168.16.0/20"),
+			AddressPrefixes: []*string{new("192.168.16.0/20"), new("fd00:0:0:10::/64")},
 			NetworkSecurityGroup: &armnetwork.SecurityGroup{
 				ID: new(nsgId),
 			},
@@ -1215,7 +1217,7 @@ func (s *environSuite) assertStartInstanceRequests(
 	var vmDependsOn []string
 	if bootstrapping {
 		if args.existingNetwork == "" {
-			addressPrefixes := to.SliceOfPtrs("192.168.0.0/20", "192.168.16.0/20")
+			addressPrefixes := to.SliceOfPtrs("192.168.0.0/20", "fd00::/48", "192.168.16.0/20")
 			templateResources = append(templateResources, armtemplates.Resource{
 				APIVersion: azure.NetworkAPIVersion,
 				Type:       "Microsoft.Network/networkSecurityGroups",
@@ -1306,10 +1308,17 @@ func (s *environSuite) assertStartInstanceRequests(
 		}
 	}
 	var publicIPAddress *armnetwork.PublicIPAddress
+	var ipv6PublicIPAddress *armnetwork.PublicIPAddress
 	if args.publicIP {
 		publicIPAddressId := `[resourceId('Microsoft.Network/publicIPAddresses', 'juju-06f00d-0-public-ip')]`
 		publicIPAddress = &armnetwork.PublicIPAddress{
 			ID: new(publicIPAddressId),
+		}
+		if args.dualStackIPFamily {
+			ipv6PIPId := `[resourceId('Microsoft.Network/publicIPAddresses', 'juju-06f00d-0-public-ip-ipv6')]`
+			ipv6PublicIPAddress = &armnetwork.PublicIPAddress{
+				ID: new(ipv6PIPId),
+			}
 		}
 	}
 
@@ -1332,6 +1341,23 @@ func (s *environSuite) assertStartInstanceRequests(
 		if primary && publicIPAddress != nil {
 			ipConfigurations[0].Properties.PublicIPAddress = publicIPAddress
 			nicDependsOn = append(nicDependsOn, *publicIPAddress.ID)
+		}
+		// For dual-stack, add an IPv6 IP configuration to the primary NIC.
+		if primary && args.dualStackIPFamily {
+			ipv6Props := &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+				Primary:                   new(false),
+				PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+				PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+				Subnet:                    &armnetwork.Subnet{ID: new(subnetId)},
+			}
+			if ipv6PublicIPAddress != nil {
+				ipv6Props.PublicIPAddress = ipv6PublicIPAddress
+				nicDependsOn = append(nicDependsOn, *ipv6PublicIPAddress.ID)
+			}
+			ipConfigurations = append(ipConfigurations, &armnetwork.InterfaceIPConfiguration{
+				Name:       new("primary-ipv6"),
+				Properties: ipv6Props,
+			})
 		}
 
 		nicId := fmt.Sprintf(`[resourceId('Microsoft.Network/networkInterfaces', 'juju-06f00d-0-%s')]`, name)
@@ -1389,6 +1415,20 @@ func (s *environSuite) assertStartInstanceRequests(
 			},
 			Sku: &armtemplates.Sku{Name: "Standard"},
 		})
+		if args.dualStackIPFamily {
+			templateResources = append(templateResources, armtemplates.Resource{
+				APIVersion: azure.NetworkAPIVersion,
+				Type:       "Microsoft.Network/publicIPAddresses",
+				Name:       "juju-06f00d-0-public-ip-ipv6",
+				Location:   "westus",
+				Tags:       s.vmTags,
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+				},
+				Sku: &armtemplates.Sku{Name: "Standard"},
+			})
+		}
 	}
 	templateResources = append(templateResources, nicResources...)
 	vmTemplate := armtemplates.Resource{
@@ -2228,6 +2268,143 @@ func (s *environSuite) TestBootstrapIPFamilyDualStandardSKUAccepted(c *tc.C) {
 		return
 	}
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDual(c *tc.C) {
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference:    &jammyImageReferenceGen2,
+		diskSizeGB:        32,
+		osProfile:         &s.linuxOsProfile,
+		instanceType:      "Standard_A1",
+		publicIP:          true,
+		dualStackIPFamily: true,
+	})
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyIPv4(c *tc.C) {
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.IPv4)
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference: &jammyImageReferenceGen2,
+		diskSizeGB:     32,
+		osProfile:      &s.linuxOsProfile,
+		instanceType:   "Standard_A1",
+		publicIP:       true,
+	})
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDualNoPublicIP(c *tc.C) {
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Constraints.AllocatePublicIP = new(bool)
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference:    &jammyImageReferenceGen2,
+		diskSizeGB:        32,
+		osProfile:         &s.linuxOsProfile,
+		instanceType:      "Standard_A1",
+		publicIP:          false,
+		dualStackIPFamily: true,
+	})
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDualPlacementIPv6Subnet(c *tc.C) {
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("192.168.0.0/20"),
+		},
+	}, {
+		ID:   new("/path/to/subnet2"),
+		Name: new("subnet2"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{new("10.0.0.0/24"), new("fd00::/64")},
+		},
+	}}
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets:   subnets,
+	})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Placement = "subnet=subnet2"
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference:    &jammyImageReferenceGen2,
+		diskSizeGB:        32,
+		osProfile:         &s.linuxOsProfile,
+		instanceType:      "Standard_A1",
+		publicIP:          true,
+		subnets:           []string{"/path/to/subnet2"},
+		placementSubnet:   "subnet2",
+		dualStackIPFamily: true,
+	})
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDualPlacementIPv4OnlySubnet(c *tc.C) {
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("192.168.0.0/20"),
+		},
+	}, {
+		ID:   new("/path/to/subnet2"),
+		Name: new("subnet2"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("10.0.0.0/24"),
+		},
+	}}
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets:   subnets,
+	})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Placement = "subnet=subnet2"
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	_, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorMatches,
+		`.*placement subnet "subnet2" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
 }
 
 func (s *environSuite) TestConstraintsValidatorVocabulary(c *tc.C) {

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2270,6 +2270,37 @@ func (s *environSuite) TestBootstrapIPFamilyDualStandardSKUAccepted(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *environSuite) TestStartInstanceIPFamilyDualBootstrapPlacementIPv4OnlySubnet(c *tc.C) {
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("192.168.0.0/20"),
+		},
+	}, {
+		ID:   new("/path/to/subnet2"),
+		Name: new("subnet2"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("10.0.0.0/24"),
+		},
+	}}
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets:   subnets,
+	})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Placement = "subnet=subnet2"
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+	params.InstanceConfig.Bootstrap = &instancecfg.BootstrapConfig{}
+
+	_, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorMatches,
+		`.*subnet "subnet2" does not support ip-family=dual: no IPv6 /64 prefix found; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
+}
+
 func (s *environSuite) TestStartInstanceIPFamilyDual(c *tc.C) {
 	env := s.openEnviron(c)
 	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2422,7 +2422,7 @@ func (s *environSuite) TestStartInstanceIPFamilyDualPlacementIPv4OnlySubnet(c *t
 
 	_, err := env.StartInstance(c.Context(), params)
 	c.Assert(err, tc.ErrorMatches,
-		`.*subnet "subnet2" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
+		`.*subnet "subnet2" does not support ip-family=dual: no IPv6 /64 prefix found; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
 }
 
 func (s *environSuite) TestStartInstanceIPFamilyDualPlacementNon64IPv6Subnet(c *tc.C) {
@@ -2452,7 +2452,7 @@ func (s *environSuite) TestStartInstanceIPFamilyDualPlacementNon64IPv6Subnet(c *
 
 	_, err := env.StartInstance(c.Context(), params)
 	c.Assert(err, tc.ErrorMatches,
-		`.*subnet "subnet3" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
+		`.*subnet "subnet3" does not support ip-family=dual: no IPv6 /64 prefix found; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
 }
 
 func (s *environSuite) TestStartInstanceIPFamilyDualSpaceConstraintIPv4OnlySubnet(c *tc.C) {

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2494,6 +2494,51 @@ func (s *environSuite) TestStartInstanceIPFamilyDualSpaceConstraintIPv4OnlySubne
 	})
 }
 
+func (s *environSuite) TestStartInstanceIPFamilyDualPlacementWithSpaceConstraint(c *tc.C) {
+	// When ip-family=dual is set with both a space constraint and a placement
+	// directive, and the space contains only the :ipv6-suffixed variant of a
+	// dual-stack subnet, the provider must still resolve the placement subnet
+	// correctly.  Previously, the bare placement ID did not match the
+	// :ipv6-suffixed SubnetsToZones key, causing a spurious "subnet not found"
+	// error.
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{new("192.168.0.0/20"), new("fd00::/64")},
+		},
+	}}
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets:   subnets,
+	})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Constraints.Spaces = &[]string{"beta"}
+	params.SubnetsToZones = []map[corenetwork.Id][]string{
+		{"/path/to/subnet1:ipv6": nil},
+	}
+	params.Placement = "subnet=subnet1"
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference:    &jammyImageReferenceGen2,
+		diskSizeGB:        32,
+		osProfile:         &s.linuxOsProfile,
+		instanceType:      "Standard_A1",
+		publicIP:          true,
+		subnets:           []string{"/path/to/subnet1"},
+		placementSubnet:   "subnet1",
+		dualStackIPFamily: true,
+	})
+}
+
 func (s *environSuite) TestStartInstanceIPFamilyDualLegacyIPv4OnlySubnet(c *tc.C) {
 	// When ip-family=dual is set without placement, the provider proceeds
 	// to create the VM. The Juju-managed VNet template always creates

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -1512,7 +1512,13 @@ func (s *environSuite) assertStartInstanceRequests(
 			if args.diskEncryptionSet != "" && args.vaultName != "" {
 				c.Assert(requests, tc.HasLen, numExpectedStartInstanceRequests+4)
 			} else if args.hasSpaceConstraints {
-				c.Assert(requests, tc.HasLen, numExpectedStartInstanceRequests-1)
+				if args.dualStackIPFamily {
+					// Dual + space constraint adds a subnets-list
+					// request from findSubnetByID resolution.
+					c.Assert(requests, tc.HasLen, numExpectedStartInstanceRequests)
+				} else {
+					c.Assert(requests, tc.HasLen, numExpectedStartInstanceRequests-1)
+				}
 			} else if args.withConflictRetry {
 				c.Assert(requests, tc.HasLen, numExpectedStartInstanceRequests+3)
 			} else if args.withQuotaRetry {
@@ -1543,6 +1549,9 @@ func (s *environSuite) assertStartInstanceRequests(
 		c.Assert(requests[nexti()].Method, tc.Equals, "GET") // wait for common deployment
 		if len(args.subnets) == 0 {
 			c.Assert(requests[nexti()].Method, tc.Equals, "GET") // subnets
+		}
+		if args.hasSpaceConstraints && args.dualStackIPFamily {
+			c.Assert(requests[nexti()].Method, tc.Equals, "GET") // subnets (findSubnetByID)
 		}
 	}
 	if args.placementSubnet != "" {
@@ -2487,6 +2496,9 @@ func (s *environSuite) TestStartInstanceIPFamilyDualPlacementNon64IPv6Subnet(c *
 }
 
 func (s *environSuite) TestStartInstanceIPFamilyDualSpaceConstraintIPv4OnlySubnet(c *tc.C) {
+	// When ip-family=dual is set with a space constraint and the selected
+	// subnet is IPv4-only, the provider should fail validation early
+	// instead of deferring to Azure.
 	env := s.openEnviron(c)
 	subnets := []*armnetwork.Subnet{{
 		ID:   new("/path/to/subnet1"),
@@ -2495,11 +2507,20 @@ func (s *environSuite) TestStartInstanceIPFamilyDualSpaceConstraintIPv4OnlySubne
 			AddressPrefix: new("192.168.0.0/20"),
 		},
 	}}
-	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
-		bootstrap:           false,
-		hasSpaceConstraints: true,
-		subnets:             subnets,
-	})
+	// Build senders manually because the space-constraint + dual path
+	// makes extra API calls (common-deployment + subnets-list for
+	// findSubnetByID). Senders are consumed sequentially:
+	//   tenantID, RG → consumed by openEnviron
+	//   resourceSKUs, ubuntuSKUs, common-deployment, subnets-list
+	//   → consumed by StartInstance
+	s.sender = azuretesting.Senders{
+		makeSender(".*/skus", armcompute.ResourceSKUsResult{Value: s.skus}),
+		makeSender(".*/Canonical/.*/0001-com-ubuntu-server-jammy/skus", s.ubuntuServerSKUs),
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: subnets,
+		}),
+	}
 	s.requests = nil
 	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
 	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
@@ -2509,20 +2530,9 @@ func (s *environSuite) TestStartInstanceIPFamilyDualSpaceConstraintIPv4OnlySubne
 	}
 	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
 
-	result, err := env.StartInstance(c.Context(), params)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(result, tc.NotNil)
-
-	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
-		imageReference:      &jammyImageReferenceGen2,
-		diskSizeGB:          32,
-		osProfile:           &s.linuxOsProfile,
-		instanceType:        "Standard_A1",
-		publicIP:            true,
-		subnets:             []string{"/path/to/subnet1"},
-		hasSpaceConstraints: true,
-		dualStackIPFamily:   true,
-	})
+	_, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorMatches,
+		`.*subnet "subnet1" does not support ip-family=dual: no IPv6 /64 prefix found; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
 }
 
 func (s *environSuite) TestStartInstanceIPFamilyDualPlacementWithSpaceConstraint(c *tc.C) {
@@ -2571,11 +2581,9 @@ func (s *environSuite) TestStartInstanceIPFamilyDualPlacementWithSpaceConstraint
 }
 
 func (s *environSuite) TestStartInstanceIPFamilyDualLegacyIPv4OnlySubnet(c *tc.C) {
-	// When ip-family=dual is set without placement, the provider proceeds
-	// to create the VM. The Juju-managed VNet template always creates
-	// dual-stack subnets, so this is safe. If the user configured a
-	// virtual-network-name with an IPv4-only subnet, Azure itself rejects
-	// the NIC creation — Juju does not pre-validate this path.
+	// When ip-family=dual is set without placement, the provider validates
+	// the resolved default subnet. If it is IPv4-only, validation should fail
+	// early rather than deferring to Azure.
 	env := s.openEnviron(c)
 	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
 	s.requests = nil
@@ -2583,17 +2591,53 @@ func (s *environSuite) TestStartInstanceIPFamilyDualLegacyIPv4OnlySubnet(c *tc.C
 	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
 	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
 
+	_, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorMatches,
+		`.*subnet "juju-internal-subnet" does not support ip-family=dual: no IPv6 /64 prefix found; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDualSpaceConstraintDualStackSubnet(c *tc.C) {
+	// When ip-family=dual is set with a space constraint and the selected
+	// subnet is dual-stack, the provider should succeed.
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{new("192.168.0.0/20"), new("fd00::/64")},
+		},
+	}}
+	s.sender = azuretesting.Senders{
+		makeSender(".*/skus", armcompute.ResourceSKUsResult{Value: s.skus}),
+		makeSender(".*/Canonical/.*/0001-com-ubuntu-server-jammy/skus", s.ubuntuServerSKUs),
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: subnets,
+		}),
+		makeSender("/deployments/juju-06f00d-0", s.deployment),
+	}
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Constraints.Spaces = &[]string{"foo"}
+	params.SubnetsToZones = []map[corenetwork.Id][]string{
+		{"/path/to/subnet1": nil},
+	}
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
 	result, err := env.StartInstance(c.Context(), params)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result, tc.NotNil)
 
 	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
-		imageReference:    &jammyImageReferenceGen2,
-		diskSizeGB:        32,
-		osProfile:         &s.linuxOsProfile,
-		instanceType:      "Standard_A1",
-		publicIP:          true,
-		dualStackIPFamily: true,
+		imageReference:      &jammyImageReferenceGen2,
+		diskSizeGB:          32,
+		osProfile:           &s.linuxOsProfile,
+		instanceType:        "Standard_A1",
+		publicIP:            true,
+		subnets:             []string{"/path/to/subnet1"},
+		hasSpaceConstraints: true,
+		dualStackIPFamily:   true,
 	})
 }
 

--- a/internal/provider/azure/export_test.go
+++ b/internal/provider/azure/export_test.go
@@ -7,6 +7,9 @@ const ComputeAPIVersion = computeAPIVersion
 const NetworkAPIVersion = networkAPIVersion
 
 var NetworkTemplateResources = networkTemplateResources
+var SubnetProviderIDForFamily = subnetProviderIDForFamily
+var StripIPFamilySuffix = stripIPFamilySuffix
+var StripAndDeduplicateSubnetIDs = stripAndDeduplicateSubnetIDs
 
 const SecurityGroupName = internalSecurityGroupName
 const InternalNetworkName = internalNetworkName

--- a/internal/provider/azure/export_test.go
+++ b/internal/provider/azure/export_test.go
@@ -3,6 +3,16 @@
 
 package azure
 
+import (
+	"context"
+
+	azurenetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
+)
+
 const ComputeAPIVersion = computeAPIVersion
 const NetworkAPIVersion = networkAPIVersion
 
@@ -20,3 +30,11 @@ const ControllerSubnetPrefix = controllerSubnetPrefix
 const InternalSubnetIPv6Prefix = internalSubnetIPv6Prefix
 const ControllerSubnetIPv6Prefix = controllerSubnetIPv6Prefix
 const VnetIPv6Prefix = vnetIPv6Prefix
+
+func FindSubnetByID(ctx context.Context, env environs.Environ, id network.Id) (*azurenetwork.Subnet, error) {
+	azEnv, ok := env.(*azureEnviron)
+	if !ok {
+		return nil, errors.Errorf("expected *azureEnviron, got %T", env)
+	}
+	return azEnv.findSubnetByID(ctx, id)
+}

--- a/internal/provider/azure/export_test.go
+++ b/internal/provider/azure/export_test.go
@@ -5,3 +5,15 @@ package azure
 
 const ComputeAPIVersion = computeAPIVersion
 const NetworkAPIVersion = networkAPIVersion
+
+var NetworkTemplateResources = networkTemplateResources
+
+const SecurityGroupName = internalSecurityGroupName
+const InternalNetworkName = internalNetworkName
+const InternalSubnetName = internalSubnetName
+const ControllerSubnetName = controllerSubnetName
+const InternalSubnetPrefix = internalSubnetPrefix
+const ControllerSubnetPrefix = controllerSubnetPrefix
+const InternalSubnetIPv6Prefix = internalSubnetIPv6Prefix
+const ControllerSubnetIPv6Prefix = controllerSubnetIPv6Prefix
+const VnetIPv6Prefix = vnetIPv6Prefix

--- a/internal/provider/azure/export_test.go
+++ b/internal/provider/azure/export_test.go
@@ -19,7 +19,9 @@ const NetworkAPIVersion = networkAPIVersion
 var NetworkTemplateResources = networkTemplateResources
 var SubnetProviderIDForFamily = subnetProviderIDForFamily
 var StripIPFamilySuffix = stripIPFamilySuffix
-var StripAndDeduplicateSubnetIDs = stripAndDeduplicateSubnetIDs
+var DeduplicateSubnets = deduplicateSubnets
+
+type SubnetSelection = subnetSelection
 
 const SecurityGroupName = internalSecurityGroupName
 const InternalNetworkName = internalNetworkName

--- a/internal/provider/azure/networking.go
+++ b/internal/provider/azure/networking.go
@@ -42,6 +42,19 @@ const (
 	// controllerSubnetPrefix is the address prefix for the subnet that
 	// each controller machine's primary NIC is attached to.
 	controllerSubnetPrefix = "192.168.16.0/20"
+
+	// vnetIPv6Prefix is the ULA IPv6 address prefix added to the VNet
+	// address space to enable dual-stack networking.
+	vnetIPv6Prefix = "fd00::/48"
+
+	// internalSubnetIPv6Prefix is the IPv6 address prefix added to the
+	// internal subnet for dual-stack machines.
+	internalSubnetIPv6Prefix = "fd00::/64"
+
+	// controllerSubnetIPv6Prefix is the IPv6 address prefix added to the
+	// controller subnet for dual-stack machines. It uses a distinct /64
+	// to avoid overlap with the internal subnet.
+	controllerSubnetIPv6Prefix = "fd00:0:0:10::/64"
 )
 
 const (
@@ -132,19 +145,19 @@ func networkTemplateResources(
 	subnets := []*armnetwork.Subnet{{
 		Name: new(internalSubnetName),
 		Properties: &armnetwork.SubnetPropertiesFormat{
-			AddressPrefix: new(internalSubnetPrefix),
+			AddressPrefixes: []*string{new(internalSubnetPrefix), new(internalSubnetIPv6Prefix)},
 			NetworkSecurityGroup: &armnetwork.SecurityGroup{
 				ID: new(nsgID),
 			},
 		},
 	}}
-	addressPrefixes := []*string{new(internalSubnetPrefix)}
+	addressPrefixes := []*string{new(internalSubnetPrefix), new(vnetIPv6Prefix)}
 	if len(apiPorts) > 0 {
 		addressPrefixes = append(addressPrefixes, new(controllerSubnetPrefix))
 		subnets = append(subnets, &armnetwork.Subnet{
 			Name: new(controllerSubnetName),
 			Properties: &armnetwork.SubnetPropertiesFormat{
-				AddressPrefix: new(controllerSubnetPrefix),
+				AddressPrefixes: []*string{new(controllerSubnetPrefix), new(controllerSubnetIPv6Prefix)},
 				NetworkSecurityGroup: &armnetwork.SecurityGroup{
 					ID: new(nsgID),
 				},


### PR DESCRIPTION
This PR implements Task 3 of the JUJU-9599 ip-family implementation plan.
When `ip-family=dual` is set, the Azure provider now allocates an IPv6
public IP alongside the existing IPv4 public IP and configures the primary
NIC with two IP configurations (IPv4 + IPv6). The Juju-managed VNet and
subnet are always created as dual-stack; only the VM-level artefacts (second
public IP, second NIC IP config) are conditional on the constraint.

**New Commit (Task 3b)**: This PR also includes a follow-up fix (JUJU-9876) that 
correctly exposes dual-stack Azure subnets via `allSubnets()` and `NetworkInterfaces()`. 
The Azure provider now properly handles IPv6 suffixes in dual-stack subnets, preventing 
synthetic `/128` host-only subnets from appearing in `juju subnets` output.

**Note:** Those suffixes for ipv6 provider id may clash with adding ipv6 subnets to already discovered set.
This will requires https://github.com/juju/juju/issues/22710 to be fixed but can be done independently.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests)~ (integration tests are deferred to Task 4 of the implementation plan)
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451)~ (no new packages added or changed)

## QA steps

> **Note:** Integration tests are deferred to Task 4 of the implementation
> plan. The unit tests in this PR exercise `networkTemplateResources`
> directly and the `StartInstance` paths for each IPFamily mode.

> **Known limitation (out of scope for this PR):** QA Step 2 below
> (`set-model-constraints ip-family=dual` then `add-machine`) does not
> currently propagate the model-level constraint to the provisioner in the
> new DQLite domain layer. This is a pre-existing gap, not specific to
> Azure, and is tracked as [juju/juju#22735](https://github.com/juju/juju/issues/22735)
> Steps 1, 3, 4, 5 below all use per-machine/per-bootstrap constraints and are unaffected.

### 1. Bootstrap constraint

```sh
juju bootstrap azure --bootstrap-constraints "ip-family=dual"
```

Confirm the controller VM has both an IPv4 and an IPv6 public IP:

```sh
az network public-ip list --resource-group <juju-resource-group> \
  --query "[].{Name:name, Version:publicIPAddressVersion, IP:ipAddress}"
```

Confirm `juju model-constraints` reports `ip-family=dual`.

### 2. Model constraint — add-machine after set-model-constraints

> **Blocked** by [juju/juju#22735](https://github.com/juju/juju/issues/22735) —
> model-constraint propagation gap in the domain-layer provisioner.

```sh
juju set-model-constraints ip-family=dual
juju add-machine
```

Expected today: VM is IPv4-only (model constraint not propagated to the
provisioner). Will start working once the follow-up is merged.

### 3. Per-machine add-machine constraint

```sh
juju add-machine --constraints "ip-family=dual"
```

Confirm the new machine has both an IPv4 and an IPv6 public IP.

### 4. Application deploy constraint

```sh
juju deploy ubuntu --constraints "ip-family=dual"
```

Confirm all units of the application have both an IPv4 and an IPv6 public
IP.

### 5. IPv6 reachability

Find the machine's public IPv6 address. juju show-machine lists every
address with its scope; the dual-stack machine reports both an IPv4 and an
IPv6 public address:

    juju show-machine 0 --format yaml | grep -A2 -i /128

Probe ingress by connecting to that public IPv6 over SSH. Port 22 is the only
port opened for IPv6 inbound at the NSG (SourceAddressPrefix '*'), so connect
directly to the public IPv6 address:

    ssh -6 ubuntu@<public-ipv6-address> -- hostname

This will fail because you don't have the proper ssh key, but it is enough to prove reachability.

Note: the Juju API port is bound to the IPv4 controller subnet prefix and is
intentionally not reachable over IPv6, so SSH is the correct ingress probe.

### 6. Regression guard

Bootstrap without `ip-family` and confirm it still succeeds with an
IPv4-only controller.

---

## NEW QA Steps: Verify Dual-Stack Subnet Exposure (JUJU-9876)

These steps verify that the dual-stack subnet read paths correctly expose both IPv4 and IPv6 prefixes.

### 7. Bootstrap and provision dual-stack machine

```bash
juju bootstrap azure/eastus <controller> --bootstrap-constraints "ip-family=dual"
juju add-machine --constraints "ip-family=dual"
juju wait-for machine 1 "agent-status=idle" "instance-status=running"
```

### 8. Verify subnets show both IPv4 and IPv6 prefixes

```bash
juju subnets
```

**Expected output**: Both IPv4 and IPv6 subnet entries with distinct `provider-id` values:
- IPv4 entry: bare provider-id (e.g., `/subscriptions/.../subnets/juju-internal-subnet`)
- IPv6 entry: provider-id suffixed with `:ipv6` (e.g., `/subscriptions/.../subnets/juju-internal-subnet:ipv6`)
- **NO** synthetic `/128` host-only entries

**Example**:
```
subnets:
  192.168.0.0/20:
    type: ipv4
    provider-id: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/juju-abc123/providers/Microsoft.Network/virtualNetworks/juju-internal-network/subnets/juju-internal-subnet
    space: alpha
    zones:
    - ""
  fd00::/64:
    type: ipv6
    provider-id: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/juju-abc123/providers/Microsoft.Network/virtualNetworks/juju-internal-network/subnets/juju-internal-subnet:ipv6
    space: alpha
    zones:
    - ""
```

### 9. Verify machine addresses tagged with correct per-family CIDR

```bash
juju show-machine 1 --format yaml
```

**Expected**: 
- IPv4 address tagged with IPv4 subnet CIDR: `subnet-cidr: 192.168.0.0/20`
- IPv6 address tagged with IPv6 subnet CIDR: `subnet-cidr: fd00::/64` (NOT the IPv4 CIDR)

**Example**:
```yaml
machines:
  "1":
    machine-status:
      current: started
    instance-id: <instance-id>
    network-interfaces:
    - addresses:
      - address: 192.168.0.10
        subnet-cidr: 192.168.0.0/20
        provider-subnet-id: /subscriptions/.../subnets/juju-internal-subnet
      - address: fd00::10
        subnet-cidr: fd00::/64
        provider-subnet-id: /subscriptions/.../subnets/juju-internal-subnet:ipv6
```

### 10. Test space operations with dual-stack machine

```bash
juju create-space dual-test
juju move-to-space dual-test machine:1
juju show-machine 1 --format yaml
```

**Expected**: Space assignment succeeds and addresses maintain correct per-family CIDR tags.

### 11. Regression: IPv4-only machines unchanged

```bash
juju add-machine  # no ip-family constraint
juju wait-for machine 2 "agent-status=idle"
juju subnets
juju show-machine 2 --format yaml
```

**Expected**:
- Only IPv4 subnet entry (no IPv6)
- Addresses tagged with IPv4 CIDR only
- No `/128` host-only entries
- Exact same behavior as before

### 11. Bootstrap with placement on an IPv4-only subnet (should fail)

Create or identify an IPv4-only subnet in an existing VNet

```sh
az network vnet create -g my-rg -n my-vnet --address-prefix 10.0.0.0/16
az network vnet subnet create -g my-rg --vnet-name my-vnet -n ipv4-only --address-prefix 10.0.1.0/24
```

bootstrap:

```sh
juju bootstrap azure my-controller \
    --bootstrap-constraints "ip-family=dual" \
    --to subnet=ipv4-only
```

**Expected:** Bootstrap fails early with:

`subnet "ipv4-only" does not support ip-family=dual: no IPv6 /64 prefix found;
add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`

**Regression check:** The same bootstrap without ip-family=dual should succeed normally.


### 12. Bootstrap with placement on a dual-stack subnet (should succeed)

Tests that the fix doesn't break the happy path.

Create a dual-stack subnet

```sh
az network vnet create -g my-rg -n my-vnet --address-prefix 10.0.0.0/16
az network vnet subnet create -g my-rg --vnet-name my-vnet -n dual-stack \
    --address-prefixes 10.0.1.0/24 fd00::/64
```
Bootstrap:

```sh
juju bootstrap azure my-controller \
    --bootstrap-constraints "ip-family=dual" \
    --to subnet=dual-stack
```

**Expected:** Bootstrap succeeds. Controller VM has both IPv4 and IPv6 public IPs.


### 13. Add-machine with dual-stack, space constraint, and placement

`juju bootstrap azure my-controller --bootstrap-constraints "ip-family=dual"`

Create a space containing only the IPv6 variant of a dual-stack subnet

```sh
juju add-space dual
juju move-to-space dual <ipv6-subnet-cidr>
```

Add a machine with placement into that subnet, using dual-stack

```sh
juju add-machine --constraints "ip-family=dual" --to subnet=<subnet-name>
```

**Expected:** Machine is provisioned successfully. Without the fix, this would fail with a spurious "subnet not found" error because the bare placement ID didn't match the :ipv6-suffixed ID from SubnetsToZones.

### 14. Add-machine with no dual-stack, space constraint to a ipv6 only space

`juju bootstrap azure my-controller`

Create a space containing only the IPv6 variant of a dual-stack subnet

```sh
juju add-space ipv6
juju move-to-space ipv6 <ipv6-subnet-cidr>
```

Add a machine with spaces constraint, but no ip-family constraint

```sh
juju add-machine --constraints "spaces=ipv6"
```

**Expected:** Machine isn't provisioned, the space violate the constraint (no subnets in the space for this machine)

`juju show-machine 0` should return something like:

```sh
machines:
  "0":
    instance-id: pending
    machine-status:
      current: allocating
      message: 'failed to start machine 0 (creating virtual machine "juju-4c3733-0":
        subnet "/subscriptions/a0e9f101-e490-4b63-8f13-81df0609cbc1/resourceGroups/juju-test-81f5629d/providers/Microsoft.Network/virtualNetworks/juju-internal-network/subnets/juju-internal-subnet"
        was selected via an IPv6-only space; set ip-family=dual to provision an IPv6
        address), retrying in 10s (5 more attempts)'
```

If you deploy with constraints `spaces=ipv6 ip-family=dual` however, the machine is successfully provisionned.

## Documentation changes

None. User-facing documentation updates are deferred to Task 5 of the
implementation plan.

## Links

**Jira card:** [JUJU-9876](https://warthogs.atlassian.net/browse/JUJU-9876)
**Implementation plan:** [JUJU-9599 implementation plan](https://github.com/juju/juju-agent-specs/blob/main/2610/JUJU-9599/implementation_plan.md)
**Spec:** [JUJU-9599 spec](https://github.com/juju/juju-agent-specs/blob/main/2610/JUJU-9599/spec.md)
**Dual-stack subnet exposure spec:** [juju-agent-specs PR #24](https://github.com/juju/juju-agent-specs/pull/24)

[JUJU-9876]: https://warthogs.atlassian.net/browse/JUJU-9876
