### PR TITLE
fix: flaky TestManifoldStart timeout in sshserver

### DIFF
--- a/internal/worker/sshserver/manifold_test.go
+++ b/internal/worker/sshserver/manifold_test.go
@@ -16,6 +16,7 @@ import (
 	dt "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/virtualhostname"
 	"github.com/juju/juju/core/watcher"
@@ -192,6 +193,12 @@ func (s *manifoldSuite) setupMocks(c *tc.C) *gomock.Controller {
 	s.controllerConfigService.EXPECT().WatchControllerConfig(gomock.Any()).DoAndReturn(func(context.Context) (watcher.Watcher[[]string], error) {
 		return watchertest.NewMockStringsWatcher(make(<-chan []string)), nil
 	}).AnyTimes()
+	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).DoAndReturn(func(context.Context) (controller.Config, error) {
+		return controller.Config{
+			controller.SSHServerPort:               22,
+			controller.SSHMaxConcurrentConnections: 10,
+		}, nil
+	}).AnyTimes()
 	return ctrl
 }
 
@@ -226,7 +233,7 @@ func (s *manifoldSuite) newManifoldConfig(c *tc.C, modifier func(cfg *ManifoldCo
 
 func (s *manifoldSuite) TestManifoldUninstall(c *tc.C) {
 	// Unset feature flag
-	os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
+	_ = os.Unsetenv(osenv.JujuFeatureFlagEnvKey)
 	featureflag.SetFlagsFromEnvironment(osenv.JujuFeatureFlagEnvKey)
 
 	defer s.setupMocks(c).Finish()


### PR DESCRIPTION
`TestManifoldSuite/TestManifoldStart` was flaky in CI, timing out after 10
minutes. Under `stress`, the test would hang consistently.

The test starts a real `serverWrapperWorker` via the manifold. The worker's
`loop()` calls `ControllerConfigService.ControllerConfig()` to fetch initial
controller configuration. However, `setupMocks` only mocked
`WatchControllerConfig` — the `ControllerConfig` method had no expectation set.

When gomock received the unexpected `ControllerConfig` call, it invoked
`t.Fatalf()` which calls `runtime.Goexit()` from inside the catacomb's
goroutine. This terminated the goroutine without ever calling
`catacomb.Kill()`, leaving the catacomb's `WaitGroup` permanently blocked. The
worker's `Wait()` never returned, and `workertest.CleanKill` hung indefinitely.

**Fix:** Added a `ControllerConfig` mock expectation in `setupMocks` returning
valid controller config (port 22, max connections 10), matching the pattern
used in `worker_test.go`.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
go test ./internal/worker/sshserver/ -c -race
timeout 120 stress -timeout 30s ./sshserver.test
```

## Documentation changes

## Links
- Failed test: https://jenkins.juju.canonical.com/job/github-make-check-juju/37614/console

```text
panic: test timed out after 10m0s
14:08:35 	running tests:
14:08:35 		TestManifoldSuite (10m0s)
14:08:35 		TestManifoldSuite/TestManifoldStart (10m0s)
14:08:35 
14:08:35 goroutine 26 [running]:
14:08:35 testing.(*M).startAlarm.func1()
14:08:35 	/usr/local/go/src/testing/testing.go:2802 +0x605
14:08:35 created by time.goFunc
14:08:35 	/usr/local/go/src/time/sleep.go:215 +0x45
14:08:35 
14:08:35 goroutine 1 [chan receive, 9 minutes]:
14:08:35 testing.(*T).Run(0xc00061eb48, {0x4495695, 0x11}, 0x45e31b8)
14:08:35 	/usr/local/go/src/testing/testing.go:2109 +0xb3e
14:08:35 testing.runTests.func1(0xc00061eb48)
14:08:35 	/usr/local/go/src/testing/testing.go:2585 +0x85
14:08:35 testing.tRunner(0xc00061eb48, 0xc000653ad0)
14:08:35 	/usr/local/go/src/testing/testing.go:2036 +0x21d
14:08:35 testing.runTests({0x449cebc, 0x14}, {0x44ea344, 0x2e}, 0xc0005c4720, {0x64f0940, 0x5, 0x5}, {0xc287b8d0c36a4163, 0x8bb61c0286, ...})
14:08:35 	/usr/local/go/src/testing/testing.go:2583 +0x9ea
14:08:35 testing.(*M).Run(0xc0005ce5a0)
14:08:35 	/usr/local/go/src/testing/testing.go:2443 +0xf4c
14:08:35 main.main()
14:08:35 	_testmain.go:54 +0x165
14:08:35 
14:08:35 goroutine 37 [chan receive, 9 minutes]:
14:08:35 testing.(*T).Run(0xc00061e008, {0x3c714ae, 0x11}, 0xc0002da450)
14:08:35 	/usr/local/go/src/testing/testing.go:2109 +0xb3e
14:08:35 github.com/juju/tc.(*suiteRunner).run(0xc000590050, 0xc00061e008)
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/tc@v0.0.0-20251023013639-77c6a1d20e5a/check.go:183 +0x371
14:08:35 github.com/juju/tc.Run(0xc00061e008, {0x43a3260, 0xc000412500})
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/tc@v0.0.0-20251023013639-77c6a1d20e5a/run.go:90 +0x4f
14:08:35 github.com/juju/juju/internal/worker/sshserver.TestManifoldSuite.func1(0xc00061e008)
14:08:35 	/home/jenkins/go/src/github.com/juju/juju/internal/worker/sshserver/manifold_test.go:40 +0xac
14:08:35 github.com/juju/juju/internal/testhelpers.PrintGoroutineLeaks(0xc00061e008, 0x45e33c8)
14:08:35 	/home/jenkins/go/src/github.com/juju/juju/internal/testhelpers/goleak.go:87 +0x19a
14:08:35 github.com/juju/juju/internal/worker/sshserver.TestManifoldSuite(0xc00061e008)
14:08:35 	/home/jenkins/go/src/github.com/juju/juju/internal/worker/sshserver/manifold_test.go:39 +0x2e
14:08:35 testing.tRunner(0xc00061e008, 0x45e31b8)
14:08:35 	/usr/local/go/src/testing/testing.go:2036 +0x21d
14:08:35 created by testing.(*T).Run in goroutine 1
14:08:35 	/usr/local/go/src/testing/testing.go:2101 +0xb13
14:08:35 
14:08:35 goroutine 38 [chan receive, 9 minutes]:
14:08:35 github.com/juju/juju/internal/testhelpers.leakSentinel(...)
14:08:35 	/home/jenkins/go/src/github.com/juju/juju/internal/testhelpers/goleak.go:91
14:08:35 created by github.com/juju/juju/internal/testhelpers.PrintGoroutineLeaks in goroutine 37
14:08:35 	/home/jenkins/go/src/github.com/juju/juju/internal/testhelpers/goleak.go:42 +0xec
14:08:35 
14:08:35 goroutine 41 [select, 9 minutes]:
14:08:35 github.com/juju/worker/v5/workertest.CheckKilled({0x4632920, 0xc000420480}, {0x46042c0, 0xc0006689c0})
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/worker/v5@v5.0.0/workertest/check.go:68 +0x25a
14:08:35 github.com/juju/worker/v5/workertest.CheckKill({0x4632920, 0xc000420480}, {0x46042c0, 0xc0006689c0})
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/worker/v5@v5.0.0/workertest/check.go:86 +0x65
14:08:35 github.com/juju/worker/v5/workertest.CleanKill({0x4632920, 0xc000420480}, {0x46042c0, 0xc0006689c0})
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/worker/v5@v5.0.0/workertest/check.go:101 +0x5f
14:08:35 github.com/juju/juju/internal/worker/sshserver.(*manifoldSuite).TestManifoldStart(0xc000412500, 0xc000420480)
14:08:35 	/home/jenkins/go/src/github.com/juju/juju/internal/worker/sshserver/manifold_test.go:161 +0xcf1
14:08:35 reflect.Value.call({0x43a3260?, 0xc000412500?, 0xc000663b60?}, {0x447e312, 0x4}, {0xc000663cc8, 0x1, 0x558a1e?})
14:08:35 	/usr/local/go/src/reflect/value.go:586 +0x1232
14:08:35 reflect.Value.Call({0x43a3260?, 0xc000412500?, 0x0?}, {0xc000663cc8, 0x1, 0x1})
14:08:35 	/usr/local/go/src/reflect/value.go:369 +0xb6
14:08:35 github.com/juju/tc.(*methodType).Call(0xc0000ead20, 0xc000420480)
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/tc@v0.0.0-20251023013639-77c6a1d20e5a/check.go:88 +0x2af
14:08:35 github.com/juju/tc.(*suiteRunner).runTest(0xc000590050, 0xc00061f8c8, 0xc0000ead20)
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/tc@v0.0.0-20251023013639-77c6a1d20e5a/check.go:225 +0x626
14:08:35 github.com/juju/tc.(*suiteRunner).run.func3(0xc00061f8c8)
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/tc@v0.0.0-20251023013639-77c6a1d20e5a/check.go:184 +0x45
14:08:35 testing.tRunner(0xc00061f8c8, 0xc0002da450)
14:08:35 	/usr/local/go/src/testing/testing.go:2036 +0x21d
14:08:35 created by testing.(*T).Run in goroutine 37
14:08:35 	/usr/local/go/src/testing/testing.go:2101 +0xb13
14:08:35 
14:08:35 goroutine 25 [chan receive, 9 minutes]:
14:08:35 gopkg.in/tomb%2ev2.(*Tomb).Wait(0xc0006689c0)
14:08:35 	/home/jenkins/go/pkg/mod/gopkg.in/tomb.v2@v2.0.0-20161208151619-d5d1b5820637/tomb.go:126 +0x4f
14:08:35 github.com/juju/worker/v5/catacomb.(*Catacomb).Wait(...)
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/worker/v5@v5.0.0/catacomb/catacomb.go:219
14:08:35 github.com/juju/juju/internal/worker/sshserver.(*serverWrapperWorker).Wait(0xc0006689c0)
14:08:35 	/home/jenkins/go/src/github.com/juju/juju/internal/worker/sshserver/worker.go:124 +0x29
14:08:35 github.com/juju/worker/v5/workertest.CheckKilled.func1()
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/worker/v5@v5.0.0/workertest/check.go:64 +0x43
14:08:35 created by github.com/juju/worker/v5/workertest.CheckKilled in goroutine 41
14:08:35 	/home/jenkins/go/pkg/mod/github.com/juju/worker/v5@v5.0.0/workertest/check.go:63 +0x131
14:08:35 FAIL	github.com/juju/juju/internal/worker/sshserver	600.189s
```
