### PR TITLE
fix(uniter): contain manifest removeDiff to the charm directory

### DIFF
--- a/internal/worker/uniter/charm/manifest_deployer.go
+++ b/internal/worker/uniter/charm/manifest_deployer.go
@@ -71,6 +71,13 @@ func (d *manifestDeployer) Stage(info BundleInfo, abort <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
+	// A charm archive controls its own member names, so validate them before
+	// they are stored: an unsafe entry would poison the manifest and direct
+	// later removals outside the charm directory.
+	manifest, err = validateManifest(manifest)
+	if err != nil {
+		return err
+	}
 	url := info.URL()
 	if err := d.storeManifest(url, manifest); err != nil {
 		return err
@@ -150,6 +157,13 @@ func (d *manifestDeployer) startDeploy() error {
 // removeDiff removes every path in oldManifest that is not present in newManifest.
 func (d *manifestDeployer) removeDiff(oldManifest, newManifest set.Strings) error {
 	diff := oldManifest.Difference(newManifest)
+	// Manifests are validated when they are ingested, but re-validate the
+	// diff here so an unsafe entry can never direct os.RemoveAll outside the
+	// charm directory.
+	diff, err := validateManifest(diff)
+	if err != nil {
+		d.logger.Warningf("skipping removal of manifest entries: %v", err)
+	}
 	for _, path := range diff.SortedValues() {
 		fullPath := filepath.Join(d.charmPath, filepath.FromSlash(path))
 		if err := os.RemoveAll(fullPath); err != nil {
@@ -157,6 +171,29 @@ func (d *manifestDeployer) removeDiff(oldManifest, newManifest set.Strings) erro
 		}
 	}
 	return nil
+}
+
+// validateManifest returns the subset of manifest entries that are safe to
+// join onto the charm directory. A charm archive controls its own member
+// names, so an entry like "../../x" or an absolute path would reach outside
+// the charm directory, and an entry that cleans to "." would remove the charm
+// directory itself. Unsafe entries are dropped from the returned set and
+// reported in the error.
+func validateManifest(manifest set.Strings) (set.Strings, error) {
+	valid := set.NewStrings()
+	var invalid []string
+	for _, path := range manifest.SortedValues() {
+		relPath := filepath.FromSlash(path)
+		if !filepath.IsLocal(relPath) || filepath.Clean(relPath) == "." {
+			invalid = append(invalid, path)
+			continue
+		}
+		valid.Add(path)
+	}
+	if len(invalid) > 0 {
+		return valid, errors.Errorf("charm manifest contains unsafe paths %q", invalid)
+	}
+	return valid, nil
 }
 
 // finishDeploy persists the fact that we've finished deploying the staged bundle.
@@ -218,7 +255,14 @@ func (d *manifestDeployer) loadManifest(urlFilePath string) (string, set.Strings
 		d.logger.Warningf("manifest not found at %q: files from charm %q may be left unremoved", path, url)
 		err = nil
 	}
-	return url, set.NewStrings(manifest...), err
+	// Manifests are validated before they are stored, but one written by an
+	// older agent (or tampered with on disk) may still hold unsafe entries;
+	// drop them rather than fail, so the deploy can still proceed.
+	valid, invalidErr := validateManifest(set.NewStrings(manifest...))
+	if invalidErr != nil {
+		d.logger.Warningf("ignoring entries in stored manifest for charm %q: %v", url, invalidErr)
+	}
+	return url, valid, err
 }
 
 // CharmPath returns the supplied path joined to the ManifestDeployer's charm directory.

--- a/internal/worker/uniter/charm/manifest_deployer_test.go
+++ b/internal/worker/uniter/charm/manifest_deployer_test.go
@@ -5,6 +5,7 @@ package charm_test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -26,6 +27,7 @@ type ManifestDeployerSuite struct {
 	testing.BaseSuite
 	bundles    *bundleReader
 	targetPath string
+	dataPath   string
 	deployer   charm.Deployer
 }
 
@@ -39,8 +41,8 @@ func (s *ManifestDeployerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.bundles = &bundleReader{}
 	s.targetPath = filepath.Join(c.MkDir(), "target")
-	deployerPath := filepath.Join(c.MkDir(), "deployer")
-	s.deployer = charm.NewManifestDeployer(s.targetPath, deployerPath, s.bundles, loggo.GetLogger("test"))
+	s.dataPath = filepath.Join(c.MkDir(), "deployer")
+	s.deployer = charm.NewManifestDeployer(s.targetPath, s.dataPath, s.bundles, loggo.GetLogger("test"))
 }
 
 func (s *ManifestDeployerSuite) addMockCharm(revision int, bundle charm.Bundle) charm.BundleInfo {
@@ -165,6 +167,73 @@ func (s *ManifestDeployerSuite) TestUpgradePreserveUserFiles(c *gc.C) {
 	preserveUserContent.Check(c, s.targetPath)
 	removeUserContent.AsRemoveds().Check(c, s.targetPath)
 	originalCharmContent.AsRemoveds().Check(c, s.targetPath)
+}
+
+func (s *ManifestDeployerSuite) TestStageRejectsManifestPathTraversal(c *gc.C) {
+	// A charm archive controls its own member names, so entries that would
+	// reach outside the charm directory (or remove it outright) must be
+	// refused before the manifest is stored.
+	bad := mockBundle{
+		paths: set.NewStrings("charm-file", "../victim", "/abs", "."),
+	}
+	info := s.addMockCharm(1, bad)
+	err := s.deployer.Stage(info, nil)
+	c.Assert(err, gc.ErrorMatches, "charm manifest contains unsafe paths .*")
+}
+
+func (s *ManifestDeployerSuite) TestUpgradeRefusesManifestPathTraversal(c *gc.C) {
+	// Stage refuses unsafe manifests, so one can only reach removeDiff via
+	// stored state written by an older agent or tampered with on disk.
+	// Simulate that and check an upgrade cannot remove a file outside the
+	// charm directory.
+	victimPath := filepath.Join(filepath.Dir(s.targetPath), "victim")
+	err := os.WriteFile(victimPath, []byte("keep me"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	base := mockBundle{
+		paths: set.NewStrings("charm-file"),
+		expand: func(dir string) error {
+			ft.File{"charm-file", "base", 0644}.Create(c, dir)
+			return nil
+		},
+	}
+	info := s.addMockCharm(1, base)
+	err = s.deployer.Stage(info, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.deployer.Deploy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Poison the stored manifest for revision 1 with an entry that escapes
+	// the charm directory.
+	manifestsDir := filepath.Join(s.dataPath, "manifests")
+	entries, err := os.ReadDir(manifestsDir)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(entries, gc.HasLen, 1)
+	manifestPath := filepath.Join(manifestsDir, entries[0].Name())
+	err = os.WriteFile(manifestPath, []byte("- charm-file\n- ../victim\n"), 0644)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Upgrade to a revision without the escaping entry; an unguarded
+	// removeDiff would call os.RemoveAll("<charm>/../victim").
+	upgrade := mockBundle{
+		paths: set.NewStrings("charm-file"),
+		expand: func(dir string) error {
+			ft.File{"charm-file", "new", 0644}.Create(c, dir)
+			return nil
+		},
+	}
+	info = s.addMockCharm(2, upgrade)
+	err = s.deployer.Stage(info, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.deployer.Deploy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The file outside the charm directory survives the upgrade and the
+	// legitimate charm content was still updated.
+	data, err := os.ReadFile(victimPath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(data), gc.Equals, "keep me")
+	ft.File{"charm-file", "new", 0644}.Check(c, s.targetPath)
 }
 
 func (s *ManifestDeployerSuite) TestUpgradeConflictResolveRetrySameCharm(c *gc.C) {


### PR DESCRIPTION
The uniter builds a charm's manifest from the raw zip member names, so a member like `../../x` survives into removeDiff and lets os.RemoveAll delete a file outside the charm directory when a later revision drops that entry.

Per review, manifests are now validated where they are ingested via `validateManifest(manifest set.Strings) (set.Strings, error)`, which rejects entries that fail `filepath.IsLocal` as well as anything that cleans to `"."` (so a dropped entry can never RemoveAll the charm directory itself):

- `Stage()` validates right after `bundle.ArchiveMembers()` and refuses the charm, so an unsafe manifest is never stored.
- `loadManifest()` validates after the yaml read, but only warns and drops the unsafe entries, so a stored manifest written by an older agent can't wedge Deploy.
- `removeDiff()` re-validates the diff and skips unsafe entries as a backstop.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
go test ./internal/worker/uniter/charm/ -check.f 'PathTraversal'
```

`TestStageRejectsManifestPathTraversal` checks a charm with escaping member names is refused at stage time. `TestUpgradeRefusesManifestPathTraversal` poisons the stored manifest yaml with `../victim` (the only way one can now reach removeDiff), upgrades, and asserts the file outside the charm directory survives while the legitimate charm file is still updated to the new content. Both fail with the guards reverted.
