### PR TITLE
feat: persist controller unit FQDNs for k8s controller HA

### DIFF
--- a/caas/broker.go
+++ b/caas/broker.go
@@ -312,6 +312,7 @@ type VolumeInfo struct {
 type Unit struct {
 	Id             string
 	Address        string
+	FQDN           string
 	Ports          []string
 	Dying          bool
 	Stateful       bool

--- a/domain/application/modelmigration/import_test.go
+++ b/domain/application/modelmigration/import_test.go
@@ -152,7 +152,7 @@ func (s *importSuite) TestApplicationImportWithMinimalCharmForCAAS(c *tc.C) {
 			UnitName:     "prometheus/0",
 			PasswordHash: new("passwordhash"),
 		},
-		CloudContainer: new(application.CloudContainerParams{
+		K8sPod: new(application.K8sPodParams{
 			ProviderID: "provider-id",
 			Address: new(network.SpaceAddress{
 				MachineAddress: network.MachineAddress{

--- a/domain/application/modelmigration/import_unit.go
+++ b/domain/application/modelmigration/import_unit.go
@@ -48,25 +48,25 @@ func (i *importOperation) importCAASUnit(ctx context.Context, unit description.U
 		return service.ImportCAASUnitArg{}, errors.Capture(err)
 	}
 
-	var cloudContainer *application.CloudContainerParams
+	var k8sPod *application.K8sPodParams
 	if cc := unit.CloudContainer(); cc != nil {
 		address, origin := i.makeAddress(cc.Address())
 
-		cloudContainer = &application.CloudContainerParams{
+		k8sPod = &application.K8sPodParams{
 			Address:       address,
 			AddressOrigin: origin,
 		}
 		if cc.ProviderId() != "" {
-			cloudContainer.ProviderID = cc.ProviderId()
+			k8sPod.ProviderID = cc.ProviderId()
 		}
 		if len(cc.Ports()) > 0 {
-			cloudContainer.Ports = new(cc.Ports())
+			k8sPod.Ports = new(cc.Ports())
 		}
 	}
 
 	return service.ImportCAASUnitArg{
-		ImportUnitArg:  unitArgs,
-		CloudContainer: cloudContainer,
+		ImportUnitArg: unitArgs,
+		K8sPod:        k8sPod,
 	}, nil
 }
 

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -540,46 +540,46 @@ func makeCAASUnitArgs(units []ImportCAASUnitArg, charmUUID corecharm.ID) ([]appl
 			}
 		}
 
-		var cloudContainer *application.CloudContainer
-		if u.CloudContainer != nil {
-			cloudContainer = makeCloudContainerArg(u.UnitName, *u.CloudContainer)
+		var k8sPod *application.K8sPod
+		if u.K8sPod != nil {
+			k8sPod = makeK8sPodArg(u.UnitName, *u.K8sPod)
 		}
 
 		unitArgs[i] = application.ImportCAASUnitArg{
-			ImportUnitArg:  arg,
-			CloudContainer: cloudContainer,
+			ImportUnitArg: arg,
+			K8sPod:        k8sPod,
 		}
 	}
 	return unitArgs, nil
 }
 
-func makeCloudContainerArg(unitName coreunit.Name, cloudContainer application.CloudContainerParams) *application.CloudContainer {
-	result := &application.CloudContainer{
-		ProviderID: cloudContainer.ProviderID,
-		Ports:      cloudContainer.Ports,
+func makeK8sPodArg(unitName coreunit.Name, k8sPod application.K8sPodParams) *application.K8sPod {
+	result := &application.K8sPod{
+		ProviderID: k8sPod.ProviderID,
+		Ports:      k8sPod.Ports,
 	}
-	if cloudContainer.Address != nil {
-		// TODO(units) - handle the cloudContainer.Address space ID
+	if k8sPod.Address != nil {
+		// TODO(units) - handle the k8sPod.Address space ID
 		// For k8s we'll initially create a /32 subnet off the container address
 		// and add that to the default space.
-		result.Address = &application.ContainerAddress{
-			// For cloud containers, the device is a placeholder without
+		result.Address = &application.K8sPodAddress{
+			// For k8s pods, the device is a placeholder without
 			// a MAC address and once inserted, not updated. It just exists
 			// to tie the address to the net node corresponding to the
-			// cloud container.
-			Device: application.ContainerDevice{
-				Name:              fmt.Sprintf("placeholder for %q cloud container", unitName),
+			// k8s pod.
+			Device: application.K8sPodDevice{
+				Name:              fmt.Sprintf("placeholder for %q k8s pod", unitName),
 				DeviceTypeID:      domainnetwork.DeviceTypeUnknown,
 				VirtualPortTypeID: domainnetwork.NonVirtualPortType,
 			},
-			Value:       cloudContainer.Address.Value,
-			AddressType: ipaddress.MarshallAddressType(cloudContainer.Address.AddressType()),
-			Scope:       ipaddress.MarshallScope(cloudContainer.Address.Scope),
+			Value:       k8sPod.Address.Value,
+			AddressType: ipaddress.MarshallAddressType(k8sPod.Address.AddressType()),
+			Scope:       ipaddress.MarshallScope(k8sPod.Address.Scope),
 			Origin:      ipaddress.MarshallOrigin(network.OriginProvider),
 			ConfigType:  ipaddress.MarshallConfigType(network.ConfigDHCP),
 		}
-		if cloudContainer.AddressOrigin != nil {
-			result.Address.Origin = ipaddress.MarshallOrigin(*cloudContainer.AddressOrigin)
+		if k8sPod.AddressOrigin != nil {
+			result.Address.Origin = ipaddress.MarshallOrigin(*k8sPod.AddressOrigin)
 		}
 	}
 	return result

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -379,7 +379,7 @@ type MockStateMockRecorder struct {
 	getAddressesHashExpects                                   []*gomock.Call3_2[context.Context, application.UUID, string, string, error]
 	getAllEndpointBindingsExpects                             []*gomock.Call1_2[context.Context, map[string]map[string]string, error]
 	getAllExposedEndpointsExpects                             []*gomock.Call1_2[context.Context, map[string]map[string]application0.ExposedEndpoint, error]
-	getAllUnitCloudContainerIDsForApplicationExpects          []*gomock.Call2_2[context.Context, application.UUID, map[unit.Name]string, error]
+	getAllUnitK8sPodIDsForApplicationExpects                  []*gomock.Call2_2[context.Context, application.UUID, map[unit.Name]string, error]
 	getAllUnitLifeForApplicationExpects                       []*gomock.Call2_2[context.Context, application.UUID, map[string]int, error]
 	getAllUnitNamesExpects                                    []*gomock.Call1_2[context.Context, []unit.Name, error]
 	getApplicationCharmOriginExpects                          []*gomock.Call2_2[context.Context, application.UUID, application0.CharmOrigin, error]
@@ -775,23 +775,23 @@ func (mr *MockStateMockRecorder) GetAllExposedEndpoints(ctx any) *MockStateGetAl
 // MockStateGetAllExposedEndpointsCall is the typed call wrapper for GetAllExposedEndpoints.
 type MockStateGetAllExposedEndpointsCall = gomock.Call1_2[context.Context, map[string]map[string]application0.ExposedEndpoint, error]
 
-// GetAllUnitCloudContainerIDsForApplication mocks base method.
-func (m *MockState) GetAllUnitCloudContainerIDsForApplication(arg0 context.Context, arg1 application.UUID) (map[unit.Name]string, error) {
+// GetAllUnitK8sPodIDsForApplication mocks base method.
+func (m *MockState) GetAllUnitK8sPodIDsForApplication(arg0 context.Context, arg1 application.UUID) (map[unit.Name]string, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_2(&m.recorder.getAllUnitCloudContainerIDsForApplicationExpects, m.ctrl, m, "GetAllUnitCloudContainerIDsForApplication", arg0, arg1)
+	return gomock.Dispatch2_2(&m.recorder.getAllUnitK8sPodIDsForApplicationExpects, m.ctrl, m, "GetAllUnitK8sPodIDsForApplication", arg0, arg1)
 }
 
-// GetAllUnitCloudContainerIDsForApplication indicates an expected call of GetAllUnitCloudContainerIDsForApplication.
-func (mr *MockStateMockRecorder) GetAllUnitCloudContainerIDsForApplication(arg0, arg1 any) *MockStateGetAllUnitCloudContainerIDsForApplicationCall {
+// GetAllUnitK8sPodIDsForApplication indicates an expected call of GetAllUnitK8sPodIDsForApplication.
+func (mr *MockStateMockRecorder) GetAllUnitK8sPodIDsForApplication(arg0, arg1 any) *MockStateGetAllUnitK8sPodIDsForApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, application.UUID, map[unit.Name]string, error](mr.mock.ctrl.T, mr.mock, "GetAllUnitCloudContainerIDsForApplication", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
-	mr.getAllUnitCloudContainerIDsForApplicationExpects = append(mr.getAllUnitCloudContainerIDsForApplicationExpects, call)
+	call := gomock.NewCall2_2[context.Context, application.UUID, map[unit.Name]string, error](mr.mock.ctrl.T, mr.mock, "GetAllUnitK8sPodIDsForApplication", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
+	mr.getAllUnitK8sPodIDsForApplicationExpects = append(mr.getAllUnitK8sPodIDsForApplicationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
-// MockStateGetAllUnitCloudContainerIDsForApplicationCall is the typed call wrapper for GetAllUnitCloudContainerIDsForApplication.
-type MockStateGetAllUnitCloudContainerIDsForApplicationCall = gomock.Call2_2[context.Context, application.UUID, map[unit.Name]string, error]
+// MockStateGetAllUnitK8sPodIDsForApplicationCall is the typed call wrapper for GetAllUnitK8sPodIDsForApplication.
+type MockStateGetAllUnitK8sPodIDsForApplicationCall = gomock.Call2_2[context.Context, application.UUID, map[unit.Name]string, error]
 
 // GetAllUnitLifeForApplication mocks base method.
 func (m *MockState) GetAllUnitLifeForApplication(arg0 context.Context, arg1 application.UUID) (map[string]int, error) {

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -93,7 +93,7 @@ type AddApplicationArgs struct {
 	IsController bool
 }
 
-// AddressParams contains parameters for a unit/cloud container address.
+// AddressParams contains parameters for a unit/k8s pod address.
 type AddressParams struct {
 	Value       string
 	AddressType string
@@ -143,17 +143,17 @@ type ImportIAASUnitArg struct {
 // ImportCAASUnitArg contains parameters for importing a CAAS unit.
 type ImportCAASUnitArg struct {
 	ImportUnitArg
-	CloudContainer *application.CloudContainerParams
+	K8sPod *application.K8sPodParams
 }
 
 // UpdateCAASUnitParams contains parameters for updating a CAAS unit.
 type UpdateCAASUnitParams struct {
-	ProviderID           *string
-	Address              *string
-	Ports                *[]string
-	AgentStatus          *status.StatusInfo
-	WorkloadStatus       *status.StatusInfo
-	CloudContainerStatus *status.StatusInfo
+	ProviderID     *string
+	Address        *string
+	Ports          *[]string
+	AgentStatus    *status.StatusInfo
+	WorkloadStatus *status.StatusInfo
+	K8sPodStatus   *status.StatusInfo
 }
 
 // ScalingState contains attributes that describes

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -110,11 +110,6 @@ type AddUnitArg struct {
 	// StorageInstancesToAttach contains the list of existing Storage instance
 	// UUIDs to be attached to this unit.
 	StorageInstancesToAttach []domainstorage.StorageInstanceUUID
-
-	// FQDN, when set, is the stable, cluster-resolvable per-pod DNS name to
-	// persist as the unit's network identity. It is currently only supplied
-	// for controller CAAS units; it is a no-op for all other callers.
-	FQDN *string
 }
 
 // AddIAASUnitArg contains parameters for adding a IAAS unit to the model.
@@ -154,6 +149,11 @@ type UpdateCAASUnitParams struct {
 	AgentStatus    *status.StatusInfo
 	WorkloadStatus *status.StatusInfo
 	K8sPodStatus   *status.StatusInfo
+
+	// FQDN, when set, is the stable, cluster-resolvable per-pod DNS name to
+	// persist as the unit's network identity. It is currently only supplied
+	// for controller units.
+	FQDN *string
 }
 
 // ScalingState contains attributes that describes

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -110,6 +110,11 @@ type AddUnitArg struct {
 	// StorageInstancesToAttach contains the list of existing Storage instance
 	// UUIDs to be attached to this unit.
 	StorageInstancesToAttach []domainstorage.StorageInstanceUUID
+
+	// FQDN, when set, is the stable, cluster-resolvable per-pod DNS name to
+	// persist as the unit's network identity. It is currently only supplied
+	// for controller CAAS units; it is a no-op for all other callers.
+	FQDN *string
 }
 
 // AddIAASUnitArg contains parameters for adding a IAAS unit to the model.

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -574,6 +574,9 @@ func (s *ProviderService) RegisterCAASUnit(
 	if len(caasUnit.Ports) != 0 {
 		registerArgs.Ports = &caasUnit.Ports
 	}
+	if caasUnit.FQDN != "" {
+		registerArgs.FQDN = &caasUnit.FQDN
+	}
 
 	var storageArg domainstorage.RegisterUnitStorageArg
 	if isRegistered {

--- a/domain/application/service/status.go
+++ b/domain/application/service/status.go
@@ -22,7 +22,7 @@ type StatusHistory interface {
 	RecordStatus(context.Context, statushistory.Namespace, corestatus.StatusInfo) error
 }
 
-// encodeK8sPodStatusType converts a core status to a db cloud container
+// encodeK8sPodStatusType converts a core status to a db k8s pod
 // status id.
 func encodeK8sPodStatusType(s corestatus.Status) (status.K8sPodStatusType, error) {
 	switch s {
@@ -37,7 +37,7 @@ func encodeK8sPodStatusType(s corestatus.Status) (status.K8sPodStatusType, error
 	case corestatus.Error:
 		return status.K8sPodStatusError, nil
 	default:
-		return -1, errors.Errorf("unknown cloud container status %q", s)
+		return -1, errors.Errorf("unknown k8s pod status %q", s)
 	}
 }
 

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -965,6 +965,7 @@ func (s *ProviderService) makeCAASUnitArgs(
 				Placement:            placement,
 				UnitStatusArg:        s.makeCAASUnitStatusArgs(),
 			},
+			FQDN: u.FQDN,
 		}
 		args[i] = arg
 	}

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -75,7 +75,7 @@ type UnitState interface {
 	// [applicationerrors.UnitNotAssigned] when the unit was not assigned
 	RegisterCAASUnit(context.Context, string, application.RegisterCAASUnitArg) error
 
-	// UpdateCAASUnit updates the cloud container for specified unit,
+	// UpdateCAASUnit updates the k8s pod for specified unit,
 	// returning an error satisfying [applicationerrors.UnitNotFoundError]
 	// if the unit doesn't exist.
 	UpdateCAASUnit(context.Context, coreunit.Name, application.UpdateCAASUnitParams) error
@@ -225,12 +225,12 @@ type UnitState interface {
 	// - [uniterrors.UnitNotFound] if the unit does not exist
 	GetUnitNetNodesByName(ctx context.Context, name coreunit.Name) ([]string, error)
 
-	// GetAllUnitCloudContainerIDsForApplication returns a map of the unit names
-	// and their cloud container provider IDs for the given application.
+	// GetAllUnitK8sPodIDsForApplication returns a map of the unit names
+	// and their k8s pod provider IDs for the given application.
 	//   - If the application is dead, [applicationerrors.ApplicationIsDead] is returned.
 	//   - If the application is not found, [applicationerrors.ApplicationNotFound]
 	//     is returned.
-	GetAllUnitCloudContainerIDsForApplication(context.Context, coreapplication.UUID) (map[coreunit.Name]string, error)
+	GetAllUnitK8sPodIDsForApplication(context.Context, coreapplication.UUID) (map[coreunit.Name]string, error)
 
 	// GetStorageAddInfoByUnitUUID returns the deploy metadata and how many
 	// storage instances exist for the named storage on the specified unit.
@@ -1025,7 +1025,7 @@ func (s *Service) UpdateCAASUnit(ctx context.Context, unitName coreunit.Name, pa
 	if err != nil {
 		return errors.Errorf("encoding workload status: %w", err)
 	}
-	k8sPodStatus, err := encodeK8sPodStatus(params.CloudContainerStatus)
+	k8sPodStatus, err := encodeK8sPodStatus(params.K8sPodStatus)
 	if err != nil {
 		return errors.Errorf("encoding k8s pod status: %w", err)
 	}
@@ -1461,13 +1461,13 @@ func (s *Service) GetAllUnitLifeForApplication(ctx context.Context, appID coreap
 	return namesAndCoreLives, nil
 }
 
-// GetAllUnitCloudContainerIDsForApplication returns a map of the unit names
-// and their cloud container provider IDs for the given application.
+// GetAllUnitK8sPodIDsForApplication returns a map of the unit names
+// and their k8s pod provider IDs for the given application.
 //   - If the application is dead, [applicationerrors.ApplicationIsDead] is returned.
 //   - If the application is not found, [applicationerrors.ApplicationNotFound]
 //     is returned.
 //   - If the application UUID is not valid, [coreerrors.NotValid] is returned.
-func (s *Service) GetAllUnitCloudContainerIDsForApplication(ctx context.Context, appUUID coreapplication.UUID) (map[coreunit.Name]string, error) {
+func (s *Service) GetAllUnitK8sPodIDsForApplication(ctx context.Context, appUUID coreapplication.UUID) (map[coreunit.Name]string, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -1475,7 +1475,7 @@ func (s *Service) GetAllUnitCloudContainerIDsForApplication(ctx context.Context,
 		return nil, errors.Capture(err)
 	}
 
-	idMap, err := s.st.GetAllUnitCloudContainerIDsForApplication(ctx, appUUID)
+	idMap, err := s.st.GetAllUnitK8sPodIDsForApplication(ctx, appUUID)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -965,7 +965,6 @@ func (s *ProviderService) makeCAASUnitArgs(
 				Placement:            placement,
 				UnitStatusArg:        s.makeCAASUnitStatusArgs(),
 			},
-			FQDN: u.FQDN,
 		}
 		args[i] = arg
 	}
@@ -1037,6 +1036,7 @@ func (s *Service) UpdateCAASUnit(ctx context.Context, unitName coreunit.Name, pa
 		AgentStatus:    agentStatus,
 		WorkloadStatus: workloadStatus,
 		K8sPodStatus:   k8sPodStatus,
+		FQDN:           params.FQDN,
 	}
 
 	if err := s.st.UpdateCAASUnit(ctx, unitName, cassUnitUpdate); err != nil {

--- a/domain/application/service/unit_test.go
+++ b/domain/application/service/unit_test.go
@@ -359,7 +359,7 @@ func (s *unitServiceSuite) TestUpdateCAASUnit(c *tc.C) {
 			Data:    map[string]any{"foo": "bar"},
 			Since:   new(now),
 		}),
-		CloudContainerStatus: new(corestatus.StatusInfo{
+		K8sPodStatus: new(corestatus.StatusInfo{
 			Status:  corestatus.Running,
 			Message: "container status",
 			Data:    map[string]any{"foo": "bar"},
@@ -829,7 +829,7 @@ func (s *unitServiceSuite) TestGetAllUnitLifeForApplicationError(c *tc.C) {
 	c.Check(allUnitLife, tc.IsNil)
 }
 
-func (s *unitServiceSuite) TestGetAllUnitCloudContainerIDsForApplication(c *tc.C) {
+func (s *unitServiceSuite) TestGetAllUnitK8sPodIDsForApplication(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	appID := tc.Must(c, coreapplication.NewUUID)
@@ -838,31 +838,31 @@ func (s *unitServiceSuite) TestGetAllUnitCloudContainerIDsForApplication(c *tc.C
 		"test/4": "foo",
 		"test/5": "bar",
 	}
-	s.state.EXPECT().GetAllUnitCloudContainerIDsForApplication(gomock.Any(), appID).
+	s.state.EXPECT().GetAllUnitK8sPodIDsForApplication(gomock.Any(), appID).
 		Return(expectedResult, nil)
 
-	result, err := s.service.GetAllUnitCloudContainerIDsForApplication(c.Context(), appID)
+	result, err := s.service.GetAllUnitK8sPodIDsForApplication(c.Context(), appID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(result, tc.DeepEquals, expectedResult)
 }
 
-func (s *unitServiceSuite) TestGetAllUnitCloudContainerIDsForApplicationErrors(c *tc.C) {
+func (s *unitServiceSuite) TestGetAllUnitK8sPodIDsForApplicationErrors(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	appID := tc.Must(c, coreapplication.NewUUID)
 
-	s.state.EXPECT().GetAllUnitCloudContainerIDsForApplication(gomock.Any(), appID).
+	s.state.EXPECT().GetAllUnitK8sPodIDsForApplication(gomock.Any(), appID).
 		Return(nil, errors.New("nope"))
 
-	_, err := s.service.GetAllUnitCloudContainerIDsForApplication(c.Context(), appID)
+	_, err := s.service.GetAllUnitK8sPodIDsForApplication(c.Context(), appID)
 	c.Assert(err, tc.NotNil)
 }
 
-func (s *unitServiceSuite) TestGetAllUnitCloudContainerIDsForApplicationInvalidApplicationUUID(c *tc.C) {
+func (s *unitServiceSuite) TestGetAllUnitK8sPodIDsForApplicationInvalidApplicationUUID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	appID := coreapplication.UUID("$")
-	_, err := s.service.GetAllUnitCloudContainerIDsForApplication(c.Context(), appID)
+	_, err := s.service.GetAllUnitK8sPodIDsForApplication(c.Context(), appID)
 	c.Assert(err, tc.NotNil)
 }
 

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1449,7 +1449,7 @@ WHERE  c.source_id < 2;
 //
 // It first checks if a cloud service exists for the application, if there is
 // then it returns the net node UUID for the cloud service without checking for
-// the unit's net node since it corresponds to the cloud container address
+// the unit's net node since it corresponds to the k8s pod address
 // instead.
 //
 // If the unit does not exist an error satisfying

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -348,7 +348,7 @@ func (st *State) importCAASUnit(
 		insertUnitArg{
 			CharmUUID:       charmUUID,
 			UnitName:        args.UnitName.String(),
-			CloudContainer:  args.CloudContainer,
+			K8sPod:          args.K8sPod,
 			Password:        args.Password,
 			Constraints:     args.Constraints,
 			WorkloadVersion: args.WorkloadVersion,

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -236,6 +236,20 @@ type ipAddress struct {
 	DeviceID     string `db:"device_uuid"`
 }
 
+// fqdnAddress is the DB representation of a row in the fqdn_address table.
+type fqdnAddress struct {
+	UUID    string `db:"uuid"`
+	Address string `db:"address"`
+	ScopeID int    `db:"scope_id"`
+}
+
+// netNodeFQDNAddress is the DB representation of a row in the
+// net_node_fqdn_address junction table linking a net_node to an fqdn_address.
+type netNodeFQDNAddress struct {
+	NetNodeUUID string `db:"net_node_uuid"`
+	AddressUUID string `db:"address_uuid"`
+}
+
 type spaceAddress struct {
 	Value        string                      `db:"address_value"`
 	ConfigTypeID int                         `db:"config_type_id"`

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -177,12 +177,12 @@ type unitStatusInfo struct {
 	UpdatedAt *time.Time `db:"updated_at"`
 }
 
-type cloudContainer struct {
+type k8sPod struct {
 	UnitUUID   string `db:"unit_uuid"`
 	ProviderID string `db:"provider_id"`
 }
 
-type unitNameCloudContainer struct {
+type unitNameK8sPod struct {
 	Name       string `db:"name"`
 	ProviderID string `db:"provider_id"`
 }
@@ -202,7 +202,7 @@ type k8sServiceDevice struct {
 	VirtualPortTypeID int    `db:"virtual_port_type_id"`
 }
 
-type cloudContainerDevice struct {
+type k8sPodDevice struct {
 	UUID              string `db:"uuid"`
 	Name              string `db:"name"`
 	NetNodeID         string `db:"net_node_uuid"`

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -881,6 +881,7 @@ func (st *State) RegisterCAASUnit(ctx context.Context, appName string, arg appli
 			},
 		},
 		CloudContainer: cloudContainer,
+		FQDN:           arg.FQDN,
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -1046,6 +1047,7 @@ func (st *State) insertCAASUnitWithName(
 		CloudContainer: args.CloudContainer,
 		Constraints:    args.Constraints,
 		UnitStatusArg:  args.UnitStatusArg,
+		FQDN:           args.FQDN,
 	})
 	if err != nil {
 		return "", errors.Errorf("inserting unit for CAAS application %q: %w", appUUID, err)

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -804,10 +804,25 @@ func (st *State) getUnitDetails(ctx context.Context, tx *sqlair.TX, unitName str
 	return &unit, nil
 }
 
+// networkAddressScopeLocalCloud is the network_address_scope id for the
+// "local-cloud" scope. NOTE: this is the network_address_scope lookup table
+// (used by fqdn_address/hostname_address), which is distinct from the
+// ip_address_scope table used by ip_address. In network_address_scope:
+// local-host=0, local-cloud=1, public=2. The fqdn_address CHECK constraint
+// forbids local-host.
+const networkAddressScopeLocalCloud = 1
+
 func makeK8sPodArg(unitName coreunit.Name, k8sPod application.K8sPodParams) *application.K8sPod {
 	result := &application.K8sPod{
 		ProviderID: k8sPod.ProviderID,
 		Ports:      k8sPod.Ports,
+	}
+	if k8sPod.FQDN != nil {
+		result.FQDN = k8sPod.FQDN
+		// Pod FQDNs are resolvable within the cluster, so default them to the
+		// local-cloud network address scope. Set here alongside the pod
+		// address scope rather than in the state insert helper.
+		result.FQDNScope = networkAddressScopeLocalCloud
 	}
 	if k8sPod.Address != nil {
 		// TODO(units) - handle the k8sPod.Address space ID
@@ -853,6 +868,7 @@ func (st *State) RegisterCAASUnit(ctx context.Context, appName string, arg appli
 	k8sPodParams := application.K8sPodParams{
 		ProviderID: arg.ProviderID,
 		Ports:      arg.Ports,
+		FQDN:       arg.FQDN,
 	}
 	if arg.Address != nil {
 		addr := network.NewSpaceAddress(*arg.Address, network.WithScope(network.ScopeMachineLocal))
@@ -881,7 +897,6 @@ func (st *State) RegisterCAASUnit(ctx context.Context, appName string, arg appli
 			},
 		},
 		K8sPod: k8sPod,
-		FQDN:   arg.FQDN,
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -1047,7 +1062,6 @@ func (st *State) insertCAASUnitWithName(
 		K8sPod:        args.K8sPod,
 		Constraints:   args.Constraints,
 		UnitStatusArg: args.UnitStatusArg,
-		FQDN:          args.FQDN,
 	})
 	if err != nil {
 		return "", errors.Errorf("inserting unit for CAAS application %q: %w", appUUID, err)
@@ -1145,6 +1159,7 @@ func (st *State) UpdateCAASUnit(ctx context.Context, unitName coreunit.Name, par
 		k8sPodParams := application.K8sPodParams{
 			ProviderID: *params.ProviderID,
 			Ports:      params.Ports,
+			FQDN:       params.FQDN,
 		}
 		if params.Address != nil {
 			addr := network.NewSpaceAddress(*params.Address, network.WithScope(network.ScopeMachineLocal))

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -804,27 +804,27 @@ func (st *State) getUnitDetails(ctx context.Context, tx *sqlair.TX, unitName str
 	return &unit, nil
 }
 
-func makeCloudContainerArg(unitName coreunit.Name, cloudContainer application.CloudContainerParams) *application.CloudContainer {
-	result := &application.CloudContainer{
-		ProviderID: cloudContainer.ProviderID,
-		Ports:      cloudContainer.Ports,
+func makeK8sPodArg(unitName coreunit.Name, k8sPod application.K8sPodParams) *application.K8sPod {
+	result := &application.K8sPod{
+		ProviderID: k8sPod.ProviderID,
+		Ports:      k8sPod.Ports,
 	}
-	if cloudContainer.Address != nil {
-		// TODO(units) - handle the cloudContainer.Address space ID
+	if k8sPod.Address != nil {
+		// TODO(units) - handle the k8sPod.Address space ID
 		// For k8s we'll initially create a /32 subnet off the container address
 		// and add that to the default space.
-		result.Address = &application.ContainerAddress{
-			// For cloud containers, the device is a placeholder without
+		result.Address = &application.K8sPodAddress{
+			// For k8s pods, the device is a placeholder without
 			// a MAC address and once inserted, not updated. It just exists
 			// to tie the address to the net node corresponding to the
-			// cloud container.
-			Device: application.ContainerDevice{
-				Name:              fmt.Sprintf("placeholder for %q cloud container", unitName),
+			// k8s pod.
+			Device: application.K8sPodDevice{
+				Name:              fmt.Sprintf("placeholder for %q k8s pod", unitName),
 				DeviceTypeID:      domainnetwork.DeviceTypeUnknown,
 				VirtualPortTypeID: domainnetwork.NonVirtualPortType,
 			},
-			Value:       cloudContainer.Address.Value,
-			AddressType: ipaddress.MarshallAddressType(cloudContainer.Address.AddressType()),
+			Value:       k8sPod.Address.Value,
+			AddressType: ipaddress.MarshallAddressType(k8sPod.Address.AddressType()),
 			// The k8s container must have the lowest scope. This is needed to
 			// ensure that these are correctly matched with respect to k8s
 			// service addresses when retrieving unit public/private addresses.
@@ -832,8 +832,8 @@ func makeCloudContainerArg(unitName coreunit.Name, cloudContainer application.Cl
 			Origin:     ipaddress.MarshallOrigin(network.OriginProvider),
 			ConfigType: ipaddress.MarshallConfigType(network.ConfigDHCP),
 		}
-		if cloudContainer.AddressOrigin != nil {
-			result.Address.Origin = ipaddress.MarshallOrigin(*cloudContainer.AddressOrigin)
+		if k8sPod.AddressOrigin != nil {
+			result.Address.Origin = ipaddress.MarshallOrigin(*k8sPod.AddressOrigin)
 		}
 	}
 	return result
@@ -850,17 +850,17 @@ func (st *State) RegisterCAASUnit(ctx context.Context, appName string, arg appli
 		return errors.Capture(err)
 	}
 
-	cloudContainerParams := application.CloudContainerParams{
+	k8sPodParams := application.K8sPodParams{
 		ProviderID: arg.ProviderID,
 		Ports:      arg.Ports,
 	}
 	if arg.Address != nil {
 		addr := network.NewSpaceAddress(*arg.Address, network.WithScope(network.ScopeMachineLocal))
-		cloudContainerParams.Address = &addr
+		k8sPodParams.Address = &addr
 		origin := network.OriginProvider
-		cloudContainerParams.AddressOrigin = &origin
+		k8sPodParams.AddressOrigin = &origin
 	}
-	cloudContainer := makeCloudContainerArg(arg.UnitName, cloudContainerParams)
+	k8sPod := makeK8sPodArg(arg.UnitName, k8sPodParams)
 
 	now := new(st.clock.Now().UTC())
 	addUnitArg := application.AddCAASUnitArg{
@@ -880,8 +880,8 @@ func (st *State) RegisterCAASUnit(ctx context.Context, appName string, arg appli
 				},
 			},
 		},
-		CloudContainer: cloudContainer,
-		FQDN:           arg.FQDN,
+		K8sPod: k8sPod,
+		FQDN:   arg.FQDN,
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -933,15 +933,15 @@ func (st *State) RegisterCAASUnit(ctx context.Context, appName string, arg appli
 			return errors.Errorf("dead unit %q already exists", arg.UnitName).Add(applicationerrors.UnitAlreadyExists)
 		}
 
-		// Unit already exists and is not dead. Update the cloud container.
+		// Unit already exists and is not dead. Update the k8s pod.
 		toUpdate, err := st.getUnitDetails(ctx, tx, arg.UnitName.String())
 		if err != nil {
 			return errors.Capture(err)
 		}
 
-		err = st.upsertUnitCloudContainer(ctx, tx, toUpdate.Name, toUpdate.UnitUUID, toUpdate.NetNodeID, cloudContainer)
+		err = st.upsertUnitK8sPod(ctx, tx, toUpdate.Name, toUpdate.UnitUUID, toUpdate.NetNodeID, k8sPod)
 		if err != nil {
-			return errors.Errorf("updating cloud container for unit %q: %w", arg.UnitName, err)
+			return errors.Errorf("updating k8s pod for unit %q: %w", arg.UnitName, err)
 		}
 
 		err = st.setFilesystemProviderIDs(ctx, tx, arg.FilesystemProviderIDs)
@@ -1042,12 +1042,12 @@ func (st *State) insertCAASUnitWithName(
 	unitUUID := args.UnitUUID.String()
 
 	err := st.insertUnit(ctx, tx, appUUID, unitUUID, args.NetNodeUUID.String(), insertUnitArg{
-		CharmUUID:      charmUUID,
-		UnitName:       unitName,
-		CloudContainer: args.CloudContainer,
-		Constraints:    args.Constraints,
-		UnitStatusArg:  args.UnitStatusArg,
-		FQDN:           args.FQDN,
+		CharmUUID:     charmUUID,
+		UnitName:      unitName,
+		K8sPod:        args.K8sPod,
+		Constraints:   args.Constraints,
+		UnitStatusArg: args.UnitStatusArg,
+		FQDN:          args.FQDN,
 	})
 	if err != nil {
 		return "", errors.Errorf("inserting unit for CAAS application %q: %w", appUUID, err)
@@ -1131,7 +1131,7 @@ func (st *State) insertCAASUnitWithName(
 	return unitUUID, nil
 }
 
-// UpdateCAASUnit updates the cloud container for specified unit,
+// UpdateCAASUnit updates the k8s pod for specified unit,
 // returning an error satisfying [applicationerrors.UnitNotFoundError]
 // if the unit doesn't exist.
 func (st *State) UpdateCAASUnit(ctx context.Context, unitName coreunit.Name, params application.UpdateCAASUnitParams) error {
@@ -1140,19 +1140,19 @@ func (st *State) UpdateCAASUnit(ctx context.Context, unitName coreunit.Name, par
 		return errors.Capture(err)
 	}
 
-	var cloudContainer *application.CloudContainer
+	var k8sPod *application.K8sPod
 	if params.ProviderID != nil {
-		cloudContainerParams := application.CloudContainerParams{
+		k8sPodParams := application.K8sPodParams{
 			ProviderID: *params.ProviderID,
 			Ports:      params.Ports,
 		}
 		if params.Address != nil {
 			addr := network.NewSpaceAddress(*params.Address, network.WithScope(network.ScopeMachineLocal))
-			cloudContainerParams.Address = &addr
+			k8sPodParams.Address = &addr
 			origin := network.OriginProvider
-			cloudContainerParams.AddressOrigin = &origin
+			k8sPodParams.AddressOrigin = &origin
 		}
-		cloudContainer = makeCloudContainerArg(unitName, cloudContainerParams)
+		k8sPod = makeK8sPodArg(unitName, k8sPodParams)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -1161,10 +1161,10 @@ func (st *State) UpdateCAASUnit(ctx context.Context, unitName coreunit.Name, par
 			return errors.Errorf("getting unit %q: %w", unitName, err)
 		}
 
-		if cloudContainer != nil {
-			err = st.upsertUnitCloudContainer(ctx, tx, toUpdate.Name, toUpdate.UnitUUID, toUpdate.NetNodeID, cloudContainer)
+		if k8sPod != nil {
+			err = st.upsertUnitK8sPod(ctx, tx, toUpdate.Name, toUpdate.UnitUUID, toUpdate.NetNodeID, k8sPod)
 			if err != nil {
-				return errors.Errorf("updating cloud container for unit %q: %w", unitName, err)
+				return errors.Errorf("updating k8s pod for unit %q: %w", unitName, err)
 			}
 		}
 
@@ -1881,12 +1881,12 @@ WHERE  unit_uuid = $unitWorkloadVersion.unit_uuid
 	return version.Version, nil
 }
 
-// GetAllUnitCloudContainerIDsForApplication returns a map of the unit names
-// and their cloud container provider IDs for the given application.
+// GetAllUnitK8sPodIDsForApplication returns a map of the unit names
+// and their k8s pod provider IDs for the given application.
 //   - If the application is dead, [applicationerrors.ApplicationIsDead] is returned.
 //   - If the application is not found, [applicationerrors.ApplicationNotFound]
 //     is returned.
-func (st *State) GetAllUnitCloudContainerIDsForApplication(
+func (st *State) GetAllUnitK8sPodIDsForApplication(
 	ctx context.Context,
 	appUUID coreapplication.UUID,
 ) (map[coreunit.Name]string, error) {
@@ -1897,17 +1897,17 @@ func (st *State) GetAllUnitCloudContainerIDsForApplication(
 
 	input := entityUUID{UUID: appUUID.String()}
 	query := `
-SELECT (u.name, kp.provider_id) AS (&unitNameCloudContainer.*)
+SELECT (u.name, kp.provider_id) AS (&unitNameK8sPod.*)
 FROM unit u
 JOIN k8s_pod kp ON u.uuid = kp.unit_uuid
 WHERE u.application_uuid = $entityUUID.uuid
 `
-	stmt, err := st.Prepare(query, unitNameCloudContainer{}, input)
+	stmt, err := st.Prepare(query, unitNameK8sPod{}, input)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	var result []unitNameCloudContainer
+	var result []unitNameK8sPod
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := st.checkApplicationNotDead(ctx, tx, appUUID)
 		if err != nil {

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -140,13 +140,13 @@ WHERE u.name=?`,
 	c.Assert(gotPorts, tc.SameContents, ports)
 }
 
-func (s *unitStateSuite) TestUpdateCAASUnitCloudContainer(c *tc.C) {
+func (s *unitStateSuite) TestUpdateCAASUnitK8sPod(c *tc.C) {
 	u := application.AddCAASUnitArg{
-		CloudContainer: &application.CloudContainer{
+		K8sPod: &application.K8sPod{
 			ProviderID: "some-id",
 			Ports:      new([]string{"666", "668"}),
-			Address: new(application.ContainerAddress{
-				Device: application.ContainerDevice{
+			Address: new(application.K8sPodAddress{
+				Device: application.K8sPodDevice{
 					Name:              "placeholder",
 					DeviceTypeID:      domainnetwork.DeviceTypeUnknown,
 					VirtualPortTypeID: domainnetwork.NonVirtualPortType,
@@ -1669,10 +1669,10 @@ func (s *unitStateSuite) TestGetUnitsK8sPodInfo(c *tc.C) {
 			UnitUUID:    tc.Must(c, coreunit.NewUUID),
 			NetNodeUUID: tc.Must(c, domainnetwork.NewNetNodeUUID),
 		},
-		CloudContainer: &application.CloudContainer{
+		K8sPod: &application.K8sPod{
 			ProviderID: "foo-id",
 			Ports:      new([]string{"666", "668"}),
-			Address: new(application.ContainerAddress{
+			Address: new(application.K8sPodAddress{
 				Value: "10.6.6.6/24",
 			}),
 		},
@@ -1686,10 +1686,10 @@ func (s *unitStateSuite) TestGetUnitsK8sPodInfo(c *tc.C) {
 			UnitUUID:    tc.Must(c, coreunit.NewUUID),
 			NetNodeUUID: tc.Must(c, domainnetwork.NewNetNodeUUID),
 		},
-		CloudContainer: &application.CloudContainer{
+		K8sPod: &application.K8sPod{
 			ProviderID: "bar-id",
 			Ports:      new([]string{"777"}),
-			Address: new(application.ContainerAddress{
+			Address: new(application.K8sPodAddress{
 				Value: "10.6.6.7/24",
 			}),
 		},
@@ -1704,10 +1704,10 @@ func (s *unitStateSuite) TestGetUnitsK8sPodInfo(c *tc.C) {
 			UnitUUID:    tc.Must(c, coreunit.NewUUID),
 			NetNodeUUID: tc.Must(c, domainnetwork.NewNetNodeUUID),
 		},
-		CloudContainer: &application.CloudContainer{
+		K8sPod: &application.K8sPod{
 			ProviderID: "zoo-id",
 			Ports:      new([]string{"666", "668"}),
-			Address: new(application.ContainerAddress{
+			Address: new(application.K8sPodAddress{
 				Value: "10.6.6.8/24",
 			}),
 		},
@@ -1737,11 +1737,11 @@ func (s *unitStateSuite) TestGetUnitsK8sPodInfo(c *tc.C) {
 func (s *unitStateSuite) TestGetUnitK8sPodInfo(c *tc.C) {
 	// Arrange:
 	appUUID := s.createCAASApplication(c, "foo", life.Alive, application.AddCAASUnitArg{
-		CloudContainer: &application.CloudContainer{
+		K8sPod: &application.K8sPod{
 			ProviderID: "some-id",
 			Ports:      new([]string{"666", "668"}),
-			Address: new(application.ContainerAddress{
-				Device: application.ContainerDevice{
+			Address: new(application.K8sPodAddress{
+				Device: application.K8sPodDevice{
 					Name:              "placeholder",
 					DeviceTypeID:      domainnetwork.DeviceTypeUnknown,
 					VirtualPortTypeID: domainnetwork.NonVirtualPortType,
@@ -1904,24 +1904,24 @@ VALUES (?, ?, ?, 1)
 	c.Check(gotNetNodeUUID, tc.Equals, netNodeUUID)
 }
 
-func (s *unitStateSuite) GetAllUnitCloudContainerIDsForApplication(c *tc.C) {
+func (s *unitStateSuite) GetAllUnitK8sPodIDsForApplication(c *tc.C) {
 	appID := s.createCAASApplication(c, "foo", life.Alive, application.AddCAASUnitArg{
-		CloudContainer: &application.CloudContainer{
+		K8sPod: &application.K8sPod{
 			ProviderID: "a",
 		},
 	}, application.AddCAASUnitArg{
-		CloudContainer: &application.CloudContainer{
+		K8sPod: &application.K8sPod{
 			ProviderID: "b",
 		},
 	})
 
 	_ = s.createCAASApplication(c, "bar", life.Alive, application.AddCAASUnitArg{
-		CloudContainer: &application.CloudContainer{
+		K8sPod: &application.K8sPod{
 			ProviderID: "c",
 		},
 	})
 
-	result, err := s.state.GetAllUnitCloudContainerIDsForApplication(c.Context(), appID)
+	result, err := s.state.GetAllUnitK8sPodIDsForApplication(c.Context(), appID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(result, tc.DeepEquals, map[coreunit.Name]string{
 		"foo/0": "a",

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -338,6 +338,57 @@ func (s *unitStateSuite) TestRegisterCAASUnitDuplicateFQDN(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `.*fqdn address ".*" already exists.*`)
 }
 
+// TestUpdateCAASUnitSetsFQDN verifies that the FQDN supplied to UpdateCAASUnit
+// (the flow used at bootstrap for controller/0) is persisted as a local-cloud
+// fqdn_address row linked to the unit's net_node, in the same flow that upserts
+// the k8s pod. It is also idempotent across repeated updates.
+func (s *unitStateSuite) TestUpdateCAASUnitSetsFQDN(c *tc.C) {
+	u := application.AddCAASUnitArg{
+		K8sPod: &application.K8sPod{
+			ProviderID: "some-id",
+		},
+	}
+	appUUID := s.createCAASApplication(c, "foo", life.Alive, u)
+
+	unitNames, err := s.state.GetUnitNamesForApplication(c.Context(), appUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	fqdn := "controller-0.controller-service-endpoints.controller-foo.svc.cluster.local"
+	params := application.UpdateCAASUnitParams{
+		ProviderID: new("some-id"),
+		FQDN:       &fqdn,
+	}
+	err = s.state.UpdateCAASUnit(c.Context(), unitNames[0], params)
+	c.Assert(err, tc.ErrorIsNil)
+
+	assertFQDN := func() {
+		var (
+			gotAddress string
+			gotScopeID int
+			gotCount   int
+		)
+		err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			return tx.QueryRowContext(ctx, `
+SELECT fa.address, fa.scope_id, count(*)
+FROM   fqdn_address AS fa
+JOIN   net_node_fqdn_address AS nnfa ON nnfa.address_uuid = fa.uuid
+JOIN   unit AS un ON un.net_node_uuid = nnfa.net_node_uuid
+WHERE  un.name = ?`, unitNames[0].String()).Scan(&gotAddress, &gotScopeID, &gotCount)
+		})
+		c.Assert(err, tc.ErrorIsNil)
+		c.Check(gotAddress, tc.Equals, fqdn)
+		c.Check(gotScopeID, tc.Equals, 1)
+		c.Check(gotCount, tc.Equals, 1)
+	}
+	assertFQDN()
+
+	// A repeated update with the same FQDN is a no-op (the k8s pod is upserted
+	// again) rather than an error.
+	err = s.state.UpdateCAASUnit(c.Context(), unitNames[0], params)
+	c.Assert(err, tc.ErrorIsNil)
+	assertFQDN()
+}
+
 func (s *unitStateSuite) TestRegisterCAASUnitErrorNotScaling(c *tc.C) {
 	s.createCAASScalingApplication(c, "foo", life.Alive, 1)
 

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -259,6 +259,85 @@ func (s *unitStateSuite) TestRegisterCAASUnit(c *tc.C) {
 	s.assertCAASUnit(c, "bar/0", "passwordhash", "10.6.6.6/8", []string{"0"})
 }
 
+func (s *unitStateSuite) TestRegisterCAASUnitWithFQDN(c *tc.C) {
+	s.createCAASScalingApplication(c, "bar", life.Alive, 1)
+
+	// Allow scaling.
+	err := s.state.SetApplicationScalingState(c.Context(), "bar", 1, true)
+	c.Assert(err, tc.ErrorIsNil)
+
+	fqdn := "controller-0.controller-service-endpoints.controller-foo.svc.cluster.local"
+	p := application.RegisterCAASUnitArg{
+		UnitUUID:     tc.Must(c, coreunit.NewUUID),
+		UnitName:     "bar/0",
+		PasswordHash: "passwordhash",
+		ProviderID:   "some-id",
+		Address:      new("10.6.6.6/8"),
+		Ports:        new([]string{"0"}),
+		OrderedScale: true,
+		OrderedId:    0,
+		FQDN:         &fqdn,
+	}
+	err = s.state.RegisterCAASUnit(c.Context(), "bar", p)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The FQDN is persisted as a local-cloud fqdn_address row linked to the
+	// unit's net_node.
+	var (
+		gotAddress string
+		gotScopeID int
+		gotLinked  bool
+	)
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+SELECT fa.address, fa.scope_id, 1
+FROM   fqdn_address AS fa
+JOIN   net_node_fqdn_address AS nnfa ON nnfa.address_uuid = fa.uuid
+JOIN   unit AS u ON u.net_node_uuid = nnfa.net_node_uuid
+WHERE  u.name = ?`, "bar/0").Scan(&gotAddress, &gotScopeID, &gotLinked)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotAddress, tc.Equals, fqdn)
+	c.Check(gotScopeID, tc.Equals, 1)
+	c.Check(gotLinked, tc.IsTrue)
+}
+
+// TestRegisterCAASUnitDuplicateFQDN verifies that persisting a unit FQDN that
+// collides with an existing fqdn_address (globally unique) is surfaced as an
+// error rather than silently reused: a given FQDN identifies exactly one unit.
+func (s *unitStateSuite) TestRegisterCAASUnitDuplicateFQDN(c *tc.C) {
+	s.createCAASScalingApplication(c, "bar", life.Alive, 1)
+
+	err := s.state.SetApplicationScalingState(c.Context(), "bar", 1, true)
+	c.Assert(err, tc.ErrorIsNil)
+
+	fqdn := "controller-0.controller-service-endpoints.controller-foo.svc.cluster.local"
+
+	// Seed a pre-existing fqdn_address row with the same address.
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			"INSERT INTO fqdn_address (uuid, address, scope_id) VALUES (?, ?, ?)",
+			"existing-fqdn-uuid", fqdn, 1,
+		)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	p := application.RegisterCAASUnitArg{
+		UnitUUID:     tc.Must(c, coreunit.NewUUID),
+		UnitName:     "bar/0",
+		PasswordHash: "passwordhash",
+		ProviderID:   "some-id",
+		Address:      new("10.6.6.6/8"),
+		Ports:        new([]string{"0"}),
+		OrderedScale: true,
+		OrderedId:    0,
+		FQDN:         &fqdn,
+	}
+	err = s.state.RegisterCAASUnit(c.Context(), "bar", p)
+	c.Assert(err, tc.ErrorMatches, `.*fqdn address ".*" already exists.*`)
+}
+
 func (s *unitStateSuite) TestRegisterCAASUnitErrorNotScaling(c *tc.C) {
 	s.createCAASScalingApplication(c, "foo", life.Alive, 1)
 

--- a/domain/application/state/unitstate.go
+++ b/domain/application/state/unitstate.go
@@ -191,7 +191,6 @@ type insertUnitArg struct {
 	Password        *application.PasswordInfo
 	Constraints     constraints.Constraints
 	WorkloadVersion string
-	FQDN            *string
 }
 
 // insertUnit inserts a unit into state. IAAS or CAAS specific details
@@ -251,11 +250,6 @@ func (st *State) insertUnit(
 	if args.K8sPod != nil {
 		if err := st.upsertUnitK8sPod(ctx, tx, args.UnitName, unitUUID, netNodeUUID, args.K8sPod); err != nil {
 			return errors.Errorf("creating k8s pod for unit %q: %w", args.UnitName, err)
-		}
-	}
-	if args.FQDN != nil && *args.FQDN != "" {
-		if err := st.insertNetNodeFQDNAddress(ctx, tx, netNodeUUID, *args.FQDN); err != nil {
-			return errors.Errorf("creating fqdn address for unit %q: %w", args.UnitName, err)
 		}
 	}
 	if err := st.setUnitAgentStatus(ctx, tx, unitUUID, args.AgentStatus); err != nil {
@@ -426,6 +420,11 @@ WHERE unit_uuid = $k8sPod.unit_uuid
 			return errors.Errorf("updating k8s pod ports for unit %q: %w", unitName, err)
 		}
 	}
+	if cc.FQDN != nil && *cc.FQDN != "" {
+		if err := st.ensureNetNodeFQDNAddress(ctx, tx, netNodeUUID, *cc.FQDN, cc.FQDNScope); err != nil {
+			return errors.Errorf("creating fqdn address for unit %q: %w", unitName, err)
+		}
+	}
 	return nil
 }
 
@@ -547,21 +546,29 @@ ON CONFLICT(uuid) DO UPDATE SET
 	return nil
 }
 
-// networkAddressScopeLocalCloud is the network_address_scope id for the
-// "local-cloud" scope. NOTE: this is the network_address_scope lookup table
-// (fqdn_address/hostname_address), which is distinct from the ip_address_scope
-// table used by ip_address. In network_address_scope: local-host=0,
-// local-cloud=1, public=2. The fqdn_address CHECK constraint forbids
-// local-host (0).
-const networkAddressScopeLocalCloud = 1
+// ensureNetNodeFQDNAddress idempotently persists the given FQDN as an
+// fqdn_address row with the supplied network_address_scope id and links it to
+// the given net_node via the net_node_fqdn_address junction.
+func (st *State) ensureNetNodeFQDNAddress(ctx context.Context, tx *sqlair.TX, netNodeUUID, address string, scopeID int) error {
+	// If this net_node already has this FQDN, there is nothing to do.
+	lookup := netNodeFQDNAddress{NetNodeUUID: netNodeUUID}
+	addrIn := fqdnAddress{Address: address}
+	existsStmt, err := st.Prepare(`
+SELECT fa.uuid AS &netNodeFQDNAddress.address_uuid
+FROM   fqdn_address AS fa
+JOIN   net_node_fqdn_address AS nnfa ON nnfa.address_uuid = fa.uuid
+WHERE  fa.address = $fqdnAddress.address
+AND    nnfa.net_node_uuid = $netNodeFQDNAddress.net_node_uuid`, addrIn, lookup)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	err = tx.Query(ctx, existsStmt, addrIn, lookup).Get(&lookup)
+	if err == nil {
+		return nil
+	} else if !errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Errorf("looking up fqdn address %q: %w", address, err)
+	}
 
-// insertNetNodeFQDNAddress persists the given FQDN as an fqdn_address row
-// (scope local-cloud) and links it to the supplied net_node via the
-// net_node_fqdn_address junction. fqdn_address.address is globally unique: a
-// given FQDN identifies exactly one unit, so a collision on insert indicates a
-// stale/orphaned row or a bug and is surfaced as an error rather than silently
-// reused. The net_node must already exist.
-func (st *State) insertNetNodeFQDNAddress(ctx context.Context, tx *sqlair.TX, netNodeUUID, address string) error {
 	addrUUID, err := uuid.NewUUID()
 	if err != nil {
 		return errors.Capture(err)
@@ -569,7 +576,7 @@ func (st *State) insertNetNodeFQDNAddress(ctx context.Context, tx *sqlair.TX, ne
 	fqdnAddr := fqdnAddress{
 		UUID:    addrUUID.String(),
 		Address: address,
-		ScopeID: networkAddressScopeLocalCloud,
+		ScopeID: scopeID,
 	}
 
 	insertStmt, err := st.Prepare(`

--- a/domain/application/state/unitstate.go
+++ b/domain/application/state/unitstate.go
@@ -183,13 +183,15 @@ func (st *State) InsertIAASUnit(
 }
 
 type insertUnitArg struct {
+	application.UnitStatusArg
+
 	CharmUUID       string
 	UnitName        string
 	CloudContainer  *application.CloudContainer
 	Password        *application.PasswordInfo
 	Constraints     constraints.Constraints
 	WorkloadVersion string
-	application.UnitStatusArg
+	FQDN            *string
 }
 
 // insertUnit inserts a unit into state. IAAS or CAAS specific details
@@ -249,6 +251,11 @@ func (st *State) insertUnit(
 	if args.CloudContainer != nil {
 		if err := st.upsertUnitCloudContainer(ctx, tx, args.UnitName, unitUUID, netNodeUUID, args.CloudContainer); err != nil {
 			return errors.Errorf("creating cloud container for unit %q: %w", args.UnitName, err)
+		}
+	}
+	if args.FQDN != nil && *args.FQDN != "" {
+		if err := st.insertNetNodeFQDNAddress(ctx, tx, netNodeUUID, *args.FQDN); err != nil {
+			return errors.Errorf("creating fqdn address for unit %q: %w", args.UnitName, err)
 		}
 	}
 	if err := st.setUnitAgentStatus(ctx, tx, unitUUID, args.AgentStatus); err != nil {
@@ -536,6 +543,57 @@ ON CONFLICT(uuid) DO UPDATE SET
 	// Update the address values.
 	if err = tx.Query(ctx, upsertAddressStmt, ipAddr).Run(); err != nil {
 		return errors.Errorf("updating cloud container address attributes for device %q: %w", deviceUUID, err)
+	}
+	return nil
+}
+
+// networkAddressScopeLocalCloud is the network_address_scope id for the
+// "local-cloud" scope. NOTE: this is the network_address_scope lookup table
+// (fqdn_address/hostname_address), which is distinct from the ip_address_scope
+// table used by ip_address. In network_address_scope: local-host=0,
+// local-cloud=1, public=2. The fqdn_address CHECK constraint forbids
+// local-host (0).
+const networkAddressScopeLocalCloud = 1
+
+// insertNetNodeFQDNAddress persists the given FQDN as an fqdn_address row
+// (scope local-cloud) and links it to the supplied net_node via the
+// net_node_fqdn_address junction. fqdn_address.address is globally unique: a
+// given FQDN identifies exactly one unit, so a collision on insert indicates a
+// stale/orphaned row or a bug and is surfaced as an error rather than silently
+// reused. The net_node must already exist.
+func (st *State) insertNetNodeFQDNAddress(ctx context.Context, tx *sqlair.TX, netNodeUUID, address string) error {
+	addrUUID, err := uuid.NewUUID()
+	if err != nil {
+		return errors.Capture(err)
+	}
+	fqdnAddr := fqdnAddress{
+		UUID:    addrUUID.String(),
+		Address: address,
+		ScopeID: networkAddressScopeLocalCloud,
+	}
+
+	insertStmt, err := st.Prepare(`
+INSERT INTO fqdn_address (*) VALUES ($fqdnAddress.*)`, fqdnAddr)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if err := tx.Query(ctx, insertStmt, fqdnAddr).Run(); internaldatabase.IsErrConstraintUnique(err) {
+		return errors.Errorf("fqdn address %q already exists", address)
+	} else if err != nil {
+		return errors.Errorf("inserting fqdn address %q: %w", address, err)
+	}
+
+	junction := netNodeFQDNAddress{
+		NetNodeUUID: netNodeUUID,
+		AddressUUID: fqdnAddr.UUID,
+	}
+	linkStmt, err := st.Prepare(`
+INSERT INTO net_node_fqdn_address (*) VALUES ($netNodeFQDNAddress.*)`, junction)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if err := tx.Query(ctx, linkStmt, junction).Run(); err != nil {
+		return errors.Errorf("linking fqdn address %q to net node %q: %w", address, netNodeUUID, err)
 	}
 	return nil
 }

--- a/domain/application/state/unitstate.go
+++ b/domain/application/state/unitstate.go
@@ -187,7 +187,7 @@ type insertUnitArg struct {
 
 	CharmUUID       string
 	UnitName        string
-	CloudContainer  *application.CloudContainer
+	K8sPod          *application.K8sPod
 	Password        *application.PasswordInfo
 	Constraints     constraints.Constraints
 	WorkloadVersion string
@@ -195,7 +195,7 @@ type insertUnitArg struct {
 }
 
 // insertUnit inserts a unit into state. IAAS or CAAS specific details
-// are handled by the callers, modulo CloudContainer functionality.
+// are handled by the callers, modulo K8sPod functionality.
 func (st *State) insertUnit(
 	ctx context.Context, tx *sqlair.TX,
 	appUUID, unitUUID, netNodeUUID string,
@@ -245,12 +245,12 @@ func (st *State) insertUnit(
 		return errors.Errorf("creating unit for unit %q: %w", args.UnitName, err)
 	}
 	// TODO (hml) 8-Dec-2025
-	// CloudContainer is specific to CAAS units. The callers should handle
+	// K8sPod is specific to CAAS units. The callers should handle
 	// this after insertUnit when a CAAS unit is created, not inside the
 	// generic add unit method.
-	if args.CloudContainer != nil {
-		if err := st.upsertUnitCloudContainer(ctx, tx, args.UnitName, unitUUID, netNodeUUID, args.CloudContainer); err != nil {
-			return errors.Errorf("creating cloud container for unit %q: %w", args.UnitName, err)
+	if args.K8sPod != nil {
+		if err := st.upsertUnitK8sPod(ctx, tx, args.UnitName, unitUUID, netNodeUUID, args.K8sPod); err != nil {
+			return errors.Errorf("creating k8s pod for unit %q: %w", args.UnitName, err)
 		}
 	}
 	if args.FQDN != nil && *args.FQDN != "" {
@@ -359,28 +359,28 @@ func (st *State) newUnitName(
 	return unitName.String(), errors.Capture(err)
 }
 
-func (st *State) upsertUnitCloudContainer(
+func (st *State) upsertUnitK8sPod(
 	ctx context.Context,
 	tx *sqlair.TX,
 	unitName, unitUUID, netNodeUUID string,
-	cc *application.CloudContainer,
+	cc *application.K8sPod,
 ) error {
-	containerInfo := cloudContainer{
+	containerInfo := k8sPod{
 		UnitUUID:   unitUUID,
 		ProviderID: cc.ProviderID,
 	}
 
 	queryStmt, err := st.Prepare(`
-SELECT &cloudContainer.*
+SELECT &k8sPod.*
 FROM k8s_pod
-WHERE unit_uuid = $cloudContainer.unit_uuid
+WHERE unit_uuid = $k8sPod.unit_uuid
 `, containerInfo)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	insertStmt, err := st.Prepare(`
-INSERT INTO k8s_pod (*) VALUES ($cloudContainer.*)
+INSERT INTO k8s_pod (*) VALUES ($k8sPod.*)
 `, containerInfo)
 	if err != nil {
 		return errors.Capture(err)
@@ -388,8 +388,8 @@ INSERT INTO k8s_pod (*) VALUES ($cloudContainer.*)
 
 	updateStmt, err := st.Prepare(`
 UPDATE k8s_pod SET
-    provider_id = $cloudContainer.provider_id
-WHERE unit_uuid = $cloudContainer.unit_uuid
+    provider_id = $k8sPod.provider_id
+WHERE unit_uuid = $k8sPod.unit_uuid
 `, containerInfo)
 	if err != nil {
 		return errors.Capture(err)
@@ -397,7 +397,7 @@ WHERE unit_uuid = $cloudContainer.unit_uuid
 
 	err = tx.Query(ctx, queryStmt, containerInfo).Get(&containerInfo)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return errors.Errorf("looking up cloud container %q: %w", unitName, err)
+		return errors.Errorf("looking up k8s pod %q: %w", unitName, err)
 	}
 	if err == nil {
 		newProviderID := cc.ProviderID
@@ -408,73 +408,73 @@ WHERE unit_uuid = $cloudContainer.unit_uuid
 		}
 		containerInfo.ProviderID = newProviderID
 		if err := tx.Query(ctx, updateStmt, containerInfo).Run(); err != nil {
-			return errors.Errorf("updating cloud container for unit %q: %w", unitName, err)
+			return errors.Errorf("updating k8s pod for unit %q: %w", unitName, err)
 		}
 	} else {
 		if err := tx.Query(ctx, insertStmt, containerInfo).Run(); err != nil {
-			return errors.Errorf("inserting cloud container for unit %q: %w", unitName, err)
+			return errors.Errorf("inserting k8s pod for unit %q: %w", unitName, err)
 		}
 	}
 
 	if cc.Address != nil {
-		if err := st.upsertCloudContainerAddress(ctx, tx, unitName, netNodeUUID, *cc.Address); err != nil {
-			return errors.Errorf("updating cloud container address for unit %q: %w", unitName, err)
+		if err := st.upsertK8sPodAddress(ctx, tx, unitName, netNodeUUID, *cc.Address); err != nil {
+			return errors.Errorf("updating k8s pod address for unit %q: %w", unitName, err)
 		}
 	}
 	if cc.Ports != nil {
-		if err := st.upsertCloudContainerPorts(ctx, tx, unitUUID, *cc.Ports); err != nil {
-			return errors.Errorf("updating cloud container ports for unit %q: %w", unitName, err)
+		if err := st.upsertK8sPodPorts(ctx, tx, unitUUID, *cc.Ports); err != nil {
+			return errors.Errorf("updating k8s pod ports for unit %q: %w", unitName, err)
 		}
 	}
 	return nil
 }
 
-func (st *State) upsertCloudContainerAddress(
-	ctx context.Context, tx *sqlair.TX, unitName, netNodeUUID string, address application.ContainerAddress,
+func (st *State) upsertK8sPodAddress(
+	ctx context.Context, tx *sqlair.TX, unitName, netNodeUUID string, address application.K8sPodAddress,
 ) error {
 	// First ensure the address link layer device is upserted.
-	// For cloud containers, the device is a placeholder without
+	// For k8s pods, the device is a placeholder without
 	// a MAC address. It just exits to tie the address to the
-	// net node corresponding to the cloud container.
-	cloudContainerDeviceInfo := cloudContainerDevice{
+	// net node corresponding to the k8s pod.
+	k8sPodDeviceInfo := k8sPodDevice{
 		Name:              address.Device.Name,
 		NetNodeID:         netNodeUUID,
 		DeviceTypeID:      int(address.Device.DeviceTypeID),
 		VirtualPortTypeID: int(address.Device.VirtualPortTypeID),
 	}
 
-	selectCloudContainerDeviceStmt, err := st.Prepare(`
-SELECT &cloudContainerDevice.uuid
+	selectK8sPodDeviceStmt, err := st.Prepare(`
+SELECT &k8sPodDevice.uuid
 FROM link_layer_device
-WHERE net_node_uuid = $cloudContainerDevice.net_node_uuid
-`, cloudContainerDeviceInfo)
+WHERE net_node_uuid = $k8sPodDevice.net_node_uuid
+`, k8sPodDeviceInfo)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
-	insertCloudContainerDeviceStmt, err := st.Prepare(`
-INSERT INTO link_layer_device (*) VALUES ($cloudContainerDevice.*)
-`, cloudContainerDeviceInfo)
+	insertK8sPodDeviceStmt, err := st.Prepare(`
+INSERT INTO link_layer_device (*) VALUES ($k8sPodDevice.*)
+`, k8sPodDeviceInfo)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	// See if the link layer device exists, if not insert it.
-	err = tx.Query(ctx, selectCloudContainerDeviceStmt, cloudContainerDeviceInfo).Get(&cloudContainerDeviceInfo)
+	err = tx.Query(ctx, selectK8sPodDeviceStmt, k8sPodDeviceInfo).Get(&k8sPodDeviceInfo)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return errors.Errorf("querying cloud container link layer device for unit %q: %w", unitName, err)
+		return errors.Errorf("querying k8s pod link layer device for unit %q: %w", unitName, err)
 	}
 	if errors.Is(err, sqlair.ErrNoRows) {
 		deviceUUID, err := uuid.NewUUID()
 		if err != nil {
 			return errors.Capture(err)
 		}
-		cloudContainerDeviceInfo.UUID = deviceUUID.String()
-		if err := tx.Query(ctx, insertCloudContainerDeviceStmt, cloudContainerDeviceInfo).Run(); err != nil {
-			return errors.Errorf("inserting cloud container device for unit %q: %w", unitName, err)
+		k8sPodDeviceInfo.UUID = deviceUUID.String()
+		if err := tx.Query(ctx, insertK8sPodDeviceStmt, k8sPodDeviceInfo).Run(); err != nil {
+			return errors.Errorf("inserting k8s pod device for unit %q: %w", unitName, err)
 		}
 	}
-	deviceUUID := cloudContainerDeviceInfo.UUID
+	deviceUUID := k8sPodDeviceInfo.UUID
 
 	subnetUUIDs, err := st.k8sSubnetUUIDsByAddressType(ctx, tx)
 	if err != nil {
@@ -528,7 +528,7 @@ ON CONFLICT(uuid) DO UPDATE SET
 	// First see if there's an existing address recorded.
 	err = tx.Query(ctx, selectAddressUUIDStmt, ipAddr).Get(&ipAddr)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return errors.Errorf("querying existing cloud container address for device %q: %w", deviceUUID, err)
+		return errors.Errorf("querying existing k8s pod address for device %q: %w", deviceUUID, err)
 	}
 
 	// Create a UUID for new addresses.
@@ -542,7 +542,7 @@ ON CONFLICT(uuid) DO UPDATE SET
 
 	// Update the address values.
 	if err = tx.Query(ctx, upsertAddressStmt, ipAddr).Run(); err != nil {
-		return errors.Errorf("updating cloud container address attributes for device %q: %w", deviceUUID, err)
+		return errors.Errorf("updating k8s pod address attributes for device %q: %w", deviceUUID, err)
 	}
 	return nil
 }
@@ -598,7 +598,7 @@ INSERT INTO net_node_fqdn_address (*) VALUES ($netNodeFQDNAddress.*)`, junction)
 	return nil
 }
 
-func (st *State) upsertCloudContainerPorts(ctx context.Context, tx *sqlair.TX, unitUUID string, portValues []string) error {
+func (st *State) upsertK8sPodPorts(ctx context.Context, tx *sqlair.TX, unitUUID string, portValues []string) error {
 	type ports []string
 
 	ccPort := unitK8sPodPort{
@@ -624,13 +624,13 @@ DO NOTHING
 	}
 
 	if err := tx.Query(ctx, deleteStmt, ports(portValues), ccPort).Run(); err != nil {
-		return errors.Errorf("removing cloud container ports for %q: %w", unitUUID, err)
+		return errors.Errorf("removing k8s pod ports for %q: %w", unitUUID, err)
 	}
 
 	for _, port := range portValues {
 		ccPort.Port = port
 		if err := tx.Query(ctx, upsertStmt, ccPort).Run(); err != nil {
-			return errors.Errorf("updating cloud container ports for %q: %w", unitUUID, err)
+			return errors.Errorf("updating k8s pod ports for %q: %w", unitUUID, err)
 		}
 	}
 

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -193,6 +193,12 @@ type ContainerAddress struct {
 type AddCAASUnitArg struct {
 	AddUnitArg
 	CloudContainer *CloudContainer
+
+	// FQDN, when set, is the stable, cluster-resolvable per-pod DNS name to
+	// persist as the unit's network identity (an fqdn_address row linked to
+	// the unit's net_node). It is currently only supplied for controller
+	// units.
+	FQDN *string
 }
 
 // AddUnitArg contains parameters for adding a unit to state.
@@ -246,6 +252,11 @@ type RegisterCAASUnitArg struct {
 	NetNodeUUID  domainnetwork.NetNodeUUID
 	OrderedScale bool
 	OrderedId    int
+
+	// FQDN, when set, is the stable, cluster-resolvable per-pod DNS name to
+	// persist as the unit's network identity. It is currently only supplied
+	// for controller units.
+	FQDN *string
 
 	// RegisterUnitStorageArg contains parameters for creating storage and also
 	// attaching existing storage to the unit. Described as well is the set of

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -166,6 +166,17 @@ type K8sPod struct {
 	ProviderID string
 	Address    *K8sPodAddress
 	Ports      *[]string
+
+	// FQDN, when set, is the stable, cluster-resolvable per-pod DNS name to
+	// persist as the unit's network identity (an fqdn_address row linked to
+	// the unit's net_node). It is currently only supplied for controller
+	// units.
+	FQDN *string
+
+	// FQDNScope is the network_address_scope id to persist for FQDN. It is
+	// only meaningful when FQDN is set, and is defaulted in makeK8sPodArg
+	// alongside the pod address scope.
+	FQDNScope int
 }
 
 // K8sPodDevice is the placeholder link layer device
@@ -193,12 +204,6 @@ type K8sPodAddress struct {
 type AddCAASUnitArg struct {
 	AddUnitArg
 	K8sPod *K8sPod
-
-	// FQDN, when set, is the stable, cluster-resolvable per-pod DNS name to
-	// persist as the unit's network identity (an fqdn_address row linked to
-	// the unit's net_node). It is currently only supplied for controller
-	// units.
-	FQDN *string
 }
 
 // AddUnitArg contains parameters for adding a unit to state.
@@ -296,6 +301,11 @@ type UpdateCAASUnitParams struct {
 	AgentStatus    *status.StatusInfo[status.UnitAgentStatusType]
 	WorkloadStatus *status.StatusInfo[status.WorkloadStatusType]
 	K8sPodStatus   *status.StatusInfo[status.K8sPodStatusType]
+
+	// FQDN, when set, is the stable, cluster-resolvable per-pod DNS name to
+	// persist as the unit's network identity. It is currently only supplied
+	// for controller units.
+	FQDN *string
 }
 
 // K8sPodParams contains parameters for a unit k8s pod.
@@ -304,6 +314,11 @@ type K8sPodParams struct {
 	Address       *network.SpaceAddress
 	AddressOrigin *network.Origin
 	Ports         *[]string
+
+	// FQDN, when set, is the stable, cluster-resolvable per-pod DNS name to
+	// persist as the unit's network identity. It is currently only supplied
+	// for controller units.
+	FQDN *string
 }
 
 // CharmDownloadInfo contains parameters for downloading a charm.

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -161,27 +161,27 @@ type PasswordInfo struct {
 	HashAlgorithm int
 }
 
-// CloudContainer contains parameters for a unit's cloud container.
-type CloudContainer struct {
+// K8sPod contains parameters for a unit's k8s pod.
+type K8sPod struct {
 	ProviderID string
-	Address    *ContainerAddress
+	Address    *K8sPodAddress
 	Ports      *[]string
 }
 
-// ContainerDevice is the placeholder link layer device
-// used to tie the cloud container IP address to the container.
-type ContainerDevice struct {
+// K8sPodDevice is the placeholder link layer device
+// used to tie the k8s pod IP address to the pod.
+type K8sPodDevice struct {
 	Name              string
 	DeviceTypeID      domainnetwork.DeviceType
 	VirtualPortTypeID domainnetwork.VirtualPortType
 }
 
-// ContainerAddress contains parameters for a cloud container address.
-// Device is an attribute of address rather than cloud container
+// K8sPodAddress contains parameters for a k8s pod address.
+// Device is an attribute of address rather than k8s pod
 // since it's a placeholder used to tie the address to the
-// cloud container and is only needed if the address exists.
-type ContainerAddress struct {
-	Device      ContainerDevice
+// k8s pod and is only needed if the address exists.
+type K8sPodAddress struct {
+	Device      K8sPodDevice
 	Value       string
 	AddressType ipaddress.AddressType
 	Scope       ipaddress.Scope
@@ -192,7 +192,7 @@ type ContainerAddress struct {
 // AddCAASUnitArg contains parameters for adding a CAAS unit to state.
 type AddCAASUnitArg struct {
 	AddUnitArg
-	CloudContainer *CloudContainer
+	K8sPod *K8sPod
 
 	// FQDN, when set, is the stable, cluster-resolvable per-pod DNS name to
 	// persist as the unit's network identity (an fqdn_address row linked to
@@ -298,8 +298,8 @@ type UpdateCAASUnitParams struct {
 	K8sPodStatus   *status.StatusInfo[status.K8sPodStatusType]
 }
 
-// CloudContainerParams contains parameters for a unit cloud container.
-type CloudContainerParams struct {
+// K8sPodParams contains parameters for a unit k8s pod.
+type K8sPodParams struct {
 	ProviderID    string
 	Address       *network.SpaceAddress
 	AddressOrigin *network.Origin
@@ -425,7 +425,7 @@ type ImportIAASUnitArg struct {
 // ImportCAASUnitArg is used to import a CAAS unit.
 type ImportCAASUnitArg struct {
 	ImportUnitArg
-	CloudContainer *CloudContainer
+	K8sPod *K8sPod
 }
 
 // UnitAttributes contains parameters for exporting a unit.

--- a/domain/removal/state/model/remoteapplicationofferer.go
+++ b/domain/removal/state/model/remoteapplicationofferer.go
@@ -363,13 +363,6 @@ WHERE  a.uuid = $entityUUID.uuid
 		return errors.Capture(err)
 	}
 
-	deleteFqdnAddressStmt, err := st.Prepare(`
-DELETE FROM net_node_fqdn_address
-WHERE net_node_uuid IN ($uuids[:])`, uuids{})
-	if err != nil {
-		return errors.Capture(err)
-	}
-
 	deleteHostnameAddressStmt, err := st.Prepare(`
 DELETE FROM net_node_hostname_address
 WHERE net_node_uuid IN ($uuids[:])`, uuids{})
@@ -408,7 +401,7 @@ WHERE application_uuid = $entityUUID.uuid`, synthApp)
 
 	netNodeUUIDs := uuids(transform.Slice(netNodeEntityUUIDs, func(e entityUUID) string { return e.UUID }))
 
-	if err := tx.Query(ctx, deleteFqdnAddressStmt, netNodeUUIDs).Run(); err != nil {
+	if err := st.deleteNetNodesFQDNAddresses(ctx, tx, netNodeUUIDs); err != nil {
 		return errors.Errorf("deleting net node fqdn address for synth units: %w", err)
 	}
 
@@ -439,13 +432,6 @@ WHERE uuid = $entityUUID.uuid`, synthUnit)
 		return errors.Capture(err)
 	}
 
-	deleteFqdnAddressStmt, err := st.Prepare(`
-DELETE FROM net_node_fqdn_address
-WHERE net_node_uuid = $entityUUID.uuid`, entityUUID{})
-	if err != nil {
-		return errors.Capture(err)
-	}
-
 	deleteHostnameAddressStmt, err := st.Prepare(`
 DELETE FROM net_node_hostname_address
 WHERE net_node_uuid = $entityUUID.uuid`, entityUUID{})
@@ -470,7 +456,8 @@ WHERE uuid = $entityUUID.uuid`, entityUUID{})
 		return errors.Errorf("deleting synthetic unit: %w", err)
 	}
 
-	if err := tx.Query(ctx, deleteFqdnAddressStmt, netNode).Run(); err != nil {
+	// Delete the fqdn junction rows and any now-orphaned fqdn_address rows.
+	if err := st.deleteNetNodeFQDNAddresses(ctx, tx, netNode.UUID); err != nil {
 		return errors.Errorf("deleting net node fqdn address for synthetic unit: %w", err)
 	}
 

--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -735,6 +735,12 @@ WHERE  uuid = $entityUUID.uuid;`, unitUUIDRec)
 		return errors.Errorf("deleting cloud container for unit %q: %w", unitUUID, err)
 	}
 
+	if netNodeUUIDRec.UUID != "" {
+		if err := st.deleteNetNodeFQDNAddresses(ctx, tx, netNodeUUIDRec.UUID); err != nil {
+			return errors.Errorf("deleting fqdn addresses for unit %q: %w", unitUUID, err)
+		}
+	}
+
 	if err := st.deleteForeignKeyUnitReferences(ctx, tx, unitUUID); err != nil {
 		return errors.Errorf("deleting unit references for unit %q: %w", unitUUID, err)
 	}
@@ -854,6 +860,71 @@ WHERE net_node_uuid = $entityUUID.uuid`, netNodeIDRec)
 	}
 	if err := tx.Query(ctx, deleteDeviceStmt, netNodeIDRec).Run(); err != nil {
 		return errors.Errorf("removing cloud container link layer devices for %q: %w", netNodeID, err)
+	}
+	return nil
+}
+
+// deleteNetNodeFQDNAddresses deletes the net_node_fqdn_address junction rows
+// for the given net_node and then deletes any fqdn_address rows that are left
+// unreferenced. It is a thin wrapper over deleteNetNodesFQDNAddresses.
+func (st *State) deleteNetNodeFQDNAddresses(ctx context.Context, tx *sqlair.TX, netNodeID string) error {
+	return st.deleteNetNodesFQDNAddresses(ctx, tx, []string{netNodeID})
+}
+
+// deleteNetNodesFQDNAddresses deletes the net_node_fqdn_address junction rows
+// for the given net_nodes and then deletes any fqdn_address rows that are left
+// unreferenced. fqdn_address rows are globally unique and may be shared across
+// net_nodes (many-to-many), so only orphaned rows are removed. This prevents
+// stale fqdn_address rows from colliding with a deterministic FQDN on a later
+// re-creation of the same ordinal.
+func (st *State) deleteNetNodesFQDNAddresses(ctx context.Context, tx *sqlair.TX, netNodeIDs []string) error {
+	if len(netNodeIDs) == 0 {
+		return nil
+	}
+	netNodeUUIDs := uuids(netNodeIDs)
+
+	// Capture the address UUIDs linked to these net nodes before removing the
+	// junction rows.
+	selectAddressesStmt, err := st.Prepare(`
+SELECT   address_uuid AS &entityUUID.uuid
+FROM     net_node_fqdn_address
+WHERE    net_node_uuid IN ($uuids[:])`, entityUUID{}, netNodeUUIDs)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	deleteJunctionStmt, err := st.Prepare(`
+DELETE FROM net_node_fqdn_address
+WHERE net_node_uuid IN ($uuids[:])`, netNodeUUIDs)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	deleteOrphanStmt, err := st.Prepare(`
+WITH referenced AS (
+	SELECT nnfa.address_uuid AS uuid
+	FROM   net_node_fqdn_address AS nnfa
+)
+DELETE FROM fqdn_address
+WHERE uuid IN ($uuids[:])
+AND uuid NOT IN referenced`, uuids{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	var addressUUIDs entityUUIDs
+	if err := tx.Query(ctx, selectAddressesStmt, netNodeUUIDs).GetAll(&addressUUIDs); errors.Is(err, sqlair.ErrNoRows) {
+		return nil
+	} else if err != nil {
+		return errors.Errorf("getting fqdn addresses for net nodes: %w", err)
+	}
+
+	if err := tx.Query(ctx, deleteJunctionStmt, netNodeUUIDs).Run(); err != nil {
+		return errors.Errorf("removing fqdn address junctions: %w", err)
+	}
+
+	if err := tx.Query(ctx, deleteOrphanStmt, addressUUIDs.uuids()).Run(); err != nil {
+		return errors.Errorf("removing orphaned fqdn addresses: %w", err)
 	}
 	return nil
 }

--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -732,7 +732,7 @@ WHERE  uuid = $entityUUID.uuid;`, unitUUIDRec)
 	}
 
 	if err := st.deleteK8sPod(ctx, tx, unitUUID, netNodeUUIDRec.UUID); err != nil {
-		return errors.Errorf("deleting cloud container for unit %q: %w", unitUUID, err)
+		return errors.Errorf("deleting k8s pod for unit %q: %w", unitUUID, err)
 	}
 
 	if netNodeUUIDRec.UUID != "" {
@@ -815,11 +815,11 @@ WHERE  unit_uuid = $unitUUID.unit_uuid`, unitUUIDRec, entityAssociationCount{})
 	// Delete the k8s pod ports and addresses.
 
 	if err := st.deleteK8sPodPorts(ctx, tx, uUUID); err != nil {
-		return errors.Errorf("removing cloud container ports: %w", err)
+		return errors.Errorf("removing k8s pod ports: %w", err)
 	}
 
 	if err := st.deletedK8sPodAddresses(ctx, tx, netNodeUUID); err != nil {
-		return errors.Errorf("removing cloud container addresses: %w", err)
+		return errors.Errorf("removing k8s pod addresses: %w", err)
 	}
 
 	deleteK8sPodStmt, err := st.Prepare(`
@@ -856,10 +856,10 @@ WHERE net_node_uuid = $entityUUID.uuid`, netNodeIDRec)
 		return errors.Capture(err)
 	}
 	if err := tx.Query(ctx, deleteAddressStmt, netNodeIDRec).Run(); err != nil {
-		return errors.Errorf("removing cloud container addresses for %q: %w", netNodeID, err)
+		return errors.Errorf("removing k8s pod addresses for %q: %w", netNodeID, err)
 	}
 	if err := tx.Query(ctx, deleteDeviceStmt, netNodeIDRec).Run(); err != nil {
-		return errors.Errorf("removing cloud container link layer devices for %q: %w", netNodeID, err)
+		return errors.Errorf("removing k8s pod link layer devices for %q: %w", netNodeID, err)
 	}
 	return nil
 }
@@ -939,7 +939,7 @@ WHERE unit_uuid = $unitUUID.unit_uuid`, unitUUIDRec)
 		return errors.Capture(err)
 	}
 	if err := tx.Query(ctx, deleteStmt, unitUUIDRec).Run(); err != nil {
-		return errors.Errorf("removing cloud container ports: %w", err)
+		return errors.Errorf("removing k8s pod ports: %w", err)
 	}
 	return nil
 }

--- a/domain/removal/state/model/unit_test.go
+++ b/domain/removal/state/model/unit_test.go
@@ -1015,6 +1015,54 @@ func (s *unitSuite) TestDeleteCAASUnit(c *tc.C) {
 	s.checkCharmsCount(c, 1)
 }
 
+// TestDeleteCAASUnitCleansUpFQDNAddress verifies that deleting a CAAS unit
+// removes both the net_node_fqdn_address junction and the referenced
+// fqdn_address row, so a deterministic FQDN does not collide on re-creation.
+func (s *unitSuite) TestDeleteCAASUnitCleansUpFQDNAddress(c *tc.C) {
+	svc := s.setupApplicationService(c)
+	appUUID := s.createCAASApplication(c, svc, "some-app", applicationservice.AddUnitArg{})
+
+	unitUUIDs := s.getAllUnitUUIDs(c, appUUID)
+	c.Assert(len(unitUUIDs), tc.Equals, 1)
+	unitUUID := unitUUIDs[0]
+
+	const fqdn = "controller-0.controller-service-endpoints.controller-foo.svc.cluster.local"
+	fqdnUUID := "test-fqdn-uuid"
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		var netNodeUUID string
+		if err := tx.QueryRowContext(
+			ctx, "SELECT net_node_uuid FROM unit WHERE uuid = ?", unitUUID.String(),
+		).Scan(&netNodeUUID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx,
+			"INSERT INTO fqdn_address (uuid, address, scope_id) VALUES (?, ?, ?)",
+			fqdnUUID, fqdn, 1,
+		); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx,
+			"INSERT INTO net_node_fqdn_address (net_node_uuid, address_uuid) VALUES (?, ?)",
+			netNodeUUID, fqdnUUID,
+		)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(s.getRowCount(c, "fqdn_address"), tc.Equals, 1)
+	c.Check(s.getRowCount(c, "net_node_fqdn_address"), tc.Equals, 1)
+
+	s.advanceUnitLife(c, unitUUID, life.Dead)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err = st.DeleteUnit(c.Context(), unitUUID.String(), false)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Both the junction and the orphaned fqdn_address row are gone.
+	c.Check(s.getRowCount(c, "net_node_fqdn_address"), tc.Equals, 0)
+	c.Check(s.getRowCount(c, "fqdn_address"), tc.Equals, 0)
+}
+
 // TestDeleteUnitWithDanglingCharmReference ensures that unit removal and
 // charm's cleanup are in two different transactions. So even if the latter fails, the unit
 // is still removed.

--- a/internal/bootstrap/deployer_caas.go
+++ b/internal/bootstrap/deployer_caas.go
@@ -99,10 +99,6 @@ func (b *CAASDeployer) AddCAASControllerApplication(ctx context.Context, info De
 	}
 
 	unitArg := applicationservice.AddUnitArg{}
-	if b.controllerFQDN != "" {
-		fqdn := b.controllerFQDN
-		unitArg.FQDN = &fqdn
-	}
 
 	if _, err := b.applicationService.CreateCAASApplication(ctx,
 		bootstrap.ControllerApplicationName,
@@ -143,9 +139,16 @@ func (d *CAASDeployer) CompleteCAASProcess(ctx context.Context) error {
 	}
 
 	providerID := controllerProviderID(controllerUnit)
-	if err := d.applicationService.UpdateCAASUnit(ctx, controllerUnit, applicationservice.UpdateCAASUnitParams{
+	updateParams := applicationservice.UpdateCAASUnitParams{
 		ProviderID: &providerID,
-	}); err != nil {
+	}
+	// Persist the controller pod's stable FQDN as the unit's network identity,
+	// in the same flow that upserts the k8s pod (provider id).
+	if d.controllerFQDN != "" {
+		fqdn := d.controllerFQDN
+		updateParams.FQDN = &fqdn
+	}
+	if err := d.applicationService.UpdateCAASUnit(ctx, controllerUnit, updateParams); err != nil {
 		return errors.Errorf("updating controller unit: %w", err)
 	}
 	if err := d.passwordService.SetUnitPassword(ctx, controllerUnit, d.unitPassword); err != nil {

--- a/internal/bootstrap/deployer_caas.go
+++ b/internal/bootstrap/deployer_caas.go
@@ -32,6 +32,7 @@ type CAASDeployerConfig struct {
 	ApplicationService CAASApplicationService
 	ServiceManager     ServiceManager
 	UnitPassword       string
+	ControllerFQDN     string
 }
 
 // Validate validates the configuration.
@@ -55,6 +56,7 @@ type CAASDeployer struct {
 	applicationService CAASApplicationService
 	serviceManager     ServiceManager
 	unitPassword       string
+	controllerFQDN     string
 }
 
 // NewCAASDeployer returns a new ControllerCharmDeployer for CAAS workloads.
@@ -68,6 +70,7 @@ func NewCAASDeployer(config CAASDeployerConfig) (*CAASDeployer, error) {
 		applicationService: config.ApplicationService,
 		serviceManager:     config.ServiceManager,
 		unitPassword:       config.UnitPassword,
+		controllerFQDN:     config.ControllerFQDN,
 	}, nil
 }
 
@@ -95,6 +98,12 @@ func (b *CAASDeployer) AddCAASControllerApplication(ctx context.Context, info De
 		return errors.Errorf("creating download info: %w", err)
 	}
 
+	unitArg := applicationservice.AddUnitArg{}
+	if b.controllerFQDN != "" {
+		fqdn := b.controllerFQDN
+		unitArg.FQDN = &fqdn
+	}
+
 	if _, err := b.applicationService.CreateCAASApplication(ctx,
 		bootstrap.ControllerApplicationName,
 		info.Charm,
@@ -115,7 +124,7 @@ func (b *CAASDeployer) AddCAASControllerApplication(ctx context.Context, info De
 			Constraints:  b.constraints,
 			IsController: true,
 		},
-		applicationservice.AddUnitArg{},
+		unitArg,
 	); err != nil {
 		return errors.Errorf("creating CAAS controller application: %w", err)
 	}

--- a/internal/bootstrap/deployer_caas_test.go
+++ b/internal/bootstrap/deployer_caas_test.go
@@ -4,6 +4,7 @@
 package bootstrap
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 
+	coreapplication "github.com/juju/juju/core/application"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	network "github.com/juju/juju/core/network"
@@ -165,6 +167,60 @@ func (s *deployerCAASSuite) TestCompleteCAASProcess(c *tc.C) {
 	deployer := s.newDeployerWithConfig(c, cfg)
 	err := deployer.CompleteCAASProcess(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *deployerCAASSuite) TestAddCAASControllerApplicationSetsFQDN(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	cfg := s.newConfig(c)
+	const fqdn = "controller-0.controller-service-endpoints.controller-foo.svc.cluster.local"
+	cfg.ControllerFQDN = fqdn
+
+	var gotUnitArgs []applicationservice.AddUnitArg
+	s.caasApplicationService.EXPECT().CreateCAASApplication(
+		gomock.Any(), bootstrap.ControllerApplicationName, s.charm, gomock.Any(), gomock.Any(), gomock.Any(),
+	).DoAndReturn(func(
+		_ context.Context,
+		_ string,
+		_ charm.Charm,
+		_ corecharm.Origin,
+		_ applicationservice.AddApplicationArgs,
+		units ...applicationservice.AddUnitArg,
+	) (coreapplication.UUID, error) {
+		gotUnitArgs = units
+		return "", nil
+	})
+
+	deployer := s.newDeployerWithConfig(c, cfg)
+
+	origin := corecharm.Origin{
+		Source:   corecharm.CharmHub,
+		Type:     "charm",
+		Channel:  &charm.Channel{},
+		Revision: new(1),
+		Hash:     "sha-256",
+		Platform: corecharm.Platform{
+			Architecture: "arm64",
+			OS:           "ubuntu",
+			Channel:      "22.04",
+		},
+	}
+	err := deployer.AddCAASControllerApplication(c.Context(), DeployCharmInfo{
+		URL:    charm.MustParseURL("ch:juju-controller-0"),
+		Charm:  s.charm,
+		Origin: &origin,
+		DownloadInfo: &corecharm.DownloadInfo{
+			CharmhubIdentifier: "abcd",
+			DownloadURL:        "https://inferi.com",
+			DownloadSize:       42,
+		},
+		ArchivePath:     "path",
+		ObjectStoreUUID: "1234",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(gotUnitArgs, tc.HasLen, 1)
+	c.Assert(gotUnitArgs[0].FQDN, tc.NotNil)
+	c.Check(*gotUnitArgs[0].FQDN, tc.Equals, fqdn)
 }
 
 func (s *deployerCAASSuite) newDeployer(c *tc.C) *CAASDeployer {

--- a/internal/bootstrap/deployer_caas_test.go
+++ b/internal/bootstrap/deployer_caas_test.go
@@ -4,7 +4,6 @@
 package bootstrap
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 
-	coreapplication "github.com/juju/juju/core/application"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	network "github.com/juju/juju/core/network"
@@ -169,58 +167,27 @@ func (s *deployerCAASSuite) TestCompleteCAASProcess(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *deployerCAASSuite) TestAddCAASControllerApplicationSetsFQDN(c *tc.C) {
+func (s *deployerCAASSuite) TestCompleteCAASProcessSetsFQDN(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	cfg := s.newConfig(c)
 	const fqdn = "controller-0.controller-service-endpoints.controller-foo.svc.cluster.local"
 	cfg.ControllerFQDN = fqdn
 
-	var gotUnitArgs []applicationservice.AddUnitArg
-	s.caasApplicationService.EXPECT().CreateCAASApplication(
-		gomock.Any(), bootstrap.ControllerApplicationName, s.charm, gomock.Any(), gomock.Any(), gomock.Any(),
-	).DoAndReturn(func(
-		_ context.Context,
-		_ string,
-		_ charm.Charm,
-		_ corecharm.Origin,
-		_ applicationservice.AddApplicationArgs,
-		units ...applicationservice.AddUnitArg,
-	) (coreapplication.UUID, error) {
-		gotUnitArgs = units
-		return "", nil
+	unitName := unit.Name("controller/0")
+
+	s.caasApplicationService.EXPECT().UpdateK8sService(gomock.Any(), bootstrap.ControllerApplicationName, controllerProviderID(unitName), gomock.Any()).Return(nil)
+	// The controller FQDN is persisted in the same flow that upserts the k8s
+	// pod (provider id), i.e. via UpdateCAASUnit.
+	s.caasApplicationService.EXPECT().UpdateCAASUnit(gomock.Any(), unitName, applicationservice.UpdateCAASUnitParams{
+		ProviderID: new("controller-0"),
+		FQDN:       new(fqdn),
 	})
+	s.agentPasswordService.EXPECT().SetUnitPassword(gomock.Any(), unitName, cfg.UnitPassword)
 
 	deployer := s.newDeployerWithConfig(c, cfg)
-
-	origin := corecharm.Origin{
-		Source:   corecharm.CharmHub,
-		Type:     "charm",
-		Channel:  &charm.Channel{},
-		Revision: new(1),
-		Hash:     "sha-256",
-		Platform: corecharm.Platform{
-			Architecture: "arm64",
-			OS:           "ubuntu",
-			Channel:      "22.04",
-		},
-	}
-	err := deployer.AddCAASControllerApplication(c.Context(), DeployCharmInfo{
-		URL:    charm.MustParseURL("ch:juju-controller-0"),
-		Charm:  s.charm,
-		Origin: &origin,
-		DownloadInfo: &corecharm.DownloadInfo{
-			CharmhubIdentifier: "abcd",
-			DownloadURL:        "https://inferi.com",
-			DownloadSize:       42,
-		},
-		ArchivePath:     "path",
-		ObjectStoreUUID: "1234",
-	})
+	err := deployer.CompleteCAASProcess(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(gotUnitArgs, tc.HasLen, 1)
-	c.Assert(gotUnitArgs[0].FQDN, tc.NotNil)
-	c.Check(*gotUnitArgs[0].FQDN, tc.Equals, fqdn)
 }
 
 func (s *deployerCAASSuite) newDeployer(c *tc.C) *CAASDeployer {

--- a/internal/provider/kubernetes/application/application.go
+++ b/internal/provider/kubernetes/application/application.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/annotations"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/core/status"
@@ -1554,6 +1555,13 @@ func (a *app) Units() ([]caas.Unit, error) {
 				Message: statusMessage,
 				Since:   &since,
 			},
+		}
+		// Controller pods are governed by a headless service that gives each
+		// pod a stable per-ordinal FQDN. Surface it so it can be persisted as
+		// the controller unit's stable network identity. Non-controller pods
+		// have no persisted FQDN (see caas.Unit.FQDN).
+		if a.name == coreapplication.ControllerApplicationName && a.deploymentType == caas.DeploymentStateful {
+			unitInfo.FQDN = utils.ControllerPodFQDN(p.Name, a.namespace)
 		}
 
 		volumesByName := make(map[string]corev1.Volume)

--- a/internal/provider/kubernetes/constants/constants.go
+++ b/internal/provider/kubernetes/constants/constants.go
@@ -66,6 +66,18 @@ const (
 	// ControllerServiceFQDNTemplate is the FQDN of the controller service using the cluster DNS.
 	ControllerServiceFQDNTemplate = "controller-service.controller-%s.svc.cluster.local"
 
+	// ControllerServiceEndpointsName is the name of the headless service that
+	// governs the controller StatefulSet. It gives each controller pod a
+	// stable per-ordinal DNS name for Dqlite peering. It must match the name
+	// derived for the headless service during bootstrap
+	// (getBootstrapResourceName(JujuControllerStackName, "service-endpoints")).
+	ControllerServiceEndpointsName = JujuControllerStackName + "-service-endpoints"
+
+	// ClusterLocalDomain is the default cluster-internal DNS domain suffix used
+	// by Kubernetes for service and pod FQDNs. Non-default cluster DNS domains
+	// are not currently supported.
+	ClusterLocalDomain = "svc.cluster.local"
+
 	// CharmVolumeName is the name of the k8s volume where shared charm data is stored.
 	CharmVolumeName = "charm-data"
 

--- a/internal/provider/kubernetes/k8s.go
+++ b/internal/provider/kubernetes/k8s.go
@@ -31,6 +31,7 @@ import (
 	"github.com/juju/juju/caas"
 	k8s "github.com/juju/juju/caas/kubernetes"
 	k8sannotations "github.com/juju/juju/core/annotations"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/assumes"
 	"github.com/juju/juju/core/semversion"
@@ -937,6 +938,13 @@ func (k *kubernetesClient) Units(ctx context.Context, appName string) ([]caas.Un
 				Since:   &since,
 			},
 		}
+		// Controller pods are governed by a headless service that gives each
+		// pod a stable per-ordinal FQDN. Surface it so it can be persisted as
+		// the controller unit's stable network identity. Non-controller pods
+		// have no persisted FQDN (see caas.Unit.FQDN).
+		if appName == coreapplication.ControllerApplicationName && isStateful(&p) {
+			unitInfo.FQDN = utils.ControllerPodFQDN(p.Name, k.namespace)
+		}
 
 		volumesByName := make(map[string]core.Volume)
 		for _, pv := range p.Spec.Volumes {
@@ -980,6 +988,16 @@ func (k *kubernetesClient) Units(ctx context.Context, appName string) ([]caas.Un
 		units = append(units, unitInfo)
 	}
 	return units, nil
+}
+
+// ControllerUnitFQDN returns the stable, cluster-resolvable per-pod DNS name
+// for the controller unit with the given ordinal, as assigned by the
+// controller headless service in this broker's namespace. The provider is the
+// sole owner of this naming; callers persist the returned string as the
+// controller unit's stable network identity.
+func (k *kubernetesClient) ControllerUnitFQDN(ordinal int) string {
+	podName := fmt.Sprintf("controller-%d", ordinal)
+	return utils.ControllerPodFQDN(podName, k.namespace)
 }
 
 // ListPods filters a list of pods for the provided namespace and labels.

--- a/internal/provider/kubernetes/k8s_test.go
+++ b/internal/provider/kubernetes/k8s_test.go
@@ -224,6 +224,18 @@ func (s *K8sBrokerSuite) TestAPIVersion(c *tc.C) {
 	c.Assert(ver, tc.DeepEquals, "1.16.0")
 }
 
+func (s *K8sBrokerSuite) TestControllerUnitFQDN(c *tc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	// The broker's namespace in tests is "test".
+	c.Check(
+		s.broker.ControllerUnitFQDN(0),
+		tc.Equals,
+		"controller-0.controller-service-endpoints.test.svc.cluster.local",
+	)
+}
+
 func (s *K8sBrokerSuite) TestConfig(c *tc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()

--- a/internal/provider/kubernetes/utils/address.go
+++ b/internal/provider/kubernetes/utils/address.go
@@ -4,10 +4,33 @@
 package utils
 
 import (
+	"fmt"
+
 	core "k8s.io/api/core/v1"
 
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/internal/provider/kubernetes/constants"
 )
+
+// ControllerPodFQDN returns the stable, cluster-resolvable per-pod DNS name
+// assigned to the controller pod named podName in the given namespace by the
+// controller headless service. It is the single source of truth for the
+// controller pod FQDN string. The form is:
+//
+//	<pod-name>.controller-service-endpoints.<namespace>.svc.cluster.local
+//
+// for example:
+//
+//	controller-0.controller-service-endpoints.controller-a.svc.cluster.local
+func ControllerPodFQDN(podName, namespace string) string {
+	return fmt.Sprintf(
+		"%s.%s.%s.%s",
+		podName,
+		constants.ControllerServiceEndpointsName,
+		namespace,
+		constants.ClusterLocalDomain,
+	)
+}
 
 // GetSvcAddresses returns the network addresses for the given service.
 func GetSvcAddresses(svc *core.Service, includeClusterIP bool) []network.ProviderAddress {

--- a/internal/provider/kubernetes/utils/fqdn_test.go
+++ b/internal/provider/kubernetes/utils/fqdn_test.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/internal/provider/kubernetes/utils"
+)
+
+type FQDNSuite struct{}
+
+func TestFQDNSuite(t *testing.T) {
+	tc.Run(t, &FQDNSuite{})
+}
+
+func (s *FQDNSuite) TestControllerPodFQDN(c *tc.C) {
+	c.Check(
+		utils.ControllerPodFQDN("controller-0", "controller-foo"),
+		tc.Equals,
+		"controller-0.controller-service-endpoints.controller-foo.svc.cluster.local",
+	)
+	c.Check(
+		utils.ControllerPodFQDN("controller-2", "controller-bar"),
+		tc.Equals,
+		"controller-2.controller-service-endpoints.controller-bar.svc.cluster.local",
+	)
+}

--- a/internal/worker/bootstrap/deployer.go
+++ b/internal/worker/bootstrap/deployer.go
@@ -31,6 +31,10 @@ import (
 type ServiceManager interface {
 	// GetService returns the service for the specified application.
 	GetService(ctx context.Context, appName string, includeClusterIP bool) (*caas.Service, error)
+
+	// ControllerUnitFQDN returns the stable, cluster-resolvable per-pod DNS
+	// name for the controller unit with the given ordinal.
+	ControllerUnitFQDN(ordinal int) string
 }
 
 // ServiceManagerGetterFunc is the function that is used to get a service manager.
@@ -106,11 +110,16 @@ func CAASControllerCharmUploader(ctx context.Context, cfg ControllerCharmDeploye
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
 	return bootstrap.NewCAASDeployer(bootstrap.CAASDeployerConfig{
 		BaseDeployerConfig: makeBaseDeployerConfig(cfg),
 		ApplicationService: cfg.ApplicationService,
 		UnitPassword:       cfg.UnitPassword,
 		ServiceManager:     serviceManager,
+		// The provider owns Kubernetes naming, so it supplies the deterministic
+		// controller/0 pod FQDN that the deployer persists as the controller
+		// unit's stable network identity.
+		ControllerFQDN: serviceManager.ControllerUnitFQDN(0),
 	})
 }
 

--- a/internal/worker/caasapplicationprovisioner/mocks/domain_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/domain_mock.go
@@ -34,26 +34,26 @@ type MockApplicationService struct {
 
 // MockApplicationServiceMockRecorder is the mock recorder for MockApplicationService.
 type MockApplicationServiceMockRecorder struct {
-	mock                                             *MockApplicationService
-	clearApplicationHasK8sResourcesExpects           []*gomock.Call2_1[context.Context, application.UUID, error]
-	getAllUnitCloudContainerIDsForApplicationExpects []*gomock.Call2_2[context.Context, application.UUID, map[unit.Name]string, error]
-	getAllUnitLifeForApplicationExpects              []*gomock.Call2_2[context.Context, application.UUID, map[unit.Name]life.Value, error]
-	getApplicationLifeExpects                        []*gomock.Call2_2[context.Context, application.UUID, life.Value, error]
-	getApplicationNameExpects                        []*gomock.Call2_2[context.Context, application.UUID, string, error]
-	getApplicationScaleExpects                       []*gomock.Call2_2[context.Context, string, int, error]
-	getApplicationScalingStateExpects                []*gomock.Call2_2[context.Context, string, service.ScalingState, error]
-	getApplicationTrustSettingExpects                []*gomock.Call2_2[context.Context, string, bool, error]
-	getCharmByApplicationUUIDExpects                 []*gomock.Call2_3[context.Context, application.UUID, charm0.Charm, charm.CharmLocator, error]
-	getUnitLifeExpects                               []*gomock.Call2_2[context.Context, unit.Name, life.Value, error]
-	isControllerApplicationExpects                   []*gomock.Call2_2[context.Context, application.UUID, bool, error]
-	setApplicationHasK8sResourcesExpects             []*gomock.Call2_1[context.Context, application.UUID, error]
-	setApplicationScalingStateExpects                []*gomock.Call4_1[context.Context, string, int, bool, error]
-	updateCAASUnitExpects                            []*gomock.Call3_1[context.Context, unit.Name, service.UpdateCAASUnitParams, error]
-	updateK8sServiceExpects                          []*gomock.Call4_1[context.Context, string, string, network.ProviderAddresses, error]
-	watchApplicationScaleExpects                     []*gomock.Call2_2[context.Context, string, watcher.NotifyWatcher, error]
-	watchApplicationSettingsExpects                  []*gomock.Call2_2[context.Context, string, watcher.NotifyWatcher, error]
-	watchApplicationUnitLifeExpects                  []*gomock.Call2_2[context.Context, string, watcher.StringsWatcher, error]
-	watchApplicationsExpects                         []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
+	mock                                     *MockApplicationService
+	clearApplicationHasK8sResourcesExpects   []*gomock.Call2_1[context.Context, application.UUID, error]
+	getAllUnitK8sPodIDsForApplicationExpects []*gomock.Call2_2[context.Context, application.UUID, map[unit.Name]string, error]
+	getAllUnitLifeForApplicationExpects      []*gomock.Call2_2[context.Context, application.UUID, map[unit.Name]life.Value, error]
+	getApplicationLifeExpects                []*gomock.Call2_2[context.Context, application.UUID, life.Value, error]
+	getApplicationNameExpects                []*gomock.Call2_2[context.Context, application.UUID, string, error]
+	getApplicationScaleExpects               []*gomock.Call2_2[context.Context, string, int, error]
+	getApplicationScalingStateExpects        []*gomock.Call2_2[context.Context, string, service.ScalingState, error]
+	getApplicationTrustSettingExpects        []*gomock.Call2_2[context.Context, string, bool, error]
+	getCharmByApplicationUUIDExpects         []*gomock.Call2_3[context.Context, application.UUID, charm0.Charm, charm.CharmLocator, error]
+	getUnitLifeExpects                       []*gomock.Call2_2[context.Context, unit.Name, life.Value, error]
+	isControllerApplicationExpects           []*gomock.Call2_2[context.Context, application.UUID, bool, error]
+	setApplicationHasK8sResourcesExpects     []*gomock.Call2_1[context.Context, application.UUID, error]
+	setApplicationScalingStateExpects        []*gomock.Call4_1[context.Context, string, int, bool, error]
+	updateCAASUnitExpects                    []*gomock.Call3_1[context.Context, unit.Name, service.UpdateCAASUnitParams, error]
+	updateK8sServiceExpects                  []*gomock.Call4_1[context.Context, string, string, network.ProviderAddresses, error]
+	watchApplicationScaleExpects             []*gomock.Call2_2[context.Context, string, watcher.NotifyWatcher, error]
+	watchApplicationSettingsExpects          []*gomock.Call2_2[context.Context, string, watcher.NotifyWatcher, error]
+	watchApplicationUnitLifeExpects          []*gomock.Call2_2[context.Context, string, watcher.StringsWatcher, error]
+	watchApplicationsExpects                 []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
 }
 
 // NewMockApplicationService creates a new mock instance.
@@ -86,23 +86,23 @@ func (mr *MockApplicationServiceMockRecorder) ClearApplicationHasK8sResources(ct
 // MockApplicationServiceClearApplicationHasK8sResourcesCall is the typed call wrapper for ClearApplicationHasK8sResources.
 type MockApplicationServiceClearApplicationHasK8sResourcesCall = gomock.Call2_1[context.Context, application.UUID, error]
 
-// GetAllUnitCloudContainerIDsForApplication mocks base method.
-func (m *MockApplicationService) GetAllUnitCloudContainerIDsForApplication(ctx context.Context, id application.UUID) (map[unit.Name]string, error) {
+// GetAllUnitK8sPodIDsForApplication mocks base method.
+func (m *MockApplicationService) GetAllUnitK8sPodIDsForApplication(ctx context.Context, id application.UUID) (map[unit.Name]string, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_2(&m.recorder.getAllUnitCloudContainerIDsForApplicationExpects, m.ctrl, m, "GetAllUnitCloudContainerIDsForApplication", ctx, id)
+	return gomock.Dispatch2_2(&m.recorder.getAllUnitK8sPodIDsForApplicationExpects, m.ctrl, m, "GetAllUnitK8sPodIDsForApplication", ctx, id)
 }
 
-// GetAllUnitCloudContainerIDsForApplication indicates an expected call of GetAllUnitCloudContainerIDsForApplication.
-func (mr *MockApplicationServiceMockRecorder) GetAllUnitCloudContainerIDsForApplication(ctx, id any) *MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall {
+// GetAllUnitK8sPodIDsForApplication indicates an expected call of GetAllUnitK8sPodIDsForApplication.
+func (mr *MockApplicationServiceMockRecorder) GetAllUnitK8sPodIDsForApplication(ctx, id any) *MockApplicationServiceGetAllUnitK8sPodIDsForApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, application.UUID, map[unit.Name]string, error](mr.mock.ctrl.T, mr.mock, "GetAllUnitCloudContainerIDsForApplication", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(id))
-	mr.getAllUnitCloudContainerIDsForApplicationExpects = append(mr.getAllUnitCloudContainerIDsForApplicationExpects, call)
+	call := gomock.NewCall2_2[context.Context, application.UUID, map[unit.Name]string, error](mr.mock.ctrl.T, mr.mock, "GetAllUnitK8sPodIDsForApplication", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(id))
+	mr.getAllUnitK8sPodIDsForApplicationExpects = append(mr.getAllUnitK8sPodIDsForApplicationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
-// MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall is the typed call wrapper for GetAllUnitCloudContainerIDsForApplication.
-type MockApplicationServiceGetAllUnitCloudContainerIDsForApplicationCall = gomock.Call2_2[context.Context, application.UUID, map[unit.Name]string, error]
+// MockApplicationServiceGetAllUnitK8sPodIDsForApplicationCall is the typed call wrapper for GetAllUnitK8sPodIDsForApplication.
+type MockApplicationServiceGetAllUnitK8sPodIDsForApplicationCall = gomock.Call2_2[context.Context, application.UUID, map[unit.Name]string, error]
 
 // GetAllUnitLifeForApplication mocks base method.
 func (m *MockApplicationService) GetAllUnitLifeForApplication(arg0 context.Context, arg1 application.UUID) (map[unit.Name]life.Value, error) {

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -471,7 +471,7 @@ func updateState(
 		}
 	}
 
-	unitToPod, err := applicationService.GetAllUnitCloudContainerIDsForApplication(ctx, appUUID)
+	unitToPod, err := applicationService.GetAllUnitK8sPodIDsForApplication(ctx, appUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -498,7 +498,7 @@ func updateState(
 			Address:    &u.Address,
 			Ports:      &u.Ports,
 		}
-		args.AgentStatus, args.CloudContainerStatus = updateStatus(u.Status, clk)
+		args.AgentStatus, args.K8sPodStatus = updateStatus(u.Status, clk)
 
 		lastStatus, ok := lastReportedStatus[unitName]
 		reportedStatus[unitName] = args
@@ -943,10 +943,10 @@ func provisioningInfo(
 	return pi, nil
 }
 
-// updateStatus constructs the agent and cloud container status values.
+// updateStatus constructs the agent and k8s pod status values.
 func updateStatus(podStatus status.StatusInfo, clk clock.Clock) (
 	agentStatus *status.StatusInfo,
-	cloudContainerStatus *status.StatusInfo,
+	k8sPodStatus *status.StatusInfo,
 ) {
 	now := clk.Now()
 	switch podStatus.Status {
@@ -961,7 +961,7 @@ func updateStatus(podStatus status.StatusInfo, clk clock.Clock) (
 			Message: podStatus.Message,
 			Since:   &now,
 		}
-		cloudContainerStatus = &status.StatusInfo{
+		k8sPodStatus = &status.StatusInfo{
 			Status:  status.Waiting,
 			Message: podStatus.Message,
 			Data:    podStatus.Data,
@@ -973,7 +973,7 @@ func updateStatus(podStatus status.StatusInfo, clk clock.Clock) (
 			Status: status.Idle,
 			Since:  &now,
 		}
-		cloudContainerStatus = &status.StatusInfo{
+		k8sPodStatus = &status.StatusInfo{
 			Status:  status.Running,
 			Message: podStatus.Message,
 			Data:    podStatus.Data,
@@ -986,7 +986,7 @@ func updateStatus(podStatus status.StatusInfo, clk clock.Clock) (
 			Data:    podStatus.Data,
 			Since:   &now,
 		}
-		cloudContainerStatus = &status.StatusInfo{
+		k8sPodStatus = &status.StatusInfo{
 			Status:  status.Error,
 			Message: podStatus.Message,
 			Data:    podStatus.Data,
@@ -997,14 +997,14 @@ func updateStatus(podStatus status.StatusInfo, clk clock.Clock) (
 			Status: status.Idle,
 			Since:  &now,
 		}
-		cloudContainerStatus = &status.StatusInfo{
+		k8sPodStatus = &status.StatusInfo{
 			Status:  status.Blocked,
 			Message: podStatus.Message,
 			Data:    podStatus.Data,
 			Since:   &now,
 		}
 	}
-	return agentStatus, cloudContainerStatus
+	return agentStatus, k8sPodStatus
 }
 
 func readDockerImageResource(reader io.Reader) (coreresource.DockerImageDetails, error) {

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -136,7 +136,7 @@ func (s *OpsSuite) TestUpdateState(c *tc.C) {
 		},
 		Since: &now,
 	}
-	cloudContainerIDs := map[unit.Name]string{
+	k8sPodIDs := map[unit.Name]string{
 		"test/0": "a",
 		"test/1": "b",
 	}
@@ -149,7 +149,7 @@ func (s *OpsSuite) TestUpdateState(c *tc.C) {
 			Status: status.Idle,
 			Since:  &now,
 		},
-		CloudContainerStatus: &status.StatusInfo{
+		K8sPodStatus: &status.StatusInfo{
 			Status:  status.Running,
 			Message: "different",
 			Since:   &now,
@@ -163,7 +163,7 @@ func (s *OpsSuite) TestUpdateState(c *tc.C) {
 			SpaceName:      "space-name",
 		}}).Return(nil),
 		statusService.EXPECT().SetOperatorStatus(gomock.Any(), "test", appStatus).Return(nil),
-		applicationService.EXPECT().GetAllUnitCloudContainerIDsForApplication(gomock.Any(), appId).Return(cloudContainerIDs, nil),
+		applicationService.EXPECT().GetAllUnitK8sPodIDsForApplication(gomock.Any(), appId).Return(k8sPodIDs, nil),
 		app.EXPECT().Units().Return(units, nil),
 		applicationService.EXPECT().UpdateCAASUnit(gomock.Any(), unit.Name("test/0"), gomock.Any()).DoAndReturn(func(_ context.Context, _ unit.Name, args applicationservice.UpdateCAASUnitParams) error {
 			c.Check(args.ProviderID, tc.DeepEquals, unit0Update.ProviderID)
@@ -172,9 +172,9 @@ func (s *OpsSuite) TestUpdateState(c *tc.C) {
 			c.Assert(args.AgentStatus, tc.NotNil, tc.Commentf("AgentStatus should not be nil"))
 			c.Assert(args.AgentStatus.Since, tc.NotNil, tc.Commentf("AgentStatus.Since should not be nil"))
 			c.Check(*args.AgentStatus.Since, tc.Equals, now, tc.Commentf("AgentStatus.Since should be set to current time"))
-			c.Assert(args.CloudContainerStatus, tc.NotNil, tc.Commentf("CloudContainerStatus should not be nil"))
-			c.Assert(args.CloudContainerStatus.Since, tc.NotNil, tc.Commentf("CloudContainerStatus.Since should not be nil"))
-			c.Check(*args.CloudContainerStatus.Since, tc.Equals, now, tc.Commentf("CloudContainerStatus.Since should be set to current time"))
+			c.Assert(args.K8sPodStatus, tc.NotNil, tc.Commentf("K8sPodStatus should not be nil"))
+			c.Assert(args.K8sPodStatus.Since, tc.NotNil, tc.Commentf("K8sPodStatus.Since should not be nil"))
+			c.Check(*args.K8sPodStatus.Since, tc.Equals, now, tc.Commentf("K8sPodStatus.Since should be set to current time"))
 			return nil
 		}),
 		broker.EXPECT().AnnotateUnit(gomock.Any(), "test", "a", names.NewUnitTag("test/0")).Return(nil),
@@ -190,7 +190,7 @@ func (s *OpsSuite) TestUpdateState(c *tc.C) {
 				Message: "same",
 				Since:   &now,
 			},
-			CloudContainerStatus: &status.StatusInfo{
+			K8sPodStatus: &status.StatusInfo{
 				Status:  status.Waiting,
 				Message: "same",
 				Since:   &now,
@@ -208,7 +208,7 @@ func (s *OpsSuite) TestUpdateState(c *tc.C) {
 				Status: status.Idle,
 				Since:  &now,
 			},
-			CloudContainerStatus: &status.StatusInfo{
+			K8sPodStatus: &status.StatusInfo{
 				Status:  status.Running,
 				Message: "different",
 				Since:   &now,
@@ -223,7 +223,7 @@ func (s *OpsSuite) TestUpdateState(c *tc.C) {
 				Message: "same",
 				Since:   &now,
 			},
-			CloudContainerStatus: &status.StatusInfo{
+			K8sPodStatus: &status.StatusInfo{
 				Status:  status.Waiting,
 				Message: "same",
 				Since:   &now,

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -125,9 +125,9 @@ type ApplicationService interface {
 	// UpdateCAASUnit updates the specified CAAS unit
 	UpdateCAASUnit(context.Context, unit.Name, applicationservice.UpdateCAASUnitParams) error
 
-	// GetAllUnitCloudContainerIDsForApplication returns a map of the unit names
-	// and their cloud container provider IDs for the given application.
-	GetAllUnitCloudContainerIDsForApplication(ctx context.Context, id coreapplication.UUID) (map[unit.Name]string, error)
+	// GetAllUnitK8sPodIDsForApplication returns a map of the unit names
+	// and their k8s pod provider IDs for the given application.
+	GetAllUnitK8sPodIDsForApplication(ctx context.Context, id coreapplication.UUID) (map[unit.Name]string, error)
 
 	// GetCharmByApplicationUUID returns the charm for the specified application
 	// UUID.


### PR DESCRIPTION
Controller units now get a stable, cluster-resolvable per-pod FQDN persisted as an fqdn_address row (scope local-cloud) linked to the unit's net_node, at unit-creation time. This gives each controller pod a stored, queryable network identity for downstream HA work (Dqlite peering) rather than recomputing provider-specific naming.

The FQDN string is constructed solely in the Kubernetes provider, which owns pod/service naming and the controller headless service. A new ControllerPodFQDN helper is the single source of truth, and the broker exposes ControllerUnitFQDN(ordinal) for the bootstrap deployer.

Persistence happens at the shared insertUnit chokepoint, covering both creation paths:
- bootstrap injects the controller/0 FQDN into the CAAS deployer;
- the register path carries it across the caas.Unit boundary (built defensively; inert for controllers under current code).

The write is optional and a no-op when no FQDN is supplied, so IAAS and non-controller CAAS units are unaffected. fqdn_address.address is globally unique, so a collision on insert is surfaced as an error: a given FQDN identifies exactly one unit.

CAAS unit removal (and the synthetic-unit removal paths) now delete the net_node_fqdn_address junction and any orphaned fqdn_address rows, keeping the lifecycle symmetric and preventing collisions on later re-creation of the same ordinal.

## QA steps

```
$ juju bootstrap minikube mini
$ juju switch controller
$ juju ssh 0
$ juju_db_repl
repl (controller)> .switch model-controller
repl (model-controller)> SELECT * FROM fqdn_address;
uuid					address										scope_id	
00b92cf7-14a0-40b8-81bd-3c92098e052d	controller-0.controller-service-endpoints.controller-mini.svc.cluster.local	1		

repl (model-controller)> SELECT * FROM net_node_fqdn_address
net_node_uuid				address_uuid				
d8d9a91f-2917-4f67-85c7-e50a0cbc6ccd	00b92cf7-14a0-40b8-81bd-3c92098e052d	

repl (model-controller)> SELECT * FROM net_node_fqdn_address
net_node_uuid				address_uuid				
d8d9a91f-2917-4f67-85c7-e50a0cbc6ccd	00b92cf7-14a0-40b8-81bd-3c92098e052d	
```