### PR TITLE
fix: populate origin hash for local charms

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1290,7 +1290,7 @@ func (api *APIBase) GetCharmURLOrigin(args params.ApplicationGet) (params.CharmU
 	if corecharm.Source(chOrigin.Source) == corecharm.Local && result.Origin.Hash == "" {
 		ch, err := api.backend.Charm(*charmURL)
 		if err != nil {
-			result.Error = apiservererrors.ServerError(errors.NotFoundf("charm origin hash for %q", args.ApplicationName))
+			result.Error = apiservererrors.ServerError(errors.Annotatef(err, "getting charm origin hash for %q", args.ApplicationName))
 			return result, nil
 		}
 		result.Origin.Hash = ch.BundleSha256()

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1284,6 +1284,17 @@ func (api *APIBase) GetCharmURLOrigin(args params.ApplicationGet) (params.CharmU
 		result.Error = apiservererrors.ServerError(errors.NotFoundf("charm origin for %q", args.ApplicationName))
 		return result, nil
 	}
+	// Local charms do not carry a hash on their origin
+	// Populate with the archive SHA256 that was computed previously
+	// TODO(luci1900): save the hash at the point of origin like for store charms
+	if corecharm.Source(chOrigin.Source) == corecharm.Local && result.Origin.Hash == "" {
+		ch, err := api.backend.Charm(*charmURL)
+		if err != nil {
+			result.Error = apiservererrors.ServerError(errors.NotFoundf("charm origin hash for %q", args.ApplicationName))
+			return result, nil
+		}
+		result.Origin.Hash = ch.BundleSha256()
+	}
 	result.Origin.InstanceKey = charmhub.CreateInstanceKey(oneApplication.ApplicationTag(), api.model.ModelTag())
 	return result, nil
 }

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -3713,13 +3713,24 @@ func (s *ApplicationSuite) TestIllegalSettingsParsing(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unknown option "yummy"`)
 }
 
+// expectGetCharmURLOriginApplication sets up an application returning the
+// given origin for the GetCharmURLOrigin facade call.
+func (s *ApplicationSuite) expectGetCharmURLOriginApplication(ctrl *gomock.Controller, origin *state.CharmOrigin) *mocks.MockApplication {
+	app := s.expectDefaultApplication(ctrl)
+	app.EXPECT().CharmOrigin().Return(origin)
+	s.backend.EXPECT().Application("postgresql").Return(app, nil)
+	return app
+}
+
+// TestApplicationGetCharmURLOrigin verifies that, for a local charm whose
+// origin carries no hash, the facade populates the hash from the charm
+// document's stored archive SHA256.
 func (s *ApplicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 	ctrl := s.setup(c)
 	defer ctrl.Finish()
 
 	rev := 42
-	app := s.expectDefaultApplication(ctrl)
-	app.EXPECT().CharmOrigin().Return(&state.CharmOrigin{
+	app := s.expectGetCharmURLOriginApplication(ctrl, &state.CharmOrigin{
 		Source:   "local",
 		Revision: &rev,
 		Channel: &state.Channel{
@@ -3733,7 +3744,12 @@ func (s *ApplicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 			Channel:      "22.04/stable",
 		},
 	})
-	s.backend.EXPECT().Application("postgresql").Return(app, nil)
+	// Local charms have no hash on their origin, so the facade sources the
+	// archive SHA256 stored at upload time from the charm document.
+	const sha256 = "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"
+	ch := mocks.NewMockCharm(ctrl)
+	ch.EXPECT().BundleSha256().Return(sha256)
+	s.backend.EXPECT().Charm("ch:postgresql-42").Return(ch, nil)
 
 	result, err := s.api.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "postgresql"})
 	c.Assert(err, jc.ErrorIsNil)
@@ -3745,6 +3761,7 @@ func (s *ApplicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 
 	c.Assert(result.Origin, jc.DeepEquals, params.CharmOrigin{
 		Source:       "local",
+		Hash:         sha256,
 		Risk:         "stable",
 		Revision:     &rev,
 		Track:        &latest,
@@ -3753,4 +3770,84 @@ func (s *ApplicationSuite) TestApplicationGetCharmURLOrigin(c *gc.C) {
 		Base:         params.Base{Name: "ubuntu", Channel: "22.04/stable"},
 		InstanceKey:  charmhub.CreateInstanceKey(app.ApplicationTag(), coretesting.ModelTag),
 	})
+}
+
+// TestApplicationGetCharmURLOriginCharmhub verifies that for a charmhub
+// charm the hash-population block is skipped entirely: the origin hash comes
+// straight from the stored origin and backend.Charm is never consulted.
+func (s *ApplicationSuite) TestApplicationGetCharmURLOriginCharmhub(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	rev := 42
+	const originHash = "abc123"
+	s.expectGetCharmURLOriginApplication(ctrl, &state.CharmOrigin{
+		Source:   "charm-hub",
+		Hash:     originHash,
+		Revision: &rev,
+		Platform: &state.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Channel:      "22.04/stable",
+		},
+	})
+	// No s.backend.EXPECT().Charm(...): the gomock controller fails the test
+	// if backend.Charm is called for a charmhub charm.
+
+	result, err := s.api.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "postgresql"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+	c.Assert(result.Origin.Hash, gc.Equals, originHash)
+}
+
+// TestApplicationGetCharmURLOriginLocalWithHash verifies that a local charm
+// whose origin already carries a hash is left untouched and backend.Charm is
+// not consulted.
+func (s *ApplicationSuite) TestApplicationGetCharmURLOriginLocalWithHash(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	rev := 42
+	const originHash = "preexistinghash"
+	s.expectGetCharmURLOriginApplication(ctrl, &state.CharmOrigin{
+		Source:   "local",
+		Hash:     originHash,
+		Revision: &rev,
+		Platform: &state.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Channel:      "22.04/stable",
+		},
+	})
+	// No s.backend.EXPECT().Charm(...): the hash is already set, so the
+	// backend lookup must be skipped.
+
+	result, err := s.api.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "postgresql"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.IsNil)
+	c.Assert(result.Origin.Hash, gc.Equals, originHash)
+}
+
+// TestApplicationGetCharmURLOriginLocalCharmError verifies that if the charm
+// document lookup fails, a not found error is returned in the result.
+func (s *ApplicationSuite) TestApplicationGetCharmURLOriginLocalCharmError(c *gc.C) {
+	ctrl := s.setup(c)
+	defer ctrl.Finish()
+
+	rev := 42
+	s.expectGetCharmURLOriginApplication(ctrl, &state.CharmOrigin{
+		Source:   "local",
+		Revision: &rev,
+		Platform: &state.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Channel:      "22.04/stable",
+		},
+	})
+	s.backend.EXPECT().Charm("ch:postgresql-42").Return(nil, errors.New("boom"))
+
+	result, err := s.api.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "postgresql"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Error, gc.NotNil)
+	c.Assert(result.Error.Message, gc.Equals, `charm origin hash for "postgresql" not found`)
 }

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -3849,5 +3849,5 @@ func (s *ApplicationSuite) TestApplicationGetCharmURLOriginLocalCharmError(c *gc
 	result, err := s.api.GetCharmURLOrigin(params.ApplicationGet{ApplicationName: "postgresql"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Error, gc.NotNil)
-	c.Assert(result.Error.Message, gc.Equals, `charm origin hash for "postgresql" not found`)
+	c.Assert(result.Error.Message, gc.Equals, `getting charm origin hash for "postgresql": boom`)
 }

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -143,6 +143,7 @@ type Charm interface {
 	Actions() *charm.Actions
 	Revision() int
 	IsUploaded() bool
+	BundleSha256() string
 }
 
 // CharmMeta describes methods that inform charm operation.

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -1728,6 +1728,20 @@ func (mr *MockCharmMockRecorder) Actions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Actions", reflect.TypeOf((*MockCharm)(nil).Actions))
 }
 
+// BundleSha256 mocks base method.
+func (m *MockCharm) BundleSha256() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BundleSha256")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// BundleSha256 indicates an expected call of BundleSha256.
+func (mr *MockCharmMockRecorder) BundleSha256() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BundleSha256", reflect.TypeOf((*MockCharm)(nil).BundleSha256))
+}
+
 // Config mocks base method.
 func (m *MockCharm) Config() *charm.Config {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/application/updatebase_mocks_test.go
+++ b/apiserver/facades/client/application/updatebase_mocks_test.go
@@ -605,6 +605,20 @@ func (mr *MockCharmMockRecorder) Actions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Actions", reflect.TypeOf((*MockCharm)(nil).Actions))
 }
 
+// BundleSha256 mocks base method.
+func (m *MockCharm) BundleSha256() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BundleSha256")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// BundleSha256 indicates an expected call of BundleSha256.
+func (mr *MockCharmMockRecorder) BundleSha256() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BundleSha256", reflect.TypeOf((*MockCharm)(nil).BundleSha256))
+}
+
 // Config mocks base method.
 func (m *MockCharm) Config() *charm.Config {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
In Juju 3.6, `GetCharmURLOrigin` for a local charm returns an empty string origin hash. This field is correctly populated in Juju 4.0.

The field is useful for a stateful client detecting a deploy/refresh that happened through a different client. Specifically, this is useful for the Terraform provider to detect drift on deployed local charms, typically caused by using `juju refresh` directly.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Pull this PR https://github.com/juju/terraform-provider-juju/pull/1303

Remove the juju <4 skip from this test `TestAcc_ResourceApplication_LocalCharm_Drift`.
https://github.com/juju/terraform-provider-juju/pull/1303/changes#diff-c5b3a59276709ec0fc297a334b145d74a113e382b3af731e78cd353b4b0f55e9R3301

Run the test against a released 3.6 controller. It will fail to detect drift.

Run the test against a controller from this branch. It will correctly detect drift.

## Links

Useful for https://github.com/juju/terraform-provider-juju/pull/1303