### PR TITLE
fix(migration): ignore deleted secret refs during backend rewrite

### DIFF
--- a/domain/secretbackend/service/import.go
+++ b/domain/secretbackend/service/import.go
@@ -52,9 +52,9 @@ func (s *Service) ImportSecretBackendReferences(
 // It is read-only: it looks up each distinct backend by name and writes no
 // state. The v8 migration import driver in internal/migration calls it, after
 // the controller-scoped data is applied and before the model-DB insert, to
-// rewrite the model-DB payload's secret_value_ref and secret_deleted_value_ref
-// BackendUUID fields from the source controller's backend UUIDs to the
-// target's. Returns a nil map for an empty refs slice.
+// rewrite the model-DB payload's secret_value_ref BackendUUID fields from the
+// source controller's backend UUIDs to the target's. Returns a nil map for an
+// empty refs slice.
 func (s *Service) GetSecretBackendReferenceMapping(
 	ctx context.Context, refs []coremodelmigration.SecretBackendReference,
 ) (map[string]string, error) {

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -114,9 +114,9 @@ func (i *ModelImporter) ImportModel(
 	}
 
 	// Now that the controller data is applied, rewrite the model-DB payload's
-	// secret backend UUIDs from the source controller's to the target's (matched
-	// by name) before the insert. An unmapped revision is a hard error; no
-	// model-DB rows are written.
+	// live secret value ref backend UUIDs from the source controller's to the
+	// target's (matched by name) before the insert. An unmapped live revision
+	// is a hard error; no model-DB rows are written.
 	if err := reconcileSecretBackendUUIDs(ctx, deps, args.ControllerModelInfo, args.ModelDBPayload); err != nil {
 		return internalerrors.Errorf(
 			"rewriting secret backend UUIDs for model %q: %w", modelUUID, err)
@@ -133,9 +133,9 @@ func (i *ModelImporter) ImportModel(
 }
 
 type CharmService interface {
-	// GetCharmArchive returns a ReadCloser stream for the charm archive for a given
-	// charm id, along with the hash of the charm archive. Clients can use the hash
-	// to verify the integrity of the charm archive.
+	// GetCharmArchive returns a ReadCloser stream for the charm archive for a
+	// given charm id, along with the hash of the charm archive. Clients can use
+	// the hash to verify the integrity of the charm archive.
 	GetCharmArchive(context.Context, domaincharm.CharmLocator) (io.ReadCloser, string, error)
 }
 

--- a/internal/migration/modelimporter_test.go
+++ b/internal/migration/modelimporter_test.go
@@ -181,9 +181,10 @@ func (s *modelImporterSuite) createExternalSecretBackend(c *tc.C, name string) s
 	return backendUUID
 }
 
-// TestImportModelSecretBackendRewrite verifies that secret_value_ref and
-// secret_deleted_value_ref backend_uuid fields are rewritten from the source
-// controller's backend UUIDs to the target's before the model-DB insert.
+// TestImportModelSecretBackendRewrite verifies that secret_value_ref
+// backend_uuid fields are rewritten from the source controller's backend UUIDs
+// to the target's before the model-DB insert. Deleted value refs do not have
+// controller secret backend references, so they do not require a mapping.
 func (s *modelImporterSuite) TestImportModelSecretBackendRewrite(c *tc.C) {
 	modelUUID := tc.Must(c, coremodel.NewUUID)
 	controllerFactory := s.TxnRunnerFactory()
@@ -244,7 +245,6 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewrite(c *tc.C) {
 			},
 			SecretBackendRefs: []coremodelmigration.SecretBackendReference{
 				{BackendName: targetBackendName, SecretRevisionUUID: revUUID1, SecretID: secretID},
-				{BackendName: targetBackendName, SecretRevisionUUID: revUUID2, SecretID: secretID},
 			},
 		},
 		ModelDBPayload: payload,
@@ -267,15 +267,14 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewrite(c *tc.C) {
 		tc.Commentf("secret_value_ref should carry target backend UUID, got %q", insertedBackendUUID))
 	c.Check(insertedRevisionID, tc.Equals, "ext-rev-1")
 
-	// Verify secret_deleted_value_ref row carries the target backend UUID.
+	// Verify secret_deleted_value_ref row did not require a backend mapping.
 	err = modelRunner.StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		return tx.QueryRowContext(ctx,
 			`SELECT backend_uuid, revision_id FROM secret_deleted_value_ref WHERE revision_uuid = ?`, revUUID2,
 		).Scan(&insertedBackendUUID, &insertedRevisionID)
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(insertedBackendUUID, tc.Equals, targetBackendUUID,
-		tc.Commentf("secret_deleted_value_ref should carry target backend UUID, got %q", insertedBackendUUID))
+	c.Check(insertedBackendUUID, tc.Equals, sourceBackendUUID)
 	c.Check(insertedRevisionID, tc.Equals, "ext-rev-2")
 }
 

--- a/internal/migration/secretrewrite.go
+++ b/internal/migration/secretrewrite.go
@@ -37,17 +37,22 @@ func reconcileSecretBackendUUIDs(
 	if err != nil {
 		return errors.Errorf("resolving target secret backends: %w", err)
 	}
-	return RewriteSecretBackendUUIDs(payload, revisionToTargetBackend)
+	return rewriteSecretBackendUUIDs(payload, revisionToTargetBackend)
 }
 
-// RewriteSecretBackendUUIDs rewrites the transformed model-DB payload's
-// secret_value_ref and secret_deleted_value_ref backend UUIDs from the
-// source controller's backend UUIDs to the target's, keyed by secret revision
-// UUID. revisionToTargetBackend maps each external-backed secret revision UUID
-// to the target backend UUID resolved during the controller-data import.
+// rewriteSecretBackendUUIDs rewrites the transformed model-DB payload's
+// secret_value_ref backend UUIDs from the source controller's backend UUIDs to
+// the target's, keyed by secret revision UUID. revisionToTargetBackend maps
+// each external-backed secret revision UUID to the target backend UUID resolved
+// during the controller-data import.
 //
-// A value-ref / deleted-value-ref revision with no mapping is a hard error
-// (the model-DB insert has not run yet, so no rows leak).
+// A value-ref revision with no mapping is a hard error (the model-DB insert has
+// not run yet, so no rows leak). Deleted value refs are not rewritten here:
+// source controllers remove secret_backend_reference rows when revisions move
+// to secret_deleted_value_ref, so there is no revision-to-backend-name mapping
+// available. The cleanup path only reads revision_id from those rows, so
+// keeping them in the payload preserves the deferred external cleanup marker
+// without inventing an impossible target backend mapping.
 //
 // The rewrite runs after the controller-data import and before any model-DB
 // write. If it errors (missing mapping), the caller returns the error. The v8
@@ -55,12 +60,12 @@ func reconcileSecretBackendUUIDs(
 // 11 AbortImport / RemoveOnAbortImport cleans the controller-DB data and the
 // partial model. No model-DB rows were written, so the rewrite needs no
 // compensation of its own.
-func RewriteSecretBackendUUIDs(payload *latest.ModelExport, revisionToTargetBackend map[string]string) error {
+func rewriteSecretBackendUUIDs(payload *latest.ModelExport, revisionToTargetBackend map[string]string) error {
 	if payload == nil {
 		return nil
 	}
 
-	if len(payload.SecretValueRef) == 0 && len(payload.SecretDeletedValueRef) == 0 {
+	if len(payload.SecretValueRef) == 0 {
 		return nil
 	}
 
@@ -72,16 +77,6 @@ func RewriteSecretBackendUUIDs(payload *latest.ModelExport, revisionToTargetBack
 				"no target secret backend for secret revision %q", rev)
 		}
 		payload.SecretValueRef[i].BackendUUID = targetBackend
-	}
-
-	for i := range payload.SecretDeletedValueRef {
-		rev := payload.SecretDeletedValueRef[i].RevisionUUID
-		targetBackend, ok := revisionToTargetBackend[rev]
-		if !ok {
-			return errors.Errorf(
-				"no target secret backend for secret revision %q (deleted value ref)", rev)
-		}
-		payload.SecretDeletedValueRef[i].BackendUUID = targetBackend
 	}
 
 	return nil

--- a/internal/migration/secretrewrite_test.go
+++ b/internal/migration/secretrewrite_test.go
@@ -1,7 +1,7 @@
 // Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package migration_test
+package migration
 
 import (
 	"testing"
@@ -10,11 +10,10 @@ import (
 
 	"github.com/juju/juju/domain/export/types/latest"
 	"github.com/juju/juju/domain/export/types/v4_1_0"
-	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/testhelpers"
 )
 
-// secretRewriteSuite exercises [migration.RewriteSecretBackendUUIDs].
+// secretRewriteSuite exercises rewriteSecretBackendUUIDs.
 type secretRewriteSuite struct {
 	testhelpers.IsolationSuite
 }
@@ -24,13 +23,13 @@ func TestSecretRewriteSuite(t *testing.T) {
 }
 
 func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsNilPayload(c *tc.C) {
-	err := migration.RewriteSecretBackendUUIDs(nil, map[string]string{"rev-1": "target-id"})
+	err := rewriteSecretBackendUUIDs(nil, map[string]string{"rev-1": "target-id"})
 	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsEmptyPayload(c *tc.C) {
 	payload := &latest.ModelExport{}
-	err := migration.RewriteSecretBackendUUIDs(payload, map[string]string{"rev-1": "target-id"})
+	err := rewriteSecretBackendUUIDs(payload, map[string]string{"rev-1": "target-id"})
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -40,18 +39,17 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsEmptyMap(c *tc.C) {
 			{RevisionUUID: "rev-1", BackendUUID: "source-id"},
 		},
 	}
-	err := migration.RewriteSecretBackendUUIDs(payload, nil)
+	err := rewriteSecretBackendUUIDs(payload, nil)
 	c.Assert(err, tc.ErrorMatches, `no target secret backend for secret revision "rev-1"`)
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsRewriteBoth(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsRewriteValueRefs(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretValueRef: []v4_1_0.SecretValueRef{
 			{RevisionUUID: "rev-1", BackendUUID: "source-1", RevisionID: "rid-1"},
 			{RevisionUUID: "rev-2", BackendUUID: "source-2", RevisionID: "rid-2"},
 		},
 		SecretDeletedValueRef: []v4_1_0.SecretDeletedValueRef{
-			{RevisionUUID: "rev-1", BackendUUID: "source-1", RevisionID: "rid-1"},
 			{RevisionUUID: "rev-3", BackendUUID: "source-3", RevisionID: "rid-3"},
 		},
 	}
@@ -59,10 +57,9 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsRewriteBoth(c *tc.C) {
 	revisionMap := map[string]string{
 		"rev-1": "target-1",
 		"rev-2": "target-2",
-		"rev-3": "target-3",
 	}
 
-	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	err := rewriteSecretBackendUUIDs(payload, revisionMap)
 	c.Assert(err, tc.ErrorIsNil)
 
 	// Value refs rewritten.
@@ -71,11 +68,9 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsRewriteBoth(c *tc.C) {
 	c.Check(payload.SecretValueRef[1].BackendUUID, tc.Equals, "target-2")
 	c.Check(payload.SecretValueRef[1].RevisionID, tc.Equals, "rid-2")
 
-	// Deleted value refs rewritten.
-	c.Check(payload.SecretDeletedValueRef[0].BackendUUID, tc.Equals, "target-1")
-	c.Check(payload.SecretDeletedValueRef[0].RevisionID, tc.Equals, "rid-1")
-	c.Check(payload.SecretDeletedValueRef[1].BackendUUID, tc.Equals, "target-3")
-	c.Check(payload.SecretDeletedValueRef[1].RevisionID, tc.Equals, "rid-3")
+	// Deleted value refs are deferred cleanup markers, not rewritten refs.
+	c.Check(payload.SecretDeletedValueRef[0].BackendUUID, tc.Equals, "source-3")
+	c.Check(payload.SecretDeletedValueRef[0].RevisionID, tc.Equals, "rid-3")
 }
 
 func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsMissingRevision(c *tc.C) {
@@ -89,23 +84,20 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsMissingRevision(c *tc.
 		"rev-other": "target-other",
 	}
 
-	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	err := rewriteSecretBackendUUIDs(payload, revisionMap)
 	c.Assert(err, tc.ErrorMatches, `no target secret backend for secret revision "rev-1"`)
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsMissingDeletedRevision(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsOnlyDeletedRefs(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretDeletedValueRef: []v4_1_0.SecretDeletedValueRef{
 			{RevisionUUID: "rev-1", BackendUUID: "source-1"},
 		},
 	}
 
-	revisionMap := map[string]string{
-		"rev-other": "target-other",
-	}
-
-	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
-	c.Assert(err, tc.ErrorMatches, `no target secret backend for secret revision "rev-1" \(deleted value ref\)`)
+	err := rewriteSecretBackendUUIDs(payload, nil)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(payload.SecretDeletedValueRef[0].BackendUUID, tc.Equals, "source-1")
 }
 
 func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsDistinctBackends(c *tc.C) {
@@ -121,7 +113,7 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsDistinctBackends(c *tc
 		"rev-2": "tgt-b",
 	}
 
-	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	err := rewriteSecretBackendUUIDs(payload, revisionMap)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(payload.SecretValueRef[0].BackendUUID, tc.Equals, "tgt-a")
 	c.Check(payload.SecretValueRef[1].BackendUUID, tc.Equals, "tgt-b")
@@ -136,23 +128,23 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsOnlyValueRefs(c *tc.C)
 
 	revisionMap := map[string]string{"rev-1": "target-1"}
 
-	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	err := rewriteSecretBackendUUIDs(payload, revisionMap)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(payload.SecretValueRef[0].BackendUUID, tc.Equals, "target-1")
 }
 
-func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsOnlyDeletedRefs(c *tc.C) {
+func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsNoMappedDeletedRefs(c *tc.C) {
 	payload := &latest.ModelExport{
 		SecretDeletedValueRef: []v4_1_0.SecretDeletedValueRef{
 			{RevisionUUID: "rev-1", BackendUUID: "source-1"},
 		},
 	}
 
-	revisionMap := map[string]string{"rev-1": "target-1"}
+	revisionMap := map[string]string{"rev-2": "target-2"}
 
-	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	err := rewriteSecretBackendUUIDs(payload, revisionMap)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(payload.SecretDeletedValueRef[0].BackendUUID, tc.Equals, "target-1")
+	c.Check(payload.SecretDeletedValueRef[0].BackendUUID, tc.Equals, "source-1")
 }
 
 func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsNoRows(c *tc.C) {
@@ -165,6 +157,6 @@ func (s *secretRewriteSuite) TestRewriteSecretBackendUUIDsNoRows(c *tc.C) {
 
 	revisionMap := map[string]string{"rev-1": "target-1"}
 
-	err := migration.RewriteSecretBackendUUIDs(payload, revisionMap)
+	err := rewriteSecretBackendUUIDs(payload, revisionMap)
 	c.Assert(err, tc.ErrorIsNil)
 }


### PR DESCRIPTION
On https://github.com/juju/juju/pull/22783, modelimport rewrote secret backend UUIDs for both live and deleted secret value refs. Deleted value
refs no longer have controller secret backend references after revision deletion, so models with pending
external secret cleanup could fail import because no target backend mapping existed.

The rewrite now applies only to live secret_value_ref rows, where the controller mapping still exists.
`secret_deleted_value_ref` rows are kept as deferred cleanup markers without requiring a backend mapping,
and the rewrite helper is private because it is only used inside the migration package.

_Note: this is a follow-up patch for https://github.com/juju/juju/pull/22783#pullrequestreview-4635123096._
## QA steps

Running 
```
 go test ./internal/migration -run 'TestModelImporterSuite/^TestImportModelSecretBackendRewrite$' -v
```
Should flex the change (ignoring `secret_deleted_value_ref`). Reverting the changes on this PR except this test would show on the other hand that the test fails.

## Links

**Jira card:** [JUJU-9908](https://warthogs.atlassian.net/browse/JUJU-9908)


[JUJU-9908]: https://warthogs.atlassian.net/browse/JUJU-9908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ