### PR TITLE
feat(ci): add juju_exec_output helper to prevent stdout/stderr mixing in juju exec

### DIFF
--- a/tests/includes/exec.sh
+++ b/tests/includes/exec.sh
@@ -1,0 +1,51 @@
+# juju_exec_output wraps `juju exec --format yaml` to reliably extract
+# command stdout without mixing it with stderr (log noise, error messages
+# from the coveruploader, juju-level ERROR output, etc.).
+#
+# Usage:
+#   juju_exec_output [juju exec options] [--] <command>
+#
+# Examples:
+#   value=$(juju_exec_output --unit hello/0 -- secret-add foo=bar)
+#   juju_exec_output --all -- hostname
+#   juju_exec_output -a myapp -- network-get myendpoint
+#
+# Behaviour:
+#   - Success: prints the stdout of the executed command(s) to stdout.
+#   - Failure (any task with non-zero return code): returns 1.
+#   - Every task's stderr AND juju exec's own stderr (ERROR messages,
+#     log noise) are always forwarded to stderr and never captured as data.
+juju_exec_output() {
+	local yaml_output juju_rc fail_count
+
+	# Capture juju exec stdout (YAML) while forwarding its stderr to the
+	# caller's stderr in real time. FD 3 bridges the subshell's stderr to
+	# the outer stderr: the block sets 3>&2, then inside $() juju exec's
+	# stderr goes to FD 3 (2>&3) and FD 3 is closed (3>&-) so it is not
+	# captured.
+	{
+		yaml_output=$(juju exec --format yaml "$@" 2>&3 3>&-) && juju_rc=0 || juju_rc=$?
+	} 3>&2
+
+	# Hard failure: juju produced no parseable YAML. Surface exit code only.
+	if [[ -z ${yaml_output} ]]; then
+		return "${juju_rc}"
+	fi
+
+	# Forward stderr from ALL tasks to real stderr.
+	printf '%s\n' "${yaml_output}" |
+		yq -r '.[].results.stderr // "" | select(. != "")' >&2 2>/dev/null
+
+	# Count tasks with a non-zero (or missing) return code. Quoted key
+	# access avoids any bare-hyphen ambiguity, and a null result counts
+	# as a failure.
+	fail_count=$(printf '%s\n' "${yaml_output}" |
+		yq '[.[] | select(.results["return-code"] != 0)] | length' 2>/dev/null) || true
+
+	if ((${fail_count:-0} > 0)); then
+		return 1
+	fi
+
+	# Emit stdout from all results (target order preserved).
+	printf '%s\n' "${yaml_output}" | yq -r '.[].results.stdout // ""'
+}

--- a/tests/includes/network.sh
+++ b/tests/includes/network.sh
@@ -33,7 +33,7 @@ assert_net_iface_for_endpoint_matches() {
 	exp_if_name=${3}
 
 	# shellcheck disable=SC2086,SC2016
-	got_if=$(juju exec -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: en" | awk '{print $2}' || echo "")
+	got_if=$(juju_exec_output -a ${app_name} "network-get ${endpoint_name}" | grep "interfacename: en" | awk '{print $2}' || echo "")
 	if [ "$got_if" != "$exp_if_name" ]; then
 		# shellcheck disable=SC2086,SC2016,SC2046
 		echo $(red "Expected network interface for ${app_name}:${endpoint_name} to be ${exp_if_name}; got ${got_if}")

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -17,6 +17,8 @@ wait_for_controller_leader() {
 	# leadership can not be determined, so there is no fixed number of attempts
 	# that we can rely on.
 	# shellcheck disable=SC2143
+	# Not using juju_exec_output: uptime is a plain system command that
+	# produces no stderr, so the stdout/stderr mixing bug does not apply.
 	until [[ "$(juju exec -m controller --unit controller/leader uptime | grep load)" ]]; do
 		echo "[+] waiting for controller leadership"
 	done

--- a/tests/suites/controller/query_tracing.sh
+++ b/tests/suites/controller/query_tracing.sh
@@ -1,5 +1,7 @@
 cat_query_tracing_enabled_agent_conf() {
 	# shellcheck disable=SC2046
+	# Not using juju_exec_output: sudo cat produces no stderr, so the
+	# stdout/stderr mixing bug does not apply.
 	echo $(juju exec -m controller --machine 0 'sudo cat /var/lib/juju/agents/machine-0/agent.conf' | grep "querytracingenabled")
 }
 
@@ -40,6 +42,8 @@ run_query_tracing_enabled() {
 
 cat_query_tracing_threshold_agent_conf() {
 	# shellcheck disable=SC2046
+	# Not using juju_exec_output: sudo cat produces no stderr, so the
+	# stdout/stderr mixing bug does not apply.
 	echo $(juju exec -m controller --machine 0 'sudo cat /var/lib/juju/agents/machine-0/agent.conf' | grep "querytracingthreshold")
 }
 

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -310,6 +310,8 @@ run_deploy_lxd_to_container() {
 	lxd_profile_0="juju-test-deploy-lxd-container-${short_uuid}-lxd-profile-alt-0"
 	lxd_profile_1="juju-test-deploy-lxd-container-${short_uuid}-lxd-profile-alt-1"
 
+	# Not using juju_exec_output: lxc profile commands are plain system
+	# commands that produce no stderr noise.
 	OUT=$(juju exec --machine 0 -- sh -c "sudo lxc profile show \"${lxd_profile_0}\"")
 	echo "${OUT}" | grep -E "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"
 
@@ -322,6 +324,8 @@ run_deploy_lxd_to_container() {
 
 	attempt=0
 	while true; do
+		# Not using juju_exec_output: lxc profile commands are plain
+		# system commands that produce no stderr noise.
 		OUT=$(juju exec --machine 0 -- sh -c "sudo lxc profile show \"${lxd_profile_1}\"" || echo 'NOT FOUND')
 		if echo "${OUT}" | grep -E -q "linux.kernel_modules: ([a-zA-Z0-9\_,]+)?ip_tables,ip6_tables([a-zA-Z0-9\_,]+)?"; then
 			break
@@ -338,6 +342,8 @@ run_deploy_lxd_to_container() {
 	# Ensure that the old one is removed
 	attempt=0
 	while true; do
+		# Not using juju_exec_output: lxc profile commands are plain
+		# system commands that produce no stderr noise.
 		OUT=$(juju exec --machine 0 -- sh -c "sudo lxc profile list" || echo 'NOT FOUND')
 		if echo "${OUT}" | grep -v "${lxd_profile_0}"; then
 			break

--- a/tests/suites/firewall/expose_app.sh
+++ b/tests/suites/firewall/expose_app.sh
@@ -30,7 +30,7 @@ assert_opened_ports_output() {
 	# Test the backwards-compatible version of opened-ports where the output
 	# includes the unique set of opened ports for all endpoints.
 	exp="1234/tcp 1337-1339/tcp"
-	got=$(juju exec --unit ubuntu-lite/0 "opened-ports" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
+	got=$(juju_exec_output --unit ubuntu-lite/0 "opened-ports" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
 	if [ "$got" != "$exp" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected opened-ports output to be:\n${exp}\nGOT:\n${got}")
@@ -39,7 +39,7 @@ assert_opened_ports_output() {
 
 	# Try the new version where we group by endpoint.
 	exp="1234/tcp (ubuntu) 1337-1339/tcp (*)"
-	got=$(juju exec --unit ubuntu-lite/0 "opened-ports --endpoints" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
+	got=$(juju_exec_output --unit ubuntu-lite/0 "opened-ports --endpoints" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
 	if [ "$got" != "$exp" ]; then
 		# shellcheck disable=SC2046
 		echo $(red "expected opened-ports output when using --endpoints to be:\n${exp}\nGOT:\n${got}")

--- a/tests/suites/hooktools/storage_tools.sh
+++ b/tests/suites/hooktools/storage_tools.sh
@@ -10,7 +10,7 @@ run_storage_list() {
 		--storage multi-fs=2
 	wait_for "x" "$(idle_condition "x")"
 
-	storage=$(juju exec --unit x/0 'storage-list')
+	storage=$(juju_exec_output --unit x/0 'storage-list')
 	echo "$storage" | awk -F'/' '/^multi-fs/{count++} END{print count+0}' | check '2'
 	echo "$storage" | awk -F'/' '/^single-fs/{count++} END{print count+0}' | check '1'
 
@@ -28,13 +28,13 @@ run_storage_get() {
 	juju deploy juju-qa-dummy-storage x --storage single-fs=1
 	wait_for "x" "$(idle_condition "x")"
 
-	kind=$(juju exec --unit x/0 'storage-get -s single-fs/0 kind')
+	kind=$(juju_exec_output --unit x/0 'storage-get -s single-fs/0 kind')
 	echo $kind | check 'filesystem'
-	
-	location=$(juju exec --unit x/0 'storage-get -s single-fs/0 location')
+
+	location=$(juju_exec_output --unit x/0 'storage-get -s single-fs/0 location')
 	check_contains "$location" '/srv/single-fs'
 
-	yaml=$(juju exec --unit x/0 'storage-get -s single-fs/0 --format=yaml')
+	yaml=$(juju_exec_output --unit x/0 'storage-get -s single-fs/0 --format=yaml')
 	echo "$yaml" | yq -r '.kind' | check "$kind"
 	echo "$yaml" | yq -r '.location' | check "$location"
 
@@ -52,16 +52,16 @@ run_storage_add() {
 	juju deploy juju-qa-dummy-storage x
 	wait_for "x" "$(idle_condition "x")"
 
-	storage=$(juju exec --unit x/0 'storage-list')
+	storage=$(juju_exec_output --unit x/0 'storage-list')
 	echo "$storage" | awk -F'/' '/^single-fs/{count++} END{print count+0}' | check '0'
 	echo "$storage" | awk -F'/' '/^multi-fs/{count++} END{print count+0}' | check '0'
-	
+
 	juju exec --unit x/0 'storage-add single-fs'
-	storage=$(juju exec --unit x/0 'storage-list')
+	storage=$(juju_exec_output --unit x/0 'storage-list')
 	echo "$storage" | awk -F'/' '/^single-fs/{count++} END{print count+0}' | check '1'
-	
+
 	juju exec --unit x/0 'storage-add multi-fs=2'
-	storage=$(juju exec --unit x/0 'storage-list')
+	storage=$(juju_exec_output --unit x/0 'storage-list')
 	echo "$storage" | awk -F'/' '/^multi-fs/{count++} END{print count+0}' | check '2'
 
 	destroy_model "${model_name}"
@@ -80,7 +80,7 @@ test_storage_hook_tools() {
 
 		run "run_storage_get"
 		run "run_storage_list"
-		
+
 		case "${BOOTSTRAP_PROVIDER:-}" in
 		"k8s")
 			echo "==> TEST SKIPPED: storage_add"

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -19,15 +19,15 @@ run_model_migration() {
 	user_secret_short_uri=${user_secret_uri##*:}
 	check_contains "$(juju --show-log show-secret mysecret --revisions | yq ".${user_secret_short_uri}.description")" 'this is a user secret'
 	juju --show-log grant-secret mysecret "ubuntu"
-	check_contains "$(juju exec --unit "ubuntu/0" -- secret-get $user_secret_short_uri)" "owned-by: model"
+	check_contains "$(juju_exec_output --unit "ubuntu/0" -- secret-get $user_secret_short_uri)" "owned-by: model"
 
 	# create charm-owned secret.
-	unit_owned_secret_uri=$(juju exec --unit ubuntu/0 -- secret-add --owner unit owned-by=ubuntu/0)
+	unit_owned_secret_uri=$(juju_exec_output --unit ubuntu/0 -- secret-add --owner unit owned-by=ubuntu/0)
 	unit_owned_secret_short_uri=${unit_owned_secret_uri##*:}
-	check_contains "$(juju exec --unit "ubuntu/0" -- secret-get $unit_owned_secret_short_uri)" "owned-by: ubuntu/0"
-	app_owned_secret_uri=$(juju exec --unit ubuntu/0 -- secret-add owned-by=ubuntu)
+	check_contains "$(juju_exec_output --unit "ubuntu/0" -- secret-get $unit_owned_secret_short_uri)" "owned-by: ubuntu/0"
+	app_owned_secret_uri=$(juju_exec_output --unit ubuntu/0 -- secret-add owned-by=ubuntu)
 	app_owned_secret_short_uri=${app_owned_secret_uri##*:}
-	check_contains "$(juju exec --unit "ubuntu/0" -- secret-get $app_owned_secret_short_uri)" "owned-by: ubuntu"
+	check_contains "$(juju_exec_output --unit "ubuntu/0" -- secret-get $app_owned_secret_short_uri)" "owned-by: ubuntu"
 
 	# Capture logs to ensure they are migrated
 	old_logs="$(juju debug-log --no-tail -l DEBUG)"
@@ -46,17 +46,17 @@ run_model_migration() {
 
 	# Check that the secrets are still present and accessible.
 	check_contains "$(juju --show-log show-secret mysecret --revisions | yq ".${user_secret_short_uri}.description")" 'this is a user secret'
-	check_contains "$(juju exec --unit "ubuntu/0" -- secret-get $user_secret_short_uri)" "owned-by: model"
-	check_contains "$(juju exec --unit "ubuntu/0" -- secret-get $unit_owned_secret_short_uri)" "owned-by: ubuntu/0"
-	check_contains "$(juju exec --unit "ubuntu/0" -- secret-get $app_owned_secret_short_uri)" "owned-by: ubuntu"
+	check_contains "$(juju_exec_output --unit "ubuntu/0" -- secret-get $user_secret_short_uri)" "owned-by: model"
+	check_contains "$(juju_exec_output --unit "ubuntu/0" -- secret-get $unit_owned_secret_short_uri)" "owned-by: ubuntu/0"
+	check_contains "$(juju_exec_output --unit "ubuntu/0" -- secret-get $app_owned_secret_short_uri)" "owned-by: ubuntu"
 
 	# check we can still create new secrets.
 	user_secret_uri1=$(juju --show-log add-secret mysecret1 owned-by="model-as-well" --info "this is another user secret")
 	user_secret_short_uri1=${user_secret_uri1##*:}
 	check_contains "$(juju --show-log show-secret mysecret1 --revisions | yq ".${user_secret_short_uri1}.description")" 'this is another user secret'
-	unit_owned_secret_uri1=$(juju exec --unit ubuntu/0 -- secret-add --owner unit owned-by=ubuntu/0)
+	unit_owned_secret_uri1=$(juju_exec_output --unit ubuntu/0 -- secret-add --owner unit owned-by=ubuntu/0)
 	unit_owned_secret_short_uri1=${unit_owned_secret_uri1##*:}
-	check_contains "$(juju exec --unit "ubuntu/0" -- secret-get $unit_owned_secret_short_uri1)" "owned-by: ubuntu/0"
+	check_contains "$(juju_exec_output --unit "ubuntu/0" -- secret-get $unit_owned_secret_short_uri1)" "owned-by: ubuntu/0"
 
 	# Add a unit to ubuntu to ensure the model is functional
 	juju add-unit ubuntu

--- a/tests/suites/network/network_health.sh
+++ b/tests/suites/network/network_health.sh
@@ -36,6 +36,8 @@ check_default_routes() {
 	echo "[+] checking default routes"
 
 	for machine in $(juju machines --format=json | yq -r "select(.machines) | .machines | keys | .[]"); do
+		# Not using juju_exec_output: ip route show is a plain system
+		# command that produces no stderr noise.
 		default=$(juju exec --machine "$machine" -- ip route show | grep default)
 		if [ -z "$default" ]; then
 			echo "No default route detected for machine ${machine}"
@@ -56,6 +58,8 @@ check_accessibility() {
 		# Check that each of the principles can access the subordinate.
 		for principle_unit in "ubuntu-focal/0" "ubuntu-jammy/0"; do
 			echo "checking network health unit ${net_health_unit} reachability from ${principle_unit} using ${ip}:8039"
+			# Not using juju_exec_output: curl -s suppresses stderr,
+			# so the stdout/stderr mixing bug does not apply.
 			check_contains "$(juju exec --unit $principle_unit "$curl_cmd")" "pass"
 		done
 
@@ -93,6 +97,8 @@ run_ip_address_change() {
 	attempt=0
 	echo "getting the new ip address for machine-0"
 	while true; do
+		# Not using juju_exec_output: timeout cannot wrap a shell
+		# function, and hostname -I produces no stderr noise.
 		new_ip_instance_0_from_jujuexec=$(timeout 5s juju exec --unit juju-qa-test/0 -- hostname -I || true)
 		if echo "${new_ip_instance_0_from_jujuexec}" | grep -qF "${new_ip_instance_0}"; then
 			# shellcheck disable=SC2046
@@ -122,6 +128,8 @@ run_ip_address_change() {
 	attempt=0
 	echo "getting the new ip address for machine-1"
 	while true; do
+		# Not using juju_exec_output: timeout cannot wrap a shell
+		# function, and hostname -I produces no stderr noise.
 		new_ip_instance_1_from_jujuexec=$(timeout 5s juju exec --unit juju-qa-test/1 -- hostname -I || true)
 		if echo "${new_ip_instance_1_from_jujuexec}" | grep -qF "${new_ip_instance_1}"; then
 			# shellcheck disable=SC2046

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -21,13 +21,13 @@ run_relation_data_exchange() {
 
 	echo "Get the leader unit name"
 	non_leader_dummy_sink_unit=$(juju status --format json | yq -r '.applications."dummy-sink".units | to_entries[] | select(.value.leader!=true) | .key')
-	dummy_sink_relation_id=$(juju exec --unit "dummy-sink/leader" 'relation-ids source')
-	dummy_source_relation_id=$(juju exec --unit "dummy-source/leader" 'relation-ids sink')
+	dummy_sink_relation_id=$(juju_exec_output --unit "dummy-sink/leader" 'relation-ids source')
+	dummy_source_relation_id=$(juju_exec_output --unit "dummy-source/leader" 'relation-ids sink')
 	# stop there
 	echo "Block until the relation is joined; otherwise, the relation-set commands below will fail"
 	attempt=0
 	while true; do
-		got=$(juju exec --unit "dummy-sink/leader" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" || echo 'NOT FOUND')
+		got=$(juju_exec_output --unit "dummy-sink/leader" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" || echo 'NOT FOUND')
 		if [ "${got}" != "NOT FOUND" ]; then
 			break
 		fi
@@ -41,7 +41,7 @@ run_relation_data_exchange() {
 	done
 	attempt=0
 	while true; do
-		got=$(juju exec --unit 'dummy-source/0' "relation-get --app -r ${dummy_sink_relation_id} origin dummy-source" || echo 'NOT FOUND')
+		got=$(juju_exec_output --unit 'dummy-source/0' "relation-get --app -r ${dummy_sink_relation_id} origin dummy-source" || echo 'NOT FOUND')
 		if [ "${got}" != "NOT FOUND" ]; then
 			break
 		fi
@@ -61,11 +61,11 @@ run_relation_data_exchange() {
 	juju exec --unit 'dummy-source/0' "relation-set --app -r ${dummy_source_relation_id} origin=dummy-source"
 
 	echo "Check 1: ensure that leaders can read the application databag for their own application"
-	juju exec --unit "dummy-sink/leader" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" | check "dummy-sink"
-	juju exec --unit 'dummy-source/0' "relation-get --app -r ${dummy_source_relation_id} origin dummy-source" | check "dummy-source"
+	juju_exec_output --unit "dummy-sink/leader" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" | check "dummy-sink"
+	juju_exec_output --unit 'dummy-source/0' "relation-get --app -r ${dummy_source_relation_id} origin dummy-source" | check "dummy-source"
 
 	echo "Check 2: ensure that non-leader units are not allowed to read their own application databag for non-peer relations"
-	juju exec --unit "${non_leader_dummy_sink_unit}" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" 2>&1 || echo "PERMISSION DENIED" | check "PERMISSION DENIED"
+	juju_exec_output --unit "${non_leader_dummy_sink_unit}" "relation-get --app -r ${dummy_sink_relation_id} origin dummy-sink" || echo "PERMISSION DENIED" | check "PERMISSION DENIED"
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -22,7 +22,7 @@ run_relation_list_app() {
 	wait_for "dummy-source" "$(idle_condition "dummy-source" 0)"
 
 	echo "Figure out the right relation IDs to use for our hook tool invocations"
-	sink_rel_id=$(juju exec --unit dummy-source/0 "relation-ids sink" | cut -d':' -f2)
+	sink_rel_id=$(juju_exec_output --unit dummy-source/0 "relation-ids sink" | cut -d':' -f2)
 
 	echo "Remove dummy-sink unit"
 	# the dummy-sink-source relation is still established but there are no units present in the dummy-sink side
@@ -30,7 +30,7 @@ run_relation_list_app() {
 	wait_for null '.applications."dummy-sink".units."dummy-sink/0"'
 
 	echo "Check relation-list hook"
-	juju exec --unit dummy-source/0 "relation-list --app -r ${sink_rel_id}" | check "dummy-sink"
+	juju_exec_output --unit dummy-source/0 "relation-list --app -r ${sink_rel_id}" | check "dummy-sink"
 
 	destroy_model "${model_name}"
 }

--- a/tests/suites/relations/relation_model_get.sh
+++ b/tests/suites/relations/relation_model_get.sh
@@ -19,11 +19,11 @@ run_relation_model_get() {
 	wait_for "dummy-source" "$(idle_condition "dummy-source" 0)"
 
 	echo "Figure out the right relation IDs to use for hook command invocations"
-	sink_rel_id=$(juju exec --unit dummy-source/0 "relation-ids sink" | cut -d':' -f2)
+	sink_rel_id=$(juju_exec_output --unit dummy-source/0 "relation-ids sink" | cut -d':' -f2)
 
 	echo "Check relation-model-get hook"
 	model_uuid=$(juju show-model --format json | yq -r '.["test-relation-model-get"]["model-uuid"]')
-	juju exec --unit dummy-source/0 "relation-model-get -r ${sink_rel_id}" | check "${model_uuid}"
+	juju_exec_output --unit dummy-source/0 "relation-model-get -r ${sink_rel_id}" | check "${model_uuid}"
 
 	echo "Setting up cross model relation"
 	juju offer dummy-source:sink
@@ -37,10 +37,10 @@ run_relation_model_get() {
 	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0)"
 
 	echo "Figure out the right relation IDs to use for hook command invocations"
-	sink_rel_id=$(juju exec --unit dummy-sink/0 "relation-ids source" | cut -d':' -f2)
+	sink_rel_id=$(juju_exec_output --unit dummy-sink/0 "relation-ids source" | cut -d':' -f2)
 
 	echo "Check relation-model-get hook"
-	juju exec --unit dummy-sink/0 "relation-model-get -r ${sink_rel_id}" | check "${model_uuid}"
+	juju_exec_output --unit dummy-sink/0 "relation-model-get -r ${sink_rel_id}" | check "${model_uuid}"
 
 	destroy_model "${model_name}"
 	destroy_model "${another_model_name}"

--- a/tests/suites/secrets_iaas/cmr.sh
+++ b/tests/suites/secrets_iaas/cmr.sh
@@ -23,43 +23,43 @@ run_secrets_cmr() {
 	wait_for "1" '.offers["dummy-source"]["active-connected-count"]'
 
 	echo "Create and share a secret on the offer side"
-	secret_uri=$(juju exec -m model-secrets-offer --unit dummy-source/0 -- secret-add foo=bar)
+	secret_uri=$(juju_exec_output -m model-secrets-offer --unit dummy-source/0 -- secret-add foo=bar)
 	relation_id=$(juju --show-log show-unit -m model-secrets-offer dummy-source/0 --format json | yq '."dummy-source/0"."relation-info"[0]."relation-id"')
 	juju exec -m model-secrets-offer --unit dummy-source/0 -- secret-grant "$secret_uri" -r "$relation_id"
 
 	echo "Checking: the secret can be read by the consumer"
 	juju switch "model-secrets-consume"
 	echo "Checking:  secret-get by URI - consume content"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label mylabel "$secret_uri")" 'foo: bar'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get --label mylabel "$secret_uri")" 'foo: bar'
 	echo "Checking:  secret-get by URI - consume content"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label mylabel)" 'foo: bar'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get --label mylabel)" 'foo: bar'
 
 	echo "Checking: add a new revision and check consumer can see it"
 	juju switch "model-secrets-offer"
 	juju exec --unit dummy-source/0 -- secret-set "$secret_uri" foo=bar2
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label mylabel)" 'foo: bar'
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label mylabel --peek)" 'foo: bar2'
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label mylabel)" 'foo: bar'
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label mylabel --refresh)" 'foo: bar2'
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label mylabel)" 'foo: bar2'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get --label mylabel)" 'foo: bar'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get --label mylabel --peek)" 'foo: bar2'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get --label mylabel)" 'foo: bar'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get --label mylabel --refresh)" 'foo: bar2'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get --label mylabel)" 'foo: bar2'
 
 	echo "Checking: suspend relation and check access is lost"
 	juju switch "model-secrets-offer"
 	juju suspend-relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
 	echo "Checking: resume relation and access is restored"
 	juju switch "model-secrets-offer"
 	juju resume-relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label mylabel)" 'foo: bar2'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get --label mylabel)" 'foo: bar2'
 
 	echo "Checking: secret-revoke by relation ID"
 	juju switch "model-secrets-offer"
 	juju exec --unit dummy-source/0 -- secret-revoke "$secret_uri" --relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
 }
 
 test_secrets_cmr() {

--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -230,13 +230,13 @@ obsolete_secret_revisions() {
 	secret_id=${1}
 
 	yaml_out=$(
-juju ssh juju-qa-test/0 sh <<EOF
+		juju ssh juju-qa-test/0 sh <<EOF
 . /etc/profile.d/juju-introspection.sh
 juju_engine_report
 EOF
 	)
-	 out=$(echo "${yaml_out}" | sed 1d | yq "..style=\"flow\" | .manifolds.deployer.report.handler.units.workers.\"juju-qa-test/0\".report.manifolds.uniter.report.secrets.\"obsolete-revisions\".\"${secret_id}\"")
-	 echo "${out}"
+	out=$(echo "${yaml_out}" | sed 1d | yq "..style=\"flow\" | .manifolds.deployer.report.handler.units.workers.\"juju-qa-test/0\".report.manifolds.uniter.report.secrets.\"obsolete-revisions\".\"${secret_id}\"")
+	echo "${out}"
 }
 
 run_obsolete_revisions() {
@@ -368,21 +368,21 @@ run_secret_nonleader_unit_owned() {
 	echo "Non-leader unit: $non_leader"
 
 	echo "Checking: non-leader can create and remove its own unit-owned secret"
-	secret_uri=$(juju exec --unit "$non_leader" -- secret-add --owner unit nonleader=secret)
+	secret_uri=$(juju_exec_output --unit "$non_leader" -- secret-add --owner unit nonleader=secret)
 	juju exec --unit "$non_leader" -- secret-remove "$secret_uri"
-	check_contains "$(juju exec --unit "$non_leader" -- secret-get "$secret_uri" 2>&1)" 'not found'
+	check_contains "$(juju_exec_output --unit "$non_leader" -- secret-get "$secret_uri" 2>&1)" 'not found'
 
 	echo "Checking: non-leader can grant its own unit-owned secret"
-	secret_uri=$(juju exec --unit "$non_leader" -- secret-add --owner unit grantme=value)
+	secret_uri=$(juju_exec_output --unit "$non_leader" -- secret-add --owner unit grantme=value)
 	relation_id=$(juju --show-log show-unit "$non_leader" --format json | yq ".\"${non_leader}\".\"relation-info\"[0].\"relation-id\"")
 	juju exec --unit "$non_leader" -- secret-grant "$secret_uri" -r "$relation_id"
 
 	echo "Checking: consumer can read the granted secret"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri")" 'grantme: value'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get "$secret_uri")" 'grantme: value'
 
 	echo "Checking: non-leader can revoke its own unit-owned secret"
 	juju exec --unit "$non_leader" -- secret-revoke "$secret_uri" --app dummy-sink
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
 
 	echo "Cleaning up non-leader secret"
 	juju exec --unit "$non_leader" -- secret-remove "$secret_uri"
@@ -424,15 +424,15 @@ run_track_latest_revision() {
 
 	# Step 1: create secret at rev 1 and read it.
 	# Reading establishes a consumer record at current_revision=1.
-	secret_uri=$(juju exec --unit juju-qa-test/0 -- secret-add val=one)
+	secret_uri=$(juju_exec_output --unit juju-qa-test/0 -- secret-add val=one)
 	secret_id=${secret_uri##*/}
-	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-get "$secret_uri")" 'val: one'
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 -- secret-get "$secret_uri")" 'val: one'
 
 	# Step 2: update to rev 2 and refresh tracking in a single hook execution
 	# (single CommitHookChanges call). trackSecrets must update the consumer
 	# record to current_revision=2 inside the DB transaction, and
 	# markSecretRevisionsObsolete must insert rev 1 into secret_revision_obsolete.
-	check_contains "$(juju exec --unit juju-qa-test/0 \
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 \
 		-- "secret-set $secret_uri val=two; secret-get $secret_uri --refresh")" 'val: two'
 
 	# Revision 1 must appear in the engine report's obsolete-revisions map.
@@ -456,7 +456,7 @@ run_track_latest_revision() {
 	# If trackSecrets did not run, current_revision would still be 1 and
 	# this check would return 'val: one' instead.
 	echo "Checking: consumer record tracks revision 2 after CommitHookChanges"
-	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-get "$secret_uri")" 'val: two'
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 -- secret-get "$secret_uri")" 'val: two'
 }
 
 # run_atomic_secret_create verifies that multiple secret creations through
@@ -468,8 +468,8 @@ run_atomic_secret_create() {
 	# Create two secrets in one hook execution. Both must appear in
 	# secret_ids and be readable immediately, proving atomic commit.
 	echo "Checking: multiple secret-add in one hook commits atomically"
-	output=$(juju exec --unit juju-qa-test/0 -- \
-		"secret_uri1=\$(secret-add val=first --label=create-one); echo \$secret_uri1; secret_uri2=\$(secret-add val=second --label=create-two); echo \$secret_uri2")
+	output=$(juju_exec_output --unit juju-qa-test/0 -- \
+		'secret_uri1=$(secret-add val=first --label=create-one); echo $secret_uri1; secret_uri2=$(secret-add val=second --label=create-two); echo $secret_uri2')
 
 	secret_uri1=$(echo "$output" | head -1)
 	secret_uri2=$(echo "$output" | tail -1)
@@ -477,13 +477,13 @@ run_atomic_secret_create() {
 	secret_id2=${secret_uri2##*/}
 
 	# Verify both secrets exist and are readable.
-	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-get "$secret_uri1")" 'val: first'
-	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-get "$secret_uri2")" 'val: second'
-	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-info-get "$secret_uri1" --format json | yq ".${secret_id1}.label")" 'create-one'
-	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-info-get "$secret_uri2" --format json | yq ".${secret_id2}.label")" 'create-two'
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 -- secret-get "$secret_uri1")" 'val: first'
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 -- secret-get "$secret_uri2")" 'val: second'
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 -- secret-info-get "$secret_uri1" --format json | yq ".${secret_id1}.label")" 'create-one'
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 -- secret-info-get "$secret_uri2" --format json | yq ".${secret_id2}.label")" 'create-two'
 
 	# Verify both appear in secret-ids output.
-	secret_ids=$(juju exec --unit juju-qa-test/0 -- secret-ids)
+	secret_ids=$(juju_exec_output --unit juju-qa-test/0 -- secret-ids)
 	check_contains "$secret_ids" "$secret_id1"
 	check_contains "$secret_ids" "$secret_id2"
 
@@ -504,26 +504,26 @@ run_atomic_secret_update() {
 	echo
 
 	# Step 1: create a secret at rev 1.
-	secret_uri=$(juju exec --unit juju-qa-test/0 -- secret-add val=one)
+	secret_uri=$(juju_exec_output --unit juju-qa-test/0 -- secret-add val=one)
 	secret_id=${secret_uri##*/}
-	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-get "$secret_uri")" 'val: one'
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 -- secret-get "$secret_uri")" 'val: one'
 
 	# Step 2: update content and metadata in a single hook execution (one
 	# CommitHookChanges call). The content update creates rev 2 and the
 	# metadata changes (label, rotate) must be applied in the same
 	# transaction.
 	echo "Checking: content + metadata update in one hook"
-	check_contains "$(juju exec --unit juju-qa-test/0 \
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 \
 		-- "secret-set $secret_uri val=two --label=mylabel --rotate=daily; secret-get $secret_uri --refresh")" 'val: two'
 
 	# The metadata changes must have been persisted by the same transaction.
-	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-info-get "$secret_uri" --format json | yq ".${secret_id}.label")" 'mylabel'
-	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-info-get "$secret_uri" --format json | yq ".${secret_id}.revision")" '2'
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 -- secret-info-get "$secret_uri" --format json | yq ".${secret_id}.label")" 'mylabel'
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 -- secret-info-get "$secret_uri" --format json | yq ".${secret_id}.revision")" '2'
 	check_contains "$(juju show-secret "$secret_uri" --format json | yq ".[].rotation")" 'daily'
 
 	# Fresh hook with no --refresh: the consumer record must already track
 	# rev 2, proving the update was committed.
-	check_contains "$(juju exec --unit juju-qa-test/0 -- secret-get "$secret_uri")" 'val: two'
+	check_contains "$(juju_exec_output --unit juju-qa-test/0 -- secret-get "$secret_uri")" 'val: two'
 
 	# Rev 1 must be marked obsolete after the update.
 	echo "Checking: revision 1 is marked obsolete after the update"
@@ -552,7 +552,7 @@ run_atomic_secret_update() {
 run_atomic_secret_update_grant() {
 	echo
 
-	secret_uri=$(juju exec --unit dummy-source/0 -- secret-add --owner unit val=one)
+	secret_uri=$(juju_exec_output --unit dummy-source/0 -- secret-add --owner unit val=one)
 	relation_id=$(juju --show-log show-unit dummy-source/0 --format json | yq '."dummy-source/0"."relation-info"[0]."relation-id"')
 
 	# Update the content and grant to the consumer in a single hook. The
@@ -560,7 +560,7 @@ run_atomic_secret_update_grant() {
 	# read the new revision.
 	echo "Checking: content update + grant in one hook"
 	juju exec --unit dummy-source/0 -- "secret-set $secret_uri val=two; secret-grant $secret_uri -r $relation_id"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri")" 'val: two'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get "$secret_uri")" 'val: two'
 
 	echo "Cleaning up atomic update grant secret"
 	juju exec --unit dummy-source/0 -- secret-remove "$secret_uri"
@@ -575,7 +575,7 @@ run_atomic_secret_update_grant() {
 run_checksum_deduplication_no_leak() {
 	echo
 
-	secret_uri=$(juju exec --unit juju-qa-test/0 -- secret-add val=original)
+	secret_uri=$(juju_exec_output --unit juju-qa-test/0 -- secret-add val=original)
 	secret_id=${secret_uri##*/}
 
 	initial_revs=$(juju show-secret "$secret_uri" --revisions --format yaml | yq ".${secret_id}.revisions | length")

--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -15,9 +15,9 @@ check_secrets() {
 	wait_for "active" "$(workload_status "dummy-sink" 0).current"
 
 	echo "Apps deployed, creating secrets"
-	secret_owned_by_dummy_source_0=$(juju exec --unit dummy-source/0 -- secret-add --owner unit owned-by=dummy-source/0)
+	secret_owned_by_dummy_source_0=$(juju_exec_output --unit dummy-source/0 -- secret-add --owner unit owned-by=dummy-source/0)
 	secret_owned_by_dummy_source_0_id=${secret_owned_by_dummy_source_0##*/}
-	secret_owned_by_dummy_source=$(juju exec --unit dummy-source/0 -- secret-add owned-by=dummy-source-app)
+	secret_owned_by_dummy_source=$(juju_exec_output --unit dummy-source/0 -- secret-add owned-by=dummy-source-app)
 	secret_owned_by_dummy_source_id=${secret_owned_by_dummy_source##*/}
 
 	echo "Checking secrets' backend name with juju secrets --revisions"
@@ -36,8 +36,8 @@ check_secrets() {
 	juju exec --unit dummy-source/0 -- secret-set "$secret_owned_by_dummy_source_id" owned-by=dummy-source-app
 
 	echo "Checking secret ids"
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-ids)" "$secret_owned_by_dummy_source_id"
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-ids)" "$secret_owned_by_dummy_source_0_id"
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-ids)" "$secret_owned_by_dummy_source_id"
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-ids)" "$secret_owned_by_dummy_source_0_id"
 
 	echo "Set a label for the unit owned secret $secret_owned_by_dummy_source_0."
 	juju exec --unit dummy-source/0 -- secret-set "$secret_owned_by_dummy_source_0" --label=dummy-source_0
@@ -45,55 +45,53 @@ check_secrets() {
 	juju exec --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source" --label=dummy-source-app
 
 	echo "Checking: secret-get by URI - content"
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source_0")" 'owned-by: dummy-source/0'
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source")" 'owned-by: dummy-source-app'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source_0")" 'owned-by: dummy-source/0'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source")" 'owned-by: dummy-source-app'
 
 	echo "Checking: secret-get by URI - metadata"
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source_0" --format json | yq ".${secret_owned_by_dummy_source_0_id}.owner")" 'unit'
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source" --format json | yq ".${secret_owned_by_dummy_source_id}.owner")" 'application'
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source" --format json | yq ".${secret_owned_by_dummy_source_id}.revision")" '1'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source_0" --format json | yq ".${secret_owned_by_dummy_source_0_id}.owner")" 'unit'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source" --format json | yq ".${secret_owned_by_dummy_source_id}.owner")" 'application'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source" --format json | yq ".${secret_owned_by_dummy_source_id}.revision")" '1'
 
 	echo "Checking: secret-get by label or consumer label - content"
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-get --label=dummy-source_0)" 'owned-by: dummy-source/0'
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-get --label=dummy-source-app)" 'owned-by: dummy-source-app'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-get --label=dummy-source_0)" 'owned-by: dummy-source/0'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-get --label=dummy-source-app)" 'owned-by: dummy-source-app'
 
 	echo "Checking: secret-get by label - metadata"
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-info-get --label=dummy-source_0 --format json | yq ".${secret_owned_by_dummy_source_0_id}.label")" 'dummy-source_0'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-info-get --label=dummy-source_0 --format json | yq ".${secret_owned_by_dummy_source_0_id}.label")" 'dummy-source_0'
 
 	relation_id=$(juju --show-log show-unit dummy-source/0 --format json | yq '."dummy-source/0"."relation-info"[0]."relation-id"')
 	juju exec --unit dummy-source/0 -- secret-grant "$secret_owned_by_dummy_source_0" -r "$relation_id"
 	juju exec --unit dummy-source/0 -- secret-grant "$secret_owned_by_dummy_source" -r "$relation_id"
 
 	echo "Checking: secret-get by label - refresh with pending updates"
-	another_secret_owned_by_dummy_source=$(juju exec --unit dummy-source/0 -- secret-add value=1 --label=mysecret)
-	check_contains "$(juju exec --unit dummy-source/0 -- "secret-set ${another_secret_owned_by_dummy_source} value=2; secret-get ${another_secret_owned_by_dummy_source} --refresh")" "2"
-	check_contains "$(juju exec --unit dummy-source/0 -- "secret-set ${another_secret_owned_by_dummy_source} value=3; secret-get --label=mysecret --refresh")" "3"
-	check_contains "$(juju exec --unit dummy-source/0 -- "secret-get --label=mysecret")" "3"
-	check_contains "$(
-		juju exec --unit dummy-source/0 -- "secret-set ${another_secret_owned_by_dummy_source} value=4"
-		juju exec --unit dummy-source/0 -- secret-get --label=mysecret --refresh
-	)" "4"
+	another_secret_owned_by_dummy_source=$(juju_exec_output --unit dummy-source/0 -- secret-add value=1 --label=mysecret)
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- "secret-set ${another_secret_owned_by_dummy_source} value=2; secret-get ${another_secret_owned_by_dummy_source} --refresh")" "2"
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- "secret-set ${another_secret_owned_by_dummy_source} value=3; secret-get --label=mysecret --refresh")" "3"
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- "secret-get --label=mysecret")" "3"
+	juju exec --unit dummy-source/0 -- "secret-set ${another_secret_owned_by_dummy_source} value=4"
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-get --label=mysecret --refresh)" "4"
 
 	echo "Checking: secret-get by URI - consume content by ID"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source_0" --label=consumer_label_secret_owned_by_dummy_source_0)" 'owned-by: dummy-source/0'
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source" --label=consumer_label_secret_owned_by_dummy_source)" 'owned-by: dummy-source-app'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source_0" --label=consumer_label_secret_owned_by_dummy_source_0)" 'owned-by: dummy-source/0'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source" --label=consumer_label_secret_owned_by_dummy_source)" 'owned-by: dummy-source-app'
 
 	echo "Checking: secret-get by URI - consume content by label"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label=consumer_label_secret_owned_by_dummy_source_0)" 'owned-by: dummy-source/0'
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get --label=consumer_label_secret_owned_by_dummy_source)" 'owned-by: dummy-source-app'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get --label=consumer_label_secret_owned_by_dummy_source_0)" 'owned-by: dummy-source/0'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get --label=consumer_label_secret_owned_by_dummy_source)" 'owned-by: dummy-source-app'
 
 	echo "Set different content for $secret_owned_by_dummy_source."
 	juju exec --unit dummy-source/0 -- secret-set "$secret_owned_by_dummy_source_id" foo=bar
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source" --format json | yq ".${secret_owned_by_dummy_source_id}.revision")" '2'
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-get --refresh "$secret_owned_by_dummy_source")" 'foo: bar'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-info-get "$secret_owned_by_dummy_source" --format json | yq ".${secret_owned_by_dummy_source_id}.revision")" '2'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-get --refresh "$secret_owned_by_dummy_source")" 'foo: bar'
 
 	echo "Checking: secret-revoke by relation ID"
 	juju exec --unit dummy-source/0 -- secret-revoke "$secret_owned_by_dummy_source" --relation "$relation_id"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source" 2>&1)" 'is not allowed to read this secret'
 
 	echo "Checking: secret-revoke by app name"
 	juju exec --unit dummy-source/0 -- secret-revoke "$secret_owned_by_dummy_source_0" --app dummy-sink
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source_0" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju_exec_output --unit dummy-sink/0 -- secret-get "$secret_owned_by_dummy_source_0" 2>&1)" 'is not allowed to read this secret'
 
 	echo "Checking secret rotate"
 	juju exec --unit dummy-source/0 -- secret-set "$secret_owned_by_dummy_source_0" --rotate daily
@@ -120,11 +118,11 @@ check_secrets() {
 
 	echo "Checking: secret-remove"
 	juju exec --unit dummy-source/0 -- secret-remove "$secret_owned_by_dummy_source_0"
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source_0" 2>&1)" 'not found'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source_0" 2>&1)" 'not found'
 	juju exec --unit dummy-source/0 -- secret-remove "$secret_owned_by_dummy_source"
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source" 2>&1)" 'not found'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-get "$secret_owned_by_dummy_source" 2>&1)" 'not found'
 	juju exec --unit dummy-source/0 -- secret-remove "$another_secret_owned_by_dummy_source"
-	check_contains "$(juju exec --unit dummy-source/0 -- secret-get "$another_secret_owned_by_dummy_source" 2>&1)" 'not found'
+	check_contains "$(juju_exec_output --unit dummy-source/0 -- secret-get "$another_secret_owned_by_dummy_source" 2>&1)" 'not found'
 }
 
 run_user_secrets() {
@@ -160,9 +158,9 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret "$secret_uri" --revisions | yq ".${secret_short_uri}.description")" 'info'
 
 	# grant secret to the app, and now the application can access the revision 2.
-	check_contains "$(juju exec --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju_exec_output --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
 	juju --show-log grant-secret mysecret "$app_name"
-	check_contains "$(juju exec --unit "$app_name/0" -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
+	check_contains "$(juju_exec_output --unit "$app_name/0" -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
 
 	# create a new revision 3.
 	juju --show-log update-secret "$secret_uri" owned-by="$model_name-3"
@@ -186,9 +184,9 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 2 | yq .${secret_short_uri}.content)" "owned-by: $model_name-2"
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 3 | yq .${secret_short_uri}.content)" "owned-by: $model_name-3"
 
-	check_contains "$(juju exec --unit "$app_name/0" -- secret-get $secret_short_uri --peek)" "owned-by: $model_name-3"
-	check_contains "$(juju exec --unit "$app_name/0" -- secret-get $secret_short_uri --refresh)" "owned-by: $model_name-3"
-	check_contains "$(juju exec --unit "$app_name/0" -- secret-get $secret_short_uri)" "owned-by: $model_name-3"
+	check_contains "$(juju_exec_output --unit "$app_name/0" -- secret-get $secret_short_uri --peek)" "owned-by: $model_name-3"
+	check_contains "$(juju_exec_output --unit "$app_name/0" -- secret-get $secret_short_uri --refresh)" "owned-by: $model_name-3"
+	check_contains "$(juju_exec_output --unit "$app_name/0" -- secret-get $secret_short_uri)" "owned-by: $model_name-3"
 
 	# revision 2 should be pruned.
 	# revision 3 is the latest revision, so it should not be pruned.
@@ -196,7 +194,7 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 3 | yq .${secret_short_uri}.content)" "owned-by: $model_name-3"
 
 	juju --show-log revoke-secret mysecret "$app_name"
-	check_contains "$(juju exec --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju_exec_output --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
 
 	juju --show-log remove-secret mysecret
 	check_num_secrets 0
@@ -249,7 +247,7 @@ run_obsolete_revisions() {
 	juju --show-log deploy juju-qa-test
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
-	secret_uri=$(juju --show-log exec -u juju-qa-test/0 -- secret-add foo=bar)
+	secret_uri=$(juju_exec_output -u juju-qa-test/0 -- secret-add foo=bar)
 	# Extract bare secret id (without "secret:" prefix) for matching logs and keep prefixed form for engine report keys.
 	secret_id=${secret_uri##*/}
 	secret_short_uri="secret:${secret_id}"

--- a/tests/suites/secrets_iaas/vault.sh
+++ b/tests/suites/secrets_iaas/vault.sh
@@ -55,8 +55,8 @@ run_secret_drain() {
 	wait_for "active" '.applications["ubuntu-lite"] | ."application-status".current'
 	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite" 0)"
 
-	secret_owned_by_unit=$(juju exec --unit ubuntu-lite/0 -- secret-add --owner unit owned-by=ubuntu-lite/0)
-	secret_owned_by_app=$(juju exec --unit ubuntu-lite/0 -- secret-add owned-by=ubuntu-lite-app)
+	secret_owned_by_unit=$(juju_exec_output --unit ubuntu-lite/0 -- secret-add --owner unit owned-by=ubuntu-lite/0)
+	secret_owned_by_app=$(juju_exec_output --unit ubuntu-lite/0 -- secret-add owned-by=ubuntu-lite-app)
 
 	juju show-secret --reveal "$secret_owned_by_unit"
 	juju show-secret --reveal "$secret_owned_by_app"
@@ -118,7 +118,7 @@ run_user_secret_drain() {
 	check_contains "$(vault kv list -format json "${model_name}-${model_uuid: -6}" | yq length)" 1
 
 	juju --show-log grant-secret "$secret_uri" ubuntu-lite
-	check_contains "$(juju exec --unit ubuntu-lite/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
+	check_contains "$(juju_exec_output --unit ubuntu-lite/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
 
 	# change the secret backend to internal.
 	juju model-secret-backend auto
@@ -152,7 +152,7 @@ run_user_secret_drain() {
 	done
 
 	# ensure the application can still read the user secret.
-	check_contains "$(juju exec --unit ubuntu-lite/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
+	check_contains "$(juju_exec_output --unit ubuntu-lite/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
 
 	juju show-secret --reveal mysecret
 	juju show-secret --reveal anothersecret

--- a/tests/suites/secrets_k8s/cmr.sh
+++ b/tests/suites/secrets_k8s/cmr.sh
@@ -16,43 +16,43 @@ run_secrets_cmr() {
 	wait_for "1" '.offers["source"]["active-connected-count"]'
 
 	echo "Create and share a secret on the offer side"
-	secret_uri=$(juju exec --unit source/0 -- secret-add foo=bar)
+	secret_uri=$(juju_exec_output --unit source/0 -- secret-add foo=bar)
 	relation_id=$(juju --show-log show-unit -m model-secrets-offer source/0 --format json | yq '."source/0"."relation-info" | .[] | select(."endpoint"=="self-metrics-endpoint") | ."relation-id"')
 	juju exec --unit source/0 -- secret-grant "$secret_uri" -r "$relation_id"
 
 	echo "Checking: the secret can be read by the consumer"
 	juju switch "model-secrets-consume"
 	echo "Checking:  secret-get by URI - consume content"
-	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel "$secret_uri")" 'foo: bar'
+	check_contains "$(juju_exec_output --unit sink/0 -- secret-get --label mylabel "$secret_uri")" 'foo: bar'
 	echo "Checking:  secret-get by URI - consume content"
-	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar'
+	check_contains "$(juju_exec_output --unit sink/0 -- secret-get --label mylabel)" 'foo: bar'
 
 	echo "Checking: add a new revision and check consumer can see it"
 	juju switch "model-secrets-offer"
 	juju exec --unit source/0 -- secret-set "$secret_uri" foo=bar2
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar'
-	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel --peek)" 'foo: bar2'
-	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar'
-	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel --refresh)" 'foo: bar2'
-	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar2'
+	check_contains "$(juju_exec_output --unit sink/0 -- secret-get --label mylabel)" 'foo: bar'
+	check_contains "$(juju_exec_output --unit sink/0 -- secret-get --label mylabel --peek)" 'foo: bar2'
+	check_contains "$(juju_exec_output --unit sink/0 -- secret-get --label mylabel)" 'foo: bar'
+	check_contains "$(juju_exec_output --unit sink/0 -- secret-get --label mylabel --refresh)" 'foo: bar2'
+	check_contains "$(juju_exec_output --unit sink/0 -- secret-get --label mylabel)" 'foo: bar2'
 
 	echo "Checking: suspend relation and check access is lost"
 	juju switch "model-secrets-offer"
 	juju suspend-relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju_exec_output --unit sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
 	echo "Checking: resume relation and access is restored"
 	juju switch "model-secrets-offer"
 	juju resume-relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit sink/0 -- secret-get --label mylabel)" 'foo: bar2'
+	check_contains "$(juju_exec_output --unit sink/0 -- secret-get --label mylabel)" 'foo: bar2'
 
 	echo "Checking: secret-revoke by relation ID"
 	juju switch "model-secrets-offer"
 	juju exec --unit source/0 -- secret-revoke "$secret_uri" --relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju_exec_output --unit sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
 }
 
 test_secrets_cmr() {

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -10,9 +10,9 @@ run_secrets() {
 	juju --show-log deploy prometheus-k8s --trust
 	wait_for "prometheus-k8s" "$(active_idle_condition "prometheus-k8s" 0)"
 	wait_for "prometheus-k8s" "$(idle_condition "prometheus-k8s")"
-	full_uri1=$(juju exec --unit prometheus-k8s/0 -- secret-add foo=bar)
+	full_uri1=$(juju_exec_output --unit prometheus-k8s/0 -- secret-add foo=bar)
 	short_uri1=${full_uri1##*/}
-	full_uri2=$(juju exec --unit prometheus-k8s/0 -- secret-add --owner unit foo=bar2)
+	full_uri2=$(juju_exec_output --unit prometheus-k8s/0 -- secret-add --owner unit foo=bar2)
 	short_uri2=${full_uri2##*/}
 	check_contains "$(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri1}"'-1")')" "${short_uri1}-1"
 	check_contains "$(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri2}"'-1")')" "${short_uri2}-1"
@@ -20,7 +20,7 @@ run_secrets() {
 	echo "add another unit and create a unit owned secret"
 	juju --show-log scale-application prometheus-k8s 2
 	wait_for "prometheus-k8s" "$(active_idle_condition "prometheus-k8s" 1)"
-	full_uri3=$(juju exec --unit prometheus-k8s/1 -- secret-add --owner unit foo=bar3)
+	full_uri3=$(juju_exec_output --unit prometheus-k8s/1 -- secret-add --owner unit foo=bar3)
 	short_uri3=${full_uri3##*/}
 	check_contains "$(kubectl -n "$model_name" get secrets -o json | yq -r '.items[].metadata.name | select(. == "'"${short_uri3}"'-1")')" "${short_uri3}-1"
 
@@ -77,14 +77,14 @@ run_secrets() {
 	wait_for "hello" '.applications["world"] | .relations.metrics-endpoint[0].related-application'
 
 	echo "Apps deployed, creating secrets"
-	unit_owned_full_uri=$(juju exec --unit hello/0 -- secret-add --owner unit owned-by=hello/0)
+	unit_owned_full_uri=$(juju_exec_output --unit hello/0 -- secret-add --owner unit owned-by=hello/0)
 	unit_owned_short_uri=${unit_owned_full_uri##*/}
-	app_owned_full_uri=$(juju exec --unit hello/0 -- secret-add owned-by=hello-app)
+	app_owned_full_uri=$(juju_exec_output --unit hello/0 -- secret-add owned-by=hello-app)
 	app_owned_short_uri=${app_owned_full_uri##*/}
 
 	echo "Checking: secret ids"
-	check_contains "$(juju exec --unit hello/0 -- secret-ids)" "$app_owned_short_uri"
-	check_contains "$(juju exec --unit hello/0 -- secret-ids)" "$unit_owned_short_uri"
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-ids)" "$app_owned_short_uri"
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-ids)" "$unit_owned_short_uri"
 
 	echo "Set a label for the unit owned secret $unit_owned_full_uri."
 	juju exec --unit hello/0 -- secret-set "$unit_owned_full_uri" --label=hello_0
@@ -92,50 +92,50 @@ run_secrets() {
 	juju exec --unit hello/0 -- secret-get "$app_owned_full_uri" --label=hello-app
 
 	echo "Checking: secret-get by URI - content"
-	check_contains "$(juju exec --unit hello/0 -- secret-get $unit_owned_full_uri)" 'owned-by: hello/0'
-	check_contains "$(juju exec --unit hello/0 -- secret-get $app_owned_full_uri)" 'owned-by: hello-app'
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-get $unit_owned_full_uri)" 'owned-by: hello/0'
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-get $app_owned_full_uri)" 'owned-by: hello-app'
 
 	echo "Checking: secret-info-get by URI - metadata"
-	check_contains "$(juju exec --unit hello/0 -- secret-info-get $unit_owned_full_uri --format json | yq ".${unit_owned_short_uri}.owner")" unit
-	check_contains "$(juju exec --unit hello/0 -- secret-info-get $app_owned_full_uri --format json | yq ".${app_owned_short_uri}.owner")" application
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-info-get $unit_owned_full_uri --format json | yq ".${unit_owned_short_uri}.owner")" unit
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-info-get $app_owned_full_uri --format json | yq ".${app_owned_short_uri}.owner")" application
 
 	echo "Checking: secret-get by label or consumer label - content"
-	check_contains "$(juju exec --unit hello/0 -- secret-get --label=hello_0)" 'owned-by: hello/0'
-	check_contains "$(juju exec --unit hello/0 -- secret-get --label=hello-app)" 'owned-by: hello-app'
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-get --label=hello_0)" 'owned-by: hello/0'
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-get --label=hello-app)" 'owned-by: hello-app'
 
 	echo "Checking: secret-info-get by label - metadata"
-	check_contains "$(juju exec --unit hello/0 -- secret-info-get --label=hello_0 --format json | yq ".${unit_owned_short_uri}.label")" hello_0
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-info-get --label=hello_0 --format json | yq ".${unit_owned_short_uri}.label")" hello_0
 
 	relation_id=$(juju --show-log show-unit hello/0 --format json | yq '."hello/0"."relation-info"[1]."relation-id"')
 	juju exec --unit hello/0 -- secret-grant "$unit_owned_full_uri" -r "$relation_id"
 	juju exec --unit hello/0 -- secret-grant "$app_owned_full_uri" -r "$relation_id"
 
 	echo "Checking: secret-get by URI - consume content"
-	check_contains "$(juju exec --unit world/0 -- secret-get "$unit_owned_full_uri")" 'owned-by: hello/0'
-	check_contains "$(juju exec --unit world/0 -- secret-get "$app_owned_full_uri")" 'owned-by: hello-app'
+	check_contains "$(juju_exec_output --unit world/0 -- secret-get "$unit_owned_full_uri")" 'owned-by: hello/0'
+	check_contains "$(juju_exec_output --unit world/0 -- secret-get "$app_owned_full_uri")" 'owned-by: hello-app'
 
 	echo "Checking: secret-get by label - consume content"
 	juju exec --unit world/0 -- secret-get "$unit_owned_full_uri" --label=consumer_label_secret_owned_by_hello_0
 	juju exec --unit world/0 -- secret-get "$app_owned_full_uri" --label=consumer_label_secret_owned_by_hello
-	check_contains "$(juju exec --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello_0)" 'owned-by: hello/0'
-	check_contains "$(juju exec --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello)" 'owned-by: hello-app'
+	check_contains "$(juju_exec_output --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello_0)" 'owned-by: hello/0'
+	check_contains "$(juju_exec_output --unit world/0 -- secret-get --label=consumer_label_secret_owned_by_hello)" 'owned-by: hello-app'
 
 	check_contains "$(kubectl -n "$model_name" get "secrets/${unit_owned_short_uri}-1" -o json | yq -r '.data["owned-by"]' | base64 -d)" "hello/0"
 	check_contains "$(kubectl -n "$model_name" get "secrets/${app_owned_short_uri}-1" -o json | yq -r '.data["owned-by"]' | base64 -d)" "hello-app"
 
 	echo "Checking: secret-revoke by relation ID"
 	juju exec --unit hello/0 -- secret-revoke "$app_owned_full_uri" --relation "$relation_id"
-	check_contains "$(juju exec --unit world/0 -- secret-get "$app_owned_full_uri" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju_exec_output --unit world/0 -- secret-get "$app_owned_full_uri" 2>&1)" 'is not allowed to read this secret'
 
 	echo "Checking: secret-revoke by app name"
 	juju exec --unit hello/0 -- secret-revoke "$unit_owned_short_uri" --app world
-	check_contains "$(juju exec --unit world/0 -- secret-get "$unit_owned_short_uri" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju_exec_output --unit world/0 -- secret-get "$unit_owned_short_uri" 2>&1)" 'is not allowed to read this secret'
 
 	echo "Checking: secret-remove"
 	juju exec --unit hello/0 -- secret-remove "$unit_owned_short_uri"
-	check_contains "$(juju exec --unit hello/0 -- secret-get "$unit_owned_short_uri" 2>&1)" 'not found'
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-get "$unit_owned_short_uri" 2>&1)" 'not found'
 	juju exec --unit hello/0 -- secret-remove "$app_owned_full_uri"
-	check_contains "$(juju exec --unit hello/0 -- secret-get "$app_owned_full_uri" 2>&1)" 'not found'
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-get "$app_owned_full_uri" 2>&1)" 'not found'
 
 	# TODO: no need to remove-relation before destroying model once we fixed(lp:1952221).
 	juju --show-log remove-relation world hello
@@ -168,9 +168,9 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret "$secret_uri" --revisions | yq ".${secret_short_uri}.description")" 'info'
 
 	# grant secret to snappass-test app, and now the application can access the revision 2.
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju_exec_output --unit snappass-test/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
 	juju --show-log grant-secret "$secret_uri" snappass-test
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
+	check_contains "$(juju_exec_output --unit snappass-test/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
 
 	# create a new revision 3.
 	juju --show-log update-secret "$secret_uri" owned-by="$model_name-3"
@@ -194,9 +194,9 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 2 | yq .${secret_short_uri}.content)" "owned-by: $model_name-2"
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 3 | yq .${secret_short_uri}.content)" "owned-by: $model_name-3"
 
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri --peek)" "owned-by: $model_name-3"
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri --refresh)" "owned-by: $model_name-3"
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-3"
+	check_contains "$(juju_exec_output --unit snappass-test/0 -- secret-get $secret_short_uri --peek)" "owned-by: $model_name-3"
+	check_contains "$(juju_exec_output --unit snappass-test/0 -- secret-get $secret_short_uri --refresh)" "owned-by: $model_name-3"
+	check_contains "$(juju_exec_output --unit snappass-test/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-3"
 
 	# revision 2 should be pruned.
 	# revision 3 is the latest revision, so it should not be pruned.
@@ -204,7 +204,7 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 3 | yq .${secret_short_uri}.content)" "owned-by: $model_name-3"
 
 	juju --show-log revoke-secret $secret_uri snappass-test
-	check_contains "$(juju exec --unit snappass-test/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju_exec_output --unit snappass-test/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
 
 	juju --show-log remove-secret $secret_uri
 	check_num_secrets 0
@@ -232,9 +232,9 @@ run_secret_drain() {
 	wait_for "active" '.applications["hello"] | ."application-status".current'
 	wait_for "hello" "$(idle_condition "hello")"
 
-	unit_owned_full_uri=$(juju exec --unit hello/0 -- secret-add --owner unit owned-by=hello/0)
+	unit_owned_full_uri=$(juju_exec_output --unit hello/0 -- secret-add --owner unit owned-by=hello/0)
 	unit_owned_short_uri=${unit_owned_full_uri##*/}
-	app_owned_full_uri=$(juju exec --unit hello/0 -- secret-add owned-by=hello-app)
+	app_owned_full_uri=$(juju_exec_output --unit hello/0 -- secret-add owned-by=hello-app)
 	app_owned_short_uri=${app_owned_full_uri##*/}
 
 	juju show-secret --reveal "$unit_owned_full_uri"
@@ -304,7 +304,7 @@ run_user_secret_drain() {
 	juju show-secret --reveal "$secret_uri"
 
 	juju --show-log grant-secret "$secret_uri" hello
-	check_contains "$(juju exec --unit hello/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
 
 	check_contains "$(kubectl -n "$model_name" get secrets -l "app.juju.is/created-by=$model_uuid" -o jsonpath='{.items[*].metadata.name}')" "${secret_short_uri}-1"
 
@@ -325,7 +325,7 @@ run_user_secret_drain() {
 	# ensure the user secret is in vault backend.
 	check_contains "$(vault kv list -format json "${model_name}-${model_uuid: -6}" | yq length)" 1
 	# ensure the application can still read the user secret.
-	check_contains "$(juju exec --unit hello/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
 
 	juju model-secret-backend auto
 
@@ -343,7 +343,7 @@ run_user_secret_drain() {
 	# ensure the user secret is removed from vault backend.
 	check_contains "$(vault kv list -format json "${model_name}-${model_uuid: -6}" | yq length)" 0
 	# ensure the application can still read the user secret.
-	check_contains "$(juju exec --unit hello/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
+	check_contains "$(juju_exec_output --unit hello/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-1"
 
 	destroy_model "$model_name"
 }


### PR DESCRIPTION
## Problem

When juju is built with coverage instrumentation (e.g. `internal/debug/coveruploader`), the coveruploader emits log lines via `log.Printf` to stderr. These can mix with the actual command output captured by `$(juju exec ...)`, corrupting variable values in CI test scripts.

## Solution

Introduces a `juju_exec_output` bash helper in `tests/includes/exec.sh` that:

- Forces `--format yaml` and extracts only `results.stdout` via yq — pollution-proof
- Forwards **all** task stderr and juju's own stderr to stderr (via FD-3 bridge, no temp files)
- Returns `1` if any task has a non-zero return code, `0` otherwise

```bash
# Before (vulnerable to pollution):
value=$(juju exec --unit hello/0 -- secret-add foo=bar)

# After (clean):
value=$(juju_exec_output --unit hello/0 -- secret-add foo=bar)
```

## Cherry-pick from 3.6 (#22776)

This is a cherry-pick of PR #22776 onto 4.0. The cherry-pick required conflict resolution for:

- `secrets_iaas/cmr.sh`: added `-m model-secrets-offer` flag (4.0 change)
- `secrets_iaas/juju.sh` and `secrets_k8s/k8s.sh`: error message changed from `'permission denied'` to `'is not allowed to read this secret'` (4.0 change)
- `secrets_k8s/k8s.sh`: `run_secrets_token_reuse` function omitted (does not exist on 4.0)
- `mongo_memory_profile.sh`: file was deleted on 4.0 (chore: remove mongo bash test)

### Merge conflict resolution fixes (amended into first commit)

1. **Deleted empty `mongo_memory_profile.sh`**: The file was deleted on 4.0 by `a1061d82a7` (chore: remove mongo bash test). The cherry-pick incorrectly created an empty file. Fixed by removing it.
2. **Fixed spaces→tab in `relation_data_exchange.sh:24`**: Merge conflict resolution introduced two spaces instead of a tab. Fixed.

### New 4.0 call site migration (second commit)

31 capturing `juju exec` calls in test functions added on 4.0 (not present when #22776 was created) are migrated to `juju_exec_output`:

**`tests/suites/secrets_iaas/juju.sh`** — 24 calls across 6 new functions:
- `run_secret_nonleader_unit_owned()` (5 calls)
- `run_track_latest_revision()` (4 calls)
- `run_atomic_secret_create()` (6 calls)
- `run_atomic_secret_update()` (6 calls)
- `run_atomic_secret_update_grant()` (2 calls)
- `run_checksum_deduplication_no_leak()` (1 call)

**`tests/suites/hooktools/storage_tools.sh`** — 7 calls across 3 functions:
- `run_storage_list()` (4 calls)
- `run_storage_get()` (3 calls)
- `run_storage_add()` (non-capturing `storage-add` calls left as `juju exec`)

Also fixes pre-existing shfmt issues in both files.

## Intentionally skipped

Sites running **plain system commands** (`uptime`, `sudo cat`, `ip route show`, `curl -s`, `lxc profile`, `hostname -I`) are skipped with explanatory comments — these produce no stderr noise and don't go through the hook tool code path where the bug lives.

## Verification

- `shfmt -l -s` — clean on all modified files
- `shellcheck --severity=warning` — clean on all modified files
- No remaining capturing `juju exec` calls in converted files
- run test suites (secret_iaas and hooktools)