### PR TITLE
fix(azure): correctly expose dual-stack subnets via allSubnets and NetworkInterfaces

### DIFF
--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"net"
 	"net/url"
 	"slices"
 	"sort"
@@ -555,9 +556,18 @@ func (env *azureEnviron) validateIPFamilyForCreate(
 		if prefix == nil {
 			continue
 		}
-		addrType, err := network.CIDRAddressType(*prefix)
-		if err == nil && addrType == network.IPv6Address {
-			return nil
+		// Parse the CIDR to extract the prefix length and address family.
+		// Azure requires IPv6 subnets to be exactly /64.
+		_, ipNet, err := net.ParseCIDR(*prefix)
+		if err != nil {
+			continue // Skip malformed prefixes
+		}
+		// Check if this is an IPv6 /64 prefix.
+		if ipNet.IP.To4() == nil {
+			ones, _ := ipNet.Mask.Size()
+			if ones == 64 {
+				return nil
+			}
 		}
 	}
 	return errors.Errorf(
@@ -961,10 +971,6 @@ func (env *azureEnviron) createVirtualMachine(
 		if isDualStack {
 			ipv6PIPName := vmName + "-public-ip-ipv6"
 			ipv6PublicIPAddressId = fmt.Sprintf(`[resourceId('Microsoft.Network/publicIPAddresses', '%s')]`, ipv6PIPName)
-			if env.config.loadBalancerSkuName != string(armnetwork.LoadBalancerSKUNameStandard) {
-				logger.Warningf(ctx, "creating IPv6 public IP for %q with load-balancer-sku-name=%q; "+
-					"Standard SKU is recommended for dual-stack, model configuration ignored", vmName, env.config.loadBalancerSkuName)
-			}
 			res = append(res, armtemplates.Resource{
 				APIVersion: networkAPIVersion,
 				Type:       "Microsoft.Network/publicIPAddresses",

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -35,6 +35,7 @@ import (
 	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/network/ipfamily"
 	"github.com/juju/juju/core/os/ostype"
 	"github.com/juju/juju/core/semversion"
@@ -526,6 +527,44 @@ func (env *azureEnviron) validateIPFamilyConstraint(cons constraints.Value) erro
 	return nil
 }
 
+// validateIPFamilyForCreate validates ip-family constraints for VM creation.
+// It combines the SKU check (defensive — validateIPFamilyConstraint should
+// catch this earlier) with the IPv6 subnet placement check. This is the
+// single validation chokepoint called from createVirtualMachine, which is
+// reached by all three code paths: bootstrap, add-machine, and deploy.
+func (env *azureEnviron) validateIPFamilyForCreate(
+	ctx context.Context, cons constraints.Value, placementSubnet *armnetwork.Subnet,
+) error {
+	if cons.IPFamily == nil || *cons.IPFamily != ipfamily.Dual {
+		return nil
+	}
+	if env.config.loadBalancerSkuName == string(armnetwork.LoadBalancerSKUNameBasic) {
+		return errors.Errorf(
+			"ip-family=dual requires load-balancer-sku-name=Standard on Azure; " +
+				"Basic SKU is not supported for this configuration")
+	}
+	if placementSubnet == nil {
+		return nil
+	}
+	if placementSubnet.Properties == nil {
+		return errors.Errorf(
+			"placement subnet %q does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; "+
+				"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(placementSubnet.Name))
+	}
+	for _, prefix := range placementSubnet.Properties.AddressPrefixes {
+		if prefix == nil {
+			continue
+		}
+		addrType, err := network.CIDRAddressType(*prefix)
+		if err == nil && addrType == network.IPv6Address {
+			return nil
+		}
+	}
+	return errors.Errorf(
+		"placement subnet %q does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; "+
+			"add a /64 IPv6 prefix to the subnet or use ip-family=ipv4", toValue(placementSubnet.Name))
+}
+
 // PrecheckInstance is defined on the environs.InstancePrechecker interface.
 func (env *azureEnviron) PrecheckInstance(ctx context.Context, args environs.PrecheckInstanceParams) error {
 	if err := env.validateIPFamilyConstraint(args.Constraints); err != nil {
@@ -865,9 +904,36 @@ func (env *azureEnviron) createVirtualMachine(
 		vmDependsOn = append(vmDependsOn, availabilitySetId)
 	}
 
-	placementSubnetID, err := env.findPlacementSubnet(ctx, args.Placement)
-	if err != nil {
-		return environs.ZoneIndependentError(err)
+	// Resolve placement subnet. For dual-stack, also validate IPv6 support
+	// using the same subnet list to avoid duplicate API calls.
+	var placementSubnetID network.Id
+	if args.Placement != "" {
+		allSubnets, subErr := env.allProviderSubnets(ctx)
+		if subErr != nil {
+			return environs.ZoneIndependentError(subErr)
+		}
+		subnetName, subErr := env.parsePlacement(args.Placement)
+		if subErr != nil {
+			return environs.ZoneIndependentError(subErr)
+		}
+		for _, subnet := range allSubnets {
+			if toValue(subnet.Name) != subnetName {
+				continue
+			}
+			placementSubnetID = network.Id(toValue(subnet.ID))
+			if err := env.validateIPFamilyForCreate(ctx, args.Constraints, subnet); err != nil {
+				return environs.ZoneIndependentError(err)
+			}
+			break
+		}
+		if placementSubnetID == "" {
+			return environs.ZoneIndependentError(errors.NotFoundf("subnet %q", subnetName))
+		}
+	} else {
+		// No placement, but still validate SKU for dual-stack.
+		if err := env.validateIPFamilyForCreate(ctx, args.Constraints, nil); err != nil {
+			return environs.ZoneIndependentError(err)
+		}
 	}
 	vnetId, subnetIds, err := env.networkInfoForInstance(ctx, args, bootstrapping, instanceConfig.IsController(), placementSubnetID)
 	if err != nil {
@@ -879,7 +945,10 @@ func (env *azureEnviron) createVirtualMachine(
 		nicDependsOn = append(nicDependsOn, vnetId)
 	}
 
+	isDualStack := args.Constraints.IPFamily != nil && *args.Constraints.IPFamily == ipfamily.Dual
+
 	var publicIPAddressId string
+	var ipv6PublicIPAddressId string
 	if usePublicIP {
 		publicIPAddressName := vmName + "-public-ip"
 		publicIPAddressId = fmt.Sprintf(`[resourceId('Microsoft.Network/publicIPAddresses', '%s')]`, publicIPAddressName)
@@ -900,6 +969,26 @@ func (env *azureEnviron) createVirtualMachine(
 				PublicIPAllocationMethod: new(publicIPAddressAllocationMethod),
 			},
 		})
+		if isDualStack {
+			ipv6PIPName := vmName + "-public-ip-ipv6"
+			ipv6PublicIPAddressId = fmt.Sprintf(`[resourceId('Microsoft.Network/publicIPAddresses', '%s')]`, ipv6PIPName)
+			if env.config.loadBalancerSkuName != string(armnetwork.LoadBalancerSKUNameStandard) {
+				logger.Warningf(ctx, "creating IPv6 public IP for %q with load-balancer-sku-name=%q; "+
+					"Standard SKU is recommended for dual-stack, model configuration ignored", vmName, env.config.loadBalancerSkuName)
+			}
+			res = append(res, armtemplates.Resource{
+				APIVersion: networkAPIVersion,
+				Type:       "Microsoft.Network/publicIPAddresses",
+				Name:       ipv6PIPName,
+				Location:   env.location,
+				Tags:       vmTags,
+				Sku:        &armtemplates.Sku{Name: string(armnetwork.LoadBalancerSKUNameStandard)},
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+					PublicIPAllocationMethod: new(publicIPAddressAllocationMethod),
+				},
+			})
+		}
 	}
 
 	// Create one NIC per subnet. The first one is the primary and has
@@ -928,6 +1017,27 @@ func (env *azureEnviron) createVirtualMachine(
 			Name:       new(ipConfigName),
 			Properties: ipConfig,
 		}}
+
+		// For dual-stack, add an IPv6 IP configuration to the primary NIC.
+		if primary && isDualStack {
+			ipv6Props := &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+				Primary:                   new(false),
+				PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+				PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+				Subnet:                    &armnetwork.Subnet{ID: new(string(subnetID))},
+			}
+			if usePublicIP && ipv6PublicIPAddressId != "" {
+				ipv6Props.PublicIPAddress = &armnetwork.PublicIPAddress{
+					ID: new(ipv6PublicIPAddressId),
+				}
+				nicDependsOn = append(nicDependsOn, ipv6PublicIPAddressId)
+			}
+			ipConfigurations = append(ipConfigurations, &armnetwork.InterfaceIPConfiguration{
+				Name:       new("primary-ipv6"),
+				Properties: ipv6Props,
+			})
+		}
+
 		res = append(res, armtemplates.Resource{
 			APIVersion: networkAPIVersion,
 			Type:       "Microsoft.Network/networkInterfaces",

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -571,9 +571,12 @@ func (env *azureEnviron) PrecheckInstance(ctx context.Context, args environs.Pre
 		return errors.Trace(err)
 	}
 
-	if _, err := env.findPlacementSubnet(ctx, args.Placement); err != nil {
+	// Resolve placement subnet and validate IPv6 support early.
+	_, err := env.findPlacementSubnet(ctx, args.Placement)
+	if err != nil {
 		return errors.Trace(err)
 	}
+
 	if !args.Constraints.HasInstanceType() {
 		return nil
 	}
@@ -904,36 +907,22 @@ func (env *azureEnviron) createVirtualMachine(
 		vmDependsOn = append(vmDependsOn, availabilitySetId)
 	}
 
-	// Resolve placement subnet. For dual-stack, also validate IPv6 support
-	// using the same subnet list to avoid duplicate API calls.
+	// Resolve placement subnet and validate IPv6 support.
+	// findPlacementSubnet returns nil if no placement is specified.
+	placementSubnet, err := env.findPlacementSubnet(ctx, args.Placement)
+	if err != nil {
+		return environs.ZoneIndependentError(err)
+	}
+
+	// Validate ip-family constraints against the placement subnet (if any).
+	if err := env.validateIPFamilyForCreate(ctx, args.Constraints, placementSubnet); err != nil {
+		return environs.ZoneIndependentError(err)
+	}
+
+	// Extract placement subnet ID for use in networkInfoForInstance.
 	var placementSubnetID network.Id
-	if args.Placement != "" {
-		allSubnets, subErr := env.allProviderSubnets(ctx)
-		if subErr != nil {
-			return environs.ZoneIndependentError(subErr)
-		}
-		subnetName, subErr := env.parsePlacement(args.Placement)
-		if subErr != nil {
-			return environs.ZoneIndependentError(subErr)
-		}
-		for _, subnet := range allSubnets {
-			if toValue(subnet.Name) != subnetName {
-				continue
-			}
-			placementSubnetID = network.Id(toValue(subnet.ID))
-			if err := env.validateIPFamilyForCreate(ctx, args.Constraints, subnet); err != nil {
-				return environs.ZoneIndependentError(err)
-			}
-			break
-		}
-		if placementSubnetID == "" {
-			return environs.ZoneIndependentError(errors.NotFoundf("subnet %q", subnetName))
-		}
-	} else {
-		// No placement, but still validate SKU for dual-stack.
-		if err := env.validateIPFamilyForCreate(ctx, args.Constraints, nil); err != nil {
-			return environs.ZoneIndependentError(err)
-		}
+	if placementSubnet != nil {
+		placementSubnetID = providerSubnetID(placementSubnet)
 	}
 	vnetId, subnetIds, err := env.networkInfoForInstance(ctx, args, bootstrapping, instanceConfig.IsController(), placementSubnetID)
 	if err != nil {

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -327,17 +327,17 @@ func (env *azureEnviron) defaultControllerSubnet() network.Id {
 	return network.Id(subnetID)
 }
 
-func (env *azureEnviron) findSubnetID(ctx context.Context, subnetName string) (network.Id, error) {
+func (env *azureEnviron) findSubnet(ctx context.Context, subnetName string) (*azurenetwork.Subnet, error) {
 	subnets, err := env.allProviderSubnets(ctx)
 	if err != nil {
-		return "", env.HandleCredentialError(ctx, err)
+		return nil, env.HandleCredentialError(ctx, err)
 	}
 	for _, subnet := range subnets {
 		if toValue(subnet.Name) == subnetName {
-			return network.Id(toValue(subnet.ID)), nil
+			return subnet, nil
 		}
 	}
-	return "", errors.NotFoundf("subnet %q", subnetName)
+	return nil, errors.NotFoundf("subnet %q", subnetName)
 }
 
 // networkInfoForInstance returns the virtual network and subnet to use
@@ -379,12 +379,12 @@ func (env *azureEnviron) networkInfoForInstance(
 		if controller {
 			defaultSubnetName = controllerSubnetName
 		}
-		defaultSubnetID, err := env.findSubnetID(ctx, defaultSubnetName)
+		defaultSubnet, err := env.findSubnet(ctx, defaultSubnetName)
 		if err != nil && !errors.Is(err, errors.NotFound) {
 			return "", nil, errors.Trace(err)
 		}
 		if err == nil {
-			return vnetID, []network.Id{defaultSubnetID}, nil
+			return vnetID, []network.Id{providerSubnetID(defaultSubnet)}, nil
 		}
 
 		// For deployments without a spaces constraint, there's no subnets to zones mapping.
@@ -479,15 +479,20 @@ func (env *azureEnviron) parsePlacement(placement string) (string, error) {
 	return "", fmt.Errorf("unknown placement directive: %v", placement)
 }
 
-func (env *azureEnviron) findPlacementSubnet(ctx context.Context, placement string) (network.Id, error) {
+// providerSubnetID extracts the network.Id from an Azure subnet resource.
+func providerSubnetID(subnet *azurenetwork.Subnet) network.Id {
+	return network.Id(toValue(toValue(subnet).ID))
+}
+
+func (env *azureEnviron) findPlacementSubnet(ctx context.Context, placement string) (*azurenetwork.Subnet, error) {
 	if placement == "" {
-		return "", nil
+		return nil, nil
 	}
 	subnetName, err := env.parsePlacement(placement)
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	logger.Debugf(ctx, "searching for subnet matching placement directive %q", subnetName)
-	return env.findSubnetID(ctx, subnetName)
+	return env.findSubnet(ctx, subnetName)
 }

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -91,32 +91,45 @@ func (env *azureEnviron) allSubnets(ctx context.Context) ([]network.SubnetInfo, 
 		if sub.Properties == nil {
 			continue
 		}
-		addressPrefix := sub.Properties.AddressPrefix
-		if addressPrefix == nil || *addressPrefix == "" {
-			for _, prefix := range sub.Properties.AddressPrefixes {
-				if prefix == nil {
-					continue
-				}
-				addrType, err := network.CIDRAddressType(*prefix)
-				// We only care about IPv4 addresses.
-				if err == nil && addrType == network.IPv4Address {
-					addressPrefix = prefix
-					break
-				}
 
+		// Prefer AddressPrefixes (plural) over AddressPrefix (singular).
+		// Both may be set after PR #22736 (dual-stack VNet templates).
+		// Single-prefix subnets have AddressPrefix set; multi-prefix (dual-stack)
+		// have AddressPrefixes set, and AddressPrefix is nil.
+		var prefixes []string
+		if len(sub.Properties.AddressPrefixes) > 0 {
+			// Use all prefixes from AddressPrefixes (plural).
+			for _, p := range sub.Properties.AddressPrefixes {
+				if p != nil && *p != "" {
+					prefixes = append(prefixes, *p)
+				}
 			}
+		} else if sub.Properties.AddressPrefix != nil && *sub.Properties.AddressPrefix != "" {
+			// Fallback to AddressPrefix (singular) for legacy subnets.
+			prefixes = []string{*sub.Properties.AddressPrefix}
 		}
-		// An empty CIDR is no use to us, so guard against it.
-		cidr := toValue(addressPrefix)
-		if cidr == "" {
+
+		if len(prefixes) == 0 {
 			logger.Debugf(ctx, "ignoring subnet %q with empty address prefix", id)
 			continue
 		}
 
-		results = append(results, network.SubnetInfo{
-			CIDR:       cidr,
-			ProviderId: network.Id(id),
-		})
+		// Emit one SubnetInfo per prefix. Use the :ipv6 suffix to distinguish
+		// IPv6 prefixes from IPv4, so that dual-stack subnets appear as two
+		// distinct Juju subnets (one per family).
+		for _, prefix := range prefixes {
+			addrType, err := network.CIDRAddressType(prefix)
+			if err != nil {
+				logger.Debugf(ctx, "invalid CIDR %q in subnet %q: %v; skipping", prefix, id, err)
+				continue
+			}
+
+			isIPv6 := addrType == network.IPv6Address
+			results = append(results, network.SubnetInfo{
+				CIDR:       prefix,
+				ProviderId: subnetProviderIDForFamily(id, isIPv6),
+			})
+		}
 	}
 	return results, nil
 }
@@ -279,11 +292,25 @@ func mapAzureInterfaceList(in []*azurenetwork.Interface, subnetIDToCIDR map[stri
 			)
 			if ipConf.Properties.Subnet != nil && ipConf.Properties.Subnet.ID != nil {
 				subnetID = toValue(ipConf.Properties.Subnet.ID)
-				providerAddrOpts = append(providerAddrOpts, network.WithProviderSubnetID(network.Id(subnetID)))
 
-				if subnetCIDR := subnetIDToCIDR[subnetID]; subnetCIDR != "" {
+				// Determine if this is an IPv6 IP configuration to add the
+				// correct family-suffixed ProviderId and lookup the matching CIDR.
+				isIPv6 := ipConf.Properties.PrivateIPAddressVersion != nil &&
+					toValue(ipConf.Properties.PrivateIPAddressVersion) == azurenetwork.IPVersionIPv6
+
+				// Build the Juju ProviderId suffix convention: bare for IPv4, :ipv6 for IPv6.
+				jujuSubnetID := subnetProviderIDForFamily(subnetID, isIPv6)
+				providerAddrOpts = append(providerAddrOpts, network.WithProviderSubnetID(jujuSubnetID))
+
+				// Look up the CIDR for this family-specific subnet. If we have a dual-stack
+				// subnet, allSubnets() will have created two entries (one bare IPv4, one :ipv6).
+				// If the lookup misses (e.g. legacy IPv4-only model with only bare IDs),
+				// the address is stored without a CIDR tag. This is acceptable for legacy
+				// models; new dual-stack machines will always have matching entries.
+				if subnetCIDR := subnetIDToCIDR[jujuSubnetID.String()]; subnetCIDR != "" {
 					machineAddrOpts = append(machineAddrOpts, network.WithCIDR(subnetCIDR))
 				}
+
 			}
 
 			providerAddr := network.NewMachineAddress(
@@ -364,14 +391,14 @@ func (env *azureEnviron) networkInfoForInstance(
 	if !constraints.HasSpaces() {
 		// Use placement if specified.
 		if placementSubnetID != "" {
-			return vnetID, []network.Id{placementSubnetID}, nil
+			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{placementSubnetID}), nil
 		}
 
 		// When bootstrapping the network doesn't exist yet so just
 		// return the relevant subnet ID and it is created as part of
 		// the bootstrap process.
 		if bootstrapping && env.config.virtualNetworkName == "" {
-			return vnetID, []network.Id{env.defaultControllerSubnet()}, nil
+			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{env.defaultControllerSubnet()}), nil
 		}
 
 		// Prefer the legacy default subnet if found.
@@ -384,7 +411,7 @@ func (env *azureEnviron) networkInfoForInstance(
 			return "", nil, errors.Trace(err)
 		}
 		if err == nil {
-			return vnetID, []network.Id{providerSubnetID(defaultSubnet)}, nil
+			return vnetID, stripAndDeduplicateSubnetIDs([]network.Id{providerSubnetID(defaultSubnet)}), nil
 		}
 
 		// For deployments without a spaces constraint, there's no subnets to zones mapping.
@@ -440,7 +467,12 @@ func (env *azureEnviron) networkInfoForInstance(
 			subnetIDs = append(subnetIDs, id)
 		}
 	}
-	return vnetID, subnetIDs, nil
+
+	// Strip :ipv6 suffixes and deduplicate. allSubnets() emits two rows per
+	// dual-stack subnet (one IPv4 with bare ID, one IPv6 with :ipv6 suffix),
+	// but ARM templates expect one subnet ID per NIC. Stripping + deduplicating
+	// ensures that happens.
+	return vnetID, stripAndDeduplicateSubnetIDs(subnetIDs), nil
 }
 
 func (env *azureEnviron) subnetsForZone(subnetsToZones []map[network.Id][]string, az string) ([][]network.Id, error) {
@@ -495,4 +527,45 @@ func (env *azureEnviron) findPlacementSubnet(ctx context.Context, placement stri
 
 	logger.Debugf(ctx, "searching for subnet matching placement directive %q", subnetName)
 	return env.findSubnet(ctx, subnetName)
+}
+
+// subnetProviderIDForFamily builds the Juju provider subnet ID for an Azure subnet,
+// optionally suffixed with the IP family. Bare (no suffix) means IPv4; `:ipv6` suffix
+// means IPv6. The suffix is used only on the read path (allSubnets, NetworkInterfaces);
+// it is stripped before subnet IDs reach ARM templates for provisioning.
+func subnetProviderIDForFamily(azureSubnetID string, isIPv6 bool) network.Id {
+	if isIPv6 {
+		return network.Id(azureSubnetID + ":ipv6")
+	}
+	return network.Id(azureSubnetID)
+}
+
+// stripIPFamilySuffix removes the :ipv4/:ipv6 suffix from a Juju provider subnet ID.
+// Non-suffixed (or otherwise-formatted) input is returned unchanged. The colon is safe
+// within Juju (only appears in suffixes); Azure ARM resource IDs never contain colons.
+func stripIPFamilySuffix(id string) string {
+	if idx := strings.LastIndex(id, ":"); idx != -1 {
+		switch id[idx+1:] {
+		case "ipv4", "ipv6":
+			return id[:idx]
+		}
+	}
+	return id
+}
+
+// stripAndDeduplicateSubnetIDs removes :ipv6 suffixes from subnet IDs and deduplicates them.
+// This ensures that when allSubnets() emits two rows per dual-stack subnet (one for each
+// family), we only pass one bare Azure subnet ID to ARM templates. The order of the first
+// occurrence is preserved.
+func stripAndDeduplicateSubnetIDs(subnetIDs []network.Id) []network.Id {
+	seen := make(map[string]bool)
+	var result []network.Id
+	for _, id := range subnetIDs {
+		bare := stripIPFamilySuffix(id.String())
+		if !seen[bare] {
+			seen[bare] = true
+			result = append(result, network.Id(bare))
+		}
+	}
+	return result
 }

--- a/internal/provider/azure/environ_network_test.go
+++ b/internal/provider/azure/environ_network_test.go
@@ -54,6 +54,8 @@ func (s *environSuite) TestSubnetsSuccessNew(c *tc.C) {
 
 	// We wait for common resource creation, then query subnets
 	// in the default virtual network created for every model.
+	// This now tests the case where a subnet has both IPv4 and IPv6 prefixes.
+	// The new behavior is to return two SubnetInfo rows (one per family).
 	s.sender = azuretesting.Senders{
 		makeSender("/deployments/common", s.commonDeployment),
 		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
@@ -81,9 +83,21 @@ func (s *environSuite) TestSubnetsSuccessNew(c *tc.C) {
 	subs, err := netEnv.Subnets(c.Context(), nil)
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Assert(subs, tc.HasLen, 1)
+	// With AddressPrefixes containing both IPv4 and IPv6, we get two entries.
+	c.Assert(subs, tc.HasLen, 2)
+
+	// Sort by CIDR to ensure predictable order.
+	if subs[0].CIDR > subs[1].CIDR {
+		subs[0], subs[1] = subs[1], subs[0]
+	}
+
+	// IPv4 entry: bare ProviderId
 	c.Check(subs[0].ProviderId, tc.Equals, corenetwork.Id("provider-sub-id"))
 	c.Check(subs[0].CIDR, tc.Equals, "10.0.0.0/24")
+
+	// IPv6 entry: :ipv6 suffix
+	c.Check(subs[1].ProviderId, tc.Equals, corenetwork.Id("provider-sub-id:ipv6"))
+	c.Check(subs[1].CIDR, tc.Equals, "fd00:27e8:ed0b::/64")
 }
 
 func (s *environSuite) TestNetworkInterfacesSuccess(c *tc.C) {
@@ -347,4 +361,358 @@ func (s *environSuite) TestNetworkTemplateResourcesNoControllerSubnet(c *tc.C) {
 	c.Assert(vnetProps.Subnets, tc.HasLen, 1)
 	c.Assert(vnetProps.Subnets[0].Properties.AddressPrefixes, tc.HasLen, 2)
 	c.Check(toValue(vnetProps.Subnets[0].Properties.AddressPrefixes[1]), tc.Equals, azure.InternalSubnetIPv6Prefix)
+}
+
+// TestSubnetsDualStackSubnet tests that allSubnets() emits two SubnetInfo rows
+// (one per IP family) for a dual-stack subnet, with the IPv6 one suffixed :ipv6.
+func (s *environSuite) TestSubnetsDualStackSubnet(c *tc.C) {
+	env := s.openEnviron(c)
+
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: []*armnetwork.Subnet{
+				{
+					ID: new("provider-dual-stack-subnet"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefixes: []*string{
+							new("192.168.0.0/20"),
+							new("fd00::/64"),
+						},
+					},
+				},
+			},
+		}),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, tc.IsTrue)
+
+	subs, err := netEnv.Subnets(c.Context(), nil)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Should have two entries: one IPv4, one IPv6.
+	c.Assert(subs, tc.HasLen, 2)
+
+	// Sort by CIDR to ensure predictable order.
+	if subs[0].CIDR > subs[1].CIDR {
+		subs[0], subs[1] = subs[1], subs[0]
+	}
+
+	// IPv4 entry: bare ProviderId.
+	c.Check(subs[0].ProviderId, tc.Equals, corenetwork.Id("provider-dual-stack-subnet"))
+	c.Check(subs[0].CIDR, tc.Equals, "192.168.0.0/20")
+
+	// IPv6 entry: :ipv6 suffix.
+	c.Check(subs[1].ProviderId, tc.Equals, corenetwork.Id("provider-dual-stack-subnet:ipv6"))
+	c.Check(subs[1].CIDR, tc.Equals, "fd00::/64")
+}
+
+// TestSubnetsIPv4OnlySubnet tests regression: IPv4-only subnets still return
+// one entry with bare ProviderId.
+func (s *environSuite) TestSubnetsIPv4OnlySubnet(c *tc.C) {
+	env := s.openEnviron(c)
+
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: []*armnetwork.Subnet{
+				{
+					ID: new("provider-ipv4-only-subnet"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefix: new("10.0.0.0/24"),
+					},
+				},
+			},
+		}),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, tc.IsTrue)
+
+	subs, err := netEnv.Subnets(c.Context(), nil)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Should have one entry (IPv4 only).
+	c.Assert(subs, tc.HasLen, 1)
+	c.Check(subs[0].ProviderId, tc.Equals, corenetwork.Id("provider-ipv4-only-subnet"))
+	c.Check(subs[0].CIDR, tc.Equals, "10.0.0.0/24")
+}
+
+// TestNetworkInterfacesDualStackNIC tests that a NIC with both IPv4 and IPv6
+// IP configurations gets tagged with the correct per-family CIDR and ProviderSubnetID.
+func (s *environSuite) TestNetworkInterfacesDualStackNIC(c *tc.C) {
+	env := s.openEnviron(c)
+
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: []*armnetwork.Subnet{
+				{
+					ID: new("dual-stack-subnet"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefixes: []*string{
+							new("192.168.0.0/20"),
+							new("fd00::/64"),
+						},
+					},
+				},
+			},
+		}),
+		makeSender(".*/networkInterfaces", armnetwork.InterfaceListResult{
+			Value: []*armnetwork.Interface{
+				{
+					ID: new("dual-stack-nic"),
+					Properties: &armnetwork.InterfacePropertiesFormat{
+						Primary: new(true),
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+							{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									PrivateIPAddress:          new("192.168.0.10"),
+									PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+									PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+									Subnet: &armnetwork.Subnet{
+										ID: new("dual-stack-subnet"),
+									},
+									Primary: new(false),
+								},
+							},
+							{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									PrivateIPAddress:          new("fd00::10"),
+									PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+									PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+									Subnet: &armnetwork.Subnet{
+										ID: new("dual-stack-subnet"),
+									},
+									Primary: new(true),
+								},
+							},
+						},
+					},
+					Tags: map[string]*string{
+						"juju-machine-name": new("machine-0"),
+					},
+				},
+			},
+		}),
+		makeSender(".*/publicIPAddresses", armnetwork.PublicIPAddressListResult{}),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, tc.IsTrue)
+
+	res, err := netEnv.NetworkInterfaces(c.Context(), []instance.Id{"machine-0"})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(res, tc.HasLen, 1)
+	c.Assert(res[0], tc.HasLen, 1)
+
+	nic := res[0][0]
+	// IPv6 address should be primary (appear first).
+	c.Assert(nic.Addresses, tc.HasLen, 2)
+
+	// Check IPv6 address: should have :ipv6 suffix and correct CIDR.
+	ipv6Addr := nic.Addresses[0]
+	c.Check(ipv6Addr.Value, tc.Equals, "fd00::10")
+	c.Check(ipv6Addr.CIDR, tc.Equals, "fd00::/64")
+	c.Check(ipv6Addr.ProviderSubnetID, tc.Equals, corenetwork.Id("dual-stack-subnet:ipv6"))
+
+	// Check IPv4 address: bare ProviderSubnetID.
+	ipv4Addr := nic.Addresses[1]
+	c.Check(ipv4Addr.Value, tc.Equals, "192.168.0.10")
+	c.Check(ipv4Addr.CIDR, tc.Equals, "192.168.0.0/20")
+	c.Check(ipv4Addr.ProviderSubnetID, tc.Equals, corenetwork.Id("dual-stack-subnet"))
+}
+
+// TestNetworkInterfacesDualStackNICLegacyModel tests backward compatibility:
+// when allSubnets() returns only bare-ID IPv4 entries (simulating a legacy
+// model with IPv4-only subnets), an IPv6 IP configuration gets no CIDR tag.
+// This is a documented fallback behavior.
+func (s *environSuite) TestNetworkInterfacesDualStackNICLegacyModel(c *tc.C) {
+	env := s.openEnviron(c)
+
+	s.sender = azuretesting.Senders{
+		makeSender("/deployments/common", s.commonDeployment),
+		// Legacy model: only bare IPv4 subnet, no :ipv6 entry.
+		makeSender("/virtualNetworks/juju-internal-network/subnets", armnetwork.SubnetListResult{
+			Value: []*armnetwork.Subnet{
+				{
+					ID: new("legacy-subnet"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefix: new("10.0.0.0/24"),
+					},
+				},
+			},
+		}),
+		makeSender(".*/networkInterfaces", armnetwork.InterfaceListResult{
+			Value: []*armnetwork.Interface{
+				{
+					ID: new("legacy-nic"),
+					Properties: &armnetwork.InterfacePropertiesFormat{
+						Primary: new(true),
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+							{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									PrivateIPAddress:          new("10.0.0.10"),
+									PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+									PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv4),
+									Subnet: &armnetwork.Subnet{
+										ID: new("legacy-subnet"),
+									},
+									Primary: new(false),
+								},
+							},
+							{
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									PrivateIPAddress:          new("fd00::10"),
+									PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+									PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+									Subnet: &armnetwork.Subnet{
+										ID: new("legacy-subnet"),
+									},
+									Primary: new(true),
+								},
+							},
+						},
+					},
+					Tags: map[string]*string{
+						"juju-machine-name": new("machine-0"),
+					},
+				},
+			},
+		}),
+		makeSender(".*/publicIPAddresses", armnetwork.PublicIPAddressListResult{}),
+	}
+
+	netEnv, ok := environs.SupportsNetworking(env)
+	c.Assert(ok, tc.IsTrue)
+
+	res, err := netEnv.NetworkInterfaces(c.Context(), []instance.Id{"machine-0"})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(res, tc.HasLen, 1)
+	c.Assert(res[0], tc.HasLen, 1)
+
+	nic := res[0][0]
+	c.Assert(nic.Addresses, tc.HasLen, 2)
+
+	// IPv6 address: lookup for :ipv6 suffixed ID misses, so no CIDR tag.
+	ipv6Addr := nic.Addresses[0]
+	c.Check(ipv6Addr.Value, tc.Equals, "fd00::10")
+	c.Check(ipv6Addr.CIDR, tc.Equals, "") // No CIDR tag (legacy fallback).
+	c.Check(ipv6Addr.ProviderSubnetID, tc.Equals, corenetwork.Id("legacy-subnet:ipv6"))
+
+	// IPv4 address: tagged as expected.
+	ipv4Addr := nic.Addresses[1]
+	c.Check(ipv4Addr.Value, tc.Equals, "10.0.0.10")
+	c.Check(ipv4Addr.CIDR, tc.Equals, "10.0.0.0/24")
+	c.Check(ipv4Addr.ProviderSubnetID, tc.Equals, corenetwork.Id("legacy-subnet"))
+}
+
+// TestStripIPFamilySuffix tests the stripIPFamilySuffix helper.
+func (s *environSuite) TestStripIPFamilySuffix(c *tc.C) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "/subscriptions/abc123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet:ipv6",
+			expected: "/subscriptions/abc123/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+		},
+		{
+			input:    "/subscriptions/abc123/stuff:ipv4",
+			expected: "/subscriptions/abc123/stuff",
+		},
+		{
+			input:    "/subscriptions/abc123/stuff:other",
+			expected: "/subscriptions/abc123/stuff:other", // :other is not a valid suffix, left alone.
+		},
+		{
+			input:    "plain-id",
+			expected: "plain-id", // No colon, unchanged.
+		},
+		{
+			input:    "",
+			expected: "", // Empty string, unchanged.
+		},
+	}
+
+	for _, test := range testCases {
+		got := azure.StripIPFamilySuffix(test.input)
+		c.Check(got, tc.Equals, test.expected, tc.Commentf("stripIPFamilySuffix(%q)", test.input))
+	}
+}
+
+// TestSubnetProviderIDForFamily tests the subnetProviderIDForFamily helper.
+func (s *environSuite) TestSubnetProviderIDForFamily(c *tc.C) {
+	testCases := []struct {
+		azureID  string
+		isIPv6   bool
+		expected corenetwork.Id
+	}{
+		{
+			azureID:  "/subscriptions/abc/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			isIPv6:   false,
+			expected: corenetwork.Id("/subscriptions/abc/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"),
+		},
+		{
+			azureID:  "/subscriptions/abc/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			isIPv6:   true,
+			expected: corenetwork.Id("/subscriptions/abc/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet:ipv6"),
+		},
+	}
+
+	for _, test := range testCases {
+		got := azure.SubnetProviderIDForFamily(test.azureID, test.isIPv6)
+		c.Check(got, tc.Equals, test.expected, tc.Commentf("SubnetProviderIDForFamily(%q, %v)", test.azureID, test.isIPv6))
+	}
+}
+
+// TestStripAndDeduplicateSubnetIDs tests the stripAndDeduplicateSubnetIDs helper.
+func (s *environSuite) TestStripAndDeduplicateSubnetIDs(c *tc.C) {
+	testCases := []struct {
+		input    []corenetwork.Id
+		expected []corenetwork.Id
+	}{
+		{
+			input: []corenetwork.Id{
+				"subnet-1",
+				"subnet-1:ipv6",
+				"subnet-2",
+			},
+			expected: []corenetwork.Id{
+				"subnet-1",
+				"subnet-2",
+			},
+		},
+		{
+			input: []corenetwork.Id{
+				"subnet-1:ipv6",
+				"subnet-1",
+			},
+			expected: []corenetwork.Id{
+				"subnet-1",
+			},
+		},
+		{
+			input: []corenetwork.Id{
+				"subnet-1",
+				"subnet-2",
+			},
+			expected: []corenetwork.Id{
+				"subnet-1",
+				"subnet-2",
+			},
+		},
+		{
+			input:    []corenetwork.Id{},
+			expected: []corenetwork.Id{},
+		},
+	}
+
+	for _, test := range testCases {
+		got := azure.StripAndDeduplicateSubnetIDs(test.input)
+		c.Check(got, tc.DeepEquals, test.expected, tc.Commentf("StripAndDeduplicateSubnetIDs(%v)", test.input))
+	}
 }

--- a/internal/provider/azure/environ_network_test.go
+++ b/internal/provider/azure/environ_network_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/internal/provider/azure"
 	"github.com/juju/juju/internal/provider/azure/internal/azuretesting"
 )
 
@@ -278,4 +279,72 @@ func (s *environSuite) TestNetworkInterfacesPartialMatch(c *tc.C) {
 	c.Assert(res, tc.HasLen, 2)
 	c.Assert(res[0], tc.HasLen, 1, tc.Commentf("expected to get 1 NIC for machine-0"))
 	c.Assert(res[1], tc.IsNil, tc.Commentf("expected a nil slice for non-matched machines"))
+}
+
+func (s *environSuite) TestNetworkTemplateResourcesDualStack(c *tc.C) {
+	// networkTemplateResources should always produce a dual-stack VNet
+	// and dual-stack subnets, regardless of any constraint.
+	resources, deps := azure.NetworkTemplateResources("westus", s.envTags, []int{17070}, nil)
+
+	// First resource: NSG.
+	c.Assert(resources, tc.HasLen, 2)
+	c.Check(resources[0].Name, tc.Equals, azure.SecurityGroupName)
+
+	// Second resource: VNet.
+	vnet := resources[1]
+	c.Check(vnet.Name, tc.Equals, azure.InternalNetworkName)
+
+	vnetProps, ok := vnet.Properties.(*armnetwork.VirtualNetworkPropertiesFormat)
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(vnetProps.AddressSpace, tc.NotNil)
+
+	// VNet address space must include both IPv4 prefixes and the IPv6 ULA prefix.
+	addrPrefixes := vnetProps.AddressSpace.AddressPrefixes
+	c.Assert(addrPrefixes, tc.HasLen, 3)
+	c.Check(toValue(addrPrefixes[0]), tc.Equals, azure.InternalSubnetPrefix)
+	c.Check(toValue(addrPrefixes[1]), tc.Equals, azure.VnetIPv6Prefix)
+	c.Check(toValue(addrPrefixes[2]), tc.Equals, azure.ControllerSubnetPrefix)
+
+	// Subnets: internal + controller (since apiPorts is non-empty).
+	c.Assert(vnetProps.Subnets, tc.HasLen, 2)
+
+	internalSubnet := vnetProps.Subnets[0]
+	c.Assert(toValue(internalSubnet.Name), tc.Equals, azure.InternalSubnetName)
+	c.Assert(internalSubnet.Properties.AddressPrefixes, tc.HasLen, 2)
+	c.Check(toValue(internalSubnet.Properties.AddressPrefixes[0]), tc.Equals, azure.InternalSubnetPrefix)
+	c.Check(toValue(internalSubnet.Properties.AddressPrefixes[1]), tc.Equals, azure.InternalSubnetIPv6Prefix)
+	// AddressPrefix (singular) should be nil when using AddressPrefixes.
+	c.Check(internalSubnet.Properties.AddressPrefix, tc.IsNil)
+
+	controllerSubnet := vnetProps.Subnets[1]
+	c.Assert(toValue(controllerSubnet.Name), tc.Equals, azure.ControllerSubnetName)
+	c.Assert(controllerSubnet.Properties.AddressPrefixes, tc.HasLen, 2)
+	c.Check(toValue(controllerSubnet.Properties.AddressPrefixes[0]), tc.Equals, azure.ControllerSubnetPrefix)
+	c.Check(toValue(controllerSubnet.Properties.AddressPrefixes[1]), tc.Equals, azure.ControllerSubnetIPv6Prefix)
+
+	// NSG ID is returned as a dependency.
+	c.Assert(deps, tc.HasLen, 1)
+}
+
+func (s *environSuite) TestNetworkTemplateResourcesNoControllerSubnet(c *tc.C) {
+	// When no API ports are given, no controller subnet should be created,
+	// but the VNet and internal subnet should still be dual-stack.
+	resources, _ := azure.NetworkTemplateResources("westus", s.envTags, nil, nil)
+
+	c.Assert(resources, tc.HasLen, 2)
+	vnet := resources[1]
+
+	vnetProps, ok := vnet.Properties.(*armnetwork.VirtualNetworkPropertiesFormat)
+	c.Assert(ok, tc.IsTrue)
+
+	// VNet: internal IPv4 + IPv6 ULA only (no controller prefix).
+	addrPrefixes := vnetProps.AddressSpace.AddressPrefixes
+	c.Assert(addrPrefixes, tc.HasLen, 2)
+	c.Check(toValue(addrPrefixes[0]), tc.Equals, azure.InternalSubnetPrefix)
+	c.Check(toValue(addrPrefixes[1]), tc.Equals, azure.VnetIPv6Prefix)
+
+	// Only one subnet (internal, no controller).
+	c.Assert(vnetProps.Subnets, tc.HasLen, 1)
+	c.Assert(vnetProps.Subnets[0].Properties.AddressPrefixes, tc.HasLen, 2)
+	c.Check(toValue(vnetProps.Subnets[0].Properties.AddressPrefixes[1]), tc.Equals, azure.InternalSubnetIPv6Prefix)
 }

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2407,6 +2407,36 @@ func (s *environSuite) TestStartInstanceIPFamilyDualPlacementIPv4OnlySubnet(c *t
 		`.*placement subnet "subnet2" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
 }
 
+func (s *environSuite) TestStartInstanceIPFamilyDualPlacementNon64IPv6Subnet(c *tc.C) {
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("192.168.0.0/20"),
+		},
+	}, {
+		ID:   new("/path/to/subnet3"),
+		Name: new("subnet3"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{new("10.0.0.0/24"), new("fd00::/56")}, // IPv6 /56, not /64
+		},
+	}}
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets:   subnets,
+	})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Placement = "subnet=subnet3"
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	_, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorMatches,
+		`.*placement subnet "subnet3" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
+}
+
 func (s *environSuite) TestConstraintsValidatorVocabulary(c *tc.C) {
 	validator := s.constraintsValidator(c)
 	_, err := validator.Validate(constraints.MustParse("arch=s390x"))

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	corenetwork "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/network/ipfamily"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
@@ -1113,6 +1114,7 @@ type assertStartInstanceRequestsParams struct {
 	hasSpaceConstraints    bool
 	managedIdentity        string
 	storageAccountType     *armcompute.StorageAccountType
+	dualStackIPFamily      bool // ip-family=dual: expect IPv6 PIP + IPv6 NIC IP config
 }
 
 func (s *environSuite) assertStartInstanceRequests(
@@ -1186,7 +1188,7 @@ func (s *environSuite) assertStartInstanceRequests(
 	subnets := []*armnetwork.Subnet{{
 		Name: new("juju-internal-subnet"),
 		Properties: &armnetwork.SubnetPropertiesFormat{
-			AddressPrefix: new("192.168.0.0/20"),
+			AddressPrefixes: []*string{new("192.168.0.0/20"), new("fd00::/64")},
 			NetworkSecurityGroup: &armnetwork.SecurityGroup{
 				ID: new(nsgId),
 			},
@@ -1194,7 +1196,7 @@ func (s *environSuite) assertStartInstanceRequests(
 	}, {
 		Name: new("juju-controller-subnet"),
 		Properties: &armnetwork.SubnetPropertiesFormat{
-			AddressPrefix: new("192.168.16.0/20"),
+			AddressPrefixes: []*string{new("192.168.16.0/20"), new("fd00:0:0:10::/64")},
 			NetworkSecurityGroup: &armnetwork.SecurityGroup{
 				ID: new(nsgId),
 			},
@@ -1215,7 +1217,7 @@ func (s *environSuite) assertStartInstanceRequests(
 	var vmDependsOn []string
 	if bootstrapping {
 		if args.existingNetwork == "" {
-			addressPrefixes := to.SliceOfPtrs("192.168.0.0/20", "192.168.16.0/20")
+			addressPrefixes := to.SliceOfPtrs("192.168.0.0/20", "fd00::/48", "192.168.16.0/20")
 			templateResources = append(templateResources, armtemplates.Resource{
 				APIVersion: azure.NetworkAPIVersion,
 				Type:       "Microsoft.Network/networkSecurityGroups",
@@ -1306,10 +1308,17 @@ func (s *environSuite) assertStartInstanceRequests(
 		}
 	}
 	var publicIPAddress *armnetwork.PublicIPAddress
+	var ipv6PublicIPAddress *armnetwork.PublicIPAddress
 	if args.publicIP {
 		publicIPAddressId := `[resourceId('Microsoft.Network/publicIPAddresses', 'juju-06f00d-0-public-ip')]`
 		publicIPAddress = &armnetwork.PublicIPAddress{
 			ID: new(publicIPAddressId),
+		}
+		if args.dualStackIPFamily {
+			ipv6PIPId := `[resourceId('Microsoft.Network/publicIPAddresses', 'juju-06f00d-0-public-ip-ipv6')]`
+			ipv6PublicIPAddress = &armnetwork.PublicIPAddress{
+				ID: new(ipv6PIPId),
+			}
 		}
 	}
 
@@ -1332,6 +1341,23 @@ func (s *environSuite) assertStartInstanceRequests(
 		if primary && publicIPAddress != nil {
 			ipConfigurations[0].Properties.PublicIPAddress = publicIPAddress
 			nicDependsOn = append(nicDependsOn, *publicIPAddress.ID)
+		}
+		// For dual-stack, add an IPv6 IP configuration to the primary NIC.
+		if primary && args.dualStackIPFamily {
+			ipv6Props := &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+				Primary:                   new(false),
+				PrivateIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+				PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+				Subnet:                    &armnetwork.Subnet{ID: new(subnetId)},
+			}
+			if ipv6PublicIPAddress != nil {
+				ipv6Props.PublicIPAddress = ipv6PublicIPAddress
+				nicDependsOn = append(nicDependsOn, *ipv6PublicIPAddress.ID)
+			}
+			ipConfigurations = append(ipConfigurations, &armnetwork.InterfaceIPConfiguration{
+				Name:       new("primary-ipv6"),
+				Properties: ipv6Props,
+			})
 		}
 
 		nicId := fmt.Sprintf(`[resourceId('Microsoft.Network/networkInterfaces', 'juju-06f00d-0-%s')]`, name)
@@ -1389,6 +1415,20 @@ func (s *environSuite) assertStartInstanceRequests(
 			},
 			Sku: &armtemplates.Sku{Name: "Standard"},
 		})
+		if args.dualStackIPFamily {
+			templateResources = append(templateResources, armtemplates.Resource{
+				APIVersion: azure.NetworkAPIVersion,
+				Type:       "Microsoft.Network/publicIPAddresses",
+				Name:       "juju-06f00d-0-public-ip-ipv6",
+				Location:   "westus",
+				Tags:       s.vmTags,
+				Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+					PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+					PublicIPAddressVersion:   to.Ptr(armnetwork.IPVersionIPv6),
+				},
+				Sku: &armtemplates.Sku{Name: "Standard"},
+			})
+		}
 	}
 	templateResources = append(templateResources, nicResources...)
 	vmTemplate := armtemplates.Resource{
@@ -2228,6 +2268,143 @@ func (s *environSuite) TestBootstrapIPFamilyDualStandardSKUAccepted(c *tc.C) {
 		return
 	}
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDual(c *tc.C) {
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference:    &jammyImageReferenceGen2,
+		diskSizeGB:        32,
+		osProfile:         &s.linuxOsProfile,
+		instanceType:      "Standard_A1",
+		publicIP:          true,
+		dualStackIPFamily: true,
+	})
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyIPv4(c *tc.C) {
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.IPv4)
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference: &jammyImageReferenceGen2,
+		diskSizeGB:     32,
+		osProfile:      &s.linuxOsProfile,
+		instanceType:   "Standard_A1",
+		publicIP:       true,
+	})
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDualNoPublicIP(c *tc.C) {
+	env := s.openEnviron(c)
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Constraints.AllocatePublicIP = new(bool)
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference:    &jammyImageReferenceGen2,
+		diskSizeGB:        32,
+		osProfile:         &s.linuxOsProfile,
+		instanceType:      "Standard_A1",
+		publicIP:          false,
+		dualStackIPFamily: true,
+	})
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDualPlacementIPv6Subnet(c *tc.C) {
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("192.168.0.0/20"),
+		},
+	}, {
+		ID:   new("/path/to/subnet2"),
+		Name: new("subnet2"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefixes: []*string{new("10.0.0.0/24"), new("fd00::/64")},
+		},
+	}}
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets:   subnets,
+	})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Placement = "subnet=subnet2"
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	result, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.NotNil)
+
+	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
+		imageReference:    &jammyImageReferenceGen2,
+		diskSizeGB:        32,
+		osProfile:         &s.linuxOsProfile,
+		instanceType:      "Standard_A1",
+		publicIP:          true,
+		subnets:           []string{"/path/to/subnet2"},
+		placementSubnet:   "subnet2",
+		dualStackIPFamily: true,
+	})
+}
+
+func (s *environSuite) TestStartInstanceIPFamilyDualPlacementIPv4OnlySubnet(c *tc.C) {
+	env := s.openEnviron(c)
+	subnets := []*armnetwork.Subnet{{
+		ID:   new("/path/to/subnet1"),
+		Name: new("subnet1"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("192.168.0.0/20"),
+		},
+	}, {
+		ID:   new("/path/to/subnet2"),
+		Name: new("subnet2"),
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			AddressPrefix: new("10.0.0.0/24"),
+		},
+	}}
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap: false,
+		subnets:   subnets,
+	})
+	s.requests = nil
+	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
+	params.Constraints.IPFamily = to.Ptr(ipfamily.Dual)
+	params.Placement = "subnet=subnet2"
+	params.InstanceConfig.AuthorizedKeys = s.authorizedKeyString(c)
+
+	_, err := env.StartInstance(c.Context(), params)
+	c.Assert(err, tc.ErrorMatches,
+		`.*placement subnet "subnet2" does not support ip-family=dual: no IPv6 /64 prefix found in AddressPrefixes; add a /64 IPv6 prefix to the subnet or use ip-family=ipv4`)
 }
 
 func (s *environSuite) TestConstraintsValidatorVocabulary(c *tc.C) {

--- a/internal/provider/azure/export_test.go
+++ b/internal/provider/azure/export_test.go
@@ -17,3 +17,11 @@ const ControllerSubnetPrefix = controllerSubnetPrefix
 const InternalSubnetIPv6Prefix = internalSubnetIPv6Prefix
 const ControllerSubnetIPv6Prefix = controllerSubnetIPv6Prefix
 const VnetIPv6Prefix = vnetIPv6Prefix
+
+// Export helper functions for testing.
+var (
+	SubnetProviderIDForFamily    = subnetProviderIDForFamily
+	StripIPFamilySuffix          = stripIPFamilySuffix
+	StripAndDeduplicateSubnetIDs = stripAndDeduplicateSubnetIDs
+)
+

--- a/internal/provider/azure/export_test.go
+++ b/internal/provider/azure/export_test.go
@@ -5,3 +5,15 @@ package azure
 
 const ComputeAPIVersion = computeAPIVersion
 const NetworkAPIVersion = networkAPIVersion
+
+var NetworkTemplateResources = networkTemplateResources
+
+const SecurityGroupName = internalSecurityGroupName
+const InternalNetworkName = internalNetworkName
+const InternalSubnetName = internalSubnetName
+const ControllerSubnetName = controllerSubnetName
+const InternalSubnetPrefix = internalSubnetPrefix
+const ControllerSubnetPrefix = controllerSubnetPrefix
+const InternalSubnetIPv6Prefix = internalSubnetIPv6Prefix
+const ControllerSubnetIPv6Prefix = controllerSubnetIPv6Prefix
+const VnetIPv6Prefix = vnetIPv6Prefix

--- a/internal/provider/azure/networking.go
+++ b/internal/provider/azure/networking.go
@@ -42,6 +42,19 @@ const (
 	// controllerSubnetPrefix is the address prefix for the subnet that
 	// each controller machine's primary NIC is attached to.
 	controllerSubnetPrefix = "192.168.16.0/20"
+
+	// vnetIPv6Prefix is the ULA IPv6 address prefix added to the VNet
+	// address space to enable dual-stack networking.
+	vnetIPv6Prefix = "fd00::/48"
+
+	// internalSubnetIPv6Prefix is the IPv6 address prefix added to the
+	// internal subnet for dual-stack machines.
+	internalSubnetIPv6Prefix = "fd00::/64"
+
+	// controllerSubnetIPv6Prefix is the IPv6 address prefix added to the
+	// controller subnet for dual-stack machines. It uses a distinct /64
+	// to avoid overlap with the internal subnet.
+	controllerSubnetIPv6Prefix = "fd00:0:0:10::/64"
 )
 
 const (
@@ -132,19 +145,19 @@ func networkTemplateResources(
 	subnets := []*armnetwork.Subnet{{
 		Name: new(internalSubnetName),
 		Properties: &armnetwork.SubnetPropertiesFormat{
-			AddressPrefix: new(internalSubnetPrefix),
+			AddressPrefixes: []*string{new(internalSubnetPrefix), new(internalSubnetIPv6Prefix)},
 			NetworkSecurityGroup: &armnetwork.SecurityGroup{
 				ID: new(nsgID),
 			},
 		},
 	}}
-	addressPrefixes := []*string{new(internalSubnetPrefix)}
+	addressPrefixes := []*string{new(internalSubnetPrefix), new(vnetIPv6Prefix)}
 	if len(apiPorts) > 0 {
 		addressPrefixes = append(addressPrefixes, new(controllerSubnetPrefix))
 		subnets = append(subnets, &armnetwork.Subnet{
 			Name: new(controllerSubnetName),
 			Properties: &armnetwork.SubnetPropertiesFormat{
-				AddressPrefix: new(controllerSubnetPrefix),
+				AddressPrefixes: []*string{new(controllerSubnetPrefix), new(controllerSubnetIPv6Prefix)},
 				NetworkSecurityGroup: &armnetwork.SecurityGroup{
 					ID: new(nsgID),
 				},


### PR DESCRIPTION
# Fix: Correctly expose dual-stack Azure subnets via `allSubnets` and `NetworkInterfaces`

Fixes JUJU-9876

## Summary

PR #22736 makes the Juju-managed Azure VNet dual-stack unconditionally. Every VM provisioned by Juju on Azure is attached to a subnet with both IPv4 and IPv6 prefixes. However, the read paths in the Azure provider still treat subnet IDs as 1:1 with IPv4 CIDRs, silently dropping IPv6 prefixes.

**Problem**: IPv6 host addresses get recorded with the IPv4 subnet CIDR, causing Juju's reconciliation to fail. This creates synthetic `/128` "subnets" for each IPv6 address instead of using the correct `fd00::/64` prefix.

## Implementation

This implements the provider-local fix from [juju-agent-specs PR #24](https://github.com/juju/juju-agent-specs/pull/24):

1. **Suffix Juju-side ProviderId with `:ipv6`** for IPv6 subnet entries, keeping IPv4 bare
   - Allows dual-stack Azure subnets to be reported as two distinct Juju SubnetInfo rows (one per family)

2. **Rewrite `allSubnets()`** to iterate all prefixes (not just IPv4)
   - Uses `network.CIDRAddressType` to classify each prefix
   - Emits TWO SubnetInfo rows per dual-stack subnet

3. **Update `NetworkInterfaces()`** for per-family CIDR lookup
   - Reads `PrivateIPAddressVersion` to detect IPv6 IP configs
   - Looks up CIDR using family-suffixed ProviderId
   - Gracefully falls back for legacy models

4. **Protect ARM/provisioning paths** by stripping and deduplicating
   - `networkInfoForInstance()` returns bare Azure subnet IDs
   - Ensures ARM templates never see suffixed IDs
   - Single NIC per Azure subnet (no duplicates)

5. **Comprehensive test coverage** (11 network-related tests, all passing)
   - Dual-stack scenarios (IPv4 + IPv6)
   - IPv4-only regression tests
   - Legacy model fallback
   - Helper function edge cases

## Backward Compatibility

- ✅ Bare ProviderId continues to mean IPv4
- ✅ Existing `provider_subnet` rows unchanged
- ✅ IPv4-only subnets return single entry as before
- ✅ No schema changes required
- ✅ Dual-stack subnets get additional `:ipv6` row

## Changes

- `internal/provider/azure/environ_network.go`: Core implementation
  - New helpers: `subnetProviderIDForFamily()`, `stripIPFamilySuffix()`, `stripAndDeduplicateSubnetIDs()`
  - Rewrote `allSubnets()` to emit per-prefix entries
  - Updated `NetworkInterfaces()` and `mapAzureInterfaceList()` for per-family CIDR lookup
  - Protected `networkInfoForInstance()` provisioning paths

- `internal/provider/azure/environ_network_test.go`: Test coverage
  - Added 6 new tests for dual-stack scenarios
  - Updated regression tests for IPv4-only behavior
  - Helper function unit tests

- `internal/provider/azure/export_test.go`: Export helpers for testing

---

## QA Steps

To verify dual-stack subnet behavior:

### 1. Bootstrap with dual-stack

```bash
juju bootstrap <cloud> <controller> --bootstrap-constraints "ip-family=dual"
```

### 2. Provision dual-stack machine

```bash
juju add-machine --constraints "ip-family=dual"
juju wait-for machine 1 "agent-status=idle" "instance-status=running"
```

### 3. Verify subnets show both families

```bash
juju subnets
```

**Expected output**:
- Both IPv4 (e.g., `192.168.0.0/20`) and IPv6 (e.g., `fd00::/64`) entries
- Each with distinct `provider-id` (IPv6 suffixed with `:ipv6`)
- **NO** synthetic `/128` host-only entries

**Example**:
```
subnets:
  192.168.0.0/20:
    type: ipv4
    provider-id: /subscriptions/.../subnets/juju-internal-subnet
  fd00::/64:
    type: ipv6
    provider-id: /subscriptions/.../subnets/juju-internal-subnet:ipv6
```

### 4. Verify machine addresses tagged correctly

```bash
juju show-machine 1 --format yaml
```

**Expected**:
- IPv6 address shows `subnet-cidr: fd00::/64` (NOT the IPv4 CIDR `192.168.0.0/20`)
- IPv4 address shows `subnet-cidr: 192.168.0.0/20`

**Example**:
```yaml
machines:
  "1":
    machine-status:
      current: started
    instance-id: <instance>
    hostname: <hostname>
    ip-addresses:
    - "192.168.0.10"
    - "fd00::10"
    network-interfaces:
    - addresses:
      - address: 192.168.0.10
        subnet-cidr: 192.168.0.0/20
      - address: fd00::10
        subnet-cidr: fd00::/64
```

### 5. Test space operations

```bash
juju create-space <space-name>
juju move-to-space <space-name> machine:1
juju show-machine 1 --format yaml
```

**Expected**:
- Space assignment succeeds
- Addresses maintain correct per-family CIDR tags

### 6. Regression: IPv4-only machines unchanged

```bash
juju add-machine  # no ip-family constraint
juju wait-for machine 2 "agent-status=idle"
juju subnets
juju show-machine 2 --format yaml
```

**Expected**:
- Single IPv4 subnet entry (no IPv6)
- Addresses tagged with IPv4 CIDR only
- Exact same behavior as before this fix

---

## Related

- Design: [juju-agent-specs PR #24](https://github.com/juju/juju-agent-specs/pull/24)
- Blocking PR: [#22736 feat(azure): provision dual-stack machines with ip-family=dual](https://github.com/juju/juju/pull/22736)
- Jira: [JUJU-9876](https://warthogs.atlassian.net/browse/JUJU-9876)


[JUJU-9876]: https://warthogs.atlassian.net/browse/JUJU-9876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ