### PR TITLE
fix: implement generate-password for K8s applications

### DIFF
--- a/scripts/generate-password/main.go
+++ b/scripts/generate-password/main.go
@@ -4,7 +4,9 @@
 package main
 
 import (
+	"encoding/base64"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -74,7 +76,9 @@ func main() {
 		fmt.Printf(`db.%s.update({"_id": "%s:%s"}, {$set: {"passwordhash": "%s"}})`+"\n",
 			collection, modelUUID, agent, hash)
 		if agentType == targetK8sApplicationAgent {
-			printK8sApplicationAgentHelp(*modelName, agent, passwd)
+			if err := printK8sApplicationAgentHelp(os.Stdout, *modelName, agent, passwd); err != nil {
+				log.Fatal(err)
+			}
 		}
 	}
 }
@@ -99,13 +103,14 @@ func classifyTarget(target string) (targetType, string) {
 	return targetK8sApplicationAgent, "applications"
 }
 
-func printK8sApplicationAgentHelp(modelName, appName, password string) {
-	fmt.Printf("\nKubernetes application-agent recovery:\n")
-	fmt.Printf("1. Update the introduction secret for new pod init.\n")
-	fmt.Printf(
-		`kubectl -n %s patch secret %s-application-config --type merge -p '{"stringData":{"JUJU_K8S_APPLICATION_PASSWORD":"%s"}}'`+"\n",
-		modelName, appName, password,
-	)
-	fmt.Printf("2. Restart workload pods so init picks up the new secret.\n")
-	fmt.Printf(`kubectl -n %s delete pod -l app.kubernetes.io/name=%s`+"\n", modelName, appName)
+func printK8sApplicationAgentHelp(w io.Writer, modelName, appName, password string) error {
+	passwordBase64 := base64.StdEncoding.EncodeToString([]byte(password))
+	_, err := fmt.Fprintf(w, `
+Kubernetes application-agent recovery:
+1. Update the introduction secret for new pod init.
+kubectl -n %s patch secret %s-application-config --type merge -p '{"data":{"JUJU_K8S_APPLICATION_PASSWORD":"%s"}}'
+2. Restart workload pods so init picks up the new secret.
+kubectl -n %s delete pod -l app.kubernetes.io/name=%s
+`, modelName, appName, passwordBase64, modelName, appName)
+	return err
 }

--- a/scripts/generate-password/main.go
+++ b/scripts/generate-password/main.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	gnuflag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s <modeluuid> <agent> [<password>] | --user <username> [password]\n", os.Args[0])
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: %s <modeluuid> <agent> [<password>] | --user <username> [password]\n", os.Args[0])
 		gnuflag.PrintDefaults()
 	}
 	user := gnuflag.String("user", "", "supply a username to generate a password instead of modeluuid and agent")
@@ -63,20 +63,44 @@ func main() {
 		fmt.Printf(`db.users.update({"_id": "%s"}, {"$set": {"passwordsalt": "%s", "passwordhash": "%s"}})`+"\n",
 			*user, salt, hash)
 	} else {
-		var collection string
-		if strings.Index(agent, "/") < 0 {
-			// must be a machine
-			collection = "machines"
-			if _, err := strconv.Atoi(agent); err != nil {
-				fmt.Fprintf(os.Stderr, "Agent %q isn't a unit agent (with /) nor an integer machine id\n", agent)
-				os.Exit(1)
-			}
-		} else {
-			collection = "units"
-		}
+		agentType, collection := classifyTarget(agent)
 		hash := utils.AgentPasswordHash(passwd)
 		fmt.Printf("oldpassword: %s\n", passwd)
 		fmt.Printf(`db.%s.update({"_id": "%s:%s"}, {$set: {"passwordhash": "%s"}})`+"\n",
 			collection, modelUUID, agent, hash)
+		if agentType == targetK8sApplicationAgent {
+			printK8sApplicationAgentHelp(agent)
+		}
 	}
+}
+
+type targetType int
+
+const (
+	targetMachine targetType = iota
+	targetUnit
+	targetK8sApplicationAgent
+)
+
+func classifyTarget(target string) (targetType, string) {
+	if strings.Contains(target, "/") {
+		return targetUnit, "units"
+	}
+	if _, err := strconv.Atoi(target); err == nil {
+		return targetMachine, "machines"
+	}
+	// Bare non-integer, non-unit identifiers are treated as CAAS application
+	// names for password-hash recovery.
+	return targetK8sApplicationAgent, "applications"
+}
+
+func printK8sApplicationAgentHelp(appName string) {
+	fmt.Printf("\nKubernetes application-agent recovery:\n")
+	fmt.Printf("1. Update the introduction secret for new pod init.\n")
+	fmt.Printf(
+		`kubectl -n <model-namespace> patch secret %s-application-config --type merge -p '{"stringData":{"JUJU_K8S_APPLICATION_PASSWORD":"<password>"}}'`+"\n",
+		appName,
+	)
+	fmt.Printf("2. Restart workload pods so init picks up the new secret.\n")
+	fmt.Printf(`kubectl -n <model-namespace> delete pod -l app.kubernetes.io/name=%s`+"\n", appName)
 }

--- a/scripts/generate-password/main.go
+++ b/scripts/generate-password/main.go
@@ -16,10 +16,11 @@ import (
 
 func main() {
 	gnuflag.Usage = func() {
-		_, _ = fmt.Fprintf(os.Stderr, "Usage: %s <modeluuid> <agent> [<password>] | --user <username> [password]\n", os.Args[0])
+		_, _ = fmt.Fprintf(os.Stderr, "Usage: %s [--model-name <modelname>] <modeluuid> <agent> [<password>] | --user <username> [password]\n", os.Args[0])
 		gnuflag.PrintDefaults()
 	}
 	user := gnuflag.String("user", "", "supply a username to generate a password instead of modeluuid and agent")
+	modelName := gnuflag.String("model-name", "", "Kubernetes model name, used as the namespace for application-agent recovery")
 	gnuflag.Parse(true)
 	args := gnuflag.Args()
 	var modelUUID string
@@ -64,12 +65,16 @@ func main() {
 			*user, salt, hash)
 	} else {
 		agentType, collection := classifyTarget(agent)
+		if agentType == targetK8sApplicationAgent && *modelName == "" {
+			_, _ = fmt.Fprintln(os.Stderr, "--model-name is required for Kubernetes application-agent recovery")
+			os.Exit(1)
+		}
 		hash := utils.AgentPasswordHash(passwd)
 		fmt.Printf("oldpassword: %s\n", passwd)
 		fmt.Printf(`db.%s.update({"_id": "%s:%s"}, {$set: {"passwordhash": "%s"}})`+"\n",
 			collection, modelUUID, agent, hash)
 		if agentType == targetK8sApplicationAgent {
-			printK8sApplicationAgentHelp(agent)
+			printK8sApplicationAgentHelp(*modelName, agent, passwd)
 		}
 	}
 }
@@ -94,13 +99,13 @@ func classifyTarget(target string) (targetType, string) {
 	return targetK8sApplicationAgent, "applications"
 }
 
-func printK8sApplicationAgentHelp(appName string) {
+func printK8sApplicationAgentHelp(modelName, appName, password string) {
 	fmt.Printf("\nKubernetes application-agent recovery:\n")
 	fmt.Printf("1. Update the introduction secret for new pod init.\n")
 	fmt.Printf(
-		`kubectl -n <model-namespace> patch secret %s-application-config --type merge -p '{"stringData":{"JUJU_K8S_APPLICATION_PASSWORD":"<password>"}}'`+"\n",
-		appName,
+		`kubectl -n %s patch secret %s-application-config --type merge -p '{"stringData":{"JUJU_K8S_APPLICATION_PASSWORD":"%s"}}'`+"\n",
+		modelName, appName, password,
 	)
 	fmt.Printf("2. Restart workload pods so init picks up the new secret.\n")
-	fmt.Printf(`kubectl -n <model-namespace> delete pod -l app.kubernetes.io/name=%s`+"\n", appName)
+	fmt.Printf(`kubectl -n %s delete pod -l app.kubernetes.io/name=%s`+"\n", modelName, appName)
 }


### PR DESCRIPTION
Give the instructions for how to update a K8s application with a newly generated password.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

I have not completed a full validation workflow. However it should look something like:

```sh
$ juju bootstrap k8s src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
$ juju models --uuid
$ ./generate-password juju-qa-test UUID --model-name moveme1
```

That should give you the ability to update the mongo database with a password which is *not* the application password, causing the units to start failing. Essentially, apply the database patch, but not the Kubernetes application patch.
You should start seeing failures in `juju debug-log`.
Once you have done so, run the same `generate-password` again, only this time apply both the database patch and the kubernetes patch. At which point, the unit should come back up happily.

## Documentation changes

I don't believe we have official documentation for `generate-password` but the help text should be correct.

## Links

**Issue:** Fixes #22532.
