### PR TITLE
fix: add api/docker type for external consumers

### DIFF
--- a/api/docker/doc.go
+++ b/api/docker/doc.go
@@ -1,0 +1,9 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package docker provides the public API types for OCI image and registry
+// credential representation. These types carry the JSON and YAML struct tags
+// required for wire-level serialization so that external clients (e.g. the
+// Terraform Juju provider) can marshal resources that the Juju controller can
+// deserialize correctly.
+package docker

--- a/api/docker/docker.go
+++ b/api/docker/docker.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package docker
+
+import (
+	"time"
+)
+
+// Token defines a token value with expiration time.
+type Token struct {
+	// Value is the value of the token.
+	Value string
+
+	// ExpiresAt is the unix time in seconds and milliseconds when the
+	// authorization token expires.
+	ExpiresAt *time.Time
+}
+
+// BasicAuthConfig contains authorization information for basic auth.
+type BasicAuthConfig struct {
+	// Auth is the base64 encoded "username:password" string.
+	Auth *Token `json:"auth,omitempty" yaml:"auth,omitempty"`
+
+	// Username holds the username used to gain access to a non-public image.
+	Username string `json:"username" yaml:"username"`
+
+	// Password holds the password used to gain access to a non-public image.
+	Password string `json:"password" yaml:"password"`
+}
+
+// TokenAuthConfig contains authorization information for token auth.
+// Juju does not support the docker credential helper because k8s does not
+// support it either.
+// https://kubernetes.io/docs/concepts/containers/images/#configuring-nodes-to-authenticate-to-a-private-registry
+type TokenAuthConfig struct {
+	Email string `json:"email,omitempty" yaml:"email,omitempty"`
+
+	// IdentityToken is used to authenticate the user and get an access token
+	// for the registry.
+	IdentityToken *Token `json:"identitytoken,omitempty" yaml:"identitytoken,omitempty"`
+
+	// RegistryToken is a bearer token to be sent to a registry.
+	RegistryToken *Token `json:"registrytoken,omitempty" yaml:"registrytoken,omitempty"`
+}
+
+// ImageRepoDetails contains authorization information for connecting to a
+// Registry.
+type ImageRepoDetails struct {
+	BasicAuthConfig `json:",inline" yaml:",inline"`
+	TokenAuthConfig `json:",inline" yaml:",inline"`
+
+	// Repository is the namespace of the image repo.
+	Repository string `json:"repository,omitempty" yaml:"repository,omitempty"`
+
+	// ServerAddress is the auth server address.
+	ServerAddress string `json:"serveraddress,omitempty" yaml:"serveraddress,omitempty"`
+
+	// Region is the cloud region.
+	Region string `json:"region,omitempty" yaml:"region,omitempty"`
+}
+
+// DockerImageDetails holds the details for a Docker resource type.
+type DockerImageDetails struct {
+	// RegistryPath holds the path of the Docker image (including host and
+	// sha256) in a docker registry.
+	RegistryPath string `json:"ImageName" yaml:"registrypath"`
+
+	ImageRepoDetails `json:",inline" yaml:",inline"`
+}

--- a/cmd/juju/resource/deploy_test.go
+++ b/cmd/juju/resource/deploy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/tc"
 
 	apiresources "github.com/juju/juju/api/client/resources"
+	apidocker "github.com/juju/juju/api/docker"
 	"github.com/juju/juju/cmd/modelcmd"
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
 	"github.com/juju/juju/internal/docker"
@@ -466,10 +467,10 @@ password: hunter2
 	data := bytes.NewBufferString(content)
 	dets, err := unMarshalDockerDetails(data)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(dets, tc.DeepEquals, docker.DockerImageDetails{
+	c.Assert(dets, tc.DeepEquals, apidocker.DockerImageDetails{
 		RegistryPath: "registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image",
-		ImageRepoDetails: docker.ImageRepoDetails{
-			BasicAuthConfig: docker.BasicAuthConfig{
+		ImageRepoDetails: apidocker.ImageRepoDetails{
+			BasicAuthConfig: apidocker.BasicAuthConfig{
 				Username: "docker-registry",
 				Password: "hunter2",
 			},
@@ -486,10 +487,10 @@ password: hunter2
 	data = bytes.NewBufferString(content)
 	dets, err = unMarshalDockerDetails(data)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(dets, tc.DeepEquals, docker.DockerImageDetails{
+	c.Assert(dets, tc.DeepEquals, apidocker.DockerImageDetails{
 		RegistryPath: "registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image",
-		ImageRepoDetails: docker.ImageRepoDetails{
-			BasicAuthConfig: docker.BasicAuthConfig{
+		ImageRepoDetails: apidocker.ImageRepoDetails{
+			BasicAuthConfig: apidocker.BasicAuthConfig{
 				Username: "docker-registry",
 				Password: "hunter2",
 			},
@@ -518,10 +519,10 @@ func (s *DeploySuite) TestGetDockerDetailsData(c *tc.C) {
 	fs := osFilesystem{}
 	result, err := getDockerDetailsData("registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image", fs.Open)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(result, tc.DeepEquals, docker.DockerImageDetails{
+	c.Assert(result, tc.DeepEquals, apidocker.DockerImageDetails{
 		RegistryPath: "registry.staging.jujucharms.com/wallyworld/mysql-k8s/mysql_image",
-		ImageRepoDetails: docker.ImageRepoDetails{
-			BasicAuthConfig: docker.BasicAuthConfig{
+		ImageRepoDetails: apidocker.ImageRepoDetails{
+			BasicAuthConfig: apidocker.BasicAuthConfig{
 				Username: "",
 				Password: "",
 			},
@@ -540,10 +541,10 @@ func (s *DeploySuite) TestGetDockerDetailsData(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	result, err = getDockerDetailsData(yamlFile, fs.Open)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(result, tc.DeepEquals, docker.DockerImageDetails{
+	c.Assert(result, tc.DeepEquals, apidocker.DockerImageDetails{
 		RegistryPath: "mariadb/mariadb:10.2",
-		ImageRepoDetails: docker.ImageRepoDetails{
-			BasicAuthConfig: docker.BasicAuthConfig{
+		ImageRepoDetails: apidocker.ImageRepoDetails{
+			BasicAuthConfig: apidocker.BasicAuthConfig{
 				Username: "",
 				Password: "",
 			},

--- a/cmd/juju/resource/validation.go
+++ b/cmd/juju/resource/validation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
 
+	apidocker "github.com/juju/juju/api/docker"
 	"github.com/juju/juju/cmd/juju/application/utils"
 	"github.com/juju/juju/cmd/modelcmd"
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
@@ -44,7 +45,7 @@ func ValidateResources(resources map[string]charmresource.Meta) error {
 
 // getDockerDetailsData determines if path is a local file path and extracts the
 // details from that otherwise path is considered to be a registry path.
-func getDockerDetailsData(path string, osOpen osOpenFunc) (docker.DockerImageDetails, error) {
+func getDockerDetailsData(path string, osOpen osOpenFunc) (apidocker.DockerImageDetails, error) {
 	f, err := osOpen(path)
 	if err == nil {
 		defer f.Close()
@@ -54,11 +55,11 @@ func getDockerDetailsData(path string, osOpen osOpenFunc) (docker.DockerImageDet
 		}
 		return details, nil
 	} else if err := docker.ValidateDockerRegistryPath(path); err == nil {
-		return docker.DockerImageDetails{
+		return apidocker.DockerImageDetails{
 			RegistryPath: path,
 		}, nil
 	}
-	return docker.DockerImageDetails{}, errors.NotValidf("filepath or registry path: %s", path)
+	return apidocker.DockerImageDetails{}, errors.NotValidf("filepath or registry path: %s", path)
 
 }
 
@@ -72,13 +73,10 @@ func ValidateResourceDetails(res map[string]string, resMeta map[string]charmreso
 		case charmresource.TypeFile:
 			err = utils.CheckFile(name, value, fs)
 		case charmresource.TypeContainerImage:
-			var dockerDetails docker.DockerImageDetails
-			dockerDetails, err = getDockerDetailsData(value, fs.Open)
+			_, err := getDockerDetailsData(value, fs.Open)
 			if err != nil {
 				return errors.Annotatef(err, "resource %q", name)
 			}
-			// At the moment this is the same validation that occurs in getDockerDetailsData
-			err = docker.CheckDockerDetails(name, dockerDetails)
 		default:
 			return fmt.Errorf("unknown resource: %s", name)
 		}
@@ -123,8 +121,8 @@ func (noopCloser) Close() error {
 	return nil
 }
 
-func unMarshalDockerDetails(data io.Reader) (docker.DockerImageDetails, error) {
-	var details docker.DockerImageDetails
+func unMarshalDockerDetails(data io.Reader) (apidocker.DockerImageDetails, error) {
+	var details apidocker.DockerImageDetails
 	contents, err := io.ReadAll(data)
 	if err != nil {
 		return details, errors.Trace(err)
@@ -144,7 +142,7 @@ func unMarshalDockerDetails(data io.Reader) (docker.DockerImageDetails, error) {
 		}
 	}
 	if err := docker.ValidateDockerRegistryPath(details.RegistryPath); err != nil {
-		return docker.DockerImageDetails{}, err
+		return apidocker.DockerImageDetails{}, err
 	}
 	return details, nil
 }

--- a/internal/docker/serialization.go
+++ b/internal/docker/serialization.go
@@ -22,12 +22,6 @@ func ValidateDockerRegistryPath(path string) error {
 	return nil
 }
 
-// CheckDockerDetails validates the provided resource is suitable for use.
-func CheckDockerDetails(name string, details DockerImageDetails) error {
-	// TODO (veebers): Validate the URL actually works.
-	return ValidateDockerRegistryPath(details.RegistryPath)
-}
-
 // UnmarshalDockerResource unmarshals the docker resource file from data.
 func UnmarshalDockerResource(data []byte) (DockerImageDetails, error) {
 	var resourceBody DockerImageDetails

--- a/internal/docker/serialization_test.go
+++ b/internal/docker/serialization_test.go
@@ -4,10 +4,13 @@
 package docker_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/juju/tc"
+	"gopkg.in/yaml.v3"
 
+	apidocker "github.com/juju/juju/api/docker"
 	"github.com/juju/juju/internal/docker"
 )
 
@@ -43,7 +46,7 @@ func (s *DockerResourceSuite) TestDockerImageDetailsUnmarshalJson(c *tc.C) {
 	data := []byte(`{"ImageName":"testing@sha256:beef-deed","Username":"docker-registry","Password":"fragglerock"}`)
 	result, err := docker.UnmarshalDockerResource(data)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(result, tc.DeepEquals, docker.DockerImageDetails{
+	c.Check(result, tc.DeepEquals, docker.DockerImageDetails{
 		RegistryPath: "testing@sha256:beef-deed",
 		ImageRepoDetails: docker.ImageRepoDetails{
 			BasicAuthConfig: docker.BasicAuthConfig{
@@ -62,7 +65,7 @@ password: fragglerock
 `[1:])
 	result, err := docker.UnmarshalDockerResource(data)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(result, tc.DeepEquals, docker.DockerImageDetails{
+	c.Check(result, tc.DeepEquals, docker.DockerImageDetails{
 		RegistryPath: "testing@sha256:beef-deed",
 		ImageRepoDetails: docker.ImageRepoDetails{
 			BasicAuthConfig: docker.BasicAuthConfig{
@@ -71,4 +74,90 @@ password: fragglerock
 			},
 		},
 	})
+}
+
+// TestAPIDockerYAMLCompatibility verifies that YAML marshalled by the public
+// api/docker type can be unmarshalled by UnmarshalDockerResource. This is the
+// core guarantee that allows external clients (e.g. the Terraform provider)
+// to use the api/docker types instead of mirroring the internal structs.
+// If the struct tags ever diverge, this test fails at the source of truth.
+func (s *DockerResourceSuite) TestAPIDockerYAMLCompatibility(c *tc.C) {
+	apiDetails := apidocker.DockerImageDetails{
+		RegistryPath: "registry.example.com/myimage@sha256:abcdef",
+		ImageRepoDetails: apidocker.ImageRepoDetails{
+			BasicAuthConfig: apidocker.BasicAuthConfig{
+				Username: "user",
+				Password: "pass",
+			},
+			Repository:    "myrepo",
+			ServerAddress: "registry.example.com",
+		},
+	}
+
+	data, err := yaml.Marshal(apiDetails)
+	c.Assert(err, tc.ErrorIsNil)
+
+	result, err := docker.UnmarshalDockerResource(data)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result.RegistryPath, tc.Equals, "registry.example.com/myimage@sha256:abcdef")
+	c.Check(result.Username, tc.Equals, "user")
+	c.Check(result.Password, tc.Equals, "pass")
+	c.Check(result.Repository, tc.Equals, "myrepo")
+	c.Check(result.ServerAddress, tc.Equals, "registry.example.com")
+}
+
+// TestAPIDockerJSONCompatibility verifies that JSON marshalled by the public
+// api/docker type can be unmarshalled by UnmarshalDockerResource.
+func (s *DockerResourceSuite) TestAPIDockerJSONCompatibility(c *tc.C) {
+	apiDetails := apidocker.DockerImageDetails{
+		RegistryPath: "registry.example.com/myimage@sha256:abcdef",
+		ImageRepoDetails: apidocker.ImageRepoDetails{
+			BasicAuthConfig: apidocker.BasicAuthConfig{
+				Username: "user",
+				Password: "pass",
+			},
+			Repository:    "myrepo",
+			ServerAddress: "registry.example.com",
+		},
+	}
+
+	data, err := json.Marshal(apiDetails)
+	c.Assert(err, tc.ErrorIsNil)
+
+	result, err := docker.UnmarshalDockerResource(data)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result.RegistryPath, tc.Equals, "registry.example.com/myimage@sha256:abcdef")
+	c.Check(result.Username, tc.Equals, "user")
+	c.Check(result.Password, tc.Equals, "pass")
+	c.Check(result.Repository, tc.Equals, "myrepo")
+	c.Check(result.ServerAddress, tc.Equals, "registry.example.com")
+}
+
+// TestInternalDockerYAMLToAPI verifies that YAML produced by the internal
+// type can be consumed by the api/docker type. This ensures the controller's
+// output is readable by external clients.
+func (s *DockerResourceSuite) TestInternalDockerYAMLToAPI(c *tc.C) {
+	internalDetails := docker.DockerImageDetails{
+		RegistryPath: "registry.example.com/myimage@sha256:abcdef",
+		ImageRepoDetails: docker.ImageRepoDetails{
+			BasicAuthConfig: docker.BasicAuthConfig{
+				Username: "user",
+				Password: "pass",
+			},
+			Repository:    "myrepo",
+			ServerAddress: "registry.example.com",
+		},
+	}
+
+	data, err := yaml.Marshal(internalDetails)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var apiDetails apidocker.DockerImageDetails
+	err = yaml.Unmarshal(data, &apiDetails)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(apiDetails.RegistryPath, tc.Equals, "registry.example.com/myimage@sha256:abcdef")
+	c.Check(apiDetails.Username, tc.Equals, "user")
+	c.Check(apiDetails.Password, tc.Equals, "pass")
+	c.Check(apiDetails.Repository, tc.Equals, "myrepo")
+	c.Check(apiDetails.ServerAddress, tc.Equals, "registry.example.com")
 }


### PR DESCRIPTION
# Description

There was a mismatch between the `internal` types consumed by API server and the one present in `core`.
So i've create a new transport type for the docker types.
Key points:
- the docker type is not consumed normally as the other rpc params, but it gets marshalled into a []byte and then unmashalled into the internal docker type, for this reason to make sure these types match i've created a test for the `docker.UnmarshalDockerResource`. In this way if they ever diverge this test will fail, and somebody will have to change the unmarshal function
- i've changed the type used in the CLI to consume the api docker type, so we make sure that we fail before updates reach the downstream terraform provider
- removed `CheckDockerDetails` because was doing nothing more than validating the `path`, which is already done by an other public method and i was unsure whether to put it in `api` and use it with the new type.


 # QA
 
I've tested this with Terraform and it works. See https://github.com/juju/terraform-provider-juju/pull/1280 where i've mirror the 

