### PR TITLE
docs: add resource revision example to refresh help text

### DIFF
--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -218,8 +218,6 @@ Pin a resource to a specific Charmhub revision:
 
     juju refresh foo --resource bar=42
 
-Where bar and baz are resources named in the metadata for the foo charm.
-
 Storage constraints may be added or updated at upgrade time by specifying
 the ` + "`--storage`" + ` option, with the same format as specified in ` + "`juju deploy`" + `.
 If new required storage is added by the new charm revision, then you must
@@ -287,9 +285,15 @@ To refresh the application config from a file for application ` + "`foo`" + `:
 
 	juju refresh foo --config config.yaml
 
-To refresh the resources for application ` + "`foo`" + `:
+To refresh the resources for application ` + "`foo`" + ` using a local file:
 
 	juju refresh foo --resource bar=/some/file.tgz --resource baz=./docs/cfg.xml
+
+To pin a resource to a specific Charmhub revision:
+
+	juju refresh foo --resource bar=42
+
+Where ` + "`bar`" + ` and ` + "`baz`" + ` are resources named in the metadata for the ` + "`foo`" + ` charm.
 `
 
 const upgradedApplicationHasUnitsMessage = `

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -181,10 +181,42 @@ match what was originally used to deploy the charm as a superficial check that t
 updated charm is compatible.
 
 Resources may be uploaded at upgrade time by specifying the ` + "`--resource`" + ` option.
-Following the resource option should be name=filepath pair.  This option may be
-repeated more than once to upload more than one resource.
+The format is
+
+    --resource <resource name>=<resource>
+
+where the resource name is the name from the ` + "`metadata.yaml`" + ` file of the charm
+and where, depending on the type of the resource, the resource can be specified
+as follows:
+
+- If the resource is type ` + "`file`" + `, you can specify it by providing one of the following:
+
+    a. the resource revision number.
+
+    b. a path to a local file. Caveat: If you choose this, you will not be able
+	 to go back to using a resource from Charmhub.
+
+- If the resource is type ` + "`oci-image`" + `, you can specify it by providing one of the following:
+
+    a. the resource revision number.
+
+	b. a path to the local file for your private OCI image as well as the
+	username and password required to access the private OCI image.
+	Caveat: If you choose this, you will not be able to go back to using a
+	resource from Charmhub.
+
+    c. a link to a public OCI image. Caveat: If you choose this, you will not be
+	 able to go back to using a resource from Charmhub.
+
+Note: If multiple resources are needed, repeat the option.
+
+Upload a local file:
 
     juju refresh foo --resource bar=/some/file.tgz --resource baz=./docs/cfg.xml
+
+Pin a resource to a specific Charmhub revision:
+
+    juju refresh foo --resource bar=42
 
 Where bar and baz are resources named in the metadata for the foo charm.
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
@@ -37,9 +37,15 @@ To refresh the application config from a file for application `foo`:
 
 	juju refresh foo --config config.yaml
 
-To refresh the resources for application `foo`:
+To refresh the resources for application `foo` using a local file:
 
 	juju refresh foo --resource bar=/some/file.tgz --resource baz=./docs/cfg.xml
+
+To pin a resource to a specific Charmhub revision:
+
+	juju refresh foo --resource bar=42
+
+Where `bar` and `baz` are resources named in the metadata for the `foo` charm.
 
 
 ## Details
@@ -99,8 +105,6 @@ Upload a local file:
 Pin a resource to a specific Charmhub revision:
 
     juju refresh foo --resource bar=42
-
-Where bar and baz are resources named in the metadata for the foo charm.
 
 Storage constraints may be added or updated at upgrade time by specifying
 the `--storage` option, with the same format as specified in `juju deploy`.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/refresh.md
@@ -63,10 +63,42 @@ match what was originally used to deploy the charm as a superficial check that t
 updated charm is compatible.
 
 Resources may be uploaded at upgrade time by specifying the `--resource` option.
-Following the resource option should be name=filepath pair.  This option may be
-repeated more than once to upload more than one resource.
+The format is
+
+    --resource <resource name>=<resource>
+
+where the resource name is the name from the `metadata.yaml` file of the charm
+and where, depending on the type of the resource, the resource can be specified
+as follows:
+
+- If the resource is type `file`, you can specify it by providing one of the following:
+
+    a. the resource revision number.
+
+    b. a path to a local file. Caveat: If you choose this, you will not be able
+	 to go back to using a resource from Charmhub.
+
+- If the resource is type `oci-image`, you can specify it by providing one of the following:
+
+    a. the resource revision number.
+
+	b. a path to the local file for your private OCI image as well as the
+	username and password required to access the private OCI image.
+	Caveat: If you choose this, you will not be able to go back to using a
+	resource from Charmhub.
+
+    c. a link to a public OCI image. Caveat: If you choose this, you will not be
+	 able to go back to using a resource from Charmhub.
+
+Note: If multiple resources are needed, repeat the option.
+
+Upload a local file:
 
     juju refresh foo --resource bar=/some/file.tgz --resource baz=./docs/cfg.xml
+
+Pin a resource to a specific Charmhub revision:
+
+    juju refresh foo --resource bar=42
 
 Where bar and baz are resources named in the metadata for the foo charm.
 


### PR DESCRIPTION
Fixes #20051.

The `--resource` flag help only documented the file-path form `name=filepath`. This PR adds an example showing the Charmhub revision form `name=revision-number`, e.g. `--resource bar=42`, and clarifies that the value can be either a file path or a revision number. Includes the regenerated CLI reference doc.