### PR TITLE
(2.9) fix(openstack): delete orphaned cinder attachments during volume destroy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/dustin/go-humanize v1.0.1
-	github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4
+	github.com/go-goose/goose/v5 v5.1.7
 	github.com/go-logr/logr v1.4.3
 	github.com/go-macaroon-bakery/macaroon-bakery/v3 v3.0.2
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hH
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4 h1:IzjmVasvOk8hqDbP0uSOTFZRTSsP4WYmVl9VcQPS92o=
-github.com/go-goose/goose/v5 v5.0.0-20220707165353-781664254fe4/go.mod h1:BxICmnmP7QlxZhKP2BHkpWQS0tbb3LrsrLtd9TQyyms=
+github.com/go-goose/goose/v5 v5.1.7 h1:Knfot0QcBz/pAiW3UgO1Lk1qckiadeO6I9AMVX6dd6o=
+github.com/go-goose/goose/v5 v5.1.7/go.mod h1:wm2H9/ef6rvcIrvqv9WumylTUczf8m/f103RkZwYNdA=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -481,7 +481,12 @@ func destroyVolume(ctx context.ProviderCallContext, storageAdapter OpenstackStor
 		// ordinary detach can't finalise, and this frees the wedged volume.
 		// Cinder returns 409 while it's still in use, in which case we wait.
 		if !issuedDeleteAttachment {
+			attemptedDeleteAttachment := false
 			for _, a := range v.Attachments {
+				if a.AttachmentId == "" {
+					continue
+				}
+				attemptedDeleteAttachment = true
 				if err := storageAdapter.DeleteAttachment(a.AttachmentId); err != nil {
 					if gooseerrors.IsConflict(err) {
 						return false, nil
@@ -498,7 +503,7 @@ func destroyVolume(ctx context.ProviderCallContext, storageAdapter OpenstackStor
 					}
 				}
 			}
-			issuedDeleteAttachment = true
+			issuedDeleteAttachment = attemptedDeleteAttachment
 		}
 		return false, nil
 	})

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -498,6 +498,10 @@ func destroyVolume(ctx context.ProviderCallContext, storageAdapter OpenstackStor
 						logger.Warningf("cannot delete attachment for volume %q (not permitted for these credentials); waiting for it to detach", volumeId)
 						break
 					}
+					if gooseerrors.IsNotImplemented(err) {
+						logger.Warningf("cannot delete attachment for volume %q (not supported by the Block Storage API); waiting for it to detach", volumeId)
+						break
+					}
 					if !IsNotFoundError(err) {
 						return false, errors.Trace(err)
 					}

--- a/provider/openstack/cinder.go
+++ b/provider/openstack/cinder.go
@@ -36,7 +36,9 @@ const (
 	autoAssignedMountPoint = ""
 
 	volumeStatusAvailable = "available"
+	volumeStatusAttaching = "attaching"
 	volumeStatusDeleting  = "deleting"
+	volumeStatusDetaching = "detaching"
 	volumeStatusError     = "error"
 	volumeStatusInUse     = "in-use"
 )
@@ -447,16 +449,16 @@ func destroyVolume(ctx context.ProviderCallContext, storageAdapter OpenstackStor
 	// still be in-use when the instance it is attached to is
 	// in the process of being terminated.
 	var issuedDetach bool
+	var issuedDeleteAttachment bool
 	volume, err := waitVolume(storageAdapter, volumeId, func(v *cinder.Volume) (bool, error) {
 		switch v.Status {
+		case volumeStatusAvailable, volumeStatusDeleting, volumeStatusError:
+			return true, nil
+		case volumeStatusInUse, volumeStatusAttaching, volumeStatusDetaching:
+			// Detach / delete attachment below.
 		default:
 			// Not ready for deletion; keep waiting.
 			return false, nil
-		case volumeStatusAvailable, volumeStatusDeleting, volumeStatusError:
-			return true, nil
-		case volumeStatusInUse:
-			// Detach below.
-			break
 		}
 		// Volume is still attached, so detach it.
 		if !issuedDetach {
@@ -474,6 +476,29 @@ func destroyVolume(ctx context.ProviderCallContext, storageAdapter OpenstackStor
 				}
 			}
 			issuedDetach = true
+		}
+		// Also delete the attachment directly: if the instance is gone the
+		// ordinary detach can't finalise, and this frees the wedged volume.
+		// Cinder returns 409 while it's still in use, in which case we wait.
+		if !issuedDeleteAttachment {
+			for _, a := range v.Attachments {
+				if err := storageAdapter.DeleteAttachment(a.AttachmentId); err != nil {
+					if gooseerrors.IsConflict(err) {
+						return false, nil
+					}
+					if gooseerrors.IsForbidden(err) {
+						// The attachment-delete policy is not granted to these
+						// credentials, so fall back to plain polling and let the
+						// volume settle on its own.
+						logger.Warningf("cannot delete attachment for volume %q (not permitted for these credentials); waiting for it to detach", volumeId)
+						break
+					}
+					if !IsNotFoundError(err) {
+						return false, errors.Trace(err)
+					}
+				}
+			}
+			issuedDeleteAttachment = true
 		}
 		return false, nil
 	})
@@ -694,6 +719,7 @@ type OpenstackStorage interface {
 	CreateVolume(cinder.CreateVolumeVolumeParams) (*cinder.Volume, error)
 	AttachVolume(serverId, volumeId, mountPoint string) (*nova.VolumeAttachment, error)
 	DetachVolume(serverId, attachmentId string) error
+	DeleteAttachment(attachmentId string) error
 	ListVolumeAttachments(serverId string) ([]nova.VolumeAttachment, error)
 	SetVolumeMetadata(volumeId string, metadata map[string]string) (map[string]string, error)
 	ListVolumeAvailabilityZones() ([]cinder.AvailabilityZone, error)
@@ -786,6 +812,17 @@ func (ga *openstackStorageAdapter) DeleteVolume(volumeId string) error {
 	if err := ga.cinderClient.DeleteVolume(volumeId); err != nil {
 		if IsNotFoundError(err) {
 			return errors.NotFoundf("volume %q", volumeId)
+		}
+		return err
+	}
+	return nil
+}
+
+// DeleteAttachment is part of the OpenstackStorage interface.
+func (ga *openstackStorageAdapter) DeleteAttachment(attachmentId string) error {
+	if err := ga.cinderClient.DeleteAttachment(attachmentId); err != nil {
+		if IsNotFoundError(err) {
+			return errors.NotFoundf("attachment %q", attachmentId)
 		}
 		return err
 	}

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -1066,9 +1066,18 @@ func (s *cinderVolumeSourceSuite) TestDestroyVolumesDeleteAttachmentOrphaned(c *
 }
 
 func (s *cinderVolumeSourceSuite) TestDestroyVolumesDeleteAttachmentForbidden(c *gc.C) {
-	// If the attachment-delete policy forbids these credentials cinder returns
-	// 403. The destroy must not fail on that: it falls back to plain polling
-	// and deletes the volume once it settles to "available".
+	s.assertDestroyVolumesDeleteAttachmentFallback(
+		c, gooseerrors.NewForbiddenf(nil, nil, "forbidden"),
+	)
+}
+
+func (s *cinderVolumeSourceSuite) TestDestroyVolumesDeleteAttachmentNotImplemented(c *gc.C) {
+	s.assertDestroyVolumesDeleteAttachmentFallback(
+		c, gooseerrors.NewNotImplementedf(nil, nil, "not implemented"),
+	)
+}
+
+func (s *cinderVolumeSourceSuite) assertDestroyVolumesDeleteAttachmentFallback(c *gc.C, deleteErr error) {
 	attempted := false
 	mockAdapter := &mockAdapter{
 		getVolume: func(volId string) (*cinder.Volume, error) {
@@ -1086,7 +1095,7 @@ func (s *cinderVolumeSourceSuite) TestDestroyVolumesDeleteAttachmentForbidden(c 
 		deleteAttachment: func(attId string) error {
 			c.Check(attId, gc.Equals, "att-1")
 			attempted = true
-			return gooseerrors.NewForbiddenf(nil, nil, "forbidden")
+			return deleteErr
 		},
 	}
 	volSource := openstack.NewCinderVolumeSource(mockAdapter, s.env)

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -847,6 +847,7 @@ type mockAdapter struct {
 	createVolume          func(cinder.CreateVolumeVolumeParams) (*cinder.Volume, error)
 	attachVolume          func(string, string, string) (*nova.VolumeAttachment, error)
 	detachVolume          func(string, string) error
+	deleteAttachment      func(string) error
 	listVolumeAttachments func(string) ([]nova.VolumeAttachment, error)
 	setVolumeMetadata     func(string, map[string]string) (map[string]string, error)
 	listAvailabilityZones func() ([]cinder.AvailabilityZone, error)
@@ -893,6 +894,14 @@ func (ma *mockAdapter) AttachVolume(serverId, volumeId, mountPoint string) (*nov
 		return ma.attachVolume(serverId, volumeId, mountPoint)
 	}
 	return nil, errors.NotImplementedf("AttachVolume")
+}
+
+func (ma *mockAdapter) DeleteAttachment(attachmentId string) error {
+	ma.MethodCall(ma, "DeleteAttachment", attachmentId)
+	if ma.deleteAttachment != nil {
+		return ma.deleteAttachment(attachmentId)
+	}
+	return ma.NextErr()
 }
 
 func (ma *mockAdapter) DetachVolume(serverId, attachmentId string) error {
@@ -1019,4 +1028,111 @@ func (s *cinderVolumeSourceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	).Return(map[instance.Id]string{mockServerId: "zone-1"}, nil).AnyTimes()
 
 	return ctrl
+}
+
+func (s *cinderVolumeSourceSuite) TestDestroyVolumesDeleteAttachmentOrphaned(c *gc.C) {
+	// A volume wedged in "detaching" whose instance is gone: the Compute-API
+	// detach cannot finalize it, so destroyVolume deletes the attachment
+	// directly, after which the volume becomes available and is deleted.
+	deleted := false
+	mockAdapter := &mockAdapter{
+		getVolume: func(volId string) (*cinder.Volume, error) {
+			if deleted {
+				return &cinder.Volume{ID: volId, Status: "available"}, nil
+			}
+			return &cinder.Volume{
+				ID:     volId,
+				Status: "detaching",
+				Attachments: []cinder.VolumeAttachment{{
+					// On modern cinder Id is the volume id; the attachment is
+					// identified by AttachmentId, which is what attachment-delete
+					// must target.
+					Id: volId, AttachmentId: "att-1", ServerId: "srv-gone", VolumeId: volId,
+				}},
+			}, nil
+		},
+		deleteAttachment: func(attId string) error {
+			c.Check(attId, gc.Equals, "att-1")
+			deleted = true
+			return nil
+		},
+	}
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, s.env)
+	errs, err := volSource.DestroyVolumes(s.callCtx, []string{mockVolId})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, jc.DeepEquals, []error{nil})
+	mockAdapter.CheckCallNames(c,
+		"GetVolume", "DetachVolume", "DeleteAttachment", "GetVolume", "DeleteVolume")
+}
+
+func (s *cinderVolumeSourceSuite) TestDestroyVolumesDeleteAttachmentForbidden(c *gc.C) {
+	// If the attachment-delete policy forbids these credentials cinder returns
+	// 403. The destroy must not fail on that: it falls back to plain polling
+	// and deletes the volume once it settles to "available".
+	attempted := false
+	mockAdapter := &mockAdapter{
+		getVolume: func(volId string) (*cinder.Volume, error) {
+			if attempted {
+				return &cinder.Volume{ID: volId, Status: "available"}, nil
+			}
+			return &cinder.Volume{
+				ID:     volId,
+				Status: "detaching",
+				Attachments: []cinder.VolumeAttachment{{
+					Id: volId, AttachmentId: "att-1", ServerId: "srv-1", VolumeId: volId,
+				}},
+			}, nil
+		},
+		deleteAttachment: func(attId string) error {
+			c.Check(attId, gc.Equals, "att-1")
+			attempted = true
+			return gooseerrors.NewForbiddenf(nil, nil, "forbidden")
+		},
+	}
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, s.env)
+	errs, err := volSource.DestroyVolumes(s.callCtx, []string{mockVolId})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, jc.DeepEquals, []error{nil})
+	mockAdapter.CheckCallNames(c,
+		"GetVolume", "DetachVolume", "DeleteAttachment", "GetVolume", "DeleteVolume")
+}
+
+func (s *cinderVolumeSourceSuite) TestDestroyVolumesDeleteAttachmentConflict(c *gc.C) {
+	// While the instance is still using the volume cinder refuses
+	// attachment-delete with 409 (Conflict). destroyVolume must not fail or give
+	// up on that: it keeps waiting and retries, and once the instance is gone the
+	// delete succeeds and the volume is removed.
+	conflicts := 1
+	deleted := false
+	mockAdapter := &mockAdapter{
+		getVolume: func(volId string) (*cinder.Volume, error) {
+			if deleted {
+				return &cinder.Volume{ID: volId, Status: "available"}, nil
+			}
+			return &cinder.Volume{
+				ID:     volId,
+				Status: "detaching",
+				Attachments: []cinder.VolumeAttachment{{
+					Id: volId, AttachmentId: "att-1", ServerId: "srv-1", VolumeId: volId,
+				}},
+			}, nil
+		},
+		deleteAttachment: func(attId string) error {
+			c.Check(attId, gc.Equals, "att-1")
+			if conflicts > 0 {
+				conflicts--
+				return gooseerrors.NewConflictf(nil, nil, "conflict")
+			}
+			deleted = true
+			return nil
+		},
+	}
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, s.env)
+	errs, err := volSource.DestroyVolumes(s.callCtx, []string{mockVolId})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, jc.DeepEquals, []error{nil})
+	mockAdapter.CheckCallNames(c,
+		"GetVolume", "DetachVolume", "DeleteAttachment",
+		"GetVolume", "DeleteAttachment",
+		"GetVolume", "DeleteVolume")
 }

--- a/provider/openstack/cinder_test.go
+++ b/provider/openstack/cinder_test.go
@@ -1097,6 +1097,39 @@ func (s *cinderVolumeSourceSuite) TestDestroyVolumesDeleteAttachmentForbidden(c 
 		"GetVolume", "DetachVolume", "DeleteAttachment", "GetVolume", "DeleteVolume")
 }
 
+func (s *cinderVolumeSourceSuite) TestDestroyVolumesSkipsEmptyAttachmentId(c *gc.C) {
+	getVolumeCalls := 0
+	var deletedAttachmentIds []string
+	mockAdapter := &mockAdapter{
+		getVolume: func(volId string) (*cinder.Volume, error) {
+			getVolumeCalls++
+			if getVolumeCalls == 3 {
+				return &cinder.Volume{ID: volId, Status: "available"}, nil
+			}
+			attachmentId := ""
+			if getVolumeCalls == 2 {
+				attachmentId = "att-1"
+			}
+			return &cinder.Volume{
+				ID:     volId,
+				Status: "detaching",
+				Attachments: []cinder.VolumeAttachment{{
+					Id: volId, AttachmentId: attachmentId, ServerId: "srv-1", VolumeId: volId,
+				}},
+			}, nil
+		},
+		deleteAttachment: func(attachmentId string) error {
+			deletedAttachmentIds = append(deletedAttachmentIds, attachmentId)
+			return nil
+		},
+	}
+	volSource := openstack.NewCinderVolumeSource(mockAdapter, s.env)
+	errs, err := volSource.DestroyVolumes(s.callCtx, []string{mockVolId})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(errs, jc.DeepEquals, []error{nil})
+	c.Assert(deletedAttachmentIds, jc.DeepEquals, []string{"att-1"})
+}
+
 func (s *cinderVolumeSourceSuite) TestDestroyVolumesDeleteAttachmentConflict(c *gc.C) {
 	// While the instance is still using the volume cinder refuses
 	// attachment-delete with 409 (Conflict). destroyVolume must not fail or give

--- a/provider/openstack/export_test.go
+++ b/provider/openstack/export_test.go
@@ -147,7 +147,7 @@ var GetVolumeEndpointURL = getVolumeEndpointURL
 func GetModelGroupNames(e environs.Environ) ([]string, error) {
 	env := e.(*Environ)
 	neutronFw := env.firewaller.(*neutronFirewaller)
-	groups, err := env.neutron().ListSecurityGroupsV2()
+	groups, err := env.neutron().ListSecurityGroupsV2(neutron.ListSecurityGroupsV2Query{})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -469,7 +469,7 @@ func (c *neutronFirewaller) ensureGroup(name string, rules []neutron.RuleInfoV2)
 	} else if err != nil && strings.Contains(err.Error(), "failed to find security group") {
 		// TODO(hml): We should use a typed error here.  SecurityGroupByNameV2
 		// doesn't currently return one for this case.
-		g, err := neutronClient.CreateSecurityGroupV2(name, "juju group")
+		g, err := neutronClient.CreateSecurityGroupV2(name, "juju group", nil)
 		if err != nil {
 			return zeroGroup, err
 		}
@@ -590,7 +590,7 @@ func newRuleInfoSetFromRuleInfo(rules []neutron.RuleInfoV2) ruleInfoSet {
 
 func (c *neutronFirewaller) deleteSecurityGroups(ctx context.ProviderCallContext, match func(name string) bool) error {
 	neutronClient := c.environ.neutron()
-	securityGroups, err := neutronClient.ListSecurityGroupsV2()
+	securityGroups, err := neutronClient.ListSecurityGroupsV2(neutron.ListSecurityGroupsV2Query{})
 	if err != nil {
 		handleCredentialError(err, ctx)
 		return errors.Annotate(err, "cannot list security groups")
@@ -627,7 +627,7 @@ func (c *neutronFirewaller) DeleteAllModelGroups(ctx context.ProviderCallContext
 // UpdateGroupController implements Firewaller interface.
 func (c *neutronFirewaller) UpdateGroupController(ctx context.ProviderCallContext, controllerUUID string) error {
 	neutronClient := c.environ.neutron()
-	groups, err := neutronClient.ListSecurityGroupsV2()
+	groups, err := neutronClient.ListSecurityGroupsV2(neutron.ListSecurityGroupsV2Query{})
 	if err != nil {
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
@@ -666,7 +666,7 @@ func (c *neutronFirewaller) updateGroupControllerUUID(group *neutron.SecurityGro
 		return errors.Trace(err)
 	}
 	client := c.environ.neutron()
-	_, err = client.UpdateSecurityGroupV2(group.Id, newName, group.Description)
+	_, err = client.UpdateSecurityGroupV2(group.Id, newName, group.Description, nil)
 	return errors.Trace(err)
 }
 
@@ -772,7 +772,7 @@ func (c *neutronFirewaller) matchingGroup(ctx context.ProviderCallContext, nameR
 		return neutron.SecurityGroupV2{}, err
 	}
 	neutronClient := c.environ.neutron()
-	allGroups, err := neutronClient.ListSecurityGroupsV2()
+	allGroups, err := neutronClient.ListSecurityGroupsV2(neutron.ListSecurityGroupsV2Query{})
 	if err != nil {
 		handleCredentialError(err, ctx)
 		return neutron.SecurityGroupV2{}, err

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -906,7 +906,7 @@ func (s *localServerSuite) TestStartInstanceDeletesSecurityGroupsOnFailure(c *gc
 
 func assertSecurityGroups(c *gc.C, env environs.Environ, expected []string) {
 	neutronClient := openstack.GetNeutronClient(env)
-	groups, err := neutronClient.ListSecurityGroupsV2()
+	groups, err := neutronClient.ListSecurityGroupsV2(neutron.ListSecurityGroupsV2Query{})
 	c.Assert(err, jc.ErrorIsNil)
 	for _, name := range expected {
 		found := false


### PR DESCRIPTION
Backport of #22753 to 2.9.

Destroying a model hangs forever when a cinder volume is wedged in detaching/attaching.
Detach is orchestrated by nova, so if the instance is removed before nova finalizes it, the attachment is orphaned and the volume never leaves the transitional state.
destroyVolume only issues a Compute-API detach and then polls, so the poll times out and the destroy retries forever.

This change deletes the attachment directly via the cinder Attachments API (DELETE /v3/{project}/attachments/{id}, OpenStack-API-Version: volume 3.27) right after requesting the ordinary Compute-API detach.
It is permitted for the volume's owner, so no admin rights are needed.
Cinder removes the attachment when the instance is gone.
It returns 409 (Conflict) while the volume is still in use, and we keep waiting in that case.
On 403 we log and fall back to plain polling, so such a deployment is no worse off than before.

In destroyVolume, a transitional detaching/attaching volume now falls through to DeleteAttachment(attachmentId) once per attachment, instead of polling blindly.
The attachment id comes from VolumeAttachment.AttachmentId (attachment_id), not Id.
On modern cinder (2026.1, v3) attachments[].id is the volume id.

The cinder changes are the same code as the 3.6 commits, only the package path differs.

2.9 was still on a 2022 goose, so the bump to v5.1.7 is a big jump.
It changes three neutron security group signatures, which now take a tags argument.
2.9 does not tag security groups, so those call sites pass no tags and behavior is unchanged.

Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~~Integration tests (https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~ provider-level behavior is exercised by the unit tests and the live QA below
- [ ] ~~doc.go (https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~ no package responsibilities changed

QA steps

Unit tests:

go test ./provider/openstack/ -check.f TestDestroyVolumesDeleteAttachment -count=1

Live (OpenStack 2026.1, cinder v3 mv 3.71), stock 2.9.57 controller against patched 2.9.61 controller:

1. juju deploy postgresql --storage pgdata=cinder,1G; wait for the volume to be in-use.
2. Orphan it with openstack server delete <instance-id>. The server is then gone, but the volume keeps an attachment pointing at it.
3. juju remove-machine 0 --force. The out-of-band delete leaves Juju's machine and filesystem records stale, which blocks storage-attachment cleanup before the volume is destroyed. The real bug already has the machine gone, so this just reproduces that state.
4. juju destroy-model fd-repro --no-prompt --destroy-storage.
  - Stock 2.9.57: destroy retries forever. The model status shows attempt 4 to destroy model failed (will retry): model not empty, found 1 volume, and the cinder volume stays in-use. It did not finish on its own after 13 minutes.
  - Patched 2.9.61: DeleteAttachment clears the orphan, the volume is deleted, and destroy-model completes in 24 seconds.

Deleting the orphaned attachment by hand with openstack volume attachment delete <attachment-id>, which is the same cinder call the patch makes, also frees the stock volume back to available.

Documentation changes

None. juju CLI output, flags and the client API are unchanged.

Links

- Backport of: #22753
- Related: #1845172 (https://bugs.launchpad.net/juju/+bug/1845172), #1784876 (https://bugs.launchpad.net/juju/+bug/1784876), #1854893 (https://bugs.launchpad.net/juju/+bug/1854893), nova #2060696 (https://bugs.launchpad.net/nova/+bug/2060696)
- Goose release used: go-goose/goose v5.1.7 (https://github.com/go-goose/goose/releases/tag/v5.1.7)