### PR TITLE
ci: add missing Pillow build dependencies to sphinx ci job

### DIFF
--- a/.github/actions/notify-mm/action.yml
+++ b/.github/actions/notify-mm/action.yml
@@ -1,0 +1,31 @@
+name: Send Mattermost notification
+description: Send a message to a Mattermost channel
+
+inputs:
+  mm_token:
+    description: Mattermost access token
+    required: true
+  mm_url:
+    description: Mattermost server URL
+    required: true
+  channel:
+    description: Mattermost channel to post the message to
+    required: true
+  message:
+    description: Message to post
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        MM_URL: ${{ inputs.mm_url }}
+        MM_TOKEN: ${{ inputs.mm_token }}
+        CHANNEL: ${{ inputs.channel }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        curl https://releases.mattermost.com/mmctl/v10.11.6/linux_amd64.tar -Lo mmctl.tar
+        tar -xvf mmctl.tar
+        ./mmctl auth login "$MM_URL" --name Charmhub --access-token $MM_TOKEN
+        ./mmctl post create $MM_CHANNEL --message "$MESSAGE"

--- a/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
@@ -41,13 +41,25 @@ jobs:
           set -ex
           sudo apt -y update
           sudo apt -y install \
-            cargo \
+            cmake \
+            libfreetype6-dev \
+            libharfbuzz-dev \
+            libjpeg8-dev \
+            liblcms2-dev \
+            libopenjp2-7-dev \
             libpython3-dev \
+            libtiff5-dev \
+            libwebp-dev \
+            libxcb1-dev \
             libxml2-dev \
             libxslt1-dev \
             make \
+            ninja-build \
             python3-venv \
-            rustc
+            zlib1g-dev
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+            sh -s -- -y --default-toolchain stable
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Build Sphinx venv
         run: |
@@ -55,5 +67,5 @@ jobs:
           cd docs
           make -f Makefile \
             install \
-            PIPOPTS="--no-binary :all:" \
-            || ( cat .sphinx/venv/pip_install.log && exit 1 )
+            PIPOPTS="--no-binary :all: --only-binary canonical-sphinx" \
+            || ( cat .venv/pip_install.log && exit 1 )

--- a/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
@@ -69,3 +69,18 @@ jobs:
             install \
             PIPOPTS="--no-binary :all: --only-binary canonical-sphinx" \
             || ( cat .venv/pip_install.log && exit 1 )
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-mm
+        with:
+          mm_url: ${{ secrets.MM_URL }}
+          mm_token: ${{ secrets.MM_TOKEN }}
+          channel: ${{ secrets.MM_CHANNEL }}
+          message: |
+            🤖 **Beep boop! Build failure detected!**
+
+            📍 **Branch:** `${{ github.ref_name }}`
+            🔗 **Workflow run:** [Click here to investigate](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            ⚠️ The Sphinx venv build has failed. Please review the logs and fix the issue.

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -84,13 +84,9 @@ jobs:
 
       - name: Notify if merge has conflicts
         if: steps.merge.outputs.conflicts == 'true' && steps.message.outputs.message != ''
-        env:
-          MM_URL: ${{ secrets.MM_URL }}
-          MM_TOKEN: ${{ secrets.MM_TOKEN }}
-          MM_CHANNEL: ${{ secrets.MM_CHANNEL }}
-          MESSAGE: ${{ steps.message.outputs.message }}
-        run: |
-          curl https://releases.mattermost.com/mmctl/v10.11.6/linux_amd64.tar -Lo mmctl.tar
-          tar -xvf mmctl.tar
-          ./mmctl auth login "$MM_URL" --name Charmhub --access-token $MM_TOKEN
-          ./mmctl post create $MM_CHANNEL --message "$MESSAGE"
+        uses: ./.github/actions/notify-mm
+        with:
+          mm_url: ${{ secrets.MM_URL }}
+          mm_token: ${{ secrets.MM_TOKEN }}
+          channel: ${{ secrets.MM_CHANNEL }}
+          message: ${{ steps.message.outputs.message }}


### PR DESCRIPTION
The `docs-sphinx-python-dependency-build-checks` workflow forces building the
Sphinx virtual environment entirely from source (`--no-binary :all:`) to
document required build packages. This fixes several issues that prevented it
from succeeding.

**Changes:**

- Replaced stale `cargo`/`rustc` apt packages with rustup to get a current Rust
  toolchain (needed by `watchfiles`)
- Added Pillow build dependencies: `libfreetype6-dev`, `libharfbuzz-dev`,
  `libjpeg8-dev`, `liblcms2-dev`, `libopenjp2-7-dev`, `libtiff5-dev`,
  `libwebp-dev`, `libxcb1-dev`, `zlib1g-dev`
- Added `cmake` and `ninja-build` — needed to build `pybind11` from source,
  which Pillow 12.2.0 requires as a build dependency (pip propagates
`--no-binary` to isolated build environments)
- Added `--only-binary canonical-sphinx` to allow this pure-Python meta-package
  to install as a wheel
- Fixed error-log path from `.sphinx/venv/pip_install.log` to
  `.venv/pip_install.log` to match the Makefile's `DOCS_VENVDIR`
- Send mattermost notification when the job fails
