### PR TITLE
feat(agent): add machine-agent-only gate

### DIFF
--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -269,6 +269,9 @@ type machineAgentCommand struct {
 	machineId string
 	// TODO(controlleragent) - this will be in a new controller agent command
 	controllerId string
+
+	// machineAgentOnly suppresses controller workers for this process.
+	machineAgentOnly bool
 }
 
 // Init is called by the cmd system to initialize the structure for
@@ -329,6 +332,7 @@ func (a *machineAgentCommand) Run(c *cmd.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	machineAgent.machineAgentOnly = a.machineAgentOnly
 	return machineAgent.Run(c)
 }
 
@@ -338,6 +342,7 @@ func (a *machineAgentCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&a.machineId, "machine-id", "", "id of the machine to run")
 	f.StringVar(&a.controllerId, "controller-id", "", "id of the controller to run")
 	f.BoolVar(&a.logToStdErr, "log-to-stderr", false, "log to stderr instead of logsink.log")
+	f.BoolVar(&a.machineAgentOnly, "machine-agent-only", false, "suppress in-process controller workers")
 }
 
 // Info returns usage information for the command.
@@ -476,6 +481,9 @@ type MachineAgent struct {
 
 	isCaasAgent bool
 	cmdRunner   CommandRunner
+
+	// machineAgentOnly suppresses controller workers for this process.
+	machineAgentOnly bool
 }
 
 // Wait waits for the machine agent to finish.
@@ -615,10 +623,7 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 	a.bootstrapLock = gate.NewLock()
 	a.upgradeDBLock = internalupgrade.NewLock(agentConfig, jujuversion.Current)
 	a.upgradeStepsLock = internalupgrade.NewLock(agentConfig, jujuversion.Current)
-	a.controllerAgentConfigReadyLock = gate.NewLock()
-	if _, isController := agentConfig.ControllerAgentInfo(); !isController {
-		a.controllerAgentConfigReadyLock.Unlock()
-	}
+	a.initControllerAgentConfigReadyLock(agentConfig)
 
 	createEngine := a.makeEngineCreator(agentName, agentConfig.UpgradedToVersion(), bufferedLogger, legacyLogSinkWriter, logSink)
 	if err := a.createJujudSymlinks(agentConfig.DataDir()); err != nil {
@@ -638,6 +643,14 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 		err = a.executeRebootOrShutdown(params.ShouldShutdown)
 	}
 	return cmdutil.AgentDone(logger, err)
+}
+
+func (a *MachineAgent) initControllerAgentConfigReadyLock(agentConfig agent.Config) {
+	a.controllerAgentConfigReadyLock = gate.NewLock()
+	_, isController := agentConfig.ControllerAgentInfo()
+	if !isController || a.machineAgentOnly {
+		a.controllerAgentConfigReadyLock.Unlock()
+	}
 }
 
 func (a *MachineAgent) makeEngineCreator(
@@ -718,6 +731,7 @@ func (a *MachineAgent) makeEngineCreator(
 			NewBrokerFunc:                     newBroker,
 			MachineStartup:                    a.machineStartup,
 			IsCaasConfig:                      a.isCaasAgent,
+			MachineAgentOnly:                  a.machineAgentOnly,
 			UnitEngineConfig: func() dependency.EngineConfig {
 				return agentengine.DependencyEngineConfig(
 					controllerMetricsSink,

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -341,6 +341,12 @@ type ManifoldsConfig struct {
 	// MachineStartup is passed to the machine manifold. It does
 	// machine setup work which relies on an API connection.
 	MachineStartup func(context.Context, api.Connection, corelogger.Logger) error
+
+	// MachineAgentOnly, when true, suppresses in-process controller
+	// workers even when the agent configuration contains
+	// ControllerAgentInfo. It is false by default and is set via the
+	// --machine-agent-only flag on the machine agent command.
+	MachineAgentOnly bool
 }
 
 // commonManifolds returns a set of co-configured manifolds covering the
@@ -449,6 +455,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		stateConfigWatcherName: stateconfigwatcher.Manifold(stateconfigwatcher.ManifoldConfig{
 			AgentName:          agentName,
 			AgentConfigChanged: config.AgentConfigChanged,
+			MachineAgentOnly:   config.MachineAgentOnly,
 		}),
 
 		// The api-config-watcher manifold monitors the API server

--- a/cmd/jujuagentd/agent/machine/manifolds_test.go
+++ b/cmd/jujuagentd/agent/machine/manifolds_test.go
@@ -857,6 +857,134 @@ func (s *ManifoldsSuite) TestManifoldsDependenciesCAAS(c *tc.C) {
 	)
 }
 
+func (s *ManifoldsSuite) TestManifoldNamesIAMachineAgentOnly(c *tc.C) {
+	s.assertManifoldNames(
+		c,
+		machine.IAASManifolds(machine.ManifoldsConfig{
+			Agent:            &mockAgent{},
+			PreUpgradeSteps:  preUpgradeSteps,
+			MachineAgentOnly: true,
+		}),
+		[]string{
+			"agent-config-updater",
+			"agent",
+			"api-address-setter",
+			"api-address-updater",
+			"api-caller",
+			"api-config-watcher",
+			"api-remote-caller",
+			"api-remote-relation-caller",
+			"api-server",
+			"audit-config-updater",
+			"bootstrap",
+			"broker-tracker",
+			"certificate-updater",
+			"certificate-watcher",
+			"change-stream-pruner",
+			"change-stream",
+			"clock",
+			"control-socket",
+			"controller-agent-config",
+			"controller-agent-config-ready-flag",
+			"controller-agent-config-ready-gate",
+			"controller-presence",
+			"controller-trace",
+			"trace-services",
+			"db-accessor",
+			"deployer",
+			"disk-manager",
+			"domain-services",
+			"external-controller-updater",
+			"file-notify-watcher",
+			"flight-recorder",
+			"host-key-reporter",
+			"http-client",
+			"http-server-args",
+			"http-server",
+			"is-bootstrap-flag",
+			"is-bootstrap-gate",
+			"is-controller-flag",
+			"is-not-controller-flag",
+			"is-primary-controller-flag",
+			"jwt-parser",
+			"lease-expiry",
+			"lease-manager",
+			"log-sink",
+			"controller-log-sink",
+			"non-controller-log-sink",
+			"controller-log-router",
+			"log-router",
+			"logging-config-updater",
+			"loki-endpoint-updater",
+			"lxd-container-provisioner",
+			"machine-action-runner",
+			"machine-setup",
+			"machiner",
+			"migration-fortress",
+			"migration-inactive-flag",
+			"migration-minion",
+			"model-worker-manager",
+			"object-store-fortress",
+			"object-store-facade",
+			"object-store-drainer",
+			"object-store-s3-caller",
+			"object-store-services",
+			"object-store",
+			"provider-services",
+			"provider-tracker",
+			"proxy-config-updater",
+			"query-logger",
+			"reboot-executor",
+			"secret-backend-rotate",
+			"ssh-authkeys-updater",
+			"ssh-identity-writer",
+			"ssh-server",
+			"ssh-tunneler",
+			"state-config-watcher",
+			"machine-converter",
+			"storage-provisioner",
+			"storage-registry",
+			"termination-signal-handler",
+			"tools-version-checker",
+			"trace",
+			"undertaker",
+			"upgrade-check-flag",
+			"upgrade-check-gate",
+			"upgrade-database-flag",
+			"upgrade-database-gate",
+			"upgrade-database-runner",
+			"upgrade-services",
+			"upgrade-steps-flag",
+			"upgrade-steps-gate",
+			"upgrade-controller-steps-runner",
+			"upgrade-agent-steps-runner",
+			"upgrader",
+			"valid-credential-flag",
+			"watcher-registry",
+		},
+	)
+}
+
+func (s *ManifoldsSuite) TestControllerPathsDependOnIsControllerFlagWithGateEnabled(c *tc.C) {
+	manifolds := machine.IAASManifolds(machine.ManifoldsConfig{
+		Agent:            &mockAgent{},
+		PreUpgradeSteps:  preUpgradeSteps,
+		MachineAgentOnly: true,
+	})
+
+	for _, name := range []string{
+		"db-accessor",
+		"controller-agent-config",
+		"api-server",
+	} {
+		c.Logf("checking %s", name)
+		manifold, ok := manifolds[name]
+		c.Assert(ok, tc.IsTrue)
+		deps := agenttest.ManifoldDependencies(manifolds, manifold)
+		c.Check(deps.Contains("is-controller-flag"), tc.IsTrue)
+	}
+}
+
 var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 	"agent": {},
 	"agent-config-updater": {

--- a/cmd/jujuagentd/agent/machine_test.go
+++ b/cmd/jujuagentd/agent/machine_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 
 	jujuerrors "github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 
+	agentconfig "github.com/juju/juju/agent/config"
 	internalerrors "github.com/juju/juju/internal/errors"
 	internalworker "github.com/juju/juju/internal/worker"
 )
@@ -37,6 +40,111 @@ func (s *MachineSuite) TestStub(c *tc.C) {
 - Test that certificate DNS names are updated when the agent starts with an invalid private key
 - Test that all machine workers are started
 `)
+}
+
+func (s *MachineSuite) TestMachineAgentOnlyFlagAbsent(c *tc.C) {
+	cmd := &machineAgentCommand{
+		agentInitializer: &mockAgentInitializer{},
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ContinueOnError)
+	cmd.SetFlags(f)
+	err := f.Parse(false, []string{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cmd.machineAgentOnly, tc.IsFalse)
+}
+
+func (s *MachineSuite) TestMachineAgentOnlyFlagPresent(c *tc.C) {
+	cmd := &machineAgentCommand{
+		agentInitializer: &mockAgentInitializer{},
+	}
+	f := gnuflag.NewFlagSet("test", gnuflag.ContinueOnError)
+	cmd.SetFlags(f)
+	err := f.Parse(false, []string{"--machine-agent-only"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cmd.machineAgentOnly, tc.IsTrue)
+}
+
+func (s *MachineSuite) TestMachineAgentOnlyFlagPassedToMachineAgent(c *tc.C) {
+	for _, test := range []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "absent"},
+		{name: "present", args: []string{"--machine-agent-only"}, want: true},
+	} {
+		c.Logf("testing %s", test.name)
+		func() {
+			machineAgent := &MachineAgent{
+				AgentConfigWriter: &failingAgentConfigWriter{},
+				agentTag:          names.NewMachineTag("0"),
+				dead:              make(chan struct{}),
+			}
+			command := &machineAgentCommand{
+				agentInitializer: &mockAgentInitializer{},
+				agentTag:         names.NewMachineTag("0"),
+				machineAgentFactory: func(names.Tag, bool) (*MachineAgent, error) {
+					return machineAgent, nil
+				},
+			}
+			flags := gnuflag.NewFlagSet("test", gnuflag.ContinueOnError)
+			command.SetFlags(flags)
+			c.Assert(flags.Parse(false, test.args), tc.ErrorIsNil)
+
+			err := command.Run(nil)
+			c.Check(err, tc.ErrorMatches, "cannot read agent configuration: test config read failed")
+			c.Check(machineAgent.machineAgentOnly, tc.Equals, test.want)
+		}()
+	}
+}
+
+func (s *MachineSuite) TestControllerAgentConfigReadyLock(c *tc.C) {
+	for _, test := range []struct {
+		name             string
+		isController     bool
+		machineAgentOnly bool
+		wantUnlocked     bool
+	}{
+		{name: "controller", isController: true},
+		{name: "non-controller", wantUnlocked: true},
+		{name: "machine-agent-only", isController: true, machineAgentOnly: true, wantUnlocked: true},
+	} {
+		c.Logf("testing %s", test.name)
+		func() {
+			machineAgent := &MachineAgent{machineAgentOnly: test.machineAgentOnly}
+			machineAgent.initControllerAgentConfigReadyLock(&fakeMachineConfig{
+				controllerInfoFound: test.isController,
+			})
+
+			select {
+			case <-machineAgent.controllerAgentConfigReadyLock.Unlocked():
+				c.Check(test.wantUnlocked, tc.IsTrue)
+			default:
+				c.Check(test.wantUnlocked, tc.IsFalse)
+			}
+		}()
+	}
+}
+
+type mockAgentInitializer struct{}
+
+func (m *mockAgentInitializer) AddFlags(f *gnuflag.FlagSet) {
+}
+
+func (m *mockAgentInitializer) CheckArgs([]string) error {
+	return nil
+}
+
+func (m *mockAgentInitializer) DataDir() string {
+	return ""
+}
+
+type failingAgentConfigWriter struct {
+	agentconfig.AgentConfigWriter
+}
+
+func (*failingAgentConfigWriter) ReadConfig(string) error {
+	return jujuerrors.New("test config read failed")
 }
 
 func (s *MachineSuite) TestIntegrationStub(c *tc.C) {

--- a/cmd/jujuagentd/util/stateflag_test.go
+++ b/cmd/jujuagentd/util/stateflag_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package util_test
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+	dt "github.com/juju/worker/v5/dependency/testing"
+	"github.com/juju/worker/v5/workertest"
+
+	"github.com/juju/juju/agent/engine"
+	"github.com/juju/juju/cmd/jujuagentd/util"
+)
+
+func TestIsControllerFlagManifold(t *testing.T) {
+	tc.Run(t, &stateFlagSuite{})
+}
+
+type stateFlagSuite struct{}
+
+func (s *stateFlagSuite) TestControllerAndNonControllerFlags(c *tc.C) {
+	for _, test := range []struct {
+		name           string
+		isController   bool
+		controllerFlag bool
+	}{
+		{name: "controller", isController: true, controllerFlag: true},
+		{name: "non-controller", controllerFlag: false},
+	} {
+		c.Logf("testing %s", test.name)
+		func() {
+			getter := dt.StubGetter(map[string]any{"state-config-watcher": test.isController})
+			assertFlag := func(yes, want bool) {
+				manifold := util.IsControllerFlagManifold("state-config-watcher", yes)
+				worker, err := manifold.Start(c.Context(), getter)
+				c.Assert(err, tc.ErrorIsNil)
+				defer workertest.DirtyKill(c, worker)
+
+				var flag engine.Flag
+				err = manifold.Output(worker, &flag)
+				c.Assert(err, tc.ErrorIsNil)
+				c.Check(flag.Check(), tc.Equals, want)
+			}
+
+			assertFlag(true, test.controllerFlag)
+			assertFlag(false, !test.controllerFlag)
+		}()
+	}
+}

--- a/internal/worker/stateconfigwatcher/manifold.go
+++ b/internal/worker/stateconfigwatcher/manifold.go
@@ -22,6 +22,8 @@ var logger = internallogger.GetLogger("juju.worker.stateconfigwatcher")
 type ManifoldConfig struct {
 	AgentName          string
 	AgentConfigChanged *voyeur.Value
+	// MachineAgentOnly forces the effective controller role to false.
+	MachineAgentOnly bool
 }
 
 // Manifold returns a dependency.Manifold which wraps the machine
@@ -57,6 +59,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			w := &stateConfigWatcher{
 				agent:              a,
 				agentConfigChanged: config.AgentConfigChanged,
+				machineAgentOnly:   config.MachineAgentOnly,
 			}
 			w.tomb.Go(w.loop)
 			return w, nil
@@ -85,9 +88,14 @@ type stateConfigWatcher struct {
 	tomb               tomb.Tomb
 	agent              agent.Agent
 	agentConfigChanged *voyeur.Value
+	// machineAgentOnly forces the effective controller role to false.
+	machineAgentOnly bool
 }
 
 func (w *stateConfigWatcher) isControllerAgent() bool {
+	if w.machineAgentOnly {
+		return false
+	}
 	config := w.agent.CurrentConfig()
 	_, ok := config.ControllerAgentInfo()
 	return ok

--- a/internal/worker/stateconfigwatcher/manifold_test.go
+++ b/internal/worker/stateconfigwatcher/manifold_test.go
@@ -4,6 +4,7 @@
 package stateconfigwatcher_test
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -180,6 +181,90 @@ func (s *ManifoldSuite) TestClosedVoyeur(c *tc.C) {
 	c.Check(waitForExit(c, w), tc.ErrorMatches, "config changed value closed")
 }
 
+func (s *ManifoldSuite) TestMachineAgentOnlyGateDisabledControllerInfoPresent(c *tc.C) {
+	s.agent.conf.setControllerAgentInfo(true)
+	s.manifold = stateconfigwatcher.Manifold(stateconfigwatcher.ManifoldConfig{
+		AgentName:          "agent",
+		AgentConfigChanged: s.agentConfigChanged,
+		MachineAgentOnly:   false,
+	})
+	w, err := s.manifold.Start(c.Context(), s.getter)
+	c.Assert(err, tc.ErrorIsNil)
+	defer checkStop(c, w)
+
+	var out bool
+	err = s.manifold.Output(w, &out)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(out, tc.IsTrue)
+}
+
+func (s *ManifoldSuite) TestMachineAgentOnlyGateDisabledControllerInfoAbsent(c *tc.C) {
+	s.agent.conf.setControllerAgentInfo(false)
+	s.manifold = stateconfigwatcher.Manifold(stateconfigwatcher.ManifoldConfig{
+		AgentName:          "agent",
+		AgentConfigChanged: s.agentConfigChanged,
+		MachineAgentOnly:   false,
+	})
+	w, err := s.manifold.Start(c.Context(), s.getter)
+	c.Assert(err, tc.ErrorIsNil)
+	defer checkStop(c, w)
+
+	var out bool
+	err = s.manifold.Output(w, &out)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(out, tc.IsFalse)
+}
+
+func (s *ManifoldSuite) TestMachineAgentOnlyGateEnabledControllerInfoPresent(c *tc.C) {
+	s.agent.conf.setControllerAgentInfo(true)
+	s.manifold = stateconfigwatcher.Manifold(stateconfigwatcher.ManifoldConfig{
+		AgentName:          "agent",
+		AgentConfigChanged: s.agentConfigChanged,
+		MachineAgentOnly:   true,
+	})
+	w, err := s.manifold.Start(c.Context(), s.getter)
+	c.Assert(err, tc.ErrorIsNil)
+	defer checkStop(c, w)
+
+	var out bool
+	err = s.manifold.Output(w, &out)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(out, tc.IsFalse)
+}
+
+func (s *ManifoldSuite) TestMachineAgentOnlyGateEnabledNoBounceOnControllerInfoChange(c *tc.C) {
+	for _, test := range []struct {
+		name    string
+		initial bool
+		changed bool
+	}{
+		{name: "controller information removed", initial: true},
+		{name: "controller information added", changed: true},
+	} {
+		c.Logf("testing %s", test.name)
+		func() {
+			s.agent.conf.setControllerAgentInfo(test.initial)
+			s.manifold = stateconfigwatcher.Manifold(stateconfigwatcher.ManifoldConfig{
+				AgentName:          "agent",
+				AgentConfigChanged: s.agentConfigChanged,
+				MachineAgentOnly:   true,
+			})
+			w, err := s.manifold.Start(c.Context(), s.getter)
+			c.Assert(err, tc.ErrorIsNil)
+			defer checkStop(c, w)
+
+			s.agent.conf.setControllerAgentInfo(test.changed)
+			s.agentConfigChanged.Set(0)
+			checkNotExiting(c, w)
+
+			var out bool
+			err = s.manifold.Output(w, &out)
+			c.Assert(err, tc.ErrorIsNil)
+			c.Check(out, tc.IsFalse)
+		}()
+	}
+}
+
 func checkStop(c *tc.C, w worker.Worker) {
 	err := worker.Stop(w)
 	c.Check(err, tc.ErrorIsNil)
@@ -192,10 +277,12 @@ func checkNotExiting(c *tc.C, w worker.Worker) {
 		close(exited)
 	}()
 
+	ctx, cancel := context.WithTimeout(c.Context(), coretesting.ShortWait)
+	defer cancel()
 	select {
 	case <-exited:
 		c.Fatal("worker exited unexpectedly")
-	case <-time.After(coretesting.ShortWait):
+	case <-ctx.Done():
 		// Worker didn't exit (good)
 	}
 }


### PR DESCRIPTION
Prepare `jujuagentd` for the standalone controller topology without changing
the current bootstrap behavior.

When a controller is provided by the controller snap, the machine agent must
continue performing machine work while avoiding its legacy in-process
controller responsibilities. This change introduces a dormant, explicit runtime
mode that lets later bootstrap wiring select that separation safely. The
default remains unchanged: existing bootstrap paths continue to run the
combined machine and controller agent until the controller-snap flow explicitly
opts in.

The mode ensures the machine agent is treated as non-controller by the
dependency engine and does not block machine deployment on controller-only
readiness that it intentionally will not provide.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Not integrated into bootstrap yet.

Unit tests are passing.

## Documentation changes

## Links

**Jira card:** [JUJU-9705](https://warthogs.atlassian.net/browse/JUJU-9705)


[JUJU-9705]: https://warthogs.atlassian.net/browse/JUJU-9705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ