### PR TITLE
docs: extend secret lifecycle section to cover user-secret lifecycle

### DIFF
--- a/docs/reference/hook.md
+++ b/docs/reference/hook.md
@@ -492,6 +492,8 @@ Thereafter, any subsequent `secret-changed` hooks will be run with this label.
 
 All units observing the affected secret.
 
+For a {ref}`user secret <user-secret>`, `secret-changed` is the **only** secret hook an observer ever receives. It fires when the user updates the secret content with `juju update-secret`. The `juju grant-secret` command does **not** fire a hook; the secret only becomes observable after the user also configures the application with the secret URI (which triggers `config-changed`). User secrets have no rotate, expire, or remove lifecycle.
+
 ```{note}
 Upon receiving that event (or at any time after that) a consumer can choose to:
 

--- a/docs/reference/secret.md
+++ b/docs/reference/secret.md
@@ -202,9 +202,7 @@ An entity that does not own the secret can only **view** it (call `secret-get`),
 
 ## Secret lifecycle
 
-```{important}
-This section currently covers only the lifecycle of a charm secret.
-```
+### Charm-secret lifecycle
 
 Charms can use relations to share secrets, such as API keys, a database's address, credentials and so on. Like a relation has a "provider" and a "requirer", so a secret has an "owner" and an "observer" -- though these need not coincide with the applications' roles in the relation.
 
@@ -235,4 +233,17 @@ Juju maintains a list of which observers are tracking each revision of each secr
 Charms that create secrets should _always_ handle the `secret-remove` event. That is because secret revisions, even if obsolete, remain until removed by the charm; if a charm does not remove them, they accumulate indefinitely.
 
 ```
+
+### User-secret lifecycle
+
+A user secret's lifecycle consists of:
+
+1. **Create**: A model admin creates the secret: `juju add-secret <name> <key>=<value>`.
+2. **Grant**: The admin grants access to an application: `juju grant-secret <name> <app-name>` — this does **not** fire a hook on the observing charm.
+3. **Configure**: The admin sets the application's configuration option to the secret URI: `juju config <app-name> <option>=<secret-uri>` — this triggers a `config-changed` hook on the observing charm.
+4. **Update**: The admin updates the secret content: `juju update-secret <name> <key>=<new-value>` — this triggers `secret-changed` on all observing units.
+
+The **only hook** a user-secret observer receives is `secret-changed`. There is no `secret-rotate`, `secret-expired`, or `secret-remove` lifecycle for user secrets.
+
+> See also: {ref}`hook-secret-changed`, {ref}`manage-secrets`
 


### PR DESCRIPTION
Backport of #22529 into `3.6`.

Extends the secret reference docs to cover the user-secret lifecycle:
- Replaces the "charm secrets only" important note in `secret.md` with a `Charm-secret lifecycle` subheading, and adds a new `User-secret lifecycle` subsection describing the create → grant → configure → update flow.
- Adds a note to the `secret-changed` entry in hook.md clarifying that it is the **only** hook a user-secret observer receives, and that `grant-secret` does not fire a hook.