### PR TITLE
feat: port emphemeral key methods

### DIFF
--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -1199,7 +1199,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		authenticationWorkerName: ifNotMigrating(authenticationworker.Manifold(authenticationworker.ManifoldConfig{
 			AgentName:     agentName,
 			APICallerName: apiCallerName,
-		})),
+		}, authenticationworker.Output)),
 
 		hostKeyReporterName: ifNotMigrating(hostkeyreporter.Manifold(hostkeyreporter.ManifoldConfig{
 			AgentName:     agentName,

--- a/core/machineauthentication/doc.go
+++ b/core/machineauthentication/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package machineauthentication holds core types needed for Juju for
+// representing machine authentication information.
+package machineauthentication

--- a/core/machineauthentication/machineauthentication.go
+++ b/core/machineauthentication/machineauthentication.go
@@ -1,8 +1,6 @@
 // Copyright 2023 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Package machineauthentication holds core types needed for Juju for
-// representing machine authentication information.
 package machineauthentication
 
 import (

--- a/core/machineauthentication/machineauthentication.go
+++ b/core/machineauthentication/machineauthentication.go
@@ -1,0 +1,19 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package machineauthentication holds core types needed for Juju for
+// representing machine authentication information.
+package machineauthentication
+
+import (
+	"github.com/juju/juju/internal/errors"
+)
+
+const (
+	// ErrAuthenticationWorkerDying is used to indicate to callers that the
+	// authentication worker is dying, instead of catacomb.ErrDying, which is
+	// unsuitable for propagating inter-worker.
+	// This error indicates to consuming workers that their dependency has
+	// become unmet and a restart by the dependency engine is imminent.
+	ErrAuthenticationWorkerDying = errors.ConstError("authentication worker is dying")
+)

--- a/internal/worker/authenticationworker/manifold.go
+++ b/internal/worker/authenticationworker/manifold.go
@@ -24,7 +24,11 @@ type ManifoldConfig engine.AgentAPIManifoldConfig
 func Manifold(config ManifoldConfig) dependency.Manifold {
 	typedConfig := engine.AgentAPIManifoldConfig(config)
 
-	return engine.AgentAPIManifold(typedConfig, newWorker)
+	manifold := engine.AgentAPIManifold(typedConfig, newWorker)
+	// Expose the worker's EphemeralKeysUpdater so that the sshsession worker can
+	// inject and remove ephemeral keys for the lifetime of a reverse tunnel.
+	manifold.Output = output
+	return manifold
 }
 
 func newWorker(_ context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
@@ -33,4 +37,19 @@ func newWorker(_ context.Context, a agent.Agent, apiCaller base.APICaller) (work
 		return nil, errors.Annotate(err, "cannot start ssh auth-keys updater worker")
 	}
 	return w, nil
+}
+
+// output extracts an EphemeralKeysUpdater from the running AuthWorker.
+func output(in worker.Worker, out any) error {
+	w, ok := in.(*AuthWorker)
+	if !ok {
+		return errors.Errorf("expected *AuthWorker, got %T", in)
+	}
+	switch outPtr := out.(type) {
+	case *EphemeralKeysUpdater:
+		*outPtr = w
+	default:
+		return errors.Errorf("expected *EphemeralKeysUpdater, got %T", out)
+	}
+	return nil
 }

--- a/internal/worker/authenticationworker/manifold.go
+++ b/internal/worker/authenticationworker/manifold.go
@@ -21,7 +21,7 @@ type ManifoldConfig engine.AgentAPIManifoldConfig
 
 // Manifold returns a dependency manifold that runs a authenticationworker worker,
 // using the resource names defined in the supplied config.
-func Manifold(config ManifoldConfig) dependency.Manifold {
+func Manifold(config ManifoldConfig, output dependency.OutputFunc) dependency.Manifold {
 	typedConfig := engine.AgentAPIManifoldConfig(config)
 
 	manifold := engine.AgentAPIManifold(typedConfig, newWorker)
@@ -40,7 +40,7 @@ func newWorker(_ context.Context, a agent.Agent, apiCaller base.APICaller) (work
 }
 
 // output extracts an EphemeralKeysUpdater from the running AuthWorker.
-func output(in worker.Worker, out any) error {
+func Output(in worker.Worker, out any) error {
 	w, ok := in.(*AuthWorker)
 	if !ok {
 		return errors.Errorf("expected *AuthWorker, got %T", in)

--- a/internal/worker/authenticationworker/manifold_test.go
+++ b/internal/worker/authenticationworker/manifold_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authenticationworker
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+	"github.com/juju/worker/v5"
+
+	"github.com/juju/juju/internal/testhelpers"
+)
+
+type manifoldSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestManifoldSuite(t *testing.T) {
+	tc.Run(t, &manifoldSuite{})
+}
+
+func (s *manifoldSuite) TestManifoldHasOutput(c *tc.C) {
+	manifold := Manifold(ManifoldConfig{
+		AgentName:     "agent",
+		APICallerName: "api-caller",
+	})
+	c.Check(manifold.Output, tc.NotNil)
+	c.Check(manifold.Inputs, tc.SameContents, []string{"agent", "api-caller"})
+}
+
+func (s *manifoldSuite) TestOutputExtractsEphemeralKeysUpdater(c *tc.C) {
+	in := &AuthWorker{Worker: &stubWorker{}}
+
+	var updater EphemeralKeysUpdater
+	err := output(in, &updater)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(updater, tc.Equals, in)
+}
+
+func (s *manifoldSuite) TestOutputWrongInputType(c *tc.C) {
+	var updater EphemeralKeysUpdater
+	err := output(&stubWorker{}, &updater)
+	c.Check(err, tc.ErrorMatches, `expected \*AuthWorker, got .*`)
+}
+
+func (s *manifoldSuite) TestOutputWrongOutputType(c *tc.C) {
+	in := &AuthWorker{Worker: &stubWorker{}}
+
+	var wrong worker.Worker
+	err := output(in, &wrong)
+	c.Check(err, tc.ErrorMatches, `expected \*EphemeralKeysUpdater, got .*`)
+}
+
+type stubWorker struct{}
+
+func (*stubWorker) Kill()       {}
+func (*stubWorker) Wait() error { return nil }

--- a/internal/worker/authenticationworker/manifold_test.go
+++ b/internal/worker/authenticationworker/manifold_test.go
@@ -24,31 +24,31 @@ func (s *manifoldSuite) TestManifoldHasOutput(c *tc.C) {
 	manifold := Manifold(ManifoldConfig{
 		AgentName:     "agent",
 		APICallerName: "api-caller",
-	})
+	}, Output)
 	c.Check(manifold.Output, tc.NotNil)
 	c.Check(manifold.Inputs, tc.SameContents, []string{"agent", "api-caller"})
 }
 
 func (s *manifoldSuite) TestOutputExtractsEphemeralKeysUpdater(c *tc.C) {
-	in := &AuthWorker{Worker: &stubWorker{}}
+	in := &AuthWorker{}
 
 	var updater EphemeralKeysUpdater
-	err := output(in, &updater)
+	err := Output(in, &updater)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(updater, tc.Equals, in)
 }
 
 func (s *manifoldSuite) TestOutputWrongInputType(c *tc.C) {
 	var updater EphemeralKeysUpdater
-	err := output(&stubWorker{}, &updater)
+	err := Output(&stubWorker{}, &updater)
 	c.Check(err, tc.ErrorMatches, `expected \*AuthWorker, got .*`)
 }
 
 func (s *manifoldSuite) TestOutputWrongOutputType(c *tc.C) {
-	in := &AuthWorker{Worker: &stubWorker{}}
+	in := &AuthWorker{}
 
 	var wrong worker.Worker
-	err := output(in, &wrong)
+	err := Output(in, &wrong)
 	c.Check(err, tc.ErrorMatches, `expected \*EphemeralKeysUpdater, got .*`)
 }
 

--- a/internal/worker/authenticationworker/utils.go
+++ b/internal/worker/authenticationworker/utils.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package authenticationworker
+
+import (
+	"fmt"
+
+	"github.com/juju/utils/v4/ssh"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// jujuEphemeralCommentPrefix is the comment prefix used to identify ephemeral
+// keys in the authorized_keys file so they can be removed when no longer
+// needed (for example when the worker is restarted).
+const jujuEphemeralCommentPrefix = ssh.JujuCommentPrefix + "Ephemeral:"
+
+// ensureJujuEphemeralComment returns a key with comment in the OpenSSH
+// authorized_keys file format. Note the string does not include a new line at
+// the end for compatibility with juju/utils `ParseAuthorisedKey`.
+// The comment is used to identify the ephemeral keys and delete them when the
+// worker is restarted.
+func ensureJujuEphemeralComment(key gossh.PublicKey, comment string) string {
+	authKey := gossh.MarshalAuthorizedKey(key)
+	// Strip off the trailing new line so we can add a comment.
+	authKey = authKey[:len(authKey)-1]
+	comment = jujuEphemeralCommentPrefix + comment
+	return fmt.Sprintf("%s %s", authKey, comment)
+}

--- a/internal/worker/authenticationworker/worker.go
+++ b/internal/worker/authenticationworker/worker.go
@@ -6,13 +6,13 @@ package authenticationworker
 import (
 	"context"
 	"strings"
-	"sync"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 	"github.com/juju/utils/v4/ssh"
 	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/catacomb"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/agent"
@@ -32,19 +32,6 @@ type Client interface {
 	WatchAuthorisedKeys(ctx context.Context, tag names.MachineTag) (watcher.NotifyWatcher, error)
 }
 
-type keyupdaterWorker struct {
-	client Client
-	tag    names.MachineTag
-	// mu serialises all mutations to the authorized_keys file, so that model
-	// key updates (Handle) do not race ephemeral key add/remove operations.
-	mu *sync.Mutex
-	// jujuKeys are the most recently retrieved keys from state.
-	jujuKeys set.Strings
-	// nonJujuKeys are those added externally to auth keys file
-	// such keys do not have comments with the Juju: prefix.
-	nonJujuKeys []string
-}
-
 // EphemeralKeysUpdater adds and removes ephemeral SSH keys from the machine's
 // authorized_keys file. It is consumed by the sshsession worker, which injects
 // an ephemeral key for the lifetime of a reverse SSH tunnel.
@@ -56,17 +43,71 @@ type EphemeralKeysUpdater interface {
 	RemoveEphemeralKey(key gossh.PublicKey) error
 }
 
+// opType identifies the kind of ephemeral key operation carried by a request.
+type opType int
+
+const (
+	addOp opType = iota
+	removeOp
+)
+
+// ephemeralRequest is used to pass ephemeral key add/remove operations into the
+// worker loop, so that all writes to the authorized_keys file are serialised
+// through a single goroutine. The done channel is buffered so the loop never
+// blocks replying to a caller that has stopped waiting.
+type ephemeralRequest struct {
+	op      opType
+	key     gossh.PublicKey
+	comment string
+	done    chan error
+}
+
+// makeAddRequest creates a request to add the supplied ephemeral key, tagged
+// with the given comment for later removal.
+func makeAddRequest(key gossh.PublicKey, comment string) ephemeralRequest {
+	return ephemeralRequest{
+		op:      addOp,
+		key:     key,
+		comment: comment,
+		done:    make(chan error, 1),
+	}
+}
+
+// makeRemoveRequest creates a request to remove the supplied ephemeral key.
+func makeRemoveRequest(key gossh.PublicKey) ephemeralRequest {
+	return ephemeralRequest{
+		op:   removeOp,
+		key:  key,
+		done: make(chan error, 1),
+	}
+}
+
 // AuthWorker is a worker that keeps track of the machine's authorised ssh keys
 // and ensures the ~/.ssh/authorized_keys file is up to date. It additionally
 // supports adding and removing ephemeral keys, used by the sshsession worker
 // for the lifetime of a reverse SSH tunnel.
+//
+// All mutations to the authorized_keys file - model key updates and ephemeral
+// key add/remove operations - are serialised through the worker loop. Ephemeral
+// key requests are enqueued onto the requests channel and applied by the loop
+// goroutine, so they cannot race a model key update.
 type AuthWorker struct {
-	worker.Worker
+	catacomb catacomb.Catacomb
 
-	// mu is shared with the inner keyupdaterWorker so that ephemeral key
-	// add/remove operations are serialised against model key updates. Both
-	// mutate the same authorized_keys file.
-	mu *sync.Mutex
+	client Client
+	tag    names.MachineTag
+
+	// requests carries ephemeral key add/remove operations into the loop.
+	requests chan ephemeralRequest
+
+	// The following fields are owned by the loop goroutine and must only be
+	// accessed from it.
+
+	// jujuKeys are the most recently retrieved keys from state.
+	jujuKeys set.Strings
+	// nonJujuKeys are those added externally to the auth keys file; such keys
+	// do not have comments with the Juju: prefix.
+	nonJujuKeys []string
 }
 
 // NewWorker returns a worker that keeps track of
@@ -77,63 +118,115 @@ func NewWorker(client Client, agentConfig agent.Config) (worker.Worker, error) {
 	if !ok {
 		return nil, errors.NotValidf("machine tag %v", agentConfig.Tag())
 	}
-	// A single mutex is shared between the key updater handler and the
-	// AuthWorker's ephemeral key methods to serialise all writes to the
-	// authorized_keys file.
-	mu := &sync.Mutex{}
-	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
-		Handler: &keyupdaterWorker{
-			client: client,
-			tag:    machineTag,
-			mu:     mu,
-		},
-	})
-	if err != nil {
+	w := &AuthWorker{
+		client:   client,
+		tag:      machineTag,
+		requests: make(chan ephemeralRequest),
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Name: "authentication",
+		Site: &w.catacomb,
+		Work: w.loop,
+	}); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &AuthWorker{Worker: w, mu: mu}, nil
+	return w, nil
+}
+
+// Kill is part of the worker.Worker interface.
+func (a *AuthWorker) Kill() {
+	a.catacomb.Kill(nil)
+}
+
+// Wait is part of the worker.Worker interface.
+func (a *AuthWorker) Wait() error {
+	return a.catacomb.Wait()
 }
 
 // AddEphemeralKey adds an ephemeral key to the authorized_keys file. The
-// supplied comment is used to identify the key for later removal.
+// supplied comment is used to identify the key for later removal. The write is
+// performed by the worker loop, so it cannot race a model key update.
 func (a *AuthWorker) AddEphemeralKey(key gossh.PublicKey, comment string) error {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	keyWithComment := ensureJujuEphemeralComment(key, comment)
-	if err := ssh.AddKeys(SSHUser, keyWithComment); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	return a.enqueue(makeAddRequest(key, comment))
 }
 
 // RemoveEphemeralKey removes an ephemeral key from the authorized_keys file.
+// The write is performed by the worker loop, so it cannot race a model key
+// update.
 func (a *AuthWorker) RemoveEphemeralKey(ephemeralKey gossh.PublicKey) error {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	fingerprint := gossh.FingerprintLegacyMD5(ephemeralKey)
-	if err := ssh.DeleteKeys(SSHUser, fingerprint); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	return a.enqueue(makeRemoveRequest(ephemeralKey))
 }
 
-// SetUp is defined on the worker.NotifyWatchHandler interface.
-func (kw *keyupdaterWorker) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
-	// Record the keys Juju knows about.
-	jujuKeys, err := kw.client.AuthorisedKeys(ctx, kw.tag)
+// enqueue sends an ephemeral key request into the worker loop and waits for it
+// to be applied, returning any error. If the worker is dying it returns an
+// error indicating so.
+func (a *AuthWorker) enqueue(req ephemeralRequest) error {
+	select {
+	case a.requests <- req:
+	case <-a.catacomb.Dying():
+		return errors.Trace(a.catacomb.ErrDying())
+	}
+
+	select {
+	case err := <-req.done:
+		return errors.Trace(err)
+	case <-a.catacomb.Dying():
+		return errors.Trace(a.catacomb.ErrDying())
+	}
+}
+
+func (a *AuthWorker) loop() error {
+	ctx, cancel := a.scopedContext()
+	defer cancel()
+
+	// Perform the initial synchronisation of the authorized_keys file before
+	// we start watching for changes. On startup any dangling ephemeral keys
+	// are intentionally not preserved, so a restart flushes them.
+	watch, err := a.setUp(ctx)
 	if err != nil {
-		err = errors.Annotatef(err, "reading Juju ssh keys for %q", kw.tag)
+		return errors.Trace(err)
+	}
+	if err := a.catacomb.Add(watch); err != nil {
+		return errors.Trace(err)
+	}
+
+	for {
+		select {
+		case <-a.catacomb.Dying():
+			return a.catacomb.ErrDying()
+		case req := <-a.requests:
+			// Ephemeral key requests are non-fatal: reply the result to the
+			// caller and keep serving. A bad request must not bring down the
+			// worker and, with it, the machine's key management.
+			req.done <- a.handleEphemeralRequest(req)
+		case _, ok := <-watch.Changes():
+			if !ok {
+				return errors.New("change channel closed")
+			}
+			if err := a.handleModelKeyUpdate(ctx); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+}
+
+// setUp records the keys Juju knows about and the keys not managed by Juju,
+// writes out the authorized_keys file to match, and starts watching for
+// authorised key changes.
+func (a *AuthWorker) setUp(ctx context.Context) (watcher.NotifyWatcher, error) {
+	// Record the keys Juju knows about.
+	jujuKeys, err := a.client.AuthorisedKeys(ctx, a.tag)
+	if err != nil {
+		err = errors.Annotatef(err, "reading Juju ssh keys for %q", a.tag)
 		logger.Infof(ctx, err.Error())
 		return nil, err
 	}
-	kw.jujuKeys = set.NewStrings(jujuKeys...)
+	a.jujuKeys = set.NewStrings(jujuKeys...)
 
 	// Read the keys currently in ~/.ssh/authorised_keys.
 	sshKeys, err := ssh.ListKeys(SSHUser, ssh.FullKeys)
 	if err != nil {
-		err = errors.Annotatef(err, "reading ssh authorized keys for %q", kw.tag)
+		err = errors.Annotatef(err, "reading ssh authorized keys for %q", a.tag)
 		logger.Infof(ctx, err.Error())
 		return nil, err
 	}
@@ -142,26 +235,76 @@ func (kw *keyupdaterWorker) SetUp(ctx context.Context) (watcher.NotifyWatcher, e
 		_, comment, err := ssh.KeyFingerprint(key)
 		// Also record keys which we cannot parse.
 		if err != nil || !strings.HasPrefix(comment, ssh.JujuCommentPrefix) {
-			kw.nonJujuKeys = append(kw.nonJujuKeys, key)
+			a.nonJujuKeys = append(a.nonJujuKeys, key)
 		}
 	}
 	// Write out the ssh authorised keys file to match the current state of the
 	// world. On startup any dangling ephemeral keys are intentionally not
 	// preserved, so a restart flushes them.
-	if err := kw.writeSSHKeys(jujuKeys, false); err != nil {
+	if err := a.writeSSHKeys(jujuKeys, false); err != nil {
 		err = errors.Annotate(err, "adding current Juju keys to ssh authorised keys")
 		logger.Infof(ctx, err.Error())
 		return nil, err
 	}
 
-	w, err := kw.client.WatchAuthorisedKeys(ctx, kw.tag)
+	w, err := a.client.WatchAuthorisedKeys(ctx, a.tag)
 	if err != nil {
 		err = errors.Annotate(err, "starting key updater worker")
 		logger.Infof(ctx, err.Error())
 		return nil, err
 	}
-	logger.Infof(ctx, "%q key updater worker started", kw.tag)
+	logger.Infof(ctx, "%q key updater worker started", a.tag)
 	return w, nil
+}
+
+// handleEphemeralRequest applies a single ephemeral key add or remove
+// operation. It runs on the loop goroutine, so it is serialised against model
+// key updates and other ephemeral requests.
+func (a *AuthWorker) handleEphemeralRequest(req ephemeralRequest) error {
+	switch req.op {
+	case addOp:
+		keyWithComment := ensureJujuEphemeralComment(req.key, req.comment)
+		if err := ssh.AddKeys(SSHUser, keyWithComment); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	case removeOp:
+		fingerprint := gossh.FingerprintLegacyMD5(req.key)
+		if err := ssh.DeleteKeys(SSHUser, fingerprint); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	default:
+		return errors.Errorf("unknown op %v", req.op)
+	}
+}
+
+// handleModelKeyUpdate reconciles the authorized_keys file with the latest set
+// of keys reported by Juju. It runs on the loop goroutine.
+func (a *AuthWorker) handleModelKeyUpdate(ctx context.Context) error {
+	// Read the keys that Juju has.
+	newKeys, err := a.client.AuthorisedKeys(ctx, a.tag)
+	if err != nil {
+		err = errors.Annotatef(err, "reading Juju ssh keys for %q", a.tag)
+		logger.Infof(ctx, err.Error())
+		return err
+	}
+	// Figure out if any keys have been added or deleted.
+	newJujuKeys := set.NewStrings(newKeys...)
+	deleted := a.jujuKeys.Difference(newJujuKeys)
+	added := newJujuKeys.Difference(a.jujuKeys)
+	if added.Size() > 0 || deleted.Size() > 0 {
+		logger.Infof(ctx, "adding ssh keys to authorised keys: %v", added)
+		logger.Infof(ctx, "deleting ssh keys from authorised keys: %v", deleted)
+		// Preserve any in-flight ephemeral keys across the model key update.
+		if err = a.writeSSHKeys(newKeys, true); err != nil {
+			err = errors.Annotate(err, "updating ssh keys")
+			logger.Infof(ctx, err.Error())
+			return err
+		}
+	}
+	a.jujuKeys = newJujuKeys
+	return nil
 }
 
 // writeSSHKeys writes out a new ~/.ssh/authorised_keys file, retaining any non
@@ -169,16 +312,13 @@ func (kw *keyupdaterWorker) SetUp(ctx context.Context) (watcher.NotifyWatcher, e
 // is true, any ephemeral keys currently present in the file are retained too,
 // so that a model key update does not clobber an in-flight tunnel's key.
 //
-// It holds the shared mutex for the duration of the read-modify-write so that
-// it cannot race the AuthWorker's ephemeral key add/remove operations, which
-// mutate the same file.
-func (kw *keyupdaterWorker) writeSSHKeys(jujuKeys []string, preserveEphemeral bool) error {
-	kw.mu.Lock()
-	defer kw.mu.Unlock()
-
+// It is only ever called from the loop goroutine, so it does not need its own
+// locking: the loop serialises it against ephemeral key add/remove operations,
+// which mutate the same file.
+func (a *AuthWorker) writeSSHKeys(jujuKeys []string, preserveEphemeral bool) error {
 	// Copy nonJujuKeys so appends below never mutate the shared slice across
 	// calls.
-	allKeys := append([]string(nil), kw.nonJujuKeys...)
+	allKeys := append([]string(nil), a.nonJujuKeys...)
 
 	// Preserve any ephemeral keys currently in the file so that a model key
 	// update does not drop them. They carry the Juju ephemeral comment prefix,
@@ -204,35 +344,10 @@ func (kw *keyupdaterWorker) writeSSHKeys(jujuKeys []string, preserveEphemeral bo
 	return ssh.ReplaceKeys(SSHUser, allKeys...)
 }
 
-// Handle is defined on the worker.NotifyWatchHandler interface.
-func (kw *keyupdaterWorker) Handle(ctx context.Context) error {
-	// Read the keys that Juju has.
-	newKeys, err := kw.client.AuthorisedKeys(ctx, kw.tag)
-	if err != nil {
-		err = errors.Annotatef(err, "reading Juju ssh keys for %q", kw.tag)
-		logger.Infof(ctx, err.Error())
-		return err
-	}
-	// Figure out if any keys have been added or deleted.
-	newJujuKeys := set.NewStrings(newKeys...)
-	deleted := kw.jujuKeys.Difference(newJujuKeys)
-	added := newJujuKeys.Difference(kw.jujuKeys)
-	if added.Size() > 0 || deleted.Size() > 0 {
-		logger.Infof(ctx, "adding ssh keys to authorised keys: %v", added)
-		logger.Infof(ctx, "deleting ssh keys from authorised keys: %v", deleted)
-		// Preserve any in-flight ephemeral keys across the model key update.
-		if err = kw.writeSSHKeys(newKeys, true); err != nil {
-			err = errors.Annotate(err, "updating ssh keys")
-			logger.Infof(ctx, err.Error())
-			return err
-		}
-	}
-	kw.jujuKeys = newJujuKeys
-	return nil
-}
-
-// TearDown is defined on the worker.NotifyWatchHandler interface.
-func (kw *keyupdaterWorker) TearDown() error {
-	// Nothing to do here.
-	return nil
+// scopedContext returns a context that is in the scope of the worker lifetime.
+// It returns a cancellable context that is cancelled when the action has
+// completed.
+func (a *AuthWorker) scopedContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	return a.catacomb.Context(ctx), cancel
 }

--- a/internal/worker/authenticationworker/worker.go
+++ b/internal/worker/authenticationworker/worker.go
@@ -28,7 +28,10 @@ var logger = internallogger.GetLogger("juju.worker.authenticationworker")
 
 // Client provides the key updater api client.
 type Client interface {
+	// AuthorisedKeys returns the authorised ssh keys for the machine specified by machineTag.
 	AuthorisedKeys(ctx context.Context, tag names.MachineTag) ([]string, error)
+	// WatchAuthorisedKeys returns a notify watcher that looks for changes in the
+	// authorised ssh keys for the machine specified by machineTag.
 	WatchAuthorisedKeys(ctx context.Context, tag names.MachineTag) (watcher.NotifyWatcher, error)
 }
 
@@ -176,8 +179,7 @@ func (a *AuthWorker) enqueue(req ephemeralRequest) error {
 }
 
 func (a *AuthWorker) loop() error {
-	ctx, cancel := a.scopedContext()
-	defer cancel()
+	ctx := a.catacomb.Context(context.Background())
 
 	// Perform the initial synchronisation of the authorized_keys file before
 	// we start watching for changes. On startup any dangling ephemeral keys
@@ -342,12 +344,4 @@ func (a *AuthWorker) writeSSHKeys(jujuKeys []string, preserveEphemeral bool) err
 	}
 	allKeys = append(allKeys, jujuKeys...)
 	return ssh.ReplaceKeys(SSHUser, allKeys...)
-}
-
-// scopedContext returns a context that is in the scope of the worker lifetime.
-// It returns a cancellable context that is cancelled when the action has
-// completed.
-func (a *AuthWorker) scopedContext() (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
-	return a.catacomb.Context(ctx), cancel
 }

--- a/internal/worker/authenticationworker/worker.go
+++ b/internal/worker/authenticationworker/worker.go
@@ -6,6 +6,7 @@ package authenticationworker
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
@@ -34,6 +35,9 @@ type Client interface {
 type keyupdaterWorker struct {
 	client Client
 	tag    names.MachineTag
+	// mu serialises all mutations to the authorized_keys file, so that model
+	// key updates (Handle) do not race ephemeral key add/remove operations.
+	mu *sync.Mutex
 	// jujuKeys are the most recently retrieved keys from state.
 	jujuKeys set.Strings
 	// nonJujuKeys are those added externally to auth keys file
@@ -58,6 +62,11 @@ type EphemeralKeysUpdater interface {
 // for the lifetime of a reverse SSH tunnel.
 type AuthWorker struct {
 	worker.Worker
+
+	// mu is shared with the inner keyupdaterWorker so that ephemeral key
+	// add/remove operations are serialised against model key updates. Both
+	// mutate the same authorized_keys file.
+	mu *sync.Mutex
 }
 
 // NewWorker returns a worker that keeps track of
@@ -68,21 +77,29 @@ func NewWorker(client Client, agentConfig agent.Config) (worker.Worker, error) {
 	if !ok {
 		return nil, errors.NotValidf("machine tag %v", agentConfig.Tag())
 	}
+	// A single mutex is shared between the key updater handler and the
+	// AuthWorker's ephemeral key methods to serialise all writes to the
+	// authorized_keys file.
+	mu := &sync.Mutex{}
 	w, err := watcher.NewNotifyWorker(watcher.NotifyConfig{
 		Handler: &keyupdaterWorker{
 			client: client,
 			tag:    machineTag,
+			mu:     mu,
 		},
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &AuthWorker{Worker: w}, nil
+	return &AuthWorker{Worker: w, mu: mu}, nil
 }
 
 // AddEphemeralKey adds an ephemeral key to the authorized_keys file. The
 // supplied comment is used to identify the key for later removal.
 func (a *AuthWorker) AddEphemeralKey(key gossh.PublicKey, comment string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	keyWithComment := ensureJujuEphemeralComment(key, comment)
 	if err := ssh.AddKeys(SSHUser, keyWithComment); err != nil {
 		return errors.Trace(err)
@@ -92,6 +109,9 @@ func (a *AuthWorker) AddEphemeralKey(key gossh.PublicKey, comment string) error 
 
 // RemoveEphemeralKey removes an ephemeral key from the authorized_keys file.
 func (a *AuthWorker) RemoveEphemeralKey(ephemeralKey gossh.PublicKey) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
 	fingerprint := gossh.FingerprintLegacyMD5(ephemeralKey)
 	if err := ssh.DeleteKeys(SSHUser, fingerprint); err != nil {
 		return errors.Trace(err)
@@ -125,8 +145,10 @@ func (kw *keyupdaterWorker) SetUp(ctx context.Context) (watcher.NotifyWatcher, e
 			kw.nonJujuKeys = append(kw.nonJujuKeys, key)
 		}
 	}
-	// Write out the ssh authorised keys file to match the current state of the world.
-	if err := kw.writeSSHKeys(jujuKeys); err != nil {
+	// Write out the ssh authorised keys file to match the current state of the
+	// world. On startup any dangling ephemeral keys are intentionally not
+	// preserved, so a restart flushes them.
+	if err := kw.writeSSHKeys(jujuKeys, false); err != nil {
 		err = errors.Annotate(err, "adding current Juju keys to ssh authorised keys")
 		logger.Infof(ctx, err.Error())
 		return nil, err
@@ -142,10 +164,38 @@ func (kw *keyupdaterWorker) SetUp(ctx context.Context) (watcher.NotifyWatcher, e
 	return w, nil
 }
 
-// writeSSHKeys writes out a new ~/.ssh/authorised_keys file, retaining any non Juju keys
-// and adding the specified set of Juju keys.
-func (kw *keyupdaterWorker) writeSSHKeys(jujuKeys []string) error {
-	allKeys := kw.nonJujuKeys
+// writeSSHKeys writes out a new ~/.ssh/authorised_keys file, retaining any non
+// Juju keys and adding the specified set of Juju keys. When preserveEphemeral
+// is true, any ephemeral keys currently present in the file are retained too,
+// so that a model key update does not clobber an in-flight tunnel's key.
+//
+// It holds the shared mutex for the duration of the read-modify-write so that
+// it cannot race the AuthWorker's ephemeral key add/remove operations, which
+// mutate the same file.
+func (kw *keyupdaterWorker) writeSSHKeys(jujuKeys []string, preserveEphemeral bool) error {
+	kw.mu.Lock()
+	defer kw.mu.Unlock()
+
+	// Copy nonJujuKeys so appends below never mutate the shared slice across
+	// calls.
+	allKeys := append([]string(nil), kw.nonJujuKeys...)
+
+	// Preserve any ephemeral keys currently in the file so that a model key
+	// update does not drop them. They carry the Juju ephemeral comment prefix,
+	// so they are neither recorded as non-Juju keys nor part of the model keys.
+	if preserveEphemeral {
+		currentKeys, err := ssh.ListKeys(SSHUser, ssh.FullKeys)
+		if err != nil {
+			return errors.Annotate(err, "reading current ssh authorised keys")
+		}
+		for _, key := range currentKeys {
+			if _, comment, err := ssh.KeyFingerprint(key); err == nil &&
+				strings.HasPrefix(comment, jujuEphemeralCommentPrefix) {
+				allKeys = append(allKeys, key)
+			}
+		}
+	}
+
 	// Ensure any Juju keys have the required prefix in their comment.
 	for i, key := range jujuKeys {
 		jujuKeys[i] = ssh.EnsureJujuComment(key)
@@ -170,7 +220,8 @@ func (kw *keyupdaterWorker) Handle(ctx context.Context) error {
 	if added.Size() > 0 || deleted.Size() > 0 {
 		logger.Infof(ctx, "adding ssh keys to authorised keys: %v", added)
 		logger.Infof(ctx, "deleting ssh keys from authorised keys: %v", deleted)
-		if err = kw.writeSSHKeys(newKeys); err != nil {
+		// Preserve any in-flight ephemeral keys across the model key update.
+		if err = kw.writeSSHKeys(newKeys, true); err != nil {
 			err = errors.Annotate(err, "updating ssh keys")
 			logger.Infof(ctx, err.Error())
 			return err

--- a/internal/worker/authenticationworker/worker.go
+++ b/internal/worker/authenticationworker/worker.go
@@ -16,6 +16,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/agent"
+	coremachineauthentication "github.com/juju/juju/core/machineauthentication"
 	"github.com/juju/juju/core/watcher"
 	internallogger "github.com/juju/juju/internal/logger"
 )
@@ -167,14 +168,14 @@ func (a *AuthWorker) enqueue(req ephemeralRequest) error {
 	select {
 	case a.requests <- req:
 	case <-a.catacomb.Dying():
-		return errors.Trace(a.catacomb.ErrDying())
+		return errors.Trace(coremachineauthentication.ErrAuthenticationWorkerDying)
 	}
 
 	select {
 	case err := <-req.done:
 		return errors.Trace(err)
 	case <-a.catacomb.Dying():
-		return errors.Trace(a.catacomb.ErrDying())
+		return errors.Trace(coremachineauthentication.ErrAuthenticationWorkerDying)
 	}
 }
 

--- a/internal/worker/authenticationworker/worker.go
+++ b/internal/worker/authenticationworker/worker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/utils/v4/ssh"
 	"github.com/juju/worker/v5"
+	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/watcher"
@@ -40,6 +41,25 @@ type keyupdaterWorker struct {
 	nonJujuKeys []string
 }
 
+// EphemeralKeysUpdater adds and removes ephemeral SSH keys from the machine's
+// authorized_keys file. It is consumed by the sshsession worker, which injects
+// an ephemeral key for the lifetime of a reverse SSH tunnel.
+type EphemeralKeysUpdater interface {
+	// AddEphemeralKey adds an ephemeral key to the authorized_keys file,
+	// tagged with the supplied comment for later removal.
+	AddEphemeralKey(key gossh.PublicKey, comment string) error
+	// RemoveEphemeralKey removes a previously added ephemeral key.
+	RemoveEphemeralKey(key gossh.PublicKey) error
+}
+
+// AuthWorker is a worker that keeps track of the machine's authorised ssh keys
+// and ensures the ~/.ssh/authorized_keys file is up to date. It additionally
+// supports adding and removing ephemeral keys, used by the sshsession worker
+// for the lifetime of a reverse SSH tunnel.
+type AuthWorker struct {
+	worker.Worker
+}
+
 // NewWorker returns a worker that keeps track of
 // the machine's authorised ssh keys and ensures the
 // ~/.ssh/authorized_keys file is up to date.
@@ -57,7 +77,26 @@ func NewWorker(client Client, agentConfig agent.Config) (worker.Worker, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return w, nil
+	return &AuthWorker{Worker: w}, nil
+}
+
+// AddEphemeralKey adds an ephemeral key to the authorized_keys file. The
+// supplied comment is used to identify the key for later removal.
+func (a *AuthWorker) AddEphemeralKey(key gossh.PublicKey, comment string) error {
+	keyWithComment := ensureJujuEphemeralComment(key, comment)
+	if err := ssh.AddKeys(SSHUser, keyWithComment); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// RemoveEphemeralKey removes an ephemeral key from the authorized_keys file.
+func (a *AuthWorker) RemoveEphemeralKey(ephemeralKey gossh.PublicKey) error {
+	fingerprint := gossh.FingerprintLegacyMD5(ephemeralKey)
+	if err := ssh.DeleteKeys(SSHUser, fingerprint); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // SetUp is defined on the worker.NotifyWatchHandler interface.

--- a/internal/worker/authenticationworker/worker_test.go
+++ b/internal/worker/authenticationworker/worker_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/canonical/gomock/gomock"
+	"github.com/juju/collections/set"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/utils/v4/ssh"
@@ -85,6 +86,29 @@ func (s *workerSuite) waitSSHKeys(c *tc.C, expected []string) {
 				continue
 			}
 			return
+		}
+	}
+}
+
+// waitSSHKeysUnordered is like waitSSHKeys but compares the authorised keys as
+// a set rather than an ordered list. It is used where the final ordering of
+// keys in the file depends on concurrent operations interleaving, but the set
+// of keys present is deterministic. Ordering in authorized_keys is not
+// significant.
+func (s *workerSuite) waitSSHKeysUnordered(c *tc.C, expected []string) {
+	expectedSet := set.NewStrings(expected...)
+	timeout := time.After(coretesting.LongWait)
+	for {
+		select {
+		case <-timeout:
+			c.Fatalf("timeout while waiting for authorised ssh keys to change")
+		case <-time.After(coretesting.ShortWait):
+			keys, err := ssh.ListKeys(authenticationworker.SSHUser, ssh.FullKeys)
+			c.Assert(err, tc.ErrorIsNil)
+			if set.NewStrings(keys...).Difference(expectedSet).IsEmpty() &&
+				expectedSet.Difference(set.NewStrings(keys...)).IsEmpty() {
+				return
+			}
 		}
 	}
 }
@@ -313,4 +337,53 @@ func (s *workerSuite) TestEphemeralKeyRemovedOnRestart(c *tc.C) {
 	defer workertest.CleanKill(c, authWorker)
 
 	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey))
+}
+
+func (s *workerSuite) TestAddEphemeralKeyDuringModelChange(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	ch := make(chan struct{}, 1)
+	watch := watchertest.NewMockNotifyWatcher(ch)
+
+	tag := names.NewMachineTag("666")
+	client := mocks.NewMockClient(ctrl)
+
+	// The model key changes to key three on the watcher fire.
+	changedModelKey := sshtesting.ValidKeyThree.Key + " yetanother@host"
+	gomock.InOrder(
+		client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return(s.existingModelKeys, nil),
+		client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return([]string{changedModelKey}, nil),
+	)
+	client.EXPECT().WatchAuthorisedKeys(gomock.Any(), tag).Return(watch, nil)
+
+	authWorker, err := authenticationworker.NewWorker(client, agentConfig(c, tag))
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, authWorker)
+	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey))
+
+	updater, ok := authWorker.(authenticationworker.EphemeralKeysUpdater)
+	c.Assert(ok, tc.IsTrue)
+
+	key4, _, _, _, err := gossh.ParseAuthorizedKey([]byte(sshtesting.ValidKeyFour.Key))
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Add an ephemeral key in a goroutine to simulate it racing with a model
+	// key change being processed by the worker's Handle. The two writers to
+	// authorized_keys must not clobber each other: the final state must contain
+	// both the changed model key and the ephemeral key.
+	go func() {
+		c.Check(updater.AddEphemeralKey(key4, "key4-comment"), tc.ErrorIsNil)
+	}()
+
+	// Fire the watcher so the worker processes the model key change. This
+	// replaces the original model key (existingEnvKey) with the changed key.
+	ch <- struct{}{}
+
+	// The final ordering of keys depends on how AddEphemeralKey interleaves
+	// with the model key update, so compare as a set. The invariant under test
+	// is that neither write clobbers the other: both keys must be present.
+	changedModelKeyWithComment := sshtesting.ValidKeyThree.Key + " Juju:yetanother@host"
+	ephemeralKeyWithComment := sshtesting.ValidKeyFour.Key + " Juju:Ephemeral:key4-comment"
+	s.waitSSHKeysUnordered(c, append(s.existingKeys, changedModelKeyWithComment, ephemeralKeyWithComment))
 }

--- a/internal/worker/authenticationworker/worker_test.go
+++ b/internal/worker/authenticationworker/worker_test.go
@@ -19,6 +19,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/agent"
+	coremachineauthentication "github.com/juju/juju/core/machineauthentication"
 	"github.com/juju/juju/core/watcher/watchertest"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/authenticationworker"
@@ -386,4 +387,31 @@ func (s *workerSuite) TestAddEphemeralKeyDuringModelChange(c *tc.C) {
 	changedModelKeyWithComment := sshtesting.ValidKeyThree.Key + " Juju:yetanother@host"
 	ephemeralKeyWithComment := sshtesting.ValidKeyFour.Key + " Juju:Ephemeral:key4-comment"
 	s.waitSSHKeysUnordered(c, append(s.existingKeys, changedModelKeyWithComment, ephemeralKeyWithComment))
+}
+
+// TestEphemeralKeyOpsReturnWorkerDying asserts that once the worker is dying,
+// both AddEphemeralKey and RemoveEphemeralKey return
+// ErrAuthenticationWorkerDying rather than the catacomb's internal dying error,
+// so consuming workers can distinguish a lifecycle stop from a real failure.
+func (s *workerSuite) TestEphemeralKeyOpsReturnWorkerDying(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	authWorker := s.startWorker(c, ctrl)
+
+	updater, ok := authWorker.(authenticationworker.EphemeralKeysUpdater)
+	c.Assert(ok, tc.IsTrue)
+
+	pub, _, _, _, err := gossh.ParseAuthorizedKey([]byte(sshtesting.ValidKeyThree.Key))
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Stop the worker so that enqueue observes the catacomb dying and any
+	// ephemeral key operation short-circuits with the sentinel error.
+	workertest.CleanKill(c, authWorker)
+
+	err = updater.AddEphemeralKey(pub, "tunnel-0")
+	c.Check(err, tc.ErrorIs, coremachineauthentication.ErrAuthenticationWorkerDying)
+
+	err = updater.RemoveEphemeralKey(pub)
+	c.Check(err, tc.ErrorIs, coremachineauthentication.ErrAuthenticationWorkerDying)
 }

--- a/internal/worker/authenticationworker/worker_test.go
+++ b/internal/worker/authenticationworker/worker_test.go
@@ -303,13 +303,13 @@ func (s *workerSuite) TestAddAndRemoveEphemeralKey(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	ephemeralKey := sshtesting.ValidKeyThree.Key + " Juju:Ephemeral:tunnel-0"
-	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey, ephemeralKey))
+	s.waitSSHKeysUnordered(c, append(s.existingKeys, s.existingEnvKey, ephemeralKey))
 
 	// Removing the ephemeral key drops it again.
 	err = updater.RemoveEphemeralKey(pub)
 	c.Assert(err, tc.ErrorIsNil)
 
-	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey))
+	s.waitSSHKeysUnordered(c, append(s.existingKeys, s.existingEnvKey))
 }
 
 func (s *workerSuite) TestEphemeralKeyRemovedOnRestart(c *tc.C) {

--- a/internal/worker/authenticationworker/worker_test.go
+++ b/internal/worker/authenticationworker/worker_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/juju/tc"
 	"github.com/juju/utils/v4/ssh"
 	sshtesting "github.com/juju/utils/v4/ssh/testing"
+	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
+	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -237,4 +239,78 @@ func (s *workerSuite) TestWorkerRestart(c *tc.C) {
 	s.waitSSHKeys(c, append(s.existingKeys, yetAnotherKeyWithCommentPrefix))
 
 	workertest.CleanKill(c, authWorker)
+}
+
+// startWorker starts an auth worker that only reports the existing model keys,
+// and returns it. The watcher never fires so the authorized_keys file settles
+// to the existing keys plus the model key.
+func (s *workerSuite) startWorker(c *tc.C, ctrl *gomock.Controller) worker.Worker {
+	ch := make(chan struct{}, 1)
+	watch := watchertest.NewMockNotifyWatcher(ch)
+
+	tag := names.NewMachineTag("666")
+	client := mocks.NewMockClient(ctrl)
+	client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return(s.existingModelKeys, nil).AnyTimes()
+	client.EXPECT().WatchAuthorisedKeys(gomock.Any(), tag).Return(watch, nil)
+
+	authWorker, err := authenticationworker.NewWorker(client, agentConfig(c, tag))
+	c.Assert(err, tc.ErrorIsNil)
+	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey))
+	return authWorker
+}
+
+func (s *workerSuite) TestAddAndRemoveEphemeralKey(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	authWorker := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, authWorker)
+
+	updater, ok := authWorker.(authenticationworker.EphemeralKeysUpdater)
+	c.Assert(ok, tc.IsTrue)
+
+	pub, _, _, _, err := gossh.ParseAuthorizedKey([]byte(sshtesting.ValidKeyThree.Key))
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Adding the ephemeral key writes it into the authorized_keys file, tagged
+	// with the ephemeral comment prefix.
+	err = updater.AddEphemeralKey(pub, "tunnel-0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	ephemeralKey := sshtesting.ValidKeyThree.Key + " Juju:Ephemeral:tunnel-0"
+	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey, ephemeralKey))
+
+	// Removing the ephemeral key drops it again.
+	err = updater.RemoveEphemeralKey(pub)
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey))
+}
+
+func (s *workerSuite) TestEphemeralKeyRemovedOnRestart(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	authWorker := s.startWorker(c, ctrl)
+
+	updater, ok := authWorker.(authenticationworker.EphemeralKeysUpdater)
+	c.Assert(ok, tc.IsTrue)
+
+	pub, _, _, _, err := gossh.ParseAuthorizedKey([]byte(sshtesting.ValidKeyThree.Key))
+	c.Assert(err, tc.ErrorIsNil)
+	err = updater.AddEphemeralKey(pub, "tunnel-0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	ephemeralKey := sshtesting.ValidKeyThree.Key + " Juju:Ephemeral:tunnel-0"
+	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey, ephemeralKey))
+
+	// Stop the worker, leaving the ephemeral key dangling in authorized_keys.
+	workertest.CleanKill(c, authWorker)
+
+	// A fresh worker must strip any dangling ephemeral keys on startup, since
+	// they carry the Juju comment prefix and are not part of the model keys.
+	authWorker = s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, authWorker)
+
+	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey))
 }


### PR DESCRIPTION
# Description
This PR ports the ephemeral SSH key methods Add/RemoveEphemeralKey onto the authentication worker, so the upcoming sshsession worker can inject a its short lived keys into authorized_keys for the lifetime of a reverse SSH tunnel and remove it afterwards.

# Issue found
While porting the tests from conn suite to mocks, I found a latent race (which I then reproduced via -count consistently) in the original feature/ssh design.

The worker writes to authorized_keys from two places: 
1. The model-key updater (Handle)
2. The ephemeral add/remove methods. 

Both do a read-modify-write on the same file with no synchronisation, so if they run at the same time one can overwrite the othe. More importantly, I *think* a model key update could silently drop an in-flight tunnel's ephemeral key. This was hard to prove just running the test as it was simply timing out waiting for the keys which I'm pretty sure is because the model key updater was just beating the empheral key to the write.

I think the original feature/ssh test never caught this because the conn suite harness was slow enough that the two writes never actually overlapped but the new faster mock based test exposed it reliably.

To fix it, all writes to authorized_keys now share a single mutex so they can't interleave, and the model key update path preserves any ephemeral keys already present rather than rebuilding the file without them (startup still deliberately flushes stale ephemeral keys).

# Final note
I initially thought the fixes may be moot as we'll be dropping the old authorised keys for SSH at some point in the future, but I think we'd still require the auth worker for the system key on the model (**can someone confirm this please?**) - And if that's right, then we'll definitely require the mux changes I've added. 

Other than this change, everything else is a straight forward port.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
We can't QA the ephemeral keys right now, but we can prove the existing behaviour still works.

1. Bootstrap a controller
2. Add a model
3. Add an ssh key to the model
4. Deploy ubuntu
5. SSH via that key
6. Check authorized_keys and make sure the pub key matches the additional key you added like so:

ubuntu@juju-9c45c0-0:~$ cat ~/.ssh/authorized_keys -> should contain 3 keys and 1 of those keys should correspond to the pub key you added.