### PR TITLE
4.0 docs fix take your deployment offline redirect issue 22789

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -91,6 +91,7 @@ user/howto/manage-your-deployment/harden-your-deployment howto/manage-your-juju-
 user/howto/manage-your-deployment howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/
 user/howto/manage-your-deployment/manage-your-deployment-environment howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/
 user/howto/manage-your-deployment/take-your-deployment-offline howto/manage-your-juju-deployment/set-up-your-juju-deployment-offline/
+howto/manage-your-deployment/take-your-deployment-offline howto/manage-your-juju-deployment/set-up-your-juju-deployment-offline/
 user/howto/manage-your-deployment/troubleshoot-your-deployment howto/manage-your-juju-deployment/troubleshoot-your-juju-deployment/
 user/howto/manage-your-deployment/upgrade-your-deployment howto/manage-your-juju-deployment/troubleshoot-your-juju-deployment/
 user .


### PR DESCRIPTION
Cherry-picks https://github.com/juju/juju/pull/22800 into 4.0.

## QA

https://canonical-juju-1--22801.com.readthedocs.build/22800/howto/manage-your-deployment/take-your-deployment-offline 

redirects to

https://canonical-juju-1--22801.com.readthedocs.build/22800/howto/manage-your-juju-deployment/set-up-your-juju-deployment-offline/index.html