### PR TITLE
fix: flaky TestPingsTimesOut

### DIFF
--- a/api/monitor_internal_test.go
+++ b/api/monitor_internal_test.go
@@ -90,14 +90,17 @@ func (s *MonitorSuite) TestLaterPingFails(c *tc.C) {
 }
 
 func (s *MonitorSuite) TestPingsTimesOut(c *tc.C) {
-	s.monitor.ping = func(context.Context) error {
-		// Advance the clock only once this ping call is being waited on.
-		s.waitThenAdvance(c, testPingTimeout)
-		return nil
+	s.monitor.ping = func(ctx context.Context) error {
+		// Block until the context is cancelled so that only the
+		// timeout case in pingWithTimeout can fire.
+		<-ctx.Done()
+		return ctx.Err()
 	}
 	go s.monitor.run()
 
-	s.waitThenAdvance(c, testPingPeriod)
+	s.waitThenAdvance(c, testPingPeriod) // in run
+	s.waitForClock(c)                    // in pingWithTimeout
+	s.clock.Advance(testPingTimeout)
 	assertEvent(c, s.broken)
 }
 


### PR DESCRIPTION
# Description

fix flaky test encountered in https://jenkins.juju.canonical.com/job/github-juju-check-jobs/24255/

The problem was here in `pingWithTimeout`:
```
result := make(chan error, 1)
	go func() {
		// Note that result is buffered so that we don't leak this
		// goroutine when a timeout happens.
		result <- m.ping(ctx)
	}()

	select {
	case err := <-result:
		if err != nil {
			logger.Debugf(ctx, "health ping failed: %v", err)
		}
		return err == nil

	case <-m.clock.After(m.pingTimeout):
		logger.Warningf(ctx, "health ping timed out after %s", m.pingTimeout)
		return false
	}
```

it's rare, but sometimes result was published in the channel before the clock caught the advance to signal the timeout, making this test to fail with `timed out waiting for channel event`.

I've changed the ping function to basically never return unless the test has done, so this test is not flaky anymore but keeps the original intent.

# QA
```
go test ./api -c -race -o /tmp/api.test && \
timeout 121 stress -p 16 -timeout 120s /tmp/api.test -test.run 'TestMonitorSuite/TestPingsTimesOut'
```