### PR TITLE
refactor: prevent tracing from killing juju

### DIFF
--- a/internal/worker/trace/tracer.go
+++ b/internal/worker/trace/tracer.go
@@ -327,8 +327,8 @@ func (s *limitedSpan) End(attrs ...coretrace.Attribute) {
 
 func attributes(attrs []coretrace.Attribute) []attribute.KeyValue {
 	kv := make([]attribute.KeyValue, len(attrs))
-	for _, attr := range attrs {
-		kv = append(kv, attribute.String(attr.Key(), attr.Value()))
+	for i, attr := range attrs {
+		kv[i] = attribute.String(attr.Key(), attr.Value())
 	}
 	return kv
 }

--- a/internal/worker/trace/tracer.go
+++ b/internal/worker/trace/tracer.go
@@ -90,21 +90,26 @@ func (t *tracer) Wait() error {
 
 // Start creates a span and a context.Context containing the newly-created span.
 func (t *tracer) Start(ctx context.Context, name string, opts ...coretrace.Option) (context.Context, coretrace.Span) {
+	select {
+	case <-t.tomb.Dying():
+		return ctx, coretrace.NoopSpan{}
+	default:
+	}
+
 	o := coretrace.NewTracerOptions()
 	for _, opt := range opts {
 		opt(o)
 	}
 
-	// Tie the lifetime of the span to the lifetime of the worker. If the
-	// worker dies then the span will be ended. The consumer of the span
-	// should use the context returned from this method to ensure that the
-	// they also die at the same time as the worker.
-	var (
-		cancel context.CancelFunc
-		span   ClientSpan
-	)
 	ctx = t.buildRequestContext(ctx)
-	ctx, cancel = t.scopedContext(ctx)
+	originalCtx := ctx
+
+	// Tie the lifetime of the internal tracing context to the worker without
+	// allowing tracer shutdown to cancel the caller's operation context.
+	tracerCtx := t.tomb.Context(ctx)
+	if t.isDyingContext(originalCtx) {
+		return originalCtx, coretrace.NoopSpan{}
+	}
 
 	// Grab any attributes from the options and add them to the span.
 	attrs := attributes(o.Attributes())
@@ -115,22 +120,26 @@ func (t *tracer) Start(ctx context.Context, name string, opts ...coretrace.Optio
 		attribute.Stringer("namespace.kind", t.namespace.Kind),
 	)
 
-	ctx, span = t.clientTracer.Start(ctx, name, trace.WithAttributes(attrs...))
+	var span ClientSpan
+	tracerCtx, span = t.clientTracer.Start(tracerCtx, name, trace.WithAttributes(attrs...))
+	if t.isDyingContext(originalCtx) {
+		span.End()
+		return originalCtx, coretrace.NoopSpan{}
+	}
 
 	// If the span is sampled then we should log the trace and span ID.
 	if t.logger.IsLevelEnabled(logger.TRACE) {
 		if spanContext := span.SpanContext(); spanContext.IsSampled() {
-			t.logger.Tracef(ctx, "SpanContext: trace-id %s, span-id %s", spanContext.TraceID(), spanContext.SpanID())
+			t.logger.Tracef(tracerCtx, "SpanContext: trace-id %s, span-id %s", spanContext.TraceID(), spanContext.SpanID())
 		}
 	}
 
 	managed := &managedSpan{
 		span:               span,
-		cancel:             cancel,
 		scope:              managedScope{span: span},
 		stackTracesEnabled: t.requiresStackTrace(o.StackTrace()),
 	}
-	return coretrace.WithSpan(ctx, &limitedSpan{
+	return contextWithSpan(originalCtx, span, &limitedSpan{
 		Span:   managed,
 		logger: t.logger,
 	}), managed
@@ -172,12 +181,27 @@ func (t *tracer) loop() error {
 	return tomb.ErrDying
 }
 
-// scopedContext returns a context that is in the scope of the worker lifetime.
-// It returns a cancellable context that is cancelled when the action has
-// completed.
-func (w *tracer) scopedContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(ctx)
-	return w.tomb.Context(ctx), cancel
+func (t *tracer) isDyingContext(originalCtx context.Context) bool {
+	if originalCtx.Err() != nil {
+		return false
+	}
+	select {
+	case <-t.tomb.Dying():
+		return true
+	default:
+		return false
+	}
+}
+
+func contextWithSpan(ctx context.Context, span ClientSpan, coreSpan coretrace.Span) context.Context {
+	if otelSpan, ok := span.(trace.Span); ok {
+		ctx = trace.ContextWithSpan(ctx, otelSpan)
+	}
+	spanContext := span.SpanContext()
+	if spanContext.TraceID().IsValid() {
+		ctx = coretrace.WithTraceID(ctx, spanContext.TraceID().String())
+	}
+	return coretrace.WithSpan(ctx, coreSpan)
 }
 
 // buildRequestContext returns a context that may contain a remote span context.
@@ -224,7 +248,6 @@ func (t *tracer) buildRequestContext(ctx context.Context) context.Context {
 
 type managedSpan struct {
 	span               ClientSpan
-	cancel             context.CancelFunc
 	scope              coretrace.Scope
 	stackTracesEnabled bool
 }
@@ -263,8 +286,6 @@ func (s *managedSpan) RecordError(err error, attrs ...coretrace.Attribute) {
 // is called. Therefore, updates to the Span are not allowed after this
 // method has been called.
 func (s *managedSpan) End(attrs ...coretrace.Attribute) {
-	defer s.cancel()
-
 	s.span.SetAttributes(attributes(attrs)...)
 	s.span.End(trace.WithStackTrace(s.stackTracesEnabled))
 }

--- a/internal/worker/trace/tracer_test.go
+++ b/internal/worker/trace/tracer_test.go
@@ -245,6 +245,104 @@ func (s *tracerSuite) TestTracerStartContext(c *tc.C) {
 	}
 }
 
+func (s *tracerSuite) TestTracerStartAfterKilledReturnsNoop(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectClient()
+
+	tracer := s.newTracer(c)
+	workertest.DirtyKill(c, tracer)
+
+	parentCtx := c.Context()
+	ctx, span := tracer.Start(parentCtx, "foo")
+	c.Check(ctx, tc.Equals, parentCtx)
+	c.Check(ctx.Err(), tc.ErrorIsNil)
+
+	_, ok := span.(coretrace.NoopSpan)
+	c.Check(ok, tc.IsTrue)
+}
+
+func (s *tracerSuite) TestTracerStartContextNotCanceledWhenTracerDies(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectClient()
+
+	tracer := s.newTracer(c)
+
+	ctx, span := tracer.Start(c.Context(), "foo")
+	workertest.DirtyKill(c, tracer)
+	defer span.End()
+
+	select {
+	case <-ctx.Done():
+		c.Fatalf("context should not be done")
+	default:
+	}
+}
+
+func (s *tracerSuite) TestTracerStartContextCarriesCoreSpan(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectClient()
+
+	tracer := s.newTracer(c)
+	defer workertest.CleanKill(c, tracer)
+
+	ctx, span := tracer.Start(c.Context(), "foo")
+	defer span.End()
+
+	_, ok := coretrace.SpanFromContext(ctx).(*limitedSpan)
+	c.Check(ok, tc.IsTrue)
+}
+
+func (s *tracerSuite) TestTracerStartReturnsBuiltRequestContext(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectClient()
+
+	tracer := s.newTracer(c)
+	defer workertest.CleanKill(c, tracer)
+
+	ctx := coretrace.WithTraceScope(c.Context(), "80f198ee56343ba864fe8b2a57d3eff7", "ff00000000000000", 1)
+	ctx, span := tracer.Start(ctx, "foo")
+	defer span.End()
+
+	traceID, spanID, flags, ok := coretrace.ScopeFromContext(ctx)
+	c.Check(ok, tc.IsFalse)
+	c.Check(traceID, tc.Equals, "")
+	c.Check(spanID, tc.Equals, "")
+	c.Check(flags, tc.Equals, 0)
+
+	traceID, ok = coretrace.TraceIDFromContext(ctx)
+	c.Check(ok, tc.IsTrue)
+	c.Check(traceID, tc.Equals, "80f198ee56343ba864fe8b2a57d3eff7")
+}
+
+func (s *tracerSuite) TestContextWithSpanCarriesTraceValues(c *tc.C) {
+	traceID, err := trace.TraceIDFromHex("80f198ee56343ba864fe8b2a57d3eff7")
+	c.Assert(err, tc.ErrorIsNil)
+	spanID, err := trace.SpanIDFromHex("ff00000000000000")
+	c.Assert(err, tc.ErrorIsNil)
+
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	})
+	otelCtx := trace.ContextWithSpanContext(c.Context(), spanContext)
+	otelSpan := trace.SpanFromContext(otelCtx)
+	coreSpan := coretrace.NoopSpan{}
+
+	ctx := contextWithSpan(c.Context(), otelSpan, coreSpan)
+	c.Check(ctx.Err(), tc.ErrorIsNil)
+	c.Check(coretrace.SpanFromContext(ctx), tc.Equals, coreSpan)
+
+	gotTraceID, ok := coretrace.TraceIDFromContext(ctx)
+	c.Check(ok, tc.IsTrue)
+	c.Check(gotTraceID, tc.Equals, traceID.String())
+	c.Check(trace.SpanFromContext(ctx).SpanContext().TraceID(), tc.Equals, traceID)
+	c.Check(trace.SpanFromContext(ctx).SpanContext().SpanID(), tc.Equals, spanID)
+}
+
 func (s *tracerSuite) TestTracerStartContextShouldBeCanceled(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 


### PR DESCRIPTION
~~Requires https://github.com/juju/juju/pull/22832~~

----

This one is a tricky one, and it can be manifested if you change
the tracing config at the wrong time. Essentially, if there is an
existing trace request happening, and we swap out the underlying trace
client (tracer worker), then the tomb is set to dying. This means
that any request that is happening with that context & span becomes
a poison pill - poisoning the well. There is nothing we can do, it
will taint the whole connection - it's that invasive. It takes time
to recover and sometimes it didn't!

The solution is not to return a context that is not tied to the
tomb, but does have all the information in the context that is
required.

This was horrible to workout.

## QA steps


Get a tempo working, can be with or without cos.

You'll need the latest controller charm and the observability charm 

```sh
$ juju bootstrap lxd src --bootstrap-base=ubuntu@24.04 --controller-charm-path=./juju-controller_ubuntu@24.04-amd64.charm --build-agent
$ juju switch controller 
$ juju deploy ./observability_amd64.charm 
$ juju config controller \
    workload-tracing-sample-ratio=1 \
    workload-tracing-tail-sampling-threshold=1ms \
    workload-tracing-insecure-skip-verify=true 
$ juju config observability http-endpoint="http://<IP ADDRESS>/v1/traces"
$ juju integrate controller:workload-tracing observability:workload-tracing
```

Now change one of the controller configs, it shouldn't tank juju.