### PR TITLE
docs: document how to map a juju snap revision to a juju version

### DIFF
--- a/docs/howto/manage-juju.md
+++ b/docs/howto/manage-juju.md
@@ -33,7 +33,7 @@ To install `juju` from snap, run:
 sudo snap install juju
 ```
 
-To select a particular version, run `snap info juju` to find out what versions are available, then `sudo snap install juju --channel=<track/risk[/branch]>` to install the version of your choice (e.g., `sudo snap install juju --channel=3.4/stable`).
+To select a particular version, run `snap info juju` to find out what versions are available, then `sudo snap install juju --channel=<track/risk[/branch]>` to install the version of your choice (e.g., `sudo snap install juju --channel=3.4/stable`). The output also shows the snap revision number in parentheses next to each version.
 
 ````{dropdown} Example
 


### PR DESCRIPTION
Fixes #22785.

Add an inline sentence to the snap info juju paragraph in `howto/manage-juju.md` noting that revision numbers are shown alongside versions in the output, and explaining how to reverse-lookup a Juju version from a snap revision number (`snap download --revision`, `unsquashfs`, inspect `bin/jujud-version.yaml`).