### PR TITLE
fix(migration): ignore synthetic CMR units in version prechecks

### DIFF
--- a/domain/modelagent/service/service.go
+++ b/domain/modelagent/service/service.go
@@ -87,10 +87,11 @@ type ModelState interface {
 	// checks.
 	GetUnitsAgentBinaryMetadata(context.Context) (map[coreunit.Name]agentbinary.Metadata, error)
 
-	// GetUnitsNotAtTargetAgentVersion returns the list of units where their
-	// agent version is not the same as the models target agent version or who
-	// have no agent version reported at all. If no units exist that match the
-	// criteria an empty slice is returned.
+	// GetUnitsNotAtTargetAgentVersion returns the list of non-synthetic units
+	// where their agent version is not the same as the model's target agent
+	// version or who have no agent version reported at all. Synthetic CMR units
+	// are excluded because they do not run unit agents. If no units exist that
+	// match the criteria an empty slice is returned.
 	GetUnitsNotAtTargetAgentVersion(context.Context) ([]coreunit.Name, error)
 
 	// GetUnitRunningAgentBinaryVersion returns the running unit agent binary
@@ -478,9 +479,10 @@ func (s *Service) GetUnitsAgentBinaryMetadata(
 	return s.modelSt.GetUnitsAgentBinaryMetadata(ctx)
 }
 
-// GetUnitsNotAtTargetAgentVersion reports all of the units in the model that
-// are currently not at the desired target agent version. This also returns
-// units that have no reported agent version set. If all units are up to the
+// GetUnitsNotAtTargetAgentVersion reports all non-synthetic units in the
+// model that are currently not at the desired target agent version. This also
+// returns units that have no reported agent version set. Synthetic CMR units
+// are excluded because they do not run unit agents. If all units are up to the
 // target version or no units exist in the model a zero length slice is
 // returned.
 func (s *Service) GetUnitsNotAtTargetAgentVersion(

--- a/domain/modelagent/state/model/state.go
+++ b/domain/modelagent/state/model/state.go
@@ -815,10 +815,11 @@ FROM   unit
 	return rval, nil
 }
 
-// GetUnitsNotAtTargetAgentVersion returns the list of units where
-// their agent version is not the same as the models target agent version or
-// who have no agent version reproted at all. If no units exist that match
-// this criteria an empty slice is returned.
+// GetUnitsNotAtTargetAgentVersion returns the list of non-synthetic units
+// where their agent version is not the same as the model's target agent
+// version or who have no agent version reported at all. Synthetic CMR units
+// are excluded because they do not run unit agents. If no units exist that
+// match this criteria an empty slice is returned.
 func (st *State) GetUnitsNotAtTargetAgentVersion(
 	ctx context.Context,
 ) ([]coreunit.Name, error) {
@@ -828,14 +829,21 @@ func (st *State) GetUnitsNotAtTargetAgentVersion(
 	}
 
 	query := `
-SELECT &unitName.*
-FROM v_unit_target_agent_version
-WHERE version != target_version
-UNION
-SELECT name
-FROM unit
-WHERE uuid NOT IN (SELECT unit_uuid
-                   FROM v_unit_target_agent_version)
+WITH agent_units AS (
+    SELECT u.uuid AS unit_uuid,
+           u.name AS unit_name
+    FROM unit AS u
+    JOIN charm AS c ON c.uuid = u.charm_uuid
+    -- Don't include units from CMR charm source (source_id >= 2).
+    WHERE c.source_id < 2
+)
+SELECT au.unit_name AS &unitName.name
+FROM agent_units AS au
+LEFT JOIN v_unit_target_agent_version AS utav
+ON au.unit_uuid = utav.unit_uuid
+WHERE utav.unit_uuid IS NULL
+OR utav.version != utav.target_version
+ORDER BY au.unit_name
 `
 
 	queryStmt, err := st.Prepare(query, unitName{})

--- a/domain/modelagent/state/model/state_test.go
+++ b/domain/modelagent/state/model/state_test.go
@@ -619,6 +619,85 @@ func (s *modelStateSuite) TestUnitsNotAtTargetAgentVersionUnreported(c *tc.C) {
 	})
 }
 
+// TestUnitsNotAtTargetAgentVersionIgnoresSyntheticCMRUnits tests that
+// synthetic CMR units are excluded because they do not run unit agents.
+func (s *modelStateSuite) TestUnitsNotAtTargetAgentVersionIgnoresSyntheticCMRUnits(c *tc.C) {
+	s.createTestingApplicationWithName(c, "foo")
+	s.createTestingUnitForApplication(c, "foo")
+	unitUUID := s.createTestingUnitForApplication(c, "foo")
+
+	remoteAppUUID := s.createTestingApplicationWithName(c, "remote-app")
+	s.createTestingUnitForApplication(c, "remote-app")
+
+	// Convert the application to a synthetic CMR application after adding its
+	// unit. The application state rejects adding units to synthetic apps.
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE charm
+SET source_id = 2, architecture_id = NULL
+WHERE uuid = (
+    SELECT charm_uuid
+    FROM application
+    WHERE uuid = ?
+)`, remoteAppUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.setModelTargetAgentVersion(c, "4.0.1")
+	s.setUnitAgentVersion(c, unitUUID, "4.0.1")
+
+	st := NewState(s.TxnRunnerFactory())
+	list, err := st.GetUnitsNotAtTargetAgentVersion(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(list, tc.DeepEquals, []coreunit.Name{
+		coreunit.Name("foo/0"),
+	})
+}
+
+// TestUnitsNotAtTargetAgentVersionIgnoresSyntheticCMRUnitsStaleVersion
+// tests that a synthetic CMR unit is excluded even when a stale agent
+// version is recorded for it. The charm source filter is applied in the CTE
+// before the join on the target agent version view, so no version state on a
+// CMR unit can make it appear in the list.
+func (s *modelStateSuite) TestUnitsNotAtTargetAgentVersionIgnoresSyntheticCMRUnitsStaleVersion(c *tc.C) {
+	s.createTestingApplicationWithName(c, "foo")
+	unitUUID := s.createTestingUnitForApplication(c, "foo")
+
+	remoteAppUUID := s.createTestingApplicationWithName(c, "remote-app")
+	remoteUnitUUID := s.createTestingUnitForApplication(c, "remote-app")
+
+	// Convert the application to a synthetic CMR application after adding its
+	// unit. The application state rejects adding units to synthetic apps.
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE charm
+SET source_id = 2, architecture_id = NULL
+WHERE uuid = (
+    SELECT charm_uuid
+    FROM application
+    WHERE uuid = ?
+)`, remoteAppUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.setModelTargetAgentVersion(c, "4.1.0")
+	// Synthetic CMR units never report an agent version in practice, but
+	// record a stale one to prove the exclusion holds regardless of any
+	// recorded version state.
+	s.setUnitAgentVersion(c, remoteUnitUUID, "4.0.1")
+	// A normal unit behind the target version must still be reported.
+	s.setUnitAgentVersion(c, unitUUID, "4.0.1")
+
+	st := NewState(s.TxnRunnerFactory())
+	list, err := st.GetUnitsNotAtTargetAgentVersion(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(list, tc.DeepEquals, []coreunit.Name{
+		coreunit.Name("foo/0"),
+	})
+}
+
 // TestUnitsNotAtTargetAgentVersionFallingBehind is testing that when a
 // unit's agent version is behind that of the target for the model it is
 // reported in the list.


### PR DESCRIPTION
Synthetic CMR applications materialise remote units in the model, but those units do not run an agent
and therefore never report a `unit_agent_version`. The migration source precheck treated every unit
without a reported version as lagging, causing models with a related consumed offer to fail before
migration starts.

Restrict the agent-version precheck to units backed by normal local or charmhub charms. Synthetic CMR
units are excluded, while normal units that are missing or behind their target agent version continue to
block migration. 
This is done simply by checking the source of the charm for the given units.


## QA steps

Although migrations 4.0->4.0 are not allowed (and we will add a guard later), this is only done as a simple way to prove that the source prechecks succeed. Later when 4.0->4.1 migrations are fully finished, this won't block.

```
# Source controller and offering model.
juju bootstrap localhost src
juju add-model offering -c src
juju deploy juju-qa-dummy-source --base ubuntu@22.04
juju offer dummy-source:sink

# Consumer model: consume and relate the offer.
juju add-model consuming -c src
juju deploy juju-qa-dummy-sink --base ubuntu@22.04
juju consume src:admin/offering.dummy-source
juju relate dummy-sink dummy-source

# Wait until the offer is connected. 
juju status -m src:offering --format json | \
    jq '.offers["dummy-source"]["active-connected-count"]'
```
```
# Bootstrap a destination controller and migrate the offering model.
juju bootstrap localhost dst
juju migrate src:offering dst
```
Before this change, migration fails during source prechecks with:
```
there exists units in the model that are not running the target agent version
... [remote-<uuid>/0]
```

## Links


<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10142](https://warthogs.atlassian.net/browse/JUJU-10142)


[JUJU-10142]: https://warthogs.atlassian.net/browse/JUJU-10142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ