### PR TITLE
fix(watcher): return tomb.ErrDying on shutdown race in NamespaceWatcher and NotifyWatcher

### DIFF
--- a/core/watcher/eventsource/namespace.go
+++ b/core/watcher/eventsource/namespace.go
@@ -118,13 +118,29 @@ func (w *NamespaceWatcher) loop() error {
 
 	subscription, err := w.watchableDB.Subscribe(w.summary, w.filterOpts...)
 	if err != nil {
-		return errors.Errorf("subscribing to namespaces: %w", err)
+		// If the tomb is dying, we don't want to return a raw error that
+		// could propagate through the catacomb. The dying signal takes
+		// precedence.
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		default:
+			return errors.Errorf("subscribing to namespaces: %w", err)
+		}
 	}
 	defer subscription.Kill()
 
 	changes, err := w.initialQuery(ctx, w.watchableDB)
 	if err != nil {
-		return errors.Errorf("retrieving initial watcher state: %w", err)
+		// If the tomb is dying, we don't want to return a raw error that
+		// could propagate through the catacomb. The dying signal takes
+		// precedence.
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		default:
+			return errors.Errorf("retrieving initial watcher state: %w", err)
+		}
 	}
 
 	// By reassigning the in and out channels, we effectively ticktock between

--- a/core/watcher/eventsource/notify.go
+++ b/core/watcher/eventsource/notify.go
@@ -98,7 +98,12 @@ func (w *NotifyWatcher) loop() error {
 
 	subscription, err := w.watchableDB.Subscribe(w.summary, w.filterOpts...)
 	if err != nil {
-		return errors.Errorf("subscribing to namespaces: %w", err)
+		select {
+		case <-w.tomb.Dying():
+			return tomb.ErrDying
+		default:
+			return errors.Errorf("subscribing to namespaces: %w", err)
+		}
 	}
 	defer subscription.Kill()
 


### PR DESCRIPTION
A race condition during API server teardown causes flaky test failures.
Observed in `TestWithoutControllerSuite` in
`apiserver/facades/agent/provisioner`:

```
apiserver.go:381:
    c.Assert(err, tc.ErrorIs, apiserver.ErrAPIServerDying)
... obtained ("retrieving initial watcher state: sql: transaction has already been committed or rolled back")
... expected "api-server worker is dying"
```

**Sequence:**

1. `TearDownTest` calls `Server.Stop()` → `Kill()` + `Wait()`
2. The server's catacomb starts dying, killing managed workers (including the `controllerConfigWatcher`, a `NamespaceWatcher` added at `apiserver/apiserver.go:643`)
3. The watcher's context gets cancelled while `initialQuery` is mid-transaction against dqlite
4. The SQL driver returns `"transaction has already been committed or rolled back"`
5. The watcher wraps and returns this error from its loop
6. The catacomb propagates it as the server's death reason instead of `ErrAPIServerDying`
7. The teardown assertion fails

The root cause is that `Subscribe` and `initialQuery` error paths in both
`NamespaceWatcher.loop()` and `NotifyWatcher.loop()` return raw errors
unconditionally, without checking whether the tomb is already dying.

## Fix

Before returning errors from `Subscribe` or `initialQuery`, check
`w.tomb.Dying()`. If the tomb is dying, return `tomb.ErrDying` instead.
`tombv2` treats `ErrDying` as a clean shutdown signal — the existing nil kill
reason is preserved and the catacomb sees no error, allowing
`ErrAPIServerDying` from the server's main loop to win.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test ./apiserver/facades/agent/provisioner/ -c -race
timeout 120 stress -timeout 30s ./provisioner.test
```

## Documentation changes

## Links
Test failure: https://jenkins.juju.canonical.com/job/github-make-check-juju/37497/console

```text
**17:35:30** --- FAIL: TestWithoutControllerSuite (2.92s)
**17:35:30**     --- FAIL: TestWithoutControllerSuite/TestStubSuite (1.47s)
**17:35:30**         /home/jenkins/go/src/github.com/juju/juju/apiserver/facades/agent/provisioner/provisioninginfo_test.go:10
**17:35:30**         securitylog.go:423: WARNING juju.security {"datetime":"2026-06-24T15:33:35.691187724Z","appid":"juju.controller","event":"sys_startup:admin","level":"WARN","description":"User admin spawned a new instance"}
**17:35:30**         provisioninginfo_test.go:11: This suite is missing tests for the following scenarios:
**17:35:30**             - ProvisioningInfo where the alpha space is explicitly set for all bindings and
**17:35:30**               as a constraint, causing ProvisioningNetworkTopology to have only subnets and
**17:35:30**               zones from the alpha space.
**17:35:30**             - TestStorageProviderFallbackToType: Check ProvisioningInfo for includes volume
**17:35:30**               attachment information where one provider is environ-managed and one is not.
**17:35:30**             - TestStorageProviderVolumes: Check ProvisioningInfo for includes volume
**17:35:30**               attachment information for already-provisioned volumes.
**17:35:30**             - TestProvisioningInfoWithLXDProfile: Check ProvisioningInfo for includes
**17:35:30**               CharmLXDProfiles when a unit with an LXD profile is on the machine.
**17:35:30**             
**17:35:30**         securitylog.go:423: WARNING juju.security {"datetime":"2026-06-24T15:33:35.691489347Z","appid":"juju.controller","event":"sys_shutdown:admin","level":"WARN","description":"User admin stopped this instance"}
**17:35:30**         apiserver.go:381: 
**17:35:30**                 c.Assert(err, tc.ErrorIs, apiserver.ErrAPIServerDying)
**17:35:30**             ... obtained *errors.Err = &errors.unformatter{message:"", cause:errors.link{error:errors.frameTracer{error:(*fmt.wrapError)(0xc000712000), pc:0x32aafb7}}, previous:errors.link{error:errors.frameTracer{error:(*fmt.wrapError)(0xc000712000), pc:0x32aafb7}}, function:"github.com/juju/juju/apiserver.(*Server).Wait", line:495} ("retrieving initial watcher state: sql: transaction has already been committed or rolled back")
**17:35:30**             ... error errors.ConstError = "api-server worker is dying"
**17:35:30** FAIL
**17:35:30** FAIL	github.com/juju/juju/apiserver/facades/agent/provisioner	5.703s
```
