### PR TITLE
feat: handle charm and model type mismatch at deploy

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -1050,6 +1050,9 @@ type DeployInfo struct {
 	Name string
 	// Revision is the revision of the charm deployed.
 	Revision int
+	// Warnings holds advisory, non-blocking messages about the deployment
+	// (e.g. a charm/model-type mismatch) to surface to the user.
+	Warnings []string
 }
 
 type PendingResourceUpload struct {
@@ -1158,6 +1161,7 @@ func deployInfoFromParams(di params.DeployFromRepositoryInfo) (DeployInfo, error
 		EffectiveChannel: di.EffectiveChannel,
 		Name:             di.Name,
 		Revision:         di.Revision,
+		Warnings:         di.Warnings,
 	}, err
 }
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2354,11 +2354,13 @@ func (api *APIBase) DeployFromRepository(ctx context.Context, args params.Deploy
 	results := make([]params.DeployFromRepositoryResult, len(args.Args))
 	for i, entity := range args.Args {
 		info, pending, errs := api.repoDeploy.DeployFromRepository(ctx, entity)
+		// Always set Info so advisory warnings (e.g. a charm/model-type
+		// mismatch) reach the client even when the deploy is rejected.
+		results[i].Info = info
 		if len(errs) > 0 {
 			results[i].Errors = apiservererrors.ServerErrors(errs)
 			continue
 		}
-		results[i].Info = info
 		results[i].PendingResourceUploads = pending
 	}
 	return params.DeployFromRepositoryResults{

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -553,21 +553,20 @@ func validateAndParseAttachStorage(input []string, numUnits int) ([]names.Storag
 	return attachStorage, errs
 }
 
-// modelTypeMismatchWarnings returns user-facing warnings when the charm's type
-// (machine vs Kubernetes) does not match the model type. It is advisory only and
-// never blocks the deploy. The warnings are both logged (for clients that do not
-// render result warnings, e.g. some API-only callers) and returned so they can
-// be surfaced on the deploying client's terminal.
-func (v *deployFromRepositoryValidator) modelTypeMismatchWarnings(ctx context.Context, meta *charm.Meta) []string {
+// modelTypeMismatch checks the charm's type against the model type: a
+// Kubernetes charm on a machine model is rejected with an error, while a
+// charm declaring no containers on a Kubernetes model only yields an advisory
+// warning, which is also logged for clients that do not render result
+// warnings.
+func (v *deployFromRepositoryValidator) modelTypeMismatch(ctx context.Context, meta *charm.Meta) (string, error) {
 	if meta == nil {
-		return nil
+		return "", nil
 	}
-	warning := meta.ModelMismatchWarning(v.modelInfo.Type == coremodel.CAAS, v.modelInfo.Name)
-	if warning == "" {
-		return nil
+	warning, err := meta.ModelMismatch(v.modelInfo.Type == coremodel.CAAS, v.modelInfo.Name)
+	if warning != "" {
+		v.logger.Warningf(ctx, "%s", warning)
 	}
-	v.logger.Warningf(ctx, "%s", warning)
-	return []string{warning}
+	return warning, err
 }
 
 func (v *deployFromRepositoryValidator) resolvedCharmValidation(ctx context.Context, resolvedCharm charm.Charm, arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
@@ -648,6 +647,22 @@ func (v *deployFromRepositoryValidator) resolvedCharmValidation(ctx context.Cont
 		v.logger.Warningf(ctx, "proceeding with deployment of application even though the charm feature requirements could not be met as --force was specified")
 	}
 
+	// A Kubernetes charm can never run its workload on a machine model, so it
+	// is rejected outright unless --force is given; the inverse direction
+	// cannot be determined with certainty, so it only warns.
+	warning, mismatchErr := v.modelTypeMismatch(ctx, resolvedCharm.Meta())
+	if mismatchErr != nil {
+		if !arg.Force {
+			errs = append(errs, mismatchErr)
+		} else {
+			v.logger.Warningf(ctx, "proceeding with deployment of application even though the charm and model types do not match as --force was specified")
+		}
+	}
+	var warnings []string
+	if warning != "" {
+		warnings = []string{warning}
+	}
+
 	dt := deployTemplate{
 		trust:             arg.Trust || trustFromYAML,
 		applicationName:   appName,
@@ -656,7 +671,7 @@ func (v *deployFromRepositoryValidator) resolvedCharmValidation(ctx context.Cont
 		constraints:       cons,
 		numUnits:          numUnits,
 		resources:         arg.Resources,
-		warnings:          v.modelTypeMismatchWarnings(ctx, resolvedCharm.Meta()),
+		warnings:          warnings,
 	}
 
 	return dt, errs

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -99,7 +99,9 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(
 	dt, errs := api.validator.ValidateArg(ctx, arg)
 
 	if len(errs) > 0 {
-		return params.DeployFromRepositoryInfo{}, nil, errs
+		// Surface advisory warnings (e.g. charm/model-type mismatch) even when
+		// the deploy is rejected, so the user sees the context alongside the error.
+		return params.DeployFromRepositoryInfo{Warnings: dt.warnings}, nil, errs
 	}
 
 	info := params.DeployFromRepositoryInfo{
@@ -112,6 +114,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(
 		EffectiveChannel: nil,
 		Name:             dt.applicationName,
 		Revision:         dt.charmURL.Revision,
+		Warnings:         dt.warnings,
 	}
 	if dt.dryRun {
 		return info, nil, nil
@@ -382,6 +385,7 @@ type deployTemplate struct {
 	resourcesToUpload []*params.PendingResourceUpload
 	resolvedResources applicationservice.ResolvedResources
 	downloadInfo      corecharm.DownloadInfo
+	warnings          []string
 }
 
 type validatorConfig struct {
@@ -549,6 +553,23 @@ func validateAndParseAttachStorage(input []string, numUnits int) ([]names.Storag
 	return attachStorage, errs
 }
 
+// modelTypeMismatchWarnings returns user-facing warnings when the charm's type
+// (machine vs Kubernetes) does not match the model type. It is advisory only and
+// never blocks the deploy. The warnings are both logged (for clients that do not
+// render result warnings, e.g. some API-only callers) and returned so they can
+// be surfaced on the deploying client's terminal.
+func (v *deployFromRepositoryValidator) modelTypeMismatchWarnings(ctx context.Context, meta *charm.Meta) []string {
+	if meta == nil {
+		return nil
+	}
+	warning, ok := meta.ModelMismatchWarning(v.modelInfo.Type == coremodel.CAAS, v.modelInfo.Name)
+	if !ok {
+		return nil
+	}
+	v.logger.Warningf(ctx, "%s", warning)
+	return []string{warning}
+}
+
 func (v *deployFromRepositoryValidator) resolvedCharmValidation(ctx context.Context, resolvedCharm charm.Charm, arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
 	errs := make([]error, 0)
 
@@ -635,6 +656,7 @@ func (v *deployFromRepositoryValidator) resolvedCharmValidation(ctx context.Cont
 		constraints:       cons,
 		numUnits:          numUnits,
 		resources:         arg.Resources,
+		warnings:          v.modelTypeMismatchWarnings(ctx, resolvedCharm.Meta()),
 	}
 
 	return dt, errs

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -126,7 +126,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(
 			params.CodeNotSupported,
 			"attaching storage to CAAS units is not supported",
 		)
-		return params.DeployFromRepositoryInfo{}, nil, []error{err}
+		return info, nil, []error{err}
 	}
 
 	if len(dt.attachStorage) > 0 && dt.numUnits != 1 {
@@ -134,7 +134,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(
 			params.CodeNotFound,
 			"attaching existing storage can only be done when the number of units is 1",
 		)
-		return params.DeployFromRepositoryInfo{}, nil, []error{err}
+		return info, nil, []error{err}
 	}
 
 	// Dedupe the supplied input to avoid repeated work.
@@ -163,7 +163,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(
 				"storage instance %q does not exist",
 				storageTag.Id(),
 			)
-			return params.DeployFromRepositoryInfo{}, nil, []error{err}
+			return info, nil, []error{err}
 		} else if err != nil {
 			// Log the error instead of reporting verbatim to client
 			api.logger.Warningf(
@@ -175,7 +175,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(
 			err = errors.Errorf(
 				"getting information for storage instance %q", storageTag.Id(),
 			)
-			return params.DeployFromRepositoryInfo{}, nil, []error{err}
+			return info, nil, []error{err}
 		}
 
 		storageUUIDsToAttach = append(storageUUIDsToAttach, storageUUID)
@@ -228,7 +228,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(
 		)
 	}
 	if err != nil {
-		return params.DeployFromRepositoryInfo{}, nil, []error{
+		return info, nil, []error{
 			handleApplicationDomainDeployError(errors.Trace(err)),
 		}
 	}
@@ -562,8 +562,8 @@ func (v *deployFromRepositoryValidator) modelTypeMismatchWarnings(ctx context.Co
 	if meta == nil {
 		return nil
 	}
-	warning, ok := meta.ModelMismatchWarning(v.modelInfo.Type == coremodel.CAAS, v.modelInfo.Name)
-	if !ok {
+	warning := meta.ModelMismatchWarning(v.modelInfo.Type == coremodel.CAAS, v.modelInfo.Name)
+	if warning == "" {
 		return nil
 	}
 	v.logger.Warningf(ctx, "%s", warning)

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -11,11 +12,13 @@ import (
 	"github.com/juju/tc"
 
 	corecharm "github.com/juju/juju/core/charm"
+	coremodel "github.com/juju/juju/core/model"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/deployment/charm/repository"
 	"github.com/juju/juju/domain/deployment/charm/resource"
 	"github.com/juju/juju/environs/config"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -169,4 +172,87 @@ func (s *deployRepositorySuite) expectValidator() deployFromRepositoryValidator 
 		},
 	}
 	return validator
+}
+
+func (s *deployRepositorySuite) TestModelTypeMismatchWarningsK8sCharmOnMachineModel(c *tc.C) {
+	v := deployFromRepositoryValidator{
+		modelInfo: coremodel.ModelInfo{Type: coremodel.IAAS, Name: "machinemodel"},
+		logger:    loggertesting.WrapCheckLog(c),
+	}
+	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
+	warnings := v.modelTypeMismatchWarnings(c.Context(), meta)
+
+	c.Assert(warnings, tc.HasLen, 1)
+	c.Check(warnings[0], tc.Equals,
+		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine (IAAS) model; its workload will not run`)
+}
+
+func (s *deployRepositorySuite) TestModelTypeMismatchWarningsNilMeta(c *tc.C) {
+	v := deployFromRepositoryValidator{
+		modelInfo: coremodel.ModelInfo{Type: coremodel.CAAS, Name: "k8smodel"},
+		logger:    loggertesting.WrapCheckLog(c),
+	}
+	c.Check(v.modelTypeMismatchWarnings(c.Context(), nil), tc.HasLen, 0)
+}
+
+func (s *deployRepositorySuite) TestModelTypeMismatchWarningsConsistent(c *tc.C) {
+	v := deployFromRepositoryValidator{
+		modelInfo: coremodel.ModelInfo{Type: coremodel.CAAS, Name: "k8smodel"},
+		logger:    loggertesting.WrapCheckLog(c),
+	}
+	// A sidecar charm on a Kubernetes model is consistent: no warning.
+	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
+	c.Check(v.modelTypeMismatchWarnings(c.Context(), meta), tc.HasLen, 0)
+}
+
+// TestDeployFromRepositoryReturnsWarningsOnError checks that advisory warnings
+// (e.g. a charm/model-type mismatch) are returned to the client in the result
+// Info even when the deploy is rejected with errors, so they reach the terminal.
+func (s *deployRepositorySuite) TestDeployFromRepositoryReturnsWarningsOnError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectAuthClient()
+	s.expectHasWritePermission()
+	s.expectAnyChangeOrRemoval()
+	s.newCAASAPI(c)
+
+	info := params.DeployFromRepositoryInfo{Warnings: []string{"a charm/model mismatch warning"}}
+	s.deployFromRepo.EXPECT().DeployFromRepository(gomock.Any(), gomock.Any()).
+		Return(info, nil, []error{errors.New("rejected")})
+
+	res, err := s.api.DeployFromRepository(c.Context(), params.DeployFromRepositoryArgs{
+		Args: []params.DeployFromRepositoryArg{{CharmName: "x"}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res.Results, tc.HasLen, 1)
+	c.Check(res.Results[0].Errors, tc.HasLen, 1)
+	c.Check(res.Results[0].Info.Warnings, tc.DeepEquals, []string{"a charm/model mismatch warning"})
+}
+
+// stubValidator returns preset results, letting us drive the inner
+// DeployFromRepositoryAPI.DeployFromRepository directly.
+type stubValidator struct {
+	dt   deployTemplate
+	errs []error
+}
+
+func (v stubValidator) ValidateArg(context.Context, params.DeployFromRepositoryArg) (deployTemplate, []error) {
+	return v.dt, v.errs
+}
+
+// TestDeployFromRepositoryWarningsSurviveValidationError checks the inner
+// early-return path: when ValidateArg fails, the warnings accumulated on the
+// deployTemplate are still returned in the result Info.
+func (s *deployRepositorySuite) TestDeployFromRepositoryWarningsSurviveValidationError(c *tc.C) {
+	api := &DeployFromRepositoryAPI{
+		validator: stubValidator{
+			dt:   deployTemplate{warnings: []string{"a charm/model mismatch warning"}},
+			errs: []error{errors.New("validation failed")},
+		},
+		logger: loggertesting.WrapCheckLog(c),
+	}
+
+	info, _, errs := api.DeployFromRepository(c.Context(), params.DeployFromRepositoryArg{})
+
+	c.Assert(errs, tc.HasLen, 1)
+	c.Check(info.Warnings, tc.DeepEquals, []string{"a charm/model mismatch warning"})
 }

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/canonical/gomock/gomock"
+	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 
 	corecharm "github.com/juju/juju/core/charm"
@@ -184,7 +185,7 @@ func (s *deployRepositorySuite) TestModelTypeMismatchWarningsK8sCharmOnMachineMo
 
 	c.Assert(warnings, tc.HasLen, 1)
 	c.Check(warnings[0], tc.Equals,
-		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine (IAAS) model; its workload will not run`)
+		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine model; its workload will not run`)
 }
 
 func (s *deployRepositorySuite) TestModelTypeMismatchWarningsNilMeta(c *tc.C) {
@@ -247,6 +248,29 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryWarningsSurviveValidatio
 		validator: stubValidator{
 			dt:   deployTemplate{warnings: []string{"a charm/model mismatch warning"}},
 			errs: []error{errors.New("validation failed")},
+		},
+		logger: loggertesting.WrapCheckLog(c),
+	}
+
+	info, _, errs := api.DeployFromRepository(c.Context(), params.DeployFromRepositoryArg{})
+
+	c.Assert(errs, tc.HasLen, 1)
+	c.Check(info.Warnings, tc.DeepEquals, []string{"a charm/model mismatch warning"})
+}
+
+// TestDeployFromRepositoryWarningsSurvivePostValidationError checks that
+// warnings are returned when the deploy fails after validation has already
+// succeeded, e.g. the Kubernetes attach-storage rejection.
+func (s *deployRepositorySuite) TestDeployFromRepositoryWarningsSurvivePostValidationError(c *tc.C) {
+	api := &DeployFromRepositoryAPI{
+		modelType: coremodel.CAAS,
+		validator: stubValidator{
+			dt: deployTemplate{
+				charmURL:      charm.MustParseURL("ch:ubuntu-0"),
+				origin:        corecharm.Origin{Channel: &charm.Channel{Risk: charm.Stable}},
+				attachStorage: []names.StorageTag{names.NewStorageTag("data/0")},
+				warnings:      []string{"a charm/model mismatch warning"},
+			},
 		},
 		logger: loggertesting.WrapCheckLog(c),
 	}

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/tc"
 
 	corecharm "github.com/juju/juju/core/charm"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/deployment/charm"
@@ -175,35 +176,55 @@ func (s *deployRepositorySuite) expectValidator() deployFromRepositoryValidator 
 	return validator
 }
 
-func (s *deployRepositorySuite) TestModelTypeMismatchWarningsK8sCharmOnMachineModel(c *tc.C) {
+func (s *deployRepositorySuite) TestModelTypeMismatchK8sCharmOnMachineModel(c *tc.C) {
 	v := deployFromRepositoryValidator{
 		modelInfo: coremodel.ModelInfo{Type: coremodel.IAAS, Name: "machinemodel"},
 		logger:    loggertesting.WrapCheckLog(c),
 	}
+	// A sidecar charm on a machine model is unambiguous: error.
 	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
-	warnings := v.modelTypeMismatchWarnings(c.Context(), meta)
+	warning, err := v.modelTypeMismatch(c.Context(), meta)
 
-	c.Assert(warnings, tc.HasLen, 1)
-	c.Check(warnings[0], tc.Equals,
-		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine model; its workload will not run`)
+	c.Check(warning, tc.Equals, "")
+	c.Check(err, tc.ErrorIs, coreerrors.NotSupported)
 }
 
-func (s *deployRepositorySuite) TestModelTypeMismatchWarningsNilMeta(c *tc.C) {
+func (s *deployRepositorySuite) TestModelTypeMismatchMachineCharmOnK8sModel(c *tc.C) {
 	v := deployFromRepositoryValidator{
 		modelInfo: coremodel.ModelInfo{Type: coremodel.CAAS, Name: "k8smodel"},
 		logger:    loggertesting.WrapCheckLog(c),
 	}
-	c.Check(v.modelTypeMismatchWarnings(c.Context(), nil), tc.HasLen, 0)
+	// A charm with no containers on a Kubernetes model: warn only.
+	meta := &charm.Meta{Name: "mysql"}
+	warning, err := v.modelTypeMismatch(c.Context(), meta)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(warning, tc.Equals,
+		`"mysql" declares no containers but "k8smodel" is a Kubernetes model; it has no workload to run there`)
 }
 
-func (s *deployRepositorySuite) TestModelTypeMismatchWarningsConsistent(c *tc.C) {
+func (s *deployRepositorySuite) TestModelTypeMismatchNilMeta(c *tc.C) {
 	v := deployFromRepositoryValidator{
 		modelInfo: coremodel.ModelInfo{Type: coremodel.CAAS, Name: "k8smodel"},
 		logger:    loggertesting.WrapCheckLog(c),
 	}
-	// A sidecar charm on a Kubernetes model is consistent: no warning.
+	warning, err := v.modelTypeMismatch(c.Context(), nil)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(warning, tc.Equals, "")
+}
+
+func (s *deployRepositorySuite) TestModelTypeMismatchConsistent(c *tc.C) {
+	v := deployFromRepositoryValidator{
+		modelInfo: coremodel.ModelInfo{Type: coremodel.CAAS, Name: "k8smodel"},
+		logger:    loggertesting.WrapCheckLog(c),
+	}
+	// A sidecar charm on a Kubernetes model is consistent: no warning, no error.
 	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
-	c.Check(v.modelTypeMismatchWarnings(c.Context(), meta), tc.HasLen, 0)
+	warning, err := v.modelTypeMismatch(c.Context(), meta)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(warning, tc.Equals, "")
 }
 
 // TestDeployFromRepositoryReturnsWarningsOnError checks that advisory warnings

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -2450,6 +2450,12 @@
                         },
                         "revision": {
                             "type": "integer"
+                        },
+                        "warnings": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     },
                     "additionalProperties": false,

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -66,6 +66,26 @@ func checkCharmFormat(ctx context.Context, m ModelCommand, charmInfo *apicharms.
 	return nil
 }
 
+// modelTypeMismatchWarning returns a warning when the charm's type (machine vs
+// Kubernetes) does not match the type of model it is being deployed to, or the
+// empty string when they are consistent. It is advisory only.
+func modelTypeMismatchWarning(ctx context.Context, m ModelCommand, meta *charm.Meta) string {
+	if meta == nil {
+		return ""
+	}
+	modelType, err := m.ModelType(ctx)
+	if err != nil {
+		return ""
+	}
+	modelName, _, err := m.ModelDetails(ctx)
+	if err != nil || modelName == "" {
+		// The model name is cosmetic; avoid emitting an empty quoted name.
+		modelName = "the target model"
+	}
+	warning, _ := meta.ModelMismatchWarning(modelType == model.CAAS, modelName)
+	return warning
+}
+
 // deploy is the business logic of deploying a charm after
 // it's been prepared.
 func (d *deployCharm) deploy(
@@ -79,6 +99,12 @@ func (d *deployCharm) deploy(
 	}
 	if err := checkCharmFormat(ctx, d.model, charmInfo); err != nil {
 		return err
+	}
+
+	// Warn (without blocking) if the charm's type does not match the model type,
+	// e.g. a Kubernetes charm on a machine model or vice versa.
+	if warning := modelTypeMismatchWarning(ctx, d.model, charmInfo.Meta); warning != "" {
+		ctx.Warningf("%s", warning)
 	}
 
 	// Check storage on containers is supported.
@@ -378,6 +404,12 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		Storage:          c.storage,
 		Trust:            c.trust,
 	})
+
+	// Surface advisory warnings (e.g. a charm/model-type mismatch) before any
+	// errors, so the user sees the context even when the deploy is rejected.
+	for _, warning := range info.Warnings {
+		ctx.Warningf("%s", warning)
+	}
 
 	for _, err := range errs {
 		ctx.Errorf(err.Error())

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -66,23 +66,24 @@ func checkCharmFormat(ctx context.Context, m ModelCommand, charmInfo *apicharms.
 	return nil
 }
 
-// modelTypeMismatchWarning returns a warning when the charm's type (machine vs
-// Kubernetes) does not match the type of model it is being deployed to, or the
-// empty string when they are consistent. It is advisory only.
-func modelTypeMismatchWarning(ctx context.Context, m ModelCommand, meta *charm.Meta) string {
+// modelTypeMismatch checks the charm's type against the type of the model it
+// is being deployed to: a Kubernetes charm on a machine model is rejected with
+// an error, while a charm declaring no containers on a Kubernetes model only
+// yields an advisory warning.
+func modelTypeMismatch(ctx context.Context, m ModelCommand, meta *charm.Meta) (string, error) {
 	if meta == nil {
-		return ""
+		return "", nil
 	}
 	modelType, err := m.ModelType(ctx)
 	if err != nil {
-		return ""
+		return "", nil
 	}
 	modelName, _, err := m.ModelDetails(ctx)
 	if err != nil || modelName == "" {
 		// The model name is cosmetic; avoid emitting an empty quoted name.
 		modelName = "the target model"
 	}
-	return meta.ModelMismatchWarning(modelType == model.CAAS, modelName)
+	return meta.ModelMismatch(modelType == model.CAAS, modelName)
 }
 
 // deploy is the business logic of deploying a charm after
@@ -96,9 +97,17 @@ func (d *deployCharm) deploy(
 	if err != nil {
 		return err
 	}
-	// Warn (without blocking) if the charm's type does not match the model type,
-	// e.g. a Kubernetes charm on a machine model or vice versa.
-	if warning := modelTypeMismatchWarning(ctx, d.model, charmInfo.Meta); warning != "" {
+	// A Kubernetes charm can never run its workload on a machine model, so it
+	// is rejected outright unless --force is given; the inverse direction
+	// cannot be determined with certainty, so it only warns.
+	warning, mismatchErr := modelTypeMismatch(ctx, d.model, charmInfo.Meta)
+	if mismatchErr != nil {
+		if !d.force {
+			return mismatchErr
+		}
+		ctx.Warningf("%s", mismatchErr.Error())
+	}
+	if warning != "" {
 		ctx.Warningf("%s", warning)
 	}
 

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -82,8 +82,7 @@ func modelTypeMismatchWarning(ctx context.Context, m ModelCommand, meta *charm.M
 		// The model name is cosmetic; avoid emitting an empty quoted name.
 		modelName = "the target model"
 	}
-	warning, _ := meta.ModelMismatchWarning(modelType == model.CAAS, modelName)
-	return warning
+	return meta.ModelMismatchWarning(modelType == model.CAAS, modelName)
 }
 
 // deploy is the business logic of deploying a charm after
@@ -97,14 +96,14 @@ func (d *deployCharm) deploy(
 	if err != nil {
 		return err
 	}
-	if err := checkCharmFormat(ctx, d.model, charmInfo); err != nil {
-		return err
-	}
-
 	// Warn (without blocking) if the charm's type does not match the model type,
 	// e.g. a Kubernetes charm on a machine model or vice versa.
 	if warning := modelTypeMismatchWarning(ctx, d.model, charmInfo.Meta); warning != "" {
 		ctx.Warningf("%s", warning)
+	}
+
+	if err := checkCharmFormat(ctx, d.model, charmInfo); err != nil {
+		return err
 	}
 
 	// Check storage on containers is supported.

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -83,7 +83,7 @@ func (s *charmSuite) TestModelTypeMismatchWarningK8sCharmOnMachineModel(c *tc.C)
 	warning := modelTypeMismatchWarning(c.Context(), m, meta)
 
 	c.Check(warning, tc.Equals,
-		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine (IAAS) model; its workload will not run`)
+		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine model; its workload will not run`)
 }
 
 func (s *charmSuite) TestModelTypeMismatchWarningConsistent(c *tc.C) {

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/cmd/juju/application/deployer/mocks"
 	"github.com/juju/juju/cmd/modelcmd"
 	corebase "github.com/juju/juju/core/base"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/deployment/charm"
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
@@ -72,42 +73,65 @@ func (s *charmSuite) TestSimpleCharmDeploy(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *charmSuite) TestModelTypeMismatchWarningK8sCharmOnMachineModel(c *tc.C) {
+func (s *charmSuite) TestModelTypeMismatchK8sCharmOnMachineModel(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	m := mocks.NewMockModelCommand(ctrl)
 	m.EXPECT().ModelType(gomock.Any()).Return(model.IAAS, nil)
 	m.EXPECT().ModelDetails(gomock.Any()).Return("machinemodel", nil, nil)
 
+	// A sidecar charm on a machine model is unambiguous: error.
 	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
-	warning := modelTypeMismatchWarning(c.Context(), m, meta)
+	warning, err := modelTypeMismatch(c.Context(), m, meta)
 
-	c.Check(warning, tc.Equals,
-		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine model; its workload will not run`)
+	c.Check(warning, tc.Equals, "")
+	c.Check(err, tc.ErrorIs, coreerrors.NotSupported)
 }
 
-func (s *charmSuite) TestModelTypeMismatchWarningConsistent(c *tc.C) {
+func (s *charmSuite) TestModelTypeMismatchMachineCharmOnK8sModel(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	m := mocks.NewMockModelCommand(ctrl)
 	m.EXPECT().ModelType(gomock.Any()).Return(model.CAAS, nil)
 	m.EXPECT().ModelDetails(gomock.Any()).Return("k8smodel", nil, nil)
 
-	// A sidecar charm on a Kubernetes model is consistent: no warning.
-	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
-	c.Check(modelTypeMismatchWarning(c.Context(), m, meta), tc.Equals, "")
+	// A charm with no containers on a Kubernetes model: warn only.
+	meta := &charm.Meta{Name: "mysql"}
+	warning, err := modelTypeMismatch(c.Context(), m, meta)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(warning, tc.Equals,
+		`"mysql" declares no containers but "k8smodel" is a Kubernetes model; it has no workload to run there`)
 }
 
-func (s *charmSuite) TestModelTypeMismatchWarningNilMeta(c *tc.C) {
+func (s *charmSuite) TestModelTypeMismatchConsistent(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	m := mocks.NewMockModelCommand(ctrl)
+	m.EXPECT().ModelType(gomock.Any()).Return(model.CAAS, nil)
+	m.EXPECT().ModelDetails(gomock.Any()).Return("k8smodel", nil, nil)
+
+	// A sidecar charm on a Kubernetes model is consistent: no warning, no error.
+	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
+	warning, err := modelTypeMismatch(c.Context(), m, meta)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(warning, tc.Equals, "")
+}
+
+func (s *charmSuite) TestModelTypeMismatchNilMeta(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	// No expectations: a nil Meta must short-circuit before touching the model.
 	m := mocks.NewMockModelCommand(ctrl)
 
-	c.Check(modelTypeMismatchWarning(c.Context(), m, nil), tc.Equals, "")
+	warning, err := modelTypeMismatch(c.Context(), m, nil)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(warning, tc.Equals, "")
 }
 
-func (s *charmSuite) TestModelTypeMismatchWarningModelNameFallback(c *tc.C) {
+func (s *charmSuite) TestModelTypeMismatchModelNameFallback(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	m := mocks.NewMockModelCommand(ctrl)
@@ -116,10 +140,39 @@ func (s *charmSuite) TestModelTypeMismatchWarningModelNameFallback(c *tc.C) {
 	m.EXPECT().ModelDetails(gomock.Any()).Return("", nil, errors.New("boom"))
 
 	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
-	warning := modelTypeMismatchWarning(c.Context(), m, meta)
+	_, err := modelTypeMismatch(c.Context(), m, meta)
 
-	c.Check(strings.Contains(warning, "the target model"), tc.IsTrue)
-	c.Check(strings.Contains(warning, `""`), tc.IsFalse)
+	c.Assert(err, tc.NotNil)
+	c.Check(strings.Contains(err.Error(), "the target model"), tc.IsTrue)
+	c.Check(strings.Contains(err.Error(), `""`), tc.IsFalse)
+}
+
+func (s *charmSuite) TestDeployK8sCharmOnMachineModelRejected(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// The model type from setupMocks is IAAS; a charm declaring containers
+	// must be rejected before the deploy is attempted.
+	s.charmInfo.Meta.Containers = map[string]charm.Container{"redis": {}}
+
+	err := s.newDeployCharm().deploy(s.ctx, s.deployerAPI)
+	c.Check(err, tc.ErrorIs, coreerrors.NotSupported)
+}
+
+func (s *charmSuite) TestDeployK8sCharmOnMachineModelForced(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	s.modelCommand.EXPECT().Filesystem().Return(s.filesystem).AnyTimes()
+	s.configFlag.EXPECT().AbsoluteFileNames(gomock.Any()).Return(nil, nil)
+	s.configFlag.EXPECT().ReadConfigPairs(gomock.Any()).Return(nil, nil)
+	s.deployerAPI.EXPECT().Deploy(gomock.Any(), gomock.Any()).Return(nil)
+
+	// With --force the rejection is downgraded to a warning and the deploy
+	// proceeds.
+	s.charmInfo.Meta.Containers = map[string]charm.Container{"redis": {}}
+	dCharm := s.newDeployCharm()
+	dCharm.force = true
+
+	err := dCharm.deploy(s.ctx, s.deployerAPI)
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *charmSuite) TestRepositoryCharmDeployDryRunDefaultSeriesForce(c *tc.C) {

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -6,6 +6,7 @@ package deployer
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/canonical/gomock/gomock"
@@ -69,6 +70,56 @@ func (s *charmSuite) TestSimpleCharmDeploy(c *tc.C) {
 
 	err := s.newDeployCharm().deploy(s.ctx, s.deployerAPI)
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *charmSuite) TestModelTypeMismatchWarningK8sCharmOnMachineModel(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	m := mocks.NewMockModelCommand(ctrl)
+	m.EXPECT().ModelType(gomock.Any()).Return(model.IAAS, nil)
+	m.EXPECT().ModelDetails(gomock.Any()).Return("machinemodel", nil, nil)
+
+	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
+	warning := modelTypeMismatchWarning(c.Context(), m, meta)
+
+	c.Check(warning, tc.Equals,
+		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine (IAAS) model; its workload will not run`)
+}
+
+func (s *charmSuite) TestModelTypeMismatchWarningConsistent(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	m := mocks.NewMockModelCommand(ctrl)
+	m.EXPECT().ModelType(gomock.Any()).Return(model.CAAS, nil)
+	m.EXPECT().ModelDetails(gomock.Any()).Return("k8smodel", nil, nil)
+
+	// A sidecar charm on a Kubernetes model is consistent: no warning.
+	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
+	c.Check(modelTypeMismatchWarning(c.Context(), m, meta), tc.Equals, "")
+}
+
+func (s *charmSuite) TestModelTypeMismatchWarningNilMeta(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	// No expectations: a nil Meta must short-circuit before touching the model.
+	m := mocks.NewMockModelCommand(ctrl)
+
+	c.Check(modelTypeMismatchWarning(c.Context(), m, nil), tc.Equals, "")
+}
+
+func (s *charmSuite) TestModelTypeMismatchWarningModelNameFallback(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	m := mocks.NewMockModelCommand(ctrl)
+	m.EXPECT().ModelType(gomock.Any()).Return(model.IAAS, nil)
+	// ModelDetails failing must not produce an empty quoted model name.
+	m.EXPECT().ModelDetails(gomock.Any()).Return("", nil, errors.New("boom"))
+
+	meta := &charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
+	warning := modelTypeMismatchWarning(c.Context(), m, meta)
+
+	c.Check(strings.Contains(warning, "the target model"), tc.IsTrue)
+	c.Check(strings.Contains(warning, `""`), tc.IsFalse)
 }
 
 func (s *charmSuite) TestRepositoryCharmDeployDryRunDefaultSeriesForce(c *tc.C) {
@@ -271,6 +322,7 @@ func (s *charmSuite) setupMocks(c *tc.C) *gomock.Controller {
 
 	s.modelCommand = mocks.NewMockModelCommand(ctrl)
 	s.modelCommand.EXPECT().ModelType(gomock.Any()).Return(model.IAAS, nil).AnyTimes()
+	s.modelCommand.EXPECT().ModelDetails(gomock.Any()).Return("test-model", nil, nil).AnyTimes()
 	s.configFlag = mocks.NewMockDeployConfigFlag(ctrl)
 	return ctrl
 }

--- a/domain/deployment/charm/charm.go
+++ b/domain/deployment/charm/charm.go
@@ -55,7 +55,7 @@ func metaFormatReasons(ch CharmMeta) (Format, []FormatSelectionReason) {
 		}
 	}
 
-	if len(ch.Meta().Containers) > 0 {
+	if ch.Meta().IsSidecar() {
 		reasons.Add(SelectionContainers)
 	}
 

--- a/domain/deployment/charm/meta.go
+++ b/domain/deployment/charm/meta.go
@@ -287,26 +287,27 @@ func (m Meta) IsSidecar() bool {
 	return len(m.Containers) > 0
 }
 
-// ModelMismatchWarning returns a user-facing warning, and true, when the charm's
-// type does not match the type of model it is being deployed to:
+// ModelMismatchWarning returns a user-facing warning when the charm's type
+// does not match the type of model it is being deployed to:
 //   - a Kubernetes (sidecar) charm deployed to a machine model, or
 //   - a charm declaring no containers deployed to a Kubernetes model.
 //
 // Subordinate charms declare no containers but are machine charms by nature, so
-// they are never flagged on a Kubernetes model. It returns ("", false) when the
-// placement is consistent. This is messaging-only and never blocks a deploy.
-func (m Meta) ModelMismatchWarning(isCAAS bool, modelName string) (string, bool) {
+// they are never flagged on a Kubernetes model. It returns the empty string
+// when the placement is consistent. This is messaging-only and never blocks a
+// deploy.
+func (m Meta) ModelMismatchWarning(isK8s bool, modelName string) string {
 	switch {
-	case !isCAAS && m.IsSidecar():
+	case !isK8s && m.IsSidecar():
 		return fmt.Sprintf(
-			"%q is a Kubernetes charm (it declares containers) but %q is a machine (IAAS) model; its workload will not run",
-			m.Name, modelName), true
-	case isCAAS && !m.IsSidecar() && !m.Subordinate:
+			"%q is a Kubernetes charm (it declares containers) but %q is a machine model; its workload will not run",
+			m.Name, modelName)
+	case isK8s && !m.IsSidecar() && !m.Subordinate:
 		return fmt.Sprintf(
-			"%q declares no containers but %q is a Kubernetes (CAAS) model; it has no workload to run there",
-			m.Name, modelName), true
+			"%q declares no containers but %q is a Kubernetes model; it has no workload to run there",
+			m.Name, modelName)
 	}
-	return "", false
+	return ""
 }
 
 // Container specifies the possible systems it supports and mounts it wants.

--- a/domain/deployment/charm/meta.go
+++ b/domain/deployment/charm/meta.go
@@ -279,6 +279,36 @@ type Meta struct {
 	CharmUser  RunAs                   `json:"charm-user,omitempty" yaml:"charm-user,omitempty"`
 }
 
+// IsSidecar reports whether the charm is a Kubernetes (sidecar) charm, i.e. it
+// declares one or more workload containers. This mirrors the model's own
+// authoritative SupportsContainers check, which counts container rows, so an
+// empty `containers: {}` block (no workload) is not a sidecar charm.
+func (m Meta) IsSidecar() bool {
+	return len(m.Containers) > 0
+}
+
+// ModelMismatchWarning returns a user-facing warning, and true, when the charm's
+// type does not match the type of model it is being deployed to:
+//   - a Kubernetes (sidecar) charm deployed to a machine model, or
+//   - a charm declaring no containers deployed to a Kubernetes model.
+//
+// Subordinate charms declare no containers but are machine charms by nature, so
+// they are never flagged on a Kubernetes model. It returns ("", false) when the
+// placement is consistent. This is messaging-only and never blocks a deploy.
+func (m Meta) ModelMismatchWarning(isCAAS bool, modelName string) (string, bool) {
+	switch {
+	case !isCAAS && m.IsSidecar():
+		return fmt.Sprintf(
+			"%q is a Kubernetes charm (it declares containers) but %q is a machine (IAAS) model; its workload will not run",
+			m.Name, modelName), true
+	case isCAAS && !m.IsSidecar() && !m.Subordinate:
+		return fmt.Sprintf(
+			"%q declares no containers but %q is a Kubernetes (CAAS) model; it has no workload to run there",
+			m.Name, modelName), true
+	}
+	return "", false
+}
+
 // Container specifies the possible systems it supports and mounts it wants.
 type Container struct {
 	Resource string  `json:"resource,omitempty" yaml:"resource,omitempty"`

--- a/domain/deployment/charm/meta.go
+++ b/domain/deployment/charm/meta.go
@@ -287,27 +287,29 @@ func (m Meta) IsSidecar() bool {
 	return len(m.Containers) > 0
 }
 
-// ModelMismatchWarning returns a user-facing warning when the charm's type
-// does not match the type of model it is being deployed to:
-//   - a Kubernetes (sidecar) charm deployed to a machine model, or
-//   - a charm declaring no containers deployed to a Kubernetes model.
-//
-// Subordinate charms declare no containers but are machine charms by nature, so
-// they are never flagged on a Kubernetes model. It returns the empty string
-// when the placement is consistent. This is messaging-only and never blocks a
-// deploy.
-func (m Meta) ModelMismatchWarning(isK8s bool, modelName string) string {
+// ModelMismatch checks the charm's type against the type of the model it is
+// being deployed to. A Kubernetes (sidecar) charm deployed to a machine model
+// is unambiguous — its declared workload containers can never run — so it is
+// rejected. A charm declaring no containers deployed to a Kubernetes model
+// cannot be classified with certainty (charm metadata has no positive machine
+// charm marker), so it yields an advisory warning instead; subordinate charms
+// declare no containers but are machine charms by nature and are never
+// flagged. Both returns are empty when the placement is consistent.
+// The following errors may be returned:
+//   - [coreerrors.NotSupported] when a Kubernetes charm is deployed to a
+//     machine model.
+func (m Meta) ModelMismatch(isK8s bool, modelName string) (string, error) {
 	switch {
 	case !isK8s && m.IsSidecar():
-		return fmt.Sprintf(
+		return "", internalerrors.Errorf(
 			"%q is a Kubernetes charm (it declares containers) but %q is a machine model; its workload will not run",
-			m.Name, modelName)
+			m.Name, modelName).Add(coreerrors.NotSupported)
 	case isK8s && !m.IsSidecar() && !m.Subordinate:
 		return fmt.Sprintf(
 			"%q declares no containers but %q is a Kubernetes model; it has no workload to run there",
-			m.Name, modelName)
+			m.Name, modelName), nil
 	}
-	return ""
+	return "", nil
 }
 
 // Container specifies the possible systems it supports and mounts it wants.

--- a/domain/deployment/charm/meta_test.go
+++ b/domain/deployment/charm/meta_test.go
@@ -53,34 +53,46 @@ func (s *MetaSuite) TestIsSidecar(c *tc.C) {
 	c.Check(emptyContainers.IsSidecar(), tc.IsFalse)
 }
 
-func (s *MetaSuite) TestModelMismatchWarningK8sCharmOnMachineModel(c *tc.C) {
-	// A sidecar charm deployed to a machine model: warn.
+func (s *MetaSuite) TestModelMismatchK8sCharmOnMachineModel(c *tc.C) {
+	// A sidecar charm deployed to a machine model is unambiguous: error.
 	meta := charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
-	c.Check(meta.ModelMismatchWarning(false, "machinemodel"), tc.Equals,
-		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine model; its workload will not run`)
+	warning, err := meta.ModelMismatch(false, "machinemodel")
+	c.Check(warning, tc.Equals, "")
+	c.Check(err, tc.ErrorIs, coreerrors.NotSupported)
+	c.Check(err, tc.ErrorMatches,
+		`"redis-k8s" is a Kubernetes charm \(it declares containers\) but "machinemodel" is a machine model; its workload will not run`)
 }
 
-func (s *MetaSuite) TestModelMismatchWarningMachineCharmOnK8sModel(c *tc.C) {
-	// A charm with no containers deployed to a Kubernetes model: warn.
+func (s *MetaSuite) TestModelMismatchMachineCharmOnK8sModel(c *tc.C) {
+	// A charm with no containers deployed to a Kubernetes model cannot be
+	// classified with certainty: warn only.
 	meta := charm.Meta{Name: "mysql"}
-	c.Check(meta.ModelMismatchWarning(true, "k8smodel"), tc.Equals,
+	warning, err := meta.ModelMismatch(true, "k8smodel")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(warning, tc.Equals,
 		`"mysql" declares no containers but "k8smodel" is a Kubernetes model; it has no workload to run there`)
 }
 
-func (s *MetaSuite) TestModelMismatchWarningNoMismatch(c *tc.C) {
+func (s *MetaSuite) TestModelMismatchNone(c *tc.C) {
 	sidecar := charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
 	machine := charm.Meta{Name: "mysql"}
 
-	// Correct placements produce no warning.
-	c.Check(sidecar.ModelMismatchWarning(true, "k8smodel"), tc.Equals, "")
-	c.Check(machine.ModelMismatchWarning(false, "machinemodel"), tc.Equals, "")
+	// Correct placements produce no warning and no error.
+	warning, err := sidecar.ModelMismatch(true, "k8smodel")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(warning, tc.Equals, "")
+	warning, err = machine.ModelMismatch(false, "machinemodel")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(warning, tc.Equals, "")
 }
 
-func (s *MetaSuite) TestModelMismatchWarningSubordinateNotWarnedOnK8s(c *tc.C) {
+func (s *MetaSuite) TestModelMismatchSubordinateNotWarnedOnK8s(c *tc.C) {
 	// Subordinates declare no containers but are machine charms by nature; they
 	// must not be flagged as "machine charm on k8s".
 	sub := charm.Meta{Name: "nrpe", Subordinate: true}
-	c.Check(sub.ModelMismatchWarning(true, "k8smodel"), tc.Equals, "")
+	warning, err := sub.ModelMismatch(true, "k8smodel")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(warning, tc.Equals, "")
 }
 
 func (s *MetaSuite) TestReadMetaVersion1(c *tc.C) {

--- a/domain/deployment/charm/meta_test.go
+++ b/domain/deployment/charm/meta_test.go
@@ -54,43 +54,33 @@ func (s *MetaSuite) TestIsSidecar(c *tc.C) {
 }
 
 func (s *MetaSuite) TestModelMismatchWarningK8sCharmOnMachineModel(c *tc.C) {
-	// A sidecar charm deployed to a machine (IAAS) model: warn.
+	// A sidecar charm deployed to a machine model: warn.
 	meta := charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
-	warning, mismatched := meta.ModelMismatchWarning(false, "machinemodel")
-	c.Check(mismatched, tc.IsTrue)
-	c.Check(warning, tc.Equals,
-		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine (IAAS) model; its workload will not run`)
+	c.Check(meta.ModelMismatchWarning(false, "machinemodel"), tc.Equals,
+		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine model; its workload will not run`)
 }
 
 func (s *MetaSuite) TestModelMismatchWarningMachineCharmOnK8sModel(c *tc.C) {
-	// A charm with no containers deployed to a Kubernetes (CAAS) model: warn.
+	// A charm with no containers deployed to a Kubernetes model: warn.
 	meta := charm.Meta{Name: "mysql"}
-	warning, mismatched := meta.ModelMismatchWarning(true, "k8smodel")
-	c.Check(mismatched, tc.IsTrue)
-	c.Check(warning, tc.Equals,
-		`"mysql" declares no containers but "k8smodel" is a Kubernetes (CAAS) model; it has no workload to run there`)
+	c.Check(meta.ModelMismatchWarning(true, "k8smodel"), tc.Equals,
+		`"mysql" declares no containers but "k8smodel" is a Kubernetes model; it has no workload to run there`)
 }
 
 func (s *MetaSuite) TestModelMismatchWarningNoMismatch(c *tc.C) {
 	sidecar := charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
 	machine := charm.Meta{Name: "mysql"}
 
-	// Correct placements produce no warning and an empty message.
-	warning, mismatched := sidecar.ModelMismatchWarning(true, "k8smodel") // sidecar on CAAS
-	c.Check(mismatched, tc.IsFalse)
-	c.Check(warning, tc.Equals, "")
-	warning, mismatched = machine.ModelMismatchWarning(false, "machinemodel") // machine on IAAS
-	c.Check(mismatched, tc.IsFalse)
-	c.Check(warning, tc.Equals, "")
+	// Correct placements produce no warning.
+	c.Check(sidecar.ModelMismatchWarning(true, "k8smodel"), tc.Equals, "")
+	c.Check(machine.ModelMismatchWarning(false, "machinemodel"), tc.Equals, "")
 }
 
 func (s *MetaSuite) TestModelMismatchWarningSubordinateNotWarnedOnK8s(c *tc.C) {
 	// Subordinates declare no containers but are machine charms by nature; they
 	// must not be flagged as "machine charm on k8s".
 	sub := charm.Meta{Name: "nrpe", Subordinate: true}
-	warning, mismatched := sub.ModelMismatchWarning(true, "k8smodel")
-	c.Check(mismatched, tc.IsFalse)
-	c.Check(warning, tc.Equals, "")
+	c.Check(sub.ModelMismatchWarning(true, "k8smodel"), tc.Equals, "")
 }
 
 func (s *MetaSuite) TestReadMetaVersion1(c *tc.C) {

--- a/domain/deployment/charm/meta_test.go
+++ b/domain/deployment/charm/meta_test.go
@@ -38,6 +38,61 @@ func TestMetaSuite(t *testing.T) {
 	tc.Run(t, &MetaSuite{})
 }
 
+func (s *MetaSuite) TestIsSidecar(c *tc.C) {
+	// A charm that declares a workload container is a Kubernetes/sidecar charm.
+	withContainer := charm.Meta{Containers: map[string]charm.Container{"workload": {}}}
+	c.Check(withContainer.IsSidecar(), tc.IsTrue)
+
+	// A charm with no containers block is a machine charm.
+	c.Check(charm.Meta{}.IsSidecar(), tc.IsFalse)
+
+	// An empty `containers: {}` block declares no workload containers. juju's own
+	// SupportsContainers counts container rows, so an empty map is not a sidecar
+	// charm and must classify the same way (durable across the store round-trip).
+	emptyContainers := charm.Meta{Containers: map[string]charm.Container{}}
+	c.Check(emptyContainers.IsSidecar(), tc.IsFalse)
+}
+
+func (s *MetaSuite) TestModelMismatchWarningK8sCharmOnMachineModel(c *tc.C) {
+	// A sidecar charm deployed to a machine (IAAS) model: warn.
+	meta := charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
+	warning, mismatched := meta.ModelMismatchWarning(false, "machinemodel")
+	c.Check(mismatched, tc.IsTrue)
+	c.Check(warning, tc.Equals,
+		`"redis-k8s" is a Kubernetes charm (it declares containers) but "machinemodel" is a machine (IAAS) model; its workload will not run`)
+}
+
+func (s *MetaSuite) TestModelMismatchWarningMachineCharmOnK8sModel(c *tc.C) {
+	// A charm with no containers deployed to a Kubernetes (CAAS) model: warn.
+	meta := charm.Meta{Name: "mysql"}
+	warning, mismatched := meta.ModelMismatchWarning(true, "k8smodel")
+	c.Check(mismatched, tc.IsTrue)
+	c.Check(warning, tc.Equals,
+		`"mysql" declares no containers but "k8smodel" is a Kubernetes (CAAS) model; it has no workload to run there`)
+}
+
+func (s *MetaSuite) TestModelMismatchWarningNoMismatch(c *tc.C) {
+	sidecar := charm.Meta{Name: "redis-k8s", Containers: map[string]charm.Container{"redis": {}}}
+	machine := charm.Meta{Name: "mysql"}
+
+	// Correct placements produce no warning and an empty message.
+	warning, mismatched := sidecar.ModelMismatchWarning(true, "k8smodel") // sidecar on CAAS
+	c.Check(mismatched, tc.IsFalse)
+	c.Check(warning, tc.Equals, "")
+	warning, mismatched = machine.ModelMismatchWarning(false, "machinemodel") // machine on IAAS
+	c.Check(mismatched, tc.IsFalse)
+	c.Check(warning, tc.Equals, "")
+}
+
+func (s *MetaSuite) TestModelMismatchWarningSubordinateNotWarnedOnK8s(c *tc.C) {
+	// Subordinates declare no containers but are machine charms by nature; they
+	// must not be flagged as "machine charm on k8s".
+	sub := charm.Meta{Name: "nrpe", Subordinate: true}
+	warning, mismatched := sub.ModelMismatchWarning(true, "k8smodel")
+	c.Check(mismatched, tc.IsFalse)
+	c.Check(warning, tc.Equals, "")
+}
+
 func (s *MetaSuite) TestReadMetaVersion1(c *tc.C) {
 	meta, err := charm.ReadMeta(repoMeta(c, "dummy"))
 	c.Assert(err, tc.IsNil)

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -683,6 +683,9 @@ type DeployFromRepositoryInfo struct {
 	Name string `json:"name"`
 	// Revision is the revision of the charm deployed.
 	Revision int `json:"revision"`
+	// Warnings holds advisory, non-blocking messages about the deployment
+	// (e.g. a charm/model-type mismatch) for the client to surface to the user.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // PendingResourceUpload holds data required to upload a


### PR DESCRIPTION
Deploying a Kubernetes (sidecar) charm to a machine model, or a machine charm
to a Kubernetes model, is not something Juju guards against. Unless the charm
declares `assumes: k8s-api`, both directions deploy cleanly and then break
silently: the unit starts but the workload never runs. When the deploy does
fail, it fails on an incidental check — typically `block storage "..." is not
supported for container charms` — which never mentions the actual problem.

At deploy time the charm is resolved but not yet persisted, so state-backed
checks are unusable on both the client and the apiserver. Charm metadata is
the only available signal, and it has no positive "machine charm" marker; what
it does have is containers:

- `Meta.IsSidecar` and `Meta.ModelMismatch` classify the charm and build the
  rejection or warning. `IsSidecar` matches the row-counting semantics of the
  model's `SupportsContainers` check, so an empty `containers: {}` block is
  not a sidecar charm, and subordinates — machine charms with no containers
  by nature — are never flagged.
- The `DeployFromRepository` result gains an additive `Warnings` field:
  charmhub deploys resolve server side, and the result previously carried
  nothing short of an error back to the user. Warnings are also logged on the
  controller for API clients that do not render results. **The major change
  is in eaa13acea0.**
- The CLI prints the warning: directly for local charm deploys, and from the
  returned `Warnings` — ahead of any errors — for charmhub deploys.

Before this change a mismatched deploy produced silence or a misleading
error. After it, both paths print, for example:

```
WARNING "juju-norma" declares no containers but "mymodel" is a Kubernetes model; it has no workload to run there
```

Per review, the two directions are treated differently. A Kubernetes charm
on a machine model is unambiguous — the declared containers can never run —
so it is now rejected with a not-supported error (`--force` downgrades the
rejection to a warning, mirroring the existing `assumes` behaviour). The
machine-charm-on-Kubernetes direction is inferential (charm metadata has no
positive machine-charm marker), so it remains an advisory warning.

`APIBase.DeployFromRepository` previously set a result's `Info` only on
success, which would have dropped the warnings for rejected deploys; it is
now set unconditionally.

**Bundle deploys are not instrumented** — a mismatched charm inside a bundle
does not warn. The bundle seam is deliberate follow-up scope.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~ (advisory output only; unit tests cover all three layers, manual QA below)
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~ (no new packages)

## QA steps

Machine charm on a Kubernetes model (charmhub deploy):

```sh
$ juju add-model k8stest
$ juju deploy juju-norma -m k8stest
WARNING "juju-norma" declares no containers but "k8stest" is a Kubernetes model; it has no workload to run there
ERROR block storage "blk" is not supported for container charms
ERROR failed to deploy charm "juju-norma"
```

Kubernetes charm on a machine model (local charm deploy):

```sh
$ juju deploy ./juju-norma-k8s_*.charm -m lxdtest
ERROR "juju-norma-k8s" is a Kubernetes charm (it declares containers) but "lxdtest" is a machine model; its workload will not run
$ juju deploy ./juju-norma-k8s_*.charm -m lxdtest --force   # proceeds with a warning
```

Correct placements emit no warning:

```sh
$ juju deploy juju-norma -m lxdtest
$ juju deploy juju-norma-k8s -m k8stest
```

The controller log carries the same warning for non-CLI clients:

```sh
$ juju debug-log -m controller --include-module juju.apiserver.deployfromrepo
```

Facade change (additive `Warnings` result field), so model migration was
verified:

```sh
$ juju bootstrap lxd src36            # 3.6.24
$ juju add-model moveme1 && juju deploy juju-qa-test
$ juju bootstrap lxd dst40            # this branch, --build-agent
$ juju migrate src36:moveme1 dst40 && juju add-unit juju-qa-test
$ juju debug-log -m dst40:controller && juju debug-log -m dst40:moveme1
```

The model migrated, the added unit came up active, and the only ERROR-level
log lines are the standard migration-cutover watcher shutdowns and the
fresh machine's "container types not yet available" transient; nothing
references the new field or the application facade.

**The 4.0 to 4.0 leg cannot currently be exercised: it is broken on the 4.0
branch itself, independent of this change.** The source side of the
password-to-macaroon exchange landed on 4.0 in #22675 and requires
MigrationTarget v8 on the target (internal/migration/auth.go:42), but the
target-side v8 facade landed on main only (#22655, #22674) and has not been
backported, so any password-authenticated 4.0 to 4.0 migration fails at
precheck with "target controller is too old...". This PR touches no
migration, auth or facade-registration files; the leg will be re-run once
v8 reaches 4.0.

## Documentation changes

~None — advisory warning only; the `Warnings` result field is additive and no
CLI flags or command shapes change.~

## Links

**Jira card:** [JUJU-10101](https://warthogs.atlassian.net/browse/JUJU-10101)


[JUJU-10101]: https://warthogs.atlassian.net/browse/JUJU-10101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ