### PR TITLE
docs: 3.6 fix cloud ref update

### DIFF
--- a/docs/reference/cloud.md
+++ b/docs/reference/cloud.md
@@ -41,3 +41,7 @@ A **Kubernetes cloud** is a cloud backed by an existing Kubernetes cluster. Juju
 See more: {ref}`List of supported Kubernetes clouds <list-of-supported-kubernetes-clouds>`
 ```
 
+## Cloud definition
+
+The structure of a cloud definition and its supported authentication types and configuration keys depend on the specific cloud. See the relevant {ref}`cloud reference page <list-of-supported-clouds>` for details.
+

--- a/docs/reference/cloud/list-of-supported-clouds/amazon-ec2.md
+++ b/docs/reference/cloud/list-of-supported-clouds/amazon-ec2.md
@@ -21,7 +21,78 @@ This reference assumes basic familiarity with Juju. If you are new to Juju, star
 (ec2-cloud-requirements-iam)=
 ## Requirements
 
-Juju needs Service Account Key Admin, Compute Instance Admin, and Compute Security Admin to create and manage the EC2 resources used during cloud registration and bootstrap.
+Juju requires the following AWS IAM permissions to create and manage EC2 resources during cloud registration and bootstrap:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "JujuEC2Actions",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AssociateIamInstanceProfile",
+        "ec2:AttachVolume",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteVolume",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeIamInstanceProfileAssociations",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSpotPriceHistory",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVpcs",
+        "ec2:DetachVolume",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RunInstances",
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "JujuIAMActions",
+      "Effect": "Allow",
+      "Action": [
+        "iam:AddRoleToInstanceProfile",
+        "iam:CreateInstanceProfile",
+        "iam:CreateRole",
+        "iam:DeleteInstanceProfile",
+        "iam:DeleteRole",
+        "iam:DeleteRolePolicy",
+        "iam:GetInstanceProfile",
+        "iam:GetRole",
+        "iam:ListInstanceProfiles",
+        "iam:ListRolePolicies",
+        "iam:ListRoles",
+        "iam:PassRole",
+        "iam:PutRolePolicy",
+        "iam:RemoveRoleFromInstanceProfile"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "JujuSSMActions",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:ListInstanceAssociations",
+        "ssm:UpdateInstanceInformation"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
 
 (ec2-cloud-concepts)=
 ## Concepts

--- a/docs/reference/cloud/list-of-supported-clouds/index.md
+++ b/docs/reference/cloud/list-of-supported-clouds/index.md
@@ -12,7 +12,7 @@ myst:
 
 Amazon EC2 <amazon-ec2>
 Amazon EKS <amazon-eks>
-Canonical K8s <canonical-kubernetes>
+Canonical Kubernetes <canonical-kubernetes>
 Equinix Metal <equinix-metal>
 Google GCE <google-gce>
 Google GKE <google-gke>

--- a/docs/reference/cloud/list-of-supported-clouds/lxd.md
+++ b/docs/reference/cloud/list-of-supported-clouds/lxd.md
@@ -7,7 +7,7 @@ myst:
 (cloud-lxd)=
 # LXD
 
-In Juju, [LXD](https://ubuntu.com/lxd) is a {ref}`machine cloud <machine-cloud>` that can run both system containers and virtual machines, and works as described below.
+In Juju, [LXD](https://canonical.com/lxd) is a {ref}`machine cloud <machine-cloud>` that can run both system containers and virtual machines, and works as described below.
 
 ```{note}
 This reference assumes basic familiarity with Juju. If you are new to Juju, start with the {ref}`Tutorial <tutorial>`, then use this page together with the generic materials it links to. For a cloud-specific starting point, see {ref}`lxd-appendix-example-workflows`.

--- a/docs/reference/cloud/list-of-supported-clouds/microk8s.md
+++ b/docs/reference/cloud/list-of-supported-clouds/microk8s.md
@@ -7,7 +7,7 @@ myst:
 (cloud-kubernetes-microk8s)=
 # MicroK8s
 
-In Juju, [MicroK8s](https://microk8s.io/) is a {ref}`Kubernetes cloud <kubernetes-cloud>` and works as described below.
+In Juju, [MicroK8s](https://canonical.com/microk8s) is a {ref}`Kubernetes cloud <kubernetes-cloud>` and works as described below.
 
 ```{note}
 This reference assumes basic familiarity with Juju. If you are new to Juju, start with the {ref}`Tutorial <tutorial>`, then use this page together with the generic materials it links to.

--- a/docs/reference/cloud/list-of-supported-clouds/microsoft-aks.md
+++ b/docs/reference/cloud/list-of-supported-clouds/microsoft-aks.md
@@ -52,13 +52,14 @@ See more: {ref}`add-a-kubernetes-cloud`
 
 ## Pods
 
-```Distribution-specific notes
-
-(aks-cloud-adding)=
-### Adding the cloud
-
-When adding this cloud to Juju using the {ref}`juju CLI client <juju-client>`, starting with Juju 3.0 you must run the `add-k8s` command with the 'raw' client because the `juju` client snap is strictly confined but the AKS cloud CLI snap is not.
-
-```{ibnote}
-See more: {ref}`add-a-kubernetes-cloud`
+```{include} ./reuse/k8s/constraints.md
 ```
+
+```{include} ./reuse/k8s/pod-deployment-patterns.md
+```
+
+## Storage
+
+```{include} ./reuse/k8s/storage-provider.md
+```
+

--- a/docs/reference/credential.md
+++ b/docs/reference/credential.md
@@ -21,6 +21,10 @@ Clouds can have one or more sets of credentials associated with them.
 
 When you create a  {ref}`model <model>` in Juju it must always be associated with a cloud/credential pair -- the model needs that to create resources on the underlying cloud.
 
+## Credential definition
+
+The structure of a credential and its supported authentication types depend on the cloud. See the relevant {ref}`cloud reference page <list-of-supported-clouds>` for details.
+
 ## Client vs. controller credential
 
 Juju credentials can be created for either the Juju client or the Juju controller or both -- where a **client credential** (previously known as a 'local credential') denotes a credential that the client is aware of and a **controller credential** (previously known as a 'remote credential') denotes a credential that a controller is aware of. When you bootstrap a controller and use a client credential, this credential gets automatically uploaded to the controller, so it becomes a controller credential also.


### PR DESCRIPTION
Backports fixes in light of reviewer feedback from #22765: renames `Canonical K8s` to `Canonical Kubernetes` in the cloud index, updates the LXD link from `ubuntu.com/lxd` to `canonical.com/lxd` and the MicroK8s link from `microk8s.io` to `canonical.com/microk8s`, removes a malformed duplicate block from `microsoft-aks.md` and replaces it with the correct `Pods` and `Storage` sections, replaces incorrect GCP IAM role names in the EC2 requirements section with the full IAM policy JSON, and adds `Cloud definition` and `Credential definition` section headings in `cloud.md` and `credential.md` with forwarding notes to the per-cloud reference pages.