### PR TITLE
feat: add headless service for k8s controller statefulset

### DIFF
--- a/internal/provider/kubernetes/application/application.go
+++ b/internal/provider/kubernetes/application/application.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/pointer"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/annotations"
@@ -320,7 +319,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 
 		var numPods *int32
 		if !exists {
-			numPods = pointer.Int32(int32(config.InitialScale))
+			numPods = new(int32(config.InitialScale))
 		}
 
 		var volumeClaimTemplates []corev1.PersistentVolumeClaim
@@ -387,7 +386,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 
 		var numPods *int32
 		if !exists {
-			numPods = pointer.Int32(int32(config.InitialScale))
+			numPods = new(int32(config.InitialScale))
 		}
 		// Config storage to update the podspec with storage info.
 		if err = a.configureStorage(
@@ -490,7 +489,7 @@ func (a *app) applyServiceAccountAndSecrets(applier resources.Applier, config ca
 			Labels:      a.labels(),
 			Annotations: a.annotations(config),
 		},
-		AutomountServiceAccountToken: pointer.Bool(false),
+		AutomountServiceAccountToken: new(false),
 	}
 	serviceAccount := resources.NewServiceAccount(a.client.CoreV1().ServiceAccounts(a.namespace), a.namespace, a.serviceAccountName(), sa)
 	applier.Apply(serviceAccount)
@@ -704,10 +703,26 @@ func HeadlessServiceName(appName string) string {
 	return fmt.Sprintf("%s-endpoints", appName)
 }
 
+// IsManagedHeadlessService reports whether the given service is a Juju-managed
+// headless service that exists solely to provide stable per-pod DNS
+// (endpoints) for a StatefulSet's pods. Such services carry no routable
+// address of their own and must be excluded when resolving an application's
+// primary service. Detection prefers the LabelJujuServiceType label and falls
+// back to the legacy "-endpoints" name suffix for services created before the
+// label existed.
+func IsManagedHeadlessService(svc corev1.Service) bool {
+	if svc.Labels[constants.LabelJujuServiceType] == constants.ServiceTypeEndpoints {
+		return true
+	}
+	return strings.HasSuffix(svc.Name, "-endpoints")
+}
+
 func (a *app) configureHeadlessService(name string, annotation annotations.Annotation) error {
 	svc := resources.NewService(a.client.CoreV1().Services(a.namespace), a.namespace, HeadlessServiceName(name), &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: a.labels(),
+			Labels: utils.LabelsMerge(a.labels(), labels.Set{
+				constants.LabelJujuServiceType: constants.ServiceTypeEndpoints,
+			}),
 			Annotations: annotation.
 				Add("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true"),
 		},
@@ -1826,19 +1841,19 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		switch config.CharmUser {
 		case caas.RunAsRoot:
 			charmContainer.SecurityContext = &corev1.SecurityContext{
-				RunAsUser:  pointer.Int64(0),
-				RunAsGroup: pointer.Int64(0),
+				RunAsUser:  new(int64(0)),
+				RunAsGroup: new(int64(0)),
 			}
 		case caas.RunAsSudoer:
 			charmContainer.SecurityContext = &corev1.SecurityContext{
-				RunAsUser:  pointer.Int64(constants.JujuSudoUserID),
-				RunAsGroup: pointer.Int64(constants.JujuSudoGroupID),
+				RunAsUser:  new(constants.JujuSudoUserID),
+				RunAsGroup: new(constants.JujuSudoGroupID),
 			}
 			pebbleIdentitiesEnabled = true
 		case caas.RunAsNonRoot:
 			charmContainer.SecurityContext = &corev1.SecurityContext{
-				RunAsUser:  pointer.Int64(constants.JujuUserID),
-				RunAsGroup: pointer.Int64(constants.JujuGroupID),
+				RunAsUser:  new(constants.JujuUserID),
+				RunAsGroup: new(constants.JujuGroupID),
 			}
 			pebbleIdentitiesEnabled = true
 		}
@@ -1847,8 +1862,8 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 	} else {
 		// Pre-3.5 logic.
 		charmContainer.SecurityContext = &corev1.SecurityContext{
-			RunAsUser:  pointer.Int64(0),
-			RunAsGroup: pointer.Int64(0),
+			RunAsUser:  new(int64(0)),
+			RunAsGroup: new(int64(0)),
 		}
 	}
 
@@ -1933,16 +1948,16 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		if requireSecurityContext {
 			container.SecurityContext = &corev1.SecurityContext{}
 			if v.Uid != nil {
-				container.SecurityContext.RunAsUser = pointer.Int64(int64(*v.Uid))
+				container.SecurityContext.RunAsUser = new(int64(*v.Uid))
 			}
 			if v.Gid != nil {
-				container.SecurityContext.RunAsGroup = pointer.Int64(int64(*v.Gid))
+				container.SecurityContext.RunAsGroup = new(int64(*v.Gid))
 			}
 		} else {
 			// Pre-3.5 logic.
 			container.SecurityContext = &corev1.SecurityContext{
-				RunAsUser:  pointer.Int64(0),
-				RunAsGroup: pointer.Int64(0),
+				RunAsUser:  new(int64(0)),
+				RunAsGroup: new(int64(0)),
 			}
 		}
 		if pebbleIdentitiesEnabled {
@@ -2003,9 +2018,9 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		uid := 0
 		switch config.CharmUser {
 		case caas.RunAsSudoer:
-			uid = constants.JujuSudoUserID
+			uid = int(constants.JujuSudoUserID)
 		case caas.RunAsNonRoot:
-			uid = constants.JujuUserID
+			uid = int(constants.JujuUserID)
 		}
 		containerAgentArgs = append(containerAgentArgs, "--pebble-charm-identity", strconv.Itoa(uid))
 	}
@@ -2071,18 +2086,18 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		switch config.CharmUser {
 		case caas.RunAsRoot:
 			charmInitContainer.SecurityContext = &corev1.SecurityContext{
-				RunAsUser:  pointer.Int64(0),
-				RunAsGroup: pointer.Int64(0),
+				RunAsUser:  new(int64(0)),
+				RunAsGroup: new(int64(0)),
 			}
 		case caas.RunAsSudoer:
 			charmInitContainer.SecurityContext = &corev1.SecurityContext{
-				RunAsUser:  pointer.Int64(constants.JujuSudoUserID),
-				RunAsGroup: pointer.Int64(constants.JujuSudoGroupID),
+				RunAsUser:  new(constants.JujuSudoUserID),
+				RunAsGroup: new(constants.JujuSudoGroupID),
 			}
 		case caas.RunAsNonRoot:
 			charmInitContainer.SecurityContext = &corev1.SecurityContext{
-				RunAsUser:  pointer.Int64(constants.JujuUserID),
-				RunAsGroup: pointer.Int64(constants.JujuGroupID),
+				RunAsUser:  new(constants.JujuUserID),
+				RunAsGroup: new(constants.JujuGroupID),
 			}
 		}
 	} else {
@@ -2095,7 +2110,7 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		AutomountServiceAccountToken:  &automountToken,
 		ServiceAccountName:            a.serviceAccountName(),
 		ImagePullSecrets:              imagePullSecrets,
-		TerminationGracePeriodSeconds: pointer.Int64(30),
+		TerminationGracePeriodSeconds: new(int64(30)),
 		InitContainers:                []corev1.Container{charmInitContainer},
 		Containers:                    containerSpecs,
 		Volumes: []corev1.Volume{
@@ -2133,7 +2148,7 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		// Rootless charms are any charm after juju 3.5 that declare
 		// either the charm as rootless or any workload.
 		spec.SecurityContext = &corev1.PodSecurityContext{
-			FSGroup:            pointer.Int64(constants.JujuFSGroupID),
+			FSGroup:            new(constants.JujuFSGroupID),
 			SupplementalGroups: []int64{constants.JujuFSGroupID},
 		}
 	}

--- a/internal/provider/kubernetes/application/application_test.go
+++ b/internal/provider/kubernetes/application/application_test.go
@@ -547,6 +547,7 @@ func (s *applicationSuite) TestEnsureStateful(c *tc.C) {
 			Labels: map[string]string{
 				"app.kubernetes.io/name":       "gitlab",
 				"app.kubernetes.io/managed-by": "juju",
+				"service.juju.is/type":         "endpoints",
 			},
 			Annotations: map[string]string{
 				"juju.is/version": "3.5-beta1",
@@ -1032,6 +1033,7 @@ func (s *applicationSuite) TestEnsureStatefulRootless35(c *tc.C) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "gitlab",
 						"app.kubernetes.io/managed-by": "juju",
+						"service.juju.is/type":         "endpoints",
 					},
 					Annotations: map[string]string{
 						"juju.is/version": "3.5-beta1",
@@ -1122,6 +1124,7 @@ func (s *applicationSuite) TestEnsureStatefulRootless(c *tc.C) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "gitlab",
 						"app.kubernetes.io/managed-by": "juju",
+						"service.juju.is/type":         "endpoints",
 					},
 					Annotations: map[string]string{
 						"juju.is/version": "3.6-beta3",
@@ -1232,6 +1235,7 @@ func (s *applicationSuite) TestEnsureStatefulRootlessWithTempFSStorage(c *tc.C) 
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "gitlab",
 						"app.kubernetes.io/managed-by": "juju",
+						"service.juju.is/type":         "endpoints",
 					},
 					Annotations: map[string]string{
 						"juju.is/version": "4.0-beta8",
@@ -1361,6 +1365,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *tc.C) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "gitlab",
 						"app.kubernetes.io/managed-by": "juju",
+						"service.juju.is/type":         "endpoints",
 					},
 					Annotations: map[string]string{
 						"juju.is/version": "3.5-beta1",
@@ -3493,6 +3498,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *tc.C) {
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "gitlab",
 						"app.kubernetes.io/managed-by": "juju",
+						"service.juju.is/type":         "endpoints",
 					},
 					Annotations: map[string]string{
 						"juju.is/version": "3.5-beta1",
@@ -4381,4 +4387,41 @@ func (s *applicationSuite) TestDeleteAllCreatedResources(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(validatingWebhookConfigurations.Items, tc.NotNil)
 	c.Assert(validatingWebhookConfigurations.Items, tc.HasLen, 1)
+}
+
+type headlessServiceSuite struct{}
+
+func TestHeadlessServiceSuite(t *stdtesting.T) {
+	tc.Run(t, &headlessServiceSuite{})
+}
+
+func (s *headlessServiceSuite) TestIsManagedHeadlessServiceByLabel(c *tc.C) {
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "not-an-endpoints-suffixed-name",
+			Labels: map[string]string{
+				constants.LabelJujuServiceType: constants.ServiceTypeEndpoints,
+			},
+		},
+	}
+	c.Check(application.IsManagedHeadlessService(svc), tc.IsTrue)
+}
+
+func (s *headlessServiceSuite) TestIsManagedHeadlessServiceByLegacySuffix(c *tc.C) {
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "gitlab-endpoints"},
+	}
+	c.Check(application.IsManagedHeadlessService(svc), tc.IsTrue)
+}
+
+func (s *headlessServiceSuite) TestIsManagedHeadlessServiceFalse(c *tc.C) {
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gitlab",
+			Labels: map[string]string{
+				constants.LabelJujuServiceType: "something-else",
+			},
+		},
+	}
+	c.Check(application.IsManagedHeadlessService(svc), tc.IsFalse)
 }

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -154,6 +154,7 @@ type controllerStack struct {
 	portSSHServer int
 
 	resourceNameService,
+	resourceNameHeadlessService,
 	resourceNameConfigMap,
 	resourceNameSecret, resourceNamedockerSecret,
 	resourceNameVolBootstrapParams, resourceNameVolAgentConf string
@@ -289,6 +290,7 @@ func newControllerStack(
 		portSSHServer: pcfg.Bootstrap.ControllerConfig.SSHServerPort(),
 	}
 	cs.resourceNameService = cs.getResourceName("service")
+	cs.resourceNameHeadlessService = cs.getResourceName("service-endpoints")
 	cs.resourceNameConfigMap = cs.getResourceName("configmap")
 	cs.resourceNameSecret = cs.getResourceName("secret")
 	cs.resourceNamedockerSecret = constants.CAASImageRepoSecretName
@@ -398,6 +400,15 @@ func (c *controllerStack) Deploy(ctx context.Context) (err error) {
 	// create service for controller pod.
 	if err = c.createControllerService(ctx); err != nil {
 		return errors.Annotate(err, "creating service for controller")
+	}
+	if environsbootstrap.IsContextDone(ctx) {
+		return environsbootstrap.Cancelled()
+	}
+
+	// Create the headless service governing the controller statefulset so
+	// each pod gets a stable per-ordinal DNS name for Dqlite peering.
+	if err = c.createControllerHeadlessService(ctx); err != nil {
+		return errors.Annotate(err, "creating headless service for controller")
 	}
 	if environsbootstrap.IsContextDone(ctx) {
 		return environsbootstrap.Cancelled()
@@ -600,8 +611,12 @@ func (c *controllerStack) createControllerService(ctx context.Context) error {
 	}
 
 	c.addCleanUp(func() {
-		logger.Debugf(context.TODO(), "deleting %q", svcName)
-		_ = c.broker.deleteService(ctx, svcName)
+		logger.Debugf(ctx, "deleting %q", svcName)
+		if err := c.broker.deleteService(ctx, svcName); err != nil {
+			logger.Warningf(ctx,
+				"could not clean up service %q, it may be left dangling: %v",
+				svcName, err)
+		}
 	})
 
 	publicAddressPoller := func() error {
@@ -635,6 +650,54 @@ func (c *controllerStack) createControllerService(ctx context.Context) error {
 		return errors.Timeoutf("waiting for controller service address fully provisioned")
 	}
 	return errors.Trace(err)
+}
+
+// createControllerHeadlessService creates the headless service that governs
+// the controller StatefulSet. Unlike the routable controller API service, this
+// service has no cluster IP; its sole purpose is to give each controller pod a
+// stable per-ordinal DNS name (controller-<ordinal>.<service>.<namespace>.svc)
+// that Dqlite peers can bind to and dial. PublishNotReadyAddresses is set so a
+// joining pod is resolvable before it becomes Ready, avoiding a join/readiness
+// deadlock. It is labelled as an endpoints service so address lookups exclude
+// it when resolving the controller's routable service.
+func (c *controllerStack) createControllerHeadlessService(ctx context.Context) error {
+	svcName := c.resourceNameHeadlessService
+
+	spec := &core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: svcName,
+			Labels: providerutils.LabelsMerge(c.stackLabels, labels.Set{
+				constants.LabelJujuServiceType: constants.ServiceTypeEndpoints,
+			}),
+			Namespace:   c.broker.Namespace(),
+			Annotations: c.stackAnnotations,
+		},
+		Spec: core.ServiceSpec{
+			Selector:  c.selectorLabels,
+			Type:      core.ServiceTypeClusterIP,
+			ClusterIP: "None",
+			// Publish addresses for not-yet-Ready pods so a joining node is
+			// DNS-resolvable before it becomes Ready; otherwise peers cannot
+			// dial it to admit it into the cluster and it can never become
+			// Ready (a join/readiness deadlock).
+			PublishNotReadyAddresses: true,
+		},
+	}
+
+	logger.Debugf(ctx, "creating controller headless service: \n%+v", spec)
+	if _, err := c.broker.ensureK8sService(ctx, spec); err != nil {
+		return errors.Trace(err)
+	}
+
+	c.addCleanUp(func() {
+		logger.Debugf(ctx, "deleting %q", svcName)
+		if err := c.broker.deleteService(ctx, svcName); err != nil {
+			logger.Warningf(ctx,
+				"could not clean up controller headless service %q, it may be left dangling: %v",
+				svcName, err)
+		}
+	})
+	return nil
 }
 
 func (c *controllerStack) addCleanUp(cleanUp func()) {
@@ -827,7 +890,7 @@ func (c *controllerStack) createControllerStatefulset(ctx context.Context) error
 			Annotations: c.stackAnnotations,
 		},
 		Spec: apps.StatefulSetSpec{
-			ServiceName: c.resourceNameService,
+			ServiceName: c.resourceNameHeadlessService,
 			Replicas:    &numberOfPods,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: c.selectorLabels,
@@ -857,8 +920,12 @@ func (c *controllerStack) createControllerStatefulset(ctx context.Context) error
 
 	logger.Tracef(context.TODO(), "creating controller statefulset: \n%+v", controllerStatefulSet)
 	c.addCleanUp(func() {
-		logger.Debugf(context.TODO(), "deleting %q statefulset", controllerStatefulSet.Name)
-		_ = c.broker.deleteStatefulSet(ctx, controllerStatefulSet.Name)
+		logger.Debugf(ctx, "deleting %q statefulset", controllerStatefulSet.Name)
+		if err := c.broker.deleteStatefulSet(ctx, controllerStatefulSet.Name); err != nil {
+			logger.Warningf(ctx,
+				"could not clean up statefulset %q, it may be left dangling: %v",
+				controllerStatefulSet.Name, err)
+		}
 	})
 	w, err := c.broker.WatchUnits(c.stackName)
 	if err != nil {

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -408,6 +408,25 @@ func (s *bootstrapSuite) TestBootstrap(c *tc.C) {
 		},
 	}
 
+	headlessSvc := &core.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "juju-controller-test-service-endpoints",
+			Namespace: s.namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "juju",
+				"app.kubernetes.io/name":       "juju-controller-test",
+				"service.juju.is/type":         "endpoints",
+			},
+			Annotations: map[string]string{"controller.juju.is/id": coretesting.ControllerTag.Id()},
+		},
+		Spec: core.ServiceSpec{
+			Selector:                 map[string]string{"app.kubernetes.io/name": "juju-controller-test"},
+			Type:                     core.ServiceType("ClusterIP"),
+			ClusterIP:                "None",
+			PublishNotReadyAddresses: true,
+		},
+	}
+
 	secretControllerAppConfig := &core.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "juju-controller-test-application-config",
@@ -469,7 +488,7 @@ func (s *bootstrapSuite) TestBootstrap(c *tc.C) {
 			Annotations: map[string]string{"controller.juju.is/id": coretesting.ControllerTag.Id()},
 		},
 		Spec: apps.StatefulSetSpec{
-			ServiceName: "juju-controller-test-service",
+			ServiceName: "juju-controller-test-service-endpoints",
 			Replicas:    &numberOfPods,
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "juju-controller-test"},
@@ -1036,6 +1055,10 @@ exec /opt/pebble run --http :38811 --verbose
 		c.Assert(err, tc.ErrorIsNil)
 		c.Assert(svc, tc.DeepEquals, svcProvisioned)
 
+		headless, err := s.mockServices.Get(c.Context(), `juju-controller-test-service-endpoints`, v1.GetOptions{})
+		c.Assert(err, tc.ErrorIsNil)
+		c.Assert(headless, tc.DeepEquals, headlessSvc)
+
 		secret, err := s.mockSecrets.Get(c.Context(), "juju-controller-test-application-config", v1.GetOptions{})
 		c.Assert(err, tc.ErrorIsNil)
 		c.Assert(secret, tc.DeepEquals, secretControllerAppConfig)
@@ -1099,6 +1122,10 @@ func (s *bootstrapSuite) TestBootstrapFailedTimeout(c *tc.C) {
 	s.ensureJujuNamespaceAnnotations(true, ns)
 
 	ctxDoneChan := make(chan struct{}, 1)
+
+	// Logging during bootstrap/cleanup extracts the trace ID from the
+	// context, so allow Value lookups from the mock context.
+	mockStdCtx.EXPECT().Value(gomock.Any()).Return(nil).AnyTimes()
 
 	gomock.InOrder(
 		mockStdCtx.EXPECT().Err().Return(nil),

--- a/internal/provider/kubernetes/configmap.go
+++ b/internal/provider/kubernetes/configmap.go
@@ -21,7 +21,13 @@ func (k *kubernetesClient) ensureConfigMap(ctx context.Context, cm *core.ConfigM
 	out, err := k.createConfigMap(ctx, cm)
 	if err == nil {
 		logger.Debugf(context.TODO(), "configmap %q created", out.GetName())
-		cleanUp = func() { _ = k.deleteConfigMap(ctx, out.GetName(), out.GetUID()) }
+		cleanUp = func() {
+			if err := k.deleteConfigMap(ctx, out.GetName(), out.GetUID()); err != nil {
+				logger.Warningf(ctx,
+					"could not clean up configmap %q, it may be left dangling: %v",
+					out.GetName(), err)
+			}
+		}
 		return cleanUp, nil
 	}
 	if !errors.Is(err, errors.AlreadyExists) {

--- a/internal/provider/kubernetes/constants/constants.go
+++ b/internal/provider/kubernetes/constants/constants.go
@@ -71,16 +71,16 @@ const (
 
 	// JujuUserID is the juju user id for rootless juju agents.
 	// NOTE: 170 uid/gid must be updated here and in caas/Dockerfile and caas/scripts.go
-	JujuUserID = 170
+	JujuUserID int64 = 170
 	// JujuGroupID is the juju group id for rootless juju agents.
-	JujuGroupID = 170
+	JujuGroupID int64 = 170
 	// JujuSudoUserID is the juju user id for rootless juju agents with sudo.
 	// NOTE: 171 uid/gid must be updated here and in caas/Dockerfile
-	JujuSudoUserID = 171
+	JujuSudoUserID int64 = 171
 	// JujuSudoGroupID is the juju group id for rootless juju agents with sudo.
-	JujuSudoGroupID = 171
+	JujuSudoGroupID int64 = 171
 	// JujuFSGroupID is the group id for all fs entries written to k8s volumes.
-	JujuFSGroupID = 170
+	JujuFSGroupID int64 = 170
 )
 
 const (

--- a/internal/provider/kubernetes/constants/labels.go
+++ b/internal/provider/kubernetes/constants/labels.go
@@ -75,6 +75,13 @@ const (
 	// Since LabelVersion1.
 	LabelJujuStorageName = "storage.juju.is/name"
 
+	// LabelJujuServiceType is the juju label applied to Juju-managed
+	// Kubernetes services to describe their role, so that auxiliary services
+	// (such as the headless service backing a StatefulSet) can be
+	// distinguished from an application's primary service without relying on
+	// a fragile name suffix.
+	LabelJujuServiceType = "service.juju.is/type"
+
 	// LegacyLabelKubernetesAppName is the legacy label key used for juju app
 	// identification. This purely exists to maintain backwards functionality.
 	// See https://bugs.launchpad.net/juju/+bug/1888513
@@ -104,4 +111,11 @@ const (
 	// See https://bugs.launchpad.net/juju/+bug/1888513
 	// For LegacyLabelVersion.
 	LegacyLabelStorageName = "juju-storage"
+)
+
+const (
+	// ServiceTypeEndpoints is the value of LabelJujuServiceType marking a
+	// headless service that exists solely to provide stable per-pod DNS
+	// (endpoints) for a StatefulSet's pods.
+	ServiceTypeEndpoints = "endpoints"
 )

--- a/internal/provider/kubernetes/k8s.go
+++ b/internal/provider/kubernetes/k8s.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -44,6 +43,7 @@ import (
 	"github.com/juju/juju/internal/cloudconfig/podcfg"
 	"github.com/juju/juju/internal/docker"
 	internallogger "github.com/juju/juju/internal/logger"
+	"github.com/juju/juju/internal/provider/kubernetes/application"
 	"github.com/juju/juju/internal/provider/kubernetes/constants"
 	"github.com/juju/juju/internal/provider/kubernetes/resources"
 	"github.com/juju/juju/internal/provider/kubernetes/utils"
@@ -649,7 +649,7 @@ func (k *kubernetesClient) GetService(ctx context.Context, appName string, inclu
 		for _, v := range servicesList.Items {
 			s := v
 			// Ignore any headless service for this app.
-			if !strings.HasSuffix(s.Name, "-endpoints") {
+			if !application.IsManagedHeadlessService(s) {
 				svc = &s
 				break
 			}

--- a/internal/provider/kubernetes/k8s_test.go
+++ b/internal/provider/kubernetes/k8s_test.go
@@ -842,6 +842,71 @@ func (s *K8sBrokerSuite) TestGetServiceSvcNotFound(c *tc.C) {
 	c.Assert(caasSvc, tc.DeepEquals, &caas.Service{})
 }
 
+// TestGetServiceSkipsLabelledHeadlessService verifies that GetService excludes
+// a headless service identified by the LabelJujuServiceType label, even when
+// its name does not carry the legacy "-endpoints" suffix, and returns the
+// routable service instead.
+func (s *K8sBrokerSuite) TestGetServiceSkipsLabelledHeadlessService(c *tc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	selectorLabels := map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"}
+	labels := k8sutils.LabelsMerge(selectorLabels, k8sutils.LabelsJuju)
+	selector := k8sutils.LabelsToSelector(labels).String()
+
+	// A headless service whose name does NOT end in "-endpoints"; it must be
+	// filtered out via the label, not the legacy suffix.
+	headlessLabels := k8sutils.LabelsMerge(labels, map[string]string{
+		"service.juju.is/type": "endpoints",
+	})
+	svcHeadless := core.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "app-name-dqlite",
+			Labels: headlessLabels,
+		},
+		Spec: core.ServiceSpec{
+			Selector:                 selectorLabels,
+			Type:                     core.ServiceTypeClusterIP,
+			ClusterIP:                "None",
+			PublishNotReadyAddresses: true,
+		},
+	}
+	svc := core.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:   "app-name",
+			Labels: labels,
+		},
+		Spec: core.ServiceSpec{
+			Selector:       selectorLabels,
+			Type:           core.ServiceTypeLoadBalancer,
+			LoadBalancerIP: "10.0.0.1",
+		},
+	}
+	svc.SetUID("uid-xxxxx")
+
+	gomock.InOrder(
+		// Return the headless service first to ensure it is skipped rather
+		// than being picked as the primary service.
+		s.mockServices.EXPECT().List(gomock.Any(), v1.ListOptions{LabelSelector: selector}).
+			Return(&core.ServiceList{Items: []core.Service{svcHeadless, svc}}, nil),
+		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "juju-operator-app-name", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockStatefulSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockDeployments.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+		s.mockDaemonSets.EXPECT().Get(gomock.Any(), "app-name", v1.GetOptions{}).
+			Return(nil, s.k8sNotFoundError()),
+	)
+
+	caasSvc, err := s.broker.GetService(c.Context(), "app-name", false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(caasSvc.Id, tc.Equals, "uid-xxxxx")
+	c.Assert(caasSvc.Addresses, tc.DeepEquals, network.ProviderAddresses{
+		network.NewMachineAddress("10.0.0.1", network.WithScope(network.ScopePublic)).AsProviderAddress(),
+	})
+}
+
 func (s *K8sBrokerSuite) assertGetService(c *tc.C, expectedSvcResult *caas.Service, assertCalls ...any) {
 	selectorLabels := map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "app-name"}
 	labels := k8sutils.LabelsMerge(selectorLabels, k8sutils.LabelsJuju)

--- a/internal/provider/kubernetes/rbac.go
+++ b/internal/provider/kubernetes/rbac.go
@@ -71,7 +71,13 @@ func (k *kubernetesClient) ensureServiceAccount(ctx context.Context, sa *core.Se
 	out, err = k.createServiceAccount(ctx, sa)
 	if err == nil {
 		logger.Debugf(ctx, "service account %q created", out.GetName())
-		cleanups = append(cleanups, func() { _ = k.deleteServiceAccount(ctx, out.GetName(), out.GetUID()) })
+		cleanups = append(cleanups, func() {
+			if err := k.deleteServiceAccount(ctx, out.GetName(), out.GetUID()); err != nil {
+				logger.Warningf(ctx,
+					"could not clean up service account %q, it may be left dangling: %v",
+					out.GetName(), err)
+			}
+		})
 		return out, cleanups, nil
 	}
 	if !errors.IsAlreadyExists(err) {
@@ -151,7 +157,13 @@ func (k *kubernetesClient) ensureRole(ctx context.Context, role *rbacv1.Role) (o
 	out, err = k.createRole(ctx, role)
 	if err == nil {
 		logger.Debugf(ctx, "role %q created", out.GetName())
-		cleanups = append(cleanups, func() { _ = k.deleteRole(ctx, out.GetName(), out.GetUID()) })
+		cleanups = append(cleanups, func() {
+			if err := k.deleteRole(ctx, out.GetName(), out.GetUID()); err != nil {
+				logger.Warningf(ctx,
+					"could not clean up role %q, it may be left dangling: %v",
+					out.GetName(), err)
+			}
+		})
 		return out, cleanups, nil
 	}
 	if !errors.Is(err, errors.AlreadyExists) {
@@ -320,7 +332,13 @@ func (k *kubernetesClient) ensureRoleBinding(ctx context.Context, rb *rbacv1.Rol
 	}
 	if isFirstDeploy {
 		// only do cleanup for the first time, don't do this for existing deployments.
-		cleanups = append(cleanups, func() { _ = k.deleteRoleBinding(ctx, out.GetName(), out.GetUID()) })
+		cleanups = append(cleanups, func() {
+			if err := k.deleteRoleBinding(ctx, out.GetName(), out.GetUID()); err != nil {
+				logger.Warningf(ctx,
+					"could not clean up role binding %q, it may be left dangling: %v",
+					out.GetName(), err)
+			}
+		})
 	}
 	logger.Debugf(ctx, "role binding %q created", rb.GetName())
 	return out, cleanups, nil

--- a/internal/provider/kubernetes/secrets.go
+++ b/internal/provider/kubernetes/secrets.go
@@ -57,7 +57,13 @@ func (k *kubernetesClient) ensureSecret(ctx context.Context, sec *core.Secret) (
 	out, err := k.createSecret(ctx, sec)
 	if err == nil {
 		logger.Debugf(context.TODO(), "secret %q created", out.GetName())
-		cleanUp = func() { _ = k.deleteSecret(ctx, out.GetName(), out.GetUID()) }
+		cleanUp = func() {
+			if err := k.deleteSecret(ctx, out.GetName(), out.GetUID()); err != nil {
+				logger.Warningf(ctx,
+					"could not clean up secret %q, it may be left dangling: %v",
+					out.GetName(), err)
+			}
+		}
 		return cleanUp, nil
 	}
 	if !errors.Is(err, errors.AlreadyExists) {

--- a/internal/provider/kubernetes/services.go
+++ b/internal/provider/kubernetes/services.go
@@ -36,7 +36,13 @@ func (k *kubernetesClient) ensureK8sService(ctx context.Context, spec *core.Serv
 		var svcCreated *core.Service
 		svcCreated, err = api.Create(ctx, spec, meta.CreateOptions{})
 		if err == nil {
-			cleanUp = func() { _ = k.deleteService(ctx, svcCreated.GetName()) }
+			cleanUp = func() {
+				if err := k.deleteService(ctx, svcCreated.GetName()); err != nil {
+					logger.Warningf(ctx,
+						"could not clean up service %q, it may be left dangling: %v",
+						svcCreated.GetName(), err)
+				}
+			}
 		}
 	}
 	return cleanUp, errors.Trace(err)
@@ -77,17 +83,16 @@ func findServiceForApplication(
 	}
 
 	services := []core.Service{}
-	endpointSvcName := application.HeadlessServiceName(appName)
-	// We want to filter out the endpoints services made by juju as they should
-	// not be considered.
+	// We want to filter out the headless endpoints services made by juju as
+	// they carry no routable address and should not be considered.
 	for _, svc := range servicesList.Items {
-		if svc.Name != endpointSvcName {
+		if !application.IsManagedHeadlessService(svc) {
 			services = append(services, svc)
 		}
 	}
 
 	if len(services) != 1 {
-		return nil, errors.NotValidf("unable to handle mutiple services %d for application %s", len(servicesList.Items), appName)
+		return nil, errors.NotValidf("unable to handle multiple services %d for application %s", len(services), appName)
 	}
 
 	return &services[0], nil

--- a/internal/provider/kubernetes/services_test.go
+++ b/internal/provider/kubernetes/services_test.go
@@ -52,7 +52,7 @@ func (s *servicesSuite) TestFindServiceForApplication(c *tc.C) {
 	)
 
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(svc.Name, tc.Equals, "wallyworld")
+	c.Check(svc.Name, tc.Equals, "wallyworld")
 }
 
 func (s *servicesSuite) TestFindServiceForApplicationWithEndpoints(c *tc.C) {
@@ -94,7 +94,53 @@ func (s *servicesSuite) TestFindServiceForApplicationWithEndpoints(c *tc.C) {
 	)
 
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(svc.Name, tc.Equals, "wallyworld")
+	c.Check(svc.Name, tc.Equals, "wallyworld")
+}
+
+func (s *servicesSuite) TestFindServiceForApplicationWithLabelledHeadless(c *tc.C) {
+	_, err := s.client.CoreV1().Services("test").Create(
+		c.Context(),
+		&core.Service{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "wallyworld",
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       "wallyworld",
+					"app.kubernetes.io/managed-by": "juju",
+				},
+			},
+		},
+		meta.CreateOptions{},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// A headless service whose name does not end in "-endpoints"; it must be
+	// filtered out via the LabelJujuServiceType label rather than the legacy
+	// suffix.
+	_, err = s.client.CoreV1().Services("test").Create(
+		c.Context(),
+		&core.Service{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "wallyworld-dqlite",
+				Labels: map[string]string{
+					"app.kubernetes.io/name":       "wallyworld",
+					"app.kubernetes.io/managed-by": "juju",
+					constants.LabelJujuServiceType: constants.ServiceTypeEndpoints,
+				},
+			},
+		},
+		meta.CreateOptions{},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	svc, err := findServiceForApplication(
+		c.Context(),
+		s.client.CoreV1().Services("test"),
+		"wallyworld",
+		constants.LabelVersion1,
+	)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(svc.Name, tc.Equals, "wallyworld")
 }
 
 func (s *servicesSuite) TestFindServiceForApplicationWithMultiple(c *tc.C) {


### PR DESCRIPTION
Introduce a dedicated headless service (ClusterIP: None, PublishNotReadyAddresses: true) to govern the controller StatefulSet on Kubernetes, giving each controller pod a stable per-ordinal DNS name (controller-<ordinal>.<service>.<namespace>.svc). This is the substrate prerequisite for per-pod Dqlite peering needed by controller HA on CAAS; previously the StatefulSet's ServiceName pointed at the routable API service, which does not reliably mint per-pod DNS.

Changes:
- Add a headless service creator in the controller bootstrap and repoint the StatefulSet ServiceName at it (resourceNameHeadlessService, "controller-service-endpoints").
- Add the service.juju.is/type=endpoints label and an IsHeadlessService helper; switch GetService/findServiceForApplication from the fragile "-endpoints" name-suffix check to a label-based check, keeping the suffix as a legacy fallback for services created before the label existed. Label the existing application headless service to match.

Drive-by changes (made separately, folded into this commit):
- application.go: replace k8s.io/utils/pointer helpers (pointer.Int64, pointer.Bool, pointer.Int32) with the go1.26 new(expr) builtin and drop the pointer dependency.

## QA steps

```
$ juju bootstrap minikube mini
$ juju switch controller
$ juju status
Model       Controller  Cloud/Region  Version    Timestamp
controller  mini        minikube      4.1-beta2  14:15:26+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Address        Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  10.101.105.94  no       

Unit           Workload  Agent  Address       Ports            Message
controller/0*  active    idle   10.244.0.108  17022,17070/tcp  

$ kubectl -n controller-mini get all 
NAME                                 READY   STATUS    RESTARTS   AGE
pod/controller-0                     2/2     Running   0          75s
pod/modeloperator-76b786d7d9-m8ps8   1/1     Running   0          54s

NAME                                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)               AGE
service/controller-service             ClusterIP   10.101.105.94   <none>        17070/TCP,17022/TCP   79s
service/controller-service-endpoints   ClusterIP   None            <none>        <none>                79s
service/modeloperator                  ClusterIP   10.108.213.0    <none>        17071/TCP             55s

NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/modeloperator   1/1     1            1           54s

NAME                                       DESIRED   CURRENT   READY   AGE
replicaset.apps/modeloperator-76b786d7d9   1         1         1       54s

NAME                          READY   AGE
statefulset.apps/controller   1/1     75s

$ kubectl -n controller-mini describe service controller-service-endpoints
Name:                     controller-service-endpoints
Namespace:                controller-mini
Labels:                   app.kubernetes.io/managed-by=juju
                          app.kubernetes.io/name=controller
                          service.juju.is/type=endpoints
Annotations:              controller.juju.is/id: 4b30a627-576d-4607-87a3-c3fc153919cb
Selector:                 app.kubernetes.io/name=controller
Type:                     ClusterIP
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       None
IPs:                      None
Session Affinity:         None
Internal Traffic Policy:  Cluster
Events:                   <none>
```