### PR TITLE
fix(cmr): ignore stale relation settings changes

### DIFF
--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -247,6 +247,10 @@ func (api *CrossModelRelationsAPIv3) handlePublishSettings(
 		applicationSettings,
 		unitSettings,
 	); err != nil {
+		if errors.Is(err, relationerrors.ApplicationNotFoundForRelation) {
+			return errors.NotFoundf(
+				"application %q for relation %q", applicationUUID, relationUUID)
+		}
 		return errors.Annotatef(err, "setting application and unit settings %q", relationUUID)
 	}
 

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	jujuerrors "github.com/juju/errors"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5"
@@ -553,6 +554,39 @@ func (s *facadeSuite) TestPublishRelationChangesHandlePublishSettingsApplication
 		},
 	})
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *facadeSuite) TestPublishRelationChangesHandlePublishSettingsApplicationNotInRelation(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	applicationUUID := tc.Must(c, application.NewUUID)
+	relationUUID := tc.Must(c, corerelation.NewUUID)
+	unitSettings := map[unit.Name]map[string]string{
+		"foo/0": {"key": "value"},
+	}
+
+	s.crossModelRelationService.EXPECT().
+		EnsureUnitsExist(gomock.Any(), applicationUUID, []unit.Name{"foo/0"}).
+		Return(nil)
+	s.relationService.EXPECT().
+		SetRelationRemoteApplicationAndUnitSettings(
+			gomock.Any(), applicationUUID, relationUUID, nil, unitSettings,
+		).
+		Return(relationerrors.ApplicationNotFoundForRelation)
+
+	err := s.api(c).handlePublishSettings(
+		c.Context(),
+		relationUUID,
+		applicationUUID,
+		"foo",
+		params.RemoteRelationChangeEvent{
+			ChangedUnits: []params.RemoteRelationUnitChange{{
+				UnitId:   0,
+				Settings: map[string]any{"key": "value"},
+			}},
+		},
+	)
+	c.Assert(err, tc.ErrorIs, jujuerrors.NotFound)
 }
 
 func (s *facadeSuite) TestPublishRelationChangesHandlePublishSettingsApplicationUnitSettingsBadApplicationSettings(c *tc.C) {

--- a/domain/relation/state/remoterelation.go
+++ b/domain/relation/state/remoterelation.go
@@ -284,15 +284,33 @@ AND    u.application_uuid = $entityUUID.uuid
 				return relationerrors.CannotEnterScopeNotAlive
 			}
 
-			// Get the IDs of the applications in the relation.
-			appIDs, err := st.getApplicationsInRelation(ctx, tx, relationUUID)
+			// Remote relations can never be peer relations, but guard
+			// against the impossible state to fail fast rather than
+			// silently proceeding.
+			isPeer, err := st.isPeerRelation(ctx, tx, relationUUID)
 			if err != nil {
-				return errors.Errorf("getting applications in relation: %w", err)
+				return errors.Errorf("checking if relation is peer: %w", err)
+			}
+			if isPeer {
+				return relationerrors.CannotEnterScopePeerRelation
 			}
 
-			// Ensure the unit can enter scope in this relation.
-			if err := st.checkUnitCanEnterScopeForRemoteRelation(ctx, tx, applicationUUID, appIDs); err != nil {
-				return errors.Capture(err)
+			// Ensure the unit's application is in the relation before entering
+			// scope.
+			inRelation, err := st.isApplicationInRelation(ctx, tx, relationUUID, applicationUUID)
+			if err != nil {
+				return errors.Errorf("checking application in relation: %w", err)
+			}
+			if !inRelation {
+				return relationerrors.ApplicationNotFoundForRelation
+			}
+
+			// If the unit application is a subordinate, it can not enter
+			// scope.
+			if subordinate, err := st.isSubordinate(ctx, tx, applicationUUID); err != nil {
+				return errors.Errorf("checking if application is subordinate: %w", err)
+			} else if subordinate {
+				return relationerrors.CannotEnterScopeForSubordinate
 			}
 
 			// Set all the unit settings that are available.
@@ -328,30 +346,59 @@ AND    u.application_uuid = $entityUUID.uuid
 	return nil
 }
 
-// checkUnitCanEnterScopeForRemoteRelation checks that the unit can enter scope
-// in the given relation.
-func (st *State) checkUnitCanEnterScopeForRemoteRelation(ctx context.Context, tx *sqlair.TX, unitsAppID string, appIDs []string) error {
-	// Check that the application of the unit is in the relation. Remote
-	// relations can not be peer relations, or for a subordinate unit.
-	switch len(appIDs) {
-	case 1: // Peer relation.
-		return relationerrors.CannotEnterScopePeerRelation
-	case 2: // Regular relation.
-		// Ensure the unit's application is in the relation before entering
-		// scope.
-		if !set.NewStrings(appIDs...).Contains(unitsAppID) {
-			return relationerrors.ApplicationNotFoundForRelation
-		}
-		// If the unit application is a subordinate, it can not enter scope.
-		if subordinate, err := st.isSubordinate(ctx, tx, unitsAppID); err != nil {
-			return errors.Errorf("checking if application is subordinate: %w", err)
-		} else if subordinate {
-			return relationerrors.CannotEnterScopeForSubordinate
-		}
-		return nil
-	default:
-		return errors.Errorf("unexpected number of applications in relation: %d", len(appIDs))
+// isApplicationInRelation checks if the given application is part of the
+// specified relation by querying the relation endpoints.
+func (st *State) isApplicationInRelation(
+	ctx context.Context,
+	tx *sqlair.TX,
+	relationUUID, appUUID string,
+) (bool, error) {
+	relUUID := entityUUID{UUID: relationUUID}
+	app := applicationUUID{UUID: appUUID}
+
+	stmt, err := st.Prepare(`
+SELECT &applicationUUID.application_uuid
+FROM   relation_endpoint re
+JOIN   application_endpoint ae ON re.endpoint_uuid = ae.uuid
+WHERE  re.relation_uuid = $entityUUID.uuid
+AND    ae.application_uuid = $applicationUUID.application_uuid
+`, relUUID, app)
+	if err != nil {
+		return false, errors.Capture(err)
 	}
+
+	err = tx.Query(ctx, stmt, relUUID, app).Get(&app)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Capture(err)
+	}
+	return true, nil
+}
+
+// isPeerRelation checks if the given relation is a peer relation
+// (i.e. it has exactly one endpoint) within an existing transaction.
+func (st *State) isPeerRelation(
+	ctx context.Context,
+	tx *sqlair.TX,
+	relationUUID string,
+) (bool, error) {
+	relUUID := entityUUID{UUID: relationUUID}
+
+	stmt, err := st.Prepare(`
+SELECT count(*) AS &rows.count
+FROM   relation_endpoint
+WHERE  relation_uuid = $entityUUID.uuid
+`, rows{}, relUUID)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	var found rows
+	if err := tx.Query(ctx, stmt, relUUID).Get(&found); err != nil {
+		return false, errors.Errorf("counting relation endpoints for uuid %q: %w", relationUUID, err)
+	}
+	return found.Count == 1, nil
 }
 
 func (st *State) insertRelationUnitSettings(

--- a/domain/relation/state/remoterelation.go
+++ b/domain/relation/state/remoterelation.go
@@ -210,6 +210,20 @@ WHERE relation_uuid = $relationStatus.relation_uuid
 // Additionally, it will prevent a unit from entering scope if:
 // - the relation is a peer relation
 // - the unit's application is a subordinate
+// - the unit's application is not part of the relation
+//
+// The following error types can be expected to be returned:
+//   - [relationerrors.ApplicationNotFoundForRelation] is returned if the
+//     application is not part of the relation.
+//   - [relationerrors.CannotEnterScopeNotAlive] is returned if the relation
+//     is not alive.
+//   - [relationerrors.CannotEnterScopePeerRelation] is returned if the
+//     relation is a peer relation.
+//   - [relationerrors.CannotEnterScopeForSubordinate] is returned if the
+//     unit's application is a subordinate.
+//   - [relationerrors.RelationNotFound] is returned if the relation UUID
+//     is not found.
+//   - [applicationerrors.UnitNotFound] is returned if a unit is not found.
 func (st *State) SetRelationRemoteApplicationAndUnitSettings(
 	ctx context.Context,
 	applicationUUID, relationUUID string,
@@ -323,6 +337,11 @@ func (st *State) checkUnitCanEnterScopeForRemoteRelation(ctx context.Context, tx
 	case 1: // Peer relation.
 		return relationerrors.CannotEnterScopePeerRelation
 	case 2: // Regular relation.
+		// Ensure the unit's application is in the relation before entering
+		// scope.
+		if !set.NewStrings(appIDs...).Contains(unitsAppID) {
+			return relationerrors.ApplicationNotFoundForRelation
+		}
 		// If the unit application is a subordinate, it can not enter scope.
 		if subordinate, err := st.isSubordinate(ctx, tx, unitsAppID); err != nil {
 			return errors.Errorf("checking if application is subordinate: %w", err)

--- a/domain/relation/state/remoterelation_test.go
+++ b/domain/relation/state/remoterelation_test.go
@@ -414,6 +414,48 @@ func (s *remoteRelationSuite) TestSetRelationRemoteApplicationAndUnitSettingsMul
 	c.Check(err, tc.ErrorMatches, `.*missing: \[app1\/4\]`)
 }
 
+func (s *remoteRelationSuite) TestSetRelationRemoteApplicationAndUnitSettingsApplicationNotInRelation(c *tc.C) {
+	endpoint1 := domainrelation.Endpoint{
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-1",
+			Role:      charm.RoleProvider,
+			Interface: "database",
+			Scope:     charm.ScopeGlobal,
+		},
+	}
+	endpoint2 := domainrelation.Endpoint{
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-2",
+			Role:      charm.RoleRequirer,
+			Interface: "database",
+			Scope:     charm.ScopeGlobal,
+		},
+	}
+	charmRelationUUID1 := s.addCharmRelation(c, s.fakeCharmUUID1, endpoint1.Relation)
+	charmRelationUUID2 := s.addCharmRelation(c, s.fakeCharmUUID2, endpoint2.Relation)
+	applicationEndpointUUID1 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelationUUID1)
+	applicationEndpointUUID2 := s.addApplicationEndpoint(c, s.fakeApplicationUUID2, charmRelationUUID2)
+	relationUUID := s.addRelation(c)
+	s.addRelationEndpoint(c, relationUUID, applicationEndpointUUID1)
+	s.addRelationEndpoint(c, relationUUID, applicationEndpointUUID2)
+
+	charmUUID := s.addCharm(c)
+	applicationUUID := s.addApplication(c, charmUUID, "unrelated-application")
+	unitName := coreunittesting.GenNewName(c, "unrelated-application/0")
+	s.addUnit(c, unitName, applicationUUID, charmUUID)
+
+	err := s.state.SetRelationRemoteApplicationAndUnitSettings(
+		c.Context(),
+		applicationUUID.String(),
+		relationUUID.String(),
+		nil,
+		map[string]map[string]string{
+			unitName.String(): {"foo": "bar"},
+		},
+	)
+	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationNotFoundForRelation)
+}
+
 func (s *remoteRelationSuite) TestSetRelationRemoteApplicationAndUnitSettingsSubordinate(c *tc.C) {
 	// Arrange: Populate charm metadata with subordinate data.
 	s.addCharmMetadata(c, s.fakeCharmUUID1, true)

--- a/domain/relation/state/remoterelation_test.go
+++ b/domain/relation/state/remoterelation_test.go
@@ -621,7 +621,7 @@ func (s *remoteRelationSuite) TestSetRelationRemoteApplicationAndUnitSettingsUni
 	)
 
 	// Assert:
-	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
+	c.Assert(err, tc.ErrorIs, relationerrors.ApplicationNotFoundForRelation)
 }
 
 func (s *remoteRelationSuite) TestSetRelationRemoteApplicationAndUnitSettingsRelationNotFound(c *tc.C) {


### PR DESCRIPTION
Removing a cross-model relation can race with an already queued unit-settings event. The offering
controller could resolve the old synthetic application after its relation endpoint was removed,
causing a generic “expected 1 row inserted, got 0” error and restarting the remote relation consumer
worker.

The relation state now verifies that a unit’s application belongs to the relation before entering
scope. The API translates a mismatch into the existing not-found response, allowing the consumer
worker to safely ignore the stale event while normal removal deletes the offer connection. Regression
tests cover both the state validation and API error translation.

## QA steps

Taken from https://github.com/juju/juju/issues/22347 :
```
$ juju bootstrap microk8s cos
$ juju add-model cos
$ juju deploy prometheus-k8s prom
$ juju offer prom:metrics-endpoint
```
```
$ juju bootstrap lxd test
$ juju switch controller
$ juju consume admin/cos.prom
$ juju integrate controller:metrics-endpoint prom:metrics-endpoint
```
Check user exists in the db.
Then remove the relation

The user should have gone.
```
juju show-user juju-metrics-r1
{}
ERROR juju-metrics-r1: user "juju-metrics-r1" not found
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22347.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9810](https://warthogs.atlassian.net/browse/JUJU-9810)


[JUJU-9810]: https://warthogs.atlassian.net/browse/JUJU-9810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ