### PR TITLE
feat: exclude virtual Ethernet devices for API addresses

### DIFF
--- a/domain/network/service/interface.go
+++ b/domain/network/service/interface.go
@@ -124,6 +124,13 @@ type NetConfigState interface {
 	// - [uniterrors.UnitNotFound] if the unit does not exist.
 	GetUnitAndK8sServiceAddresses(ctx context.Context, uuid coreunit.UUID) (network.SpaceAddresses, error)
 
+	// GetControllerAPIAddresses returns the addresses which can be used as
+	// controller API addresses for the specified unit.
+	//
+	// The following errors may be returned:
+	// - [uniterrors.UnitNotFound] if the unit does not exist.
+	GetControllerAPIAddresses(ctx context.Context, uuid coreunit.UUID) (network.SpaceAddresses, error)
+
 	// GetUnitAddresses returns the addresses of the specified unit.
 	//
 	// The following errors may be returned:

--- a/domain/network/service/package_mock_test.go
+++ b/domain/network/service/package_mock_test.go
@@ -42,6 +42,7 @@ type MockStateMockRecorder struct {
 	getAllSpacesExpects                         []*gomock.Call1_2[context.Context, network.SpaceInfos, error]
 	getAllSubnetsExpects                        []*gomock.Call1_2[context.Context, network.SubnetInfos, error]
 	getContainerNetworkingMethodExpects         []*gomock.Call1_2[context.Context, string, error]
+	getControllerAPIAddressesExpects            []*gomock.Call2_2[context.Context, unit.UUID, network.SpaceAddresses, error]
 	getControllerUnitUUIDByNameExpects          []*gomock.Call2_2[context.Context, unit.Name, unit.UUID, error]
 	getMachineAppBindingsExpects                []*gomock.Call2_2[context.Context, string, []internal.SpaceName, error]
 	getMachineNetNodeUUIDExpects                []*gomock.Call2_2[context.Context, string, string, error]
@@ -268,6 +269,24 @@ func (mr *MockStateMockRecorder) GetContainerNetworkingMethod(ctx any) *MockStat
 
 // MockStateGetContainerNetworkingMethodCall is the typed call wrapper for GetContainerNetworkingMethod.
 type MockStateGetContainerNetworkingMethodCall = gomock.Call1_2[context.Context, string, error]
+
+// GetControllerAPIAddresses mocks base method.
+func (m *MockState) GetControllerAPIAddresses(ctx context.Context, uuid unit.UUID) (network.SpaceAddresses, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_2(&m.recorder.getControllerAPIAddressesExpects, m.ctrl, m, "GetControllerAPIAddresses", ctx, uuid)
+}
+
+// GetControllerAPIAddresses indicates an expected call of GetControllerAPIAddresses.
+func (mr *MockStateMockRecorder) GetControllerAPIAddresses(ctx, uuid any) *MockStateGetControllerAPIAddressesCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_2[context.Context, unit.UUID, network.SpaceAddresses, error](mr.mock.ctrl.T, mr.mock, "GetControllerAPIAddresses", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(uuid))
+	mr.getControllerAPIAddressesExpects = append(mr.getControllerAPIAddressesExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockStateGetControllerAPIAddressesCall is the typed call wrapper for GetControllerAPIAddresses.
+type MockStateGetControllerAPIAddressesCall = gomock.Call2_2[context.Context, unit.UUID, network.SpaceAddresses, error]
 
 // GetControllerUnitUUIDByName mocks base method.
 func (m *MockState) GetControllerUnitUUIDByName(arg0 context.Context, arg1 unit.Name) (unit.UUID, error) {

--- a/domain/network/service/unitaddress.go
+++ b/domain/network/service/unitaddress.go
@@ -97,29 +97,21 @@ func (s *Service) GetUnitPublicAddresses(ctx context.Context, unitName unit.Name
 //
 // The following errors may be returned:
 //   - [applicationerrors.UnitNotFound] if the unit does not exist or is
-//     not a controller application unit
-//   - [network.NoAddressError] if the unit has no api address associated
+//     not a controller application unit.
+//   - [network.NoAddressError] if the unit has no suitable API addresses.
 func (s *Service) GetControllerAPIAddresses(ctx context.Context, unitName unit.Name) (network.SpaceAddresses, error) {
 	unitUUID, err := s.st.GetControllerUnitUUIDByName(ctx, unitName)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
-	addrs, err := s.st.GetUnitAndK8sServiceAddresses(ctx, unitUUID)
+	addrs, err := s.st.GetControllerAPIAddresses(ctx, unitUUID)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	// First remove local-machine scoped addresses.
-	matchedAddrs := make(network.SpaceAddresses, 0)
-	for _, addr := range addrs {
-		if addr.Scope == network.ScopeMachineLocal {
-			continue
-		}
-		matchedAddrs = append(matchedAddrs, addr)
-	}
-	if len(matchedAddrs) == 0 {
+	if len(addrs) == 0 {
 		return nil, network.NoAddressError("API")
 	}
 
-	return matchedAddrs, nil
+	return addrs, nil
 }

--- a/domain/network/service/unitaddress_test.go
+++ b/domain/network/service/unitaddress_test.go
@@ -447,15 +447,6 @@ func (s *unitAddressSuite) TestGetControllerAPIAddresses(c *tc.C) {
 		{
 			SpaceID: network.AlphaSpaceId,
 			MachineAddress: network.MachineAddress{
-				Value:      "54.32.1.2/24",
-				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv4Address,
-				Scope:      network.ScopeMachineLocal,
-			},
-		},
-		{
-			SpaceID: network.AlphaSpaceId,
-			MachineAddress: network.MachineAddress{
 				Value:      "54.32.1.3/24",
 				ConfigType: network.ConfigDHCP,
 				Type:       network.IPv4Address,
@@ -465,15 +456,14 @@ func (s *unitAddressSuite) TestGetControllerAPIAddresses(c *tc.C) {
 	}
 
 	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName).Return("foo", nil)
-	s.st.EXPECT().GetUnitAndK8sServiceAddresses(gomock.Any(), unit.UUID("foo")).Return(unitAddresses, nil)
+	s.st.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.UUID("foo")).Return(unitAddresses, nil)
 
 	// Act
 	addrs, err := s.service(c).GetControllerAPIAddresses(c.Context(), unitName)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-	// The three addresses should be returned.
-	c.Check(addrs, tc.DeepEquals, append(unitAddresses[:2], unitAddresses[3:]...))
+	c.Check(addrs, tc.DeepEquals, unitAddresses)
 }
 
 func (s *unitAddressSuite) TestGetControllerAPIAddressesNoAddresses(c *tc.C) {
@@ -482,7 +472,7 @@ func (s *unitAddressSuite) TestGetControllerAPIAddressesNoAddresses(c *tc.C) {
 	// Arrange
 	unitName := unit.Name("foo/0")
 	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName).Return(unit.UUID("foo"), nil)
-	s.st.EXPECT().GetUnitAndK8sServiceAddresses(gomock.Any(), unit.UUID("foo")).Return(network.SpaceAddresses{}, nil)
+	s.st.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.UUID("foo")).Return(network.SpaceAddresses{}, nil)
 
 	// Act
 	_, err := s.service(c).GetControllerAPIAddresses(c.Context(), unitName)

--- a/domain/network/state/unitaddress.go
+++ b/domain/network/state/unitaddress.go
@@ -59,6 +59,89 @@ WHERE     ua.unit_uuid = $entityUUID.uuid
 	return encodeIPAddresses(address)
 }
 
+// GetControllerAPIAddresses returns the addresses which can be used as
+// controller API addresses for the specified unit.
+//
+// The addresses are taken from the union of the net node UUIDs of the cloud
+// service (if any) and the net node UUIDs of the unit, where each net node has
+// an associated address.
+//
+// Addresses belonging to virtual Ethernet devices are excluded because those
+// devices are not suitable for advertised ingress.
+//
+// The following errors may be returned:
+// - [uniterrors.UnitNotFound] if the unit does not exist.
+func (st *State) GetControllerAPIAddresses(ctx context.Context, uuid coreunit.UUID) (corenetwork.SpaceAddresses, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var address []spaceAddress
+	ident := entityUUID{UUID: uuid.String()}
+	type apiAddressFilter struct {
+		DeviceTypeName string `db:"device_type_name"`
+		ScopeName      string `db:"scope_name"`
+	}
+	filter := apiAddressFilter{
+		DeviceTypeName: corenetwork.VirtualEthernetDevice.String(),
+		ScopeName:      corenetwork.ScopeMachineLocal.String(),
+	}
+	queryUnitAPIAddressesStmt, err := st.Prepare(`
+WITH unit_net_node AS (
+    SELECT ks.net_node_uuid
+    FROM   unit AS u
+    JOIN   application AS app ON u.application_uuid = app.uuid
+    JOIN   k8s_service AS ks ON app.uuid = ks.application_uuid
+    WHERE  u.uuid = $entityUUID.uuid
+    UNION
+    SELECT u.net_node_uuid
+    FROM   unit AS u
+    WHERE  u.uuid = $entityUUID.uuid
+)
+SELECT ipa.address_value AS &spaceAddress.address_value,
+       iact.name AS &spaceAddress.config_type_name,
+       iat.name AS &spaceAddress.type_name,
+       iao.name AS &spaceAddress.origin_name,
+       ias.name AS &spaceAddress.scope_name,
+       ipa.device_uuid AS &spaceAddress.device_uuid,
+       sn.space_uuid AS &spaceAddress.space_uuid,
+       sn.cidr AS &spaceAddress.cidr
+FROM   unit_net_node AS unn
+JOIN   ip_address AS ipa ON unn.net_node_uuid = ipa.net_node_uuid
+JOIN   link_layer_device AS lld
+       ON ipa.device_uuid = lld.uuid
+       AND unn.net_node_uuid = lld.net_node_uuid
+JOIN   link_layer_device_type AS lldt ON lld.device_type_id = lldt.id
+JOIN   ip_address_config_type AS iact ON ipa.config_type_id = iact.id
+JOIN   ip_address_type AS iat ON ipa.type_id = iat.id
+JOIN   ip_address_origin AS iao ON ipa.origin_id = iao.id
+JOIN   ip_address_scope AS ias ON ipa.scope_id = ias.id
+LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid
+WHERE  lldt.name != $apiAddressFilter.device_type_name
+AND    ias.name != $apiAddressFilter.scope_name
+`, spaceAddress{}, entityUUID{}, apiAddressFilter{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		address = nil
+		if err := st.checkUnitNotDead(ctx, tx, ident); err != nil {
+			return errors.Capture(err)
+		}
+		err := tx.Query(ctx, queryUnitAPIAddressesStmt, ident, filter).GetAll(&address)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("querying API addresses for unit %q: %w", uuid, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return encodeIPAddresses(address)
+}
+
 // GetUnitAddresses returns the addresses of the specified unit.
 //
 // The following errors may be returned:

--- a/domain/network/state/unitaddress_test.go
+++ b/domain/network/state/unitaddress_test.go
@@ -140,6 +140,115 @@ func (s *unitAddressSuite) TestGetUnitAndK8sServiceAddressesNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
+func (s *unitAddressSuite) TestGetControllerAPIAddressesExcludesVeth(c *tc.C) {
+	// Arrange
+	nodeUUID := s.addNetNode(c)
+	ethDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
+		c, nodeUUID, "eth0", "00:11:22:33:44:55",
+		corenetwork.EthernetDevice,
+	)
+	vethDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
+		c, nodeUUID, "veth0", "00:11:22:33:44:66",
+		corenetwork.VirtualEthernetDevice,
+	)
+	localDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
+		c, nodeUUID, "eth1", "00:11:22:33:44:77",
+		corenetwork.EthernetDevice,
+	)
+
+	spaceUUID := s.addSpace(c)
+	subnetUUID, cidr := s.addsubnet(c, spaceUUID)
+	s.addIPAddressWithSubnetAndScope(
+		c, ethDeviceUUID, nodeUUID, subnetUUID, "10.0.0.1",
+		corenetwork.ScopeCloudLocal,
+	)
+	s.addIPAddressWithSubnetAndScope(
+		c, vethDeviceUUID, nodeUUID, subnetUUID, "10.0.0.2",
+		corenetwork.ScopeCloudLocal,
+	)
+	s.addIPAddressWithSubnetAndScope(
+		c, localDeviceUUID, nodeUUID, subnetUUID, "10.0.0.3",
+		corenetwork.ScopeMachineLocal,
+	)
+
+	charmUUID := s.addCharm(c)
+	appUUID := s.addApplication(c, charmUUID, spaceUUID)
+	unitUUID := s.addUnit(c, appUUID, charmUUID, nodeUUID)
+
+	// Act
+	addr, err := s.state.GetControllerAPIAddresses(c.Context(), unitUUID)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(addr, tc.DeepEquals, corenetwork.SpaceAddresses{{
+		SpaceID: corenetwork.SpaceUUID(spaceUUID),
+		Origin:  corenetwork.OriginProvider,
+		MachineAddress: corenetwork.MachineAddress{
+			Value:      "10.0.0.1",
+			CIDR:       cidr,
+			Type:       corenetwork.IPv4Address,
+			Scope:      corenetwork.ScopeCloudLocal,
+			ConfigType: corenetwork.ConfigStatic,
+		},
+	}})
+}
+
+func (s *unitAddressSuite) TestGetControllerAPIAddressesExcludesK8sServiceVeth(c *tc.C) {
+	// Arrange
+	podNodeUUID := s.addNetNode(c)
+	podDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
+		c, podNodeUUID, "eth0", "00:11:22:33:44:55",
+		corenetwork.EthernetDevice,
+	)
+
+	svcNodeUUID := s.addNetNode(c)
+	svcVethDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
+		c, svcNodeUUID, "veth0", "00:11:22:33:44:66",
+		corenetwork.VirtualEthernetDevice,
+	)
+	svcEthDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
+		c, svcNodeUUID, "eth1", "00:11:22:33:44:77",
+		corenetwork.EthernetDevice,
+	)
+
+	spaceUUID := s.addSpace(c)
+	subnetUUID, cidr := s.addsubnet(c, spaceUUID)
+	s.addIPAddressWithSubnetAndScope(
+		c, podDeviceUUID, podNodeUUID, subnetUUID, "10.0.0.1",
+		corenetwork.ScopeMachineLocal,
+	)
+	s.addIPAddressWithSubnetAndScope(
+		c, svcVethDeviceUUID, svcNodeUUID, subnetUUID, "10.0.0.2",
+		corenetwork.ScopeCloudLocal,
+	)
+	s.addIPAddressWithSubnetAndScope(
+		c, svcEthDeviceUUID, svcNodeUUID, subnetUUID, "10.0.0.3",
+		corenetwork.ScopeCloudLocal,
+	)
+
+	charmUUID := s.addCharm(c)
+	appUUID := s.addApplication(c, charmUUID, spaceUUID)
+	unitUUID := s.addUnit(c, appUUID, charmUUID, podNodeUUID)
+	s.addK8sService(c, svcNodeUUID, appUUID)
+
+	// Act
+	addr, err := s.state.GetControllerAPIAddresses(c.Context(), unitUUID)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(addr, tc.SameContents, corenetwork.SpaceAddresses{{
+		SpaceID: corenetwork.SpaceUUID(spaceUUID),
+		Origin:  corenetwork.OriginProvider,
+		MachineAddress: corenetwork.MachineAddress{
+			Value:      "10.0.0.3",
+			CIDR:       cidr,
+			Type:       corenetwork.IPv4Address,
+			Scope:      corenetwork.ScopeCloudLocal,
+			ConfigType: corenetwork.ConfigStatic,
+		},
+	}})
+}
+
 func (s *unitAddressSuite) TestGetUnitAddresses(c *tc.C) {
 	// Arrange
 	nodeUUID := s.addNetNode(c)


### PR DESCRIPTION
This follows what was done previously for network info ingress addresses under https://github.com/juju/juju/pull/22054.

Virtual Ethernet devices do not have addresses suitable for ingress, so we should discount them for API addresses.

Since we added a new device type argument, a new dedicated query is used with both the scope and type filtering pushed into the state layer.

## QA steps

This is a lazy way to get a _veth_ device, but anyhow.
- `juju bootstrap lxd lxd --debug --bootstrap-constraints virt-type=virtual-machine`.
- `juju switch controller`.
- `juju deploy k8s --channel=1.33/stable --to 0` and wait until it settles.
- `juju ssh 0` and run `sudo systemctl restart jujud-machine-0`.
- `juju show-machine 0` will show the freshly discovered `cilium_host` virtual device added by k8s.
- SSH to the machine again and run `sudo cat /var/lib/juju/agents/machine-0/agent.conf`. There will be only one API address; the one from `cilium_host` is never used.