### PR TITLE
docs: add missing redirect for howto/manage-your-deployment/take-your…

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -87,6 +87,7 @@ user/howto/manage-your-deployment/harden-your-deployment howto/manage-your-juju-
 user/howto/manage-your-deployment howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/
 user/howto/manage-your-deployment/manage-your-deployment-environment howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/
 user/howto/manage-your-deployment/take-your-deployment-offline howto/manage-your-juju-deployment/set-up-your-juju-deployment-offline/
+howto/manage-your-deployment/take-your-deployment-offline howto/manage-your-juju-deployment/set-up-your-juju-deployment-offline/
 user/howto/manage-your-deployment/troubleshoot-your-deployment howto/manage-your-juju-deployment/troubleshoot-your-juju-deployment/
 user/howto/manage-your-deployment/upgrade-your-deployment howto/manage-your-juju-deployment/troubleshoot-your-juju-deployment/
 user .


### PR DESCRIPTION
Fixes #22789.

The URL `howto/manage-your-deployment/take-your-deployment-offline` was returning a 404 because only the `user/`-prefixed variant had a redirect entry in redirects.txt. This adds the missing non-prefixed path, redirecting it to the current page at `howto/manage-your-juju-deployment/set-up-your-juju-deployment-offline/`.

## QA

https://canonical-juju-1--22800.com.readthedocs.build/22800/howto/manage-your-deployment/take-your-deployment-offline 

redirects to

https://canonical-juju-1--22800.com.readthedocs.build/22800/howto/manage-your-juju-deployment/set-up-your-juju-deployment-offline/index.html