### PR TITLE
test(cloud_azure): add ip-family integration tests

### DIFF
--- a/tests/suites/cloud_azure/ip_family.sh
+++ b/tests/suites/cloud_azure/ip_family.sh
@@ -2,6 +2,14 @@ run_ip_family_dual_stack() {
 	(
 		log_file="${TEST_DIR}/ip-family-dual.log"
 
+		# The SSH reachability probes below require IPv6 egress on the CI
+		# runner; fail fast instead of paying for an Azure bootstrap that
+		# cannot be fully verified.
+		if ! ip -6 route show default | grep -q .; then
+			echo "==> ERROR: no IPv6 egress on CI runner, cannot verify SSH reachability"
+			return 1
+		fi
+
 		bootstrap_additional_args=(--constraints "ip-family=dual")
 		BOOTSTRAP_ADDITIONAL_ARGS="${bootstrap_additional_args[*]}" \
 			BOOTSTRAP_REUSE=false \
@@ -13,69 +21,100 @@ run_ip_family_dual_stack() {
 		# (mirrors constraints_model.sh:14).
 		juju switch controller
 
-		# Test #3: model-constraints includes ip-family=dual
+		# Test #1: model-constraints includes ip-family=dual
 		check_contains "$(juju model-constraints)" "ip-family=dual"
 
-		# Test #2: IPv6 reachability (per PR #22736 QA step 5).
-		ipv6_addr=$(juju show-machine 0 --format json |
-			yq -r '.machines["0"]["ip-addresses"][] | select(. | test(":"))' |
-			head -1)
+		# Test #2: the controller machine got an IPv6 address and is
+		# reachable over IPv6 (per PR #22736 QA step 5).
+		ipv6_addr=$(machine_ipv6 0)
 		if [[ -z ${ipv6_addr} ]]; then
 			echo "ERROR: no IPv6 address found on controller machine"
 			return 1
 		fi
-
-		# Port 22 is the only IPv6-open port at the NSG. Reaching auth
-		# ("Permission denied") proves reachability; timeout/unreachable
-		# would indicate no route. BatchMode makes the auth failure
-		# immediate and deterministic (no interactive password prompt).
-		# The probe runs only when the runner has IPv6 egress; the
-		# allocation check above is the primary assertion.
-		if ip -6 route show default | grep -q .; then
-			ssh_out=$(timeout 10 ssh -6 -o BatchMode=yes \
-				-o StrictHostKeyChecking=no -o ConnectTimeout=5 \
-				ubuntu@"${ipv6_addr}" hostname 2>&1 || true)
-			echo "${ssh_out}" >>"$log_file"
-			check_contains "${ssh_out}" "Permission denied"
-		else
-			echo "==> ERROR: no IPv6 egress on CI runner cannot verify SSH reachability"
+		controller_hostname=$(juju show-machine 0 --format json |
+			yq -r '.machines["0"]["hostname"]')
+		if [[ -z ${controller_hostname} ]]; then
+			echo "ERROR: controller machine has no hostname"
 			return 1
 		fi
 
-		# Tests #4/#5: post-bootstrap provisioning paths. Run them in the
+		# On the controller machine we have an ssh key, so the probe
+		# succeeds and returns the hostname.
+		check_ipv6_ssh_probe "${ipv6_addr}" "${controller_hostname}" "$log_file"
+
+		# Tests #3/#4: post-bootstrap provisioning paths. Run them in the
 		# harness-created "ip-family-dual" model: bootstrap --constraints
 		# lands only on the controller model (domain/model/bootstrap/
 		# bootstrap.go:213), so this model is constraint-free and each
 		# path must carry its own constraint. Machine IDs restart at 0.
 		juju switch ip-family-dual
 
-		# Test #4: per-machine constraint path
+		# Test #3: per-machine constraint path
 		# (machine domain -> provisioner -> StartInstance; PR #22736 QA step 3).
 		juju add-machine --constraints "ip-family=dual" >>"$log_file" 2>&1
 		wait_for_machine_agent_status "0" "started"
-		ipv6_m0=$(juju show-machine 0 --format json |
-			yq -r '.machines["0"]["ip-addresses"][] | select(. | test(":"))' |
-			head -1)
+		ipv6_m0=$(machine_ipv6 0)
 		if [[ -z ${ipv6_m0} ]]; then
 			echo "ERROR: no IPv6 on machine 0 (add-machine --constraints ip-family=dual)"
 			return 1
 		fi
 
-		# Test #5: application deploy constraint path
+		# Workload machines have no ssh key by default.
+		check_ipv6_ssh_probe "${ipv6_m0}" "Permission denied" "$log_file"
+
+		# Test #4: application deploy constraint path
 		# (application service -> provisioner -> StartInstance; PR #22736 QA step 4).
 		# Deploy provisions a fresh machine per unit by default -> machine 1.
 		juju deploy ubuntu --constraints "ip-family=dual" >>"$log_file" 2>&1
 		wait_for_machine_agent_status "1" "started"
-		ipv6_m1=$(juju show-machine 1 --format json |
-			yq -r '.machines["1"]["ip-addresses"][] | select(. | test(":"))' |
-			head -1)
+		ipv6_m1=$(machine_ipv6 1)
 		if [[ -z ${ipv6_m1} ]]; then
 			echo "ERROR: no IPv6 on machine 1 (deploy --constraints ip-family=dual)"
 			return 1
 		fi
 
+		check_ipv6_ssh_probe "${ipv6_m1}" "Permission denied" "$log_file"
+
 		destroy_controller "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
 	)
+}
+
+# machine_ipv6 echoes the first IPv6 address of the given machine.
+# Candidates are restricted to hex digits and colons with at least two
+# colons, and anything shaped like a MAC address is excluded.
+machine_ipv6() {
+	local id
+
+	id=${1}
+
+	juju show-machine "${id}" --format json |
+		MACHINE_ID="${id}" yq -r '.machines[strenv(MACHINE_ID)]["ip-addresses"][] |
+			select(. | test("^[0-9a-fA-F:]+$") and test(":.*:") and
+				(test("^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$") | not))' |
+		head -1
+}
+
+# check_ipv6_ssh_probe probes SSH over IPv6 on the given address and checks
+# the output against an expected string. Port 22 is the only IPv6-open port
+# at the NSG. On the controller machine an ssh key is available, so the
+# remote command succeeds and returns the hostname; workload machines have
+# no ssh key by default, so we expect "Permission denied", which still
+# proves IPv6 reachability. A timeout/unreachable error would indicate no
+# route. BatchMode makes auth failures immediate and deterministic (no
+# interactive password prompt).
+check_ipv6_ssh_probe() {
+	local addr expected log_file ssh_out
+
+	addr=${1}
+	expected=${2}
+	log_file=${3}
+
+	echo "Probe ssh connection through ${addr}"
+	ssh_out=$(timeout 30 ssh -6 -o BatchMode=yes \
+		-o StrictHostKeyChecking=no -o ConnectTimeout=5 \
+		ubuntu@"${addr}" hostname 2>&1 || true)
+	echo "${ssh_out}" >>"${log_file}"
+	check_contains "${ssh_out}" "${expected}"
 }
 
 test_ip_family() {

--- a/tests/suites/cloud_azure/ip_family.sh
+++ b/tests/suites/cloud_azure/ip_family.sh
@@ -50,7 +50,7 @@ run_ip_family_dual_stack() {
 		juju switch ip-family-dual
 
 		# Test #3: per-machine constraint path
-		# (machine domain -> provisioner -> StartInstance; PR #22736 QA step 3).
+		# (machine domain -> provisioner -> StartInstance).
 		juju add-machine --constraints "ip-family=dual" >>"$log_file" 2>&1
 		wait_for_machine_agent_status "0" "started"
 		ipv6_m0=$(machine_ipv6 0)
@@ -63,7 +63,7 @@ run_ip_family_dual_stack() {
 		check_ipv6_ssh_probe "${ipv6_m0}" "Permission denied" "$log_file"
 
 		# Test #4: application deploy constraint path
-		# (application service -> provisioner -> StartInstance; PR #22736 QA step 4).
+		# (application service -> provisioner -> StartInstance).
 		# Deploy provisions a fresh machine per unit by default -> machine 1.
 		juju deploy ubuntu --constraints "ip-family=dual" >>"$log_file" 2>&1
 		wait_for_machine_agent_status "1" "started"

--- a/tests/suites/cloud_azure/ip_family.sh
+++ b/tests/suites/cloud_azure/ip_family.sh
@@ -1,0 +1,103 @@
+run_ip_family_dual_stack() {
+	(
+		log_file="${TEST_DIR}/ip-family-dual.log"
+
+		bootstrap_additional_args=(--constraints "ip-family=dual")
+		BOOTSTRAP_ADDITIONAL_ARGS="${bootstrap_additional_args[*]}" \
+			BOOTSTRAP_REUSE=false \
+			bootstrap "ip-family-dual" "$log_file"
+
+		# The bootstrap helper leaves the newly added (empty) model active;
+		# switch back to the controller model, where the bootstrap machine
+		# and the bootstrap-time model constraints live
+		# (mirrors constraints_model.sh:14).
+		juju switch controller
+
+		# Test #3: model-constraints includes ip-family=dual
+		check_contains "$(juju model-constraints)" "ip-family=dual"
+
+		# Test #2: IPv6 reachability (per PR #22736 QA step 5).
+		ipv6_addr=$(juju show-machine 0 --format json |
+			yq -r '.machines["0"]["ip-addresses"][] | select(. | test(":"))' |
+			head -1)
+		if [[ -z ${ipv6_addr} ]]; then
+			echo "ERROR: no IPv6 address found on controller machine"
+			return 1
+		fi
+
+		# Port 22 is the only IPv6-open port at the NSG. Reaching auth
+		# ("Permission denied") proves reachability; timeout/unreachable
+		# would indicate no route. BatchMode makes the auth failure
+		# immediate and deterministic (no interactive password prompt).
+		# The probe runs only when the runner has IPv6 egress; the
+		# allocation check above is the primary assertion.
+		if ip -6 route show default | grep -q .; then
+			ssh_out=$(timeout 10 ssh -6 -o BatchMode=yes \
+				-o StrictHostKeyChecking=no -o ConnectTimeout=5 \
+				ubuntu@"${ipv6_addr}" hostname 2>&1 || true)
+			echo "${ssh_out}" >>"$log_file"
+			check_contains "${ssh_out}" "Permission denied"
+		else
+			echo "==> No IPv6 egress on runner; IPv6 allocation check only"
+		fi
+
+		# Tests #4/#5: post-bootstrap provisioning paths. Run them in the
+		# harness-created "ip-family-dual" model: bootstrap --constraints
+		# lands only on the controller model (domain/model/bootstrap/
+		# bootstrap.go:213), so this model is constraint-free and each
+		# path must carry its own constraint. Machine IDs restart at 0.
+		juju switch ip-family-dual
+
+		# Test #4: per-machine constraint path
+		# (machine domain -> provisioner -> StartInstance; PR #22736 QA step 3).
+		juju add-machine --constraints "ip-family=dual" >>"$log_file" 2>&1
+		wait_for_machine_agent_status "0" "started"
+		ipv6_m0=$(juju show-machine 0 --format json |
+			yq -r '.machines["0"]["ip-addresses"][] | select(. | test(":"))' |
+			head -1)
+		if [[ -z ${ipv6_m0} ]]; then
+			echo "ERROR: no IPv6 on machine 0 (add-machine --constraints ip-family=dual)"
+			return 1
+		fi
+
+		# Test #5: application deploy constraint path
+		# (application service -> provisioner -> StartInstance; PR #22736 QA step 4).
+		# Deploy provisions a fresh machine per unit by default -> machine 1.
+		juju deploy ubuntu --constraints "ip-family=dual" >>"$log_file" 2>&1
+		wait_for_machine_agent_status "1" "started"
+		ipv6_m1=$(juju show-machine 1 --format json |
+			yq -r '.machines["1"]["ip-addresses"][] | select(. | test(":"))' |
+			head -1)
+		if [[ -z ${ipv6_m1} ]]; then
+			echo "ERROR: no IPv6 on machine 1 (deploy --constraints ip-family=dual)"
+			return 1
+		fi
+
+		destroy_controller "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+	)
+}
+
+test_ip_family() {
+	if [ "$(skip 'test_ip_family')" ]; then
+		echo "==> TEST SKIPPED: ip-family"
+		return
+	fi
+
+	if [ "${BOOTSTRAP_PROVIDER}" != "azure" ]; then
+		echo "==> TEST SKIPPED: ip-family tests, not using azure"
+		return
+	fi
+
+	if [ "$(az account list | yq -r 'length')" -lt 1 ]; then
+		echo "==> TEST SKIPPED: not logged in to Azure cloud"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_ip_family_dual_stack"
+	)
+}

--- a/tests/suites/cloud_azure/ip_family.sh
+++ b/tests/suites/cloud_azure/ip_family.sh
@@ -38,7 +38,8 @@ run_ip_family_dual_stack() {
 			echo "${ssh_out}" >>"$log_file"
 			check_contains "${ssh_out}" "Permission denied"
 		else
-			echo "==> No IPv6 egress on runner; IPv6 allocation check only"
+			echo "==> ERROR: no IPv6 egress on CI runner cannot verify SSH reachability"
+			return 1
 		fi
 
 		# Tests #4/#5: post-bootstrap provisioning paths. Run them in the

--- a/tests/suites/cloud_azure/task.sh
+++ b/tests/suites/cloud_azure/task.sh
@@ -17,4 +17,5 @@ test_cloud_azure() {
 
 	test_managed_identity
 	test_storage_account_type
+	test_ip_family
 }


### PR DESCRIPTION
Add `test_ip_family` to the `cloud_azure` suite (JUJU-9877, Task 4), covering the Azure `ip-family` constraint end to end:

- Bootstrap with `--constraints "ip-family=dual"` succeeds.
- Controller `model-constraints` reports `ip-family=dual`.
- `juju add-machine --constraints "ip-family=dual"` produces a dual-stack machine.
- `juju deploy ubuntu --constraints "ip-family=dual"` produces a dual-stack machine.
- All machines are reachable through ssh on their ipV6 address.

The post-bootstrap checks run in the harness-created `ip-family-dual` model, which is constraint-free (bootstrap `--constraints` lands only on the controller model — `domain/model/bootstrap/bootstrap.go:213`), so each provisioning path must carry its own constraint. This also keeps the assertions unambiguous once JUJU-10072 (model-constraint propagation) is fixed.

Negative paths (`ip-family=ipv6` rejection, Basic SKU + dual rejection) and a no-constraint regression bootstrap are deliberately omitted: they are covered by unit tests (`internal/provider/azure/environ_test.go`) and each would cost an extra Azure bootstrap.

Follow-up (separate PR in `juju/juju-qa-jenkins`, after this merges): register `test_ip_family` under `cloud_azure` in `tools/gen-wire-tests/main.yaml` and regenerate `jobs/ci-run/integration/gen/test-cloud_azure.yml` (`main`/4.1+ only; `4.0.yaml`/`3.6.yaml` unchanged).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~ (no Go changes)
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~ (no packages changed)

## QA steps

Verified statically: `shellcheck` clean and `bash -n` passes on the new file.

To run the test against Azure (requires `az login` and an Azure credential registered with the Juju client):

```sh
cd tests
./main.sh -p azure cloud_azure test_ip_family
```

This bootstraps an Azure controller with `--constraints "ip-family=dual"` and runs the five assertions above (~19 min). Alternatively, wait for CI once the follow-up `juju-qa-jenkins` PR registers the test in the `cloud_azure` suite.

## Documentation changes

None — CI test addition only, no CLI/API surface change.

## Links

**Jira card:** [JUJU-9877](https://warthogs.atlassian.net/browse/JUJU-9877)

[JUJU-9877]: https://warthogs.atlassian.net/browse/JUJU-9877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ