### PR TITLE
fix: rework logrouter manifold dependencies

### DIFF
--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -162,16 +162,7 @@ func (p machineControllerStartupValueProvider) APIInfo() (*api.Info, error) {
 // agent config. It re-reads current values on each call so bounced workers
 // see current logging destination settings.
 func (p machineControllerStartupValueProvider) CurrentLokiConfig() (logrouter.ConfigSnapshot, error) {
-	cfg := p.agent.CurrentConfig()
-	return logrouter.ConfigSnapshot{
-		Endpoint:           cfg.LokiEndpoint(),
-		CACertificate:      cfg.LokiCACert(),
-		InsecureSkipVerify: cfg.LokiInsecureSkipVerify(),
-		ControllerUUID:     cfg.Controller().Id(),
-		ModelUUID:          cfg.Model().Id(),
-		AgentID:            cfg.Tag().String(),
-		OrgID:              cfg.LokiOrgID(),
-	}, nil
+	return logrouter.ConfigSnapshotFromAgentConfig(p.agent.CurrentConfig()), nil
 }
 
 // machineModelStartupValueProvider supplies current model-local startup

--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -75,6 +75,7 @@ import (
 	workerflightrecorder "github.com/juju/juju/internal/worker/flightrecorder"
 	"github.com/juju/juju/internal/worker/gate"
 	"github.com/juju/juju/internal/worker/introspection"
+	"github.com/juju/juju/internal/worker/logrouter"
 	"github.com/juju/juju/internal/worker/logsender"
 	"github.com/juju/juju/internal/worker/migrationmaster"
 	"github.com/juju/juju/internal/worker/modelworkermanager"
@@ -155,6 +156,22 @@ func (p machineControllerStartupValueProvider) APIInfo() (*api.Info, error) {
 		return nil, errors.NotFoundf("API info")
 	}
 	return info, nil
+}
+
+// CurrentLokiConfig returns the current logrouter backend configuration from
+// agent config. It re-reads current values on each call so bounced workers
+// see current logging destination settings.
+func (p machineControllerStartupValueProvider) CurrentLokiConfig() (logrouter.ConfigSnapshot, error) {
+	cfg := p.agent.CurrentConfig()
+	return logrouter.ConfigSnapshot{
+		Endpoint:           cfg.LokiEndpoint(),
+		CACertificate:      cfg.LokiCACert(),
+		InsecureSkipVerify: cfg.LokiInsecureSkipVerify(),
+		ControllerUUID:     cfg.Controller().Id(),
+		ModelUUID:          cfg.Model().Id(),
+		AgentID:            cfg.Tag().String(),
+		OrgID:              cfg.LokiOrgID(),
+	}, nil
 }
 
 // machineModelStartupValueProvider supplies current model-local startup

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -608,9 +608,9 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The log router owns the buffered log stream and forwards records to
 		// one active backend at a time.
 		logRouterName: ifNotMigrating(logrouter.Manifold(logrouter.ManifoldConfig{
-			AgentName:            agentName,
 			APICallerName:        apiCallerName,
 			HTTPClientName:       httpClientName,
+			LokiConfigProvider:   config.StartupValueProvider,
 			LogSource:            config.LogSource,
 			AgentConfigChanged:   config.AgentConfigChanged,
 			Logger:               internallogger.GetLogger("juju.worker.logrouter"),
@@ -686,8 +686,8 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// local logsink directly in logsink mode, avoiding the cycle:
 		// log-router -> api-caller -> api-server -> log-sink -> log-router.
 		controllerLogRouterName: ifController(logrouter.ControllerManifold(logrouter.ControllerManifoldConfig{
-			AgentName:            agentName,
 			HTTPClientName:       httpClientName,
+			LokiConfigProvider:   config.StartupValueProvider,
 			AgentConfigChanged:   config.AgentConfigChanged,
 			Logger:               internallogger.GetLogger("juju.worker.logrouter.controller"),
 			Clock:                config.Clock,
@@ -1571,6 +1571,7 @@ type ControllerStartupValueProvider interface {
 	apiservercertwatcher.CertReader
 	apiserver.LocalConfigReader
 	apiremotecaller.APIInfoProvider
+	logrouter.LokiConfigProvider
 }
 
 const (

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -608,9 +608,9 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The log router owns the buffered log stream and forwards records to
 		// one active backend at a time.
 		logRouterName: ifNotMigrating(logrouter.Manifold(logrouter.ManifoldConfig{
+			AgentName:            agentName,
 			APICallerName:        apiCallerName,
 			HTTPClientName:       httpClientName,
-			LokiConfigProvider:   config.StartupValueProvider,
 			LogSource:            config.LogSource,
 			AgentConfigChanged:   config.AgentConfigChanged,
 			Logger:               internallogger.GetLogger("juju.worker.logrouter"),

--- a/internal/provider/kubernetes/export_test.go
+++ b/internal/provider/kubernetes/export_test.go
@@ -50,6 +50,7 @@ type ControllerStackerForTest interface {
 	GetControllerUnitAgentPassword() string
 	GetStorageSize() resource.Quantity
 	GetControllerSvcSpec(string, *podcfg.BootstrapConfig) (*controllerServiceSpec, error)
+	SetControllerAgentLokiConfig(string, *string, *bool, string)
 }
 
 func (cs *controllerStack) GetControllerAgentConfigContent(c *tc.C) string {
@@ -74,6 +75,10 @@ func (cs *controllerStack) GetStorageSize() resource.Quantity {
 
 func (cs *controllerStack) GetControllerSvcSpec(cloudType string, cfg *podcfg.BootstrapConfig) (*controllerServiceSpec, error) {
 	return cs.getControllerSvcSpec(cloudType, cfg)
+}
+
+func (cs *controllerStack) SetControllerAgentLokiConfig(endpoint string, caCert *string, insecureSkipVerify *bool, orgID string) {
+	cs.agentConfig.SetLokiConfig(endpoint, caCert, insecureSkipVerify, orgID)
 }
 
 func NewcontrollerStackForTest(

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -44,19 +44,12 @@ type ControllerBackendFuncFactory func(
 
 // ManifoldConfig defines the names of the manifolds used by logrouter.
 type ManifoldConfig struct {
-	// AgentName is the dependency name for the agent manifold. When set,
-	// the manifold reads the current agent config to create a
-	// LokiConfigProvider. Use AgentName for non-controller paths
-	// where the agent is available through the dependency graph.
+	// AgentName is the dependency name for the agent manifold. The manifold
+	// reads the current agent config to create a LokiConfigProvider.
 	AgentName string
 
 	APICallerName  string
 	HTTPClientName string
-
-	// LokiConfigProvider is a direct LokiConfigProvider. When set, it
-	// takes precedence over AgentName. Use this for controller paths
-	// where the provider is injected directly.
-	LokiConfigProvider LokiConfigProvider
 
 	LogSource            logsender.LogRecordCh
 	AgentConfigChanged   *voyeur.Value
@@ -73,8 +66,8 @@ type ManifoldConfig struct {
 
 // Validate validates the manifold configuration.
 func (c ManifoldConfig) Validate() error {
-	if c.AgentName == "" && c.LokiConfigProvider == nil {
-		return errors.NotValidf("empty AgentName and nil LokiConfigProvider")
+	if c.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
 	}
 	if c.APICallerName == "" {
 		return errors.NotValidf("empty APICallerName")
@@ -111,26 +104,17 @@ func (c ManifoldConfig) Validate() error {
 
 // Manifold returns a dependency manifold that runs the logrouter worker.
 func Manifold(config ManifoldConfig) dependency.Manifold {
-	inputs := []string{config.APICallerName, config.HTTPClientName}
-	if config.AgentName != "" {
-		inputs = append([]string{config.AgentName}, inputs...)
-	}
-
 	return dependency.Manifold{
-		Inputs: inputs,
+		Inputs: []string{config.AgentName, config.APICallerName, config.HTTPClientName},
 		Output: outputFunc,
 		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 			if err := config.Validate(); err != nil {
 				return nil, internalerrors.Capture(err)
 			}
 
-			lokiConfigProvider := config.LokiConfigProvider
-			if lokiConfigProvider == nil {
-				var a agent.Agent
-				if err := getter.Get(config.AgentName, &a); err != nil {
-					return nil, err
-				}
-				lokiConfigProvider = agentLokiConfigProvider{agent: a}
+			var a agent.Agent
+			if err := getter.Get(config.AgentName, &a); err != nil {
+				return nil, err
 			}
 
 			var apiCaller base.APICaller
@@ -147,7 +131,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			return NewWorker(WorkerConfig{
-				LokiConfigProvider:        lokiConfigProvider,
+				LokiConfigProvider:        agentLokiConfigProvider{agent: a},
 				LogSource:                 config.LogSource,
 				AgentConfigChanged:        config.AgentConfigChanged,
 				Logger:                    config.Logger,
@@ -170,16 +154,7 @@ type agentLokiConfigProvider struct {
 }
 
 func (p agentLokiConfigProvider) CurrentLokiConfig() (ConfigSnapshot, error) {
-	cfg := p.agent.CurrentConfig()
-	return ConfigSnapshot{
-		Endpoint:           cfg.LokiEndpoint(),
-		CACertificate:      cfg.LokiCACert(),
-		InsecureSkipVerify: cfg.LokiInsecureSkipVerify(),
-		ControllerUUID:     cfg.Controller().Id(),
-		ModelUUID:          cfg.Model().Id(),
-		AgentID:            cfg.Tag().String(),
-		OrgID:              cfg.LokiOrgID(),
-	}, nil
+	return ConfigSnapshotFromAgentConfig(p.agent.CurrentConfig()), nil
 }
 
 // ControllerManifoldConfig defines the names of the manifolds used by the

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -44,9 +44,20 @@ type ControllerBackendFuncFactory func(
 
 // ManifoldConfig defines the names of the manifolds used by logrouter.
 type ManifoldConfig struct {
-	AgentName            string
-	APICallerName        string
-	HTTPClientName       string
+	// AgentName is the dependency name for the agent manifold. When set,
+	// the manifold reads the current agent config to create a
+	// LokiConfigProvider. Use AgentName for non-controller paths
+	// where the agent is available through the dependency graph.
+	AgentName string
+
+	APICallerName  string
+	HTTPClientName string
+
+	// LokiConfigProvider is a direct LokiConfigProvider. When set, it
+	// takes precedence over AgentName. Use this for controller paths
+	// where the provider is injected directly.
+	LokiConfigProvider LokiConfigProvider
+
 	LogSource            logsender.LogRecordCh
 	AgentConfigChanged   *voyeur.Value
 	Logger               corelogger.Logger
@@ -56,19 +67,14 @@ type ManifoldConfig struct {
 
 	NewBackendFunc BackendFuncFactory
 
-	// RemoveLegacyLogSinkWriter is called when switching to Loki
-	// backend mode. It must be idempotent.
 	RemoveLegacyLogSinkWriter func()
-
-	// AddLegacyLogSinkWriter is called when switching to LogSink
-	// backend mode. It must be idempotent.
-	AddLegacyLogSinkWriter func() error
+	AddLegacyLogSinkWriter    func() error
 }
 
 // Validate validates the manifold configuration.
 func (c ManifoldConfig) Validate() error {
-	if c.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
+	if c.AgentName == "" && c.LokiConfigProvider == nil {
+		return errors.NotValidf("empty AgentName and nil LokiConfigProvider")
 	}
 	if c.APICallerName == "" {
 		return errors.NotValidf("empty APICallerName")
@@ -105,22 +111,28 @@ func (c ManifoldConfig) Validate() error {
 
 // Manifold returns a dependency manifold that runs the logrouter worker.
 func Manifold(config ManifoldConfig) dependency.Manifold {
+	inputs := []string{config.APICallerName, config.HTTPClientName}
+	if config.AgentName != "" {
+		inputs = append([]string{config.AgentName}, inputs...)
+	}
+
 	return dependency.Manifold{
-		Inputs: []string{
-			config.AgentName,
-			config.APICallerName,
-			config.HTTPClientName,
-		},
+		Inputs: inputs,
 		Output: outputFunc,
 		Start: func(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 			if err := config.Validate(); err != nil {
 				return nil, internalerrors.Capture(err)
 			}
 
-			var a agent.Agent
-			if err := getter.Get(config.AgentName, &a); err != nil {
-				return nil, err
+			lokiConfigProvider := config.LokiConfigProvider
+			if lokiConfigProvider == nil {
+				var a agent.Agent
+				if err := getter.Get(config.AgentName, &a); err != nil {
+					return nil, err
+				}
+				lokiConfigProvider = agentLokiConfigProvider{agent: a}
 			}
+
 			var apiCaller base.APICaller
 			if err := getter.Get(config.APICallerName, &apiCaller); err != nil {
 				return nil, err
@@ -135,7 +147,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			return NewWorker(WorkerConfig{
-				Agent:                     a,
+				LokiConfigProvider:        lokiConfigProvider,
 				LogSource:                 config.LogSource,
 				AgentConfigChanged:        config.AgentConfigChanged,
 				Logger:                    config.Logger,
@@ -151,11 +163,30 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 	}
 }
 
+// agentLokiConfigProvider wraps an agent.Agent and implements
+// LokiConfigProvider by reading from the current agent config.
+type agentLokiConfigProvider struct {
+	agent agent.Agent
+}
+
+func (p agentLokiConfigProvider) CurrentLokiConfig() (ConfigSnapshot, error) {
+	cfg := p.agent.CurrentConfig()
+	return ConfigSnapshot{
+		Endpoint:           cfg.LokiEndpoint(),
+		CACertificate:      cfg.LokiCACert(),
+		InsecureSkipVerify: cfg.LokiInsecureSkipVerify(),
+		ControllerUUID:     cfg.Controller().Id(),
+		ModelUUID:          cfg.Model().Id(),
+		AgentID:            cfg.Tag().String(),
+		OrgID:              cfg.LokiOrgID(),
+	}, nil
+}
+
 // ControllerManifoldConfig defines the names of the manifolds used by the
 // controller-local logrouter path.
 type ControllerManifoldConfig struct {
-	AgentName            string
 	HTTPClientName       string
+	LokiConfigProvider   LokiConfigProvider
 	AgentConfigChanged   *voyeur.Value
 	Logger               corelogger.Logger
 	Clock                clock.Clock
@@ -167,11 +198,11 @@ type ControllerManifoldConfig struct {
 
 // Validate validates the controller-local manifold configuration.
 func (c ControllerManifoldConfig) Validate() error {
-	if c.AgentName == "" {
-		return errors.NotValidf("empty AgentName")
-	}
 	if c.HTTPClientName == "" {
 		return errors.NotValidf("empty HTTPClientName")
+	}
+	if c.LokiConfigProvider == nil {
+		return errors.NotValidf("nil LokiConfigProvider")
 	}
 	if c.AgentConfigChanged == nil {
 		return errors.NotValidf("nil AgentConfigChanged")
@@ -200,7 +231,6 @@ func (c ControllerManifoldConfig) Validate() error {
 func ControllerManifold(config ControllerManifoldConfig) dependency.Manifold {
 	return dependency.Manifold{
 		Inputs: []string{
-			config.AgentName,
 			config.HTTPClientName,
 		},
 		Output: outputFunc,
@@ -209,10 +239,6 @@ func ControllerManifold(config ControllerManifoldConfig) dependency.Manifold {
 				return nil, internalerrors.Capture(err)
 			}
 
-			var a agent.Agent
-			if err := getter.Get(config.AgentName, &a); err != nil {
-				return nil, err
-			}
 			var httpClientGetter corehttp.HTTPClientGetter
 			if err := getter.Get(config.HTTPClientName, &httpClientGetter); err != nil {
 				return nil, err
@@ -223,7 +249,7 @@ func ControllerManifold(config ControllerManifoldConfig) dependency.Manifold {
 			}
 
 			return NewWorker(WorkerConfig{
-				Agent:                     a,
+				LokiConfigProvider:        config.LokiConfigProvider,
 				LogSource:                 make(logsender.LogRecordCh),
 				AgentConfigChanged:        config.AgentConfigChanged,
 				Logger:                    config.Logger,

--- a/internal/worker/logrouter/manifold_test.go
+++ b/internal/worker/logrouter/manifold_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/worker/v5/workertest"
 	"github.com/prometheus/client_golang/prometheus"
 
-	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	corehttp "github.com/juju/juju/core/http"
 	corelogger "github.com/juju/juju/core/logger"
@@ -34,6 +33,15 @@ func TestManifoldSuite(t *testing.T) {
 
 func (s *manifoldSuite) TestInputs(c *tc.C) {
 	manifold := Manifold(ManifoldConfig{
+		APICallerName:  "api-caller",
+		HTTPClientName: "http-client",
+	})
+
+	c.Check(manifold.Inputs, tc.DeepEquals, []string{"api-caller", "http-client"})
+}
+
+func (s *manifoldSuite) TestInputsIncludesAgentName(c *tc.C) {
+	manifold := Manifold(ManifoldConfig{
 		AgentName:      "agent",
 		APICallerName:  "api-caller",
 		HTTPClientName: "http-client",
@@ -44,11 +52,10 @@ func (s *manifoldSuite) TestInputs(c *tc.C) {
 
 func (s *manifoldSuite) TestControllerInputs(c *tc.C) {
 	manifold := ControllerManifold(ControllerManifoldConfig{
-		AgentName:      "agent",
 		HTTPClientName: "http-client",
 	})
 
-	c.Check(manifold.Inputs, tc.DeepEquals, []string{"agent", "http-client"})
+	c.Check(manifold.Inputs, tc.DeepEquals, []string{"http-client"})
 }
 
 func (s *manifoldSuite) TestValidateAcceptsValidConfig(c *tc.C) {
@@ -74,17 +81,15 @@ func (s *manifoldSuite) TestStartValidatesBeforeGetter(c *tc.C) {
 	})
 	c.Check(w, tc.IsNil)
 	c.Assert(err, tc.NotNil)
-	c.Check(err.Error(), tc.Equals, `empty AgentName not valid`)
+	c.Check(err.Error(), tc.Equals, `empty AgentName and nil LokiConfigProvider not valid`)
 	c.Check(getterCalled.Load(), tc.IsFalse)
 }
 
 func (s *manifoldSuite) TestStartCreatesWorkerWithoutUsingAPICaller(c *tc.C) {
-	fixture := newFixture(c, "http://loki/loki/api/v1/push")
 	cfg := s.validManifoldConfig(c)
 	manifold := Manifold(cfg)
 
 	w, err := manifold.Start(c.Context(), manifoldGetter{
-		agent:     fixture.agent,
 		apiCaller: stubAPICaller{},
 		http:      stubHTTPClientGetter{},
 	})
@@ -93,13 +98,11 @@ func (s *manifoldSuite) TestStartCreatesWorkerWithoutUsingAPICaller(c *tc.C) {
 }
 
 func (s *manifoldSuite) TestControllerStartCreatesWorkerWithoutAPICaller(c *tc.C) {
-	fixture := newFixture(c, "http://loki/loki/api/v1/push")
 	cfg := s.validControllerManifoldConfig(c)
 	manifold := ControllerManifold(cfg)
 
 	w, err := manifold.Start(c.Context(), manifoldGetter{
-		agent: fixture.agent,
-		http:  stubHTTPClientGetter{},
+		http: stubHTTPClientGetter{},
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
@@ -238,9 +241,9 @@ func (s *manifoldSuite) TestNewControllerBackendUsesLokiBackendForLokiMode(c *tc
 func (s *manifoldSuite) validManifoldConfig(c *tc.C) ManifoldConfig {
 	fixture := newFixture(c, "http://loki/loki/api/v1/push")
 	return ManifoldConfig{
-		AgentName:            "agent",
 		APICallerName:        "api-caller",
 		HTTPClientName:       "http-client",
+		LokiConfigProvider:   fixture.agent,
 		LogSource:            fixture.logs,
 		AgentConfigChanged:   fixture.configChanged,
 		Logger:               internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -257,8 +260,8 @@ func (s *manifoldSuite) validManifoldConfig(c *tc.C) ManifoldConfig {
 func (s *manifoldSuite) validControllerManifoldConfig(c *tc.C) ControllerManifoldConfig {
 	fixture := newFixture(c, "http://loki/loki/api/v1/push")
 	return ControllerManifoldConfig{
-		AgentName:            "agent",
 		HTTPClientName:       "http-client",
+		LokiConfigProvider:   fixture.agent,
 		AgentConfigChanged:   fixture.configChanged,
 		Logger:               internallogger.GetLogger("juju.worker.logrouter.test"),
 		Clock:                clock.WallClock,
@@ -285,7 +288,6 @@ func (s *manifoldSuite) TestValidateRejectsNilAddLegacyLogSinkWriter(c *tc.C) {
 }
 
 type manifoldGetter struct {
-	agent     coreagent.Agent
 	apiCaller base.APICaller
 	http      corehttp.HTTPClientGetter
 	called    *atomic.Bool
@@ -300,8 +302,6 @@ func (g manifoldGetter) Get(_ string, out any) error {
 		return g.err
 	}
 	switch out := out.(type) {
-	case *coreagent.Agent:
-		*out = g.agent
 	case *base.APICaller:
 		*out = g.apiCaller
 	case *corehttp.HTTPClientGetter:

--- a/internal/worker/logrouter/manifold_test.go
+++ b/internal/worker/logrouter/manifold_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/worker/v5/workertest"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/base"
 	corehttp "github.com/juju/juju/core/http"
 	corelogger "github.com/juju/juju/core/logger"
@@ -32,15 +33,7 @@ func TestManifoldSuite(t *testing.T) {
 }
 
 func (s *manifoldSuite) TestInputs(c *tc.C) {
-	manifold := Manifold(ManifoldConfig{
-		APICallerName:  "api-caller",
-		HTTPClientName: "http-client",
-	})
-
-	c.Check(manifold.Inputs, tc.DeepEquals, []string{"api-caller", "http-client"})
-}
-
-func (s *manifoldSuite) TestInputsIncludesAgentName(c *tc.C) {
+	// Intentionally partial config — only Inputs is checked, not Validate.
 	manifold := Manifold(ManifoldConfig{
 		AgentName:      "agent",
 		APICallerName:  "api-caller",
@@ -51,6 +44,7 @@ func (s *manifoldSuite) TestInputsIncludesAgentName(c *tc.C) {
 }
 
 func (s *manifoldSuite) TestControllerInputs(c *tc.C) {
+	// Intentionally partial config — only Inputs is checked, not Validate.
 	manifold := ControllerManifold(ControllerManifoldConfig{
 		HTTPClientName: "http-client",
 	})
@@ -81,15 +75,17 @@ func (s *manifoldSuite) TestStartValidatesBeforeGetter(c *tc.C) {
 	})
 	c.Check(w, tc.IsNil)
 	c.Assert(err, tc.NotNil)
-	c.Check(err.Error(), tc.Equals, `empty AgentName and nil LokiConfigProvider not valid`)
+	c.Check(err.Error(), tc.Equals, `empty AgentName not valid`)
 	c.Check(getterCalled.Load(), tc.IsFalse)
 }
 
 func (s *manifoldSuite) TestStartCreatesWorkerWithoutUsingAPICaller(c *tc.C) {
 	cfg := s.validManifoldConfig(c)
 	manifold := Manifold(cfg)
+	fixture := newFixture(c, "http://loki/loki/api/v1/push")
 
 	w, err := manifold.Start(c.Context(), manifoldGetter{
+		agent:     fixture.agent,
 		apiCaller: stubAPICaller{},
 		http:      stubHTTPClientGetter{},
 	})
@@ -241,9 +237,9 @@ func (s *manifoldSuite) TestNewControllerBackendUsesLokiBackendForLokiMode(c *tc
 func (s *manifoldSuite) validManifoldConfig(c *tc.C) ManifoldConfig {
 	fixture := newFixture(c, "http://loki/loki/api/v1/push")
 	return ManifoldConfig{
+		AgentName:            "agent",
 		APICallerName:        "api-caller",
 		HTTPClientName:       "http-client",
-		LokiConfigProvider:   fixture.agent,
 		LogSource:            fixture.logs,
 		AgentConfigChanged:   fixture.configChanged,
 		Logger:               internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -288,13 +284,14 @@ func (s *manifoldSuite) TestValidateRejectsNilAddLegacyLogSinkWriter(c *tc.C) {
 }
 
 type manifoldGetter struct {
+	agent     agent.Agent
 	apiCaller base.APICaller
 	http      corehttp.HTTPClientGetter
 	called    *atomic.Bool
 	err       error
 }
 
-func (g manifoldGetter) Get(_ string, out any) error {
+func (g manifoldGetter) Get(name string, out any) error {
 	if g.called != nil {
 		g.called.Store(true)
 	}
@@ -302,6 +299,11 @@ func (g manifoldGetter) Get(_ string, out any) error {
 		return g.err
 	}
 	switch out := out.(type) {
+	case *agent.Agent:
+		if g.agent == nil {
+			return stderrors.New("missing agent dependency")
+		}
+		*out = g.agent
 	case *base.APICaller:
 		*out = g.apiCaller
 	case *corehttp.HTTPClientGetter:

--- a/internal/worker/logrouter/worker.go
+++ b/internal/worker/logrouter/worker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/worker/v5/catacomb"
 	"gopkg.in/tomb.v2"
 
+	"github.com/juju/juju/agent"
 	corelogger "github.com/juju/juju/core/logger"
 	internalerrors "github.com/juju/juju/internal/errors"
 	internalworker "github.com/juju/juju/internal/worker"
@@ -44,7 +45,9 @@ const (
 
 // LokiConfigProvider supplies the current logrouter configuration values.
 // Implementations must re-read current values on each call so bounced workers
-// see current logging destination settings.
+// see current logging destination settings. Returning an error from
+// CurrentLokiConfig causes the logrouter worker to die; the dependency
+// engine will restart it.
 type LokiConfigProvider interface {
 	CurrentLokiConfig() (ConfigSnapshot, error)
 }
@@ -82,18 +85,31 @@ type Metrics interface {
 
 // WorkerConfig contains logrouter worker configuration.
 type WorkerConfig struct {
-	LokiConfigProvider        LokiConfigProvider
-	LogSource                 logsender.LogRecordCh
-	AgentConfigChanged        *voyeur.Value
-	Logger                    corelogger.Logger
-	Clock                     clock.Clock
-	Metrics                   Metrics
-	DrainOnly                 bool
-	ConvergeTimeout           time.Duration
-	RestartDelay              time.Duration
-	NewBackend                BackendFunc
+	// LokiConfigProvider supplies the current backend configuration.
+	// It is called on startup and on each config change; returning an
+	// error kills the worker, which the dependency engine restarts.
+	LokiConfigProvider LokiConfigProvider
+	LogSource          logsender.LogRecordCh
+	AgentConfigChanged *voyeur.Value
+	Logger             corelogger.Logger
+	Clock              clock.Clock
+	Metrics            Metrics
+
+	DrainOnly       bool
+	ConvergeTimeout time.Duration
+	RestartDelay    time.Duration
+
+	NewBackend BackendFunc
+
+	// RemoveLegacyLogSinkWriter is called when switching to Loki
+	// backend mode. It should remove the legacy "logsink" writer
+	// from the default loggo context. It must be idempotent.
 	RemoveLegacyLogSinkWriter func()
-	AddLegacyLogSinkWriter    func() error
+
+	// AddLegacyLogSinkWriter is called when switching to LogSink
+	// backend mode. It should add the legacy "logsink" writer to
+	// the default loggo context. It must be idempotent.
+	AddLegacyLogSinkWriter func() error
 }
 
 // ConfigSnapshot is the local logging destination configuration.
@@ -106,6 +122,20 @@ type ConfigSnapshot struct {
 	ModelUUID          string
 	AgentID            string
 	OrgID              string
+}
+
+// ConfigSnapshotFromAgentConfig builds a ConfigSnapshot from the Loki-
+// related fields of an agent config.
+func ConfigSnapshotFromAgentConfig(cfg agent.Config) ConfigSnapshot {
+	return ConfigSnapshot{
+		Endpoint:           cfg.LokiEndpoint(),
+		CACertificate:      cfg.LokiCACert(),
+		InsecureSkipVerify: cfg.LokiInsecureSkipVerify(),
+		ControllerUUID:     cfg.Controller().Id(),
+		ModelUUID:          cfg.Model().Id(),
+		AgentID:            cfg.Tag().String(),
+		OrgID:              cfg.LokiOrgID(),
+	}
 }
 
 func (s ConfigSnapshot) sameBackend(other ConfigSnapshot) bool {
@@ -304,7 +334,10 @@ func (w *logRouter) loop() error {
 	w.drainRecords = drainRecords
 	w.setActiveBackend(backendDrainID, drainSnapshot, drainRecords)
 
-	next := w.currentSnapshot()
+	next, err := w.currentSnapshot()
+	if err != nil {
+		return internalerrors.Capture(err)
+	}
 	_, activeSnapshot, _ := w.activeBackend()
 	if !next.sameBackend(activeSnapshot) {
 		err = w.switchBackend(ctx, next)
@@ -324,7 +357,10 @@ func (w *logRouter) loop() error {
 			if !ok {
 				return nil
 			}
-			next := w.currentSnapshot()
+			next, err := w.currentSnapshot()
+			if err != nil {
+				return internalerrors.Capture(err)
+			}
 			_, activeSnapshot, _ := w.activeBackend()
 			if !next.sameBackend(activeSnapshot) {
 				err = w.switchBackend(ctx, next)
@@ -337,7 +373,10 @@ func (w *logRouter) loop() error {
 			}
 
 		case <-w.configChanges:
-			next := w.currentSnapshot()
+			next, err := w.currentSnapshot()
+			if err != nil {
+				return internalerrors.Capture(err)
+			}
 			_, activeSnapshot, _ := w.activeBackend()
 			if next.sameBackend(activeSnapshot) {
 				continue
@@ -405,11 +444,10 @@ func (w *logRouter) nextBackendID() string {
 	return "backend-" + strconv.Itoa(w.backendSeq)
 }
 
-func (w *logRouter) currentSnapshot() ConfigSnapshot {
+func (w *logRouter) currentSnapshot() (ConfigSnapshot, error) {
 	snapshot, err := w.config.LokiConfigProvider.CurrentLokiConfig()
 	if err != nil {
-		w.config.Logger.Warningf(context.TODO(), "failed to read logrouter snapshot: %v", err)
-		return ConfigSnapshot{Mode: BackendTypeDrain}
+		return ConfigSnapshot{}, internalerrors.Capture(err)
 	}
 	switch {
 	case w.config.DrainOnly:
@@ -419,7 +457,7 @@ func (w *logRouter) currentSnapshot() ConfigSnapshot {
 	default:
 		snapshot.Mode = BackendTypeLogSink
 	}
-	return snapshot
+	return snapshot, nil
 }
 
 func (w *logRouter) startBackend(

--- a/internal/worker/logrouter/worker.go
+++ b/internal/worker/logrouter/worker.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/worker/v5/catacomb"
 	"gopkg.in/tomb.v2"
 
-	"github.com/juju/juju/agent"
 	corelogger "github.com/juju/juju/core/logger"
 	internalerrors "github.com/juju/juju/internal/errors"
 	internalworker "github.com/juju/juju/internal/worker"
@@ -43,10 +42,11 @@ const (
 	BackendTypeDrain BackendType = "drain-only"
 )
 
-// Agent describes the agent configuration methods used by the router.
-type Agent interface {
-	// CurrentConfig returns the latest agent configuration snapshot.
-	CurrentConfig() agent.Config
+// LokiConfigProvider supplies the current logrouter configuration values.
+// Implementations must re-read current values on each call so bounced workers
+// see current logging destination settings.
+type LokiConfigProvider interface {
+	CurrentLokiConfig() (ConfigSnapshot, error)
 }
 
 // Backend is a worker that accepts log records.
@@ -82,28 +82,18 @@ type Metrics interface {
 
 // WorkerConfig contains logrouter worker configuration.
 type WorkerConfig struct {
-	Agent              Agent
-	LogSource          logsender.LogRecordCh
-	AgentConfigChanged *voyeur.Value
-	Logger             corelogger.Logger
-	Clock              clock.Clock
-	Metrics            Metrics
-
-	DrainOnly       bool
-	ConvergeTimeout time.Duration
-	RestartDelay    time.Duration
-
-	NewBackend BackendFunc
-
-	// RemoveLegacyLogSinkWriter is called when switching to Loki
-	// backend mode. It should remove the legacy "logsink" writer
-	// from the default loggo context. It must be idempotent.
+	LokiConfigProvider        LokiConfigProvider
+	LogSource                 logsender.LogRecordCh
+	AgentConfigChanged        *voyeur.Value
+	Logger                    corelogger.Logger
+	Clock                     clock.Clock
+	Metrics                   Metrics
+	DrainOnly                 bool
+	ConvergeTimeout           time.Duration
+	RestartDelay              time.Duration
+	NewBackend                BackendFunc
 	RemoveLegacyLogSinkWriter func()
-
-	// AddLegacyLogSinkWriter is called when switching to LogSink
-	// backend mode. It should add the legacy "logsink" writer to
-	// the default loggo context. It must be idempotent.
-	AddLegacyLogSinkWriter func() error
+	AddLegacyLogSinkWriter    func() error
 }
 
 // ConfigSnapshot is the local logging destination configuration.
@@ -139,8 +129,8 @@ func (s ConfigSnapshot) sameBackend(other ConfigSnapshot) bool {
 
 // Validate checks that the worker configuration is usable.
 func (c *WorkerConfig) Validate() error {
-	if c.Agent == nil {
-		return errors.NotValidf("nil Agent")
+	if c.LokiConfigProvider == nil {
+		return errors.NotValidf("nil LokiConfigProvider")
 	}
 	if c.LogSource == nil {
 		return errors.NotValidf("nil LogSource")
@@ -416,15 +406,10 @@ func (w *logRouter) nextBackendID() string {
 }
 
 func (w *logRouter) currentSnapshot() ConfigSnapshot {
-	cfg := w.config.Agent.CurrentConfig()
-	snapshot := ConfigSnapshot{
-		Endpoint:           cfg.LokiEndpoint(),
-		CACertificate:      cfg.LokiCACert(),
-		InsecureSkipVerify: cfg.LokiInsecureSkipVerify(),
-		ControllerUUID:     cfg.Controller().Id(),
-		ModelUUID:          cfg.Model().Id(),
-		AgentID:            cfg.Tag().String(),
-		OrgID:              cfg.LokiOrgID(),
+	snapshot, err := w.config.LokiConfigProvider.CurrentLokiConfig()
+	if err != nil {
+		w.config.Logger.Warningf(context.TODO(), "failed to read logrouter snapshot: %v", err)
+		return ConfigSnapshot{Mode: BackendTypeDrain}
 	}
 	switch {
 	case w.config.DrainOnly:

--- a/internal/worker/logrouter/worker_test.go
+++ b/internal/worker/logrouter/worker_test.go
@@ -528,8 +528,9 @@ func newFixture(c *tc.C, lokiEndpoint string) fixture {
 }
 
 type testAgent struct {
-	mu  sync.Mutex
-	cfg agent.ConfigSetterWriter
+	mu        sync.Mutex
+	cfg       agent.ConfigSetterWriter
+	configErr error
 }
 
 func (a *testAgent) CurrentConfig() agent.Config {
@@ -545,23 +546,32 @@ func (a *testAgent) ChangeConfig(change agent.ConfigMutator) error {
 }
 
 func (a *testAgent) CurrentLokiConfig() (ConfigSnapshot, error) {
-	cfg := a.CurrentConfig()
-	snapshot := ConfigSnapshot{
-		Endpoint:           cfg.LokiEndpoint(),
-		CACertificate:      cfg.LokiCACert(),
-		InsecureSkipVerify: cfg.LokiInsecureSkipVerify(),
-		ControllerUUID:     cfg.Controller().Id(),
-		ModelUUID:          cfg.Model().Id(),
-		AgentID:            cfg.Tag().String(),
-		OrgID:              cfg.LokiOrgID(),
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.configErr != nil {
+		return ConfigSnapshot{}, a.configErr
 	}
-	return snapshot, nil
+	return ConfigSnapshotFromAgentConfig(a.cfg.Clone()), nil
 }
 
 func (a *testAgent) setLokiConfig(endpoint, caCert string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.cfg.SetLokiConfig(endpoint, &caCert, nil, "")
+}
+
+func (a *testAgent) setConfigError(err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.configErr = err
+}
+
+type errorLokiConfigProvider struct {
+	err error
+}
+
+func (p *errorLokiConfigProvider) CurrentLokiConfig() (ConfigSnapshot, error) {
+	return ConfigSnapshot{}, p.err
 }
 
 type backendEvent struct {
@@ -1052,6 +1062,63 @@ func (s *workerSuite) TestManageLegacyLogSinkWriterDrainOnly(c *tc.C) {
 		c.Fatal("unexpected RemoveLegacyLogSinkWriter call in DrainOnly mode")
 	default:
 	}
+}
+
+func (s *workerSuite) TestConfigReadErrorKillsWorker(c *tc.C) {
+	expectErr := stderrors.New("config read failed")
+	provider := &errorLokiConfigProvider{err: expectErr}
+	events := make(chan backendEvent, 10)
+
+	w, err := NewWorker(WorkerConfig{
+		LokiConfigProvider:        provider,
+		LogSource:                 make(logsender.LogRecordCh, 1),
+		AgentConfigChanged:        voyeur.NewValue(false),
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		ConvergeTimeout:           defaultConvergeTimeout,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                recordingBackendFunc(events, defaultBackendBufferSize),
+		RemoveLegacyLogSinkWriter: func() {},
+		AddLegacyLogSinkWriter:    func() error { return nil },
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = w.Wait()
+	c.Check(err, tc.ErrorIs, expectErr)
+}
+
+func (s *workerSuite) TestConfigReadErrorOnConfigChangeKillsWorker(c *tc.C) {
+	fixture := newFixture(c, "")
+	events := make(chan backendEvent, 20)
+
+	w, err := NewWorker(WorkerConfig{
+		LokiConfigProvider:        fixture.agent,
+		LogSource:                 fixture.logs,
+		AgentConfigChanged:        fixture.configChanged,
+		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
+		Clock:                     clock.WallClock,
+		ConvergeTimeout:           defaultConvergeTimeout,
+		RestartDelay:              time.Millisecond * 10,
+		NewBackend:                recordingBackendFunc(events, defaultBackendBufferSize),
+		RemoveLegacyLogSinkWriter: func() {},
+		AddLegacyLogSinkWriter:    func() error { return nil },
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	waitForEvents(c, events, backendEvent{
+		backend: "drain-only",
+		kind:    "start",
+	}, backendEvent{
+		backend: "logsink",
+		kind:    "start",
+	})
+
+	expectErr := stderrors.New("config read failed")
+	fixture.agent.setConfigError(expectErr)
+	fixture.configChanged.Set(true)
+
+	err = w.Wait()
+	c.Check(err, tc.ErrorIs, expectErr)
 }
 
 func sendLog(c *tc.C, logs logsender.LogRecordCh, record *logsender.LogRecord) {

--- a/internal/worker/logrouter/worker_test.go
+++ b/internal/worker/logrouter/worker_test.go
@@ -39,7 +39,7 @@ func (s *workerSuite) TestStartsLogSinkWhenLokiEndpointEmpty(c *tc.C) {
 	events := make(chan backendEvent, 10)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -67,7 +67,7 @@ func (s *workerSuite) TestSwitchStopsOldBackendAndStartsNew(c *tc.C) {
 	events := make(chan backendEvent, 20)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -113,7 +113,7 @@ func (s *workerSuite) TestSwitchReplaysPendingRecordsToNewBackend(c *tc.C) {
 	var oldBackend *pendingBackend
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:              fixture.agent,
+		LokiConfigProvider: fixture.agent,
 		LogSource:          fixture.logs,
 		AgentConfigChanged: fixture.configChanged,
 		Logger:             internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -173,7 +173,7 @@ func (s *workerSuite) TestConcurrentLogDuringBackendSwitch(c *tc.C) {
 	events := make(chan backendEvent, 50)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -255,7 +255,7 @@ func (s *workerSuite) TestDrainOnlyOverridesEndpoint(c *tc.C) {
 	events := make(chan backendEvent, 10)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -281,7 +281,7 @@ func (s *workerSuite) TestBackendFailureFallsBackToDrain(c *tc.C) {
 	events := make(chan backendEvent, 20)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -328,7 +328,7 @@ func (s *workerSuite) TestBackendStartErrorFallsBackToDrain(c *tc.C) {
 	events := make(chan backendEvent, 20)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -375,7 +375,7 @@ func (s *workerSuite) TestBackendRestartRefreshesActiveChannel(c *tc.C) {
 	events := make(chan backendEvent, 20)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -450,7 +450,7 @@ func (s *workerSuite) TestReportIncludesActiveBackendAndBackendReports(c *tc.C) 
 	events := make(chan backendEvent, 10)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -542,6 +542,20 @@ func (a *testAgent) ChangeConfig(change agent.ConfigMutator) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return change(a.cfg)
+}
+
+func (a *testAgent) CurrentLokiConfig() (ConfigSnapshot, error) {
+	cfg := a.CurrentConfig()
+	snapshot := ConfigSnapshot{
+		Endpoint:           cfg.LokiEndpoint(),
+		CACertificate:      cfg.LokiCACert(),
+		InsecureSkipVerify: cfg.LokiInsecureSkipVerify(),
+		ControllerUUID:     cfg.Controller().Id(),
+		ModelUUID:          cfg.Model().Id(),
+		AgentID:            cfg.Tag().String(),
+		OrgID:              cfg.LokiOrgID(),
+	}
+	return snapshot, nil
 }
 
 func (a *testAgent) setLokiConfig(endpoint, caCert string) {
@@ -836,7 +850,7 @@ func (s *workerSuite) TestManageLegacyLogSinkWriterOnLokiSwitch(c *tc.C) {
 	removeCh := make(chan struct{}, 1)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -904,7 +918,7 @@ func (s *workerSuite) TestManageLegacyLogSinkWriterOnLogSinkSwitch(c *tc.C) {
 	removeCh := make(chan struct{}, 1)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),
@@ -1007,7 +1021,7 @@ func (s *workerSuite) TestManageLegacyLogSinkWriterDrainOnly(c *tc.C) {
 	removeCh := make(chan struct{}, 1)
 
 	w, err := NewWorker(WorkerConfig{
-		Agent:                     fixture.agent,
+		LokiConfigProvider:        fixture.agent,
 		LogSource:                 fixture.logs,
 		AgentConfigChanged:        fixture.configChanged,
 		Logger:                    internallogger.GetLogger("juju.worker.logrouter.test"),


### PR DESCRIPTION
Remove the unconditional nil LokiConfigProvider check in
ManifoldConfig.Validate() that blocked the AgentName-based fallback path
used by non-controller call sites (containeragent, jujuagentd model
operator, deployer).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ juju bootstrap lxd ctrl-test --build-agent
Creating Juju controller "ctrl-test" on lxd/default
Building local Juju agent binary version 4.1-beta2 for amd64
To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
Launching controller instance(s) on lxd/default...
 - juju-373fb3-0 (arch=amd64)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.159.202.166:22
Connected to 10.159.202.166
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.159.202.166 to verify accessibility...

Bootstrap complete, controller "ctrl-test" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

❯ jst -m controller
Model       Controller  Cloud/Region  Version      Timestamp
controller  ctrl-test   lxd/default   4.1-beta2.1  13:18:45+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  4.1/stable  157  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.159.202.166  17022,17070/tcp

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.166  juju-373fb3-0  ubuntu@24.04  tuxedo  Running

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer
```

## Documentation changes


## Links

