### PR TITLE
fix: handle proxy connection errors

### DIFF
--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -23,6 +23,8 @@ import (
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/errors"
 	caasprovider "github.com/juju/juju/internal/provider/kubernetes"
+	k8sproxy "github.com/juju/juju/internal/provider/kubernetes/proxy"
+	proxyerrors "github.com/juju/juju/internal/proxy/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -71,14 +73,14 @@ func WaitForAgentInitialisation(
 
 	ctx.Infof("Contacting Juju controller%s to verify accessibility...", addressInfo)
 
-	var apiAttempts int
+	apiAttempts := 1
 	err = retry.Call(retry.CallArgs{
 		Clock:    clock.WallClock,
 		Attempts: bootstrapReadyPollCount,
 		Delay:    bootstrapReadyPollDelay,
 		Stop:     ctx.Done(),
 		NotifyFunc: func(lastErr error, attempts int) {
-			apiAttempts = attempts
+			apiAttempts = attempts + 1
 		},
 		IsFatalError: func(err error) bool {
 			return errors.Is(err, unknownError) ||
@@ -120,6 +122,10 @@ func WaitForAgentInitialisation(
 				ctx.Verbosef("Still waiting for API to become available: %v", retryErr)
 				return retryErr
 			case errors.Is(retryErr, rpc.ErrShutdown):
+				ctx.Verbosef("Still waiting for API to become available: %v", retryErr)
+				return retryErr
+			case proxyerrors.IsProxyConnectError(retryErr) &&
+				proxyerrors.ProxyType(retryErr) == k8sproxy.ProxierTypeKey:
 				ctx.Verbosef("Still waiting for API to become available: %v", retryErr)
 				return retryErr
 			case params.ErrCode(retryErr) == params.CodeUpgradeInProgress:

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -80,7 +80,7 @@ func WaitForAgentInitialisation(
 		Delay:    bootstrapReadyPollDelay,
 		Stop:     ctx.Done(),
 		NotifyFunc: func(lastErr error, attempts int) {
-			apiAttempts = attempts + 1
+			apiAttempts = attempts
 		},
 		IsFatalError: func(err error) bool {
 			return errors.Is(err, unknownError) ||

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/juju/juju/cmd/modelcmd"
 	"github.com/juju/juju/core/version"
 	environscmd "github.com/juju/juju/environs/cmd"
+	k8sproxy "github.com/juju/juju/internal/provider/kubernetes/proxy"
+	proxyerrors "github.com/juju/juju/internal/proxy/errors"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
@@ -97,6 +99,29 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *tc.C) {
 		})
 	})
 
+	c.Run("K8sProxyConnectErrorRetries", func(c *stdtesting.T) {
+		count := 0
+		tryAPI := func(ctx context.Context, c *modelcmd.ModelCommandBase) error {
+			count++
+			if count == 1 {
+				return errors.Annotate(
+					proxyerrors.NewProxyConnectError(
+						errors.New("lost connection to pod"),
+						k8sproxy.ProxierTypeKey,
+					),
+					"cannot connect to k8s api server",
+				)
+			}
+			return nil
+		}
+		runInCommand(&tc.TBC{TB: c}, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
+			bootstrapCtx := environscmd.BootstrapContext(c.Context(), ctx)
+			err := WaitForAgentInitialisation(bootstrapCtx, base, false, "arthur", tryAPI)
+			tc.Assert(c, err, tc.ErrorIsNil)
+			tc.Check(c, count, tc.Equals, 2)
+		})
+	})
+
 	c.Run("ExhaustedRetries", func(c *stdtesting.T) {
 		count := 0
 		tryAPI := func(ctx context.Context, c *modelcmd.ModelCommandBase) error {
@@ -107,6 +132,17 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *tc.C) {
 			bootstrapCtx := environscmd.BootstrapContext(c.Context(), ctx)
 			err := WaitForAgentInitialisation(bootstrapCtx, base, false, "arthur", tryAPI)
 			tc.Assert(c, err, tc.ErrorMatches, `unable to contact api server after.*`)
+		})
+	})
+
+	c.Run("UnknownErrorAttemptCount", func(c *stdtesting.T) {
+		tryAPI := func(ctx context.Context, c *modelcmd.ModelCommandBase) error {
+			return errors.New("foobar")
+		}
+		runInCommand(&tc.TBC{TB: c}, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
+			bootstrapCtx := environscmd.BootstrapContext(c.Context(), ctx)
+			err := WaitForAgentInitialisation(bootstrapCtx, base, false, "arthur", tryAPI)
+			tc.Assert(c, err, tc.ErrorMatches, `unable to contact api server after 1 attempts: .*foobar`)
 		})
 	})
 }


### PR DESCRIPTION
If the proxy is shutdown (pod got rescheduled, the proxy fell over) whilst deploying to k8s (mainly microk8s) then retry it correctly.

Whilst we're here, it should start at 1, not 0. There was 1 attempt, it has already run, so it shouldn't start at 0.


## QA steps

microk8s should bootstrap whilst allowing retries.