### PR TITLE
docs: document 10,000 line maximum for debug-log --lines/--limit

### DIFF
--- a/cmd/juju/commands/debuglog.go
+++ b/cmd/juju/commands/debuglog.go
@@ -84,6 +84,7 @@ The ` + "`--lines`" + ` and ` + "`--limit`" + ` options control the number of lo
 * the ` + "`--lines`" + ` option prints the specified number of the most recent lines and then waits for new lines. This implies --tail.
 * the ` + "`--limit`" + ` option prints up to the specified number of the most recent lines and exits. This implies --no-tail.
 * setting ` + "`--lines`" + ` or ` + "`--limit`" + ` to 0 will print the maximum number of the most recent lines available.
+* the maximum value for ` + "`--lines`" + ` and ` + "`--limit`" + ` is 10,000. Requests above this limit return an error.
 
 The ` + "`--replay`" + ` option displays log lines starting from the beginning.
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/debug-log.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/debug-log.md
@@ -161,6 +161,7 @@ The `--lines` and `--limit` options control the number of log lines displayed:
 * the `--lines` option prints the specified number of the most recent lines and then waits for new lines. This implies --tail.
 * the `--limit` option prints up to the specified number of the most recent lines and exits. This implies --no-tail.
 * setting `--lines` or `--limit` to 0 will print the maximum number of the most recent lines available.
+* the maximum value for `--lines` and `--limit` is 10,000. Requests above this limit return an error.
 
 The `--replay` option displays log lines starting from the beginning.
 


### PR DESCRIPTION
Cherry-picks https://github.com/juju/juju/pull/22824 into `4.0`.