### PR TITLE
fix: link loki to tempo

### DIFF
--- a/core/trace/context.go
+++ b/core/trace/context.go
@@ -131,6 +131,31 @@ func TraceIDFromContext(ctx context.Context) (string, bool) {
 	return traceID, ok && traceID != ""
 }
 
+// TraceIDAndSpanIDFromContext returns the traceID and spanID from the context.
+// The traceID is required, but the spanID is optional. If the traceID is not
+// found, then both will be empty and false will be returned. If the traceID is
+// found, but the spanID is not, then the spanID will be empty and true will be
+// returned.
+func TraceIDAndSpanIDFromContext(ctx context.Context) (string, string, bool) {
+	trace := ctx.Value(traceIDContextKey)
+	if trace == nil {
+		return "", "", false
+	}
+
+	traceID, ok := trace.(string)
+	if !ok {
+		return "", "", false
+	}
+
+	span := ctx.Value(spanIDContextKey)
+	if span == nil {
+		return traceID, "", traceID != ""
+	}
+
+	spanID, ok := span.(string)
+	return traceID, spanID, ok && traceID != ""
+}
+
 // WithTraceID returns a new context with the given trace ID.
 func WithTraceID(ctx context.Context, traceID string) context.Context {
 	return context.WithValue(ctx, traceIDContextKey, traceID)

--- a/core/trace/context.go
+++ b/core/trace/context.go
@@ -153,7 +153,10 @@ func TraceIDAndSpanIDFromContext(ctx context.Context) (string, string, bool) {
 	}
 
 	spanID, ok := span.(string)
-	return traceID, spanID, ok && traceID != ""
+	if !ok {
+		return traceID, "", traceID != ""
+	}
+	return traceID, spanID, traceID != ""
 }
 
 // WithTraceID returns a new context with the given trace ID.

--- a/core/trace/context_test.go
+++ b/core/trace/context_test.go
@@ -86,6 +86,15 @@ func (s *contextSuite) TestTraceIDAndSpanIDFromContextRemovedScope(c *tc.C) {
 	c.Check(ok, tc.IsFalse)
 }
 
+func (s *contextSuite) TestTraceIDAndSpanIDFromContextNonStringSpan(c *tc.C) {
+	ctx := WithTraceID(c.Context(), "trace-id")
+	ctx = context.WithValue(ctx, spanIDContextKey, 123)
+	traceID, spanID, ok := TraceIDAndSpanIDFromContext(ctx)
+	c.Check(traceID, tc.Equals, "trace-id")
+	c.Check(spanID, tc.Equals, "")
+	c.Check(ok, tc.IsTrue)
+}
+
 type stubTracer struct{}
 
 func (stubTracer) Start(ctx context.Context, name string, options ...Option) (context.Context, Span) {

--- a/core/trace/context_test.go
+++ b/core/trace/context_test.go
@@ -46,6 +46,46 @@ func (s *contextSuite) TestTracerFromContextTracer(c *tc.C) {
 	c.Check(span, tc.Not(tc.Equals), NoopSpan{})
 }
 
+func (s *contextSuite) TestTraceIDAndSpanIDFromContextEmpty(c *tc.C) {
+	traceID, spanID, ok := TraceIDAndSpanIDFromContext(c.Context())
+	c.Check(traceID, tc.Equals, "")
+	c.Check(spanID, tc.Equals, "")
+	c.Check(ok, tc.IsFalse)
+}
+
+func (s *contextSuite) TestTraceIDAndSpanIDFromContextTraceIDOnly(c *tc.C) {
+	ctx := WithTraceID(c.Context(), "abc123")
+	traceID, spanID, ok := TraceIDAndSpanIDFromContext(ctx)
+	c.Check(traceID, tc.Equals, "abc123")
+	c.Check(spanID, tc.Equals, "")
+	c.Check(ok, tc.IsTrue)
+}
+
+func (s *contextSuite) TestTraceIDAndSpanIDFromContextTraceIDAndSpanID(c *tc.C) {
+	ctx := WithTraceScope(c.Context(), "trace-id", "span-id", 0)
+	traceID, spanID, ok := TraceIDAndSpanIDFromContext(ctx)
+	c.Check(traceID, tc.Equals, "trace-id")
+	c.Check(spanID, tc.Equals, "span-id")
+	c.Check(ok, tc.IsTrue)
+}
+
+func (s *contextSuite) TestTraceIDAndSpanIDFromContextEmptyTraceID(c *tc.C) {
+	ctx := WithTraceScope(c.Context(), "", "span-id", 0)
+	traceID, spanID, ok := TraceIDAndSpanIDFromContext(ctx)
+	c.Check(traceID, tc.Equals, "")
+	c.Check(spanID, tc.Equals, "span-id")
+	c.Check(ok, tc.IsFalse)
+}
+
+func (s *contextSuite) TestTraceIDAndSpanIDFromContextRemovedScope(c *tc.C) {
+	ctx := WithTraceScope(c.Context(), "trace-id", "span-id", 0)
+	ctx = RemoveTraceScope(ctx)
+	traceID, spanID, ok := TraceIDAndSpanIDFromContext(ctx)
+	c.Check(traceID, tc.Equals, "")
+	c.Check(spanID, tc.Equals, "")
+	c.Check(ok, tc.IsFalse)
+}
+
 type stubTracer struct{}
 
 func (stubTracer) Start(ctx context.Context, name string, options ...Option) (context.Context, Span) {

--- a/internal/logger/loggo.go
+++ b/internal/logger/loggo.go
@@ -143,13 +143,14 @@ func (c loggoLogger) GetChildByName(name string) logger.Logger {
 }
 
 func (c loggoLogger) labelsFromContext(ctx context.Context) (map[string]string, bool) {
-	traceID, ok := trace.TraceIDFromContext(ctx)
+	traceID, spanID, ok := trace.TraceIDAndSpanIDFromContext(ctx)
 	if !ok {
 		return nil, false
 	}
 
 	return map[string]string{
-		"traceid": traceID,
+		"trace_id": traceID,
+		"span_id":  spanID,
 	}, true
 }
 

--- a/internal/logger/loggo_test.go
+++ b/internal/logger/loggo_test.go
@@ -146,7 +146,31 @@ func (s *loggoSuite) TestLogWithTrace(c *tc.C) {
 		c.Check(log[0].Module, tc.Equals, "foo")
 		c.Check(log[0].Message, tc.Equals, "message")
 		c.Check(log[0].Labels, tc.DeepEquals, loggo.Labels{
-			"traceid": "traceid",
+			"trace_id": "traceid",
+			"span_id":  "",
 		})
 	}
+}
+
+func (s *loggoSuite) TestLogWithTraceAndSpan(c *tc.C) {
+	writer := &loggo.TestWriter{}
+	logContext := loggo.NewContext(loggo.TRACE)
+	logContext.AddWriter("test", writer)
+
+	ctx := trace.WithTraceScope(
+		c.Context(),
+		"0123456789abcdef0123456789abcdef",
+		"0123456789abcdef",
+		1,
+	)
+
+	logger := WrapLoggoContext(logContext)
+	logger.GetLogger("foo").Infof(ctx, "message")
+
+	log := writer.Log()
+	c.Assert(log, tc.HasLen, 1)
+	c.Check(log[0].Labels, tc.DeepEquals, loggo.Labels{
+		"trace_id": "0123456789abcdef0123456789abcdef",
+		"span_id":  "0123456789abcdef",
+	})
 }

--- a/internal/loki/client.go
+++ b/internal/loki/client.go
@@ -51,6 +51,11 @@ type Record struct {
 	// not in Loki labels.
 	Fields map[string]string
 
+	// ServiceName is the value of the service_name stream label included in
+	// every pushed log record. It defaults to "juju" when empty, making Juju
+	// agent logs identifiable in Grafana/Loki.
+	ServiceName string
+
 	// TraceID is the OpenTelemetry trace ID for this record, if present.
 	TraceID string
 
@@ -630,7 +635,11 @@ func buildPayload(records []Record, serviceName string) pushPayload {
 
 func topologyLabels(r Record, serviceName string) map[string]string {
 	labels := make(map[string]string, 4)
-	labels["service_name"] = serviceName
+	if r.ServiceName != "" {
+		labels["service_name"] = r.ServiceName
+	} else {
+		labels["service_name"] = serviceName
+	}
 	if r.ControllerUUID != "" {
 		labels["juju_controller"] = r.ControllerUUID
 	}
@@ -647,10 +656,10 @@ func structuredFields(r Record) map[string]string {
 	fields := make(map[string]string, len(r.Fields)+2)
 	maps.Copy(fields, r.Fields)
 	if isLowerHex(r.TraceID, 32) {
-		fields["trace_id"] = r.TraceID
+		fields["traceID"] = r.TraceID
 	}
 	if isLowerHex(r.SpanID, 16) {
-		fields["span_id"] = r.SpanID
+		fields["spanID"] = r.SpanID
 	}
 	if len(fields) == 0 {
 		return nil

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -716,14 +716,14 @@ func (s *clientSuite) TestBuildPayload(c *tc.C) {
 	c.Check(payload.Streams[0].Values, tc.HasLen, 2)
 	c.Check(payload.Streams[0].Values[0].Line, tc.Equals, "a1")
 	c.Check(payload.Streams[0].Values[0].Fields, tc.DeepEquals, map[string]string{
-		"module":   "apiserver",
-		"trace_id": "0123456789abcdef0123456789abcdef",
-		"span_id":  "0123456789abcdef",
+		"module":  "apiserver",
+		"traceID": "0123456789abcdef0123456789abcdef",
+		"spanID":  "0123456789abcdef",
 	})
 	c.Check(payload.Streams[0].Values[1].Line, tc.Equals, "a2")
 	c.Check(payload.Streams[0].Values[1].Fields, tc.DeepEquals, map[string]string{
 		"request_id": "req-123",
-		"span_id":    "0123456789abcdef",
+		"spanID":     "0123456789abcdef",
 	})
 
 	c.Check(
@@ -750,6 +750,54 @@ func (s *clientSuite) TestLabelKey(c *tc.C) {
 func (s *clientSuite) TestLabelKeyEmpty(c *tc.C) {
 	c.Check(labelKey(nil), tc.Equals, "")
 	c.Check(labelKey(map[string]string{}), tc.Equals, "")
+}
+
+func (s *clientSuite) TestBuildPayloadRecordServiceNameOverridesDefault(c *tc.C) {
+	ts := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{
+			Timestamp:      ts,
+			Line:           "a1",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
+			ServiceName:    "custom-service",
+		},
+	}
+
+	payload := buildPayload(records, DefaultServiceName)
+	c.Assert(payload.Streams, tc.HasLen, 1)
+	c.Check(
+		payload.Streams[0].Stream,
+		tc.DeepEquals,
+		map[string]string{
+			"service_name":    "custom-service",
+			"juju_controller": "controller",
+			"juju_model":      "model",
+			"juju_agent":      "machine-0",
+		},
+	)
+}
+
+func (s *clientSuite) TestBuildPayloadRecordServiceNameEmptyFallsBackToDefault(c *tc.C) {
+	ts := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	records := []Record{
+		{
+			Timestamp:      ts,
+			Line:           "a1",
+			ControllerUUID: "controller",
+			ModelUUID:      "model",
+			AgentID:        "machine-0",
+		},
+	}
+
+	payload := buildPayload(records, "fallback-service")
+	c.Assert(payload.Streams, tc.HasLen, 1)
+	c.Check(
+		payload.Streams[0].Stream["service_name"],
+		tc.Equals,
+		"fallback-service",
+	)
 }
 
 // testConfig returns a Config suitable for tests with fast

--- a/internal/worker/logrouter/backends/loki.go
+++ b/internal/worker/logrouter/backends/loki.go
@@ -25,6 +25,7 @@ type LokiConfig struct {
 	ControllerUUID       string
 	ModelUUID            string
 	AgentID              string
+	ServiceName          string
 	PrometheusRegisterer prometheus.Registerer
 	NewClient            NewLokiClientFunc
 }
@@ -39,6 +40,9 @@ func (c LokiConfig) Validate() error {
 	}
 	if c.PrometheusRegisterer == nil {
 		return errors.NotValidf("nil PrometheusRegisterer")
+	}
+	if c.ServiceName == "" {
+		return errors.NotValidf("empty ServiceName")
 	}
 	if c.NewClient == nil {
 		return errors.NotValidf("nil NewClient")
@@ -140,8 +144,9 @@ func (w *lokiBackend) WatchRefresh() <-chan struct{} {
 // Report returns a report of the backend's current state.
 func (w *lokiBackend) Report(ctx context.Context) map[string]any {
 	return map[string]any{
-		"name":   "loki-backend",
-		"client": w.client.Report(ctx),
+		"name":         "loki-backend",
+		"service_name": w.cfg.ServiceName,
+		"client":       w.client.Report(ctx),
 	}
 }
 
@@ -181,6 +186,9 @@ func (w *lokiBackend) loop() error {
 					"location": rec.Location,
 					"level":    rec.Level.String(),
 				},
+				ServiceName: w.cfg.ServiceName,
+				TraceID:     rec.Labels["trace_id"],
+				SpanID:      rec.Labels["span_id"],
 			}); err != nil {
 				return internalerrors.Capture(err)
 			}

--- a/internal/worker/logrouter/backends/loki_test.go
+++ b/internal/worker/logrouter/backends/loki_test.go
@@ -39,6 +39,7 @@ func (s *lokiSuite) TestUsesClientInterfaceAndManagesLifecycle(c *tc.C) {
 		ControllerUUID:       "controller",
 		ModelUUID:            "model",
 		AgentID:              "machine-0",
+		ServiceName:          "juju-controller",
 		PrometheusRegisterer: prometheus.NewRegistry(),
 		NewClient: func(endpoint string, cfg loki.Config) (LokiClient, error) {
 			c.Check(endpoint, tc.Equals, "http://loki/loki/api/v1/push")
@@ -62,6 +63,7 @@ func (s *lokiSuite) TestUsesClientInterfaceAndManagesLifecycle(c *tc.C) {
 	c.Check(got.ControllerUUID, tc.Equals, "controller")
 	c.Check(got.ModelUUID, tc.Equals, "model")
 	c.Check(got.AgentID, tc.Equals, "machine-0")
+	c.Check(got.ServiceName, tc.Equals, "juju-controller")
 	c.Check(got.Fields, tc.DeepEquals, map[string]string{
 		"module":   "test.module",
 		"location": "worker.go:10",
@@ -74,6 +76,70 @@ func (s *lokiSuite) TestUsesClientInterfaceAndManagesLifecycle(c *tc.C) {
 	c.Check(client.waited.Load(), tc.IsTrue)
 }
 
+func (s *lokiSuite) TestForwardsTraceAndSpanFromLabels(c *tc.C) {
+	client := newRecordingLokiClient()
+
+	w, err := NewLoki(LokiConfig{
+		BackendBufferSize: 1,
+		ClientConfig: loki.Config{
+			HTTPClient: &http.Client{},
+		},
+		Endpoint:             "http://loki/loki/api/v1/push",
+		ControllerUUID:       "controller",
+		ModelUUID:            "model",
+		AgentID:              "machine-0",
+		ServiceName:          "juju-unit",
+		PrometheusRegisterer: prometheus.NewRegistry(),
+		NewClient: func(string, loki.Config) (LokiClient, error) {
+			return client, nil
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	w.LogRecords() <- &logsender.LogRecord{
+		Time:     time.Now(),
+		Module:   "test.module",
+		Location: "worker.go:10",
+		Level:    loggo.INFO,
+		Message:  "traced request",
+		Labels: map[string]string{
+			"trace_id": "0123456789abcdef0123456789abcdef",
+			"span_id":  "0123456789abcdef",
+		},
+	}
+
+	got := client.waitRecord(c)
+	c.Check(got.TraceID, tc.Equals, "0123456789abcdef0123456789abcdef")
+	c.Check(got.SpanID, tc.Equals, "0123456789abcdef")
+	c.Check(got.ServiceName, tc.Equals, "juju-unit")
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *lokiSuite) TestReportIncludesServiceName(c *tc.C) {
+	client := newRecordingLokiClient()
+
+	w, err := NewLoki(LokiConfig{
+		BackendBufferSize: 1,
+		ClientConfig: loki.Config{
+			HTTPClient: &http.Client{},
+		},
+		Endpoint:             "http://loki/loki/api/v1/push",
+		ServiceName:          "juju-controller",
+		PrometheusRegisterer: prometheus.NewRegistry(),
+		NewClient: func(string, loki.Config) (LokiClient, error) {
+			return client, nil
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	report := w.Report(c.Context())
+	c.Check(report["name"], tc.Equals, "loki-backend")
+	c.Check(report["service_name"], tc.Equals, "juju-controller")
+}
+
 func (s *lokiSuite) TestUnregistersMetricsCollectorOnStop(c *tc.C) {
 	client := newRecordingLokiClient()
 	registerer := &countingRegisterer{}
@@ -81,6 +147,7 @@ func (s *lokiSuite) TestUnregistersMetricsCollectorOnStop(c *tc.C) {
 	w, err := NewLoki(LokiConfig{
 		BackendBufferSize:    1,
 		Endpoint:             "http://loki/loki/api/v1/push",
+		ServiceName:          "juju-controller",
 		PrometheusRegisterer: registerer,
 		NewClient: func(string, loki.Config) (LokiClient, error) {
 			return client, nil
@@ -108,6 +175,7 @@ func (s *lokiSuite) TestAllowsDistinctWrappedRegisterersOnSharedRegistry(c *tc.C
 	apiBackend, err := NewLoki(LokiConfig{
 		BackendBufferSize:    1,
 		Endpoint:             "http://loki/loki/api/v1/push",
+		ServiceName:          "juju-controller",
 		PrometheusRegisterer: apiRegisterer,
 		NewClient: func(string, loki.Config) (LokiClient, error) {
 			return newRecordingLokiClient(), nil
@@ -119,6 +187,7 @@ func (s *lokiSuite) TestAllowsDistinctWrappedRegisterersOnSharedRegistry(c *tc.C
 	controllerBackend, err := NewLoki(LokiConfig{
 		BackendBufferSize:    1,
 		Endpoint:             "http://loki/loki/api/v1/push",
+		ServiceName:          "juju-controller",
 		PrometheusRegisterer: controllerRegisterer,
 		NewClient: func(string, loki.Config) (LokiClient, error) {
 			return newRecordingLokiClient(), nil
@@ -144,6 +213,10 @@ func (s *lokiSuite) TestLokiConfigValidate(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorMatches, "nil PrometheusRegisterer not valid")
 
 	cfg = validLokiConfig()
+	cfg.ServiceName = ""
+	c.Check(cfg.Validate(), tc.ErrorMatches, "empty ServiceName not valid")
+
+	cfg = validLokiConfig()
 	cfg.NewClient = nil
 	c.Check(cfg.Validate(), tc.ErrorMatches, "nil NewClient not valid")
 }
@@ -152,6 +225,7 @@ func validLokiConfig() LokiConfig {
 	return LokiConfig{
 		BackendBufferSize:    1,
 		Endpoint:             "http://loki/loki/api/v1/push",
+		ServiceName:          "juju-controller",
 		PrometheusRegisterer: prometheus.NewRegistry(),
 		NewClient: func(string, loki.Config) (LokiClient, error) {
 			return newRecordingLokiClient(), nil

--- a/internal/worker/logrouter/manifold.go
+++ b/internal/worker/logrouter/manifold.go
@@ -24,6 +24,14 @@ import (
 	"github.com/juju/juju/internal/worker/logsender"
 )
 
+const (
+	// ControllerServiceName is the service name used for controller-local log
+	// delivery.
+	ControllerServiceName = "juju-controller"
+	// UnitServiceName is the service name used for unit-local log delivery.
+	UnitServiceName = "juju-unit"
+)
+
 // BackendFuncFactory returns a backend constructor for the supplied agent
 // resources.
 type BackendFuncFactory func(
@@ -131,15 +139,20 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			return NewWorker(WorkerConfig{
-				LokiConfigProvider:        agentLokiConfigProvider{agent: a},
-				LogSource:                 config.LogSource,
-				AgentConfigChanged:        config.AgentConfigChanged,
-				Logger:                    config.Logger,
-				Clock:                     config.Clock,
-				DrainOnly:                 config.DrainOnly,
-				ConvergeTimeout:           defaultConvergeTimeout,
-				RestartDelay:              defaultRestartDelay,
-				NewBackend:                config.NewBackendFunc(apiCaller, httpClient, config.Clock, config.PrometheusRegisterer),
+				LokiConfigProvider: agentLokiConfigProvider{agent: a},
+				LogSource:          config.LogSource,
+				AgentConfigChanged: config.AgentConfigChanged,
+				Logger:             config.Logger,
+				Clock:              config.Clock,
+				DrainOnly:          config.DrainOnly,
+				ConvergeTimeout:    defaultConvergeTimeout,
+				RestartDelay:       defaultRestartDelay,
+				NewBackend: config.NewBackendFunc(
+					apiCaller,
+					httpClient,
+					config.Clock,
+					config.PrometheusRegisterer,
+				),
 				RemoveLegacyLogSinkWriter: config.RemoveLegacyLogSinkWriter,
 				AddLegacyLogSinkWriter:    config.AddLegacyLogSinkWriter,
 			})
@@ -224,14 +237,19 @@ func ControllerManifold(config ControllerManifoldConfig) dependency.Manifold {
 			}
 
 			return NewWorker(WorkerConfig{
-				LokiConfigProvider:        config.LokiConfigProvider,
-				LogSource:                 make(logsender.LogRecordCh),
-				AgentConfigChanged:        config.AgentConfigChanged,
-				Logger:                    config.Logger,
-				Clock:                     config.Clock,
-				ConvergeTimeout:           defaultConvergeTimeout,
-				RestartDelay:              defaultRestartDelay,
-				NewBackend:                config.NewBackendFunc(config.LocalLogSink, httpClient, config.Clock, config.PrometheusRegisterer),
+				LokiConfigProvider: config.LokiConfigProvider,
+				LogSource:          make(logsender.LogRecordCh),
+				AgentConfigChanged: config.AgentConfigChanged,
+				Logger:             config.Logger,
+				Clock:              config.Clock,
+				ConvergeTimeout:    defaultConvergeTimeout,
+				RestartDelay:       defaultRestartDelay,
+				NewBackend: config.NewBackendFunc(
+					config.LocalLogSink,
+					httpClient,
+					config.Clock,
+					config.PrometheusRegisterer,
+				),
 				RemoveLegacyLogSinkWriter: func() {},
 				AddLegacyLogSinkWriter:    func() error { return nil },
 			})
@@ -293,6 +311,7 @@ func NewBackend(
 				ControllerUUID:       snapshot.ControllerUUID,
 				ModelUUID:            snapshot.ModelUUID,
 				AgentID:              snapshot.AgentID,
+				ServiceName:          UnitServiceName,
 				PrometheusRegisterer: registerer,
 				NewClient: func(endpoint string, cfg loki.Config) (backends.LokiClient, error) {
 					return loki.NewClient(endpoint, cfg)
@@ -348,6 +367,7 @@ func NewControllerBackend(
 				ControllerUUID:       snapshot.ControllerUUID,
 				ModelUUID:            snapshot.ModelUUID,
 				AgentID:              snapshot.AgentID,
+				ServiceName:          ControllerServiceName,
 				PrometheusRegisterer: registerer,
 				NewClient: func(endpoint string, cfg loki.Config) (backends.LokiClient, error) {
 					return loki.NewClient(endpoint, cfg)

--- a/internal/worker/logrouter/manifold_test.go
+++ b/internal/worker/logrouter/manifold_test.go
@@ -228,6 +228,7 @@ func (s *manifoldSuite) TestNewControllerBackendUsesLokiBackendForLokiMode(c *tc
 
 	report := backend.Report(c.Context())
 	c.Check(report["name"], tc.Equals, "loki-backend")
+	c.Check(report["service_name"], tc.Equals, ControllerServiceName)
 
 	sink.mu.Lock()
 	defer sink.mu.Unlock()

--- a/internal/worker/logrouter/manifold_test.go
+++ b/internal/worker/logrouter/manifold_test.go
@@ -120,6 +120,22 @@ func (s *manifoldSuite) TestNewBackendUpdatesLokiCACert(c *tc.C) {
 	c.Check(client.insecureSkipVerify.Load(), tc.IsFalse)
 }
 
+func (s *manifoldSuite) TestNewBackendUsesLokiBackendForLokiMode(c *tc.C) {
+	client := &recordingCACertUpdaterClient{}
+	backendFunc := NewBackend(stubAPICaller{}, client, clock.WallClock, prometheus.NewRegistry())
+
+	backend, err := backendFunc(BackendTypeLoki, ConfigSnapshot{
+		Mode:     BackendTypeLoki,
+		Endpoint: "http://loki/loki/api/v1/push",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, backend)
+
+	report := backend.Report(c.Context())
+	c.Check(report["name"], tc.Equals, "loki-backend")
+	c.Check(report["service_name"], tc.Equals, UnitServiceName)
+}
+
 func (s *manifoldSuite) TestNewBackendReturnsCACertUpdateError(c *tc.C) {
 	expectErr := stderrors.New("boom")
 	client := &recordingCACertUpdaterClient{err: expectErr}


### PR DESCRIPTION
Juju agents push partially structured logs to Loki and traces to Tempo, but the two were never correlated - the trace and span IDs existed in the logging pipeline (attached as loggo labels via context) yet were silently dropped before reaching Loki. This meant Grafana's trace-to-log linking was non-functional: no trace icon on log lines, no log panel in Tempo.

The root cause was a broken chain across three layers. In core/trace, only TraceIDFromContext existed, which returned the trace ID but not the span ID. The loggo adapter in internal/logger used that function and emitted a single traceid label with no span information. The Loki client and logrouter backend had TraceID/SpanID fields on their record types, but the backend never populated them from LogRecord.Labels, and the field names written to Loki (trace_id/span_id) were non-canonical — Grafana expects traceID/spanID for auto-detection.

This PR closes that gap. A new TraceIDAndSpanIDFromContext function in core/trace returns both IDs, treating the span ID as optional so a trace ID alone still produces labels. The loggo adapter now emits both trace_id and span_id labels. The loki backend extracts those labels from each LogRecord and populates loki.Record.TraceID/SpanID, which the Loki client writes as canonical traceID/spanID structured fields. Along the way, ServiceName was added to loki.Record and LokiConfig (required and validated) so controller logs (juju-controller) and unit logs (juju-unit) are distinguishable in Loki streams, and the manifold wires the appropriate constant into each backend constructor.

## QA steps

You can either use COS or [docker-compose.yaml](https://gist.github.com/SimonRichardson/8a7421dd91eb0cfbaa4d0ae5df5790c6).

The observability and controller charm is also required from the main branch if using docker-compose, or just the controller charm with COS.

```sh
$ juju bootstrap lxd src --bootstrap-base=ubuntu@24.04 --controller-charm-path=./juju-controller_ubuntu@24.04-amd64.charm --build-agent
$ juju switch controller &&
juju config controller \
    workload-tracing-sample-ratio=1 \
    workload-tracing-tail-sampling-threshold=1ms \
    workload-tracing-insecure-skip-verify=true \
    loki-org-id=tenant1 \
    loki-insecure-skip-verify=true &&
juju deploy ./observability_amd64.charm &&
juju config observability \
    loki-url="http://192.168.0.38:3100/loki/api/v1/push" \
    http-endpoint="http://192.168.0.38:4318/v1/traces" &&
juju integrate controller:loki-push-api observability:loki-push-api &&
juju integrate controller:workload-tracing observability:workload-tracing
```

"Logs for this span" now appears, and it's possible to click that and get all the logs associated with the trace.

> [!NOTE]
> We don't actually log that much information during a request. This makes somethings harder to debug. We might want to reconsider that pattern.

<img width="1513" height="617" alt="Screenshot from 2026-07-16 10-37-30" src="https://github.com/user-attachments/assets/6da30460-592b-46b1-b813-81df2164b307" />


