### PR TITLE
refactor!: remove pip requirements file

### DIFF
--- a/caas/requirements.txt
+++ b/caas/requirements.txt
@@ -1,4 +1,0 @@
-charmhelpers>=0.20.15,<1.0.0
-charms.reactive>=0.1.0,<2.0.0
-kubernetes==10.0.*
-google_auth>=1.21.0,<1.22.0

--- a/make_functions.sh
+++ b/make_functions.sh
@@ -119,7 +119,6 @@ build_push_operator_image() {
 
     WORKDIR=$(_make_docker_staging_dir)
     cp "${PROJECT_DIR}/caas/Dockerfile" "${WORKDIR}/"
-    cp "${PROJECT_DIR}/caas/requirements.txt" "${WORKDIR}/"
     if [[ "${OCI_BUILDER}" = "docker" ]]; then
         output="-o type=oci,dest=${BUILD_DIR}/oci.tar.gz"
         if [[ "$push_image" = true ]]; then


### PR DESCRIPTION
In PR[1] we removed the dependency on the python dependency inside of the docker file for k8s. This requirements file should have been removed at that point.

This is deadcode in 4.0. This will prevent dependabot from telling us about dead code.

 1. https://github.com/juju/juju/pull/21074



## QA steps

```sh
$ juju bootstrap microk8s test
```