### PR TITLE
fix(machine): persist merged model constraints on add-machine

### DIFF
--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -145,7 +145,7 @@ func (s *ProviderService) mergeMachineAndModelConstraints(ctx context.Context, c
 
 	modelCons, err := s.st.GetModelConstraints(ctx)
 	if err != nil && !errors.Is(err, modelerrors.ConstraintsNotFound) {
-		return constraints.Value{}, errors.Errorf("retrieving model constraints constraints: %w	", err)
+		return constraints.Value{}, errors.Errorf("retrieving model constraints: %w", err)
 	}
 
 	mergedCons, err := validator.Merge(

--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -97,6 +97,12 @@ func (s *ProviderService) AddMachine(ctx context.Context, args domainmachine.Add
 		return AddMachineResults{}, errors.Errorf("prechecking instance for create machine: %w", err)
 	}
 
+	// Persist the merged constraints (model defaults with machine overrides)
+	// on the machine row, so that the provisioning path observes the
+	// effective constraints. This mirrors the application deployment path
+	// and the pre-4.0 behaviour.
+	args.Constraints = domainconstraints.DecodeConstraints(mergedCons)
+
 	_, machineNames, err := s.st.AddMachine(ctx, args)
 	if err != nil {
 		return AddMachineResults{}, errors.Capture(err)
@@ -126,8 +132,11 @@ func encodeOSType(ostype deployment.OSType) (string, error) {
 	}
 }
 
-// mergeMachineAndModelConstraints resolves given application constraints, taking
-// into account the model constraints
+// mergeMachineAndModelConstraints resolves given machine constraints, taking
+// into account the model constraints. Machine constraints take precedence
+// over model constraints. The returned value never has a Container
+// constraint set; machine constraints do not use a container constraint
+// value, so it is cleared before returning.
 func (s *ProviderService) mergeMachineAndModelConstraints(ctx context.Context, cons domainconstraints.Constraints) (constraints.Value, error) {
 	validator, err := s.constraintsValidator(ctx)
 	if err != nil {
@@ -141,8 +150,13 @@ func (s *ProviderService) mergeMachineAndModelConstraints(ctx context.Context, c
 
 	mergedCons, err := validator.Merge(domainconstraints.EncodeConstraints(modelCons), domainconstraints.EncodeConstraints(cons))
 	if err != nil {
-		return constraints.Value{}, errors.Errorf("merging application and model constraints: %w", err)
+		return constraints.Value{}, errors.Errorf("merging machine and model constraints: %w", err)
 	}
+
+	// Machine constraints do not use a container constraint value, so clear
+	// it to prevent a container constraint coming from the model constraints
+	// from being persisted on the machine row.
+	mergedCons.Container = nil
 
 	return mergedCons, nil
 }

--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -136,7 +136,7 @@ func encodeOSType(ostype deployment.OSType) (string, error) {
 // into account the model constraints. Machine constraints take precedence
 // over model constraints. The returned value never has a Container
 // constraint set; machine constraints do not use a container constraint
-// value, so it is cleared before returning.
+// value, so it is stripped from both inputs before merging.
 func (s *ProviderService) mergeMachineAndModelConstraints(ctx context.Context, cons domainconstraints.Constraints) (constraints.Value, error) {
 	validator, err := s.constraintsValidator(ctx)
 	if err != nil {
@@ -148,17 +148,27 @@ func (s *ProviderService) mergeMachineAndModelConstraints(ctx context.Context, c
 		return constraints.Value{}, errors.Errorf("retrieving model constraints constraints: %w	", err)
 	}
 
-	mergedCons, err := validator.Merge(domainconstraints.EncodeConstraints(modelCons), domainconstraints.EncodeConstraints(cons))
+	mergedCons, err := validator.Merge(
+		encodeMachineConstraints(modelCons),
+		encodeMachineConstraints(cons),
+	)
 	if err != nil {
 		return constraints.Value{}, errors.Errorf("merging machine and model constraints: %w", err)
 	}
 
-	// Machine constraints do not use a container constraint value, so clear
-	// it to prevent a container constraint coming from the model constraints
-	// from being persisted on the machine row.
-	mergedCons.Container = nil
-
 	return mergedCons, nil
+}
+
+// encodeMachineConstraints encodes domain constraints into a constraints
+// value suitable for machines. Machine constraints do not use a container
+// constraint value: machine container placement and type are represented
+// separately from constraints. Container is therefore stripped before any
+// merge, so it can neither participate in merge or conflict behaviour nor
+// be persisted on the machine row.
+func encodeMachineConstraints(cons domainconstraints.Constraints) constraints.Value {
+	value := domainconstraints.EncodeConstraints(cons)
+	value.Container = nil
+	return value
 }
 
 // constraintsValidator queries the provider for a constraints validator.

--- a/domain/machine/service/provider_test.go
+++ b/domain/machine/service/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/core/base"
 	coreconstraints "github.com/juju/juju/core/constraints"
 	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/domain/constraints"
@@ -195,6 +196,149 @@ func (s *providerServiceSuite) TestAddMachineContainer(c *tc.C) {
 	c.Check(res.MachineName, tc.Equals, machine.Name("0"))
 	c.Assert(res.ChildMachineName, tc.NotNil)
 	c.Check(*res.ChildMachineName, tc.Equals, machine.Name("0/lxd/0"))
+}
+
+// TestAddMachinePersistsMergedModelConstraints asserts that the constraints
+// persisted for a new machine are the model constraints merged with the
+// machine constraints, and not the raw machine constraints.
+func (s *providerServiceSuite) TestAddMachinePersistsMergedModelConstraints(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{
+		CpuCores: new(uint64(4)),
+		Mem:      new(uint64(1024)),
+	}, nil)
+	s.provider.EXPECT().ConstraintsValidator(gomock.Any()).Return(coreconstraints.NewValidator(), nil)
+	s.provider.EXPECT().PrecheckInstance(gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().AddMachine(gomock.Any(), domainmachine.AddMachineArgs{
+		Constraints: constraints.Constraints{
+			CpuCores: new(uint64(4)),
+			Mem:      new(uint64(1024)),
+		},
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	}).Return("netNodeUUID", []machine.Name{"name"}, nil)
+
+	s.expectCreateMachineStatusHistory(c, machine.Name("name"))
+
+	res, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(res.MachineName, tc.Equals, machine.Name("name"))
+}
+
+// TestAddMachineMachineConstraintsOverrideModelConstraints asserts that
+// machine constraints take precedence over model constraints when both are
+// persisted for a new machine.
+func (s *providerServiceSuite) TestAddMachineMachineConstraintsOverrideModelConstraints(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{
+		CpuCores: new(uint64(4)),
+		Mem:      new(uint64(1024)),
+	}, nil)
+	s.provider.EXPECT().ConstraintsValidator(gomock.Any()).Return(coreconstraints.NewValidator(), nil)
+	s.provider.EXPECT().PrecheckInstance(gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().AddMachine(gomock.Any(), domainmachine.AddMachineArgs{
+		Constraints: constraints.Constraints{
+			CpuCores: new(uint64(4)),
+			Mem:      new(uint64(2048)),
+		},
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	}).Return("netNodeUUID", []machine.Name{"name"}, nil)
+
+	s.expectCreateMachineStatusHistory(c, machine.Name("name"))
+
+	res, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Constraints: constraints.Constraints{
+			Mem: new(uint64(2048)),
+		},
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(res.MachineName, tc.Equals, machine.Name("name"))
+}
+
+// TestAddMachineModelContainerConstraintCleared asserts that a container
+// constraint coming from the model constraints is never persisted on the
+// machine row. Machine constraints do not use a container constraint value.
+func (s *providerServiceSuite) TestAddMachineModelContainerConstraintCleared(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{
+		Container: new(instance.LXD),
+		CpuCores:  new(uint64(4)),
+	}, nil)
+	s.provider.EXPECT().ConstraintsValidator(gomock.Any()).Return(coreconstraints.NewValidator(), nil)
+	s.provider.EXPECT().PrecheckInstance(gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().AddMachine(gomock.Any(), domainmachine.AddMachineArgs{
+		Constraints: constraints.Constraints{
+			CpuCores: new(uint64(4)),
+		},
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	}).Return("netNodeUUID", []machine.Name{"name"}, nil)
+
+	s.expectCreateMachineStatusHistory(c, machine.Name("name"))
+
+	res, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(res.MachineName, tc.Equals, machine.Name("name"))
+}
+
+// TestAddMachineMachineContainerConstraintCleared asserts that a container
+// constraint coming from the machine constraints is never persisted on the
+// machine row. Machine constraints do not use a container constraint value,
+// so it is cleared regardless of its source.
+func (s *providerServiceSuite) TestAddMachineMachineContainerConstraintCleared(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().GetModelConstraints(gomock.Any()).Return(constraints.Constraints{}, nil)
+	s.provider.EXPECT().ConstraintsValidator(gomock.Any()).Return(coreconstraints.NewValidator(), nil)
+	s.provider.EXPECT().PrecheckInstance(gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().AddMachine(gomock.Any(), domainmachine.AddMachineArgs{
+		Constraints: constraints.Constraints{
+			CpuCores: new(uint64(4)),
+		},
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	}).Return("netNodeUUID", []machine.Name{"name"}, nil)
+
+	s.expectCreateMachineStatusHistory(c, machine.Name("name"))
+
+	res, err := s.service.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Constraints: constraints.Constraints{
+			Container: new(instance.LXD),
+			CpuCores:  new(uint64(4)),
+		},
+		Platform: deployment.Platform{
+			OSType:  deployment.Ubuntu,
+			Channel: "22.04",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(res.MachineName, tc.Equals, machine.Name("name"))
 }
 
 // TestAddMachineError asserts that an error coming from the state layer is

--- a/tests/suites/constraints/constraints_vm.sh
+++ b/tests/suites/constraints/constraints_vm.sh
@@ -25,5 +25,18 @@ run_constraints_vm() {
 	check_ge "${machine1_cores}" "cores=4"
 	check_ge "${machine1_rootdisk}" "root-disk=16384M"
 
+	# Model constraints must propagate to machines added afterwards.
+	# Regression test for https://github.com/juju/juju/issues/22735
+	echo "Deploy a machine with model constraints applied"
+	juju set-model-constraints "cores=4"
+	juju add-machine
+
+	wait_for_machine_agent_status "2" "started"
+
+	echo "Ensure machine 2 honours the model constraint cores=4"
+	machine2_hardware=$(juju machines --format json | yq -r '.["machines"]["2"]["hardware"]')
+	machine2_cores=$(echo "$machine2_hardware" | awk '{for(i=1;i<=NF;i++){if($i ~ /cores/){print $i}}}')
+	check_ge "${machine2_cores}" "cores=4"
+
 	destroy_model "constraints-vm"
 }


### PR DESCRIPTION
## Why

Model-level constraints set via `juju set-model-constraints` were not
propagated to machines added with `juju add-machine`.
`ProviderService.AddMachine` merged model and machine constraints for
`PrecheckInstance` but persisted only the raw machine constraints, so the
provisioner never saw the model defaults at `StartInstance` time. This was a
regression from 3.6 (where `state.ResolveConstraints` merged model constraints
before persisting them on the machine row) and diverged from the 4.0
application deployment path, which already merges and persists at creation.

The fix persists the merged constraints (model defaults with machine overrides)
on the machine row, and clears the `container` constraint from the merged value
since machine rows do not carry a container constraint value (mirroring 3.6's
`resolveMachineConstraints`).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

No facade migration impact: machine migration imports constraints at the state
level (`CreateMachine` directly), so the merged values are re-imported as-is
with no double-merge against the target model constraints.

Reproduce the original bug (now fixed) on any VM cloud, e.g. LXD:

```sh
$ juju bootstrap lxd ctrl
$ juju add-model m
$ juju set-model-constraints cores=4
$ juju add-machine
$ juju machines --format json | yq -r '.["machines"]["0"]["hardware"]'
# hardware must include cores=4
```

The added bash regression in `tests/suites/constraints/constraints_vm.sh`
covers this automatically for all VM clouds:

```sh
$ cd tests && ./main.sh constraints test_constraints_common
```

## Documentation changes

None. Model constraints are already documented as applying to all machines;
this restores that behaviour for `add-machine`.

## Links

**Issue:** Fixes #22735.
**Jira card:** [JUJU-10072](https://warthogs.atlassian.net/browse/JUJU-10072)


[JUJU-10072]: https://warthogs.atlassian.net/browse/JUJU-10072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ