### PR TITLE
test: fix brittle watchertests

### DIFF
--- a/state/watcher/hubwatcher_test.go
+++ b/state/watcher/hubwatcher_test.go
@@ -404,7 +404,7 @@ func (s *HubWatcherSuite) TestDetectsDeadReceivers(c *gc.C) {
 	// stack trace).
 	c.Assert(tw.Log(), jc.LogMatches, jc.SimpleMessages{{
 		loggo.CRITICAL,
-		`0x.......... programming error, e.ch=0x.......... did not accept {test a 22} - missing Unwatch\?\nwatch source:\ngoroutine .*`,
+		`(?s)0x[0-9a-f]+ programming error, e.ch=0x[0-9a-f]+ did not accept {test a 22} - missing Unwatch\?\nwatch source:\ngoroutine .*`,
 	}})
 }
 
@@ -435,7 +435,7 @@ func (s *HubWatcherSuite) TestWatchMultiDeadReceivers(c *gc.C) {
 	// stack trace).
 	c.Assert(tw.Log(), jc.LogMatches, jc.SimpleMessages{{
 		loggo.CRITICAL,
-		`0x.......... programming error, e.ch=0x.......... did not accept {test b 3} - missing Unwatch\?\nwatch source:\ngoroutine .*`,
+		`(?s)0x[0-9a-f]+ programming error, e.ch=0x[0-9a-f]+ did not accept {test b 3} - missing Unwatch\?\nwatch source:\ngoroutine .*`,
 	}})
 }
 
@@ -464,6 +464,6 @@ func (s *HubWatcherSuite) TestWatchCollectionDeadReceivers(c *gc.C) {
 	// stack trace).
 	c.Assert(tw.Log(), jc.LogMatches, jc.SimpleMessages{{
 		loggo.CRITICAL,
-		`0x.......... programming error, e.ch=0x.......... did not accept {test b 3} - missing Unwatch\?\nwatch source:\ngoroutine .*`,
+		`(?s)0x[0-9a-f]+ programming error, e.ch=0x[0-9a-f]+ did not accept {test b 3} - missing Unwatch\?\nwatch source:\ngoroutine .*`,
 	}})
 }

--- a/tests/suites/unit/unit_series.sh
+++ b/tests/suites/unit/unit_series.sh
@@ -6,20 +6,20 @@ run_unit_set_series() {
 	file="${TEST_DIR}/test-unit-series.log"
 	ensure "unit-series" "${file}"
 
-	echo "Deploy ubuntu jammy"
-	juju deploy ubuntu --base ubuntu@22.04
+	echo "Deploy ubuntu focal"
+	juju deploy ubuntu --base ubuntu@20.04
 
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
-	echo "Change application base to noble and add-unit"
-	juju set-application-base ubuntu noble
+	echo "Change application base to jammy and add-unit"
+	juju set-application-base ubuntu jammy
 	juju add-unit ubuntu
 
 	wait_for "ubuntu" "$(idle_condition "ubuntu" 0 1)"
 
 	echo "Check the base for machine of added unit"
 	juju status --format=json | yq -r '.machines | .["1"] | .base | .name' | grep "ubuntu"
-	juju status --format=json | yq -r '.machines | .["1"] | .base | .channel' | grep "24.04"
+	juju status --format=json | yq -r '.machines | .["1"] | .base | .channel' | grep "22.04"
 
 	destroy_model "unit-series"
 }


### PR DESCRIPTION
There's 2 test fixes:

1. unit tests for the hub watcher used brittle regexp for matching log entries (breaks depending on the host)
2. the ubuntu charm doesn't support noble so use a different base

## QA steps

state/watcher unit tests
unit suite ci test