### PR TITLE
docs: add 5 MiB size limit note for config values read from file

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -53,6 +53,8 @@ key's value to the contents of a file:
 
     juju config <app> key=@/tmp/configvalue
 
+The maximum size of a config value read from a file this way is 5 MiB.
+
 You can also reset config keys to their default values:
 
     juju config <app> --reset key1

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/config.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/config.md
@@ -63,6 +63,8 @@ key's value to the contents of a file:
 
     juju config <app> key=@/tmp/configvalue
 
+The maximum size of a config value read from a file this way is 5 MiB.
+
 You can also reset config keys to their default values:
 
     juju config <app> --reset key1


### PR DESCRIPTION
Fixes #19738.

The `@` directive allows setting a config key's value from a file, but the 5 MiB maximum size (enforced in `utils.go`) was not documented anywhere. This PR adds a sentence noting the limit immediately after the `@` directive example in the command help text, and include the regenerated CLI reference doc.