### PR TITLE
refactor: drop down to xxlarge instead of quad-xlarge

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,7 +11,7 @@ jobs:
       - linux
       - x64
       - ${{ (github.repository_owner == 'juju' && 'aws') || (github.repository_owner == 'canonical' && 'noble') }}
-      - ${{ (github.repository_owner == 'juju' && 'quad-xlarge') || (github.repository_owner == 'canonical' && 'xlarge') }}
+      - ${{ (github.repository_owner == 'juju' && 'xxlarge') || (github.repository_owner == 'canonical' && 'xlarge') }}
     timeout-minutes: 60
     if: github.event.pull_request.draft == false
     strategy:
@@ -101,7 +101,7 @@ jobs:
 
   deploy:
     name: Deploy test (LXD, ${{ matrix.deploy_test.name }})
-    runs-on: [self-hosted, linux, x64, aws, quad-xlarge]
+    runs-on: [self-hosted, linux, x64, aws, xxlarge]
     timeout-minutes: 60
     if: github.event.pull_request.draft == false
     strategy:


### PR DESCRIPTION
This drops from quad-xlarge to xxlarge. We should probably check other ones, quad-xlarge seems a bit heavy for runners.

## QA steps

Make sure smoke tests correctly pass.
