### PR TITLE
3.6 docs document manual ssh controller bootstrap issue 22572

### DIFF
--- a/docs/reference/cloud/list-of-supported-clouds/manual.md
+++ b/docs/reference/cloud/list-of-supported-clouds/manual.md
@@ -106,6 +106,12 @@ See also: {ref}`controller`, {ref}`Juju | Manage controllers <manage-controllers
 
 When adding the cloud, enter the SSH connection information for the machine where a Juju controller will be bootstrapped, e.g., `username@<hostname or IP>` (where we assume `username` is `ubuntu`) or `<hostname or IP>`.
 
+Alternatively, you can pass the SSH target inline to `juju bootstrap`, skipping the `add-cloud` step entirely:
+
+```text
+juju bootstrap manual/ubuntu@<IP> <controller-name>
+```
+
 (manual-controller-bootstrap-behavior)=
 ### Bootstrap behavior
 


### PR DESCRIPTION
Fixes #22572.

The inline syntax for bootstrapping a manual cloud controller without a prior `add-cloud` step (`juju bootstrap manual/ubuntu@<IP> <name>`) was undiscoverable -- users had to find it via an LLM. This PR adds it to the ## Controllers section of the manual cloud reference doc, immediately before the bootstrap behavior detail.