### PR TITLE
fix(model-defaults): preserve empty defaults and safe comparisons

### DIFF
--- a/cmd/juju/model/defaults.go
+++ b/cmd/juju/model/defaults.go
@@ -194,6 +194,7 @@ func (a defaultAttrs) CoerceFormat(region string) (defaultAttrs, error) {
 			"value": schema.Any(),
 		}, nil)),
 	}, schema.Defaults{
+		"default":    schema.Omit,
 		"controller": schema.Omit,
 		"regions":    schema.Omit,
 	})

--- a/cmd/juju/model/defaults_test.go
+++ b/cmd/juju/model/defaults_test.go
@@ -532,6 +532,34 @@ func (s *DefaultsCommandSuite) TestRoundTripYAMLEmptyControllerValue(c *tc.C) {
 		})
 }
 
+func (s *DefaultsCommandSuite) TestRoundTripYAMLControllerOnlyNoDefault(c *tc.C) {
+	// This tests the case where the command emits an entry with a controller
+	// value but no default key. The CoerceFormat schema must accept this
+	// without falling back to stringifying the whole map.
+	s.fakeDefaultsAPI.defaults["attr2"] = config.AttributeDefaultValues{
+		Controller: "bar",
+	}
+
+	outputCtx, err := s.run(c, "--format=yaml")
+	c.Assert(err, tc.ErrorIsNil)
+	output := cmdtesting.Stdout(outputCtx)
+	c.Assert(output, tc.Contains, "attr2:\n  controller: bar\n")
+
+	inputCtx := cmdtesting.Context(c)
+	inputCtx.Stdin = strings.NewReader(output)
+	code := cmd.Main(model.NewDefaultsCommandForTest(
+		s.fakeAPIRoot, s.fakeDefaultsAPI, s.fakeCloudAPI, s.store), inputCtx,
+		[]string{"--file", "-"})
+
+	c.Assert(code, tc.Equals, 0)
+	c.Check(cmdtesting.Stdout(inputCtx), tc.Equals, "")
+	c.Check(cmdtesting.Stderr(inputCtx), tc.Equals, "")
+	c.Assert(s.fakeDefaultsAPI.defaults["attr2"], tc.DeepEquals,
+		config.AttributeDefaultValues{
+			Controller: "bar",
+		})
+}
+
 func (s *DefaultsCommandSuite) TestSetFromFileUsingYAMLTargettingCloudRegion(c *tc.C) {
 	table := []struct {
 		input, cloud, region string

--- a/cmd/juju/model/defaults_test.go
+++ b/cmd/juju/model/defaults_test.go
@@ -504,6 +504,34 @@ special:
 	})
 }
 
+func (s *DefaultsCommandSuite) TestRoundTripYAMLEmptyControllerValue(c *tc.C) {
+	s.fakeDefaultsAPI.defaults["mode"] = config.AttributeDefaultValues{
+		Default:    config.RequiresPromptsMode,
+		Controller: "",
+	}
+
+	outputCtx, err := s.run(c, "--format=yaml")
+	c.Assert(err, tc.ErrorIsNil)
+	output := cmdtesting.Stdout(outputCtx)
+	c.Assert(output, tc.Contains, "mode:\n  default: requires-prompts\n  controller: \"\"\n")
+
+	inputCtx := cmdtesting.Context(c)
+	inputCtx.Stdin = strings.NewReader(output)
+	code := cmd.Main(model.NewDefaultsCommandForTest(
+		s.fakeAPIRoot, s.fakeDefaultsAPI, s.fakeCloudAPI, s.store), inputCtx,
+		[]string{"--file", "-"})
+
+	c.Assert(code, tc.Equals, 0)
+	c.Check(cmdtesting.Stdout(inputCtx), tc.Equals, "")
+	c.Check(cmdtesting.Stderr(inputCtx), tc.Equals, "")
+	c.Assert(s.fakeDefaultsAPI.defaults["mode"], tc.DeepEquals,
+		config.AttributeDefaultValues{
+			Default:    nil,
+			Controller: "",
+			Regions:    nil,
+		})
+}
+
 func (s *DefaultsCommandSuite) TestSetFromFileUsingYAMLTargettingCloudRegion(c *tc.C) {
 	table := []struct {
 		input, cloud, region string

--- a/domain/modelconfig/service/service_test.go
+++ b/domain/modelconfig/service/service_test.go
@@ -77,6 +77,35 @@ func (s *serviceSuite) TestGetModelConfigContainsAgentInformation(c *tc.C) {
 	c.Check(cfg.AgentStream(), tc.Equals, coreagentbinary.AgentStreamReleased.String())
 }
 
+func (s *serviceSuite) TestModelConfigValuesSupportsMapValues(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := tc.Must0(c, coremodel.NewUUID)
+	s.mockState.EXPECT().ModelConfig(gomock.Any()).Return(
+		map[string]string{
+			config.NameKey:         "wallyworld",
+			config.UUIDKey:         modelUUID.String(),
+			config.TypeKey:         "testprovider",
+			config.ResourceTagsKey: "key=value",
+		}, nil,
+	)
+
+	s.mockModelConfigProvider.EXPECT().ConfigSchema().Return(schema.Fields{})
+
+	var defaults ModelDefaultsProviderFunc = func(_ context.Context) (modeldefaults.Defaults, error) {
+		return modeldefaults.Defaults{
+			config.ResourceTagsKey: {
+				Default: "",
+			},
+		}, nil
+	}
+
+	svc := NewService(defaults, config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	values, err := svc.ModelConfigValues(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(values[config.ResourceTagsKey].Source, tc.Equals, config.JujuModelConfigSource)
+}
+
 // TestUpdateModelConfigAgentStream checks that the model agent stream value
 // cannot be changed via model config and if it is we get back an errors that
 // satisfies [config.ValidationError].

--- a/domain/modeldefaults/types.go
+++ b/domain/modeldefaults/types.go
@@ -126,14 +126,9 @@ func (d DefaultAttributeValue) ApplyStrategy(setVal any) any {
 // values are equal. If the current value of [DefaultAttributeValue.Value] or
 // val is nil then false and empty string for source is returned.
 //
-// For legacy reasons we have worked with types of "any" for model config values
-// and trying to apply comparison logic over these types is hard to get right.
-// For this reason this function only considers values to be equal if their
-// types are comparable via == and or the type of Value is of []any, in which
-// case we will defer to the reflect package for DeepEqual.
-//
-// This is carry over logic from legacy Juju. Over time we can look at removing
-// the use of any for more concrete types.
+// For legacy reasons we have worked with types of "any" for model config
+// values. This is carry over logic from legacy Juju. Over time we can look at
+// removing the use of any for more concrete types.
 func (d DefaultAttributeValue) ValueSource(val any) (bool, string) {
 	if valuesEqual(val, d.Default) {
 		return true, config.JujuDefaultSource
@@ -154,14 +149,11 @@ func valuesEqual(val1, val2 any) bool {
 		return false
 	}
 
-	equal := false
-	switch val2.(type) {
-	case []any:
-		equal = reflect.DeepEqual(val1, val2)
-	default:
-		equal = val1 == val2
+	if !reflect.TypeOf(val1).Comparable() ||
+		!reflect.TypeOf(val2).Comparable() {
+		return reflect.DeepEqual(val1, val2)
 	}
-	return equal
+	return val1 == val2
 }
 
 // Apply implements [ApplyStrategy] interface for [PreferDefaultApplyStrategy]

--- a/domain/modeldefaults/types.go
+++ b/domain/modeldefaults/types.go
@@ -149,11 +149,15 @@ func valuesEqual(val1, val2 any) bool {
 		return false
 	}
 
-	if !reflect.TypeOf(val1).Comparable() ||
-		!reflect.TypeOf(val2).Comparable() {
-		return reflect.DeepEqual(val1, val2)
+	val1Type := reflect.TypeOf(val1)
+	val2Type := reflect.TypeOf(val2)
+	if val1Type != val2Type {
+		return false
 	}
-	return val1 == val2
+	if val1Type.Comparable() {
+		return val1 == val2
+	}
+	return reflect.DeepEqual(val1, val2)
 }
 
 // Apply implements [ApplyStrategy] interface for [PreferDefaultApplyStrategy]

--- a/domain/modeldefaults/types_test.go
+++ b/domain/modeldefaults/types_test.go
@@ -96,6 +96,24 @@ func (s *typesSuite) TestValueSourceSupport(c *tc.C) {
 	c.Check(source, tc.Equals, "")
 }
 
+func (s *typesSuite) TestValueSourceSupportsMapValues(c *tc.C) {
+	val := DefaultAttributeValue{
+		Controller: map[string]string{
+			"key": "value",
+		},
+	}
+
+	has, source := val.ValueSource(map[string]string{
+		"key": "value",
+	})
+	c.Check(has, tc.IsTrue)
+	c.Check(source, tc.Equals, "controller")
+
+	has, source = val.ValueSource("value")
+	c.Check(has, tc.IsFalse)
+	c.Check(source, tc.Equals, "")
+}
+
 // testApplyStrategy is a test implementation of ApplyStrategy that is here to
 // just indicate that the Apply method of the strategy has been called.
 type testApplyStrategy struct {

--- a/domain/modeldefaults/types_test.go
+++ b/domain/modeldefaults/types_test.go
@@ -114,6 +114,22 @@ func (s *typesSuite) TestValueSourceSupportsMapValues(c *tc.C) {
 	c.Check(source, tc.Equals, "")
 }
 
+// TestValueSourceSupportsSliceValues ensures that non-comparable slice values
+// are compared using reflect.DeepEqual rather than panicking on == comparison.
+func (s *typesSuite) TestValueSourceSupportsSliceValues(c *tc.C) {
+	val := DefaultAttributeValue{
+		Controller: []any{"a", "b"},
+	}
+
+	has, source := val.ValueSource([]any{"a", "b"})
+	c.Check(has, tc.IsTrue)
+	c.Check(source, tc.Equals, "controller")
+
+	has, source = val.ValueSource([]any{"a", "c"})
+	c.Check(has, tc.IsFalse)
+	c.Check(source, tc.Equals, "")
+}
+
 // testApplyStrategy is a test implementation of ApplyStrategy that is here to
 // just indicate that the Apply method of the strategy has been called.
 type testApplyStrategy struct {

--- a/environs/config/source.go
+++ b/environs/config/source.go
@@ -5,8 +5,10 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/juju/schema"
+	"gopkg.in/yaml.v2"
 )
 
 // These constants define named sources of model config attributes.
@@ -82,6 +84,40 @@ type AttributeDefaultValues struct {
 	// Regions is a slice of Region representing the values as set in each
 	// region.
 	Regions []RegionDefaultValue `json:"regions,omitempty" yaml:"regions,omitempty"`
+}
+
+// MarshalJSON preserves explicitly empty default values.
+func (a AttributeDefaultValues) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.marshalMap())
+}
+
+// MarshalYAML preserves explicitly empty default values.
+func (a AttributeDefaultValues) MarshalYAML() (any, error) {
+	items := yaml.MapSlice{}
+	if a.Default != nil {
+		items = append(items, yaml.MapItem{Key: "default", Value: a.Default})
+	}
+	if a.Controller != nil {
+		items = append(items, yaml.MapItem{Key: "controller", Value: a.Controller})
+	}
+	if len(a.Regions) > 0 {
+		items = append(items, yaml.MapItem{Key: "regions", Value: a.Regions})
+	}
+	return items, nil
+}
+
+func (a AttributeDefaultValues) marshalMap() map[string]any {
+	values := map[string]any{}
+	if a.Default != nil {
+		values["default"] = a.Default
+	}
+	if a.Controller != nil {
+		values["controller"] = a.Controller
+	}
+	if len(a.Regions) > 0 {
+		values["regions"] = a.Regions
+	}
+	return values
 }
 
 // RegionDefaultValue holds the region information for each region in DefaultSetting.

--- a/environs/config/source.go
+++ b/environs/config/source.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/juju/schema"
 	"gopkg.in/yaml.v2"
@@ -86,12 +85,10 @@ type AttributeDefaultValues struct {
 	Regions []RegionDefaultValue `json:"regions,omitempty" yaml:"regions,omitempty"`
 }
 
-// MarshalJSON preserves explicitly empty default values.
-func (a AttributeDefaultValues) MarshalJSON() ([]byte, error) {
-	return json.Marshal(a.marshalMap())
-}
-
 // MarshalYAML preserves explicitly empty default values.
+// yaml.v2's omitempty treats empty strings as empty for any-typed fields,
+// causing explicitly empty controller values (e.g. mode="") to be lost on
+// export. This method only omits nil values, keeping empty strings.
 func (a AttributeDefaultValues) MarshalYAML() (any, error) {
 	items := yaml.MapSlice{}
 	if a.Default != nil {
@@ -104,20 +101,6 @@ func (a AttributeDefaultValues) MarshalYAML() (any, error) {
 		items = append(items, yaml.MapItem{Key: "regions", Value: a.Regions})
 	}
 	return items, nil
-}
-
-func (a AttributeDefaultValues) marshalMap() map[string]any {
-	values := map[string]any{}
-	if a.Default != nil {
-		values["default"] = a.Default
-	}
-	if a.Controller != nil {
-		values["controller"] = a.Controller
-	}
-	if len(a.Regions) > 0 {
-		values["regions"] = a.Regions
-	}
-	return values
 }
 
 // RegionDefaultValue holds the region information for each region in DefaultSetting.

--- a/environs/config/source_test.go
+++ b/environs/config/source_test.go
@@ -32,7 +32,7 @@ func (*SourceSuite) TestAttributeDefaultValuesMarshalPreservesEmptyValues(c *tc.
 	jsonBytes, err := json.Marshal(values)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(string(jsonBytes), tc.Equals,
-		`{"controller":"","default":"requires-prompts","regions":[{"name":"dummy-region","value":"dummy-value"}]}`)
+		`{"default":"requires-prompts","controller":"","regions":[{"name":"dummy-region","value":"dummy-value"}]}`)
 
 	yamlBytes, err := yaml.Marshal(values)
 	c.Assert(err, tc.ErrorIsNil)

--- a/environs/config/source_test.go
+++ b/environs/config/source_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package config_test
+
+import (
+	"encoding/json"
+	stdtesting "testing"
+
+	"github.com/juju/tc"
+	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/environs/config"
+)
+
+type SourceSuite struct{}
+
+func TestSourceSuite(t *stdtesting.T) {
+	tc.Run(t, &SourceSuite{})
+}
+
+func (*SourceSuite) TestAttributeDefaultValuesMarshalPreservesEmptyValues(c *tc.C) {
+	values := config.AttributeDefaultValues{
+		Default:    config.RequiresPromptsMode,
+		Controller: "",
+		Regions: []config.RegionDefaultValue{{
+			Name:  "dummy-region",
+			Value: "dummy-value",
+		}},
+	}
+
+	jsonBytes, err := json.Marshal(values)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(jsonBytes), tc.Equals,
+		`{"controller":"","default":"requires-prompts","regions":[{"name":"dummy-region","value":"dummy-value"}]}`)
+
+	yamlBytes, err := yaml.Marshal(values)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(yamlBytes), tc.Equals, ""+
+		"default: requires-prompts\n"+
+		"controller: \"\"\n"+
+		"regions:\n"+
+		"- name: dummy-region\n"+
+		"  value: dummy-value\n")
+}
+
+func (*SourceSuite) TestAttributeDefaultValuesMarshalOmitsNilValues(c *tc.C) {
+	values := config.AttributeDefaultValues{
+		Controller: "",
+	}
+
+	jsonBytes, err := json.Marshal(values)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(jsonBytes), tc.Equals, `{"controller":""}`)
+
+	yamlBytes, err := yaml.Marshal(values)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(yamlBytes), tc.Equals, "controller: \"\"\n")
+}


### PR DESCRIPTION
Model defaults export could lose explicitly empty controller-level values because normal `omitempty`
handling treated `""` the same as an absent value. That broke round-tripping for values such as `mode=`,
where `controller: ""` is meaningful and should override the built-in `requires-prompts` default.

This change preserves explicitly empty model default values in YAML and JSON output by only omitting nil
values, not empty strings. It also hardens model default source detection so map-valued config, such as
coerced `resource-tags`, is compared with `reflect.DeepEqual` instead of `==`, preventing `model-config`
from panicking while building config source metadata.

## QA steps
Steps as taken from https://github.com/juju/juju/issues/22716:
```
juju bootstrap localhost c --model-default mode=
juju model-defaults --cloud localhost --format=yaml \
  | juju model-defaults --cloud localhost --ignore-read-only-fields --file -
juju add-model probe
# this step shouldn't fail
juju model-config mode -m probe 
juju deploy ubuntu-lite probe-app -m probe
# this step shouldn't ask for confirmation
juju remove-application probe-app -m probe
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22716.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10060](https://warthogs.atlassian.net/browse/JUJU-10060)


[JUJU-10060]: https://warthogs.atlassian.net/browse/JUJU-10060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ