### PR TITLE
fix: constraint errors when removing machines with storage

### DIFF
--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -589,32 +589,6 @@ WHERE uuid = $machine.uuid;
 			return errors.Errorf("getting net node: %w", err)
 		}
 
-		// Before proceeding, check that no units (including dead ones) still
-		// reference this machine's net node. Dead units that have not yet been
-		// deleted from the DB hold a FK reference to net_node, so attempting to
-		// delete the net_node while they exist will cause a constraint
-		// violation. Return RemovalJobIncomplete so the machine removal job
-		// retries once the unit removal job has finished.
-		// This applies unconditionally: even force removals cascade separate
-		// removal jobs for units, so by the time this runs those jobs must have
-		// completed.
-		countUnitsOnNetNodeStmt, err := st.Prepare(`
-SELECT COUNT(*) AS &count.count
-FROM   unit
-WHERE  net_node_uuid = $node.uuid`, count{}, node)
-		if err != nil {
-			return errors.Capture(err)
-		}
-		var unitNodeCount count
-		if err := tx.Query(ctx, countUnitsOnNetNodeStmt, node).Get(&unitNodeCount); err != nil {
-			return errors.Errorf("checking units on net node: %w", err)
-		} else if unitNodeCount.Count > 0 {
-			return errors.Errorf(
-				"machine net node still referenced by %d unit(s), waiting for unit removal",
-				unitNodeCount.Count,
-			).Add(removalerrors.RemovalJobIncomplete)
-		}
-
 		// Remove the machine entry
 		if err := tx.Query(ctx, deleteMachineStmt, machine(machineUUIDParam)).Run(); err != nil {
 			return errors.Errorf("deleting machine: %w", err)
@@ -771,25 +745,149 @@ func (st *State) removeNetNode(ctx context.Context, tx *sqlair.TX, netNodeUUID s
 	type node entityUUID
 	netNodeUUIDRec := node{UUID: netNodeUUID}
 
+	// This is defensive. It is technically impossible for a net node to have
+	// machines at this point. Cloud service net nodes never have machines,
+	// and machine net nodes have already had their machine deleted by this point.
+	// Return RemovalJobIncomplete so this removal job retries later, once the
+	// machine removal job has finished.
+	countNodeMachinesQuery := `
+SELECT COUNT(*) AS &count.count
+FROM   machine
+WHERE  net_node_uuid = $node.uuid`
+	countNodeMachinesStmt, err := st.Prepare(countNodeMachinesQuery, node{}, count{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	var machineCount count
+	if err := tx.Query(ctx, countNodeMachinesStmt, netNodeUUIDRec).Get(&machineCount); err != nil {
+		return errors.Errorf("counting machines on net node: %w", err)
+	} else if machineCount.Count > 0 {
+		return errors.Errorf("net node %q still has machines", netNodeUUIDRec.UUID).
+			Add(removalerrors.RemovalJobIncomplete)
+	}
+
+	// This is defensive. It is technically impossible for a net node to have
+	// k8s services at this point. IAAS models never have k8s services, and the
+	// k8s service path has already deleted any k8s services that reference this
+	// net node. Return RemovalJobIncomplete so this removal job retries later,
+	// once the k8s service removal job has finished.
+	countK8sServicesQuery := `
+SELECT COUNT(*) AS &count.count
+FROM   k8s_service
+WHERE  net_node_uuid = $node.uuid`
+	countK8sServicesStmt, err := st.Prepare(countK8sServicesQuery, node{}, count{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	var k8sServiceCount count
+	if err := tx.Query(ctx, countK8sServicesStmt, netNodeUUIDRec).Get(&k8sServiceCount); err != nil {
+		return errors.Errorf("counting k8s services on net node: %w", err)
+	} else if k8sServiceCount.Count > 0 {
+		return errors.Errorf("net node %q still has k8s services", netNodeUUIDRec.UUID).
+			Add(removalerrors.RemovalJobIncomplete)
+	}
+
+	// This is required. Units reference net nodes, and are cleaned up by their
+	// own job, so we need to check that they have been removed before we can
+	// delete the net node. Return RemovalJobIncomplete so the removal job retries
+	// once the unit removal job has finished.
+	countNodeUnitsQuery := `
+SELECT COUNT(*) AS &count.count
+FROM   unit
+WHERE  net_node_uuid = $node.uuid`
+	countNodeUnitsStmt, err := st.Prepare(countNodeUnitsQuery, node{}, count{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	var unitCount count
+	if err := tx.Query(ctx, countNodeUnitsStmt, netNodeUUIDRec).Get(&unitCount); err != nil {
+		return errors.Errorf("counting units on net node: %w", err)
+	} else if unitCount.Count > 0 {
+		return errors.Errorf(
+			"net node still referenced by %d unit(s), waiting for unit removal",
+			unitCount.Count,
+		).Add(removalerrors.RemovalJobIncomplete)
+	}
+
+	// This is required. Filesystem attachments reference net nodes, and are cleaned
+	// up by their own job, so we need to check that they have been removed
+	// before we can delete the net node. Return RemovalJobIncomplete so the removal
+	// job retries once the unit removal job has finished.
+	countStorageFilesystemAttachmentsQuery := `
+SELECT COUNT(*) AS &count.count
+FROM   storage_filesystem_attachment
+WHERE  net_node_uuid = $node.uuid`
+	countStorageFilesystemAttachmentsStmt, err := st.Prepare(countStorageFilesystemAttachmentsQuery, node{}, count{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	var storageFilesystemAttachmentCount count
+	if err := tx.Query(ctx, countStorageFilesystemAttachmentsStmt, netNodeUUIDRec).Get(&storageFilesystemAttachmentCount); err != nil {
+		return errors.Errorf("counting storage filesystem attachments on net node: %w", err)
+	} else if storageFilesystemAttachmentCount.Count > 0 {
+		return errors.Errorf("net node %q still has storage filesystem attachments", netNodeUUIDRec.UUID).
+			Add(removalerrors.RemovalJobIncomplete)
+	}
+
+	// This is required. Volume attachments reference net nodes, and are cleaned
+	// up by their own job, so we need to check that they have been removed
+	// before we can delete the net node. Return RemovalJobIncomplete so the
+	// removal job retries once the unit removal job has finished.
+	countStorageVolumeAttachmentsQuery := `
+SELECT COUNT(*) AS &count.count
+FROM   storage_volume_attachment
+WHERE  net_node_uuid = $node.uuid`
+	countStorageVolumeAttachmentsStmt, err := st.Prepare(countStorageVolumeAttachmentsQuery, node{}, count{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	var storageVolumeAttachmentCount count
+	if err := tx.Query(ctx, countStorageVolumeAttachmentsStmt, netNodeUUIDRec).Get(&storageVolumeAttachmentCount); err != nil {
+		return errors.Errorf("counting storage volume attachments on net node: %w", err)
+	} else if storageVolumeAttachmentCount.Count > 0 {
+		return errors.Errorf("net node %q still has storage volume attachments", netNodeUUIDRec.UUID).
+			Add(removalerrors.RemovalJobIncomplete)
+	}
+
+	// This is required. Volume attachment plans reference net nodes, and are
+	// cleaned up by their own job, so we need to check that they have been removed
+	// before we can delete the net node. Return RemovalJobIncomplete so the removal
+	// job retries once the unit removal job has finished.
+	countStorageVolumeAttachmentPlansQuery := `
+SELECT COUNT(*) AS &count.count
+FROM   storage_volume_attachment_plan
+WHERE  net_node_uuid = $node.uuid`
+	countStorageVolumeAttachmentPlansStmt, err := st.Prepare(countStorageVolumeAttachmentPlansQuery, node{}, count{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	var storageVolumeAttachmentPlanCount count
+	if err := tx.Query(ctx, countStorageVolumeAttachmentPlansStmt, netNodeUUIDRec).Get(&storageVolumeAttachmentPlanCount); err != nil {
+		return errors.Errorf("counting storage volume attachment plans on net node: %w", err)
+	} else if storageVolumeAttachmentPlanCount.Count > 0 {
+		return errors.Errorf("net node %q still has storage volume attachment plans", netNodeUUIDRec.UUID).
+			Add(removalerrors.RemovalJobIncomplete)
+	}
+
 	// Start by deleting any IP addresses associated with the net node.
-	q := `
+	deleteProviderIPQuery := `
 DELETE FROM provider_ip_address
 WHERE address_uuid IN (
     SELECT uuid FROM ip_address WHERE net_node_uuid = $node.uuid
 )`
-	stmt, err := st.Prepare(q, node{})
+	deleteProviderIPStmt, err := st.Prepare(deleteProviderIPQuery, node{})
 	if err != nil {
 		return errors.Capture(err)
 	}
-	if err := tx.Query(ctx, stmt, netNodeUUIDRec).Run(); err != nil {
+	if err := tx.Query(ctx, deleteProviderIPStmt, netNodeUUIDRec).Run(); err != nil {
 		return errors.Errorf("deleting net node IP address provider IDs: %w", err)
 	}
 
-	stmt, err = st.Prepare("DELETE FROM ip_address WHERE net_node_uuid = $node.uuid", node{})
+	deleteProviderIPStmt, err = st.Prepare("DELETE FROM ip_address WHERE net_node_uuid = $node.uuid", node{})
 	if err != nil {
 		return errors.Capture(err)
 	}
-	if err := tx.Query(ctx, stmt, netNodeUUIDRec).Run(); err != nil {
+	if err := tx.Query(ctx, deleteProviderIPStmt, netNodeUUIDRec).Run(); err != nil {
 		return errors.Errorf("deleting net node IP addresses: %w", err)
 	}
 
@@ -853,26 +951,13 @@ WHERE  net_node_uuid = $node.uuid`
 	}
 
 	// Delete the net node.
-
-	deleteByNetNode := []string{
-		// TODO (stickupkid): We need to ensure that no unit is still using this
-		// net node. If it is, we need to return an error.
-		"DELETE FROM net_node WHERE uuid = $node.uuid",
+	deleteNetNodeQuery := "DELETE FROM net_node WHERE uuid = $node.uuid"
+	deleteNetNodeStmt, err := st.Prepare(deleteNetNodeQuery, node{})
+	if err != nil {
+		return errors.Capture(err)
 	}
-
-	for _, query := range deleteByNetNode {
-		stmt, err := st.Prepare(query, node{})
-		if err != nil {
-			return errors.Capture(err)
-		}
-
-		if err := tx.Query(ctx, stmt, netNodeUUIDRec).Run(); err != nil {
-			removeErr := errors.Errorf("deleting net node in query %q: %w", query, err)
-			if database.IsErrConstraintForeignKey(err) {
-				removeErr = removeErr.Add(removalerrors.RemovalJobIncomplete)
-			}
-			return removeErr
-		}
+	if err := tx.Query(ctx, deleteNetNodeStmt, netNodeUUIDRec).Run(); err != nil {
+		return errors.Errorf("deleting net node: %w", err)
 	}
 	return nil
 }

--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/domain/removal"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	"github.com/juju/juju/domain/removal/internal"
-	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -869,68 +868,9 @@ WHERE  net_node_uuid = $node.uuid`
 			Add(removalerrors.RemovalJobIncomplete)
 	}
 
-	// Start by deleting any IP addresses associated with the net node.
-	deleteProviderIPQuery := `
-DELETE FROM provider_ip_address
-WHERE address_uuid IN (
-    SELECT uuid FROM ip_address WHERE net_node_uuid = $node.uuid
-)`
-	deleteProviderIPStmt, err := st.Prepare(deleteProviderIPQuery, node{})
+	err = st.removeNetNodeLLDs(ctx, tx, netNodeUUIDRec.UUID)
 	if err != nil {
-		return errors.Capture(err)
-	}
-	if err := tx.Query(ctx, deleteProviderIPStmt, netNodeUUIDRec).Run(); err != nil {
-		return errors.Errorf("deleting net node IP address provider IDs: %w", err)
-	}
-
-	deleteProviderIPStmt, err = st.Prepare("DELETE FROM ip_address WHERE net_node_uuid = $node.uuid", node{})
-	if err != nil {
-		return errors.Capture(err)
-	}
-	if err := tx.Query(ctx, deleteProviderIPStmt, netNodeUUIDRec).Run(); err != nil {
-		return errors.Errorf("deleting net node IP addresses: %w", err)
-	}
-
-	// Get all link-layer devices associated with the net node.
-	selectDevices := `
-SELECT uuid AS &entityUUID.uuid
-FROM   link_layer_device
-WHERE  net_node_uuid = $node.uuid`
-	devStmt, err := st.Prepare(selectDevices, entityUUID{}, netNodeUUIDRec)
-	if err != nil {
-		return errors.Errorf("preparing devices for deletion statement: %w", err)
-	}
-
-	var devsToDelete []entityUUID
-	if err := tx.Query(ctx, devStmt, netNodeUUIDRec).GetAll(&devsToDelete); err != nil {
-		if !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("running devices for deletion query: %w", err)
-		}
-	}
-
-	llDevicesToDelete := uuids(transform.Slice(devsToDelete, func(d entityUUID) string { return d.UUID }))
-
-	// Delete all relations that reference the link-layer devices and the devices themselves.
-	deleteDevicesRelations := []string{
-		`DELETE FROM link_layer_device_parent WHERE device_uuid IN ($uuids[:]) OR parent_uuid IN ($uuids[:])`,
-		`DELETE FROM provider_link_layer_device WHERE device_uuid IN ($uuids[:])`,
-		`DELETE FROM link_layer_device_dns_domain WHERE device_uuid IN ($uuids[:])`,
-		`DELETE FROM link_layer_device_dns_address WHERE device_uuid IN ($uuids[:])`,
-		`DELETE FROM link_layer_device WHERE uuid IN ($uuids[:])`,
-	}
-	for _, query := range deleteDevicesRelations {
-		stmt, err := st.Prepare(query, llDevicesToDelete)
-		if err != nil {
-			return errors.Capture(err)
-		}
-
-		if err := tx.Query(ctx, stmt, llDevicesToDelete).Run(); err != nil {
-			removeErr := errors.Errorf("deleting reference to machine network in query %q: %w", query, err)
-			if database.IsErrConstraintForeignKey(err) {
-				removeErr = removeErr.Add(removalerrors.RemovalJobIncomplete)
-			}
-			return removeErr
-		}
+		return errors.Errorf("removing net node link-layer devices: %w", err)
 	}
 
 	// Delete the net node fqdn and hostname addresses before deleting the net node.
@@ -959,6 +899,86 @@ WHERE  net_node_uuid = $node.uuid`
 	if err := tx.Query(ctx, deleteNetNodeStmt, netNodeUUIDRec).Run(); err != nil {
 		return errors.Errorf("deleting net node: %w", err)
 	}
+	return nil
+}
+
+func (st *State) removeNetNodeLLDs(ctx context.Context, tx *sqlair.TX, netNodeUUID string) error {
+	type node entityUUID
+	netNodeUUIDRec := node{UUID: netNodeUUID}
+
+	// Start by deleting any IP addresses associated with the device. IP addresses
+	// are (currently) owned by LLDs
+	deleteProviderIPQuery := `
+DELETE FROM provider_ip_address
+WHERE address_uuid IN (
+    SELECT uuid FROM ip_address WHERE net_node_uuid = $node.uuid
+)`
+	deleteProviderIPStmt, err := st.Prepare(deleteProviderIPQuery, node{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if err := tx.Query(ctx, deleteProviderIPStmt, netNodeUUIDRec).Run(); err != nil {
+		return errors.Errorf("deleting net node IP address provider IDs: %w", err)
+	}
+
+	deleteProviderIPStmt, err = st.Prepare(`DELETE FROM ip_address WHERE net_node_uuid = $node.uuid`, node{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if err := tx.Query(ctx, deleteProviderIPStmt, netNodeUUIDRec).Run(); err != nil {
+		return errors.Errorf("deleting net node IP addresses: %w", err)
+	}
+
+	// Get all link-layer devices associated with the net node.
+	selectDevices := `
+SELECT uuid AS &entityUUID.uuid
+FROM   link_layer_device
+WHERE  net_node_uuid = $node.uuid`
+	devStmt, err := st.Prepare(selectDevices, entityUUID{}, netNodeUUIDRec)
+	if err != nil {
+		return errors.Errorf("preparing devices for deletion statement: %w", err)
+	}
+
+	var devsToDelete []entityUUID
+	if err := tx.Query(ctx, devStmt, netNodeUUIDRec).GetAll(&devsToDelete); errors.Is(err, sqlair.ErrNoRows) {
+		return nil
+	} else if err != nil {
+		return errors.Errorf("running devices for deletion query: %w", err)
+	}
+
+	llDevicesToDelete := entityUUIDs(devsToDelete).uuids()
+
+	// Delete all relations that reference the link-layer devices and the devices themselves.
+	//
+	// NOTE: parent-child LLDs MUST have both members associated with the same net node,
+	// so it is safe to delete only via one the child half of the relation.
+	deleteDevicesReferencer := []string{
+		`DELETE FROM link_layer_device_parent WHERE device_uuid IN ($uuids[:])`,
+		`DELETE FROM provider_link_layer_device WHERE device_uuid IN ($uuids[:])`,
+		`DELETE FROM link_layer_device_dns_domain WHERE device_uuid IN ($uuids[:])`,
+		`DELETE FROM link_layer_device_dns_address WHERE device_uuid IN ($uuids[:])`,
+		`DELETE FROM link_layer_device_route WHERE device_uuid IN ($uuids[:])`,
+	}
+	for _, query := range deleteDevicesReferencer {
+		stmt, err := st.Prepare(query, llDevicesToDelete)
+		if err != nil {
+			return errors.Capture(err)
+		}
+
+		if err := tx.Query(ctx, stmt, llDevicesToDelete).Run(); err != nil {
+			return errors.Errorf("deleting reference to link layer device in query %q: %w", query, err)
+		}
+	}
+
+	deleteDevicesQuery := `DELETE FROM link_layer_device WHERE uuid IN ($uuids[:])`
+	deleteDevicesStmt, err := st.Prepare(deleteDevicesQuery, llDevicesToDelete)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if err := tx.Query(ctx, deleteDevicesStmt, llDevicesToDelete).Run(); err != nil {
+		return errors.Errorf("deleting link-layer devices: %w", err)
+	}
+
 	return nil
 }
 

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -15,12 +15,14 @@ import (
 	coremachine "github.com/juju/juju/core/machine"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/deployment"
+	internalcharm "github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/life"
 	domainmachine "github.com/juju/juju/domain/machine"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	internalstorage "github.com/juju/juju/internal/storage"
 )
 
 type machineSuite struct {
@@ -1520,6 +1522,143 @@ func (s *machineSuite) TestDeleteMachineWithForce(c *tc.C) {
 	err = s.DB().QueryRow("SELECT count(*) FROM net_node WHERE uuid = ?", netNodeUUID).Scan(&count)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(count, tc.Equals, 0)
+}
+
+func (s *machineSuite) getMachineNetNode(c *tc.C, machineUUID coremachine.UUID) string {
+	var netNodeUUID string
+	err := s.DB().QueryRow(
+		"SELECT net_node_uuid FROM machine WHERE uuid = ?", machineUUID.String(),
+	).Scan(&netNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(netNodeUUID, tc.Not(tc.Equals), "")
+	return netNodeUUID
+}
+
+// machineWithVolumeAttachment deploys a single-unit application with
+// model-scoped block storage and then removes the unit, leaving a
+// storage_volume_attachment referencing the machine's net node.
+func (s *machineSuite) machineWithVolumeAttachment(c *tc.C) (coremachine.UUID, string) {
+	svc := s.setupStorageApplicationService(c)
+	poolUUID := s.createStoragePool(c, "blk", internalstorage.ProviderType("modelscoped-block"))
+	appUUID := s.deployIAASUnitWithStorage(
+		c, svc, "block-app", "data", internalcharm.StorageBlock, poolUUID)
+
+	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
+	netNodeUUID := s.getMachineNetNode(c, machineUUID)
+
+	s.removeUnitLeavingStorage(c, s.getAllUnitUUIDs(c, appUUID)[0])
+	return machineUUID, netNodeUUID
+}
+
+// machineWithFilesystemAttachment deploys a single-unit application with
+// model-scoped filesystem storage and then removes the unit, leaving a
+// storage_filesystem_attachment referencing the machine's net node.
+func (s *machineSuite) machineWithFilesystemAttachment(c *tc.C) (coremachine.UUID, string) {
+	svc := s.setupStorageApplicationService(c)
+	poolUUID := s.createStoragePool(c, "fs", internalstorage.ProviderType("modelscoped"))
+	appUUID := s.deployIAASUnitWithStorage(
+		c, svc, "fs-app", "data", internalcharm.StorageFilesystem, poolUUID)
+
+	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
+	netNodeUUID := s.getMachineNetNode(c, machineUUID)
+
+	s.removeUnitLeavingStorage(c, s.getAllUnitUUIDs(c, appUUID)[0])
+	return machineUUID, netNodeUUID
+}
+
+// machineWithVolumeAttachmentPlan deploys a single-unit application with
+// model-scoped block storage, records the volume attachment plan as the storage
+// provisioner would, then removes the unit and the volume attachment. This
+// leaves only the storage_volume_attachment_plan referencing the net node,
+// modelling the teardown window where the plan removal job has not yet run.
+// Crucially there is no remaining volume attachment, machine_volume or
+// machine_filesystem, so checkNoMachineDependents does not flag the machine.
+func (s *machineSuite) machineWithVolumeAttachmentPlan(c *tc.C) (coremachine.UUID, string) {
+	svc := s.setupStorageApplicationService(c)
+	poolUUID := s.createStoragePool(c, "blk", internalstorage.ProviderType("modelscoped-block"))
+	appUUID := s.deployIAASUnitWithStorage(
+		c, svc, "block-app", "data", internalcharm.StorageBlock, poolUUID)
+
+	machineUUID := s.getMachineUUIDFromApp(c, appUUID)
+	netNodeUUID := s.getMachineNetNode(c, machineUUID)
+
+	s.createVolumeAttachmentPlan(c, netNodeUUID)
+	s.removeUnitLeavingStorage(c, s.getAllUnitUUIDs(c, appUUID)[0])
+	s.deleteVolumeAttachment(c, netNodeUUID)
+	return machineUUID, netNodeUUID
+}
+
+// markMachineDeadNonForce drives the real, non-force lifecycle to dead. Each
+// step runs checkNoMachineDependents, so it only succeeds for scenarios the
+// dependents check does not flag (i.e. the volume attachment plan case).
+func (s *machineSuite) markMachineDeadNonForce(c *tc.C, st *State, machineUUID coremachine.UUID) {
+	_, err := st.EnsureMachineNotAliveCascade(c.Context(), machineUUID.String(), false)
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.MarkInstanceAsDead(c.Context(), machineUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.MarkMachineAsDead(c.Context(), machineUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// markMachineDyingForce drives the real, force lifecycle so the machine and its
+// instance are no longer alive. Force deletion does not require dead.
+func (s *machineSuite) markMachineDyingForce(c *tc.C, st *State, machineUUID coremachine.UUID) {
+	_, err := st.EnsureMachineNotAliveCascade(c.Context(), machineUUID.String(), true)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestDeleteMachineDanglingVolumeAttachmentPlanNonForce is the non-force failing
+// path: checkNoMachineDependents does not account for volume attachment plans,
+// so the machine progresses to dead and DeleteMachine then hits the net node FK.
+func (s *machineSuite) TestDeleteMachineDanglingVolumeAttachmentPlanNonForce(c *tc.C) {
+	machineUUID, _ := s.machineWithVolumeAttachmentPlan(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	s.markMachineDeadNonForce(c, st, machineUUID)
+
+	err := st.DeleteMachine(c.Context(), machineUUID.String(), false)
+	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobIncomplete)
+	c.Check(err, tc.ErrorMatches, ".*net node .* still has storage volume attachment plans")
+}
+
+// TestDeleteMachineDanglingVolumeAttachmentForce is a force failing path. Force
+// skips checkNoMachineDependents entirely, so a lingering volume attachment is
+// not detected before the net node delete is attempted.
+func (s *machineSuite) TestDeleteMachineDanglingVolumeAttachmentForce(c *tc.C) {
+	machineUUID, _ := s.machineWithVolumeAttachment(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	s.markMachineDyingForce(c, st, machineUUID)
+
+	err := st.DeleteMachine(c.Context(), machineUUID.String(), true)
+	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobIncomplete)
+	c.Check(err, tc.ErrorMatches, ".*net node .* still has storage volume attachments")
+}
+
+// TestDeleteMachineDanglingFilesystemAttachmentForce is the filesystem
+// equivalent force failing path.
+func (s *machineSuite) TestDeleteMachineDanglingFilesystemAttachmentForce(c *tc.C) {
+	machineUUID, _ := s.machineWithFilesystemAttachment(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	s.markMachineDyingForce(c, st, machineUUID)
+
+	err := st.DeleteMachine(c.Context(), machineUUID.String(), true)
+	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobIncomplete)
+	c.Check(err, tc.ErrorMatches, ".*net node .* still has storage filesystem attachments")
+}
+
+// TestDeleteMachineDanglingVolumeAttachmentPlanForce is the attachment-plan
+// force failing path.
+func (s *machineSuite) TestDeleteMachineDanglingVolumeAttachmentPlanForce(c *tc.C) {
+	machineUUID, _ := s.machineWithVolumeAttachmentPlan(c)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	s.markMachineDyingForce(c, st, machineUUID)
+
+	err := st.DeleteMachine(c.Context(), machineUUID.String(), true)
+	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobIncomplete)
+	c.Check(err, tc.ErrorMatches, ".*net node .* still has storage volume attachment plans")
 }
 
 func (s *machineSuite) TestDeleteMachineWithForceNotDyingInstance(c *tc.C) {

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -2066,6 +2066,24 @@ func (s *machineSuite) TestDeleteMachineWithLinkLayerDevice(c *tc.C) {
 	ipUUID := s.addIPAddress(c, machineUUID.String(), lldParentUUID, subnetUUID)
 	s.addIPAddressProviderID(c, "whatever", ipUUID)
 
+	// Add records to the tables that reference link-layer devices. These
+	// should all be deleted when the machine (and its devices) are deleted.
+	_, err = s.DB().ExecContext(c.Context(),
+		"INSERT INTO link_layer_device_dns_domain (device_uuid, search_domain) VALUES (?, ?)",
+		lldParentUUID, "example.com",
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = s.DB().ExecContext(c.Context(),
+		"INSERT INTO link_layer_device_dns_address (device_uuid, dns_address) VALUES (?, ?)",
+		lldParentUUID, "10.0.0.1",
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = s.DB().ExecContext(c.Context(),
+		"INSERT INTO link_layer_device_route (device_uuid, destination_cidr, gateway_ip, metric) VALUES (?, ?, ?, ?)",
+		lldParentUUID, "10.0.0.0/16", "10.0.0.1", 0,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	s.advanceMachineLife(c, machineUUID, life.Dead)
@@ -2090,6 +2108,19 @@ func (s *machineSuite) TestDeleteMachineWithLinkLayerDevice(c *tc.C) {
 	c.Check(count, tc.Equals, 0)
 
 	err = s.DB().QueryRow("SELECT count(*) FROM link_layer_device WHERE uuid = ?", lldChildUUID).Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+
+	// The tables referencing the link-layer devices should also be cleaned up.
+	err = s.DB().QueryRow("SELECT count(*) FROM link_layer_device_dns_domain WHERE device_uuid = ?", lldParentUUID).Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+
+	err = s.DB().QueryRow("SELECT count(*) FROM link_layer_device_dns_address WHERE device_uuid = ?", lldParentUUID).Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+
+	err = s.DB().QueryRow("SELECT count(*) FROM link_layer_device_route WHERE device_uuid = ?", lldParentUUID).Scan(&count)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(count, tc.Equals, 0)
 }

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -52,11 +52,17 @@ import (
 	relationstate "github.com/juju/juju/domain/relation/state"
 	"github.com/juju/juju/domain/removal"
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	domainstorage "github.com/juju/juju/domain/storage"
+	storageservice "github.com/juju/juju/domain/storage/service"
+	storagestate "github.com/juju/juju/domain/storage/state"
+	storageprovisioningservice "github.com/juju/juju/domain/storageprovisioning/service"
+	storageprovisioningstate "github.com/juju/juju/domain/storageprovisioning/state"
 	domaintesting "github.com/juju/juju/domain/testing"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	internalstorage "github.com/juju/juju/internal/storage"
+	dummystorage "github.com/juju/juju/internal/storage/provider/dummy"
 	internaltesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -1376,4 +1382,198 @@ func (caasApplication) Units() ([]caas.Unit, error) {
 	}, {
 		Id: "some-otherapp-0",
 	}}, nil
+}
+
+// storageRegistryGetter returns a storage provider registry exposing the dummy
+// model-scoped providers. Model-scoped (environ) storage is what clouds such as
+// EC2/EBS use: it does not create machine_volume / machine_filesystem rows, so
+// the net-node-scoped storage_volume_attachment / storage_filesystem_attachment
+// (and any volume attachment plan) are the only machine references - matching
+// the conditions in https://github.com/juju/juju/issues/22193.
+func (s *baseSuite) storageRegistryGetter() corestorage.ModelStorageRegistryGetter {
+	return corestorage.ConstModelStorageRegistry(func() internalstorage.ProviderRegistry {
+		return dummystorage.StorageProviders()
+	})
+}
+
+// setupStorageApplicationService is like setupApplicationService but wires in a
+// working storage provider registry so that deploying a storage charm
+// provisions real volume/filesystem attachment rows.
+func (s *baseSuite) setupStorageApplicationService(c *tc.C) *applicationservice.ProviderService {
+	modelDB := func(ctx context.Context) (database.TxnRunner, error) {
+		return s.ModelTxnRunner(), nil
+	}
+
+	providerGetter := func(ctx context.Context) (applicationservice.Provider, error) {
+		return appProvider{}, nil
+	}
+	caasProviderGetter := func(ctx context.Context) (applicationservice.CAASProvider, error) {
+		return appProvider{}, nil
+	}
+	cloudInfoGetter := func(ctx context.Context) (applicationservice.CloudInfoProvider, error) {
+		return nil, coreerrors.NotSupported
+	}
+	registryGetter := s.storageRegistryGetter()
+	state := applicationstate.NewState(modelDB, coremodel.UUID(s.ModelUUID()), clock.WallClock, loggertesting.WrapCheckLog(c))
+	storageSvc := applicationstorageservice.NewService(
+		state,
+		applicationstorageservice.NewStoragePoolProvider(registryGetter, state),
+		loggertesting.WrapCheckLog(c),
+	)
+
+	return applicationservice.NewProviderService(
+		state,
+		storageSvc,
+		domaintesting.NoopLeaderEnsurer(),
+		nil,
+		providerGetter,
+		caasProviderGetter,
+		cloudInfoGetter,
+		nil,
+		domain.NewStatusHistory(loggertesting.WrapCheckLog(c), clock.WallClock),
+		coremodel.UUID(s.ModelUUID()),
+		clock.WallClock,
+		loggertesting.WrapCheckLog(c),
+	)
+}
+
+// createStoragePool creates a storage pool through the storage domain service.
+func (s *baseSuite) createStoragePool(
+	c *tc.C, name string, providerType internalstorage.ProviderType,
+) domainstorage.StoragePoolUUID {
+	svc := storageservice.NewService(
+		storagestate.NewState(s.TxnRunnerFactory()),
+		loggertesting.WrapCheckLog(c),
+		clock.WallClock,
+		s.storageRegistryGetter(),
+	)
+	poolUUID, err := svc.CreateStoragePool(
+		c.Context(), name, domainstorage.ProviderType(providerType.String()), nil,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	return poolUUID
+}
+
+// deployIAASUnitWithStorage deploys a single-unit IAAS application whose charm
+// requires one storage item backed by the supplied pool. Placing the unit
+// provisions the storage instance plus the volume/filesystem attachment against
+// the unit's (machine's) net node. It returns the application UUID.
+func (s *baseSuite) deployIAASUnitWithStorage(
+	c *tc.C,
+	svc *applicationservice.ProviderService,
+	appName, storageName string,
+	storageType internalcharm.StorageType,
+	poolUUID domainstorage.StoragePoolUUID,
+) coreapplication.UUID {
+	ch := &stubCharm{
+		name: "test-charm",
+		storage: map[string]internalcharm.Storage{
+			storageName: {
+				Name:        storageName,
+				Type:        storageType,
+				CountMin:    1,
+				CountMax:    1,
+				MinimumSize: 100,
+			},
+		},
+	}
+
+	appID, err := svc.CreateIAASApplication(c.Context(), appName, ch, corecharm.Origin{
+		Source: corecharm.CharmHub,
+		Platform: corecharm.Platform{
+			Channel:      "24.04",
+			OS:           "ubuntu",
+			Architecture: "amd64",
+		},
+	}, applicationservice.AddApplicationArgs{
+		ReferenceName: appName,
+		DownloadInfo: &charm.DownloadInfo{
+			Provenance:  charm.ProvenanceDownload,
+			DownloadURL: "http://example.com",
+		},
+		ResolvedResources: applicationservice.ResolvedResources{{
+			Name:     "buzz",
+			Revision: new(42),
+			Origin:   charmresource.OriginStore,
+		}},
+		StorageDirectiveOverrides: map[string]applicationservice.StorageDirectiveOverrides{
+			storageName: {
+				PoolUUID: &poolUUID,
+				Count:    new(uint32(1)),
+				Size:     new(uint64(100)),
+			},
+		},
+	}, applicationservice.AddIAASUnitArg{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.setCharmObjectStoreMetadata(c, appID)
+
+	return appID
+}
+
+// removeUnitLeavingStorage drives the real unit removal so that the unit row is
+// deleted while its volume/filesystem attachments remain referencing the net
+// node. This mirrors production, where unit removal and net-node-scoped storage
+// attachment removal are independent jobs.
+//
+// The unit's storage_attachment (unit<->instance link) must be torn down for
+// the unit row to be deletable; that is driven here through the removal domain
+// too. The net-node-scoped storage_volume_attachment / storage_filesystem_
+// attachment rows are deliberately left in place.
+func (s *baseSuite) removeUnitLeavingStorage(c *tc.C, unitUUID unit.UUID) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	cascaded, err := st.EnsureUnitNotAliveCascade(c.Context(), unitUUID.String(), true)
+	c.Assert(err, tc.ErrorIsNil)
+
+	for _, saUUID := range cascaded.StorageAttachmentUUIDs {
+		_, err := st.EnsureStorageAttachmentDeadCascade(c.Context(), saUUID)
+		c.Assert(err, tc.ErrorIsNil)
+		err = st.DeleteStorageAttachment(c.Context(), saUUID)
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	err = st.DeleteUnit(c.Context(), unitUUID.String(), true)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// volumeAttachmentUUIDForNetNode reads the UUID of the volume attachment on the
+// supplied net node. This is a read-only lookup; in production this is known
+// from the storage provisioning watchers.
+func (s *baseSuite) volumeAttachmentUUIDForNetNode(c *tc.C, netNodeUUID string) string {
+	var vaUUID string
+	err := s.DB().QueryRow(
+		"SELECT uuid FROM storage_volume_attachment WHERE net_node_uuid = ?", netNodeUUID,
+	).Scan(&vaUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	return vaUUID
+}
+
+// createVolumeAttachmentPlan records a volume attachment plan, through the
+// storage provisioning service, for the volume attachment on the supplied net
+// node. The storage provisioner records such a plan for every attached volume.
+func (s *baseSuite) createVolumeAttachmentPlan(c *tc.C, netNodeUUID string) {
+	vaUUID := s.volumeAttachmentUUIDForNetNode(c, netNodeUUID)
+	svc := storageprovisioningservice.NewService(
+		storageprovisioningstate.NewState(s.TxnRunnerFactory()),
+		nil,
+		loggertesting.WrapCheckLog(c),
+	)
+	_, err := svc.CreateVolumeAttachmentPlan(
+		c.Context(),
+		domainstorage.VolumeAttachmentUUID(vaUUID),
+		domainstorage.VolumeDeviceTypeLocal,
+		nil,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// deleteVolumeAttachment removes the volume attachment on the supplied net node
+// through the removal domain, leaving any volume attachment plan behind. In
+// production the attachment and its plan are removed by independent jobs.
+func (s *baseSuite) deleteVolumeAttachment(c *tc.C, netNodeUUID string) {
+	vaUUID := s.volumeAttachmentUUIDForNetNode(c, netNodeUUID)
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err := st.DeleteVolumeAttachment(c.Context(), vaUUID)
+	c.Assert(err, tc.ErrorIsNil)
 }


### PR DESCRIPTION
Constraint violation errors should never be raised to the user, in logs
or anywhere else. Our pattern is, when it can occur, to check entities
for dependencies and error out with a RemovalJobIncomplete error. This
means the job will be retried in a bit, hopefully when the dependency
has been resolved.

When removing net nodes, we were incorrectly catching all foreign key
constraint violations and returning them with the decorated
RemovalJobIncomplete. This means the db error was printed in logs, even
if behaviour was technically correct.

This was a splatter-gun approach. Instead, now we check for each of the
different entities that could have a foreign key to net nodes before we
attempt to remove the net node. Move the check for units inside
removeNetNode. This is a bit more conservative than is technically
necessary, but is defensive.

Add some unit tests that exercise the cases we explicitly catch now.

Fixes: https://github.com/juju/juju/issues/22193

## QA steps

Tests pass

Reproducer [here](https://github.com/juju/juju/issues/22193) is no longer seen