### PR TITLE
feat: generalise Dqlite bootstrap addressing

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -52,6 +52,7 @@ import (
 type DqliteInitializerFunc func(
 	ctx context.Context,
 	mgr database.BootstrapNodeManager,
+	bootstrapAddresses corenetwork.ProviderAddresses,
 	modelUUID coremodel.UUID,
 	logger logger.Logger,
 	options ...database.BootstrapOpt,
@@ -70,9 +71,10 @@ func CheckJWKSReachable(url string) error {
 
 // AgentBootstrap is used to initialize the state for a new controller.
 type AgentBootstrap struct {
-	adminUser       names.UserTag
-	agentConfig     agent.ConfigSetter
-	bootstrapDqlite DqliteInitializerFunc
+	adminUser                 names.UserTag
+	agentConfig               agent.ConfigSetter
+	bootstrapDqlite           DqliteInitializerFunc
+	bootstrapMachineAddresses corenetwork.ProviderAddresses
 
 	stateInitializationParams instancecfg.StateInitializationParams
 
@@ -134,6 +136,7 @@ func NewAgentBootstrap(args AgentBootstrapArgs) (*AgentBootstrap, error) {
 		adminUser:                 args.AdminUser,
 		agentConfig:               args.AgentConfig,
 		bootstrapDqlite:           args.BootstrapDqlite,
+		bootstrapMachineAddresses: args.BootstrapMachineAddresses,
 		clock:                     clock.WallClock,
 		logger:                    args.Logger,
 		stateInitializationParams: args.StateInitializationParams,
@@ -255,26 +258,8 @@ func (b *AgentBootstrap) Initialize(ctx context.Context) (resultErr error) {
 		)
 	}
 
-	// If we're running caas, we need to bind to the loopback address
-	// and eschew TLS termination.
-	// This is to prevent dqlite to become all at sea when the controller pod
-	// is rescheduled. This is only a temporary measure until we have HA
-	// dqlite for k8s.
-	isLoopbackPreferred := isCAAS
-
-	agentInfo, _ := b.agentConfig.ControllerAgentInfo()
-	nodeManagerCfg := database.NodeManagerConfig{
-		DataDir:              b.agentConfig.DataDir(),
-		CACert:               b.agentConfig.CACert(),
-		ControllerCert:       agentInfo.Cert,
-		ControllerPrivateKey: agentInfo.PrivateKey,
-	}
-	if err := b.bootstrapDqlite(
-		ctx,
-		database.NewNodeManager(nodeManagerCfg, isLoopbackPreferred, b.logger, coredatabase.NoopSlowQueryLogger{}),
-		controllerModelUUID,
-		b.logger,
-		databaseBootstrapOptions...,
+	if err := b.initializeDqlite(
+		ctx, controllerModelUUID, databaseBootstrapOptions...,
 	); err != nil {
 		return errors.Trace(err)
 	}
@@ -291,6 +276,29 @@ func (b *AgentBootstrap) Initialize(ctx context.Context) (resultErr error) {
 	b.agentConfig.SetPassword(newPassword)
 
 	return nil
+}
+
+func (b *AgentBootstrap) initializeDqlite(
+	ctx context.Context, controllerModelUUID coremodel.UUID,
+	options ...database.BootstrapOpt,
+) error {
+	agentInfo, _ := b.agentConfig.ControllerAgentInfo()
+	nodeManagerCfg := database.NodeManagerConfig{
+		DataDir:              b.agentConfig.DataDir(),
+		CACert:               b.agentConfig.CACert(),
+		ControllerCert:       agentInfo.Cert,
+		ControllerPrivateKey: agentInfo.PrivateKey,
+	}
+	return b.bootstrapDqlite(
+		ctx,
+		database.NewNodeManager(
+			nodeManagerCfg, b.logger, coredatabase.NoopSlowQueryLogger{},
+		),
+		b.bootstrapMachineAddresses,
+		controllerModelUUID,
+		b.logger,
+		options...,
+	)
 }
 
 func (b *AgentBootstrap) getCloudCredential() (cloud.Credential, names.CloudCredentialTag, error) {

--- a/agent/agentbootstrap/bootstrap_internal_test.go
+++ b/agent/agentbootstrap/bootstrap_internal_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agentbootstrap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/juju/names/v6"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/controller"
+	corelogger "github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/internal/database"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type bootstrapInternalSuite struct{}
+
+func TestBootstrapInternalSuite(t *testing.T) {
+	tc.Run(t, &bootstrapInternalSuite{})
+}
+
+func (*bootstrapInternalSuite) TestBootstrapMachineAddressesReachDqlite(c *tc.C) {
+	addresses := network.NewMachineAddresses([]string{"10.0.0.1"}).AsProviderAddresses()
+	var gotAddresses network.ProviderAddresses
+	bootstrap, err := NewAgentBootstrap(AgentBootstrapArgs{
+		AdminUser:                 names.NewLocalUserTag("admin"),
+		AgentConfig:               stubAgentConfig{dataDir: c.MkDir()},
+		BootstrapEnviron:          stubBootstrapEnviron{},
+		BootstrapMachineAddresses: addresses,
+		BootstrapDqlite: func(
+			_ context.Context, manager database.BootstrapNodeManager,
+			bootstrapAddresses network.ProviderAddresses, _ model.UUID,
+			_ corelogger.Logger,
+			_ ...database.BootstrapOpt,
+		) error {
+			c.Check(manager, tc.NotNil)
+			gotAddresses = bootstrapAddresses
+			return nil
+		},
+		Logger: loggertesting.WrapCheckLog(c),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = bootstrap.initializeDqlite(c.Context(), tc.Must0(c, model.NewUUID))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotAddresses, tc.DeepEquals, addresses)
+}
+
+type stubAgentConfig struct {
+	agent.ConfigSetter
+	dataDir string
+}
+
+func (s stubAgentConfig) DataDir() string {
+	return s.dataDir
+}
+
+func (stubAgentConfig) CACert() string {
+	return "ca-cert"
+}
+
+func (stubAgentConfig) ControllerAgentInfo() (controller.ControllerAgentInfo, bool) {
+	return controller.ControllerAgentInfo{
+		Cert:       "controller-cert",
+		PrivateKey: "controller-key",
+	}, true
+}
+
+type stubBootstrapEnviron struct {
+	environs.BootstrapEnviron
+}

--- a/cmd/jujuagentd/agent/agenttest/agent.go
+++ b/cmd/jujuagentd/agent/agenttest/agent.go
@@ -150,7 +150,10 @@ func (s *AgentSuite) PrimeStateAgentVersion(c *tc.C, tag names.Tag, password str
 	}
 	err = database.BootstrapDqlite(
 		c.Context(),
-		database.NewNodeManager(nodeManagerCfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{}),
+		database.NewNodeManager(nodeManagerCfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{}),
+		network.NewMachineAddresses(
+			[]string{"127.0.0.1"}, network.WithScope(network.ScopeCloudLocal),
+		).AsProviderAddresses(),
 		tc.Must0(c, coremodel.NewUUID),
 		loggertesting.WrapCheckLog(c),
 	)

--- a/cmd/jujuagentd/agent/bootstrap.go
+++ b/cmd/jujuagentd/agent/bootstrap.go
@@ -273,9 +273,11 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 	if err := ensureSSHServerHostKey(&args); err != nil {
 		return errors.Trace(err)
 	}
-	addrs, err := getInstanceAddresses(isCAAS, env, ctx, args)
+	addrs, err := bootstrapControllerAddresses(
+		ctx, env, args.BootstrapMachineInstanceId,
+	)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "getting bootstrap controller addresses")
 	}
 
 	if err = c.ChangeConfig(func(agentConfig agent.ConfigSetter) error {
@@ -333,30 +335,15 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 	return nil
 }
 
-func getInstanceAddresses(
-	isCAAS bool,
-	env environs.BootstrapEnviron,
-	ctx context.Context,
-	args instancecfg.StateInitializationParams,
+func bootstrapControllerAddresses(
+	ctx context.Context, env environs.BootstrapEnviron, providerID instance.Id,
 ) (network.ProviderAddresses, error) {
-	if isCAAS {
-		return network.NewMachineAddresses([]string{"localhost"}).AsProviderAddresses(), nil
-	}
-
-	instanceLister, ok := env.(environs.InstanceLister)
-	if !ok {
-		// this should never happened.
-		return nil, errors.NotValidf("InstanceLister missing for IAAS controller provider")
-	}
-	instances, err := instanceLister.Instances(ctx, []instance.Id{args.BootstrapMachineInstanceId})
+	addressFinder, err := environs.NewBootstrapAddressFinder(env, providerID)
 	if err != nil {
-		return nil, errors.Annotate(err, "getting bootstrap instance")
+		return nil, errors.Annotate(err, "selecting bootstrap address provider")
 	}
-	addrs, err := instances[0].Addresses(ctx)
-	if err != nil {
-		return nil, errors.Annotate(err, "getting bootstrap instance addresses")
-	}
-	return addrs, nil
+	addresses, err := addressFinder.BootstrapControllerAddresses(ctx)
+	return addresses, errors.Trace(err)
 }
 
 // ensureSSHServerHostKey ensures that either a) a user has provided a host key

--- a/cmd/jujuagentd/agent/bootstrap_test.go
+++ b/cmd/jujuagentd/agent/bootstrap_test.go
@@ -4,9 +4,13 @@
 package agent
 
 import (
+	"context"
 	stdtesting "testing"
 
 	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs"
 )
 
 type BootstrapSuite struct {
@@ -26,4 +30,27 @@ func (s *BootstrapSuite) TestStub(c *tc.C) {
   - Test set constraints for bootstrap machine and model.
   - Test system identity is written to the data directory.
 `)
+}
+
+func (s *BootstrapSuite) TestBootstrapControllerAddressesUsesProviderInterface(c *tc.C) {
+	want := network.NewMachineAddresses([]string{"10.0.0.1"}).AsProviderAddresses()
+	env := &stubBootstrapAddressEnviron{addresses: want}
+
+	got, err := bootstrapControllerAddresses(c.Context(), env, "bootstrap-instance")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, want)
+	c.Check(env.calls, tc.Equals, 1)
+}
+
+type stubBootstrapAddressEnviron struct {
+	environs.BootstrapEnviron
+	addresses network.ProviderAddresses
+	calls     int
+}
+
+func (e *stubBootstrapAddressEnviron) BootstrapControllerAddresses(
+	_ context.Context,
+) (network.ProviderAddresses, error) {
+	e.calls++
+	return e.addresses, nil
 }

--- a/cmd/jujuagentd/agent/dbrepl.go
+++ b/cmd/jujuagentd/agent/dbrepl.go
@@ -31,7 +31,6 @@ import (
 	cmdutil "github.com/juju/juju/cmd/jujuagentd/util"
 	internaldependency "github.com/juju/juju/internal/dependency"
 	internallogger "github.com/juju/juju/internal/logger"
-	k8sconstants "github.com/juju/juju/internal/provider/kubernetes/constants"
 	internalworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/dbreplaccessor"
 	"github.com/juju/juju/internal/worker/gate"
@@ -64,7 +63,6 @@ type dbReplAgentCommand struct {
 	replMachineAgentFactory dbReplMachineAgentFactoryFnType
 	ctx                     *cmd.Context
 
-	isCaas   bool
 	agentTag names.Tag
 
 	// The following are set via command-line flags.
@@ -107,8 +105,6 @@ func (a *dbReplAgentCommand) Init(args []string) error {
 	if err := os.MkdirAll(config.LogDir(), 0644); err != nil {
 		logger.Warningf(context.TODO(), "cannot create log dir: %v", err)
 	}
-	a.isCaas = config.Value(agent.ProviderType) == k8sconstants.CAASProviderType
-
 	return nil
 }
 
@@ -119,7 +115,7 @@ func (a *dbReplAgentCommand) Run(c *cmd.Context) error {
 		fmt.Fprint(os.Stderr, replWarningHeader)
 	}
 
-	machineAgent, err := a.replMachineAgentFactory(a.agentTag, a.isCaas)
+	machineAgent, err := a.replMachineAgentFactory(a.agentTag)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -155,7 +151,7 @@ Type '.help' for help.
 `
 )
 
-type dbReplMachineAgentFactoryFnType func(names.Tag, bool) (*replMachineAgent, error)
+type dbReplMachineAgentFactoryFnType func(names.Tag) (*replMachineAgent, error)
 
 // DBReplMachineAgentFactoryFn returns a function which instantiates a
 // replMachineAgent given a machineId.
@@ -163,7 +159,7 @@ func DBReplMachineAgentFactoryFn(
 	agentConfWriter agentconfig.AgentConfigWriter,
 	newDBReplWorkerFunc dbreplaccessor.NewDBReplWorkerFunc,
 ) dbReplMachineAgentFactoryFnType {
-	return func(agentTag names.Tag, isCaasAgent bool) (*replMachineAgent, error) {
+	return func(agentTag names.Tag) (*replMachineAgent, error) {
 		runner, err := worker.NewRunner(worker.RunnerParams{
 			Name:          "repl",
 			IsFatal:       agenterrors.IsFatal,
@@ -179,7 +175,6 @@ func DBReplMachineAgentFactoryFn(
 			agentConfWriter,
 			runner,
 			newDBReplWorkerFunc,
-			isCaasAgent,
 		)
 	}
 }
@@ -190,7 +185,6 @@ func NewREPLMachineAgent(
 	agentConfWriter agentconfig.AgentConfigWriter,
 	runner *worker.Runner,
 	newDBReplWorkerFunc dbreplaccessor.NewDBReplWorkerFunc,
-	isCaasAgent bool,
 ) (*replMachineAgent, error) {
 	a := &replMachineAgent{
 		agentTag:            agentTag,
@@ -199,7 +193,6 @@ func NewREPLMachineAgent(
 		dead:                make(chan struct{}),
 		runner:              runner,
 		newDBReplWorkerFunc: newDBReplWorkerFunc,
-		isCaasAgent:         isCaasAgent,
 	}
 	return a, nil
 }
@@ -218,8 +211,6 @@ type replMachineAgent struct {
 	newDBReplWorkerFunc dbreplaccessor.NewDBReplWorkerFunc
 
 	controllerUnlocker gate.Lock
-
-	isCaasAgent bool
 }
 
 // Wait waits for the repl machine agent to finish.
@@ -316,12 +307,7 @@ func (a *replMachineAgent) makeEngineCreator(
 			Stdin:  stdin,
 		}
 
-		var manifolds dependency.Manifolds
-		if a.isCaasAgent {
-			manifolds = dbrepl.CAASManifolds(manifoldsCfg)
-		} else {
-			manifolds = dbrepl.IAASManifolds(manifoldsCfg)
-		}
+		manifolds := dbrepl.Manifolds(manifoldsCfg)
 
 		if err := dependency.Install(eng, manifolds); err != nil {
 			if err := worker.Stop(eng); err != nil {

--- a/cmd/jujuagentd/agent/dbrepl/manifolds.go
+++ b/cmd/jujuagentd/agent/dbrepl/manifolds.go
@@ -5,7 +5,6 @@ package dbrepl
 
 import (
 	"io"
-	"maps"
 
 	"github.com/juju/clock"
 	"github.com/juju/worker/v5/dependency"
@@ -59,10 +58,9 @@ type ManifoldsConfig struct {
 	Stdin io.Reader
 }
 
-// commonManifolds returns manifolds shared between IAAS and CAAS controller
-// REPL engines.  The controller binary is always a controller, so no
-// ifController gating is required.
-func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
+// Manifolds returns manifolds for a controller REPL engine. The controller
+// binary is always a controller, so no ifController gating is required.
+func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	return dependency.Manifolds{
 		// The termination worker returns ErrTerminateAgent if a
 		// termination signal is received by the process it's running
@@ -85,6 +83,18 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			},
 		),
 
+		dbReplAccessorName: dbreplaccessor.Manifold(dbreplaccessor.ManifoldConfig{
+			DataDir:              config.DataDir,
+			CACert:               config.CACert,
+			ControllerCert:       config.ControllerCert,
+			ControllerPrivateKey: config.ControllerPrivateKey,
+			Clock:                config.Clock,
+			Logger:               internallogger.GetLogger("juju.worker.dbreplaccessor"),
+			NewApp:               dbreplaccessor.NewApp,
+			NewDBReplWorker:      config.NewDBReplWorkerFunc,
+			NewNodeManager:       dbreplaccessor.NewNodeManager,
+		}),
+
 		// The db-repl manifold drives the interactive REPL worker.
 		dbReplName: dbrepl.Manifold(dbrepl.ManifoldConfig{
 			DBReplAccessorName: dbReplAccessorName,
@@ -94,48 +104,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Stdin:              config.Stdin,
 		}),
 	}
-}
-
-// IAASManifolds returns manifolds for an IAAS controller REPL engine.
-func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
-	return mergeManifolds(config, dependency.Manifolds{
-		dbReplAccessorName: dbreplaccessor.Manifold(dbreplaccessor.ManifoldConfig{
-			DataDir:              config.DataDir,
-			CACert:               config.CACert,
-			ControllerCert:       config.ControllerCert,
-			ControllerPrivateKey: config.ControllerPrivateKey,
-			Clock:                config.Clock,
-			Logger:               internallogger.GetLogger("juju.worker.dbreplaccessor"),
-			NewApp:               dbreplaccessor.NewApp,
-			NewDBReplWorker:      config.NewDBReplWorkerFunc,
-			NewNodeManager:       dbreplaccessor.IAASNodeManager,
-		}),
-	})
-}
-
-// CAASManifolds returns manifolds for a CAAS controller REPL engine.
-func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
-	return mergeManifolds(config, dependency.Manifolds{
-		dbReplAccessorName: dbreplaccessor.Manifold(dbreplaccessor.ManifoldConfig{
-			DataDir:              config.DataDir,
-			CACert:               config.CACert,
-			ControllerCert:       config.ControllerCert,
-			ControllerPrivateKey: config.ControllerPrivateKey,
-			Clock:                config.Clock,
-			Logger:               internallogger.GetLogger("juju.worker.dbreplaccessor"),
-			NewApp:               dbreplaccessor.NewApp,
-			NewDBReplWorker:      config.NewDBReplWorkerFunc,
-			NewNodeManager:       dbreplaccessor.CAASNodeManager,
-		}),
-	})
-}
-
-func mergeManifolds(
-	config ManifoldsConfig, manifolds dependency.Manifolds,
-) dependency.Manifolds {
-	result := commonManifolds(config)
-	maps.Copy(result, manifolds)
-	return result
 }
 
 const (

--- a/cmd/jujuagentd/agent/dbrepl/manifolds_test.go
+++ b/cmd/jujuagentd/agent/dbrepl/manifolds_test.go
@@ -27,12 +27,8 @@ func (s *ManifoldsSuite) SetUpTest(c *tc.C) {
 	s.BaseSuite.SetUpTest(c)
 }
 
-func (s *ManifoldsSuite) TestStartFuncsIAAS(c *tc.C) {
-	s.assertStartFuncs(c, dbrepl.IAASManifolds(newManifoldsConfig()))
-}
-
-func (s *ManifoldsSuite) TestStartFuncsCAAS(c *tc.C) {
-	s.assertStartFuncs(c, dbrepl.CAASManifolds(newManifoldsConfig()))
+func (s *ManifoldsSuite) TestStartFuncs(c *tc.C) {
+	s.assertStartFuncs(c, dbrepl.Manifolds(newManifoldsConfig()))
 }
 
 func (*ManifoldsSuite) assertStartFuncs(c *tc.C, manifolds dependency.Manifolds) {
@@ -42,21 +38,9 @@ func (*ManifoldsSuite) assertStartFuncs(c *tc.C, manifolds dependency.Manifolds)
 	}
 }
 
-func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *tc.C) {
+func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 	s.assertManifoldNames(c,
-		dbrepl.IAASManifolds(newManifoldsConfig()),
-		[]string{
-			"controller-agent-config",
-			"db-repl-accessor",
-			"db-repl",
-			"termination-signal-handler",
-		},
-	)
-}
-
-func (s *ManifoldsSuite) TestManifoldNamesCAAS(c *tc.C) {
-	s.assertManifoldNames(c,
-		dbrepl.CAASManifolds(newManifoldsConfig()),
+		dbrepl.Manifolds(newManifoldsConfig()),
 		[]string{
 			"controller-agent-config",
 			"db-repl-accessor",
@@ -75,17 +59,8 @@ func (*ManifoldsSuite) assertManifoldNames(c *tc.C, manifolds dependency.Manifol
 	c.Assert(keys, tc.SameContents, expectedKeys)
 }
 
-func (s *ManifoldsSuite) TestManifoldsDependenciesIAAS(c *tc.C) {
-	manifolds := dbrepl.IAASManifolds(newManifoldsConfig())
-	for name, expected := range expectedManifoldsWithDependencies {
-		manifold, ok := manifolds[name]
-		c.Assert(ok, tc.IsTrue, tc.Commentf("manifold %q not found", name))
-		c.Check(manifold.Inputs, tc.SameContents, expected, tc.Commentf("manifold %q", name))
-	}
-}
-
-func (s *ManifoldsSuite) TestManifoldsDependenciesCAAS(c *tc.C) {
-	manifolds := dbrepl.CAASManifolds(newManifoldsConfig())
+func (s *ManifoldsSuite) TestManifoldsDependencies(c *tc.C) {
+	manifolds := dbrepl.Manifolds(newManifoldsConfig())
 	for name, expected := range expectedManifoldsWithDependencies {
 		manifold, ok := manifolds[name]
 		c.Assert(ok, tc.IsTrue, tc.Commentf("manifold %q not found", name))

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -815,6 +815,20 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger: internallogger.GetLogger("juju.worker.querylogger"),
 		})),
 
+		// DBAccessor is a manifold that provides a DBAccessor worker
+		// that can be used to access the database.
+		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
+			QueryLoggerName:           queryLoggerName,
+			ControllerAgentConfigName: controllerAgentConfigName,
+			ControllerStartupValues:   config.StartupValueProvider,
+			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
+			PrometheusRegisterer:      config.PrometheusRegisterer,
+			NewApp:                    dbaccessor.NewApp,
+			NewDBWorker:               config.NewDBWorkerFunc,
+			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
+			NewNodeManager:            dbaccessor.NewNodeManager,
+		})),
+
 		fileNotifyWatcherName: ifController(filenotifywatcher.Manifold(filenotifywatcher.ManifoldConfig{
 			Clock:             config.Clock,
 			Logger:            internallogger.GetLogger("juju.worker.filenotifywatcher"),
@@ -1225,20 +1239,6 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			APICallerName: apiCallerName,
 		})),
 
-		// DBAccessor is a manifold that provides a DBAccessor worker
-		// that can be used to access the database.
-		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			QueryLoggerName:           queryLoggerName,
-			ControllerAgentConfigName: controllerAgentConfigName,
-			ControllerStartupValues:   config.StartupValueProvider,
-			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-			PrometheusRegisterer:      config.PrometheusRegisterer,
-			NewApp:                    dbaccessor.NewApp,
-			NewDBWorker:               config.NewDBWorkerFunc,
-			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
-			NewNodeManager:            dbaccessor.IAASNodeManager,
-		})),
-
 		// The diskmanager worker periodically lists block devices on the
 		// machine it runs on. This worker will be run on all Juju-managed
 		// machines (one per machine agent).
@@ -1462,20 +1462,6 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewAgentWorker:       upgradestepsagent.NewAgentWorker,
 			Logger:               internallogger.GetLogger("juju.worker.upgradestepsagent"),
 			Clock:                config.Clock,
-		})),
-
-		// DBAccessor is a manifold that provides a DBAccessor worker
-		// that can be used to access the database.
-		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			QueryLoggerName:           queryLoggerName,
-			ControllerAgentConfigName: controllerAgentConfigName,
-			ControllerStartupValues:   config.StartupValueProvider,
-			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-			PrometheusRegisterer:      config.PrometheusRegisterer,
-			NewApp:                    dbaccessor.NewApp,
-			NewDBWorker:               config.NewDBWorkerFunc,
-			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
-			NewNodeManager:            dbaccessor.CAASNodeManager,
 		})),
 	})
 }

--- a/cmd/jujuagentd/agent/safemode.go
+++ b/cmd/jujuagentd/agent/safemode.go
@@ -33,7 +33,6 @@ import (
 	"github.com/juju/juju/core/semversion"
 	internaldependency "github.com/juju/juju/internal/dependency"
 	internallogger "github.com/juju/juju/internal/logger"
-	k8sconstants "github.com/juju/juju/internal/provider/kubernetes/constants"
 	internalworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/dbaccessor"
 	jujunames "github.com/juju/juju/juju/names"
@@ -66,7 +65,6 @@ type safeModeAgentCommand struct {
 	safeModeMachineAgentFactory safeModeMachineAgentFactoryFnType
 	ctx                         *cmd.Context
 
-	isCaas   bool
 	agentTag names.Tag
 
 	// The following are set via command-line flags.
@@ -109,8 +107,6 @@ func (a *safeModeAgentCommand) Init(args []string) error {
 	if err := os.MkdirAll(config.LogDir(), 0o644); err != nil {
 		logger.Warningf(context.TODO(), "cannot create log dir: %v", err)
 	}
-	a.isCaas = config.Value(agent.ProviderType) == k8sconstants.CAASProviderType
-
 	return nil
 }
 
@@ -129,7 +125,7 @@ func (a *safeModeAgentCommand) Run(c *cmd.Context) error {
 	// it's better than nothing).
 	fmt.Fprint(os.Stderr, safeModeWarningHeader)
 
-	machineAgent, err := a.safeModeMachineAgentFactory(a.agentTag, a.isCaas)
+	machineAgent, err := a.safeModeMachineAgentFactory(a.agentTag)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -171,7 +167,7 @@ before running in safe mode.
 `
 )
 
-type safeModeMachineAgentFactoryFnType func(names.Tag, bool) (*SafeModeMachineAgent, error)
+type safeModeMachineAgentFactoryFnType func(names.Tag) (*SafeModeMachineAgent, error)
 
 // SafeModeMachineAgentFactoryFn returns a function which instantiates a
 // SafeModeMachineAgent given a machineId.
@@ -179,7 +175,7 @@ func SafeModeMachineAgentFactoryFn(
 	agentConfWriter agentconfig.AgentConfigWriter,
 	newDBWorkerFunc dbaccessor.NewDBWorkerFunc,
 ) safeModeMachineAgentFactoryFnType {
-	return func(agentTag names.Tag, isCaasAgent bool) (*SafeModeMachineAgent, error) {
+	return func(agentTag names.Tag) (*SafeModeMachineAgent, error) {
 		runner, err := worker.NewRunner(worker.RunnerParams{
 			Name:          "safemode",
 			IsFatal:       agenterrors.IsFatal,
@@ -195,7 +191,6 @@ func SafeModeMachineAgentFactoryFn(
 			agentConfWriter,
 			runner,
 			newDBWorkerFunc,
-			isCaasAgent,
 		)
 	}
 }
@@ -206,7 +201,6 @@ func NewSafeModeMachineAgent(
 	agentConfWriter agentconfig.AgentConfigWriter,
 	runner *worker.Runner,
 	newDBWorkerFunc dbaccessor.NewDBWorkerFunc,
-	isCaasAgent bool,
 ) (*SafeModeMachineAgent, error) {
 	a := &SafeModeMachineAgent{
 		agentTag:          agentTag,
@@ -216,7 +210,6 @@ func NewSafeModeMachineAgent(
 		dead:              make(chan struct{}),
 		runner:            runner,
 		newDBWorkerFunc:   newDBWorkerFunc,
-		isCaasAgent:       isCaasAgent,
 	}
 	return a, nil
 }
@@ -235,8 +228,6 @@ type SafeModeMachineAgent struct {
 	workersStarted chan struct{}
 
 	newDBWorkerFunc dbaccessor.NewDBWorkerFunc
-
-	isCaasAgent bool
 }
 
 // Wait waits for the safe mode machine agent to finish.
@@ -320,15 +311,9 @@ func (a *SafeModeMachineAgent) makeEngineCreator(
 			LogDir:                  agentConfig.LogDir(),
 			ConfigChangeSocketPath:  path.Join(agentConfig.DataDir(), "configchange.socket"),
 			Clock:                   clock.WallClock,
-			IsCaasConfig:            a.isCaasAgent,
 		}
 
-		var manifolds dependency.Manifolds
-		if a.isCaasAgent {
-			manifolds = safemode.CAASManifolds(manifoldsCfg)
-		} else {
-			manifolds = safemode.IAASManifolds(manifoldsCfg)
-		}
+		manifolds := safemode.Manifolds(manifoldsCfg)
 
 		if err := dependency.Install(eng, manifolds); err != nil {
 			if err := worker.Stop(eng); err != nil {

--- a/cmd/jujuagentd/agent/safemode/manifolds.go
+++ b/cmd/jujuagentd/agent/safemode/manifolds.go
@@ -4,8 +4,6 @@
 package safemode
 
 import (
-	"maps"
-
 	"github.com/juju/clock"
 	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v5/dependency"
@@ -51,16 +49,13 @@ type ManifoldsConfig struct {
 
 	// Clock supplies timekeeping services to various workers.
 	Clock clock.Clock
-
-	// IsCaasConfig is true if this config is for a caas agent.
-	IsCaasConfig bool
 }
 
-// commonManifolds returns a set of co-configured manifolds covering the
-// various responsibilities of a machine agent.
+// Manifolds returns a set of co-configured manifolds covering the various
+// responsibilities of a machine agent in safe mode.
 //
 // Thou Shalt Not Use String Literals In This Function. Or Else.
-func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
+func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 	manifolds := dependency.Manifolds{
 		// The agent manifold references the enclosing agent, and is the
 		// foundation stone on which most other manifolds ultimately depend.
@@ -102,51 +97,21 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			LogDir: config.LogDir,
 			Logger: internallogger.GetLogger("juju.worker.querylogger"),
 		})),
+
+		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
+			QueryLoggerName:           queryLoggerName,
+			ControllerAgentConfigName: controllerAgentConfigName,
+			ControllerStartupValues:   config.ControllerStartupValues,
+			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
+			PrometheusRegisterer:      noopPrometheusRegisterer{},
+			NewApp:                    dbaccessor.NewApp,
+			NewDBWorker:               config.NewDBWorkerFunc,
+			NewNodeManager:            dbaccessor.NewNodeManager,
+			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
+		})),
 	}
 
 	return manifolds
-}
-
-// IAASManifolds returns a set of co-configured manifolds covering the
-// various responsibilities of a IAAS machine agent.
-func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
-	return mergeManifolds(config, dependency.Manifolds{
-		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			QueryLoggerName:           queryLoggerName,
-			ControllerAgentConfigName: controllerAgentConfigName,
-			ControllerStartupValues:   config.ControllerStartupValues,
-			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-			PrometheusRegisterer:      noopPrometheusRegisterer{},
-			NewApp:                    dbaccessor.NewApp,
-			NewDBWorker:               config.NewDBWorkerFunc,
-			NewNodeManager:            dbaccessor.IAASNodeManager,
-			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
-		})),
-	})
-}
-
-// CAASManifolds returns a set of co-configured manifolds covering the
-// various responsibilities of a CAAS machine agent.
-func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
-	return mergeManifolds(config, dependency.Manifolds{
-		dbAccessorName: ifController(dbaccessor.Manifold(dbaccessor.ManifoldConfig{
-			QueryLoggerName:           queryLoggerName,
-			ControllerAgentConfigName: controllerAgentConfigName,
-			ControllerStartupValues:   config.ControllerStartupValues,
-			Logger:                    internallogger.GetLogger("juju.worker.dbaccessor"),
-			PrometheusRegisterer:      noopPrometheusRegisterer{},
-			NewApp:                    dbaccessor.NewApp,
-			NewDBWorker:               config.NewDBWorkerFunc,
-			NewNodeManager:            dbaccessor.CAASNodeManager,
-			NewMetricsCollector:       dbaccessor.NewMetricsCollector,
-		})),
-	})
-}
-
-func mergeManifolds(config ManifoldsConfig, manifolds dependency.Manifolds) dependency.Manifolds {
-	result := commonManifolds(config)
-	maps.Copy(result, manifolds)
-	return result
 }
 
 var ifController = engine.Housing{

--- a/cmd/jujuagentd/agent/safemode/manifolds_test.go
+++ b/cmd/jujuagentd/agent/safemode/manifolds_test.go
@@ -32,14 +32,8 @@ func (s *ManifoldsSuite) SetUpTest(c *tc.C) {
 	s.BaseSuite.SetUpTest(c)
 }
 
-func (s *ManifoldsSuite) TestStartFuncsIAAS(c *tc.C) {
-	s.assertStartFuncs(c, safemode.IAASManifolds(safemode.ManifoldsConfig{
-		Agent: &mockAgent{},
-	}))
-}
-
-func (s *ManifoldsSuite) TestStartFuncsCAAS(c *tc.C) {
-	s.assertStartFuncs(c, safemode.CAASManifolds(safemode.ManifoldsConfig{
+func (s *ManifoldsSuite) TestStartFuncs(c *tc.C) {
+	s.assertStartFuncs(c, safemode.Manifolds(safemode.ManifoldsConfig{
 		Agent: &mockAgent{},
 	}))
 }
@@ -51,26 +45,9 @@ func (*ManifoldsSuite) assertStartFuncs(c *tc.C, manifolds dependency.Manifolds)
 	}
 }
 
-func (s *ManifoldsSuite) TestManifoldNamesIAAS(c *tc.C) {
+func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 	s.assertManifoldNames(c,
-		safemode.IAASManifolds(safemode.ManifoldsConfig{
-			Agent: &mockAgent{},
-		}),
-		[]string{
-			"agent",
-			"controller-agent-config",
-			"db-accessor",
-			"is-controller-flag",
-			"query-logger",
-			"state-config-watcher",
-			"termination-signal-handler",
-		},
-	)
-}
-
-func (s *ManifoldsSuite) TestManifoldNamesCAAS(c *tc.C) {
-	s.assertManifoldNames(c,
-		safemode.CAASManifolds(safemode.ManifoldsConfig{
+		safemode.Manifolds(safemode.ManifoldsConfig{
 			Agent: &mockAgent{},
 		}),
 		[]string{
@@ -95,7 +72,7 @@ func (*ManifoldsSuite) assertManifoldNames(c *tc.C, manifolds dependency.Manifol
 }
 
 func (*ManifoldsSuite) TestSingularGuardsUsed(c *tc.C) {
-	manifolds := safemode.IAASManifolds(safemode.ManifoldsConfig{
+	manifolds := safemode.Manifolds(safemode.ManifoldsConfig{
 		Agent: &mockAgent{},
 	})
 
@@ -146,56 +123,16 @@ func checkNotContains(c *tc.C, names []string, seek string) {
 	}
 }
 
-func (s *ManifoldsSuite) TestManifoldsDependenciesIAAS(c *tc.C) {
+func (s *ManifoldsSuite) TestManifoldsDependencies(c *tc.C) {
 	agenttest.AssertManifoldsDependencies(c,
-		safemode.IAASManifolds(safemode.ManifoldsConfig{
+		safemode.Manifolds(safemode.ManifoldsConfig{
 			Agent: &mockAgent{},
 		}),
-		expectedMachineManifoldsWithDependenciesIAAS,
+		expectedManifoldsWithDependencies,
 	)
 }
 
-func (s *ManifoldsSuite) TestManifoldsDependenciesCAAS(c *tc.C) {
-	agenttest.AssertManifoldsDependencies(c,
-		safemode.CAASManifolds(safemode.ManifoldsConfig{
-			Agent: &mockAgent{},
-		}),
-		expectedMachineManifoldsWithDependenciesCAAS,
-	)
-}
-
-var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
-
-	"agent": {},
-
-	"controller-agent-config": {
-		"agent",
-		"is-controller-flag",
-		"state-config-watcher",
-	},
-
-	"db-accessor": {
-		"agent",
-		"controller-agent-config",
-		"is-controller-flag",
-		"query-logger",
-		"state-config-watcher",
-	},
-
-	"is-controller-flag": {"agent", "state-config-watcher"},
-
-	"query-logger": {
-		"agent",
-		"is-controller-flag",
-		"state-config-watcher",
-	},
-
-	"state-config-watcher": {"agent"},
-
-	"termination-signal-handler": {},
-}
-
-var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
+var expectedManifoldsWithDependencies = map[string][]string{
 
 	"agent": {},
 

--- a/domain/controllernode/state/types.go
+++ b/domain/controllernode/state/types.go
@@ -12,7 +12,8 @@ type dbControllerNode struct {
 	// db issues when the high bit is set).
 	DqliteNodeID string `db:"dqlite_node_id"`
 
-	// DqliteBindAddress is the IP address (no port) that Dqlite is bound to.
+	// DqliteBindAddress is the hostname or IP address (no port) that Dqlite is
+	// bound to.
 	DqliteBindAddress string `db:"dqlite_bind_address"`
 }
 

--- a/domain/schema/controller/sql/0010-controller-node.sql
+++ b/domain/schema/controller/sql/0010-controller-node.sql
@@ -1,7 +1,7 @@
 CREATE TABLE controller_node (
     controller_id TEXT NOT NULL PRIMARY KEY,
     dqlite_node_id TEXT,              -- This is the uint64 from Dqlite NodeInfo, stored as text.
-    dqlite_bind_address TEXT          -- IP address (no port) that Dqlite is bound to.
+    dqlite_bind_address TEXT          -- Hostname or IP address (no port) that Dqlite is bound to.
 );
 
 CREATE UNIQUE INDEX idx_controller_node_dqlite_node

--- a/domain/schema/testing/controllersuite.go
+++ b/domain/schema/testing/controllersuite.go
@@ -35,7 +35,9 @@ func (s *ControllerSuite) SetUpTest(c *tc.C) {
 		Schema:  schema.ControllerDDL(),
 		Verbose: s.Verbose,
 	})
-	err := database.InsertControllerNodeID(c.Context(), s.TxnRunner(), DqliteNodeID)
+	err := database.InsertControllerNodeID(
+		c.Context(), s.TxnRunner(), DqliteNodeID, "127.0.0.1",
+	)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -46,7 +48,7 @@ func (s *ControllerSuite) ApplyDDLForRunner(c *tc.C, runner coredatabase.TxnRunn
 		Schema:  schema.ControllerDDL(),
 		Verbose: s.Verbose,
 	}, runner)
-	err := database.InsertControllerNodeID(c.Context(), runner, DqliteNodeID)
+	err := database.InsertControllerNodeID(c.Context(), runner, DqliteNodeID, "127.0.0.1")
 	c.Assert(err, tc.ErrorIsNil)
 }
 

--- a/environs/bootstrapaddresses.go
+++ b/environs/bootstrapaddresses.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package environs
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
+)
+
+// BootstrapAddressFinder returns the stable provider addresses for the
+// initial controller.
+type BootstrapAddressFinder interface {
+	// BootstrapControllerAddresses returns the provider addresses for the
+	// initial controller.
+	BootstrapControllerAddresses(context.Context) (network.ProviderAddresses, error)
+}
+
+// NewBootstrapAddressFinder returns the bootstrap address implementation for
+// an opened bootstrap environment.
+func NewBootstrapAddressFinder(
+	env BootstrapEnviron, instanceID instance.Id,
+) (BootstrapAddressFinder, error) {
+	if finder, ok := env.(BootstrapAddressFinder); ok {
+		return finder, nil
+	}
+	if lister, ok := env.(InstanceLister); ok {
+		return instanceBootstrapAddressFinder{
+			lister:     lister,
+			instanceID: instanceID,
+		}, nil
+	}
+	return nil, errors.NotSupportedf("bootstrap controller addresses for environ %T", env)
+}
+
+type instanceBootstrapAddressFinder struct {
+	lister     InstanceLister
+	instanceID instance.Id
+}
+
+// BootstrapControllerAddresses returns the provider addresses for the
+// requested bootstrap instance.
+func (f instanceBootstrapAddressFinder) BootstrapControllerAddresses(
+	ctx context.Context,
+) (network.ProviderAddresses, error) {
+	instances, err := f.lister.Instances(ctx, []instance.Id{f.instanceID})
+	if err != nil && !errors.Is(err, ErrPartialInstances) {
+		return nil, errors.Annotatef(err, "getting bootstrap instance %q", f.instanceID)
+	}
+	if len(instances) != 1 || instances[0] == nil {
+		return nil, errors.NotFoundf("bootstrap instance %q", f.instanceID)
+	}
+	if returnedID := instances[0].Id(); returnedID != f.instanceID {
+		return nil, errors.NotFoundf(
+			"bootstrap instance %q (provider returned %q)", f.instanceID, returnedID,
+		)
+	}
+
+	addresses, err := instances[0].Addresses(ctx)
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting bootstrap instance %q addresses", f.instanceID)
+	}
+	return addresses, nil
+}

--- a/environs/bootstrapaddresses_test.go
+++ b/environs/bootstrapaddresses_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package environs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/juju/errors"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs/instances"
+)
+
+type bootstrapAddressSuite struct{}
+
+func TestBootstrapAddressSuite(t *testing.T) {
+	tc.Run(t, &bootstrapAddressSuite{})
+}
+
+func (*bootstrapAddressSuite) TestInstanceAddresses(c *tc.C) {
+	addresses := network.NewMachineAddresses([]string{"10.0.0.1"}).AsProviderAddresses()
+	finder, err := NewBootstrapAddressFinder(instanceBootstrapEnviron{
+		stubInstanceLister: stubInstanceLister{
+			instances: []instances.Instance{
+				stubInstance{id: "bootstrap", addresses: addresses},
+			},
+		},
+	}, "bootstrap")
+	c.Assert(err, tc.ErrorIsNil)
+
+	got, err := finder.BootstrapControllerAddresses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, addresses)
+}
+
+func (*bootstrapAddressSuite) TestInstanceLookupError(c *tc.C) {
+	boom := errors.New("boom")
+	finder := instanceBootstrapAddressFinder{
+		lister:     stubInstanceLister{err: boom},
+		instanceID: "bootstrap",
+	}
+
+	_, err := finder.BootstrapControllerAddresses(c.Context())
+	c.Check(err, tc.ErrorIs, boom)
+}
+
+func (*bootstrapAddressSuite) TestPartialInstanceResult(c *tc.C) {
+	addresses := network.NewMachineAddresses([]string{"10.0.0.1"}).AsProviderAddresses()
+	finder := instanceBootstrapAddressFinder{lister: stubInstanceLister{
+		instances: []instances.Instance{stubInstance{id: "bootstrap", addresses: addresses}},
+		err:       ErrPartialInstances,
+	}, instanceID: "bootstrap"}
+
+	got, err := finder.BootstrapControllerAddresses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, addresses)
+}
+
+func (*bootstrapAddressSuite) TestMissingInstance(c *tc.C) {
+	finder := instanceBootstrapAddressFinder{
+		lister:     stubInstanceLister{},
+		instanceID: "bootstrap",
+	}
+
+	_, err := finder.BootstrapControllerAddresses(c.Context())
+	c.Check(err, tc.ErrorMatches, `bootstrap instance "bootstrap" not found`)
+}
+
+func (*bootstrapAddressSuite) TestNilInstance(c *tc.C) {
+	finder := instanceBootstrapAddressFinder{lister: stubInstanceLister{
+		instances: []instances.Instance{nil},
+		err:       ErrPartialInstances,
+	}, instanceID: "bootstrap"}
+
+	_, err := finder.BootstrapControllerAddresses(c.Context())
+	c.Check(err, tc.ErrorMatches, `bootstrap instance "bootstrap" not found`)
+}
+
+func (*bootstrapAddressSuite) TestWrongInstance(c *tc.C) {
+	finder := instanceBootstrapAddressFinder{lister: stubInstanceLister{
+		instances: []instances.Instance{stubInstance{id: "other"}},
+	}, instanceID: "bootstrap"}
+
+	_, err := finder.BootstrapControllerAddresses(c.Context())
+	c.Check(err, tc.ErrorMatches, `bootstrap instance "bootstrap" \(provider returned "other"\) not found`)
+}
+
+func (*bootstrapAddressSuite) TestInstanceAddressesError(c *tc.C) {
+	boom := errors.New("boom")
+	finder := instanceBootstrapAddressFinder{lister: stubInstanceLister{
+		instances: []instances.Instance{stubInstance{id: "bootstrap", err: boom}},
+	}, instanceID: "bootstrap"}
+
+	_, err := finder.BootstrapControllerAddresses(c.Context())
+	c.Check(err, tc.ErrorIs, boom)
+}
+
+func (*bootstrapAddressSuite) TestUnsupportedEnviron(c *tc.C) {
+	_, err := NewBootstrapAddressFinder(unsupportedBootstrapEnviron{}, "bootstrap")
+	c.Check(err, tc.ErrorMatches, `bootstrap controller addresses for environ environs.unsupportedBootstrapEnviron not supported`)
+}
+
+type instanceBootstrapEnviron struct {
+	BootstrapEnviron
+	stubInstanceLister
+}
+
+type unsupportedBootstrapEnviron struct {
+	BootstrapEnviron
+}
+
+type stubInstanceLister struct {
+	instances []instances.Instance
+	err       error
+}
+
+func (s stubInstanceLister) Instances(context.Context, []instance.Id) ([]instances.Instance, error) {
+	return s.instances, s.err
+}
+
+type stubInstance struct {
+	id        instance.Id
+	addresses network.ProviderAddresses
+	err       error
+}
+
+func (s stubInstance) Id() instance.Id {
+	return s.id
+}
+
+func (stubInstance) Status(context.Context) instance.Status {
+	return instance.Status{}
+}
+
+func (s stubInstance) Addresses(context.Context) (network.ProviderAddresses, error) {
+	return s.addresses, s.err
+}

--- a/internal/database/bootstrap.go
+++ b/internal/database/bootstrap.go
@@ -26,18 +26,9 @@ type BootstrapNodeManager interface {
 	// a path determined by the agent config, then returns that path.
 	EnsureDataDir() (string, error)
 
-	// IsLoopbackPreferred returns true if the Dqlite application should
-	// be bound to the loopback address.
-	IsLoopbackPreferred() bool
-
-	// WithLoopbackAddressOption returns a Dqlite application
-	// Option that will bind Dqlite to the loopback IP.
-	WithLoopbackAddressOption() app.Option
-
-	// WithPreferredCloudLocalAddressOption uses the input network config
-	// source to return a local-cloud address to which to bind Dqlite,
-	// provided that a unique one can be determined.
-	WithPreferredCloudLocalAddressOption(network.ConfigSource) (app.Option, error)
+	// WithAddressOption returns a Dqlite application Option for binding to the
+	// supplied address.
+	WithAddressOption(string) app.Option
 
 	// WithTLSOption returns a Dqlite application Option for TLS encryption
 	// of traffic between clients and clustered application nodes.
@@ -68,6 +59,7 @@ type BootstrapOpt func(
 func BootstrapDqlite(
 	ctx context.Context,
 	mgr BootstrapNodeManager,
+	bootstrapAddresses network.ProviderAddresses,
 	uuid model.UUID,
 	logger logger.Logger,
 	opts ...BootstrapOpt,
@@ -77,21 +69,19 @@ func BootstrapDqlite(
 		return errors.Trace(err)
 	}
 
-	options := []app.Option{mgr.WithLogFuncOption()}
-	if mgr.IsLoopbackPreferred() {
-		options = append(options, mgr.WithLoopbackAddressOption())
-	} else {
-		addrOpt, err := mgr.WithPreferredCloudLocalAddressOption(network.DefaultConfigSource())
-		if err != nil {
-			return errors.Annotate(err, "generating bind address option")
-		}
-
-		tlsOpt, err := mgr.WithTLSOption()
-		if err != nil {
-			return errors.Annotate(err, "generating TLS option")
-		}
-
-		options = append(options, addrOpt, tlsOpt)
+	address, ok := bootstrapAddresses.OneMatchingScope(network.ScopeMatchCloudLocal)
+	if !ok {
+		return errors.NotFoundf("Dqlite bootstrap address")
+	}
+	bindAddress := address.Value
+	tlsOpt, err := mgr.WithTLSOption()
+	if err != nil {
+		return errors.Annotate(err, "generating TLS option")
+	}
+	options := []app.Option{
+		mgr.WithLogFuncOption(),
+		mgr.WithAddressOption(bindAddress),
+		tlsOpt,
 	}
 
 	dqlite, err := app.New(dir, options...)
@@ -108,7 +98,10 @@ func BootstrapDqlite(
 		return errors.Annotatef(err, "waiting for Dqlite readiness")
 	}
 
-	controller, err := runMigration(ctx, dqlite, coredatabase.ControllerNS, schema.ControllerDDL(), controllerBootstrapInit, logger)
+	controller, err := runMigration(
+		ctx, dqlite, coredatabase.ControllerNS, schema.ControllerDDL(),
+		controllerBootstrapInit(bindAddress), logger,
+	)
 	if err != nil {
 		return errors.Annotate(err, "running controller migration")
 	}
@@ -153,17 +146,18 @@ func runMigration(ctx context.Context, dqlite *app.App, namespace string, schema
 
 // InsertControllerNodeID inserts the node ID of the controller node
 // into the controller_node table.
-func InsertControllerNodeID(ctx context.Context, runner coredatabase.TxnRunner, nodeID uint64) error {
+func InsertControllerNodeID(
+	ctx context.Context, runner coredatabase.TxnRunner, nodeID uint64, bindAddress string,
+) error {
 	q := `
 -- TODO (manadart 2023-06-06): At the time of writing, 
 -- we have not yet modelled machines. 
 -- Accordingly, the controller ID remains the ID of the machine, 
 -- but it should probably become a UUID once machines have one.
--- While HA is not supported in K8s, this doesn't matter.
 INSERT INTO controller_node (controller_id, dqlite_node_id, dqlite_bind_address)
-VALUES ('0', ?, '127.0.0.1');`
+VALUES ('0', ?, ?);`
 	return runner.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		result, err := tx.ExecContext(ctx, q, nodeID)
+		result, err := tx.ExecContext(ctx, q, nodeID, bindAddress)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -205,17 +199,13 @@ type bootstrapInit = func(ctx context.Context, runner coredatabase.TxnRunner, dq
 // controllerBootstrapInit is used to initialise the controller database with
 // a controller node ID. The controller node ID is required to be present in
 // the controller_node table as this is used for referential integrity.
-func controllerBootstrapInit(ctx context.Context, runner coredatabase.TxnRunner, dqlite *app.App) error {
-	if err := InsertControllerNodeID(ctx, runner, dqlite.ID()); err != nil {
-		// If the controller node ID already exists, we assume that
-		// the database has already been bootstrapped. Mask the unique
-		// constraint error with a more user-friendly error.
-		if IsErrConstraintUnique(err) {
-			return errors.AlreadyExistsf("controller node ID")
+func controllerBootstrapInit(bindAddress string) bootstrapInit {
+	return func(ctx context.Context, runner coredatabase.TxnRunner, dqlite *app.App) error {
+		if err := InsertControllerNodeID(ctx, runner, dqlite.ID(), bindAddress); err != nil {
+			return errors.Annotatef(err, "inserting controller node ID")
 		}
-		return errors.Annotatef(err, "inserting controller node ID")
+		return nil
 	}
-	return nil
 }
 
 // emptyInit is a BootstrapInit type that does nothing.

--- a/internal/database/bootstrap_test.go
+++ b/internal/database/bootstrap_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/internal/database/client"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
+	jujutesting "github.com/juju/juju/internal/testing"
 )
 
 type bootstrapSuite struct {
@@ -31,6 +32,10 @@ func TestBootstrapSuite(t *testing.T) {
 }
 
 func (s *bootstrapSuite) TestBootstrapSuccess(c *tc.C) {
+	const bootstrapAddress = "10.0.0.1"
+	addresses := network.NewMachineAddresses(
+		[]string{bootstrapAddress}, network.WithScope(network.ScopeCloudLocal),
+	).AsProviderAddresses()
 	mgr := &testNodeManager{c: c}
 
 	// check tests the variadic operation functionality
@@ -72,23 +77,73 @@ func (s *bootstrapSuite) TestBootstrapSuccess(c *tc.C) {
 			if nodeID == 0 {
 				return fmt.Errorf("expected dqlite_node_id to be non-zero")
 			}
-			if bindAddress != "127.0.0.1" {
-				return fmt.Errorf("expected dqlite_bind_address to be 127.0.0.1")
+			if bindAddress != bootstrapAddress {
+				return fmt.Errorf(
+					"expected dqlite_bind_address to be %q", bootstrapAddress,
+				)
 			}
 
 			return nil
 		})
 	}
 
-	err := BootstrapDqlite(c.Context(), mgr, tc.Must0(c, coremodel.NewUUID), loggertesting.WrapCheckLog(c), check)
+	err := BootstrapDqlite(
+		c.Context(), mgr, addresses, tc.Must0(c, coremodel.NewUUID),
+		loggertesting.WrapCheckLog(c), check,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(mgr.addressOption, tc.Equals, bootstrapAddress)
+	c.Check(mgr.tlsOptionCalled, tc.IsTrue)
+}
+
+func (s *bootstrapSuite) TestBootstrapNoAddress(c *tc.C) {
+	mgr := &testNodeManager{c: c}
+
+	err := BootstrapDqlite(
+		c.Context(), mgr, nil, tc.Must0(c, coremodel.NewUUID),
+		loggertesting.WrapCheckLog(c),
+	)
+	c.Check(err, tc.ErrorMatches, "Dqlite bootstrap address not found")
+}
+
+func (s *bootstrapSuite) TestInsertControllerNodeIDPersistsHostname(c *tc.C) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() {
+		c.Assert(db.Close(), tc.ErrorIsNil)
+	}()
+
+	_, err = db.Exec(`CREATE TABLE controller_node (
+		controller_id TEXT PRIMARY KEY,
+		dqlite_node_id INT NOT NULL,
+		dqlite_bind_address TEXT NOT NULL
+	)`)
 	c.Assert(err, tc.ErrorIsNil)
 
+	runner := &txnRunner{db: db}
+	err = InsertControllerNodeID(
+		c.Context(), runner, 42,
+		"controller-0.controller-service-endpoints.test.svc.cluster.local",
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var address string
+	err = db.QueryRow(
+		"SELECT dqlite_bind_address FROM controller_node WHERE controller_id = '0'",
+	).Scan(&address)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(
+		address, tc.Equals,
+		"controller-0.controller-service-endpoints.test.svc.cluster.local",
+	)
 }
 
 type testNodeManager struct {
-	c       *tc.C
-	dataDir string
-	port    int
+	c               *tc.C
+	dataDir         string
+	port            int
+	addressOption   string
+	tlsOptionCalled bool
 }
 
 func (f *testNodeManager) EnsureDataDir() (string, error) {
@@ -98,21 +153,16 @@ func (f *testNodeManager) EnsureDataDir() (string, error) {
 	return f.dataDir, nil
 }
 
-func (f *testNodeManager) IsLoopbackPreferred() bool {
-	return true
-}
-
-func (f *testNodeManager) WithPreferredCloudLocalAddressOption(network.ConfigSource) (app.Option, error) {
-	return f.WithLoopbackAddressOption(), nil
-}
-
-func (f *testNodeManager) WithLoopbackAddressOption() app.Option {
+func (f *testNodeManager) WithAddressOption(address string) app.Option {
+	f.addressOption = address
 	if f.port == 0 {
 		l, err := net.Listen("tcp", ":0")
 		f.c.Assert(err, tc.ErrorIsNil)
 		f.c.Assert(l.Close(), tc.ErrorIsNil)
 		f.port = l.Addr().(*net.TCPAddr).Port
 	}
+	// Bind the test Dqlite app to loopback so the provider address under test
+	// does not need to exist on the host running the test.
 	return app.WithAddress(fmt.Sprintf("127.0.0.1:%d", f.port))
 }
 
@@ -127,5 +177,12 @@ func (f *testNodeManager) WithTracingOption() app.Option {
 }
 
 func (f *testNodeManager) WithTLSOption() (app.Option, error) {
-	return nil, nil
+	f.tlsOptionCalled = true
+	listen, dial, err := dqliteTLSConfig(
+		jujutesting.CACert, jujutesting.ServerCert, jujutesting.ServerKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return app.WithTLS(listen, dial), nil
 }

--- a/internal/database/node.go
+++ b/internal/database/node.go
@@ -23,16 +23,13 @@ import (
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
-	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/internal/database/app"
 	"github.com/juju/juju/internal/database/client"
 	"github.com/juju/juju/internal/database/dqlite"
 	dqlitedriver "github.com/juju/juju/internal/database/driver"
-	"github.com/juju/juju/internal/network"
 )
 
 const (
-	dqliteBootstrapBindIP = "127.0.0.1"
 	dqliteDataDir         = "dqlite"
 	dqlitePort            = 17666
 	dqliteClusterFileName = "cluster.yaml"
@@ -79,45 +76,27 @@ type NodeManagerConfig struct {
 // and emitting configuration for starting its Dqlite `App` based on
 // operational requirements and controller agent config.
 type NodeManager struct {
-	cfg                 NodeManagerConfig
-	port                int
-	isLoopbackPreferred bool
-	logger              logger.Logger
-	slowQueryLogger     coredatabase.SlowQueryLogger
+	cfg             NodeManagerConfig
+	port            int
+	logger          logger.Logger
+	slowQueryLogger coredatabase.SlowQueryLogger
 
 	dataDir string
 }
 
 // NewNodeManager returns a new NodeManager reference
 // based on the input controller runtime configuration.
-//
-// If isLoopbackPreferred is true, we bind Dqlite to 127.0.0.1 and eschew TLS
-// termination. This is useful primarily in unit testing and a temporary
-// workaround for CAAS, which does not yet support high availability.
-//
-// If it is false, we attempt to identify a unique local-cloud address.
-// If we find one, we use it as the bind address. Otherwise, we fall back
-// to the loopback binding.
-func NewNodeManager(cfg NodeManagerConfig, isLoopbackPreferred bool, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) *NodeManager {
+func NewNodeManager(cfg NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) *NodeManager {
 	m := &NodeManager{
-		cfg:                 cfg,
-		port:                dqlitePort,
-		isLoopbackPreferred: isLoopbackPreferred,
-		logger:              logger,
-		slowQueryLogger:     slowQueryLogger,
+		cfg:             cfg,
+		port:            dqlitePort,
+		logger:          logger,
+		slowQueryLogger: slowQueryLogger,
 	}
 	if cfg.DqlitePort != 0 {
 		m.port = cfg.DqlitePort
 	}
 	return m
-}
-
-// IsLoopbackPreferred returns true if we should prefer to bind Dqlite
-// to the loopback IP address.
-// This is currently true for CAAS and unit testing. Once CAAS supports
-// high availability we'll have to revisit this.
-func (m *NodeManager) IsLoopbackPreferred() bool {
-	return m.isLoopbackPreferred
 }
 
 // IsLoopbackBound returns true if we are a cluster of one,
@@ -140,7 +119,12 @@ func (m *NodeManager) IsLoopbackBound(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	return strings.HasPrefix(servers[0].Address, "127."), nil
+	host, _, err := net.SplitHostPort(servers[0].Address)
+	if err != nil {
+		return false, errors.Annotate(err, "parsing Dqlite node address")
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback(), nil
 }
 
 // IsExistingNode returns true if this machine or container has
@@ -270,60 +254,12 @@ func (m *NodeManager) WithBusyTimeoutOption() app.Option {
 	return app.WithBusyTimeout(max(m.cfg.DqliteBusyTimeout, 0))
 }
 
-// WithPreferredCloudLocalAddressOption uses the input network config source to
-// return a local-cloud address to which to bind Dqlite, provided that a unique
-// one can be determined.
-// If there are zero or multiple local-cloud addresses detected on the host,
-// we fall back to binding to the loopback address.
-// This method is only relevant to bootstrap. At all other times (such as when
-// joining a cluster) the bind address is determined externally and passed as
-// the argument to WithAddressOption.
-func (m *NodeManager) WithPreferredCloudLocalAddressOption(source corenetwork.ConfigSource) (app.Option, error) {
-	nics, err := source.Interfaces()
-	if err != nil {
-		return nil, errors.Annotate(err, "querying local network interfaces")
-	}
-
-	var addrs corenetwork.MachineAddresses
-	for _, nic := range nics {
-		name := nic.Name()
-		if nic.Type() == corenetwork.LoopbackDevice ||
-			name == network.DefaultLXDBridge ||
-			name == network.DefaultDockerBridge {
-			continue
-		}
-
-		sysAddrs, err := nic.Addresses()
-		if err != nil || len(sysAddrs) == 0 {
-			continue
-		}
-
-		for _, addr := range sysAddrs {
-			addrs = append(addrs, corenetwork.NewMachineAddress(addr.IP().String()))
-		}
-	}
-
-	cloudLocal := addrs.AllMatchingScope(corenetwork.ScopeMatchCloudLocal).Values()
-	if len(cloudLocal) == 1 {
-		return m.WithAddressOption(cloudLocal[0]), nil
-	}
-
-	m.logger.Warningf(context.TODO(), "failed to determine a unique local-cloud address; falling back to 127.0.0.1 for Dqlite")
-	return m.WithLoopbackAddressOption(), nil
-}
-
-// WithLoopbackAddressOption returns a Dqlite application
-// Option that will bind Dqlite to the loopback IP.
-func (m *NodeManager) WithLoopbackAddressOption() app.Option {
-	return m.WithAddressOption(dqliteBootstrapBindIP)
-}
-
 // WithAddressOption returns a Dqlite application Option
 // for specifying the local address:port to use.
-func (m *NodeManager) WithAddressOption(ip string) app.Option {
+func (m *NodeManager) WithAddressOption(address string) app.Option {
 	// dqlite expects an ipv6 address to be in square brackets
 	// e.g. [::1]:1234 so we need to use net.JoinHostPort.
-	return app.WithAddress(net.JoinHostPort(ip, strconv.Itoa(m.port)))
+	return app.WithAddress(net.JoinHostPort(address, strconv.Itoa(m.port)))
 }
 
 // WithTLSOption returns a Dqlite application Option for TLS encryption

--- a/internal/database/node_test.go
+++ b/internal/database/node_test.go
@@ -14,21 +14,17 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 	"gopkg.in/yaml.v3"
 
 	coredatabase "github.com/juju/juju/core/database"
-	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/internal/database/app"
 	"github.com/juju/juju/internal/database/dqlite"
 	dqlitetesting "github.com/juju/juju/internal/database/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
-	"github.com/juju/juju/internal/network"
 	"github.com/juju/juju/internal/testhelpers"
 	jujutesting "github.com/juju/juju/internal/testing"
 )
@@ -53,7 +49,7 @@ func (s *nodeManagerSuite) TestEnsureDataDirSuccess(c *tc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
 	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
-	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(cfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	expected := fmt.Sprintf("/tmp/%s/%s", subDir, dqliteDataDir)
 	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
@@ -74,34 +70,13 @@ func (s *nodeManagerSuite) TestEnsureDataDirSuccess(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *nodeManagerSuite) TestIsLoopbackPreferred(c *tc.C) {
-	subDir := strconv.Itoa(rand.Intn(10))
-
-	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
-	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
-
-	// Check to see if the loopback address is preferred.
-	// This is only set during the construction, so we need to create multiple
-	// instances of the node manager.
-
-	m0 := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
-
-	ok := m0.IsLoopbackPreferred()
-	c.Check(ok, tc.IsTrue)
-
-	m1 := NewNodeManager(cfg, false, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
-
-	ok = m1.IsLoopbackPreferred()
-	c.Check(ok, tc.IsFalse)
-}
-
 func (s *nodeManagerSuite) TestIsExistingNode(c *tc.C) {
 	subDir := strconv.Itoa(rand.Intn(10))
 
 	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
 	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
-	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(cfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	// Empty directory indicates we've never started.
 	extant, err := m.IsExistingNode()
@@ -127,7 +102,7 @@ func (s *nodeManagerSuite) TestIsBootstrappedNode(c *tc.C) {
 	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
 	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
-	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(cfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	ctx := c.Context()
 
 	// Empty directory indicates we are not the bootstrapped node.
@@ -192,7 +167,7 @@ func (s *nodeManagerSuite) TestSetClusterServersSuccess(c *tc.C) {
 	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
 	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
-	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(cfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	ctx := c.Context()
 
 	dataDir, err := m.EnsureDataDir()
@@ -237,7 +212,7 @@ func (s *nodeManagerSuite) TestSetGetNodeInfoSuccess(c *tc.C) {
 	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
 	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
-	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(cfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	dataDir, err := m.EnsureDataDir()
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -275,7 +250,7 @@ func (s *nodeManagerSuite) TestSetClusterToLocalNodeSuccess(c *tc.C) {
 	cfg := NodeManagerConfig{DataDir: "/tmp/" + subDir}
 	s.AddCleanup(func(*tc.C) { _ = os.RemoveAll(cfg.DataDir) })
 
-	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(cfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	ctx := c.Context()
 
 	_, err := m.EnsureDataDir()
@@ -308,7 +283,7 @@ func (s *nodeManagerSuite) TestSetClusterToLocalNodeSuccess(c *tc.C) {
 }
 
 func (s *nodeManagerSuite) TestWithAddressOptionIPv4Success(c *tc.C) {
-	m := NewNodeManager(NodeManagerConfig{DqlitePort: dqlitetesting.FindTCPPort(c)}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{DqlitePort: dqlitetesting.FindTCPPort(c)}, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("127.0.0.1"))
 	c.Assert(err, tc.ErrorIsNil)
@@ -318,7 +293,7 @@ func (s *nodeManagerSuite) TestWithAddressOptionIPv4Success(c *tc.C) {
 }
 
 func (s *nodeManagerSuite) TestWithAddressOptionIPv6Success(c *tc.C) {
-	m := NewNodeManager(NodeManagerConfig{DqlitePort: dqlitetesting.FindTCPPort(c)}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{DqlitePort: dqlitetesting.FindTCPPort(c)}, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("::1"))
 	c.Assert(err, tc.ErrorIsNil)
@@ -329,7 +304,7 @@ func (s *nodeManagerSuite) TestWithAddressOptionIPv6Success(c *tc.C) {
 
 func (s *nodeManagerSuite) TestWithTLSOptionSuccess(c *tc.C) {
 	cfg := tlsNodeManagerConfig()
-	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(cfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	withTLS, err := m.WithTLSOption()
 	c.Assert(err, tc.ErrorIsNil)
@@ -359,7 +334,7 @@ func (s *nodeManagerSuite) TestDqliteTLSConfigSuccess(c *tc.C) {
 
 func (s *nodeManagerSuite) TestWithTLSOptionRejectsClientWithoutCertificate(c *tc.C) {
 	cfg := tlsNodeManagerConfig()
-	m := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(cfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	m.port = dqlitetesting.FindTCPPort(c)
 
 	withTLS, err := m.WithTLSOption()
@@ -402,7 +377,7 @@ func (s *nodeManagerSuite) TestWithTLSOptionRejectsClientWithoutCertificate(c *t
 func (s *nodeManagerSuite) TestWithTLSOptionJoinClusterSuccess(c *tc.C) {
 	cfg := tlsNodeManagerConfig()
 
-	m0 := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m0 := NewNodeManager(cfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	m0.port = dqlitetesting.FindTCPPort(c)
 
 	withTLS0, err := m0.WithTLSOption()
@@ -420,7 +395,7 @@ func (s *nodeManagerSuite) TestWithTLSOptionJoinClusterSuccess(c *tc.C) {
 	err = app0.Ready(ctx)
 	c.Assert(err, tc.ErrorIsNil)
 
-	m1 := NewNodeManager(cfg, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m1 := NewNodeManager(cfg, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	m1.port = dqlitetesting.FindTCPPort(c)
 
 	withTLS1, err := m1.WithTLSOption()
@@ -443,7 +418,7 @@ func (s *nodeManagerSuite) TestWithTLSOptionJoinClusterSuccess(c *tc.C) {
 }
 
 func (s *nodeManagerSuite) TestWithClusterOptionIPv4Success(c *tc.C) {
-	m := NewNodeManager(NodeManagerConfig{}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{}, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithClusterOption([]string{"10.6.6.6"}))
 	c.Assert(err, tc.ErrorIsNil)
@@ -453,84 +428,13 @@ func (s *nodeManagerSuite) TestWithClusterOptionIPv4Success(c *tc.C) {
 }
 
 func (s *nodeManagerSuite) TestWithClusterOptionIPv6Success(c *tc.C) {
-	m := NewNodeManager(NodeManagerConfig{}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{}, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithClusterOption([]string{"::1"}))
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = dqliteApp.Close()
 	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *nodeManagerSuite) TestWithPreferredCloudLocalAddressOptionNoAddrFallback(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	// Having no interfaces will trigger the loopback address fallback.
-	src := NewMockConfigSource(ctrl)
-	src.EXPECT().Interfaces().Return(nil, nil)
-
-	m := NewNodeManager(NodeManagerConfig{}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
-	m.port = dqlitetesting.FindTCPPort(c)
-
-	opt, err := m.WithPreferredCloudLocalAddressOption(src)
-	c.Assert(err, tc.ErrorIsNil)
-
-	dqliteApp, err := app.New(c.MkDir(), opt)
-	c.Assert(err, tc.ErrorIsNil)
-
-	c.Check(strings.Split(dqliteApp.Address(), ":")[0], tc.Equals, "127.0.0.1")
-
-	err = dqliteApp.Close()
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *nodeManagerSuite) TestWithPreferredCloudLocalAddressOptionSingleAddrSuccess(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	localCloudIP := "192.168.10.254"
-
-	// Loopback is ignored.
-	loopback := NewMockConfigSourceNIC(ctrl)
-	loopback.EXPECT().Type().Return(corenetwork.LoopbackDevice)
-	loopback.EXPECT().Name().Return("lo")
-
-	// Default LXD bridge is ignored.
-	lxdbr0 := NewMockConfigSourceNIC(ctrl)
-	lxdbr0.EXPECT().Type().Return(corenetwork.BridgeDevice)
-	lxdbr0.EXPECT().Name().Return(network.DefaultLXDBridge)
-
-	// A unique local-cloud address is used.
-	addr := NewMockConfigSourceAddr(ctrl)
-	addr.EXPECT().IP().Return(net.ParseIP(localCloudIP))
-
-	eth0 := NewMockConfigSourceNIC(ctrl)
-	eth0.EXPECT().Type().Return(corenetwork.EthernetDevice)
-	eth0.EXPECT().Name().Return("eth0")
-	eth0.EXPECT().Addresses().Return([]corenetwork.ConfigSourceAddr{addr}, nil)
-
-	src := NewMockConfigSource(ctrl)
-	src.EXPECT().Interfaces().Return([]corenetwork.ConfigSourceNIC{loopback, lxdbr0, eth0}, nil)
-
-	m := NewNodeManager(NodeManagerConfig{}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
-	m.port = dqlitetesting.FindTCPPort(c)
-
-	opt, err := m.WithPreferredCloudLocalAddressOption(src)
-	c.Assert(err, tc.ErrorIsNil)
-
-	dqliteApp, err := app.New(c.MkDir(), opt)
-
-	// Now it is very unlikely that the machine we are running on just happens
-	// to have the address we've chosen above, but we can verify the correct
-	// behaviour either way.
-	if err != nil {
-		c.Check(err.Error(), tc.Contains, localCloudIP)
-	} else {
-		c.Check(strings.Split(dqliteApp.Address(), ":")[0], tc.Equals, localCloudIP)
-		err = dqliteApp.Close()
-		c.Assert(err, tc.ErrorIsNil)
-	}
 }
 
 // tlsNodeManagerConfig returns a NodeManagerConfig populated with the test
@@ -545,7 +449,7 @@ func tlsNodeManagerConfig() NodeManagerConfig {
 
 func (s *nodeManagerSuite) TestNodeManagerConfigDqlitePort(c *tc.C) {
 	port := dqlitetesting.FindTCPPort(c)
-	m := NewNodeManager(NodeManagerConfig{DqlitePort: port}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{DqlitePort: port}, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("127.0.0.1"))
 	c.Assert(err, tc.ErrorIsNil)
@@ -562,7 +466,7 @@ func (s *nodeManagerSuite) TestNodeManagerConfigDqlitePort(c *tc.C) {
 
 func (s *nodeManagerSuite) TestWithTracingOptionQueryTracingEnabled(c *tc.C) {
 	port := dqlitetesting.FindTCPPort(c)
-	m := NewNodeManager(NodeManagerConfig{QueryTracingEnabled: true}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{QueryTracingEnabled: true}, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	m.port = port
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("127.0.0.1"), m.WithTracingOption(), m.WithLogFuncOption())
@@ -574,7 +478,7 @@ func (s *nodeManagerSuite) TestWithTracingOptionQueryTracingEnabled(c *tc.C) {
 
 func (s *nodeManagerSuite) TestWithBusyTimeoutOption(c *tc.C) {
 	port := dqlitetesting.FindTCPPort(c)
-	m := NewNodeManager(NodeManagerConfig{DqliteBusyTimeout: 5 * time.Second}, true, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
+	m := NewNodeManager(NodeManagerConfig{DqliteBusyTimeout: 5 * time.Second}, loggertesting.WrapCheckLog(c), coredatabase.NoopSlowQueryLogger{})
 	m.port = port
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithAddressOption("127.0.0.1"), m.WithBusyTimeoutOption())

--- a/internal/provider/kubernetes/k8s.go
+++ b/internal/provider/kubernetes/k8s.go
@@ -34,6 +34,7 @@ import (
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/assumes"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/core/status"
 	jujuversion "github.com/juju/juju/core/version"
@@ -998,6 +999,17 @@ func (k *kubernetesClient) Units(ctx context.Context, appName string) ([]caas.Un
 func (k *kubernetesClient) ControllerUnitFQDN(ordinal int) string {
 	podName := fmt.Sprintf("controller-%d", ordinal)
 	return utils.ControllerPodFQDN(podName, k.namespace)
+}
+
+// BootstrapControllerAddresses returns the stable provider addresses for the
+// initial controller.
+func (k *kubernetesClient) BootstrapControllerAddresses(
+	_ context.Context,
+) (network.ProviderAddresses, error) {
+	return network.NewMachineAddresses(
+		[]string{k.ControllerUnitFQDN(0)},
+		network.WithScope(network.ScopeCloudLocal),
+	).AsProviderAddresses(), nil
 }
 
 // ListPods filters a list of pods for the provided namespace and labels.

--- a/internal/provider/kubernetes/k8s_test.go
+++ b/internal/provider/kubernetes/k8s_test.go
@@ -236,6 +236,21 @@ func (s *K8sBrokerSuite) TestControllerUnitFQDN(c *tc.C) {
 	)
 }
 
+func (s *K8sBrokerSuite) TestBootstrapControllerAddresses(c *tc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+
+	addresses, err := s.broker.BootstrapControllerAddresses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(addresses, tc.DeepEquals, network.ProviderAddresses{{
+		MachineAddress: network.MachineAddress{
+			Value: "controller-0.controller-service-endpoints.test.svc.cluster.local",
+			Type:  network.HostName,
+			Scope: network.ScopeCloudLocal,
+		},
+	}})
+}
+
 func (s *K8sBrokerSuite) TestConfig(c *tc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()

--- a/internal/worker/dbaccessor/manifold.go
+++ b/internal/worker/dbaccessor/manifold.go
@@ -202,16 +202,9 @@ func dbAccessorOutput(in worker.Worker, out any) error {
 	return nil
 }
 
-// IAASNodeManager returns a NodeManager that is configured to use
-// the cloud-local TLS terminated address for Dqlite.
-func IAASNodeManager(cfg database.NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
-	return database.NewNodeManager(cfg, false, logger, slowQueryLogger)
-}
-
-// CAASNodeManager returns a NodeManager that is configured to use
-// the loopback address for Dqlite.
-func CAASNodeManager(cfg database.NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
-	return database.NewNodeManager(cfg, true, logger, slowQueryLogger)
+// NewNodeManager returns a NodeManager for a controller Dqlite node.
+func NewNodeManager(cfg database.NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
+	return database.NewNodeManager(cfg, logger, slowQueryLogger)
 }
 
 type clusterDetailer struct {

--- a/internal/worker/dbaccessor/package_mock_test.go
+++ b/internal/worker/dbaccessor/package_mock_test.go
@@ -190,7 +190,6 @@ type MockNodeManagerMockRecorder struct {
 	ensureDataDirExpects         []*gomock.Call0_2[string, error]
 	isExistingNodeExpects        []*gomock.Call0_2[bool, error]
 	isLoopbackBoundExpects       []*gomock.Call1_2[context.Context, bool, error]
-	isLoopbackPreferredExpects   []*gomock.Call0_1[bool]
 	setClusterServersExpects     []*gomock.Call2_1[context.Context, []dqlite.NodeInfo, error]
 	setClusterToLocalNodeExpects []*gomock.Call1_1[context.Context, error]
 	setNodeInfoExpects           []*gomock.Call1_1[dqlite.NodeInfo, error]
@@ -285,24 +284,6 @@ func (mr *MockNodeManagerMockRecorder) IsLoopbackBound(arg0 any) *MockNodeManage
 
 // MockNodeManagerIsLoopbackBoundCall is the typed call wrapper for IsLoopbackBound.
 type MockNodeManagerIsLoopbackBoundCall = gomock.Call1_2[context.Context, bool, error]
-
-// IsLoopbackPreferred mocks base method.
-func (m *MockNodeManager) IsLoopbackPreferred() bool {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch0_1(&m.recorder.isLoopbackPreferredExpects, m.ctrl, m, "IsLoopbackPreferred")
-}
-
-// IsLoopbackPreferred indicates an expected call of IsLoopbackPreferred.
-func (mr *MockNodeManagerMockRecorder) IsLoopbackPreferred() *MockNodeManagerIsLoopbackPreferredCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[bool](mr.mock.ctrl.T, mr.mock, "IsLoopbackPreferred")
-	mr.isLoopbackPreferredExpects = append(mr.isLoopbackPreferredExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockNodeManagerIsLoopbackPreferredCall is the typed call wrapper for IsLoopbackPreferred.
-type MockNodeManagerIsLoopbackPreferredCall = gomock.Call0_1[bool]
 
 // SetClusterServers mocks base method.
 func (m *MockNodeManager) SetClusterServers(arg0 context.Context, arg1 []dqlite.NodeInfo) error {

--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -52,10 +52,6 @@ type NodeManager interface {
 	// Dqlite node in the past.
 	IsExistingNode() (bool, error)
 
-	// IsLoopbackPreferred returns true if the Dqlite application should
-	// be bound to the loopback address.
-	IsLoopbackPreferred() bool
-
 	// IsLoopbackBound returns true if we are a cluster of one,
 	// and bound to the loopback IP address.
 	IsLoopbackBound(context.Context) (bool, error)
@@ -574,33 +570,21 @@ func (w *dbWorker) DeleteDB(namespace string) error {
 // when this host has run a node previously.
 func (w *dbWorker) startExistingDqliteNode(ctx context.Context) error {
 	mgr := w.cfg.NodeManager
-	if mgr.IsLoopbackPreferred() {
+	loopbackBound, err := mgr.IsLoopbackBound(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if loopbackBound {
 		w.cfg.Logger.Infof(ctx, "Dqlite node is configured to bind to the loopback address")
-
 		return errors.Trace(w.initialiseDqlite(ctx))
 	}
 
 	w.cfg.Logger.Infof(ctx, "Dqlite node is configured to bind to a cloud-local address")
-
-	asBootstrapped, err := mgr.IsLoopbackBound(ctx)
+	withTLS, err := mgr.WithTLSOption()
 	if err != nil {
 		return errors.Trace(err)
 	}
-
-	// If this existing node is not as bootstrapped, then it is part of a
-	// cluster. The Dqlite Raft log and configuration in the Dqlite data
-	// directory will indicate the cluster members, but we need to ensure
-	// TLS for traffic between nodes explicitly.
-	var options []app.Option
-	if !asBootstrapped {
-		withTLS, err := mgr.WithTLSOption()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		options = append(options, withTLS)
-	}
-
-	return errors.Trace(w.initialiseDqlite(ctx, options...))
+	return errors.Trace(w.initialiseDqlite(ctx, withTLS))
 }
 
 // initialiseDqlite starts the local Dqlite app node,
@@ -819,30 +803,6 @@ func (w *dbWorker) handleClusterConfigChange(ctx context.Context, noConfigIsFata
 	extant, err := mgr.IsExistingNode()
 	if err != nil {
 		return errors.Trace(err)
-	}
-
-	// If we prefer the loopback address, we shouldn't need to do anything.
-	// We double-check that we are bound to the loopback address. if not,
-	// we bounce the worker and try and resolve that in the next go around.
-	if mgr.IsLoopbackPreferred() {
-		if extant {
-			isLoopbackBound, err := mgr.IsLoopbackBound(ctx)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			// Everything is fine, we're bound to the loopback address and
-			// can return early.
-			if isLoopbackBound {
-				return nil
-			}
-
-			// This should never happen, but we want to be conservative.
-			w.cfg.Logger.Warningf(ctx, "existing Dqlite node is not bound to loopback, but should be; restarting worker")
-		}
-
-		// We don't have a Dqlite node, but somehow we got here, we should just
-		// bounce the worker and try again.
-		return dependency.ErrBounce
 	}
 
 	// If we are an existing node, we need to check whether we must rebind for

--- a/internal/worker/dbaccessor/worker_integration_test.go
+++ b/internal/worker/dbaccessor/worker_integration_test.go
@@ -58,7 +58,7 @@ func (s *integrationSuite) SetUpTest(c *tc.C) {
 	logger := loggertesting.WrapCheckLog(c)
 	nodeManager := database.NewNodeManager(
 		database.NodeManagerConfig{DataDir: s.RootPath()},
-		false, logger, coredatabase.NoopSlowQueryLogger{},
+		logger, coredatabase.NoopSlowQueryLogger{},
 	)
 
 	db, err := s.DBApp().Open(c.Context(), coredatabase.ControllerNS)
@@ -73,7 +73,9 @@ func (s *integrationSuite) SetUpTest(c *tc.C) {
 		runner, logger, schema.ControllerDDL()).Apply(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = database.InsertControllerNodeID(c.Context(), runner, s.DBApp().ID())
+	err = database.InsertControllerNodeID(
+		c.Context(), runner, s.DBApp().ID(), "127.0.0.1",
+	)
 	c.Assert(err, tc.ErrorIsNil)
 
 	w, err := dbaccessor.NewWorker(dbaccessor.WorkerConfig{

--- a/internal/worker/dbaccessor/worker_namespace_test.go
+++ b/internal/worker/dbaccessor/worker_namespace_test.go
@@ -52,7 +52,6 @@ func (s *namespaceSuite) TestEnsureNamespaceForModelNotFound(c *tc.C) {
 	// If this is an existing node, we do not
 	// invoke the address or cluster options.
 	mgrExp.IsExistingNode().Return(true, nil)
-	mgrExp.IsLoopbackPreferred().Return(false)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
@@ -90,7 +89,6 @@ func (s *namespaceSuite) TestEnsureNamespaceForModel(c *tc.C) {
 	// If this is an existing node, we do not
 	// invoke the address or cluster options.
 	mgrExp.IsExistingNode().Return(true, nil)
-	mgrExp.IsLoopbackPreferred().Return(false)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
@@ -114,7 +112,7 @@ func (s *namespaceSuite) TestEnsureNamespaceForModel(c *tc.C) {
 	workertest.CleanKill(c, dbw)
 }
 
-func (s *namespaceSuite) TestEnsureNamespaceForModelLoopbackPreferred(c *tc.C) {
+func (s *namespaceSuite) TestEnsureNamespaceForLoopbackBoundModel(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
@@ -126,8 +124,7 @@ func (s *namespaceSuite) TestEnsureNamespaceForModelLoopbackPreferred(c *tc.C) {
 	// If this is an existing node, we do not
 	// invoke the address or cluster options.
 	mgrExp.IsExistingNode().Return(true, nil)
-	mgrExp.IsLoopbackPreferred().Return(true)
-	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(1)
+	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
 	mgrExp.WithBusyTimeoutOption().Return(nil)
@@ -162,7 +159,6 @@ func (s *namespaceSuite) TestEnsureNamespaceForModelWithCache(c *tc.C) {
 	// If this is an existing node, we do not
 	// invoke the address or cluster options.
 	mgrExp.IsExistingNode().Return(true, nil)
-	mgrExp.IsLoopbackPreferred().Return(false)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
@@ -228,7 +224,6 @@ func (s *namespaceSuite) TestCloseDatabaseForController(c *tc.C) {
 	// If this is an existing node, we do not
 	// invoke the address or cluster options.
 	mgrExp.IsExistingNode().Return(true, nil)
-	mgrExp.IsLoopbackPreferred().Return(false)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
@@ -264,7 +259,6 @@ func (s *namespaceSuite) TestCloseDatabaseForModel(c *tc.C) {
 	// If this is an existing node, we do not
 	// invoke the address or cluster options.
 	mgrExp.IsExistingNode().Return(true, nil)
-	mgrExp.IsLoopbackPreferred().Return(false)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
@@ -295,7 +289,7 @@ func (s *namespaceSuite) TestCloseDatabaseForModel(c *tc.C) {
 	workertest.CleanKill(c, dbw)
 }
 
-func (s *namespaceSuite) TestCloseDatabaseForModelLoopbackPreferred(c *tc.C) {
+func (s *namespaceSuite) TestCloseDatabaseForLoopbackBoundModel(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectClock()
@@ -307,8 +301,7 @@ func (s *namespaceSuite) TestCloseDatabaseForModelLoopbackPreferred(c *tc.C) {
 	// If this is an existing node, we do not
 	// invoke the address or cluster options.
 	mgrExp.IsExistingNode().Return(true, nil)
-	mgrExp.IsLoopbackPreferred().Return(true)
-	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(1)
+	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
 	mgrExp.WithBusyTimeoutOption().Return(nil)
@@ -354,7 +347,6 @@ func (s *namespaceSuite) TestDeleteDatabaseForUnknownModel(c *tc.C) {
 	// If this is an existing node, we do not
 	// invoke the address or cluster options.
 	mgrExp.IsExistingNode().Return(true, nil)
-	mgrExp.IsLoopbackPreferred().Return(false)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)

--- a/internal/worker/dbaccessor/worker_test.go
+++ b/internal/worker/dbaccessor/worker_test.go
@@ -72,7 +72,6 @@ func (s *workerSuite) TestKilledGetDBErrDying(c *tc.C) {
 	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
 	mgrExp.IsExistingNode().Return(true, nil).Times(1)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2)
-	mgrExp.IsLoopbackPreferred().Return(false)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
 	mgrExp.WithBusyTimeoutOption().Return(nil)
@@ -109,7 +108,6 @@ func (s *workerSuite) TestStartupTimeoutSingleControllerReconfigure(c *tc.C) {
 	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
 	mgrExp.IsExistingNode().Return(true, nil).Times(2)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(false, nil).Times(3)
-	mgrExp.IsLoopbackPreferred().Return(false).Times(2)
 	mgrExp.WithTLSOption().Return(nil, nil)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
@@ -146,7 +144,6 @@ func (s *workerSuite) TestStartupTimeoutMultipleControllerRetry(c *tc.C) {
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(false, nil).Times(4)
 
 	// We expect 1 attempt to start and 2 attempts to reconfigure.
-	mgrExp.IsLoopbackPreferred().Return(false).Times(3)
 
 	// We expect 2 attempts to start.
 	mgrExp.WithTLSOption().Return(nil, nil).Times(2)
@@ -201,7 +198,6 @@ func (s *workerSuite) TestStartupNotExistingNodeThenCluster(c *tc.C) {
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(false, nil)
 
 	// Expects 1 attempt to start and 2 attempts to reconfigure.
-	mgrExp.IsLoopbackPreferred().Return(false).Times(3)
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
 
@@ -295,7 +291,6 @@ func (s *workerSuite) TestWorkerStartupExistingNode(c *tc.C) {
 	// and at shutdown when checking for handover.
 	mgrExp.IsExistingNode().Return(true, nil).MinTimes(1)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(false, nil).MinTimes(1)
-	mgrExp.IsLoopbackPreferred().Return(false).MinTimes(1)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTLSOption().Return(nil, nil)
 	mgrExp.WithTracingOption().Return(nil)
@@ -323,7 +318,7 @@ func (s *workerSuite) TestWorkerStartupExistingNode(c *tc.C) {
 	ensureStartup(c, w.(*dbWorker))
 }
 
-func (s *workerSuite) TestWorkerStartupExistingNodeWithLoopbackPreferred(c *tc.C) {
+func (s *workerSuite) TestWorkerStartupExistingLoopbackBoundNode(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	dbDone := make(chan struct{})
@@ -341,7 +336,6 @@ func (s *workerSuite) TestWorkerStartupExistingNodeWithLoopbackPreferred(c *tc.C
 	// We don't expect a handover, because we're not rebinding.
 	mgrExp.IsExistingNode().Return(true, nil).MinTimes(1)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).MinTimes(1)
-	mgrExp.IsLoopbackPreferred().Return(false).MinTimes(1)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
 	mgrExp.WithBusyTimeoutOption().Return(nil)
@@ -378,7 +372,6 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeSingleServerNoRebind(c *tc
 	// invoke the address or cluster options.
 	mgrExp.IsExistingNode().Return(true, nil).MinTimes(1)
 	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(4)
-	mgrExp.IsLoopbackPreferred().Return(false).Times(3)
 	mgrExp.WithLogFuncOption().Return(nil)
 	mgrExp.WithTracingOption().Return(nil)
 	mgrExp.WithBusyTimeoutOption().Return(nil)
@@ -444,7 +437,6 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigure(c *tc.C) {
 	// If this is an existing node, we do not
 	// invoke the address or cluster options.
 	mgrExp.IsExistingNode().Return(true, nil).Times(2)
-	mgrExp.IsLoopbackPreferred().Return(false).Times(2)
 	gomock.InOrder(
 		mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2),
 		// This is the check at shutdown.
@@ -520,7 +512,7 @@ func (s *workerSuite) newWorker(c *tc.C) worker.Worker {
 	return s.newWorkerWithDB(c, s.trackedDB)
 }
 
-func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigureWithLoopbackPreferred(c *tc.C) {
+func (s *workerSuite) TestWorkerStartupExistingDNSBoundSingleMemberRemainsRunning(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	dbDone := make(chan struct{})
@@ -531,17 +523,17 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigureWithLoopbac
 	mgrExp := s.nodeManager.EXPECT()
 	mgrExp.EnsureDataDir().Return(dataDir, nil).MinTimes(1)
 	mgrExp.WithLogFuncOption().Return(nil)
+	mgrExp.WithTLSOption().Return(nil, nil)
 	mgrExp.WithTracingOption().Return(nil)
 	mgrExp.WithBusyTimeoutOption().Return(nil)
 
-	// If this is a loopback preferred node, we do not invoke the TLS or
-	// cluster options.
+	// A DNS-bound node starts with TLS and without cluster options.
 	mgrExp.IsExistingNode().Return(true, nil).Times(2)
-	mgrExp.IsLoopbackPreferred().Return(true).Times(2)
-	mgrExp.IsLoopbackBound(gomock.Any()).Return(true, nil).Times(2)
+	mgrExp.IsLoopbackBound(gomock.Any()).Return(false, nil).Times(3)
 
 	// Ensure that we expect a clean startup and shutdown.
 	s.expectNodeStartupAndShutdown()
+	s.dbApp.EXPECT().Handover(gomock.Any()).Return(nil)
 
 	// First time though, there is no config, then we get a
 	// notification for a change on disk.
@@ -550,7 +542,9 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigureWithLoopbac
 
 	gomock.InOrder(
 		s.clusterConfig.EXPECT().DBBindAddresses().Return(nil, errors.New("not there")),
-		s.clusterConfig.EXPECT().DBBindAddresses().Return(map[string]string{"0": "10.6.6.6"}, nil),
+		s.clusterConfig.EXPECT().DBBindAddresses().Return(map[string]string{
+			"0": "controller-0.controller-service-endpoints.test.svc.cluster.local",
+		}, nil),
 	)
 
 	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
@@ -565,11 +559,8 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigureWithLoopbac
 
 	ensureStartup(c, dbw)
 
-	// At this point we have started successfully.
-	// Push a config change notification to simulate a move into HA.
-	// Notice the absence of expected calls to [Set]ClusterServer
-	// and SetNodeInfo methods, because we eschew reconfiguration when
-	// loopback binding is preferred.
+	// At this point we have started successfully. Push a single-member config
+	// change notification and ensure that the worker stays running.
 	select {
 	case ch <- struct{}{}:
 	case <-time.After(testhelpers.LongWait):

--- a/internal/worker/dbreplaccessor/manifold.go
+++ b/internal/worker/dbreplaccessor/manifold.go
@@ -138,14 +138,7 @@ func dbAccessorOutput(in worker.Worker, out any) error {
 	return nil
 }
 
-// IAASNodeManager returns a NodeManager that is configured to use
-// the cloud-local TLS terminated address for Dqlite.
-func IAASNodeManager(cfg database.NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
-	return database.NewNodeManager(cfg, false, logger, slowQueryLogger)
-}
-
-// CAASNodeManager returns a NodeManager that is configured to use
-// the loopback address for Dqlite.
-func CAASNodeManager(cfg database.NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
-	return database.NewNodeManager(cfg, true, logger, slowQueryLogger)
+// NewNodeManager returns a NodeManager for a controller Dqlite node.
+func NewNodeManager(cfg database.NodeManagerConfig, logger logger.Logger, slowQueryLogger coredatabase.SlowQueryLogger) NodeManager {
+	return database.NewNodeManager(cfg, logger, slowQueryLogger)
 }


### PR DESCRIPTION
Introduce a provider-level bootstrap address finder so the bootstrap command no longer contains substrate-specific address discovery. Instance-backed providers reuse InstanceLister, while Kubernetes supplies the stable controller-0 FQDN with local-cloud scope.

Pass provider addresses through AgentBootstrap into the common Dqlite initializer. Resolve a unique provider address first, fall back to filtered local interfaces, and finally loopback when discovery is absent or ambiguous. Use the selected hostname or IP for both Dqlite startup and controller_node persistence, with TLS enabled consistently during bootstrap.

Remove the loopback-preference flag from node managers and accessor interfaces. Runtime startup now derives TLS behavior from the persisted Dqlite cluster binding, and all IAAS and CAAS manifolds use the same node-manager constructor and reconciliation path.

Add provider, resolver, bootstrap propagation, persistence, Kubernetes FQDN, and DNS-bound accessor coverage, and regenerate the affected db-accessor mock.

NOTE: My agent ended up going down a different path to what I expected, but I think I am happy with where it has taken me

## QA steps

```
$ juju bootstrap minikube mini

$ kubectl exec -n controller-mini controller-0 -c api-server -- \
    cat /var/lib/juju/dqlite/info.yaml

$ kubectl exec -n controller-mini controller-0 -c api-server -- \
    cat /var/lib/juju/dqlite/cluster.yaml
```

  Expected in both:
```
  Address: controller-0.controller-service-endpoints.controller-mini.svc.cluster.local:17666
```