### PR TITLE
test: fix flaky TestOneChangeWithDelayedTermDone in changestream/stream

### DIFF
--- a/internal/changestream/stream/stream_test.go
+++ b/internal/changestream/stream/stream_test.go
@@ -260,7 +260,9 @@ func (s *streamSuite) TestOneChangeWithDelayedTermDone(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectFileNotifyWatcher()
-	s.expectTermAfterAnyTimes()
+	// Handles both term-timeout and backoff After calls to prevent
+	// deadlock in the backoff path after term.Done completes.
+	s.expectAfterWithoutTermTimeout()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()


### PR DESCRIPTION
The test `TestOneChangeWithDelayedTermDone` in `stream_test.go` hangs
intermittently in CI with a 10-minute test timeout. The panic trace shows the
test blocked in `workertest.CleanKill` waiting for the stream worker to die.

### Root cause

1. The test calls `term.Done(false, make(chan struct{}))` — the term completes
   normally (abort channel is never closed)
2. The stream loop processes the term, records the term view, and loops back to
   `OUTER`
3. `readChanges()` finds 0 changes (only one was inserted and already
   consumed), enters the backoff path at `stream.go:345`
4. Calls `s.clock.After(backOffStrategy(0, 1))` = `clock.After(140ms)`
5. The mock `expectTermAfterAnyTimes()` only matches
   `After(defaultWaitTermTimeout)` (30s) — not `After(140ms)`
6. With no matching gomock expectation for 140ms, the goroutine deadlocks

All select statements in the production `stream.loop()` correctly include `case
<-s.tomb.Dying()`, so the deadlock is purely a test mock setup issue.

### Fix

Replace `s.expectTermAfterAnyTimes()` with `s.expectAfterWithoutTermTimeout()`
in `TestOneChangeWithDelayedTermDone`. The latter matches all `After`
durations: it returns a never-closed channel for the term timeout (`30s`) and
`time.After(d)` for backoff durations, allowing the backoff to complete and the
stream to die cleanly when killed.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ go test -c -race ./internal/changestream/stream
❯ stress -timeout 120s ./stream.test
```

## Documentation changes

## Links

