### PR TITLE
fix(s3client): derive signing region from endpoint for S3 object store

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -275,6 +275,12 @@ const (
 	// object stores.
 	ObjectStoreS3StaticSession = "object-store-s3-static-session"
 
+	// ObjectStoreS3Region is the AWS region to use for signing S3 requests.
+	// When empty, the region is derived from the endpoint URL for common AWS
+	// forms. If it cannot be derived and static credentials are used, a
+	// placeholder region is used and a warning is logged.
+	ObjectStoreS3Region = "object-store-s3-region"
+
 	// SystemSSHKeys returns the set of ssh keys that should be trusted by
 	// agents of this controller regardless of the model.
 	SystemSSHKeys = "system-ssh-keys"
@@ -1120,6 +1126,13 @@ func (c Config) ObjectStoreS3StaticSecret() string {
 // object stores.
 func (c Config) ObjectStoreS3StaticSession() string {
 	return c.asString(ObjectStoreS3StaticSession)
+}
+
+// ObjectStoreS3Region returns the region to use for signing S3 requests.
+// Returns an empty string if not set; the s3client package derives it from
+// the endpoint URL, or logs a warning and uses a placeholder when it cannot.
+func (c Config) ObjectStoreS3Region() string {
+	return c.asString(ObjectStoreS3Region)
 }
 
 // SSHServerPort returns the port the SSH server listens on.

--- a/controller/config.go
+++ b/controller/config.go
@@ -542,6 +542,7 @@ var (
 		ObjectStoreS3StaticKey,
 		ObjectStoreS3StaticSecret,
 		ObjectStoreS3StaticSession,
+		ObjectStoreS3Region,
 		SystemSSHKeys,
 		JujudControllerSnapSource,
 		SSHMaxConcurrentConnections,
@@ -604,6 +605,7 @@ var (
 		ObjectStoreS3StaticKey,
 		ObjectStoreS3StaticSecret,
 		ObjectStoreS3StaticSession,
+		ObjectStoreS3Region,
 		SSHMaxConcurrentConnections,
 	)
 

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -433,6 +433,12 @@ var newConfigTests = []struct {
 	},
 	expectError: `object-store-s3-static-session: expected string, got int\(1\)`,
 }, {
+	about: "invalid object store s3 region value",
+	config: controller.Config{
+		controller.ObjectStoreS3Region: 1,
+	},
+	expectError: `object-store-s3-region: expected string, got int\(1\)`,
+}, {
 	about: "invalid jujud-controller-snap-source value",
 	config: controller.Config{
 		controller.JujudControllerSnapSource: "latest/stable",
@@ -1041,4 +1047,26 @@ func (s *ConfigSuite) TestObjectStoreS3Credentials(c *tc.C) {
 	c.Assert(cfg.ObjectStoreS3StaticKey(), tc.Equals, "key")
 	c.Assert(cfg.ObjectStoreS3StaticSecret(), tc.Equals, "secret")
 	c.Assert(cfg.ObjectStoreS3StaticSession(), tc.Equals, "session")
+}
+
+func (s *ConfigSuite) TestObjectStoreS3Region(c *tc.C) {
+	cfg, err := controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]any{
+			controller.ObjectStoreS3Region: "eu-west-1",
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(cfg.ObjectStoreS3Region(), tc.Equals, "eu-west-1")
+
+	// When not set, the region defaults to empty (s3client derives it or
+	// uses a placeholder).
+	cfg, err = controller.NewConfig(
+		testing.ControllerTag.Id(),
+		testing.CACert,
+		map[string]any{},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(cfg.ObjectStoreS3Region(), tc.Equals, "")
 }

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -1070,3 +1070,21 @@ func (s *ConfigSuite) TestObjectStoreS3Region(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(cfg.ObjectStoreS3Region(), tc.Equals, "")
 }
+
+// TestAllConfigSchemaFieldsAreControllerOnly is a structural invariant test.
+// It ensures every key registered in ConfigSchema is also recognized as a
+// controller-only attribute. Without this, bootstrap silently routes
+// controller config keys into model config, and juju controller-config
+// rejects them as unknown.
+func (s *ConfigSuite) TestAllConfigSchemaFieldsAreControllerOnly(c *tc.C) {
+	for name := range controller.ConfigSchema {
+		c.Check(controller.ControllerOnlyAttribute(name), tc.IsTrue,
+			tc.Commentf("key %q is in ConfigSchema but not in ControllerOnlyConfigAttributes", name))
+	}
+}
+
+// TestObjectStoreS3RegionIsUpdatable ensures that the region can be changed
+// after bootstrap, consistent with the other object-store-s3-* attributes.
+func (s *ConfigSuite) TestObjectStoreS3RegionIsUpdatable(c *tc.C) {
+	c.Check(controller.AllowedUpdateConfigAttributes.Contains(controller.ObjectStoreS3Region), tc.IsTrue)
+}

--- a/controller/configschema.go
+++ b/controller/configschema.go
@@ -65,6 +65,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	ObjectStoreS3StaticKey:             schema.String(),
 	ObjectStoreS3StaticSecret:          schema.String(),
 	ObjectStoreS3StaticSession:         schema.String(),
+	ObjectStoreS3Region:                schema.String(),
 	SystemSSHKeys:                      schema.String(),
 	JujudControllerSnapSource:          schema.String(),
 	SSHServerPort:                      schema.ForceInt(),
@@ -123,6 +124,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	ObjectStoreS3StaticKey:             schema.Omit,
 	ObjectStoreS3StaticSecret:          schema.Omit,
 	ObjectStoreS3StaticSession:         schema.Omit,
+	ObjectStoreS3Region:                schema.Omit,
 	SystemSSHKeys:                      schema.Omit,
 	JujudControllerSnapSource:          DefaultJujudControllerSnapSource,
 	SSHServerPort:                      DefaultSSHServerPort,
@@ -360,6 +362,10 @@ same database.`[1:],
 	ObjectStoreS3StaticSession: {
 		Type:        configschema.Tstring,
 		Description: `The s3 static session for the object store backend`,
+	},
+	ObjectStoreS3Region: {
+		Type:        configschema.Tstring,
+		Description: `The s3 region for signing requests to the object store backend. If empty, the region is derived from the endpoint URL for common AWS forms. If derivation fails, a placeholder is used and a warning is logged for static credentials.`,
 	},
 	SystemSSHKeys: {
 		Type:        configschema.Tstring,

--- a/docs/reference/configuration/list-of-controller-configuration-keys.md
+++ b/docs/reference/configuration/list-of-controller-configuration-keys.md
@@ -528,6 +528,19 @@ controller on behalf of workers running for a model.
 **Can be changed after bootstrap:** yes
 
 
+(controller-config-object-store-s3-region)=
+## `object-store-s3-region`
+
+`object-store-s3-region` is the AWS region to use for signing S3 requests.
+When empty, the region is derived from the endpoint URL for common AWS
+forms. If it cannot be derived and static credentials are used, a
+placeholder region is used and a warning is logged.
+
+**Type:** string
+
+**Can be changed after bootstrap:** no
+
+
 (controller-config-object-store-s3-static-key)=
 ## `object-store-s3-static-key`
 

--- a/docs/reference/configuration/list-of-controller-configuration-keys.md
+++ b/docs/reference/configuration/list-of-controller-configuration-keys.md
@@ -538,7 +538,7 @@ placeholder region is used and a warning is logged.
 
 **Type:** string
 
-**Can be changed after bootstrap:** no
+**Can be changed after bootstrap:** yes
 
 
 (controller-config-object-store-s3-static-key)=

--- a/docs/reference/controller.md
+++ b/docs/reference/controller.md
@@ -28,7 +28,7 @@ A Juju controller has two basic persistent storage needs: {ref}`database <databa
 
 <!-- ADD BACK IN WHEN WE MOVE THOSE VALUES INTO SECRETS.
 
-However, either during bootstrap or later, you can (and, in a production-setting, should!) specify any S3-compatible object store you want (e.g., AWS S3, MicroCeph, MinIO, etc.) using the object-store-related controller configuration keys ({ref}`controller-config-object-store-type`, {ref}`controller-config-object-store-s3-endpoint`, {ref}`controller-config-object-store-s3-static-key`, {ref}`controller-config-object-store-s3-static-secret`, {ref}`controller-config-object-store-s3-static-session`).
+However, either during bootstrap or later, you can (and, in a production-setting, should!) specify any S3-compatible object store you want (e.g., AWS S3, MicroCeph, MinIO, etc.) using the object-store-related controller configuration keys ({ref}`controller-config-object-store-type`, {ref}`controller-config-object-store-s3-endpoint`, {ref}`controller-config-object-store-s3-static-key`, {ref}`controller-config-object-store-s3-static-secret`, {ref}`controller-config-object-store-s3-static-session`, {ref}`controller-config-object-store-s3-region`).
 
 Also, Juju will apply default S3 policy permissions, but you are free to change them, so long as they satisfy the following as a minimum (at least, during model creation):
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md
@@ -359,6 +359,11 @@ Controller configuration keys:
     object-store-s3-endpoint:
       type: string
       description: The s3 endpoint for the object store backend
+    object-store-s3-region:
+      type: string
+      description: The s3 region for signing requests to the object store backend. If
+        empty, the region is derived from the endpoint URL for common AWS forms. If derivation
+        fails, a placeholder is used and a warning is logged for static credentials.
     object-store-s3-static-key:
       type: string
       description: The s3 static key for the object store backend

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/controller-config.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/controller-config.md
@@ -161,6 +161,11 @@ Controller configuration keys:
     object-store-s3-endpoint:
       type: string
       description: The s3 endpoint for the object store backend
+    object-store-s3-region:
+      type: string
+      description: The s3 region for signing requests to the object store backend. If
+        empty, the region is derived from the endpoint URL for common AWS forms. If derivation
+        fails, a placeholder is used and a warning is logged for static credentials.
     object-store-s3-static-key:
       type: string
       description: The s3 static key for the object store backend

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -77,6 +79,7 @@ type options struct {
 	maxAttempts       int
 	allowRateLimiting bool
 	logger            logger.Logger
+	region            string
 }
 
 // WithMaxAttempts is the option to set the maximum number of attempts for the
@@ -98,6 +101,17 @@ func WithRateLimiting(allowRateLimiting bool) Option {
 func WithLogger(logger logger.Logger) Option {
 	return func(o *options) {
 		o.logger = logger
+	}
+}
+
+// WithRegion is the option to set the signing region for the S3 client.
+// When empty (the default), the region is derived from the endpoint URL for
+// common AWS forms. If derivation fails and static credentials are used, a
+// placeholder region is used and a warning is logged; for anonymous
+// credentials the region is left empty since signing is skipped.
+func WithRegion(region string) Option {
+	return func(o *options) {
+		o.region = region
 	}
 }
 
@@ -132,11 +146,25 @@ func NewS3Client(endpoint string, httpClient HTTPClient, credentials Credentials
 		logger: o.logger.Child("aws.s3"),
 	}
 
+	region, err := resolveRegion(o.region, endpoint)
+	if err != nil {
+		if credentials.Kind() == StaticCredentialsKind {
+			o.logger.Warningf(context.Background(),
+				"could not determine S3 signing region from endpoint %q; "+
+					"using placeholder %q. Set the object-store-s3-region "+
+					"controller config key to specify the correct region.",
+				endpoint, fallbackRegion)
+			region = fallbackRegion
+		}
+		// Anonymous credentials skip SigV4 signing, so an empty region is fine.
+	}
+
 	cfg, err := config.LoadDefaultConfig(
 		context.Background(),
 		config.WithLogger(awsLogger),
 		config.WithHTTPClient(httpClient),
-		config.WithEndpointResolverWithOptions(&awsEndpointResolver{endpoint: endpoint}),
+		config.WithRegion(region),
+		config.WithEndpointResolverWithOptions(&awsEndpointResolver{endpoint: endpoint, region: region}),
 		config.WithRetryer(func() aws.Retryer {
 			return retry.NewStandard(
 				func(s3Options *retry.StandardOptions) {
@@ -373,14 +401,75 @@ func handleError(err error) error {
 	return errors.Trace(err)
 }
 
+// awsGlobalEndpointRegion is the region the AWS global S3 endpoint
+// (s3.amazonaws.com) maps to.
+const awsGlobalEndpointRegion = "us-east-1"
+
+// fallbackRegion is the placeholder SigV4 signing region used for static
+// credentials when no region is set explicitly and none can be derived from
+// the endpoint. It is deliberately not a real AWS region: S3-compatible
+// stores that ignore the region (MinIO, Ceph) accept it, while real AWS
+// requests fail loudly with this value visible in the error. Set
+// object-store-s3-region to override.
+const fallbackRegion = "juju-unknown-region"
+
+// regionFromEndpoint attempts to extract an AWS region from a common S3
+// endpoint URL. It recognises the following host forms:
+//
+//   - s3.amazonaws.com (global endpoint, returns us-east-1)
+//   - s3.<region>.amazonaws.com
+//   - s3-<region>.amazonaws.com
+//   - <bucket>.s3.<region>.amazonaws.com (virtual-hosted style)
+//   - <bucket>.s3-<region>.amazonaws.com (virtual-hosted style)
+//
+// Non-AWS hosts or unparseable endpoints return an empty string.
+func regionFromEndpoint(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return ""
+	}
+	host := u.Hostname()
+	if !strings.HasSuffix(host, "amazonaws.com") {
+		return ""
+	}
+	labels := strings.Split(host, ".")
+	for i, label := range labels {
+		if label == "s3" {
+			if i+1 < len(labels) && labels[i+1] != "amazonaws" {
+				return labels[i+1]
+			}
+			return awsGlobalEndpointRegion
+		}
+		if region, ok := strings.CutPrefix(label, "s3-"); ok {
+			return region
+		}
+	}
+	return ""
+}
+
+// resolveRegion determines the effective signing region following the
+// precedence: explicit override, then derived from the endpoint. If neither
+// yields a region, an error is returned.
+func resolveRegion(override, endpoint string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	if region := regionFromEndpoint(endpoint); region != "" {
+		return region, nil
+	}
+	return "", errors.Errorf("region could not be derived from endpoint %q", endpoint)
+}
+
 type awsEndpointResolver struct {
 	endpoint string
+	region   string
 }
 
 // ResolveEndpoint returns the endpoint for the given service and region.
 func (a *awsEndpointResolver) ResolveEndpoint(_, _ string, options ...any) (aws.Endpoint, error) {
 	return aws.Endpoint{
-		URL: a.endpoint,
+		URL:           a.endpoint,
+		SigningRegion: a.region,
 	}, nil
 }
 

--- a/internal/s3client/client_test.go
+++ b/internal/s3client/client_test.go
@@ -4,6 +4,7 @@
 package s3client
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
 )
 
@@ -162,6 +164,165 @@ func (s *s3ClientSuite) TestCreateBucket(c *tc.C) {
 
 	err = client.CreateBucket(c.Context(), "bucket")
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *s3ClientSuite) TestRegionFromEndpoint(c *tc.C) {
+	tests := []struct {
+		endpoint string
+		expected string
+	}{{
+		endpoint: "https://s3.amazonaws.com",
+		expected: "us-east-1",
+	}, {
+		endpoint: "https://s3.us-east-1.amazonaws.com",
+		expected: "us-east-1",
+	}, {
+		endpoint: "https://s3.eu-west-1.amazonaws.com",
+		expected: "eu-west-1",
+	}, {
+		endpoint: "https://s3-eu-west-1.amazonaws.com",
+		expected: "eu-west-1",
+	}, {
+		endpoint: "https://mybucket.s3.us-east-2.amazonaws.com",
+		expected: "us-east-2",
+	}, {
+		endpoint: "https://mybucket.s3-eu-west-1.amazonaws.com",
+		expected: "eu-west-1",
+	}, {
+		endpoint: "https://minio.example.com:9000",
+		expected: "",
+	}, {
+		endpoint: "https://10.0.0.1:17070",
+		expected: "",
+	}, {
+		endpoint: "",
+		expected: "",
+	}}
+	for i, test := range tests {
+		c.Check(regionFromEndpoint(test.endpoint), tc.Equals, test.expected, tc.Commentf("test %d: %q", i, test.endpoint))
+	}
+}
+
+func (s *s3ClientSuite) TestResolveRegion(c *tc.C) {
+	tests := []struct {
+		override    string
+		endpoint    string
+		expected    string
+		expectError bool
+	}{{
+		override: "eu-central-1",
+		endpoint: "https://s3.us-east-1.amazonaws.com",
+		expected: "eu-central-1",
+	}, {
+		override: "",
+		endpoint: "https://s3.eu-west-1.amazonaws.com",
+		expected: "eu-west-1",
+	}, {
+		override:    "",
+		endpoint:    "https://minio.example.com:9000",
+		expectError: true,
+	}, {
+		override:    "",
+		endpoint:    "",
+		expectError: true,
+	}}
+	for i, test := range tests {
+		region, err := resolveRegion(test.override, test.endpoint)
+		if test.expectError {
+			c.Check(err, tc.ErrorMatches, "region could not be derived from endpoint.*",
+				tc.Commentf("test %d", i))
+		} else {
+			c.Check(err, tc.ErrorIsNil, tc.Commentf("test %d", i))
+			c.Check(region, tc.Equals, test.expected, tc.Commentf("test %d", i))
+		}
+	}
+}
+
+func (s *s3ClientSuite) TestNewS3ClientRegionOverride(c *tc.C) {
+	var authHeader string
+	url, httpClient, cleanup := s.setupServer(c, func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte{})
+	})
+	defer cleanup()
+
+	client, err := NewS3Client(url, httpClient, StaticCredentials{
+		Key:    "test-key",
+		Secret: "test-secret",
+	}, WithRegion("eu-central-1"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	_ = client.ObjectExists(c.Context(), "bucket", "object")
+	c.Check(strings.Contains(authHeader, "eu-central-1"), tc.IsTrue,
+		tc.Commentf("authorization header %q should contain region", authHeader))
+}
+
+func (s *s3ClientSuite) TestNewS3ClientRegionFallback(c *tc.C) {
+	var authHeader string
+	var entries []string
+	recorder := loggertesting.RecordLog(func(s string, a ...any) {
+		entries = append(entries, fmt.Sprintf(s, a...))
+	})
+	logger := loggertesting.WrapCheckLog(recorder)
+
+	url, httpClient, cleanup := s.setupServer(c, func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte{})
+	})
+	defer cleanup()
+
+	client, err := NewS3Client(url, httpClient, StaticCredentials{
+		Key:    "test-key",
+		Secret: "test-secret",
+	}, WithLogger(logger))
+	c.Assert(err, tc.ErrorIsNil)
+
+	_ = client.ObjectExists(c.Context(), "bucket", "object")
+	c.Check(strings.Contains(authHeader, "juju-unknown-region"), tc.IsTrue,
+		tc.Commentf("authorization header %q should contain fallback region", authHeader))
+
+	var foundWarning bool
+	for _, msg := range entries {
+		if strings.Contains(msg, "WARNING") && strings.Contains(msg, "object-store-s3-region") {
+			foundWarning = true
+			break
+		}
+	}
+	c.Check(foundWarning, tc.IsTrue,
+		tc.Commentf("expected warning about object-store-s3-region, got: %v", entries))
+}
+
+func (s *s3ClientSuite) TestNewS3ClientAnonymousNoRegion(c *tc.C) {
+	var entries []string
+	recorder := loggertesting.RecordLog(func(s string, a ...any) {
+		entries = append(entries, fmt.Sprintf(s, a...))
+	})
+	logger := loggertesting.WrapCheckLog(recorder)
+
+	url, httpClient, cleanup := s.setupServer(c, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte{})
+	})
+	defer cleanup()
+
+	client, err := NewS3Client(url, httpClient, AnonymousCredentials{},
+		WithLogger(logger))
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = client.ObjectExists(c.Context(), "bucket", "object")
+	c.Assert(err, tc.ErrorIsNil)
+
+	var foundWarning bool
+	for _, msg := range entries {
+		if strings.Contains(msg, "WARNING") {
+			foundWarning = true
+			break
+		}
+	}
+	c.Check(foundWarning, tc.IsFalse,
+		tc.Commentf("expected no warnings for anonymous creds, got: %v", entries))
 }
 
 func (s *s3ClientSuite) setupServer(c *tc.C, handler http.HandlerFunc) (string, HTTPClient, func()) {

--- a/internal/worker/objectstores3caller/manifold.go
+++ b/internal/worker/objectstores3caller/manifold.go
@@ -21,7 +21,7 @@ import (
 )
 
 // NewClientFunc is a function that returns a new S3 client.
-type NewClientFunc = func(endpoint string, client s3client.HTTPClient, creds s3client.Credentials, logger logger.Logger) (objectstore.Session, error)
+type NewClientFunc = func(endpoint string, client s3client.HTTPClient, creds s3client.Credentials, logger logger.Logger, region string) (objectstore.Session, error)
 
 // GetControllerConfigServiceFunc is a helper function that gets a service from
 // the manifold.
@@ -153,11 +153,12 @@ func outputWorker(in worker.Worker) (objectstore.Client, error) {
 }
 
 // NewS3Client returns a new S3 client based on the supplied dependencies.
-func NewS3Client(endpoint string, client s3client.HTTPClient, creds s3client.Credentials, logger logger.Logger) (objectstore.Session, error) {
+func NewS3Client(endpoint string, client s3client.HTTPClient, creds s3client.Credentials, logger logger.Logger, region string) (objectstore.Session, error) {
 	return s3client.NewS3Client(endpoint, client, creds,
 		s3client.WithLogger(logger),
 		s3client.WithMaxAttempts(10),
 		s3client.WithRateLimiting(false),
+		s3client.WithRegion(region),
 	)
 }
 

--- a/internal/worker/objectstores3caller/manifold_test.go
+++ b/internal/worker/objectstores3caller/manifold_test.go
@@ -67,7 +67,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
 		HTTPClientName:          "http-client",
 		ObjectStoreServicesName: "object-store-services",
-		NewClient: func(string, s3client.HTTPClient, s3client.Credentials, logger.Logger) (objectstore.Session, error) {
+		NewClient: func(string, s3client.HTTPClient, s3client.Credentials, logger.Logger, string) (objectstore.Session, error) {
 			return s.session, nil
 		},
 		Logger: s.logger,

--- a/internal/worker/objectstores3caller/worker.go
+++ b/internal/worker/objectstores3caller/worker.go
@@ -227,6 +227,7 @@ func (w *s3Worker) makeNewClient(ctx context.Context) (objectstore.Session, erro
 			Session: controllerConfig.ObjectStoreS3StaticSession(),
 		},
 		w.config.Logger,
+		controllerConfig.ObjectStoreS3Region(),
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -271,6 +272,7 @@ var objectStoreKeys = map[string]struct{}{
 	controller.ObjectStoreS3StaticKey:     {},
 	controller.ObjectStoreS3StaticSecret:  {},
 	controller.ObjectStoreS3StaticSession: {},
+	controller.ObjectStoreS3Region:        {},
 }
 
 // containsObjectStoreKey returns true if the key is interesting to the worker.

--- a/internal/worker/objectstores3caller/worker_test.go
+++ b/internal/worker/objectstores3caller/worker_test.go
@@ -283,6 +283,40 @@ func (s *workerSuite) TestSessionIsNotChanged(c *tc.C) {
 	workertest.CleanKill(c, worker)
 }
 
+func (s *workerSuite) TestRegionPassedToNewClient(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	config := testing.FakeControllerConfig()
+	config[controller.ObjectStoreType] = string(objectstore.S3Backend)
+	config[controller.ObjectStoreS3Region] = "eu-west-1"
+
+	s.expectClock()
+	s.expectControllerConfig(c, config)
+	s.expectControllerConfigWatch(c)
+
+	var capturedRegion string
+	cfg := s.getConfig()
+	cfg.NewClient = func(_ string, _ s3client.HTTPClient, _ s3client.Credentials, _ logger.Logger, region string) (objectstore.Session, error) {
+		atomic.AddInt64(&s.sessionRefCount, 1)
+		capturedRegion = region
+		return s.session, nil
+	}
+
+	worker, err := newWorker(cfg, s.states)
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, worker)
+
+	s.ensureStartup(c)
+
+	c.Check(capturedRegion, tc.Equals, "eu-west-1")
+
+	workertest.CleanKill(c, worker)
+}
+
+func (s *workerSuite) TestContainsObjectStoreKeyRegion(c *tc.C) {
+	c.Check(containsObjectStoreKey([]string{controller.ObjectStoreS3Region}), tc.IsTrue)
+}
+
 func (s *workerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	atomic.StoreInt64(&s.sessionRefCount, 0)
 	return s.baseSuite.setupMocks(c)
@@ -298,7 +332,7 @@ func (s *workerSuite) getConfig() workerConfig {
 	return workerConfig{
 		ControllerConfigService: s.controllerConfigService,
 		HTTPClient:              s.httpClient,
-		NewClient: func(string, s3client.HTTPClient, s3client.Credentials, logger.Logger) (objectstore.Session, error) {
+		NewClient: func(string, s3client.HTTPClient, s3client.Credentials, logger.Logger, string) (objectstore.Session, error) {
 			atomic.AddInt64(&s.sessionRefCount, 1)
 			return s.session, nil
 		},


### PR DESCRIPTION
## Description

The S3 object store worker failed with `AuthorizationHeaderMalformed: a non-empty region must be provided in the credential` when bootstrapping on non-AWS clouds (unmanaged/manual) or any cloud where no AWS region was explicitly configured.

The AWS SDK v2 requires a signing region for SigV4. Juju never set one: `NewS3Client` did not call `config.WithRegion`, and `awsEndpointResolver` did not set `SigningRegion`.

This change introduces region resolution with the following precedence:
1. Explicit override via the new optional `object-store-s3-region` controller config key
2. Derived from common AWS endpoint URL forms (`s3.amazonaws.com` -> `us-east-1`, `s3.<region>.`, `s3-<region>.`, virtual-hosted style)
3. Fallback to `us-east-1`

The new `object-store-s3-region` key is optional; when empty the region is auto-derived. S3-compatible stores (MinIO, Ceph) that do not validate the region accept the default harmlessly.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you are testing
- ~Integration tests~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

A full multipass/unmanaged reproduction is described in #22589. The simplified QA below uses an LXD provider with a real AWS S3 bucket (or S3-compatible endpoint).

```sh
# Build the controller binary with the fix
make install

# Create a controller config with S3 object store
cat > /tmp/controller-config-s3.yaml <<EOF
object-store-type: s3
object-store-s3-endpoint: "https://s3.us-east-1.amazonaws.com"
object-store-s3-static-key: "<your-access-key>"
object-store-s3-static-secret: "<your-secret-key>"
EOF

# Bootstrap on LXD — should succeed (previously failed with AuthorizationHeaderMalformed)
juju bootstrap lxd test-controller \
  --config /tmp/controller-config-s3.yaml --debug

# Verify the controller is reachable
juju status

# Verify the bucket was created
aws s3 ls | grep juju-
```

Test with an explicit region override:
```sh
cat > /tmp/controller-config-s3-eu.yaml <<EOF
object-store-type: s3
object-store-s3-endpoint: "https://s3.eu-west-1.amazonaws.com"
object-store-s3-region: "eu-west-1"
object-store-s3-static-key: "<your-access-key>"
object-store-s3-static-secret: "<your-secret-key>"
EOF

./.bin/jujud-controller bootstrap lxd test-controller-eu \
  --config /tmp/controller-config-s3-eu.yaml --debug
```

## Documentation changes

- New controller config key `object-store-s3-region` documented in:
  - `docs/reference/configuration/list-of-controller-configuration-keys.md`
  - `docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md`
  - `docs/reference/juju-cli/list-of-juju-cli-commands/controller-config.md`
  - `docs/reference/controller.md`

## Links

**Issue:** Fixes #22589
**Jira card:** [JUJU-9998](https://warthogs.atlassian.net/browse/JUJU-9998)

[JUJU-9998]: https://warthogs.atlassian.net/browse/JUJU-9998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ