### PR TITLE
fix(authenticationworker): last key removal and worker error cleanup

### DIFF
--- a/internal/worker/authenticationworker/worker.go
+++ b/internal/worker/authenticationworker/worker.go
@@ -25,6 +25,10 @@ import (
 // Override for testing.
 var SSHUser = "ubuntu"
 
+// authorizedKeysFile is the name of the ssh authorized_keys file that the
+// worker manages, relative to the user's .ssh directory.
+const authorizedKeysFile = "authorized_keys"
+
 var logger = internallogger.GetLogger("juju.worker.authenticationworker")
 
 // Client provides the key updater api client.
@@ -207,7 +211,15 @@ func (a *AuthWorker) loop() error {
 				return errors.New("change channel closed")
 			}
 			if err := a.handleModelKeyUpdate(ctx); err != nil {
-				return errors.Trace(err)
+				// A Kill cancels the catacomb context, which surfaces here as a
+				// cancelled-context error from the API call. Report that as a
+				// normal shutdown (ErrDying) rather than a worker failure.
+				select {
+				case <-a.catacomb.Dying():
+					return a.catacomb.ErrDying()
+				default:
+					return errors.Trace(err)
+				}
 			}
 		}
 	}
@@ -273,7 +285,10 @@ func (a *AuthWorker) handleEphemeralRequest(req ephemeralRequest) error {
 		return nil
 	case removeOp:
 		fingerprint := gossh.FingerprintLegacyMD5(req.key)
-		if err := ssh.DeleteKeys(SSHUser, fingerprint); err != nil {
+		// Use DeleteKeysFromFile rather than DeleteKeys: the latter refuses to
+		// remove the final key in the file, which would leave a torn-down
+		// tunnel's ephemeral key authorised until the worker restarts.
+		if err := ssh.DeleteKeysFromFile(SSHUser, authorizedKeysFile, []string{fingerprint}); err != nil {
 			return errors.Trace(err)
 		}
 		return nil

--- a/internal/worker/authenticationworker/worker_test.go
+++ b/internal/worker/authenticationworker/worker_test.go
@@ -4,6 +4,7 @@
 package authenticationworker_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -310,6 +311,106 @@ func (s *workerSuite) TestAddAndRemoveEphemeralKey(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	s.waitSSHKeysUnordered(c, append(s.existingKeys, s.existingEnvKey))
+}
+
+// TestRemoveLastEphemeralKey asserts that removing an ephemeral key succeeds
+// even when it is the only key in the authorized_keys file. The underlying
+// DeleteKeys helper refuses to delete the final key, so the worker must use
+// the delete-all variant; otherwise a torn-down tunnel's key would remain
+// authorised until the worker restarts.
+func (s *workerSuite) TestRemoveLastEphemeralKey(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	// Clear the authorized_keys file (SetUpTest seeds one existing key) and
+	// start a worker with no model keys, so the ephemeral key becomes the only
+	// key present.
+	err := ssh.DeleteKeysFromFile(authenticationworker.SSHUser, "authorized_keys", []string{"existinguser@host"})
+	c.Assert(err, tc.ErrorIsNil)
+
+	ch := make(chan struct{}, 1)
+	watch := watchertest.NewMockNotifyWatcher(ch)
+	tag := names.NewMachineTag("666")
+	client := mocks.NewMockClient(ctrl)
+	client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return([]string{}, nil).AnyTimes()
+	client.EXPECT().WatchAuthorisedKeys(gomock.Any(), tag).Return(watch, nil)
+
+	authWorker, err := authenticationworker.NewWorker(client, agentConfig(c, tag))
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, authWorker)
+	s.waitSSHKeysUnordered(c, nil)
+
+	updater, ok := authWorker.(authenticationworker.EphemeralKeysUpdater)
+	c.Assert(ok, tc.IsTrue)
+
+	pub, _, _, _, err := gossh.ParseAuthorizedKey([]byte(sshtesting.ValidKeyThree.Key))
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = updater.AddEphemeralKey(pub, "tunnel-0")
+	c.Assert(err, tc.ErrorIsNil)
+	ephemeralKey := sshtesting.ValidKeyThree.Key + " Juju:Ephemeral:tunnel-0"
+	s.waitSSHKeysUnordered(c, []string{ephemeralKey})
+
+	// Removing the only key must succeed, leaving an empty key set.
+	err = updater.RemoveEphemeralKey(pub)
+	c.Assert(err, tc.ErrorIsNil)
+	s.waitSSHKeysUnordered(c, nil)
+}
+
+// TestKillDuringModelKeyUpdateReportsCleanShutdown asserts that killing the
+// worker while a model key update is in flight is reported as a normal
+// shutdown. A Kill cancels the catacomb context, which the in-flight
+// AuthorisedKeys call surfaces as a cancelled-context error; the worker must
+// translate that into ErrDying rather than reporting a failure to the runner.
+func (s *workerSuite) TestKillDuringModelKeyUpdateReportsCleanShutdown(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	ch := make(chan struct{}, 1)
+	watch := watchertest.NewMockNotifyWatcher(ch)
+
+	tag := names.NewMachineTag("666")
+	client := mocks.NewMockClient(ctrl)
+	client.EXPECT().WatchAuthorisedKeys(gomock.Any(), tag).Return(watch, nil)
+
+	// blocked signals that the model key update is in flight; release lets it
+	// return once the worker has been killed.
+	blocked := make(chan struct{})
+	release := make(chan struct{})
+	gomock.InOrder(
+		// The initial setUp synchronisation.
+		client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return(s.existingModelKeys, nil),
+		// The model key update triggered by the watcher: block until killed,
+		// then return the cancelled-context error the real client would.
+		client.EXPECT().AuthorisedKeys(gomock.Any(), tag).DoAndReturn(
+			func(ctx context.Context, _ names.MachineTag) ([]string, error) {
+				close(blocked)
+				<-release
+				return nil, ctx.Err()
+			},
+		),
+	)
+
+	authWorker, err := authenticationworker.NewWorker(client, agentConfig(c, tag))
+	c.Assert(err, tc.ErrorIsNil)
+	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey))
+
+	// Fire the watcher and wait for the model key update to be in flight.
+	ch <- struct{}{}
+	select {
+	case <-blocked:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out waiting for model key update to start")
+	}
+
+	// Kill the worker (cancelling the context), then release the API call so it
+	// returns the cancelled-context error.
+	authWorker.Kill()
+	close(release)
+
+	// A clean kill must observe ErrDying, not the cancelled-context failure.
+	err = workertest.CheckKilled(c, authWorker)
+	c.Check(err, tc.ErrorIsNil)
 }
 
 func (s *workerSuite) TestEphemeralKeyRemovedOnRestart(c *tc.C) {


### PR DESCRIPTION
This PR has some follow up robustness fixes for the authentication worker, addressing two review comments left on #22778 .

1. Deleting the last ephemeral key. RemoveEphemeralKey used ssh.DeleteKeys, which refuses to remove the final key in authorized_keys ("cannot delete all keys"). When a torn-down tunnel's ephemeral key was the only key present, removal failed and the key stayed authorised until the worker restarted. The remove path now uses ssh.DeleteKeysFromFile, whose delete-all variant permits removing the last key. This one might actually have been a no-op, because the system key will always be present, and as such, deleting our ephemeral key is always *safe*. I did it anyway because if in the future we do not require a system key, this feature will continue to function.

2. Second, killing the worker while a model key update was in flight was reported as a failure rather than a normal shutdown. The worker fetches the latest keys from the controller using its catacomb scoped context, and a Kill cancels that context — so an in flight AuthorisedKeys call returns a cancelled context error. Previously that error was returned as the worker's exit reason, causing an intentional stop to be treated as a crash. The loop now checks whether the worker is dying when the update errors, and returns a proper catacomb.ErrDying in that case so the shutdown is recognised as normal.

For both of these scenarios, I've added 2 additional worker tests to exercise the flows.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
N/A.