### PR TITLE
feat(migration): rewrite secret backend UUIDs during model import

### DIFF
--- a/domain/secretbackend/service/import.go
+++ b/domain/secretbackend/service/import.go
@@ -31,23 +31,62 @@ func (s *Service) ImportSecretBackendReferences(
 		return nil
 	}
 
-	backendIDs := make(map[string]string)
-	for _, ref := range refs {
-		backendID, ok := backendIDs[ref.BackendName]
-		if !ok {
-			backend, err := s.st.GetSecretBackend(ctx, secretbackend.BackendIdentifier{Name: ref.BackendName})
-			if err != nil {
-				return errors.Errorf("looking up secret backend %q: %w", ref.BackendName, err)
-			}
-			backendID = backend.ID
-			backendIDs[ref.BackendName] = backendID
-		}
+	revisionMap, err := s.resolveBackendUUIDsByRevision(ctx, refs)
+	if err != nil {
+		return errors.Capture(err)
+	}
 
+	for _, ref := range refs {
 		if _, err := s.st.AddSecretBackendReference(
-			ctx, &secrets.ValueRef{BackendID: backendID}, modelUUID, ref.SecretRevisionUUID, ref.SecretID,
+			ctx, &secrets.ValueRef{BackendID: revisionMap[ref.SecretRevisionUUID]}, modelUUID, ref.SecretRevisionUUID, ref.SecretID,
 		); err != nil {
 			return errors.Errorf("adding secret backend reference for revision %q: %w", ref.SecretRevisionUUID, err)
 		}
 	}
 	return nil
+}
+
+// GetSecretBackendReferenceMapping resolves the target controller's backend
+// UUID for each secret revision carried in refs, keyed by secret revision UUID.
+//
+// It is read-only: it looks up each distinct backend by name and writes no
+// state. The v8 migration import driver in internal/migration calls it, after
+// the controller-scoped data is applied and before the model-DB insert, to
+// rewrite the model-DB payload's secret_value_ref and secret_deleted_value_ref
+// BackendUUID fields from the source controller's backend UUIDs to the
+// target's. Returns a nil map for an empty refs slice.
+func (s *Service) GetSecretBackendReferenceMapping(
+	ctx context.Context, refs []coremodelmigration.SecretBackendReference,
+) (map[string]string, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	return s.resolveBackendUUIDsByRevision(ctx, refs)
+}
+
+// resolveBackendUUIDsByRevision maps each ref's secret revision UUID to its
+// target backend UUID, looking up each distinct backend name once. It performs
+// no writes. Returns a nil map when refs is empty.
+func (s *Service) resolveBackendUUIDsByRevision(
+	ctx context.Context, refs []coremodelmigration.SecretBackendReference,
+) (map[string]string, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+
+	backendIDs := make(map[string]string)
+	revisionMap := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		backendID, ok := backendIDs[ref.BackendName]
+		if !ok {
+			backend, err := s.st.GetSecretBackend(ctx, secretbackend.BackendIdentifier{Name: ref.BackendName})
+			if err != nil {
+				return nil, errors.Errorf("looking up secret backend %q: %w", ref.BackendName, err)
+			}
+			backendID = backend.ID
+			backendIDs[ref.BackendName] = backendID
+		}
+		revisionMap[ref.SecretRevisionUUID] = backendID
+	}
+	return revisionMap, nil
 }

--- a/domain/secretbackend/service/import.go
+++ b/domain/secretbackend/service/import.go
@@ -74,6 +74,17 @@ func (s *Service) resolveBackendUUIDsByRevision(
 		return nil, nil
 	}
 
+	revisionBackendNames := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		if backendName, ok := revisionBackendNames[ref.SecretRevisionUUID]; ok {
+			return nil, errors.Errorf(
+				"secret revision %q has multiple backend references: %q and %q",
+				ref.SecretRevisionUUID, backendName, ref.BackendName,
+			)
+		}
+		revisionBackendNames[ref.SecretRevisionUUID] = ref.BackendName
+	}
+
 	backendIDs := make(map[string]string)
 	revisionMap := make(map[string]string, len(refs))
 	for _, ref := range refs {

--- a/domain/secretbackend/service/import_test.go
+++ b/domain/secretbackend/service/import_test.go
@@ -88,9 +88,9 @@ func (s *importSuite) TestImportSecretBackendReferencesLookupError(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, expected)
 }
 
-// TestGetSecretBackendReferenceMapping resolves the revision→target-backend-UUID
-// map read-only: it looks up each distinct backend name once and writes no
-// references.
+// TestGetSecretBackendReferenceMapping resolves the revision-to-target-backend
+// UUID map read-only: it looks up each distinct backend name once and writes
+// no references.
 func (s *importSuite) TestGetSecretBackendReferenceMapping(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -169,5 +169,22 @@ func (s *importSuite) TestGetSecretBackendReferenceMappingLookupError(c *tc.C) {
 		[]coremodelmigration.SecretBackendReference{{BackendName: "vault", SecretRevisionUUID: "rev-1"}},
 	)
 	c.Assert(err, tc.ErrorIs, expected)
+	c.Check(revisionMap, tc.IsNil)
+}
+
+func (s *importSuite) TestGetSecretBackendReferenceMappingDuplicateRevision(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	revisionMap, err := NewService(s.state, loggertesting.WrapCheckLog(c)).GetSecretBackendReferenceMapping(
+		c.Context(),
+		[]coremodelmigration.SecretBackendReference{{
+			BackendName:        "vault",
+			SecretRevisionUUID: "rev-1",
+		}, {
+			BackendName:        "k8s",
+			SecretRevisionUUID: "rev-1",
+		}},
+	)
+	c.Assert(err, tc.ErrorMatches, `secret revision "rev-1" has multiple backend references: "vault" and "k8s"`)
 	c.Check(revisionMap, tc.IsNil)
 }

--- a/domain/secretbackend/service/import_test.go
+++ b/domain/secretbackend/service/import_test.go
@@ -87,3 +87,87 @@ func (s *importSuite) TestImportSecretBackendReferencesLookupError(c *tc.C) {
 	)
 	c.Assert(err, tc.ErrorIs, expected)
 }
+
+// TestGetSecretBackendReferenceMapping resolves the revision→target-backend-UUID
+// map read-only: it looks up each distinct backend name once and writes no
+// references.
+func (s *importSuite) TestGetSecretBackendReferenceMapping(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	backend := &secretbackend.SecretBackend{ID: uuid.MustNewUUID().String(), Name: "vault"}
+
+	// One lookup for the two same-named refs; no AddSecretBackendReference.
+	s.state.EXPECT().GetSecretBackend(gomock.Any(), secretbackend.BackendIdentifier{Name: "vault"}).
+		Return(backend, nil)
+
+	revisionMap, err := NewService(s.state, loggertesting.WrapCheckLog(c)).GetSecretBackendReferenceMapping(
+		c.Context(),
+		[]coremodelmigration.SecretBackendReference{{
+			BackendName:        "vault",
+			SecretRevisionUUID: "rev-1",
+			SecretID:           "secret:1",
+		}, {
+			BackendName:        "vault",
+			SecretRevisionUUID: "rev-2",
+			SecretID:           "secret:2",
+		}},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(revisionMap, tc.DeepEquals, map[string]string{
+		"rev-1": backend.ID,
+		"rev-2": backend.ID,
+	})
+}
+
+func (s *importSuite) TestGetSecretBackendReferenceMappingDistinctBackends(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	vault := &secretbackend.SecretBackend{ID: uuid.MustNewUUID().String(), Name: "vault"}
+	k8s := &secretbackend.SecretBackend{ID: uuid.MustNewUUID().String(), Name: "k8s"}
+
+	s.state.EXPECT().GetSecretBackend(gomock.Any(), secretbackend.BackendIdentifier{Name: "vault"}).
+		Return(vault, nil)
+	s.state.EXPECT().GetSecretBackend(gomock.Any(), secretbackend.BackendIdentifier{Name: "k8s"}).
+		Return(k8s, nil)
+
+	revisionMap, err := NewService(s.state, loggertesting.WrapCheckLog(c)).GetSecretBackendReferenceMapping(
+		c.Context(),
+		[]coremodelmigration.SecretBackendReference{{
+			BackendName:        "vault",
+			SecretRevisionUUID: "rev-1",
+		}, {
+			BackendName:        "k8s",
+			SecretRevisionUUID: "rev-2",
+		}},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(revisionMap, tc.DeepEquals, map[string]string{
+		"rev-1": vault.ID,
+		"rev-2": k8s.ID,
+	})
+}
+
+func (s *importSuite) TestGetSecretBackendReferenceMappingEmpty(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	revisionMap, err := NewService(s.state, loggertesting.WrapCheckLog(c)).GetSecretBackendReferenceMapping(
+		c.Context(), nil,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(revisionMap, tc.IsNil)
+}
+
+func (s *importSuite) TestGetSecretBackendReferenceMappingLookupError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	expected := errors.New("boom")
+	s.state.EXPECT().GetSecretBackend(gomock.Any(), secretbackend.BackendIdentifier{Name: "vault"}).
+		Return(nil, expected)
+
+	revisionMap, err := NewService(s.state, loggertesting.WrapCheckLog(c)).GetSecretBackendReferenceMapping(
+		c.Context(),
+		[]coremodelmigration.SecretBackendReference{{BackendName: "vault", SecretRevisionUUID: "rev-1"}},
+	)
+	c.Assert(err, tc.ErrorIs, expected)
+	c.Check(revisionMap, tc.IsNil)
+}

--- a/internal/migration/import.go
+++ b/internal/migration/import.go
@@ -81,6 +81,10 @@ type ImportModelArgs struct {
 // coordinator constructs the controller-scoped domain services once and
 // orchestrates the call order FK-/dependency-safely.
 //
+// It writes only controller-database state. Any source→target rewrite of the
+// model-DB payload (e.g. secret backend UUIDs) is read back and applied
+// separately by reconcileSecretBackendUUIDs once these writes have landed.
+//
 // sourceMigrationUUID is the source-side migration UUID recorded on the target
 // import claim. If a claim already exists for info.ModelInfo.UUID, the returned
 // error wraps [coreerrors.AlreadyExists] (phase-specific wording is supplied by

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -93,24 +93,41 @@ func (i *ModelImporter) ImportModel(
 ) error {
 	modelUUID := coremodel.UUID(args.ControllerModelInfo.ModelInfo.UUID)
 	scope := i.scope(modelUUID)
-
-	if err := ImportControllerModelInfo(ctx, Deps{
+	deps := Deps{
 		ControllerDB: scope.ControllerDB(),
 		ModelDB:      scope.ModelDB(),
 		Clock:        i.clock,
 		Logger:       i.logger,
-	}, args.SourceMigrationUUID, args.ControllerModelInfo, view); err != nil {
+	}
+
+	// Apply the controller-scoped data (claim, bootstrap, users, credential,
+	// permissions, secret backend references, ...). Writes only; no return
+	// value beyond the error.
+	if err := ImportControllerModelInfo(
+		ctx, deps, args.SourceMigrationUUID, args.ControllerModelInfo, view,
+	); err != nil {
 		return internalerrors.Capture(err)
+	}
+
+	if args.ModelDBPayload == nil {
+		return nil
+	}
+
+	// Now that the controller data is applied, rewrite the model-DB payload's
+	// secret backend UUIDs from the source controller's to the target's (matched
+	// by name) before the insert. An unmapped revision is a hard error; no
+	// model-DB rows are written.
+	if err := reconcileSecretBackendUUIDs(ctx, deps, args.ControllerModelInfo, args.ModelDBPayload); err != nil {
+		return internalerrors.Errorf(
+			"rewriting secret backend UUIDs for model %q: %w", modelUUID, err)
 	}
 
 	// Model-DB import: insert the transformed, target-version payload into the
 	// model DB. The importer is constructed per import because it binds to the
 	// model DB resolved from the scope for this model UUID (the ModelImporter
 	// itself is not bound to a single model).
-	if args.ModelDBPayload != nil {
-		if err := modelimport.NewImporter(scope.ModelDB()).Import(ctx, args.ModelDBPayload); err != nil {
-			return internalerrors.Errorf("model-DB import for model %q: %w", modelUUID, err)
-		}
+	if err := modelimport.NewImporter(scope.ModelDB()).Import(ctx, args.ModelDBPayload); err != nil {
+		return internalerrors.Errorf("model-DB import for model %q: %w", modelUUID, err)
 	}
 	return nil
 }

--- a/internal/migration/modelimporter_test.go
+++ b/internal/migration/modelimporter_test.go
@@ -5,7 +5,9 @@ package migration_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/tc"
@@ -20,6 +22,7 @@ import (
 	accessstate "github.com/juju/juju/domain/access/state"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	"github.com/juju/juju/domain/export"
+	v4_1_0 "github.com/juju/juju/domain/export/types/v4_1_0"
 	modeltesting "github.com/juju/juju/domain/model/state/testing"
 	migrationclaimstate "github.com/juju/juju/domain/modelmigration/state/controller"
 	schematesting "github.com/juju/juju/domain/schema/testing"
@@ -108,4 +111,193 @@ func (s *modelImporterSuite) TestImportModel(c *tc.C) {
 	// caching stale state.
 	err = importer.ImportModel(c.Context(), importArgs, view)
 	c.Check(err, tc.ErrorIs, coreerrors.AlreadyExists)
+}
+
+// createExternalSecretBackend inserts a named external secret backend on the
+// controller DB and returns its target UUID.
+func (s *modelImporterSuite) createExternalSecretBackend(c *tc.C, name string) string {
+	backendUUID := uuid.MustNewUUID().String()
+	controllerRunner := s.ControllerTxnRunner()
+	err := controllerRunner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO secret_backend (uuid, name, backend_type_id)
+			VALUES (?, ?, 1)
+			ON CONFLICT (name) DO NOTHING
+		`, backendUUID, name)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return backendUUID
+}
+
+// TestImportModelSecretBackendRewrite verifies that secret_value_ref and
+// secret_deleted_value_ref backend_uuid fields are rewritten from the source
+// controller's backend UUIDs to the target's before the model-DB insert.
+func (s *modelImporterSuite) TestImportModelSecretBackendRewrite(c *tc.C) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	controllerFactory := s.TxnRunnerFactory()
+	modelRunner := s.ModelTxnRunner(c, modelUUID.String())
+	modelFactory := func(context.Context) (coredatabase.TxnRunner, error) {
+		return modelRunner, nil
+	}
+
+	// Create a named external backend on the target with a fresh UUID.
+	targetBackendName := "vault-external"
+	targetBackendUUID := s.createExternalSecretBackend(c, targetBackendName)
+
+	// Source backend UUID — different from the target's.
+	sourceBackendUUID := uuid.MustNewUUID().String()
+
+	now := time.Now().UTC()
+	secretID := uuid.MustNewUUID().String()
+	revUUID1 := uuid.MustNewUUID().String()
+	revUUID2 := uuid.MustNewUUID().String()
+	passwordHash := "some-hash"
+
+	payload := &v4_1_0.ModelExport{
+		ModelAgent: []v4_1_0.ModelAgent{
+			{ModelUUID: modelUUID.String(), PasswordHash: &passwordHash},
+		},
+		Secret: []v4_1_0.Secret{
+			{ID: secretID},
+		},
+		SecretMetadata: []v4_1_0.SecretMetadata{
+			{SecretID: secretID, Version: 1, RotatePolicyID: 0, CreateTime: now, UpdateTime: now},
+		},
+		SecretRevision: []v4_1_0.SecretRevision{
+			{UUID: revUUID1, SecretID: secretID, Revision: 1, CreateTime: now},
+		},
+		SecretValueRef: []v4_1_0.SecretValueRef{
+			{RevisionUUID: revUUID1, BackendUUID: sourceBackendUUID, RevisionID: "ext-rev-1"},
+		},
+		SecretDeletedValueRef: []v4_1_0.SecretDeletedValueRef{
+			{RevisionUUID: revUUID2, BackendUUID: sourceBackendUUID, RevisionID: "ext-rev-2"},
+		},
+	}
+
+	scope := func(coremodel.UUID) coremodelmigration.Scope {
+		return coremodelmigration.NewScope(controllerFactory, modelFactory, nil, nil, modelUUID)
+	}
+	importer := migration.NewModelImporter(scope, nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
+
+	importArgs := migration.ImportModelArgs{
+		SourceMigrationUUID: uuid.MustNewUUID().String(),
+		ControllerModelInfo: coremodelmigration.ControllerModelInfo{
+			ModelInfo: coremodelmigration.ModelIdentityInfo{
+				UUID:      modelUUID.String(),
+				Name:      "imported-model",
+				Qualifier: "prod",
+				Type:      "iaas",
+				Cloud:     s.cloudName,
+				Life:      "alive",
+			},
+			SecretBackendRefs: []coremodelmigration.SecretBackendReference{
+				{BackendName: targetBackendName, SecretRevisionUUID: revUUID1, SecretID: secretID},
+				{BackendName: targetBackendName, SecretRevisionUUID: revUUID2, SecretID: secretID},
+			},
+		},
+		ModelDBPayload: payload,
+	}
+	view := export.ProjectionView{AgentTargetVersion: jujuversion.Current}
+
+	err := importer.ImportModel(c.Context(), importArgs, view)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Verify secret_value_ref row carries the target backend UUID.
+	var insertedBackendUUID string
+	var insertedRevisionID string
+	err = modelRunner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			`SELECT backend_uuid, revision_id FROM secret_value_ref WHERE revision_uuid = ?`, revUUID1,
+		).Scan(&insertedBackendUUID, &insertedRevisionID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(insertedBackendUUID, tc.Equals, targetBackendUUID,
+		tc.Commentf("secret_value_ref should carry target backend UUID, got %q", insertedBackendUUID))
+	c.Check(insertedRevisionID, tc.Equals, "ext-rev-1")
+
+	// Verify secret_deleted_value_ref row carries the target backend UUID.
+	err = modelRunner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			`SELECT backend_uuid, revision_id FROM secret_deleted_value_ref WHERE revision_uuid = ?`, revUUID2,
+		).Scan(&insertedBackendUUID, &insertedRevisionID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(insertedBackendUUID, tc.Equals, targetBackendUUID,
+		tc.Commentf("secret_deleted_value_ref should carry target backend UUID, got %q", insertedBackendUUID))
+	c.Check(insertedRevisionID, tc.Equals, "ext-rev-2")
+}
+
+// TestImportModelSecretBackendRewriteMissingRef verifies that a
+// secret_value_ref revision absent from SecretBackendRefs causes
+// ImportModel to error before committing any model-DB rows.
+func (s *modelImporterSuite) TestImportModelSecretBackendRewriteMissingRef(c *tc.C) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	controllerFactory := s.TxnRunnerFactory()
+	modelRunner := s.ModelTxnRunner(c, modelUUID.String())
+	modelFactory := func(context.Context) (coredatabase.TxnRunner, error) {
+		return modelRunner, nil
+	}
+
+	targetBackendName := "vault-external"
+	s.createExternalSecretBackend(c, targetBackendName)
+
+	sourceBackendUUID := uuid.MustNewUUID().String()
+	now := time.Now().UTC()
+	secretID := uuid.MustNewUUID().String()
+	revUUID := uuid.MustNewUUID().String()
+	passwordHash := "some-hash"
+
+	payload := &v4_1_0.ModelExport{
+		ModelAgent: []v4_1_0.ModelAgent{
+			{ModelUUID: modelUUID.String(), PasswordHash: &passwordHash},
+		},
+		Secret: []v4_1_0.Secret{
+			{ID: secretID},
+		},
+		SecretMetadata: []v4_1_0.SecretMetadata{
+			{SecretID: secretID, Version: 1, RotatePolicyID: 0, CreateTime: now, UpdateTime: now},
+		},
+		SecretRevision: []v4_1_0.SecretRevision{
+			{UUID: revUUID, SecretID: secretID, Revision: 1, CreateTime: now},
+		},
+		SecretValueRef: []v4_1_0.SecretValueRef{
+			{RevisionUUID: revUUID, BackendUUID: sourceBackendUUID, RevisionID: "ext-rev-1"},
+		},
+	}
+
+	scope := func(coremodel.UUID) coremodelmigration.Scope {
+		return coremodelmigration.NewScope(controllerFactory, modelFactory, nil, nil, modelUUID)
+	}
+	importer := migration.NewModelImporter(scope, nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
+
+	importArgs := migration.ImportModelArgs{
+		SourceMigrationUUID: uuid.MustNewUUID().String(),
+		ControllerModelInfo: coremodelmigration.ControllerModelInfo{
+			ModelInfo: coremodelmigration.ModelIdentityInfo{
+				UUID:      modelUUID.String(),
+				Name:      "imported-model",
+				Qualifier: "prod",
+				Type:      "iaas",
+				Cloud:     s.cloudName,
+				Life:      "alive",
+			},
+			// Deliberately omit SecretBackendRefs — the revision has no mapping.
+		},
+		ModelDBPayload: payload,
+	}
+	view := export.ProjectionView{AgentTargetVersion: jujuversion.Current}
+
+	err := importer.ImportModel(c.Context(), importArgs, view)
+	c.Assert(err, tc.ErrorMatches, `.*no target secret backend for secret revision.*`)
+
+	// Verify no secret_value_ref rows were committed.
+	var count int
+	err = modelRunner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM secret_value_ref WHERE revision_uuid = ?`, revUUID,
+		).Scan(&count)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
 }

--- a/internal/migration/modelimporter_test.go
+++ b/internal/migration/modelimporter_test.go
@@ -22,6 +22,7 @@ import (
 	accessstate "github.com/juju/juju/domain/access/state"
 	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	"github.com/juju/juju/domain/export"
+	"github.com/juju/juju/domain/export/types/latest"
 	v4_1_0 "github.com/juju/juju/domain/export/types/v4_1_0"
 	modeltesting "github.com/juju/juju/domain/model/state/testing"
 	migrationclaimstate "github.com/juju/juju/domain/modelmigration/state/controller"
@@ -34,8 +35,8 @@ import (
 // modelImporterSuite is a thin smoke test for ModelImporter.ImportModel, the
 // public method the migrationtarget facade calls. The orchestration itself is
 // covered in this package's direct ImportControllerModelInfo tests; this only
-// proves the delegator resolves the migration scope for the model UUID and wires
-// it through correctly.
+// proves the delegator resolves the migration scope for the model UUID and
+// wires it through correctly.
 type modelImporterSuite struct {
 	schematesting.ControllerModelSuite
 
@@ -113,6 +114,56 @@ func (s *modelImporterSuite) TestImportModel(c *tc.C) {
 	c.Check(err, tc.ErrorIs, coreerrors.AlreadyExists)
 }
 
+func (s *modelImporterSuite) TestImportModelNoSecretBackendRewriteRows(c *tc.C) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	controllerFactory := s.TxnRunnerFactory()
+	modelRunner := s.ModelTxnRunner(c, modelUUID.String())
+	modelFactory := func(context.Context) (coredatabase.TxnRunner, error) {
+		return modelRunner, nil
+	}
+
+	passwordHash := "some-hash"
+	payload := &latest.ModelExport{
+		ModelAgent: []v4_1_0.ModelAgent{
+			{ModelUUID: modelUUID.String(), PasswordHash: &passwordHash},
+		},
+		Sequence: []v4_1_0.Sequence{{Namespace: "machine", Value: 7}},
+	}
+
+	scope := func(coremodel.UUID) coremodelmigration.Scope {
+		return coremodelmigration.NewScope(controllerFactory, modelFactory, nil, nil, modelUUID)
+	}
+	importer := migration.NewModelImporter(scope, nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
+
+	importArgs := migration.ImportModelArgs{
+		SourceMigrationUUID: uuid.MustNewUUID().String(),
+		ControllerModelInfo: coremodelmigration.ControllerModelInfo{
+			ModelInfo: coremodelmigration.ModelIdentityInfo{
+				UUID:      modelUUID.String(),
+				Name:      "imported-model",
+				Qualifier: "prod",
+				Type:      "iaas",
+				Cloud:     s.cloudName,
+				Life:      "alive",
+			},
+		},
+		ModelDBPayload: payload,
+	}
+	view := export.ProjectionView{AgentTargetVersion: jujuversion.Current}
+
+	err := importer.ImportModel(c.Context(), importArgs, view)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var sequenceValue int64
+	err = modelRunner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			`SELECT value FROM sequence WHERE namespace = ?`, "machine",
+		).Scan(&sequenceValue)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(sequenceValue, tc.Equals, int64(7))
+}
+
 // createExternalSecretBackend inserts a named external secret backend on the
 // controller DB and returns its target UUID.
 func (s *modelImporterSuite) createExternalSecretBackend(c *tc.C, name string) string {
@@ -154,7 +205,7 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewrite(c *tc.C) {
 	revUUID2 := uuid.MustNewUUID().String()
 	passwordHash := "some-hash"
 
-	payload := &v4_1_0.ModelExport{
+	payload := &latest.ModelExport{
 		ModelAgent: []v4_1_0.ModelAgent{
 			{ModelUUID: modelUUID.String(), PasswordHash: &passwordHash},
 		},
@@ -248,7 +299,7 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewriteMissingRef(c *tc
 	revUUID := uuid.MustNewUUID().String()
 	passwordHash := "some-hash"
 
-	payload := &v4_1_0.ModelExport{
+	payload := &latest.ModelExport{
 		ModelAgent: []v4_1_0.ModelAgent{
 			{ModelUUID: modelUUID.String(), PasswordHash: &passwordHash},
 		},
@@ -292,6 +343,77 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewriteMissingRef(c *tc
 	c.Assert(err, tc.ErrorMatches, `.*no target secret backend for secret revision.*`)
 
 	// Verify no secret_value_ref rows were committed.
+	var count int
+	err = modelRunner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM secret_value_ref WHERE revision_uuid = ?`, revUUID,
+		).Scan(&count)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+}
+
+func (s *modelImporterSuite) TestImportModelSecretBackendRewriteMissingBackend(c *tc.C) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	controllerFactory := s.TxnRunnerFactory()
+	modelRunner := s.ModelTxnRunner(c, modelUUID.String())
+	modelFactory := func(context.Context) (coredatabase.TxnRunner, error) {
+		return modelRunner, nil
+	}
+
+	sourceBackendUUID := uuid.MustNewUUID().String()
+	now := time.Now().UTC()
+	secretID := uuid.MustNewUUID().String()
+	revUUID := uuid.MustNewUUID().String()
+	passwordHash := "some-hash"
+
+	payload := &latest.ModelExport{
+		ModelAgent: []v4_1_0.ModelAgent{
+			{ModelUUID: modelUUID.String(), PasswordHash: &passwordHash},
+		},
+		Secret: []v4_1_0.Secret{
+			{ID: secretID},
+		},
+		SecretMetadata: []v4_1_0.SecretMetadata{
+			{SecretID: secretID, Version: 1, RotatePolicyID: 0, CreateTime: now, UpdateTime: now},
+		},
+		SecretRevision: []v4_1_0.SecretRevision{
+			{UUID: revUUID, SecretID: secretID, Revision: 1, CreateTime: now},
+		},
+		SecretValueRef: []v4_1_0.SecretValueRef{
+			{RevisionUUID: revUUID, BackendUUID: sourceBackendUUID, RevisionID: "ext-rev-1"},
+		},
+	}
+
+	scope := func(coremodel.UUID) coremodelmigration.Scope {
+		return coremodelmigration.NewScope(controllerFactory, modelFactory, nil, nil, modelUUID)
+	}
+	importer := migration.NewModelImporter(scope, nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
+
+	importArgs := migration.ImportModelArgs{
+		SourceMigrationUUID: uuid.MustNewUUID().String(),
+		ControllerModelInfo: coremodelmigration.ControllerModelInfo{
+			ModelInfo: coremodelmigration.ModelIdentityInfo{
+				UUID:      modelUUID.String(),
+				Name:      "imported-model",
+				Qualifier: "prod",
+				Type:      "iaas",
+				Cloud:     s.cloudName,
+				Life:      "alive",
+			},
+			SecretBackendRefs: []coremodelmigration.SecretBackendReference{{
+				BackendName:        "nonexistent",
+				SecretRevisionUUID: revUUID,
+				SecretID:           secretID,
+			}},
+		},
+		ModelDBPayload: payload,
+	}
+	view := export.ProjectionView{AgentTargetVersion: jujuversion.Current}
+
+	err := importer.ImportModel(c.Context(), importArgs, view)
+	c.Assert(err, tc.ErrorMatches, `.*looking up secret backend "nonexistent".*`)
+
 	var count int
 	err = modelRunner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		return tx.QueryRowContext(ctx,

--- a/internal/migration/secretrewrite.go
+++ b/internal/migration/secretrewrite.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+import (
+	"context"
+
+	coremodelmigration "github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/domain/export/types/latest"
+	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
+	secretbackendstate "github.com/juju/juju/domain/secretbackend/state"
+	"github.com/juju/juju/internal/errors"
+)
+
+// reconcileSecretBackendUUIDs rewrites the model-DB payload's secret backend
+// UUIDs from the source controller's to the target's, matched by backend name.
+// It reads the target backends from the controller DB (read-only) and rewrites
+// the in-memory payload in place; it runs after the controller data is imported
+// and before the model-DB insert.
+//
+// It is the import-time counterpart to the activate-phase reconcile helpers:
+// read controller-scoped data, reconcile the model's data. The reconciliation
+// is a pre-insert payload rewrite (not a post-insert row update) because the
+// target backends are already resolvable at import time — unlike source-
+// controller CMR references, whose target values are only known at activation.
+func reconcileSecretBackendUUIDs(
+	ctx context.Context,
+	deps Deps,
+	info coremodelmigration.ControllerModelInfo,
+	payload *latest.ModelExport,
+) error {
+	secretBackend := secretbackendservice.NewService(
+		secretbackendstate.NewState(deps.ControllerDB, deps.Logger), deps.Logger,
+	)
+	revisionToTargetBackend, err := secretBackend.GetSecretBackendReferenceMapping(ctx, info.SecretBackendRefs)
+	if err != nil {
+		return errors.Errorf("resolving target secret backends: %w", err)
+	}
+	return RewriteSecretBackendUUIDs(payload, revisionToTargetBackend)
+}
+
+// RewriteSecretBackendUUIDs rewrites the transformed model-DB payload's
+// secret_value_ref and secret_deleted_value_ref backend UUIDs from the
+// source controller's backend UUIDs to the target's, keyed by secret revision
+// UUID. revisionToTargetBackend maps each external-backed secret revision UUID
+// to the target backend UUID resolved during the controller-data import.
+//
+// A value-ref / deleted-value-ref revision with no mapping is a hard error
+// (the model-DB insert has not run yet, so no rows leak).
+//
+// The rewrite runs after the controller-data import and before any model-DB
+// write. If it errors (missing mapping), the caller returns the error → the v8
+// Import returns a generic import failure → the source enters ABORT → Task 11
+// AbortImport / RemoveOnAbortImport cleans the controller-DB data and the
+// partial model. No model-DB rows were written, so the rewrite needs no
+// compensation of its own.
+func RewriteSecretBackendUUIDs(payload *latest.ModelExport, revisionToTargetBackend map[string]string) error {
+	if payload == nil {
+		return nil
+	}
+
+	if payload.SecretValueRef == nil && payload.SecretDeletedValueRef == nil {
+		return nil
+	}
+
+	for i := range payload.SecretValueRef {
+		rev := payload.SecretValueRef[i].RevisionUUID
+		targetBackend, ok := revisionToTargetBackend[rev]
+		if !ok {
+			return errors.Errorf(
+				"no target secret backend for secret revision %q", rev)
+		}
+		payload.SecretValueRef[i].BackendUUID = targetBackend
+	}
+
+	for i := range payload.SecretDeletedValueRef {
+		rev := payload.SecretDeletedValueRef[i].RevisionUUID
+		targetBackend, ok := revisionToTargetBackend[rev]
+		if !ok {
+			return errors.Errorf(
+				"no target secret backend for secret revision %q (deleted value ref)", rev)
+		}
+		payload.SecretDeletedValueRef[i].BackendUUID = targetBackend
+	}
+
+	return nil
+}

--- a/internal/migration/secretrewrite.go
+++ b/internal/migration/secretrewrite.go
@@ -50,9 +50,9 @@ func reconcileSecretBackendUUIDs(
 // (the model-DB insert has not run yet, so no rows leak).
 //
 // The rewrite runs after the controller-data import and before any model-DB
-// write. If it errors (missing mapping), the caller returns the error → the v8
-// Import returns a generic import failure → the source enters ABORT → Task 11
-// AbortImport / RemoveOnAbortImport cleans the controller-DB data and the
+// write. If it errors (missing mapping), the caller returns the error. The v8
+// import returns a generic import failure, the source enters ABORT, and Task
+// 11 AbortImport / RemoveOnAbortImport cleans the controller-DB data and the
 // partial model. No model-DB rows were written, so the rewrite needs no
 // compensation of its own.
 func RewriteSecretBackendUUIDs(payload *latest.ModelExport, revisionToTargetBackend map[string]string) error {
@@ -60,7 +60,7 @@ func RewriteSecretBackendUUIDs(payload *latest.ModelExport, revisionToTargetBack
 		return nil
 	}
 
-	if payload.SecretValueRef == nil && payload.SecretDeletedValueRef == nil {
+	if len(payload.SecretValueRef) == 0 && len(payload.SecretDeletedValueRef) == 0 {
 		return nil
 	}
 

--- a/internal/migration/secretrewrite_test.go
+++ b/internal/migration/secretrewrite_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration_test
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/domain/export/types/latest"
+	"github.com/juju/juju/domain/export/types/v4_1_0"
+	"github.com/juju/juju/internal/migration"
+	"github.com/juju/juju/internal/testhelpers"
+)
+
+// secretRewriteSuite exercises [migration.RewriteSecretBackendUUIDs].
+type secretRewriteSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestSecretRewriteSuite(t *testing.T) {
+	tc.Run(t, &secretRewriteSuite{})
+}
+
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_NilPayload(c *tc.C) {
+	err := migration.RewriteSecretBackendUUIDs(nil, map[string]string{"rev-1": "target-id"})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_EmptyPayload(c *tc.C) {
+	payload := &latest.ModelExport{}
+	err := migration.RewriteSecretBackendUUIDs(payload, map[string]string{"rev-1": "target-id"})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_EmptyMap(c *tc.C) {
+	payload := &latest.ModelExport{
+		SecretValueRef: []v4_1_0.SecretValueRef{
+			{RevisionUUID: "rev-1", BackendUUID: "source-id"},
+		},
+	}
+	err := migration.RewriteSecretBackendUUIDs(payload, nil)
+	c.Assert(err, tc.ErrorMatches, `no target secret backend for secret revision "rev-1"`)
+}
+
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_RewriteBoth(c *tc.C) {
+	payload := &latest.ModelExport{
+		SecretValueRef: []v4_1_0.SecretValueRef{
+			{RevisionUUID: "rev-1", BackendUUID: "source-1", RevisionID: "rid-1"},
+			{RevisionUUID: "rev-2", BackendUUID: "source-2", RevisionID: "rid-2"},
+		},
+		SecretDeletedValueRef: []v4_1_0.SecretDeletedValueRef{
+			{RevisionUUID: "rev-1", BackendUUID: "source-1", RevisionID: "rid-1"},
+			{RevisionUUID: "rev-3", BackendUUID: "source-3", RevisionID: "rid-3"},
+		},
+	}
+
+	revisionMap := map[string]string{
+		"rev-1": "target-1",
+		"rev-2": "target-2",
+		"rev-3": "target-3",
+	}
+
+	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Value refs rewritten.
+	c.Check(payload.SecretValueRef[0].BackendUUID, tc.Equals, "target-1")
+	c.Check(payload.SecretValueRef[0].RevisionID, tc.Equals, "rid-1") // unchanged
+	c.Check(payload.SecretValueRef[1].BackendUUID, tc.Equals, "target-2")
+	c.Check(payload.SecretValueRef[1].RevisionID, tc.Equals, "rid-2") // unchanged
+
+	// Deleted value refs rewritten.
+	c.Check(payload.SecretDeletedValueRef[0].BackendUUID, tc.Equals, "target-1")
+	c.Check(payload.SecretDeletedValueRef[0].RevisionID, tc.Equals, "rid-1") // unchanged
+	c.Check(payload.SecretDeletedValueRef[1].BackendUUID, tc.Equals, "target-3")
+	c.Check(payload.SecretDeletedValueRef[1].RevisionID, tc.Equals, "rid-3") // unchanged
+}
+
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_MissingRevision(c *tc.C) {
+	payload := &latest.ModelExport{
+		SecretValueRef: []v4_1_0.SecretValueRef{
+			{RevisionUUID: "rev-1", BackendUUID: "source-1"},
+		},
+	}
+
+	revisionMap := map[string]string{
+		"rev-other": "target-other",
+	}
+
+	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	c.Assert(err, tc.ErrorMatches, `no target secret backend for secret revision "rev-1"`)
+}
+
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_MissingDeletedRevision(c *tc.C) {
+	payload := &latest.ModelExport{
+		SecretDeletedValueRef: []v4_1_0.SecretDeletedValueRef{
+			{RevisionUUID: "rev-1", BackendUUID: "source-1"},
+		},
+	}
+
+	revisionMap := map[string]string{
+		"rev-other": "target-other",
+	}
+
+	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	c.Assert(err, tc.ErrorMatches, `no target secret backend for secret revision "rev-1" \(deleted value ref\)`)
+}
+
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_DistinctBackends(c *tc.C) {
+	payload := &latest.ModelExport{
+		SecretValueRef: []v4_1_0.SecretValueRef{
+			{RevisionUUID: "rev-1", BackendUUID: "src-a"},
+			{RevisionUUID: "rev-2", BackendUUID: "src-b"},
+		},
+	}
+
+	revisionMap := map[string]string{
+		"rev-1": "tgt-a",
+		"rev-2": "tgt-b",
+	}
+
+	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(payload.SecretValueRef[0].BackendUUID, tc.Equals, "tgt-a")
+	c.Check(payload.SecretValueRef[1].BackendUUID, tc.Equals, "tgt-b")
+}
+
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_OnlyValueRefs(c *tc.C) {
+	payload := &latest.ModelExport{
+		SecretValueRef: []v4_1_0.SecretValueRef{
+			{RevisionUUID: "rev-1", BackendUUID: "source-1"},
+		},
+	}
+
+	revisionMap := map[string]string{"rev-1": "target-1"}
+
+	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(payload.SecretValueRef[0].BackendUUID, tc.Equals, "target-1")
+}
+
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_OnlyDeletedRefs(c *tc.C) {
+	payload := &latest.ModelExport{
+		SecretDeletedValueRef: []v4_1_0.SecretDeletedValueRef{
+			{RevisionUUID: "rev-1", BackendUUID: "source-1"},
+		},
+	}
+
+	revisionMap := map[string]string{"rev-1": "target-1"}
+
+	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(payload.SecretDeletedValueRef[0].BackendUUID, tc.Equals, "target-1")
+}
+
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_NoRows(c *tc.C) {
+	payload := &latest.ModelExport{
+		SecretValueRef:        nil,
+		SecretDeletedValueRef: nil,
+		// Some other payload fields to show it's a real payload.
+		Sequence: []v4_1_0.Sequence{{Namespace: "test", Value: 42}},
+	}
+
+	revisionMap := map[string]string{"rev-1": "target-1"}
+
+	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	c.Assert(err, tc.ErrorIsNil)
+}

--- a/internal/migration/secretrewrite_test.go
+++ b/internal/migration/secretrewrite_test.go
@@ -23,18 +23,18 @@ func TestSecretRewriteSuite(t *testing.T) {
 	tc.Run(t, &secretRewriteSuite{})
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_NilPayload(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsNilPayload(c *tc.C) {
 	err := migration.RewriteSecretBackendUUIDs(nil, map[string]string{"rev-1": "target-id"})
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_EmptyPayload(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsEmptyPayload(c *tc.C) {
 	payload := &latest.ModelExport{}
 	err := migration.RewriteSecretBackendUUIDs(payload, map[string]string{"rev-1": "target-id"})
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_EmptyMap(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsEmptyMap(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretValueRef: []v4_1_0.SecretValueRef{
 			{RevisionUUID: "rev-1", BackendUUID: "source-id"},
@@ -44,7 +44,7 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_EmptyMap(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `no target secret backend for secret revision "rev-1"`)
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_RewriteBoth(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsRewriteBoth(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretValueRef: []v4_1_0.SecretValueRef{
 			{RevisionUUID: "rev-1", BackendUUID: "source-1", RevisionID: "rid-1"},
@@ -67,18 +67,18 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_RewriteBoth(c *tc.C) 
 
 	// Value refs rewritten.
 	c.Check(payload.SecretValueRef[0].BackendUUID, tc.Equals, "target-1")
-	c.Check(payload.SecretValueRef[0].RevisionID, tc.Equals, "rid-1") // unchanged
+	c.Check(payload.SecretValueRef[0].RevisionID, tc.Equals, "rid-1")
 	c.Check(payload.SecretValueRef[1].BackendUUID, tc.Equals, "target-2")
-	c.Check(payload.SecretValueRef[1].RevisionID, tc.Equals, "rid-2") // unchanged
+	c.Check(payload.SecretValueRef[1].RevisionID, tc.Equals, "rid-2")
 
 	// Deleted value refs rewritten.
 	c.Check(payload.SecretDeletedValueRef[0].BackendUUID, tc.Equals, "target-1")
-	c.Check(payload.SecretDeletedValueRef[0].RevisionID, tc.Equals, "rid-1") // unchanged
+	c.Check(payload.SecretDeletedValueRef[0].RevisionID, tc.Equals, "rid-1")
 	c.Check(payload.SecretDeletedValueRef[1].BackendUUID, tc.Equals, "target-3")
-	c.Check(payload.SecretDeletedValueRef[1].RevisionID, tc.Equals, "rid-3") // unchanged
+	c.Check(payload.SecretDeletedValueRef[1].RevisionID, tc.Equals, "rid-3")
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_MissingRevision(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsMissingRevision(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretValueRef: []v4_1_0.SecretValueRef{
 			{RevisionUUID: "rev-1", BackendUUID: "source-1"},
@@ -93,7 +93,7 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_MissingRevision(c *tc
 	c.Assert(err, tc.ErrorMatches, `no target secret backend for secret revision "rev-1"`)
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_MissingDeletedRevision(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsMissingDeletedRevision(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretDeletedValueRef: []v4_1_0.SecretDeletedValueRef{
 			{RevisionUUID: "rev-1", BackendUUID: "source-1"},
@@ -108,7 +108,7 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_MissingDeletedRevisio
 	c.Assert(err, tc.ErrorMatches, `no target secret backend for secret revision "rev-1" \(deleted value ref\)`)
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_DistinctBackends(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsDistinctBackends(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretValueRef: []v4_1_0.SecretValueRef{
 			{RevisionUUID: "rev-1", BackendUUID: "src-a"},
@@ -127,7 +127,7 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_DistinctBackends(c *t
 	c.Check(payload.SecretValueRef[1].BackendUUID, tc.Equals, "tgt-b")
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_OnlyValueRefs(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsOnlyValueRefs(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretValueRef: []v4_1_0.SecretValueRef{
 			{RevisionUUID: "rev-1", BackendUUID: "source-1"},
@@ -141,7 +141,7 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_OnlyValueRefs(c *tc.C
 	c.Check(payload.SecretValueRef[0].BackendUUID, tc.Equals, "target-1")
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_OnlyDeletedRefs(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsOnlyDeletedRefs(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretDeletedValueRef: []v4_1_0.SecretDeletedValueRef{
 			{RevisionUUID: "rev-1", BackendUUID: "source-1"},
@@ -155,7 +155,7 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_OnlyDeletedRefs(c *tc
 	c.Check(payload.SecretDeletedValueRef[0].BackendUUID, tc.Equals, "target-1")
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDs_NoRows(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsNoRows(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretValueRef:        nil,
 		SecretDeletedValueRef: nil,


### PR DESCRIPTION
When a model migrates to a new controller, each secret backend on the target is given its own random 
identifier and is matched to the source only by name. The new-format import copies the model's secret 
rows as they were on the source, so the backend identifiers in those rows still point at the source 
controller and mean nothing on the target. Left alone, every external secret would reference a backend
that does not exist here.

This change fixes those identifiers before the model data is written. Once the controller-level data 
has been imported, a small step looks up each backend by name on the target, builds the mapping from 
each secret revision to the target's backend identifier, and rewrites the payload to use it, right 
before the model database insert. If a revision has no matching backend the import stops with a clear 
error, and because this runs before anything is written to the model database, nothing is left half 
applied. It sits at the import stage, rather than at activation like the cross-model relation work, 
because the target backends already exist and can be resolved by name at this point.

The behavior is covered by unit tests for the rewrite itself and by real-database tests that import a
model with an external backend and confirm the stored rows end up with the target's identifier, along
with a negative case proving that an unmapped revision fails without writing anything. Nothing else 
on the import path changes, so this sets up the later activation and secret re-attach work to rely on 
correct target identifiers.


## QA steps

Not fully wired yet, unit tests must pass though.

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9908](https://warthogs.atlassian.net/browse/JUJU-9908)


[JUJU-9908]: https://warthogs.atlassian.net/browse/JUJU-9908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ