### PR TITLE
feat(api): report client version on the main API websocket dial

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -715,8 +715,12 @@ func gorillaDialWebsocket(ctx context.Context, urlStr string, tlsConfig *tls.Con
 		HandshakeTimeout: 45 * time.Second,
 		TLSClientConfig:  tlsConfig,
 	}
-	// Note: no extra headers.
-	c, resp, err := dialer.Dial(urlStr, nil)
+	// Report the client version via the same header the stream and HTTP
+	// connections send. Controllers currently ignore it; intermediaries
+	// such as JIMM use it to apply client compatibility rules.
+	requestHeader := make(http.Header)
+	requestHeader.Set(params.JujuClientVersion, jujuversion.Current.String())
+	c, resp, err := dialer.Dial(urlStr, requestHeader)
 	if err != nil {
 		if err == websocket.ErrBadHandshake {
 			// If ErrBadHandshake is returned, a non-nil response

--- a/api/apiclient_whitebox_test.go
+++ b/api/apiclient_whitebox_test.go
@@ -8,17 +8,21 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"regexp"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	proxyutils "github.com/juju/proxy"
 	"github.com/juju/tc"
 
 	proxy "github.com/juju/juju/api/proxy/config"
+	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/internal/testhelpers"
 	jtesting "github.com/juju/juju/internal/testing"
+	"github.com/juju/juju/rpc/params"
 )
 
 type apiclientWhiteboxSuite struct {
@@ -63,6 +67,32 @@ func (s *apiclientWhiteboxSuite) TestDialWebsocketMultiCancelled(c *tc.C) {
 	listen.Close()
 	_, err = dialAPI(ctx, info, opts)
 	c.Check(err, tc.NotNil)
+}
+
+func (s *apiclientWhiteboxSuite) TestGorillaDialWebsocketSendsClientVersionHeader(c *tc.C) {
+	headers := make(chan http.Header, 1)
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers <- r.Header.Clone()
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err == nil {
+			ws.Close()
+		}
+	}))
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	c.Assert(err, tc.ErrorIsNil)
+	conn, err := gorillaDialWebsocket(c.Context(), "ws://"+srvURL.Host+"/api", nil, srvURL.Host)
+	c.Assert(err, tc.ErrorIsNil)
+	defer conn.Close()
+
+	select {
+	case h := <-headers:
+		c.Check(h.Get(params.JujuClientVersion), tc.Equals, jujuversion.Current.String())
+	case <-time.After(jtesting.LongWait):
+		c.Fatalf("timed out waiting %s for the dial to reach the server", jtesting.LongWait)
+	}
 }
 
 func (s *apiclientWhiteboxSuite) TestDialWebsocketMultiClosed(c *tc.C) {


### PR DESCRIPTION
The client already sends the X-Juju-ClientVersion header on its stream and plain HTTP connections, but the main API websocket dial sent no headers at all. Set the same header there, so the server side of the main API connection can learn the client's version at the websocket upgrade, before authentication.

Controllers currently ignore the header; JIMM will be its first consumer, using it to apply client/controller compatibility rules (model placement and model-connection gating) for mixed 3.6/4.x controller fleets.

For full context see the [spec](https://docs.google.com/document/d/1hQSs5S1AxPwq85VVhwmsrrNhg4mnCQbC_8c8VXesMQE/edit?pli=1&tab=t.0#heading=h.eub42fk0f73n).

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

N/A atm