### PR TITLE
fix(provisioner): emit URLs for all API addresses in FindTools

### DIFF
--- a/internal/worker/computeprovisioner/provisioner_adapters.go
+++ b/internal/worker/computeprovisioner/provisioner_adapters.go
@@ -331,6 +331,12 @@ func (a *toolsFinderAdapter) FindTools(
 	osType string,
 	arch string,
 ) (coretools.List, error) {
+	filter := coretools.Filter{
+		Number: v,
+		OSType: osType,
+		Arch:   arch,
+	}
+
 	var baseList coretools.List
 
 	// Check local agent storage first (same as server-side
@@ -354,11 +360,6 @@ func (a *toolsFinderAdapter) FindTools(
 				SHA256:  m.SHA256,
 			})
 		}
-		filter := coretools.Filter{
-			Number: v,
-			OSType: osType,
-			Arch:   arch,
-		}
 		matched, matchErr := storageList.Match(filter)
 		if matchErr == nil && len(matched) > 0 {
 			baseList = matched
@@ -368,11 +369,6 @@ func (a *toolsFinderAdapter) FindTools(
 	// Fall back to simplestreams when agent-binary storage has no match.
 	if len(baseList) == 0 {
 		finder := a.agentBinarySvc.GetEnvironAgentBinariesFinder()
-		filter := coretools.Filter{
-			Number: v,
-			OSType: osType,
-			Arch:   arch,
-		}
 		streamList, streamErr := finder(ctx, v.Major, v.Minor, v, "", filter)
 		if streamErr != nil {
 			return nil, errors.Trace(streamErr)
@@ -401,6 +397,7 @@ func (a *toolsFinderAdapter) FindTools(
 	for _, baseTools := range baseList {
 		for _, addr := range addrs {
 			tools := *baseTools // copy — don't mutate the shared pointer
+			// TODO(#22910): use url.URL + url.JoinPath instead of Sprintf.
 			serverRoot := fmt.Sprintf("https://%s/model/%s", addr, a.modelUUID)
 			tools.URL = fmt.Sprintf("%s/tools/%s", serverRoot, tools.Version.String())
 			fullList = append(fullList, &tools)

--- a/internal/worker/computeprovisioner/provisioner_adapters.go
+++ b/internal/worker/computeprovisioner/provisioner_adapters.go
@@ -320,13 +320,21 @@ type toolsFinderAdapter struct {
 }
 
 // FindTools implements ToolsFinder.
+//
+// It mirrors the server-side FindAgents + ToolsURLs logic from
+// apiserver/common/tools.go: matched tools from agent-binary storage (or
+// simplestreams fallback) are expanded into one entry per API address so the
+// cloud-init template can cycle through all addresses on download failure.
 func (a *toolsFinderAdapter) FindTools(
 	ctx context.Context,
 	v semversion.Number,
 	osType string,
 	arch string,
 ) (coretools.List, error) {
-	// Check local agent storage first (same as server-side matchingStorageAgent).
+	var baseList coretools.List
+
+	// Check local agent storage first (same as server-side
+	// matchingStorageAgent).
 	allMetadata, err := a.agentBinarySvc.ListAgentBinaries(ctx)
 	if err == nil {
 		var storageList coretools.List
@@ -353,26 +361,52 @@ func (a *toolsFinderAdapter) FindTools(
 		}
 		matched, matchErr := storageList.Match(filter)
 		if matchErr == nil && len(matched) > 0 {
-			// Generate URLs pointing at the API server for local tools.
-			addrs, addrErr := a.ctrlNodeSvc.GetAllAPIAddressesForAgents(ctx)
-			if addrErr == nil && len(addrs) > 0 {
-				for _, t := range matched {
-					serverRoot := fmt.Sprintf("https://%s/model/%s", addrs[0], a.modelUUID)
-					t.URL = fmt.Sprintf("%s/tools/%s", serverRoot, t.Version.String())
-				}
-				return matched, nil
-			}
+			baseList = matched
 		}
 	}
 
-	// Fall back to simplestreams.
-	finder := a.agentBinarySvc.GetEnvironAgentBinariesFinder()
-	filter := coretools.Filter{
-		Number: v,
-		OSType: osType,
-		Arch:   arch,
+	// Fall back to simplestreams when agent-binary storage has no match.
+	if len(baseList) == 0 {
+		finder := a.agentBinarySvc.GetEnvironAgentBinariesFinder()
+		filter := coretools.Filter{
+			Number: v,
+			OSType: osType,
+			Arch:   arch,
+		}
+		streamList, streamErr := finder(ctx, v.Major, v.Minor, v, "", filter)
+		if streamErr != nil {
+			return nil, errors.Trace(streamErr)
+		}
+		baseList = streamList
 	}
-	return finder(ctx, v.Major, v.Minor, v, "", filter)
+
+	if len(baseList) == 0 {
+		return nil, coretools.ErrNoMatches
+	}
+
+	// Rewrite URLs to point at the API server, producing one entry per
+	// (tool, address) pair — same as FindAgents -> ToolsURLs on the server
+	// side. This ensures the cloud-init download script cycles through all
+	// API addresses and can fall back from unreachable private IPs to public
+	// ones.
+	addrs, addrErr := a.ctrlNodeSvc.GetAllAPIAddressesForAgents(ctx)
+	if addrErr != nil {
+		return nil, errors.Annotate(addrErr, "getting API addresses for tools URLs")
+	}
+	if len(addrs) == 0 {
+		return nil, errors.New("no suitable API server address to pick from")
+	}
+
+	var fullList coretools.List
+	for _, baseTools := range baseList {
+		for _, addr := range addrs {
+			tools := *baseTools // copy — don't mutate the shared pointer
+			serverRoot := fmt.Sprintf("https://%s/model/%s", addr, a.modelUUID)
+			tools.URL = fmt.Sprintf("%s/tools/%s", serverRoot, tools.Version.String())
+			fullList = append(fullList, &tools)
+		}
+	}
+	return fullList, nil
 }
 
 // distributionGroupFinderAdapter implements DistributionGroupFinder using

--- a/internal/worker/computeprovisioner/provisioner_adapters_test.go
+++ b/internal/worker/computeprovisioner/provisioner_adapters_test.go
@@ -266,6 +266,42 @@ func (s *ProvisionerAdaptersSuite) TestFindToolsSimplestreamsFinderErrorPropagat
 	c.Check(err.Error(), tc.Contains, "streams down")
 }
 
+func (s *ProvisionerAdaptersSuite) TestFindToolsListAgentBinariesErrorFallsBackToSimplestreams(c *tc.C) {
+	addrs := []string{"10.0.0.1:17070", "public.example.com:17070"}
+	v := semversion.MustParse("4.0.0")
+
+	adapter := &toolsFinderAdapter{
+		agentBinarySvc: &fakeAgentBinaryService{
+			metadata: nil,
+			listErr:  errors.New("storage down"),
+			finderFunc: func(
+				ctx context.Context,
+				major, minor int,
+				version semversion.Number,
+				requestedStream string,
+				filter coretools.Filter,
+			) (coretools.List, error) {
+				binVer := semversion.Binary{Number: v, Arch: "amd64", Release: "ubuntu"}
+				return coretools.List{&coretools.Tools{
+					Version: binVer,
+					URL:     "https://streams.internal/juju-tools-4.0.0.tgz",
+				}}, nil
+			},
+		},
+		ctrlNodeSvc: &fakeControllerNodeService{addrs: addrs},
+		modelUUID:   "model-uuid",
+	}
+
+	result, err := adapter.FindTools(c.Context(), v, "ubuntu", "amd64")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.HasLen, 2)
+
+	for i, addr := range addrs {
+		want := fmt.Sprintf("https://%s/model/model-uuid/tools/4.0.0-ubuntu-amd64", addr)
+		c.Check(result[i].URL, tc.Equals, want)
+	}
+}
+
 func (s *ProvisionerAdaptersSuite) TestFindToolsNoAddressesReturnsError(c *tc.C) {
 	adapter := &toolsFinderAdapter{
 		agentBinarySvc: &fakeAgentBinaryService{

--- a/internal/worker/computeprovisioner/provisioner_adapters_test.go
+++ b/internal/worker/computeprovisioner/provisioner_adapters_test.go
@@ -5,6 +5,7 @@ package computeprovisioner
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/juju/errors"
@@ -14,9 +15,13 @@ import (
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/instance"
 	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/semversion"
 	corestatus "github.com/juju/juju/core/status"
+	"github.com/juju/juju/domain/agentbinary"
+	agentbinaryservice "github.com/juju/juju/domain/agentbinary/service"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	provisioning "github.com/juju/juju/domain/provisioner"
+	coretools "github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -144,3 +149,180 @@ var _ ProvisionerDomainService = (*fakeProvisionerService)(nil)
 var _ ControllerConfigService = fakeControllerConfigService{}
 var _ ModelInfoService = fakeModelInfoService{}
 var _ StatusDomainService = (*fakeStatusService)(nil)
+
+// --- FindTools fakes ---
+
+type fakeAgentBinaryService struct {
+	metadata   []agentbinary.Metadata
+	listErr    error
+	finderFunc agentbinaryservice.EnvironAgentBinariesFinderFunc
+}
+
+func (f *fakeAgentBinaryService) ListAgentBinaries(ctx context.Context) ([]agentbinary.Metadata, error) {
+	return f.metadata, f.listErr
+}
+
+func (f *fakeAgentBinaryService) GetEnvironAgentBinariesFinder() agentbinaryservice.EnvironAgentBinariesFinderFunc {
+	return f.finderFunc
+}
+
+type fakeControllerNodeService struct {
+	addrs    []string
+	addrsErr error
+}
+
+func (f *fakeControllerNodeService) GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error) {
+	return f.addrs, f.addrsErr
+}
+
+var _ AgentBinaryDomainService = (*fakeAgentBinaryService)(nil)
+var _ ControllerNodeService = (*fakeControllerNodeService)(nil)
+
+// --- FindTools tests ---
+
+func (s *ProvisionerAdaptersSuite) TestFindToolsEmitsOneEntryPerAPIAddress(c *tc.C) {
+	addrs := []string{"10.0.0.1:17070", "52.1.2.3:17070", "localhost:17070"}
+	adapter := &toolsFinderAdapter{
+		agentBinarySvc: &fakeAgentBinaryService{
+			metadata: []agentbinary.Metadata{{
+				Version: "4.0.0",
+				Arch:    "amd64",
+				Size:    1024,
+				SHA256:  "abc123",
+			}},
+		},
+		ctrlNodeSvc: &fakeControllerNodeService{addrs: addrs},
+		modelUUID:   "test-uuid",
+	}
+
+	result, err := adapter.FindTools(c.Context(), semversion.MustParse("4.0.0"), "ubuntu", "amd64")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.HasLen, 3)
+
+	for i, addr := range addrs {
+		want := fmt.Sprintf("https://%s/model/test-uuid/tools/4.0.0-ubuntu-amd64", addr)
+		c.Check(result[i].URL, tc.Equals, want)
+	}
+}
+
+func (s *ProvisionerAdaptersSuite) TestFindToolsSimplestreamsFallbackRewritesURLs(c *tc.C) {
+	addrs := []string{"10.0.0.1:17070", "public.example.com:17070"}
+	v := semversion.MustParse("4.0.0")
+
+	adapter := &toolsFinderAdapter{
+		agentBinarySvc: &fakeAgentBinaryService{
+			// Storage empty — triggers simplestreams fallback.
+			metadata: nil,
+			finderFunc: func(
+				ctx context.Context,
+				major, minor int,
+				version semversion.Number,
+				requestedStream string,
+				filter coretools.Filter,
+			) (coretools.List, error) {
+				binVer := semversion.Binary{Number: v, Arch: "amd64", Release: "ubuntu"}
+				return coretools.List{&coretools.Tools{
+					Version: binVer,
+					URL:     "https://streams.internal/juju-tools-4.0.0.tgz",
+				}}, nil
+			},
+		},
+		ctrlNodeSvc: &fakeControllerNodeService{addrs: addrs},
+		modelUUID:   "model-uuid",
+	}
+
+	result, err := adapter.FindTools(c.Context(), v, "ubuntu", "amd64")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.HasLen, 2)
+
+	for i, addr := range addrs {
+		want := fmt.Sprintf("https://%s/model/model-uuid/tools/4.0.0-ubuntu-amd64", addr)
+		c.Check(result[i].URL, tc.Equals, want)
+	}
+}
+
+func (s *ProvisionerAdaptersSuite) TestFindToolsSimplestreamsFinderErrorPropagates(c *tc.C) {
+	v := semversion.MustParse("4.0.0")
+	adapter := &toolsFinderAdapter{
+		agentBinarySvc: &fakeAgentBinaryService{
+			finderFunc: func(
+				ctx context.Context,
+				major, minor int,
+				version semversion.Number,
+				requestedStream string,
+				filter coretools.Filter,
+			) (coretools.List, error) {
+				return nil, errors.New("streams down")
+			},
+		},
+		ctrlNodeSvc: &fakeControllerNodeService{
+			addrs: []string{"10.0.0.1:17070"},
+		},
+		modelUUID: "test-uuid",
+	}
+
+	_, err := adapter.FindTools(c.Context(), v, "ubuntu", "amd64")
+	c.Assert(err, tc.NotNil)
+	c.Check(err.Error(), tc.Contains, "streams down")
+}
+
+func (s *ProvisionerAdaptersSuite) TestFindToolsNoAddressesReturnsError(c *tc.C) {
+	adapter := &toolsFinderAdapter{
+		agentBinarySvc: &fakeAgentBinaryService{
+			metadata: []agentbinary.Metadata{{
+				Version: "4.0.0",
+				Arch:    "amd64",
+			}},
+		},
+		ctrlNodeSvc: &fakeControllerNodeService{addrs: nil},
+		modelUUID:   "test-uuid",
+	}
+
+	_, err := adapter.FindTools(c.Context(), semversion.MustParse("4.0.0"), "ubuntu", "amd64")
+	c.Assert(err, tc.NotNil)
+	c.Check(err.Error(), tc.Contains, "no suitable API server address")
+}
+
+func (s *ProvisionerAdaptersSuite) TestFindToolsGetAddressesErrorReturnsError(c *tc.C) {
+	adapter := &toolsFinderAdapter{
+		agentBinarySvc: &fakeAgentBinaryService{
+			metadata: []agentbinary.Metadata{{
+				Version: "4.0.0",
+				Arch:    "amd64",
+			}},
+		},
+		ctrlNodeSvc: &fakeControllerNodeService{
+			addrsErr: errors.New("controller db down"),
+		},
+		modelUUID: "test-uuid",
+	}
+
+	_, err := adapter.FindTools(c.Context(), semversion.MustParse("4.0.0"), "ubuntu", "amd64")
+	c.Assert(err, tc.NotNil)
+	c.Check(err.Error(), tc.Contains, "controller db down")
+	c.Check(err.Error(), tc.Contains, "getting API addresses")
+}
+
+func (s *ProvisionerAdaptersSuite) TestFindToolsDoesNotMutateSharedPointers(c *tc.C) {
+	addrs := []string{"addr1:17070", "addr2:17070"}
+	adapter := &toolsFinderAdapter{
+		agentBinarySvc: &fakeAgentBinaryService{
+			metadata: []agentbinary.Metadata{{
+				Version: "4.0.0",
+				Arch:    "amd64",
+				Size:    2048,
+				SHA256:  "deadbeef",
+			}},
+		},
+		ctrlNodeSvc: &fakeControllerNodeService{addrs: addrs},
+		modelUUID:   "test-uuid",
+	}
+
+	result, err := adapter.FindTools(c.Context(), semversion.MustParse("4.0.0"), "ubuntu", "amd64")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.HasLen, 2)
+
+	// Mutating one result should not affect the other.
+	result[0].URL = "tampered"
+	c.Check(result[1].URL, tc.Not(tc.Equals), "tampered")
+}


### PR DESCRIPTION
## Why this change is needed and what it does

`toolsFinderAdapter.FindTools` in `internal/worker/computeprovisioner/provisioner_adapters.go`
uses `addrs[0]` (the first API address) when constructing download URLs for tools.
This means the cloud-init download script only gets a single URL — typically the
cloud-local/private address. Machines in other VNets that cannot reach the
private IP are stuck retrying forever.

When the simplestreams fallback path was taken, raw simplestreams URLs were
returned with no URL rewriting at all.

Both behaviours diverge from the server-side `FindAgents`→`ToolsURLs` logic,
which iterates **all** API addresses and produces one tools entry per address.
The cloud-init template renders one `curl` per URL with sequential fallback,
so a single URL means no fallback is possible.

This fix makes the adapter:

- Expand matched tools from agent-binary storage to one entry per API address
  (was `addrs[0]` only)
- Rewrite simplestreams-fallback tools to point at the API server and similarly
  expand them (was returning raw simplestreams URLs)
- Return an error when address lookup fails or returns no addresses instead of
  silently proceeding
- Safely copy shared pointers per entry to prevent aliasing
- Deduplicate the `coretools.Filter` construction (feedback from #22905 review)

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you are testing
- ~Integration tests~
- ~doc.go added or updated in changed packages~

## QA steps

This bug was discovered while working on #22758 — the Azure dual-stack NSG
firewaller PR. The warning block in that PR describes the issue; this PR is the
fix.

> [!WARNING]
> After merging, the warning block in #22758 should be updated to note that this
> PR fixes the connectivity issue described there.

1. Bootstrap a controller on Azure:
```sh
juju bootstrap azure
```

2. Add a model and a machine:
```sh
juju add-model test
juju add-machine
```

3. **Without the fix**: the machine never reports and stays in a pending state
   (the cloud-init tool download script has only the private address and cannot
   reach it from the new machine's VNet).

4. **With the fix**: the machine eventually starts — the download script cycles
   through all API addresses (including the public one) and succeeds.

## Follow-ups

- [#22910](https://github.com/juju/juju/issues/22910) — replace `fmt.Sprintf` URL construction with `url.URL` + `url.JoinPath` in both the worker adapter and the server-side `ToolsURL` helper.

## Links

**Issue:** Fixes #22906
**JIRA:** [JUJU-10167](https://warthogs.atlassian.net/browse/JUJU-10167)

[JUJU-10167]: https://warthogs.atlassian.net/browse/JUJU-10167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ