### PR TITLE
feat: full table scans detector

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -59,3 +59,13 @@ jobs:
         run: |
           export GOEXPERIMENT=goroutineleakprofile
           make race-test TEST_PACKAGE_LIST="${TEST_PACKAGE_LIST}"
+
+      - name: "Detect Full Table Scans"
+        run: |
+          TEST_PACKAGE_LIST=$(mktemp)
+          go list ./domain/... | sort > "${TEST_PACKAGE_LIST}"
+          make test BUILD_TAGS=sqlite_trace TEST_ARGS=-v \
+            TEST_PACKAGE_LIST="${TEST_PACKAGE_LIST}" 2>&1 | tee full-table-scans.log
+          if grep -Fq "sqlite statement performed full table scan" full-table-scans.log; then
+            exit 1
+          fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -64,8 +64,10 @@ jobs:
         run: |
           TEST_PACKAGE_LIST=$(mktemp)
           go list ./domain/... | sort > "${TEST_PACKAGE_LIST}"
-          make test BUILD_TAGS=sqlite_trace TEST_ARGS=-v \
-            TEST_PACKAGE_LIST="${TEST_PACKAGE_LIST}" 2>&1 | tee full-table-scans.log
+          make test BUILD_TAGS=sqlite_trace \
+            TEST_ARGS=-v \
+            TEST_PACKAGE_LIST="${TEST_PACKAGE_LIST}" \
+            JUJU_TEST_VERBOSE=1 2>&1 | tee full-table-scans.log
           if grep -Fq "sqlite statement performed full table scan" full-table-scans.log; then
             exit 1
           fi

--- a/core/database/schema/query.go
+++ b/core/database/schema/query.go
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS schema (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_schema_version ON schema (version);
+CREATE INDEX IF NOT EXISTS idx_schema_version_hash ON schema (version, hash);
 `
 
 // Create the schema table.

--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -480,9 +480,10 @@ FROM    v_user_auth u
         JOIN user AS creator ON u.created_by_uuid = creator.uuid
         LEFT JOIN v_permission p ON u.uuid = p.grant_to AND p.grant_on = $dbPermission.grant_on 
         LEFT JOIN v_everyone_external ee ON ee.grant_on = $dbPermission.grant_on
-WHERE   u.disabled = false
-AND     u.removed = false
-AND     (p.uuid IS NOT NULL OR (u.external AND ee.uuid IS NOT NULL))
+WHERE   (u.disabled = false
+         AND u.removed = false
+         AND p.uuid IS NOT NULL)
+OR      (u.uuid >= '' AND u.external AND ee.uuid IS NOT NULL)
 `
 	stmt, err := st.Prepare(query, grantOn, dbPermissionUser{}, dbEveryoneExternal{})
 	if err != nil {

--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -402,10 +402,16 @@ func (st *PermissionState) ReadAllUserAccessForUser(ctx context.Context, subject
 	query := `
 SELECT (u.uuid, u.name, u.display_name, u.external, u.created_at, u.disabled) AS (&dbPermissionUser.*),
        creator.name AS &dbPermissionUser.created_by_name,
-       (p.*) AS (&dbPermission.*)
+       p.uuid AS &dbPermission.uuid,
+       p.grant_on AS &dbPermission.grant_on,
+       p.grant_to AS &dbPermission.grant_to,
+       pat.type AS &dbPermission.access_type,
+       pot.type AS &dbPermission.object_type
 FROM   v_user_auth u
        JOIN user AS creator ON u.created_by_uuid = creator.uuid
-       LEFT JOIN v_permission p ON u.uuid = p.grant_to
+       LEFT JOIN permission p ON u.uuid = p.grant_to
+       LEFT JOIN permission_access_type pat ON p.access_type_id = pat.id
+       LEFT JOIN permission_object_type pot ON p.object_type_id = pot.id
 WHERE  u.removed = false
        AND u.name = $userName.name
 `
@@ -476,7 +482,7 @@ FROM    v_user_auth u
         LEFT JOIN v_everyone_external ee ON ee.grant_on = $dbPermission.grant_on
 WHERE   u.disabled = false
 AND     u.removed = false
-AND     (p.uuid IS NOT NULL) OR (u.external AND ee.uuid IS NOT NULL)
+AND     (p.uuid IS NOT NULL OR (u.external AND ee.uuid IS NOT NULL))
 `
 	stmt, err := st.Prepare(query, grantOn, dbPermissionUser{}, dbEveryoneExternal{})
 	if err != nil {

--- a/domain/access/state/permission_test.go
+++ b/domain/access/state/permission_test.go
@@ -847,6 +847,64 @@ func (s *permissionStateSuite) TestReadAllUserAccessForTargetExternalUser(c *tc.
 	c.Assert(accesses, tc.DeepEquals, expectedWithExternal)
 }
 
+func (s *permissionStateSuite) TestReadAllUserAccessForTargetDisabledExternalUser(c *tc.C) {
+	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	jimUserName := usertesting.GenNewName(c, "jim@juju")
+	s.ensureUser(c, "777", jimUserName.Name(), "42", true)
+
+	cloudTarget := corepermission.ID{
+		ObjectType: corepermission.Cloud,
+		Key:        "test-cloud",
+	}
+	everyoneCloud, err := st.CreatePermission(c.Context(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
+		User: corepermission.EveryoneUserName,
+		AccessSpec: corepermission.AccessSpec{
+			Target: cloudTarget,
+			Access: corepermission.AdminAccess,
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.disableUser(c, "777")
+
+	accesses, err := st.ReadAllUserAccessForTarget(c.Context(), cloudTarget)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(accesses, tc.HasLen, 1)
+	c.Check(accesses[0].UserName, tc.Equals, jimUserName)
+	c.Check(accesses[0].PermissionID, tc.Equals, everyoneCloud.PermissionID)
+	c.Check(accesses[0].Access, tc.Equals, everyoneCloud.Access)
+}
+
+func (s *permissionStateSuite) TestReadAllUserAccessForTargetRemovedExternalUser(c *tc.C) {
+	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	jimUserName := usertesting.GenNewName(c, "jim@juju")
+	s.ensureUser(c, "777", jimUserName.Name(), "42", true)
+
+	cloudTarget := corepermission.ID{
+		ObjectType: corepermission.Cloud,
+		Key:        "test-cloud",
+	}
+	everyoneCloud, err := st.CreatePermission(c.Context(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
+		User: corepermission.EveryoneUserName,
+		AccessSpec: corepermission.AccessSpec{
+			Target: cloudTarget,
+			Access: corepermission.AdminAccess,
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.removeUser(c, "777")
+
+	accesses, err := st.ReadAllUserAccessForTarget(c.Context(), cloudTarget)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(accesses, tc.HasLen, 1)
+	c.Check(accesses[0].UserName, tc.Equals, jimUserName)
+	c.Check(accesses[0].PermissionID, tc.Equals, everyoneCloud.PermissionID)
+	c.Check(accesses[0].Access, tc.Equals, everyoneCloud.Access)
+}
+
 func (s *permissionStateSuite) TestReadAllAccessForUserAndObjectTypeCloud(c *tc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 

--- a/domain/access/state/user.go
+++ b/domain/access/state/user.go
@@ -222,6 +222,7 @@ FROM   v_user_auth u
        LEFT JOIN v_user_last_login AS ull
        ON        u.uuid = ull.user_uuid
 WHERE  u.removed = false
+ORDER BY u.created_at
 `, dbUser{})
 	if err != nil {
 		return nil, errors.Errorf("preparing select getAllUsers query: %w", err)

--- a/domain/agentbinary/state/controller/state.go
+++ b/domain/agentbinary/state/controller/state.go
@@ -301,7 +301,8 @@ func (s *ControllerState) ListAgentBinaries(ctx context.Context) ([]agentbinary.
 
 	stmt, err := s.Prepare(`
 SELECT &metadataRecord.*
-FROM   v_agent_binary_store`, metadataRecord{})
+FROM   v_agent_binary_store
+ORDER BY version, architecture_id`, metadataRecord{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/agentbinary/state/model/state.go
+++ b/domain/agentbinary/state/model/state.go
@@ -304,7 +304,8 @@ func (s *ModelState) ListAgentBinaries(ctx context.Context) ([]agentbinary.Metad
 
 	stmt, err := s.Prepare(`
 SELECT &metadataRecord.*
-FROM   v_agent_binary_store`, metadataRecord{})
+FROM   v_agent_binary_store
+ORDER BY version, architecture_id`, metadataRecord{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/annotation/state/state.go
+++ b/domain/annotation/state/state.go
@@ -98,7 +98,8 @@ func (st *State) getAnnotationsForModel(ctx context.Context) (map[string]string,
 
 	getAnnotationsStmt, err := st.Prepare(`
 SELECT (key, value) AS (&annotation.*)
-FROM   annotation_model`, annotation{})
+FROM   annotation_model
+ORDER BY key`, annotation{})
 	if err != nil {
 		return nil, errors.Errorf("preparing get annotations query for model: %w", err)
 	}

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -800,7 +800,8 @@ WHERE  life_id != 0 AND c.source_id < 2;
 	checkUnitsStmt, err := st.Prepare(`
 SELECT &unitName.*
 FROM   unit
-WHERE  life_id != 0
+WHERE  name >= ''
+AND    life_id != 0
 `, unitName{})
 	if err != nil {
 		return errors.Capture(err)
@@ -831,7 +832,8 @@ func (st *State) checkNoUnitsUpgrading(ctx context.Context, tx *sqlair.TX) error
 SELECT u.name AS &unitName.*
 FROM   unit AS u
 JOIN   application AS a ON a.uuid = u.application_uuid
-WHERE  u.charm_uuid != a.charm_uuid
+WHERE  u.uuid >= ''
+AND    u.charm_uuid != a.charm_uuid
 `, unitName{})
 	if err != nil {
 		return errors.Capture(err)
@@ -2250,8 +2252,12 @@ FROM   v_revision_updater_application
 	}
 
 	numUnitsQuery := `
-SELECT &revisionUpdaterApplicationNumUnits.*
-FROM   v_revision_updater_application_unit
+SELECT a.uuid AS &revisionUpdaterApplicationNumUnits.uuid,
+       COUNT(u.uuid) AS &revisionUpdaterApplicationNumUnits.num_units
+FROM   application AS a
+LEFT JOIN unit AS u ON a.uuid = u.application_uuid
+WHERE  a.uuid >= ''
+GROUP BY a.uuid
 `
 
 	numUnitsStmt, err := st.Prepare(numUnitsQuery, revisionUpdaterApplicationNumUnits{})

--- a/domain/application/state/application_endpoint.go
+++ b/domain/application/state/application_endpoint.go
@@ -38,6 +38,7 @@ SELECT a.name AS &applicationEndpointBinding.application_name,
 FROM   application_endpoint ae
 JOIN   charm_relation cr ON cr.uuid = ae.charm_relation_uuid
 JOIN   application a ON a.uuid = ae.application_uuid
+WHERE  ae.application_uuid >= ''
 `, applicationEndpointBinding{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -50,17 +51,18 @@ SELECT a.name AS &applicationEndpointBinding.application_name,
 FROM   application_extra_endpoint aee
 JOIN   charm_extra_binding ceb ON ceb.uuid = aee.charm_extra_binding_uuid
 JOIN   application a ON a.uuid = aee.application_uuid
+WHERE  aee.application_uuid >= ''
 `, applicationEndpointBinding{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	defaultSpacesStmt, err := st.Prepare(`SELECT &applicationSpaceUUID.* FROM application`, applicationSpaceUUID{})
+	defaultSpacesStmt, err := st.Prepare(`SELECT &applicationSpaceUUID.* FROM application WHERE uuid >= ''`, applicationSpaceUUID{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	spacesStmt, err := st.Prepare(`SELECT &space.* FROM space`, space{})
+	spacesStmt, err := st.Prepare(`SELECT &space.* FROM space WHERE uuid >= ''`, space{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -655,7 +657,8 @@ WHERE charm_relation.charm_uuid = $entityUUID.uuid
 func (st *State) checkSpaceNames(ctx context.Context, tx *sqlair.TX, inputs []network.SpaceName) (map[network.SpaceName]string, error) {
 	fetchStmt, err := st.Prepare(`
 SELECT &space.*
-FROM space`, space{})
+FROM space
+WHERE uuid >= ''`, space{})
 	if err != nil {
 		return nil, errors.Errorf("preparing fetch space: %w", err)
 	}

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -40,7 +40,6 @@ import (
 	charmresource "github.com/juju/juju/domain/deployment/charm/resource"
 	"github.com/juju/juju/domain/life"
 	domainnetwork "github.com/juju/juju/domain/network"
-	removalstatemodel "github.com/juju/juju/domain/removal/state/model"
 	"github.com/juju/juju/domain/resource"
 	"github.com/juju/juju/domain/status"
 	statusstate "github.com/juju/juju/domain/status/state/model"
@@ -1127,14 +1126,11 @@ func (s *applicationStateSuite) TestCheckApplicationsForMigrationAliveWithDyingU
 	// Arrange: an application with some dying units
 	_, units := s.createIAASApplicationWithNUnits(c, "foo", life.Alive, 3)
 
-	removalState := removalstatemodel.NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-	_, err := removalState.EnsureUnitNotAliveCascade(c.Context(), units[0].String(), false)
-	c.Assert(err, tc.ErrorIsNil)
-	_, err = removalState.EnsureUnitNotAliveCascade(c.Context(), units[1].String(), false)
-	c.Assert(err, tc.ErrorIsNil)
+	s.setUnitLife(c, units[0], life.Dying)
+	s.setUnitLife(c, units[1], life.Dying)
 
 	// Act:
-	err = s.state.CheckApplicationsForMigration(c.Context())
+	err := s.state.CheckApplicationsForMigration(c.Context())
 
 	// Assert: an error of correct type, mentioning the correct unit, is returned.
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotAlive)

--- a/domain/application/state/config_test.go
+++ b/domain/application/state/config_test.go
@@ -313,7 +313,7 @@ func (s *configStateSuite) TestConfigType(c *tc.C) {
 	}
 
 	stmt := sqlair.MustPrepare(`
-SELECT charm_config_type.* AS &charmConfigType.* FROM charm_config_type ORDER BY id;
+SELECT charm_config_type.* AS &charmConfigType.* FROM charm_config_type WHERE id >= 0 ORDER BY id;
 `, charmConfigType{})
 
 	var results []charmConfigType

--- a/domain/application/state/manifest_test.go
+++ b/domain/application/state/manifest_test.go
@@ -270,7 +270,7 @@ func (s *manifestStateSuite) TestManifestArchitecture(c *tc.C) {
 	}
 
 	stmt := sqlair.MustPrepare(`
-SELECT architecture.* AS &archType.* FROM architecture ORDER BY id;
+SELECT architecture.* AS &archType.* FROM architecture WHERE id >= 0 ORDER BY id;
 `, archType{})
 
 	var results []archType

--- a/domain/application/state/metadata_test.go
+++ b/domain/application/state/metadata_test.go
@@ -481,7 +481,7 @@ func (s *metadataStateSuite) TestMetadataRunAs(c *tc.C) {
 	}
 
 	stmt := sqlair.MustPrepare(`
-SELECT charm_run_as_kind.* AS &charmRunAs.* FROM charm_run_as_kind ORDER BY id;
+SELECT charm_run_as_kind.* AS &charmRunAs.* FROM charm_run_as_kind WHERE id >= 0 ORDER BY id;
 `, charmRunAs{})
 
 	var results []charmRunAs
@@ -518,7 +518,7 @@ func (s *metadataStateSuite) TestMetadataRelationRole(c *tc.C) {
 	}
 
 	stmt := sqlair.MustPrepare(`
-SELECT charm_relation_role.* AS &charmRelationRole.* FROM charm_relation_role ORDER BY id;
+SELECT charm_relation_role.* AS &charmRelationRole.* FROM charm_relation_role WHERE id >= 0 ORDER BY id;
 `, charmRelationRole{})
 
 	var results []charmRelationRole
@@ -554,7 +554,7 @@ func (s *metadataStateSuite) TestMetadataRelationScope(c *tc.C) {
 	}
 
 	stmt := sqlair.MustPrepare(`
-SELECT charm_relation_scope.* AS &charmRelationScope.* FROM charm_relation_scope ORDER BY id;
+SELECT charm_relation_scope.* AS &charmRelationScope.* FROM charm_relation_scope WHERE id >= 0 ORDER BY id;
 `, charmRelationScope{})
 
 	var results []charmRelationScope
@@ -589,7 +589,7 @@ func (s *metadataStateSuite) TestMetadataStorageKind(c *tc.C) {
 	}
 
 	stmt := sqlair.MustPrepare(`
-SELECT charm_storage_kind.* AS &storageKind.* FROM charm_storage_kind ORDER BY id;
+SELECT charm_storage_kind.* AS &storageKind.* FROM charm_storage_kind WHERE id >= 0 ORDER BY id;
 `, storageKind{})
 
 	var results []storageKind
@@ -624,7 +624,7 @@ func (s *metadataStateSuite) TestMetadataResourceKind(c *tc.C) {
 	}
 
 	stmt := sqlair.MustPrepare(`
-SELECT charm_resource_kind.* AS &charmResourceKind.* FROM charm_resource_kind ORDER BY id;
+SELECT charm_resource_kind.* AS &charmResourceKind.* FROM charm_resource_kind WHERE id >= 0 ORDER BY id;
 `, charmResourceKind{})
 
 	var results []charmResourceKind

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -308,16 +308,27 @@ func (st *State) getStorageInstancesInfoForAttachByProviderIDs(
 ) ([]storageInstanceInfoForAttach, error) {
 	q := `
 WITH matched_storage_instances AS (
-    SELECT DISTINCT si.uuid
-    FROM      storage_instance si
-    LEFT JOIN storage_instance_filesystem sif ON si.uuid = sif.storage_instance_uuid
-    LEFT JOIN storage_filesystem sf ON sif.storage_filesystem_uuid = sf.uuid
-    LEFT JOIN storage_instance_volume siv ON si.uuid = siv.storage_instance_uuid
-    LEFT JOIN storage_volume sv ON siv.storage_volume_uuid = sv.uuid
-    LEFT JOIN storage_unit_owner suo ON si.uuid = suo.storage_instance_uuid
-    WHERE     suo.storage_instance_uuid IS NULL
-    AND       (sf.provider_id IN ($storageProviderIDs[:])
-           OR  sv.provider_id IN ($storageProviderIDs[:]))
+    SELECT sif.storage_instance_uuid AS uuid
+    FROM   storage_filesystem AS sf
+    JOIN   storage_instance_filesystem AS sif
+    ON     sif.storage_filesystem_uuid = sf.uuid
+    WHERE  sf.provider_id IN ($storageProviderIDs[:])
+    AND    NOT EXISTS (
+        SELECT 1
+        FROM   storage_unit_owner AS suo
+        WHERE  suo.storage_instance_uuid = sif.storage_instance_uuid
+    )
+    UNION
+    SELECT siv.storage_instance_uuid
+    FROM   storage_volume AS sv
+    JOIN   storage_instance_volume AS siv
+    ON     siv.storage_volume_uuid = sv.uuid
+    WHERE  sv.provider_id IN ($storageProviderIDs[:])
+    AND    NOT EXISTS (
+        SELECT 1
+        FROM   storage_unit_owner AS suo
+        WHERE  suo.storage_instance_uuid = siv.storage_instance_uuid
+    )
 )
 SELECT * AS &storageInstanceInfoForAttach.* FROM (
     SELECT    si.uuid,
@@ -382,16 +393,27 @@ func (st *State) getStorageInstanceUnitAttachmentsForProviderIDs(
 ) ([]storageInstanceUnitAttachmentByStorageUUID, error) {
 	q := `
 WITH matched_storage_instances AS (
-    SELECT DISTINCT si.uuid
-    FROM      storage_instance si
-    LEFT JOIN storage_instance_filesystem sif ON si.uuid = sif.storage_instance_uuid
-    LEFT JOIN storage_filesystem sf ON sif.storage_filesystem_uuid = sf.uuid
-    LEFT JOIN storage_instance_volume siv ON si.uuid = siv.storage_instance_uuid
-    LEFT JOIN storage_volume sv ON siv.storage_volume_uuid = sv.uuid
-    LEFT JOIN storage_unit_owner suo ON si.uuid = suo.storage_instance_uuid
-    WHERE     suo.storage_instance_uuid IS NULL
-    AND       (sf.provider_id IN ($storageProviderIDs[:])
-           OR  sv.provider_id IN ($storageProviderIDs[:]))
+    SELECT sif.storage_instance_uuid AS uuid
+    FROM   storage_filesystem AS sf
+    JOIN   storage_instance_filesystem AS sif
+    ON     sif.storage_filesystem_uuid = sf.uuid
+    WHERE  sf.provider_id IN ($storageProviderIDs[:])
+    AND    NOT EXISTS (
+        SELECT 1
+        FROM   storage_unit_owner AS suo
+        WHERE  suo.storage_instance_uuid = sif.storage_instance_uuid
+    )
+    UNION
+    SELECT siv.storage_instance_uuid
+    FROM   storage_volume AS sv
+    JOIN   storage_instance_volume AS siv
+    ON     siv.storage_volume_uuid = sv.uuid
+    WHERE  sv.provider_id IN ($storageProviderIDs[:])
+    AND    NOT EXISTS (
+        SELECT 1
+        FROM   storage_unit_owner AS suo
+        WHERE  suo.storage_instance_uuid = siv.storage_instance_uuid
+    )
 )
 SELECT &storageInstanceUnitAttachmentByStorageUUID.*
 FROM (
@@ -623,8 +645,8 @@ SELECT * AS &storageInstanceInfoForAttach.* FROM (
               sv.size_mib AS volume_size_mib,
               sv.provision_scope_id AS volume_provision_scope_id,
               mv.machine_uuid AS volume_owned_machine_uuid
-    FROM      storage_unit_owner suo
-    JOIN      storage_instance si ON suo.storage_instance_uuid = si.uuid
+    FROM      storage_unit_owner suo INDEXED BY idx_storage_unit_owner_unit
+    CROSS JOIN storage_instance si ON suo.storage_instance_uuid = si.uuid
     LEFT JOIN storage_instance_filesystem sif ON si.uuid = sif.storage_instance_uuid
     LEFT JOIN storage_filesystem sf ON sif.storage_filesystem_uuid = sf.uuid
     LEFT JOIN machine_filesystem mf ON sif.storage_filesystem_uuid = mf.filesystem_uuid
@@ -2524,52 +2546,38 @@ func (st *State) GetModelStoragePools(
 	}
 
 	modelConfigPools, err := st.Prepare(`
-WITH 	blockdevice_pool_name AS (
-            SELECT sk.id AS storage_kind_id,
-                   value AS name
-            FROM   model_config mc,
-                   storage_kind sk
-            WHERE  key=$storageModelConfigKeys.blockdevice_key
-            AND    sk.kind = 'block'
-		),
-		filesystem_pool_name AS (
-            SELECT sk.id AS storage_kind_id,
-                   value AS name
-            FROM   model_config mc,
-                   storage_kind sk
-            WHERE  key=$storageModelConfigKeys.filesystem_key
-            AND    sk.kind = 'filesystem'
-		),
-		mc_pools AS (
-            SELECT bpn.storage_kind_id,
-                   sp.uuid AS storage_pool_uuid
-            FROM   blockdevice_pool_name bpn
-            JOIN   storage_pool sp ON bpn.name=sp.name
-            UNION
-            SELECT fpn.storage_kind_id,
-                   sp.uuid AS storage_pool_uuid
-            FROM   filesystem_pool_name fpn
-            JOIN   storage_pool sp ON fpn.name=sp.name
-		)
-SELECT &modelStoragePools.* FROM (
-    SELECT storage_kind_id,
-           storage_pool_uuid
-    FROM   mc_pools
-    UNION
-    SELECT storage_kind_id,
-           storage_pool_uuid
-    FROM   model_storage_pool
-    WHERE  storage_kind_id NOT IN (SELECT storage_kind_id
-                                   FROM   mc_pools)
-)
+SELECT sk.id AS &modelStoragePools.storage_kind_id,
+       sp.uuid AS &modelStoragePools.storage_pool_uuid
+FROM   model_config AS mc
+CROSS JOIN storage_kind AS sk
+JOIN   storage_pool AS sp ON sp.name = mc.value
+WHERE  (mc.key = $storageModelConfigKeys.blockdevice_key AND sk.kind = 'block')
+OR     (mc.key = $storageModelConfigKeys.filesystem_key AND sk.kind = 'filesystem')
 `, storageModelConfigKeys, modelStoragePools{})
 	if err != nil {
 		return internal.ModelStoragePools{}, errors.Capture(err)
 	}
 
-	var dbVals []modelStoragePools
+	modelStoragePoolsStmt, err := st.Prepare(`
+SELECT &modelStoragePools.*
+FROM   model_storage_pool
+WHERE  storage_kind_id >= 0
+`, modelStoragePools{})
+	if err != nil {
+		return internal.ModelStoragePools{}, errors.Capture(err)
+	}
+
+	var modelConfigVals, modelVals []modelStoragePools
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, modelConfigPools, storageModelConfigKeys).GetAll(&dbVals)
+		modelConfigVals = nil
+		modelVals = nil
+
+		err := tx.Query(ctx, modelStoragePoolsStmt).GetAll(&modelVals)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Capture(err)
+		}
+
+		err = tx.Query(ctx, modelConfigPools, storageModelConfigKeys).GetAll(&modelConfigVals)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Capture(err)
 		}
@@ -2580,6 +2588,7 @@ SELECT &modelStoragePools.* FROM (
 	}
 
 	rval := internal.ModelStoragePools{}
+	dbVals := append(modelVals, modelConfigVals...)
 	for _, v := range dbVals {
 		switch v.StorageKindID {
 		case int(domainstorage.StorageKindBlock):

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -1974,7 +1974,8 @@ LEFT JOIN link_layer_device lld ON lld.net_node_uuid = u.net_node_uuid
 LEFT JOIN ip_address ip ON ip.device_uuid = lld.uuid
 LEFT JOIN k8s_pod_port kpp ON kpp.unit_uuid = u.uuid
 WHERE
-	u.life_id != $entityLife.life_id
+	u.name >= ''
+	AND u.life_id != $entityLife.life_id
 GROUP BY
 	u.name
 `

--- a/domain/application/state/unitstate.go
+++ b/domain/application/state/unitstate.go
@@ -646,7 +646,7 @@ DO NOTHING
 
 func (st *State) k8sSubnetUUIDsByAddressType(ctx context.Context, tx *sqlair.TX) (map[network.AddressType]string, error) {
 	result := make(map[network.AddressType]string)
-	subnetStmt, err := st.Prepare(`SELECT &subnet.* FROM subnet`, subnet{})
+	subnetStmt, err := st.Prepare(`SELECT &subnet.* FROM subnet WHERE cidr >= ''`, subnet{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/blockcommand/state/state.go
+++ b/domain/blockcommand/state/state.go
@@ -146,7 +146,7 @@ func (s *State) GetBlocks(ctx context.Context) ([]blockcommand.Block, error) {
 	}
 
 	var block blockCommand
-	stmt, err := s.Prepare("SELECT &blockCommand.* FROM block_command ORDER BY rowid", block)
+	stmt, err := s.Prepare("SELECT &blockCommand.* FROM block_command INDEXED BY idx_block_command_get_blocks ORDER BY rowid", block)
 	if err != nil {
 		return nil, errors.Errorf("preparing block command select: %w", err)
 	}

--- a/domain/blockdevice/state/state.go
+++ b/domain/blockdevice/state/state.go
@@ -629,6 +629,7 @@ func (st *State) GetBlockDevicesForAllMachines(
 	blockDeviceStmt, err := st.Prepare(`
 SELECT &blockDevice.*
 FROM   block_device
+WHERE  machine_uuid >= ''
 `, blockDevice{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -637,6 +638,7 @@ FROM   block_device
 	devLinkStmt, err := st.Prepare(`
 SELECT &deviceLink.*
 FROM   block_device_link_device
+WHERE  machine_uuid >= ''
 `, deviceLink{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -645,6 +647,7 @@ FROM   block_device_link_device
 	machineNameStmt, err := st.Prepare(`
 SELECT &entityName.*
 FROM   machine
+WHERE  name >= ''
 `, entityName{})
 
 	if err != nil {

--- a/domain/changestream/state/state.go
+++ b/domain/changestream/state/state.go
@@ -80,7 +80,11 @@ func (st *State) Prune(ctx context.Context, currentWindow changestream.Window) (
 }
 
 func (st *State) locateLowestWatermark(ctx context.Context, tx *sqlair.TX, current changestream.Window) (Watermark, changestream.Window, error) {
-	selectWitnessQuery, err := st.Prepare(`SELECT &Watermark.* FROM change_log_witness;`, Watermark{})
+	selectWitnessQuery, err := st.Prepare(`
+SELECT &Watermark.*
+FROM change_log_witness
+ORDER BY lower_bound, updated_at;
+`, Watermark{})
 	if err != nil {
 		return Watermark{}, changestream.Window{}, errors.Capture(err)
 	}

--- a/domain/changestream/state/state_test.go
+++ b/domain/changestream/state/state_test.go
@@ -357,7 +357,8 @@ VALUES ($M.id, 4, 10002, 0, $M.created_at);
 
 func (s *stateSuite) expectChangeLogWitnesses(c *tc.C, runner coredatabase.TxnRunner, watermarks []Watermark) {
 	query, err := sqlair.Prepare(`
-SELECT (controller_id, lower_bound, updated_at) AS (&Watermark.*) FROM change_log_witness;
+SELECT (controller_id, lower_bound, updated_at) AS (&Watermark.*) FROM change_log_witness
+ORDER BY lower_bound, updated_at;
 `, Watermark{})
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -376,13 +377,18 @@ SELECT (controller_id, lower_bound, updated_at) AS (&Watermark.*) FROM change_lo
 
 func (s *stateSuite) expectChangeLogItems(c *tc.C, runner coredatabase.TxnRunner, amount, lowerBound, upperBound int) {
 	query, err := sqlair.Prepare(`
-SELECT (id, edit_type_id, namespace_id, changed, created_at) AS (&ChangeLogItem.*) FROM change_log;
-	`, ChangeLogItem{})
+SELECT (id, edit_type_id, namespace_id, changed, created_at) AS (&ChangeLogItem.*)
+FROM change_log
+WHERE id BETWEEN $M.lower_bound AND $M.upper_bound;
+	`, ChangeLogItem{}, sqlair.M{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	var got []ChangeLogItem
 	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, query).GetAll(&got)
+		err := tx.Query(ctx, query, sqlair.M{
+			"lower_bound": lowerBound,
+			"upper_bound": upperBound,
+		}).GetAll(&got)
 		if err != nil {
 			return err
 		}

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -172,6 +172,8 @@ func LoadClouds(ctx context.Context, st domain.Preparer, tx *sqlair.TX, name str
 		args = append(args, sqlair.M{
 			"cloud_name": name,
 		})
+	} else {
+		q += "WHERE uuid >= ''"
 	}
 
 	loadCloudStmt, err := st.Prepare(q, sqlair.M{}, dbCloud{})
@@ -436,7 +438,7 @@ ON CONFLICT(uuid) DO UPDATE SET name=excluded.name,
 func loadAuthTypes(ctx context.Context, tx *sqlair.TX) (map[string]int, error) {
 	var dbAuthTypes = map[string]int{}
 
-	stmt, err := sqlair.Prepare("SELECT &authType.* FROM auth_type", authType{})
+	stmt, err := sqlair.Prepare("SELECT &authType.* FROM auth_type WHERE id >= 0", authType{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -125,7 +125,7 @@ func (s *stateSuite) assertAuthTypes(c *tc.C, cloudUUID string, expected cloud.A
 
 	var dbAuthTypes = map[int]string{}
 
-	rows, err := db.Query("SELECT id, type FROM auth_type")
+	rows, err := db.Query("SELECT id, type FROM auth_type WHERE id >= 0")
 	c.Assert(err, tc.ErrorIsNil)
 	defer func() { _ = rows.Close() }()
 

--- a/domain/cloudimagemetadata/state/helpers_test.go
+++ b/domain/cloudimagemetadata/state/helpers_test.go
@@ -38,6 +38,7 @@ SELECT
     image_id
 FROM cloud_image_metadata
 JOIN architecture arch on cloud_image_metadata.architecture_id = arch.id
+WHERE cloud_image_metadata.uuid >= ''
 `)
 		if err != nil {
 			return errors.Capture(err)

--- a/domain/cloudimagemetadata/state/state_test.go
+++ b/domain/cloudimagemetadata/state/state_test.go
@@ -46,7 +46,7 @@ func (s *stateSuite) TestArchitectureIDsByName(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	var loadArchsStmt *sqlair.Statement
-	loadArchsStmt, err = sqlair.Prepare(`SELECT &architecture.* FROM architecture;`, architecture{})
+	loadArchsStmt, err = sqlair.Prepare(`SELECT &architecture.* FROM architecture WHERE id >= 0;`, architecture{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	var archs []architecture

--- a/domain/controller/state/state.go
+++ b/domain/controller/state/state.go
@@ -100,7 +100,7 @@ func (st *State) GetModelNamespaces(ctx context.Context) ([]string, error) {
 		return nil, errors.Capture(err)
 	}
 
-	stmt, err := st.Prepare(`SELECT &namespace.* FROM namespace_list`, namespace{})
+	stmt, err := st.Prepare(`SELECT &namespace.* FROM namespace_list WHERE namespace >= ''`, namespace{})
 	if err != nil {
 		return nil, errors.Errorf("preparing select model namespaces statement: %w", err)
 	}

--- a/domain/controllerconfig/state/state.go
+++ b/domain/controllerconfig/state/state.go
@@ -34,7 +34,7 @@ func (st *State) ControllerConfig(ctx context.Context) (map[string]string, error
 		return nil, errors.Capture(err)
 	}
 
-	stmt, err := st.Prepare("SELECT &KeyValue.* FROM v_controller_config", KeyValue{})
+	stmt, err := st.Prepare("SELECT &KeyValue.* FROM v_controller_config WHERE key >= ''", KeyValue{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -491,6 +491,7 @@ func (st *State) getAllAPIAddressesForClients(ctx context.Context, tx *sqlair.TX
 	stmt, err := st.Prepare(`
 SELECT &controllerAPIAddress.* 
 FROM controller_api_address
+WHERE controller_id >= ''
 `, controllerAPIAddress{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/controllerupgrader/state/controller.go
+++ b/domain/controllerupgrader/state/controller.go
@@ -106,6 +106,7 @@ func (s *ControllerState) GetControllerNodes(ctx context.Context) ([]internal.Co
 	stmt, err := s.Prepare(`
 SELECT &controllerNodeAgentVersion.*
 FROM   controller_node_agent_version
+       INDEXED BY idx_controller_node_agent_version_details
 `,
 		controllerNodeAgentVersion{})
 	if err != nil {

--- a/domain/crossmodelrelation/state/controller/offer_test.go
+++ b/domain/crossmodelrelation/state/controller/offer_test.go
@@ -308,7 +308,7 @@ func (s *controllerOfferSuite) addOfferPermission(c *tc.C, userUUID, offerUUID s
 }
 
 func (s *controllerOfferSuite) readPermissions(c *tc.C) []permission {
-	rows, err := s.DB().QueryContext(c.Context(), `SELECT * FROM v_permission`)
+	rows, err := s.DB().QueryContext(c.Context(), `SELECT * FROM v_permission WHERE uuid >= ''`)
 	c.Assert(err, tc.IsNil)
 	defer func() { _ = rows.Close() }()
 	foundPermissions := []permission{}

--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -327,6 +327,7 @@ func (st *State) getOfferDetails(ctx context.Context, tx *sqlair.TX) (offerDetai
 	stmt, err := st.Prepare(`
 SELECT &offerDetail.*
 FROM   v_offer_detail
+WHERE  offer_uuid >= ''
 `, offerDetail{})
 	if err != nil {
 		return nil, errors.Errorf("preparing offer detail query: %w", err)
@@ -374,6 +375,7 @@ AND    (application_description LIKE $offerFilter.application_description OR $of
 AND    (endpoint_name = $offerFilter.endpoint_name OR $offerFilter.endpoint_name = '')
 AND    (endpoint_role = $offerFilter.endpoint_role OR $offerFilter.endpoint_role = '')
 AND    (endpoint_interface = $offerFilter.endpoint_interface OR $offerFilter.endpoint_interface = '')
+AND    offer_uuid >= ''
 `, offerDetail{}, offerFilter{})
 	if err != nil {
 		return nil, errors.Errorf("preparing filtered offer detail query: %w", err)

--- a/domain/crossmodelrelation/state/model/package_test.go
+++ b/domain/crossmodelrelation/state/model/package_test.go
@@ -50,7 +50,7 @@ func (s *baseSuite) SetUpTest(c *tc.C) {
 }
 
 func (s *baseSuite) readOffers(c *tc.C) []nameAndUUID {
-	rows, err := s.DB().QueryContext(c.Context(), `SELECT * FROM offer`)
+	rows, err := s.DB().QueryContext(c.Context(), `SELECT * FROM offer WHERE name >= ''`)
 	c.Assert(err, tc.IsNil)
 	defer func() { _ = rows.Close() }()
 	foundOffers := []nameAndUUID{}
@@ -64,7 +64,7 @@ func (s *baseSuite) readOffers(c *tc.C) []nameAndUUID {
 }
 
 func (s *baseSuite) readOfferEndpoints(c *tc.C) []offerEndpoint {
-	rows, err := s.DB().QueryContext(c.Context(), `SELECT * FROM offer_endpoint`)
+	rows, err := s.DB().QueryContext(c.Context(), `SELECT * FROM offer_endpoint WHERE endpoint_uuid >= ''`)
 	c.Assert(err, tc.IsNil)
 	defer func() { _ = rows.Close() }()
 	foundOfferEndpoints := []offerEndpoint{}

--- a/domain/crossmodelrelation/state/model/remoteapplication.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication.go
@@ -1001,6 +1001,7 @@ func (st *State) InitialWatchStatementForConsumerRelations() (string, eventsourc
 SELECT DISTINCT re.relation_uuid AS &uuid.uuid
 FROM   v_relation_endpoint AS re
 JOIN   application_remote_offerer AS aro ON aro.application_uuid = re.application_uuid
+WHERE  re.relation_uuid >= ''
 `, uuid{})
 		if err != nil {
 			return nil, errors.Capture(err)
@@ -1046,6 +1047,7 @@ func (st *State) GetConsumerRelationUUIDs(ctx context.Context, relationUUIDs ...
 SELECT DISTINCT re.relation_uuid AS &uuid.uuid
 FROM   v_relation_endpoint AS re
 JOIN   application_remote_offerer AS aro ON aro.application_uuid = re.application_uuid
+WHERE  re.relation_uuid >= ''
 `, uuid{})
 		if err != nil {
 			return nil, errors.Capture(err)

--- a/domain/crossmodelrelation/state/model/secrets.go
+++ b/domain/crossmodelrelation/state/model/secrets.go
@@ -37,6 +37,7 @@ LEFT JOIN secret_revision sr ON sr.secret_id = sruc.secret_id
 JOIN      application app ON app.name = substr(sruc.unit_name, 1, instr(sruc.unit_name, '/')-1)
 JOIN      application_remote_consumer arc ON arc.offer_connection_uuid = app.uuid
 WHERE     arc.offerer_application_uuid = $applicationUUID.uuid
+AND       sruc.secret_id >= ''
 GROUP BY  sruc.secret_id
 HAVING    sruc.current_revision < MAX(sr.revision)`
 		app := applicationUUID{UUID: appUUID}
@@ -268,22 +269,31 @@ ON CONFLICT(secret_id, unit_name) DO UPDATE SET
 func (st *State) markObsoleteRevisions(ctx context.Context, tx *sqlair.TX, uri *coresecrets.URI) error {
 	query, err := st.Prepare(`
 SELECT sr.uuid AS &revisionUUID.uuid
-FROM   secret_revision sr
-       LEFT JOIN (
-           -- revisions that have local consumers.
-           SELECT DISTINCT current_revision AS revision FROM secret_unit_consumer suc
-           WHERE  suc.secret_id = $secretRef.secret_id
-           UNION
-           -- revisions that have remote consumers.
-           SELECT DISTINCT current_revision AS revision FROM secret_remote_unit_consumer suc
-           WHERE  suc.secret_id = $secretRef.secret_id
-           UNION
-           -- the latest revision.
-           SELECT MAX(revision) FROM secret_revision rev
-           WHERE  rev.secret_id = $secretRef.secret_id
-       ) in_use ON sr.revision = in_use.revision
+FROM   secret_revision AS sr
 WHERE sr.secret_id = $secretRef.secret_id
-AND (in_use.revision IS NULL OR in_use.revision = 0);
+AND sr.revision >= 0
+AND (
+    sr.revision = 0
+    OR (
+        NOT EXISTS (
+            SELECT 1
+            FROM secret_unit_consumer AS suc
+            WHERE suc.secret_id = $secretRef.secret_id
+            AND suc.current_revision = sr.revision
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM secret_remote_unit_consumer AS sruc
+            WHERE sruc.secret_id = $secretRef.secret_id
+            AND sruc.current_revision = sr.revision
+        )
+        AND sr.revision != (
+            SELECT MAX(rev.revision)
+            FROM secret_revision AS rev
+            WHERE rev.secret_id = $secretRef.secret_id
+        )
+    )
+);
 `, secretRef{}, revisionUUID{})
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/export/state/model/export.go
+++ b/domain/export/state/model/export.go
@@ -21,999 +21,999 @@ func (st *State) Export(ctx context.Context) (*v4_1_0.ModelExport, error) {
 	var err error
 
 	// Prepare statements first using the typed samples from the generated types package.
-	stmtAgentBinaryStore, err := sqlair.Prepare(`SELECT &AgentBinaryStore.* FROM "agent_binary_store"`, v4_1_0.AgentBinaryStore{})
+	stmtAgentBinaryStore, err := sqlair.Prepare(`SELECT &AgentBinaryStore.* FROM "agent_binary_store" WHERE rowid >= -9223372036854775808`, v4_1_0.AgentBinaryStore{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AgentBinaryStore statement: %w", err)
 	}
-	stmtAgentStream, err := sqlair.Prepare(`SELECT &AgentStream.* FROM "agent_stream"`, v4_1_0.AgentStream{})
+	stmtAgentStream, err := sqlair.Prepare(`SELECT &AgentStream.* FROM "agent_stream" WHERE rowid >= -9223372036854775808`, v4_1_0.AgentStream{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AgentStream statement: %w", err)
 	}
-	stmtAgentVersion, err := sqlair.Prepare(`SELECT &AgentVersion.* FROM "agent_version"`, v4_1_0.AgentVersion{})
+	stmtAgentVersion, err := sqlair.Prepare(`SELECT &AgentVersion.* FROM "agent_version" WHERE rowid >= -9223372036854775808`, v4_1_0.AgentVersion{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AgentVersion statement: %w", err)
 	}
-	stmtAnnotationApplication, err := sqlair.Prepare(`SELECT &AnnotationApplication.* FROM "annotation_application"`, v4_1_0.AnnotationApplication{})
+	stmtAnnotationApplication, err := sqlair.Prepare(`SELECT &AnnotationApplication.* FROM "annotation_application" WHERE rowid >= -9223372036854775808`, v4_1_0.AnnotationApplication{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AnnotationApplication statement: %w", err)
 	}
-	stmtAnnotationCharm, err := sqlair.Prepare(`SELECT &AnnotationCharm.* FROM "annotation_charm"`, v4_1_0.AnnotationCharm{})
+	stmtAnnotationCharm, err := sqlair.Prepare(`SELECT &AnnotationCharm.* FROM "annotation_charm" WHERE rowid >= -9223372036854775808`, v4_1_0.AnnotationCharm{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AnnotationCharm statement: %w", err)
 	}
-	stmtAnnotationMachine, err := sqlair.Prepare(`SELECT &AnnotationMachine.* FROM "annotation_machine"`, v4_1_0.AnnotationMachine{})
+	stmtAnnotationMachine, err := sqlair.Prepare(`SELECT &AnnotationMachine.* FROM "annotation_machine" WHERE rowid >= -9223372036854775808`, v4_1_0.AnnotationMachine{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AnnotationMachine statement: %w", err)
 	}
-	stmtAnnotationModel, err := sqlair.Prepare(`SELECT &AnnotationModel.* FROM "annotation_model"`, v4_1_0.AnnotationModel{})
+	stmtAnnotationModel, err := sqlair.Prepare(`SELECT &AnnotationModel.* FROM "annotation_model" WHERE rowid >= -9223372036854775808`, v4_1_0.AnnotationModel{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AnnotationModel statement: %w", err)
 	}
-	stmtAnnotationStorageFilesystem, err := sqlair.Prepare(`SELECT &AnnotationStorageFilesystem.* FROM "annotation_storage_filesystem"`, v4_1_0.AnnotationStorageFilesystem{})
+	stmtAnnotationStorageFilesystem, err := sqlair.Prepare(`SELECT &AnnotationStorageFilesystem.* FROM "annotation_storage_filesystem" WHERE rowid >= -9223372036854775808`, v4_1_0.AnnotationStorageFilesystem{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AnnotationStorageFilesystem statement: %w", err)
 	}
-	stmtAnnotationStorageInstance, err := sqlair.Prepare(`SELECT &AnnotationStorageInstance.* FROM "annotation_storage_instance"`, v4_1_0.AnnotationStorageInstance{})
+	stmtAnnotationStorageInstance, err := sqlair.Prepare(`SELECT &AnnotationStorageInstance.* FROM "annotation_storage_instance" WHERE rowid >= -9223372036854775808`, v4_1_0.AnnotationStorageInstance{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AnnotationStorageInstance statement: %w", err)
 	}
-	stmtAnnotationStorageVolume, err := sqlair.Prepare(`SELECT &AnnotationStorageVolume.* FROM "annotation_storage_volume"`, v4_1_0.AnnotationStorageVolume{})
+	stmtAnnotationStorageVolume, err := sqlair.Prepare(`SELECT &AnnotationStorageVolume.* FROM "annotation_storage_volume" WHERE rowid >= -9223372036854775808`, v4_1_0.AnnotationStorageVolume{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AnnotationStorageVolume statement: %w", err)
 	}
-	stmtAnnotationUnit, err := sqlair.Prepare(`SELECT &AnnotationUnit.* FROM "annotation_unit"`, v4_1_0.AnnotationUnit{})
+	stmtAnnotationUnit, err := sqlair.Prepare(`SELECT &AnnotationUnit.* FROM "annotation_unit" WHERE rowid >= -9223372036854775808`, v4_1_0.AnnotationUnit{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AnnotationUnit statement: %w", err)
 	}
-	stmtApplication, err := sqlair.Prepare(`SELECT &Application.* FROM "application"`, v4_1_0.Application{})
+	stmtApplication, err := sqlair.Prepare(`SELECT &Application.* FROM "application" WHERE rowid >= -9223372036854775808`, v4_1_0.Application{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Application statement: %w", err)
 	}
-	stmtApplicationAgent, err := sqlair.Prepare(`SELECT &ApplicationAgent.* FROM "application_agent"`, v4_1_0.ApplicationAgent{})
+	stmtApplicationAgent, err := sqlair.Prepare(`SELECT &ApplicationAgent.* FROM "application_agent" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationAgent{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationAgent statement: %w", err)
 	}
-	stmtApplicationChannel, err := sqlair.Prepare(`SELECT &ApplicationChannel.* FROM "application_channel"`, v4_1_0.ApplicationChannel{})
+	stmtApplicationChannel, err := sqlair.Prepare(`SELECT &ApplicationChannel.* FROM "application_channel" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationChannel{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationChannel statement: %w", err)
 	}
-	stmtApplicationConfig, err := sqlair.Prepare(`SELECT &ApplicationConfig.* FROM "application_config"`, v4_1_0.ApplicationConfig{})
+	stmtApplicationConfig, err := sqlair.Prepare(`SELECT &ApplicationConfig.* FROM "application_config" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationConfig statement: %w", err)
 	}
-	stmtApplicationConfigHash, err := sqlair.Prepare(`SELECT &ApplicationConfigHash.* FROM "application_config_hash"`, v4_1_0.ApplicationConfigHash{})
+	stmtApplicationConfigHash, err := sqlair.Prepare(`SELECT &ApplicationConfigHash.* FROM "application_config_hash" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationConfigHash{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationConfigHash statement: %w", err)
 	}
-	stmtApplicationConstraint, err := sqlair.Prepare(`SELECT &ApplicationConstraint.* FROM "application_constraint"`, v4_1_0.ApplicationConstraint{})
+	stmtApplicationConstraint, err := sqlair.Prepare(`SELECT &ApplicationConstraint.* FROM "application_constraint" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationConstraint{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationConstraint statement: %w", err)
 	}
-	stmtApplicationController, err := sqlair.Prepare(`SELECT &ApplicationController.* FROM "application_controller"`, v4_1_0.ApplicationController{})
+	stmtApplicationController, err := sqlair.Prepare(`SELECT &ApplicationController.* FROM "application_controller" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationController{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationController statement: %w", err)
 	}
-	stmtApplicationEndpoint, err := sqlair.Prepare(`SELECT &ApplicationEndpoint.* FROM "application_endpoint"`, v4_1_0.ApplicationEndpoint{})
+	stmtApplicationEndpoint, err := sqlair.Prepare(`SELECT &ApplicationEndpoint.* FROM "application_endpoint" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationEndpoint{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationEndpoint statement: %w", err)
 	}
-	stmtApplicationExposedEndpointCidr, err := sqlair.Prepare(`SELECT &ApplicationExposedEndpointCidr.* FROM "application_exposed_endpoint_cidr"`, v4_1_0.ApplicationExposedEndpointCidr{})
+	stmtApplicationExposedEndpointCidr, err := sqlair.Prepare(`SELECT &ApplicationExposedEndpointCidr.* FROM "application_exposed_endpoint_cidr" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationExposedEndpointCidr{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationExposedEndpointCidr statement: %w", err)
 	}
-	stmtApplicationExposedEndpointSpace, err := sqlair.Prepare(`SELECT &ApplicationExposedEndpointSpace.* FROM "application_exposed_endpoint_space"`, v4_1_0.ApplicationExposedEndpointSpace{})
+	stmtApplicationExposedEndpointSpace, err := sqlair.Prepare(`SELECT &ApplicationExposedEndpointSpace.* FROM "application_exposed_endpoint_space" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationExposedEndpointSpace{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationExposedEndpointSpace statement: %w", err)
 	}
-	stmtApplicationExtraEndpoint, err := sqlair.Prepare(`SELECT &ApplicationExtraEndpoint.* FROM "application_extra_endpoint"`, v4_1_0.ApplicationExtraEndpoint{})
+	stmtApplicationExtraEndpoint, err := sqlair.Prepare(`SELECT &ApplicationExtraEndpoint.* FROM "application_extra_endpoint" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationExtraEndpoint{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationExtraEndpoint statement: %w", err)
 	}
-	stmtApplicationK8sResourcesManaged, err := sqlair.Prepare(`SELECT &ApplicationK8sResourcesManaged.* FROM "application_k8s_resources_managed"`, v4_1_0.ApplicationK8sResourcesManaged{})
+	stmtApplicationK8sResourcesManaged, err := sqlair.Prepare(`SELECT &ApplicationK8sResourcesManaged.* FROM "application_k8s_resources_managed" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationK8sResourcesManaged{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationK8sResourcesManaged statement: %w", err)
 	}
-	stmtApplicationPlatform, err := sqlair.Prepare(`SELECT &ApplicationPlatform.* FROM "application_platform"`, v4_1_0.ApplicationPlatform{})
+	stmtApplicationPlatform, err := sqlair.Prepare(`SELECT &ApplicationPlatform.* FROM "application_platform" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationPlatform{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationPlatform statement: %w", err)
 	}
-	stmtApplicationRemoteConsumer, err := sqlair.Prepare(`SELECT &ApplicationRemoteConsumer.* FROM "application_remote_consumer"`, v4_1_0.ApplicationRemoteConsumer{})
+	stmtApplicationRemoteConsumer, err := sqlair.Prepare(`SELECT &ApplicationRemoteConsumer.* FROM "application_remote_consumer" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationRemoteConsumer{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationRemoteConsumer statement: %w", err)
 	}
-	stmtApplicationRemoteOfferer, err := sqlair.Prepare(`SELECT &ApplicationRemoteOfferer.* FROM "application_remote_offerer"`, v4_1_0.ApplicationRemoteOfferer{})
+	stmtApplicationRemoteOfferer, err := sqlair.Prepare(`SELECT &ApplicationRemoteOfferer.* FROM "application_remote_offerer" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationRemoteOfferer{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationRemoteOfferer statement: %w", err)
 	}
-	stmtApplicationRemoteOffererRelationMacaroon, err := sqlair.Prepare(`SELECT &ApplicationRemoteOffererRelationMacaroon.* FROM "application_remote_offerer_relation_macaroon"`, v4_1_0.ApplicationRemoteOffererRelationMacaroon{})
+	stmtApplicationRemoteOffererRelationMacaroon, err := sqlair.Prepare(`SELECT &ApplicationRemoteOffererRelationMacaroon.* FROM "application_remote_offerer_relation_macaroon" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationRemoteOffererRelationMacaroon{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationRemoteOffererRelationMacaroon statement: %w", err)
 	}
-	stmtApplicationRemoteOffererStatus, err := sqlair.Prepare(`SELECT &ApplicationRemoteOffererStatus.* FROM "application_remote_offerer_status"`, v4_1_0.ApplicationRemoteOffererStatus{})
+	stmtApplicationRemoteOffererStatus, err := sqlair.Prepare(`SELECT &ApplicationRemoteOffererStatus.* FROM "application_remote_offerer_status" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationRemoteOffererStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationRemoteOffererStatus statement: %w", err)
 	}
-	stmtApplicationResource, err := sqlair.Prepare(`SELECT &ApplicationResource.* FROM "application_resource"`, v4_1_0.ApplicationResource{})
+	stmtApplicationResource, err := sqlair.Prepare(`SELECT &ApplicationResource.* FROM "application_resource" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationResource{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationResource statement: %w", err)
 	}
-	stmtApplicationScale, err := sqlair.Prepare(`SELECT &ApplicationScale.* FROM "application_scale"`, v4_1_0.ApplicationScale{})
+	stmtApplicationScale, err := sqlair.Prepare(`SELECT &ApplicationScale.* FROM "application_scale" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationScale{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationScale statement: %w", err)
 	}
-	stmtApplicationSetting, err := sqlair.Prepare(`SELECT &ApplicationSetting.* FROM "application_setting"`, v4_1_0.ApplicationSetting{})
+	stmtApplicationSetting, err := sqlair.Prepare(`SELECT &ApplicationSetting.* FROM "application_setting" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationSetting{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationSetting statement: %w", err)
 	}
-	stmtApplicationStatus, err := sqlair.Prepare(`SELECT &ApplicationStatus.* FROM "application_status"`, v4_1_0.ApplicationStatus{})
+	stmtApplicationStatus, err := sqlair.Prepare(`SELECT &ApplicationStatus.* FROM "application_status" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationStatus statement: %w", err)
 	}
-	stmtApplicationStorageDirective, err := sqlair.Prepare(`SELECT &ApplicationStorageDirective.* FROM "application_storage_directive"`, v4_1_0.ApplicationStorageDirective{})
+	stmtApplicationStorageDirective, err := sqlair.Prepare(`SELECT &ApplicationStorageDirective.* FROM "application_storage_directive" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationStorageDirective{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationStorageDirective statement: %w", err)
 	}
-	stmtApplicationWorkloadVersion, err := sqlair.Prepare(`SELECT &ApplicationWorkloadVersion.* FROM "application_workload_version"`, v4_1_0.ApplicationWorkloadVersion{})
+	stmtApplicationWorkloadVersion, err := sqlair.Prepare(`SELECT &ApplicationWorkloadVersion.* FROM "application_workload_version" WHERE rowid >= -9223372036854775808`, v4_1_0.ApplicationWorkloadVersion{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationWorkloadVersion statement: %w", err)
 	}
-	stmtArchitecture, err := sqlair.Prepare(`SELECT &Architecture.* FROM "architecture"`, v4_1_0.Architecture{})
+	stmtArchitecture, err := sqlair.Prepare(`SELECT &Architecture.* FROM "architecture" WHERE rowid >= -9223372036854775808`, v4_1_0.Architecture{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Architecture statement: %w", err)
 	}
-	stmtAvailabilityZone, err := sqlair.Prepare(`SELECT &AvailabilityZone.* FROM "availability_zone"`, v4_1_0.AvailabilityZone{})
+	stmtAvailabilityZone, err := sqlair.Prepare(`SELECT &AvailabilityZone.* FROM "availability_zone" WHERE rowid >= -9223372036854775808`, v4_1_0.AvailabilityZone{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AvailabilityZone statement: %w", err)
 	}
-	stmtAvailabilityZoneSubnet, err := sqlair.Prepare(`SELECT &AvailabilityZoneSubnet.* FROM "availability_zone_subnet"`, v4_1_0.AvailabilityZoneSubnet{})
+	stmtAvailabilityZoneSubnet, err := sqlair.Prepare(`SELECT &AvailabilityZoneSubnet.* FROM "availability_zone_subnet" WHERE rowid >= -9223372036854775808`, v4_1_0.AvailabilityZoneSubnet{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing AvailabilityZoneSubnet statement: %w", err)
 	}
-	stmtBlockCommand, err := sqlair.Prepare(`SELECT &BlockCommand.* FROM "block_command"`, v4_1_0.BlockCommand{})
+	stmtBlockCommand, err := sqlair.Prepare(`SELECT &BlockCommand.* FROM "block_command" WHERE rowid >= -9223372036854775808`, v4_1_0.BlockCommand{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing BlockCommand statement: %w", err)
 	}
-	stmtBlockCommandType, err := sqlair.Prepare(`SELECT &BlockCommandType.* FROM "block_command_type"`, v4_1_0.BlockCommandType{})
+	stmtBlockCommandType, err := sqlair.Prepare(`SELECT &BlockCommandType.* FROM "block_command_type" WHERE rowid >= -9223372036854775808`, v4_1_0.BlockCommandType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing BlockCommandType statement: %w", err)
 	}
-	stmtBlockDevice, err := sqlair.Prepare(`SELECT &BlockDevice.* FROM "block_device"`, v4_1_0.BlockDevice{})
+	stmtBlockDevice, err := sqlair.Prepare(`SELECT &BlockDevice.* FROM "block_device" WHERE rowid >= -9223372036854775808`, v4_1_0.BlockDevice{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing BlockDevice statement: %w", err)
 	}
-	stmtBlockDeviceLinkDevice, err := sqlair.Prepare(`SELECT &BlockDeviceLinkDevice.* FROM "block_device_link_device"`, v4_1_0.BlockDeviceLinkDevice{})
+	stmtBlockDeviceLinkDevice, err := sqlair.Prepare(`SELECT &BlockDeviceLinkDevice.* FROM "block_device_link_device" WHERE rowid >= -9223372036854775808`, v4_1_0.BlockDeviceLinkDevice{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing BlockDeviceLinkDevice statement: %w", err)
 	}
-	stmtBlockDeviceProvenance, err := sqlair.Prepare(`SELECT &BlockDeviceProvenance.* FROM "block_device_provenance"`, v4_1_0.BlockDeviceProvenance{})
+	stmtBlockDeviceProvenance, err := sqlair.Prepare(`SELECT &BlockDeviceProvenance.* FROM "block_device_provenance" WHERE rowid >= -9223372036854775808`, v4_1_0.BlockDeviceProvenance{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing BlockDeviceProvenance statement: %w", err)
 	}
-	stmtChangeLog, err := sqlair.Prepare(`SELECT &ChangeLog.* FROM "change_log"`, v4_1_0.ChangeLog{})
+	stmtChangeLog, err := sqlair.Prepare(`SELECT &ChangeLog.* FROM "change_log" WHERE rowid >= -9223372036854775808`, v4_1_0.ChangeLog{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ChangeLog statement: %w", err)
 	}
-	stmtChangeLogEditType, err := sqlair.Prepare(`SELECT &ChangeLogEditType.* FROM "change_log_edit_type"`, v4_1_0.ChangeLogEditType{})
+	stmtChangeLogEditType, err := sqlair.Prepare(`SELECT &ChangeLogEditType.* FROM "change_log_edit_type" WHERE rowid >= -9223372036854775808`, v4_1_0.ChangeLogEditType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ChangeLogEditType statement: %w", err)
 	}
-	stmtChangeLogNamespace, err := sqlair.Prepare(`SELECT &ChangeLogNamespace.* FROM "change_log_namespace"`, v4_1_0.ChangeLogNamespace{})
+	stmtChangeLogNamespace, err := sqlair.Prepare(`SELECT &ChangeLogNamespace.* FROM "change_log_namespace" WHERE rowid >= -9223372036854775808`, v4_1_0.ChangeLogNamespace{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ChangeLogNamespace statement: %w", err)
 	}
-	stmtChangeLogWitness, err := sqlair.Prepare(`SELECT &ChangeLogWitness.* FROM "change_log_witness"`, v4_1_0.ChangeLogWitness{})
+	stmtChangeLogWitness, err := sqlair.Prepare(`SELECT &ChangeLogWitness.* FROM "change_log_witness" WHERE rowid >= -9223372036854775808`, v4_1_0.ChangeLogWitness{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ChangeLogWitness statement: %w", err)
 	}
-	stmtCharm, err := sqlair.Prepare(`SELECT &Charm.* FROM "charm"`, v4_1_0.Charm{})
+	stmtCharm, err := sqlair.Prepare(`SELECT &Charm.* FROM "charm" WHERE rowid >= -9223372036854775808`, v4_1_0.Charm{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Charm statement: %w", err)
 	}
-	stmtCharmAction, err := sqlair.Prepare(`SELECT &CharmAction.* FROM "charm_action"`, v4_1_0.CharmAction{})
+	stmtCharmAction, err := sqlair.Prepare(`SELECT &CharmAction.* FROM "charm_action" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmAction{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmAction statement: %w", err)
 	}
-	stmtCharmCategory, err := sqlair.Prepare(`SELECT &CharmCategory.* FROM "charm_category"`, v4_1_0.CharmCategory{})
+	stmtCharmCategory, err := sqlair.Prepare(`SELECT &CharmCategory.* FROM "charm_category" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmCategory{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmCategory statement: %w", err)
 	}
-	stmtCharmConfig, err := sqlair.Prepare(`SELECT &CharmConfig.* FROM "charm_config"`, v4_1_0.CharmConfig{})
+	stmtCharmConfig, err := sqlair.Prepare(`SELECT &CharmConfig.* FROM "charm_config" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmConfig statement: %w", err)
 	}
-	stmtCharmConfigType, err := sqlair.Prepare(`SELECT &CharmConfigType.* FROM "charm_config_type"`, v4_1_0.CharmConfigType{})
+	stmtCharmConfigType, err := sqlair.Prepare(`SELECT &CharmConfigType.* FROM "charm_config_type" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmConfigType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmConfigType statement: %w", err)
 	}
-	stmtCharmContainer, err := sqlair.Prepare(`SELECT &CharmContainer.* FROM "charm_container"`, v4_1_0.CharmContainer{})
+	stmtCharmContainer, err := sqlair.Prepare(`SELECT &CharmContainer.* FROM "charm_container" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmContainer{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmContainer statement: %w", err)
 	}
-	stmtCharmContainerMount, err := sqlair.Prepare(`SELECT &CharmContainerMount.* FROM "charm_container_mount"`, v4_1_0.CharmContainerMount{})
+	stmtCharmContainerMount, err := sqlair.Prepare(`SELECT &CharmContainerMount.* FROM "charm_container_mount" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmContainerMount{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmContainerMount statement: %w", err)
 	}
-	stmtCharmDevice, err := sqlair.Prepare(`SELECT &CharmDevice.* FROM "charm_device"`, v4_1_0.CharmDevice{})
+	stmtCharmDevice, err := sqlair.Prepare(`SELECT &CharmDevice.* FROM "charm_device" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmDevice{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmDevice statement: %w", err)
 	}
-	stmtCharmDownloadInfo, err := sqlair.Prepare(`SELECT &CharmDownloadInfo.* FROM "charm_download_info"`, v4_1_0.CharmDownloadInfo{})
+	stmtCharmDownloadInfo, err := sqlair.Prepare(`SELECT &CharmDownloadInfo.* FROM "charm_download_info" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmDownloadInfo{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmDownloadInfo statement: %w", err)
 	}
-	stmtCharmExtraBinding, err := sqlair.Prepare(`SELECT &CharmExtraBinding.* FROM "charm_extra_binding"`, v4_1_0.CharmExtraBinding{})
+	stmtCharmExtraBinding, err := sqlair.Prepare(`SELECT &CharmExtraBinding.* FROM "charm_extra_binding" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmExtraBinding{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmExtraBinding statement: %w", err)
 	}
-	stmtCharmHash, err := sqlair.Prepare(`SELECT &CharmHash.* FROM "charm_hash"`, v4_1_0.CharmHash{})
+	stmtCharmHash, err := sqlair.Prepare(`SELECT &CharmHash.* FROM "charm_hash" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmHash{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmHash statement: %w", err)
 	}
-	stmtCharmManifestBase, err := sqlair.Prepare(`SELECT &CharmManifestBase.* FROM "charm_manifest_base"`, v4_1_0.CharmManifestBase{})
+	stmtCharmManifestBase, err := sqlair.Prepare(`SELECT &CharmManifestBase.* FROM "charm_manifest_base" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmManifestBase{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmManifestBase statement: %w", err)
 	}
-	stmtCharmMetadata, err := sqlair.Prepare(`SELECT &CharmMetadata.* FROM "charm_metadata"`, v4_1_0.CharmMetadata{})
+	stmtCharmMetadata, err := sqlair.Prepare(`SELECT &CharmMetadata.* FROM "charm_metadata" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmMetadata{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmMetadata statement: %w", err)
 	}
-	stmtCharmProvenance, err := sqlair.Prepare(`SELECT &CharmProvenance.* FROM "charm_provenance"`, v4_1_0.CharmProvenance{})
+	stmtCharmProvenance, err := sqlair.Prepare(`SELECT &CharmProvenance.* FROM "charm_provenance" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmProvenance{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmProvenance statement: %w", err)
 	}
-	stmtCharmRelation, err := sqlair.Prepare(`SELECT &CharmRelation.* FROM "charm_relation"`, v4_1_0.CharmRelation{})
+	stmtCharmRelation, err := sqlair.Prepare(`SELECT &CharmRelation.* FROM "charm_relation" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmRelation{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmRelation statement: %w", err)
 	}
-	stmtCharmRelationRole, err := sqlair.Prepare(`SELECT &CharmRelationRole.* FROM "charm_relation_role"`, v4_1_0.CharmRelationRole{})
+	stmtCharmRelationRole, err := sqlair.Prepare(`SELECT &CharmRelationRole.* FROM "charm_relation_role" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmRelationRole{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmRelationRole statement: %w", err)
 	}
-	stmtCharmRelationScope, err := sqlair.Prepare(`SELECT &CharmRelationScope.* FROM "charm_relation_scope"`, v4_1_0.CharmRelationScope{})
+	stmtCharmRelationScope, err := sqlair.Prepare(`SELECT &CharmRelationScope.* FROM "charm_relation_scope" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmRelationScope{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmRelationScope statement: %w", err)
 	}
-	stmtCharmResource, err := sqlair.Prepare(`SELECT &CharmResource.* FROM "charm_resource"`, v4_1_0.CharmResource{})
+	stmtCharmResource, err := sqlair.Prepare(`SELECT &CharmResource.* FROM "charm_resource" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmResource{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmResource statement: %w", err)
 	}
-	stmtCharmResourceKind, err := sqlair.Prepare(`SELECT &CharmResourceKind.* FROM "charm_resource_kind"`, v4_1_0.CharmResourceKind{})
+	stmtCharmResourceKind, err := sqlair.Prepare(`SELECT &CharmResourceKind.* FROM "charm_resource_kind" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmResourceKind{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmResourceKind statement: %w", err)
 	}
-	stmtCharmRunAsKind, err := sqlair.Prepare(`SELECT &CharmRunAsKind.* FROM "charm_run_as_kind"`, v4_1_0.CharmRunAsKind{})
+	stmtCharmRunAsKind, err := sqlair.Prepare(`SELECT &CharmRunAsKind.* FROM "charm_run_as_kind" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmRunAsKind{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmRunAsKind statement: %w", err)
 	}
-	stmtCharmSource, err := sqlair.Prepare(`SELECT &CharmSource.* FROM "charm_source"`, v4_1_0.CharmSource{})
+	stmtCharmSource, err := sqlair.Prepare(`SELECT &CharmSource.* FROM "charm_source" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmSource{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmSource statement: %w", err)
 	}
-	stmtCharmStorage, err := sqlair.Prepare(`SELECT &CharmStorage.* FROM "charm_storage"`, v4_1_0.CharmStorage{})
+	stmtCharmStorage, err := sqlair.Prepare(`SELECT &CharmStorage.* FROM "charm_storage" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmStorage{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmStorage statement: %w", err)
 	}
-	stmtCharmStorageKind, err := sqlair.Prepare(`SELECT &CharmStorageKind.* FROM "charm_storage_kind"`, v4_1_0.CharmStorageKind{})
+	stmtCharmStorageKind, err := sqlair.Prepare(`SELECT &CharmStorageKind.* FROM "charm_storage_kind" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmStorageKind{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmStorageKind statement: %w", err)
 	}
-	stmtCharmStorageProperty, err := sqlair.Prepare(`SELECT &CharmStorageProperty.* FROM "charm_storage_property"`, v4_1_0.CharmStorageProperty{})
+	stmtCharmStorageProperty, err := sqlair.Prepare(`SELECT &CharmStorageProperty.* FROM "charm_storage_property" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmStorageProperty{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmStorageProperty statement: %w", err)
 	}
-	stmtCharmTag, err := sqlair.Prepare(`SELECT &CharmTag.* FROM "charm_tag"`, v4_1_0.CharmTag{})
+	stmtCharmTag, err := sqlair.Prepare(`SELECT &CharmTag.* FROM "charm_tag" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmTag{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmTag statement: %w", err)
 	}
-	stmtCharmTerm, err := sqlair.Prepare(`SELECT &CharmTerm.* FROM "charm_term"`, v4_1_0.CharmTerm{})
+	stmtCharmTerm, err := sqlair.Prepare(`SELECT &CharmTerm.* FROM "charm_term" WHERE rowid >= -9223372036854775808`, v4_1_0.CharmTerm{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmTerm statement: %w", err)
 	}
-	stmtConstraint, err := sqlair.Prepare(`SELECT &Constraint.* FROM "constraint"`, v4_1_0.Constraint{})
+	stmtConstraint, err := sqlair.Prepare(`SELECT &Constraint.* FROM "constraint" WHERE rowid >= -9223372036854775808`, v4_1_0.Constraint{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Constraint statement: %w", err)
 	}
-	stmtConstraintSpace, err := sqlair.Prepare(`SELECT &ConstraintSpace.* FROM "constraint_space"`, v4_1_0.ConstraintSpace{})
+	stmtConstraintSpace, err := sqlair.Prepare(`SELECT &ConstraintSpace.* FROM "constraint_space" WHERE rowid >= -9223372036854775808`, v4_1_0.ConstraintSpace{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ConstraintSpace statement: %w", err)
 	}
-	stmtConstraintTag, err := sqlair.Prepare(`SELECT &ConstraintTag.* FROM "constraint_tag"`, v4_1_0.ConstraintTag{})
+	stmtConstraintTag, err := sqlair.Prepare(`SELECT &ConstraintTag.* FROM "constraint_tag" WHERE rowid >= -9223372036854775808`, v4_1_0.ConstraintTag{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ConstraintTag statement: %w", err)
 	}
-	stmtConstraintZone, err := sqlair.Prepare(`SELECT &ConstraintZone.* FROM "constraint_zone"`, v4_1_0.ConstraintZone{})
+	stmtConstraintZone, err := sqlair.Prepare(`SELECT &ConstraintZone.* FROM "constraint_zone" WHERE rowid >= -9223372036854775808`, v4_1_0.ConstraintZone{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ConstraintZone statement: %w", err)
 	}
-	stmtContainerType, err := sqlair.Prepare(`SELECT &ContainerType.* FROM "container_type"`, v4_1_0.ContainerType{})
+	stmtContainerType, err := sqlair.Prepare(`SELECT &ContainerType.* FROM "container_type" WHERE rowid >= -9223372036854775808`, v4_1_0.ContainerType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ContainerType statement: %w", err)
 	}
-	stmtDeviceConstraint, err := sqlair.Prepare(`SELECT &DeviceConstraint.* FROM "device_constraint"`, v4_1_0.DeviceConstraint{})
+	stmtDeviceConstraint, err := sqlair.Prepare(`SELECT &DeviceConstraint.* FROM "device_constraint" WHERE rowid >= -9223372036854775808`, v4_1_0.DeviceConstraint{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing DeviceConstraint statement: %w", err)
 	}
-	stmtDeviceConstraintAttribute, err := sqlair.Prepare(`SELECT &DeviceConstraintAttribute.* FROM "device_constraint_attribute"`, v4_1_0.DeviceConstraintAttribute{})
+	stmtDeviceConstraintAttribute, err := sqlair.Prepare(`SELECT &DeviceConstraintAttribute.* FROM "device_constraint_attribute" WHERE rowid >= -9223372036854775808`, v4_1_0.DeviceConstraintAttribute{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing DeviceConstraintAttribute statement: %w", err)
 	}
-	stmtFqdnAddress, err := sqlair.Prepare(`SELECT &FqdnAddress.* FROM "fqdn_address"`, v4_1_0.FqdnAddress{})
+	stmtFqdnAddress, err := sqlair.Prepare(`SELECT &FqdnAddress.* FROM "fqdn_address" WHERE rowid >= -9223372036854775808`, v4_1_0.FqdnAddress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing FqdnAddress statement: %w", err)
 	}
-	stmtHashKind, err := sqlair.Prepare(`SELECT &HashKind.* FROM "hash_kind"`, v4_1_0.HashKind{})
+	stmtHashKind, err := sqlair.Prepare(`SELECT &HashKind.* FROM "hash_kind" WHERE rowid >= -9223372036854775808`, v4_1_0.HashKind{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing HashKind statement: %w", err)
 	}
-	stmtHostnameAddress, err := sqlair.Prepare(`SELECT &HostnameAddress.* FROM "hostname_address"`, v4_1_0.HostnameAddress{})
+	stmtHostnameAddress, err := sqlair.Prepare(`SELECT &HostnameAddress.* FROM "hostname_address" WHERE rowid >= -9223372036854775808`, v4_1_0.HostnameAddress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing HostnameAddress statement: %w", err)
 	}
-	stmtInstanceTag, err := sqlair.Prepare(`SELECT &InstanceTag.* FROM "instance_tag"`, v4_1_0.InstanceTag{})
+	stmtInstanceTag, err := sqlair.Prepare(`SELECT &InstanceTag.* FROM "instance_tag" WHERE rowid >= -9223372036854775808`, v4_1_0.InstanceTag{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing InstanceTag statement: %w", err)
 	}
-	stmtIpAddress, err := sqlair.Prepare(`SELECT &IpAddress.* FROM "ip_address"`, v4_1_0.IpAddress{})
+	stmtIpAddress, err := sqlair.Prepare(`SELECT &IpAddress.* FROM "ip_address" WHERE rowid >= -9223372036854775808`, v4_1_0.IpAddress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing IpAddress statement: %w", err)
 	}
-	stmtIpAddressConfigType, err := sqlair.Prepare(`SELECT &IpAddressConfigType.* FROM "ip_address_config_type"`, v4_1_0.IpAddressConfigType{})
+	stmtIpAddressConfigType, err := sqlair.Prepare(`SELECT &IpAddressConfigType.* FROM "ip_address_config_type" WHERE rowid >= -9223372036854775808`, v4_1_0.IpAddressConfigType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing IpAddressConfigType statement: %w", err)
 	}
-	stmtIpAddressOrigin, err := sqlair.Prepare(`SELECT &IpAddressOrigin.* FROM "ip_address_origin"`, v4_1_0.IpAddressOrigin{})
+	stmtIpAddressOrigin, err := sqlair.Prepare(`SELECT &IpAddressOrigin.* FROM "ip_address_origin" WHERE rowid >= -9223372036854775808`, v4_1_0.IpAddressOrigin{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing IpAddressOrigin statement: %w", err)
 	}
-	stmtIpAddressScope, err := sqlair.Prepare(`SELECT &IpAddressScope.* FROM "ip_address_scope"`, v4_1_0.IpAddressScope{})
+	stmtIpAddressScope, err := sqlair.Prepare(`SELECT &IpAddressScope.* FROM "ip_address_scope" WHERE rowid >= -9223372036854775808`, v4_1_0.IpAddressScope{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing IpAddressScope statement: %w", err)
 	}
-	stmtIpAddressType, err := sqlair.Prepare(`SELECT &IpAddressType.* FROM "ip_address_type"`, v4_1_0.IpAddressType{})
+	stmtIpAddressType, err := sqlair.Prepare(`SELECT &IpAddressType.* FROM "ip_address_type" WHERE rowid >= -9223372036854775808`, v4_1_0.IpAddressType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing IpAddressType statement: %w", err)
 	}
-	stmtK8sPod, err := sqlair.Prepare(`SELECT &K8sPod.* FROM "k8s_pod"`, v4_1_0.K8sPod{})
+	stmtK8sPod, err := sqlair.Prepare(`SELECT &K8sPod.* FROM "k8s_pod" WHERE rowid >= -9223372036854775808`, v4_1_0.K8sPod{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing K8sPod statement: %w", err)
 	}
-	stmtK8sPodPort, err := sqlair.Prepare(`SELECT &K8sPodPort.* FROM "k8s_pod_port"`, v4_1_0.K8sPodPort{})
+	stmtK8sPodPort, err := sqlair.Prepare(`SELECT &K8sPodPort.* FROM "k8s_pod_port" WHERE rowid >= -9223372036854775808`, v4_1_0.K8sPodPort{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing K8sPodPort statement: %w", err)
 	}
-	stmtK8sPodStatus, err := sqlair.Prepare(`SELECT &K8sPodStatus.* FROM "k8s_pod_status"`, v4_1_0.K8sPodStatus{})
+	stmtK8sPodStatus, err := sqlair.Prepare(`SELECT &K8sPodStatus.* FROM "k8s_pod_status" WHERE rowid >= -9223372036854775808`, v4_1_0.K8sPodStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing K8sPodStatus statement: %w", err)
 	}
-	stmtK8sPodStatusValue, err := sqlair.Prepare(`SELECT &K8sPodStatusValue.* FROM "k8s_pod_status_value"`, v4_1_0.K8sPodStatusValue{})
+	stmtK8sPodStatusValue, err := sqlair.Prepare(`SELECT &K8sPodStatusValue.* FROM "k8s_pod_status_value" WHERE rowid >= -9223372036854775808`, v4_1_0.K8sPodStatusValue{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing K8sPodStatusValue statement: %w", err)
 	}
-	stmtK8sService, err := sqlair.Prepare(`SELECT &K8sService.* FROM "k8s_service"`, v4_1_0.K8sService{})
+	stmtK8sService, err := sqlair.Prepare(`SELECT &K8sService.* FROM "k8s_service" WHERE rowid >= -9223372036854775808`, v4_1_0.K8sService{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing K8sService statement: %w", err)
 	}
-	stmtLife, err := sqlair.Prepare(`SELECT &Life.* FROM "life"`, v4_1_0.Life{})
+	stmtLife, err := sqlair.Prepare(`SELECT &Life.* FROM "life" WHERE rowid >= -9223372036854775808`, v4_1_0.Life{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Life statement: %w", err)
 	}
-	stmtLinkLayerDevice, err := sqlair.Prepare(`SELECT &LinkLayerDevice.* FROM "link_layer_device"`, v4_1_0.LinkLayerDevice{})
+	stmtLinkLayerDevice, err := sqlair.Prepare(`SELECT &LinkLayerDevice.* FROM "link_layer_device" WHERE rowid >= -9223372036854775808`, v4_1_0.LinkLayerDevice{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing LinkLayerDevice statement: %w", err)
 	}
-	stmtLinkLayerDeviceDnsAddress, err := sqlair.Prepare(`SELECT &LinkLayerDeviceDnsAddress.* FROM "link_layer_device_dns_address"`, v4_1_0.LinkLayerDeviceDnsAddress{})
+	stmtLinkLayerDeviceDnsAddress, err := sqlair.Prepare(`SELECT &LinkLayerDeviceDnsAddress.* FROM "link_layer_device_dns_address" WHERE rowid >= -9223372036854775808`, v4_1_0.LinkLayerDeviceDnsAddress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing LinkLayerDeviceDnsAddress statement: %w", err)
 	}
-	stmtLinkLayerDeviceDnsDomain, err := sqlair.Prepare(`SELECT &LinkLayerDeviceDnsDomain.* FROM "link_layer_device_dns_domain"`, v4_1_0.LinkLayerDeviceDnsDomain{})
+	stmtLinkLayerDeviceDnsDomain, err := sqlair.Prepare(`SELECT &LinkLayerDeviceDnsDomain.* FROM "link_layer_device_dns_domain" WHERE rowid >= -9223372036854775808`, v4_1_0.LinkLayerDeviceDnsDomain{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing LinkLayerDeviceDnsDomain statement: %w", err)
 	}
-	stmtLinkLayerDeviceParent, err := sqlair.Prepare(`SELECT &LinkLayerDeviceParent.* FROM "link_layer_device_parent"`, v4_1_0.LinkLayerDeviceParent{})
+	stmtLinkLayerDeviceParent, err := sqlair.Prepare(`SELECT &LinkLayerDeviceParent.* FROM "link_layer_device_parent" WHERE rowid >= -9223372036854775808`, v4_1_0.LinkLayerDeviceParent{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing LinkLayerDeviceParent statement: %w", err)
 	}
-	stmtLinkLayerDeviceRoute, err := sqlair.Prepare(`SELECT &LinkLayerDeviceRoute.* FROM "link_layer_device_route"`, v4_1_0.LinkLayerDeviceRoute{})
+	stmtLinkLayerDeviceRoute, err := sqlair.Prepare(`SELECT &LinkLayerDeviceRoute.* FROM "link_layer_device_route" WHERE rowid >= -9223372036854775808`, v4_1_0.LinkLayerDeviceRoute{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing LinkLayerDeviceRoute statement: %w", err)
 	}
-	stmtLinkLayerDeviceType, err := sqlair.Prepare(`SELECT &LinkLayerDeviceType.* FROM "link_layer_device_type"`, v4_1_0.LinkLayerDeviceType{})
+	stmtLinkLayerDeviceType, err := sqlair.Prepare(`SELECT &LinkLayerDeviceType.* FROM "link_layer_device_type" WHERE rowid >= -9223372036854775808`, v4_1_0.LinkLayerDeviceType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing LinkLayerDeviceType statement: %w", err)
 	}
-	stmtMachine, err := sqlair.Prepare(`SELECT &Machine.* FROM "machine"`, v4_1_0.Machine{})
+	stmtMachine, err := sqlair.Prepare(`SELECT &Machine.* FROM "machine" WHERE rowid >= -9223372036854775808`, v4_1_0.Machine{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Machine statement: %w", err)
 	}
-	stmtMachineAgentPresence, err := sqlair.Prepare(`SELECT &MachineAgentPresence.* FROM "machine_agent_presence"`, v4_1_0.MachineAgentPresence{})
+	stmtMachineAgentPresence, err := sqlair.Prepare(`SELECT &MachineAgentPresence.* FROM "machine_agent_presence" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineAgentPresence{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineAgentPresence statement: %w", err)
 	}
-	stmtMachineAgentVersion, err := sqlair.Prepare(`SELECT &MachineAgentVersion.* FROM "machine_agent_version"`, v4_1_0.MachineAgentVersion{})
+	stmtMachineAgentVersion, err := sqlair.Prepare(`SELECT &MachineAgentVersion.* FROM "machine_agent_version" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineAgentVersion{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineAgentVersion statement: %w", err)
 	}
-	stmtMachineCloudInstance, err := sqlair.Prepare(`SELECT &MachineCloudInstance.* FROM "machine_cloud_instance"`, v4_1_0.MachineCloudInstance{})
+	stmtMachineCloudInstance, err := sqlair.Prepare(`SELECT &MachineCloudInstance.* FROM "machine_cloud_instance" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineCloudInstance{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineCloudInstance statement: %w", err)
 	}
-	stmtMachineCloudInstanceStatus, err := sqlair.Prepare(`SELECT &MachineCloudInstanceStatus.* FROM "machine_cloud_instance_status"`, v4_1_0.MachineCloudInstanceStatus{})
+	stmtMachineCloudInstanceStatus, err := sqlair.Prepare(`SELECT &MachineCloudInstanceStatus.* FROM "machine_cloud_instance_status" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineCloudInstanceStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineCloudInstanceStatus statement: %w", err)
 	}
-	stmtMachineCloudInstanceStatusValue, err := sqlair.Prepare(`SELECT &MachineCloudInstanceStatusValue.* FROM "machine_cloud_instance_status_value"`, v4_1_0.MachineCloudInstanceStatusValue{})
+	stmtMachineCloudInstanceStatusValue, err := sqlair.Prepare(`SELECT &MachineCloudInstanceStatusValue.* FROM "machine_cloud_instance_status_value" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineCloudInstanceStatusValue{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineCloudInstanceStatusValue statement: %w", err)
 	}
-	stmtMachineConstraint, err := sqlair.Prepare(`SELECT &MachineConstraint.* FROM "machine_constraint"`, v4_1_0.MachineConstraint{})
+	stmtMachineConstraint, err := sqlair.Prepare(`SELECT &MachineConstraint.* FROM "machine_constraint" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineConstraint{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineConstraint statement: %w", err)
 	}
-	stmtMachineContainerType, err := sqlair.Prepare(`SELECT &MachineContainerType.* FROM "machine_container_type"`, v4_1_0.MachineContainerType{})
+	stmtMachineContainerType, err := sqlair.Prepare(`SELECT &MachineContainerType.* FROM "machine_container_type" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineContainerType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineContainerType statement: %w", err)
 	}
-	stmtMachineFilesystem, err := sqlair.Prepare(`SELECT &MachineFilesystem.* FROM "machine_filesystem"`, v4_1_0.MachineFilesystem{})
+	stmtMachineFilesystem, err := sqlair.Prepare(`SELECT &MachineFilesystem.* FROM "machine_filesystem" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineFilesystem{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineFilesystem statement: %w", err)
 	}
-	stmtMachineLxdProfile, err := sqlair.Prepare(`SELECT &MachineLxdProfile.* FROM "machine_lxd_profile"`, v4_1_0.MachineLxdProfile{})
+	stmtMachineLxdProfile, err := sqlair.Prepare(`SELECT &MachineLxdProfile.* FROM "machine_lxd_profile" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineLxdProfile{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineLxdProfile statement: %w", err)
 	}
-	stmtMachineManual, err := sqlair.Prepare(`SELECT &MachineManual.* FROM "machine_manual"`, v4_1_0.MachineManual{})
+	stmtMachineManual, err := sqlair.Prepare(`SELECT &MachineManual.* FROM "machine_manual" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineManual{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineManual statement: %w", err)
 	}
-	stmtMachineParent, err := sqlair.Prepare(`SELECT &MachineParent.* FROM "machine_parent"`, v4_1_0.MachineParent{})
+	stmtMachineParent, err := sqlair.Prepare(`SELECT &MachineParent.* FROM "machine_parent" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineParent{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineParent statement: %w", err)
 	}
-	stmtMachinePlacement, err := sqlair.Prepare(`SELECT &MachinePlacement.* FROM "machine_placement"`, v4_1_0.MachinePlacement{})
+	stmtMachinePlacement, err := sqlair.Prepare(`SELECT &MachinePlacement.* FROM "machine_placement" WHERE rowid >= -9223372036854775808`, v4_1_0.MachinePlacement{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachinePlacement statement: %w", err)
 	}
-	stmtMachinePlacementScope, err := sqlair.Prepare(`SELECT &MachinePlacementScope.* FROM "machine_placement_scope"`, v4_1_0.MachinePlacementScope{})
+	stmtMachinePlacementScope, err := sqlair.Prepare(`SELECT &MachinePlacementScope.* FROM "machine_placement_scope" WHERE rowid >= -9223372036854775808`, v4_1_0.MachinePlacementScope{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachinePlacementScope statement: %w", err)
 	}
-	stmtMachinePlatform, err := sqlair.Prepare(`SELECT &MachinePlatform.* FROM "machine_platform"`, v4_1_0.MachinePlatform{})
+	stmtMachinePlatform, err := sqlair.Prepare(`SELECT &MachinePlatform.* FROM "machine_platform" WHERE rowid >= -9223372036854775808`, v4_1_0.MachinePlatform{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachinePlatform statement: %w", err)
 	}
-	stmtMachineRequiresReboot, err := sqlair.Prepare(`SELECT &MachineRequiresReboot.* FROM "machine_requires_reboot"`, v4_1_0.MachineRequiresReboot{})
+	stmtMachineRequiresReboot, err := sqlair.Prepare(`SELECT &MachineRequiresReboot.* FROM "machine_requires_reboot" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineRequiresReboot{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineRequiresReboot statement: %w", err)
 	}
-	stmtMachineSshHostKey, err := sqlair.Prepare(`SELECT &MachineSshHostKey.* FROM "machine_ssh_host_key"`, v4_1_0.MachineSshHostKey{})
+	stmtMachineSshHostKey, err := sqlair.Prepare(`SELECT &MachineSshHostKey.* FROM "machine_ssh_host_key" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineSshHostKey{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineSshHostKey statement: %w", err)
 	}
-	stmtMachineStatus, err := sqlair.Prepare(`SELECT &MachineStatus.* FROM "machine_status"`, v4_1_0.MachineStatus{})
+	stmtMachineStatus, err := sqlair.Prepare(`SELECT &MachineStatus.* FROM "machine_status" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineStatus statement: %w", err)
 	}
-	stmtMachineStatusValue, err := sqlair.Prepare(`SELECT &MachineStatusValue.* FROM "machine_status_value"`, v4_1_0.MachineStatusValue{})
+	stmtMachineStatusValue, err := sqlair.Prepare(`SELECT &MachineStatusValue.* FROM "machine_status_value" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineStatusValue{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineStatusValue statement: %w", err)
 	}
-	stmtMachineVirtualSshHostKey, err := sqlair.Prepare(`SELECT &MachineVirtualSshHostKey.* FROM "machine_virtual_ssh_host_key"`, v4_1_0.MachineVirtualSshHostKey{})
+	stmtMachineVirtualSshHostKey, err := sqlair.Prepare(`SELECT &MachineVirtualSshHostKey.* FROM "machine_virtual_ssh_host_key" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineVirtualSshHostKey{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineVirtualSshHostKey statement: %w", err)
 	}
-	stmtMachineVolume, err := sqlair.Prepare(`SELECT &MachineVolume.* FROM "machine_volume"`, v4_1_0.MachineVolume{})
+	stmtMachineVolume, err := sqlair.Prepare(`SELECT &MachineVolume.* FROM "machine_volume" WHERE rowid >= -9223372036854775808`, v4_1_0.MachineVolume{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineVolume statement: %w", err)
 	}
-	stmtModel, err := sqlair.Prepare(`SELECT &Model.* FROM "model"`, v4_1_0.Model{})
+	stmtModel, err := sqlair.Prepare(`SELECT &Model.* FROM "model" WHERE rowid >= -9223372036854775808`, v4_1_0.Model{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Model statement: %w", err)
 	}
-	stmtModelAgent, err := sqlair.Prepare(`SELECT &ModelAgent.* FROM "model_agent"`, v4_1_0.ModelAgent{})
+	stmtModelAgent, err := sqlair.Prepare(`SELECT &ModelAgent.* FROM "model_agent" WHERE rowid >= -9223372036854775808`, v4_1_0.ModelAgent{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ModelAgent statement: %w", err)
 	}
-	stmtModelConfig, err := sqlair.Prepare(`SELECT &ModelConfig.* FROM "model_config"`, v4_1_0.ModelConfig{})
+	stmtModelConfig, err := sqlair.Prepare(`SELECT &ModelConfig.* FROM "model_config" WHERE rowid >= -9223372036854775808`, v4_1_0.ModelConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ModelConfig statement: %w", err)
 	}
-	stmtModelConstraint, err := sqlair.Prepare(`SELECT &ModelConstraint.* FROM "model_constraint"`, v4_1_0.ModelConstraint{})
+	stmtModelConstraint, err := sqlair.Prepare(`SELECT &ModelConstraint.* FROM "model_constraint" WHERE rowid >= -9223372036854775808`, v4_1_0.ModelConstraint{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ModelConstraint statement: %w", err)
 	}
-	stmtModelLife, err := sqlair.Prepare(`SELECT &ModelLife.* FROM "model_life"`, v4_1_0.ModelLife{})
+	stmtModelLife, err := sqlair.Prepare(`SELECT &ModelLife.* FROM "model_life" WHERE rowid >= -9223372036854775808`, v4_1_0.ModelLife{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ModelLife statement: %w", err)
 	}
-	stmtModelMigrating, err := sqlair.Prepare(`SELECT &ModelMigrating.* FROM "model_migrating"`, v4_1_0.ModelMigrating{})
+	stmtModelMigrating, err := sqlair.Prepare(`SELECT &ModelMigrating.* FROM "model_migrating" WHERE rowid >= -9223372036854775808`, v4_1_0.ModelMigrating{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ModelMigrating statement: %w", err)
 	}
-	stmtModelStoragePool, err := sqlair.Prepare(`SELECT &ModelStoragePool.* FROM "model_storage_pool"`, v4_1_0.ModelStoragePool{})
+	stmtModelStoragePool, err := sqlair.Prepare(`SELECT &ModelStoragePool.* FROM "model_storage_pool" WHERE rowid >= -9223372036854775808`, v4_1_0.ModelStoragePool{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ModelStoragePool statement: %w", err)
 	}
-	stmtNetNode, err := sqlair.Prepare(`SELECT &NetNode.* FROM "net_node"`, v4_1_0.NetNode{})
+	stmtNetNode, err := sqlair.Prepare(`SELECT &NetNode.* FROM "net_node" WHERE rowid >= -9223372036854775808`, v4_1_0.NetNode{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing NetNode statement: %w", err)
 	}
-	stmtNetNodeFqdnAddress, err := sqlair.Prepare(`SELECT &NetNodeFqdnAddress.* FROM "net_node_fqdn_address"`, v4_1_0.NetNodeFqdnAddress{})
+	stmtNetNodeFqdnAddress, err := sqlair.Prepare(`SELECT &NetNodeFqdnAddress.* FROM "net_node_fqdn_address" WHERE rowid >= -9223372036854775808`, v4_1_0.NetNodeFqdnAddress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing NetNodeFqdnAddress statement: %w", err)
 	}
-	stmtNetNodeHostnameAddress, err := sqlair.Prepare(`SELECT &NetNodeHostnameAddress.* FROM "net_node_hostname_address"`, v4_1_0.NetNodeHostnameAddress{})
+	stmtNetNodeHostnameAddress, err := sqlair.Prepare(`SELECT &NetNodeHostnameAddress.* FROM "net_node_hostname_address" WHERE rowid >= -9223372036854775808`, v4_1_0.NetNodeHostnameAddress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing NetNodeHostnameAddress statement: %w", err)
 	}
-	stmtNetworkAddressScope, err := sqlair.Prepare(`SELECT &NetworkAddressScope.* FROM "network_address_scope"`, v4_1_0.NetworkAddressScope{})
+	stmtNetworkAddressScope, err := sqlair.Prepare(`SELECT &NetworkAddressScope.* FROM "network_address_scope" WHERE rowid >= -9223372036854775808`, v4_1_0.NetworkAddressScope{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing NetworkAddressScope statement: %w", err)
 	}
-	stmtObjectStoreMetadata, err := sqlair.Prepare(`SELECT &ObjectStoreMetadata.* FROM "object_store_metadata"`, v4_1_0.ObjectStoreMetadata{})
+	stmtObjectStoreMetadata, err := sqlair.Prepare(`SELECT &ObjectStoreMetadata.* FROM "object_store_metadata" WHERE rowid >= -9223372036854775808`, v4_1_0.ObjectStoreMetadata{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ObjectStoreMetadata statement: %w", err)
 	}
-	stmtObjectStoreMetadataPath, err := sqlair.Prepare(`SELECT &ObjectStoreMetadataPath.* FROM "object_store_metadata_path"`, v4_1_0.ObjectStoreMetadataPath{})
+	stmtObjectStoreMetadataPath, err := sqlair.Prepare(`SELECT &ObjectStoreMetadataPath.* FROM "object_store_metadata_path" WHERE rowid >= -9223372036854775808`, v4_1_0.ObjectStoreMetadataPath{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ObjectStoreMetadataPath statement: %w", err)
 	}
-	stmtObjectStorePlacement, err := sqlair.Prepare(`SELECT &ObjectStorePlacement.* FROM "object_store_placement"`, v4_1_0.ObjectStorePlacement{})
+	stmtObjectStorePlacement, err := sqlair.Prepare(`SELECT &ObjectStorePlacement.* FROM "object_store_placement" WHERE rowid >= -9223372036854775808`, v4_1_0.ObjectStorePlacement{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ObjectStorePlacement statement: %w", err)
 	}
-	stmtOffer, err := sqlair.Prepare(`SELECT &Offer.* FROM "offer"`, v4_1_0.Offer{})
+	stmtOffer, err := sqlair.Prepare(`SELECT &Offer.* FROM "offer" WHERE rowid >= -9223372036854775808`, v4_1_0.Offer{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Offer statement: %w", err)
 	}
-	stmtOfferConnection, err := sqlair.Prepare(`SELECT &OfferConnection.* FROM "offer_connection"`, v4_1_0.OfferConnection{})
+	stmtOfferConnection, err := sqlair.Prepare(`SELECT &OfferConnection.* FROM "offer_connection" WHERE rowid >= -9223372036854775808`, v4_1_0.OfferConnection{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OfferConnection statement: %w", err)
 	}
-	stmtOfferEndpoint, err := sqlair.Prepare(`SELECT &OfferEndpoint.* FROM "offer_endpoint"`, v4_1_0.OfferEndpoint{})
+	stmtOfferEndpoint, err := sqlair.Prepare(`SELECT &OfferEndpoint.* FROM "offer_endpoint" WHERE rowid >= -9223372036854775808`, v4_1_0.OfferEndpoint{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OfferEndpoint statement: %w", err)
 	}
-	stmtOperation, err := sqlair.Prepare(`SELECT &Operation.* FROM "operation"`, v4_1_0.Operation{})
+	stmtOperation, err := sqlair.Prepare(`SELECT &Operation.* FROM "operation" WHERE rowid >= -9223372036854775808`, v4_1_0.Operation{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Operation statement: %w", err)
 	}
-	stmtOperationAction, err := sqlair.Prepare(`SELECT &OperationAction.* FROM "operation_action"`, v4_1_0.OperationAction{})
+	stmtOperationAction, err := sqlair.Prepare(`SELECT &OperationAction.* FROM "operation_action" WHERE rowid >= -9223372036854775808`, v4_1_0.OperationAction{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationAction statement: %w", err)
 	}
-	stmtOperationMachineTask, err := sqlair.Prepare(`SELECT &OperationMachineTask.* FROM "operation_machine_task"`, v4_1_0.OperationMachineTask{})
+	stmtOperationMachineTask, err := sqlair.Prepare(`SELECT &OperationMachineTask.* FROM "operation_machine_task" WHERE rowid >= -9223372036854775808`, v4_1_0.OperationMachineTask{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationMachineTask statement: %w", err)
 	}
-	stmtOperationParameter, err := sqlair.Prepare(`SELECT &OperationParameter.* FROM "operation_parameter"`, v4_1_0.OperationParameter{})
+	stmtOperationParameter, err := sqlair.Prepare(`SELECT &OperationParameter.* FROM "operation_parameter" WHERE rowid >= -9223372036854775808`, v4_1_0.OperationParameter{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationParameter statement: %w", err)
 	}
-	stmtOperationTask, err := sqlair.Prepare(`SELECT &OperationTask.* FROM "operation_task"`, v4_1_0.OperationTask{})
+	stmtOperationTask, err := sqlair.Prepare(`SELECT &OperationTask.* FROM "operation_task" WHERE rowid >= -9223372036854775808`, v4_1_0.OperationTask{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationTask statement: %w", err)
 	}
-	stmtOperationTaskLog, err := sqlair.Prepare(`SELECT &OperationTaskLog.* FROM "operation_task_log"`, v4_1_0.OperationTaskLog{})
+	stmtOperationTaskLog, err := sqlair.Prepare(`SELECT &OperationTaskLog.* FROM "operation_task_log" WHERE rowid >= -9223372036854775808`, v4_1_0.OperationTaskLog{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationTaskLog statement: %w", err)
 	}
-	stmtOperationTaskOutput, err := sqlair.Prepare(`SELECT &OperationTaskOutput.* FROM "operation_task_output"`, v4_1_0.OperationTaskOutput{})
+	stmtOperationTaskOutput, err := sqlair.Prepare(`SELECT &OperationTaskOutput.* FROM "operation_task_output" WHERE rowid >= -9223372036854775808`, v4_1_0.OperationTaskOutput{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationTaskOutput statement: %w", err)
 	}
-	stmtOperationTaskStatus, err := sqlair.Prepare(`SELECT &OperationTaskStatus.* FROM "operation_task_status"`, v4_1_0.OperationTaskStatus{})
+	stmtOperationTaskStatus, err := sqlair.Prepare(`SELECT &OperationTaskStatus.* FROM "operation_task_status" WHERE rowid >= -9223372036854775808`, v4_1_0.OperationTaskStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationTaskStatus statement: %w", err)
 	}
-	stmtOperationTaskStatusValue, err := sqlair.Prepare(`SELECT &OperationTaskStatusValue.* FROM "operation_task_status_value"`, v4_1_0.OperationTaskStatusValue{})
+	stmtOperationTaskStatusValue, err := sqlair.Prepare(`SELECT &OperationTaskStatusValue.* FROM "operation_task_status_value" WHERE rowid >= -9223372036854775808`, v4_1_0.OperationTaskStatusValue{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationTaskStatusValue statement: %w", err)
 	}
-	stmtOperationUnitTask, err := sqlair.Prepare(`SELECT &OperationUnitTask.* FROM "operation_unit_task"`, v4_1_0.OperationUnitTask{})
+	stmtOperationUnitTask, err := sqlair.Prepare(`SELECT &OperationUnitTask.* FROM "operation_unit_task" WHERE rowid >= -9223372036854775808`, v4_1_0.OperationUnitTask{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationUnitTask statement: %w", err)
 	}
-	stmtOperatorStatus, err := sqlair.Prepare(`SELECT &OperatorStatus.* FROM "operator_status"`, v4_1_0.OperatorStatus{})
+	stmtOperatorStatus, err := sqlair.Prepare(`SELECT &OperatorStatus.* FROM "operator_status" WHERE rowid >= -9223372036854775808`, v4_1_0.OperatorStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperatorStatus statement: %w", err)
 	}
-	stmtOs, err := sqlair.Prepare(`SELECT &Os.* FROM "os"`, v4_1_0.Os{})
+	stmtOs, err := sqlair.Prepare(`SELECT &Os.* FROM "os" WHERE rowid >= -9223372036854775808`, v4_1_0.Os{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Os statement: %w", err)
 	}
-	stmtPasswordHashAlgorithm, err := sqlair.Prepare(`SELECT &PasswordHashAlgorithm.* FROM "password_hash_algorithm"`, v4_1_0.PasswordHashAlgorithm{})
+	stmtPasswordHashAlgorithm, err := sqlair.Prepare(`SELECT &PasswordHashAlgorithm.* FROM "password_hash_algorithm" WHERE rowid >= -9223372036854775808`, v4_1_0.PasswordHashAlgorithm{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing PasswordHashAlgorithm statement: %w", err)
 	}
-	stmtPendingApplicationResource, err := sqlair.Prepare(`SELECT &PendingApplicationResource.* FROM "pending_application_resource"`, v4_1_0.PendingApplicationResource{})
+	stmtPendingApplicationResource, err := sqlair.Prepare(`SELECT &PendingApplicationResource.* FROM "pending_application_resource" WHERE rowid >= -9223372036854775808`, v4_1_0.PendingApplicationResource{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing PendingApplicationResource statement: %w", err)
 	}
-	stmtPortRange, err := sqlair.Prepare(`SELECT &PortRange.* FROM "port_range"`, v4_1_0.PortRange{})
+	stmtPortRange, err := sqlair.Prepare(`SELECT &PortRange.* FROM "port_range" WHERE rowid >= -9223372036854775808`, v4_1_0.PortRange{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing PortRange statement: %w", err)
 	}
-	stmtProtocol, err := sqlair.Prepare(`SELECT &Protocol.* FROM "protocol"`, v4_1_0.Protocol{})
+	stmtProtocol, err := sqlair.Prepare(`SELECT &Protocol.* FROM "protocol" WHERE rowid >= -9223372036854775808`, v4_1_0.Protocol{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Protocol statement: %w", err)
 	}
-	stmtProviderIpAddress, err := sqlair.Prepare(`SELECT &ProviderIpAddress.* FROM "provider_ip_address"`, v4_1_0.ProviderIpAddress{})
+	stmtProviderIpAddress, err := sqlair.Prepare(`SELECT &ProviderIpAddress.* FROM "provider_ip_address" WHERE rowid >= -9223372036854775808`, v4_1_0.ProviderIpAddress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ProviderIpAddress statement: %w", err)
 	}
-	stmtProviderLinkLayerDevice, err := sqlair.Prepare(`SELECT &ProviderLinkLayerDevice.* FROM "provider_link_layer_device"`, v4_1_0.ProviderLinkLayerDevice{})
+	stmtProviderLinkLayerDevice, err := sqlair.Prepare(`SELECT &ProviderLinkLayerDevice.* FROM "provider_link_layer_device" WHERE rowid >= -9223372036854775808`, v4_1_0.ProviderLinkLayerDevice{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ProviderLinkLayerDevice statement: %w", err)
 	}
-	stmtProviderNetwork, err := sqlair.Prepare(`SELECT &ProviderNetwork.* FROM "provider_network"`, v4_1_0.ProviderNetwork{})
+	stmtProviderNetwork, err := sqlair.Prepare(`SELECT &ProviderNetwork.* FROM "provider_network" WHERE rowid >= -9223372036854775808`, v4_1_0.ProviderNetwork{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ProviderNetwork statement: %w", err)
 	}
-	stmtProviderNetworkSubnet, err := sqlair.Prepare(`SELECT &ProviderNetworkSubnet.* FROM "provider_network_subnet"`, v4_1_0.ProviderNetworkSubnet{})
+	stmtProviderNetworkSubnet, err := sqlair.Prepare(`SELECT &ProviderNetworkSubnet.* FROM "provider_network_subnet" WHERE rowid >= -9223372036854775808`, v4_1_0.ProviderNetworkSubnet{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ProviderNetworkSubnet statement: %w", err)
 	}
-	stmtProviderSpace, err := sqlair.Prepare(`SELECT &ProviderSpace.* FROM "provider_space"`, v4_1_0.ProviderSpace{})
+	stmtProviderSpace, err := sqlair.Prepare(`SELECT &ProviderSpace.* FROM "provider_space" WHERE rowid >= -9223372036854775808`, v4_1_0.ProviderSpace{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ProviderSpace statement: %w", err)
 	}
-	stmtProviderSubnet, err := sqlair.Prepare(`SELECT &ProviderSubnet.* FROM "provider_subnet"`, v4_1_0.ProviderSubnet{})
+	stmtProviderSubnet, err := sqlair.Prepare(`SELECT &ProviderSubnet.* FROM "provider_subnet" WHERE rowid >= -9223372036854775808`, v4_1_0.ProviderSubnet{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ProviderSubnet statement: %w", err)
 	}
-	stmtRelation, err := sqlair.Prepare(`SELECT &Relation.* FROM "relation"`, v4_1_0.Relation{})
+	stmtRelation, err := sqlair.Prepare(`SELECT &Relation.* FROM "relation" WHERE rowid >= -9223372036854775808`, v4_1_0.Relation{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Relation statement: %w", err)
 	}
-	stmtRelationApplicationSetting, err := sqlair.Prepare(`SELECT &RelationApplicationSetting.* FROM "relation_application_setting"`, v4_1_0.RelationApplicationSetting{})
+	stmtRelationApplicationSetting, err := sqlair.Prepare(`SELECT &RelationApplicationSetting.* FROM "relation_application_setting" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationApplicationSetting{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationApplicationSetting statement: %w", err)
 	}
-	stmtRelationApplicationSettingsHash, err := sqlair.Prepare(`SELECT &RelationApplicationSettingsHash.* FROM "relation_application_settings_hash"`, v4_1_0.RelationApplicationSettingsHash{})
+	stmtRelationApplicationSettingsHash, err := sqlair.Prepare(`SELECT &RelationApplicationSettingsHash.* FROM "relation_application_settings_hash" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationApplicationSettingsHash{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationApplicationSettingsHash statement: %w", err)
 	}
-	stmtRelationEndpoint, err := sqlair.Prepare(`SELECT &RelationEndpoint.* FROM "relation_endpoint"`, v4_1_0.RelationEndpoint{})
+	stmtRelationEndpoint, err := sqlair.Prepare(`SELECT &RelationEndpoint.* FROM "relation_endpoint" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationEndpoint{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationEndpoint statement: %w", err)
 	}
-	stmtRelationNetworkEgress, err := sqlair.Prepare(`SELECT &RelationNetworkEgress.* FROM "relation_network_egress"`, v4_1_0.RelationNetworkEgress{})
+	stmtRelationNetworkEgress, err := sqlair.Prepare(`SELECT &RelationNetworkEgress.* FROM "relation_network_egress" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationNetworkEgress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationNetworkEgress statement: %w", err)
 	}
-	stmtRelationNetworkIngress, err := sqlair.Prepare(`SELECT &RelationNetworkIngress.* FROM "relation_network_ingress"`, v4_1_0.RelationNetworkIngress{})
+	stmtRelationNetworkIngress, err := sqlair.Prepare(`SELECT &RelationNetworkIngress.* FROM "relation_network_ingress" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationNetworkIngress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationNetworkIngress statement: %w", err)
 	}
-	stmtRelationStatus, err := sqlair.Prepare(`SELECT &RelationStatus.* FROM "relation_status"`, v4_1_0.RelationStatus{})
+	stmtRelationStatus, err := sqlair.Prepare(`SELECT &RelationStatus.* FROM "relation_status" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationStatus statement: %w", err)
 	}
-	stmtRelationStatusType, err := sqlair.Prepare(`SELECT &RelationStatusType.* FROM "relation_status_type"`, v4_1_0.RelationStatusType{})
+	stmtRelationStatusType, err := sqlair.Prepare(`SELECT &RelationStatusType.* FROM "relation_status_type" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationStatusType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationStatusType statement: %w", err)
 	}
-	stmtRelationUnit, err := sqlair.Prepare(`SELECT &RelationUnit.* FROM "relation_unit"`, v4_1_0.RelationUnit{})
+	stmtRelationUnit, err := sqlair.Prepare(`SELECT &RelationUnit.* FROM "relation_unit" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationUnit{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationUnit statement: %w", err)
 	}
-	stmtRelationUnitSetting, err := sqlair.Prepare(`SELECT &RelationUnitSetting.* FROM "relation_unit_setting"`, v4_1_0.RelationUnitSetting{})
+	stmtRelationUnitSetting, err := sqlair.Prepare(`SELECT &RelationUnitSetting.* FROM "relation_unit_setting" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationUnitSetting{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationUnitSetting statement: %w", err)
 	}
-	stmtRelationUnitSettingArchive, err := sqlair.Prepare(`SELECT &RelationUnitSettingArchive.* FROM "relation_unit_setting_archive"`, v4_1_0.RelationUnitSettingArchive{})
+	stmtRelationUnitSettingArchive, err := sqlair.Prepare(`SELECT &RelationUnitSettingArchive.* FROM "relation_unit_setting_archive" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationUnitSettingArchive{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationUnitSettingArchive statement: %w", err)
 	}
-	stmtRelationUnitSettingsHash, err := sqlair.Prepare(`SELECT &RelationUnitSettingsHash.* FROM "relation_unit_settings_hash"`, v4_1_0.RelationUnitSettingsHash{})
+	stmtRelationUnitSettingsHash, err := sqlair.Prepare(`SELECT &RelationUnitSettingsHash.* FROM "relation_unit_settings_hash" WHERE rowid >= -9223372036854775808`, v4_1_0.RelationUnitSettingsHash{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationUnitSettingsHash statement: %w", err)
 	}
-	stmtRemoval, err := sqlair.Prepare(`SELECT &Removal.* FROM "removal"`, v4_1_0.Removal{})
+	stmtRemoval, err := sqlair.Prepare(`SELECT &Removal.* FROM "removal" WHERE rowid >= -9223372036854775808`, v4_1_0.Removal{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Removal statement: %w", err)
 	}
-	stmtRemovalType, err := sqlair.Prepare(`SELECT &RemovalType.* FROM "removal_type"`, v4_1_0.RemovalType{})
+	stmtRemovalType, err := sqlair.Prepare(`SELECT &RemovalType.* FROM "removal_type" WHERE rowid >= -9223372036854775808`, v4_1_0.RemovalType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RemovalType statement: %w", err)
 	}
-	stmtResolveMode, err := sqlair.Prepare(`SELECT &ResolveMode.* FROM "resolve_mode"`, v4_1_0.ResolveMode{})
+	stmtResolveMode, err := sqlair.Prepare(`SELECT &ResolveMode.* FROM "resolve_mode" WHERE rowid >= -9223372036854775808`, v4_1_0.ResolveMode{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ResolveMode statement: %w", err)
 	}
-	stmtResource, err := sqlair.Prepare(`SELECT &Resource.* FROM "resource"`, v4_1_0.Resource{})
+	stmtResource, err := sqlair.Prepare(`SELECT &Resource.* FROM "resource" WHERE rowid >= -9223372036854775808`, v4_1_0.Resource{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Resource statement: %w", err)
 	}
-	stmtResourceContainerImageMetadataStore, err := sqlair.Prepare(`SELECT &ResourceContainerImageMetadataStore.* FROM "resource_container_image_metadata_store"`, v4_1_0.ResourceContainerImageMetadataStore{})
+	stmtResourceContainerImageMetadataStore, err := sqlair.Prepare(`SELECT &ResourceContainerImageMetadataStore.* FROM "resource_container_image_metadata_store" WHERE rowid >= -9223372036854775808`, v4_1_0.ResourceContainerImageMetadataStore{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ResourceContainerImageMetadataStore statement: %w", err)
 	}
-	stmtResourceFileStore, err := sqlair.Prepare(`SELECT &ResourceFileStore.* FROM "resource_file_store"`, v4_1_0.ResourceFileStore{})
+	stmtResourceFileStore, err := sqlair.Prepare(`SELECT &ResourceFileStore.* FROM "resource_file_store" WHERE rowid >= -9223372036854775808`, v4_1_0.ResourceFileStore{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ResourceFileStore statement: %w", err)
 	}
-	stmtResourceImageStore, err := sqlair.Prepare(`SELECT &ResourceImageStore.* FROM "resource_image_store"`, v4_1_0.ResourceImageStore{})
+	stmtResourceImageStore, err := sqlair.Prepare(`SELECT &ResourceImageStore.* FROM "resource_image_store" WHERE rowid >= -9223372036854775808`, v4_1_0.ResourceImageStore{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ResourceImageStore statement: %w", err)
 	}
-	stmtResourceOriginType, err := sqlair.Prepare(`SELECT &ResourceOriginType.* FROM "resource_origin_type"`, v4_1_0.ResourceOriginType{})
+	stmtResourceOriginType, err := sqlair.Prepare(`SELECT &ResourceOriginType.* FROM "resource_origin_type" WHERE rowid >= -9223372036854775808`, v4_1_0.ResourceOriginType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ResourceOriginType statement: %w", err)
 	}
-	stmtResourceRetrievedBy, err := sqlair.Prepare(`SELECT &ResourceRetrievedBy.* FROM "resource_retrieved_by"`, v4_1_0.ResourceRetrievedBy{})
+	stmtResourceRetrievedBy, err := sqlair.Prepare(`SELECT &ResourceRetrievedBy.* FROM "resource_retrieved_by" WHERE rowid >= -9223372036854775808`, v4_1_0.ResourceRetrievedBy{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ResourceRetrievedBy statement: %w", err)
 	}
-	stmtResourceRetrievedByType, err := sqlair.Prepare(`SELECT &ResourceRetrievedByType.* FROM "resource_retrieved_by_type"`, v4_1_0.ResourceRetrievedByType{})
+	stmtResourceRetrievedByType, err := sqlair.Prepare(`SELECT &ResourceRetrievedByType.* FROM "resource_retrieved_by_type" WHERE rowid >= -9223372036854775808`, v4_1_0.ResourceRetrievedByType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ResourceRetrievedByType statement: %w", err)
 	}
-	stmtResourceState, err := sqlair.Prepare(`SELECT &ResourceState.* FROM "resource_state"`, v4_1_0.ResourceState{})
+	stmtResourceState, err := sqlair.Prepare(`SELECT &ResourceState.* FROM "resource_state" WHERE rowid >= -9223372036854775808`, v4_1_0.ResourceState{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ResourceState statement: %w", err)
 	}
-	stmtSchema, err := sqlair.Prepare(`SELECT &Schema.* FROM "schema"`, v4_1_0.Schema{})
+	stmtSchema, err := sqlair.Prepare(`SELECT &Schema.* FROM "schema" WHERE rowid >= -9223372036854775808`, v4_1_0.Schema{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Schema statement: %w", err)
 	}
-	stmtSecret, err := sqlair.Prepare(`SELECT &Secret.* FROM "secret"`, v4_1_0.Secret{})
+	stmtSecret, err := sqlair.Prepare(`SELECT &Secret.* FROM "secret" WHERE rowid >= -9223372036854775808`, v4_1_0.Secret{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Secret statement: %w", err)
 	}
-	stmtSecretApplicationOwner, err := sqlair.Prepare(`SELECT &SecretApplicationOwner.* FROM "secret_application_owner"`, v4_1_0.SecretApplicationOwner{})
+	stmtSecretApplicationOwner, err := sqlair.Prepare(`SELECT &SecretApplicationOwner.* FROM "secret_application_owner" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretApplicationOwner{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretApplicationOwner statement: %w", err)
 	}
-	stmtSecretContent, err := sqlair.Prepare(`SELECT &SecretContent.* FROM "secret_content"`, v4_1_0.SecretContent{})
+	stmtSecretContent, err := sqlair.Prepare(`SELECT &SecretContent.* FROM "secret_content" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretContent{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretContent statement: %w", err)
 	}
-	stmtSecretDeletedValueRef, err := sqlair.Prepare(`SELECT &SecretDeletedValueRef.* FROM "secret_deleted_value_ref"`, v4_1_0.SecretDeletedValueRef{})
+	stmtSecretDeletedValueRef, err := sqlair.Prepare(`SELECT &SecretDeletedValueRef.* FROM "secret_deleted_value_ref" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretDeletedValueRef{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretDeletedValueRef statement: %w", err)
 	}
-	stmtSecretGrantScopeType, err := sqlair.Prepare(`SELECT &SecretGrantScopeType.* FROM "secret_grant_scope_type"`, v4_1_0.SecretGrantScopeType{})
+	stmtSecretGrantScopeType, err := sqlair.Prepare(`SELECT &SecretGrantScopeType.* FROM "secret_grant_scope_type" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretGrantScopeType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretGrantScopeType statement: %w", err)
 	}
-	stmtSecretGrantSubjectType, err := sqlair.Prepare(`SELECT &SecretGrantSubjectType.* FROM "secret_grant_subject_type"`, v4_1_0.SecretGrantSubjectType{})
+	stmtSecretGrantSubjectType, err := sqlair.Prepare(`SELECT &SecretGrantSubjectType.* FROM "secret_grant_subject_type" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretGrantSubjectType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretGrantSubjectType statement: %w", err)
 	}
-	stmtSecretMetadata, err := sqlair.Prepare(`SELECT &SecretMetadata.* FROM "secret_metadata"`, v4_1_0.SecretMetadata{})
+	stmtSecretMetadata, err := sqlair.Prepare(`SELECT &SecretMetadata.* FROM "secret_metadata" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretMetadata{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretMetadata statement: %w", err)
 	}
-	stmtSecretModelOwner, err := sqlair.Prepare(`SELECT &SecretModelOwner.* FROM "secret_model_owner"`, v4_1_0.SecretModelOwner{})
+	stmtSecretModelOwner, err := sqlair.Prepare(`SELECT &SecretModelOwner.* FROM "secret_model_owner" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretModelOwner{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretModelOwner statement: %w", err)
 	}
-	stmtSecretPermission, err := sqlair.Prepare(`SELECT &SecretPermission.* FROM "secret_permission"`, v4_1_0.SecretPermission{})
+	stmtSecretPermission, err := sqlair.Prepare(`SELECT &SecretPermission.* FROM "secret_permission" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretPermission{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretPermission statement: %w", err)
 	}
-	stmtSecretReference, err := sqlair.Prepare(`SELECT &SecretReference.* FROM "secret_reference"`, v4_1_0.SecretReference{})
+	stmtSecretReference, err := sqlair.Prepare(`SELECT &SecretReference.* FROM "secret_reference" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretReference{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretReference statement: %w", err)
 	}
-	stmtSecretRemoteUnitConsumer, err := sqlair.Prepare(`SELECT &SecretRemoteUnitConsumer.* FROM "secret_remote_unit_consumer"`, v4_1_0.SecretRemoteUnitConsumer{})
+	stmtSecretRemoteUnitConsumer, err := sqlair.Prepare(`SELECT &SecretRemoteUnitConsumer.* FROM "secret_remote_unit_consumer" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretRemoteUnitConsumer{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretRemoteUnitConsumer statement: %w", err)
 	}
-	stmtSecretReservation, err := sqlair.Prepare(`SELECT &SecretReservation.* FROM "secret_reservation"`, v4_1_0.SecretReservation{})
+	stmtSecretReservation, err := sqlair.Prepare(`SELECT &SecretReservation.* FROM "secret_reservation" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretReservation{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretReservation statement: %w", err)
 	}
-	stmtSecretRevision, err := sqlair.Prepare(`SELECT &SecretRevision.* FROM "secret_revision"`, v4_1_0.SecretRevision{})
+	stmtSecretRevision, err := sqlair.Prepare(`SELECT &SecretRevision.* FROM "secret_revision" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretRevision{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretRevision statement: %w", err)
 	}
-	stmtSecretRevisionExpire, err := sqlair.Prepare(`SELECT &SecretRevisionExpire.* FROM "secret_revision_expire"`, v4_1_0.SecretRevisionExpire{})
+	stmtSecretRevisionExpire, err := sqlair.Prepare(`SELECT &SecretRevisionExpire.* FROM "secret_revision_expire" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretRevisionExpire{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretRevisionExpire statement: %w", err)
 	}
-	stmtSecretRevisionObsolete, err := sqlair.Prepare(`SELECT &SecretRevisionObsolete.* FROM "secret_revision_obsolete"`, v4_1_0.SecretRevisionObsolete{})
+	stmtSecretRevisionObsolete, err := sqlair.Prepare(`SELECT &SecretRevisionObsolete.* FROM "secret_revision_obsolete" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretRevisionObsolete{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretRevisionObsolete statement: %w", err)
 	}
-	stmtSecretRole, err := sqlair.Prepare(`SELECT &SecretRole.* FROM "secret_role"`, v4_1_0.SecretRole{})
+	stmtSecretRole, err := sqlair.Prepare(`SELECT &SecretRole.* FROM "secret_role" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretRole{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretRole statement: %w", err)
 	}
-	stmtSecretRotatePolicy, err := sqlair.Prepare(`SELECT &SecretRotatePolicy.* FROM "secret_rotate_policy"`, v4_1_0.SecretRotatePolicy{})
+	stmtSecretRotatePolicy, err := sqlair.Prepare(`SELECT &SecretRotatePolicy.* FROM "secret_rotate_policy" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretRotatePolicy{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretRotatePolicy statement: %w", err)
 	}
-	stmtSecretRotation, err := sqlair.Prepare(`SELECT &SecretRotation.* FROM "secret_rotation"`, v4_1_0.SecretRotation{})
+	stmtSecretRotation, err := sqlair.Prepare(`SELECT &SecretRotation.* FROM "secret_rotation" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretRotation{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretRotation statement: %w", err)
 	}
-	stmtSecretUnitConsumer, err := sqlair.Prepare(`SELECT &SecretUnitConsumer.* FROM "secret_unit_consumer"`, v4_1_0.SecretUnitConsumer{})
+	stmtSecretUnitConsumer, err := sqlair.Prepare(`SELECT &SecretUnitConsumer.* FROM "secret_unit_consumer" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretUnitConsumer{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretUnitConsumer statement: %w", err)
 	}
-	stmtSecretUnitOwner, err := sqlair.Prepare(`SELECT &SecretUnitOwner.* FROM "secret_unit_owner"`, v4_1_0.SecretUnitOwner{})
+	stmtSecretUnitOwner, err := sqlair.Prepare(`SELECT &SecretUnitOwner.* FROM "secret_unit_owner" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretUnitOwner{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretUnitOwner statement: %w", err)
 	}
-	stmtSecretValueRef, err := sqlair.Prepare(`SELECT &SecretValueRef.* FROM "secret_value_ref"`, v4_1_0.SecretValueRef{})
+	stmtSecretValueRef, err := sqlair.Prepare(`SELECT &SecretValueRef.* FROM "secret_value_ref" WHERE rowid >= -9223372036854775808`, v4_1_0.SecretValueRef{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretValueRef statement: %w", err)
 	}
-	stmtSequence, err := sqlair.Prepare(`SELECT &Sequence.* FROM "sequence"`, v4_1_0.Sequence{})
+	stmtSequence, err := sqlair.Prepare(`SELECT &Sequence.* FROM "sequence" WHERE rowid >= -9223372036854775808`, v4_1_0.Sequence{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Sequence statement: %w", err)
 	}
-	stmtSpace, err := sqlair.Prepare(`SELECT &Space.* FROM "space"`, v4_1_0.Space{})
+	stmtSpace, err := sqlair.Prepare(`SELECT &Space.* FROM "space" WHERE rowid >= -9223372036854775808`, v4_1_0.Space{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Space statement: %w", err)
 	}
-	stmtSshConnectionRequest, err := sqlair.Prepare(`SELECT &SshConnectionRequest.* FROM "ssh_connection_request"`, v4_1_0.SshConnectionRequest{})
+	stmtSshConnectionRequest, err := sqlair.Prepare(`SELECT &SshConnectionRequest.* FROM "ssh_connection_request" WHERE rowid >= -9223372036854775808`, v4_1_0.SshConnectionRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SshConnectionRequest statement: %w", err)
 	}
-	stmtSshConnectionRequestAddress, err := sqlair.Prepare(`SELECT &SshConnectionRequestAddress.* FROM "ssh_connection_request_address"`, v4_1_0.SshConnectionRequestAddress{})
+	stmtSshConnectionRequestAddress, err := sqlair.Prepare(`SELECT &SshConnectionRequestAddress.* FROM "ssh_connection_request_address" WHERE rowid >= -9223372036854775808`, v4_1_0.SshConnectionRequestAddress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SshConnectionRequestAddress statement: %w", err)
 	}
-	stmtSshKeyAlgorithmType, err := sqlair.Prepare(`SELECT &SshKeyAlgorithmType.* FROM "ssh_key_algorithm_type"`, v4_1_0.SshKeyAlgorithmType{})
+	stmtSshKeyAlgorithmType, err := sqlair.Prepare(`SELECT &SshKeyAlgorithmType.* FROM "ssh_key_algorithm_type" WHERE rowid >= -9223372036854775808`, v4_1_0.SshKeyAlgorithmType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SshKeyAlgorithmType statement: %w", err)
 	}
-	stmtStorageAttachment, err := sqlair.Prepare(`SELECT &StorageAttachment.* FROM "storage_attachment"`, v4_1_0.StorageAttachment{})
+	stmtStorageAttachment, err := sqlair.Prepare(`SELECT &StorageAttachment.* FROM "storage_attachment" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageAttachment{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageAttachment statement: %w", err)
 	}
-	stmtStorageFilesystem, err := sqlair.Prepare(`SELECT &StorageFilesystem.* FROM "storage_filesystem"`, v4_1_0.StorageFilesystem{})
+	stmtStorageFilesystem, err := sqlair.Prepare(`SELECT &StorageFilesystem.* FROM "storage_filesystem" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageFilesystem{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageFilesystem statement: %w", err)
 	}
-	stmtStorageFilesystemAttachment, err := sqlair.Prepare(`SELECT &StorageFilesystemAttachment.* FROM "storage_filesystem_attachment"`, v4_1_0.StorageFilesystemAttachment{})
+	stmtStorageFilesystemAttachment, err := sqlair.Prepare(`SELECT &StorageFilesystemAttachment.* FROM "storage_filesystem_attachment" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageFilesystemAttachment{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageFilesystemAttachment statement: %w", err)
 	}
-	stmtStorageFilesystemStatus, err := sqlair.Prepare(`SELECT &StorageFilesystemStatus.* FROM "storage_filesystem_status"`, v4_1_0.StorageFilesystemStatus{})
+	stmtStorageFilesystemStatus, err := sqlair.Prepare(`SELECT &StorageFilesystemStatus.* FROM "storage_filesystem_status" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageFilesystemStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageFilesystemStatus statement: %w", err)
 	}
-	stmtStorageFilesystemStatusValue, err := sqlair.Prepare(`SELECT &StorageFilesystemStatusValue.* FROM "storage_filesystem_status_value"`, v4_1_0.StorageFilesystemStatusValue{})
+	stmtStorageFilesystemStatusValue, err := sqlair.Prepare(`SELECT &StorageFilesystemStatusValue.* FROM "storage_filesystem_status_value" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageFilesystemStatusValue{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageFilesystemStatusValue statement: %w", err)
 	}
-	stmtStorageInstance, err := sqlair.Prepare(`SELECT &StorageInstance.* FROM "storage_instance"`, v4_1_0.StorageInstance{})
+	stmtStorageInstance, err := sqlair.Prepare(`SELECT &StorageInstance.* FROM "storage_instance" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageInstance{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageInstance statement: %w", err)
 	}
-	stmtStorageInstanceFilesystem, err := sqlair.Prepare(`SELECT &StorageInstanceFilesystem.* FROM "storage_instance_filesystem"`, v4_1_0.StorageInstanceFilesystem{})
+	stmtStorageInstanceFilesystem, err := sqlair.Prepare(`SELECT &StorageInstanceFilesystem.* FROM "storage_instance_filesystem" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageInstanceFilesystem{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageInstanceFilesystem statement: %w", err)
 	}
-	stmtStorageInstanceVolume, err := sqlair.Prepare(`SELECT &StorageInstanceVolume.* FROM "storage_instance_volume"`, v4_1_0.StorageInstanceVolume{})
+	stmtStorageInstanceVolume, err := sqlair.Prepare(`SELECT &StorageInstanceVolume.* FROM "storage_instance_volume" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageInstanceVolume{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageInstanceVolume statement: %w", err)
 	}
-	stmtStorageKind, err := sqlair.Prepare(`SELECT &StorageKind.* FROM "storage_kind"`, v4_1_0.StorageKind{})
+	stmtStorageKind, err := sqlair.Prepare(`SELECT &StorageKind.* FROM "storage_kind" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageKind{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageKind statement: %w", err)
 	}
-	stmtStoragePool, err := sqlair.Prepare(`SELECT &StoragePool.* FROM "storage_pool"`, v4_1_0.StoragePool{})
+	stmtStoragePool, err := sqlair.Prepare(`SELECT &StoragePool.* FROM "storage_pool" WHERE rowid >= -9223372036854775808`, v4_1_0.StoragePool{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StoragePool statement: %w", err)
 	}
-	stmtStoragePoolAttribute, err := sqlair.Prepare(`SELECT &StoragePoolAttribute.* FROM "storage_pool_attribute"`, v4_1_0.StoragePoolAttribute{})
+	stmtStoragePoolAttribute, err := sqlair.Prepare(`SELECT &StoragePoolAttribute.* FROM "storage_pool_attribute" WHERE rowid >= -9223372036854775808`, v4_1_0.StoragePoolAttribute{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StoragePoolAttribute statement: %w", err)
 	}
-	stmtStoragePoolOrigin, err := sqlair.Prepare(`SELECT &StoragePoolOrigin.* FROM "storage_pool_origin"`, v4_1_0.StoragePoolOrigin{})
+	stmtStoragePoolOrigin, err := sqlair.Prepare(`SELECT &StoragePoolOrigin.* FROM "storage_pool_origin" WHERE rowid >= -9223372036854775808`, v4_1_0.StoragePoolOrigin{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StoragePoolOrigin statement: %w", err)
 	}
-	stmtStorageProvisionScope, err := sqlair.Prepare(`SELECT &StorageProvisionScope.* FROM "storage_provision_scope"`, v4_1_0.StorageProvisionScope{})
+	stmtStorageProvisionScope, err := sqlair.Prepare(`SELECT &StorageProvisionScope.* FROM "storage_provision_scope" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageProvisionScope{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageProvisionScope statement: %w", err)
 	}
-	stmtStorageUnitOwner, err := sqlair.Prepare(`SELECT &StorageUnitOwner.* FROM "storage_unit_owner"`, v4_1_0.StorageUnitOwner{})
+	stmtStorageUnitOwner, err := sqlair.Prepare(`SELECT &StorageUnitOwner.* FROM "storage_unit_owner" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageUnitOwner{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageUnitOwner statement: %w", err)
 	}
-	stmtStorageVolume, err := sqlair.Prepare(`SELECT &StorageVolume.* FROM "storage_volume"`, v4_1_0.StorageVolume{})
+	stmtStorageVolume, err := sqlair.Prepare(`SELECT &StorageVolume.* FROM "storage_volume" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageVolume{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolume statement: %w", err)
 	}
-	stmtStorageVolumeAttachment, err := sqlair.Prepare(`SELECT &StorageVolumeAttachment.* FROM "storage_volume_attachment"`, v4_1_0.StorageVolumeAttachment{})
+	stmtStorageVolumeAttachment, err := sqlair.Prepare(`SELECT &StorageVolumeAttachment.* FROM "storage_volume_attachment" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageVolumeAttachment{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolumeAttachment statement: %w", err)
 	}
-	stmtStorageVolumeAttachmentPlan, err := sqlair.Prepare(`SELECT &StorageVolumeAttachmentPlan.* FROM "storage_volume_attachment_plan"`, v4_1_0.StorageVolumeAttachmentPlan{})
+	stmtStorageVolumeAttachmentPlan, err := sqlair.Prepare(`SELECT &StorageVolumeAttachmentPlan.* FROM "storage_volume_attachment_plan" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageVolumeAttachmentPlan{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolumeAttachmentPlan statement: %w", err)
 	}
-	stmtStorageVolumeAttachmentPlanAttr, err := sqlair.Prepare(`SELECT &StorageVolumeAttachmentPlanAttr.* FROM "storage_volume_attachment_plan_attr"`, v4_1_0.StorageVolumeAttachmentPlanAttr{})
+	stmtStorageVolumeAttachmentPlanAttr, err := sqlair.Prepare(`SELECT &StorageVolumeAttachmentPlanAttr.* FROM "storage_volume_attachment_plan_attr" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageVolumeAttachmentPlanAttr{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolumeAttachmentPlanAttr statement: %w", err)
 	}
-	stmtStorageVolumeDeviceType, err := sqlair.Prepare(`SELECT &StorageVolumeDeviceType.* FROM "storage_volume_device_type"`, v4_1_0.StorageVolumeDeviceType{})
+	stmtStorageVolumeDeviceType, err := sqlair.Prepare(`SELECT &StorageVolumeDeviceType.* FROM "storage_volume_device_type" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageVolumeDeviceType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolumeDeviceType statement: %w", err)
 	}
-	stmtStorageVolumeStatus, err := sqlair.Prepare(`SELECT &StorageVolumeStatus.* FROM "storage_volume_status"`, v4_1_0.StorageVolumeStatus{})
+	stmtStorageVolumeStatus, err := sqlair.Prepare(`SELECT &StorageVolumeStatus.* FROM "storage_volume_status" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageVolumeStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolumeStatus statement: %w", err)
 	}
-	stmtStorageVolumeStatusValue, err := sqlair.Prepare(`SELECT &StorageVolumeStatusValue.* FROM "storage_volume_status_value"`, v4_1_0.StorageVolumeStatusValue{})
+	stmtStorageVolumeStatusValue, err := sqlair.Prepare(`SELECT &StorageVolumeStatusValue.* FROM "storage_volume_status_value" WHERE rowid >= -9223372036854775808`, v4_1_0.StorageVolumeStatusValue{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolumeStatusValue statement: %w", err)
 	}
-	stmtSubnet, err := sqlair.Prepare(`SELECT &Subnet.* FROM "subnet"`, v4_1_0.Subnet{})
+	stmtSubnet, err := sqlair.Prepare(`SELECT &Subnet.* FROM "subnet" WHERE rowid >= -9223372036854775808`, v4_1_0.Subnet{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Subnet statement: %w", err)
 	}
-	stmtUnit, err := sqlair.Prepare(`SELECT &Unit.* FROM "unit"`, v4_1_0.Unit{})
+	stmtUnit, err := sqlair.Prepare(`SELECT &Unit.* FROM "unit" WHERE rowid >= -9223372036854775808`, v4_1_0.Unit{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Unit statement: %w", err)
 	}
-	stmtUnitAgentPresence, err := sqlair.Prepare(`SELECT &UnitAgentPresence.* FROM "unit_agent_presence"`, v4_1_0.UnitAgentPresence{})
+	stmtUnitAgentPresence, err := sqlair.Prepare(`SELECT &UnitAgentPresence.* FROM "unit_agent_presence" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitAgentPresence{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitAgentPresence statement: %w", err)
 	}
-	stmtUnitAgentStatus, err := sqlair.Prepare(`SELECT &UnitAgentStatus.* FROM "unit_agent_status"`, v4_1_0.UnitAgentStatus{})
+	stmtUnitAgentStatus, err := sqlair.Prepare(`SELECT &UnitAgentStatus.* FROM "unit_agent_status" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitAgentStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitAgentStatus statement: %w", err)
 	}
-	stmtUnitAgentStatusValue, err := sqlair.Prepare(`SELECT &UnitAgentStatusValue.* FROM "unit_agent_status_value"`, v4_1_0.UnitAgentStatusValue{})
+	stmtUnitAgentStatusValue, err := sqlair.Prepare(`SELECT &UnitAgentStatusValue.* FROM "unit_agent_status_value" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitAgentStatusValue{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitAgentStatusValue statement: %w", err)
 	}
-	stmtUnitAgentVersion, err := sqlair.Prepare(`SELECT &UnitAgentVersion.* FROM "unit_agent_version"`, v4_1_0.UnitAgentVersion{})
+	stmtUnitAgentVersion, err := sqlair.Prepare(`SELECT &UnitAgentVersion.* FROM "unit_agent_version" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitAgentVersion{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitAgentVersion statement: %w", err)
 	}
-	stmtUnitPrincipal, err := sqlair.Prepare(`SELECT &UnitPrincipal.* FROM "unit_principal"`, v4_1_0.UnitPrincipal{})
+	stmtUnitPrincipal, err := sqlair.Prepare(`SELECT &UnitPrincipal.* FROM "unit_principal" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitPrincipal{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitPrincipal statement: %w", err)
 	}
-	stmtUnitResolved, err := sqlair.Prepare(`SELECT &UnitResolved.* FROM "unit_resolved"`, v4_1_0.UnitResolved{})
+	stmtUnitResolved, err := sqlair.Prepare(`SELECT &UnitResolved.* FROM "unit_resolved" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitResolved{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitResolved statement: %w", err)
 	}
-	stmtUnitResource, err := sqlair.Prepare(`SELECT &UnitResource.* FROM "unit_resource"`, v4_1_0.UnitResource{})
+	stmtUnitResource, err := sqlair.Prepare(`SELECT &UnitResource.* FROM "unit_resource" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitResource{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitResource statement: %w", err)
 	}
-	stmtUnitState, err := sqlair.Prepare(`SELECT &UnitState.* FROM "unit_state"`, v4_1_0.UnitState{})
+	stmtUnitState, err := sqlair.Prepare(`SELECT &UnitState.* FROM "unit_state" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitState{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitState statement: %w", err)
 	}
-	stmtUnitStateCharm, err := sqlair.Prepare(`SELECT &UnitStateCharm.* FROM "unit_state_charm"`, v4_1_0.UnitStateCharm{})
+	stmtUnitStateCharm, err := sqlair.Prepare(`SELECT &UnitStateCharm.* FROM "unit_state_charm" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitStateCharm{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitStateCharm statement: %w", err)
 	}
-	stmtUnitStateRelation, err := sqlair.Prepare(`SELECT &UnitStateRelation.* FROM "unit_state_relation"`, v4_1_0.UnitStateRelation{})
+	stmtUnitStateRelation, err := sqlair.Prepare(`SELECT &UnitStateRelation.* FROM "unit_state_relation" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitStateRelation{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitStateRelation statement: %w", err)
 	}
-	stmtUnitStorageDirective, err := sqlair.Prepare(`SELECT &UnitStorageDirective.* FROM "unit_storage_directive"`, v4_1_0.UnitStorageDirective{})
+	stmtUnitStorageDirective, err := sqlair.Prepare(`SELECT &UnitStorageDirective.* FROM "unit_storage_directive" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitStorageDirective{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitStorageDirective statement: %w", err)
 	}
-	stmtUnitVirtualSshHostKey, err := sqlair.Prepare(`SELECT &UnitVirtualSshHostKey.* FROM "unit_virtual_ssh_host_key"`, v4_1_0.UnitVirtualSshHostKey{})
+	stmtUnitVirtualSshHostKey, err := sqlair.Prepare(`SELECT &UnitVirtualSshHostKey.* FROM "unit_virtual_ssh_host_key" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitVirtualSshHostKey{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitVirtualSshHostKey statement: %w", err)
 	}
-	stmtUnitWorkloadStatus, err := sqlair.Prepare(`SELECT &UnitWorkloadStatus.* FROM "unit_workload_status"`, v4_1_0.UnitWorkloadStatus{})
+	stmtUnitWorkloadStatus, err := sqlair.Prepare(`SELECT &UnitWorkloadStatus.* FROM "unit_workload_status" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitWorkloadStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitWorkloadStatus statement: %w", err)
 	}
-	stmtUnitWorkloadVersion, err := sqlair.Prepare(`SELECT &UnitWorkloadVersion.* FROM "unit_workload_version"`, v4_1_0.UnitWorkloadVersion{})
+	stmtUnitWorkloadVersion, err := sqlair.Prepare(`SELECT &UnitWorkloadVersion.* FROM "unit_workload_version" WHERE rowid >= -9223372036854775808`, v4_1_0.UnitWorkloadVersion{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitWorkloadVersion statement: %w", err)
 	}
-	stmtVirtualPortType, err := sqlair.Prepare(`SELECT &VirtualPortType.* FROM "virtual_port_type"`, v4_1_0.VirtualPortType{})
+	stmtVirtualPortType, err := sqlair.Prepare(`SELECT &VirtualPortType.* FROM "virtual_port_type" WHERE rowid >= -9223372036854775808`, v4_1_0.VirtualPortType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing VirtualPortType statement: %w", err)
 	}
-	stmtWorkloadStatusValue, err := sqlair.Prepare(`SELECT &WorkloadStatusValue.* FROM "workload_status_value"`, v4_1_0.WorkloadStatusValue{})
+	stmtWorkloadStatusValue, err := sqlair.Prepare(`SELECT &WorkloadStatusValue.* FROM "workload_status_value" WHERE rowid >= -9223372036854775808`, v4_1_0.WorkloadStatusValue{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing WorkloadStatusValue statement: %w", err)
 	}

--- a/domain/keymanager/state/state.go
+++ b/domain/keymanager/state/state.go
@@ -645,13 +645,13 @@ AND model_uuid = $modelUUIDValue.model_uuid
 	// deleteUnusedUserKeys is here to clean up any public keys for a user that
 	// are not being referenced by a model.
 	deleteUnusedUserKeys, err := s.Prepare(`
-DELETE FROM user_public_ssh_key
-WHERE user_uuid = $userUUIDValue.user_uuid
-AND id IN (SELECT id
-           FROM user_public_ssh_key AS upsk
-           LEFT JOIN model_authorized_keys AS mak ON upsk.id = mak.user_public_ssh_key_id
-           GROUP BY (id)
-           HAVING count(user_public_ssh_key_id) == 0)
+DELETE FROM user_public_ssh_key AS upsk
+WHERE upsk.user_uuid = $userUUIDValue.user_uuid
+AND NOT EXISTS (
+    SELECT 1
+    FROM   model_authorized_keys AS mak
+    WHERE  mak.user_public_ssh_key_id = upsk.id
+)
 `, userUUIDVal)
 
 	if err != nil {

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -200,7 +200,7 @@ WHERE machine_uuid=$instanceData.machine_uuid
 UPDATE machine
 SET    nonce = $machineNonce.nonce
 WHERE  uuid = $machineNonce.machine_uuid
-AND    nonce IS NULL OR nonce = ''
+AND    (nonce IS NULL OR nonce = '')
 `, mNonce)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/model/state/model/state_test.go
+++ b/domain/model/state/model/state_test.go
@@ -1054,7 +1054,7 @@ func (s *modelSuite) TestSetModelStoragePools(c *tc.C) {
 
 	rows, err := s.DB().QueryContext(
 		c.Context(),
-		"SELECT storage_pool_uuid, storage_kind_id FROM model_storage_pool",
+		"SELECT storage_pool_uuid, storage_kind_id FROM model_storage_pool WHERE storage_kind_id >= 0",
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	defer func() { _ = rows.Close() }()
@@ -1111,7 +1111,7 @@ func (s *modelSuite) TestSetModelStoragePoolsSamePool(c *tc.C) {
 
 	rows, err := s.DB().QueryContext(
 		c.Context(),
-		"SELECT storage_pool_uuid, storage_kind_id FROM model_storage_pool",
+		"SELECT storage_pool_uuid, storage_kind_id FROM model_storage_pool WHERE storage_kind_id >= 0 ORDER BY storage_kind_id DESC",
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	defer func() { _ = rows.Close() }()
@@ -1198,7 +1198,7 @@ func (s *modelSuite) TestSetModelStoragePoolsOverwrite(c *tc.C) {
 
 	rows, err := s.DB().QueryContext(
 		c.Context(),
-		"SELECT storage_pool_uuid, storage_kind_id FROM model_storage_pool",
+		"SELECT storage_pool_uuid, storage_kind_id FROM model_storage_pool WHERE storage_kind_id >= 0",
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	defer func() { _ = rows.Close() }()

--- a/domain/modelagent/state/controller/state.go
+++ b/domain/modelagent/state/controller/state.go
@@ -42,6 +42,7 @@ func (s *State) GetControllerAgentVersions(ctx context.Context) ([]semversion.Nu
 	stmt, err := s.Prepare(`
 SELECT &agentVersion.*
 FROM   controller_node_agent_version
+WHERE  version >= ''
 GROUP  BY version
 `, agentVersion{})
 	if err != nil {

--- a/domain/modelagent/state/model/state.go
+++ b/domain/modelagent/state/model/state.go
@@ -276,16 +276,18 @@ func (st *State) GetMachineAgentBinaryMetadata(ctx context.Context, mName string
 	ident := machineName{Name: mName}
 	stmt, err := st.Prepare(`
 SELECT    mav.version AS &agentBinaryMetadata.version,
-          mav.architecture_name AS &agentBinaryMetadata.architecture_name,
+          a.name AS &agentBinaryMetadata.architecture_name,
           osm.size AS &agentBinaryMetadata.size,
           osm.sha_256 AS &agentBinaryMetadata.sha_256,
           osm.sha_384 AS &agentBinaryMetadata.sha_384
-FROM      v_machine_agent_version AS mav
-LEFT JOIN v_agent_binary_store AS abs ON (
+FROM      machine AS m
+JOIN      machine_agent_version AS mav ON mav.machine_uuid = m.uuid
+JOIN      architecture AS a ON a.id = mav.architecture_id
+LEFT JOIN agent_binary_store AS abs ON (
           mav.version = abs.version
 AND       mav.architecture_id = abs.architecture_id)
 LEFT JOIN object_store_metadata AS osm ON abs.object_store_uuid = osm.uuid
-WHERE     mav.name = $machineName.name
+WHERE     m.name = $machineName.name
 `, agentBinaryMetadata{}, ident)
 	if err != nil {
 		return coreagentbinary.Metadata{}, errors.Capture(err)
@@ -375,10 +377,11 @@ SELECT    mav.name AS &machineAgentBinaryMetadata.name,
           osm.sha_256 AS &machineAgentBinaryMetadata.sha_256,
           osm.sha_384 AS &machineAgentBinaryMetadata.sha_384
 FROM      v_machine_agent_version AS mav
-LEFT JOIN v_agent_binary_store AS abs ON (
+LEFT JOIN agent_binary_store AS abs ON (
           mav.version = abs.version
 AND       mav.architecture_id = abs.architecture_id)
 LEFT JOIN object_store_metadata AS osm ON abs.object_store_uuid = osm.uuid
+WHERE     mav.machine_uuid >= ''
 `, machineAgentBinaryMetadata{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -479,12 +482,15 @@ func (st *State) GetMachinesNotAtTargetAgentVersion(
 	query := `
 SELECT &machineName.*
 FROM v_machine_target_agent_version
-WHERE version != target_version
+WHERE machine_uuid >= ''
+AND   version != target_version
 UNION
 SELECT name
 FROM machine
-WHERE uuid NOT IN (SELECT machine_uuid
-                   FROM v_machine_target_agent_version)
+WHERE uuid >= ''
+AND   uuid NOT IN (SELECT machine_uuid
+                   FROM v_machine_target_agent_version
+                   WHERE machine_uuid >= '')
 `
 
 	queryStmt, err := st.Prepare(query, machineName{})
@@ -727,10 +733,11 @@ SELECT    u.name AS &unitAgentBinaryMetadata.name,
 FROM      unit_agent_version AS uav
 JOIN      unit AS u ON uav.unit_uuid = u.uuid
 JOIN      architecture AS a ON uav.architecture_id = a.id
-LEFT JOIN v_agent_binary_store AS abs ON (
+LEFT JOIN agent_binary_store AS abs ON (
           uav.version = abs.version
 AND       uav.architecture_id = abs.architecture_id)
 LEFT JOIN object_store_metadata AS osm ON abs.object_store_uuid = osm.uuid
+WHERE     uav.unit_uuid >= ''
 `, unitAgentBinaryMetadata{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -830,12 +837,15 @@ func (st *State) GetUnitsNotAtTargetAgentVersion(
 	query := `
 SELECT &unitName.*
 FROM v_unit_target_agent_version
-WHERE version != target_version
+WHERE unit_uuid >= ''
+AND   version != target_version
 UNION
 SELECT name
 FROM unit
-WHERE uuid NOT IN (SELECT unit_uuid
-                   FROM v_unit_target_agent_version)
+WHERE uuid >= ''
+AND   uuid NOT IN (SELECT unit_uuid
+                   FROM v_unit_target_agent_version
+                   WHERE unit_uuid >= '')
 `
 
 	queryStmt, err := st.Prepare(query, unitName{})
@@ -1560,6 +1570,7 @@ SELECT mp.machine_uuid AS &machineBase.machine_uuid,
        mp.channel AS &machineBase.channel
 FROM   machine_platform AS mp
 JOIN   os ON mp.os_id = os.id
+WHERE  mp.machine_uuid >= ''
 `, machineBase{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -1612,6 +1623,7 @@ func (st *State) GetAllMachinesArchitectures(ctx context.Context) ([]string, err
 SELECT DISTINCT a.name AS &name.name
 FROM   machine_platform AS mp
 JOIN   architecture AS a ON mp.architecture_id = a.id
+WHERE  mp.machine_uuid >= ''
 `, name{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/modelconfig/state/state.go
+++ b/domain/modelconfig/state/state.go
@@ -129,7 +129,7 @@ func (st *State) ModelConfig(ctx context.Context) (map[string]string, error) {
 		return config, errors.Capture(err)
 	}
 
-	stmt, err := st.Prepare(`SELECT &dbKeyValue.* FROM v_model_config`, dbKeyValue{})
+	stmt, err := st.Prepare(`SELECT &dbKeyValue.* FROM v_model_config WHERE key >= ''`, dbKeyValue{})
 	if err != nil {
 		return config, errors.Capture(err)
 	}
@@ -162,7 +162,7 @@ func (st *State) SetModelConfig(
 		return errors.Capture(err)
 	}
 
-	selectQuery := `SELECT &dbKeyValue.* FROM model_config`
+	selectQuery := `SELECT &dbKeyValue.* FROM model_config WHERE key >= ''`
 	selectStmt, err := st.Prepare(selectQuery, dbKeyValue{})
 	if err != nil {
 		return errors.Errorf("preparing select query: %w", err)

--- a/domain/modelmigration/state/controller/state.go
+++ b/domain/modelmigration/state/controller/state.go
@@ -1710,6 +1710,7 @@ WHERE  key = 'controller-name'
 	stmtAddrs, err := s.Prepare(`
 SELECT &sourceAPIAddress.*
 FROM   controller_api_address
+WHERE  controller_id >= ''
 `, sourceAPIAddress{})
 	if err != nil {
 		return modelmigrationinternal.SourceControllerInfo{}, errors.Capture(err)

--- a/domain/modelmigration/state/model/state.go
+++ b/domain/modelmigration/state/model/state.go
@@ -83,7 +83,8 @@ func (s *State) GetAllInstanceIDs(ctx context.Context) (set.Strings, error) {
 
 	query := `
 SELECT &instanceID.instance_id
-FROM   machine_cloud_instance`
+FROM   machine_cloud_instance
+WHERE  machine_uuid >= ''`
 	queryStmt, err := s.Prepare(query, instanceID{})
 	if err != nil {
 		return nil, errors.Errorf("preparing retrieve all instance IDs statement: %w", err)
@@ -217,6 +218,7 @@ FROM   unit
 SELECT &agentName.name
 FROM   application AS a
 JOIN   application_agent AS aa ON aa.application_uuid = a.uuid
+WHERE  aa.application_uuid >= ''
 `, agentName{})
 	if err != nil {
 		return modelmigrationinternal.MigrationAgents{}, errors.Capture(err)

--- a/domain/modelprovider/state/state.go
+++ b/domain/modelprovider/state/state.go
@@ -46,14 +46,18 @@ func (st *State) GetModelCloudAndCredential(ctx context.Context, uuid coremodel.
 	}
 
 	credStmt, err := st.Prepare(`
-SELECT    ca.auth_type AS &cloudCredentialWithAttribute.auth_type,
-          ca.attribute_key AS &cloudCredentialWithAttribute.attribute_key,
-          ca.attribute_value AS &cloudCredentialWithAttribute.attribute_value,
+SELECT    at.type AS &cloudCredentialWithAttribute.auth_type,
+          cca."key" AS &cloudCredentialWithAttribute.attribute_key,
+          cca.value AS &cloudCredentialWithAttribute.attribute_value,
           m.cloud_uuid AS &cloudCredentialWithAttribute.cloud_uuid,
-          m.cloud_region_name AS &cloudCredentialWithAttribute.cloud_region_name
-FROM      v_model m
-LEFT JOIN v_cloud_credential_attribute ca ON ca.uuid = m.cloud_credential_uuid
+          cr.name AS &cloudCredentialWithAttribute.cloud_region_name
+FROM      model AS m
+LEFT JOIN cloud_region AS cr ON cr.uuid = m.cloud_region_uuid
+LEFT JOIN cloud_credential AS cc ON cc.uuid = m.cloud_credential_uuid
+LEFT JOIN auth_type AS at ON at.id = cc.auth_type_id
+LEFT JOIN cloud_credential_attribute AS cca ON cca.cloud_credential_uuid = cc.uuid
 WHERE     m.uuid = $modelUUID.uuid
+AND       m.activated = TRUE
 `, cloudCredentialWithAttribute{}, modelUUID)
 	if err != nil {
 		return nil, "", nil, errors.Capture(err)

--- a/domain/network/state/cloudservice_import_test.go
+++ b/domain/network/state/cloudservice_import_test.go
@@ -65,7 +65,7 @@ func (s *k8sServiceImportSuite) TestCreateK8sServices(c *tc.C) {
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		k8sServices = nil
 
-		rows, err := tx.QueryContext(ctx, `SELECT uuid, net_node_uuid, application_uuid, provider_id FROM k8s_service`)
+		rows, err := tx.QueryContext(ctx, `SELECT uuid, net_node_uuid, application_uuid, provider_id FROM k8s_service WHERE application_uuid >= ''`)
 		if err != nil {
 			return errors.Errorf("querying net nodes: %w", err)
 		}
@@ -101,7 +101,7 @@ func (s *k8sServiceImportSuite) fetchNetNodeUUIDs(c *tc.C) []string {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		nodes = nil
 
-		rows, err := tx.QueryContext(ctx, `SELECT uuid FROM net_node`)
+		rows, err := tx.QueryContext(ctx, `SELECT uuid FROM net_node WHERE uuid >= ''`)
 		if err != nil {
 			return errors.Errorf("querying net nodes: %w", err)
 		}

--- a/domain/network/state/container.go
+++ b/domain/network/state/container.go
@@ -85,9 +85,11 @@ func (st *State) GetMachineAppBindings(ctx context.Context, machineUUID string) 
 WITH all_bound AS (
     SELECT application_uuid, space_uuid
     FROM   application_endpoint
+    WHERE  application_uuid >= ''
     UNION  
     SELECT application_uuid, space_uuid
     FROM   application_extra_endpoint
+    WHERE  application_uuid >= ''
 )
 SELECT DISTINCT 
        s.uuid AS &spaceConstraint.uuid,

--- a/domain/network/state/linklayer.go
+++ b/domain/network/state/linklayer.go
@@ -148,6 +148,7 @@ JOIN virtual_port_type AS vpt ON lld.virtual_port_type_id = vpt.id
 LEFT JOIN provider_link_layer_device AS plld ON lld.uuid = plld.device_uuid
 LEFT JOIN link_layer_device_parent AS lldp ON lld.uuid = lldp.device_uuid
 LEFT JOIN link_layer_device AS lldpn ON lldp.parent_uuid = lldpn.uuid
+WHERE lld.net_node_uuid >= ''
 `, getLinkLayerDevice{})
 	if err != nil {
 		return nil, errors.Errorf("preparing link layer device select statement: %w", err)
@@ -167,6 +168,7 @@ func (st *State) getAllDNSDomains(ctx context.Context, tx *sqlair.TX) ([]dnsSear
 	stmt, err := st.Prepare(`
 SELECT &dnsSearchDomainRow.* 
 FROM link_layer_device_dns_domain
+WHERE device_uuid >= ''
 `, dnsSearchDomainRow{})
 	if err != nil {
 		return nil, errors.Errorf("preparing DNS search domain select statement: %w", err)
@@ -186,6 +188,7 @@ func (st *State) getAllDNSAddresses(ctx context.Context, tx *sqlair.TX) ([]dnsAd
 	stmt, err := st.Prepare(`
 SELECT &dnsAddressRow.* 
 FROM link_layer_device_dns_address
+WHERE device_uuid >= ''
 `, dnsAddressRow{})
 	if err != nil {
 		return nil, errors.Errorf("preparing DNS address select statement: %w", err)
@@ -227,6 +230,7 @@ LEFT JOIN provider_ip_address AS pia ON ia.uuid = pia.address_uuid
 LEFT JOIN provider_subnet as ps ON ia.subnet_uuid = ps.subnet_uuid
 LEFT JOIN subnet as sub ON ia.subnet_uuid = sub.uuid
 LEFT JOIN space as s ON sub.space_uuid = s.uuid
+WHERE ia.net_node_uuid >= ''
 `, getIpAddress{})
 	if err != nil {
 		return nil, errors.Errorf("preparing IP address select statement: %w", err)

--- a/domain/network/state/linklayer_import_test.go
+++ b/domain/network/state/linklayer_import_test.go
@@ -215,6 +215,7 @@ SELECT
      vpt.name AS &readLinkLayerDevice.virtual_port_type
 FROM link_layer_device AS lld
 JOIN virtual_port_type AS vpt ON lld.virtual_port_type_id = vpt.id
+WHERE lld.net_node_uuid >= ''
 `, readLinkLayerDevice{})
 		if err != nil {
 			return err
@@ -257,6 +258,7 @@ func (s *linkLayerImportSuite) readProviderLinkLayerDevice(c *tc.C) []providerLi
 		stmt, err := s.state.Prepare(`
 SELECT * AS &providerLinkLayerDevice.*
 FROM provider_link_layer_device
+WHERE device_uuid >= ''
 `, providerLinkLayerDevice{})
 		if err != nil {
 			return err
@@ -294,6 +296,7 @@ JOIN ip_address_type AS ipt ON ip.type_id = ipt.id
 JOIN ip_address_config_type AS ipct ON ip.config_type_id = ipct.id
 JOIN ip_address_origin AS ipo ON ip.origin_id = ipo.id
 JOIN ip_address_scope AS ips ON ip.scope_id = ips.id
+WHERE ip.net_node_uuid >= ''
 `, readIpAddresses{})
 		if err != nil {
 			return err
@@ -315,6 +318,7 @@ func (s *linkLayerImportSuite) readProviderIpAddresses(c *tc.C) []providerIpAddr
 		stmt, err := s.state.Prepare(`
 SELECT * AS &providerIpAddressDML.*
 FROM provider_ip_address
+WHERE address_uuid >= ''
 `, providerIpAddressDML{})
 		if err != nil {
 			return err

--- a/domain/network/state/linklayer_merge.go
+++ b/domain/network/state/linklayer_merge.go
@@ -280,6 +280,7 @@ LEFT JOIN ip_address AS a ON s.uuid = a.subnet_uuid
 LEFT JOIN provider_subnet AS ps ON s.uuid = ps.subnet_uuid
 WHERE a.uuid IS NULL -- orphan subnet, linked to no addresses
 AND ps.provider_id IS NULL -- subnet without any provider id
+AND s.uuid >= ''
 AND (
     s.cidr LIKE '%.%/32' -- single address ipv4 subnet 
     OR  

--- a/domain/network/state/lookup.go
+++ b/domain/network/state/lookup.go
@@ -77,7 +77,7 @@ func getLookupNameToID[T ~string](ctx context.Context, st *State, tx *sqlair.TX,
 		return nil, errors.Errorf("invalid table name: %q", tableName)
 	}
 
-	deviceTypeStmt, err := st.Prepare(fmt.Sprintf("SELECT &lookupRow.* FROM %s", tableName), lookupRow{})
+	deviceTypeStmt, err := st.Prepare(fmt.Sprintf("SELECT &lookupRow.* FROM %s WHERE id >= 0", tableName), lookupRow{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/network/state/movesubnets.go
+++ b/domain/network/state/movesubnets.go
@@ -102,50 +102,68 @@ func (st *State) validateSubnetsLeavingSpaces(
 ) ([]positiveSpaceConstraintFailure, error) {
 
 	query := `
-WITH
-app_bindings AS (
-    SELECT application_uuid, space_uuid FROM application_endpoint
-    UNION ALL
-    SELECT application_uuid, space_uuid FROM application_extra_endpoint
-    UNION ALL
-    SELECT uuid AS application_uuid, space_uuid FROM application
-),
-machine_bindings AS (
-    SELECT m.uuid AS machine_uuid, space_uuid
-    FROM   machine AS m
-        JOIN unit AS u ON m.net_node_uuid = u.net_node_uuid
-        JOIN app_bindings AS b ON u.application_uuid = b.application_uuid
-),
-machine_constraints AS (
-    SELECT m.machine_uuid, s.uuid AS space_uuid
-    FROM   machine_constraint AS m
-        JOIN constraint_space AS cs ON m.constraint_uuid = cs.constraint_uuid
-        JOIN space AS s ON cs.space = s.name
-    WHERE  cs.exclude IS FALSE
-),
-machine_space_reqs AS (
-    SELECT machine_uuid, space_uuid FROM machine_bindings
-    UNION ALL
-    SELECT machine_uuid, space_uuid FROM machine_constraints
-),
-new_machine_spaces AS (
-    SELECT DISTINCT m.uuid AS machine_uuid, s.space_uuid
-    FROM   machine AS m
-        JOIN ip_address AS ip ON m.net_node_uuid = ip.net_node_uuid
-        JOIN subnet AS s ON ip.subnet_uuid = s.uuid
-    WHERE  s.uuid NOT IN ($uuids[:])
-),
-failed_constraints AS (
-    SELECT * from machine_space_reqs
-    EXCEPT
-    SELECT * from new_machine_spaces
+SELECT m.name AS &positiveSpaceConstraintFailure.machine_name,
+       s.name AS &positiveSpaceConstraintFailure.space_name
+FROM machine AS m
+JOIN unit AS u ON m.net_node_uuid = u.net_node_uuid
+JOIN application_endpoint AS ae ON u.application_uuid = ae.application_uuid
+JOIN space AS s ON ae.space_uuid = s.uuid
+WHERE ae.application_uuid >= ''
+AND NOT EXISTS (
+    SELECT 1
+    FROM ip_address AS ip
+    JOIN subnet AS actual ON ip.subnet_uuid = actual.uuid
+    WHERE ip.net_node_uuid = m.net_node_uuid
+    AND actual.uuid NOT IN ($uuids[:])
+    AND actual.space_uuid = s.uuid
 )
-SELECT 
-    m.name AS &positiveSpaceConstraintFailure.machine_name,
-    s.name AS &positiveSpaceConstraintFailure.space_name
-FROM failed_constraints AS fc
-    JOIN space AS s ON fc.space_uuid = s.uuid
-    JOIN machine AS m ON fc.machine_uuid = m.uuid
+UNION
+SELECT m.name, s.name
+FROM machine AS m
+JOIN unit AS u ON m.net_node_uuid = u.net_node_uuid
+JOIN application_extra_endpoint AS aee
+     ON u.application_uuid = aee.application_uuid
+JOIN space AS s ON aee.space_uuid = s.uuid
+WHERE aee.application_uuid >= ''
+AND NOT EXISTS (
+    SELECT 1
+    FROM ip_address AS ip
+    JOIN subnet AS actual ON ip.subnet_uuid = actual.uuid
+    WHERE ip.net_node_uuid = m.net_node_uuid
+    AND actual.uuid NOT IN ($uuids[:])
+    AND actual.space_uuid = s.uuid
+)
+UNION
+SELECT m.name, s.name
+FROM machine AS m
+JOIN unit AS u ON m.net_node_uuid = u.net_node_uuid
+JOIN application AS a ON u.application_uuid = a.uuid
+JOIN space AS s ON a.space_uuid = s.uuid
+WHERE a.uuid >= ''
+AND NOT EXISTS (
+    SELECT 1
+    FROM ip_address AS ip
+    JOIN subnet AS actual ON ip.subnet_uuid = actual.uuid
+    WHERE ip.net_node_uuid = m.net_node_uuid
+    AND actual.uuid NOT IN ($uuids[:])
+    AND actual.space_uuid = s.uuid
+)
+UNION
+SELECT m.name, s.name
+FROM machine AS m
+JOIN machine_constraint AS mc ON m.uuid = mc.machine_uuid
+JOIN constraint_space AS cs ON mc.constraint_uuid = cs.constraint_uuid
+JOIN space AS s ON cs.space = s.name
+WHERE mc.machine_uuid >= ''
+AND cs.exclude IS FALSE
+AND NOT EXISTS (
+    SELECT 1
+    FROM ip_address AS ip
+    JOIN subnet AS actual ON ip.subnet_uuid = actual.uuid
+    WHERE ip.net_node_uuid = m.net_node_uuid
+    AND actual.uuid NOT IN ($uuids[:])
+    AND actual.space_uuid = s.uuid
+)
 `
 	stmt, err := st.Prepare(query, movingSubnets, positiveSpaceConstraintFailure{})
 	if err != nil {
@@ -175,23 +193,18 @@ func (st *State) validateSubnetsJoiningSpace(
 	destSpace := spaceTo{UUID: spaceUUID}
 
 	query := `
-WITH 
-bound_machines AS (    
-    SELECT DISTINCT mc.machine_uuid
-    FROM machine_constraint AS mc
-        JOIN constraint_space AS cs ON mc.constraint_uuid = cs.constraint_uuid
-        JOIN space AS s ON cs.space = s.name
-    WHERE s.uuid = $spaceTo.uuid
-    AND cs.exclude IS TRUE
-) 
 -- Get all addresses from machines with constraints in any of moved subnet UUID
 SELECT 
     m.name AS &negativeSpaceConstraintFailure.machine_name, 
     a.address_value AS &negativeSpaceConstraintFailure.address_value
-FROM bound_machines
-    JOIN machine AS m ON bound_machines.machine_uuid = m.uuid
+FROM machine_constraint AS mc
+    JOIN constraint_space AS cs ON mc.constraint_uuid = cs.constraint_uuid
+    JOIN space AS s ON cs.space = s.name
+    JOIN machine AS m ON mc.machine_uuid = m.uuid
     JOIN ip_address AS a ON m.net_node_uuid = a.net_node_uuid
-WHERE a.subnet_uuid IN ($uuids[:])
+WHERE s.uuid = $spaceTo.uuid
+AND cs.exclude IS TRUE
+AND a.subnet_uuid IN ($uuids[:])
 `
 	stmt, err := st.Prepare(query, destSpace, movingSubnets, negativeSpaceConstraintFailure{})
 	if err != nil {

--- a/domain/network/state/movesubnets_test.go
+++ b/domain/network/state/movesubnets_test.go
@@ -826,6 +826,7 @@ func (s *spaceMachineSuite) fetchSubnetSpace(c *tc.C) []subnetSpace {
 SELECT subnet.uuid, space.name
 FROM subnet
 JOIN space ON space.uuid = subnet.space_uuid
+WHERE subnet.uuid >= ''
 `)
 		if err != nil {
 			return err

--- a/domain/network/state/netconfig.go
+++ b/domain/network/state/netconfig.go
@@ -326,7 +326,7 @@ func (st *State) updateDeviceParents(
 // getSubnetGroups retrieves all subnets, parses then into net.IPNet,
 // and groups the UUIDs by CIDR.
 func (st *State) getSubnetGroups(ctx context.Context, tx *sqlair.TX) (subnetGroups, error) {
-	stmt, err := st.Prepare("SELECT &subnet.* FROM subnet", subnet{})
+	stmt, err := st.Prepare("SELECT &subnet.* FROM subnet WHERE uuid >= ''", subnet{})
 	if err != nil {
 		return nil, errors.Errorf("preparing subnets statement: %w", err)
 	}

--- a/domain/network/state/netconfig_test.go
+++ b/domain/network/state/netconfig_test.go
@@ -134,7 +134,7 @@ func (s *netConfigSuite) TestSetMachineNetConfigMultipleSubnetMatch(c *tc.C) {
 	checkScalarResult(c, db, "SELECT dns_address FROM link_layer_device_dns_address", "8.8.8.8")
 
 	// Check that we created a new subnet and linked it to the address.
-	row := db.QueryRowContext(ctx, "SELECT uuid, cidr FROM subnet WHERE uuid NOT IN (?, ?)", subnetUUID1, subnetUUID2)
+	row := db.QueryRowContext(ctx, "SELECT uuid, cidr FROM subnet WHERE uuid >= '' AND uuid NOT IN (?, ?)", subnetUUID1, subnetUUID2)
 	c.Assert(row.Err(), tc.ErrorIsNil)
 
 	var newSubUUID, cidr string

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -248,6 +248,7 @@ func (st *State) GetAllSpaces(
 	s, err := st.Prepare(`
 SELECT &spaceSubnetRow.*
 FROM   v_space_subnet
+WHERE  uuid >= ''
 `, spaceSubnetRow{})
 	if err != nil {
 		return nil, errors.Errorf("preparing select all spaces statement: %w", err)

--- a/domain/network/state/space_remove.go
+++ b/domain/network/state/space_remove.go
@@ -300,20 +300,27 @@ func (st *State) getApplicationBoundToSpace(ctx context.Context, tx *sqlair.TX, 
 	current := space{Name: spaceName.String()}
 
 	stmt, err := st.Prepare(`
-WITH
-bindings AS (
-    SELECT uuid AS application_uuid, space_uuid FROM application
-    UNION ALL
-    SELECT application_uuid, space_uuid FROM application_endpoint
-    UNION ALL
-    SELECT application_uuid, space_uuid FROM application_extra_endpoint
-    UNION ALL
-    SELECT application_uuid, space_uuid FROM application_exposed_endpoint_space
-)
-SELECT DISTINCT a.name AS &application.name
-FROM bindings AS b
-JOIN application AS a ON b.application_uuid = a.uuid
-JOIN space AS s ON b.space_uuid = s.uuid
+SELECT a.name AS &application.name
+FROM application AS a
+JOIN space AS s ON a.space_uuid = s.uuid
+WHERE s.name = $space.name
+UNION
+SELECT a.name
+FROM application_endpoint AS ae
+JOIN application AS a ON ae.application_uuid = a.uuid
+JOIN space AS s ON ae.space_uuid = s.uuid
+WHERE s.name = $space.name
+UNION
+SELECT a.name
+FROM application_extra_endpoint AS aee
+JOIN application AS a ON aee.application_uuid = a.uuid
+JOIN space AS s ON aee.space_uuid = s.uuid
+WHERE s.name = $space.name
+UNION
+SELECT a.name
+FROM application_exposed_endpoint_space AS aes
+JOIN application AS a ON aes.application_uuid = a.uuid
+JOIN space AS s ON aes.space_uuid = s.uuid
 WHERE s.name = $space.name`, current, application{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -313,7 +313,8 @@ func (st *State) GetAllSubnets(
 	// Append the space uuid condition to the query only if it's passed to the function.
 	q := `
 SELECT &SubnetRow.*
-FROM   v_space_subnet`
+FROM   v_space_subnet
+WHERE  uuid >= ''`
 
 	s, err := st.Prepare(q, SubnetRow{})
 	if err != nil {

--- a/domain/network/state/unitinfo.go
+++ b/domain/network/state/unitinfo.go
@@ -105,6 +105,7 @@ WITH endpoint_binding AS (
            ae.space_uuid
     FROM   application_endpoint AS ae
     JOIN   charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
+    WHERE  ae.application_uuid >= ''
     UNION ALL
     SELECT aee.application_uuid,
            ceb.name,
@@ -112,6 +113,7 @@ WITH endpoint_binding AS (
     FROM   application_extra_endpoint AS aee
     JOIN   charm_extra_binding AS ceb
            ON aee.charm_extra_binding_uuid = ceb.uuid
+    WHERE  aee.application_uuid >= ''
 ),
 endpoint_space AS (
     SELECT eb.name AS endpoint_name,
@@ -122,35 +124,6 @@ endpoint_space AS (
     WHERE  u.uuid = $entityUUID.uuid
     AND    eb.name IN ($names[:])
 ),
-ingress_candidate AS (
-    SELECT es.endpoint_name,
-           urn.address_value,
-           urn.device_uuid,
-           urn.scope_rank,
-           urn.origin_id,
-           urn.is_secondary,
-           urn.device_type_id
-    FROM   endpoint_space AS es
-    JOIN   v_unit_relation_network AS urn
-           ON urn.unit_uuid = $entityUUID.uuid
-          AND urn.space_uuid = es.space_uuid
-),
-best_rank AS (
-    SELECT endpoint_name, MIN(scope_rank) AS scope_rank
-    FROM   ingress_candidate
-    WHERE  scope_rank IS NOT NULL
-    GROUP BY endpoint_name
-),
-selected_ingress AS (
-    SELECT ic.endpoint_name,
-           ic.address_value,
-           ic.device_uuid,
-           ic.origin_id,
-           ic.is_secondary,
-           ic.device_type_id
-    FROM   ingress_candidate AS ic
-    JOIN   best_rank USING (endpoint_name, scope_rank)
-),
 lld AS (
     SELECT lld.uuid,
            lld.name,
@@ -158,6 +131,7 @@ lld AS (
            lldt.name AS device_type
     FROM   link_layer_device AS lld
     JOIN   link_layer_device_type AS lldt ON lld.device_type_id = lldt.id
+    WHERE  lld.net_node_uuid >= ''
 ),
 endpoint_address AS (
     SELECT es.endpoint_name,
@@ -181,10 +155,18 @@ endpoint_address AS (
            ON urn.unit_uuid = $entityUUID.uuid
           AND urn.space_uuid = es.space_uuid
     JOIN   lld ON urn.device_uuid = lld.uuid
-    LEFT JOIN selected_ingress AS si
-           ON si.endpoint_name = es.endpoint_name
+    LEFT JOIN v_unit_relation_network AS si
+           ON si.unit_uuid = $entityUUID.uuid
+          AND si.space_uuid = es.space_uuid
           AND si.device_uuid = urn.device_uuid
           AND si.address_value = urn.address_value
+          AND si.scope_rank = (
+              SELECT MIN(best.scope_rank)
+              FROM v_unit_relation_network AS best
+              WHERE best.unit_uuid = $entityUUID.uuid
+              AND best.space_uuid = es.space_uuid
+              AND best.scope_rank IS NOT NULL
+          )
 )
 SELECT &endpointNetworkInfoRow.*
 FROM   endpoint_address

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -128,13 +128,13 @@ func (s *State) GetMetadataBySHA256Prefix(ctx context.Context, sha256 string) (c
 		return coreobjectstore.Metadata{}, errors.Capture(err)
 	}
 
-	sha256IdentPrefix := sha256IdentPrefix{SHA256Prefix: sha256}
+	sha256IdentPrefix := sha256IdentPrefix{SHA256Prefix: sha256 + "%"}
 	var metadata dbMetadata
 
 	stmt, err := s.Prepare(`
 SELECT &dbMetadata.*
 FROM v_object_store_metadata
-WHERE sha_256 LIKE $sha256IdentPrefix.sha_256_prefix || '%'`, metadata, sha256IdentPrefix)
+WHERE sha_256 LIKE $sha256IdentPrefix.sha_256_prefix`, metadata, sha256IdentPrefix)
 	if err != nil {
 		return coreobjectstore.Metadata{}, errors.Errorf("preparing select metadata statement: %w", err)
 	}

--- a/domain/operation/state/migration_test.go
+++ b/domain/operation/state/migration_test.go
@@ -223,7 +223,8 @@ func (s *migrationSuite) TestImportOperationsWithMultipleUnitTask(c *tc.C) {
 SELECT operation_task.task_id, unit.name 
 FROM operation_unit_task
 JOIN operation_task ON operation_task.uuid = operation_unit_task.task_uuid
-JOIN unit ON unit.uuid = operation_unit_task.unit_uuid`)
+JOIN unit ON unit.uuid = operation_unit_task.unit_uuid
+WHERE operation_unit_task.rowid > 0`)
 	c.Check(linkRows, tc.SameContents, []map[string]any{
 		{
 			"task_id": taskID1,
@@ -337,7 +338,8 @@ func (s *migrationSuite) TestImportOperationsWithMultipleMachineTasks(c *tc.C) {
 SELECT operation_task.task_id, machine.name 
 FROM operation_machine_task
 JOIN operation_task ON operation_task.uuid = operation_machine_task.task_uuid
-JOIN machine ON machine.uuid = operation_machine_task.machine_uuid`)
+JOIN machine ON machine.uuid = operation_machine_task.machine_uuid
+WHERE operation_machine_task.rowid > 0`)
 	c.Check(linkRows, tc.SameContents, []map[string]any{
 		{
 			"task_id": taskID1,

--- a/domain/operation/state/prune.go
+++ b/domain/operation/state/prune.go
@@ -254,8 +254,11 @@ SELECT COALESCE(SUM(
     octet_length(osm.path) +
     octet_length(osm.metadata_uuid)              
 ),0) AS &result.size
-FROM operation_task_output as oto
-JOIN object_store_metadata_path AS osm ON oto.store_path = osm.path
+FROM operation_task_output AS oto
+     INDEXED BY idx_operation_task_output_store_path_task_uuid
+JOIN object_store_metadata_path AS osm
+     INDEXED BY idx_object_store_metadata_path_path_uuid
+     ON oto.store_path = osm.path
 `, result{})
 	if err != nil {
 		return 0, errors.Capture(err)
@@ -271,7 +274,10 @@ WITH
 uuids AS (
     SELECT osmp.metadata_uuid
     FROM object_store_metadata_path AS osmp
-    JOIN operation_task_output AS oto ON osmp.path = oto.store_path
+         INDEXED BY idx_object_store_metadata_path_path_uuid
+    JOIN operation_task_output AS oto
+         INDEXED BY idx_operation_task_output_store_path_task_uuid
+         ON osmp.path = oto.store_path
 )
 SELECT COALESCE(SUM(
     osm.size +
@@ -279,7 +285,8 @@ SELECT COALESCE(SUM(
     octet_length(osm.sha_256) +
     octet_length(osm.sha_384) +
     octet_length(osm.size)), 0) AS &result.size
-FROM   object_store_metadata AS osm 
+FROM   object_store_metadata AS osm
+       INDEXED BY idx_object_store_metadata_details
 WHERE  uuid IN uuids`, result{})
 	if err != nil {
 		return 0, errors.Capture(err)
@@ -322,8 +329,8 @@ func (st *State) computeTableSize(ctx context.Context, tx *sqlair.TX, sizeFactor
 SELECT COALESCE(SUM(
 	%s
 	), 0) AS &result.size
-FROM %q
-`, sums, table)
+FROM %q INDEXED BY %q
+`, sums, table, "idx_"+table+"_details")
 	stmt, err := st.Prepare(query, result{})
 	if err != nil {
 		return 0, errors.Capture(err)

--- a/domain/operation/state/start_test.go
+++ b/domain/operation/state/start_test.go
@@ -374,10 +374,11 @@ func (s *startSuite) TestAddExecOperationMixedSuccessAndErrors(c *tc.C) {
 
 	// Verify the valid task was stored, and the invalid one didn't put any data in the DB.
 	tasks := s.queryRows(c, `
-SELECT DISTINCT uuid, task_id, unit_uuid, machine_uuid 
+SELECT uuid, task_id, unit_uuid, machine_uuid
 FROM operation_task
 LEFT JOIN operation_unit_task ON operation_task.uuid = operation_unit_task.task_uuid
-LEFT JOIN operation_machine_task ON operation_task.uuid = operation_machine_task.task_uuid`)
+LEFT JOIN operation_machine_task ON operation_task.uuid = operation_machine_task.task_uuid
+WHERE operation_task.rowid > 0`)
 	var validIDs, validUnitTaskUUIDs, validMachineTaskUUIDs []string
 	for _, task := range tasks {
 		validIDs = append(validIDs, task["task_id"].(string))
@@ -614,7 +615,7 @@ func (s *startSuite) TestAddActionOperationMixedSuccessAndErrors(c *tc.C) {
 	c.Check(result.Units[2].TaskInfo.ID, tc.Not(tc.Equals), "")
 
 	// Verify the valid task was stored, and the invalid one didn't put any data in the DB.
-	tasks := s.queryRows(c, `SELECT uuid, task_id FROM operation_task`)
+	tasks := s.queryRows(c, `SELECT uuid, task_id FROM operation_task WHERE rowid > 0`)
 	var validIDs, validUUIDs []string
 	for _, task := range tasks {
 		validIDs = append(validIDs, task["task_id"].(string))

--- a/domain/operation/state/state.go
+++ b/domain/operation/state/state.go
@@ -271,7 +271,8 @@ func (st *State) getTaskUUIDsByOperationUUIDs(ctx context.Context, tx *sqlair.TX
 	stmt, err := st.Prepare(`
 SELECT &task.uuid
 FROM   operation_task
-WHERE  operation_uuid IN ($uuids[:])`, toGet, task{})
+WHERE  operation_uuid IN ($uuids[:])
+ORDER BY rowid`, toGet, task{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/operation/state/state.go
+++ b/domain/operation/state/state.go
@@ -381,7 +381,8 @@ AND    (
        sv.status = 'pending'
        OR
        sv.status = 'aborting'
-)`
+)
+ORDER BY t.task_id`
 }
 
 // InitialWatchStatementMachineTask returns the namespace and an initial

--- a/domain/operation/state/task.go
+++ b/domain/operation/state/task.go
@@ -577,6 +577,7 @@ func (st *State) getOperationTasks(ctx context.Context, tx *sqlair.TX, operation
 	type opUUIDs []string
 	taskQuery := operationTaskBaseQuery + `
 WHERE t.operation_uuid IN ($opUUIDs[:])
+ORDER BY t.task_id
 `
 	ident := opUUIDs(operationUUIDs)
 	stmt, err := st.Prepare(taskQuery, taskResult{}, ident)

--- a/domain/port/state/importopenunitports.go
+++ b/domain/port/state/importopenunitports.go
@@ -141,7 +141,7 @@ func (st *State) openPorts(
 
 // getProtocolMap returns a map of protocol names to their IDs in DQLite.
 func (st *State) getProtocolMap(ctx context.Context, tx *sqlair.TX) (map[string]int, error) {
-	getProtocols, err := st.Prepare("SELECT &protocol.* FROM protocol", protocol{})
+	getProtocols, err := st.Prepare("SELECT &protocol.* FROM protocol WHERE id >= 0", protocol{})
 	if err != nil {
 		return nil, errors.Errorf("preparing get protocol ID statement: %w", err)
 	}

--- a/domain/port/state/watcher.go
+++ b/domain/port/state/watcher.go
@@ -28,6 +28,7 @@ func (*State) InitialWatchOpenedPortsStatement() (string, string) {
 	return "port_range", `
 SELECT u.uuid FROM unit AS u
 JOIN machine AS m ON u.net_node_uuid = m.net_node_uuid
+WHERE u.uuid >= ''
 ORDER BY u.uuid
 `
 }

--- a/domain/provisioner/state/controller/state.go
+++ b/domain/provisioner/state/controller/state.go
@@ -155,7 +155,8 @@ SELECT cim.image_id AS &imageMetadataRow.image_id,
        cim.priority AS &imageMetadataRow.priority
 FROM cloud_image_metadata AS cim
 JOIN architecture AS a ON cim.architecture_id = a.id
-WHERE ($imageMetadataFlags.has_version = 0 OR cim.version = $imageMetadataFilter.version)
+WHERE cim.uuid >= ''
+AND ($imageMetadataFlags.has_version = 0 OR cim.version = $imageMetadataFilter.version)
 AND ($imageMetadataFlags.has_arch = 0 OR a.name = $imageMetadataFilter.arch)
 AND ($imageMetadataFlags.has_region = 0 OR cim.region = $imageMetadataFilter.region)
 AND ($imageMetadataFlags.has_stream = 0 OR cim.stream = $imageMetadataFilter.stream)

--- a/domain/provisioner/state/model/state.go
+++ b/domain/provisioner/state/model/state.go
@@ -684,6 +684,7 @@ func (st *State) getAllSpaces(
 	stmt, err := st.Prepare(`
 SELECT &spaceSubnetRow.*
 FROM v_space_subnet
+WHERE uuid >= ''
 `, spaceSubnetRow{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/relation/state/migration.go
+++ b/domain/relation/state/migration.go
@@ -192,6 +192,7 @@ func (st *State) ExportRelations(ctx context.Context) ([]domainrelation.ExportRe
 	stmt, err := st.Prepare(`
 SELECT (r.uuid, r.relation_id) AS (&getRelation.*)
 FROM   relation r
+WHERE  r.uuid >= ''
 `, getRelation{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -2702,6 +2702,7 @@ JOIN   relation_endpoint AS re ON r.uuid = re.relation_uuid
 JOIN   relation_unit AS ru ON re.uuid = ru.relation_endpoint_uuid
 JOIN   unit AS u ON ru.unit_uuid = u.uuid
 WHERE  u.name = $name.name
+AND    r.uuid >= ''
 `, relationUUIDRow{}, name{})
 	if err != nil {
 		return nil, errors.Errorf("preparing select unit relation uuids statement: %w", err)
@@ -3323,6 +3324,7 @@ FROM      relation r
 JOIN      life l ON r.life_id = l.id
 LEFT JOIN offer_connection oc ON r.uuid = oc.remote_relation_uuid
 WHERE     oc.remote_relation_uuid IS NULL
+AND       r.uuid >= ''
 `, relationWithDetails{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/removal/state/model/application_test.go
+++ b/domain/removal/state/model/application_test.go
@@ -274,13 +274,13 @@ func (s *applicationSuite) TestEnsureApplicationOnMultipleMachines(c *tc.C) {
 
 	// There should be one unit that is alive (from app2), and one that is dying
 	// (from app1).
-	row := s.DB().QueryRow("SELECT COUNT(*), uuid FROM unit WHERE life_id = 0")
+	row := s.DB().QueryRow("SELECT life_id, uuid FROM unit WHERE uuid = ?", app2UnitUUIDs[0])
 	err = row.Scan(&count, &uuid)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(count, tc.Equals, 1)
+	c.Check(count, tc.Equals, 0)
 	c.Check(uuid, tc.Equals, app2UnitUUIDs[0].String())
 
-	row = s.DB().QueryRow("SELECT COUNT(*), uuid FROM unit WHERE life_id != 0")
+	row = s.DB().QueryRow("SELECT life_id, uuid FROM unit WHERE uuid = ?", app1UnitUUIDs[0])
 	err = row.Scan(&count, &uuid)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(count, tc.Equals, 1)
@@ -1346,24 +1346,17 @@ SELECT COUNT(*) FROM sequence WHERE namespace = CONCAT('application_', ?)`, appN
 }
 
 func (s *applicationSuite) checkUnitDyingState(c *tc.C, unitUUIDs []unit.UUID) {
-	// Ensure that there are no units left with life "alive".
-	row := s.DB().QueryRow("SELECT COUNT(*) FROM unit WHERE  life_id = 0")
-	var count int
-	err := row.Scan(&count)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(count, tc.Equals, 0)
-
 	// Ensure that all units are now "dying".
 	placeholders := strings.Repeat("?,", len(unitUUIDs)-1) + "?"
 	uuids := transform.Slice(unitUUIDs, func(u unit.UUID) any {
 		return u.String()
 	})
 
-	row = s.DB().QueryRow(fmt.Sprintf(`
+	row := s.DB().QueryRow(fmt.Sprintf(`
 SELECT COUNT(*) FROM unit WHERE life_id = 1 AND uuid IN (%s)
 `, placeholders), uuids...)
 	var dyingCount int
-	err = row.Scan(&dyingCount)
+	err := row.Scan(&dyingCount)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(dyingCount, tc.Equals, len(unitUUIDs))
 }

--- a/domain/removal/state/model/model.go
+++ b/domain/removal/state/model/model.go
@@ -133,19 +133,19 @@ func (st *State) EnsureModelNotAliveCascade(ctx context.Context, modelUUID strin
 	// - All applications in the model.
 	// - All relations in the model.
 	// - All machines in the model.
-	selectUnits, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM unit WHERE life_id < 2`, eUUID)
+	selectUnits, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM unit WHERE life_id <= 1`, eUUID)
 	if err != nil {
 		return removal.ModelArtifacts{}, errors.Errorf("preparing select units query: %w", err)
 	}
-	selectApplications, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM application WHERE life_id < 2`, eUUID)
+	selectApplications, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM application WHERE life_id <= 1`, eUUID)
 	if err != nil {
 		return removal.ModelArtifacts{}, errors.Errorf("preparing select applications query: %w", err)
 	}
-	selectRelations, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM relation WHERE life_id < 2`, eUUID)
+	selectRelations, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM relation WHERE life_id <= 1`, eUUID)
 	if err != nil {
 		return removal.ModelArtifacts{}, errors.Errorf("preparing select relations query: %w", err)
 	}
-	selectMachines, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM machine WHERE life_id < 2`, eUUID)
+	selectMachines, err := st.Prepare(`SELECT uuid AS &entityUUID.* FROM machine WHERE life_id <= 1`, eUUID)
 	if err != nil {
 		return removal.ModelArtifacts{}, errors.Errorf("preparing select machines query: %w", err)
 	}

--- a/domain/removal/state/model/model_test.go
+++ b/domain/removal/state/model/model_test.go
@@ -462,13 +462,15 @@ func (s *modelSuite) TestIsControllerModel(c *tc.C) {
 
 func (s *modelSuite) TestIsControllerModelControllerModel(c *tc.C) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		// Force the model to be a controller model.
-		_, err := tx.ExecContext(ctx, `DROP TRIGGER IF EXISTS trg_model_immutable_update;`)
-		if err != nil {
-			return err
-		}
-
-		_, err = tx.ExecContext(ctx, `UPDATE model SET is_controller_model = 1 WHERE uuid = ?`, s.getModelUUID(c))
+		_, err := tx.ExecContext(ctx, `
+INSERT OR REPLACE INTO model (
+    uuid, controller_uuid, name, qualifier, type, cloud, cloud_type,
+    cloud_region, credential_owner, credential_name, is_controller_model
+)
+SELECT uuid, controller_uuid, name, qualifier, type, cloud, cloud_type,
+       cloud_region, credential_owner, credential_name, 1
+FROM   model
+WHERE  uuid = ?`, s.getModelUUID(c))
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/removal/state/model/state.go
+++ b/domain/removal/state/model/state.go
@@ -38,7 +38,10 @@ func (st *State) GetAllJobs(ctx context.Context) ([]removal.Job, error) {
 		return nil, errors.Capture(err)
 	}
 
-	stmt, err := st.Prepare("SELECT &removalJob.* FROM removal", removalJob{})
+	stmt, err := st.Prepare(`
+SELECT &removalJob.*
+FROM   removal
+ORDER BY scheduled_for, uuid`, removalJob{})
 	if err != nil {
 		return nil, errors.Errorf("preparing select jobs query: %w", err)
 	}

--- a/domain/removal/state/model/state_test.go
+++ b/domain/removal/state/model/state_test.go
@@ -91,11 +91,12 @@ VALUES (?, ?, ?, ?, ?, ?)`
 	jID1, _ := removal.NewUUID()
 	jID2, _ := removal.NewUUID()
 	now := time.Now().UTC()
+	later := now.Add(time.Second)
 
 	_, err := s.DB().Exec(ins, jID1, 0, "rel-1", 0, now, nil)
 	c.Assert(err, tc.ErrorIsNil)
 
-	_, err = s.DB().Exec(ins, jID2, 0, "rel-2", 1, now, `{"special-key":"special-value"}`)
+	_, err = s.DB().Exec(ins, jID2, 0, "rel-2", 1, later, `{"special-key":"special-value"}`)
 	c.Assert(err, tc.ErrorIsNil)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
@@ -117,7 +118,7 @@ VALUES (?, ?, ?, ?, ?, ?)`
 		RemovalType:  removal.RelationJob,
 		EntityUUID:   "rel-2",
 		Force:        true,
-		ScheduledFor: now,
+		ScheduledFor: later,
 		Arg: map[string]any{
 			"special-key": "special-value",
 		},

--- a/domain/removal/state/model/unit.go
+++ b/domain/removal/state/model/unit.go
@@ -299,35 +299,19 @@ func (st *State) markMachineAsDyingIfAllUnitsAreNotAlive(
 	unitUUID := entityUUID{UUID: uUUID}
 
 	lastUnitStmt, err := st.Prepare(`
-WITH units_alive AS (
-    SELECT uuid, net_node_uuid
-    FROM   unit
-    WHERE  life_id = 0
-), units_not_alive AS (
-    SELECT uuid, net_node_uuid
-    FROM   unit
-    WHERE  life_id != 0
-), machines AS (
-    SELECT    m.uuid AS machine_uuid,
-              m.net_node_uuid,
-              COUNT(ua.uuid) AS unit_alive_count,
-              COUNT(una.uuid) AS unit_not_alive_count,
-			  COUNT(mp.parent_uuid) AS machine_parent_count
-    FROM      machine AS m
-    JOIN      net_node AS nn ON nn.uuid = m.net_node_uuid
-    LEFT JOIN units_alive AS ua ON ua.net_node_uuid = nn.uuid
-    LEFT JOIN units_not_alive AS una ON una.net_node_uuid = nn.uuid
-	LEFT JOIN machine_parent AS mp ON mp.parent_uuid = m.uuid
-    GROUP BY  m.uuid
-)
-SELECT unit_alive_count AS &unitMachineLifeSummary.alive_count,
-       unit_not_alive_count AS &unitMachineLifeSummary.not_alive_count,
-	   machine_parent_count AS &unitMachineLifeSummary.machine_parent_count,
-       machine_uuid AS &unitMachineLifeSummary.uuid
-FROM   machines
-LEFT JOIN unit AS u ON u.net_node_uuid = machines.net_node_uuid
-WHERE  u.uuid = $entityUUID.uuid;
-    `, unitUUID, unitMachineLifeSummary{})
+SELECT COUNT(DISTINCT CASE WHEN u.life_id = 0 THEN u.uuid END)
+           AS &unitMachineLifeSummary.alive_count,
+       COUNT(DISTINCT CASE WHEN u.life_id != 0 THEN u.uuid END)
+           AS &unitMachineLifeSummary.not_alive_count,
+       COUNT(DISTINCT mp.machine_uuid)
+           AS &unitMachineLifeSummary.machine_parent_count,
+       m.uuid AS &unitMachineLifeSummary.uuid
+FROM   unit AS target_unit
+JOIN   machine AS m ON m.net_node_uuid = target_unit.net_node_uuid
+JOIN   unit AS u ON u.net_node_uuid = m.net_node_uuid
+LEFT JOIN machine_parent AS mp ON mp.parent_uuid = m.uuid
+WHERE  target_unit.uuid = $entityUUID.uuid
+GROUP BY m.uuid`, unitUUID, unitMachineLifeSummary{})
 	if err != nil {
 		return "", cascaded, errors.Errorf("preparing unit count query: %w", err)
 	}

--- a/domain/resource/state/resource.go
+++ b/domain/resource/state/resource.go
@@ -2437,6 +2437,7 @@ func (st *State) getOriginIDs(ctx context.Context, tx *sqlair.TX) (map[string]in
 	selectOriginStmt, err := st.Prepare(`
 SELECT &origin.*
 FROM   resource_origin_type
+WHERE  id >= 0
 `, origin{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -2465,6 +2466,7 @@ func (st *State) getStateIDs(ctx context.Context, tx *sqlair.TX) (map[resource.S
 	selectStateStmt, err := st.Prepare(`
 SELECT &state.*
 FROM   resource_state
+WHERE  id >= 0
 `, state{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/resource/state/resource_test.go
+++ b/domain/resource/state/resource_test.go
@@ -409,7 +409,8 @@ func (s *resourceSuite) TestDeleteUnitResources(c *tc.C) {
 		rows, err := tx.Query(`
 SELECT uuid, name, application_uuid, unit_uuid
 FROM v_application_resource AS rv
-LEFT JOIN unit_resource AS ur ON rv.uuid = ur.resource_uuid`)
+LEFT JOIN unit_resource AS ur ON rv.uuid = ur.resource_uuid
+WHERE rv.uuid >= ''`)
 		if err != nil {
 			return err
 		}

--- a/domain/schema/controller/sql/0002-lease.sql
+++ b/domain/schema/controller/sql/0002-lease.sql
@@ -29,6 +29,9 @@ ON lease (model_uuid, lease_type_id, name);
 CREATE INDEX idx_lease_expiry
 ON lease (expiry);
 
+CREATE INDEX idx_lease_type_model_name_holder_expiry
+ON lease (lease_type_id, model_uuid, name, holder, expiry);
+
 CREATE TABLE lease_pin (
     -- The presence of entries in this table for a particular lease_uuid
     -- implies that the lease in question is pinned and cannot expire.

--- a/domain/schema/controller/sql/0003-changelog.sql
+++ b/domain/schema/controller/sql/0003-changelog.sql
@@ -47,3 +47,6 @@ CREATE TABLE change_log_witness (
     upper_bound INT NOT NULL DEFAULT (-1),
     updated_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc'))
 );
+
+CREATE INDEX idx_change_log_witness_watermark
+ON change_log_witness (lower_bound, updated_at, controller_id);

--- a/domain/schema/controller/sql/0005-cloud.sql
+++ b/domain/schema/controller/sql/0005-cloud.sql
@@ -33,6 +33,9 @@ CREATE TABLE auth_type (
 CREATE UNIQUE INDEX idx_auth_type_type
 ON auth_type (type);
 
+CREATE INDEX idx_auth_type_id_type
+ON auth_type (id, type);
+
 INSERT INTO auth_type VALUES
 (0, 'access-key'),
 (1, 'instance-role'),
@@ -154,6 +157,9 @@ CREATE TABLE cloud_credential (
 
 CREATE UNIQUE INDEX idx_cloud_credential_cloud_uuid_owner_uuid
 ON cloud_credential (cloud_uuid, owner_uuid, name);
+
+CREATE INDEX idx_cloud_credential_owner_uuid
+ON cloud_credential (owner_uuid);
 
 -- view_cloud_credential is a convenience view for accessing a
 -- credential UUID based on the natural key used to display the

--- a/domain/schema/controller/sql/0006-external-controller.sql
+++ b/domain/schema/controller/sql/0006-external-controller.sql
@@ -23,3 +23,6 @@ CREATE TABLE external_model (
     FOREIGN KEY (controller_uuid)
     REFERENCES external_controller (uuid)
 );
+
+CREATE INDEX idx_external_model_controller_uuid
+ON external_model (controller_uuid, uuid);

--- a/domain/schema/controller/sql/0007-model.sql
+++ b/domain/schema/controller/sql/0007-model.sql
@@ -58,6 +58,8 @@ CREATE TABLE model (
 -- with the same qualified name.
 CREATE UNIQUE INDEX idx_model_qualified_name ON model (name, qualifier);
 CREATE INDEX idx_model_activated ON model (activated);
+CREATE INDEX idx_model_life ON model (life_id);
+CREATE INDEX idx_model_life_uuid ON model (life_id, uuid);
 
 -- v_model_all is a view that provides a simple way to access models
 -- that have not been activated. This is useful for the model creation process

--- a/domain/schema/controller/sql/0010-controller-node.sql
+++ b/domain/schema/controller/sql/0010-controller-node.sql
@@ -39,6 +39,12 @@ CREATE TABLE controller_api_address (
     PRIMARY KEY (controller_id, address)
 );
 
+CREATE INDEX idx_controller_api_address_is_agent
+ON controller_api_address (is_agent);
+
+CREATE INDEX idx_controller_api_address_scope
+ON controller_api_address (scope);
+
 CREATE TABLE controller_node_password (
     controller_id TEXT NOT NULL PRIMARY KEY,
     password_hash_algorithm_id TEXT,

--- a/domain/schema/controller/sql/0010-controller-node.sql
+++ b/domain/schema/controller/sql/0010-controller-node.sql
@@ -7,6 +7,12 @@ CREATE TABLE controller_node (
 CREATE UNIQUE INDEX idx_controller_node_dqlite_node
 ON controller_node (dqlite_node_id);
 
+CREATE INDEX idx_controller_node_dqlite_node_controller
+ON controller_node (dqlite_node_id, controller_id);
+
+CREATE INDEX idx_controller_node_controller_dqlite_node
+ON controller_node (controller_id, dqlite_node_id);
+
 CREATE UNIQUE INDEX idx_controller_node_dqlite_bind_address
 ON controller_node (dqlite_bind_address);
 
@@ -23,6 +29,12 @@ CREATE TABLE controller_node_agent_version (
     FOREIGN KEY (architecture_id)
     REFERENCES architecture (id)
 );
+
+CREATE INDEX idx_controller_node_agent_version_version
+ON controller_node_agent_version (version);
+
+CREATE INDEX idx_controller_node_agent_version_details
+ON controller_node_agent_version (architecture_id, controller_id, version);
 
 CREATE TABLE controller_api_address (
     controller_id TEXT NOT NULL,

--- a/domain/schema/controller/sql/0012-upgrade-info.sql
+++ b/domain/schema/controller/sql/0012-upgrade-info.sql
@@ -6,6 +6,9 @@ CREATE TABLE upgrade_state_type (
 CREATE UNIQUE INDEX idx_upgrade_state_type_type
 ON upgrade_state_type (type);
 
+CREATE INDEX idx_upgrade_state_type_id_type
+ON upgrade_state_type (id, type);
+
 INSERT INTO upgrade_state_type VALUES
 (0, 'created'),
 (1, 'started'),
@@ -43,3 +46,10 @@ CREATE TABLE upgrade_info_controller_node (
 
 CREATE UNIQUE INDEX idx_upgrade_info_controller_node
 ON upgrade_info_controller_node (controller_node_id, upgrade_info_uuid);
+
+CREATE INDEX idx_upgrade_info_controller_node_upgrade_completed_controller
+ON upgrade_info_controller_node (
+    upgrade_info_uuid,
+    node_upgrade_completed_at,
+    controller_node_id
+);

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -1,6 +1,6 @@
 CREATE TABLE object_store_metadata (
     uuid TEXT NOT NULL PRIMARY KEY,
-    sha_256 TEXT NOT NULL,
+    sha_256 TEXT NOT NULL COLLATE nocase,
     sha_384 TEXT NOT NULL,
     size INT NOT NULL
 );
@@ -9,8 +9,6 @@ CREATE TABLE object_store_metadata (
 -- to ensure that the same hash is not stored multiple times.
 CREATE UNIQUE INDEX idx_object_store_metadata_sha_256 ON object_store_metadata (sha_256);
 CREATE UNIQUE INDEX idx_object_store_metadata_sha_384 ON object_store_metadata (sha_384);
-CREATE INDEX idx_object_store_metadata_sha_256_nocase
-ON object_store_metadata (sha_256 COLLATE NOCASE);
 
 CREATE TABLE object_store_metadata_path (
     path TEXT NOT NULL PRIMARY KEY,

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -9,6 +9,8 @@ CREATE TABLE object_store_metadata (
 -- to ensure that the same hash is not stored multiple times.
 CREATE UNIQUE INDEX idx_object_store_metadata_sha_256 ON object_store_metadata (sha_256);
 CREATE UNIQUE INDEX idx_object_store_metadata_sha_384 ON object_store_metadata (sha_384);
+CREATE INDEX idx_object_store_metadata_sha_256_nocase
+ON object_store_metadata (sha_256 COLLATE NOCASE);
 
 CREATE TABLE object_store_metadata_path (
     path TEXT NOT NULL PRIMARY KEY,

--- a/domain/schema/controller/sql/0015-user.sql
+++ b/domain/schema/controller/sql/0015-user.sql
@@ -15,6 +15,9 @@ CREATE UNIQUE INDEX idx_singleton_active_user ON user (name) WHERE removed IS FA
 
 CREATE INDEX idx_user_name ON user (name);
 
+CREATE INDEX idx_user_removed_details
+ON user (removed, created_at, uuid, name, display_name, external, created_by_uuid);
+
 CREATE TABLE user_authentication (
     user_uuid TEXT NOT NULL PRIMARY KEY,
     disabled BOOLEAN NOT NULL,
@@ -22,6 +25,9 @@ CREATE TABLE user_authentication (
     FOREIGN KEY (user_uuid)
     REFERENCES user (uuid)
 );
+
+CREATE INDEX idx_user_authentication_disabled_user_uuid
+ON user_authentication (disabled, user_uuid);
 
 CREATE TABLE user_password (
     user_uuid TEXT NOT NULL PRIMARY KEY,

--- a/domain/schema/controller/sql/0017-user-permission.sql
+++ b/domain/schema/controller/sql/0017-user-permission.sql
@@ -6,6 +6,9 @@ CREATE TABLE permission_access_type (
 CREATE UNIQUE INDEX idx_permission_access_type
 ON permission_access_type (type);
 
+CREATE UNIQUE INDEX idx_permission_access_type_id_type
+ON permission_access_type (id, type);
+
 -- Maps to the Access type in core/permission package.
 INSERT INTO permission_access_type VALUES
 (0, 'read'),
@@ -23,6 +26,9 @@ CREATE TABLE permission_object_type (
 
 CREATE UNIQUE INDEX idx_permission_object_type
 ON permission_object_type (type);
+
+CREATE UNIQUE INDEX idx_permission_object_type_id_type
+ON permission_object_type (id, type);
 
 -- Maps to the ObjectType type in core/permission package.
 INSERT INTO permission_object_type VALUES
@@ -85,6 +91,15 @@ ON permission (grant_to);
 
 CREATE INDEX idx_permission_object_type_grant_on
 ON permission (object_type_id, grant_on);
+
+CREATE INDEX idx_permission_details
+ON permission (
+    access_type_id,
+    object_type_id,
+    uuid,
+    grant_on,
+    grant_to
+);
 
 -- All permissions
 CREATE VIEW v_permission AS

--- a/domain/schema/controller/sql/0018-secret-backend.sql
+++ b/domain/schema/controller/sql/0018-secret-backend.sql
@@ -90,6 +90,9 @@ CREATE TABLE secret_backend_reference (
 CREATE INDEX idx_secret_backend_reference_list
 ON secret_backend_reference (secret_backend_uuid, model_uuid, secret_id);
 
+CREATE INDEX idx_secret_backend_reference_revision
+ON secret_backend_reference (secret_revision_uuid);
+
 CREATE TABLE model_secret_backend (
     model_uuid TEXT NOT NULL PRIMARY KEY,
     secret_backend_uuid TEXT NOT NULL,

--- a/domain/schema/controller/sql/0018-secret-backend.sql
+++ b/domain/schema/controller/sql/0018-secret-backend.sql
@@ -43,6 +43,9 @@ CREATE TABLE secret_backend (
 CREATE UNIQUE INDEX idx_secret_backend_name
 ON secret_backend (name);
 
+CREATE INDEX idx_secret_backend_list
+ON secret_backend (name, uuid, backend_type_id, token_rotate_interval);
+
 CREATE TABLE secret_backend_config (
     backend_uuid TEXT NOT NULL,
     name TEXT NOT NULL,
@@ -57,6 +60,9 @@ CREATE TABLE secret_backend_config (
     FOREIGN KEY (backend_uuid)
     REFERENCES secret_backend (uuid)
 );
+
+CREATE INDEX idx_secret_backend_config_list
+ON secret_backend_config (backend_uuid, name, content);
 
 CREATE TABLE secret_backend_rotation (
     backend_uuid TEXT NOT NULL PRIMARY KEY,
@@ -80,6 +86,9 @@ CREATE TABLE secret_backend_reference (
     FOREIGN KEY (secret_backend_uuid)
     REFERENCES secret_backend (uuid)
 );
+
+CREATE INDEX idx_secret_backend_reference_list
+ON secret_backend_reference (secret_backend_uuid, model_uuid, secret_id);
 
 CREATE TABLE model_secret_backend (
     model_uuid TEXT NOT NULL PRIMARY KEY,

--- a/domain/schema/controller/sql/0019-model-last-login.sql
+++ b/domain/schema/controller/sql/0019-model-last-login.sql
@@ -11,6 +11,9 @@ CREATE TABLE model_last_login (
     REFERENCES user (uuid)
 );
 
+CREATE INDEX idx_model_last_login_user_uuid_time
+ON model_last_login (user_uuid, time);
+
 CREATE VIEW v_user_last_login AS
 -- We cannot select last_login as MAX directly here because it returns a sqlite
 -- string value, not a timestamp and this stops us scanning into time.Time.

--- a/domain/schema/controller/sql/0020-macaroon.sql
+++ b/domain/schema/controller/sql/0020-macaroon.sql
@@ -19,3 +19,9 @@ CREATE TABLE macaroon_root_key (
     expires_at TIMESTAMP NOT NULL,
     root_key TEXT NOT NULL
 );
+
+CREATE INDEX idx_macaroon_root_key_expires_at
+ON macaroon_root_key (expires_at);
+
+CREATE INDEX idx_macaroon_root_key_created_expires
+ON macaroon_root_key (created_at DESC, expires_at, id, root_key);

--- a/domain/schema/controller/sql/0024-cloudimagemetadata.sql
+++ b/domain/schema/controller/sql/0024-cloudimagemetadata.sql
@@ -18,3 +18,12 @@ CREATE TABLE cloud_image_metadata (
 
 CREATE UNIQUE INDEX idx_cloud_image_metadata_unique_fields
 ON cloud_image_metadata (stream, region, version, architecture_id, virt_type, root_storage_type, source);
+
+CREATE INDEX idx_cloud_image_metadata_source
+ON cloud_image_metadata (source);
+
+CREATE INDEX idx_cloud_image_metadata_created_at
+ON cloud_image_metadata (created_at);
+
+CREATE INDEX idx_cloud_image_metadata_image_id
+ON cloud_image_metadata (image_id);

--- a/domain/schema/controller/sql/0025-agent-binary-store.sql
+++ b/domain/schema/controller/sql/0025-agent-binary-store.sql
@@ -33,3 +33,6 @@ JOIN object_store_metadata_path AS osmp ON osm.uuid = osmp.metadata_uuid;
 
 CREATE INDEX idx_agent_binary_store_object_store_uuid
 ON agent_binary_store (object_store_uuid);
+
+CREATE INDEX idx_agent_binary_store_version_architecture_object_store
+ON agent_binary_store (version, architecture_id, object_store_uuid);

--- a/domain/schema/controller/sql/0026-tracing.sql
+++ b/domain/schema/controller/sql/0026-tracing.sql
@@ -2,3 +2,6 @@ CREATE TABLE charm_tracing_config (
     "key" TEXT NOT NULL PRIMARY KEY,
     value TEXT NOT NULL
 );
+
+CREATE INDEX idx_charm_tracing_config_key_value
+ON charm_tracing_config ("key", value);

--- a/domain/schema/controller/sql/0028-workload-tracing.sql
+++ b/domain/schema/controller/sql/0028-workload-tracing.sql
@@ -2,3 +2,6 @@ CREATE TABLE workload_tracing_config (
     "key" TEXT NOT NULL PRIMARY KEY,
     value TEXT NOT NULL
 );
+
+CREATE INDEX idx_workload_tracing_config_key_value
+ON workload_tracing_config ("key", value);

--- a/domain/schema/model/sql/0000-life.sql
+++ b/domain/schema/model/sql/0000-life.sql
@@ -3,6 +3,9 @@ CREATE TABLE life (
     value TEXT NOT NULL
 );
 
+CREATE UNIQUE INDEX idx_life_value_id
+ON life (value, id);
+
 INSERT INTO life VALUES
 (0, 'alive'),
 (1, 'dying'),

--- a/domain/schema/model/sql/0001-changelog.sql
+++ b/domain/schema/model/sql/0001-changelog.sql
@@ -47,3 +47,6 @@ CREATE TABLE change_log_witness (
     upper_bound INT NOT NULL DEFAULT (-1),
     updated_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc'))
 );
+
+CREATE INDEX idx_change_log_witness_watermark
+ON change_log_witness (lower_bound, updated_at, controller_id);

--- a/domain/schema/model/sql/0006-objectstore-metadata.sql
+++ b/domain/schema/model/sql/0006-objectstore-metadata.sql
@@ -9,6 +9,11 @@ CREATE TABLE object_store_metadata (
 -- to ensure that the same hash is not stored multiple times.
 CREATE UNIQUE INDEX idx_object_store_metadata_sha_256 ON object_store_metadata (sha_256);
 CREATE UNIQUE INDEX idx_object_store_metadata_sha_384 ON object_store_metadata (sha_384);
+CREATE INDEX idx_object_store_metadata_sha_256_nocase
+ON object_store_metadata (sha_256 COLLATE NOCASE);
+
+CREATE INDEX idx_object_store_metadata_details
+ON object_store_metadata (uuid, sha_256, sha_384, size);
 
 CREATE TABLE object_store_metadata_path (
     path TEXT NOT NULL PRIMARY KEY,
@@ -20,6 +25,9 @@ CREATE TABLE object_store_metadata_path (
 
 CREATE INDEX idx_object_store_metadata_path_metadata_uuid
 ON object_store_metadata_path (metadata_uuid);
+
+CREATE INDEX idx_object_store_metadata_path_path_uuid
+ON object_store_metadata_path (path, metadata_uuid);
 
 CREATE VIEW v_object_store_metadata AS
 SELECT

--- a/domain/schema/model/sql/0006-objectstore-metadata.sql
+++ b/domain/schema/model/sql/0006-objectstore-metadata.sql
@@ -1,6 +1,6 @@
 CREATE TABLE object_store_metadata (
     uuid TEXT NOT NULL PRIMARY KEY,
-    sha_256 TEXT NOT NULL,
+    sha_256 TEXT NOT NULL COLLATE nocase,
     sha_384 TEXT NOT NULL,
     size INT NOT NULL
 );
@@ -9,8 +9,6 @@ CREATE TABLE object_store_metadata (
 -- to ensure that the same hash is not stored multiple times.
 CREATE UNIQUE INDEX idx_object_store_metadata_sha_256 ON object_store_metadata (sha_256);
 CREATE UNIQUE INDEX idx_object_store_metadata_sha_384 ON object_store_metadata (sha_384);
-CREATE INDEX idx_object_store_metadata_sha_256_nocase
-ON object_store_metadata (sha_256 COLLATE NOCASE);
 
 CREATE INDEX idx_object_store_metadata_details
 ON object_store_metadata (uuid, sha_256, sha_384, size);

--- a/domain/schema/model/sql/0009-subnet.sql
+++ b/domain/schema/model/sql/0009-subnet.sql
@@ -28,6 +28,9 @@ CREATE TABLE provider_network (
 CREATE UNIQUE INDEX idx_provider_network_id
 ON provider_network (provider_network_id);
 
+CREATE UNIQUE INDEX idx_provider_network_uuid_id
+ON provider_network (uuid, provider_network_id);
+
 CREATE TABLE provider_network_subnet (
     subnet_uuid TEXT NOT NULL PRIMARY KEY,
     provider_network_uuid TEXT NOT NULL,
@@ -38,6 +41,9 @@ CREATE TABLE provider_network_subnet (
     FOREIGN KEY (subnet_uuid)
     REFERENCES subnet (uuid)
 );
+
+CREATE INDEX idx_provider_network_subnet_network_uuid
+ON provider_network_subnet (provider_network_uuid);
 
 CREATE TABLE availability_zone (
     uuid TEXT NOT NULL PRIMARY KEY,
@@ -61,6 +67,12 @@ CREATE TABLE availability_zone_subnet (
 
 CREATE INDEX idx_subnet_space_uuid
 ON subnet (space_uuid);
+
+CREATE UNIQUE INDEX idx_subnet_cidr_details
+ON subnet (cidr, uuid, space_uuid, vlan_tag);
+
+CREATE INDEX idx_subnet_space_details
+ON subnet (space_uuid, uuid, cidr, vlan_tag);
 
 CREATE INDEX idx_availability_zone_subnet_subnet_uuid
 ON availability_zone_subnet (subnet_uuid);

--- a/domain/schema/model/sql/0010-blockdevice.sql
+++ b/domain/schema/model/sql/0010-blockdevice.sql
@@ -55,3 +55,6 @@ ON block_device_link_device (name, machine_uuid);
 
 CREATE INDEX idx_block_device_link_device_device
 ON block_device_link_device (block_device_uuid);
+
+CREATE INDEX idx_block_device_link_device_machine
+ON block_device_link_device (machine_uuid, block_device_uuid, name);

--- a/domain/schema/model/sql/0011-storage.sql
+++ b/domain/schema/model/sql/0011-storage.sql
@@ -35,6 +35,9 @@ CREATE TABLE storage_pool (
 CREATE UNIQUE INDEX idx_storage_pool_name
 ON storage_pool (name);
 
+CREATE INDEX idx_storage_pool_name_uuid
+ON storage_pool (name, uuid);
+
 -- This index is used to speed up access by type, type and name.
 -- Warning: if the "type" is not the first column in the composite query condition,
 -- then the index will not be used.
@@ -63,6 +66,9 @@ CREATE TABLE storage_kind (
 
 CREATE UNIQUE INDEX idx_storage_kind_kind
 ON storage_kind (kind);
+
+CREATE INDEX idx_storage_kind_kind_id
+ON storage_kind (kind, id);
 
 INSERT INTO storage_kind VALUES
 (0, 'block'),

--- a/domain/schema/model/sql/0011-storage.sql
+++ b/domain/schema/model/sql/0011-storage.sql
@@ -210,6 +210,9 @@ ON storage_attachment (storage_instance_uuid, unit_uuid);
 CREATE INDEX idx_storage_attachment_unit
 ON storage_attachment (unit_uuid);
 
+CREATE INDEX idx_storage_attachment_instance_uuid_uuid
+ON storage_attachment (storage_instance_uuid, uuid);
+
 CREATE TABLE storage_volume_status_value (
     id INT PRIMARY KEY,
     status TEXT NOT NULL
@@ -285,6 +288,9 @@ ON storage_volume (volume_id);
 CREATE INDEX idx_storage_volume_provider_id
 ON storage_volume (provider_id);
 
+CREATE INDEX idx_storage_volume_provision_scope_id
+ON storage_volume (provision_scope_id, volume_id);
+
 -- An instance can have at most one volume.
 -- A volume can have at most one instance.
 CREATE TABLE storage_instance_volume (
@@ -337,6 +343,9 @@ ON storage_volume_attachment (net_node_uuid);
 
 CREATE INDEX idx_storage_volume_attachment_block_device_uuid
 ON storage_volume_attachment (block_device_uuid);
+
+CREATE INDEX idx_storage_volume_attachment_provision_scope_uuid
+ON storage_volume_attachment (provision_scope_id, uuid);
 
 CREATE TABLE storage_filesystem_status_value (
     id INT PRIMARY KEY,
@@ -399,6 +408,9 @@ ON storage_filesystem (filesystem_id);
 CREATE INDEX idx_storage_filesystem_provider_id
 ON storage_filesystem (provider_id);
 
+CREATE INDEX idx_storage_filesystem_provision_scope_id
+ON storage_filesystem (provision_scope_id, filesystem_id);
+
 -- An instance can have at most one filesystem.
 -- A filesystem can have at most one instance.
 CREATE TABLE storage_instance_filesystem (
@@ -441,6 +453,12 @@ CREATE TABLE storage_filesystem_attachment (
 CREATE INDEX idx_storage_filesystem_attachment_net_node_uuid
 ON storage_filesystem_attachment (net_node_uuid);
 
+CREATE INDEX idx_storage_filesystem_attachment_filesystem_uuid
+ON storage_filesystem_attachment (storage_filesystem_uuid);
+
+CREATE INDEX idx_storage_filesystem_attachment_provision_scope_uuid
+ON storage_filesystem_attachment (provision_scope_id, uuid);
+
 CREATE TABLE storage_volume_device_type (
     id INT PRIMARY KEY,
     name TEXT NOT NULL,
@@ -481,6 +499,9 @@ CREATE TABLE storage_volume_attachment_plan (
 -- There should only one volume attachment plan per net node and volume tuple.
 CREATE UNIQUE INDEX idx_storage_volume_attachment_plan_net_node_uuid_volume_uuid
 ON storage_volume_attachment_plan (storage_volume_uuid, net_node_uuid);
+
+CREATE INDEX idx_storage_volume_attachment_plan_scope_node_volume
+ON storage_volume_attachment_plan (provision_scope_id, net_node_uuid, storage_volume_uuid, life_id);
 
 CREATE TABLE storage_volume_attachment_plan_attr (
     attachment_plan_uuid TEXT NOT NULL,

--- a/domain/schema/model/sql/0011-storage.sql
+++ b/domain/schema/model/sql/0011-storage.sql
@@ -184,6 +184,9 @@ CREATE TABLE storage_unit_owner (
     REFERENCES unit (uuid)
 );
 
+CREATE INDEX idx_storage_unit_owner_unit
+ON storage_unit_owner (unit_uuid, storage_instance_uuid);
+
 CREATE TABLE storage_attachment (
     uuid TEXT NOT NULL PRIMARY KEY,
     storage_instance_uuid TEXT NOT NULL,

--- a/domain/schema/model/sql/0012-secret.sql
+++ b/domain/schema/model/sql/0012-secret.sql
@@ -121,6 +121,9 @@ CREATE TABLE secret_deleted_value_ref (
     revision_id TEXT NOT NULL
 );
 
+CREATE INDEX idx_secret_deleted_value_ref_revision_id
+ON secret_deleted_value_ref (revision_id);
+
 -- 1:many
 CREATE TABLE secret_content (
     revision_uuid TEXT NOT NULL,

--- a/domain/schema/model/sql/0012-secret.sql
+++ b/domain/schema/model/sql/0012-secret.sql
@@ -410,12 +410,13 @@ SELECT
         WHEN sp.scope_type_id = 1 THEN sca.name
         WHEN sp.scope_type_id = 2 THEN m.uuid
     END) AS scope_id
-FROM secret_permission AS sp INDEXED BY idx_secret_permission_list
+FROM secret_permission AS sp
 LEFT JOIN unit AS suu ON sp.subject_uuid = suu.uuid
 LEFT JOIN application AS sua ON sp.subject_uuid = sua.uuid
 LEFT JOIN unit AS scu ON sp.scope_uuid = scu.uuid
 LEFT JOIN application AS sca ON sp.scope_uuid = sca.uuid
-JOIN model AS m INDEXED BY idx_secret_model_uuid_name;
+JOIN model AS m
+WHERE sp.secret_id >= '';
 
 CREATE VIEW v_secret_owner AS
 SELECT
@@ -424,8 +425,9 @@ SELECT
     m.name AS owner_name,
     so.label,
     so.secret_id
-FROM secret_model_owner AS so INDEXED BY idx_secret_model_owner_list
-JOIN model AS m INDEXED BY idx_secret_model_uuid_name -- this is a singleton
+FROM secret_model_owner AS so
+CROSS JOIN model AS m -- this is a singleton
+WHERE so.secret_id >= ''
 UNION ALL
 SELECT
     'application' AS owner_kind,
@@ -434,8 +436,8 @@ SELECT
     so.label,
     so.secret_id
 FROM secret_application_owner AS so
-INDEXED BY idx_secret_application_owner_application_label_secret
 JOIN application AS a ON so.application_uuid = a.uuid
+WHERE so.application_uuid >= ''
 UNION ALL
 SELECT
     'unit' AS owner_kind,
@@ -444,8 +446,8 @@ SELECT
     so.label,
     so.secret_id
 FROM secret_unit_owner AS so
-INDEXED BY idx_secret_unit_owner_unit_label_secret
-JOIN unit AS u ON so.unit_uuid = u.uuid;
+JOIN unit AS u ON so.unit_uuid = u.uuid
+WHERE so.unit_uuid >= '';
 
 CREATE VIEW v_secret_metadata AS
 SELECT
@@ -464,12 +466,13 @@ SELECT
     so.owner_uuid,
     so.owner_name,
     so.label
-FROM secret_metadata AS sm INDEXED BY idx_secret_metadata_list
+FROM secret_metadata AS sm
 JOIN secret_rotate_policy AS rp ON sm.rotate_policy_id = rp.id
 JOIN secret_revision AS sr ON sm.secret_id = sr.secret_id
 LEFT JOIN secret_revision_expire AS sre ON sr.uuid = sre.revision_uuid
 LEFT JOIN secret_rotation AS sro ON sm.secret_id = sro.secret_id
-LEFT JOIN v_secret_owner AS so ON sm.secret_id = so.secret_id;
+LEFT JOIN v_secret_owner AS so ON sm.secret_id = so.secret_id
+WHERE sm.secret_id >= '';
 
 -- secret_reservation tracks secret IDs that have been minted by
 -- CreateSecretURIs but not yet persisted as charm secrets. Each

--- a/domain/schema/model/sql/0012-secret.sql
+++ b/domain/schema/model/sql/0012-secret.sql
@@ -73,6 +73,18 @@ CREATE TABLE secret_metadata (
     REFERENCES secret_rotate_policy (id)
 );
 
+CREATE INDEX idx_secret_metadata_list
+ON secret_metadata (
+    secret_id,
+    version,
+    description,
+    auto_prune,
+    latest_revision_checksum,
+    create_time,
+    update_time,
+    rotate_policy_id
+);
+
 CREATE TABLE secret_rotation (
     secret_id TEXT NOT NULL PRIMARY KEY,
     next_rotation_time DATETIME NOT NULL,
@@ -80,6 +92,9 @@ CREATE TABLE secret_rotation (
     FOREIGN KEY (secret_id)
     REFERENCES secret_metadata (secret_id)
 );
+
+CREATE INDEX idx_secret_rotation_list
+ON secret_rotation (secret_id, next_rotation_time);
 
 -- 1:1
 CREATE TABLE secret_value_ref (
@@ -91,6 +106,12 @@ CREATE TABLE secret_value_ref (
     FOREIGN KEY (revision_uuid)
     REFERENCES secret_revision (uuid)
 );
+
+CREATE INDEX idx_secret_value_ref_list
+ON secret_value_ref (revision_uuid, backend_uuid, revision_id);
+
+CREATE INDEX idx_secret_value_ref_backend_list
+ON secret_value_ref (backend_uuid, revision_uuid, revision_id);
 
 -- Deleted revisions for which content is stored externally.
 -- These rows are deleted after the external content has been deleted.
@@ -135,6 +156,9 @@ CREATE TABLE secret_revision (
 CREATE UNIQUE INDEX idx_secret_revision_secret_id_revision
 ON secret_revision (secret_id, revision);
 
+CREATE INDEX idx_secret_revision_list
+ON secret_revision (secret_id, revision, uuid, create_time, update_time);
+
 CREATE TABLE secret_revision_obsolete (
     revision_uuid TEXT NOT NULL PRIMARY KEY,
     obsolete BOOLEAN NOT NULL DEFAULT (FALSE),
@@ -146,6 +170,9 @@ CREATE TABLE secret_revision_obsolete (
     REFERENCES secret_revision (uuid)
 );
 
+CREATE INDEX idx_secret_revision_obsolete_list
+ON secret_revision_obsolete (obsolete, revision_uuid, pending_delete);
+
 CREATE TABLE secret_revision_expire (
     revision_uuid TEXT NOT NULL PRIMARY KEY,
     expire_time DATETIME NOT NULL,
@@ -153,6 +180,9 @@ CREATE TABLE secret_revision_expire (
     FOREIGN KEY (revision_uuid)
     REFERENCES secret_revision (uuid)
 );
+
+CREATE INDEX idx_secret_revision_expire_list
+ON secret_revision_expire (revision_uuid, expire_time);
 
 CREATE TABLE secret_application_owner (
     secret_id TEXT NOT NULL,
@@ -173,6 +203,9 @@ ON secret_application_owner (secret_id);
 CREATE UNIQUE INDEX idx_secret_application_owner_label
 ON secret_application_owner (label, application_uuid) WHERE label != '';
 
+CREATE INDEX idx_secret_application_owner_application_label_secret
+ON secret_application_owner (application_uuid, label, secret_id);
+
 CREATE TABLE secret_unit_owner (
     secret_id TEXT NOT NULL,
     unit_uuid TEXT NOT NULL,
@@ -192,6 +225,9 @@ ON secret_unit_owner (secret_id);
 CREATE UNIQUE INDEX idx_secret_unit_owner_label
 ON secret_unit_owner (label, unit_uuid) WHERE label != '';
 
+CREATE INDEX idx_secret_unit_owner_unit_label_secret
+ON secret_unit_owner (unit_uuid, label, secret_id);
+
 CREATE TABLE secret_model_owner (
     secret_id TEXT NOT NULL PRIMARY KEY,
     label TEXT,
@@ -199,6 +235,12 @@ CREATE TABLE secret_model_owner (
     FOREIGN KEY (secret_id)
     REFERENCES secret_metadata (secret_id)
 );
+
+CREATE INDEX idx_secret_model_owner_list
+ON secret_model_owner (secret_id, label);
+
+CREATE INDEX idx_secret_model_owner_label_secret
+ON secret_model_owner (label, secret_id);
 
 CREATE UNIQUE INDEX idx_secret_model_owner_label
 ON secret_model_owner (label) WHERE label != '';
@@ -225,6 +267,17 @@ ON secret_unit_consumer (secret_id, unit_uuid);
 CREATE UNIQUE INDEX idx_secret_unit_consumer_label
 ON secret_unit_consumer (label, unit_uuid) WHERE label != '';
 
+CREATE INDEX idx_secret_unit_consumer_secret_revision
+ON secret_unit_consumer (secret_id, current_revision);
+
+CREATE INDEX idx_secret_unit_consumer_list
+ON secret_unit_consumer
+(secret_id, unit_uuid, source_model_uuid, label, current_revision);
+
+CREATE INDEX idx_secret_unit_consumer_unit_list
+ON secret_unit_consumer
+(unit_uuid, secret_id, current_revision, source_model_uuid, label);
+
 -- This table records the tracked revisions from
 -- units in the consuming model for cross model secrets.
 CREATE TABLE secret_remote_unit_consumer (
@@ -240,6 +293,12 @@ CREATE TABLE secret_remote_unit_consumer (
 
 CREATE UNIQUE INDEX idx_secret_remote_unit_consumer_secret_id_unit_name
 ON secret_remote_unit_consumer (secret_id, unit_name);
+
+CREATE INDEX idx_secret_remote_unit_consumer_details
+ON secret_remote_unit_consumer (secret_id, current_revision, unit_name);
+
+CREATE INDEX idx_secret_remote_unit_consumer_list
+ON secret_remote_unit_consumer (secret_id, unit_name, current_revision);
 
 CREATE TABLE secret_role (
     id INT PRIMARY KEY,
@@ -313,6 +372,17 @@ ON secret_permission (secret_id);
 CREATE INDEX idx_secret_permission_subject_uuid_subject_type_id
 ON secret_permission (subject_uuid, subject_type_id);
 
+CREATE INDEX idx_secret_permission_list
+ON secret_permission
+(secret_id, subject_uuid, role_id, subject_type_id, scope_uuid, scope_type_id);
+
+CREATE INDEX idx_secret_permission_role_list
+ON secret_permission
+(role_id, subject_type_id, subject_uuid, secret_id, scope_uuid, scope_type_id);
+
+CREATE INDEX idx_secret_model_uuid_name
+ON model (uuid, name);
+
 -- v_secret_permission is used to query secrets which can
 -- be accessed by a subject of application, unit, or model.
 CREATE VIEW v_secret_permission AS
@@ -337,12 +407,12 @@ SELECT
         WHEN sp.scope_type_id = 1 THEN sca.name
         WHEN sp.scope_type_id = 2 THEN m.uuid
     END) AS scope_id
-FROM secret_permission AS sp
+FROM secret_permission AS sp INDEXED BY idx_secret_permission_list
 LEFT JOIN unit AS suu ON sp.subject_uuid = suu.uuid
 LEFT JOIN application AS sua ON sp.subject_uuid = sua.uuid
 LEFT JOIN unit AS scu ON sp.scope_uuid = scu.uuid
 LEFT JOIN application AS sca ON sp.scope_uuid = sca.uuid
-JOIN model AS m;
+JOIN model AS m INDEXED BY idx_secret_model_uuid_name;
 
 CREATE VIEW v_secret_owner AS
 SELECT
@@ -351,8 +421,8 @@ SELECT
     m.name AS owner_name,
     so.label,
     so.secret_id
-FROM secret_model_owner AS so
-JOIN model AS m -- this is a singleton
+FROM secret_model_owner AS so INDEXED BY idx_secret_model_owner_list
+JOIN model AS m INDEXED BY idx_secret_model_uuid_name -- this is a singleton
 UNION ALL
 SELECT
     'application' AS owner_kind,
@@ -361,6 +431,7 @@ SELECT
     so.label,
     so.secret_id
 FROM secret_application_owner AS so
+INDEXED BY idx_secret_application_owner_application_label_secret
 JOIN application AS a ON so.application_uuid = a.uuid
 UNION ALL
 SELECT
@@ -370,6 +441,7 @@ SELECT
     so.label,
     so.secret_id
 FROM secret_unit_owner AS so
+INDEXED BY idx_secret_unit_owner_unit_label_secret
 JOIN unit AS u ON so.unit_uuid = u.uuid;
 
 CREATE VIEW v_secret_metadata AS
@@ -389,7 +461,7 @@ SELECT
     so.owner_uuid,
     so.owner_name,
     so.label
-FROM secret_metadata AS sm
+FROM secret_metadata AS sm INDEXED BY idx_secret_metadata_list
 JOIN secret_rotate_policy AS rp ON sm.rotate_policy_id = rp.id
 JOIN secret_revision AS sr ON sm.secret_id = sr.secret_id
 LEFT JOIN secret_revision_expire AS sre ON sr.uuid = sre.revision_uuid
@@ -413,3 +485,6 @@ CREATE TABLE secret_reservation (
 
 CREATE INDEX idx_secret_reservation_unit_uuid
 ON secret_reservation (unit_uuid);
+
+CREATE INDEX idx_secret_reservation_list
+ON secret_reservation (secret_id, unit_uuid, created_at);

--- a/domain/schema/model/sql/0013-annotations.sql
+++ b/domain/schema/model/sql/0013-annotations.sql
@@ -3,6 +3,9 @@ CREATE TABLE annotation_model (
     value TEXT NOT NULL
 );
 
+CREATE INDEX idx_annotation_model_key_value
+ON annotation_model ("key", value);
+
 CREATE TABLE annotation_application (
     uuid TEXT NOT NULL,
     "key" TEXT NOT NULL,

--- a/domain/schema/model/sql/0014-constraint.sql
+++ b/domain/schema/model/sql/0014-constraint.sql
@@ -67,6 +67,9 @@ CREATE TABLE constraint_space (
     PRIMARY KEY (constraint_uuid, space)
 );
 
+CREATE INDEX idx_constraint_space_space_details
+ON constraint_space (space, constraint_uuid, "exclude");
+
 CREATE TABLE constraint_zone (
     constraint_uuid TEXT NOT NULL,
     zone TEXT NOT NULL,

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -98,6 +98,9 @@ CREATE TABLE charm (
 CREATE UNIQUE INDEX idx_charm_reference_name_revision
 ON charm (source_id, reference_name, revision);
 
+CREATE INDEX idx_charm_reference_revision_uuid
+ON charm (reference_name, revision, uuid);
+
 CREATE TABLE charm_provenance (
     id INT PRIMARY KEY,
     name TEXT NOT NULL
@@ -276,6 +279,9 @@ CREATE TABLE charm_relation (
 
 CREATE UNIQUE INDEX idx_charm_relation_charm_key
 ON charm_relation (charm_uuid, name);
+
+CREATE INDEX idx_charm_relation_name_uuid
+ON charm_relation (name, uuid);
 
 CREATE VIEW v_charm_relation AS
 SELECT

--- a/domain/schema/model/sql/0018-machine.sql
+++ b/domain/schema/model/sql/0018-machine.sql
@@ -242,7 +242,7 @@ SELECT
         SELECT 1
         FROM machine_parent AS mp
         JOIN machine_agent_presence AS map
-          ON mp.machine_uuid = map.machine_uuid
+            ON mp.machine_uuid = map.machine_uuid
         WHERE mp.parent_uuid = ms.machine_uuid
     ) AS present
 FROM machine_status AS ms

--- a/domain/schema/model/sql/0018-machine.sql
+++ b/domain/schema/model/sql/0018-machine.sql
@@ -27,6 +27,12 @@ ON machine (name);
 CREATE UNIQUE INDEX idx_machine_net_node
 ON machine (net_node_uuid);
 
+CREATE INDEX idx_machine_life_name
+ON machine (life_id, name);
+
+CREATE UNIQUE INDEX idx_machine_net_node_uuid_name
+ON machine (net_node_uuid, uuid, name);
+
 CREATE TABLE machine_manual (
     machine_uuid TEXT NOT NULL PRIMARY KEY,
     CONSTRAINT fk_machine_manual_machine
@@ -49,6 +55,12 @@ CREATE TABLE machine_platform (
     FOREIGN KEY (architecture_id)
     REFERENCES architecture (id)
 );
+
+CREATE UNIQUE INDEX idx_machine_platform_machine
+ON machine_platform (machine_uuid);
+
+CREATE UNIQUE INDEX idx_machine_platform_machine_uuid
+ON machine_platform (machine_uuid);
 
 -- machine_placement_scope is a table which represents the valid scopes
 -- that can exist for a machine placement. The provider scope is the only
@@ -87,6 +99,9 @@ CREATE TABLE machine_parent (
     FOREIGN KEY (parent_uuid)
     REFERENCES machine (uuid)
 );
+
+CREATE INDEX idx_machine_parent_parent_uuid
+ON machine_parent (parent_uuid);
 
 -- machine_agent_version tracks the reported agent version running for each
 -- machine.
@@ -207,25 +222,25 @@ CREATE TABLE machine_status (
 );
 
 CREATE VIEW v_machine_status AS
-WITH machine_presence AS (
-    SELECT machine_uuid
-    FROM machine_agent_presence
-    UNION
-    SELECT mp.parent_uuid AS machine_uuid
-    FROM machine_parent AS mp
-    JOIN machine_agent_presence AS map ON mp.machine_uuid = map.machine_uuid
-)
-
 SELECT
     ms.machine_uuid,
     ms.message,
     ms.data,
     ms.updated_at,
     msv.status,
-    mp.machine_uuid IS NOT NULL AS present
+    EXISTS (
+        SELECT 1
+        FROM machine_agent_presence AS map
+        WHERE map.machine_uuid = ms.machine_uuid
+    ) OR EXISTS (
+        SELECT 1
+        FROM machine_parent AS mp
+        JOIN machine_agent_presence AS map
+          ON mp.machine_uuid = map.machine_uuid
+        WHERE mp.parent_uuid = ms.machine_uuid
+    ) AS present
 FROM machine_status AS ms
-JOIN machine_status_value AS msv ON ms.status_id = msv.id
-LEFT JOIN machine_presence AS mp ON ms.machine_uuid = mp.machine_uuid;
+JOIN machine_status_value AS msv ON ms.status_id = msv.id;
 
 -- machine_lxd_profile table keeps track of the lxd profiles (previously
 -- charm-profiles) for a machine.
@@ -245,6 +260,9 @@ CREATE TABLE container_type (
     id INT PRIMARY KEY,
     value TEXT NOT NULL
 );
+
+CREATE UNIQUE INDEX idx_container_type_value
+ON container_type (value);
 
 INSERT INTO container_type VALUES
 (0, 'none'),
@@ -322,3 +340,6 @@ CREATE TABLE machine_ssh_host_key (
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid)
 );
+
+CREATE INDEX idx_machine_ssh_host_key_machine_uuid
+ON machine_ssh_host_key (machine_uuid);

--- a/domain/schema/model/sql/0018-machine.sql
+++ b/domain/schema/model/sql/0018-machine.sql
@@ -175,6 +175,9 @@ CREATE TABLE machine_volume (
     PRIMARY KEY (machine_uuid, volume_uuid)
 );
 
+CREATE INDEX idx_machine_volume_volume
+ON machine_volume (volume_uuid, machine_uuid);
+
 CREATE TABLE machine_filesystem (
     machine_uuid TEXT NOT NULL,
     filesystem_uuid TEXT NOT NULL,
@@ -186,6 +189,9 @@ CREATE TABLE machine_filesystem (
     REFERENCES storage_filesystem (uuid),
     PRIMARY KEY (machine_uuid, filesystem_uuid)
 );
+
+CREATE INDEX idx_machine_filesystem_filesystem
+ON machine_filesystem (filesystem_uuid, machine_uuid);
 
 CREATE TABLE machine_requires_reboot (
     machine_uuid TEXT NOT NULL PRIMARY KEY,

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -24,6 +24,9 @@ ON application (name);
 CREATE INDEX idx_application_charm_uuid
 ON application (charm_uuid);
 
+CREATE INDEX idx_application_space_details
+ON application (space_uuid, uuid, name, charm_uuid);
+
 -- This table is only used to track whether a application is a controller or
 -- not. It should be sparse and only contain a single row for the controller
 -- application.
@@ -68,6 +71,9 @@ ON k8s_service (application_uuid);
 CREATE UNIQUE INDEX idx_k8s_service_net_node
 ON k8s_service (net_node_uuid);
 
+CREATE UNIQUE INDEX idx_k8s_service_details
+ON k8s_service (uuid, net_node_uuid, application_uuid, provider_id);
+
 
 CREATE TABLE operator_status (
     application_uuid TEXT NOT NULL PRIMARY KEY,
@@ -110,6 +116,13 @@ CREATE TABLE application_exposed_endpoint_space (
     FOREIGN KEY (space_uuid)
     REFERENCES space (uuid),
     PRIMARY KEY (application_uuid, application_endpoint_uuid, space_uuid)
+);
+
+CREATE INDEX idx_application_exposed_endpoint_space_space
+ON application_exposed_endpoint_space (
+    space_uuid,
+    application_uuid,
+    application_endpoint_uuid
 );
 
 -- There is no FK against the CIDR, because it's currently free-form.
@@ -190,6 +203,9 @@ CREATE TABLE application_constraint (
     FOREIGN KEY (constraint_uuid)
     REFERENCES "constraint" (uuid)
 );
+
+CREATE INDEX idx_application_constraint_constraint_application
+ON application_constraint (constraint_uuid, application_uuid);
 
 CREATE TABLE application_setting (
     application_uuid TEXT NOT NULL PRIMARY KEY,

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -27,6 +27,9 @@ ON application (charm_uuid);
 CREATE INDEX idx_application_space_details
 ON application (space_uuid, uuid, name, charm_uuid);
 
+CREATE INDEX idx_application_life_uuid
+ON application (life_id, uuid);
+
 -- This table is only used to track whether a application is a controller or
 -- not. It should be sparse and only contain a single row for the controller
 -- application.

--- a/domain/schema/model/sql/0020-unit.sql
+++ b/domain/schema/model/sql/0020-unit.sql
@@ -39,6 +39,12 @@ ON unit (application_uuid);
 CREATE INDEX idx_unit_net_node
 ON unit (net_node_uuid);
 
+CREATE INDEX idx_unit_net_node_uuid
+ON unit (net_node_uuid, uuid);
+
+CREATE UNIQUE INDEX idx_unit_uuid_name
+ON unit (uuid, name);
+
 -- unit_principal table is a table which is used to store the
 -- principal units for subordinate units.
 CREATE TABLE unit_principal (
@@ -187,6 +193,9 @@ CREATE TABLE unit_agent_status (
     FOREIGN KEY (status_id)
     REFERENCES unit_agent_status_value (id)
 );
+
+CREATE INDEX idx_unit_agent_status_status_unit
+ON unit_agent_status (status_id, unit_uuid);
 
 CREATE TABLE unit_workload_status (
     unit_uuid TEXT NOT NULL PRIMARY KEY,

--- a/domain/schema/model/sql/0020-unit.sql
+++ b/domain/schema/model/sql/0020-unit.sql
@@ -58,6 +58,9 @@ CREATE TABLE unit_principal (
     REFERENCES unit (uuid)
 );
 
+CREATE INDEX idx_unit_principal_principal
+ON unit_principal (principal_uuid, unit_uuid);
+
 CREATE TABLE unit_workload_version (
     unit_uuid TEXT NOT NULL PRIMARY KEY,
     version TEXT NOT NULL,

--- a/domain/schema/model/sql/0021-network.sql
+++ b/domain/schema/model/sql/0021-network.sql
@@ -469,44 +469,44 @@ JOIN v_ip_address_with_names AS ipa ON n.net_node_uuid = ipa.net_node_uuid
 LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid;
 
 CREATE VIEW v_unit_relation_network AS
-    SELECT
-        u.uuid AS unit_uuid,
-        ipa.address_value,
-        ipa.device_uuid,
-        sn.space_uuid,
-        sn.cidr,
-        iact.name AS config_type_name,
-        iat.name AS type_name,
-        iao.name AS origin_name,
-        ias.name AS scope_name,
-        ipa.origin_id,
-        ipa.is_secondary,
-        lld.device_type_id,
-        CASE
-            WHEN ipa.scope_id = 2 /* local-cloud */
-                AND ipa.type_id = 0 /* ipv4 */
-                THEN 1
-            WHEN ipa.scope_id = 2 /* local-cloud */
-                AND ipa.type_id = 1 /* ipv6 */
-                THEN 2
-            WHEN ipa.scope_id IN (1 /* public */, 0 /* unknown */)
-                AND ipa.type_id = 0 /* ipv4 */
-                THEN 3
-            WHEN ipa.scope_id IN (1 /* public */, 0 /* unknown */)
-                AND ipa.type_id = 1 /* ipv6 */
-                THEN 4
-        END AS scope_rank
-    FROM unit AS u
-    LEFT JOIN k8s_service AS svc ON u.application_uuid = svc.application_uuid
-    JOIN ip_address AS ipa
-         ON ipa.net_node_uuid = u.net_node_uuid
-         OR ipa.net_node_uuid = svc.net_node_uuid
-    JOIN link_layer_device AS lld ON ipa.device_uuid = lld.uuid
-    JOIN ip_address_config_type AS iact ON ipa.config_type_id = iact.id
-    JOIN ip_address_type AS iat ON ipa.type_id = iat.id
-    JOIN ip_address_origin AS iao ON ipa.origin_id = iao.id
-    JOIN ip_address_scope AS ias ON ipa.scope_id = ias.id
-    LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid;
+SELECT
+    u.uuid AS unit_uuid,
+    ipa.address_value,
+    ipa.device_uuid,
+    sn.space_uuid,
+    sn.cidr,
+    iact.name AS config_type_name,
+    iat.name AS type_name,
+    iao.name AS origin_name,
+    ias.name AS scope_name,
+    ipa.origin_id,
+    ipa.is_secondary,
+    lld.device_type_id,
+    CASE
+        WHEN ipa.scope_id = 2 /* local-cloud */
+            AND ipa.type_id = 0 /* ipv4 */
+            THEN 1
+        WHEN ipa.scope_id = 2 /* local-cloud */
+            AND ipa.type_id = 1 /* ipv6 */
+            THEN 2
+        WHEN ipa.scope_id IN (1 /* public */, 0 /* unknown */)
+            AND ipa.type_id = 0 /* ipv4 */
+            THEN 3
+        WHEN ipa.scope_id IN (1 /* public */, 0 /* unknown */)
+            AND ipa.type_id = 1 /* ipv6 */
+            THEN 4
+    END AS scope_rank
+FROM unit AS u
+LEFT JOIN k8s_service AS svc ON u.application_uuid = svc.application_uuid
+JOIN ip_address AS ipa
+    ON u.net_node_uuid = ipa.net_node_uuid
+    OR svc.net_node_uuid = ipa.net_node_uuid
+JOIN link_layer_device AS lld ON ipa.device_uuid = lld.uuid
+JOIN ip_address_config_type AS iact ON ipa.config_type_id = iact.id
+JOIN ip_address_type AS iat ON ipa.type_id = iat.id
+JOIN ip_address_origin AS iao ON ipa.origin_id = iao.id
+JOIN ip_address_scope AS ias ON ipa.scope_id = ias.id
+LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid;
 
 CREATE INDEX idx_provider_link_layer_device_device_uuid
 ON provider_link_layer_device (device_uuid, provider_id);

--- a/domain/schema/model/sql/0021-network.sql
+++ b/domain/schema/model/sql/0021-network.sql
@@ -2,6 +2,9 @@ CREATE TABLE net_node (
     uuid TEXT NOT NULL PRIMARY KEY
 );
 
+CREATE INDEX idx_net_node_uuid
+ON net_node (uuid);
+
 CREATE TABLE link_layer_device_type (
     id INT PRIMARY KEY,
     name TEXT NOT NULL
@@ -66,6 +69,22 @@ CREATE TABLE link_layer_device (
 CREATE UNIQUE INDEX idx_link_layer_device_net_node_uuid_name
 ON link_layer_device (net_node_uuid, name);
 
+CREATE INDEX idx_link_layer_device_details
+ON link_layer_device (
+    net_node_uuid,
+    uuid,
+    name,
+    mtu,
+    device_type_id,
+    virtual_port_type_id,
+    is_auto_start,
+    is_enabled,
+    is_default_gateway,
+    gateway_address,
+    vlan_tag,
+    mac_address
+);
+
 CREATE TABLE link_layer_device_parent (
     device_uuid TEXT NOT NULL PRIMARY KEY,
     parent_uuid TEXT NOT NULL,
@@ -76,6 +95,9 @@ CREATE TABLE link_layer_device_parent (
     FOREIGN KEY (parent_uuid)
     REFERENCES link_layer_device (uuid)
 );
+
+CREATE INDEX idx_link_layer_device_parent_parent_device
+ON link_layer_device_parent (parent_uuid, device_uuid);
 
 CREATE TABLE provider_link_layer_device (
     provider_id TEXT NOT NULL PRIMARY KEY,
@@ -95,6 +117,9 @@ CREATE TABLE link_layer_device_dns_domain (
     PRIMARY KEY (device_uuid, search_domain)
 );
 
+CREATE UNIQUE INDEX idx_link_layer_device_dns_domain_details
+ON link_layer_device_dns_domain (search_domain, device_uuid);
+
 CREATE TABLE link_layer_device_dns_address (
     device_uuid TEXT NOT NULL,
     dns_address TEXT NOT NULL,
@@ -103,6 +128,9 @@ CREATE TABLE link_layer_device_dns_address (
     REFERENCES link_layer_device (uuid),
     PRIMARY KEY (device_uuid, dns_address)
 );
+
+CREATE UNIQUE INDEX idx_link_layer_device_dns_address_details
+ON link_layer_device_dns_address (dns_address, device_uuid);
 
 -- Note that this table is defined for completeness in
 -- reflecting what we capture as network configuration.
@@ -243,6 +271,21 @@ ON ip_address (subnet_uuid);
 
 CREATE INDEX idx_ip_address_net_node_uuid
 ON ip_address (net_node_uuid);
+
+CREATE INDEX idx_ip_address_details
+ON ip_address (
+    net_node_uuid,
+    uuid,
+    device_uuid,
+    address_value,
+    subnet_uuid,
+    type_id,
+    config_type_id,
+    origin_id,
+    scope_id,
+    is_secondary,
+    is_shadow
+);
 
 CREATE TABLE provider_ip_address (
     provider_id TEXT NOT NULL PRIMARY KEY,
@@ -420,28 +463,14 @@ FROM (
         net_node_uuid,
         uuid
     FROM unit
+    WHERE uuid >= ''
 ) AS n
 JOIN v_ip_address_with_names AS ipa ON n.net_node_uuid = ipa.net_node_uuid
 LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid;
 
 CREATE VIEW v_unit_relation_network AS
-WITH unit_net_node AS (
     SELECT
-        s.net_node_uuid,
-        u.uuid
-    FROM unit AS u
-    JOIN application AS a ON u.application_uuid = a.uuid
-    JOIN k8s_service AS s ON a.uuid = s.application_uuid
-    UNION
-    SELECT
-        net_node_uuid,
-        uuid
-    FROM unit
-),
-
-candidate AS (
-    SELECT
-        unn.uuid AS unit_uuid,
+        u.uuid AS unit_uuid,
         ipa.address_value,
         ipa.device_uuid,
         sn.space_uuid,
@@ -467,34 +496,20 @@ candidate AS (
                 AND ipa.type_id = 1 /* ipv6 */
                 THEN 4
         END AS scope_rank
-    FROM unit_net_node AS unn
-    JOIN ip_address AS ipa ON unn.net_node_uuid = ipa.net_node_uuid
+    FROM unit AS u
+    LEFT JOIN k8s_service AS svc ON u.application_uuid = svc.application_uuid
+    JOIN ip_address AS ipa
+         ON ipa.net_node_uuid = u.net_node_uuid
+         OR ipa.net_node_uuid = svc.net_node_uuid
     JOIN link_layer_device AS lld ON ipa.device_uuid = lld.uuid
     JOIN ip_address_config_type AS iact ON ipa.config_type_id = iact.id
     JOIN ip_address_type AS iat ON ipa.type_id = iat.id
     JOIN ip_address_origin AS iao ON ipa.origin_id = iao.id
     JOIN ip_address_scope AS ias ON ipa.scope_id = ias.id
-    LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid
-)
-
-SELECT
-    candidate.unit_uuid,
-    candidate.address_value,
-    candidate.device_uuid,
-    candidate.space_uuid,
-    candidate.cidr,
-    candidate.config_type_name,
-    candidate.type_name,
-    candidate.origin_name,
-    candidate.scope_name,
-    candidate.scope_rank,
-    candidate.origin_id,
-    candidate.is_secondary,
-    candidate.device_type_id
-FROM candidate;
+    LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid;
 
 CREATE INDEX idx_provider_link_layer_device_device_uuid
-ON provider_link_layer_device (device_uuid);
+ON provider_link_layer_device (device_uuid, provider_id);
 
 CREATE INDEX idx_provider_ip_address_address_uuid
-ON provider_ip_address (address_uuid);
+ON provider_ip_address (address_uuid, provider_id);

--- a/domain/schema/model/sql/0022-port-ranges.sql
+++ b/domain/schema/model/sql/0022-port-ranges.sql
@@ -8,6 +8,12 @@ INSERT INTO protocol VALUES
 (1, 'tcp'),
 (2, 'udp');
 
+CREATE UNIQUE INDEX idx_protocol_id_protocol
+ON protocol (id, protocol);
+
+CREATE UNIQUE INDEX idx_protocol_protocol_id
+ON protocol (protocol, id);
+
 CREATE TABLE port_range (
     uuid TEXT NOT NULL PRIMARY KEY,
     protocol_id INT NOT NULL,
@@ -31,6 +37,12 @@ CREATE TABLE port_range (
 -- constraint is as far as we go here. Non-overlapping ranges must be
 -- enforced in the service/state layer.
 CREATE UNIQUE INDEX idx_port_range_endpoint ON port_range (protocol_id, from_port, relation_uuid, unit_uuid);
+
+CREATE INDEX idx_port_range_unit_details
+ON port_range (unit_uuid, relation_uuid, protocol_id, from_port, to_port, uuid);
+
+CREATE INDEX idx_port_range_details
+ON port_range (from_port, to_port, protocol_id, unit_uuid, relation_uuid, uuid);
 
 CREATE VIEW v_port_range
 AS

--- a/domain/schema/model/sql/0023-resource.sql
+++ b/domain/schema/model/sql/0023-resource.sql
@@ -51,6 +51,12 @@ CREATE TABLE resource (
     REFERENCES resource_state (id)
 );
 
+CREATE INDEX idx_resource_charm_state_origin_revision
+ON resource (charm_uuid, charm_resource_name, state_id, origin_type_id, revision);
+
+CREATE INDEX idx_resource_state_id
+ON resource (state_id);
+
 -- Links applications to the resources that they are *using*.
 -- This resource may in turn be linked through to a *different* charm than the
 -- application is using, because the charm_resource_name field indicates the
@@ -65,6 +71,9 @@ CREATE TABLE application_resource (
     FOREIGN KEY (resource_uuid)
     REFERENCES resource (uuid)
 );
+
+CREATE INDEX idx_application_resource_application_uuid
+ON application_resource (application_uuid);
 
 -- Links a resource to an application which does not exist yet.
 CREATE TABLE pending_application_resource (
@@ -117,6 +126,9 @@ CREATE TABLE unit_resource (
     REFERENCES unit (uuid),
     PRIMARY KEY (resource_uuid, unit_uuid)
 );
+
+CREATE INDEX idx_unit_resource_unit_uuid
+ON unit_resource (unit_uuid);
 
 -- This is the actual store for container image resources. The metadata
 -- necessary to retrieve the OCI Image from a registry.

--- a/domain/schema/model/sql/0024-relation.sql
+++ b/domain/schema/model/sql/0024-relation.sql
@@ -25,6 +25,14 @@ ON application_endpoint (application_uuid);
 CREATE UNIQUE INDEX idx_application_endpoint_app_relation
 ON application_endpoint (application_uuid, charm_relation_uuid);
 
+CREATE INDEX idx_application_endpoint_space_details
+ON application_endpoint (
+    space_uuid,
+    application_uuid,
+    charm_relation_uuid,
+    uuid
+);
+
 -- The application_endpoint ties an application's relation definition to an
 -- endpoint binding via a space. Only endpoint bindings which differ from the
 -- application default binding will be listed.
@@ -49,6 +57,13 @@ ON application_extra_endpoint (application_uuid);
 
 CREATE UNIQUE INDEX idx_application_extra_endpoint_app_relation
 ON application_extra_endpoint (application_uuid, charm_extra_binding_uuid);
+
+CREATE INDEX idx_application_extra_endpoint_space_details
+ON application_extra_endpoint (
+    space_uuid,
+    application_uuid,
+    charm_extra_binding_uuid
+);
 
 -- The relation_endpoint table links a relation to a single
 -- application endpoint. If the relation is of type peer,

--- a/domain/schema/model/sql/0024-relation.sql
+++ b/domain/schema/model/sql/0024-relation.sql
@@ -130,6 +130,9 @@ CREATE TABLE relation_unit (
 CREATE UNIQUE INDEX idx_relation_unit
 ON relation_unit (relation_endpoint_uuid, unit_uuid);
 
+CREATE INDEX idx_relation_unit_unit_uuid
+ON relation_unit (unit_uuid, uuid);
+
 -- The relation_unit_setting holds key value pair settings
 -- for a relation at the unit level. Keys must be unique
 -- per unit.

--- a/domain/schema/model/sql/0025-command-block.sql
+++ b/domain/schema/model/sql/0025-command-block.sql
@@ -22,3 +22,6 @@ CREATE TABLE block_command (
 
 CREATE UNIQUE INDEX idx_block_command_type
 ON block_command (block_command_type_id);
+
+CREATE INDEX idx_block_command_get_blocks
+ON block_command (block_command_type_id, message, uuid);

--- a/domain/schema/model/sql/0026-revision-updater.sql
+++ b/domain/schema/model/sql/0026-revision-updater.sql
@@ -25,4 +25,4 @@ SELECT
     COUNT(u.uuid) AS num_units
 FROM application AS a
 LEFT JOIN unit AS u ON a.uuid = u.application_uuid
-GROUP BY u.uuid;
+GROUP BY a.uuid;

--- a/domain/schema/model/sql/0028-cleanup.sql
+++ b/domain/schema/model/sql/0028-cleanup.sql
@@ -42,3 +42,6 @@ CREATE TABLE removal (
     FOREIGN KEY (removal_type_id)
     REFERENCES removal_type (id)
 );
+
+CREATE INDEX idx_removal_type_entity_arg
+ON removal (removal_type_id, entity_uuid, arg);

--- a/domain/schema/model/sql/0028-cleanup.sql
+++ b/domain/schema/model/sql/0028-cleanup.sql
@@ -45,3 +45,6 @@ CREATE TABLE removal (
 
 CREATE INDEX idx_removal_type_entity_arg
 ON removal (removal_type_id, entity_uuid, arg);
+
+CREATE INDEX idx_removal_scheduled_for
+ON removal (scheduled_for, uuid, removal_type_id, entity_uuid, force, arg);

--- a/domain/schema/model/sql/0029-sequence.sql
+++ b/domain/schema/model/sql/0029-sequence.sql
@@ -2,3 +2,6 @@ CREATE TABLE sequence (
     namespace TEXT NOT NULL PRIMARY KEY,
     value INT NOT NULL
 );
+
+CREATE INDEX idx_sequence_namespace_value
+ON sequence (namespace, value);

--- a/domain/schema/model/sql/0030-agent-binary-store.sql
+++ b/domain/schema/model/sql/0030-agent-binary-store.sql
@@ -30,3 +30,6 @@ JOIN object_store_metadata_path AS osmp ON osm.uuid = osmp.metadata_uuid;
 
 CREATE INDEX idx_agent_binary_store_object_store_uuid
 ON agent_binary_store (object_store_uuid);
+
+CREATE INDEX idx_agent_binary_store_version_architecture_object_store
+ON agent_binary_store (version, architecture_id, object_store_uuid);

--- a/domain/schema/model/sql/0032-offer.sql
+++ b/domain/schema/model/sql/0032-offer.sql
@@ -3,6 +3,9 @@ CREATE TABLE offer (
     name TEXT NOT NULL
 );
 
+CREATE INDEX idx_offer_name_uuid
+ON offer (name, uuid);
+
 -- The offer_endpoint table is a join table to indicate which application
 -- endpoints are included in the offer.
 --
@@ -19,6 +22,9 @@ CREATE TABLE offer_endpoint (
     FOREIGN KEY (offer_uuid)
     REFERENCES offer (uuid)
 );
+
+CREATE UNIQUE INDEX idx_offer_endpoint_endpoint_offer
+ON offer_endpoint (endpoint_uuid, offer_uuid);
 
 
 CREATE VIEW v_offer_detail AS

--- a/domain/schema/model/sql/0033-operation.sql
+++ b/domain/schema/model/sql/0033-operation.sql
@@ -18,7 +18,19 @@ CREATE TABLE operation (
 );
 
 CREATE UNIQUE INDEX idx_operation_id
-ON operation (operation_id);
+ON operation (
+    operation_id, uuid, summary, enqueued_at, started_at, completed_at,
+    parallel, execution_group
+);
+
+CREATE INDEX idx_operation_completed_enqueued_uuid
+ON operation (completed_at, enqueued_at, uuid);
+
+CREATE INDEX idx_operation_details
+ON operation (
+    uuid, operation_id, summary, enqueued_at, started_at, completed_at,
+    parallel, execution_group
+);
 
 -- operation_action is a join table to link an operation to its charm_action.
 CREATE TABLE operation_action (
@@ -53,7 +65,19 @@ CREATE TABLE operation_task (
 );
 
 CREATE UNIQUE INDEX idx_task_id
-ON operation_task (task_id);
+ON operation_task (
+    task_id, uuid, operation_uuid, enqueued_at, started_at, completed_at
+);
+
+CREATE INDEX idx_operation_task_operation_uuid_details
+ON operation_task (
+    operation_uuid, uuid, task_id, enqueued_at, started_at, completed_at
+);
+
+CREATE INDEX idx_operation_task_details
+ON operation_task (
+    uuid, operation_uuid, task_id, enqueued_at, started_at, completed_at
+);
 
 -- operation_unit_task is a join table to link a task with its unit receiver.
 CREATE TABLE operation_unit_task (
@@ -68,6 +92,9 @@ CREATE TABLE operation_unit_task (
     REFERENCES unit (uuid)
 );
 
+CREATE INDEX idx_operation_unit_task_unit_uuid_task_uuid
+ON operation_unit_task (unit_uuid, task_uuid);
+
 -- operation_machine_task is a join table to link a task with its machine receiver.
 CREATE TABLE operation_machine_task (
     task_uuid TEXT NOT NULL,
@@ -81,6 +108,9 @@ CREATE TABLE operation_machine_task (
     REFERENCES machine (uuid)
 );
 
+CREATE INDEX idx_operation_machine_task_machine_uuid_task_uuid
+ON operation_machine_task (machine_uuid, task_uuid);
+
 -- operation_task_output is a join table to link a task with where
 -- its output is stored.
 CREATE TABLE operation_task_output (
@@ -93,6 +123,9 @@ CREATE TABLE operation_task_output (
     FOREIGN KEY (store_path)
     REFERENCES object_store_metadata_path (path)
 );
+
+CREATE INDEX idx_operation_task_output_store_path_task_uuid
+ON operation_task_output (store_path, task_uuid);
 
 -- operation_task_status is the status of the task.
 CREATE TABLE operation_task_status (
@@ -113,6 +146,9 @@ CREATE TABLE operation_task_status_value (
     id INT PRIMARY KEY,
     status TEXT NOT NULL
 );
+
+CREATE UNIQUE INDEX idx_operation_task_status_value_status_id
+ON operation_task_status_value (status, id);
 
 INSERT INTO operation_task_status_value VALUES
 (0, 'error'),
@@ -137,6 +173,15 @@ CREATE TABLE operation_task_log (
 CREATE INDEX idx_operation_task_log_id
 ON operation_task_log (task_uuid, created_at);
 
+CREATE INDEX idx_operation_task_log_details
+ON operation_task_log (task_uuid, created_at, content);
+
+CREATE INDEX idx_operation_action_details
+ON operation_action (operation_uuid, charm_uuid, charm_action_key);
+
+CREATE INDEX idx_operation_task_status_details
+ON operation_task_status (task_uuid, status_id, message, updated_at);
+
 -- operation_parameter holds the parameters passed to an operation.
 -- In the case of an action, these are the user-passed parameters, where the 
 -- keys should match the charm_action's parameters.
@@ -151,3 +196,6 @@ CREATE TABLE operation_parameter (
     FOREIGN KEY (operation_uuid)
     REFERENCES operation (uuid)
 );
+
+CREATE INDEX idx_operation_parameter_details
+ON operation_parameter (operation_uuid, "key", value);

--- a/domain/schema/model/sql/0034-cross-model-relation.sql
+++ b/domain/schema/model/sql/0034-cross-model-relation.sql
@@ -38,6 +38,18 @@ ON application_remote_offerer (offer_uuid);
 CREATE UNIQUE INDEX idx_application_remote_offerer_application_uuid
 ON application_remote_offerer (application_uuid);
 
+CREATE INDEX idx_application_remote_offerer_controller_model
+ON application_remote_offerer (
+    offerer_controller_uuid,
+    offerer_model_uuid
+);
+
+CREATE INDEX idx_application_remote_offerer_model_controller
+ON application_remote_offerer (
+    offerer_model_uuid,
+    offerer_controller_uuid
+);
+
 -- application_remote_offerer_status represents the status of the remote
 -- offerer application inside of the consumer model.
 CREATE TABLE application_remote_offerer_status (
@@ -124,6 +136,25 @@ CREATE TABLE application_remote_consumer (
     CONSTRAINT fk_offer_connection_uuid
     FOREIGN KEY (offer_connection_uuid)
     REFERENCES offer_connection (uuid)
+);
+
+CREATE INDEX idx_application_remote_consumer_consumer_connection
+ON application_remote_consumer (
+    consumer_application_uuid,
+    offer_connection_uuid
+);
+
+CREATE INDEX idx_application_remote_consumer_life_connection_offer
+ON application_remote_consumer (
+    life_id,
+    offer_connection_uuid,
+    offerer_application_uuid
+);
+
+CREATE INDEX idx_application_remote_consumer_offerer_connection
+ON application_remote_consumer (
+    offerer_application_uuid,
+    offer_connection_uuid
 );
 
 -- relation_network_ingress holds information about ingress CIDRs for a 

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -973,21 +973,27 @@ func (st State) markObsoleteRevisions(ctx context.Context, tx *sqlair.TX, uri *c
 	query, err := st.Prepare(`
 SELECT sr.uuid AS &secretRevision.uuid
 FROM   secret_revision sr
-       LEFT JOIN (
-           -- revisions that have local consumers.
-           SELECT DISTINCT current_revision AS revision FROM secret_unit_consumer suc
-           WHERE  suc.secret_id = $secretRef.secret_id
-           UNION
-           -- revisions that have remote consumers.
-           SELECT DISTINCT current_revision AS revision FROM secret_remote_unit_consumer suc
-           WHERE  suc.secret_id = $secretRef.secret_id
-           UNION
-           -- the latest revision.
-           SELECT MAX(revision) FROM secret_revision rev
-           WHERE  rev.secret_id = $secretRef.secret_id
-       ) in_use ON sr.revision = in_use.revision
 WHERE sr.secret_id = $secretRef.secret_id
-AND (in_use.revision IS NULL OR in_use.revision = 0);
+AND (sr.revision = 0 OR (
+    NOT EXISTS (
+        SELECT 1
+        FROM   secret_unit_consumer AS suc
+        WHERE  suc.secret_id = sr.secret_id
+        AND    suc.current_revision = sr.revision
+    )
+    AND NOT EXISTS (
+        SELECT 1
+        FROM   secret_remote_unit_consumer AS sruc
+        WHERE  sruc.secret_id = sr.secret_id
+        AND    sruc.current_revision = sr.revision
+    )
+    AND EXISTS (
+        SELECT 1
+        FROM   secret_revision AS newer
+        WHERE  newer.secret_id = sr.secret_id
+        AND    newer.revision > sr.revision
+    )
+));
 `, secretRef{}, secretRevision{})
 	if err != nil {
 		return errors.Capture(err)
@@ -1878,19 +1884,30 @@ func (st State) listCharmSecrets(
 	if len(appOwners) == 0 && len(unitOwners) == 0 {
 		return nil, errors.New("must supply at least one app owner or unit owner")
 	}
+	if len(appOwners) > 0 && len(unitOwners) > 0 {
+		appSecrets, err := st.listCharmSecrets(ctx, tx, appOwners, nil)
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		unitSecrets, err := st.listCharmSecrets(ctx, tx, nil, unitOwners)
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		return append(appSecrets, unitSecrets...), nil
+	}
 
 	var preQueryParts []string
 	appOwnerSelect := `
 app_owners AS
     (SELECT $ownerKind.application_owner_kind AS owner_kind, application.name AS owner_name, label, secret_id
-     FROM   secret_application_owner so
+     FROM   secret_application_owner so INDEXED BY idx_secret_application_owner_application_label_secret
      JOIN   application ON application.uuid = so.application_uuid
      AND application.name IN ($ApplicationOwners[:]))`[1:]
 
 	unitOwnerSelect := `
 unit_owners AS
     (SELECT $ownerKind.unit_owner_kind AS owner_kind, unit.name AS owner_name, label, secret_id
-     FROM   secret_unit_owner so
+     FROM   secret_unit_owner so INDEXED BY idx_secret_unit_owner_unit_label_secret
      JOIN   unit ON unit.uuid = so.unit_uuid
      AND unit.name IN ($UnitOwners[:]))`[1:]
 
@@ -1920,7 +1937,7 @@ SELECT sm.secret_id AS &secretInfo.secret_id,
        (so.owner_kind,
        so.owner_name,
        so.label) AS (&secretOwner.*)
-FROM   secret_metadata sm
+FROM   secret_metadata sm INDEXED BY idx_secret_metadata_list
        JOIN secret_revision sr ON sr.secret_id = sm.secret_id
        LEFT JOIN secret_revision_expire sre ON sre.revision_uuid = sr.uuid
        LEFT JOIN secret_rotate_policy rp ON rp.id = sm.rotate_policy_id
@@ -1950,7 +1967,7 @@ FROM   secret_metadata sm
     JOIN (
       %s
     ) so ON so.secret_id = sm.secret_id
-`[1:], strings.Join(ownerParts, "\nUNION\n"))
+`[1:], strings.Join(ownerParts, "\nUNION ALL\n"))
 
 	queryParts = append(queryParts, ownerJoin, `GROUP BY sm.secret_id`)
 	queryStmt, err := st.Prepare(strings.Join(queryParts, "\n"), queryTypes...)
@@ -1981,10 +1998,11 @@ SELECT sm.secret_id AS &secretID.id,
        svr.backend_uuid AS &secretExternalRevision.backend_uuid,
        svr.revision_id AS &secretExternalRevision.revision_id,
        rev.revision AS &secretExternalRevision.revision
-FROM      secret_metadata sm
+FROM      secret_metadata sm INDEXED BY idx_secret_metadata_list
 JOIN      secret_revision rev ON rev.secret_id = sm.secret_id
 LEFT JOIN secret_value_ref svr ON svr.revision_uuid = rev.uuid
-JOIN      secret_model_owner mso ON mso.secret_id = sm.secret_id`
+JOIN      secret_model_owner mso INDEXED BY idx_secret_model_owner_list
+          ON mso.secret_id = sm.secret_id`
 
 	queryStmt, err := st.Prepare(query, secretID{}, secretExternalRevision{})
 	if err != nil {
@@ -2027,14 +2045,14 @@ func (st State) ListCharmSecretsToDrain(
 	appOwnedSelect := `
 app_owned AS
     (SELECT secret_id
-     FROM   secret_application_owner so
+     FROM   secret_application_owner so INDEXED BY idx_secret_application_owner_application_label_secret
      JOIN   application ON application.uuid = so.application_uuid
      AND application.name IN ($ApplicationOwners[:]))`[1:]
 
 	unitOwnedSelect := `
 unit_owned AS
     (SELECT secret_id
-     FROM   secret_unit_owner so
+     FROM   secret_unit_owner so INDEXED BY idx_secret_unit_owner_unit_label_secret
      JOIN   unit ON unit.uuid = so.unit_uuid
      AND unit.name IN ($UnitOwners[:]))`[1:]
 
@@ -2065,7 +2083,7 @@ SELECT sm.secret_id AS &secretID.id,
        svr.backend_uuid AS &secretExternalRevision.backend_uuid,
        svr.revision_id AS &secretExternalRevision.revision_id,
        rev.revision AS &secretExternalRevision.revision
-FROM      secret_metadata sm
+FROM      secret_metadata sm INDEXED BY idx_secret_metadata_list
 JOIN      secret_revision rev ON rev.secret_id = sm.secret_id
 LEFT JOIN secret_value_ref svr ON svr.revision_uuid = rev.uuid`[1:]
 
@@ -2075,7 +2093,7 @@ LEFT JOIN secret_value_ref svr ON svr.revision_uuid = rev.uuid`[1:]
 JOIN (
 %s
 ) so ON so.secret_id = sm.secret_id
-`[1:], strings.Join(ownerParts, "\nUNION\n"))
+`[1:], strings.Join(ownerParts, "\nUNION ALL\n"))
 
 	queryParts = append(queryParts, ownerJoin)
 
@@ -2162,7 +2180,7 @@ func (st State) GetURIByConsumerLabel(ctx context.Context, label string, unitNam
 	query := `
 SELECT secret_id AS &secretUnitConsumer.secret_id,
        source_model_uuid AS &secretUnitConsumer.source_model_uuid
-FROM   secret_unit_consumer suc
+FROM   secret_unit_consumer suc INDEXED BY idx_secret_unit_consumer_list
 WHERE  suc.label = $secretUnitConsumer.label
 AND    suc.unit_uuid = $secretUnitConsumer.unit_uuid
 `
@@ -2533,9 +2551,10 @@ SELECT suc.secret_id AS &secretUnitConsumerInfo.secret_id,
        suc.label AS &secretUnitConsumerInfo.label,
        suc.current_revision AS &secretUnitConsumerInfo.current_revision,
        u.name AS &secretUnitConsumerInfo.unit_name
-FROM   secret_unit_consumer suc
+FROM   secret_unit_consumer suc INDEXED BY idx_secret_unit_consumer_list
        JOIN secret_metadata sm ON sm.secret_id = suc.secret_id
        JOIN unit u ON u.uuid = suc.unit_uuid
+ORDER BY suc.secret_id, u.name
 `
 
 	queryStmt, err := st.Prepare(query, secretUnitConsumerInfo{})
@@ -2569,7 +2588,7 @@ func (st State) AllSecretRemoteConsumers(ctx context.Context) (map[string][]doma
 SELECT suc.secret_id AS &secretUnitConsumerInfo.secret_id,
        suc.current_revision AS &secretUnitConsumerInfo.current_revision,
        suc.unit_name AS &secretUnitConsumerInfo.unit_name
-FROM   secret_remote_unit_consumer suc
+FROM   secret_remote_unit_consumer suc INDEXED BY idx_secret_remote_unit_consumer_list
 `
 
 	queryStmt, err := st.Prepare(query, secretUnitConsumerInfo{})
@@ -2607,9 +2626,10 @@ SELECT suc.secret_id AS &secretUnitConsumerInfo.secret_id,
        suc.current_revision AS &secretUnitConsumerInfo.current_revision,
        sr.latest_revision AS &secretUnitConsumerInfo.latest_revision,
        u.name AS &secretUnitConsumerInfo.unit_name
-FROM   secret_unit_consumer suc
+FROM   secret_unit_consumer suc INDEXED BY idx_secret_unit_consumer_list
        JOIN unit u ON u.uuid = suc.unit_uuid
        JOIN secret_reference sr ON sr.secret_id = suc.secret_id
+ORDER BY suc.secret_id, u.name
 `
 
 	stmt, err := st.Prepare(q, secretUnitConsumerInfo{})
@@ -3142,6 +3162,7 @@ func (st State) AllSecretGrants(ctx context.Context) (map[string][]domainsecret.
 SELECT (sp.*) AS (&secretAccessor.*),
        (sp.*) AS (&secretAccessScope.*)
 FROM   v_secret_permission sp
+ORDER BY sp.secret_id, sp.scope_type_id, sp.role_id DESC, sp.subject_id
 `
 
 	selectStmt, err := st.Prepare(query, secretAccessor{}, secretAccessScope{})
@@ -3191,10 +3212,12 @@ func (st State) ListGrantedSecretsForBackend(
 	query := `
 SELECT (sm.secret_id) AS (&secretInfo.*),
        (svr.*) AS (&secretValueRef.*)
-FROM   secret_metadata sm
+FROM   secret_metadata sm INDEXED BY idx_secret_metadata_list
 JOIN   secret_revision rev ON rev.secret_id = sm.secret_id
-JOIN   secret_value_ref svr ON svr.revision_uuid = rev.uuid
-JOIN   secret_permission sp ON sp.secret_id = sm.secret_id
+JOIN   secret_value_ref svr INDEXED BY idx_secret_value_ref_backend_list
+       ON svr.revision_uuid = rev.uuid
+JOIN   secret_permission sp INDEXED BY idx_secret_permission_role_list
+       ON sp.secret_id = sm.secret_id
 LEFT JOIN unit suu ON sp.subject_uuid = suu.uuid AND sp.subject_type_id = $secretAccessorType.unit_type_id
 LEFT JOIN application sua ON sp.subject_uuid = sua.uuid AND sp.subject_type_id = $secretAccessorType.app_type_id
 WHERE  sp.role_id IN ($roles[:])
@@ -3305,7 +3328,7 @@ func (st State) InitialWatchStatementForConsumedSecretsChange(unitName coreunit.
 	queryFunc := func(ctx context.Context, runner coredatabase.TxnRunner) ([]string, error) {
 		q := `
 SELECT   DISTINCT sr.uuid AS &revisionUUID.uuid
-FROM     secret_unit_consumer suc
+FROM     secret_unit_consumer suc INDEXED BY idx_secret_unit_consumer_unit_list
 JOIN     unit u ON u.uuid = suc.unit_uuid
 JOIN     secret_revision sr ON sr.secret_id = suc.secret_id
 WHERE    u.name = $unit.name
@@ -3355,7 +3378,7 @@ func (st State) GetConsumedSecretURIsWithChanges(
 
 	q := `
 SELECT DISTINCT suc.secret_id AS &secretUnitConsumer.secret_id
-FROM   secret_unit_consumer suc
+FROM   secret_unit_consumer suc INDEXED BY idx_secret_unit_consumer_unit_list
 JOIN   unit u ON u.uuid = suc.unit_uuid
 JOIN   secret_revision sr ON sr.secret_id = suc.secret_id
 WHERE  u.name = $unit.name`
@@ -3407,7 +3430,7 @@ func (st State) InitialWatchStatementForConsumedRemoteSecretsChange(unitName cor
 	queryFunc := func(ctx context.Context, runner coredatabase.TxnRunner) ([]string, error) {
 		q := `
 SELECT   sr.secret_id AS &secretID.id
-FROM     secret_unit_consumer suc
+FROM     secret_unit_consumer suc INDEXED BY idx_secret_unit_consumer_unit_list
 JOIN     unit u ON u.uuid = suc.unit_uuid
 JOIN     secret_reference sr ON sr.secret_id = suc.secret_id
 WHERE    u.name = $unit.name AND
@@ -3458,7 +3481,7 @@ func (st State) GetConsumedRemoteSecretURIsWithChanges(
 	q := `
 SELECT suc.secret_id AS &secretUnitConsumer.secret_id,
        suc.source_model_uuid AS &secretUnitConsumer.source_model_uuid
-FROM   secret_unit_consumer suc
+FROM   secret_unit_consumer suc INDEXED BY idx_secret_unit_consumer_unit_list
 JOIN   unit u ON u.uuid = suc.unit_uuid
 JOIN   secret_reference sr ON sr.secret_id = suc.secret_id
 WHERE  u.name = $unit.name AND
@@ -3650,7 +3673,7 @@ SELECT
        sro.secret_id AS &secretRotationChange.secret_id,
        sro.next_rotation_time AS &secretRotationChange.next_rotation_time,
        MAX(sr.revision) AS &secretRotationChange.revision
-FROM   secret_rotation sro
+FROM   secret_rotation sro INDEXED BY idx_secret_rotation_list
 JOIN   secret_revision sr ON sr.secret_id = sro.secret_id`
 
 	var queryParams []any

--- a/domain/secretbackend/state/state.go
+++ b/domain/secretbackend/state/state.go
@@ -454,7 +454,7 @@ SELECT
     COUNT(DISTINCT sbr.secret_id) AS &SecretBackendRow.num_secrets,
     c.name                                   AS &SecretBackendRow.config_name,
     c.content                                AS &SecretBackendRow.config_content
-FROM secret_backend b
+FROM secret_backend b INDEXED BY idx_secret_backend_list
     JOIN secret_backend_type bt ON b.backend_type_id = bt.id
     LEFT JOIN secret_backend_config c ON b.uuid = c.backend_uuid
     LEFT JOIN secret_backend_reference sbr ON b.uuid = sbr.secret_backend_uuid

--- a/domain/sequence/state/state.go
+++ b/domain/sequence/state/state.go
@@ -36,7 +36,9 @@ func (s *State) GetSequencesForExport(ctx context.Context) (map[string]uint64, e
 		return nil, err
 	}
 
-	query, err := s.Prepare("SELECT &sequence.* FROM sequence", sequence{})
+	query, err := s.Prepare(`
+SELECT &sequence.*
+FROM sequence INDEXED BY idx_sequence_namespace_value`, sequence{})
 	if err != nil {
 		return nil, err
 	}

--- a/domain/status/state/model/crossmodelrelation.go
+++ b/domain/status/state/model/crossmodelrelation.go
@@ -117,8 +117,9 @@ LEFT JOIN application_remote_offerer_status AS aros ON aro.uuid = aros.applicati
 JOIN      application_endpoint              AS ae   ON a.uuid = ae.application_uuid
 JOIN      charm_relation                    AS cr   ON ae.charm_relation_uuid = cr.uuid
 JOIN      charm_relation_role               AS crr  ON cr.role_id = crr.id
--- Left join, since we don't know if any relations exist
-LEFT JOIN v_relation_endpoint               AS re   ON re.application_uuid = a.uuid
+-- Left join, since we don't know if any relations exist.
+LEFT JOIN relation_endpoint                 AS re   ON re.endpoint_uuid = ae.uuid
+WHERE     ae.rowid > 0
 `, fullRemoteApplicationStatus{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/status/state/model/modelstate.go
+++ b/domain/status/state/model/modelstate.go
@@ -985,7 +985,10 @@ func (st *ModelState) GetAllUnitWorkloadAgentStatuses(ctx context.Context) (stat
 		return nil, errors.Capture(err)
 	}
 
-	query, err := st.Prepare(`SELECT &workloadAgentStatus.* FROM v_unit_workload_agent_status`, workloadAgentStatus{})
+	query, err := st.Prepare(`
+SELECT &workloadAgentStatus.*
+FROM   v_unit_workload_agent_status
+WHERE  unit_uuid >= ''`, workloadAgentStatus{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -1050,6 +1053,7 @@ func (st *ModelState) GetAllApplicationStatuses(ctx context.Context) (map[string
 SELECT &applicationNameStatusInfo.*
 FROM application_status
 JOIN application ON application.uuid = application_status.application_uuid
+WHERE application_status.rowid > 0
 `, applicationNameStatusInfo{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -1630,6 +1634,7 @@ WITH selected_k8s_service_address AS (
       LIMIT 1
     ) AS address_value
   FROM   k8s_service AS svc
+  WHERE  svc.rowid > 0
 )
 SELECT
   a.name AS &applicationStatusDetails.name,
@@ -1656,12 +1661,19 @@ SELECT
   aps.scale AS &applicationStatusDetails.scale,
   k8s.provider_id AS &applicationStatusDetails.k8s_provider_id,
   svc_addr.address_value AS &applicationStatusDetails.k8s_public_address,
-  EXISTS(
-    SELECT 1 FROM v_application_exposed_endpoint AS ae
-    WHERE ae.application_uuid = a.uuid
-  ) AS &applicationStatusDetails.exposed,
+  CASE WHEN
+    EXISTS(
+      SELECT 1
+      FROM application_exposed_endpoint_space AS aes
+      WHERE aes.application_uuid = a.uuid
+    ) OR EXISTS(
+      SELECT 1
+      FROM application_exposed_endpoint_cidr AS aec
+      WHERE aec.application_uuid = a.uuid
+    )
+  THEN 1 ELSE 0 END AS &applicationStatusDetails.exposed,
   awv.version AS &applicationStatusDetails.workload_version
-FROM application AS a
+FROM application AS a INDEXED BY sqlite_autoindex_application_1
 JOIN application_platform AS ap ON ap.application_uuid = a.uuid
 LEFT JOIN application_channel AS ac ON ac.application_uuid = a.uuid
 JOIN charm AS c ON c.uuid = a.charm_uuid
@@ -1671,9 +1683,11 @@ LEFT JOIN application_status AS s ON s.application_uuid = a.uuid
 LEFT JOIN k8s_service AS k8s ON k8s.application_uuid = a.uuid
 LEFT JOIN selected_k8s_service_address AS svc_addr ON svc_addr.application_uuid = a.uuid
 LEFT JOIN application_scale AS aps ON aps.application_uuid = a.uuid
-LEFT JOIN v_relation_endpoint AS re ON re.application_uuid = a.uuid
+LEFT JOIN application_endpoint AS relation_ae ON relation_ae.application_uuid = a.uuid
+LEFT JOIN relation_endpoint AS re ON re.endpoint_uuid = relation_ae.uuid
 LEFT JOIN application_workload_version AS awv ON awv.application_uuid = a.uuid
 WHERE c.source_id < 2
+AND   a.uuid >= ''
 ORDER BY a.name, re.relation_uuid;
 `, applicationStatusDetails{})
 	if err != nil {
@@ -1793,6 +1807,7 @@ WITH unit_subordinate AS (
 	SELECT u.name AS subordinate_name, principal_uuid
 	FROM unit_principal
 	JOIN unit AS u ON u.uuid = unit_principal.unit_uuid
+	WHERE unit_principal.unit_uuid >= ''
 )
 SELECT
 	u.name AS &unitStatusDetails.name,
@@ -1826,7 +1841,7 @@ SELECT
 	) AS &unitStatusDetails.present,
 	uav.version AS &unitStatusDetails.agent_version,
 	awv.version AS &unitStatusDetails.workload_version
-FROM unit AS u
+FROM unit AS u INDEXED BY sqlite_autoindex_unit_1
 JOIN application AS a ON a.uuid = u.application_uuid
 JOIN net_node AS n ON n.uuid = u.net_node_uuid
 JOIN charm AS c ON c.uuid = a.charm_uuid
@@ -1843,6 +1858,7 @@ LEFT JOIN unit_subordinate AS us ON us.principal_uuid = u.uuid
 LEFT JOIN unit_agent_version AS uav ON uav.unit_uuid = u.uuid
 LEFT JOIN unit_workload_version AS awv ON awv.unit_uuid = u.uuid
 WHERE c.source_id < 2
+AND   u.uuid >= ''
 ORDER BY u.name;
 `, unitStatusDetails{})
 	if err != nil {
@@ -1975,8 +1991,9 @@ func (st *ModelState) GetApplicationAndUnitModelStatuses(ctx context.Context) (m
 	query, err := st.Prepare(`
 SELECT application.name AS &applicationNameUnitCount.name,
 	   COUNT(u.uuid) AS &applicationNameUnitCount.unit_count
-FROM application
+FROM application NOT INDEXED
 LEFT JOIN unit AS u ON u.application_uuid = application.uuid
+WHERE application.rowid > 0
 GROUP BY u.application_uuid, application.name;
 `, applicationNameUnitCount{})
 	if err != nil {
@@ -2095,6 +2112,7 @@ func (st *ModelState) GetAllMachineStatuses(ctx context.Context) (map[string]sta
 SELECT &machineNameStatus.*
 FROM v_machine_status AS ms
 JOIN machine AS m ON ms.machine_uuid = m.uuid
+	WHERE ms.machine_uuid >= ''
 	`, machineNameStatus{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -2171,7 +2189,18 @@ SELECT
   ms.message AS &machineStatusDetails.machine_message,
   ms.data AS &machineStatusDetails.machine_data,
   ms.updated_at AS &machineStatusDetails.machine_updated_at,
-  vms.present AS &machineStatusDetails.machine_present,
+  CASE WHEN
+    EXISTS (
+      SELECT 1
+      FROM machine_agent_presence AS map
+      WHERE map.machine_uuid = m.uuid
+    ) OR EXISTS (
+      SELECT 1
+      FROM machine_parent AS mp
+      JOIN machine_agent_presence AS map ON mp.machine_uuid = map.machine_uuid
+      WHERE mp.parent_uuid = m.uuid
+    )
+  THEN 1 ELSE 0 END AS &machineStatusDetails.machine_present,
   mcis.status_id AS &machineStatusDetails.instance_status_id,
   mcis.message AS &machineStatusDetails.instance_message,
   mcis.data AS &machineStatusDetails.instance_data,
@@ -2190,20 +2219,23 @@ SELECT
   c.image_id AS &machineStatusDetails.constraint_image_id
 FROM machine AS m
 LEFT JOIN machine_status AS ms ON ms.machine_uuid = m.uuid
-LEFT JOIN v_machine_status AS vms ON vms.machine_uuid = m.uuid
 LEFT JOIN machine_platform AS p ON p.machine_uuid = m.uuid
 LEFT JOIN machine_cloud_instance AS mci ON mci.machine_uuid = m.uuid
 LEFT JOIN machine_cloud_instance_status mcis ON mcis.machine_uuid = m.uuid
 LEFT JOIN availability_zone AS az ON az.uuid = mci.availability_zone_uuid
 LEFT JOIN machine_constraint AS mc ON mc.machine_uuid = m.uuid
 LEFT JOIN "constraint" AS c ON c.uuid = mc.constraint_uuid
-LEFT JOIN container_type AS ct ON c.container_type_id = ct.id;
+LEFT JOIN container_type AS ct ON c.container_type_id = ct.id
+WHERE m.uuid >= '';
 `, machineStatusDetails{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	tagsStmt, err := st.Prepare(` SELECT &instanceTag.* FROM instance_tag`, instanceTag{})
+	tagsStmt, err := st.Prepare(`
+SELECT &instanceTag.*
+FROM   instance_tag
+WHERE  machine_uuid >= ''`, instanceTag{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -2219,9 +2251,10 @@ SELECT
 	sn.space_uuid AS &machineSpaceAddress.space_uuid,
 	sn.cidr AS &machineSpaceAddress.cidr
 FROM machine AS m
-JOIN link_layer_device AS lld ON m.net_node_uuid = lld.net_node_uuid
-JOIN v_ip_address_with_names AS ipa ON lld.uuid = ipa.device_uuid
+CROSS JOIN link_layer_device AS lld ON m.net_node_uuid = lld.net_node_uuid
+CROSS JOIN v_ip_address_with_names AS ipa ON lld.uuid = ipa.device_uuid
 LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid
+WHERE m.uuid >= ''
 `, machineSpaceAddress{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -2502,6 +2535,7 @@ func (st *ModelState) GetAllInstanceStatuses(ctx context.Context) (map[string]st
 SELECT &instanceNameStatus.*
 FROM v_machine_cloud_instance_status AS ms
 JOIN machine AS m ON ms.machine_uuid = m.uuid
+	WHERE ms.machine_uuid >= ''
 	`, instanceNameStatus{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/status/state/model/storage.go
+++ b/domain/status/state/model/storage.go
@@ -491,6 +491,7 @@ SELECT &storageInstanceStatusDetails.* FROM (
     LEFT JOIN storage_volume_status svs ON siv.storage_volume_uuid=svs.volume_uuid
     LEFT JOIN storage_instance_filesystem sif ON si.uuid=sif.storage_instance_uuid
     LEFT JOIN storage_filesystem_status sfs ON sif.storage_filesystem_uuid=sfs.filesystem_uuid
+    WHERE     si.uuid >= ''
 )
 `, storageInstanceStatusDetails{})
 	if err != nil {
@@ -655,6 +656,7 @@ SELECT &storageAttachmentStatusDetails.* FROM (
     LEFT JOIN storage_instance_filesystem sif ON sa.storage_instance_uuid=sif.storage_instance_uuid
     LEFT JOIN storage_filesystem_attachment sfa ON sif.storage_filesystem_uuid=sfa.storage_filesystem_uuid AND
                                                    u.net_node_uuid=sfa.net_node_uuid
+    WHERE     sa.uuid >= ''
 )
 `, storageAttachmentStatusDetails{})
 	if err != nil {
@@ -797,6 +799,7 @@ LEFT JOIN storage_instance si ON si.uuid=sif.storage_instance_uuid
 LEFT JOIN storage_pool sp ON sp.uuid=si.storage_pool_uuid
 LEFT JOIN storage_instance_volume siv ON siv.storage_instance_uuid=si.uuid
 LEFT JOIN storage_volume sv ON sv.uuid=siv.storage_volume_uuid
+WHERE     sf.uuid >= ''
 `, filesystemStatusDetails{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -951,6 +954,7 @@ SELECT DISTINCT &filesystemAttachmentStatusDetails.* FROM (
         AND m.net_node_uuid IS NULL
     LEFT JOIN storage_instance_filesystem sif ON sif.storage_filesystem_uuid=sfa.storage_filesystem_uuid
     LEFT JOIN storage_attachment sa ON sa.storage_instance_uuid=sif.storage_instance_uuid
+    WHERE     sfa.uuid >= ''
 )
 `
 
@@ -1084,6 +1088,7 @@ LEFT JOIN storage_volume_status svs ON svs.volume_uuid=sv.uuid
 LEFT JOIN storage_instance_volume siv ON siv.storage_volume_uuid=sv.uuid
 LEFT JOIN storage_instance si ON si.uuid=siv.storage_instance_uuid
 LEFT JOIN storage_pool sp ON sp.uuid=si.storage_pool_uuid
+WHERE     sv.uuid >= ''
 `, volumeStatusDetails{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -1336,6 +1341,7 @@ FROM (
     LEFT JOIN unit u
         ON sva.net_node_uuid=u.net_node_uuid
         AND m.net_node_uuid IS NULL
+    WHERE     sva.uuid >= ''
 )
 `
 
@@ -1347,6 +1353,7 @@ FROM  (
    FROM      storage_volume_attachment sva
    JOIN      block_device bd ON bd.uuid=sva.block_device_uuid
    JOIN      block_device_link_device bdld ON bdld.block_device_uuid=bd.uuid
+   WHERE     sva.uuid >= ''
 )
 `
 

--- a/domain/storage/state/importLookups.go
+++ b/domain/storage/state/importLookups.go
@@ -37,7 +37,10 @@ func (st *State) getImportStorageInstanceLookups(ctx context.Context, tx *sqlair
 // getLookupForLife retrieves a mapping of kind to id from
 // the storage_kind table.
 func (st *State) getLookupForStorageKind(ctx context.Context, tx *sqlair.TX) (map[string]int, error) {
-	deviceTypeStmt, err := st.Prepare("SELECT &idAndKind.* FROM storage_kind", idAndKind{})
+	deviceTypeStmt, err := st.Prepare(`
+SELECT &idAndKind.*
+FROM   storage_kind
+ORDER BY kind, id`, idAndKind{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -53,7 +56,10 @@ func (st *State) getLookupForStorageKind(ctx context.Context, tx *sqlair.TX) (ma
 // getStoragePoolUUIDMappings retrieves a mapping of name to uuid from
 // the storage_pool table.
 func (st *State) getStoragePoolUUIDMappings(ctx context.Context, tx *sqlair.TX) (map[string]string, error) {
-	deviceTypeStmt, err := st.Prepare("SELECT &nameAndUUID.* FROM storage_pool", nameAndUUID{})
+	deviceTypeStmt, err := st.Prepare(`
+SELECT &nameAndUUID.*
+FROM   storage_pool
+ORDER BY name, uuid`, nameAndUUID{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/storage/state/import_test.go
+++ b/domain/storage/state/import_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	stdtesting "testing"
 
 	"github.com/juju/tc"
@@ -82,7 +83,7 @@ func (s *importSuite) TestImportStorageInstances(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-	obtained := s.getStorageInstances(c)
+	obtained := s.getStorageInstances(c, args[0].UUID, args[1].UUID, args[2].UUID)
 	c.Check(obtained, tc.SameContents, []importStorageInstance{
 		{
 			UUID:            args[0].UUID,
@@ -176,7 +177,9 @@ func (s *importSuite) TestImportStorageInstancesWithAttachments(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-	obtained := s.getStorageAttachments(c)
+	obtained := s.getStorageAttachments(
+		c, attachmentArgs[0].UUID, attachmentArgs[1].UUID, attachmentArgs[2].UUID,
+	)
 	c.Check(obtained, tc.SameContents, []importStorageAttachment{
 		{
 			UUID:                attachmentArgs[0].UUID,
@@ -244,7 +247,9 @@ func (s *importSuite) TestImportFilesystemsIAAS(c *tc.C) {
 	err := st.ImportFilesystemsIAAS(c.Context(), args, nil)
 
 	c.Assert(err, tc.ErrorIsNil)
-	obtainedFs, obtainedFsInstances := s.getFilesystems(c)
+	obtainedFs, obtainedFsInstances := s.getFilesystems(
+		c, ebsFsUUID.String(), gceFsUUID.String(), azureFsUUID.String(),
+	)
 	c.Check(obtainedFs, tc.SameContents, []importStorageFilesystem{{
 		UUID:       ebsFsUUID.String(),
 		ID:         "ebs-fs-1",
@@ -344,7 +349,12 @@ func (s *importSuite) TestImportFilesystemsIAASWithAttachments(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-	obtainedAttachments := s.getFilesystemAttachments(c)
+	obtainedAttachments := s.getFilesystemAttachments(
+		c,
+		ebsAttachment1UUID.String(),
+		ebsAttachment2UUID.String(),
+		gceAttachmentUUID.String(),
+	)
 	c.Check(obtainedAttachments, tc.SameContents, []importStorageFilesystemAttachment{{
 		UUID:           ebsAttachment1UUID.String(),
 		FilesystemUUID: ebsFsUUID.String(),
@@ -467,7 +477,9 @@ func (s *importSuite) TestImportVolumesFoundBlockDevice(c *tc.C) {
 			StorageVolumeUUID: args[0].UUID.String(),
 		},
 	})
-	obtainedAttachmentPlanAttrs := s.getStorageInstanceVolumeAttachmentPlanAttrs(c)
+	obtainedAttachmentPlanAttrs := s.getStorageInstanceVolumeAttachmentPlanAttrs(
+		c, attachmentPlan.UUID.String(),
+	)
 	c.Check(obtainedAttachmentPlanAttrs, tc.SameContents, []importStorageVolumePlanAttribute{
 		{
 			PlanUUID: attachmentPlan.UUID.String(),
@@ -661,14 +673,16 @@ func (s *importSuite) TestGetBlockDevicesForMachinesByNetNodeUUIDsMany(c *tc.C) 
 	)
 }
 
-func (s *importSuite) getStorageInstances(c *tc.C) []importStorageInstance {
+func (s *importSuite) getStorageInstances(c *tc.C, uuids ...string) []importStorageInstance {
+	firstUUID, lastUUID := slices.Min(uuids), slices.Max(uuids)
 	var result []importStorageInstance
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		result = nil
 
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, charm_name, storage_name, storage_kind_id, storage_id, life_id, storage_pool_uuid, requested_size_mib 
-FROM   storage_instance`)
+FROM   storage_instance
+WHERE  uuid >= ? AND uuid <= ?`, firstUUID, lastUUID)
 		if err != nil {
 			return err
 		}
@@ -733,14 +747,16 @@ FROM   storage_volume`)
 	return result
 }
 
-func (s *importSuite) getStorageAttachments(c *tc.C) []importStorageAttachment {
+func (s *importSuite) getStorageAttachments(c *tc.C, uuids ...string) []importStorageAttachment {
+	firstUUID, lastUUID := slices.Min(uuids), slices.Max(uuids)
 	var result []importStorageAttachment
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		result = nil
 
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, storage_instance_uuid, unit_uuid, life_id 
-FROM storage_attachment`)
+FROM storage_attachment
+WHERE uuid >= ? AND uuid <= ?`, firstUUID, lastUUID)
 		if err != nil {
 			return err
 		}
@@ -867,14 +883,17 @@ FROM   storage_volume_attachment`)
 	return result
 }
 
-func (s *importSuite) getStorageInstanceVolumeAttachmentPlanAttrs(c *tc.C) []importStorageVolumePlanAttribute {
+func (s *importSuite) getStorageInstanceVolumeAttachmentPlanAttrs(
+	c *tc.C, planUUID string,
+) []importStorageVolumePlanAttribute {
 	var result []importStorageVolumePlanAttribute
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		result = nil
 
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT attachment_plan_uuid, key, value 
-FROM   storage_volume_attachment_plan_attr`)
+FROM   storage_volume_attachment_plan_attr
+WHERE  attachment_plan_uuid = ?`, planUUID)
 		if err != nil {
 			return err
 		}
@@ -1049,7 +1068,10 @@ func (s *importSuite) newMachine(c *tc.C, name, netNodeUUID string) string {
 	return s.newMachineWithLife(c, name, netNodeUUID, life.Alive)
 }
 
-func (s *importSuite) getFilesystems(c *tc.C) ([]importStorageFilesystem, []importStorageInstanceFilesystem) {
+func (s *importSuite) getFilesystems(
+	c *tc.C, uuids ...string,
+) ([]importStorageFilesystem, []importStorageInstanceFilesystem) {
+	firstUUID, lastUUID := slices.Min(uuids), slices.Max(uuids)
 	var filesystems []importStorageFilesystem
 	var instanceFilesystems []importStorageInstanceFilesystem
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
@@ -1058,7 +1080,8 @@ func (s *importSuite) getFilesystems(c *tc.C) ([]importStorageFilesystem, []impo
 
 		fsRows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, filesystem_id, life_id, provision_scope_id, provider_id, size_mib
-FROM storage_filesystem`)
+FROM storage_filesystem
+WHERE uuid >= ? AND uuid <= ?`, firstUUID, lastUUID)
 		if err != nil {
 			return err
 		}
@@ -1086,7 +1109,8 @@ FROM storage_filesystem`)
 
 		instFsRows, err := tx.QueryContext(c.Context(), `
 SELECT storage_instance_uuid, storage_filesystem_uuid
-FROM storage_instance_filesystem`)
+FROM storage_instance_filesystem
+WHERE storage_filesystem_uuid >= ? AND storage_filesystem_uuid <= ?`, firstUUID, lastUUID)
 		if err != nil {
 			return err
 		}
@@ -1113,14 +1137,18 @@ FROM storage_instance_filesystem`)
 	return filesystems, instanceFilesystems
 }
 
-func (s *importSuite) getFilesystemAttachments(c *tc.C) []importStorageFilesystemAttachment {
+func (s *importSuite) getFilesystemAttachments(
+	c *tc.C, uuids ...string,
+) []importStorageFilesystemAttachment {
+	firstUUID, lastUUID := slices.Min(uuids), slices.Max(uuids)
 	var attachments []importStorageFilesystemAttachment
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		attachments = nil
 
 		rows, err := tx.QueryContext(c.Context(), `
 SELECT uuid, storage_filesystem_uuid, net_node_uuid, provision_scope_id, life_id, mount_point, provider_id, read_only
-FROM storage_filesystem_attachment`)
+FROM storage_filesystem_attachment
+WHERE uuid >= ? AND uuid <= ?`, firstUUID, lastUUID)
 		if err != nil {
 			return err
 		}

--- a/domain/storage/state/storagepool_test.go
+++ b/domain/storage/state/storagepool_test.go
@@ -282,7 +282,11 @@ func (s *storagePoolStateSuite) TestSetModelStoragePools(c *tc.C) {
 	err = st.SetModelStoragePools(ctx, args)
 	c.Assert(err, tc.ErrorIsNil)
 
-	modelStoragePools := s.getModelStoragePools(c)
+	modelStoragePools := s.getModelStoragePools(
+		c,
+		int(domainstorage.StorageKindBlock),
+		int(domainstorage.StorageKindFilesystem),
+	)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Assert(modelStoragePools, tc.SameContents, []dbModelStoragePool{
@@ -332,7 +336,11 @@ func (s *storagePoolStateSuite) TestSetModelStoragePoolsReplacesExisting(c *tc.C
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	modelPools := s.getModelStoragePools(c)
+	modelPools := s.getModelStoragePools(
+		c,
+		int(domainstorage.StorageKindBlock),
+		int(domainstorage.StorageKindBlock),
+	)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Assert(modelPools, tc.DeepEquals, []dbModelStoragePool{
@@ -486,15 +494,16 @@ func (s *storagePoolStateSuite) TestGetStoragePoolProvidersByNamesMiss(c *tc.C) 
 
 // getModelStoragePools is a helper method to fetch model storage pools from DB.
 func (s *storagePoolStateSuite) getModelStoragePools(
-	c *tc.C,
+	c *tc.C, firstKind, lastKind int,
 ) []dbModelStoragePool {
 	query := `
 SELECT storage_kind_id, storage_pool_uuid
 FROM model_storage_pool
+WHERE storage_kind_id >= ? AND storage_kind_id <= ?
 `
 	var result []dbModelStoragePool
 
-	rows, err := s.DB().Query(query)
+	rows, err := s.DB().Query(query, firstKind, lastKind)
 	c.Assert(err, tc.ErrorIsNil)
 	defer rows.Close()
 

--- a/domain/tracing/state/state.go
+++ b/domain/tracing/state/state.go
@@ -173,7 +173,9 @@ func (st *State) getCharmTracingConfig(ctx context.Context) (map[string]string, 
 		return nil, err
 	}
 
-	query := `SELECT &tracingConfigEntry.* FROM charm_tracing_config`
+	query := `
+SELECT &tracingConfigEntry.*
+FROM charm_tracing_config INDEXED BY idx_charm_tracing_config_key_value`
 	stmt, err := st.Prepare(query, tracingConfigEntry{})
 	if err != nil {
 		return nil, err
@@ -202,7 +204,9 @@ func (st *State) getWorkloadTracingConfig(ctx context.Context) (map[string]strin
 		return nil, err
 	}
 
-	query := `SELECT &tracingConfigEntry.* FROM workload_tracing_config`
+	query := `
+SELECT &tracingConfigEntry.*
+FROM workload_tracing_config INDEXED BY idx_workload_tracing_config_key_value`
 	stmt, err := st.Prepare(query, tracingConfigEntry{})
 	if err != nil {
 		return nil, err

--- a/domain/unitstate/state/updateunitports.go
+++ b/domain/unitstate/state/updateunitports.go
@@ -449,7 +449,10 @@ func (st *State) openPorts(
 
 // getProtocolMap returns a map of protocol names to their IDs in DQLite.
 func (st *State) getProtocolMap(ctx context.Context, tx *sqlair.TX) (map[string]int, error) {
-	getProtocols, err := st.Prepare("SELECT &protocol.* FROM protocol", protocol{})
+	getProtocols, err := st.Prepare(
+		"SELECT &protocol.* FROM protocol INDEXED BY idx_protocol_id_protocol",
+		protocol{},
+	)
 	if err != nil {
 		return nil, errors.Errorf("preparing get protocol ID statement: %w", err)
 	}

--- a/domain/upgrade/state/state_test.go
+++ b/domain/upgrade/state/state_test.go
@@ -57,7 +57,9 @@ func (s *stateSuite) TestEnsureUpgradeTypesMatchCore(c *tc.C) {
 	// This locks in the behaviour that the upgrade types in the database
 	// should match the upgrade types in the core upgrade package.
 
-	rows, err := db.Query(`SELECT id, type FROM upgrade_state_type`)
+	rows, err := db.Query(`
+SELECT id, type
+FROM upgrade_state_type INDEXED BY idx_upgrade_state_type_id_type`)
 	c.Assert(err, tc.ErrorIsNil)
 	defer rows.Close()
 

--- a/generate/export/state.tmpl
+++ b/generate/export/state.tmpl
@@ -22,7 +22,7 @@ func (st *State) Export(ctx context.Context) (*v{{ .VersionToken }}.ModelExport,
 
 	// Prepare statements first using the typed samples from the generated types package.
 {{- range $i, $sn := .StructNames }}
-	stmt{{ $sn }}, err := sqlair.Prepare(`SELECT &{{ $sn }}.* FROM "{{ index $.TableNames $i }}"`, v{{ $.VersionToken }}.{{ $sn }}{})
+	stmt{{ $sn }}, err := sqlair.Prepare(`SELECT &{{ $sn }}.* FROM "{{ index $.TableNames $i }}" WHERE rowid >= -9223372036854775808`, v{{ $.VersionToken }}.{{ $sn }}{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing {{ $sn }} statement: %w", err)
 	}

--- a/internal/database/app/dqlite_other.go
+++ b/internal/database/app/dqlite_other.go
@@ -20,7 +20,12 @@ import (
 )
 
 // Option can be used to tweak app parameters.
-type Option func()
+type Option func(*appOptions)
+
+type appOptions struct {
+	log     client.LogFunc
+	tracing client.LogLevel
+}
 
 // WithAddress sets the network address of the application node.
 //
@@ -36,7 +41,7 @@ type Option func()
 //
 // The address must be stable across application restarts.
 func WithAddress(address string) Option {
-	return func() {}
+	return func(*appOptions) {}
 }
 
 // WithCluster must be used when starting a newly added application node for
@@ -45,7 +50,7 @@ func WithAddress(address string) Option {
 // It should contain the addresses of one or more applications nodes which are
 // already part of the cluster.
 func WithCluster(cluster []string) Option {
-	return func() {}
+	return func(*appOptions) {}
 }
 
 // WithTLS enables TLS encryption of network traffic.
@@ -56,25 +61,29 @@ func WithCluster(cluster []string) Option {
 // The "dial" parameter must hold the TLS configuration to use when
 // establishing outgoing connections to other application nodes.
 func WithTLS(listen *tls.Config, dial *tls.Config) Option {
-	return func() {}
+	return func(*appOptions) {}
 }
 
 // WithLogFunc sets a custom log function.
 func WithLogFunc(log client.LogFunc) Option {
-	return func() {}
+	return func(o *appOptions) {
+		o.log = log
+	}
 }
 
 // WithTracing will emit a log message at the given level every time a
 // statement gets executed.
 func WithTracing(level client.LogLevel) Option {
-	return func() {}
+	return func(o *appOptions) {
+		o.tracing = level
+	}
 }
 
 // WithBusyTimeout sets the timeout for how long a database operation will wait
 // for a lock to be released before returning an error, tailoring the amount of
 // time a writer will wait for others to finish writing on the same database.
 func WithBusyTimeout(timeout time.Duration) Option {
-	return func() {}
+	return func(*appOptions) {}
 }
 
 // App is a high-level helper for initializing a typical dqlite-based Go
@@ -83,12 +92,20 @@ func WithBusyTimeout(timeout time.Duration) Option {
 // It takes care of starting a dqlite node and registering a dqlite Go SQL
 // driver.
 type App struct {
-	dir string
+	dir        string
+	driverName string
 }
 
 // New creates a new application node.
 func New(dir string, options ...Option) (*App, error) {
-	return &App{dir: dir}, nil
+	var cfg appOptions
+	for _, option := range options {
+		option(&cfg)
+	}
+	return &App{
+		dir:        dir,
+		driverName: sqliteDriverName(cfg),
+	}, nil
 }
 
 // Ready can be used to wait for a node to complete tasks that
@@ -109,7 +126,7 @@ func (a *App) Open(_ context.Context, name string) (*sql.DB, error) {
 	if name != ":memory:" {
 		path = filepath.Join(a.dir, name)
 	}
-	db, err := sql.Open("sqlite3", path)
+	db, err := sql.Open(a.driverName, path)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/database/app/sqlite_driver_other.go
+++ b/internal/database/app/sqlite_driver_other.go
@@ -1,0 +1,10 @@
+//go:build !dqlite && (!cgo || (!sqlite_trace && !trace))
+
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package app
+
+func sqliteDriverName(appOptions) string {
+	return "sqlite3"
+}

--- a/internal/database/app/sqlite_driver_trace.go
+++ b/internal/database/app/sqlite_driver_trace.go
@@ -1,0 +1,211 @@
+//go:build !dqlite && cgo && (sqlite_trace || trace)
+
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package app
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct sqlite3 sqlite3;
+typedef struct sqlite3_stmt sqlite3_stmt;
+
+#define SQLITE_OK 0
+#define SQLITE_ROW 100
+#define SQLITE_STMTSTATUS_FULLSCAN_STEP 1
+
+int sqlite3_finalize(sqlite3_stmt*);
+void sqlite3_free(void*);
+char *sqlite3_mprintf(const char*, ...);
+int sqlite3_prepare_v2(sqlite3*, const char*, int, sqlite3_stmt**, const char**);
+int sqlite3_step(sqlite3_stmt*);
+int sqlite3_stmt_status(sqlite3_stmt*, int, int);
+const unsigned char *sqlite3_column_text(sqlite3_stmt*, int);
+
+static int hasPrefix(const char *s, const char *prefix) {
+	while (*prefix != 0) {
+		if (*s != *prefix) {
+			return 0;
+		}
+		s++;
+		prefix++;
+	}
+	return 1;
+}
+
+static int contains(const char *s, const char *substr) {
+	const char *h;
+	const char *n;
+	if (*substr == 0) {
+		return 1;
+	}
+	for (; *s != 0; s++) {
+		h = s;
+		n = substr;
+		while (*h != 0 && *n != 0 && *h == *n) {
+			h++;
+			n++;
+		}
+		if (*n == 0) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static int fullScanSteps(uintptr_t stmt) {
+	return sqlite3_stmt_status(
+		(sqlite3_stmt *)stmt,
+		SQLITE_STMTSTATUS_FULLSCAN_STEP,
+		1
+	);
+}
+
+static int scansOnlyCoveringIndex(uintptr_t dbHandle, const char *query) {
+	sqlite3_stmt *stmt = 0;
+	char *explain = sqlite3_mprintf("EXPLAIN QUERY PLAN %s", query);
+	int sawCoveringIndexScan = 0;
+	int rc;
+
+	if (explain == 0) {
+		return 0;
+	}
+
+	rc = sqlite3_prepare_v2(
+		(sqlite3 *)dbHandle,
+		explain,
+		-1,
+		&stmt,
+		0
+	);
+	sqlite3_free(explain);
+	if (rc != SQLITE_OK) {
+		return 0;
+	}
+
+	while (sqlite3_step(stmt) == SQLITE_ROW) {
+		const char *detail = (const char *)sqlite3_column_text(stmt, 3);
+		if (detail == 0 || !hasPrefix(detail, "SCAN ")) {
+			continue;
+		}
+		if (!contains(detail, "USING COVERING INDEX")) {
+			sqlite3_finalize(stmt);
+			return 0;
+		}
+		sawCoveringIndexScan = 1;
+	}
+
+	sqlite3_finalize(stmt);
+	return sawCoveringIndexScan;
+}
+*/
+import "C"
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/mattn/go-sqlite3"
+
+	"github.com/juju/juju/internal/database/client"
+)
+
+var sqliteDriverID atomic.Uint64
+
+func sqliteDriverName(cfg appOptions) string {
+	if cfg.log == nil || cfg.tracing == client.LogNone {
+		return "sqlite3"
+	}
+
+	name := fmt.Sprintf("sqlite3-fullscan-%d", sqliteDriverID.Add(1))
+	sql.Register(name, &sqlite3.SQLiteDriver{
+		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			return conn.SetTrace(newFullScanTraceConfig(cfg.log, cfg.tracing))
+		},
+	})
+	return name
+}
+
+func newFullScanTraceConfig(
+	log client.LogFunc,
+	level client.LogLevel,
+) *sqlite3.TraceConfig {
+	var mu sync.Mutex
+	statements := make(map[uintptr]string)
+
+	return &sqlite3.TraceConfig{
+		Callback: func(info sqlite3.TraceInfo) int {
+			switch info.EventCode {
+			case sqlite3.TraceStmt:
+				if info.StmtHandle == 0 || strings.HasPrefix(info.StmtOrTrigger, "--") {
+					return 0
+				}
+
+				query := info.ExpandedSQL
+				if query == "" {
+					query = info.StmtOrTrigger
+				}
+
+				mu.Lock()
+				statements[info.StmtHandle] = query
+				mu.Unlock()
+
+			case sqlite3.TraceProfile:
+				if info.StmtHandle == 0 {
+					return 0
+				}
+
+				fullScanSteps := int(C.fullScanSteps(C.uintptr_t(info.StmtHandle)))
+
+				mu.Lock()
+				query := statements[info.StmtHandle]
+				delete(statements, info.StmtHandle)
+				mu.Unlock()
+
+				if fullScanSteps == 0 {
+					return 0
+				}
+
+				if scansOnlyCoveringIndex(info.ConnHandle, query) {
+					return 0
+				}
+
+				log(
+					level,
+					fmt.Sprintf(
+						"sqlite statement performed full table scan: fullscan_steps=%d query=%q",
+						fullScanSteps,
+						query,
+					),
+				)
+			}
+
+			return 0
+		},
+		EventMask:       sqlite3.TraceStmt | sqlite3.TraceProfile,
+		WantExpandedSQL: true,
+	}
+}
+
+func scansOnlyCoveringIndex(connHandle uintptr, query string) bool {
+	if strings.TrimSpace(query) == "" {
+		return false
+	}
+	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "EXPLAIN ") {
+		return false
+	}
+
+	cQuery := C.CString(query)
+	defer C.free(unsafe.Pointer(cQuery))
+
+	return C.scansOnlyCoveringIndex(
+		C.uintptr_t(connHandle),
+		cQuery,
+	) == 1
+}

--- a/internal/database/app/sqlite_driver_trace_test.go
+++ b/internal/database/app/sqlite_driver_trace_test.go
@@ -1,0 +1,148 @@
+//go:build !dqlite && cgo && (sqlite_trace || trace)
+
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package app
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/internal/database/client"
+)
+
+type sqliteTraceSuite struct{}
+
+func TestSqliteTraceSuite(t *testing.T) {
+	tc.Run(t, &sqliteTraceSuite{})
+}
+
+func (s *sqliteTraceSuite) TestFullTableScanIsLogged(c *tc.C) {
+	var logs []string
+	db := s.openDB(c, &logs)
+
+	_, err := db.ExecContext(c.Context(), `
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    age INTEGER
+)`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	for i := range 10 {
+		_, err = db.ExecContext(
+			c.Context(),
+			"INSERT INTO users (name, age) VALUES (?, ?)",
+			fmt.Sprintf("user%d", i),
+			i%3,
+		)
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	rows, err := db.QueryContext(
+		c.Context(),
+		"SELECT * FROM users WHERE age = ?",
+		2,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	consumeRows(c, rows)
+
+	found := false
+	for _, log := range logs {
+		if strings.Contains(log, "full table scan") &&
+			strings.Contains(log, "SELECT * FROM users WHERE age = 2") {
+			found = true
+		}
+	}
+	c.Check(found, tc.IsTrue, tc.Commentf("logs: %#v", logs))
+}
+
+func (s *sqliteTraceSuite) TestCoveringIndexScanIsNotLogged(c *tc.C) {
+	var logs []string
+	db := s.openDB(c, &logs)
+
+	_, err := db.ExecContext(c.Context(), `
+CREATE TABLE schema (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    version INTEGER NOT NULL,
+    hash TEXT NOT NULL,
+    updated_at DATETIME NOT NULL
+)`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = db.ExecContext(
+		c.Context(),
+		"CREATE INDEX idx_schema_version_hash ON schema (version, hash)",
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	for i := range 10 {
+		_, err = db.ExecContext(
+			c.Context(),
+			"INSERT INTO schema (version, hash, updated_at) VALUES (?, ?, strftime('%s'))",
+			i,
+			fmt.Sprintf("hash%d", i),
+		)
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	rows, err := db.QueryContext(
+		c.Context(),
+		"SELECT version, hash FROM schema ORDER BY version",
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	consumeVersionHashRows(c, rows)
+
+	for _, log := range logs {
+		c.Check(log, tc.Not(tc.Contains), "SELECT version, hash FROM schema")
+	}
+}
+
+func (s *sqliteTraceSuite) openDB(c *tc.C, logs *[]string) *sql.DB {
+	app, err := New(c.MkDir(),
+		WithTracing(client.LogWarn),
+		WithLogFunc(func(_ client.LogLevel, msg string, args ...any) {
+			*logs = append(*logs, fmt.Sprintf(msg, args...))
+		}),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	db, err := app.Open(c.Context(), ":memory:")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Cleanup(func() {
+		c.Check(db.Close(), tc.ErrorIsNil)
+	})
+	return db
+}
+
+func consumeRows(c *tc.C, rows *sql.Rows) {
+	defer func() {
+		c.Check(rows.Close(), tc.ErrorIsNil)
+	}()
+
+	for rows.Next() {
+		var id int
+		var name string
+		var age int
+		c.Assert(rows.Scan(&id, &name, &age), tc.ErrorIsNil)
+	}
+	c.Assert(rows.Err(), tc.ErrorIsNil)
+}
+
+func consumeVersionHashRows(c *tc.C, rows *sql.Rows) {
+	defer func() {
+		c.Check(rows.Close(), tc.ErrorIsNil)
+	}()
+
+	for rows.Next() {
+		var version int
+		var hash string
+		c.Assert(rows.Scan(&version, &hash), tc.ErrorIsNil)
+	}
+	c.Assert(rows.Err(), tc.ErrorIsNil)
+}


### PR DESCRIPTION
Whilst reading about how lobste.rs migrated to sqlite, and reading the original failure of the migration piqued my interest. They hit an issue where lobste.rs was really slow when they migrated. On the retrospective was a comment stating:

 > Wishes:
 >
 >  1. I wish we could say in a test, "Fail if you encounter any full
 >     table scans". Which would have caught the perf issues we
 >     experienced during the first deploy.

I want that as well. We've been bitten by this multiple times, not just with sqlite, but also with mongo. Then just as luck would have it, someone on the internet stated that it was possible with ruby-on-rails[1].

Well, I got nerd sniped! If they can do it, surely we can? So with a bit of digging, it's possible[2].

With the way we've split the testing packages makes this a breeze. We just need to create a different tag, making it opt-in (for now). This won't work with the dqlite driver as is, so we're just going to piggy back on sqlite driver itself with a C extension.

We seem to be missing a lot of indexes. Some will be false positivies, but at least we now have the ability to verify.

 1. https://tenderlovemaking.com/2026/07/15/detecting-full-table-scans-with-sqlite/
 2. https://sqlite.org/c3ref/stmt_status.html

## QA steps

```sh
$ JUJU_TEST_VERBOSE=1 go test -tags sqlite_trace -v ./domain/application/state 2>&1 \
  | grep 'DEBUG.*sqlite statement performed full table scan' \
  | sed -n 's/.*query="\([^"]*\)".*/\1/p'
```

Example of the output can be seen https://gist.github.com/SimonRichardson/9f8947d9cf5f62298f3e11f519e598bd

Enjoy.