### PR TITLE
fix: app leader pattern matching in `juju status`

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -229,6 +229,7 @@ func (c *Client) FullStatus(ctx context.Context, args params.StatusParams) (para
 			context.allAppsUnitsCharmBindings.applications,
 			context.units,
 			context.allMachines,
+			context.leaders,
 		)
 		context.applyNameMatches(matches)
 		matchedUnits = matches.Units

--- a/domain/status/service/filter_names.go
+++ b/domain/status/service/filter_names.go
@@ -4,6 +4,8 @@
 package service
 
 import (
+	"strings"
+
 	coremachine "github.com/juju/juju/core/machine"
 	coreunit "github.com/juju/juju/core/unit"
 )
@@ -19,11 +21,18 @@ type NameMatchResult struct {
 // MatchStatusNames matches exact machine, application, and unit names from the
 // supplied status snapshot and expands the result enough to keep status output
 // coherent.
+//
+// Patterns of the form "appname/leader" are resolved to the current leader unit
+// name using leaders before matching. Patterns whose application has no known
+// leader are left unchanged and will not match any entity.
+//
+// The patterns slice is mutated.
 func MatchStatusNames(
 	patterns []string,
 	applications map[string]Application,
 	units map[coreunit.Name]Unit,
 	machines map[coremachine.Name]Machine,
+	leaders map[string]string,
 ) NameMatchResult {
 	result := newNameMatchResult()
 	if len(patterns) == 0 {
@@ -37,6 +46,20 @@ func MatchStatusNames(
 			result.addMachine(machineName)
 		}
 		return result
+	}
+
+	if len(leaders) > 0 {
+		// Resolve "appname/leader" patterns to the actual leader unit name in
+		// place. Patterns whose application has no known leader are left unchanged.
+		for i, p := range patterns {
+			appName, ok := strings.CutSuffix(p, "/leader")
+			if !ok {
+				continue
+			}
+			if leaderUnit, ok := leaders[appName]; ok {
+				patterns[i] = leaderUnit
+			}
+		}
 	}
 
 	patternSet := make(map[string]struct{}, len(patterns))

--- a/domain/status/service/filter_names_test.go
+++ b/domain/status/service/filter_names_test.go
@@ -47,7 +47,7 @@ func (s *filterNamesSuite) TestMatchStatusNamesApplicationIncludesUnitsAndMachin
 		"2": {Name: "2"},
 	}
 
-	result := MatchStatusNames([]string{"mysql"}, applications, units, machines)
+	result := MatchStatusNames([]string{"mysql"}, applications, units, machines, nil)
 
 	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"mysql"})
 	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"mysql/0"})
@@ -83,7 +83,7 @@ func (s *filterNamesSuite) TestMatchStatusNamesPrincipalUnitIncludesSubordinate(
 		"1": {Name: "1"},
 	}
 
-	result := MatchStatusNames([]string{"mysql/0"}, applications, units, machines)
+	result := MatchStatusNames([]string{"mysql/0"}, applications, units, machines, nil)
 
 	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"logging", "mysql"})
 	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"logging/0", "mysql/0"})
@@ -119,7 +119,7 @@ func (s *filterNamesSuite) TestMatchStatusNamesSubordinateIncludesPrincipal(c *t
 		"1": {Name: "1"},
 	}
 
-	result := MatchStatusNames([]string{"logging/0"}, applications, units, machines)
+	result := MatchStatusNames([]string{"logging/0"}, applications, units, machines, nil)
 
 	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"logging", "mysql"})
 	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"logging/0", "mysql/0"})
@@ -155,11 +155,113 @@ func (s *filterNamesSuite) TestMatchStatusNamesMachineIncludesHostedUnitsAndCont
 		"1":       {Name: "1"},
 	}
 
-	result := MatchStatusNames([]string{"0"}, applications, units, machines)
+	result := MatchStatusNames([]string{"0"}, applications, units, machines, nil)
 
 	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"mysql", "wordpress"})
 	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"mysql/0", "wordpress/0"})
 	c.Check(sortedMachineNames(result), tc.DeepEquals, []string{"0", "0/lxd/0"})
+}
+
+func (s *filterNamesSuite) TestMatchStatusNamesLeaderPatternResolvesToLeaderUnit(c *tc.C) {
+	units := map[coreunit.Name]Unit{
+		"mysql/0": {
+			ApplicationName: "mysql",
+			MachineName:     new(coremachine.Name("1")),
+		},
+		"mysql/1": {
+			ApplicationName: "mysql",
+			MachineName:     new(coremachine.Name("2")),
+		},
+	}
+	applications := map[string]Application{
+		"mysql": {
+			Units: map[coreunit.Name]Unit{
+				"mysql/0": units["mysql/0"],
+				"mysql/1": units["mysql/1"],
+			},
+		},
+	}
+	machines := map[coremachine.Name]Machine{
+		"1": {Name: "1"},
+		"2": {Name: "2"},
+	}
+	leaders := map[string]string{"mysql": "mysql/1"}
+
+	result := MatchStatusNames([]string{"mysql/leader"}, applications, units, machines, leaders)
+	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"mysql"})
+	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"mysql/1"})
+	c.Check(sortedMachineNames(result), tc.DeepEquals, []string{"2"})
+}
+
+func (s *filterNamesSuite) TestMatchStatusNamesLeaderPatternUnresolvedMatchesNothing(c *tc.C) {
+	units := map[coreunit.Name]Unit{
+		"mysql/0": {
+			ApplicationName: "mysql",
+			MachineName:     new(coremachine.Name("1")),
+		},
+	}
+	applications := map[string]Application{
+		"mysql": {
+			Units: map[coreunit.Name]Unit{
+				"mysql/0": units["mysql/0"],
+			},
+		},
+	}
+	machines := map[coremachine.Name]Machine{
+		"1": {Name: "1"},
+	}
+
+	// No leader known — pattern is left unchanged and matches nothing.
+	result := MatchStatusNames([]string{"mysql/leader"}, applications, units, machines, nil)
+	c.Check(sortedAppNames(result), tc.HasLen, 0)
+	c.Check(sortedUnitNames(result), tc.HasLen, 0)
+	c.Check(sortedMachineNames(result), tc.HasLen, 0)
+}
+
+func (s *filterNamesSuite) TestMatchStatusNamesLeaderPatternMixedWithOtherPatterns(c *tc.C) {
+	units := map[coreunit.Name]Unit{
+		"mysql/0": {
+			ApplicationName: "mysql",
+			MachineName:     new(coremachine.Name("1")),
+		},
+		"mysql/1": {
+			ApplicationName: "mysql",
+			MachineName:     new(coremachine.Name("2")),
+		},
+		"wordpress/0": {
+			ApplicationName: "wordpress",
+			MachineName:     new(coremachine.Name("3")),
+		},
+	}
+	applications := map[string]Application{
+		"mysql": {
+			Units: map[coreunit.Name]Unit{
+				"mysql/0": units["mysql/0"],
+				"mysql/1": units["mysql/1"],
+			},
+		},
+		"wordpress": {
+			Units: map[coreunit.Name]Unit{
+				"wordpress/0": units["wordpress/0"],
+			},
+		},
+	}
+	machines := map[coremachine.Name]Machine{
+		"1": {Name: "1"},
+		"2": {Name: "2"},
+		"3": {Name: "3"},
+	}
+	leaders := map[string]string{"mysql": "mysql/1"}
+
+	// mysql/leader resolves to mysql/1; wordpress/leader has no leader and is
+	// dropped; mysql/0 is a direct unit pattern.
+	result := MatchStatusNames(
+		[]string{"mysql/leader", "wordpress/leader", "mysql/0"},
+		applications, units, machines, leaders,
+	)
+	c.Check(sortedAppNames(result), tc.DeepEquals, []string{"mysql"})
+	c.Check(sortedUnitNames(result), tc.DeepEquals, []string{"mysql/0", "mysql/1"})
+	c.Check(sortedMachineNames(result), tc.DeepEquals, []string{"1", "2"})
 }
 
 func sortedAppNames(result NameMatchResult) []string {

--- a/tests/suites/model/status.sh
+++ b/tests/suites/model/status.sh
@@ -38,7 +38,7 @@ run_status_filters() {
 
 	# Filter by a/leader: only the leader unit should appear.
 	OUT=$(juju status --format yaml a/leader 2>/dev/null)
-	echo "${OUT}" | yq ".applications.a.units | has(\"${a_leader}\")" | check "true"
+	echo "${OUT}" | yq '.applications.a.units | keys | .[]' | check "${a_leader}"
 	check_not_contains "$(echo "${OUT}" | yq '.applications | keys | .[]')" "b"
 
 	# Filter by machine 0: machine 0 and its unit should appear; no other

--- a/tests/suites/model/status.sh
+++ b/tests/suites/model/status.sh
@@ -1,3 +1,57 @@
+run_status_filters() {
+	echo
+
+	file="${TEST_DIR}/test-status-filters.log"
+	ensure "status-filters" "${file}"
+
+	# Deploy two applications with two units each.
+	juju deploy ubuntu-lite a -n 2
+	juju deploy ubuntu-lite b -n 2
+	wait_for "a" "$(idle_condition "a" 0)"
+	wait_for "a" "$(idle_condition "a" 1)"
+	wait_for "b" "$(idle_condition "b" 0)"
+	wait_for "b" "$(idle_condition "b" 1)"
+
+	# No filter: both applications and all four units must appear.
+	OUT=$(juju status --format yaml 2>/dev/null)
+	echo "${OUT}" | yq '.applications | has("a")' | check "true"
+	echo "${OUT}" | yq '.applications | has("b")' | check "true"
+	echo "${OUT}" | yq '.applications.a.units | has("a/0")' | check "true"
+	echo "${OUT}" | yq '.applications.a.units | has("a/1")' | check "true"
+	echo "${OUT}" | yq '.applications.b.units | has("b/0")' | check "true"
+	echo "${OUT}" | yq '.applications.b.units | has("b/1")' | check "true"
+
+	# Determine which unit of application a holds leadership.
+	a_leader=$(echo "${OUT}" | yq '.applications.a.units | to_entries[] | select(.value.leader == true) | .key')
+	echo "Leader of a: ${a_leader}"
+
+	# Filter by application name: only app a and its units should appear.
+	OUT=$(juju status --format yaml a 2>/dev/null)
+	echo "${OUT}" | yq '.applications | has("a")' | check "true"
+	check_not_contains "$(echo "${OUT}" | yq '.applications | keys | .[]')" "b"
+
+	# Filter by unit a/1: only a/1 should appear under application a.
+	OUT=$(juju status --format yaml a/1 2>/dev/null)
+	echo "${OUT}" | yq '.applications.a.units | has("a/1")' | check "true"
+	check_not_contains "$(echo "${OUT}" | yq '.applications.a.units | keys | .[]')" "a/0"
+	check_not_contains "$(echo "${OUT}" | yq '.applications | keys | .[]')" "b"
+
+	# Filter by a/leader: only the leader unit should appear.
+	OUT=$(juju status --format yaml a/leader 2>/dev/null)
+	echo "${OUT}" | yq ".applications.a.units | has(\"${a_leader}\")" | check "true"
+	check_not_contains "$(echo "${OUT}" | yq '.applications | keys | .[]')" "b"
+
+	# Filter by machine 0: machine 0 and its unit should appear; no other
+	# machines should be present.
+	OUT=$(juju status --format yaml 0 2>/dev/null)
+	echo "${OUT}" | yq '.machines | has("0")' | check "true"
+	check_not_contains "$(echo "${OUT}" | yq '.machines | keys | .[]')" "\"1\""
+	check_not_contains "$(echo "${OUT}" | yq '.machines | keys | .[]')" "\"2\""
+	check_not_contains "$(echo "${OUT}" | yq '.machines | keys | .[]')" "\"3\""
+
+	destroy_model "status-filters"
+}
+
 # Tests that juju status for empty models is consistent.
 # There should be an empty space between the model status and the error text below it.
 run_empty_model_status() {
@@ -19,13 +73,12 @@ run_empty_model_status() {
 run_controller_ports() {
 	echo
 
-  ## Check open ports
-  OUT=$(juju status -m controller --format=json | yq '.applications.controller.units["controller/0"]."open-ports".[]')
-  check_contains "$OUT" "17070/tcp"
-  check_contains "$OUT" "17022/tcp"
+	## Check open ports
+	OUT=$(juju status -m controller --format=json | yq '.applications.controller.units["controller/0"]."open-ports".[]')
+	check_contains "$OUT" "17070/tcp"
+	check_contains "$OUT" "17022/tcp"
 
-  juju status -m controller | grep "controller/0" | awk '{print $6}' | check "17022,17070/tcp"
-
+	juju status -m controller | grep "controller/0" | awk '{print $6}' | check "17022,17070/tcp"
 }
 
 test_model_status() {
@@ -39,6 +92,7 @@ test_model_status() {
 
 		cd .. || exit
 
+		run "run_status_filters"
 		run "run_empty_model_status"
 		run "run_controller_ports"
 	)


### PR DESCRIPTION
When an `<app>/leader` pattern is passed to `juju status`, it should return
the leader of that application, as if the user had passed `<app>/<leader unit num>`.

This passes the leadership map to the pattern matching function to achieve this.

It also adds missing coverage to the integration tests for `juju status` filter patterns.

## QA steps

Run shell tests `./main.sh model test_model_status`

Manual tests:
- Deploy an app with two units
- Run `juju status myapp/leader` should work
- Test that other filters like `0`, `myapp`, `myapp/0` still work.

## Documentation changes

N/A

## Links

**Issue:** Fixes #22919.
**Jira card:** [JUJU-10173](https://warthogs.atlassian.net/browse/JUJU-10173)

[JUJU-10173]: https://warthogs.atlassian.net/browse/JUJU-10173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ