### PR TITLE
docs(index): restructure 'in this documentation' as domains of concern (WIP)

### DIFF
--- a/docs/.sphinx/_static/css/domain-list-override.css
+++ b/docs/.sphinx/_static/css/domain-list-override.css
@@ -1,0 +1,8 @@
+/* Override sphinx-structured-toc separator colour to Ubuntu orange */
+.domain-list > ul > li > ul > li {
+    border-left: 1px solid #E95420;
+}
+
+.domain-list > ul > li > ul > li:first-child {
+    border-left: none;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -308,6 +308,7 @@ extensions = [
     'sphinx_new_tab_link',
     'sphinxcontrib.lightbox2',
     'ibnote',
+    'sphinx_structured_toc',
 ]
 
 # Customize sphinx_llm.txt
@@ -342,6 +343,7 @@ html_css_files = [
     "css/cookie-banner.css",
     "https://assets.ubuntu.com/v1/d86746ef-cookie_banner.css",
     "css/ibnote.css",
+    "css/domain-list-override.css",
 ]
 
 # Adds custom JavaScript files, located under 'html_static_path'

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,8 @@ Whether you are a CIO or SysAdmin, DevOps engineer, or SRE, Juju helps you take 
 
 **Point of entry:**
 
+Start here if you're new to Juju.
+
 * Tutorial: {ref}`Get started with Juju <tutorial>`
 * Installation: {ref}`Install Juju <install-juju>`
 
@@ -40,50 +42,61 @@ Whether you are a CIO or SysAdmin, DevOps engineer, or SRE, Juju helps you take 
 Juju models business deployment logic through charms; charms describe how an application is deployed.
 
 * **Models**: {ref}`Overview <model>` | {ref}`Manage models <manage-models>`
-* **Charmed applications**: {ref}`Charm reference <charm>` | {ref}`Manage charms <manage-charms>` | {ref}`Application reference <application>` | {ref}`Manage applications <manage-applications>`
-* **Application integration**: {ref}`Offers <offer>` | {ref}`Manage offers <manage-offers>` | {ref}`Secrets <secret>` | {ref}`Manage secrets <manage-secrets>` | {ref}`Manage secret backends <manage-secret-backends>`
-* **Exposing application knobs**: {ref}`Actions <action>` | {ref}`Manage actions <manage-actions>` | {ref}`Relations <relation>` | {ref}`Manage relations <manage-relations>` | {ref}`Resources <charm-resource>` | {ref}`Manage charm resources <manage-charm-resources>` | {ref}`Configurations <application-configuration>` | {ref}`Configure an application <configure-an-application>`
-* **Units**: {ref}`Reference <unit>` | {ref}`Manage units <manage-units>` | {ref}`Scaling <scaling>` | {ref}`Scale an application <scale-an-application>`
+* **Charmed applications**: {ref}`Charm reference <charm>` | {ref}`Manage charms <manage-charms>` | {ref}`Application reference <application>` | {ref}`Manage applications <manage-applications>` | {ref}`Bundle reference <bundle>`
+* **Application operations**: {ref}`Actions <action>` | {ref}`Manage actions <manage-actions>` | {ref}`Relations <relation>` | {ref}`Manage relations <manage-relations>` | {ref}`Offers <offer>` | {ref}`Manage offers <manage-offers>` | {ref}`Charm resources <charm-resource>` | {ref}`Manage charm resources <manage-charm-resources>` | {ref}`Configurations <application-configuration>` | {ref}`Configure an application <configure-an-application>` | {ref}`Secrets <secret>` | {ref}`Manage secrets <manage-secrets>` | {ref}`Manage secret backends <manage-secret-backends>`
+* **Units**: {ref}`Unit reference <unit>` | {ref}`Manage units <manage-units>` | {ref}`Scaling <scaling>` | {ref}`Scale an application <scale-an-application>`
 
 **Juju's core machinery**
 
-* **Overview**: {ref}`juju-architecture` | **Client — Juju CLI**: {ref}`Reference <juju-cli>` | {ref}`Manage Juju <manage-juju>`
+The controller, agents, and CLI form the engine that coordinates between the application and cloud layers.
+
+* **Architecture**: {ref}`Juju architecture <juju-architecture>`
+* **Client — Juju CLI**: {ref}`Reference <juju-cli>` | {ref}`Manage Juju <manage-juju>`
 * **Controller**: {ref}`Reference <controller>` | {ref}`Manage controllers <manage-controllers>` | {ref}`Bootstrap a controller <bootstrap-a-controller>`
 * **Database**: {ref}`Reference <database>` | {ref}`Manage the databases <manage-the-databases>` | {ref}`Juju DB REPL <juju-db-repl>`
 * **Agents**: {ref}`Reference <agent>`
 * **Pebble**: {ref}`Reference <pebble>`
 * **Hooks and hook commands**: {ref}`Hook reference <hook>` | {ref}`Hook command reference <hook-command>`
 * **Scripts**: {ref}`Reference <script>`
-* **Authentication and authorisation**: {ref}`Users <user>` | {ref}`Manage users <manage-users>` | {ref}`Manage user access <manage-user-access>` | {ref}`SSH keys <ssh-key>` | {ref}`Manage SSH keys <manage-ssh-keys>`
-* **Observability and monitoring**: {ref}`Collect metrics about a controller <collect-metrics-about-a-controller>` | {ref}`Manage logs <manage-logs>` | {ref}`Logs reference <log>` | {ref}`Telemetry reference <telemetry>`
 
 **Enterprise features**
 
-* **Juju Dashboard**: {ref}`Reference <juju-dashboard>` | {ref}`Manage the Juju Dashboard <manage-the-juju-dashboard>`
+Additional capabilities for production and enterprise deployments, including access control, observability, a web dashboard, high availability, and integrations with JAAS and Terraform.
+
+* **Authentication and authorisation**: {ref}`Users <user>` | {ref}`Manage users <manage-users>` | {ref}`Manage user access <manage-user-access>` | {ref}`SSH keys <ssh-key>` | {ref}`Manage SSH keys <manage-ssh-keys>`
 * **High availability**: {ref}`Reference <high-availability>` | {ref}`Make a controller highly available <make-a-controller-highly-available>` | {ref}`Make an application highly available <make-an-application-highly-available>`
+* **Observability and monitoring**: {ref}`Collect metrics about a controller <collect-metrics-about-a-controller>` | {ref}`Manage logs <manage-logs>` | {ref}`Logs reference <log>` | {ref}`Telemetry reference <telemetry>`
+* **Juju Dashboard**: {ref}`Reference <juju-dashboard>` | {ref}`Manage the Juju Dashboard <manage-the-juju-dashboard>`
 * IaC client — Terraform Provider for Juju: [Documentation](https://documentation.ubuntu.com/terraform-provider-juju/latest/)
 * Global view, external identity provider, and ReBAC authorisation — JAAS: [Documentation](https://documentation.ubuntu.com/jaas/latest/)
 
 **Clouds**
 
+Juju provisions and manages the cloud resources — machines, networking, storage — that applications run on.
+
 * Basics: {ref}`Cloud reference <cloud>`
 * Working with clouds: {ref}`Manage clouds <manage-clouds>`
-* Credentials: {ref}`Reference <credential>` | {ref}`Manage credentials <manage-credentials>`
-* Metadata: {ref}`Reference <metadata>` | {ref}`Manage metadata <manage-metadata>`
-* Compute: {ref}`Reference <resource-compute>` | {ref}`Machine reference <machine>` | {ref}`Manage machines <manage-machines>` | {ref}`Constraints <constraint>` | {ref}`Placement directives <placement-directive>`
-* Networking — spaces: {ref}`Reference <space>` | {ref}`Manage spaces <manage-spaces>`
-* Networking — subnets: {ref}`Reference <subnet>` | {ref}`Manage subnets <manage-subnets>`
-* Storage: {ref}`Reference <storage>` | {ref}`Manage storage <manage-storage>` | {ref}`Manage storage pools <manage-storage-pools>`
-* Zones: {ref}`Reference <zone>`
+* Credentials: {ref}`Credential reference <credential>` | {ref}`Manage credentials <manage-credentials>`
+* Metadata: {ref}`Simplestreams metadata <metadata>` | {ref}`Manage metadata <manage-metadata>`
+* Compute: {ref}`Resource (compute) <resource-compute>` | {ref}`Machine reference <machine>` | {ref}`Manage machines <manage-machines>` | {ref}`Constraints <constraint>` | {ref}`Placement directives <placement-directive>`
+* Zones: {ref}`Zone reference <zone>`
+* Networking — spaces: {ref}`Space reference <space>` | {ref}`Manage spaces <manage-spaces>`
+* Networking — subnets: {ref}`Subnet reference <subnet>` | {ref}`Manage subnets <manage-subnets>`
+* Storage: {ref}`Storage reference <storage>` | {ref}`Manage storage <manage-storage>` | {ref}`Manage storage pools <manage-storage-pools>`
 
 **Security and performance**
 
-* Security: {ref}`Overview <juju-security>` | {ref}`Harden your deployment <harden-your-deployment>`
+Guidance on securing and optimising your Juju deployment.
+
+* Security: {ref}`Juju security <juju-security>` | {ref}`Harden your deployment <harden-your-deployment>`
 * Performance: {ref}`performance-with-juju`
 
-**Deployment lifecycle:**
+**Deployment lifecycle**
 
-* Set up: {ref}`Set up your deployment <set-up-your-deployment>` | {ref}`Set up for local testing <set-things-up>` | {ref}`Set up offline <take-your-deployment-offline>` | {ref}`add-a-cloud` | {ref}`add-a-credential`
+End-to-end procedures for standing up, maintaining, and tearing down a Juju deployment.
+
+* Set up: {ref}`Set up your deployment <set-up-your-deployment>` | {ref}`Set up for local testing <set-things-up>` | {ref}`Set up offline <take-your-deployment-offline>` | {ref}`Add a cloud <add-a-cloud>` | {ref}`Add a credential <add-a-credential>`
+* Harden: {ref}`Harden your deployment <harden-your-deployment>`
 * Upgrade: {ref}`Upgrade your deployment <upgrade-your-deployment>` | {ref}`Patch version <upgrade-your-juju-components-patch-version>` | {ref}`Minor or major version <upgrade-your-juju-components-minor-or-major-version>` | {ref}`From 3.6 to 4.0 <upgrade-your-juju-deployment-from-36-to-40>`
 * Troubleshoot: {ref}`Troubleshoot your deployment <troubleshoot-your-deployment>`
 * Tear down: {ref}`Tear things down <tear-things-down>`

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,10 +30,68 @@ Whether you are a CIO or SysAdmin, DevOps engineer, or SRE, Juju helps you take 
 
 ## In this documentation
 
-* **Learn more about Juju**: {ref}`Get started with Juju <tutorial>` • {ref}`Architecture <juju-architecture>` • {ref}`Security <juju-security>` • {ref}`Performance <performance-with-juju>`
-* **Set up Juju**: {ref}`Install juju <install-juju>` • {ref}`Bootstrap a controller <bootstrap-a-controller>` • {ref}`Connect a cloud <add-a-cloud>`
-* **Handle authentication and authorization**: {ref}`Add a user <add-a-user>` • {ref}`Manage user access <manage-user-access>`
-* **Deploy infrastructure and applications**: {ref}`Deploy <deploy-an-application>` • {ref}`Configure <configure-an-application>` • {ref}`Integrate <integrate-an-application-with-another-application>` • {ref}`Scale <scale-an-application>` • {ref}`Upgrade <upgrade-an-application>`
+**Point of entry:**
+* Tutorial: {ref}`Get started with Juju <tutorial>`
+* Installation: {ref}`Install Juju <install-juju>`
+
+**Model-driven application lifecycle management:**
+* Models: {ref}`Reference <model>` | {ref}`Manage models <manage-models>`
+* Charmed applications: {ref}`Charm reference <charm>` | {ref}`Manage charms <manage-charms>` | {ref}`Application reference <application>` | {ref}`Manage applications <manage-applications>`
+* Units: {ref}`Reference <unit>` | {ref}`Manage units <manage-units>`
+* Bundles: {ref}`Reference <bundle>`
+* Charm-defined functionality: {ref}`Actions <action>` | {ref}`Manage actions <manage-actions>` | {ref}`Relations <relation>` | {ref}`Manage relations <manage-relations>` | {ref}`Resources <charm-resource>` | {ref}`Manage charm resources <manage-charm-resources>` | {ref}`Configurations <application-configuration>` | {ref}`Configure an application <configure-an-application>`
+* Offers (cross-model relations): {ref}`Reference <offer>` | {ref}`Manage offers <manage-offers>`
+* Secrets: {ref}`Reference <secret>` | {ref}`Manage secrets <manage-secrets>` | {ref}`Manage secret backends <manage-secret-backends>`
+* Scaling: {ref}`Reference <scaling>` | {ref}`Scale an application <scale-an-application>`
+* Status: {ref}`Reference <status>`
+* Removing things: {ref}`removing-things`
+* Upgrading things: {ref}`upgrading-things`
+
+**Core machinery:**
+* Client — Juju CLI: {ref}`Reference <juju-cli>` | {ref}`Manage Juju <manage-juju>`
+* Controller: {ref}`Reference <controller>` | {ref}`Manage controllers <manage-controllers>`
+* Database: {ref}`Reference <database>` | {ref}`Manage the databases <manage-the-databases>` | {ref}`Juju DB REPL <juju-db-repl>`
+* Agents: {ref}`Reference <agent>`
+* Pebble: {ref}`Reference <pebble>`
+* Hooks and hook commands: {ref}`Hook reference <hook>` | {ref}`Hook command reference <hook-command>`
+* Scripts: {ref}`Reference <script>`
+* Authentication and authorisation: {ref}`Users <user>` | {ref}`Manage users <manage-users>` | {ref}`Manage user access <manage-user-access>` | {ref}`SSH keys <ssh-key>` | {ref}`Manage SSH keys <manage-ssh-keys>`
+* Logs: {ref}`Reference <log>`
+* Telemetry: {ref}`Reference <telemetry>`
+* Constraints: {ref}`Reference <constraint>`
+* Placement directives: {ref}`Reference <placement-directive>`
+* Juju as a distributed system: {ref}`juju-architecture`
+
+**Clouds:**
+* Basics: {ref}`Cloud reference <cloud>`
+* Working with clouds: {ref}`Manage clouds <manage-clouds>`
+* Credentials: {ref}`Reference <credential>` | {ref}`Manage credentials <manage-credentials>`
+* Metadata: {ref}`Reference <metadata>` | {ref}`Manage metadata <manage-metadata>`
+
+**Resources and interfaces:**
+* Compute: {ref}`Reference <resource-compute>`, {ref}`Machine reference <machine>` | {ref}`Manage machines <manage-machines>`
+* Networking — spaces: {ref}`Reference <space>` | {ref}`Manage spaces <manage-spaces>`
+* Networking — subnets: {ref}`Reference <subnet>` | {ref}`Manage subnets <manage-subnets>`
+* Storage: {ref}`Reference <storage>` | {ref}`Manage storage <manage-storage>` | {ref}`Manage storage pools <manage-storage-pools>`
+* Zones: {ref}`Reference <zone>`
+
+**Quality:**
+* Security: {ref}`juju-security`
+* Performance: {ref}`performance-with-juju`
+* Observability: {ref}`Collect metrics about a controller <collect-metrics-about-a-controller>` | {ref}`Manage logs <manage-logs>`
+
+**Enterprise features:**
+* Juju Dashboard: {ref}`Reference <juju-dashboard>` | {ref}`Manage the Juju Dashboard <manage-the-juju-dashboard>`
+* High availability: {ref}`Reference <high-availability>` | {ref}`Make a controller highly available <make-a-controller-highly-available>` | {ref}`Make an application highly available <make-an-application-highly-available>`
+* IaC client — Terraform Provider for Juju: [Documentation](https://documentation.ubuntu.com/terraform-provider-juju/latest/)
+* Global view, external identity provider, and ReBAC authorization — JAAS: [Documentation](https://documentation.ubuntu.com/jaas/latest/)
+
+**Deployment lifecycle:**
+* Set up: {ref}`set-up-your-deployment` | {ref}`set-things-up` | {ref}`set-up-your-deployment-offline <take-your-deployment-offline>` | {ref}`Bootstrap a controller <bootstrap-a-controller>` | {ref}`add-a-cloud` | {ref}`add-a-credential`
+* Harden: {ref}`Harden your deployment <harden-your-deployment>`
+* Upgrade: {ref}`Upgrade your deployment <upgrade-your-deployment>` | {ref}`Patch version <upgrade-your-juju-components-patch-version>` | {ref}`Minor or major version <upgrade-your-juju-components-minor-or-major-version>` | {ref}`From 3.6 to 4.0 <upgrade-your-juju-deployment-from-36-to-40>`
+* Troubleshoot: {ref}`Troubleshoot your deployment <troubleshoot-your-deployment>`
+* Tear down: {ref}`Tear things down <tear-things-down>`
 
 ## How this documentation is organised
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Start here if you're new to Juju.
 
 Juju models business deployment logic through charms; charms describe how an application is deployed.
 
-* **Models**: {ref}`Overview <model>` | {ref}`Manage models <manage-models>`
+* **Models**: {ref}`Overview <model>` | {ref}`Manage models <manage-models>` | {ref}`Model configuration keys <list-of-model-configuration-keys>`
 * **Charmed applications**: {ref}`Charm reference <charm>` | {ref}`Manage charms <manage-charms>` | {ref}`Application reference <application>` | {ref}`Manage applications <manage-applications>` | {ref}`Bundle reference <bundle>`
 * **Application operations**: {ref}`Actions <action>` | {ref}`Manage actions <manage-actions>` | {ref}`Relations <relation>` | {ref}`Manage relations <manage-relations>` | {ref}`Offers <offer>` | {ref}`Manage offers <manage-offers>` | {ref}`Charm resources <charm-resource>` | {ref}`Manage charm resources <manage-charm-resources>` | {ref}`Configurations <application-configuration>` | {ref}`Configure an application <configure-an-application>` | {ref}`Secrets <secret>` | {ref}`Manage secrets <manage-secrets>` | {ref}`Manage secret backends <manage-secret-backends>`
 * **Units**: {ref}`Unit reference <unit>` | {ref}`Manage units <manage-units>` | {ref}`Scaling <scaling>` | {ref}`Scale an application <scale-an-application>`
@@ -52,7 +52,7 @@ The CLI, controller, and agents form the engine that coordinates between the app
 
 * **Architecture**: {ref}`Juju architecture <juju-architecture>`
 * **Client — Juju CLI**: {ref}`Reference <juju-cli>` | {ref}`Manage Juju <manage-juju>`
-* **Controller**: {ref}`Reference <controller>` | {ref}`Manage controllers <manage-controllers>` | {ref}`Bootstrap a controller <bootstrap-a-controller>`
+* **Controller**: {ref}`Reference <controller>` | {ref}`Manage controllers <manage-controllers>` | {ref}`Bootstrap a controller <bootstrap-a-controller>` | {ref}`Controller configuration keys <list-of-controller-configuration-keys>`
 * **Database**: {ref}`Reference <database>` | {ref}`Manage the databases <manage-the-databases>` | {ref}`Juju DB REPL <juju-db-repl>`
 * **Agents**: {ref}`Reference <agent>`
 * **Pebble**: {ref}`Reference <pebble>`
@@ -95,7 +95,7 @@ Guidance on securing and optimising your Juju deployment.
 
 End-to-end procedures for standing up, maintaining, and tearing down a Juju deployment.
 
-* Set up: {ref}`Set up your deployment <set-up-your-deployment>` | {ref}`Set up for local testing <set-things-up>` | {ref}`Set up offline <take-your-deployment-offline>` | {ref}`Add a cloud <add-a-cloud>` | {ref}`Add a credential <add-a-credential>`
+* Set up: {ref}`Set up your deployment <set-up-your-deployment>` | {ref}`Set up for local testing <set-things-up>` | {ref}`Set up offline <take-your-deployment-offline>`
 * Harden: {ref}`Harden your deployment <harden-your-deployment>`
 * Upgrade: {ref}`Upgrade your deployment <upgrade-your-deployment>` | {ref}`Patch version <upgrade-your-juju-components-patch-version>` | {ref}`Minor or major version <upgrade-your-juju-components-minor-or-major-version>` | {ref}`From 3.6 to 4.0 <upgrade-your-deployment-from-36-to-40>`
 * Troubleshoot: {ref}`Troubleshoot your deployment <troubleshoot-your-deployment>`

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ Juju models business deployment logic through charms; charms describe how an app
 
 **Juju's core machinery**
 
-The controller, agents, and CLI form the engine that coordinates between the application and cloud layers.
+The CLI, controller, and agents form the engine that coordinates between the application and cloud layers.
 
 * **Architecture**: {ref}`Juju architecture <juju-architecture>`
 * **Client — Juju CLI**: {ref}`Reference <juju-cli>` | {ref}`Manage Juju <manage-juju>`
@@ -74,7 +74,7 @@ Additional capabilities for production and enterprise deployments, including acc
 
 Juju provisions and manages the cloud resources — machines, networking, storage — that applications run on.
 
-* Basics: {ref}`Cloud reference <cloud>`
+* Basics: {ref}`Cloud reference <cloud>` | {ref}`List of supported clouds <list-of-supported-clouds>`
 * Working with clouds: {ref}`Manage clouds <manage-clouds>`
 * Credentials: {ref}`Credential reference <credential>` | {ref}`Manage credentials <manage-credentials>`
 * Metadata: {ref}`Simplestreams metadata <metadata>` | {ref}`Manage metadata <manage-metadata>`
@@ -97,7 +97,7 @@ End-to-end procedures for standing up, maintaining, and tearing down a Juju depl
 
 * Set up: {ref}`Set up your deployment <set-up-your-deployment>` | {ref}`Set up for local testing <set-things-up>` | {ref}`Set up offline <take-your-deployment-offline>` | {ref}`Add a cloud <add-a-cloud>` | {ref}`Add a credential <add-a-credential>`
 * Harden: {ref}`Harden your deployment <harden-your-deployment>`
-* Upgrade: {ref}`Upgrade your deployment <upgrade-your-deployment>` | {ref}`Patch version <upgrade-your-juju-components-patch-version>` | {ref}`Minor or major version <upgrade-your-juju-components-minor-or-major-version>` | {ref}`From 3.6 to 4.0 <upgrade-your-juju-deployment-from-36-to-40>`
+* Upgrade: {ref}`Upgrade your deployment <upgrade-your-deployment>` | {ref}`Patch version <upgrade-your-juju-components-patch-version>` | {ref}`Minor or major version <upgrade-your-juju-components-minor-or-major-version>` | {ref}`From 3.6 to 4.0 <upgrade-your-deployment-from-36-to-40>`
 * Troubleshoot: {ref}`Troubleshoot your deployment <troubleshoot-your-deployment>`
 * Tear down: {ref}`Tear things down <tear-things-down>`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,64 +31,59 @@ Whether you are a CIO or SysAdmin, DevOps engineer, or SRE, Juju helps you take 
 ## In this documentation
 
 **Point of entry:**
+
 * Tutorial: {ref}`Get started with Juju <tutorial>`
 * Installation: {ref}`Install Juju <install-juju>`
 
-**Model-driven application lifecycle management:**
-* Models: {ref}`Reference <model>` | {ref}`Manage models <manage-models>`
-* Charmed applications: {ref}`Charm reference <charm>` | {ref}`Manage charms <manage-charms>` | {ref}`Application reference <application>` | {ref}`Manage applications <manage-applications>`
-* Units: {ref}`Reference <unit>` | {ref}`Manage units <manage-units>`
-* Bundles: {ref}`Reference <bundle>`
-* Charm-defined functionality: {ref}`Actions <action>` | {ref}`Manage actions <manage-actions>` | {ref}`Relations <relation>` | {ref}`Manage relations <manage-relations>` | {ref}`Resources <charm-resource>` | {ref}`Manage charm resources <manage-charm-resources>` | {ref}`Configurations <application-configuration>` | {ref}`Configure an application <configure-an-application>`
-* Offers (cross-model relations): {ref}`Reference <offer>` | {ref}`Manage offers <manage-offers>`
-* Secrets: {ref}`Reference <secret>` | {ref}`Manage secrets <manage-secrets>` | {ref}`Manage secret backends <manage-secret-backends>`
-* Scaling: {ref}`Reference <scaling>` | {ref}`Scale an application <scale-an-application>`
-* Status: {ref}`Reference <status>`
-* Removing things: {ref}`removing-things`
-* Upgrading things: {ref}`upgrading-things`
+**Models and charms**
 
-**Core machinery:**
-* Client — Juju CLI: {ref}`Reference <juju-cli>` | {ref}`Manage Juju <manage-juju>`
-* Controller: {ref}`Reference <controller>` | {ref}`Manage controllers <manage-controllers>`
-* Database: {ref}`Reference <database>` | {ref}`Manage the databases <manage-the-databases>` | {ref}`Juju DB REPL <juju-db-repl>`
-* Agents: {ref}`Reference <agent>`
-* Pebble: {ref}`Reference <pebble>`
-* Hooks and hook commands: {ref}`Hook reference <hook>` | {ref}`Hook command reference <hook-command>`
-* Scripts: {ref}`Reference <script>`
-* Authentication and authorisation: {ref}`Users <user>` | {ref}`Manage users <manage-users>` | {ref}`Manage user access <manage-user-access>` | {ref}`SSH keys <ssh-key>` | {ref}`Manage SSH keys <manage-ssh-keys>`
-* Logs: {ref}`Reference <log>`
-* Telemetry: {ref}`Reference <telemetry>`
-* Constraints: {ref}`Reference <constraint>`
-* Placement directives: {ref}`Reference <placement-directive>`
-* Juju as a distributed system: {ref}`juju-architecture`
+Juju models business deployment logic through charms; charms describe how an application is deployed.
 
-**Clouds:**
+* **Models**: {ref}`Overview <model>` | {ref}`Manage models <manage-models>`
+* **Charmed applications**: {ref}`Charm reference <charm>` | {ref}`Manage charms <manage-charms>` | {ref}`Application reference <application>` | {ref}`Manage applications <manage-applications>`
+* **Application integration**: {ref}`Offers <offer>` | {ref}`Manage offers <manage-offers>` | {ref}`Secrets <secret>` | {ref}`Manage secrets <manage-secrets>` | {ref}`Manage secret backends <manage-secret-backends>`
+* **Exposing application knobs**: {ref}`Actions <action>` | {ref}`Manage actions <manage-actions>` | {ref}`Relations <relation>` | {ref}`Manage relations <manage-relations>` | {ref}`Resources <charm-resource>` | {ref}`Manage charm resources <manage-charm-resources>` | {ref}`Configurations <application-configuration>` | {ref}`Configure an application <configure-an-application>`
+* **Units**: {ref}`Reference <unit>` | {ref}`Manage units <manage-units>` | {ref}`Scaling <scaling>` | {ref}`Scale an application <scale-an-application>`
+
+**Juju's core machinery**
+
+* **Overview**: {ref}`juju-architecture` | **Client — Juju CLI**: {ref}`Reference <juju-cli>` | {ref}`Manage Juju <manage-juju>`
+* **Controller**: {ref}`Reference <controller>` | {ref}`Manage controllers <manage-controllers>` | {ref}`Bootstrap a controller <bootstrap-a-controller>`
+* **Database**: {ref}`Reference <database>` | {ref}`Manage the databases <manage-the-databases>` | {ref}`Juju DB REPL <juju-db-repl>`
+* **Agents**: {ref}`Reference <agent>`
+* **Pebble**: {ref}`Reference <pebble>`
+* **Hooks and hook commands**: {ref}`Hook reference <hook>` | {ref}`Hook command reference <hook-command>`
+* **Scripts**: {ref}`Reference <script>`
+* **Authentication and authorisation**: {ref}`Users <user>` | {ref}`Manage users <manage-users>` | {ref}`Manage user access <manage-user-access>` | {ref}`SSH keys <ssh-key>` | {ref}`Manage SSH keys <manage-ssh-keys>`
+* **Observability and monitoring**: {ref}`Collect metrics about a controller <collect-metrics-about-a-controller>` | {ref}`Manage logs <manage-logs>` | {ref}`Logs reference <log>` | {ref}`Telemetry reference <telemetry>`
+
+**Enterprise features**
+
+* **Juju Dashboard**: {ref}`Reference <juju-dashboard>` | {ref}`Manage the Juju Dashboard <manage-the-juju-dashboard>`
+* **High availability**: {ref}`Reference <high-availability>` | {ref}`Make a controller highly available <make-a-controller-highly-available>` | {ref}`Make an application highly available <make-an-application-highly-available>`
+* IaC client — Terraform Provider for Juju: [Documentation](https://documentation.ubuntu.com/terraform-provider-juju/latest/)
+* Global view, external identity provider, and ReBAC authorisation — JAAS: [Documentation](https://documentation.ubuntu.com/jaas/latest/)
+
+**Clouds**
+
 * Basics: {ref}`Cloud reference <cloud>`
 * Working with clouds: {ref}`Manage clouds <manage-clouds>`
 * Credentials: {ref}`Reference <credential>` | {ref}`Manage credentials <manage-credentials>`
 * Metadata: {ref}`Reference <metadata>` | {ref}`Manage metadata <manage-metadata>`
-
-**Resources and interfaces:**
-* Compute: {ref}`Reference <resource-compute>`, {ref}`Machine reference <machine>` | {ref}`Manage machines <manage-machines>`
+* Compute: {ref}`Reference <resource-compute>` | {ref}`Machine reference <machine>` | {ref}`Manage machines <manage-machines>` | {ref}`Constraints <constraint>` | {ref}`Placement directives <placement-directive>`
 * Networking — spaces: {ref}`Reference <space>` | {ref}`Manage spaces <manage-spaces>`
 * Networking — subnets: {ref}`Reference <subnet>` | {ref}`Manage subnets <manage-subnets>`
 * Storage: {ref}`Reference <storage>` | {ref}`Manage storage <manage-storage>` | {ref}`Manage storage pools <manage-storage-pools>`
 * Zones: {ref}`Reference <zone>`
 
-**Quality:**
-* Security: {ref}`juju-security`
-* Performance: {ref}`performance-with-juju`
-* Observability: {ref}`Collect metrics about a controller <collect-metrics-about-a-controller>` | {ref}`Manage logs <manage-logs>`
+**Security and performance**
 
-**Enterprise features:**
-* Juju Dashboard: {ref}`Reference <juju-dashboard>` | {ref}`Manage the Juju Dashboard <manage-the-juju-dashboard>`
-* High availability: {ref}`Reference <high-availability>` | {ref}`Make a controller highly available <make-a-controller-highly-available>` | {ref}`Make an application highly available <make-an-application-highly-available>`
-* IaC client — Terraform Provider for Juju: [Documentation](https://documentation.ubuntu.com/terraform-provider-juju/latest/)
-* Global view, external identity provider, and ReBAC authorization — JAAS: [Documentation](https://documentation.ubuntu.com/jaas/latest/)
+* Security: {ref}`Overview <juju-security>` | {ref}`Harden your deployment <harden-your-deployment>`
+* Performance: {ref}`performance-with-juju`
 
 **Deployment lifecycle:**
-* Set up: {ref}`set-up-your-deployment` | {ref}`set-things-up` | {ref}`set-up-your-deployment-offline <take-your-deployment-offline>` | {ref}`Bootstrap a controller <bootstrap-a-controller>` | {ref}`add-a-cloud` | {ref}`add-a-credential`
-* Harden: {ref}`Harden your deployment <harden-your-deployment>`
+
+* Set up: {ref}`Set up your deployment <set-up-your-deployment>` | {ref}`Set up for local testing <set-things-up>` | {ref}`Set up offline <take-your-deployment-offline>` | {ref}`add-a-cloud` | {ref}`add-a-credential`
 * Upgrade: {ref}`Upgrade your deployment <upgrade-your-deployment>` | {ref}`Patch version <upgrade-your-juju-components-patch-version>` | {ref}`Minor or major version <upgrade-your-juju-components-minor-or-major-version>` | {ref}`From 3.6 to 4.0 <upgrade-your-juju-deployment-from-36-to-40>`
 * Troubleshoot: {ref}`Troubleshoot your deployment <troubleshoot-your-deployment>`
 * Tear down: {ref}`Tear things down <tear-things-down>`

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,84 +30,250 @@ Whether you are a CIO or SysAdmin, DevOps engineer, or SRE, Juju helps you take 
 
 ## In this documentation
 
-**Point of entry:**
+**Point of entry**
 
 Start here if you're new to Juju.
 
-* Tutorial: {ref}`Get started with Juju <tutorial>`
-* Installation: {ref}`Install Juju <install-juju>`
+* Tutorial: {doc}`Get started with Juju <tutorial/index>`
+* Installation: {doc}`Install Juju <howto/manage-juju>`
 
 **Models and charms**
 
 Juju models business deployment logic through charms; charms describe how an application is deployed.
 
-* **Models**: {ref}`Overview <model>` | {ref}`Manage models <manage-models>` | {ref}`Model configuration keys <list-of-model-configuration-keys>`
-* **Charmed applications**: {ref}`Charm reference <charm>` | {ref}`Manage charms <manage-charms>` | {ref}`Application reference <application>` | {ref}`Manage applications <manage-applications>` | {ref}`Bundle reference <bundle>`
-* **Application operations**: {ref}`Actions <action>` | {ref}`Manage actions <manage-actions>` | {ref}`Relations <relation>` | {ref}`Manage relations <manage-relations>` | {ref}`Offers <offer>` | {ref}`Manage offers <manage-offers>` | {ref}`Charm resources <charm-resource>` | {ref}`Manage charm resources <manage-charm-resources>` | {ref}`Configurations <application-configuration>` | {ref}`Configure an application <configure-an-application>` | {ref}`Secrets <secret>` | {ref}`Manage secrets <manage-secrets>` | {ref}`Manage secret backends <manage-secret-backends>`
-* **Units**: {ref}`Unit reference <unit>` | {ref}`Manage units <manage-units>` | {ref}`Scaling <scaling>` | {ref}`Scale an application <scale-an-application>`
+```{eval-rst}
+.. domain:: Models and charms
+   :suppress-warnings:
+
+   .. slice:: Models
+
+      :doc:`Reference <reference/model>` slice
+      :doc:`Manage models <howto/manage-models>`
+      :doc:`Model configuration keys <reference/configuration/list-of-model-configuration-keys>`
+
+   .. slice:: Charmed applications
+
+      :doc:`Charm reference <reference/charm>`
+      :doc:`Manage charms <howto/manage-charms>`
+      :doc:`Application reference <reference/application>`
+      :doc:`Manage applications <howto/manage-applications>`
+      :doc:`Bundle reference <reference/bundle>`
+
+   .. slice:: Integration
+
+      :doc:`Relations <reference/relation>`
+      :doc:`Manage relations <howto/manage-relations>`
+      :doc:`Offers <reference/offer>`
+      :doc:`Manage offers <howto/manage-offers>`
+
+   .. slice:: Configuration and secrets
+
+      :doc:`Configuration <reference/configuration>`
+      :doc:`Secrets <reference/secret>`
+      :doc:`Manage secrets <howto/manage-secrets>`
+      :doc:`Manage secret backends <howto/manage-secret-backends>`
+
+   .. slice:: Actions and resources
+
+      :doc:`Actions <reference/action>`
+      :doc:`Manage actions <howto/manage-actions>`
+      :doc:`Charm resources <reference/resource-charm>`
+      :doc:`Manage charm resources <howto/manage-charm-resources>`
+
+   .. slice:: Units
+
+      :doc:`Unit reference <reference/unit>`
+      :doc:`Manage units <howto/manage-units>`
+      :doc:`Scaling <reference/scaling>`
+```
 
 **Juju's core machinery**
 
 The CLI, controller, and agents form the engine that coordinates between the application and cloud layers.
 
-* **Architecture**: {ref}`Juju architecture <juju-architecture>`
-* **Client — Juju CLI**: {ref}`Reference <juju-cli>` | {ref}`Manage Juju <manage-juju>`
-* **Controller**: {ref}`Reference <controller>` | {ref}`Manage controllers <manage-controllers>` | {ref}`Bootstrap a controller <bootstrap-a-controller>` | {ref}`Controller configuration keys <list-of-controller-configuration-keys>`
-* **Database**: {ref}`Reference <database>` | {ref}`Manage the databases <manage-the-databases>` | {ref}`Juju DB REPL <juju-db-repl>`
-* **Agents**: {ref}`Reference <agent>`
-* **Pebble**: {ref}`Reference <pebble>`
-* **Hooks and hook commands**: {ref}`Hook reference <hook>` | {ref}`Hook command reference <hook-command>`
-* **Scripts**: {ref}`Reference <script>`
+```{eval-rst}
+.. domain:: Juju's core machinery
+   :suppress-warnings:
+
+   .. slice:: Architecture
+
+      :doc:`Juju architecture <explanation/juju-architecture>`
+
+   .. slice:: Client
+
+      :doc:`Reference <reference/juju-cli>` slice
+      :doc:`Manage Juju <howto/manage-juju>`
+
+   .. slice:: Controller
+
+      :doc:`Reference <reference/controller>` slice
+      :doc:`Manage controllers <howto/manage-controllers>`
+      :doc:`Controller configuration keys <reference/configuration/list-of-controller-configuration-keys>`
+
+   .. slice:: Database
+
+      :doc:`Reference <reference/database>` slice
+      :doc:`Manage the databases <howto/manage-the-databases>`
+      :doc:`Juju DB REPL <reference/juju-db-repl>`
+
+   .. slice:: Agents
+
+      :doc:`Reference <reference/agent>` slice
+
+   .. slice:: Pebble
+
+      :doc:`Reference <reference/pebble>` slice
+
+   .. slice:: Hooks and hook commands
+
+      :doc:`Hook reference <reference/hook>`
+      :doc:`Hook command reference <reference/hook-command>`
+
+   .. slice:: Scripts
+
+      :doc:`Reference <reference/script>` slice
+```
 
 **Enterprise features**
 
-Additional capabilities for production and enterprise deployments, including access control, observability, a web dashboard, high availability, and integrations with JAAS and Terraform.
+Additional capabilities for production and enterprise deployments, including access control, observability, and high availability.
 
-* **Authentication and authorisation**: {ref}`Users <user>` | {ref}`Manage users <manage-users>` | {ref}`Manage user access <manage-user-access>` | {ref}`SSH keys <ssh-key>` | {ref}`Manage SSH keys <manage-ssh-keys>`
-* **High availability**: {ref}`Reference <high-availability>` | {ref}`Make a controller highly available <make-a-controller-highly-available>` | {ref}`Make an application highly available <make-an-application-highly-available>`
-* **Observability and monitoring**: {ref}`Collect metrics about a controller <collect-metrics-about-a-controller>` | {ref}`Manage logs <manage-logs>` | {ref}`Logs reference <log>` | {ref}`Telemetry reference <telemetry>`
-* **Juju Dashboard**: {ref}`Reference <juju-dashboard>` | {ref}`Manage the Juju Dashboard <manage-the-juju-dashboard>`
-* IaC client — Terraform Provider for Juju: [Documentation](https://documentation.ubuntu.com/terraform-provider-juju/latest/)
-* Global view, external identity provider, and ReBAC authorisation — JAAS: [Documentation](https://documentation.ubuntu.com/jaas/latest/)
+```{eval-rst}
+.. domain:: Enterprise features
+   :suppress-warnings:
+
+   .. slice:: Authentication and authorisation
+
+      :doc:`Users <reference/user>`
+      :doc:`Manage users <howto/manage-users>`
+      :doc:`SSH keys <reference/ssh-key>`
+      :doc:`Manage SSH keys <howto/manage-ssh-keys>`
+
+   .. slice:: High availability
+
+      :doc:`Reference <reference/high-availability>` slice
+
+   .. slice:: Observability and monitoring
+
+      :doc:`Manage logs <howto/manage-logs>`
+      :doc:`Logs reference <reference/log>`
+      :doc:`Telemetry reference <reference/telemetry>`
+
+   .. slice:: Juju Dashboard
+
+      :doc:`Reference <reference/juju-dashboard>` slice
+      :doc:`Manage the Juju Dashboard <howto/manage-the-juju-dashboard>`
+```
 
 **Clouds**
 
 Juju provisions and manages the cloud resources — machines, networking, storage — that applications run on.
 
-* Basics: {ref}`Cloud reference <cloud>` | {ref}`List of supported clouds <list-of-supported-clouds>`
-* Working with clouds: {ref}`Manage clouds <manage-clouds>`
-* Credentials: {ref}`Credential reference <credential>` | {ref}`Manage credentials <manage-credentials>`
-* Metadata: {ref}`Simplestreams metadata <metadata>` | {ref}`Manage metadata <manage-metadata>`
-* Compute: {ref}`Resource (compute) <resource-compute>` | {ref}`Machine reference <machine>` | {ref}`Manage machines <manage-machines>` | {ref}`Constraints <constraint>` | {ref}`Placement directives <placement-directive>`
-* Zones: {ref}`Zone reference <zone>`
-* Networking — spaces: {ref}`Space reference <space>` | {ref}`Manage spaces <manage-spaces>`
-* Networking — subnets: {ref}`Subnet reference <subnet>` | {ref}`Manage subnets <manage-subnets>`
-* Storage: {ref}`Storage reference <storage>` | {ref}`Manage storage <manage-storage>` | {ref}`Manage storage pools <manage-storage-pools>`
+```{eval-rst}
+.. domain:: Clouds
+   :suppress-warnings:
+
+   .. slice:: Basics
+
+      :doc:`Cloud reference <reference/cloud>`
+      :doc:`List of supported clouds <reference/cloud/list-of-supported-clouds/index>`
+
+   .. slice:: Working with clouds
+
+      :doc:`Manage clouds <howto/manage-clouds>`
+
+   .. slice:: Credentials
+
+      :doc:`Credential reference <reference/credential>`
+      :doc:`Manage credentials <howto/manage-credentials>`
+
+   .. slice:: Metadata
+
+      :doc:`Simplestreams metadata <reference/metadata>`
+      :doc:`Manage metadata <howto/manage-metadata>`
+
+   .. slice:: Zones
+
+      :doc:`Zone reference <reference/zone>`
+
+   .. slice:: Compute
+
+      :doc:`Resource (compute) <reference/resource-compute>`
+      :doc:`Machine reference <reference/machine>`
+      :doc:`Manage machines <howto/manage-machines>`
+      :doc:`Constraints <reference/constraint>`
+      :doc:`Placement directives <reference/placement-directive>`
+
+   .. slice:: Networking
+
+      :doc:`Space reference <reference/space>`
+      :doc:`Manage spaces <howto/manage-spaces>`
+      :doc:`Subnet reference <reference/subnet>`
+      :doc:`Manage subnets <howto/manage-subnets>`
+
+   .. slice:: Storage
+
+      :doc:`Storage reference <reference/storage>`
+      :doc:`Manage storage <howto/manage-storage>`
+      :doc:`Manage storage pools <howto/manage-storage-pools>`
+```
 
 **Security and performance**
 
 Guidance on securing and optimising your Juju deployment.
 
-* Security: {ref}`Juju security <juju-security>` | {ref}`Harden your deployment <harden-your-deployment>`
-* Performance: {ref}`performance-with-juju`
+```{eval-rst}
+.. domain:: Security and performance
+   :suppress-warnings:
+
+   .. slice:: Security
+
+      :doc:`Juju security <explanation/juju-security>`
+
+   .. slice:: Performance
+
+      :doc:`Performance with Juju <explanation/juju-performance>`
+```
 
 **Deployment lifecycle**
 
 End-to-end procedures for standing up, maintaining, and tearing down a Juju deployment.
 
-* Set up: {ref}`Set up your deployment <set-up-your-deployment>` | {ref}`Set up for local testing <set-things-up>` | {ref}`Set up offline <take-your-deployment-offline>`
-* Harden: {ref}`Harden your deployment <harden-your-deployment>`
-* Upgrade: {ref}`Upgrade your deployment <upgrade-your-deployment>` | {ref}`Patch version <upgrade-your-juju-components-patch-version>` | {ref}`Minor or major version <upgrade-your-juju-components-minor-or-major-version>` | {ref}`From 3.6 to 4.0 <upgrade-your-deployment-from-36-to-40>`
-* Troubleshoot: {ref}`Troubleshoot your deployment <troubleshoot-your-deployment>`
-* Tear down: {ref}`Tear things down <tear-things-down>`
+```{eval-rst}
+.. domain:: Deployment lifecycle
+   :suppress-warnings:
+
+   .. slice:: Set up
+
+      :doc:`Set up your deployment <howto/manage-your-juju-deployment/set-up-your-juju-deployment>`
+      :doc:`Set up for local testing <howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development>`
+      :doc:`Set up offline <howto/manage-your-juju-deployment/set-up-your-juju-deployment-offline>`
+
+   .. slice:: Harden
+
+      :doc:`Harden your deployment <howto/manage-your-juju-deployment/harden-your-juju-deployment>`
+
+   .. slice:: Upgrade
+
+      :doc:`Upgrade your deployment <howto/manage-your-juju-deployment/upgrade-your-juju-deployment>`
+      :doc:`From 3.6 to 4.0 <howto/upgrade-your-juju-deployment-from-36-to-40>`
+
+   .. slice:: Troubleshoot
+
+      :doc:`Troubleshoot your deployment <howto/manage-your-juju-deployment/troubleshoot-your-juju-deployment>`
+
+   .. slice:: Tear down
+
+      :doc:`Tear things down <howto/manage-your-juju-deployment/tear-down-your-juju-deployment-local-testing-and-development>`
+```
 
 ## How this documentation is organised
 
 This documentation uses the [Diátaxis documentation structure](https://diataxis.fr/).
-- The {ref}`Tutorial <tutorial>` takes you step-by-step through deploying your first application with Juju.
-- {ref}`How-to guides <how-to-guides>` provide step-by-step instructions for key operations and common tasks.
-- {ref}`Reference <reference>` provides technical specifications, APIs, and comprehensive details of all Juju components.
-- {ref}`Explanation <explanation>` offers discussion and clarification of key topics, providing background and context.
+- The {doc}`Tutorial <tutorial/index>` takes you step-by-step through deploying your first application with Juju.
+- {doc}`How-to guides <howto/index>` provide step-by-step instructions for key operations and common tasks.
+- {doc}`Reference <reference/index>` provides technical specifications, APIs, and comprehensive details of all Juju components.
+- {doc}`Explanation <explanation/index>` offers discussion and clarification of key topics, providing background and context.
 
 (project-and-community)=
 ## Project and community
@@ -122,7 +288,7 @@ Juju is an open source project that warmly welcomes community projects, contribu
 * [Contribute](https://github.com/juju/juju/blob/main/CONTRIBUTING.md)
 * [Visit our careers page](https://canonical.com/careers/engineering)
 
-* ### Releases
+### Releases
 
 * [Roadmap & Releases](releasenotes/index.md)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -36,3 +36,4 @@ vale
 sphinxext-rediraffe
 sphinx-new-tab-link
 sphinxcontrib.lightbox2
+sphinx-structured-toc


### PR DESCRIPTION
One of our roadmap commitments is to update our docs homepage in Juju 4.0 cf. the latest standard. 

This PR implements the pattern and [formatting](https://github.com/canonical/sphinx-structured-toc/) agreed with Daniele.

Preview: https://canonical-juju-1--22829.com.readthedocs.build/22829/
