### PR TITLE
feat: bootstrap controller charm on CAAS

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -664,9 +664,6 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	}
 
 	isCAASController = jujucloud.CloudIsCAAS(cloud)
-	if isCAASController && refresher.IsLocalURL(c.ControllerCharmPath) {
-		return errors.NotSupportedf("deploying a local controller charm on a k8s controller")
-	}
 	if !isCAASController {
 		if bootstrapCfg.bootstrap.ControllerServiceType != "" ||
 			bootstrapCfg.bootstrap.ControllerExternalName != "" ||

--- a/internal/bootstrap/deployer_caas.go
+++ b/internal/bootstrap/deployer_caas.go
@@ -112,6 +112,7 @@ func (b *CAASDeployer) AddCAASControllerApplication(ctx context.Context, info De
 				Status: status.Unset,
 				Since:  new(b.clock.Now()),
 			},
+			Constraints:  b.constraints,
 			IsController: true,
 		},
 		applicationservice.AddUnitArg{},

--- a/internal/bootstrap/deployer_caas_test.go
+++ b/internal/bootstrap/deployer_caas_test.go
@@ -65,6 +65,7 @@ func (s *deployerCAASSuite) TestAddCAASControllerApplication(c *tc.C) {
 
 	cfg := s.newConfig(c)
 	cfg.Clock = s.clock
+	cfg.Constraints = constraints.Value{Arch: new("arm64"), Mem: new(uint64(4096))}
 
 	curl := "ch:juju-controller-0"
 	origin := corecharm.Origin{
@@ -107,7 +108,7 @@ func (s *deployerCAASSuite) TestAddCAASControllerApplication(c *tc.C) {
 				Status: status.Unset,
 				Since:  new(now),
 			},
-			Constraints:  constraints.Value{},
+			Constraints:  constraints.Value{Arch: new("arm64"), Mem: new(uint64(4096))},
 			IsController: true,
 		},
 		applicationservice.AddUnitArg{},

--- a/internal/bootstrap/deployer_caas_test.go
+++ b/internal/bootstrap/deployer_caas_test.go
@@ -5,21 +5,29 @@ package bootstrap
 
 import (
 	"testing"
+	"time"
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 
+	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/constraints"
 	network "github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/status"
 	unit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/version"
+	domainapplication "github.com/juju/juju/domain/application"
+	applicationcharm "github.com/juju/juju/domain/application/charm"
 	applicationservice "github.com/juju/juju/domain/application/service"
+	"github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/uuid"
 )
 
 type deployerCAASSuite struct {
 	baseSuite
+	clock          *MockClock
 	serviceManager *MockServiceManager
 }
 
@@ -47,6 +55,80 @@ func (s *deployerCAASSuite) TestControllerCharmBase(c *tc.C) {
 	base, err := deployer.ControllerCharmBase()
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(base, tc.DeepEquals, version.DefaultSupportedLTSBase())
+}
+
+func (s *deployerCAASSuite) TestAddCAASControllerApplication(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	now := time.Now()
+	s.clock.EXPECT().Now().Return(now).AnyTimes()
+
+	cfg := s.newConfig(c)
+	cfg.Clock = s.clock
+
+	curl := "ch:juju-controller-0"
+	origin := corecharm.Origin{
+		Source:   corecharm.CharmHub,
+		Type:     "charm",
+		Channel:  &charm.Channel{},
+		Revision: new(1),
+		Hash:     "sha-256",
+		Platform: corecharm.Platform{
+			Architecture: "arm64",
+			OS:           "ubuntu",
+			Channel:      "22.04",
+		},
+	}
+
+	s.caasApplicationService.EXPECT().CreateCAASApplication(
+		gomock.Any(),
+		bootstrap.ControllerApplicationName,
+		s.charm,
+		origin,
+		applicationservice.AddApplicationArgs{
+			ReferenceName: bootstrap.ControllerCharmName,
+			DownloadInfo: &applicationcharm.DownloadInfo{
+				CharmhubIdentifier: "abcd",
+				Provenance:         applicationcharm.ProvenanceBootstrap,
+				DownloadURL:        "https://inferi.com",
+				DownloadSize:       42,
+			},
+			CharmStoragePath:     "path",
+			CharmObjectStoreUUID: "1234",
+			ApplicationConfig: charm.Config{
+				"is-juju":               true,
+				"identity-provider-url": "https://inferi.com",
+				"controller-url":        "wss://obscura.com:1234/api",
+			},
+			ApplicationSettings: domainapplication.ApplicationSettings{
+				Trust: true,
+			},
+			ApplicationStatus: &status.StatusInfo{
+				Status: status.Unset,
+				Since:  new(now),
+			},
+			Constraints:  constraints.Value{},
+			IsController: true,
+		},
+		applicationservice.AddUnitArg{},
+	)
+
+	deployer := s.newDeployerWithConfig(c, cfg)
+
+	downloadInfo := &corecharm.DownloadInfo{
+		CharmhubIdentifier: "abcd",
+		DownloadURL:        "https://inferi.com",
+		DownloadSize:       42,
+	}
+	err := deployer.AddCAASControllerApplication(c.Context(), DeployCharmInfo{
+		URL:             charm.MustParseURL(curl),
+		Charm:           s.charm,
+		Origin:          &origin,
+		DownloadInfo:    downloadInfo,
+		ArchivePath:     "path",
+		ObjectStoreUUID: "1234",
+	})
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *deployerCAASSuite) TestCompleteCAASProcess(c *tc.C) {
@@ -97,6 +179,7 @@ func (s *deployerCAASSuite) newDeployerWithConfig(c *tc.C, cfg CAASDeployerConfi
 func (s *deployerCAASSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := s.baseSuite.setupMocks(c)
 
+	s.clock = NewMockClock(ctrl)
 	s.serviceManager = NewMockServiceManager(ctrl)
 
 	return ctrl

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -64,7 +64,9 @@ const (
 )
 
 const (
-	apiServerContainerName = "api-server"
+	apiServerContainerName                  = "api-server"
+	localControllerCharmUploadRetryAttempts = 12
+	localControllerCharmUploadRetryDelay    = time.Second
 
 	// startupGraceTime is the number of seconds afforded to startup probes to
 	// become successful before considering them a failure.
@@ -162,7 +164,8 @@ type controllerStack struct {
 	resourceNameSecret, resourceNamedockerSecret,
 	resourceNameVolBootstrapParams, resourceNameVolAgentConf string
 
-	dockerAuthSecretData []byte
+	dockerAuthSecretData        []byte
+	controllerExecClientFactory func() (k8sexec.Executor, error)
 
 	cleanUps []func()
 }
@@ -292,6 +295,7 @@ func newControllerStack(
 		portAPIServer: pcfg.Bootstrap.ControllerConfig.APIPort(),
 		portSSHServer: pcfg.Bootstrap.ControllerConfig.SSHServerPort(),
 	}
+	cs.controllerExecClientFactory = cs.controllerExecClient
 	cs.resourceNameService = cs.getResourceName("service")
 	cs.resourceNameHeadlessService = cs.getResourceName("service-endpoints")
 	cs.resourceNameConfigMap = cs.getResourceName("configmap")
@@ -329,12 +333,13 @@ func newControllerStack(
 }
 
 func isLocalControllerCharmPath(charmPath string) bool {
+	// Mirrors refresher.IsLocalURL (cmd/juju/application/refresher/refresher.go).
 	return strings.HasPrefix(charmPath, "/") || strings.HasPrefix(charmPath, "./") ||
 		strings.HasPrefix(charmPath, "../")
 }
 
 func (c *controllerStack) localControllerCharmArchivePath() string {
-	return c.pathJoin(c.pcfg.DataDir, "charms", environsbootstrap.ControllerCharmArchive)
+	return path.Join(c.pcfg.DataDir, "charms", environsbootstrap.ControllerCharmArchive)
 }
 
 func (c *controllerStack) uploadLocalControllerCharm(ctx context.Context, podName string) error {
@@ -343,7 +348,7 @@ func (c *controllerStack) uploadLocalControllerCharm(ctx context.Context, podNam
 		return nil
 	}
 
-	execClient, err := c.controllerExecClient()
+	execClient, err := c.controllerExecClientFactory()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -353,13 +358,17 @@ func (c *controllerStack) uploadLocalControllerCharm(ctx context.Context, podNam
 	archiveDir := path.Dir(archivePath)
 	execCommand := func(commands []string) error {
 		var stdout, stderr bytes.Buffer
-		return execClient.Exec(ctx, k8sexec.ExecParams{
+		err := execClient.Exec(ctx, k8sexec.ExecParams{
 			PodName:       podName,
 			ContainerName: apiServerContainerName,
 			Commands:      commands,
 			Stdout:        &stdout,
 			Stderr:        &stderr,
 		}, nil)
+		if err != nil && stderr.Len() > 0 {
+			return errors.Annotate(err, strings.TrimSpace(stderr.String()))
+		}
+		return err
 	}
 	if err := execCommand([]string{"mkdir", "-p", archiveDir}); err != nil {
 		return errors.Annotate(err, "creating local controller charm directory")
@@ -393,11 +402,18 @@ func (c *controllerStack) uploadLocalControllerCharmWithRetry(ctx context.Contex
 		return nil
 	}
 	return retry.Call(retry.CallArgs{
-		Attempts: 12,
-		Delay:    time.Second,
+		Attempts: localControllerCharmUploadRetryAttempts,
+		Delay:    localControllerCharmUploadRetryDelay,
+		Stop:     ctx.Done(),
 		Clock:    c.broker.clock,
 		Func: func() error {
 			return c.uploadLocalControllerCharm(ctx, podName)
+		},
+		IsFatalError: func(err error) bool {
+			return errors.Is(err, errors.NotValid)
+		},
+		NotifyFunc: func(err error, attempt int) {
+			logger.Debugf(ctx, "uploading local controller charm, attempt %d/%d failed: %v", attempt, localControllerCharmUploadRetryAttempts, err)
 		},
 	})
 }
@@ -420,13 +436,6 @@ func getBootstrapResourceName(stackName string, name string) string {
 
 func (c *controllerStack) getResourceName(name string) string {
 	return getBootstrapResourceName(c.stackName, name)
-}
-
-func (c *controllerStack) pathJoin(elem ...string) string {
-	// Setting series for bootstrapping to kubernetes is currently not supported.
-	// We always use forward-slash because Linux is the only OS we support now.
-	pathSeparator := "/"
-	return strings.Join(elem, pathSeparator)
 }
 
 func (c *controllerStack) getControllerConfigMap(ctx context.Context) (cm *core.ConfigMap, err error) {
@@ -1336,18 +1345,18 @@ func (c *controllerStack) controllerContainers(setupCmd, machineCmd, controllerI
 			},
 			{
 				Name: storageName,
-				MountPath: c.pathJoin(
+				MountPath: path.Join(
 					c.pcfg.DataDir,
 					"agents",
 					"controller-"+c.pcfg.ControllerId,
 				),
-				SubPath: c.pathJoin("agents",
+				SubPath: path.Join("agents",
 					"controller-"+c.pcfg.ControllerId,
 				),
 			},
 			{
 				Name: c.resourceNameVolAgentConf,
-				MountPath: c.pathJoin(
+				MountPath: path.Join(
 					c.pcfg.DataDir,
 					"agents",
 					"controller-"+c.pcfg.ControllerId,
@@ -1358,7 +1367,7 @@ func (c *controllerStack) controllerContainers(setupCmd, machineCmd, controllerI
 			},
 			{
 				Name:      c.resourceNameVolBootstrapParams,
-				MountPath: c.pathJoin(c.pcfg.DataDir, cloudconfig.FileNameBootstrapParams),
+				MountPath: path.Join(c.pcfg.DataDir, cloudconfig.FileNameBootstrapParams),
 				SubPath:   cloudconfig.FileNameBootstrapParams,
 				ReadOnly:  true,
 			},
@@ -1433,7 +1442,7 @@ func (c *controllerStack) buildContainerSpecForController() (*core.PodSpec, erro
 		loggingOption = "--debug"
 	}
 
-	agentConfigRelativePath := c.pathJoin(
+	agentConfigRelativePath := path.Join(
 		"agents",
 		fmt.Sprintf("controller-%s", c.pcfg.ControllerId),
 		agentconstants.AgentConfigFilename,
@@ -1450,16 +1459,16 @@ func (c *controllerStack) buildContainerSpecForController() (*core.PodSpec, erro
 		// only do bootstrap-state on the bootstrap controller - controller-0.
 		bootstrapStateCmd := fmt.Sprintf(
 			"%s bootstrap-state --data-dir $JUJU_DATA_DIR %s --timeout %s",
-			c.pathJoin("$JUJU_TOOLS_DIR", "jujuagentd"),
+			path.Join("$JUJU_TOOLS_DIR", "jujuagentd"),
 			loggingOption,
 			c.timeout.String(),
 		)
 		if featureFlags != "" {
 			bootstrapStateCmd = fmt.Sprintf("%s=%s %s", osenv.JujuFeatureFlagEnvKey, featureFlags, bootstrapStateCmd)
 		}
-		agentConfigPath := c.pathJoin("$JUJU_DATA_DIR", agentConfigRelativePath)
+		agentConfigPath := path.Join("$JUJU_DATA_DIR", agentConfigRelativePath)
 		if isLocalControllerCharmPath(c.pcfg.Bootstrap.ControllerCharmPath) {
-			charmArchivePath := c.pathJoin("$JUJU_DATA_DIR", "charms", environsbootstrap.ControllerCharmArchive)
+			charmArchivePath := path.Join("$JUJU_DATA_DIR", "charms", environsbootstrap.ControllerCharmArchive)
 			setupCmd = fmt.Sprintf(
 				"if ! test -e %s; then mkdir -p %s; until test -e %s; do sleep 1; done; %s; fi",
 				agentConfigPath,
@@ -1474,7 +1483,7 @@ func (c *controllerStack) buildContainerSpecForController() (*core.PodSpec, erro
 
 	machineCmd := fmt.Sprintf(
 		"%s machine --data-dir $JUJU_DATA_DIR --controller-id %s --log-to-stderr %s",
-		c.pathJoin("$JUJU_TOOLS_DIR", "jujuagentd"),
+		path.Join("$JUJU_TOOLS_DIR", "jujuagentd"),
 		c.pcfg.ControllerId,
 		loggingOption,
 	)
@@ -1545,7 +1554,7 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 
 	agentConfigMount := core.VolumeMount{
 		Name: c.resourceNameVolAgentConf,
-		MountPath: c.pathJoin(
+		MountPath: path.Join(
 			c.pcfg.DataDir,
 			constants.TemplateFileNameAgentConf,
 		),

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -4,8 +4,10 @@
 package kubernetes
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -46,6 +48,7 @@ import (
 	"github.com/juju/juju/internal/featureflag"
 	"github.com/juju/juju/internal/provider/kubernetes/application"
 	"github.com/juju/juju/internal/provider/kubernetes/constants"
+	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"
 	"github.com/juju/juju/internal/provider/kubernetes/pebble"
 	k8sproxy "github.com/juju/juju/internal/provider/kubernetes/proxy"
 	"github.com/juju/juju/internal/provider/kubernetes/resources"
@@ -323,6 +326,88 @@ func newControllerStack(
 	}
 
 	return cs, nil
+}
+
+func isLocalControllerCharmPath(charmPath string) bool {
+	return strings.HasPrefix(charmPath, "/") || strings.HasPrefix(charmPath, "./") ||
+		strings.HasPrefix(charmPath, "../")
+}
+
+func (c *controllerStack) localControllerCharmArchivePath() string {
+	return c.pathJoin(c.pcfg.DataDir, "charms", environsbootstrap.ControllerCharmArchive)
+}
+
+func (c *controllerStack) uploadLocalControllerCharm(ctx context.Context, podName string) error {
+	charmPath := c.pcfg.Bootstrap.ControllerCharmPath
+	if !isLocalControllerCharmPath(charmPath) {
+		return nil
+	}
+
+	execClient, err := c.controllerExecClient()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	archivePath := c.localControllerCharmArchivePath()
+	uploadPath := archivePath + ".uploading"
+	archiveDir := path.Dir(archivePath)
+	execCommand := func(commands []string) error {
+		var stdout, stderr bytes.Buffer
+		return execClient.Exec(ctx, k8sexec.ExecParams{
+			PodName:       podName,
+			ContainerName: apiServerContainerName,
+			Commands:      commands,
+			Stdout:        &stdout,
+			Stderr:        &stderr,
+		}, nil)
+	}
+	if err := execCommand([]string{"mkdir", "-p", archiveDir}); err != nil {
+		return errors.Annotate(err, "creating local controller charm directory")
+	}
+
+	if err := execClient.Copy(ctx, k8sexec.CopyParams{
+		Src: k8sexec.FileResource{
+			Path: charmPath,
+		},
+		Dest: k8sexec.FileResource{
+			Path:          uploadPath,
+			PodName:       podName,
+			ContainerName: apiServerContainerName,
+		},
+	}, nil); err != nil {
+		return errors.Annotate(err, "copying local controller charm")
+	}
+
+	if err := execCommand([]string{"chmod", "0644", uploadPath}); err != nil {
+		return errors.Annotate(err, "setting local controller charm permissions")
+	}
+
+	if err := execCommand([]string{"mv", "-f", uploadPath, archivePath}); err != nil {
+		return errors.Annotate(err, "installing local controller charm")
+	}
+	return nil
+}
+
+func (c *controllerStack) uploadLocalControllerCharmWithRetry(ctx context.Context, podName string) error {
+	if !isLocalControllerCharmPath(c.pcfg.Bootstrap.ControllerCharmPath) {
+		return nil
+	}
+	return retry.Call(retry.CallArgs{
+		Attempts: 12,
+		Delay:    time.Second,
+		Clock:    c.broker.clock,
+		Func: func() error {
+			return c.uploadLocalControllerCharm(ctx, podName)
+		},
+	})
+}
+
+func (c *controllerStack) controllerExecClient() (k8sexec.Executor, error) {
+	restConfig := c.broker.restConfig()
+	if restConfig == nil {
+		return nil, errors.NotValidf("empty kubernetes rest config")
+	}
+	return k8sexec.New(c.broker.Namespace(), c.broker.client(), restConfig), nil
 }
 
 func (c *controllerStack) isPrivateRepo() bool {
@@ -943,6 +1028,9 @@ func (c *controllerStack) createControllerStatefulset(ctx context.Context) error
 		if err = c.waitForPod(ctx, w, podName); err != nil {
 			return errors.Trace(err)
 		}
+		if err = c.uploadLocalControllerCharmWithRetry(ctx, podName); err != nil {
+			return errors.Annotate(err, "uploading local controller charm")
+		}
 	}
 	return nil
 }
@@ -1369,11 +1457,19 @@ func (c *controllerStack) buildContainerSpecForController() (*core.PodSpec, erro
 		if featureFlags != "" {
 			bootstrapStateCmd = fmt.Sprintf("%s=%s %s", osenv.JujuFeatureFlagEnvKey, featureFlags, bootstrapStateCmd)
 		}
-		setupCmd = fmt.Sprintf(
-			"test -e %s || %s",
-			c.pathJoin("$JUJU_DATA_DIR", agentConfigRelativePath),
-			bootstrapStateCmd,
-		)
+		agentConfigPath := c.pathJoin("$JUJU_DATA_DIR", agentConfigRelativePath)
+		if isLocalControllerCharmPath(c.pcfg.Bootstrap.ControllerCharmPath) {
+			charmArchivePath := c.pathJoin("$JUJU_DATA_DIR", "charms", environsbootstrap.ControllerCharmArchive)
+			setupCmd = fmt.Sprintf(
+				"if ! test -e %s; then mkdir -p %s; until test -e %s; do sleep 1; done; %s; fi",
+				agentConfigPath,
+				path.Dir(charmArchivePath),
+				charmArchivePath,
+				bootstrapStateCmd,
+			)
+		} else {
+			setupCmd = fmt.Sprintf("test -e %s || %s", agentConfigPath, bootstrapStateCmd)
+		}
 	}
 
 	machineCmd := fmt.Sprintf(

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -5,7 +5,7 @@ package kubernetes_test
 
 import (
 	"context"
-	"strings"
+	"io"
 	"testing"
 	"time"
 
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	clientkubernetes "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/pointer"
@@ -39,6 +40,7 @@ import (
 	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/featureflag"
 	"github.com/juju/juju/internal/provider/kubernetes"
+	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"
 	"github.com/juju/juju/internal/provider/kubernetes/mocks"
 	k8swatcher "github.com/juju/juju/internal/provider/kubernetes/watcher"
 	k8swatchertest "github.com/juju/juju/internal/provider/kubernetes/watcher/test"
@@ -322,7 +324,238 @@ func (s *bootstrapSuite) TestControllerSpecWaitsForLocalControllerCharm(c *tc.C)
 	c.Check(startup, tc.Contains, "mkdir -p $JUJU_DATA_DIR/charms")
 	c.Check(startup, tc.Contains, "until test -e $JUJU_DATA_DIR/charms/controller.charm; do sleep 1; done")
 	c.Check(startup, tc.Contains, "$JUJU_TOOLS_DIR/jujuagentd bootstrap-state --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s")
-	c.Check(strings.Contains(startup, "test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf ||"), tc.IsFalse)
+	c.Check(startup, tc.Not(tc.Contains), "test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf ||")
+}
+
+func (s *bootstrapSuite) TestIsLocalControllerCharmPath(c *tc.C) {
+	c.Check(kubernetes.IsLocalControllerCharmPath("/tmp/controller.charm"), tc.IsTrue)
+	c.Check(kubernetes.IsLocalControllerCharmPath("./controller.charm"), tc.IsTrue)
+	c.Check(kubernetes.IsLocalControllerCharmPath("../controller.charm"), tc.IsTrue)
+	c.Check(kubernetes.IsLocalControllerCharmPath(""), tc.IsFalse)
+	c.Check(kubernetes.IsLocalControllerCharmPath("ch:juju-controller"), tc.IsFalse)
+}
+
+func (s *bootstrapSuite) TestControllerExecClientWithEmptyRestConfig(c *tc.C) {
+	newK8sClientFunc, newK8sRestClientFunc := s.setupK8sRestClient(c, s.pcfg.ControllerName)
+	var bootstrapWatchers []k8swatcher.KubernetesNotifyWatcher
+	s.setupBroker(c, newK8sClientFunc, newK8sRestClientFunc, &bootstrapWatchers)
+	s.broker.SetRestConfigForTest(nil)
+
+	_, err := s.controllerStackerGetter().ControllerExecClient()
+	c.Assert(err, tc.ErrorIs, errors.NotValid)
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharmSkipsNonLocalCharmPath(c *tc.C) {
+	s.pcfg.Bootstrap.ControllerCharmPath = "ch:juju-controller"
+	stack := s.controllerStackerGetter()
+
+	called := false
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		called = true
+		return &localControllerCharmExec{}, nil
+	})
+
+	err := stack.UploadLocalControllerCharm(c.Context(), s.pcfg.GetPodName())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(called, tc.IsFalse)
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharm(c *tc.C) {
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
+	stack := s.controllerStackerGetter()
+	execClient := &localControllerCharmExec{}
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		return execClient, nil
+	})
+
+	err := stack.UploadLocalControllerCharm(c.Context(), s.pcfg.GetPodName())
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(execClient.execCommands, tc.DeepEquals, [][]string{
+		{"mkdir", "-p", "/var/lib/juju/charms"},
+		{"chmod", "0644", "/var/lib/juju/charms/controller.charm.uploading"},
+		{"mv", "-f", "/var/lib/juju/charms/controller.charm.uploading", "/var/lib/juju/charms/controller.charm"},
+	})
+	c.Assert(execClient.copyParams, tc.HasLen, 1)
+	c.Check(execClient.copyParams[0].Src.Path, tc.Equals, "/tmp/controller.charm")
+	c.Check(execClient.copyParams[0].Dest.Path, tc.Equals, "/var/lib/juju/charms/controller.charm.uploading")
+	c.Check(execClient.copyParams[0].Dest.PodName, tc.Equals, s.pcfg.GetPodName())
+	c.Check(execClient.copyParams[0].Dest.ContainerName, tc.Equals, "api-server")
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharmExecClientError(c *tc.C) {
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
+	stack := s.controllerStackerGetter()
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		return nil, errors.NotValidf("empty kubernetes rest config")
+	})
+
+	err := stack.UploadLocalControllerCharm(c.Context(), s.pcfg.GetPodName())
+	c.Assert(err, tc.ErrorIs, errors.NotValid)
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharmMkdirError(c *tc.C) {
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
+	stack := s.controllerStackerGetter()
+	execClient := &localControllerCharmExec{
+		execErrAt: 1,
+		execErr:   errors.Errorf("mkdir failed"),
+		stderr:    "permission denied\n",
+	}
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		return execClient, nil
+	})
+
+	err := stack.UploadLocalControllerCharm(c.Context(), s.pcfg.GetPodName())
+	c.Assert(err, tc.ErrorMatches, "creating local controller charm directory: permission denied: mkdir failed")
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharmCopyError(c *tc.C) {
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
+	stack := s.controllerStackerGetter()
+	execClient := &localControllerCharmExec{copyErr: errors.Errorf("copy failed")}
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		return execClient, nil
+	})
+
+	err := stack.UploadLocalControllerCharm(c.Context(), s.pcfg.GetPodName())
+	c.Assert(err, tc.ErrorMatches, "copying local controller charm: copy failed")
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharmChmodError(c *tc.C) {
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
+	stack := s.controllerStackerGetter()
+	execClient := &localControllerCharmExec{
+		execErrAt: 2,
+		execErr:   errors.Errorf("chmod failed"),
+		stderr:    "read-only filesystem\n",
+	}
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		return execClient, nil
+	})
+
+	err := stack.UploadLocalControllerCharm(c.Context(), s.pcfg.GetPodName())
+	c.Assert(err, tc.ErrorMatches, "setting local controller charm permissions: read-only filesystem: chmod failed")
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharmMvError(c *tc.C) {
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
+	stack := s.controllerStackerGetter()
+	execClient := &localControllerCharmExec{
+		execErrAt: 3,
+		execErr:   errors.Errorf("mv failed"),
+		stderr:    "no space left on device\n",
+	}
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		return execClient, nil
+	})
+
+	err := stack.UploadLocalControllerCharm(c.Context(), s.pcfg.GetPodName())
+	c.Assert(err, tc.ErrorMatches, "installing local controller charm: no space left on device: mv failed")
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharmWithRetry(c *tc.C) {
+	newK8sClientFunc, newK8sRestClientFunc := s.setupK8sRestClient(c, s.pcfg.ControllerName)
+	var bootstrapWatchers []k8swatcher.KubernetesNotifyWatcher
+	s.setupBroker(c, newK8sClientFunc, newK8sRestClientFunc, &bootstrapWatchers)
+
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
+	stack := s.controllerStackerGetter()
+	attempts := 0
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		attempts++
+		if attempts < 3 {
+			return &localControllerCharmExec{copyErr: errors.Errorf("copy failed")}, nil
+		}
+		return &localControllerCharmExec{}, nil
+	})
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- stack.UploadLocalControllerCharmWithRetry(c.Context(), s.pcfg.GetPodName())
+	}()
+
+	err := s.clock.WaitAdvance(time.Second, coretesting.ShortWait, 1)
+	c.Assert(err, tc.ErrorIsNil)
+	err = s.clock.WaitAdvance(time.Second, coretesting.ShortWait, 1)
+	c.Assert(err, tc.ErrorIsNil)
+
+	select {
+	case err := <-errChan:
+		c.Assert(err, tc.ErrorIsNil)
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for upload retry")
+	}
+	c.Check(attempts, tc.Equals, 3)
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharmWithRetryExhaustsAttempts(c *tc.C) {
+	newK8sClientFunc, newK8sRestClientFunc := s.setupK8sRestClient(c, s.pcfg.ControllerName)
+	var bootstrapWatchers []k8swatcher.KubernetesNotifyWatcher
+	s.setupBroker(c, newK8sClientFunc, newK8sRestClientFunc, &bootstrapWatchers)
+
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
+	stack := s.controllerStackerGetter()
+	attempts := 0
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		attempts++
+		return &localControllerCharmExec{copyErr: errors.Errorf("copy failed")}, nil
+	})
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- stack.UploadLocalControllerCharmWithRetry(c.Context(), s.pcfg.GetPodName())
+	}()
+
+	for i := 0; i < 11; i++ {
+		err := s.clock.WaitAdvance(time.Second, coretesting.ShortWait, 1)
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	select {
+	case err := <-errChan:
+		c.Assert(err, tc.ErrorMatches, ".*copying local controller charm: copy failed")
+	case <-time.After(coretesting.LongWait):
+		c.Fatalf("timed out waiting for upload retry")
+	}
+	c.Check(attempts, tc.Equals, 12)
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharmWithRetrySkipsNonLocalCharmPath(c *tc.C) {
+	newK8sClientFunc, newK8sRestClientFunc := s.setupK8sRestClient(c, s.pcfg.ControllerName)
+	var bootstrapWatchers []k8swatcher.KubernetesNotifyWatcher
+	s.setupBroker(c, newK8sClientFunc, newK8sRestClientFunc, &bootstrapWatchers)
+
+	s.pcfg.Bootstrap.ControllerCharmPath = "ch:juju-controller"
+	stack := s.controllerStackerGetter()
+
+	called := false
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		called = true
+		return &localControllerCharmExec{}, nil
+	})
+
+	err := stack.UploadLocalControllerCharmWithRetry(c.Context(), s.pcfg.GetPodName())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(called, tc.IsFalse)
+}
+
+func (s *bootstrapSuite) TestUploadLocalControllerCharmWithRetryDoesNotRetryNotValid(c *tc.C) {
+	newK8sClientFunc, newK8sRestClientFunc := s.setupK8sRestClient(c, s.pcfg.ControllerName)
+	var bootstrapWatchers []k8swatcher.KubernetesNotifyWatcher
+	s.setupBroker(c, newK8sClientFunc, newK8sRestClientFunc, &bootstrapWatchers)
+
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
+	stack := s.controllerStackerGetter()
+	attempts := 0
+	stack.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		attempts++
+		return nil, errors.NotValidf("empty kubernetes rest config")
+	})
+
+	err := stack.UploadLocalControllerCharmWithRetry(c.Context(), s.pcfg.GetPodName())
+	c.Assert(err, tc.ErrorIs, errors.NotValid)
+	c.Check(attempts, tc.Equals, 1)
 }
 
 func (s *bootstrapSuite) TestBootstrap(c *tc.C) {
@@ -366,9 +599,14 @@ func (s *bootstrapSuite) TestBootstrap(c *tc.C) {
 
 	s.pcfg.Bootstrap.Timeout = 10 * time.Minute
 	s.pcfg.Bootstrap.ControllerExternalIPs = []string{"10.0.0.1"}
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
 	s.pcfg.Bootstrap.IgnoreProxy = true
 
 	controllerStacker := s.controllerStackerGetter()
+	execClient := &localControllerCharmExec{}
+	controllerStacker.SetControllerExecClientFactory(func() (k8sexec.Executor, error) {
+		return execClient, nil
+	})
 
 	scName := "some-storage"
 	sc := k8sstorage.StorageClass{
@@ -720,7 +958,7 @@ export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujuagentd $JUJU_TOOLS_DIR/jujuagentd
 
-test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf || JUJU_DEV_FEATURE_FLAGS=developer-mode $JUJU_TOOLS_DIR/jujuagentd bootstrap-state --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s
+if ! test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf; then mkdir -p $JUJU_DATA_DIR/charms; until test -e $JUJU_DATA_DIR/charms/controller.charm; do sleep 1; done; JUJU_DEV_FEATURE_FLAGS=developer-mode $JUJU_TOOLS_DIR/jujuagentd bootstrap-state --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s; fi
 
 mkdir -p /var/lib/pebble/default/layers
 cat > /var/lib/pebble/default/layers/001-jujuagentd.yaml <<EOF
@@ -1107,6 +1345,8 @@ exec /opt/pebble run --http :38811 --verbose
 		c.Assert(bootstrapWatchers, tc.HasLen, 2)
 		c.Assert(workertest.CheckKilled(c, bootstrapWatchers[0]), tc.ErrorIsNil)
 		c.Assert(workertest.CheckKilled(c, bootstrapWatchers[1]), tc.ErrorIsNil)
+		c.Assert(execClient.copyParams, tc.HasLen, 1)
+		c.Check(execClient.copyParams[0].Src.Path, tc.Equals, "/tmp/controller.charm")
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for deploy return")
 	}
@@ -1181,4 +1421,42 @@ func (s *bootstrapSuite) TestBootstrapFailedTimeout(c *tc.C) {
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for deploy return")
 	}
+}
+
+type localControllerCharmExec struct {
+	execErrAt int
+	execErr   error
+	stderr    string
+	copyErr   error
+
+	execCommands [][]string
+	copyParams   []k8sexec.CopyParams
+}
+
+func (e *localControllerCharmExec) Status(context.Context, k8sexec.StatusParams) (*k8sexec.Status, error) {
+	return nil, nil
+}
+
+func (e *localControllerCharmExec) Exec(_ context.Context, params k8sexec.ExecParams, _ <-chan struct{}) error {
+	e.execCommands = append(e.execCommands, params.Commands)
+	if e.execErrAt != len(e.execCommands) {
+		return nil
+	}
+	if e.stderr != "" && params.Stderr != nil {
+		_, _ = io.WriteString(params.Stderr, e.stderr)
+	}
+	return e.execErr
+}
+
+func (e *localControllerCharmExec) Copy(_ context.Context, params k8sexec.CopyParams, _ <-chan struct{}) error {
+	e.copyParams = append(e.copyParams, params)
+	return e.copyErr
+}
+
+func (e *localControllerCharmExec) RawClient() clientkubernetes.Interface {
+	return nil
+}
+
+func (e *localControllerCharmExec) NameSpace() string {
+	return "controller-1"
 }

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -5,6 +5,7 @@ package kubernetes_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -296,6 +297,32 @@ func (s *bootstrapSuite) TestGetControllerSvcSpec(c *tc.C) {
 		}
 		c.Check(spec, tc.DeepEquals, t.spec)
 	}
+}
+
+func (s *bootstrapSuite) TestControllerSpecWaitsForLocalControllerCharm(c *tc.C) {
+	newK8sClientFunc, newK8sRestClientFunc := s.setupK8sRestClient(c, s.pcfg.ControllerName)
+	var bootstrapWatchers []k8swatcher.KubernetesNotifyWatcher
+	s.setupBroker(c, newK8sClientFunc, newK8sRestClientFunc, &bootstrapWatchers)
+
+	s.pcfg.Bootstrap.Timeout = 10 * time.Minute
+	s.pcfg.Bootstrap.ControllerCharmPath = "/tmp/controller.charm"
+
+	spec := s.controllerStackerGetter().BuildContainerSpecForController(c)
+	var apiServer *core.Container
+	for i := range spec.Containers {
+		if spec.Containers[i].Name == "api-server" {
+			apiServer = &spec.Containers[i]
+			break
+		}
+	}
+	c.Assert(apiServer, tc.NotNil)
+	c.Assert(apiServer.Args, tc.HasLen, 2)
+
+	startup := apiServer.Args[1]
+	c.Check(startup, tc.Contains, "mkdir -p $JUJU_DATA_DIR/charms")
+	c.Check(startup, tc.Contains, "until test -e $JUJU_DATA_DIR/charms/controller.charm; do sleep 1; done")
+	c.Check(startup, tc.Contains, "$JUJU_TOOLS_DIR/jujud bootstrap-state --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s")
+	c.Check(strings.Contains(startup, "test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf ||"), tc.IsFalse)
 }
 
 func (s *bootstrapSuite) TestBootstrap(c *tc.C) {

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -507,7 +507,7 @@ func (s *bootstrapSuite) TestUploadLocalControllerCharmWithRetryExhaustsAttempts
 		errChan <- stack.UploadLocalControllerCharmWithRetry(c.Context(), s.pcfg.GetPodName())
 	}()
 
-	for i := 0; i < 11; i++ {
+	for range 11 {
 		err := s.clock.WaitAdvance(time.Second, coretesting.ShortWait, 1)
 		c.Assert(err, tc.ErrorIsNil)
 	}

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -321,7 +321,7 @@ func (s *bootstrapSuite) TestControllerSpecWaitsForLocalControllerCharm(c *tc.C)
 	startup := apiServer.Args[1]
 	c.Check(startup, tc.Contains, "mkdir -p $JUJU_DATA_DIR/charms")
 	c.Check(startup, tc.Contains, "until test -e $JUJU_DATA_DIR/charms/controller.charm; do sleep 1; done")
-	c.Check(startup, tc.Contains, "$JUJU_TOOLS_DIR/jujud bootstrap-state --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s")
+	c.Check(startup, tc.Contains, "$JUJU_TOOLS_DIR/jujuagentd bootstrap-state --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s")
 	c.Check(strings.Contains(startup, "test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf ||"), tc.IsFalse)
 }
 

--- a/internal/provider/kubernetes/export_test.go
+++ b/internal/provider/kubernetes/export_test.go
@@ -51,6 +51,7 @@ type ControllerStackerForTest interface {
 	GetStorageSize() resource.Quantity
 	GetControllerSvcSpec(string, *podcfg.BootstrapConfig) (*controllerServiceSpec, error)
 	SetControllerAgentLokiConfig(string, *string, *bool, string)
+	BuildContainerSpecForController(*tc.C) *core.PodSpec
 }
 
 func (cs *controllerStack) GetControllerAgentConfigContent(c *tc.C) string {
@@ -79,6 +80,12 @@ func (cs *controllerStack) GetControllerSvcSpec(cloudType string, cfg *podcfg.Bo
 
 func (cs *controllerStack) SetControllerAgentLokiConfig(endpoint string, caCert *string, insecureSkipVerify *bool, orgID string) {
 	cs.agentConfig.SetLokiConfig(endpoint, caCert, insecureSkipVerify, orgID)
+}
+
+func (cs *controllerStack) BuildContainerSpecForController(c *tc.C) *core.PodSpec {
+	spec, err := cs.buildContainerSpecForController()
+	c.Assert(err, tc.ErrorIsNil)
+	return spec
 }
 
 func NewcontrollerStackForTest(

--- a/internal/provider/kubernetes/export_test.go
+++ b/internal/provider/kubernetes/export_test.go
@@ -14,11 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/juju/juju/caas"
 	jujucloud "github.com/juju/juju/cloud"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/cloudconfig/podcfg"
+	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"
 	"github.com/juju/juju/internal/storage"
 )
 
@@ -36,6 +38,7 @@ var (
 
 	UpdateStrategyForStatefulSet = updateStrategyForStatefulSet
 	DecideKubeConfigDir          = decideKubeConfigDir
+	IsLocalControllerCharmPath   = isLocalControllerCharmPath
 )
 
 type (
@@ -52,6 +55,10 @@ type ControllerStackerForTest interface {
 	GetControllerSvcSpec(string, *podcfg.BootstrapConfig) (*controllerServiceSpec, error)
 	SetControllerAgentLokiConfig(string, *string, *bool, string)
 	BuildContainerSpecForController(*tc.C) *core.PodSpec
+	UploadLocalControllerCharm(context.Context, string) error
+	UploadLocalControllerCharmWithRetry(context.Context, string) error
+	ControllerExecClient() (k8sexec.Executor, error)
+	SetControllerExecClientFactory(func() (k8sexec.Executor, error))
 }
 
 func (cs *controllerStack) GetControllerAgentConfigContent(c *tc.C) string {
@@ -86,6 +93,22 @@ func (cs *controllerStack) BuildContainerSpecForController(c *tc.C) *core.PodSpe
 	spec, err := cs.buildContainerSpecForController()
 	c.Assert(err, tc.ErrorIsNil)
 	return spec
+}
+
+func (cs *controllerStack) UploadLocalControllerCharm(ctx context.Context, podName string) error {
+	return cs.uploadLocalControllerCharm(ctx, podName)
+}
+
+func (cs *controllerStack) UploadLocalControllerCharmWithRetry(ctx context.Context, podName string) error {
+	return cs.uploadLocalControllerCharmWithRetry(ctx, podName)
+}
+
+func (cs *controllerStack) ControllerExecClient() (k8sexec.Executor, error) {
+	return cs.controllerExecClient()
+}
+
+func (cs *controllerStack) SetControllerExecClientFactory(factory func() (k8sexec.Executor, error)) {
+	cs.controllerExecClientFactory = factory
 }
 
 func NewcontrollerStackForTest(
@@ -156,4 +179,10 @@ func (k *kubernetesClient) GetPod(ctx context.Context, podName string) (*core.Po
 
 func (k *kubernetesClient) GetStatefulSet(ctx context.Context, name string) (*apps.StatefulSet, error) {
 	return k.getStatefulSet(ctx, name)
+}
+
+func (k *kubernetesClient) SetRestConfigForTest(cfg *rest.Config) {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	k.k8sCfgUnlocked = cfg
 }

--- a/internal/provider/kubernetes/k8s.go
+++ b/internal/provider/kubernetes/k8s.go
@@ -298,6 +298,15 @@ func (k *kubernetesClient) client() kubernetes.Interface {
 	return client
 }
 
+func (k *kubernetesClient) restConfig() *rest.Config {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	if k.k8sCfgUnlocked == nil {
+		return nil
+	}
+	return rest.CopyConfig(k.k8sCfgUnlocked)
+}
+
 func (k *kubernetesClient) extendedClient() apiextensionsclientset.Interface {
 	k.lock.Lock()
 	defer k.lock.Unlock()


### PR DESCRIPTION
The IAAS bootstrap path has long supported deploying a local controller charm (i.e. a .charm file from the local filesystem rather than pulling from Charmhub) and correctly forwards constraints to the application service. The CAAS path was missing both of these - it explicitly rejected local charm paths with a "not supported" error, and was silently dropping constraints. This asymmetry made CAAS a second-class citizen for controller development and debugging workflows.

## QA steps

```sh
$ make microk8s-operator-update
$ juju bootstrap microk8s ops --controller-charm-path=./juju-controller_ubuntu@24.04-amd64.charm
```

## Links

**Jira card:** [JUJU-10075](https://warthogs.atlassian.net/browse/JUJU-10075)


[JUJU-10075]: https://warthogs.atlassian.net/browse/JUJU-10075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ