### PR TITLE
3.6 fix cloud ref accuracy

### DIFF
--- a/docs/agents/AGENTS.cloud-reference-documentation.md
+++ b/docs/agents/AGENTS.cloud-reference-documentation.md
@@ -329,6 +329,22 @@ Workflow heading style: `### <Verb phrase>` (e.g. `### Authenticate with managed
 2. Check `docs/reference/space.md` for cloud-specific spaces behavior (single NIC vs multiple NICs, inherited vs discovered subnets) and add any limitations to `## Limitations`.
 3. Follow the structure and conventions above. The canonical example for machine clouds is `amazon-ec2.md`; for Kubernetes clouds, use `microk8s.md` (stub) alongside the `docs/reference/cloud/list-of-supported-clouds/list-of-supported-clouds/reuse/k8s/` snippets.
 
+### Verifying constraint accuracy against code
+
+The constraint tables are the most error-prone section. Before committing, cross-check each documented constraint against the provider code:
+
+**Step 1 — Check `var unsupportedConstraints`** in `environ_policy.go` (or `environ.go`, `constraints.go` — search with `grep -rn "var unsupportedConstraints" internal/provider/<cloud>/`). Any constraint in this list must **not** appear in the doc's constraint table.
+
+**Step 2 — Check `validator.RegisterConflicts`** calls. The conflict note in the doc must exactly match what is registered. Common mistake: listing a constraint in the conflict group when it is only conditionally conflicting (e.g. OpenStack `root-disk` is validated in `PrecheckInstance`, not `RegisterConflicts`).
+
+**Step 3 — Check `validator.RegisterVocabulary`** for `constraints.Arch` and other vocabulary-restricted constraints. If arch is registered as `[amd64, arm64]`, the doc must say `Valid values: amd64, arm64`.
+
+**Step 4 — Check `RegisterConflictResolver`**. If a conflict has a resolver (e.g. EC2 and Azure allow `instance-type` + `arch` together when they are compatible), the conflict note must mention the exception.
+
+**Step 5 — Check that documented constraints are actually used.** If a constraint is not in `unsupportedConstraints` but is also never referenced in `StartInstances`/`environ.go`, Juju will accept it but silently ignore it. Such constraints should be omitted from the doc (e.g. OCI `cpu-power`).
+
+The storage provider section likewise needs checking against `storage.go`: verify `DefaultPools()` for pool names, `ConfigSchema()` for `account-type` defaults and valid values, and the storage provider type name.
+
 ---
 
 ## Changelog
@@ -342,3 +358,4 @@ Workflow heading style: `### <Verb phrase>` (e.g. `### Authenticate with managed
 | 2026-06-18 | Compacted config key format: anchored bullets, inline Type/Default. Env vars moved under specific auth type. |
 | 2026-06-24 | Major restructure session: entity axis confirmed as primary skeleton. `## Security` → `## Registration` → `## The cloud` + `## Credentials` (promoted); `## Bootstrap` → `## Controllers`; `## Compute`/`## Networking` top-level sections removed; Compute/Networking/Storage as bold sub-groupings within entity sections. `## Prerequisites` split into `## Limitations` (first) + `## Requirements`; both omitted when empty. Spaces behavior incorporated. `### Storage behavior` added parallel to `### Networking behavior` under Machines. Rationale documented. |
 | 2026-06-25 | Removed `## Distribution-specific notes` from K8s cloud template. Cloud-specific details (requirements, adding the cloud, bootstrap prep) moved into the relevant entity section (`## The cloud` or `## Controllers`). Fixed snippet path typo. |
+| 2026-06-30 | Added constraint-accuracy audit procedure to "Adding a new cloud" section. Corrections applied to all clouds: EC2 (`allocate-public-ip`, `virt-type` removed; `arch` added to `instance-type` conflict with resolver note); GCE (`arch` removed from `instance-type` conflict); Azure (`arm64` added to arch vocab; `StandardSSD_LRS` added as default storage account type); OpenStack (`access-key` auth type added; `instance-type` conflict corrected from `[mem, root-disk, cores]` to `[mem, cores]` with `root-disk` conditional note); OCI (`cpu-power` removed -- silently ignored by provider; `region` credential marked optional not required); vSphere (disk-provisioning-type corrected: `thin`, `thick` (default), `thick-lazy-zero` -- `thickEagerZero` does not exist in code). |

--- a/docs/reference/cloud/list-of-supported-clouds/amazon-ec2.md
+++ b/docs/reference/cloud/list-of-supported-clouds/amazon-ec2.md
@@ -175,7 +175,7 @@ See also: {ref}`machine`, {ref}`Juju | Manage machines <manage-machines>`, {ref}
 Amazon EC2 supports the following {ref}`constraints <constraint>`:
 
 ```{note}
-The constraints `instance-type` and `[cores, cpu-power, mem]` are mutually exclusive.
+The constraints `instance-type` and `[arch, cores, cpu-power, mem]` are mutually exclusive, unless `arch` matches the instance type's architecture, in which case they can be combined.
 ```
 
 **Compute**
@@ -188,11 +188,8 @@ The constraints `instance-type` and `[cores, cpu-power, mem]` are mutually exclu
 - {ref}`constraint-instance-role`. Values: `auto` (creates role automatically) or an [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) name.
 - {ref}`constraint-instance-type`. Valid values: Any EC2 instance type. Default: `m3.medium`.
 - {ref}`constraint-mem`
-- {ref}`constraint-virt-type`
-
 **Networking**
 
-- {ref}`constraint-allocate-public-ip`
 - {ref}`constraint-spaces`
 - {ref}`constraint-zones`
 

--- a/docs/reference/cloud/list-of-supported-clouds/google-gce.md
+++ b/docs/reference/cloud/list-of-supported-clouds/google-gce.md
@@ -191,7 +191,7 @@ See also: {ref}`machine`, {ref}`Juju | Manage machines <manage-machines>`, {ref}
 Google GCE supports the following {ref}`constraints <constraint>`:
 
 ```{note}
-The constraints `instance-type` and `[arch, cores, cpu-power, mem]` are mutually exclusive.
+The constraints `instance-type` and `[cores, cpu-power, mem]` are mutually exclusive.
 ```
 
 **Compute**

--- a/docs/reference/cloud/list-of-supported-clouds/microsoft-azure.md
+++ b/docs/reference/cloud/list-of-supported-clouds/microsoft-azure.md
@@ -206,7 +206,7 @@ The constraints `instance-type` and `[arch, cores, mem]` are mutually exclusive.
 
 **Compute**
 
-- {ref}`constraint-arch`. Valid values: `amd64`.
+- {ref}`constraint-arch`. Valid values: `amd64`, `arm64`.
 - {ref}`constraint-container`
 - {ref}`constraint-cores`
 - {ref}`constraint-instance-role`. Juju 3.6+. Valid values: `auto` or managed identity name in format `<resource-group>/<identity-name>` or `<subscription>/<resource-group>/<identity-name>`.
@@ -288,8 +288,9 @@ In addition to generic storage providers, Microsoft Azure provides the following
 
 **Configuration options:**
 
-- `account-type`: Disk type.
-  - `Standard_LRS`: Standard HDD (associated with pool `azure`)
+- `account-type`: Disk type. Default: `StandardSSD_LRS`.
+  - `Standard_LRS`: Standard HDD
+  - `StandardSSD_LRS`: Standard SSD — default (associated with pool `azure`)
   - `Premium_LRS`: Premium SSD (associated with pool `azure-premium`)
 
 ```{ibnote}

--- a/docs/reference/cloud/list-of-supported-clouds/microsoft-azure.md
+++ b/docs/reference/cloud/list-of-supported-clouds/microsoft-azure.md
@@ -216,7 +216,10 @@ The constraints `instance-type` and `[arch, cores, mem]` are mutually exclusive.
 **Networking**
 
 - {ref}`constraint-allocate-public-ip`
-- {ref}`constraint-zones`
+
+```{note}
+The `zones` constraint is not supported on Azure. Instead, Juju uses [Azure availability sets](https://learn.microsoft.com/en-us/azure/virtual-machines/availability-set-overview): for each application, an availability set is created and all units of that application are placed within it. This protects against hardware and infrastructure failures within a region, but does not map to Juju's zone abstraction — charms cannot query which zone they are in.
+```
 
 **Storage**
 

--- a/docs/reference/cloud/list-of-supported-clouds/openstack.md
+++ b/docs/reference/cloud/list-of-supported-clouds/openstack.md
@@ -106,6 +106,19 @@ Attributes:
 - `project-domain-name`: The OpenStack project domain name (optional).
 - `user-domain-name`: The OpenStack user domain name (optional).
 
+(openstack-credential-access-key)=
+#### `access-key`
+
+For OpenStack deployments that expose an EC2-compatible endpoint.
+
+Attributes:
+
+- `access-key`: The access key to authenticate with (required).
+- `secret-key`: The secret key to authenticate with (required).
+- `tenant-name`: The OpenStack tenant name (optional).
+- `tenant-id`: The OpenStack tenant ID (optional).
+- `version`: The OpenStack identity version (optional).
+
 (openstack-controller)=
 ## Controllers
 

--- a/docs/reference/cloud/list-of-supported-clouds/oracle-oci.md
+++ b/docs/reference/cloud/list-of-supported-clouds/oracle-oci.md
@@ -88,7 +88,7 @@ Attributes:
 - `key`: PEM encoded private key (required).
 - `pass-phrase`: Passphrase used to unlock the key (required).
 - `fingerprint`: Private key fingerprint (required).
-- `region`: DEPRECATED -- Region to log into (required).
+- `region`: DEPRECATED -- Region to log into (optional).
 
 (oci-controller)=
 ## Controllers

--- a/docs/reference/cloud/list-of-supported-clouds/vmware-vsphere.md
+++ b/docs/reference/cloud/list-of-supported-clouds/vmware-vsphere.md
@@ -170,7 +170,7 @@ VMware vSphere supports the following {ref}`cloud-specific model configuration k
 - **`datastore`**: The datastore in which to create VMs. If this is not specified, the process will abort unless there is only one datastore available. Type: `string`. Default: none.
 
 (vsphere-model-disk-provisioning-type)=
-- **`disk-provisioning-type`**: Specify how the disk should be provisioned when cloning the VM template. Allowed values: `thickEagerZero` (default), `thick`, `thin`. Type: `string`. Default: `"thick"`.
+- **`disk-provisioning-type`**: Specify how the disk should be provisioned when cloning the VM template. Allowed values: `thin`, `thick` (default), `thick-lazy-zero`. Type: `string`. Default: `"thick"`.
 
 (vsphere-model-enable-disk-uuid)=
 - **`enable-disk-uuid`**: Expose consistent disk UUIDs to the VM, equivalent to `disk.EnableUUID`. Enables consistent `/dev/disk/by-id/` paths in guest OS. Type: `bool`. Default: `true`.
@@ -236,7 +236,7 @@ Applies to all machines, including controller machines. Controller-specific defa
 
 **Storage**
 
-- **Root disk**: VMDK from template, extended post-clone if constraint specifies larger size. Provisioning type: `thin`, `thick`, or `thickEagerZero` via `disk-provisioning-type` config. Datastore selected from compute resource's accessible datastores (must be explicit if multiple available).
+- **Root disk**: VMDK from template, extended post-clone if constraint specifies larger size. Provisioning type: `thin`, `thick`, or `thick-lazy-zero` via `disk-provisioning-type` config. Datastore selected from compute resource's accessible datastores (must be explicit if multiple available).
 
 (vsphere-machine-networking-behavior)=
 ### Networking behavior
@@ -251,7 +251,7 @@ Applies to all machines, including controller machines. Controller-specific defa
 
 - **VMDK only**: All storage operations use VMDK provisioning from templates. Only root disk is supported -- no secondary volumes, snapshots, or persistent volume creation.
 - **Datastore selection**: Must be specified via `datastore` model config if multiple datastores are available; otherwise bootstrap aborts.
-- **Disk provisioning type**: Configurable via `disk-provisioning-type` model config (`thickEagerZero`, `thick`, or `thin`).
+- **Disk provisioning type**: Configurable via `disk-provisioning-type` model config (`thin`, `thick` (default), or `thick-lazy-zero`).
 
 (vsphere-storage)=
 ## Storage


### PR DESCRIPTION
https://github.com/juju/juju/pull/22577 made significant improvements to the structure and content of our cloud reference docs in `3.6`, but while porting the changes to `4.0` (https://github.com/juju/juju/pull/22765) I discovered technical correctness issues that I believe apply to 3.6 too; this PR ports the fixes to `3.6`.

Fixes https://github.com/juju/juju/issues/20809