### PR TITLE
test: add missing mock call

### DIFF
--- a/internal/worker/sshserver/manifold_test.go
+++ b/internal/worker/sshserver/manifold_test.go
@@ -16,6 +16,7 @@ import (
 	dt "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/virtualhostname"
 	"github.com/juju/juju/core/watcher"
@@ -192,6 +193,7 @@ func (s *manifoldSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.controllerConfigService.EXPECT().WatchControllerConfig(gomock.Any()).DoAndReturn(func(context.Context) (watcher.Watcher[[]string], error) {
 		return watchertest.NewMockStringsWatcher(make(<-chan []string)), nil
 	}).AnyTimes()
+	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(controller.Config{}, nil).AnyTimes()
 	return ctrl
 }
 


### PR DESCRIPTION
Fixes a test panic in the sshserver worker. Running the test with `go test -timeout 60s -race -run 'TestManifoldSuite/TestManifoldStart' -count 100 ./internal/worker/sshserver/` the test may fail with a panic after the 60s timeout before this change. This is caused by the fact that the test is calling `manifold.Start()` which eventually calls the server's `loop()` method which then calls the missing mock `ssw.config.ControllerConfigService.ControllerConfig(ctx)` which causes gomock to call `runtime.Goexit()`, stopping the routine which is being tracked by the catacomb's tomb. Because the routine has been killed, the catacomb/tomb is stuck.

One way of making these failures easier to debug is to use a custom test reporter when creating the gomock controller so that fatal errors do not cause the routine to exit. See https://pkg.go.dev/github.com/golang/mock/gomock#TestReporter.

The test itself may need another look as it seems to be trying to verify the manifold start logic but doesn't mock out the worker loop.

Verify the fix with `go test -timeout 60s -race -run 'TestManifoldSuite/TestManifoldStart' -count 100 ./internal/worker/sshserver/` before and after the fix.
