### PR TITLE
feat: use resource revisions matching charm revision

### DIFF
--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -312,7 +312,9 @@ func (v *deployFromRepositoryValidator) resolveResources(
 	resMeta map[string]resource.Meta,
 ) (applicationservice.ResolvedResources, []*params.PendingResourceUpload, error) {
 	var resourcesToUpload []*params.PendingResourceUpload
-	var resources []resource.Resource
+	// Use localOrOverrideResources to track local or overridden values.
+	var localOrOverrideResources []resource.Resource
+	// Use resolvedByName to track the final set of resources.
 	resolvedByName := make(map[string]resource.Resource, len(resMeta))
 
 	resourceNames := make([]string, 0, len(resMeta))
@@ -346,7 +348,7 @@ func (v *deployFromRepositoryValidator) resolveResources(
 				// A revision is coming from client.
 				r.Revision = providedRev
 			}
-			resources = append(resources, r)
+			localOrOverrideResources = append(localOrOverrideResources, r)
 			continue
 		}
 
@@ -354,16 +356,16 @@ func (v *deployFromRepositoryValidator) resolveResources(
 			resolvedByName[name] = res
 			continue
 		}
-		resources = append(resources, r)
+		localOrOverrideResources = append(localOrOverrideResources, r)
 	}
 
-	if len(resources) > 0 {
+	if len(localOrOverrideResources) > 0 {
 		// Solve revision against charm repository.
 		repo, err := v.getCharmRepository(ctx)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
-		resolvedResources, resolveErr := repo.ResolveResources(ctx, resources, corecharm.CharmID{URL: curl, Origin: origin})
+		resolvedResources, resolveErr := repo.ResolveResources(ctx, localOrOverrideResources, corecharm.CharmID{URL: curl, Origin: origin})
 		if resolveErr != nil {
 			return nil, nil, resolveErr
 		}
@@ -980,9 +982,12 @@ func (v *deployFromRepositoryValidator) resolveCharm(ctx context.Context, curl *
 		return corecharm.ResolvedDataForDeploy{}, errors.Trace(err)
 	}
 
-	// TODO (hml) 2023-05-16
-	// Use resource data found in resolvedData as part of ResolveResource.
-	// Will require a new method on the repo.
+	// ResolveForDeploy returns the resources co-released with the resolved
+	// charm revision in resolvedData.Resources. These are threaded through
+	// charmResult.RepositoryResources into resolveResources, where they are
+	// used directly when the caller supplies no resource overrides — avoiding
+	// a separate ResolveResources call and ensuring the resource revisions
+	// match the charm revision rather than the channel tip.
 	resolvedData, resolveErr := repo.ResolveForDeploy(ctx, corecharm.CharmID{URL: curl, Origin: requestedOrigin})
 	if corecharm.IsUnsupportedBaseError(resolveErr) {
 		if !force {

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -306,14 +307,23 @@ func (v *deployFromRepositoryValidator) resolveResources(
 	ctx context.Context,
 	curl *charm.URL,
 	origin corecharm.Origin,
+	defaultRepositoryResources map[string]resource.Resource,
 	deployResArg map[string]string,
 	resMeta map[string]resource.Meta,
 ) (applicationservice.ResolvedResources, []*params.PendingResourceUpload, error) {
 	var resourcesToUpload []*params.PendingResourceUpload
 	var resources []resource.Resource
+	resolvedByName := make(map[string]resource.Resource, len(resMeta))
+
+	resourceNames := make([]string, 0, len(resMeta))
+	for name := range resMeta {
+		resourceNames = append(resourceNames, name)
+	}
+	sort.Strings(resourceNames)
 
 	// Solve charm meta against resources args.
-	for name, meta := range resMeta {
+	for _, name := range resourceNames {
+		meta := resMeta[name]
 		r := resource.Resource{
 			Meta:     meta,
 			Origin:   resource.OriginStore,
@@ -336,23 +346,39 @@ func (v *deployFromRepositoryValidator) resolveResources(
 				// A revision is coming from client.
 				r.Revision = providedRev
 			}
+			resources = append(resources, r)
+			continue
+		}
+
+		if res, ok := defaultRepositoryResources[name]; ok {
+			resolvedByName[name] = res
+			continue
 		}
 		resources = append(resources, r)
 	}
 
-	// Solve revision against charm repository.
-	repo, err := v.getCharmRepository(ctx)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	resolvedResources, resolveErr := repo.ResolveResources(ctx, resources, corecharm.CharmID{URL: curl, Origin: origin})
-	if resolveErr != nil {
-		return nil, nil, resolveErr
+	if len(resources) > 0 {
+		// Solve revision against charm repository.
+		repo, err := v.getCharmRepository(ctx)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		resolvedResources, resolveErr := repo.ResolveResources(ctx, resources, corecharm.CharmID{URL: curl, Origin: origin})
+		if resolveErr != nil {
+			return nil, nil, resolveErr
+		}
+		for _, res := range resolvedResources {
+			resolvedByName[res.Name] = res
+		}
 	}
 
 	// Convert it in resolved resources.
-	result := make(applicationservice.ResolvedResources, 0, len(resolvedResources))
-	for _, res := range resolvedResources {
+	result := make(applicationservice.ResolvedResources, 0, len(resourceNames))
+	for _, name := range resourceNames {
+		res, ok := resolvedByName[name]
+		if !ok {
+			continue
+		}
 		var revision *int
 		if res.Revision >= 0 {
 			revision = &res.Revision
@@ -518,7 +544,7 @@ func (v *deployFromRepositoryValidator) validate(ctx context.Context, arg params
 	}
 
 	// Resolve resources and validate against the charm metadata.
-	resources, resourcesToUpload, resolveResErr := v.resolveResources(ctx, dt.charmURL, dt.origin, dt.resources, charmResult.Charm.Meta().Resources)
+	resources, resourcesToUpload, resolveResErr := v.resolveResources(ctx, dt.charmURL, dt.origin, charmResult.RepositoryResources, dt.resources, charmResult.Charm.Meta().Resources)
 	if resolveResErr != nil {
 		errs = append(errs, resolveResErr)
 	}
@@ -1043,6 +1069,9 @@ type charmResult struct {
 	Origin       corecharm.Origin
 	Charm        charm.Charm
 	DownloadInfo corecharm.DownloadInfo
+	// RepositoryResources is a map of resource name to resource.Resource
+	// for all resources defined in the charm's metadata.
+	RepositoryResources map[string]resource.Resource
 }
 
 // getCharm returns the charm being deployed. Either it already has been
@@ -1089,19 +1118,21 @@ func (v *deployFromRepositoryValidator) getCharm(ctx context.Context, arg params
 	})
 	if errors.Is(err, applicationerrors.CharmNotFound) {
 		return charmResult{
-			CharmURL:     resolvedData.URL,
-			Origin:       resolvedOrigin,
-			Charm:        resolvedCharm,
-			DownloadInfo: essentialMetadata.DownloadInfo,
+			CharmURL:            resolvedData.URL,
+			Origin:              resolvedOrigin,
+			Charm:               resolvedCharm,
+			DownloadInfo:        essentialMetadata.DownloadInfo,
+			RepositoryResources: resolvedData.Resources,
 		}, nil
 	} else if err != nil {
 		return charmResult{}, errors.Trace(err)
 	}
 	return charmResult{
-		CharmURL:     resolvedData.URL,
-		Origin:       resolvedOrigin,
-		Charm:        deployedCharm,
-		DownloadInfo: essentialMetadata.DownloadInfo,
+		CharmURL:            resolvedData.URL,
+		Origin:              resolvedOrigin,
+		Charm:               deployedCharm,
+		DownloadInfo:        essentialMetadata.DownloadInfo,
+		RepositoryResources: resolvedData.Resources,
 	}, nil
 
 }

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -312,21 +312,28 @@ func (v *deployFromRepositoryValidator) resolveResources(
 	resMeta map[string]resource.Meta,
 ) (applicationservice.ResolvedResources, []*params.PendingResourceUpload, error) {
 	var resourcesToUpload []*params.PendingResourceUpload
-	// Use localOrOverrideResources to track local or overridden values.
-	var localOrOverrideResources []resource.Resource
-	// Use resolvedByName to track the final set of resources.
-	resolvedByName := make(map[string]resource.Resource, len(resMeta))
+	// resourcesNeedingResolution contains resources that cannot be satisfied
+	// directly from the resolved charm revision. This includes:
+	//   - explicit CLI overrides, either as a revision or a local file
+	//   - resources missing from defaultRepositoryResources
+	var resourcesNeedingResolution []resource.Resource
+	// resolvedResourcesByName holds the final resource choice keyed by name so
+	// we can merge defaults and overrides, then emit results in stable order.
+	resolvedResourcesByName := make(map[string]resource.Resource, len(resMeta))
 
+	// Preserve a deterministic output order for callers and tests.
 	resourceNames := make([]string, 0, len(resMeta))
 	for name := range resMeta {
 		resourceNames = append(resourceNames, name)
 	}
 	sort.Strings(resourceNames)
 
-	// Solve charm meta against resources args.
+	// Walk the charm metadata and decide, per resource, whether we can reuse the
+	// resolved charm revision's co-released resource, or whether we need the
+	// repository to resolve an explicit override.
 	for _, name := range resourceNames {
 		meta := resMeta[name]
-		r := resource.Resource{
+		resourceToResolve := resource.Resource{
 			Meta:     meta,
 			Origin:   resource.OriginStore,
 			Revision: -1,
@@ -336,7 +343,7 @@ func (v *deployFromRepositoryValidator) resolveResources(
 			providedRev, err := strconv.Atoi(deployValue)
 			if err != nil {
 				// A file is coming from the client.
-				r.Origin = resource.OriginUpload
+				resourceToResolve.Origin = resource.OriginUpload
 
 				// Record resources that the client needs to upload.
 				resourcesToUpload = append(resourcesToUpload, &params.PendingResourceUpload{
@@ -345,39 +352,45 @@ func (v *deployFromRepositoryValidator) resolveResources(
 					Filename: deployValue,
 				})
 			} else {
-				// A revision is coming from client.
-				r.Revision = providedRev
+				// A specific store revision is requested by the client.
+				resourceToResolve.Revision = providedRev
 			}
-			localOrOverrideResources = append(localOrOverrideResources, r)
+			resourcesNeedingResolution = append(resourcesNeedingResolution, resourceToResolve)
 			continue
 		}
 
 		if res, ok := defaultRepositoryResources[name]; ok {
-			resolvedByName[name] = res
+			// ResolveForDeploy already gave us the co-released resource for the
+			// resolved charm revision, so reuse it directly.
+			resolvedResourcesByName[name] = res
 			continue
 		}
-		localOrOverrideResources = append(localOrOverrideResources, r)
+
+		// No explicit override and no co-released resource available: ask the
+		// repository to determine the best matching resource revision.
+		resourcesNeedingResolution = append(resourcesNeedingResolution, resourceToResolve)
 	}
 
-	if len(localOrOverrideResources) > 0 {
-		// Solve revision against charm repository.
+	if len(resourcesNeedingResolution) > 0 {
+		// Resolve any outstanding resource selections against the repository.
 		repo, err := v.getCharmRepository(ctx)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}
-		resolvedResources, resolveErr := repo.ResolveResources(ctx, localOrOverrideResources, corecharm.CharmID{URL: curl, Origin: origin})
+		resolvedResources, resolveErr := repo.ResolveResources(ctx, resourcesNeedingResolution, corecharm.CharmID{URL: curl, Origin: origin})
 		if resolveErr != nil {
 			return nil, nil, resolveErr
 		}
 		for _, res := range resolvedResources {
-			resolvedByName[res.Name] = res
+			resolvedResourcesByName[res.Name] = res
 		}
 	}
 
-	// Convert it in resolved resources.
+	// Convert the selected resources into the format expected by the
+	// application service, preserving deterministic ordering.
 	result := make(applicationservice.ResolvedResources, 0, len(resourceNames))
 	for _, name := range resourceNames {
-		res, ok := resolvedByName[name]
+		res, ok := resolvedResourcesByName[name]
 		if !ok {
 			continue
 		}

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -60,7 +60,7 @@ func (s *deployRepositorySuite) TestResolveResourcesNoResourcesOverride(c *tc.C)
 		URL:    charmURL,
 		Origin: origin,
 	}).Return(mockRepoResult, nil)
-	validator := s.expectValidator()
+	validator := s.expectValidator(1)
 
 	// Act
 	result, resourceToUpload, err := validator.resolveResources(
@@ -124,7 +124,7 @@ func (s *deployRepositorySuite) TestResolveResourcesWithResourcesWithOverride(c 
 		URL:    charmURL,
 		Origin: origin,
 	}).Return(mockRepoResult, nil)
-	validator := s.expectValidator()
+	validator := s.expectValidator(1)
 
 	// Act
 	result, resourcesToUpload, err := validator.resolveResources(
@@ -156,7 +156,7 @@ func (s *deployRepositorySuite) TestResolveResourcesWithResourcesErrorWhileCharm
 	}
 
 	s.charmRepository.EXPECT().ResolveResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, mockRepoError)
-	validator := s.expectValidator()
+	validator := s.expectValidator(1)
 
 	// Act
 	_, _, err := validator.resolveResources(c.Context(), charmURL, origin, nil, map[string]string{}, resMeta)
@@ -183,7 +183,7 @@ func (s *deployRepositorySuite) TestResolveResourcesUsesDefaultRepoResources(c *
 	}
 	charmURL := charm.MustParseURL("ch:ubuntu-0")
 	origin := corecharm.Origin{Source: corecharm.CharmHub}
-	validator := s.expectValidator()
+	validator := s.expectValidator(0)
 
 	result, resourcesToUpload, err := validator.resolveResources(
 		c.Context(),
@@ -221,7 +221,7 @@ func (s *deployRepositorySuite) TestResolveResourcesAllowsOverrides(c *tc.C) {
 	charmURL := charm.MustParseURL("ch:ubuntu-0")
 	origin := corecharm.Origin{Source: corecharm.CharmHub}
 	s.charmRepository.EXPECT().ResolveResources(gomock.Any(), gomock.InAnyOrder(mockRepoExpectedInput), corecharm.CharmID{URL: charmURL, Origin: origin}).Return(mockRepoResult, nil)
-	validator := s.expectValidator()
+	validator := s.expectValidator(1)
 
 	result, resourcesToUpload, err := validator.resolveResources(
 		c.Context(),
@@ -237,8 +237,8 @@ func (s *deployRepositorySuite) TestResolveResourcesAllowsOverrides(c *tc.C) {
 }
 
 // expectValidator sets up a mock deployFromRepositoryValidator with predefined expectations for testing purposes.
-func (s *deployRepositorySuite) expectValidator() deployFromRepositoryValidator {
-	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(&config.Config{}, nil).AnyTimes()
+func (s *deployRepositorySuite) expectValidator(expectedModelConfigCalls int) deployFromRepositoryValidator {
+	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(&config.Config{}, nil).Times(expectedModelConfigCalls)
 	validator := deployFromRepositoryValidator{
 		modelConfigService: s.modelConfigService,
 		newCharmHubRepository: func(repositoryConfig repository.CharmHubRepositoryConfig) (corecharm.Repository, error) {

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -166,7 +166,7 @@ func (s *deployRepositorySuite) TestResolveResourcesWithResourcesErrorWhileCharm
 		tc.Commentf("(Assert) should return the same error as returned when resolving resources on charm repository"))
 }
 
-func (s *deployRepositorySuite) TestResolveResourcesUsesResolvedRepositoryResources(c *tc.C) {
+func (s *deployRepositorySuite) TestResolveResourcesUsesDefaultRepoResources(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	resMeta := map[string]resource.Meta{
@@ -198,7 +198,7 @@ func (s *deployRepositorySuite) TestResolveResourcesUsesResolvedRepositoryResour
 	c.Check(resourcesToUpload, tc.IsNil)
 }
 
-func (s *deployRepositorySuite) TestResolveResourcesResolvedRepositoryResourcesStillAllowOverrides(c *tc.C) {
+func (s *deployRepositorySuite) TestResolveResourcesAllowsOverrides(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	resMeta := map[string]resource.Meta{

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -67,6 +67,7 @@ func (s *deployRepositorySuite) TestResolveResourcesNoResourcesOverride(c *tc.C)
 		c.Context(),
 		charmURL,
 		origin,
+		nil,
 		map[string]string{},
 		resMeta,
 	)
@@ -105,10 +106,10 @@ func (s *deployRepositorySuite) TestResolveResourcesWithResourcesWithOverride(c 
 		{Meta: resource.Meta{Name: "override-revision-to-container"}, Origin: resource.OriginUpload, Revision: -1},
 	}
 	expectedResult := applicationservice.ResolvedResources{
-		{Name: "override-revision-to-2", Origin: resource.OriginStore, Revision: new(2)},
 		{Name: "no-override", Origin: resource.OriginStore, Revision: new(1)},
-		{Name: "override-revision-to-file", Origin: resource.OriginUpload, Revision: nil},
+		{Name: "override-revision-to-2", Origin: resource.OriginStore, Revision: new(2)},
 		{Name: "override-revision-to-container", Origin: resource.OriginUpload, Revision: nil},
+		{Name: "override-revision-to-file", Origin: resource.OriginUpload, Revision: nil},
 	}
 	expectedResourcesToUpload := []*params.PendingResourceUpload{
 		{Name: "override-revision-to-file", Filename: "./toad.txt", Type: "file"},
@@ -130,6 +131,7 @@ func (s *deployRepositorySuite) TestResolveResourcesWithResourcesWithOverride(c 
 		c.Context(),
 		charmURL,
 		origin,
+		nil,
 		deployResArg,
 		resMeta,
 	)
@@ -157,16 +159,86 @@ func (s *deployRepositorySuite) TestResolveResourcesWithResourcesErrorWhileCharm
 	validator := s.expectValidator()
 
 	// Act
-	_, _, err := validator.resolveResources(c.Context(), charmURL, origin, map[string]string{}, resMeta)
+	_, _, err := validator.resolveResources(c.Context(), charmURL, origin, nil, map[string]string{}, resMeta)
 
 	// Assert
 	c.Check(err, tc.ErrorIs, mockRepoError,
 		tc.Commentf("(Assert) should return the same error as returned when resolving resources on charm repository"))
 }
 
+func (s *deployRepositorySuite) TestResolveResourcesUsesResolvedRepositoryResources(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	resMeta := map[string]resource.Meta{
+		"resource1": {Name: "resource1"},
+		"resource2": {Name: "resource2"},
+	}
+	defaultRepositoryResources := map[string]resource.Resource{
+		"resource1": {Meta: resource.Meta{Name: "resource1"}, Origin: resource.OriginStore, Revision: 2},
+		"resource2": {Meta: resource.Meta{Name: "resource2"}, Origin: resource.OriginStore, Revision: 3},
+	}
+	expectedResult := applicationservice.ResolvedResources{
+		{Name: "resource1", Origin: resource.OriginStore, Revision: new(2)},
+		{Name: "resource2", Origin: resource.OriginStore, Revision: new(3)},
+	}
+	charmURL := charm.MustParseURL("ch:ubuntu-0")
+	origin := corecharm.Origin{Source: corecharm.CharmHub}
+	validator := s.expectValidator()
+
+	result, resourcesToUpload, err := validator.resolveResources(
+		c.Context(),
+		charmURL,
+		origin,
+		defaultRepositoryResources,
+		map[string]string{},
+		resMeta,
+	)
+	c.Assert(err, tc.IsNil)
+	c.Check(result, tc.DeepEquals, expectedResult)
+	c.Check(resourcesToUpload, tc.IsNil)
+}
+
+func (s *deployRepositorySuite) TestResolveResourcesResolvedRepositoryResourcesStillAllowOverrides(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	resMeta := map[string]resource.Meta{
+		"resource1": {Name: "resource1", Type: resource.TypeFile},
+		"resource2": {Name: "resource2", Type: resource.TypeFile},
+	}
+	defaultRepositoryResources := map[string]resource.Resource{
+		"resource1": {Meta: resource.Meta{Name: "resource1"}, Origin: resource.OriginStore, Revision: 2},
+		"resource2": {Meta: resource.Meta{Name: "resource2"}, Origin: resource.OriginStore, Revision: 3},
+	}
+	deployResArg := map[string]string{
+		"resource1": "5",
+	}
+	mockRepoExpectedInput := []resource.Resource{{Meta: resource.Meta{Name: "resource1", Type: resource.TypeFile}, Origin: resource.OriginStore, Revision: 5}}
+	mockRepoResult := []resource.Resource{{Meta: resource.Meta{Name: "resource1"}, Origin: resource.OriginStore, Revision: 5}}
+	expectedResult := applicationservice.ResolvedResources{
+		{Name: "resource1", Origin: resource.OriginStore, Revision: new(5)},
+		{Name: "resource2", Origin: resource.OriginStore, Revision: new(3)},
+	}
+	charmURL := charm.MustParseURL("ch:ubuntu-0")
+	origin := corecharm.Origin{Source: corecharm.CharmHub}
+	s.charmRepository.EXPECT().ResolveResources(gomock.Any(), gomock.InAnyOrder(mockRepoExpectedInput), corecharm.CharmID{URL: charmURL, Origin: origin}).Return(mockRepoResult, nil)
+	validator := s.expectValidator()
+
+	result, resourcesToUpload, err := validator.resolveResources(
+		c.Context(),
+		charmURL,
+		origin,
+		defaultRepositoryResources,
+		deployResArg,
+		resMeta,
+	)
+	c.Assert(err, tc.IsNil)
+	c.Check(result, tc.DeepEquals, expectedResult)
+	c.Check(resourcesToUpload, tc.IsNil)
+}
+
 // expectValidator sets up a mock deployFromRepositoryValidator with predefined expectations for testing purposes.
 func (s *deployRepositorySuite) expectValidator() deployFromRepositoryValidator {
-	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(&config.Config{}, nil)
+	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(&config.Config{}, nil).AnyTimes()
 	validator := deployFromRepositoryValidator{
 		modelConfigService: s.modelConfigService,
 		newCharmHubRepository: func(repositoryConfig repository.CharmHubRepositoryConfig) (corecharm.Repository, error) {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -651,7 +651,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(cmd.NewAppendStringsValue(&c.BundleOverlayFile), "overlay", "Bundles to overlay on the primary bundle, applied in order")
 	f.Var(&c.ConstraintsStr, "constraints", "Set application constraints")
 	f.StringVar(&c.Base, "base", "", "The base on which to deploy")
-	f.IntVar(&c.Revision, "revision", -1, "The revision to deploy")
+	f.IntVar(&c.Revision, "revision", -1, "The charm revision to deploy. This will implicitly change the resource revision to the one released with the specified charm revision. To override that use --resource")
 	f.BoolVar(&c.DryRun, "dry-run", false, "Just show what the deploy would do")
 	f.BoolVar(&c.Force, "force", false, "Allow a charm/bundle to be deployed which bypasses checks such as supported base or LXD profile allow list")
 	f.Var(storageFlag{&c.Storage, &c.BundleStorage}, "storage", "Charm storage directives")
@@ -816,6 +816,9 @@ func (c *DeployCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
+	if c.Revision > 0 {
+		ctx.Infof("Deploying charm revision %d - resources released alongside this revision will be used, unless overridden with --resource", c.Revision)
+	}
 	return block.ProcessBlockedError(deploy.PrepareAndDeploy(ctx, deployAPI, charmAdaptor), block.BlockChange)
 }
 

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -574,7 +574,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 			return nil
 		}
 		if c.Channel.String() != oldCoreCharmOriginChannel.String() {
-			ctx.Infof("Note: all future refreshes will now use channel %q", oldCoreCharmOriginChannel.String())
+			ctx.Infof("Note: all future refreshes will now use channel %q", c.Channel.String())
 		}
 		if len(resourceIDs) > 0 {
 			ctx.Infof("resources to be upgraded")

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -342,7 +342,7 @@ func (c *refreshCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.SwitchURL, "switch", "", "Crossgrade to a different charm")
 	f.StringVar(&c.CharmPath, "path", "", "Refresh to a charm located at path")
 	f.StringVar(&c.Base, "base", "", "Specifies the base to match when picking the charm.")
-	f.IntVar(&c.Revision, "revision", -1, "Explicit revision of current charm")
+	f.IntVar(&c.Revision, "revision", -1, "Explicit revision of current charm. This will implicitly change the resource revision to the one released with the specified charm revision. To override that use --resource")
 	f.Var(stringMap{mapping: &c.Resources}, "resource", "Resource to be uploaded to the controller")
 	f.Var(storageFlag{stores: &c.Storage, bundleStores: nil}, "storage", "Charm storage directives")
 	f.Var(&c.ConfigOptions, "config", "Either a path to yaml-formatted application config file or a key=value pair ")
@@ -509,6 +509,10 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+	}
+
+	if c.Revision > 0 {
+		ctx.Infof("Refreshing to charm revision %d - resources released alongside this revision will be used, unless overridden with --resource", c.Revision)
 	}
 
 	cfg := refresher.RefresherConfig{

--- a/core/charm/repository.go
+++ b/core/charm/repository.go
@@ -112,8 +112,12 @@ type ResolvedDataForDeploy struct {
 
 	EssentialMetadata EssentialMetadata
 
-	// Resources is a map of resource names to their current repository revision
-	// based on the supplied origin
+	// Resources is a map of resource names to the resource revisions
+	// co-released with the resolved charm revision for the supplied
+	// origin. When the origin pins a revision (with a channel), these are
+	// the resources released alongside that specific charm revision rather
+	// than the channel tip. Consumers (e.g. deployFromRepositoryValidator)
+	// use these directly when no resource overrides are supplied.
 	Resources map[string]charmresource.Resource
 }
 

--- a/docs/howto/manage-charm-resources.md
+++ b/docs/howto/manage-charm-resources.md
@@ -11,7 +11,7 @@ myst:
 See also: {ref}`charm-resource`
 ```
 
-When you deploy / update an application from a charm, that automatically deploys / updates any charm resources, using the defaults specified by the charm author. However, you can also specify resources manually (e.g., to try a resource released only to `edge` or to specify a non-Charmhub resource). This document shows you how.
+Charm resources are selected based on the revision co-released with the specified charm revision. If no charm revision is specified then the resources will come from the tip of the charm's default/specified channel. However, you can also specify resources manually (e.g., to try a resource released only to `edge` or to specify a non-Charmhub resource). This document shows you how.
 
 
 ## Find out the resources available for a charm

--- a/docs/howto/manage-charm-resources.md
+++ b/docs/howto/manage-charm-resources.md
@@ -11,7 +11,7 @@ myst:
 See also: {ref}`charm-resource`
 ```
 
-Charm resources are selected based on the revision co-released with the specified charm revision. If no charm revision is specified then the resources will come from the tip of the charm's default/specified channel. However, you can also specify resources manually (e.g., to try a resource released only to `edge` or to specify a non-Charmhub resource). This document shows you how.
+When you deploy / update an application from a charm, that automatically deploys / updates any charm resources, using the defaults specified by the charm author. However, you can also specify resources manually (e.g., to try a resource released only to `edge` or to specify a non-Charmhub resource). This document shows you how.
 
 
 ## Find out the resources available for a charm

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/deploy.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/deploy.md
@@ -26,7 +26,7 @@ Deploys a new application or bundle.
 | `-n`, `--num-units` | 1 | Number of application units to deploy for principal charms |
 | `--overlay` |  | Bundles to overlay on the primary bundle, applied in order |
 | `--resource` |  | Resource to be uploaded to the controller |
-| `--revision` | -1 | The revision to deploy |
+| `--revision` | -1 | The charm revision to deploy. This will implicitly change the resource revision to the one released with the specified charm revision. To override that use --resource |
 | `--storage` |  | Charm storage directives |
 | `--to` |  | (Machine models only) Specify a comma-separated list of placement directives. If the length of this list is less than `-n`, the remaining units will be added in the default way (i.e., to new machines). |
 | `--trust` | false | Allows charm to run hooks that require access credentials |

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
@@ -22,7 +22,7 @@ Refresh an application's charm.
 | `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
 | `--path` |  | Refresh to a charm located at path |
 | `--resource` |  | Resource to be uploaded to the controller |
-| `--revision` | -1 | Explicit revision of current charm |
+| `--revision` | -1 | Explicit revision of current charm. This will implicitly change the resource revision to the one released with the specified charm revision. To override that use --resource |
 | `--storage` |  | Charm storage directives |
 | `--switch` |  | Crossgrade to a different charm |
 | `--trust` | unset | Allows charm to run hooks that require access credentials |

--- a/domain/deployment/charm/repository/charmhub.go
+++ b/domain/deployment/charm/repository/charmhub.go
@@ -149,8 +149,10 @@ func (c *CharmHubRepository) ResolveForDeploy(ctx context.Context, arg corecharm
 		DownloadSize:       int64(resp.Entity.Download.Size),
 	}
 
-	// Resources are best effort here and come directly from the Charmhub
-	// resolve response for the supplied origin.
+	// Resources should be populated with either the resources co-released
+	// with the specified charm revision + channel (if both specified), or
+	// the latest resources from the channel (if channel specified), or the
+	// latest resources from the default channel (neither specified).
 	resourceResults, err := transformResourceRevision(resp.Entity.Resources)
 	if err != nil {
 		return corecharm.ResolvedDataForDeploy{}, internalerrors.Capture(err)

--- a/domain/deployment/charm/repository/charmhub.go
+++ b/domain/deployment/charm/repository/charmhub.go
@@ -611,29 +611,41 @@ func (c *CharmHubRepository) repositoryResources(ctx context.Context, id corecha
 	}
 	var cfg charmhub.RefreshConfig
 	var err error
+
+	// Switch based on whether we know the charm's ID or only its name.
+	// Then, if the charm revision is known, we can use that to get more specific resource data.
+	// If the revision is not known, we can only get the latest resource data for the channel.
+
+	fullySpecified := origin.Channel != nil && !origin.Channel.Empty() && origin.Revision != nil && *origin.Revision >= 0
 	switch {
-	case origin.ID != "" && origin.Channel != nil && !origin.Channel.Empty() && origin.Revision != nil && *origin.Revision >= 0:
-		cfg, err = charmhub.DownloadOneFromChannelRevision(ctx, origin.ID, origin.Channel.String(), *origin.Revision, refBase)
-		if err != nil {
-			c.logger.Errorf(ctx, "creating resources config for charm (%q, %q, %d): %s", origin.ID, origin.Channel.String(), *origin.Revision, err)
-			return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
-		}
-	// Do not get resource data via revision here, it is only provided if explicitly
-	// asked for by resource revision.  The purpose here is to find a resource revision
-	// in the channel, if one was not provided on the cli.
 	case origin.ID != "":
+		if fullySpecified {
+			cfg, err = charmhub.DownloadOneFromChannelRevision(ctx, origin.ID, origin.Channel.String(), *origin.Revision, refBase)
+			if err != nil {
+				c.logger.Errorf(ctx, "creating resources config for charm (%q, %q, %d): %s", origin.ID, origin.Channel.String(), *origin.Revision, err)
+				return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
+			}
+			break
+		}
+
+		// Do not get resource data via revision here, it is only provided if explicitly
+		// asked for by resource revision. The purpose here is to find a resource revision
+		// in the channel, if one was not provided on the cli.
 		cfg, err = charmhub.DownloadOneFromChannel(ctx, origin.ID, origin.Channel.String(), refBase)
 		if err != nil {
 			c.logger.Errorf(ctx, "creating resources config for charm (%q, %q): %s", origin.ID, origin.Channel.String(), err)
 			return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
 		}
-	case origin.ID == "" && origin.Channel != nil && !origin.Channel.Empty() && origin.Revision != nil && *origin.Revision >= 0:
-		cfg, err = charmhub.DownloadOneFromChannelRevisionByName(ctx, curl.Name, origin.Channel.String(), *origin.Revision, refBase)
-		if err != nil {
-			c.logger.Errorf(ctx, "creating resources config for charm (%q, %q, %d): %s", curl.Name, origin.Channel.String(), *origin.Revision, err)
-			return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
-		}
 	case origin.ID == "":
+		if fullySpecified {
+			cfg, err = charmhub.DownloadOneFromChannelRevisionByName(ctx, curl.Name, origin.Channel.String(), *origin.Revision, refBase)
+			if err != nil {
+				c.logger.Errorf(ctx, "creating resources config for charm (%q, %q, %d): %s", curl.Name, origin.Channel.String(), *origin.Revision, err)
+				return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
+			}
+			break
+		}
+
 		cfg, err = charmhub.DownloadOneFromChannelByName(ctx, curl.Name, origin.Channel.String(), refBase)
 		if err != nil {
 			c.logger.Errorf(ctx, "creating resources config for charm (%q, %q): %s", curl.Name, origin.Channel.String(), err)

--- a/domain/deployment/charm/repository/charmhub.go
+++ b/domain/deployment/charm/repository/charmhub.go
@@ -1055,98 +1055,45 @@ func isErrSelection(err error) bool {
 	return internalerrors.Is(err, errSelection{})
 }
 
-// Method describes the method for requesting the charm using the RefreshAPI.
-type Method string
-
-const (
-	// MethodRevision utilizes an install action by the revision only. A
-	// channel must be in the origin, however it's not used in this request,
-	// but saved in the origin for future use.
-	MethodRevision Method = "revision"
-	// MethodChannel utilizes an install action by the channel only.
-	MethodChannel Method = "channel"
-	// MethodID utilizes an refresh action by the id, revision and
-	// channel (falls back to latest/stable if channel is not found).
-	MethodID Method = "id"
-)
-
 // refreshConfig creates a RefreshConfig for the given input.
 // If the origin.ID is not set, an install refresh config is returned.
 //
 // If the origin.ID is set, a refresh config is returned.
-//
-// NOTE: There is one idiosyncrasy of this method.  The charm URL and and
-// origin have a revision number in them when called by GetDownloadURL
-// to install a charm. Potentially causing an unexpected install by revision.
-// This is okay as all of the data is ready and correct in the origin.
 func refreshConfig(ctx context.Context, charmName string, origin corecharm.Origin) (charmhub.RefreshConfig, error) {
-	// Work out the correct install method.
-	rev := -1
-	var method Method
+	var revision *int
 	if origin.Revision != nil && *origin.Revision >= 0 {
-		rev = *origin.Revision
-	}
-	if origin.ID == "" && rev != -1 {
-		method = MethodRevision
+		revision = origin.Revision
 	}
 
-	var (
-		channel         string
-		nonEmptyChannel = origin.Channel != nil && !origin.Channel.Empty()
-	)
-
-	// Select the appropriate channel based on the supplied origin.
-	// We need to ensure that we always, always normalize the incoming channel
-	// before we hit the refresh API.
-	if nonEmptyChannel {
-		channel = origin.Channel.Normalize().String()
-	} else if method != MethodRevision {
-		channel = corecharm.DefaultChannel.Normalize().String()
+	base := charmhub.RefreshBase{
+		Architecture: origin.Platform.Architecture,
+		Name:         origin.Platform.OS,
+		Channel:      origin.Platform.Channel,
 	}
 
-	if method != MethodRevision && channel != "" {
-		method = MethodChannel
+	var channel *string
+	if origin.Channel != nil && !origin.Channel.Empty() {
+		normalizedChannel := origin.Channel.Normalize().String()
+		channel = &normalizedChannel
+	} else if revision == nil {
+		defaultChannel := corecharm.DefaultChannel.Normalize().String()
+		channel = &defaultChannel
 	}
 
-	// Bundles can not use method IDs, which in turn forces a refresh.
-	if !transport.BundleType.Matches(origin.Type) && origin.ID != "" {
-		method = MethodID
-	}
-
-	var (
-		cfg charmhub.RefreshConfig
-		err error
-
-		base = charmhub.RefreshBase{
-			Architecture: origin.Platform.Architecture,
-			Name:         origin.Platform.OS,
-			Channel:      origin.Platform.Channel,
+	// Bundles cannot use refresh actions by ID.
+	if origin.ID != "" && !transport.BundleType.Matches(origin.Type) {
+		channelName := ""
+		if channel != nil {
+			channelName = *channel
 		}
-	)
-	switch method {
-	case MethodChannel:
-		// Install from just the name and the channel. If there is no origin ID,
-		// we haven't downloaded this charm before.
-		// Try channel first.
-		cfg, err = charmhub.InstallOneFromChannel(ctx, charmName, channel, base)
-	case MethodRevision:
-		// If there is a revision, install it using that. If there is no origin
-		// ID, we haven't downloaded this charm before. When a tracking channel
-		// is available, include it so Charmhub can return the resources released
-		// with that specific charm revision.
-		if nonEmptyChannel {
-			cfg, err = charmhub.InstallOneFromChannelRevision(ctx, charmName, channel, rev, base)
-		} else {
-			cfg, err = charmhub.InstallOneFromRevision(ctx, charmName, rev)
+		revisionNumber := -1
+		if revision != nil {
+			revisionNumber = *revision
 		}
-	case MethodID:
-		// This must be a charm upgrade if we have an ID.  Use the refresh
-		// action for metric keeping on the CharmHub side.
-		cfg, err = charmhub.RefreshOne(ctx, origin.InstanceKey, origin.ID, rev, channel, base)
-	default:
-		return nil, internalerrors.Errorf("origin %v not valid", origin).Add(coreerrors.NotValid)
+		return charmhub.RefreshOne(ctx, origin.InstanceKey, origin.ID, revisionNumber, channelName, base)
 	}
-	return cfg, err
+
+	return charmhub.InstallOne(ctx, charmName, revision, channel, base)
 }
 
 func (c *CharmHubRepository) composeSuggestions(ctx context.Context, releases []transport.Release, origin corecharm.Origin) []string {

--- a/domain/deployment/charm/repository/charmhub.go
+++ b/domain/deployment/charm/repository/charmhub.go
@@ -149,9 +149,8 @@ func (c *CharmHubRepository) ResolveForDeploy(ctx context.Context, arg corecharm
 		DownloadSize:       int64(resp.Entity.Download.Size),
 	}
 
-	// Resources are best attempt here. If we were able to resolve the charm
-	// via a channel, the resource data will be here. If using a revision,
-	// then not. However, that does not mean that the charm has no resources.
+	// Resources are best effort here and come directly from the Charmhub
+	// resolve response for the supplied origin.
 	resourceResults, err := transformResourceRevision(resp.Entity.Resources)
 	if err != nil {
 		return corecharm.ResolvedDataForDeploy{}, internalerrors.Capture(err)
@@ -522,11 +521,8 @@ func (c *CharmHubRepository) ListResources(ctx context.Context, charmName string
 		return nil, internalerrors.Capture(err)
 	}
 
-	// If a revision is included with an install action, no resources will be
-	// returned. Resources are dependent on a channel, a specific revision can
-	// be in multiple channels.  refreshOne gives priority to a revision if
-	// specified.  ListResources is used by the "charm-resources" cli cmd,
-	// therefore specific charm revisions are less important.
+	// ListResources is used by the "charm-resources" cli cmd and continues to
+	// favour channel-based resource listing over revision-specific lookups.
 	resOrigin := resolved.Origin
 	resOrigin.Revision = nil
 	resp, err := c.refreshOne(ctx, resolved.URL.Name, resOrigin)
@@ -616,6 +612,12 @@ func (c *CharmHubRepository) repositoryResources(ctx context.Context, id corecha
 	var cfg charmhub.RefreshConfig
 	var err error
 	switch {
+	case origin.ID != "" && origin.Channel != nil && !origin.Channel.Empty() && origin.Revision != nil && *origin.Revision >= 0:
+		cfg, err = charmhub.DownloadOneFromChannelRevision(ctx, origin.ID, origin.Channel.String(), *origin.Revision, refBase)
+		if err != nil {
+			c.logger.Errorf(ctx, "creating resources config for charm (%q, %q, %d): %s", origin.ID, origin.Channel.String(), *origin.Revision, err)
+			return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
+		}
 	// Do not get resource data via revision here, it is only provided if explicitly
 	// asked for by resource revision.  The purpose here is to find a resource revision
 	// in the channel, if one was not provided on the cli.
@@ -623,6 +625,12 @@ func (c *CharmHubRepository) repositoryResources(ctx context.Context, id corecha
 		cfg, err = charmhub.DownloadOneFromChannel(ctx, origin.ID, origin.Channel.String(), refBase)
 		if err != nil {
 			c.logger.Errorf(ctx, "creating resources config for charm (%q, %q): %s", origin.ID, origin.Channel.String(), err)
+			return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
+		}
+	case origin.ID == "" && origin.Channel != nil && !origin.Channel.Empty() && origin.Revision != nil && *origin.Revision >= 0:
+		cfg, err = charmhub.DownloadOneFromChannelRevisionByName(ctx, curl.Name, origin.Channel.String(), *origin.Revision, refBase)
+		if err != nil {
+			c.logger.Errorf(ctx, "creating resources config for charm (%q, %q, %d): %s", curl.Name, origin.Channel.String(), *origin.Revision, err)
 			return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
 		}
 	case origin.ID == "":
@@ -1049,9 +1057,7 @@ const (
 )
 
 // refreshConfig creates a RefreshConfig for the given input.
-// If the origin.ID is not set, a install refresh config is returned. For
-// install. Channel and Revision are mutually exclusive in the api, only
-// one will be used.
+// If the origin.ID is not set, an install refresh config is returned.
 //
 // If the origin.ID is set, a refresh config is returned.
 //
@@ -1111,8 +1117,14 @@ func refreshConfig(ctx context.Context, charmName string, origin corecharm.Origi
 		cfg, err = charmhub.InstallOneFromChannel(ctx, charmName, channel, base)
 	case MethodRevision:
 		// If there is a revision, install it using that. If there is no origin
-		// ID, we haven't downloaded this charm before.
-		cfg, err = charmhub.InstallOneFromRevision(ctx, charmName, rev)
+		// ID, we haven't downloaded this charm before. When a tracking channel
+		// is available, include it so Charmhub can return the resources released
+		// with that specific charm revision.
+		if nonEmptyChannel {
+			cfg, err = charmhub.InstallOneFromChannelRevision(ctx, charmName, channel, rev, base)
+		} else {
+			cfg, err = charmhub.InstallOneFromRevision(ctx, charmName, rev)
+		}
 	case MethodID:
 		// This must be a charm upgrade if we have an ID.  Use the refresh
 		// action for metric keeping on the CharmHub side.

--- a/domain/deployment/charm/repository/charmhub.go
+++ b/domain/deployment/charm/repository/charmhub.go
@@ -1076,6 +1076,11 @@ func refreshConfig(ctx context.Context, charmName string, origin corecharm.Origi
 		normalizedChannel := origin.Channel.Normalize().String()
 		channel = &normalizedChannel
 	} else if revision == nil {
+		// Do not default the channel for revision-only requests. The deploy
+		// command first resolves every repository reference as a possible bundle.
+		// Constraining that probe to the default channel can fail before a charm
+		// is identified and repoCharmDeployer can report that a charm revision
+		// requires an explicit channel.
 		defaultChannel := corecharm.DefaultChannel.Normalize().String()
 		channel = &defaultChannel
 	}

--- a/domain/deployment/charm/repository/charmhub.go
+++ b/domain/deployment/charm/repository/charmhub.go
@@ -606,51 +606,38 @@ func (c *CharmHubRepository) listResourcesIfRevisions(ctx context.Context, resou
 func (c *CharmHubRepository) repositoryResources(ctx context.Context, id corecharm.CharmID) ([]transport.ResourceRevision, error) {
 	curl := id.URL
 	origin := id.Origin
-	refBase := charmhub.RefreshBase{
+	var revision *int
+	if origin.Revision != nil && *origin.Revision >= 0 {
+		revision = origin.Revision
+	}
+
+	var channel *string
+	if origin.Channel != nil && !origin.Channel.Empty() {
+		normalizedChannel := origin.Channel.Normalize().String()
+		channel = &normalizedChannel
+	} else if revision == nil {
+		defaultChannel := corecharm.DefaultChannel.Normalize().String()
+		channel = &defaultChannel
+	}
+
+	base := &charmhub.RefreshBase{
 		Architecture: origin.Platform.Architecture,
 		Name:         origin.Platform.OS,
 		Channel:      origin.Platform.Channel,
 	}
+
 	var cfg charmhub.RefreshConfig
 	var err error
-
-	// Switch based on whether we know the charm's ID or only its name.
-	// Then, if the charm revision is known, we can use that to get more specific resource data.
-	// If the revision is not known, we can only get the latest resource data for the channel.
-
-	fullySpecified := origin.Channel != nil && !origin.Channel.Empty() && origin.Revision != nil && *origin.Revision >= 0
-	switch {
-	case origin.ID != "":
-		if fullySpecified {
-			cfg, err = charmhub.DownloadOneFromChannelRevision(ctx, origin.ID, origin.Channel.String(), *origin.Revision, refBase)
-			if err != nil {
-				c.logger.Errorf(ctx, "creating resources config for charm (%q, %q, %d): %s", origin.ID, origin.Channel.String(), *origin.Revision, err)
-				return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
-			}
-			break
-		}
-
-		// Do not get resource data via revision here, it is only provided if explicitly
-		// asked for by resource revision. The purpose here is to find a resource revision
-		// in the channel, if one was not provided on the cli.
-		cfg, err = charmhub.DownloadOneFromChannel(ctx, origin.ID, origin.Channel.String(), refBase)
+	if origin.ID != "" {
+		cfg, err = charmhub.DownloadOneByID(ctx, origin.ID, revision, channel, base)
 		if err != nil {
-			c.logger.Errorf(ctx, "creating resources config for charm (%q, %q): %s", origin.ID, origin.Channel.String(), err)
+			c.logger.Errorf(ctx, "creating resources config for charm %q: %s", curl.String(), err)
 			return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
 		}
-	case origin.ID == "":
-		if fullySpecified {
-			cfg, err = charmhub.DownloadOneFromChannelRevisionByName(ctx, curl.Name, origin.Channel.String(), *origin.Revision, refBase)
-			if err != nil {
-				c.logger.Errorf(ctx, "creating resources config for charm (%q, %q, %d): %s", curl.Name, origin.Channel.String(), *origin.Revision, err)
-				return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
-			}
-			break
-		}
-
-		cfg, err = charmhub.DownloadOneFromChannelByName(ctx, curl.Name, origin.Channel.String(), refBase)
+	} else {
+		cfg, err = charmhub.DownloadOne(ctx, curl.Name, revision, channel, base)
 		if err != nil {
-			c.logger.Errorf(ctx, "creating resources config for charm (%q, %q): %s", curl.Name, origin.Channel.String(), err)
+			c.logger.Errorf(ctx, "creating resources config for charm %q: %s", curl.String(), err)
 			return nil, internalerrors.Errorf("creating resources config for charm %q: %w", curl.String(), err)
 		}
 	}
@@ -1065,12 +1052,6 @@ func refreshConfig(ctx context.Context, charmName string, origin corecharm.Origi
 		revision = origin.Revision
 	}
 
-	base := charmhub.RefreshBase{
-		Architecture: origin.Platform.Architecture,
-		Name:         origin.Platform.OS,
-		Channel:      origin.Platform.Channel,
-	}
-
 	var channel *string
 	if origin.Channel != nil && !origin.Channel.Empty() {
 		normalizedChannel := origin.Channel.Normalize().String()
@@ -1083,6 +1064,12 @@ func refreshConfig(ctx context.Context, charmName string, origin corecharm.Origi
 		// requires an explicit channel.
 		defaultChannel := corecharm.DefaultChannel.Normalize().String()
 		channel = &defaultChannel
+	}
+
+	base := charmhub.RefreshBase{
+		Architecture: origin.Platform.Architecture,
+		Name:         origin.Platform.OS,
+		Channel:      origin.Platform.Channel,
 	}
 
 	// Bundles cannot use refresh actions by ID.

--- a/domain/deployment/charm/repository/charmhub_test.go
+++ b/domain/deployment/charm/repository/charmhub_test.go
@@ -719,7 +719,11 @@ func (s *charmHubRepositorySuite) TestResolveResourcesFromStoreNoRevision(c *tc.
 	}})
 }
 
-func (s *charmHubRepositorySuite) TestResolveResourcesFromStoreWithNoCharmRevisionSpecified(c *tc.C) {
+// TestResolveResourcesFromStoreWithCharmRevisionSpecified tests the same thing
+// as TestResolveResourcesFromStoreNoRevision but specifies a charm revision,
+// i.e. verifies that a resource passed to ResolveResources with no revision
+// will be resolved to the latest revision of the resource for the specified charm revision.
+func (s *charmHubRepositorySuite) TestResolveResourcesFromStoreNoRevision_CharmRevisionSpecified(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectRefreshWithRevisionAndChannel(c, 7, true)
 

--- a/domain/deployment/charm/repository/charmhub_test.go
+++ b/domain/deployment/charm/repository/charmhub_test.go
@@ -719,7 +719,7 @@ func (s *charmHubRepositorySuite) TestResolveResourcesFromStoreNoRevision(c *tc.
 	}})
 }
 
-func (s *charmHubRepositorySuite) TestResolveResourcesFromStoreNoRevisionWithChannelRevision(c *tc.C) {
+func (s *charmHubRepositorySuite) TestResolveResourcesFromStoreWithNoCharmRevisionSpecified(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectRefreshWithRevisionAndChannel(c, 7, true)
 
@@ -987,7 +987,7 @@ func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneFromChannelFullBas
 		Architecture: arch.DefaultArchitecture, Name: "ubuntu", Channel: "20.04",
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	s.expectCharmRefreshFullWithResources(c, cfg)
+	s.expectCharmRefreshFullWithResourcesAndHash(c, cfg, "SHA256 hash")
 }
 
 func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneByRevisionResources(c *tc.C, hash string) {
@@ -998,10 +998,6 @@ func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneByRevisionResource
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	s.expectCharmRefreshFullWithResourcesAndHash(c, cfg, hash)
-}
-
-func (s *charmHubRepositorySuite) expectCharmRefreshFullWithResources(c *tc.C, cfg charmhub.RefreshConfig) {
-	s.expectCharmRefreshFullWithResourcesAndHash(c, cfg, "SHA256 hash")
 }
 
 func (s *charmHubRepositorySuite) expectCharmRefreshFullWithResourcesAndHash(c *tc.C, cfg charmhub.RefreshConfig, hash string) {
@@ -1089,7 +1085,7 @@ func (s *charmHubRepositorySuite) expectRefreshWithRevision(c *tc.C, rev int, id
 			Result:           "download",
 		},
 	}
-	s.client.EXPECT().Refresh(gomock.Any(), charmhubConfigMatcher{c: c, id: id}).Return(resp, nil)
+	s.client.EXPECT().Refresh(gomock.Any(), charmhubConfigMatcher{c: c, requireID: id}).Return(resp, nil)
 }
 
 func (s *charmHubRepositorySuite) expectRefreshWithRevisionAndChannel(c *tc.C, rev int, id bool) {
@@ -1109,7 +1105,7 @@ func (s *charmHubRepositorySuite) expectRefreshWithRevisionAndChannel(c *tc.C, r
 		Name:             "postgresql",
 		Result:           "download",
 	}}
-	s.client.EXPECT().Refresh(gomock.Any(), charmhubConfigMatcher{c: c, id: id, requireRevision: true, requireChannel: true}).Return(resp, nil)
+	s.client.EXPECT().Refresh(gomock.Any(), charmhubConfigMatcher{c: c, requireID: id, requireRevision: true, requireChannel: true}).Return(resp, nil)
 }
 
 func (s *charmHubRepositorySuite) expectListResourceRevisions(rev int) {
@@ -1626,7 +1622,7 @@ func (m RefreshConfigMatcher) String() string {
 // charmhub.RefreshMany config.
 type charmhubConfigMatcher struct {
 	c               *tc.C
-	id              bool
+	requireID       bool
 	requireRevision bool
 	requireChannel  bool
 }
@@ -1640,29 +1636,30 @@ func (m charmhubConfigMatcher) Matches(x any) bool {
 	if err != nil {
 		return false
 	}
-	if m.id && h.Actions[0].ID != nil && *h.Actions[0].ID == "meshuggah" {
-		if m.requireRevision && h.Actions[0].Revision == nil {
-			return false
-		}
-		if m.requireChannel && h.Actions[0].Channel == nil {
-			return false
-		}
-		return true
+	if len(h.Actions) == 0 {
+		return false
 	}
-	if !m.id && h.Actions[0].Name != nil && *h.Actions[0].Name == "ubuntu" {
-		if m.requireRevision && h.Actions[0].Revision == nil {
+	action := h.Actions[0]
+	matchID := action.ID != nil && *action.ID == "meshuggah"
+	matchName := action.Name != nil && *action.Name == "ubuntu"
+	if m.requireID {
+		if !matchID {
 			return false
 		}
-		if m.requireChannel && h.Actions[0].Channel == nil {
-			return false
-		}
-		return true
+	} else if !matchName {
+		return false
 	}
-	return false
+	if m.requireRevision && action.Revision == nil {
+		return false
+	}
+	if m.requireChannel && action.Channel == nil {
+		return false
+	}
+	return true
 }
 
 func (m charmhubConfigMatcher) String() string {
-	if m.id {
+	if m.requireID {
 		return "match id"
 	}
 	return "match name"

--- a/domain/deployment/charm/repository/charmhub_test.go
+++ b/domain/deployment/charm/repository/charmhub_test.go
@@ -312,6 +312,15 @@ func (s *charmHubRepositorySuite) TestResolveForDeployWithRevisionSuccess(c *tc.
 		DownloadURL:        "http://example.com/wordpress-42",
 		DownloadSize:       42,
 	})
+	c.Check(obtainedData.Resources, tc.DeepEquals, map[string]charmresource.Resource{
+		"wal-e": {
+			Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
+			Origin:      charmresource.OriginStore,
+			Revision:    5,
+			Fingerprint: fp(c),
+			Size:        0,
+		},
+	})
 }
 
 func (s *charmHubRepositorySuite) TestResolveForDeploySuccessChooseBase(c *tc.C) {
@@ -710,6 +719,30 @@ func (s *charmHubRepositorySuite) TestResolveResourcesFromStoreNoRevision(c *tc.
 	}})
 }
 
+func (s *charmHubRepositorySuite) TestResolveResourcesFromStoreNoRevisionWithChannelRevision(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectRefreshWithRevisionAndChannel(c, 7, true)
+
+	id := charmID()
+	revision := 16
+	id.Origin.Revision = &revision
+
+	result, err := s.newClient(c).ResolveResources(c.Context(), []charmresource.Resource{{
+		Meta:     charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
+		Origin:   charmresource.OriginStore,
+		Revision: -1,
+		Size:     0,
+	}}, id)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, []charmresource.Resource{{
+		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
+		Origin:      charmresource.OriginStore,
+		Revision:    7,
+		Fingerprint: fp(c),
+		Size:        0,
+	}})
+}
+
 func (s *charmHubRepositorySuite) TestResolveResourcesNoMatchingRevision(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectRefresh(c, true)
@@ -958,12 +991,20 @@ func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneFromChannelFullBas
 }
 
 func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneByRevisionResources(c *tc.C, hash string) {
-	cfg, err := charmhub.InstallOneFromRevision(c.Context(), "wordpress", 16)
+	cfg, err := charmhub.InstallOneFromChannelRevision(c.Context(), "wordpress", "latest/stable", 16, charmhub.RefreshBase{
+		Architecture: arch.DefaultArchitecture,
+		Name:         "ubuntu",
+		Channel:      "20.04",
+	})
 	c.Assert(err, tc.ErrorIsNil)
-	s.expectCharmRefresh(c, cfg, hash)
+	s.expectCharmRefreshFullWithResourcesAndHash(c, cfg, hash)
 }
 
 func (s *charmHubRepositorySuite) expectCharmRefreshFullWithResources(c *tc.C, cfg charmhub.RefreshConfig) {
+	s.expectCharmRefreshFullWithResourcesAndHash(c, cfg, "SHA256 hash")
+}
+
+func (s *charmHubRepositorySuite) expectCharmRefreshFullWithResourcesAndHash(c *tc.C, cfg charmhub.RefreshConfig, hash string) {
 	s.client.EXPECT().Refresh(gomock.Any(), RefreshConfigMatcher{c: c, Config: cfg}).DoAndReturn(func(ctx context.Context, cfg charmhub.RefreshConfig) ([]transport.RefreshResponse, error) {
 		id := charmhub.ExtractConfigInstanceKey(cfg)
 		return []transport.RefreshResponse{{
@@ -975,7 +1016,7 @@ func (s *charmHubRepositorySuite) expectCharmRefreshFullWithResources(c *tc.C, c
 				Name:     "wordpress",
 				Revision: 16,
 				Download: transport.Download{
-					HashSHA256: "SHA256 hash",
+					HashSHA256: hash,
 					HashSHA384: "SHA384 hash",
 					Size:       42,
 					URL:        "http://example.com/wordpress-42",
@@ -1049,6 +1090,26 @@ func (s *charmHubRepositorySuite) expectRefreshWithRevision(c *tc.C, rev int, id
 		},
 	}
 	s.client.EXPECT().Refresh(gomock.Any(), charmhubConfigMatcher{c: c, id: id}).Return(resp, nil)
+}
+
+func (s *charmHubRepositorySuite) expectRefreshWithRevisionAndChannel(c *tc.C, rev int, id bool) {
+	resp := []transport.RefreshResponse{{
+		Entity: transport.RefreshEntity{
+			CreatedAt: time.Date(2020, 7, 7, 9, 39, 44, 132000000, time.UTC),
+			Download:  transport.Download{HashSHA256: "c97e1efc5367d2fdcfdf29f4a2243b13765cc9cbdfad19627a29ac903c01ae63", Size: 5487460, URL: "https://api.staging.charmhub.io/api/v1/charms/download/jmeJLrjWpJX9OglKSeUHCwgyaCNuoQjD_208.charm"},
+			ID:        "jmeJLrjWpJX9OglKSeUHCwgyaCNuoQjD",
+			Name:      "ubuntu",
+			Resources: []transport.ResourceRevision{resourceRevision(rev)},
+			Revision:  19,
+			Summary:   "PostgreSQL object-relational SQL database (supported version)",
+			Version:   "208",
+		},
+		EffectiveChannel: "latest/stable",
+		Error:            (*transport.APIError)(nil),
+		Name:             "postgresql",
+		Result:           "download",
+	}}
+	s.client.EXPECT().Refresh(gomock.Any(), charmhubConfigMatcher{c: c, id: id, requireRevision: true, requireChannel: true}).Return(resp, nil)
 }
 
 func (s *charmHubRepositorySuite) expectListResourceRevisions(rev int) {
@@ -1157,6 +1218,43 @@ func (s *refreshConfigSuite) TestRefreshByRevision(c *tc.C) {
 			InstanceKey: instanceKey,
 			Name:        &name,
 			Revision:    &revision,
+		}},
+		Context: []transport.RefreshRequestContext{},
+		Fields:  expRefreshFields,
+	})
+}
+
+func (s *refreshConfigSuite) TestRefreshByChannelAndRevision(c *tc.C) {
+	revision := 1
+	name := "wordpress"
+	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.04")
+	channel := corecharm.MustParseChannel("latest/stable").Normalize()
+	origin := corecharm.Origin{
+		Platform: platform,
+		Revision: &revision,
+		Channel:  &channel,
+	}
+
+	cfg, err := refreshConfig(c.Context(), name, origin)
+	c.Assert(err, tc.ErrorIsNil)
+
+	ch := channel.String()
+	instanceKey := charmhub.ExtractConfigInstanceKey(cfg)
+
+	build, err := cfg.Build(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(build, tc.DeepEquals, transport.RefreshRequest{
+		Actions: []transport.RefreshRequestAction{{
+			Action:      "install",
+			InstanceKey: instanceKey,
+			Name:        &name,
+			Channel:     &ch,
+			Revision:    &revision,
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
+				Architecture: "amd64",
+			},
 		}},
 		Context: []transport.RefreshRequestContext{},
 		Fields:  expRefreshFields,
@@ -1527,8 +1625,10 @@ func (m RefreshConfigMatcher) String() string {
 // charmhubConfigMatcher matches only the charm IDs and revisions of a
 // charmhub.RefreshMany config.
 type charmhubConfigMatcher struct {
-	c  *tc.C
-	id bool
+	c               *tc.C
+	id              bool
+	requireRevision bool
+	requireChannel  bool
 }
 
 func (m charmhubConfigMatcher) Matches(x any) bool {
@@ -1541,9 +1641,21 @@ func (m charmhubConfigMatcher) Matches(x any) bool {
 		return false
 	}
 	if m.id && h.Actions[0].ID != nil && *h.Actions[0].ID == "meshuggah" {
+		if m.requireRevision && h.Actions[0].Revision == nil {
+			return false
+		}
+		if m.requireChannel && h.Actions[0].Channel == nil {
+			return false
+		}
 		return true
 	}
 	if !m.id && h.Actions[0].Name != nil && *h.Actions[0].Name == "ubuntu" {
+		if m.requireRevision && h.Actions[0].Revision == nil {
+			return false
+		}
+		if m.requireChannel && h.Actions[0].Channel == nil {
+			return false
+		}
 		return true
 	}
 	return false

--- a/domain/deployment/charm/repository/charmhub_test.go
+++ b/domain/deployment/charm/repository/charmhub_test.go
@@ -995,7 +995,9 @@ func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneFromChannelFullBas
 }
 
 func (s *charmHubRepositorySuite) expectCharmRefreshInstallOneByRevisionResources(c *tc.C, hash string) {
-	cfg, err := charmhub.InstallOneFromChannelRevision(c.Context(), "wordpress", "latest/stable", 16, charmhub.RefreshBase{
+	revision := 16
+	channel := "latest/stable"
+	cfg, err := charmhub.InstallOne(c.Context(), "wordpress", &revision, &channel, charmhub.RefreshBase{
 		Architecture: arch.DefaultArchitecture,
 		Name:         "ubuntu",
 		Channel:      "20.04",

--- a/domain/deployment/charm/repository/charmhub_test.go
+++ b/domain/deployment/charm/repository/charmhub_test.go
@@ -1220,6 +1220,11 @@ func (s *refreshConfigSuite) TestRefreshByRevision(c *tc.C) {
 			InstanceKey: instanceKey,
 			Name:        &name,
 			Revision:    &revision,
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
+				Architecture: "amd64",
+			},
 		}},
 		Context: []transport.RefreshRequestContext{},
 		Fields:  expRefreshFields,
@@ -1646,6 +1651,9 @@ func (m charmhubConfigMatcher) Matches(x any) bool {
 		return false
 	}
 	action := h.Actions[0]
+	if action.Action != "download" {
+		return false
+	}
 	matchID := action.ID != nil && *action.ID == "meshuggah"
 	matchName := action.Name != nil && *action.Name == "ubuntu"
 	if m.requireID {

--- a/internal/charmhub/refresh.go
+++ b/internal/charmhub/refresh.go
@@ -271,6 +271,31 @@ func InstallOneFromRevision(ctx context.Context, name string, revision int) (Ref
 	}, nil
 }
 
+// InstallOneFromChannelRevision creates a request config using both the
+// channel and revision for requesting only one charm.
+func InstallOneFromChannelRevision(ctx context.Context, name, channel string, revision int, base RefreshBase) (RefreshConfig, error) {
+	if name == "" {
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty name"))
+	}
+	if err := validateBase(base); err != nil {
+		return nil, logAndReturnError(ctx, err)
+	}
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		return nil, logAndReturnError(ctx, err)
+	}
+	return executeOne{
+		action:      installAction,
+		instanceKey: uuid.String(),
+		Name:        name,
+		Channel:     &channel,
+		Revision:    &revision,
+		Base:        base,
+		fields:      requiredRefreshFields,
+	}, nil
+
+}
+
 // AddResource adds resource revision data to a executeOne config.
 // Used for install by revision.
 func AddResource(config RefreshConfig, name string, revision int) (RefreshConfig, bool) {
@@ -347,6 +372,30 @@ func DownloadOneFromRevision(ctx context.Context, id string, revision int) (Refr
 	}, nil
 }
 
+// DownloadOneFromChannelRevision creates a request config using both the
+// channel and revision for requesting only one charm.
+func DownloadOneFromChannelRevision(ctx context.Context, id, channel string, revision int, base RefreshBase) (RefreshConfig, error) {
+	if id == "" {
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty id"))
+	}
+	if err := validateBase(base); err != nil {
+		return nil, logAndReturnError(ctx, err)
+	}
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		return nil, logAndReturnError(ctx, err)
+	}
+	return executeOne{
+		action:      downloadAction,
+		instanceKey: uuid.String(),
+		ID:          id,
+		Channel:     &channel,
+		Revision:    &revision,
+		Base:        base,
+		fields:      requiredRefreshFields,
+	}, nil
+}
+
 // DownloadOneFromRevisionByName creates a request config using the revision and not
 // the channel for requesting only one charm.
 func DownloadOneFromRevisionByName(ctx context.Context, name string, revision int) (RefreshConfig, error) {
@@ -362,6 +411,30 @@ func DownloadOneFromRevisionByName(ctx context.Context, name string, revision in
 		instanceKey: uuid.String(),
 		Name:        name,
 		Revision:    &revision,
+		fields:      requiredRefreshFields,
+	}, nil
+}
+
+// DownloadOneFromChannelRevisionByName creates a request config using both the
+// channel and revision for requesting only one charm.
+func DownloadOneFromChannelRevisionByName(ctx context.Context, name, channel string, revision int, base RefreshBase) (RefreshConfig, error) {
+	if name == "" {
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty name"))
+	}
+	if err := validateBase(base); err != nil {
+		return nil, logAndReturnError(ctx, err)
+	}
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		return nil, logAndReturnError(ctx, err)
+	}
+	return executeOne{
+		action:      downloadAction,
+		instanceKey: uuid.String(),
+		Name:        name,
+		Channel:     &channel,
+		Revision:    &revision,
+		Base:        base,
 		fields:      requiredRefreshFields,
 	}, nil
 }

--- a/internal/charmhub/refresh.go
+++ b/internal/charmhub/refresh.go
@@ -271,11 +271,14 @@ func InstallOneFromRevision(ctx context.Context, name string, revision int) (Ref
 	}, nil
 }
 
-// InstallOneFromChannelRevision creates a request config using both the
-// channel and revision for requesting only one charm.
-func InstallOneFromChannelRevision(ctx context.Context, name, channel string, revision int, base RefreshBase) (RefreshConfig, error) {
+// InstallOne creates a request config for installing one charm with the
+// supplied channel, revision, and base.
+func InstallOne(ctx context.Context, name string, revision *int, channel *string, base RefreshBase) (RefreshConfig, error) {
 	if name == "" {
 		return nil, logAndReturnError(ctx, errors.NotValidf("empty name"))
+	}
+	if revision != nil && channel == nil {
+		return InstallOneFromRevision(ctx, name, *revision)
 	}
 	if err := validateBase(base); err != nil {
 		return nil, logAndReturnError(ctx, err)
@@ -288,12 +291,11 @@ func InstallOneFromChannelRevision(ctx context.Context, name, channel string, re
 		action:      installAction,
 		instanceKey: uuid.String(),
 		Name:        name,
-		Channel:     &channel,
-		Revision:    &revision,
+		Revision:    revision,
+		Channel:     channel,
 		Base:        base,
 		fields:      requiredRefreshFields,
 	}, nil
-
 }
 
 // AddResource adds resource revision data to a executeOne config.

--- a/internal/charmhub/refresh.go
+++ b/internal/charmhub/refresh.go
@@ -277,9 +277,6 @@ func InstallOne(ctx context.Context, name string, revision *int, channel *string
 	if name == "" {
 		return nil, logAndReturnError(ctx, errors.NotValidf("empty name"))
 	}
-	if revision != nil && channel == nil {
-		return InstallOneFromRevision(ctx, name, *revision)
-	}
 	if err := validateBase(base); err != nil {
 		return nil, logAndReturnError(ctx, err)
 	}
@@ -291,6 +288,58 @@ func InstallOne(ctx context.Context, name string, revision *int, channel *string
 		action:      installAction,
 		instanceKey: uuid.String(),
 		Name:        name,
+		Revision:    revision,
+		Channel:     channel,
+		Base:        &base,
+		fields:      requiredRefreshFields,
+	}, nil
+}
+
+// DownloadOne creates a request config for downloading one charm. A revision,
+// channel, and base may be supplied independently.
+func DownloadOne(ctx context.Context, name string, revision *int, channel *string, base *RefreshBase) (RefreshConfig, error) {
+	if name == "" {
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty name"))
+	}
+	if base != nil {
+		if err := validateBase(*base); err != nil {
+			return nil, logAndReturnError(ctx, err)
+		}
+	}
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		return nil, logAndReturnError(ctx, err)
+	}
+	return executeOne{
+		action:      downloadAction,
+		instanceKey: uuid.String(),
+		Name:        name,
+		Revision:    revision,
+		Channel:     channel,
+		Base:        base,
+		fields:      requiredRefreshFields,
+	}, nil
+}
+
+// DownloadOneByID creates a request config for downloading one charm by ID. A
+// revision, channel, and base may be supplied independently.
+func DownloadOneByID(ctx context.Context, id string, revision *int, channel *string, base *RefreshBase) (RefreshConfig, error) {
+	if id == "" {
+		return nil, logAndReturnError(ctx, errors.NotValidf("empty id"))
+	}
+	if base != nil {
+		if err := validateBase(*base); err != nil {
+			return nil, logAndReturnError(ctx, err)
+		}
+	}
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		return nil, logAndReturnError(ctx, err)
+	}
+	return executeOne{
+		action:      downloadAction,
+		instanceKey: uuid.String(),
+		ID:          id,
 		Revision:    revision,
 		Channel:     channel,
 		Base:        base,
@@ -350,7 +399,7 @@ func InstallOneFromChannel(ctx context.Context, name string, channel string, bas
 		instanceKey: uuid.String(),
 		Name:        name,
 		Channel:     &channel,
-		Base:        base,
+		Base:        &base,
 		fields:      requiredRefreshFields,
 	}, nil
 }
@@ -374,30 +423,6 @@ func DownloadOneFromRevision(ctx context.Context, id string, revision int) (Refr
 	}, nil
 }
 
-// DownloadOneFromChannelRevision creates a request config using both the
-// channel and revision for requesting only one charm.
-func DownloadOneFromChannelRevision(ctx context.Context, id, channel string, revision int, base RefreshBase) (RefreshConfig, error) {
-	if id == "" {
-		return nil, logAndReturnError(ctx, errors.NotValidf("empty id"))
-	}
-	if err := validateBase(base); err != nil {
-		return nil, logAndReturnError(ctx, err)
-	}
-	uuid, err := uuid.NewUUID()
-	if err != nil {
-		return nil, logAndReturnError(ctx, err)
-	}
-	return executeOne{
-		action:      downloadAction,
-		instanceKey: uuid.String(),
-		ID:          id,
-		Channel:     &channel,
-		Revision:    &revision,
-		Base:        base,
-		fields:      requiredRefreshFields,
-	}, nil
-}
-
 // DownloadOneFromRevisionByName creates a request config using the revision and not
 // the channel for requesting only one charm.
 func DownloadOneFromRevisionByName(ctx context.Context, name string, revision int) (RefreshConfig, error) {
@@ -413,30 +438,6 @@ func DownloadOneFromRevisionByName(ctx context.Context, name string, revision in
 		instanceKey: uuid.String(),
 		Name:        name,
 		Revision:    &revision,
-		fields:      requiredRefreshFields,
-	}, nil
-}
-
-// DownloadOneFromChannelRevisionByName creates a request config using both the
-// channel and revision for requesting only one charm.
-func DownloadOneFromChannelRevisionByName(ctx context.Context, name, channel string, revision int, base RefreshBase) (RefreshConfig, error) {
-	if name == "" {
-		return nil, logAndReturnError(ctx, errors.NotValidf("empty name"))
-	}
-	if err := validateBase(base); err != nil {
-		return nil, logAndReturnError(ctx, err)
-	}
-	uuid, err := uuid.NewUUID()
-	if err != nil {
-		return nil, logAndReturnError(ctx, err)
-	}
-	return executeOne{
-		action:      downloadAction,
-		instanceKey: uuid.String(),
-		Name:        name,
-		Channel:     &channel,
-		Revision:    &revision,
-		Base:        base,
 		fields:      requiredRefreshFields,
 	}, nil
 }
@@ -459,7 +460,7 @@ func DownloadOneFromChannel(ctx context.Context, id string, channel string, base
 		instanceKey: uuid.String(),
 		ID:          id,
 		Channel:     &channel,
-		Base:        base,
+		Base:        &base,
 		fields:      requiredRefreshFields,
 	}, nil
 }
@@ -482,7 +483,7 @@ func DownloadOneFromChannelByName(ctx context.Context, name string, channel stri
 		instanceKey: uuid.String(),
 		Name:        name,
 		Channel:     &channel,
-		Base:        base,
+		Base:        &base,
 		fields:      requiredRefreshFields,
 	}, nil
 }

--- a/internal/charmhub/refresh_test.go
+++ b/internal/charmhub/refresh_test.go
@@ -610,6 +610,65 @@ func (s *RefreshConfigSuite) TestInstallOneFromRevisionFail(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, errors.NotValid)
 }
 
+func (s *RefreshConfigSuite) TestInstallOneBuild(c *tc.C) {
+	revision := 1
+	channel := "latest/stable"
+	name := "foo"
+	config, err := InstallOne(c.Context(), name, &revision, &channel, RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	config = DefineInstanceKey(c, config, "foo-bar")
+
+	req, err := config.Build(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(req, tc.DeepEquals, transport.RefreshRequest{
+		Context: []transport.RefreshRequestContext{},
+		Actions: []transport.RefreshRequestAction{{
+			Action:      "install",
+			InstanceKey: "foo-bar",
+			Name:        &name,
+			Revision:    &revision,
+			Channel:     &channel,
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
+				Architecture: arch.DefaultArchitecture,
+			},
+		}},
+		Fields: expRefreshFields,
+	})
+}
+
+func (s *RefreshConfigSuite) TestInstallOneBuildRevisionWithoutChannel(c *tc.C) {
+	revision := 1
+	name := "foo"
+	config, err := InstallOne(c.Context(), name, &revision, nil, RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	config = DefineInstanceKey(c, config, "foo-bar")
+
+	req, err := config.Build(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(req, tc.DeepEquals, transport.RefreshRequest{
+		Context: []transport.RefreshRequestContext{},
+		Actions: []transport.RefreshRequestAction{{
+			Action:      "install",
+			InstanceKey: "foo-bar",
+			Name:        &name,
+			Revision:    &revision,
+		}},
+		Fields: expRefreshFields,
+	})
+}
+
 func (s *RefreshConfigSuite) TestInstallOneBuildRevisionResources(c *tc.C) {
 	// Tests InstallOne by revision with specific resources.
 	revision := 1

--- a/internal/charmhub/refresh_test.go
+++ b/internal/charmhub/refresh_test.go
@@ -664,6 +664,11 @@ func (s *RefreshConfigSuite) TestInstallOneBuildRevisionWithoutChannel(c *tc.C) 
 			InstanceKey: "foo-bar",
 			Name:        &name,
 			Revision:    &revision,
+			Base: &transport.Base{
+				Name:         "ubuntu",
+				Channel:      "20.04",
+				Architecture: arch.DefaultArchitecture,
+			},
 		}},
 		Fields: expRefreshFields,
 	})
@@ -838,6 +843,68 @@ func (s *RefreshConfigSuite) TestDownloadOneFromRevisionBuild(c *tc.C) {
 		}},
 		Fields: expRefreshFields,
 	})
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneBuild(c *tc.C) {
+	revision := 4
+	channel := "latest/stable"
+	name := "foo"
+	base := &RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	}
+	config, err := DownloadOne(c.Context(), name, &revision, &channel, base)
+	c.Assert(err, tc.ErrorIsNil)
+
+	config = DefineInstanceKey(c, config, "foo-bar")
+	request, err := config.Build(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(request.Actions[0].Action, tc.Equals, "download")
+	c.Assert(request.Actions[0].Name, tc.DeepEquals, &name)
+	c.Assert(request.Actions[0].Revision, tc.DeepEquals, &revision)
+	c.Assert(request.Actions[0].Channel, tc.DeepEquals, &channel)
+	c.Assert(request.Actions[0].Base, tc.NotNil)
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneByIDBuild(c *tc.C) {
+	revision := 4
+	channel := "latest/stable"
+	id := "foo"
+	base := &RefreshBase{
+		Name:         "ubuntu",
+		Channel:      "20.04",
+		Architecture: arch.DefaultArchitecture,
+	}
+	config, err := DownloadOneByID(c.Context(), id, &revision, &channel, base)
+	c.Assert(err, tc.ErrorIsNil)
+
+	config = DefineInstanceKey(c, config, "foo-bar")
+	request, err := config.Build(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(request.Actions[0].Action, tc.Equals, "download")
+	c.Assert(request.Actions[0].ID, tc.DeepEquals, &id)
+	c.Assert(request.Actions[0].Revision, tc.DeepEquals, &revision)
+	c.Assert(request.Actions[0].Channel, tc.DeepEquals, &channel)
+	c.Assert(request.Actions[0].Base, tc.NotNil)
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneRevisionOnlyBuild(c *tc.C) {
+	revision := 4
+	config, err := DownloadOne(c.Context(), "foo", &revision, nil, nil)
+	c.Assert(err, tc.ErrorIsNil)
+
+	config = DefineInstanceKey(c, config, "foo-bar")
+	request, err := config.Build(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(request.Actions[0].Action, tc.Equals, "download")
+	c.Assert(request.Actions[0].Revision, tc.DeepEquals, &revision)
+	c.Assert(request.Actions[0].Base, tc.IsNil)
+}
+
+func (s *RefreshConfigSuite) TestDownloadOneByIDEmptyID(c *tc.C) {
+	_, err := DownloadOneByID(c.Context(), "", nil, nil, nil)
+	c.Assert(err, tc.ErrorMatches, `empty id not valid`)
 }
 
 func (s *RefreshConfigSuite) TestDownloadOneFromRevisionFail(c *tc.C) {

--- a/internal/charmhub/refreshconfig.go
+++ b/internal/charmhub/refreshconfig.go
@@ -92,7 +92,7 @@ type executeOne struct {
 	Name     string
 	Revision *int
 	Channel  *string
-	Base     RefreshBase
+	Base     *RefreshBase
 	// instanceKey is a private unique key that we construct for CharmHub API
 	// asynchronous calls.
 	action      action
@@ -107,9 +107,13 @@ func (c executeOne) InstanceKey() string {
 
 // Build a refresh request that can be past to the API.
 func (c executeOne) Build(ctx context.Context) (transport.RefreshRequest, error) {
-	base, err := constructRefreshBase(ctx, c.Base)
-	if err != nil {
-		return transport.RefreshRequest{}, errors.Trace(err)
+	var base *transport.Base
+	if c.Base != nil {
+		constructed, err := constructRefreshBase(ctx, *c.Base)
+		if err != nil {
+			return transport.RefreshRequest{}, errors.Trace(err)
+		}
+		base = &constructed
 	}
 
 	var id *string
@@ -131,7 +135,7 @@ func (c executeOne) Build(ctx context.Context) (transport.RefreshRequest, error)
 			Name:        name,
 			Revision:    c.Revision,
 			Channel:     c.Channel,
-			Base:        &base,
+			Base:        base,
 		}},
 		Fields: c.fields,
 	}
@@ -163,8 +167,12 @@ func (c executeOne) String() string {
 	if c.Revision != nil {
 		revision = fmt.Sprintf(" with revision: %+v", c.Revision)
 	}
-	return fmt.Sprintf("Execute One (action: %s, instanceKey: %s): using %s%s channel %v and base %s",
-		c.action, c.instanceKey, using, revision, channel, c.Base)
+	var base string
+	if c.Base != nil {
+		base = c.Base.String()
+	}
+	return fmt.Sprintf("Execute One (action: %s, instanceKey: %s): using %s%s channel %v and base %q",
+		c.action, c.instanceKey, using, revision, channel, base)
 }
 
 type executeOneByRevision struct {

--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -76,12 +76,12 @@ run_deploy_revision_refresh() {
 	ensure "${model_name}" "${file}"
 
 	# revision 23 is in channel 2.0/edge
-	juju deploy juju-qa-test --revision 23 --channel latest/edge
+	juju deploy juju-qa-test --revision 23 --channel 2.0/edge
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 23)"
 	wait_for "juju-qa-test" "$(active_idle_condition "juju-qa-test")"
 
 	# Once the application is ready, refresh is expected to immediately work.
-	juju refresh juju-qa-test
+	juju refresh juju-qa-test --channel latest/edge
 
 	# revision 21 is in channel latest/edge
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 21)"

--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -25,6 +25,32 @@ run_deploy_revision() {
 	destroy_model "${model_name}"
 }
 
+# Verify when deploying a charm with a specific revision that the resource
+# revision deployed is consistent with the charm revision that was released
+# into the channel. This test could break if the charm revision is
+# re-released into the channel with a different resource revision but this
+# is not conventionally done and is not expected to be done with the JIMM charm.
+run_deploy_revision_uses_consistent_resource() {
+	echo
+
+	model_name="test-deploy-revision-uses-consistent-resource"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	# Use the jimm charm for this test which tracks what
+	# resource revision was released alongside a charm revision.
+	# See https://github.com/canonical/jimm-k8s-operator/releases/tag/rev110
+	juju deploy juju-jimm-k8s --revision 110 --channel 3/edge
+	wait_for "juju-jimm-k8s" "$(charm_rev "juju-jimm-k8s" 110)"
+
+	# check resource revision per channel specified.
+	got=$(juju resources juju-jimm-k8s --format json | yq '.resources[0] | .["revision"] == "63"')
+	check_contains "${got}" "true"
+
+	destroy_model "${model_name}"
+}
+
 run_deploy_revision_resource() {
 	echo
 
@@ -102,6 +128,7 @@ test_deploy_revision() {
 		cd .. || exit
 
 		run "run_deploy_revision"
+		run "run_deploy_revision_uses_consistent_resource"
 		run "run_deploy_revision_fail"
 		run "run_deploy_revision_refresh"
 		run "run_deploy_revision_resource"

--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -29,7 +29,7 @@ run_deploy_revision() {
 # revision deployed is consistent with the charm revision that was released
 # into the channel. This test could break if the charm revision is
 # re-released into the channel with a different resource revision but this
-# is not conventionally done and is not expected to be done with the JIMM charm.
+# is not conventionally done.
 run_deploy_revision_uses_consistent_resource() {
 	echo
 
@@ -38,14 +38,15 @@ run_deploy_revision_uses_consistent_resource() {
 
 	ensure "${model_name}" "${file}"
 
-	# Use the jimm charm for this test which tracks what
-	# resource revision was released alongside a charm revision.
-	# See https://github.com/canonical/jimm-k8s-operator/releases/tag/rev110
-	juju deploy juju-jimm-k8s --revision 110 --channel 3/edge
-	wait_for "juju-jimm-k8s" "$(charm_rev "juju-jimm-k8s" 110)"
+	# A charm publisher can view the previous charm revisions and resource
+	# revisions released into a channel at https://charmhub.io/juju-qa-test/releases.
+	juju deploy juju-qa-test --revision 31 --channel 2.0/candidate
+	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 31)"
 
-	# check resource revision per channel specified.
-	got=$(juju resources juju-jimm-k8s --format json | yq '.resources[0] | .["revision"] == "63"')
+	# Check resource revision per channel specified.
+	# The latest resource revision released into channel 2.0/candidate is 3,
+	# here we expect 2 as that was the resource revision released with charm revision 31.
+	got=$(juju resources juju-qa-test --format json | yq '.resources[0] | .["revision"] == "2"')
 	check_contains "${got}" "true"
 
 	destroy_model "${model_name}"

--- a/tests/suites/deploy/deploy_revision.sh
+++ b/tests/suites/deploy/deploy_revision.sh
@@ -38,8 +38,6 @@ run_deploy_revision_uses_consistent_resource() {
 
 	ensure "${model_name}" "${file}"
 
-	# A charm publisher can view the previous charm revisions and resource
-	# revisions released into a channel at https://charmhub.io/juju-qa-test/releases.
 	juju deploy juju-qa-test --revision 31 --channel 2.0/candidate
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" 31)"
 

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -11,7 +11,8 @@ run_start_hook_fires_after_reboot() {
 	juju model-config -m "${model_name}" logging-config="<root>=INFO;unit=DEBUG"
 
 	charm="juju-qa-test"
-	juju deploy "$charm" --revision 22 --channel stable "$charm"
+	# Revision 22 is in 2.0/stable
+	juju deploy "$charm" --revision 22 --channel 2.0/stable "$charm"
 	wait_for "$charm" "$(idle_condition "$charm")"
 
 	# Ensure that the implicit start hook after reboot detection does not

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -123,7 +123,8 @@ run_refresh_revision() {
 
 	ensure "${model_name}" "${file}"
 
-	juju deploy juju-qa-test --revision 22 --channel stable --base ubuntu@20.04
+	# Revision 22 is in 2.0/stable
+	juju deploy juju-qa-test --revision 22 --channel 2.0/stable --base ubuntu@20.04
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	# refresh to a revision not at the tip of the stable channel

--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -34,7 +34,8 @@ run_charmhub_deploy() {
 
 	ensure "${model_name}" "${file}"
 
-	juju deploy "juju-qa-test" --revision 22 --channel stable "juju-qa-test"
+	# Revision 22 is in 2.0/stable
+	juju deploy "juju-qa-test" --revision 22 --channel 2.0/stable "juju-qa-test"
 	# TODO(nvinuesa): Ideally, we want to deploy the next 2 charms with a
 	# placement directive, both to make the test faster and also to test
 	# the placement directives. However, until machines are not fully


### PR DESCRIPTION
This PR resolves a long outstanding issue that charm resources are resolved using the latest resources from the tip of the specified channel when not pinned, making reproducible deployments more difficult. Charmhub stored the information of the resource revision that was released alongside a charm revision but never exposed it until recently. The change described in https://warthogs.atlassian.net/browse/SN-5638 and https://code.launchpad.net/~miloslu/snapdevicegw/+git/snapdevicegw/+merge/504193 is now available in the production Charmhub. 

See [the spec here](https://docs.google.com/document/d/1vTsem6zm6d1fB351vhVBTspQKSN_D9fz_DKKYHq614M/edit?tab=t.0), on the existing behaviour vs the new behaviour. In summary,
- When deploying/refreshing a charm with a specific channel and charm revision, the resources fetched will be the latest released alongside that specific charm revision in the specified channel; rather than the resources from the tip of the channel.
- When deploying/refreshing a charm with a specific channel and charm revision, Juju will validate that the charm revision was released into the specified channel; i.e. `juju deploy test-charm --channel=latest/stable --revision=10` will fail if revision 10 was never released into latest/stable.


Quoting from the Jira card,
> Once this is implemented, Juju will be able to call the store with the information about the channel and charm revision and the store will be able to return the information about that revision coupled with the resources that were released together with it.

To test the Charmhub API changes, try the following curl command against the juju-jimm-k8s charm.

Tweak the charm revision and compare it with the charm's releases https://github.com/canonical/jimm-k8s-operator/releases to see that charm revision 110 returns image 63 while charm revision 111 returns image 64.
<details>

<summary>Curl Req</summary>


```
curl -sS https://api.charmhub.io/v2/charms/refresh \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json' \
  -d '{
    "context": [],
    "actions": [
      {
        "action": "install",
        "instance-key": "",
        "name": "juju-jimm-k8s",
        "channel": "3/edge",
        "revision": 110,
        "base": {
          "name": "ubuntu",
          "channel": "22.04",
          "architecture": "amd64"
        }
      }
    ],
    "fields": [
      "id",
      "name",
      "type",
      "revision",
      "bases",
      "resources",
      "download",
      "metadata-yaml",
      "config-yaml"
    ]
  }' | jq '.results[0] | {name, revision, effective_channel: ."effective-channel", resources: .charm.resources}'
```

</details>

Making sense of the code changes is made harder by the convoluted charm deployment logic and determining what invariants are true i.e. do we always have a channel/revision/base/etc. But essentially, when we resolve a charm, we call `repo.ResolveForDeploy` which fetches the charm data, and provided the user specified a charm revision, we will receive a set of default resources associated with that charm revision. Later, when we reach `resolveResources`, we determine if there are any overrides/local resources that should take precedence or if we don't have a default resource (because the user didn't specify a charm revision), then we make an optional call to Charmhub to fetch more details.

In a follow-up I will adjust the `juju charm-resources` command to accept a `--revision` flag that would allow the client to see the resource revision for a specific charm revision (in a specific channel).

This change is targetted at Juju 4.1 but could also land in Juju 3 but speaking with @manadart, the decision was to only target Juju 4.1.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

I've QA'd this with Microk8s as I can use the juju-jimm-k8s charm as a reference where we know the charm revisions and associated resource revisions (see above) but it can also be done with LXD with the same charm.

1. make microk8s-operator-update
2. make install
3. juju bootstrap microk8s test-deploy
4. juju add-model foo
5. juju deploy juju-jimm-k8s jimm-rev-one-hundred-ten --channel=3/edge --revision=110
6. juju deploy juju-jimm-k8s jimm-rev-one-hundred-fifteen --channel=3/edge --revision=115
8. juju resources jimm-rev-one-hundred-ten
9. juju resources jimm-rev-one-hundred-fifteen
10. \# Going back to https://github.com/canonical/jimm-k8s-operator/releases, we can see that charm revision 110 should use resource rev. 63 and charm revision 115 should use resource rev. 64.

Further to verify refreshing to an intermediate charm revision works,
1. juju deploy juju-jimm-k8s jimm-rev-one-hundred-nine --channel=3/edge --revision=109
2. juju resources jimm-rev-one-hundred-nine
3. \# Observe the resource revision is 62
4. juju refresh jimm-rev-one-hundred-nine --revision=110
5. juju resources jimm-rev-one-hundred-nine
7. \# Observe the resource revision is 63

Additionally, the following is a script that I used AI to generate that tests many of the scenarios outlined in the spec - https://pastebin.canonical.com/p/9d3PVRVVqc.

Finally, one can run the deploy suite which includes a new test for this behaviour.
```
#! /bin/bash
TEST_INSPECT=1 \
BOOTSTRAP_CLOUD=localhost \
TEST_SKIP_TASKS=test_deploy_bundles,test_cmr_bundles_export_overlay \
./main.sh -v -x output.txt deploy 2>&1 | tee output.txt
```

## Documentation changes

Updated the `--revision` flag help text for the deploy and refresh commands and added an output log line when specifying the `--revision` flag to indicate that resources released alongside the charm revision will be used.

## Links

**Jira card:** [JUJU-9933](https://warthogs.atlassian.net/browse/JUJU-9933)


[JUJU-9933]: https://warthogs.atlassian.net/browse/JUJU-9933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ