### PR TITLE
fix: support zone placement for local charm deploys

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -460,7 +460,7 @@ func (api *APIBase) deployApplication(
 
 	// This check is done early so that errors deeper in the call-stack do not
 	// leave an application deployment in an unrecoverable error state.
-	if err := checkMachinePlacement(api.modelUUID, args.ApplicationName, args.Placement); err != nil {
+	if err := checkMachinePlacement(args.Placement); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -641,7 +641,7 @@ func parseApplicationConfig(
 // placement directives.
 // If the placement scope is for a machine, ensure that the machine exists.
 // If the placement scope is model-uuid, replace it with the actual model uuid.
-func checkMachinePlacement(modelID model.UUID, app string, placement []*instance.Placement) error {
+func checkMachinePlacement(placement []*instance.Placement) error {
 	for _, p := range placement {
 		if p == nil {
 			continue

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -480,7 +480,7 @@ type deployFromRepositoryValidator struct {
 func (v *deployFromRepositoryValidator) validate(ctx context.Context, arg params.DeployFromRepositoryArg) (deployTemplate, []error) {
 	errs := make([]error, 0)
 
-	if err := checkMachinePlacement(v.modelInfo.UUID, arg.ApplicationName, arg.Placement); err != nil {
+	if err := checkMachinePlacement(arg.Placement); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -159,7 +159,7 @@ func (mm *MachineManagerAPI) addOneMachine(ctx context.Context, p params.AddMach
 	}
 
 	// Check if the model exists in case of model scope placement.
-	parsedPlacement, err := deployment.ParsePlacement(p.Placement)
+	parsedPlacement, err := deployment.ParsePlacement(p.Placement, mm.modelUUID.String())
 	if err != nil {
 		return "", internalerrors.Errorf("invalid placement: %w", err)
 	}

--- a/core/instance/placement_test.go
+++ b/core/instance/placement_test.go
@@ -55,6 +55,38 @@ func (s *PlacementSuite) TestParsePlacement(c *tc.C) {
 		arg:             "non:standard",
 		expectScope:     "non",
 		expectDirective: "standard",
+	}, {
+		arg:             "model-uuid:zone=us-east-1a",
+		expectScope:     instance.ModelScope,
+		expectDirective: "zone=us-east-1a",
+	}, {
+		arg:             "model-uuid:subnet=subnet-123",
+		expectScope:     instance.ModelScope,
+		expectDirective: "subnet=subnet-123",
+	}, {
+		arg:             "model-uuid:system-id=node-1",
+		expectScope:     instance.ModelScope,
+		expectDirective: "system-id=node-1",
+	}, {
+		arg:             "model-uuid:foo:bar",
+		expectScope:     instance.ModelScope,
+		expectDirective: "foo:bar",
+	}, {
+		arg:         "model-uuid:",
+		expectScope: instance.ModelScope,
+	}, {
+		// A raw UUID scope (e.g. after the client substitutes the
+		// "model-uuid" placeholder with the real model UUID) is
+		// syntactically valid. The parser treats it as a generic
+		// scope:directive pair without interpreting its semantics.
+		arg:             "32c5aaae-6713-4cd7-83a4-d1256e9c97d0:zone=us-east-1a",
+		expectScope:     "32c5aaae-6713-4cd7-83a4-d1256e9c97d0",
+		expectDirective: "zone=us-east-1a",
+	}, {
+		// A bare "model-uuid" without a colon is not a valid
+		// scope:directive pair, so it should fail.
+		arg: "model-uuid",
+		err: "placement scope missing",
 	}}
 
 	for i, t := range parsePlacementTests {

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -761,7 +761,7 @@ func (s *ProviderService) makeIAASUnitArgs(
 ) ([]application.AddIAASUnitArg, error) {
 	args := make([]application.AddIAASUnitArg, len(units))
 	for i, u := range units {
-		placement, err := deployment.ParsePlacement(u.Placement)
+		placement, err := deployment.ParsePlacement(u.Placement, s.modelUUID.String())
 		if err != nil {
 			return nil, errors.Errorf("invalid placement: %w", err)
 		}
@@ -894,7 +894,7 @@ func (s *ProviderService) makeCAASUnitArgs(
 ) ([]application.AddCAASUnitArg, error) {
 	args := make([]application.AddCAASUnitArg, len(units))
 	for i, u := range units {
-		placement, err := deployment.ParsePlacement(u.Placement)
+		placement, err := deployment.ParsePlacement(u.Placement, s.modelUUID.String())
 		if err != nil {
 			return nil, errors.Errorf("invalid placement: %w", err)
 		}

--- a/domain/deployment/placement.go
+++ b/domain/deployment/placement.go
@@ -70,6 +70,10 @@ type Placement struct {
 // before sending it to the API server. Both the literal "model-uuid"
 // scope and the real model UUID are treated as provider placements.
 func ParsePlacement(placement *instance.Placement, modelUUID string) (Placement, error) {
+	if modelUUID == "" {
+		return Placement{}, errors.Errorf("model UUID cannot be empty")
+	}
+
 	// If no placement is present we default to an unset placement.
 	if placement == nil {
 		return Placement{
@@ -88,19 +92,13 @@ func ParsePlacement(placement *instance.Placement, modelUUID string) (Placement,
 			Directive: placement.Directive,
 		}, nil
 
-	default:
-		// Provider placements use either the literal "model-uuid"
-		// placeholder scope or the real model UUID that the client
-		// substitutes before sending to the API server. Guard against
-		// an empty modelUUID to avoid matching empty scopes.
-		if placement.Scope == instance.ModelScope ||
-			(modelUUID != "" && placement.Scope == modelUUID) {
-			return Placement{
-				Type:      PlacementTypeProvider,
-				Directive: placement.Directive,
-			}, nil
-		}
+	case instance.ModelScope, modelUUID:
+		return Placement{
+			Type:      PlacementTypeProvider,
+			Directive: placement.Directive,
+		}, nil
 
+	default:
 		container, err := instance.ParseContainerType(placement.Scope)
 		if err != nil {
 			return Placement{}, errors.Capture(err)

--- a/domain/deployment/placement.go
+++ b/domain/deployment/placement.go
@@ -63,7 +63,13 @@ type Placement struct {
 
 // ParsePlacement parses the placement from the instance placement. If the
 // placement is nil then an unset placement will be returned.
-func ParsePlacement(placement *instance.Placement) (Placement, error) {
+//
+// The modelUUID is the UUID of the model that the placement is being
+// parsed for. This is used to recognise placements where the client has
+// substituted the "model-uuid" placeholder scope with the real model UUID
+// before sending it to the API server. Both the literal "model-uuid"
+// scope and the real model UUID are treated as provider placements.
+func ParsePlacement(placement *instance.Placement, modelUUID string) (Placement, error) {
 	// If no placement is present we default to an unset placement.
 	if placement == nil {
 		return Placement{
@@ -72,7 +78,7 @@ func ParsePlacement(placement *instance.Placement) (Placement, error) {
 	}
 
 	switch placement.Scope {
-	case instance.ModelScope:
+	case instance.ModelScope, modelUUID:
 		return Placement{
 			Type:      PlacementTypeProvider,
 			Directive: placement.Directive,

--- a/domain/deployment/placement.go
+++ b/domain/deployment/placement.go
@@ -78,12 +78,6 @@ func ParsePlacement(placement *instance.Placement, modelUUID string) (Placement,
 	}
 
 	switch placement.Scope {
-	case instance.ModelScope, modelUUID:
-		return Placement{
-			Type:      PlacementTypeProvider,
-			Directive: placement.Directive,
-		}, nil
-
 	case instance.MachineScope:
 		if err := parseMachineParenting(placement.Directive); err != nil {
 			return Placement{}, errors.Capture(err)
@@ -95,6 +89,18 @@ func ParsePlacement(placement *instance.Placement, modelUUID string) (Placement,
 		}, nil
 
 	default:
+		// Provider placements use either the literal "model-uuid"
+		// placeholder scope or the real model UUID that the client
+		// substitutes before sending to the API server. Guard against
+		// an empty modelUUID to avoid matching empty scopes.
+		if placement.Scope == instance.ModelScope ||
+			(modelUUID != "" && placement.Scope == modelUUID) {
+			return Placement{
+				Type:      PlacementTypeProvider,
+				Directive: placement.Directive,
+			}, nil
+		}
+
 		container, err := instance.ParseContainerType(placement.Scope)
 		if err != nil {
 			return Placement{}, errors.Capture(err)

--- a/domain/deployment/placement_test.go
+++ b/domain/deployment/placement_test.go
@@ -158,6 +158,43 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 			modelUUID: "",
 			err:       new(`invalid container type ""`),
 		},
+		{
+			// A real model UUID scope with a different modelUUID
+			// must not be misclassified as a provider placement.
+			// It should fall through to container parsing and error.
+			input: &instance.Placement{
+				Scope:     modelUUID,
+				Directive: "zone=us-east-1a",
+			},
+			modelUUID: "00000000-0000-0000-0000-000000000000",
+			err:       new(`invalid container type "32c5aaae-6713-4cd7-83a4-d1256e9c97d0"`),
+		},
+		{
+			// The literal "model-uuid" placeholder scope works
+			// as provider placement even when modelUUID is empty.
+			input: &instance.Placement{
+				Scope:     instance.ModelScope,
+				Directive: "subnet=subnet-123",
+			},
+			modelUUID: "",
+			output: Placement{
+				Type:      PlacementTypeProvider,
+				Directive: "subnet=subnet-123",
+			},
+		},
+		{
+			// A real model UUID scope with an empty directive is
+			// still a valid provider placement.
+			input: &instance.Placement{
+				Scope:     modelUUID,
+				Directive: "",
+			},
+			modelUUID: modelUUID,
+			output: Placement{
+				Type:      PlacementTypeProvider,
+				Directive: "",
+			},
+		},
 	}
 	for _, test := range tests {
 		c.Logf("input: %v", test.input)

--- a/domain/deployment/placement_test.go
+++ b/domain/deployment/placement_test.go
@@ -24,9 +24,10 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 	const modelUUID = "32c5aaae-6713-4cd7-83a4-d1256e9c97d0"
 
 	tests := []struct {
-		input  *instance.Placement
-		output Placement
-		err    *string
+		input     *instance.Placement
+		modelUUID string
+		output    Placement
+		err       *string
 	}{
 		{
 			input: nil,
@@ -103,6 +104,30 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 			},
 		},
 		{
+			// A container type scope must still fall through to
+			// container parsing even when modelUUID is non-empty.
+			input: &instance.Placement{
+				Scope:     "lxd",
+				Directive: "0",
+			},
+			modelUUID: modelUUID,
+			output: Placement{
+				Type:      PlacementTypeContainer,
+				Container: ContainerTypeLXD,
+				Directive: "0",
+			},
+		},
+		{
+			// A non-container, non-model scope with an empty
+			// modelUUID must fall through to container parsing and
+			// error, not be misclassified as a provider placement.
+			input: &instance.Placement{
+				Scope: "not-a-real-scope",
+			},
+			modelUUID: "",
+			err:       new(`invalid container type "not-a-real-scope"`),
+		},
+		{
 			input: &instance.Placement{
 				Scope:     instance.ModelScope,
 				Directive: "zone=us-east-1a",
@@ -117,16 +142,27 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 				Scope:     modelUUID,
 				Directive: "zone=us-east-1a",
 			},
+			modelUUID: modelUUID,
 			output: Placement{
 				Type:      PlacementTypeProvider,
 				Directive: "zone=us-east-1a",
 			},
 		},
+		{
+			// An empty scope with an empty modelUUID must not be
+			// misclassified as a provider placement. It should
+			// fall through to the container type path and error.
+			input: &instance.Placement{
+				Scope: "",
+			},
+			modelUUID: "",
+			err:       new(`invalid container type ""`),
+		},
 	}
 	for _, test := range tests {
 		c.Logf("input: %v", test.input)
 
-		result, err := ParsePlacement(test.input, modelUUID)
+		result, err := ParsePlacement(test.input, test.modelUUID)
 		if test.err != nil {
 			c.Assert(err, tc.ErrorMatches, *test.err)
 		} else {

--- a/domain/deployment/placement_test.go
+++ b/domain/deployment/placement_test.go
@@ -30,7 +30,8 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 		err       *string
 	}{
 		{
-			input: nil,
+			input:     nil,
+			modelUUID: modelUUID,
 			output: Placement{
 				Type: PlacementTypeUnset,
 			},
@@ -40,6 +41,7 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 				Scope:     instance.MachineScope,
 				Directive: "0",
 			},
+			modelUUID: modelUUID,
 			output: Placement{
 				Type:      PlacementTypeMachine,
 				Directive: "0",
@@ -50,6 +52,7 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 				Scope:     instance.MachineScope,
 				Directive: "0/lxd/0",
 			},
+			modelUUID: modelUUID,
 			output: Placement{
 				Type:      PlacementTypeMachine,
 				Directive: "0/lxd/0",
@@ -60,26 +63,30 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 				Scope:     instance.MachineScope,
 				Directive: "0/kvm/0",
 			},
-			err: new(`container type "kvm" not supported`),
+			modelUUID: modelUUID,
+			err:       new(`container type "kvm" not supported`),
 		},
 		{
 			input: &instance.Placement{
 				Scope:     instance.MachineScope,
 				Directive: "0/lxd",
 			},
-			err: new(`placement directive "0/lxd" is not in the form of <parent>/<scope>/<child>`),
+			modelUUID: modelUUID,
+			err:       new(`placement directive "0/lxd" is not in the form of <parent>/<scope>/<child>`),
 		},
 		{
 			input: &instance.Placement{
 				Scope:     instance.MachineScope,
 				Directive: "0/lxd/0/0",
 			},
-			err: new(`placement directive "0/lxd/0/0" is not in the form of <parent>/<scope>/<child>`),
+			modelUUID: modelUUID,
+			err:       new(`placement directive "0/lxd/0/0" is not in the form of <parent>/<scope>/<child>`),
 		},
 		{
 			input: &instance.Placement{
 				Scope: string(instance.LXD),
 			},
+			modelUUID: modelUUID,
 			output: Placement{
 				Type:      PlacementTypeContainer,
 				Container: ContainerTypeLXD,
@@ -89,14 +96,16 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 			input: &instance.Placement{
 				Scope: string(instance.NONE),
 			},
-			output: Placement{},
-			err:    new(`invalid container type "none"`),
+			modelUUID: modelUUID,
+			output:    Placement{},
+			err:       new(`invalid container type "none"`),
 		},
 		{
 			input: &instance.Placement{
 				Scope:     "lxd",
 				Directive: "0",
 			},
+			modelUUID: modelUUID,
 			output: Placement{
 				Type:      PlacementTypeContainer,
 				Container: ContainerTypeLXD,
@@ -118,13 +127,13 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 			},
 		},
 		{
-			// A non-container, non-model scope with an empty
+			// A non-container, non-model scope with a set
 			// modelUUID must fall through to container parsing and
 			// error, not be misclassified as a provider placement.
 			input: &instance.Placement{
 				Scope: "not-a-real-scope",
 			},
-			modelUUID: "",
+			modelUUID: modelUUID,
 			err:       new(`invalid container type "not-a-real-scope"`),
 		},
 		{
@@ -132,6 +141,7 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 				Scope:     instance.ModelScope,
 				Directive: "zone=us-east-1a",
 			},
+			modelUUID: modelUUID,
 			output: Placement{
 				Type:      PlacementTypeProvider,
 				Directive: "zone=us-east-1a",
@@ -149,13 +159,12 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 			},
 		},
 		{
-			// An empty scope with an empty modelUUID must not be
-			// misclassified as a provider placement. It should
+			// An empty scope with a non-empty modelUUID must
 			// fall through to the container type path and error.
 			input: &instance.Placement{
 				Scope: "",
 			},
-			modelUUID: "",
+			modelUUID: modelUUID,
 			err:       new(`invalid container type ""`),
 		},
 		{
@@ -171,12 +180,12 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 		},
 		{
 			// The literal "model-uuid" placeholder scope works
-			// as provider placement even when modelUUID is empty.
+			// as provider placement.
 			input: &instance.Placement{
 				Scope:     instance.ModelScope,
 				Directive: "subnet=subnet-123",
 			},
-			modelUUID: "",
+			modelUUID: modelUUID,
 			output: Placement{
 				Type:      PlacementTypeProvider,
 				Directive: "subnet=subnet-123",

--- a/domain/deployment/placement_test.go
+++ b/domain/deployment/placement_test.go
@@ -21,6 +21,8 @@ func TestPlacementSuite(t *testing.T) {
 }
 
 func (s *PlacementSuite) TestPlacement(c *tc.C) {
+	const modelUUID = "32c5aaae-6713-4cd7-83a4-d1256e9c97d0"
+
 	tests := []struct {
 		input  *instance.Placement
 		output Placement
@@ -110,11 +112,21 @@ func (s *PlacementSuite) TestPlacement(c *tc.C) {
 				Directive: "zone=us-east-1a",
 			},
 		},
+		{
+			input: &instance.Placement{
+				Scope:     modelUUID,
+				Directive: "zone=us-east-1a",
+			},
+			output: Placement{
+				Type:      PlacementTypeProvider,
+				Directive: "zone=us-east-1a",
+			},
+		},
 	}
 	for _, test := range tests {
 		c.Logf("input: %v", test.input)
 
-		result, err := ParsePlacement(test.input)
+		result, err := ParsePlacement(test.input, modelUUID)
 		if test.err != nil {
 			c.Assert(err, tc.ErrorMatches, *test.err)
 		} else {

--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -42,9 +42,10 @@ func RegisterImport(coordinator Coordinator, clock clock.Clock, logger logger.Lo
 type importOperation struct {
 	modelmigration.BaseOperation
 
-	service ImportService
-	clock   clock.Clock
-	logger  logger.Logger
+	service   ImportService
+	clock     clock.Clock
+	logger    logger.Logger
+	modelUUID string
 }
 
 // ImportService defines the machine service used to import machines from
@@ -97,6 +98,7 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 		i.clock,
 		i.logger,
 	)
+	i.modelUUID = scope.ModelUUID().String()
 	return nil
 }
 
@@ -121,7 +123,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		if err != nil {
 			return errors.Errorf("parsing machine instance placement %q: %w", m.Placement(), err)
 		}
-		domainPlacement, err := deployment.ParsePlacement(placement)
+		domainPlacement, err := deployment.ParsePlacement(placement, i.modelUUID)
 		if err != nil {
 			return errors.Errorf("parsing machine domain placement %q: %w", m.Id(), err)
 		}
@@ -151,7 +153,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			if err != nil {
 				return errors.Errorf("parsing machine instance placement %q: %w", c.Placement(), err)
 			}
-			domainPlacement, err := deployment.ParsePlacement(placement)
+			domainPlacement, err := deployment.ParsePlacement(placement, i.modelUUID)
 			if err != nil {
 				return errors.Errorf("parsing machine domain placement %q: %w", c.Id(), err)
 			}

--- a/domain/machine/modelmigration/import_test.go
+++ b/domain/machine/modelmigration/import_test.go
@@ -41,9 +41,10 @@ func (s *importSuite) setupMocks(c *tc.C) *gomock.Controller {
 
 func (s *importSuite) newImportOperation(c *tc.C) *importOperation {
 	return &importOperation{
-		service: s.service,
-		clock:   clock.WallClock,
-		logger:  loggertesting.WrapCheckLog(c),
+		service:   s.service,
+		clock:     clock.WallClock,
+		logger:    loggertesting.WrapCheckLog(c),
+		modelUUID: "32c5aaae-6713-4cd7-83a4-d1256e9c97d0",
 	}
 }
 

--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -722,6 +722,7 @@ func (st *State) removeBasicMachineData(ctx context.Context, tx *sqlair.TX, mUUI
 		"DELETE FROM machine_agent_presence WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM machine_container_type WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM machine_ssh_host_key WHERE machine_uuid = $entityUUID.uuid",
+		"DELETE FROM machine_placement WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM machine_parent WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM block_device_link_device WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM block_device WHERE machine_uuid = $entityUUID.uuid",

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -2286,6 +2286,61 @@ func (s *machineSuite) TestDeleteMachineWithForceWaitsForDeadUnitRemoval(c *tc.C
 	c.Check(exists, tc.IsFalse)
 }
 
+// TestDeleteMachineWithProviderPlacement verifies that a machine created
+// with a provider placement directive (e.g. zone=us-east-1a) can be
+// deleted. The machine_placement table has a foreign key to machine(uuid),
+// so removeBasicMachineData must clean it up before deleting the machine
+// row. This test prevents a regression where provider-placed machines
+// caused "FOREIGN KEY constraint failed" during model destruction.
+func (s *machineSuite) TestDeleteMachineWithProviderPlacement(c *tc.C) {
+	svc := s.setupMachineService(c)
+	machineRes, err := svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "24.04",
+		},
+		Directive: deployment.Placement{
+			Type:      deployment.PlacementTypeProvider,
+			Directive: "zone=us-east-1a",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, err := svc.GetMachineUUID(c.Context(), machineRes.MachineName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Verify the machine_placement row was created.
+	var count int
+	err = s.DB().QueryRow(
+		"SELECT COUNT(*) FROM machine_placement WHERE machine_uuid = ?",
+		machineUUID.String(),
+	).Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 1)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	s.advanceMachineLife(c, machineUUID, life.Dead)
+	s.advanceInstanceLife(c, machineUUID, life.Dead)
+
+	// This previously failed with "FOREIGN KEY constraint failed" because
+	// machine_placement was not cleaned up by removeBasicMachineData.
+	err = st.DeleteMachine(c.Context(), machineUUID.String(), false)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The machine should be gone.
+	exists, err := st.MachineExists(c.Context(), machineUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.IsFalse)
+
+	// The machine_placement row should be gone.
+	err = s.DB().QueryRow(
+		"SELECT COUNT(*) FROM machine_placement WHERE machine_uuid = ?",
+		machineUUID.String(),
+	).Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+}
+
 func (s *machineSuite) createMachineFilesystem(
 	c *tc.C, machineUUID string,
 ) string {

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -48,6 +48,58 @@ run_deploy_charm_placement_directive() {
 	destroy_model "test-deploy-charm-placement-directive"
 }
 
+run_deploy_charm_zone_placement_directive() {
+	echo
+
+	file="${TEST_DIR}/test-deploy-charm-zone-placement-directive.log"
+
+	ensure "test-deploy-charm-zone-placement" "${file}"
+
+	# Add a machine so that we can discover the availability zone for
+	# the cloud under test. The zone is extracted from the machine's
+	# hardware info and used in the zone-based placement directive below.
+	if [[ ${BOOTSTRAP_PROVIDER} == "lxd" ]]; then
+		juju add-machine --constraints="virt-type=virtual-machine"
+	else
+		juju add-machine
+	fi
+	wait_for_machine_agent_status "0" "started"
+
+	# Extract the availability zone from the machine hardware field.
+	# The hardware field is a space-separated string of key=value pairs,
+	# e.g. "availability-zone=us-east-1a arch=amd64 cores=4 ..."
+	az=$(juju show-machine 0 --format=json |
+		yq -r '.["machines"]["0"]["hardware"]' |
+		grep -oP 'availability-zone=\K\S+')
+
+	if [[ -z "${az}" ]]; then
+		echo "==> TEST SKIPPED: no availability zone reported by provider ${BOOTSTRAP_PROVIDER}"
+		destroy_model "test-deploy-charm-zone-placement"
+		return
+	fi
+
+	# Deploy a local charm using a zone-based placement directive.
+	# A local charm deploy goes through the legacy Deploy API path, where
+	# the client substitutes the "model-uuid" placeholder scope with the
+	# real model UUID before sending it to the API server. The domain
+	# layer must recognise the model UUID scope as a provider placement
+	# directive, not attempt to parse it as a container type.
+	# shellcheck disable=SC2046
+	juju deploy $(pack_charm ./testcharms/charms/ubuntu-plus) --to "zone=${az}" ubuntu-zone-placement
+	wait_for "ubuntu-zone-placement" "$(idle_condition "ubuntu-zone-placement")"
+
+	# Verify that the machine hosting the deployed unit is in the
+	# requested availability zone.
+	machine_id=$(juju status --format=json |
+		yq -r '.applications."ubuntu-zone-placement".units."ubuntu-zone-placement/0".machine')
+	deployed_az=$(juju show-machine "${machine_id}" --format=json |
+		yq -r ".[\"machines\"][\"${machine_id}\"][\"hardware\"]" |
+		grep -oP 'availability-zone=\K\S+')
+	echo "${deployed_az}" | check "${az}"
+
+	destroy_model "test-deploy-charm-zone-placement"
+}
+
 run_deploy_charm_unsupported_series() {
 	# Test trying to deploy a charmhub charm to an operating system
 	# never supported in the specified channel. It should fail.
@@ -405,8 +457,10 @@ test_deploy_charms() {
 		"lxd")
 			if kvm-ok; then
 				run "run_deploy_charm_placement_directive"
+				run "run_deploy_charm_zone_placement_directive"
 			else
 				echo "==> TEST SKIPPED: deploy_charm_placement_directive - lxd without kvm is not supported"
+				echo "==> TEST SKIPPED: deploy_charm_zone_placement_directive - lxd without kvm is not supported"
 			fi
 			# Skip these tests for now, as they rely on lxd profiles, which
 			# have not been re-implemented yet
@@ -420,6 +474,7 @@ test_deploy_charms() {
 			;;
 		*)
 			run "run_deploy_charm_placement_directive"
+			run "run_deploy_charm_zone_placement_directive"
 			echo "==> TEST SKIPPED: deploy_lxd_to_machine - tests for LXD only"
 			echo "==> TEST SKIPPED: deploy_lxd_profile_charm - tests for LXD only"
 			echo "==> TEST SKIPPED: deploy_local_lxd_profile_charm - tests for LXD only"


### PR DESCRIPTION
Deploying a local charm with `--to zone=<az>` fails in 4.0:

```
ERROR cannot deploy "t1": preparing application args: making unit args: invalid placement: invalid container type "<model-uuid>"
```

This works in 3.6.

### Why it works in 3.6

The client substitutes the `"model-uuid"` placeholder scope with the real model UUID before sending to the apiserver. In 3.6, `state.parsePlacement` compares against the **real** model UUID and correctly treats it as a provider placement directive.

### Why it fails in 4.0

The 4.0 domain-layer `deployment.ParsePlacement` only matches the **literal** `"model-uuid"` string, not the real UUID the client sends. The real UUID falls into the `default` branch where `ParseContainerType` fails.

This only affects the legacy `Deploy` path (local charms). The `DeployFromRepository` path (charmhub) doesn't substitute, so the literal placeholder reaches the domain layer and works.

### Fix

Pass the model UUID to `ParsePlacement` so it recognises both the placeholder and the real UUID as provider scope. Updated all 5 callers across the application service, machinemanager facade, and machine migration.

### Second bug: machine deletion FK failure

Fixing the placement bug exposed a secondary bug. Provider placement creates a row in `machine_placement`, which has a FK to `machine(uuid)`. The machine deletion cleanup in `removeBasicMachineData` was missing `machine_placement` from its table list, causing `DELETE FROM machine` to fail with a FK constraint error during model destruction.

This was invisible before because provider-placed machines could never be created. Added the missing cleanup statement and a regression test.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ ./main.sh -p aws deploy run_deploy_charm_zone_placement_directive

==> Checking for dependencies
==> Using Juju located at /home/iyigun.cevik@canonical.com/go/src/github.com/iyiguncevik/juju-40/.direnv/bin/juju
==> Running subtest: run_deploy_charm_zone_placement_directive
==> TEST BEGIN: test_deploy (tmp.WYw)
==> Checking for dependencies
SKIPPING: run_deploy_charm_zone_placement_directive run_deploy_charm
SKIPPING: run_deploy_charm_zone_placement_directive run_deploy_specific_series
SKIPPING: run_deploy_charm_zone_placement_directive run_resolve_charm
SKIPPING: run_deploy_charm_zone_placement_directive run_deploy_charm_unsupported_series
SKIPPING: run_deploy_charm_zone_placement_directive run_deploy_charm_placement_directive
===> [   ] Running: deploy charm zone placement directive
==> Killed daemon (PID is 2395094)
includes/pids.sh: line 57: 2395094 Killed                  juju debug-log -m "${controller}:controller" --replay --tail 2>&1 > "${TEST_DIR}/${controller}-controller-debug.log"
==> Killed daemon (PID is 2395096)
===> [ ✔ ] Success: deploy charm zone placement directive (380s)
==> TEST SKIPPED: deploy_lxd_to_machine - tests for LXD only
==> TEST SKIPPED: deploy_lxd_profile_charm - tests for LXD only
==> TEST SKIPPED: deploy_local_lxd_profile_charm - tests for LXD only
SKIPPING: run_deploy_charm_zone_placement_directive run_deploy_lxd_to_container
SKIPPING: run_deploy_charm_zone_placement_directive run_deploy_lxd_profile_charm_container
==> TEST DONE: test_deploy (380s)
==> Cleaning up
====> Cleaning up jujus
====> Introspection gathering
====> Introspection gathered
====> Removing offers
====> Removed offers
====> Destroying juju (ctrl-9wa2e6wn)
====> Destroyed juju (ctrl-9wa2e6wn)
====> Completed cleaning up jujus

==> Test result: success
==> Tests Removed: /home/iyigun.cevik@canonical.com/go/src/github.com/iyiguncevik/juju-40/tests/tmp.WYw
==> TEST COMPLETE
```

## Documentation changes

## Links

**Issue:** Fixes #22222

**Jira card:** [JUJU-9646](https://warthogs.atlassian.net/browse/JUJU-9646)


[JUJU-9646]: https://warthogs.atlassian.net/browse/JUJU-9646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ