### PR TITLE
fix: move remove-juju-services script to /usr/sbin for usr-is-merged compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ tests/tmp.*
 *.log
 dqlite-deps.tar.bz2
 .envrc
+.direnv
 .codex

--- a/cloudconfig/userdatacfg_test.go
+++ b/cloudconfig/userdatacfg_test.go
@@ -348,7 +348,7 @@ install -D -m 600 /dev/null '/var/lib/juju/bootstrap-params'
 echo '.*' > '/var/lib/juju/bootstrap-params'
 echo 'Installing Juju machine agent'.*
 /var/lib/juju/tools/1\.2\.3-ubuntu-amd64/jujud bootstrap-state --timeout 10m0s --data-dir '/var/lib/juju' --debug '/var/lib/juju/bootstrap-params'
-/sbin/remove-juju-services
+/usr/sbin/remove-juju-services
 rm \$bin/tools\.tar\.gz && rm \$bin/juju1\.2\.3-ubuntu-amd64\.sha256
 `,
 	},

--- a/cloudconfig/userdatacfg_unix.go
+++ b/cloudconfig/userdatacfg_unix.go
@@ -57,7 +57,7 @@ while true; do
     n=$((n+1))
 done`
 
-	// removeServicesScript is written to /sbin and can be used to remove
+	// removeServicesScript is written to /usr/sbin and can be used to remove
 	// all Juju services from a machine.
 	// Once this script is run, logic to check whether such a machine is already
 	// provisioned should return false and the machine can be reused as a target
@@ -389,7 +389,7 @@ func (w *unixConfigure) ConfigureJuju() error {
 		}
 	}
 
-	w.conf.AddRunTextFile("/sbin/remove-juju-services", removeServicesScript, 0755)
+	w.conf.AddRunTextFile("/usr/sbin/remove-juju-services", removeServicesScript, 0755)
 
 	return w.addMachineAgentToBoot()
 }


### PR DESCRIPTION
On Ubuntu 26.04, the `usr-is-merged` transition is complete — vanilla images
have `/sbin` as a symlink to `/usr/sbin`. Juju was writing the
`remove-juju-services` script directly to `/sbin/remove-juju-services`, which
created a real file in `/sbin` and prevented the required `sbin -> usr/sbin`
directory symlink.

This breaks critical ecosystem tooling:

- **snapd bootstrap failures** — snapd expects `mount.fuse` and `mount.fuse3`
  in `/sbin`, but they reside in `/usr/sbin`
- **LXC container crashes** — LXD/LXC hardcodes `/sbin/init` and fails with
  `Failed to exec "/sbin/init"` when the symlink is missing

### Fix

Move the `remove-juju-services` script from `/sbin/` to `/usr/sbin/`, which is
the correct merged-usr location. This allows the OS to maintain the
`sbin@ -> usr/sbin` symlink, matching the vanilla `ubuntu:26.04` image layout.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Create charm for testing:

```sh
❯ mkdir -p testcharms/rebooter/hooks

❯ cat << EOF > testcharms/rebooter/charmcraft.yaml
type: charm
name: rebooter
summary: Reproducer for dropped juju-reboot 
description: Calls juju-reboot from config-changed.
base: ubuntu@26.04
build-base: ubuntu@26.04
platforms:
  amd64:
parts:
  rebooter:
    plugin: dump
    source: .
config:
  options:
    reboot-trigger:
      type: string
      default: ""
      description: Set to any value to ask the hook to queue a reboot.
EOF

❯ cat << EOF > testcharms/rebooter/hooks/start
#!/bin/bash
status-set active ""
EOF

❯ cat << EOF > testcharms/rebooter/hooks/install
#!/bin/bash
exit 0
EOF

❯ chmod +x testcharms/rebooter/hooks/install
❯ chmod +x testcharms/rebooter/hooks/start

❯ cd testcharms/rebooter/

❯ charmcraft pack --use-lxd
Packed rebooter_amd64.charm
```

Reproduce:

```sh
❯ juju bootstrap lxd ctrl-without-fix
❯ juju add-model m1

❯ juju deploy ./testcharms/rebooter/rebooter_amd64.charm rebooter
Located local charm "rebooter", revision 0
Deploying "rebooter" from local charm "rebooter", revision 0 on ubuntu@26.04/stable

❯ export LXD_MACHINE=$(juju status --format yaml | yq '.machines."0".hostname')

❯ lxc exec $LXD_MACHINE -- ls -l /sbin
total 4
-rwxr-xr-x 1 root root 932 Jul  7 11:40 remove-juju-services

❯ lxc exec $LXD_MACHINE -- ls -ld /sbin
drwxr-xr-x 2 root root 4096 Jul  7 11:40 /sbin

❯ lxc restart $LXD_MACHINE
Error: Failed to run: /snap/lxd/current/sbin/lxd forkstart juju-2dc59f-0 /var/snap/lxd/common/lxd/containers /var/snap/lxd/common/lxd/logs/juju-2dc59f-0/lxc.conf: exit status 1
Try `lxc info --show-log juju-2dc59f-0` for more info

❯ lxc info --show-log $LXD_MACHINE | grep ERROR
lxc juju-2dc59f-0 20260707114134.255 ERROR    start - ../src/src/lxc/start.c:start:2209 - No such file or directory - Failed to exec "/sbin/init"
lxc juju-2dc59f-0 20260707114134.255 ERROR    sync - ../src/src/lxc/sync.c:sync_wait:34 - An error occurred in another process (expected sequence number 7)
lxc juju-2dc59f-0 20260707114134.272 ERROR    start - ../src/src/lxc/start.c:__lxc_start:2119 - Failed to spawn container "juju-2dc59f-0"
lxc juju-2dc59f-0 20260707114134.272 ERROR    lxccontainer - ../src/src/lxc/lxccontainer.c:wait_on_daemonized_start:837 - Received container state "ABORTING" instead of "RUNNING"
lxc 20260707114134.377 ERROR    af_unix - ../src/src/lxc/af_unix.c:lxc_abstract_unix_recv_fds_iov:218 - Connection reset by peer - Failed to receive response
lxc 20260707114134.377 ERROR    commands - ../src/src/lxc/commands.c:lxc_cmd_rsp_recv_fds:128 - Failed to receive file descriptors for command "get_init_pid"

```

Test with 26.04:

```sh
❯ make install
❯ juju bootstrap lxd ctrl-with-fix --build-agent
❯ juju add-model m1

❯ juju deploy ./testcharms/rebooter/rebooter_amd64.charm rebooter
Located local charm "rebooter", revision 0
Deploying "rebooter" from local charm "rebooter", revision 0 on ubuntu@26.04/stable

❯ export LXD_MACHINE=$(juju status --format yaml | yq '.machines."0".hostname')

❯ lxc exec $LXD_MACHINE -- ls -ld /sbin
lrwxrwxrwx 1 root root 8 Apr 20 08:46 /sbin -> usr/sbin

❯ lxc restart $LXD_MACHINE

❯ jst
Model  Controller     Cloud/Region  Version   SLA          Timestamp
m1     ctrl-with-fix  lxd/default   3.6.25.1  unsupported  13:47:45+02:00

App       Version  Status  Scale  Charm     Channel  Rev  Exposed  Message
rebooter           active      1  rebooter             0  no

Unit         Workload  Agent  Machine  Public address  Ports  Message
rebooter/0*  active    idle   0        10.159.202.240

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.240  juju-1870c6-0  ubuntu@26.04  tuxedo  Running
```

Test with 24.04:

```sh
❯ yq -i '.base = "ubuntu@24.04" | .build-base = "ubuntu@24.04"' ./testcharms/rebooter/charmcraft.yaml

❯ cd ./testcharms/rebooter

❯ charmcraft pack --use-lxd
Packed rebooter_amd64.charm

❯ cd -
~/go/src/github.com/iyiguncevik/juju-36

❯ juju deploy ./testcharms/rebooter/rebooter_amd64.charm rebooter24
Located local charm "rebooter", revision 1
Deploying "rebooter24" from local charm "rebooter", revision 1 on ubuntu@24.04/stable

❯ export LXD_MACHINE=$(juju status --format yaml | yq '.machines."1".hostname')

❯ lxc exec $LXD_MACHINE -- cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04.4 LTS"

❯ lxc exec $LXD_MACHINE -- ls -ld /sbin
lrwxrwxrwx 1 root root 8 Apr 22  2024 /sbin -> usr/sbin

❯ lxc restart $LXD_MACHINE

❯ jst
Model  Controller     Cloud/Region  Version   SLA          Timestamp
m1     ctrl-with-fix  lxd/default   3.6.25.1  unsupported  13:54:40+02:00

App         Version  Status  Scale  Charm     Channel  Rev  Exposed  Message
rebooter             active      1  rebooter             0  no
rebooter24           active      1  rebooter             1  no

Unit           Workload  Agent  Machine  Public address  Ports  Message
rebooter24/0*  active    idle   1        10.159.202.2
rebooter/0*    active    idle   0        10.159.202.240

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.240  juju-1870c6-0  ubuntu@26.04  tuxedo  Running
1        started  10.159.202.2    juju-1870c6-1  ubuntu@24.04  tuxedo  Running

```

Test with 22.04:

```sh
❯ yq -i '.base = "ubuntu@22.04" | .build-base = "ubuntu@22.04"' ./testcharms/rebooter/charmcraft.yaml

❯ cd ./testcharms/rebooter

❯ charmcraft pack --use-lxd
Packed rebooter_amd64.charm

❯ cd -
~/go/src/github.com/iyiguncevik/juju-36

❯ juju deploy ./testcharms/rebooter/rebooter_amd64.charm rebooter22
Located local charm "rebooter", revision 2
Deploying "rebooter22" from local charm "rebooter", revision 2 on ubuntu@22.04/stable

❯ export LXD_MACHINE=$(juju status --format yaml | yq '.machines."2".hostname')

❯ lxc exec $LXD_MACHINE -- cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_CODENAME=jammy
DISTRIB_DESCRIPTION="Ubuntu 22.04.5 LTS"

❯ lxc exec $LXD_MACHINE -- ls -ld /sbin
lrwxrwxrwx 1 root root 8 Jul  5 10:51 /sbin -> usr/sbin

❯ lxc restart $LXD_MACHINE

❯ jst
Model  Controller     Cloud/Region  Version   SLA          Timestamp
m1     ctrl-with-fix  lxd/default   3.6.25.1  unsupported  14:01:02+02:00

App         Version  Status  Scale  Charm     Channel  Rev  Exposed  Message
rebooter             active      1  rebooter             0  no
rebooter22           active      1  rebooter             2  no
rebooter24           active      1  rebooter             1  no

Unit           Workload  Agent  Machine  Public address  Ports  Message
rebooter22/0*  active    idle   2        10.159.202.31
rebooter24/0*  active    idle   1        10.159.202.2
rebooter/0*    active    idle   0        10.159.202.240

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.240  juju-1870c6-0  ubuntu@26.04  tuxedo  Running
1        started  10.159.202.2    juju-1870c6-1  ubuntu@24.04  tuxedo  Running
2        started  10.159.202.31   juju-1870c6-2  ubuntu@22.04  tuxedo  Running

```

Test with 20.04:

```sh
❯ yq -i '.base = "ubuntu@20.04" | .build-base = "ubuntu@20.04"' ./testcharms/rebooter/charmcraft.yaml

❯ cd ./testcharms/rebooter

❯ charmcraft pack --use-lxd
Packed rebooter_amd64.charm

❯ cd -
~/go/src/github.com/iyiguncevik/juju-36

❯ juju deploy ./testcharms/rebooter/rebooter_amd64.charm rebooter20
Located local charm "rebooter", revision 3
Deploying "rebooter20" from local charm "rebooter", revision 3 on ubuntu@20.04/stable

❯ export LXD_MACHINE=$(juju status --format yaml | yq '.machines."3".hostname')

❯ lxc exec $LXD_MACHINE -- cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.6 LTS"

❯ lxc exec $LXD_MACHINE -- ls -ld /sbin
lrwxrwxrwx 1 root root 8 Jun 25  2025 /sbin -> usr/sbin

❯ lxc restart $LXD_MACHINE

❯ jst
Model  Controller     Cloud/Region  Version   SLA          Timestamp
m1     ctrl-with-fix  lxd/default   3.6.25.1  unsupported  14:09:45+02:00

App         Version  Status  Scale  Charm     Channel  Rev  Exposed  Message
rebooter             active      1  rebooter             0  no
rebooter20           active      1  rebooter             3  no
rebooter22           active      1  rebooter             2  no
rebooter24           active      1  rebooter             1  no

Unit           Workload  Agent  Machine  Public address  Ports  Message
rebooter20/0*  active    idle   3        10.159.202.67
rebooter22/0*  active    idle   2        10.159.202.31
rebooter24/0*  active    idle   1        10.159.202.2
rebooter/0*    active    idle   0        10.159.202.240

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.240  juju-1870c6-0  ubuntu@26.04  tuxedo  Running
1        started  10.159.202.2    juju-1870c6-1  ubuntu@24.04  tuxedo  Running
2        started  10.159.202.31   juju-1870c6-2  ubuntu@22.04  tuxedo  Running
3        started  10.159.202.67   juju-1870c6-3  ubuntu@20.04  tuxedo  Running
```


## Documentation changes

## Links

**Issue:** Fixes #22713

**Jira card:** [JUJU-10063](https://warthogs.atlassian.net/browse/JUJU-10063)


[JUJU-10063]: https://warthogs.atlassian.net/browse/JUJU-10063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ