### PR TITLE
test: fix flaky tests

### DIFF
--- a/internal/changestream/eventmultiplexer/eventmultiplexer_test.go
+++ b/internal/changestream/eventmultiplexer/eventmultiplexer_test.go
@@ -301,11 +301,15 @@ func (s *eventMultiplexerSuite) TestSubscriptionDoneWhenEventQueueKilled(c *tc.C
 	s.stream.EXPECT().Terms().Return(terms).MinTimes(1)
 
 	s.metrics.EXPECT().SubscriptionsInc()
-	s.metrics.EXPECT().SubscriptionsDec()
+	// There is a race between loop select completion and worker Kill.
+	// Killing the worker kills the subs attached to its catacomb,
+	// so they might or might not be dead when we come back to the top
+	// of the loop and clean up.
+	s.metrics.EXPECT().SubscriptionsDec().MaxTimes(1)
 	s.clock.EXPECT().Now().MinTimes(1)
 	// We might encounter a dispatch error, therefore we cannot hard-code
 	// a false on the second argument of DispatchDurationObserve.
-	s.metrics.EXPECT().DispatchDurationObserve(gomock.Any(), gomock.Any())
+	s.metrics.EXPECT().DispatchDurationObserve(gomock.Any(), gomock.Any()).MaxTimes(1)
 
 	queue, err := New(s.stream, s.clock, s.metrics, loggertesting.WrapCheckLog(c), 0)
 	c.Assert(err, tc.ErrorIsNil)
@@ -779,6 +783,11 @@ func (s *eventMultiplexerSuite) TestReportWithTopicSubscriptions(c *tc.C) {
 	s.clock.EXPECT().Now().AnyTimes()
 
 	s.metrics.EXPECT().SubscriptionsInc().Times(10)
+	// There is a race between loop select completion and worker Kill.
+	// Killing the worker kills the subs attached to its catacomb,
+	// so they might or might not be dead when we come back to the top
+	// of the loop and clean up.
+	s.metrics.EXPECT().SubscriptionsDec().AnyTimes()
 
 	queue, err := New(s.stream, s.clock, s.metrics, loggertesting.WrapCheckLog(c), 0)
 	c.Assert(err, tc.ErrorIsNil)
@@ -813,6 +822,11 @@ func (s *eventMultiplexerSuite) TestReportWithMultipleTopicSubscriptions(c *tc.C
 	s.clock.EXPECT().Now().AnyTimes()
 
 	s.metrics.EXPECT().SubscriptionsInc().Times(10)
+	// There is a race between loop select completion and worker Kill.
+	// Killing the worker kills the subs attached to its catacomb,
+	// so they might or might not be dead when we come back to the top
+	// of the loop and clean up.
+	s.metrics.EXPECT().SubscriptionsDec().AnyTimes()
 
 	queue, err := New(s.stream, s.clock, s.metrics, loggertesting.WrapCheckLog(c), 0)
 	c.Assert(err, tc.ErrorIsNil)
@@ -851,6 +865,11 @@ func (s *eventMultiplexerSuite) TestReportWithDuplicateTopicSubscriptions(c *tc.
 	s.clock.EXPECT().Now().AnyTimes()
 
 	s.metrics.EXPECT().SubscriptionsInc().Times(10)
+	// There is a race between loop select completion and worker Kill.
+	// Killing the worker kills the subs attached to its catacomb,
+	// so they might or might not be dead when we come back to the top
+	// of the loop and clean up.
+	s.metrics.EXPECT().SubscriptionsDec().AnyTimes()
 
 	queue, err := New(s.stream, s.clock, s.metrics, loggertesting.WrapCheckLog(c), 0)
 	c.Assert(err, tc.ErrorIsNil)
@@ -889,6 +908,11 @@ func (s *eventMultiplexerSuite) TestReportWithMultipleDuplicateTopicSubscription
 	s.clock.EXPECT().Now().AnyTimes()
 
 	s.metrics.EXPECT().SubscriptionsInc().Times(10)
+	// There is a race between loop select completion and worker Kill.
+	// Killing the worker kills the subs attached to its catacomb,
+	// so they might or might not be dead when we come back to the top
+	// of the loop and clean up.
+	s.metrics.EXPECT().SubscriptionsDec().AnyTimes()
 
 	queue, err := New(s.stream, s.clock, s.metrics, loggertesting.WrapCheckLog(c), 0)
 	c.Assert(err, tc.ErrorIsNil)

--- a/internal/changestream/testing/changestream.go
+++ b/internal/changestream/testing/changestream.go
@@ -150,6 +150,11 @@ func (h *TestWatchableDB) loop() error {
 
 // assertChangeStreamIdle waits for either the change stream to quickly dispatch
 // some changes or become idle before the deadline.
+//
+// The timer always resets to LongWait after receiving a dispatch state.
+// Deriving a timeout from the test deadline (c.Deadline()) is avoided because
+// under go test's default 10m deadline this would produce ~9m30s timers that
+// prevent timely failure reporting.
 func assertChangeStreamIdle(c *tc.C, label string, states <-chan []string) {
 	timer := time.NewTimer(coretesting.LongWait)
 	for {
@@ -160,16 +165,7 @@ func assertChangeStreamIdle(c *tc.C, label string, states <-chan []string) {
 				case stateIdle:
 					return
 				case stateDispatch:
-					next := coretesting.LongWait
-					if deadline, ok := c.Deadline(); ok {
-						next = time.Until(deadline) - coretesting.LongWait
-					}
-					// Clamp to a positive value so the timer does not
-					// fire immediately when the deadline is near.
-					if next <= 0 {
-						next = time.Second
-					}
-					timer.Reset(next)
+					timer.Reset(coretesting.LongWait)
 				}
 			}
 		case <-timer.C:


### PR DESCRIPTION
This PR fixes 2 separate flaky tests:

**Fix 1: TestReportWithDuplicateTopicSubscriptions** — missing SubscriptionsDec mock expectation

The EventMultiplexer's cleanupDeadSubscriptions can race with the catacomb's
shutdown goroutines during Kill, causing an unexpected SubscriptionsDec() call
to gomock. When gomock fatals from a non-test goroutine, runtime.Goexit
terminates the tomb goroutine without closing the dead channel, causing
CleanKill to hang forever.

**Fix 2: TestWatchCharm** — assertChangeStreamIdle hung due to deadline-based timer reset

The assertChangeStreamIdle function reset its internal timer based on the test
deadline after receiving a dispatch state from the change stream. Under go test
(10m deadline), this produced a ~9m50s timer that prevented timely failure when
the stream failed to reach idle, causing the global test timeout to fire
instead. The timer now always resets to LongWait.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ go test -c -race ./internal/changestream/eventmultiplexer
❯ timeout 121 stress -timeout 120s ./eventmultiplexer.test
```

```sh
❯ go test -c -race ./domain/application
❯ timeout 121 stress -timeout 120s ./application.test
```

## Documentation changes

## Links

