### PR TITLE
docs: document the ip-family constraint (JUJU-9878)

### DIFF
--- a/docs/howto/manage-spaces.md
+++ b/docs/howto/manage-spaces.md
@@ -13,10 +13,6 @@ See also: {ref}`space`
 
 Juju users are able to create, view, rename, or delete spaces.
 
-```{caution}
-Juju can deploy to an IPv6 stack or an IPv4 stack, but not both at once (i.e., dual stacks are not supported).
-```
-
 (add-a-space)=
 ## Add a space
 

--- a/docs/reference/cloud/list-of-supported-clouds/amazon-ec2.md
+++ b/docs/reference/cloud/list-of-supported-clouds/amazon-ec2.md
@@ -261,7 +261,7 @@ The constraints `instance-type` and `[arch, cores, cpu-power, mem]` are mutually
 - {ref}`constraint-mem`
 **Networking**
 
-- {ref}`constraint-ip-family`. Ignored; the effective IP family depends on VPC subnet configuration.
+- {ref}`constraint-ip-family`. Not supported; the effective IP family depends on VPC subnet configuration.
 - {ref}`constraint-spaces`
 - {ref}`constraint-zones`
 

--- a/docs/reference/cloud/list-of-supported-clouds/amazon-ec2.md
+++ b/docs/reference/cloud/list-of-supported-clouds/amazon-ec2.md
@@ -261,6 +261,7 @@ The constraints `instance-type` and `[arch, cores, cpu-power, mem]` are mutually
 - {ref}`constraint-mem`
 **Networking**
 
+- {ref}`constraint-ip-family`. Ignored; the effective IP family depends on VPC subnet configuration.
 - {ref}`constraint-spaces`
 - {ref}`constraint-zones`
 

--- a/docs/reference/cloud/list-of-supported-clouds/google-gce.md
+++ b/docs/reference/cloud/list-of-supported-clouds/google-gce.md
@@ -206,6 +206,7 @@ The constraints `instance-type` and `[cores, cpu-power, mem]` are mutually exclu
 
 **Networking**
 
+- {ref}`constraint-ip-family`. IPv4 only (hardcoded in provider).
 - {ref}`constraint-allocate-public-ip`
 - {ref}`constraint-spaces`
 - {ref}`constraint-zones`

--- a/docs/reference/cloud/list-of-supported-clouds/lxd.md
+++ b/docs/reference/cloud/list-of-supported-clouds/lxd.md
@@ -203,6 +203,7 @@ LXD supports the following {ref}`constraints <constraint>`:
 
 **Networking**
 
+- {ref}`constraint-ip-family`. The IP family is determined by the LXD bridge (`lxdbr0`) configuration on the host.
 - {ref}`constraint-zones`. LXD node name(s). In clustered LXD, specifies which cluster member to place the instance on.
 
 **Storage**

--- a/docs/reference/cloud/list-of-supported-clouds/maas.md
+++ b/docs/reference/cloud/list-of-supported-clouds/maas.md
@@ -152,6 +152,7 @@ MAAS supports the following {ref}`constraints <constraint>`:
 
 **Networking**
 
+- {ref}`constraint-ip-family`. The IP family reflects the machine's interfaces as configured in MAAS.
 - {ref}`constraint-spaces`
 - {ref}`constraint-zones`
 

--- a/docs/reference/cloud/list-of-supported-clouds/microsoft-azure.md
+++ b/docs/reference/cloud/list-of-supported-clouds/microsoft-azure.md
@@ -215,6 +215,7 @@ The constraints `instance-type` and `[arch, cores, mem]` are mutually exclusive.
 
 **Networking**
 
+- {ref}`constraint-ip-family`. Valid values: `ipv4` (default), `dual`. `dual` provisions dual-stack (IPv4 + IPv6); requires `load-balancer-sku-name=Standard`. `ipv6` is rejected by Azure (NICs require at least one IPv4 configuration).
 - {ref}`constraint-allocate-public-ip`
 
 ```{note}

--- a/docs/reference/cloud/list-of-supported-clouds/microsoft-azure.md
+++ b/docs/reference/cloud/list-of-supported-clouds/microsoft-azure.md
@@ -215,7 +215,10 @@ The constraints `instance-type` and `[arch, cores, mem]` are mutually exclusive.
 
 **Networking**
 
-- {ref}`constraint-ip-family`. Valid values: `ipv4` (default), `dual`. `dual` provisions dual-stack (IPv4 + IPv6); requires `load-balancer-sku-name=Standard`. `ipv6` is rejected by Azure (NICs require at least one IPv4 configuration).
+- {ref}`constraint-ip-family`. Valid values: `ipv4` (default), `dual`.
+  `dual` provisions dual-stack (IPv4 + IPv6); requires
+  {ref}`load-balancer-sku-name <azure-model-load-balancer-sku-name>` = `Standard`.
+  `ipv6` is rejected by Azure (NICs require at least one IPv4 configuration).
 - {ref}`constraint-allocate-public-ip`
 
 ```{note}

--- a/docs/reference/cloud/list-of-supported-clouds/openstack.md
+++ b/docs/reference/cloud/list-of-supported-clouds/openstack.md
@@ -233,6 +233,7 @@ The constraints `instance-type` and `[mem, cores]` are mutually exclusive. Addit
 
 **Networking**
 
+- {ref}`constraint-ip-family`. The IP family depends on the Neutron network configuration.
 - {ref}`constraint-allocate-public-ip`
 - {ref}`constraint-zones`
 

--- a/docs/reference/cloud/list-of-supported-clouds/oracle-oci.md
+++ b/docs/reference/cloud/list-of-supported-clouds/oracle-oci.md
@@ -164,6 +164,7 @@ Oracle OCI supports the following {ref}`constraints <constraint>`:
 
 **Networking**
 
+- {ref}`constraint-ip-family`. IPv4 only (hardcoded in provider).
 - {ref}`constraint-allocate-public-ip`
 - {ref}`constraint-zones`. Specifies availability domain. Example: `zones=us-phoenix-1:AD-1`.
 

--- a/docs/reference/cloud/list-of-supported-clouds/vmware-vsphere.md
+++ b/docs/reference/cloud/list-of-supported-clouds/vmware-vsphere.md
@@ -198,6 +198,7 @@ VMware vSphere supports the following {ref}`constraints <constraint>`:
 
 **Networking**
 
+- {ref}`constraint-ip-family`. The IP family depends on the VM network and DHCP configuration.
 - {ref}`constraint-zones`. Specifies resource pools within a host or cluster. Examples: `zones=myhost`, `zones=myfolder/myhost`, `zones=mycluster/mypool`, `zones=mycluster/myparent/mypool`.
 
 **Storage**

--- a/docs/reference/constraint.md
+++ b/docs/reference/constraint.md
@@ -70,8 +70,9 @@ Cloud-specific instance-type name. Values vary by provider, and individual deplo
 ```
 
 The IP address family for the machine's network interfaces. <p> **Valid values:**
-`ipv4`, `ipv6`, `dual`. <p> See the cloud-specific documentation for supported
-values and behavior.
+`ipv4`, `ipv6`, `dual` (`ipv6`-only is not currently supported by any
+provider). <p> See the cloud-specific documentation for supported values
+and behavior.
 
 (constraint-mem)=
 ### `mem`

--- a/docs/reference/constraint.md
+++ b/docs/reference/constraint.md
@@ -63,6 +63,16 @@ Indicates that the specified role/profile for the given cloud should be used.  <
 
 Cloud-specific instance-type name. Values vary by provider, and individual deployment in some cases. <p> **Note:** When compatibility between clouds is desired, use corresponding values for `cores`, `mem`, and `root-disk` instead.
 
+(constraint-ip-family)=
+### `ip-family`
+
+```{versionadded} 4.1.0
+```
+
+The IP address family for the machine's network interfaces. <p> **Valid values:**
+`ipv4`, `ipv6`, `dual`. <p> See the cloud-specific documentation for supported
+values and behavior.
+
 (constraint-mem)=
 ### `mem`
 


### PR DESCRIPTION
## Why this change is needed and what it does

Documents the new `ip-family` constraint as part of the JUJU-9599 Azure dual-stack feature.

## Checklist

- ~Code style: imports ordered, good names, simple structure, etc~
- ~Comments saying why design decisions were made~
- ~Go unit tests, with comments saying what you are testing~
- ~[Integration tests](https://github.com/juju/juju/tree/main/tests)~
- ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run the docs server and verify the new constraint entry renders correctly:

```sh
cd docs && make serve
```

Navigate to:
- Reference > Constraint — the new `ip-family` entry should appear between `instance-type` and `mem`
- Each cloud provider page — the `ip-family` row should appear in the Supported constraints table

## Documentation changes

This is a documentation-only PR.

Modified files:
- `docs/reference/constraint.md` — add `ip-family` constraint entry
- `docs/reference/cloud/list-of-supported-clouds/the-microsoft-azure-cloud-and-juju.md` — add ✓ row
- `docs/reference/cloud/list-of-supported-clouds/the-amazon-ec2-cloud-and-juju.md` — add ✗ row
- `docs/reference/cloud/list-of-supported-clouds/the-google-gce-cloud-and-juju.md` — add ✗ row
- `docs/reference/cloud/list-of-supported-clouds/the-openstack-cloud-and-juju.md` — add ✗ row
- `docs/reference/cloud/list-of-supported-clouds/the-oracle-oci-cloud-and-juju.md` — add ✗ row
- `docs/reference/cloud/list-of-supported-clouds/the-maas-cloud-and-juju.md` — add ✗ row
- `docs/reference/cloud/list-of-supported-clouds/the-vmware-vsphere-cloud-and-juju.md` — add ✗ row
- `docs/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md` — add ✗ row
- `docs/howto/manage-spaces.md` — remove outdated caution about dual-stack support

## Links

**Jira card:** [JUJU-9878](https://warthogs.atlassian.net/browse/JUJU-9878)


[JUJU-9878]: https://warthogs.atlassian.net/browse/JUJU-9878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ