### PR TITLE
feat: fetch actions yaml at deploy time

### DIFF
--- a/core/charm/adaptor.go
+++ b/core/charm/adaptor.go
@@ -28,7 +28,7 @@ func (adaptor charmInfoAdaptor) Config() *charm.ConfigSpec {
 }
 
 func (adaptor charmInfoAdaptor) Actions() *charm.Actions {
-	return nil // not part of the essential metadata
+	return adaptor.meta.Actions
 }
 
 func (adaptor charmInfoAdaptor) Revision() int {

--- a/core/charm/adaptor_test.go
+++ b/core/charm/adaptor_test.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package charm
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/domain/deployment/charm"
+)
+
+type adaptorSuite struct{}
+
+func TestAdaptorSuite(t *testing.T) {
+	tc.Run(t, &adaptorSuite{})
+}
+
+// TestCharmInfoAdaptorActions ensures that the charm info adaptor
+// returns the actions from the essential metadata, rather than nil.
+// This is critical for deploying charms from a repository, where the
+// adaptor is used to pass essential metadata (including actions) to
+// the application service for storage at deploy time.
+func (s *adaptorSuite) TestCharmInfoAdaptorActions(c *tc.C) {
+	actions := &charm.Actions{
+		ActionSpecs: map[string]charm.ActionSpec{
+			"backup": {
+				Description: "Take a backup",
+				Parallel:    true,
+			},
+		},
+	}
+
+	adaptor := NewCharmInfoAdaptor(EssentialMetadata{
+		Actions: actions,
+	})
+
+	c.Check(adaptor.Actions(), tc.DeepEquals, actions)
+}
+
+// TestCharmInfoAdaptorActionsNil ensures that the adaptor returns nil
+// when no actions are present in the essential metadata.
+func (s *adaptorSuite) TestCharmInfoAdaptorActionsNil(c *tc.C) {
+	adaptor := NewCharmInfoAdaptor(EssentialMetadata{})
+
+	c.Check(adaptor.Actions(), tc.IsNil)
+}
+
+// TestCharmInfoAdaptorActionsEmpty ensures that the adaptor returns an
+// empty (non-nil) actions set when the essential metadata contains one.
+func (s *adaptorSuite) TestCharmInfoAdaptorActionsEmpty(c *tc.C) {
+	adaptor := NewCharmInfoAdaptor(EssentialMetadata{
+		Actions: charm.NewActions(),
+	})
+
+	got := adaptor.Actions()
+	c.Assert(got, tc.NotNil)
+	c.Check(got.ActionSpecs, tc.HasLen, 0)
+}

--- a/core/charm/repository.go
+++ b/core/charm/repository.go
@@ -72,6 +72,7 @@ type EssentialMetadata struct {
 	Meta     *charm.Meta
 	Manifest *charm.Manifest
 	Config   *charm.ConfigSpec
+	Actions  *charm.Actions
 
 	// DownloadInfo is the information needed to download the charm
 	// directly from the charm store.

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -1160,21 +1160,6 @@ func (s *Service) ResolveCharmDownload(ctx context.Context, appUUID coreapplicat
 		return applicationerrors.CharmHashMismatch
 	}
 
-	// Make sure it's actually a valid charm.
-	charm, err := internalcharm.ReadCharmArchive(resolve.Path)
-	if err != nil {
-		return errors.Errorf("reading charm archive %q: %w", resolve.Path, err)
-	}
-
-	// Encode the charm before we even attempt to store it. The charm storage
-	// backend could be the other side of the globe.
-	domainCharm, warnings, err := encodeCharm(charm)
-	if err != nil {
-		return errors.Errorf("encoding charm %q: %w", resolve.Path, err)
-	} else if len(warnings) > 0 {
-		s.logger.Debugf(ctx, "encoding charm %q: %v", resolve.Path, warnings)
-	}
-
 	// Use the hash from the reservation, incase the caller has the wrong hash.
 	// The resulting objectStoreUUID will enable RI between the charm and the
 	// object store.
@@ -1195,7 +1180,6 @@ func (s *Service) ResolveCharmDownload(ctx context.Context, appUUID coreapplicat
 
 	// Resolve the charm download, which will set itself to available.
 	return s.st.ResolveCharmDownload(ctx, info.CharmUUID, application.ResolvedCharmDownload{
-		Actions:         domainCharm.Actions,
 		ObjectStoreUUID: result.ObjectStoreUUID,
 
 		// This is correct, we want to use the unique name of the stored charm

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -253,12 +253,6 @@ func (s *applicationServiceSuite) TestResolveCharmDownload(c *tc.C) {
 	dst := c.MkDir()
 	path := testcharms.Repo.CharmArchivePath(dst, "dummy")
 
-	// This will be removed once we get the information from charmhub store.
-	// For now, just brute force our way through to get the actions.
-	ch := testcharms.Repo.CharmDir("dummy")
-	actions, err := encodeActions(ch.Actions())
-	c.Assert(err, tc.ErrorIsNil)
-
 	appUUID := tc.Must(c, coreapplication.NewUUID)
 	charmUUID := charmtesting.GenCharmID(c)
 
@@ -280,12 +274,11 @@ func (s *applicationServiceSuite) TestResolveCharmDownload(c *tc.C) {
 		ObjectStoreUUID: objectStoreUUID,
 	}, nil)
 	s.state.EXPECT().ResolveCharmDownload(gomock.Any(), charmUUID, application.ResolvedCharmDownload{
-		Actions:         actions,
 		ObjectStoreUUID: objectStoreUUID,
 		ArchivePath:     "somepath",
 	})
 
-	err = s.service.ResolveCharmDownload(c.Context(), appUUID, application.ResolveCharmDownload{
+	err := s.service.ResolveCharmDownload(c.Context(), appUUID, application.ResolveCharmDownload{
 		CharmUUID: charmUUID,
 		SHA256:    "hash-256",
 		SHA384:    "hash-384",
@@ -403,12 +396,6 @@ func (s *applicationServiceSuite) TestResolveCharmDownloadAlreadyStored(c *tc.C)
 	dst := c.MkDir()
 	path := testcharms.Repo.CharmArchivePath(dst, "dummy")
 
-	// This will be removed once we get the information from charmhub store.
-	// For now, just brute force our way through to get the actions.
-	ch := testcharms.Repo.CharmDir("dummy")
-	actions, err := encodeActions(ch.Actions())
-	c.Assert(err, tc.ErrorIsNil)
-
 	appUUID := tc.Must(c, coreapplication.NewUUID)
 	charmUUID := charmtesting.GenCharmID(c)
 
@@ -430,12 +417,11 @@ func (s *applicationServiceSuite) TestResolveCharmDownloadAlreadyStored(c *tc.C)
 		ObjectStoreUUID: objectStoreUUID,
 	}, nil)
 	s.state.EXPECT().ResolveCharmDownload(gomock.Any(), charmUUID, application.ResolvedCharmDownload{
-		Actions:         actions,
 		ObjectStoreUUID: objectStoreUUID,
 		ArchivePath:     "somepath",
 	})
 
-	err = s.service.ResolveCharmDownload(c.Context(), appUUID, application.ResolveCharmDownload{
+	err := s.service.ResolveCharmDownload(c.Context(), appUUID, application.ResolveCharmDownload{
 		CharmUUID: charmUUID,
 		SHA256:    "hash-256",
 		SHA384:    "hash-384",

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -2157,9 +2157,7 @@ WHERE v.application_uuid = $entityUUID.uuid
 
 // ResolveCharmDownload resolves the charm download for the specified
 // application, updating the charm with the specified charm information.
-// This will only set mutable charm fields. Currently this will also set
-// actions.yaml, although that will be removed once the charmhub store
-// provides this information.
+// This will only set mutable charm fields.
 // Returns an error satisfying [applicationerrors.CharmNotFound] if the charm
 // is not found, and [applicationerrors.CharmAlreadyResolved] if the charm is
 // already resolved.
@@ -2208,12 +2206,6 @@ WHERE  uuid = $entityUUID.uuid;`
 			// If the charm is already resolved, we don't need to provide
 			// any additional information.
 			return applicationerrors.CharmAlreadyResolved
-		}
-
-		// Write the charm actions.yaml, this will actually disappear once the
-		// charmhub store provides this information.
-		if err := st.addCharmActions(ctx, tx, id, info.Actions); err != nil {
-			return errors.Errorf("setting charm actions for %q: %w", id, err)
 		}
 
 		if err := tx.Query(ctx, charmStmt, charmUUID, chState).Run(); err != nil {

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -2193,19 +2193,7 @@ func (s *applicationStateSuite) TestResolveCharmDownload(c *tc.C) {
 	info, err := s.state.GetAsyncCharmDownloadInfo(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 
-	actions := charm.Actions{
-		Actions: map[string]charm.Action{
-			"action": {
-				Description:    "description",
-				Parallel:       true,
-				ExecutionGroup: "group",
-				Params:         []byte(`{}`),
-			},
-		},
-	}
-
 	err = s.state.ResolveCharmDownload(c.Context(), info.CharmUUID, application.ResolvedCharmDownload{
-		Actions:         actions,
 		ObjectStoreUUID: objectStoreUUID,
 		ArchivePath:     "archive",
 	})
@@ -2219,7 +2207,6 @@ func (s *applicationStateSuite) TestResolveCharmDownload(c *tc.C) {
 	ch, err := s.state.GetCharmByApplicationUUID(c.Context(), id)
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Check(ch.Actions, tc.DeepEquals, actions)
 	c.Check(ch.ArchivePath, tc.DeepEquals, "archive")
 }
 

--- a/domain/application/state/charm_test.go
+++ b/domain/application/state/charm_test.go
@@ -23,9 +23,11 @@ import (
 	objectstoretesting "github.com/juju/juju/core/objectstore/testing"
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/semversion"
+	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/architecture"
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/deployment"
 	"github.com/juju/juju/domain/life"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/errors"
@@ -2814,6 +2816,84 @@ func (s *charmStateSuite) TestGetCharmActionsEmpty(c *tc.C) {
 	c.Check(config, tc.DeepEquals, charm.Actions{
 		Actions: map[string]charm.Action(nil),
 	})
+}
+
+// TestCreateApplicationThenGetCharmActionsBeforeDownloadResolved
+// verifies that actions are available immediately after an application is
+// created (deployed), without needing the async charm download to be
+// resolved.
+func (s *charmStateSuite) TestCreateApplicationThenGetCharmActionsBeforeDownloadResolved(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), s.modelUUID, clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	expectedActions := charm.Actions{
+		Actions: map[string]charm.Action{
+			"backup": {
+				Description:    "Take a backup of the database.",
+				Parallel:       false,
+				ExecutionGroup: "default",
+				Params:         []byte(`{}`),
+			},
+			"restart": {
+				Description:    "Restart the service.",
+				Parallel:       true,
+				ExecutionGroup: "restart-group",
+			},
+		},
+	}
+
+	platform := deployment.Platform{
+		Channel:      "22.04/stable",
+		OSType:       deployment.Ubuntu,
+		Architecture: architecture.ARM64,
+	}
+	channel := &deployment.Channel{
+		Track: "track",
+		Risk:  "stable",
+	}
+
+	// Create the application with actions in the charm. This simulates a
+	// deploy where the charmhub essential metadata includes actions-yaml.
+	appUUID, _, err := st.CreateIAASApplication(c.Context(), "test-app", application.AddIAASApplicationArg{
+		BaseAddApplicationArg: application.BaseAddApplicationArg{
+			Platform: platform,
+			Channel:  channel,
+			Charm: charm.Charm{
+				Metadata: charm.Metadata{
+					Name: "test-app",
+				},
+				Manifest:      s.minimalManifest(c),
+				Actions:       expectedActions,
+				ReferenceName: "test-app",
+				Source:        charm.CharmHubSource,
+				Revision:      42,
+				Hash:          "hash",
+			},
+			CharmDownloadInfo: &charm.DownloadInfo{
+				Provenance:         charm.ProvenanceDownload,
+				CharmhubIdentifier: "ident",
+				DownloadURL:        "https://example.com",
+				DownloadSize:       42,
+			},
+		},
+	}, nil)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Verify the charm is NOT yet available (download not resolved).
+	charmID, err := st.GetCharmIDByApplicationName(c.Context(), "test-app")
+	c.Assert(err, tc.ErrorIsNil)
+	available, err := st.IsCharmAvailable(c.Context(), charmID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(available, tc.IsFalse)
+
+	// Despite the charm not being downloaded yet, the actions should be
+	// available because they were stored at deploy time from the essential
+	// metadata.
+	got, err := st.GetCharmActions(c.Context(), charmID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, expectedActions)
+
+	// Sanity check: the application UUID is valid.
+	c.Check(appUUID, tc.NotNil)
 }
 
 func (s *charmStateSuite) TestAddCharmThenGetCharmArchivePath(c *tc.C) {

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -323,10 +323,6 @@ type ResolveControllerCharmDownload struct {
 
 // ResolvedCharmDownload contains parameters for a resolved charm download.
 type ResolvedCharmDownload struct {
-	// Actions is the actions that the charm supports.
-	//
-	// Deprecated: should be filled in by the charm store.
-	Actions         domaincharm.Actions
 	ObjectStoreUUID objectstore.UUID
 	ArchivePath     string
 }

--- a/domain/deployment/charm/repository/charmhub.go
+++ b/domain/deployment/charm/repository/charmhub.go
@@ -797,7 +797,7 @@ func EssentialMetadataFromResponse(charmName string, refreshResult transport.Ref
 	// the charm, e.g. postgreql. However, this will fail the charm
 	// config validation which happens in ReadConfig. Valid config
 	// are nil and "Options: {}"
-	if configYAML == "" || strings.TrimSpace(configYAML) == "{}" {
+	if isEmptyYAML(configYAML) {
 		chConfig = charm.NewConfig()
 	} else {
 		chConfig, err = charm.ReadConfig(strings.NewReader(configYAML))
@@ -824,13 +824,13 @@ func EssentialMetadataFromResponse(charmName string, refreshResult transport.Ref
 	// an actions.yaml, we default to an empty set of actions. This mirrors
 	// the behaviour of reading a charm archive that has no actions.yaml.
 	var chActions *charm.Actions
-	if actionsYAML := entity.ActionsYAML; actionsYAML != "" && strings.TrimSpace(actionsYAML) != "{}" {
-		chActions, err = charm.ReadActionsYaml(charmName, strings.NewReader(actionsYAML))
+	if isEmptyYAML(entity.ActionsYAML) {
+		chActions = charm.NewActions()
+	} else {
+		chActions, err = charm.ReadActionsYaml(charmName, strings.NewReader(entity.ActionsYAML))
 		if err != nil {
 			return corecharm.EssentialMetadata{}, internalerrors.Errorf("parsing actions.yaml for %q: %w", charmName, err)
 		}
-	} else {
-		chActions = charm.NewActions()
 	}
 
 	return corecharm.EssentialMetadata{
@@ -844,6 +844,15 @@ func EssentialMetadataFromResponse(charmName string, refreshResult transport.Ref
 			DownloadSize:       int64(entity.Download.Size),
 		},
 	}, nil
+}
+
+// isEmptyYAML reports whether the given YAML string is empty or contains
+// only an empty JSON object ("{}"). Charmhub returns "{}\n" for optional
+// metadata files (e.g. config.yaml, actions.yaml) that do not exist for a
+// charm, so callers can use this to decide whether to parse the YAML or
+// fall back to a default empty value.
+func isEmptyYAML(yaml string) bool {
+	return yaml == "" || strings.TrimSpace(yaml) == "{}"
 }
 
 func configsByID(ctx context.Context, curl *charm.URL, origin corecharm.Origin, name string, revision int) ([]charmhub.RefreshConfig, error) {

--- a/domain/deployment/charm/repository/charmhub.go
+++ b/domain/deployment/charm/repository/charmhub.go
@@ -820,10 +820,24 @@ func EssentialMetadataFromResponse(charmName string, refreshResult transport.Ref
 		})
 	}
 
+	// Actions are optional, so if the charmhub response does not include
+	// an actions.yaml, we default to an empty set of actions. This mirrors
+	// the behaviour of reading a charm archive that has no actions.yaml.
+	var chActions *charm.Actions
+	if actionsYAML := entity.ActionsYAML; actionsYAML != "" && strings.TrimSpace(actionsYAML) != "{}" {
+		chActions, err = charm.ReadActionsYaml(charmName, strings.NewReader(actionsYAML))
+		if err != nil {
+			return corecharm.EssentialMetadata{}, internalerrors.Errorf("parsing actions.yaml for %q: %w", charmName, err)
+		}
+	} else {
+		chActions = charm.NewActions()
+	}
+
 	return corecharm.EssentialMetadata{
 		Meta:     chMeta,
 		Config:   chConfig,
 		Manifest: chManifest,
+		Actions:  chActions,
 		DownloadInfo: corecharm.DownloadInfo{
 			CharmhubIdentifier: entity.ID,
 			DownloadURL:        entity.Download.URL,

--- a/domain/deployment/charm/repository/charmhub_test.go
+++ b/domain/deployment/charm/repository/charmhub_test.go
@@ -1998,3 +1998,24 @@ func (s *essentialMetadataSuite) TestEssentialMetadataWithInvalidActions(c *tc.C
 	_, err := EssentialMetadataFromResponse("wordpress", resp)
 	c.Check(err, tc.NotNil)
 }
+
+// TestIsEmptyYAML ensures that the isEmptyYAML helper correctly identifies
+// empty or "{}" YAML strings that charmhub returns for optional metadata
+// files (config.yaml, actions.yaml) that do not exist for a charm.
+func (s *essentialMetadataSuite) TestIsEmptyYAML(c *tc.C) {
+	for _, t := range []struct {
+		input string
+		empty bool
+	}{
+		{"", true},
+		{"{}", true},
+		{"{}\n", true},
+		{"  {}  ", true},
+		{"\t{}\t", true},
+		{"name: foo", false},
+		{"options:\n  foo: bar", false},
+		{"backup:\n  description: test", false},
+	} {
+		c.Check(isEmptyYAML(t.input), tc.Equals, t.empty)
+	}
+}

--- a/domain/deployment/charm/repository/charmhub_test.go
+++ b/domain/deployment/charm/repository/charmhub_test.go
@@ -35,7 +35,7 @@ var (
 	expRefreshFields = set.NewStrings(
 		"download", "id", "license", "name", "publisher", "resources",
 		"revision", "summary", "type", "version", "bases", "config-yaml",
-		"metadata-yaml",
+		"metadata-yaml", "actions-yaml",
 	).SortedValues()
 )
 
@@ -1899,4 +1899,102 @@ func (s *retryResolveWithRespBasesSuite) newClient(c *tc.C) *CharmHubRepository 
 		client: s.client,
 		logger: loggertesting.WrapCheckLog(c),
 	}
+}
+
+type essentialMetadataSuite struct{}
+
+func TestEssentialMetadataSuite(t *testing.T) {
+	tc.Run(t, &essentialMetadataSuite{})
+}
+
+// minimalRefreshResponse builds a transport.RefreshResponse with the
+// minimum fields required for EssentialMetadataFromResponse to succeed.
+func minimalRefreshResponse() transport.RefreshResponse {
+	return transport.RefreshResponse{
+		Entity: transport.RefreshEntity{
+			Type: transport.CharmType,
+			ID:   "charmID",
+			Name: "wordpress",
+			Bases: []transport.Base{{
+				Name:         "ubuntu",
+				Architecture: "amd64",
+				Channel:      "22.04",
+			}},
+			MetadataYAML: `
+name: wordpress
+summary: Blog engine
+description: Blog engine
+`[1:],
+		},
+	}
+}
+
+// TestEssentialMetadataWithActions ensures that the actions-yaml from the
+// charmhub refresh response is parsed and included in the essential
+// metadata. This is the core of the fix: actions are now available at
+// deploy time without waiting for the full charm archive download.
+func (s *essentialMetadataSuite) TestEssentialMetadataWithActions(c *tc.C) {
+	resp := minimalRefreshResponse()
+	resp.Entity.ActionsYAML = `
+backup:
+  description: Take a backup of the database.
+  parallel: false
+restart:
+  description: Restart the service.
+  parallel: true
+`[1:]
+
+	meta, err := EssentialMetadataFromResponse("wordpress", resp)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(meta.Actions, tc.NotNil)
+	c.Check(meta.Actions.ActionSpecs, tc.HasLen, 2)
+
+	backup, ok := meta.Actions.ActionSpecs["backup"]
+	c.Check(ok, tc.IsTrue)
+	c.Check(backup.Description, tc.Equals, "Take a backup of the database.")
+	c.Check(backup.Parallel, tc.IsFalse)
+
+	restart, ok := meta.Actions.ActionSpecs["restart"]
+	c.Check(ok, tc.IsTrue)
+	c.Check(restart.Description, tc.Equals, "Restart the service.")
+	c.Check(restart.Parallel, tc.IsTrue)
+}
+
+// TestEssentialMetadataWithoutActions ensures that when the charmhub
+// response does not include actions-yaml, the essential metadata
+// contains an empty (non-nil) actions set. This mirrors the behaviour
+// of reading a charm archive that has no actions.yaml file.
+func (s *essentialMetadataSuite) TestEssentialMetadataWithoutActions(c *tc.C) {
+	resp := minimalRefreshResponse()
+
+	meta, err := EssentialMetadataFromResponse("wordpress", resp)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(meta.Actions, tc.NotNil)
+	c.Check(meta.Actions.ActionSpecs, tc.HasLen, 0)
+}
+
+// TestEssentialMetadataWithEmptyActions ensures that a "{}" actions-yaml
+// (which charmhub may return for charms with no actions) results in an
+// empty actions set, not an error.
+func (s *essentialMetadataSuite) TestEssentialMetadataWithEmptyActions(c *tc.C) {
+	resp := minimalRefreshResponse()
+	resp.Entity.ActionsYAML = "{}"
+
+	meta, err := EssentialMetadataFromResponse("wordpress", resp)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(meta.Actions, tc.NotNil)
+	c.Check(meta.Actions.ActionSpecs, tc.HasLen, 0)
+}
+
+// TestEssentialMetadataWithInvalidActions ensures that invalid actions-yaml
+// results in an error.
+func (s *essentialMetadataSuite) TestEssentialMetadataWithInvalidActions(c *tc.C) {
+	resp := minimalRefreshResponse()
+	resp.Entity.ActionsYAML = "this: is: not: valid: yaml:"
+
+	_, err := EssentialMetadataFromResponse("wordpress", resp)
+	c.Check(err, tc.NotNil)
 }

--- a/internal/charmhub/refresh.go
+++ b/internal/charmhub/refresh.go
@@ -51,7 +51,7 @@ var (
 	requiredRefreshFields = set.NewStrings(
 		"download", "id", "license", "name", "publisher", "resources",
 		"revision", "summary", "type", "version", "bases", "config-yaml",
-		"metadata-yaml",
+		"metadata-yaml", "actions-yaml",
 	).SortedValues()
 )
 

--- a/internal/charmhub/refresh_test.go
+++ b/internal/charmhub/refresh_test.go
@@ -35,7 +35,7 @@ var (
 	expRefreshFields = set.NewStrings(
 		"download", "id", "license", "name", "publisher", "resources",
 		"revision", "summary", "type", "version", "bases", "config-yaml",
-		"metadata-yaml",
+		"metadata-yaml", "actions-yaml",
 	).SortedValues()
 )
 

--- a/internal/charmhub/transport/refresh.go
+++ b/internal/charmhub/transport/refresh.go
@@ -98,6 +98,7 @@ type RefreshEntity struct {
 	// The minimum set of metadata required for deploying a charm.
 	MetadataYAML string `json:"metadata-yaml,omitempty"`
 	ConfigYAML   string `json:"config-yaml,omitempty"`
+	ActionsYAML  string `json:"actions-yaml,omitempty"`
 }
 
 // RefreshResourceRevision represents a resource name revision pair for

--- a/internal/worker/charmrevisioner/worker.go
+++ b/internal/worker/charmrevisioner/worker.go
@@ -527,9 +527,7 @@ func (w *revisionUpdateWorker) storeNewCharmRevision(ctx context.Context, info l
 			essentialMetadata.Meta,
 			essentialMetadata.Manifest,
 			essentialMetadata.Config,
-			// This will be filled in once we have all the data in the
-			// response from the charmhub.
-			nil,
+			essentialMetadata.Actions,
 		),
 		// This will always be a charmhub charm.
 		Source:        corecharm.CharmHub,

--- a/internal/worker/charmrevisioner/worker_test.go
+++ b/internal/worker/charmrevisioner/worker_test.go
@@ -859,9 +859,7 @@ func (s *WorkerSuite) TestStoreNewCharmRevisionsNoResource(c *tc.C) {
 			essentialMetadata.Meta,
 			essentialMetadata.Manifest,
 			essentialMetadata.Config,
-			// These will be filled in once we have all the data in the
-			// response from the charmhub.
-			nil,
+			essentialMetadata.Actions,
 		),
 
 		Source:        charm.CharmHub,


### PR DESCRIPTION
# Description

While working on adding `juju_action` to the terraform provider I've found this problem with Juju that doesn't fill the action info at deploy time, which causes this error: 
```
╷
│ Error: Client Error
│ 
│   with juju_action.echo,
│   on main.tf line 24, in resource "juju_action" "echo":
│   24: resource "juju_action" "echo" {
│ 
│ Unable to enqueue action "echo": no actions defined for charm juju-qa-dummy-source. (not found)
```
if the action is enqueued "too fast" after an application is deployed. This is because the action yaml was downloaded asynchronously.

This is the fix for it.

# QA

Sadly with the CLI i cannot reproduce the error, but with Terraform yes.
So, here is the branch with the workaround removed for juju 4, https://github.com/SimoneDutto/terraform-provider-juju/tree/fix-juju-4-action (this branch will land once this pr will land)

```
make install
```

```tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
    }
  }
}

provider "juju" {}

resource "juju_model" "development" {
  name = "development"
}

resource "juju_application" "test_app" {
  model_uuid = juju_model.development.uuid
  name       = "test-app"

  charm {
    name = "juju-qa-dummy-source"
  }
}

resource "juju_action" "echo" {
  model_uuid       = juju_model.development.uuid
  application_name = juju_application.test_app.name
  action_name      = "echo"
  unit             = "test-app/leader"

  args = {
    value = "ciao"
  }
}

output "echo_result" {
  value = juju_action.echo.output
}
```

Before patch you should see the error, after the patch no error and it works.
