### PR TITLE
docs(tutorial): fix cloud-init URL to use juju/juju not canonical/juju

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -30,7 +30,7 @@ Now, launch an Ubuntu VM using the [cloud-init](https://cloudinit.readthedocs.io
 :copy:
 :user:
 :host:
-multipass launch 24.04 --cpus 4 --memory 8G --disk 50G --name my-juju-vm --cloud-init https://raw.githubusercontent.com/canonical/juju/4.0/docs/tutorial/cloud-init.yaml
+multipass launch 24.04 --cpus 4 --memory 8G --disk 50G --name my-juju-vm --cloud-init https://raw.githubusercontent.com/juju/juju/4.0/docs/tutorial/cloud-init.yaml
 
 Launched: my-juju-vm
 ```


### PR DESCRIPTION
A patch on top of the just merged https://github.com/juju/juju/pull/22835 .

The `multipass launch` command in the tutorial referenced the cloud-init file at `canonical/juju` instead of `juju/juju`, causing a 404 error when readers tried to follow the tutorial.