### PR TITLE
feat(azure): NSG firewaller support for dual-stack

### DIFF
--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -133,6 +133,9 @@ type azureEnviron struct {
 	commonResourcesCreated bool
 }
 
+// Ensure that environ implements FirewallFeatureQuerier.
+var _ environs.FirewallFeatureQuerier = (*azureEnviron)(nil)
+
 var _ environs.Environ = (*azureEnviron)(nil)
 
 // SetCloudSpec is specified in the environs.Environ interface.
@@ -2621,4 +2624,11 @@ func (env *azureEnviron) Region() (simplestreams.CloudSpec, error) {
 		Region:   env.cloud.Region,
 		Endpoint: env.cloud.Endpoint,
 	}, nil
+}
+
+// SupportsRulesWithIPV6CIDRs is part of the environs.FirewallFeatureQuerier
+// interface. Azure NSGs accept IPv6 source/destination prefixes natively for
+// Standard-SKU dual-stack VMs.
+func (env *azureEnviron) SupportsRulesWithIPV6CIDRs(context.Context) (bool, error) {
+	return true, nil
 }

--- a/internal/provider/azure/environ_network_test.go
+++ b/internal/provider/azure/environ_network_test.go
@@ -305,6 +305,38 @@ func (s *environSuite) TestNetworkTemplateResourcesDualStack(c *tc.C) {
 	c.Assert(resources, tc.HasLen, 2)
 	c.Check(resources[0].Name, tc.Equals, azure.SecurityGroupName)
 
+	// NSG security rules: SSH, IPv4 API, and IPv6 API — all use
+	// singular DestinationAddressPrefix.
+	nsgProps, ok := resources[0].Properties.(*armnetwork.SecurityGroupPropertiesFormat)
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(nsgProps.SecurityRules, tc.HasLen, 3)
+
+	var sshRule, apiV4Rule, apiV6Rule *armnetwork.SecurityRule
+	for _, rule := range nsgProps.SecurityRules {
+		switch toValue(rule.Name) {
+		case "SSHInbound":
+			sshRule = rule
+		case "JujuAPIInbound17070":
+			apiV4Rule = rule
+		case "JujuAPIInbound17070IPv6":
+			apiV6Rule = rule
+		}
+	}
+	c.Assert(sshRule, tc.NotNil)
+	c.Assert(sshRule.Properties, tc.NotNil)
+	c.Check(toValue(sshRule.Properties.DestinationAddressPrefix), tc.Equals, "*")
+	c.Check(sshRule.Properties.DestinationAddressPrefixes, tc.IsNil)
+
+	c.Assert(apiV4Rule, tc.NotNil)
+	c.Assert(apiV4Rule.Properties, tc.NotNil)
+	c.Check(toValue(apiV4Rule.Properties.DestinationAddressPrefix), tc.Equals, azure.ControllerSubnetPrefix)
+	c.Check(apiV4Rule.Properties.DestinationAddressPrefixes, tc.IsNil)
+
+	c.Assert(apiV6Rule, tc.NotNil)
+	c.Assert(apiV6Rule.Properties, tc.NotNil)
+	c.Check(toValue(apiV6Rule.Properties.DestinationAddressPrefix), tc.Equals, azure.ControllerSubnetIPv6Prefix)
+	c.Check(apiV6Rule.Properties.DestinationAddressPrefixes, tc.IsNil)
+
 	// Second resource: VNet.
 	vnet := resources[1]
 	c.Check(vnet.Name, tc.Equals, azure.InternalNetworkName)

--- a/internal/provider/azure/environ_network_test.go
+++ b/internal/provider/azure/environ_network_test.go
@@ -331,11 +331,13 @@ func (s *environSuite) TestNetworkTemplateResourcesDualStack(c *tc.C) {
 	c.Assert(apiV4Rule.Properties, tc.NotNil)
 	c.Check(toValue(apiV4Rule.Properties.DestinationAddressPrefix), tc.Equals, azure.ControllerSubnetPrefix)
 	c.Check(apiV4Rule.Properties.DestinationAddressPrefixes, tc.IsNil)
+	c.Check(toValue(apiV4Rule.Properties.Priority), tc.Equals, int32(101))
 
 	c.Assert(apiV6Rule, tc.NotNil)
 	c.Assert(apiV6Rule.Properties, tc.NotNil)
 	c.Check(toValue(apiV6Rule.Properties.DestinationAddressPrefix), tc.Equals, azure.ControllerSubnetIPv6Prefix)
 	c.Check(apiV6Rule.Properties.DestinationAddressPrefixes, tc.IsNil)
+	c.Check(toValue(apiV6Rule.Properties.Priority), tc.Equals, int32(102))
 
 	// Second resource: VNet.
 	vnet := resources[1]

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -3444,5 +3444,5 @@ func (s *environSuite) TestSupportsRulesWithIPV6CIDRs(c *tc.C) {
 
 	supported, err := fwQuerier.SupportsRulesWithIPV6CIDRs(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(supported, tc.Equals, true)
+	c.Assert(supported, tc.IsTrue)
 }

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -3395,3 +3395,15 @@ func (s *environSuite) TestGetArchFromResourceSKUAMD64(c *tc.C) {
 	})
 	c.Assert(arch, tc.Equals, corearch.AMD64)
 }
+
+func (s *environSuite) TestSupportsRulesWithIPV6CIDRs(c *tc.C) {
+	env := s.openEnviron(c)
+
+	// Azure should support IPv6 CIDRs in firewall rules.
+	fwQuerier, ok := env.(environs.FirewallFeatureQuerier)
+	c.Assert(ok, tc.IsTrue)
+	
+	supported, err := fwQuerier.SupportsRulesWithIPV6CIDRs(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(supported, tc.Equals, true)
+}

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -1155,6 +1155,19 @@ func (s *environSuite) assertStartInstanceRequests(
 				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
 			},
 		}, &armnetwork.SecurityRule{
+			Name: new("JujuAPIInbound443IPv6"),
+			Properties: &armnetwork.SecurityRulePropertiesFormat{
+				Description:              new("Allow API connections to controller machines (IPv6)"),
+				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+				SourceAddressPrefix:      new("*"),
+				SourcePortRange:          new("*"),
+				DestinationAddressPrefix: new("fd00:0:0:10::/64"),
+				DestinationPortRange:     new("443"),
+				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+				Priority:                 new(int32(102)),
+				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+			},
+		}, &armnetwork.SecurityRule{
 			Name: new("JujuAPIInbound80"),
 			Properties: &armnetwork.SecurityRulePropertiesFormat{
 				Description:              new("Allow API connections to controller machines"),
@@ -1164,7 +1177,20 @@ func (s *environSuite) assertStartInstanceRequests(
 				DestinationAddressPrefix: new("192.168.16.0/20"),
 				DestinationPortRange:     new("80"),
 				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-				Priority:                 new(int32(102)),
+				Priority:                 new(int32(103)),
+				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+			},
+		}, &armnetwork.SecurityRule{
+			Name: new("JujuAPIInbound80IPv6"),
+			Properties: &armnetwork.SecurityRulePropertiesFormat{
+				Description:              new("Allow API connections to controller machines (IPv6)"),
+				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+				SourceAddressPrefix:      new("*"),
+				SourcePortRange:          new("*"),
+				DestinationAddressPrefix: new("fd00:0:0:10::/64"),
+				DestinationPortRange:     new("80"),
+				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+				Priority:                 new(int32(104)),
 				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
 			},
 		})
@@ -1181,6 +1207,19 @@ func (s *environSuite) assertStartInstanceRequests(
 				DestinationPortRange:     new(port),
 				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
 				Priority:                 new(int32(101)),
+				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+			},
+		}, &armnetwork.SecurityRule{
+			Name: new("JujuAPIInbound" + port + "IPv6"),
+			Properties: &armnetwork.SecurityRulePropertiesFormat{
+				Description:              new("Allow API connections to controller machines (IPv6)"),
+				Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+				SourceAddressPrefix:      new("*"),
+				SourcePortRange:          new("*"),
+				DestinationAddressPrefix: new("fd00:0:0:10::/64"),
+				DestinationPortRange:     new(port),
+				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+				Priority:                 new(int32(102)),
 				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
 			},
 		})
@@ -3402,7 +3441,7 @@ func (s *environSuite) TestSupportsRulesWithIPV6CIDRs(c *tc.C) {
 	// Azure should support IPv6 CIDRs in firewall rules.
 	fwQuerier, ok := env.(environs.FirewallFeatureQuerier)
 	c.Assert(ok, tc.IsTrue)
-	
+
 	supported, err := fwQuerier.SupportsRulesWithIPV6CIDRs(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(supported, tc.Equals, true)

--- a/internal/provider/azure/export_test.go
+++ b/internal/provider/azure/export_test.go
@@ -16,6 +16,8 @@ import (
 const ComputeAPIVersion = computeAPIVersion
 const NetworkAPIVersion = networkAPIVersion
 
+var IsIPv6SourceCIDR = isIPv6SourceCIDR
+
 var NetworkTemplateResources = networkTemplateResources
 var SubnetProviderIDForFamily = subnetProviderIDForFamily
 var StripIPFamilySuffix = stripIPFamilySuffix

--- a/internal/provider/azure/instance.go
+++ b/internal/provider/azure/instance.go
@@ -724,7 +724,9 @@ func securityRuleName(prefix string, rule firewall.IngressRule) string {
 	} else {
 		cidr = rule.SourceCIDRs.SortedValues()[0]
 	}
-	if cidr != firewall.AllNetworksIPV4CIDR && cidr != firewall.AllNetworksIPV6CIDR && cidr != "*" {
+	if cidr == firewall.AllNetworksIPV6CIDR {
+		ruleName = fmt.Sprintf("%s-v6", ruleName)
+	} else if cidr != firewall.AllNetworksIPV4CIDR && cidr != "*" {
 		cidr = strings.Replace(cidr, ".", "-", -1)
 		cidr = strings.Replace(cidr, ":", "-", -1)
 		cidr = strings.Replace(cidr, "/", "-", -1)

--- a/internal/provider/azure/instance.go
+++ b/internal/provider/azure/instance.go
@@ -421,7 +421,11 @@ func (inst *azureInstance) openPortsOnGroup(
 			destAddr = nsgInfo.ipv6Address.Value
 		} else if from != "*" && from != "" && from != firewall.AllNetworksIPV4CIDR {
 			// Specific CIDR: classify family.
-			if at, err := corenetwork.CIDRAddressType(from); err == nil && at == corenetwork.IPv6Address {
+			at, err := corenetwork.CIDRAddressType(from)
+			if err != nil {
+				logger.Debugf(ctx, "cannot classify CIDR %q, "+
+					"treating as IPv4: %v", from, err)
+			} else if at == corenetwork.IPv6Address {
 				if nsgInfo.ipv6Address == nil {
 					logger.Debugf(ctx, "skipping IPv6 rule %q: machine has no IPv6 address", ruleName)
 					continue

--- a/internal/provider/azure/instance.go
+++ b/internal/provider/azure/instance.go
@@ -177,7 +177,8 @@ func (inst *azureInstance) Addresses(ctx context.Context) (corenetwork.ProviderA
 type securityGroupInfo struct {
 	resourceGroup  string
 	securityGroup  *armnetwork.SecurityGroup
-	primaryAddress corenetwork.SpaceAddress
+	primaryAddress corenetwork.SpaceAddress  // IPv4 private address (always present)
+	ipv6Address    *corenetwork.SpaceAddress // IPv6 private address; nil for IPv4-only machines
 }
 
 // primarySecurityGroupInfo returns info for the NIC's primary corenetwork.Address
@@ -191,6 +192,35 @@ func primarySecurityGroupInfo(ctx context.Context, env *azureEnviron, nic *armne
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	// First pass: scan for IPv6 configuration (primary-ipv6).
+	// The IPv6 config is non-primary, so we scan separately before the
+	// early return on the primary IPv4 config below.
+	var ipv6Address *corenetwork.SpaceAddress
+	for _, ipConfiguration := range nic.Properties.IPConfigurations {
+		if ipConfiguration.Properties == nil {
+			continue
+		}
+		// Check if this is an IPv6 configuration. Use the same detection idiom as
+		// mapAzureInterfaceList in environ_network.go for consistency.
+		isIPv6 := ipConfiguration.Properties.PrivateIPAddressVersion != nil &&
+			toValue(ipConfiguration.Properties.PrivateIPAddressVersion) == armnetwork.IPVersionIPv6
+		if !isIPv6 {
+			continue
+		}
+		privateIpAddress := ipConfiguration.Properties.PrivateIPAddress
+		if privateIpAddress == nil {
+			continue
+		}
+		spaceAddress := corenetwork.NewSpaceAddress(
+			toValue(privateIpAddress),
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+		)
+		ipv6Address = new(spaceAddress)
+		break
+	}
+
+	// Second pass: scan for primary IPv4 configuration and security group.
 	for _, ipConfiguration := range nic.Properties.IPConfigurations {
 		if ipConfiguration.Properties == nil {
 			continue
@@ -229,6 +259,7 @@ func primarySecurityGroupInfo(ctx context.Context, env *azureEnviron, nic *armne
 				toValue(privateIpAddress),
 				corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 			),
+			ipv6Address: ipv6Address,
 		}, nil
 	}
 	return nil, errors.NotFoundf("internal network address or security group")
@@ -339,6 +370,28 @@ func (inst *azureInstance) openPortsOnGroup(
 
 		// rule has a single source CIDR
 		from := rule.SourceCIDRs.SortedValues()[0]
+
+		// Determine destination address based on source CIDR family.
+		// Wildcards/empty are IPv4 by Azure convention; only "::/0" is IPv6 wildcard.
+		destAddr := nsgInfo.primaryAddress.Value
+		if from == firewall.AllNetworksIPV6CIDR {
+			// IPv6 wildcard
+			if nsgInfo.ipv6Address == nil {
+				logger.Debugf(ctx, "skipping IPv6 rule %q: machine has no IPv6 address", ruleName)
+				continue
+			}
+			destAddr = nsgInfo.ipv6Address.Value
+		} else if from != "*" && from != "" && from != firewall.AllNetworksIPV4CIDR {
+			// Specific CIDR: classify family.
+			if at, err := corenetwork.CIDRAddressType(from); err == nil && at == corenetwork.IPv6Address {
+				if nsgInfo.ipv6Address == nil {
+					logger.Debugf(ctx, "skipping IPv6 rule %q: machine has no IPv6 address", ruleName)
+					continue
+				}
+				destAddr = nsgInfo.ipv6Address.Value
+			}
+		}
+
 		securityRule := armnetwork.SecurityRule{
 			Properties: &armnetwork.SecurityRulePropertiesFormat{
 				Description:              new(rule.String()),
@@ -346,7 +399,7 @@ func (inst *azureInstance) openPortsOnGroup(
 				SourcePortRange:          new("*"),
 				DestinationPortRange:     new(portRange),
 				SourceAddressPrefix:      new(from),
-				DestinationAddressPrefix: new(nsgInfo.primaryAddress.Value),
+				DestinationAddressPrefix: new(destAddr),
 				Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
 				Priority:                 new(priority),
 				Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
@@ -508,7 +561,13 @@ func (inst *azureInstance) ingressRulesForGroup(ctx context.Context, machineId s
 		// Record the SourceAddressPrefix for the port range.
 		remotePrefix := toValue(rule.Properties.SourceAddressPrefix)
 		if remotePrefix == "" || remotePrefix == "*" {
-			remotePrefix = "0.0.0.0/0"
+			// Determine the destination address family to pick the right wildcard.
+			dest := toValue(rule.Properties.DestinationAddressPrefix)
+			if corenetwork.NewMachineAddress(dest).Type == corenetwork.IPv6Address {
+				remotePrefix = firewall.AllNetworksIPV6CIDR // "::/0"
+			} else {
+				remotePrefix = firewall.AllNetworksIPV4CIDR // "0.0.0.0/0"
+			}
 		}
 		for _, protocol := range protocols {
 			portRange.Protocol = protocol

--- a/internal/provider/azure/instance.go
+++ b/internal/provider/azure/instance.go
@@ -181,22 +181,13 @@ type securityGroupInfo struct {
 	ipv6Address    *corenetwork.SpaceAddress // IPv6 private address; nil for IPv4-only machines
 }
 
-// primarySecurityGroupInfo returns info for the NIC's primary corenetwork.Address
-// for the internal virtual network, and any security group on the subnet.
-// The address is used to identify the machine in network security rules.
-func primarySecurityGroupInfo(ctx context.Context, env *azureEnviron, nic *armnetwork.Interface) (*securityGroupInfo, error) {
+// fetchIPv6Address scans a NIC's IP configurations for an IPv6 address
+// and returns a pointer to the extracted SpaceAddress, or nil if not found.
+func fetchIPv6Address(nic *armnetwork.Interface) *corenetwork.SpaceAddress {
 	if nic == nil || nic.Properties == nil {
-		return nil, errors.NotFoundf("internal network address or security group")
-	}
-	subnets, err := env.subnetsClient()
-	if err != nil {
-		return nil, errors.Trace(err)
+		return nil
 	}
 
-	// First pass: scan for IPv6 configuration (primary-ipv6).
-	// The IPv6 config is non-primary, so we scan separately before the
-	// early return on the primary IPv4 config below.
-	var ipv6Address *corenetwork.SpaceAddress
 	for _, ipConfiguration := range nic.Properties.IPConfigurations {
 		if ipConfiguration.Properties == nil {
 			continue
@@ -216,11 +207,33 @@ func primarySecurityGroupInfo(ctx context.Context, env *azureEnviron, nic *armne
 			toValue(privateIpAddress),
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
 		)
-		ipv6Address = new(spaceAddress)
-		break
+		return &spaceAddress
+	}
+	return nil
+}
+
+// fetchPrimaryIPv4AndSecurityGroup finds the primary IPv4 configuration on a NIC
+// and retrieves the associated security group (from NIC or subnet).
+// Returns the private IPv4 address, security group, and any error.
+// The resource group can be extracted from the security group ID if needed.
+func fetchPrimaryIPv4AndSecurityGroup(
+	ctx context.Context,
+	env *azureEnviron,
+	nic *armnetwork.Interface,
+) (
+	string, // primaryAddress
+	*armnetwork.SecurityGroup, // securityGroup
+	error,
+) {
+	if nic == nil || nic.Properties == nil {
+		return "", nil, errors.NotFoundf("internal network address or security group")
 	}
 
-	// Second pass: scan for primary IPv4 configuration and security group.
+	subnets, err := env.subnetsClient()
+	if err != nil {
+		return "", nil, errors.Trace(err)
+	}
+
 	for _, ipConfiguration := range nic.Properties.IPConfigurations {
 		if ipConfiguration.Properties == nil {
 			continue
@@ -232,15 +245,22 @@ func primarySecurityGroupInfo(ctx context.Context, env *azureEnviron, nic *armne
 		if privateIpAddress == nil {
 			continue
 		}
+
 		securityGroup := nic.Properties.NetworkSecurityGroup
 		if securityGroup == nil && ipConfiguration.Properties.Subnet != nil {
 			idParts := strings.Split(toValue(ipConfiguration.Properties.Subnet.ID), "/")
 			lenParts := len(idParts)
-			subnet, err := subnets.Get(ctx, idParts[lenParts-7], idParts[lenParts-3], idParts[lenParts-1], &armnetwork.SubnetsClientGetOptions{
-				Expand: new("networkSecurityGroup"),
-			})
+			subnet, err := subnets.Get(
+				ctx,
+				idParts[lenParts-7],
+				idParts[lenParts-3],
+				idParts[lenParts-1],
+				&armnetwork.SubnetsClientGetOptions{
+					Expand: new("networkSecurityGroup"),
+				},
+			)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return "", nil, errors.Trace(err)
 			}
 			if subnet.Properties != nil {
 				securityGroup = subnet.Properties.NetworkSecurityGroup
@@ -250,19 +270,37 @@ func primarySecurityGroupInfo(ctx context.Context, env *azureEnviron, nic *armne
 			continue
 		}
 
-		idParts := strings.Split(toValue(securityGroup.ID), "/")
-		resourceGroup := idParts[len(idParts)-5]
-		return &securityGroupInfo{
-			resourceGroup: resourceGroup,
-			securityGroup: securityGroup,
-			primaryAddress: corenetwork.NewSpaceAddress(
-				toValue(privateIpAddress),
-				corenetwork.WithScope(corenetwork.ScopeCloudLocal),
-			),
-			ipv6Address: ipv6Address,
-		}, nil
+		return toValue(privateIpAddress), securityGroup, nil
 	}
-	return nil, errors.NotFoundf("internal network address or security group")
+	return "", nil, errors.NotFoundf("internal network address or security group")
+}
+
+// primarySecurityGroupInfo returns info for the NIC's primary corenetwork.Address
+// for the internal virtual network, and any security group on the subnet.
+// The address is used to identify the machine in network security rules.
+func primarySecurityGroupInfo(ctx context.Context, env *azureEnviron, nic *armnetwork.Interface) (*securityGroupInfo, error) {
+	// Fetch IPv6 address (non-blocking, never errors).
+	ipv6Address := fetchIPv6Address(nic)
+
+	// Fetch primary IPv4 and security group.
+	addr, sg, err := fetchPrimaryIPv4AndSecurityGroup(ctx, env, nic)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Extract resource group from security group ID.
+	idParts := strings.Split(toValue(sg.ID), "/")
+	resourceGroup := idParts[len(idParts)-5]
+
+	return &securityGroupInfo{
+		resourceGroup: resourceGroup,
+		securityGroup: sg,
+		primaryAddress: corenetwork.NewSpaceAddress(
+			addr,
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+		),
+		ipv6Address: ipv6Address,
+	}, nil
 }
 
 // getSecurityGroupInfo gets the security group information for

--- a/internal/provider/azure/instance.go
+++ b/internal/provider/azure/instance.go
@@ -414,28 +414,13 @@ func (inst *azureInstance) openPortsOnGroup(
 		from := rule.SourceCIDRs.SortedValues()[0]
 
 		// Determine destination address based on source CIDR family.
-		// Wildcards/empty are IPv4 by Azure convention; only "::/0" is IPv6 wildcard.
 		destAddr := nsgInfo.primaryAddress.Value
-		if from == firewall.AllNetworksIPV6CIDR {
-			// IPv6 wildcard
+		if isIPv6SourceCIDR(from) {
 			if nsgInfo.ipv6Address == nil {
 				logger.Debugf(ctx, "skipping IPv6 rule %q: machine has no IPv6 address", ruleName)
 				continue
 			}
 			destAddr = nsgInfo.ipv6Address.Value
-		} else if from != "*" && from != "" && from != firewall.AllNetworksIPV4CIDR {
-			// Specific CIDR: classify family.
-			at, err := corenetwork.CIDRAddressType(from)
-			if err != nil {
-				logger.Debugf(ctx, "cannot classify CIDR %q, "+
-					"treating as IPv4: %v", from, err)
-			} else if at == corenetwork.IPv6Address {
-				if nsgInfo.ipv6Address == nil {
-					logger.Debugf(ctx, "skipping IPv6 rule %q: machine has no IPv6 address", ruleName)
-					continue
-				}
-				destAddr = nsgInfo.ipv6Address.Value
-			}
 		}
 
 		securityRule := armnetwork.SecurityRule{
@@ -465,6 +450,24 @@ func (inst *azureInstance) openPortsOnGroup(
 		nsg.Properties.SecurityRules = append(nsg.Properties.SecurityRules, new(securityRule))
 	}
 	return nil
+}
+
+// isIPv6SourceCIDR returns true if the source CIDR is an IPv6 CIDR.
+// Wildcards/empty (including AllNetworksIPV4CIDR) are treated as IPv4
+// by Azure convention; only AllNetworksIPV6CIDR is treated as IPv6
+// wildcard.
+func isIPv6SourceCIDR(from string) bool {
+	if from == firewall.AllNetworksIPV6CIDR {
+		return true
+	}
+	if from == "*" || from == "" || from == firewall.AllNetworksIPV4CIDR {
+		return false
+	}
+	at, err := corenetwork.CIDRAddressType(from)
+	if err != nil {
+		return false
+	}
+	return at == corenetwork.IPv6Address
 }
 
 // ClosePorts is specified in the Instance interface.

--- a/internal/provider/azure/instance.go
+++ b/internal/provider/azure/instance.go
@@ -716,9 +716,9 @@ func securityRuleName(prefix string, rule firewall.IngressRule) string {
 	} else {
 		cidr = rule.SourceCIDRs.SortedValues()[0]
 	}
-	if cidr != firewall.AllNetworksIPV4CIDR && cidr != "*" {
+	if cidr != firewall.AllNetworksIPV4CIDR && cidr != firewall.AllNetworksIPV6CIDR && cidr != "*" {
 		cidr = strings.Replace(cidr, ".", "-", -1)
-		cidr = strings.Replace(cidr, "::", "-", -1)
+		cidr = strings.Replace(cidr, ":", "-", -1)
 		cidr = strings.Replace(cidr, "/", "-", -1)
 		ruleName = fmt.Sprintf("%s-cidr-%s", ruleName, cidr)
 	}

--- a/internal/provider/azure/instance.go
+++ b/internal/provider/azure/instance.go
@@ -181,8 +181,38 @@ type securityGroupInfo struct {
 	ipv6Address    *corenetwork.SpaceAddress // IPv6 private address; nil for IPv4-only machines
 }
 
+// primarySecurityGroupInfo returns info for the NIC's primary
+// corenetwork.Address for the internal virtual network, and any
+// security group on the subnet. The address is used to identify the
+// machine in network security rules.
+func primarySecurityGroupInfo(ctx context.Context, env *azureEnviron, nic *armnetwork.Interface) (*securityGroupInfo, error) {
+	// Fetch IPv6 address (non-blocking, never errors).
+	ipv6Address := fetchIPv6Address(nic)
+
+	// Fetch primary IPv4 and security group.
+	addr, sg, err := fetchPrimaryIPv4AndSecurityGroup(ctx, env, nic)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// Extract resource group from security group ID.
+	idParts := strings.Split(toValue(sg.ID), "/")
+	resourceGroup := idParts[len(idParts)-5]
+
+	return &securityGroupInfo{
+		resourceGroup: resourceGroup,
+		securityGroup: sg,
+		primaryAddress: corenetwork.NewSpaceAddress(
+			addr,
+			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
+		),
+		ipv6Address: ipv6Address,
+	}, nil
+}
+
 // fetchIPv6Address scans a NIC's IP configurations for an IPv6 address
-// and returns a pointer to the extracted SpaceAddress, or nil if not found.
+// and returns a pointer to the extracted SpaceAddress, or nil if not
+// found.
 func fetchIPv6Address(nic *armnetwork.Interface) *corenetwork.SpaceAddress {
 	if nic == nil || nic.Properties == nil {
 		return nil
@@ -192,8 +222,9 @@ func fetchIPv6Address(nic *armnetwork.Interface) *corenetwork.SpaceAddress {
 		if ipConfiguration.Properties == nil {
 			continue
 		}
-		// Check if this is an IPv6 configuration. Use the same detection idiom as
-		// mapAzureInterfaceList in environ_network.go for consistency.
+		// Check if this is an IPv6 configuration. Use the same
+		// detection idiom as mapAzureInterfaceList in
+		// environ_network.go for consistency.
 		isIPv6 := ipConfiguration.Properties.PrivateIPAddressVersion != nil &&
 			toValue(ipConfiguration.Properties.PrivateIPAddressVersion) == armnetwork.IPVersionIPv6
 		if !isIPv6 {
@@ -212,10 +243,11 @@ func fetchIPv6Address(nic *armnetwork.Interface) *corenetwork.SpaceAddress {
 	return nil
 }
 
-// fetchPrimaryIPv4AndSecurityGroup finds the primary IPv4 configuration on a NIC
-// and retrieves the associated security group (from NIC or subnet).
-// Returns the private IPv4 address, security group, and any error.
-// The resource group can be extracted from the security group ID if needed.
+// fetchPrimaryIPv4AndSecurityGroup finds the primary IPv4
+// configuration on a NIC and retrieves the associated security group
+// (from NIC or subnet). Returns the private IPv4 address, security
+// group, and any error. The resource group can be extracted from the
+// security group ID if needed.
 func fetchPrimaryIPv4AndSecurityGroup(
 	ctx context.Context,
 	env *azureEnviron,
@@ -273,34 +305,6 @@ func fetchPrimaryIPv4AndSecurityGroup(
 		return toValue(privateIpAddress), securityGroup, nil
 	}
 	return "", nil, errors.NotFoundf("internal network address or security group")
-}
-
-// primarySecurityGroupInfo returns info for the NIC's primary corenetwork.Address
-// for the internal virtual network, and any security group on the subnet.
-// The address is used to identify the machine in network security rules.
-func primarySecurityGroupInfo(ctx context.Context, env *azureEnviron, nic *armnetwork.Interface) (*securityGroupInfo, error) {
-	// Fetch IPv6 address (non-blocking, never errors).
-	ipv6Address := fetchIPv6Address(nic)
-
-	// Fetch primary IPv4 and security group.
-	addr, sg, err := fetchPrimaryIPv4AndSecurityGroup(ctx, env, nic)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// Extract resource group from security group ID.
-	idParts := strings.Split(toValue(sg.ID), "/")
-	resourceGroup := idParts[len(idParts)-5]
-
-	return &securityGroupInfo{
-		resourceGroup: resourceGroup,
-		securityGroup: sg,
-		primaryAddress: corenetwork.NewSpaceAddress(
-			addr,
-			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
-		),
-		ipv6Address: ipv6Address,
-	}, nil
 }
 
 // getSecurityGroupInfo gets the security group information for

--- a/internal/provider/azure/instance_test.go
+++ b/internal/provider/azure/instance_test.go
@@ -673,26 +673,46 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 	subnetSender := makeSender(internalSubnetPath, nic0IPv4Config.Properties.Subnet)
 	okSender := &azuretesting.MockSender{}
 	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
-	// Four requests: 1 subnet GET + 3 PUTs (IPv4, IPv6 wildcard, specific IPv6)
-	s.sender = azuretesting.Senders{subnetSender, okSender, okSender, okSender}
+	// Five requests: 1 subnet GET + 4 PUTs (IPv4 wildcard, IPv4
+	// specific, IPv6 wildcard, specific IPv6)
+	s.sender = azuretesting.Senders{subnetSender, okSender, okSender, okSender, okSender}
 
-	// Rules with IPv4 and IPv6 sources
+	// Rules with IPv4 wildcard, IPv4 specific, IPv6 wildcard, and
+	// specific IPv6 sources
 	err := fwInst.OpenPorts(c.Context(), "0", firewall.IngressRules{
-		firewall.NewIngressRule(corenetwork.MustParsePortRange("1234/tcp"), "10.0.0.0/24"),                // IPv4
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("4321/tcp")),                               // IPv4 wildcard (*)
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("1234/tcp"), "10.0.0.0/24"),                // IPv4 specific
 		firewall.NewIngressRule(corenetwork.MustParsePortRange("5678/tcp"), firewall.AllNetworksIPV6CIDR), // IPv6 wildcard
 		firewall.NewIngressRule(corenetwork.MustParsePortRange("9999/tcp"), "2002:db8::1/128"),            // Specific IPv6
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Assert(s.requests, tc.HasLen, 4)
+	c.Assert(s.requests, tc.HasLen, 5)
 	// Request 0: GET subnet (to resolve security group)
 	c.Assert(s.requests[0].Method, tc.Equals, "GET")
 	c.Assert(s.requests[0].URL.Path, tc.Equals, internalSubnetPath)
 
-	// Request 1: PUT IPv4 rule for IPv4 source → IPv4 destination
+	// Request 1: PUT IPv4 rule for wildcard source → IPv4 destination
 	c.Assert(s.requests[1].Method, tc.Equals, "PUT")
-	c.Assert(s.requests[1].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-1234-cidr-10-0-0-0-24"))
+	c.Assert(s.requests[1].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-4321"))
 	assertRequestBody(c, s.requests[1], &armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Description:              new("4321/tcp from *"),
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourcePortRange:          new("*"),
+			SourceAddressPrefix:      new("*"),
+			DestinationPortRange:     new("4321"),
+			DestinationAddressPrefix: new("10.0.0.4"), // IPv4 destination
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(200)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	})
+
+	// Request 2: PUT IPv4 rule for IPv4 source → IPv4 destination
+	c.Assert(s.requests[2].Method, tc.Equals, "PUT")
+	c.Assert(s.requests[2].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-1234-cidr-10-0-0-0-24"))
+	assertRequestBody(c, s.requests[2], &armnetwork.SecurityRule{
 		Properties: &armnetwork.SecurityRulePropertiesFormat{
 			Description:              new("1234/tcp from 10.0.0.0/24"),
 			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
@@ -701,15 +721,15 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 			DestinationPortRange:     new("1234"),
 			DestinationAddressPrefix: new("10.0.0.4"), // IPv4 destination
 			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-			Priority:                 new(int32(200)),
+			Priority:                 new(int32(201)),
 			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
 		},
 	})
 
-	// Request 2: PUT IPv6 rule for IPv6 wildcard source → IPv6 destination
-	c.Assert(s.requests[2].Method, tc.Equals, "PUT")
-	c.Assert(s.requests[2].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-5678"))
-	assertRequestBody(c, s.requests[2], &armnetwork.SecurityRule{
+	// Request 3: PUT IPv6 rule for IPv6 wildcard source → IPv6 destination
+	c.Assert(s.requests[3].Method, tc.Equals, "PUT")
+	c.Assert(s.requests[3].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-5678"))
+	assertRequestBody(c, s.requests[3], &armnetwork.SecurityRule{
 		Properties: &armnetwork.SecurityRulePropertiesFormat{
 			Description:              new("5678/tcp"),
 			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
@@ -718,14 +738,14 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 			DestinationPortRange:     new("5678"),
 			DestinationAddressPrefix: new("fd00::4"), // IPv6 destination
 			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-			Priority:                 new(int32(201)),
+			Priority:                 new(int32(202)),
 			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
 		},
 	})
 
-	// Request 3: PUT IPv6 rule for specific IPv6 source → IPv6 destination
-	c.Assert(s.requests[3].Method, tc.Equals, "PUT")
-	assertRequestBody(c, s.requests[3], &armnetwork.SecurityRule{
+	// Request 4: PUT IPv6 rule for specific IPv6 source → IPv6 destination
+	c.Assert(s.requests[4].Method, tc.Equals, "PUT")
+	assertRequestBody(c, s.requests[4], &armnetwork.SecurityRule{
 		Properties: &armnetwork.SecurityRulePropertiesFormat{
 			Description:              new("9999/tcp from 2002:db8::1/128"),
 			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
@@ -734,7 +754,7 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 			DestinationPortRange:     new("9999"),
 			DestinationAddressPrefix: new("fd00::4"), // IPv6 destination
 			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
-			Priority:                 new(int32(202)),
+			Priority:                 new(int32(203)),
 			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
 		},
 	})

--- a/internal/provider/azure/instance_test.go
+++ b/internal/provider/azure/instance_test.go
@@ -126,6 +126,20 @@ func makeIPConfiguration(privateIPAddress string) *armnetwork.InterfaceIPConfigu
 	return ipConfiguration
 }
 
+func makeIPv6Configuration(privateIPAddress string) *armnetwork.InterfaceIPConfiguration {
+	ipConfiguration := &armnetwork.InterfaceIPConfiguration{
+		Name: new("primary-ipv6"),
+		Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+			Primary:                 new(false),
+			PrivateIPAddressVersion: to.Ptr(armnetwork.IPVersionIPv6),
+		},
+	}
+	if privateIPAddress != "" {
+		ipConfiguration.Properties.PrivateIPAddress = new(privateIPAddress)
+	}
+	return ipConfiguration
+}
+
 func makePublicIPAddress(pipName, vmName, ipAddress string) *armnetwork.PublicIPAddress {
 	tags := map[string]*string{"juju-machine-name": &vmName}
 	pip := &armnetwork.PublicIPAddress{
@@ -625,6 +639,246 @@ func (s *instanceSuite) TestInstanceOpenPortsNoInternalAddress(c *tc.C) {
 	err := fwInst.OpenPorts(c.Context(), "0", nil)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(s.requests, tc.HasLen, 0)
+}
+
+func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
+	// Dual-stack NIC with both IPv4 (10.0.0.4) and IPv6 (fd00::4) addresses.
+	nic0IPv4Config := makeIPConfiguration("10.0.0.4")
+	nic0IPv4Config.Properties.Primary = new(true)
+	nic0IPv4Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+	}
+	nic0IPv6Config := makeIPv6Configuration("fd00::4")
+	nic0IPv6Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+	}
+	nsg := &armnetwork.SecurityGroup{
+		ID:   &internalSecurityGroupPath,
+		Name: new("juju-internal-nsg"),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{},
+		},
+	}
+	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPv4Config, nic0IPv6Config)
+	nic0.Properties.NetworkSecurityGroup = nsg
+
+	s.networkInterfaces = []*armnetwork.Interface{nic0}
+
+	nsgSender := azuretesting.NewSenderWithValue(nsg)
+	nsgSender.PathPattern = ".*/networkSecurityGroups/juju-internal-nsg"
+
+	okSender := &azuretesting.MockSender{}
+	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
+	// Three rules: IPv4 source → IPv4 dest (10.0.0.4), IPv6 source → IPv6 dest (fd00::4), IPv4 range
+	s.sender = azuretesting.Senders{nsgSender, okSender, okSender, okSender}
+
+	inst := s.getInstance(c, "machine-0")
+	fwInst, ok := inst.(instances.InstanceFirewaller)
+	c.Assert(ok, tc.Equals, true)
+
+	// Rules with IPv4 and IPv6 sources
+	err := fwInst.OpenPorts(c.Context(), "0", firewall.IngressRules{
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("1234/tcp"), "10.0.0.0/24"),                // IPv4
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("5678/tcp"), firewall.AllNetworksIPV6CIDR), // IPv6 wildcard
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("9999/tcp"), "2002:db8::1/128"),            // Specific IPv6
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(s.requests, tc.HasLen, 4)
+	// Request 0: GET NSG
+	c.Assert(s.requests[0].Method, tc.Equals, "GET")
+	c.Assert(s.requests[0].URL.Path, tc.Equals, internalSecurityGroupPath)
+
+	// Request 1: PUT IPv4 rule for IPv4 source → IPv4 destination
+	c.Assert(s.requests[1].Method, tc.Equals, "PUT")
+	c.Assert(s.requests[1].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-1234-cidr-10-0-0-0-24"))
+	assertRequestBody(c, s.requests[1], &armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Description:              new("1234/tcp from 10.0.0.0/24"),
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourcePortRange:          new("*"),
+			SourceAddressPrefix:      new("10.0.0.0/24"),
+			DestinationPortRange:     new("1234"),
+			DestinationAddressPrefix: new("10.0.0.4"), // IPv4 destination
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(200)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	})
+
+	// Request 2: PUT IPv6 rule for IPv6 wildcard source → IPv6 destination
+	c.Assert(s.requests[2].Method, tc.Equals, "PUT")
+	assertRequestBody(c, s.requests[2], &armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Description:              new("5678/tcp from ::/0"),
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourcePortRange:          new("*"),
+			SourceAddressPrefix:      new(firewall.AllNetworksIPV6CIDR), // IPv6 wildcard source
+			DestinationPortRange:     new("5678"),
+			DestinationAddressPrefix: new("fd00::4"), // IPv6 destination
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(201)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	})
+
+	// Request 3: PUT IPv6 rule for specific IPv6 source → IPv6 destination
+	c.Assert(s.requests[3].Method, tc.Equals, "PUT")
+	assertRequestBody(c, s.requests[3], &armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Description:              new("9999/tcp from 2002:db8::1/128"),
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourcePortRange:          new("*"),
+			SourceAddressPrefix:      new("2002:db8::1/128"), // Specific IPv6 source
+			DestinationPortRange:     new("9999"),
+			DestinationAddressPrefix: new("fd00::4"), // IPv6 destination
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(202)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	})
+}
+
+func (s *instanceSuite) TestInstanceOpenPortsIPv6OnIPv4OnlyNIC(c *tc.C) {
+	// IPv4-only NIC with no IPv6 configuration.
+	nic0IPv4Config := makeIPConfiguration("10.0.0.4")
+	nic0IPv4Config.Properties.Primary = new(true)
+	nic0IPv4Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+	}
+	nsg := &armnetwork.SecurityGroup{
+		ID:   &internalSecurityGroupPath,
+		Name: new("juju-internal-nsg"),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{},
+		},
+	}
+	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPv4Config)
+	nic0.Properties.NetworkSecurityGroup = nsg
+
+	s.networkInterfaces = []*armnetwork.Interface{nic0}
+
+	nsgSender := azuretesting.NewSenderWithValue(nsg)
+	nsgSender.PathPattern = ".*/networkSecurityGroups/juju-internal-nsg"
+
+	okSender := &azuretesting.MockSender{}
+	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
+	// Only ONE rule (IPv4) should be created; IPv6 rule should be skipped
+	s.sender = azuretesting.Senders{nsgSender, okSender}
+
+	inst := s.getInstance(c, "machine-0")
+	fwInst, ok := inst.(instances.InstanceFirewaller)
+	c.Assert(ok, tc.Equals, true)
+
+	// Try to open both IPv4 and IPv6 rules
+	err := fwInst.OpenPorts(c.Context(), "0", firewall.IngressRules{
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("1234/tcp"), "10.0.0.0/24"),                // IPv4
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("5678/tcp"), firewall.AllNetworksIPV6CIDR), // IPv6 - should skip
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Should have only 2 requests: GET NSG, PUT IPv4 rule (IPv6 rule skipped, no PUT)
+	c.Assert(s.requests, tc.HasLen, 2)
+	c.Assert(s.requests[0].Method, tc.Equals, "GET")
+	c.Assert(s.requests[1].Method, tc.Equals, "PUT")
+	c.Assert(s.requests[1].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-1234-cidr-10-0-0-0-24"))
+}
+
+func (s *instanceSuite) TestIngressRulesIPv6Wildcard(c *tc.C) {
+	// NSG rule with wildcard source and IPv6 destination should normalise to "::/0",
+	// not "0.0.0.0/0".
+	nsgRules := []*armnetwork.SecurityRule{{
+		Name: new("machine-0-tcp-1234"),
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			DestinationPortRange:     new("1234"),
+			SourceAddressPrefix:      new("*"),       // Wildcard needs normalisation
+			DestinationAddressPrefix: new("fd00::4"), // IPv6 destination
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(200)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	}, {
+		Name: new("machine-0-tcp-5678"),
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			DestinationPortRange:     new("5678"),
+			SourceAddressPrefix:      new("*"),        // Wildcard on IPv4 destination
+			DestinationAddressPrefix: new("10.0.0.4"), // IPv4 destination
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(201)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	}}
+
+	nsgSender := s.setupSecurityGroupRules(nsgRules...)
+	inst := s.getInstance(c, "machine-0")
+	s.sender = *nsgSender
+
+	fwInst, ok := inst.(instances.InstanceFirewaller)
+	c.Assert(ok, tc.Equals, true)
+
+	rules, err := fwInst.IngressRules(c.Context(), "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Should have two rules:
+	// - IPv6 wildcard normalized to "::/0" for port 1234
+	// - IPv4 wildcard normalized to "0.0.0.0/0" for port 5678
+	c.Assert(rules, tc.HasLen, 2)
+	c.Assert(rules[0], tc.DeepEquals, firewall.NewIngressRule(corenetwork.MustParsePortRange("1234/tcp"), firewall.AllNetworksIPV6CIDR))
+	c.Assert(rules[1], tc.DeepEquals, firewall.NewIngressRule(corenetwork.MustParsePortRange("5678/tcp"), firewall.AllNetworksIPV4CIDR))
+}
+
+func (s *instanceSuite) TestInstanceClosePortsDualStack(c *tc.C) {
+	// Verify that ClosePorts works correctly for dual-stack machines.
+	// Both IPv4 and IPv6 rules should be deleted by their correct names.
+	nsgRules := []*armnetwork.SecurityRule{{
+		Name: new("machine-0-tcp-1234"),
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Protocol:             to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			DestinationPortRange: new("1234"),
+			SourceAddressPrefix:  new("10.0.0.0/24"),
+			Access:               to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:             new(int32(200)),
+			Direction:            to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	}, {
+		Name: new("machine-0-tcp-5678-cidr-2002-db8--1-128"),
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Protocol:             to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			DestinationPortRange: new("5678"),
+			SourceAddressPrefix:  new("2002:db8::1/128"),
+			Access:               to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:             new(int32(201)),
+			Direction:            to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	}}
+
+	nsgSender := s.setupSecurityGroupRules(nsgRules...)
+	inst := s.getInstance(c, "machine-0")
+	fwInst, ok := inst.(instances.InstanceFirewaller)
+	c.Assert(ok, tc.Equals, true)
+
+	sender := &azuretesting.MockSender{}
+	notFoundSender := &azuretesting.MockSender{}
+	notFoundSender.AppendAndRepeatResponse(azuretesting.NewResponseWithStatus(
+		"rule not found", http.StatusNotFound,
+	), 2)
+	s.sender = azuretesting.Senders{nsgSender, sender, sender, notFoundSender}
+
+	err := fwInst.ClosePorts(c.Context(), "0", firewall.IngressRules{
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("1234/tcp"), "10.0.0.0/24"),
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("5678/tcp"), "2002:db8::1/128"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// GET NSG, DELETE IPv4 rule, DELETE IPv6 rule
+	c.Assert(s.requests, tc.HasLen, 3)
+	c.Assert(s.requests[0].Method, tc.Equals, "GET")
+	c.Assert(s.requests[1].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[1].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-1234-cidr-10-0-0-0-24"))
+	c.Assert(s.requests[2].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[2].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-5678-cidr-2002-db8--1-128"))
 }
 
 func (s *instanceSuite) TestAllInstances(c *tc.C) {

--- a/internal/provider/azure/instance_test.go
+++ b/internal/provider/azure/instance_test.go
@@ -760,6 +760,68 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 	})
 }
 
+func (s *instanceSuite) TestInstanceOpenPortsIPv6NilPrivateIPAddress(c *tc.C) {
+	// Dual-stack NIC with an IPv6 config that has nil PrivateIPAddress
+	// (skipped) followed by a valid IPv6 config. The IPv6 rule should
+	// route to the valid IPv6 address.
+	nsg := &armnetwork.SecurityGroup{
+		ID:   &internalSecurityGroupPath,
+		Name: new("juju-internal-nsg"),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{},
+		},
+	}
+	nic0IPv4Config := makeIPConfiguration("10.0.0.4")
+	nic0IPv4Config.Properties.Primary = new(true)
+	nic0IPv4Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			NetworkSecurityGroup: nsg,
+		},
+	}
+	nic0IPv6ConfigNil := makeIPv6Configuration("")
+	nic0IPv6Config := makeIPv6Configuration("fd00::4")
+	nic0 := makeNetworkInterface(
+		"nic-0", "machine-0",
+		nic0IPv4Config, nic0IPv6ConfigNil, nic0IPv6Config,
+	)
+
+	s.networkInterfaces = []*armnetwork.Interface{nic0}
+
+	inst := s.getInstance(c, "machine-0")
+	fwInst, ok := inst.(instances.InstanceFirewaller)
+	c.Assert(ok, tc.IsTrue)
+
+	subnetSender := makeSender(internalSubnetPath, nic0IPv4Config.Properties.Subnet)
+	okSender := &azuretesting.MockSender{}
+	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
+	// Two requests: 1 subnet GET + 1 PUT (IPv6 wildcard)
+	s.sender = azuretesting.Senders{subnetSender, okSender}
+
+	err := fwInst.OpenPorts(c.Context(), "0", firewall.IngressRules{
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("5678/tcp"), firewall.AllNetworksIPV6CIDR),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(s.requests, tc.HasLen, 2)
+	c.Assert(s.requests[0].Method, tc.Equals, "GET")
+	// IPv6 wildcard rule should route to the valid IPv6 address.
+	c.Assert(s.requests[1].Method, tc.Equals, "PUT")
+	assertRequestBody(c, s.requests[1], &armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Description:              new("5678/tcp"),
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourcePortRange:          new("*"),
+			SourceAddressPrefix:      new(firewall.AllNetworksIPV6CIDR),
+			DestinationPortRange:     new("5678"),
+			DestinationAddressPrefix: new("fd00::4"),
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(200)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	})
+}
+
 func (s *instanceSuite) TestInstanceOpenPortsIPv6OnIPv4OnlyNIC(c *tc.C) {
 	// IPv4-only NIC with no IPv6 configuration.
 	nsg := &armnetwork.SecurityGroup{

--- a/internal/provider/azure/instance_test.go
+++ b/internal/provider/azure/instance_test.go
@@ -1194,3 +1194,61 @@ var internalSubnetPath = path.Join(
 func securityRulePath(ruleName string) string {
 	return path.Join(internalSecurityGroupPath, "securityRules", ruleName)
 }
+
+func TestIsIPv6SourceCIDR(t *stdtesting.T) {
+	tests := []struct {
+		name   string
+		from   string
+		expect bool
+	}{
+		{
+			name:   "IPv6 wildcard",
+			from:   "::/0",
+			expect: true,
+		},
+		{
+			name:   "specific IPv6 CIDR",
+			from:   "2002:db8::1/128",
+			expect: true,
+		},
+		{
+			name:   "IPv6 CIDR range",
+			from:   "fd00::/64",
+			expect: true,
+		},
+		{
+			name:   "IPv4 wildcard",
+			from:   "0.0.0.0/0",
+			expect: false,
+		},
+		{
+			name:   "Azure wildcard star",
+			from:   "*",
+			expect: false,
+		},
+		{
+			name:   "empty string",
+			from:   "",
+			expect: false,
+		},
+		{
+			name:   "specific IPv4 CIDR",
+			from:   "10.0.0.0/8",
+			expect: false,
+		},
+		{
+			name:   "invalid CIDR falls back to IPv4",
+			from:   "not-a-cidr",
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *stdtesting.T) {
+			got := azure.IsIPv6SourceCIDR(tt.from)
+			if got != tt.expect {
+				t.Errorf("IsIPv6SourceCIDR(%q) = %v, want %v", tt.from, got, tt.expect)
+			}
+		})
+	}
+}

--- a/internal/provider/azure/instance_test.go
+++ b/internal/provider/azure/instance_test.go
@@ -327,7 +327,7 @@ func (s *instanceSuite) TestMultipleInstanceAddresses(c *tc.C) {
 func (s *instanceSuite) TestIngressRulesEmpty(c *tc.C) {
 	inst := s.getInstance(c, "machine-0")
 	fwInst, ok := inst.(instances.InstanceFirewaller)
-	c.Assert(ok, tc.Equals, true)
+	c.Assert(ok, tc.IsTrue)
 	nsgSender := networkSecurityGroupSender(nil)
 	s.sender = azuretesting.Senders{nsgSender}
 	rules, err := fwInst.IngressRules(c.Context(), "0")
@@ -456,7 +456,7 @@ func (s *instanceSuite) TestIngressRules(c *tc.C) {
 	s.sender = *nsgSender
 
 	fwInst, ok := inst.(instances.InstanceFirewaller)
-	c.Assert(ok, tc.Equals, true)
+	c.Assert(ok, tc.IsTrue)
 
 	rules, err := fwInst.IngressRules(c.Context(), "0")
 	c.Assert(err, tc.ErrorIsNil)
@@ -472,7 +472,7 @@ func (s *instanceSuite) TestInstanceClosePorts(c *tc.C) {
 	nsgSender := s.setupSecurityGroupRules()
 	inst := s.getInstance(c, "machine-0")
 	fwInst, ok := inst.(instances.InstanceFirewaller)
-	c.Assert(ok, tc.Equals, true)
+	c.Assert(ok, tc.IsTrue)
 
 	sender := &azuretesting.MockSender{}
 	notFoundSender := &azuretesting.MockSender{}
@@ -505,7 +505,7 @@ func (s *instanceSuite) TestInstanceOpenPorts(c *tc.C) {
 	nsgSender := s.setupSecurityGroupRules()
 	inst := s.getInstance(c, "machine-0")
 	fwInst, ok := inst.(instances.InstanceFirewaller)
-	c.Assert(ok, tc.Equals, true)
+	c.Assert(ok, tc.IsTrue)
 
 	okSender := &azuretesting.MockSender{}
 	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
@@ -597,7 +597,7 @@ func (s *instanceSuite) TestInstanceOpenPortsAlreadyOpen(c *tc.C) {
 	nsgSender := s.setupSecurityGroupRules(nsgRule)
 	inst := s.getInstance(c, "machine-0")
 	fwInst, ok := inst.(instances.InstanceFirewaller)
-	c.Assert(ok, tc.Equals, true)
+	c.Assert(ok, tc.IsTrue)
 
 	okSender := &azuretesting.MockSender{}
 	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
@@ -635,7 +635,7 @@ func (s *instanceSuite) TestInstanceOpenPortsNoInternalAddress(c *tc.C) {
 	}
 	inst := s.getInstance(c, "machine-0")
 	fwInst, ok := inst.(instances.InstanceFirewaller)
-	c.Assert(ok, tc.Equals, true)
+	c.Assert(ok, tc.IsTrue)
 	err := fwInst.OpenPorts(c.Context(), "0", nil)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(s.requests, tc.HasLen, 0)
@@ -643,15 +643,6 @@ func (s *instanceSuite) TestInstanceOpenPortsNoInternalAddress(c *tc.C) {
 
 func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 	// Dual-stack NIC with both IPv4 (10.0.0.4) and IPv6 (fd00::4) addresses.
-	nic0IPv4Config := makeIPConfiguration("10.0.0.4")
-	nic0IPv4Config.Properties.Primary = new(true)
-	nic0IPv4Config.Properties.Subnet = &armnetwork.Subnet{
-		ID: &internalSubnetPath,
-	}
-	nic0IPv6Config := makeIPv6Configuration("fd00::4")
-	nic0IPv6Config.Properties.Subnet = &armnetwork.Subnet{
-		ID: &internalSubnetPath,
-	}
 	nsg := &armnetwork.SecurityGroup{
 		ID:   &internalSecurityGroupPath,
 		Name: new("juju-internal-nsg"),
@@ -659,22 +650,31 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 			SecurityRules: []*armnetwork.SecurityRule{},
 		},
 	}
+	nic0IPv4Config := makeIPConfiguration("10.0.0.4")
+	nic0IPv4Config.Properties.Primary = new(true)
+	nic0IPv4Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			NetworkSecurityGroup: nsg,
+		},
+	}
+	nic0IPv6Config := makeIPv6Configuration("fd00::4")
+	nic0IPv6Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+	}
 	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPv4Config, nic0IPv6Config)
-	nic0.Properties.NetworkSecurityGroup = nsg
 
 	s.networkInterfaces = []*armnetwork.Interface{nic0}
 
-	nsgSender := azuretesting.NewSenderWithValue(nsg)
-	nsgSender.PathPattern = ".*/networkSecurityGroups/juju-internal-nsg"
-
-	okSender := &azuretesting.MockSender{}
-	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
-	// Three rules: IPv4 source → IPv4 dest (10.0.0.4), IPv6 source → IPv6 dest (fd00::4), IPv4 range
-	s.sender = azuretesting.Senders{nsgSender, okSender, okSender, okSender}
-
 	inst := s.getInstance(c, "machine-0")
 	fwInst, ok := inst.(instances.InstanceFirewaller)
-	c.Assert(ok, tc.Equals, true)
+	c.Assert(ok, tc.IsTrue)
+
+	subnetSender := makeSender(internalSubnetPath, nic0IPv4Config.Properties.Subnet)
+	okSender := &azuretesting.MockSender{}
+	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
+	// Four requests: 1 subnet GET + 3 PUTs (IPv4, IPv6 wildcard, specific IPv6)
+	s.sender = azuretesting.Senders{subnetSender, okSender, okSender, okSender}
 
 	// Rules with IPv4 and IPv6 sources
 	err := fwInst.OpenPorts(c.Context(), "0", firewall.IngressRules{
@@ -685,9 +685,9 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Assert(s.requests, tc.HasLen, 4)
-	// Request 0: GET NSG
+	// Request 0: GET subnet (to resolve security group)
 	c.Assert(s.requests[0].Method, tc.Equals, "GET")
-	c.Assert(s.requests[0].URL.Path, tc.Equals, internalSecurityGroupPath)
+	c.Assert(s.requests[0].URL.Path, tc.Equals, internalSubnetPath)
 
 	// Request 1: PUT IPv4 rule for IPv4 source → IPv4 destination
 	c.Assert(s.requests[1].Method, tc.Equals, "PUT")
@@ -708,9 +708,10 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 
 	// Request 2: PUT IPv6 rule for IPv6 wildcard source → IPv6 destination
 	c.Assert(s.requests[2].Method, tc.Equals, "PUT")
+	c.Assert(s.requests[2].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-5678"))
 	assertRequestBody(c, s.requests[2], &armnetwork.SecurityRule{
 		Properties: &armnetwork.SecurityRulePropertiesFormat{
-			Description:              new("5678/tcp from ::/0"),
+			Description:              new("5678/tcp"),
 			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
 			SourcePortRange:          new("*"),
 			SourceAddressPrefix:      new(firewall.AllNetworksIPV6CIDR), // IPv6 wildcard source
@@ -741,11 +742,6 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 
 func (s *instanceSuite) TestInstanceOpenPortsIPv6OnIPv4OnlyNIC(c *tc.C) {
 	// IPv4-only NIC with no IPv6 configuration.
-	nic0IPv4Config := makeIPConfiguration("10.0.0.4")
-	nic0IPv4Config.Properties.Primary = new(true)
-	nic0IPv4Config.Properties.Subnet = &armnetwork.Subnet{
-		ID: &internalSubnetPath,
-	}
 	nsg := &armnetwork.SecurityGroup{
 		ID:   &internalSecurityGroupPath,
 		Name: new("juju-internal-nsg"),
@@ -753,31 +749,38 @@ func (s *instanceSuite) TestInstanceOpenPortsIPv6OnIPv4OnlyNIC(c *tc.C) {
 			SecurityRules: []*armnetwork.SecurityRule{},
 		},
 	}
+	nic0IPv4Config := makeIPConfiguration("10.0.0.4")
+	nic0IPv4Config.Properties.Primary = new(true)
+	nic0IPv4Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			NetworkSecurityGroup: nsg,
+		},
+	}
 	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPv4Config)
-	nic0.Properties.NetworkSecurityGroup = nsg
 
 	s.networkInterfaces = []*armnetwork.Interface{nic0}
 
-	nsgSender := azuretesting.NewSenderWithValue(nsg)
-	nsgSender.PathPattern = ".*/networkSecurityGroups/juju-internal-nsg"
-
-	okSender := &azuretesting.MockSender{}
-	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
-	// Only ONE rule (IPv4) should be created; IPv6 rule should be skipped
-	s.sender = azuretesting.Senders{nsgSender, okSender}
-
 	inst := s.getInstance(c, "machine-0")
 	fwInst, ok := inst.(instances.InstanceFirewaller)
-	c.Assert(ok, tc.Equals, true)
+	c.Assert(ok, tc.IsTrue)
 
-	// Try to open both IPv4 and IPv6 rules
+	subnetSender := makeSender(internalSubnetPath, nic0IPv4Config.Properties.Subnet)
+	okSender := &azuretesting.MockSender{}
+	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
+	// Two requests: 1 subnet GET + 1 PUT (IPv6 rule skipped, no PUT)
+	s.sender = azuretesting.Senders{subnetSender, okSender}
+
+	// Try to open IPv4, IPv6 wildcard, and specific IPv6 CIDR rules
 	err := fwInst.OpenPorts(c.Context(), "0", firewall.IngressRules{
 		firewall.NewIngressRule(corenetwork.MustParsePortRange("1234/tcp"), "10.0.0.0/24"),                // IPv4
-		firewall.NewIngressRule(corenetwork.MustParsePortRange("5678/tcp"), firewall.AllNetworksIPV6CIDR), // IPv6 - should skip
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("5678/tcp"), firewall.AllNetworksIPV6CIDR), // IPv6 wildcard - should skip
+		firewall.NewIngressRule(corenetwork.MustParsePortRange("9999/tcp"), "2002:db8::1/128"),            // Specific IPv6 - should skip
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	// Should have only 2 requests: GET NSG, PUT IPv4 rule (IPv6 rule skipped, no PUT)
+	// Should have only 2 requests: GET NSG, PUT IPv4 rule
+	// (both IPv6 rules skipped, no PUT)
 	c.Assert(s.requests, tc.HasLen, 2)
 	c.Assert(s.requests[0].Method, tc.Equals, "GET")
 	c.Assert(s.requests[1].Method, tc.Equals, "PUT")
@@ -816,7 +819,7 @@ func (s *instanceSuite) TestIngressRulesIPv6Wildcard(c *tc.C) {
 	s.sender = *nsgSender
 
 	fwInst, ok := inst.(instances.InstanceFirewaller)
-	c.Assert(ok, tc.Equals, true)
+	c.Assert(ok, tc.IsTrue)
 
 	rules, err := fwInst.IngressRules(c.Context(), "0")
 	c.Assert(err, tc.ErrorIsNil)
@@ -857,7 +860,7 @@ func (s *instanceSuite) TestInstanceClosePortsDualStack(c *tc.C) {
 	nsgSender := s.setupSecurityGroupRules(nsgRules...)
 	inst := s.getInstance(c, "machine-0")
 	fwInst, ok := inst.(instances.InstanceFirewaller)
-	c.Assert(ok, tc.Equals, true)
+	c.Assert(ok, tc.IsTrue)
 
 	sender := &azuretesting.MockSender{}
 	notFoundSender := &azuretesting.MockSender{}

--- a/internal/provider/azure/instance_test.go
+++ b/internal/provider/azure/instance_test.go
@@ -728,7 +728,7 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 
 	// Request 3: PUT IPv6 rule for IPv6 wildcard source → IPv6 destination
 	c.Assert(s.requests[3].Method, tc.Equals, "PUT")
-	c.Assert(s.requests[3].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-5678"))
+	c.Assert(s.requests[3].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-5678-v6"))
 	assertRequestBody(c, s.requests[3], &armnetwork.SecurityRule{
 		Properties: &armnetwork.SecurityRulePropertiesFormat{
 			Description:              new("5678/tcp"),
@@ -755,6 +755,99 @@ func (s *instanceSuite) TestInstanceOpenPortsDualStack(c *tc.C) {
 			DestinationAddressPrefix: new("fd00::4"), // IPv6 destination
 			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
 			Priority:                 new(int32(203)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	})
+}
+
+func (s *instanceSuite) TestInstanceOpenPortsDualStackSamePort(c *tc.C) {
+	// Regression test: a single ingress rule with BOTH IPv4 and IPv6
+	// wildcards for the SAME port must produce two distinct NSG rules.
+	// Previously both got the same securityRuleName (no -v6 suffix),
+	// causing the IPv6 rule to be silently skipped as a duplicate.
+	nsg := &armnetwork.SecurityGroup{
+		ID:   &internalSecurityGroupPath,
+		Name: new("juju-internal-nsg"),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{},
+		},
+	}
+	nic0IPv4Config := makeIPConfiguration("10.0.0.4")
+	nic0IPv4Config.Properties.Primary = new(true)
+	nic0IPv4Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			NetworkSecurityGroup: nsg,
+		},
+	}
+	nic0IPv6Config := makeIPv6Configuration("fd00::4")
+	nic0IPv6Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+	}
+	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPv4Config, nic0IPv6Config)
+
+	s.networkInterfaces = []*armnetwork.Interface{nic0}
+
+	inst := s.getInstance(c, "machine-0")
+	fwInst, ok := inst.(instances.InstanceFirewaller)
+	c.Assert(ok, tc.IsTrue)
+
+	subnetSender := makeSender(internalSubnetPath, nic0IPv4Config.Properties.Subnet)
+	okSender := &azuretesting.MockSender{}
+	okSender.AppendResponse(azuretesting.NewResponseWithContent("{}")) //nolint:bodyclose
+	// Three requests: 1 subnet GET + 2 PUTs (IPv4 wildcard, IPv6 wildcard).
+	// CIDRs sort lexicographically: "0.0.0.0/0" before "::/0", so IPv4
+	// rule is created first.
+	s.sender = azuretesting.Senders{subnetSender, okSender, okSender}
+
+	// Single rule with BOTH IPv4 and IPv6 wildcards for the same port —
+	// this is what the firewaller actually sends after juju expose.
+	err := fwInst.OpenPorts(c.Context(), "0", firewall.IngressRules{
+		firewall.NewIngressRule(
+			corenetwork.MustParsePortRange("80/tcp"),
+			firewall.AllNetworksIPV4CIDR,
+			firewall.AllNetworksIPV6CIDR,
+		),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(s.requests, tc.HasLen, 3)
+
+	// Request 0: GET subnet (to resolve security group)
+	c.Assert(s.requests[0].Method, tc.Equals, "GET")
+	c.Assert(s.requests[0].URL.Path, tc.Equals, internalSubnetPath)
+
+	// Request 1: PUT IPv4 wildcard rule → IPv4 destination.
+	// String() omits wildcard CIDRs from the description.
+	c.Assert(s.requests[1].Method, tc.Equals, "PUT")
+	c.Assert(s.requests[1].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-80"))
+	assertRequestBody(c, s.requests[1], &armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Description:              new("80/tcp"),
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourcePortRange:          new("*"),
+			SourceAddressPrefix:      new(firewall.AllNetworksIPV4CIDR),
+			DestinationPortRange:     new("80"),
+			DestinationAddressPrefix: new("10.0.0.4"),
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(200)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	})
+
+	// Request 2: PUT IPv6 wildcard rule → IPv6 destination
+	c.Assert(s.requests[2].Method, tc.Equals, "PUT")
+	c.Assert(s.requests[2].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-80-v6"))
+	assertRequestBody(c, s.requests[2], &armnetwork.SecurityRule{
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Description:              new("80/tcp"),
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			SourcePortRange:          new("*"),
+			SourceAddressPrefix:      new(firewall.AllNetworksIPV6CIDR),
+			DestinationPortRange:     new("80"),
+			DestinationAddressPrefix: new("fd00::4"),
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(201)),
 			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
 		},
 	})
@@ -964,6 +1057,90 @@ func (s *instanceSuite) TestInstanceClosePortsDualStack(c *tc.C) {
 	c.Assert(s.requests[1].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-1234-cidr-10-0-0-0-24"))
 	c.Assert(s.requests[2].Method, tc.Equals, "DELETE")
 	c.Assert(s.requests[2].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-5678-cidr-2002-db8--1-128"))
+}
+
+func (s *instanceSuite) TestInstanceClosePortsDualStackWildcard(c *tc.C) {
+	// Regression test: ClosePorts must delete both IPv4 and IPv6 wildcard
+	// rules for the same port. Previously both computed the same
+	// securityRuleName, so only one DELETE was ever issued.
+	nsgRules := []*armnetwork.SecurityRule{{
+		Name: new("machine-0-tcp-80"),
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			DestinationPortRange:     new("80"),
+			SourceAddressPrefix:      new("0.0.0.0/0"),
+			DestinationAddressPrefix: new("10.0.0.4"),
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(200)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	}, {
+		Name: new("machine-0-tcp-80-v6"),
+		Properties: &armnetwork.SecurityRulePropertiesFormat{
+			Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+			DestinationPortRange:     new("80"),
+			SourceAddressPrefix:      new("::/0"),
+			DestinationAddressPrefix: new("fd00::4"),
+			Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+			Priority:                 new(int32(201)),
+			Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+		},
+	}}
+
+	nsg := &armnetwork.SecurityGroup{
+		ID:   &internalSecurityGroupPath,
+		Name: new("juju-internal-nsg"),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: nsgRules,
+		},
+	}
+	nic0IPv4Config := makeIPConfiguration("10.0.0.4")
+	nic0IPv4Config.Properties.Primary = new(true)
+	nic0IPv4Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			NetworkSecurityGroup: nsg,
+		},
+	}
+	nic0IPv6Config := makeIPv6Configuration("fd00::4")
+	nic0IPv6Config.Properties.Subnet = &armnetwork.Subnet{
+		ID: &internalSubnetPath,
+	}
+	nic0 := makeNetworkInterface("nic-0", "machine-0", nic0IPv4Config, nic0IPv6Config)
+
+	s.networkInterfaces = []*armnetwork.Interface{nic0}
+
+	inst := s.getInstance(c, "machine-0")
+	fwInst, ok := inst.(instances.InstanceFirewaller)
+	c.Assert(ok, tc.IsTrue)
+
+	subnetSender := makeSender(internalSubnetPath, nic0IPv4Config.Properties.Subnet)
+	nsgSender := networkSecurityGroupSender(nsgRules)
+	okSender := &azuretesting.MockSender{}
+	notFoundSender := &azuretesting.MockSender{}
+	notFoundSender.AppendAndRepeatResponse(azuretesting.NewResponseWithStatus(
+		"rule not found", http.StatusNotFound,
+	), 2)
+	s.sender = azuretesting.Senders{subnetSender, nsgSender, okSender, okSender, notFoundSender}
+
+	// Single rule with BOTH wildcards for the same port — mirrors the
+	// real firewaller flow after juju expose.
+	err := fwInst.ClosePorts(c.Context(), "0", firewall.IngressRules{
+		firewall.NewIngressRule(
+			corenetwork.MustParsePortRange("80/tcp"),
+			firewall.AllNetworksIPV4CIDR,
+			firewall.AllNetworksIPV6CIDR,
+		),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// GET NSG + 2 DELETEs with distinct paths
+	c.Assert(s.requests, tc.HasLen, 3)
+	c.Assert(s.requests[0].Method, tc.Equals, "GET")
+	c.Assert(s.requests[1].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[1].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-80"))
+	c.Assert(s.requests[2].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[2].URL.Path, tc.Equals, securityRulePath("machine-0-tcp-80-v6"))
 }
 
 func (s *instanceSuite) TestAllInstances(c *tc.C) {

--- a/internal/provider/azure/instance_test.go
+++ b/internal/provider/azure/instance_test.go
@@ -1039,7 +1039,7 @@ func (s *instanceSuite) TestInstanceClosePortsDualStack(c *tc.C) {
 
 	sender := &azuretesting.MockSender{}
 	notFoundSender := &azuretesting.MockSender{}
-	notFoundSender.AppendAndRepeatResponse(azuretesting.NewResponseWithStatus(
+	notFoundSender.AppendAndRepeatResponse(azuretesting.NewResponseWithStatus( //nolint:bodyclose
 		"rule not found", http.StatusNotFound,
 	), 2)
 	s.sender = azuretesting.Senders{nsgSender, sender, sender, notFoundSender}
@@ -1118,7 +1118,7 @@ func (s *instanceSuite) TestInstanceClosePortsDualStackWildcard(c *tc.C) {
 	nsgSender := networkSecurityGroupSender(nsgRules)
 	okSender := &azuretesting.MockSender{}
 	notFoundSender := &azuretesting.MockSender{}
-	notFoundSender.AppendAndRepeatResponse(azuretesting.NewResponseWithStatus(
+	notFoundSender.AppendAndRepeatResponse(azuretesting.NewResponseWithStatus( //nolint:bodyclose
 		"rule not found", http.StatusNotFound,
 	), 2)
 	s.sender = azuretesting.Senders{subnetSender, nsgSender, okSender, okSender, notFoundSender}

--- a/internal/provider/azure/networking.go
+++ b/internal/provider/azure/networking.go
@@ -199,7 +199,14 @@ func networkSecurityRules(
 			destPrefix:  controllerSubnetPrefix,
 			port:        apiPort,
 			// Two rules cannot have the same priority and direction.
-			priority: securityRuleInternalAPIInbound + i,
+			priority: securityRuleInternalAPIInbound + i*2,
+		}))
+		securityRules = append(securityRules, newSecurityRule(newSecurityRuleParams{
+			name:        fmt.Sprintf("%s%dIPv6", apiSecurityRulePrefix, apiPort),
+			description: "Allow API connections to controller machines (IPv6)",
+			destPrefix:  controllerSubnetIPv6Prefix,
+			port:        apiPort,
+			priority:    securityRuleInternalAPIInbound + i*2 + 1,
 		}))
 	}
 	securityRules = append(securityRules, extraRules...)


### PR DESCRIPTION
## Why this change is needed and what it does

This PR implements Task 6 of [JUJU-9599](https://warthogs.atlassian.net/browse/JUJU-9599): Azure NSG firewaller support for dual-stack IPv6 ingress rules.

Azure NSGs (Network Security Groups) now correctly handle IPv6 source CIDRs and destination addresses when the model is configured with `ip-family=dual-stack`. This enables the firewaller to create and manage IPv6 security rules alongside existing IPv4 rules.

### Changes

- **`environ.go`**: Implement `environs.FirewallFeatureQuerier` interface on `azureEnviron` — `SupportsRulesWithIPV6CIDRs` returns `true`, signalling the firewaller that Azure NSGs natively support IPv6 CIDR rules.
- **`instance.go`**: 
  - Extend `securityGroupInfo` struct with an optional `ipv6Address` field.
  - Extract `fetchIPv6Address` helper: scans NIC IP configurations for an IPv6 address (the `primary-ipv6` config created by Task 3 / #22736).
  - Extract `fetchPrimaryIPv4AndSecurityGroup` helper: finds the primary IPv4 configuration and associated NSG (from NIC or subnet).
  - Refactor `primarySecurityGroupInfo` to orchestrate the two helpers.
  - Add family-aware destination selection in `openPortsOnGroup`: IPv6 source CIDRs route to the IPv6 destination address; IPv4 source CIDRs route to the IPv4 destination address.
  - Replace blanket `0.0.0.0/0` wildcard normalisation in `ingressRulesForGroup` with family-aware logic keyed off the destination address family.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you are testing
- ~Integration tests~
- ~doc.go added or updated in changed packages~

## QA steps

1. Bootstrap a dual stack controller on Azure and create a dual-stack model:

```sh
juju bootstrap azure --bootstrap-constraints ip-family=dual
juju add-model dualstack
juju set-model-constraints ip-family=dual
```

Verify controller is dualstack
```sh
# Find the API rule (usually JujuAPIInbound17070IPv6)
az network nsg rule list --resource-group <rg> --nsg-name juju-internal-nsg -o table

# Or inspect the specific rule
az network nsg rule show --resource-group <rg> --nsg-name juju-internal-nsg \
  --name JujuAPIInbound17070IPv6 -o json | jq ".destinationAddressPrefix"
```

The output should show both `192.168.16.0/20` and `fd00:0:0:10::/64` in `destinationAddressPrefix`.

2. Deploy nginx charm and expose it:

```sh
juju deploy nginx --constraints "ip-family=dual"
juju expose nginx
juju exec --unit nginx/0 -- "open-port 80/tcp"
```

3. Enable IPv6 listening in nginx (nginx defaults to IPv4-only):

```sh
juju exec --unit nginx/0 -- \
  "sudo sed -i 's/listen 80 default_server;/listen 80;\n\tlisten [::]:80;/' /etc/nginx/sites-available/nginx && \
   sudo nginx -t && sudo systemctl reload nginx"
```

4. Verify NSG rules are created for both IPv4 and IPv6:
 
```sh
az network nsg rule list --resource-group <rg> --nsg-name juju-internal-nsg -o table
```

Both 0.0.0.0/0 (IPv4) and ::/0 (IPv6) source prefixes should appear.

6. Verify IPv4 connectivity:

`curl -sq4 http://<public-ipv4>:80 -o /dev/null -w "%{http_code}\n"`
Should return 200.

7. Verify IPv6 connectivity:

`curl -sq6 http://[<public-ipv6>]:80 -o /dev/null -w "%{http_code}\n"`

Should return 200.

## Links

- Depends on #22736 (Task 3: dual-stack provisioning on Azure)
- Part of [JUJU-9599](https://warthogs.atlassian.net/browse/JUJU-9599)

**Jira card:** [JUJU-9971](https://warthogs.atlassian.net/browse/JUJU-9971)

[JUJU-9599]: https://warthogs.atlassian.net/browse/JUJU-9599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JUJU-9599]: https://warthogs.atlassian.net/browse/JUJU-9599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ