### PR TITLE
fix(migration): correct swapped lease key fields in leadership import

### DIFF
--- a/domain/lease/modelmigration/import.go
+++ b/domain/lease/modelmigration/import.go
@@ -74,8 +74,8 @@ func (o *importOperation) Execute(ctx context.Context, model description.Model) 
 
 		key := lease.Key{
 			ModelUUID: model.UUID(),
-			Namespace: app.Name(),
-			Lease:     lease.ApplicationLeadershipNamespace,
+			Namespace: lease.ApplicationLeadershipNamespace,
+			Lease:     app.Name(),
 		}
 		req := lease.Request{
 			Holder:   app.Leader(),

--- a/domain/lease/modelmigration/import_test.go
+++ b/domain/lease/modelmigration/import_test.go
@@ -84,8 +84,8 @@ func (s *importSuite) TestExecuteWithApplications(c *tc.C) {
 	// Expected lease.
 	key := lease.Key{
 		ModelUUID: uuid,
-		Namespace: "postgresql",
-		Lease:     lease.ApplicationLeadershipNamespace,
+		Namespace: lease.ApplicationLeadershipNamespace,
+		Lease:     "postgresql",
 	}
 	req := lease.Request{
 		Holder:   "postgresql/0",
@@ -121,8 +121,8 @@ func (s *importSuite) TestExecuteWithMultipleApplications(c *tc.C) {
 	// Expected lease.
 	key := lease.Key{
 		ModelUUID: uuid,
-		Namespace: "postgresql",
-		Lease:     lease.ApplicationLeadershipNamespace,
+		Namespace: lease.ApplicationLeadershipNamespace,
+		Lease:     "postgresql",
 	}
 	req := lease.Request{
 		Holder:   "postgresql/0",
@@ -133,8 +133,8 @@ func (s *importSuite) TestExecuteWithMultipleApplications(c *tc.C) {
 
 	key = lease.Key{
 		ModelUUID: uuid,
-		Namespace: "wordpress",
-		Lease:     lease.ApplicationLeadershipNamespace,
+		Namespace: lease.ApplicationLeadershipNamespace,
+		Lease:     "wordpress",
 	}
 	req = lease.Request{
 		Holder:   "wordpress/1",
@@ -166,7 +166,7 @@ func (s *importSuite) TestExecuteWithError(c *tc.C) {
 	s.service.EXPECT().ClaimLease(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("boom"))
 
 	err := op.Execute(c.Context(), model)
-	c.Assert(err, tc.ErrorMatches, `claiming lease for {"postgresql" "`+uuid+`" "application-leadership"}: boom`)
+	c.Assert(err, tc.ErrorMatches, `claiming lease for {"application-leadership" "`+uuid+`" "postgresql"}: boom`)
 }
 
 func (s *importSuite) setupMocks(c *tc.C) *gomock.Controller {


### PR DESCRIPTION
During model import, `lease.Key` was built with its `Namespace` and `Lease` fields transposed, so `ClaimLease` matched no lease type and silently inserted nothing (a zero-row insert returns no error). 
Application leadership was never imported, so the target elected a fresh, unrelated leader instead of the source's.

Fixed simply by addressing this swap.

## QA steps

Bootstrap a 3.6 source controller and a 4.0 (this branch) target. 
On the source, create a model with a HA ubuntu app:

```
$ juju_36 add-model m
$ juju_36 deploy ubuntu -n3
# wait until active
$ juju_36 migrate m tgt
```
On the target, the migrated model should keep the same unit as leader:
```
$ juju status
 Model  Controller  Cloud/Region         Version      Timestamp
  m      tgt         localhost/localhost  4.0.12  22:06:34+02:00

  App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
  ubuntu  24.04    active    3/3  ubuntu  latest/stable   26  no

  Unit       Workload  Agent  Machine  Public address  Ports  Message
  ubuntu/0   active    idle   0        10.134.1.76
  ubuntu/1   active    idle   1        10.134.1.201           
  ubuntu/2*  active    idle   2        10.134.1.189

  Machine  State    Address       Inst id        Base          AZ                                Message
  0        started  10.134.1.76   juju-d0aa45-0  ubuntu@24.04  nvinuesa-ThinkPad-P16s-Gen-4-AMD  Running
  1        started  10.134.1.201  juju-d0aa45-1  ubuntu@24.04  nvinuesa-ThinkPad-P16s-Gen-4-AMD  Running
  2        started  10.134.1.189  juju-d0aa45-2  ubuntu@24.04  nvinuesa-ThinkPad-P16s-Gen-4-AMD  Running
```
