### PR TITLE
docs: document add-k8s piping requirement for Canonical K8s

### DIFF
--- a/docs/reference/cloud/list-of-supported-clouds/canonical-kubernetes.md
+++ b/docs/reference/cloud/list-of-supported-clouds/canonical-kubernetes.md
@@ -33,6 +33,14 @@ This reference assumes basic familiarity with Juju. If you are new to Juju, star
 ```{include} ./reuse/k8s/cloud-definition.md
 ```
 
+**Note for Canonical Kubernetes:** Because this cloud uses `k8s kubectl` rather than the standard `kubectl`, `juju add-k8s` cannot read the `kubeconfig` automatically. Instead, you must pipe it explicitly
+
+```text
+sudo k8s kubectl config view --raw | juju add-k8s <cloud name> --client
+```
+
+When piping via stdin, Juju cannot prompt interactively to ask whether to register the cloud on the client or a controller, so you must specify `--client` (or `--controller <name>`) explicitly.
+
 ## Credentials
 
 ```{include} ./reuse/k8s/auth-types.md


### PR DESCRIPTION
Fixes #19903.

Canonical Kubernetes uses `k8s kubectl` rather than the standard `kubectl`, so the `kubeconfig` must be piped explicitly via `sudo k8s kubectl config view --raw | juju add-k8s <name>`. Additionally, when `stdin` is piped, Juju cannot prompt interactively to choose between `--client` and `--controller`, so one of these flags must be passed explicitly.