### PR TITLE
refactor: one bucket per controller

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -686,7 +686,10 @@ func (srv *Server) loop(ready chan struct{}) error {
 }
 
 const (
-	modelRoutePrefix         = "/model/:modeluuid"
+	modelRoutePrefix = "/model/:modeluuid"
+	// These routes expose an S3-compatible API where model-<uuid> is a
+	// pseudo-bucket that identifies the model. The physical S3 backend uses one
+	// controller-scoped bucket with per-model prefixes.
 	charmsObjectsRoutePrefix = "/model-:modeluuid/charms/:object"
 	objectsRoutePrefix       = "/model-:modeluuid/objects/:object"
 	migrateResourcesPrefix   = "/migrate/resources"

--- a/core/objectstore/objectstore.go
+++ b/core/objectstore/objectstore.go
@@ -54,8 +54,9 @@ type ReadSession interface {
 	// GetObject returns a reader for the specified object.
 	GetObject(ctx context.Context, bucketName, objectName string) (io.ReadCloser, int64, string, error)
 
-	// ListObjects returns a list of objects in the specified bucket.
-	ListObjects(ctx context.Context, bucketName string) ([]string, error)
+	// ListObjects returns a list of objects in the specified bucket, optionally
+	// filtered by prefix.
+	ListObjects(ctx context.Context, bucketName, prefix string) ([]string, error)
 }
 
 // WriteSession provides read access to the object store.

--- a/internal/objectstore/bucket.go
+++ b/internal/objectstore/bucket.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package objectstore
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/controller"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
+)
+
+// ControllerBucketName returns the bucket used to store objects for a
+// controller. Objects for models are namespaced under this bucket.
+func ControllerBucketName(config controller.Config) (string, error) {
+	name := fmt.Sprintf("juju-%s", config.ControllerUUID())
+	if _, err := coreobjectstore.ParseObjectStoreBucketName(name); err != nil {
+		return "", errors.Trace(err)
+	}
+	return name, nil
+}

--- a/internal/objectstore/bucket_test.go
+++ b/internal/objectstore/bucket_test.go
@@ -22,5 +22,5 @@ func (s *bucketSuite) TestControllerBucketName(c *tc.C) {
 
 	name, err := ControllerBucketName(config)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(name, tc.Equals, "juju-"+config.ControllerUUID())
+	c.Check(name, tc.Equals, "juju-"+config.ControllerUUID())
 }

--- a/internal/objectstore/bucket_test.go
+++ b/internal/objectstore/bucket_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package objectstore
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	jujutesting "github.com/juju/juju/internal/testing"
+)
+
+type bucketSuite struct{}
+
+func TestBucketSuite(t *testing.T) {
+	tc.Run(t, &bucketSuite{})
+}
+
+func (s *bucketSuite) TestControllerBucketName(c *tc.C) {
+	config := jujutesting.FakeControllerConfig()
+
+	name, err := ControllerBucketName(config)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(name, tc.Equals, "juju-"+config.ControllerUUID())
+}

--- a/internal/objectstore/factory.go
+++ b/internal/objectstore/factory.go
@@ -82,7 +82,7 @@ func WithAllowDraining(allowDraining bool) Option {
 	}
 }
 
-// WithRootBucket is the option to set the root bucket to use.
+// WithRootBucket is the option to set the controller bucket to use.
 // This is for s3 base object stores.
 func WithRootBucket(rootBucket string) Option {
 	return func(o *options) {

--- a/internal/objectstore/objectstore_mock_test.go
+++ b/internal/objectstore/objectstore_mock_test.go
@@ -402,7 +402,7 @@ type MockSessionMockRecorder struct {
 	createBucketExpects []*gomock.Call2_1[context.Context, string, error]
 	deleteObjectExpects []*gomock.Call3_1[context.Context, string, string, error]
 	getObjectExpects    []*gomock.Call3_4[context.Context, string, string, io.ReadCloser, int64, string, error]
-	listObjectsExpects  []*gomock.Call2_2[context.Context, string, []string, error]
+	listObjectsExpects  []*gomock.Call3_2[context.Context, string, string, []string, error]
 	objectExistsExpects []*gomock.Call3_1[context.Context, string, string, error]
 	putObjectExpects    []*gomock.Call5_1[context.Context, string, string, io.Reader, string, error]
 }
@@ -474,22 +474,22 @@ func (mr *MockSessionMockRecorder) GetObject(ctx, bucketName, objectName any) *M
 type MockSessionGetObjectCall = gomock.Call3_4[context.Context, string, string, io.ReadCloser, int64, string, error]
 
 // ListObjects mocks base method.
-func (m *MockSession) ListObjects(ctx context.Context, bucketName string) ([]string, error) {
+func (m *MockSession) ListObjects(ctx context.Context, bucketName, prefix string) ([]string, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_2(&m.recorder.listObjectsExpects, m.ctrl, m, "ListObjects", ctx, bucketName)
+	return gomock.Dispatch3_2(&m.recorder.listObjectsExpects, m.ctrl, m, "ListObjects", ctx, bucketName, prefix)
 }
 
 // ListObjects indicates an expected call of ListObjects.
-func (mr *MockSessionMockRecorder) ListObjects(ctx, bucketName any) *MockSessionListObjectsCall {
+func (mr *MockSessionMockRecorder) ListObjects(ctx, bucketName, prefix any) *MockSessionListObjectsCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, string, []string, error](mr.mock.ctrl.T, mr.mock, "ListObjects", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(bucketName))
+	call := gomock.NewCall3_2[context.Context, string, string, []string, error](mr.mock.ctrl.T, mr.mock, "ListObjects", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(bucketName), gomock.EnsureMatcher(prefix))
 	mr.listObjectsExpects = append(mr.listObjectsExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockSessionListObjectsCall is the typed call wrapper for ListObjects.
-type MockSessionListObjectsCall = gomock.Call2_2[context.Context, string, []string, error]
+type MockSessionListObjectsCall = gomock.Call3_2[context.Context, string, string, []string, error]
 
 // ObjectExists mocks base method.
 func (m *MockSession) ObjectExists(ctx context.Context, bucketName, objectName string) error {

--- a/internal/objectstore/s3objectstore.go
+++ b/internal/objectstore/s3objectstore.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/juju/clock"
@@ -37,10 +38,11 @@ type S3ObjectStoreConfig struct {
 	// This is different to /tmp because the /tmp directory might be
 	// mounted on a different file system.
 	RootDir string
-	// RootBucket is the name of the root bucket.
+	// RootBucket is the name of the bucket shared by all namespaces for a
+	// controller.
 	RootBucket string
 	// Namespace is the namespace for the object store (typically the
-	// model UUID).
+	// model UUID). S3 objects are stored under this namespace prefix.
 	Namespace string
 	// Client is the object store client (s3 client).
 	Client objectstore.Client
@@ -331,12 +333,16 @@ func (t *s3ObjectStore) RemoveAll(ctx context.Context) error {
 		return errors.Errorf("cannot remove all files while the worker is running")
 	}
 
-	// TODO (stickupkid): Remove all the s3 objects in the bucket. This requires
-	// deleting the bucket as well.
-	// We can't rely on the metadata service to remove the metadata, as it
-	// might be inconsistent with the s3 bucket (e.g. the data is removed).
-	// Consider our options, maybe we have to use the s3 client directly to
-	// remove all objects in the bucket.
+	objects, err := t.listObjects(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	for _, object := range objects {
+		if err := t.deleteObject(ctx, object); err != nil {
+			return errors.Capture(err)
+		}
+	}
 
 	return nil
 }
@@ -711,19 +717,33 @@ func (t *s3ObjectStore) list(ctx context.Context) ([]objectstore.Metadata, []str
 		return nil, nil, errors.Errorf("list metadata: %w", err)
 	}
 
+	objects, err := t.listObjects(ctx)
+	if err != nil {
+		return nil, nil, errors.Errorf("list objects: %w", err)
+	}
+
+	return metadata, objects, nil
+}
+
+func (t *s3ObjectStore) listObjects(ctx context.Context) ([]string, error) {
 	var objects []string
 	if err := t.client.Session(ctx, func(ctx context.Context, s objectstore.Session) error {
 		var err error
-		objects, err = s.ListObjects(ctx, t.rootBucket)
+		objects, err = s.ListObjects(ctx, t.rootBucket, t.namespace+"/")
 		if err != nil {
 			return errors.Capture(err)
 		}
 		return nil
 	}); err != nil {
-		return nil, nil, errors.Errorf("list objects: %w", err)
+		return nil, errors.Capture(err)
 	}
 
-	return metadata, objects, nil
+	prefix := t.namespace + "/"
+	for i, object := range objects {
+		objects[i] = strings.TrimPrefix(object, prefix)
+	}
+
+	return objects, nil
 }
 
 func (t *s3ObjectStore) deleteObject(ctx context.Context, hash string) error {

--- a/internal/objectstore/s3objectstore_test.go
+++ b/internal/objectstore/s3objectstore_test.go
@@ -717,6 +717,51 @@ func (s *s3ObjectStoreSuite) TestRemoveDoesNotDeleteSharedHash(c *tc.C) {
 	workertest.CleanKill(c, store)
 }
 
+func (s *s3ObjectStoreSuite) TestRemoveAll(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
+	s.session.EXPECT().ListObjects(gomock.Any(), defaultBucketName, "inferi/").Return([]string{
+		filePath("foo"),
+		filePath("bar"),
+	}, nil)
+	s.session.EXPECT().DeleteObject(gomock.Any(), defaultBucketName, filePath("foo")).Return(nil)
+	s.session.EXPECT().DeleteObject(gomock.Any(), defaultBucketName, filePath("bar")).Return(nil)
+
+	store := s.newS3ObjectStore(c).(*s3ObjectStore)
+	defer workertest.DirtyKill(c, store)
+
+	// Ensure we've started up before we start the test.
+	s.expectStartup(c)
+
+	store.Kill()
+
+	err := store.RemoveAll(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	workertest.CleanKill(c, store)
+}
+
+func (s *s3ObjectStoreSuite) TestRemoveAllWithListError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
+	s.session.EXPECT().ListObjects(gomock.Any(), defaultBucketName, "inferi/").Return(nil, errors.Errorf("boom"))
+
+	store := s.newS3ObjectStore(c).(*s3ObjectStore)
+	defer workertest.DirtyKill(c, store)
+
+	// Ensure we've started up before we start the test.
+	s.expectStartup(c)
+
+	store.Kill()
+
+	err := store.RemoveAll(c.Context())
+	c.Assert(err, tc.ErrorMatches, `.*boom`)
+
+	workertest.CleanKill(c, store)
+}
+
 func (s *s3ObjectStoreSuite) TestList(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -734,7 +779,7 @@ func (s *s3ObjectStoreSuite) TestList(c *tc.C) {
 		Path:   fileName,
 		Size:   size,
 	}}, nil)
-	s.session.EXPECT().ListObjects(gomock.Any(), defaultBucketName).Return([]string{hexSHA384}, nil)
+	s.session.EXPECT().ListObjects(gomock.Any(), defaultBucketName, "inferi/").Return([]string{filePath(hexSHA384)}, nil)
 
 	store := s.newS3ObjectStore(c).(*s3ObjectStore)
 	defer workertest.DirtyKill(c, store)
@@ -750,6 +795,37 @@ func (s *s3ObjectStoreSuite) TestList(c *tc.C) {
 		Path:   fileName,
 		Size:   size,
 	}})
+	c.Check(files, tc.DeepEquals, []string{hexSHA384})
+
+	workertest.CleanKill(c, store)
+}
+
+func (s *s3ObjectStoreSuite) TestListStripsNamespacePrefix(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	content := "some content"
+	hexSHA384 := s.calculateHexSHA384(c, content)
+	hexSHA256 := s.calculateHexSHA256(c, content)
+
+	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
+	s.service.EXPECT().ListMetadata(gomock.Any()).Return([]objectstore.Metadata{{
+		SHA384: hexSHA384,
+		SHA256: hexSHA256,
+		Path:   "foo",
+		Size:   12,
+	}}, nil)
+	s.session.EXPECT().ListObjects(gomock.Any(), defaultBucketName, "inferi/").Return([]string{
+		filePath(hexSHA384),
+	}, nil)
+
+	store := s.newS3ObjectStore(c).(*s3ObjectStore)
+	defer workertest.DirtyKill(c, store)
+
+	// Ensure we've started up before we start the test.
+	s.expectStartup(c)
+
+	_, files, err := store.list(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
 	c.Check(files, tc.DeepEquals, []string{hexSHA384})
 
 	workertest.CleanKill(c, store)

--- a/internal/objectstore/s3objectstore_test.go
+++ b/internal/objectstore/s3objectstore_test.go
@@ -720,13 +720,31 @@ func (s *s3ObjectStoreSuite) TestRemoveDoesNotDeleteSharedHash(c *tc.C) {
 func (s *s3ObjectStoreSuite) TestRemoveAll(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	otherModelObject := "limbo/baz"
+	objects := map[string]bool{
+		filePath("foo"):  true,
+		filePath("bar"):  true,
+		otherModelObject: true,
+	}
+
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
-	s.session.EXPECT().ListObjects(gomock.Any(), defaultBucketName, "inferi/").Return([]string{
-		filePath("foo"),
-		filePath("bar"),
-	}, nil)
-	s.session.EXPECT().DeleteObject(gomock.Any(), defaultBucketName, filePath("foo")).Return(nil)
-	s.session.EXPECT().DeleteObject(gomock.Any(), defaultBucketName, filePath("bar")).Return(nil)
+	s.session.EXPECT().ListObjects(gomock.Any(), defaultBucketName, "inferi/").DoAndReturn(
+		func(_ context.Context, _, prefix string) ([]string, error) {
+			var result []string
+			for object := range objects {
+				if strings.HasPrefix(object, prefix) {
+					result = append(result, object)
+				}
+			}
+			return result, nil
+		},
+	)
+	s.session.EXPECT().DeleteObject(gomock.Any(), defaultBucketName, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _, object string) error {
+			delete(objects, object)
+			return nil
+		},
+	).Times(2)
 
 	store := s.newS3ObjectStore(c).(*s3ObjectStore)
 	defer workertest.DirtyKill(c, store)
@@ -738,6 +756,9 @@ func (s *s3ObjectStoreSuite) TestRemoveAll(c *tc.C) {
 
 	err := store.RemoveAll(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(objects, tc.DeepEquals, map[string]bool{
+		otherModelObject: true,
+	})
 
 	workertest.CleanKill(c, store)
 }

--- a/internal/s3client/blobclient.go
+++ b/internal/s3client/blobclient.go
@@ -17,8 +17,10 @@ type Session interface {
 	GetObject(ctx context.Context, bucketName, objectName string) (io.ReadCloser, int64, string, error)
 }
 
-// Blobs is the client desienged to interact with the
-// s3 compatible object store hosted by the apiserver
+// Blobs is the client designed to interact with the apiserver's S3-compatible
+// object store. The bucket name is a route-level pseudo-bucket that identifies
+// the model; it is not the name of the physical S3 bucket used by the
+// controller.
 type Blobs struct {
 	session Session
 }

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -243,13 +243,15 @@ func (c *S3Client) GetObject(ctx context.Context, bucketName, objectName string)
 	return obj.Body, size, hash, nil
 }
 
-// ListObjects returns a list of objects in the specified bucket.
-func (c *S3Client) ListObjects(ctx context.Context, bucketName string) ([]string, error) {
-	c.logger.Tracef(ctx, "listing objects in bucket %s from s3 storage", bucketName)
+// ListObjects returns a list of objects in the specified bucket, optionally
+// filtered by prefix.
+func (c *S3Client) ListObjects(ctx context.Context, bucketName, prefix string) ([]string, error) {
+	c.logger.Tracef(ctx, "listing objects in bucket %s with prefix %s from s3 storage", bucketName, prefix)
 
 	objs, err := c.client.ListObjectsV2(ctx,
 		&s3.ListObjectsV2Input{
 			Bucket: aws.String(bucketName),
+			Prefix: aws.String(prefix),
 		})
 	if err != nil {
 		if err := handleError(err); err != nil {

--- a/internal/s3client/client_test.go
+++ b/internal/s3client/client_test.go
@@ -149,6 +149,21 @@ func (s *s3ClientSuite) TestDeleteObject(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *s3ClientSuite) TestListObjectsWithPrefix(c *tc.C) {
+	url, httpClient, cleanup := s.setupServer(c, func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, tc.Equals, http.MethodGet)
+		c.Check(r.URL.Path, tc.Equals, "/bucket")
+		c.Check(r.URL.Query().Get("prefix"), tc.Equals, "model-uuid/")
+	})
+	defer cleanup()
+
+	client, err := NewS3Client(url, httpClient, AnonymousCredentials{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = client.ListObjects(c.Context(), "bucket", "model-uuid/")
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *s3ClientSuite) TestCreateBucket(c *tc.C) {
 	url, httpClient, cleanup := s.setupServer(c, func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, tc.Equals, http.MethodPut)

--- a/internal/worker/objectstore/client_mock_test.go
+++ b/internal/worker/objectstore/client_mock_test.go
@@ -73,7 +73,7 @@ type MockSessionMockRecorder struct {
 	createBucketExpects []*gomock.Call2_1[context.Context, string, error]
 	deleteObjectExpects []*gomock.Call3_1[context.Context, string, string, error]
 	getObjectExpects    []*gomock.Call3_4[context.Context, string, string, io.ReadCloser, int64, string, error]
-	listObjectsExpects  []*gomock.Call2_2[context.Context, string, []string, error]
+	listObjectsExpects  []*gomock.Call3_2[context.Context, string, string, []string, error]
 	objectExistsExpects []*gomock.Call3_1[context.Context, string, string, error]
 	putObjectExpects    []*gomock.Call5_1[context.Context, string, string, io.Reader, string, error]
 }
@@ -145,22 +145,22 @@ func (mr *MockSessionMockRecorder) GetObject(ctx, bucketName, objectName any) *M
 type MockSessionGetObjectCall = gomock.Call3_4[context.Context, string, string, io.ReadCloser, int64, string, error]
 
 // ListObjects mocks base method.
-func (m *MockSession) ListObjects(ctx context.Context, bucketName string) ([]string, error) {
+func (m *MockSession) ListObjects(ctx context.Context, bucketName, prefix string) ([]string, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_2(&m.recorder.listObjectsExpects, m.ctrl, m, "ListObjects", ctx, bucketName)
+	return gomock.Dispatch3_2(&m.recorder.listObjectsExpects, m.ctrl, m, "ListObjects", ctx, bucketName, prefix)
 }
 
 // ListObjects indicates an expected call of ListObjects.
-func (mr *MockSessionMockRecorder) ListObjects(ctx, bucketName any) *MockSessionListObjectsCall {
+func (mr *MockSessionMockRecorder) ListObjects(ctx, bucketName, prefix any) *MockSessionListObjectsCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, string, []string, error](mr.mock.ctrl.T, mr.mock, "ListObjects", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(bucketName))
+	call := gomock.NewCall3_2[context.Context, string, string, []string, error](mr.mock.ctrl.T, mr.mock, "ListObjects", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(bucketName), gomock.EnsureMatcher(prefix))
 	mr.listObjectsExpects = append(mr.listObjectsExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockSessionListObjectsCall is the typed call wrapper for ListObjects.
-type MockSessionListObjectsCall = gomock.Call2_2[context.Context, string, []string, error]
+type MockSessionListObjectsCall = gomock.Call3_2[context.Context, string, string, []string, error]
 
 // ObjectExists mocks base method.
 func (m *MockSession) ObjectExists(ctx context.Context, bucketName, objectName string) error {

--- a/internal/worker/objectstore/manifold.go
+++ b/internal/worker/objectstore/manifold.go
@@ -5,7 +5,6 @@ package objectstore
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/juju/clock"
@@ -233,7 +232,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			rootBucketName, err := bucketName(controllerConfig)
+			rootBucketName, err := objectstore.ControllerBucketName(controllerConfig)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -292,14 +291,6 @@ func output(in worker.Worker, out any) error {
 		return errors.Errorf("expected output of ObjectStoreGetter, got %T", out)
 	}
 	return nil
-}
-
-func bucketName(config controller.Config) (string, error) {
-	name := fmt.Sprintf("juju-%s", config.ControllerUUID())
-	if _, err := coreobjectstore.ParseObjectStoreBucketName(name); err != nil {
-		return "", errors.Trace(err)
-	}
-	return name, nil
 }
 
 type controllerMetadataService struct {

--- a/internal/worker/objectstore/worker.go
+++ b/internal/worker/objectstore/worker.go
@@ -57,8 +57,10 @@ type ControllerWorkerFunc func(
 // WorkerConfig encapsulates the configuration options for the
 // objectStore worker.
 type WorkerConfig struct {
-	TracerGetter               trace.TracerGetter
-	RootDir                    string
+	TracerGetter trace.TracerGetter
+	RootDir      string
+	// RootBucket is the controller-scoped bucket shared by all model
+	// namespaces.
 	RootBucket                 string
 	Clock                      clock.Clock
 	Logger                     logger.Logger

--- a/internal/worker/objectstoredrainer/manifold.go
+++ b/internal/worker/objectstoredrainer/manifold.go
@@ -5,7 +5,6 @@ package objectstoredrainer
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -197,7 +196,7 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	rootBucketName, err := bucketName(controllerConfig)
+	rootBucketName, err := objectstore.ControllerBucketName(controllerConfig)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -296,14 +295,6 @@ func GetDrainingService(getter dependency.Getter, name string) (DrainingService,
 // for the given namespace and root directory.
 func NewHashFileStoreAccessor(namespace, rootDir string, logger logger.Logger) HashFileSystemAccessor {
 	return objectstore.NewHashFileStore(namespace, rootDir, logger)
-}
-
-func bucketName(config controller.Config) (string, error) {
-	name := fmt.Sprintf("juju-%s", config.ControllerUUID())
-	if _, err := coreobjectstore.ParseObjectStoreBucketName(name); err != nil {
-		return "", errors.Trace(err)
-	}
-	return name, nil
 }
 
 type modelMetadataServiceGetter struct {

--- a/internal/worker/objectstoredrainer/objectstore_mock_test.go
+++ b/internal/worker/objectstoredrainer/objectstore_mock_test.go
@@ -74,7 +74,7 @@ type MockSessionMockRecorder struct {
 	createBucketExpects []*gomock.Call2_1[context.Context, string, error]
 	deleteObjectExpects []*gomock.Call3_1[context.Context, string, string, error]
 	getObjectExpects    []*gomock.Call3_4[context.Context, string, string, io.ReadCloser, int64, string, error]
-	listObjectsExpects  []*gomock.Call2_2[context.Context, string, []string, error]
+	listObjectsExpects  []*gomock.Call3_2[context.Context, string, string, []string, error]
 	objectExistsExpects []*gomock.Call3_1[context.Context, string, string, error]
 	putObjectExpects    []*gomock.Call5_1[context.Context, string, string, io.Reader, string, error]
 }
@@ -146,22 +146,22 @@ func (mr *MockSessionMockRecorder) GetObject(ctx, bucketName, objectName any) *M
 type MockSessionGetObjectCall = gomock.Call3_4[context.Context, string, string, io.ReadCloser, int64, string, error]
 
 // ListObjects mocks base method.
-func (m *MockSession) ListObjects(ctx context.Context, bucketName string) ([]string, error) {
+func (m *MockSession) ListObjects(ctx context.Context, bucketName, prefix string) ([]string, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_2(&m.recorder.listObjectsExpects, m.ctrl, m, "ListObjects", ctx, bucketName)
+	return gomock.Dispatch3_2(&m.recorder.listObjectsExpects, m.ctrl, m, "ListObjects", ctx, bucketName, prefix)
 }
 
 // ListObjects indicates an expected call of ListObjects.
-func (mr *MockSessionMockRecorder) ListObjects(ctx, bucketName any) *MockSessionListObjectsCall {
+func (mr *MockSessionMockRecorder) ListObjects(ctx, bucketName, prefix any) *MockSessionListObjectsCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, string, []string, error](mr.mock.ctrl.T, mr.mock, "ListObjects", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(bucketName))
+	call := gomock.NewCall3_2[context.Context, string, string, []string, error](mr.mock.ctrl.T, mr.mock, "ListObjects", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(bucketName), gomock.EnsureMatcher(prefix))
 	mr.listObjectsExpects = append(mr.listObjectsExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockSessionListObjectsCall is the typed call wrapper for ListObjects.
-type MockSessionListObjectsCall = gomock.Call2_2[context.Context, string, []string, error]
+type MockSessionListObjectsCall = gomock.Call3_2[context.Context, string, string, []string, error]
 
 // ObjectExists mocks base method.
 func (m *MockSession) ObjectExists(ctx context.Context, bucketName, objectName string) error {

--- a/internal/worker/objectstoredrainer/worker.go
+++ b/internal/worker/objectstoredrainer/worker.go
@@ -105,9 +105,11 @@ type Config struct {
 	S3Client                     objectstore.Client
 	SelectFileHash               SelectFileHashFunc
 	RootDir                      string
-	RootBucketName               string
-	Logger                       logger.Logger
-	Clock                        clock.Clock
+	// RootBucketName is the controller-scoped bucket shared by all model
+	// namespaces.
+	RootBucketName string
+	Logger         logger.Logger
+	Clock          clock.Clock
 }
 
 // Validate returns an error if the config cannot be expected to

--- a/internal/worker/objectstores3caller/package_mock_test.go
+++ b/internal/worker/objectstores3caller/package_mock_test.go
@@ -73,7 +73,7 @@ type MockSessionMockRecorder struct {
 	createBucketExpects []*gomock.Call2_1[context.Context, string, error]
 	deleteObjectExpects []*gomock.Call3_1[context.Context, string, string, error]
 	getObjectExpects    []*gomock.Call3_4[context.Context, string, string, io.ReadCloser, int64, string, error]
-	listObjectsExpects  []*gomock.Call2_2[context.Context, string, []string, error]
+	listObjectsExpects  []*gomock.Call3_2[context.Context, string, string, []string, error]
 	objectExistsExpects []*gomock.Call3_1[context.Context, string, string, error]
 	putObjectExpects    []*gomock.Call5_1[context.Context, string, string, io.Reader, string, error]
 }
@@ -145,22 +145,22 @@ func (mr *MockSessionMockRecorder) GetObject(ctx, bucketName, objectName any) *M
 type MockSessionGetObjectCall = gomock.Call3_4[context.Context, string, string, io.ReadCloser, int64, string, error]
 
 // ListObjects mocks base method.
-func (m *MockSession) ListObjects(ctx context.Context, bucketName string) ([]string, error) {
+func (m *MockSession) ListObjects(ctx context.Context, bucketName, prefix string) ([]string, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_2(&m.recorder.listObjectsExpects, m.ctrl, m, "ListObjects", ctx, bucketName)
+	return gomock.Dispatch3_2(&m.recorder.listObjectsExpects, m.ctrl, m, "ListObjects", ctx, bucketName, prefix)
 }
 
 // ListObjects indicates an expected call of ListObjects.
-func (mr *MockSessionMockRecorder) ListObjects(ctx, bucketName any) *MockSessionListObjectsCall {
+func (mr *MockSessionMockRecorder) ListObjects(ctx, bucketName, prefix any) *MockSessionListObjectsCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, string, []string, error](mr.mock.ctrl.T, mr.mock, "ListObjects", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(bucketName))
+	call := gomock.NewCall3_2[context.Context, string, string, []string, error](mr.mock.ctrl.T, mr.mock, "ListObjects", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(bucketName), gomock.EnsureMatcher(prefix))
 	mr.listObjectsExpects = append(mr.listObjectsExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockSessionListObjectsCall is the typed call wrapper for ListObjects.
-type MockSessionListObjectsCall = gomock.Call2_2[context.Context, string, []string, error]
+type MockSessionListObjectsCall = gomock.Call3_2[context.Context, string, string, []string, error]
 
 // ObjectExists mocks base method.
 func (m *MockSession) ObjectExists(ctx context.Context, bucketName, objectName string) error {

--- a/internal/worker/units3caller/package_mock_test.go
+++ b/internal/worker/units3caller/package_mock_test.go
@@ -29,7 +29,7 @@ type MockSessionMockRecorder struct {
 	createBucketExpects []*gomock.Call2_1[context.Context, string, error]
 	deleteObjectExpects []*gomock.Call3_1[context.Context, string, string, error]
 	getObjectExpects    []*gomock.Call3_4[context.Context, string, string, io.ReadCloser, int64, string, error]
-	listObjectsExpects  []*gomock.Call2_2[context.Context, string, []string, error]
+	listObjectsExpects  []*gomock.Call3_2[context.Context, string, string, []string, error]
 	objectExistsExpects []*gomock.Call3_1[context.Context, string, string, error]
 	putObjectExpects    []*gomock.Call5_1[context.Context, string, string, io.Reader, string, error]
 }
@@ -101,22 +101,22 @@ func (mr *MockSessionMockRecorder) GetObject(ctx, bucketName, objectName any) *M
 type MockSessionGetObjectCall = gomock.Call3_4[context.Context, string, string, io.ReadCloser, int64, string, error]
 
 // ListObjects mocks base method.
-func (m *MockSession) ListObjects(ctx context.Context, bucketName string) ([]string, error) {
+func (m *MockSession) ListObjects(ctx context.Context, bucketName, prefix string) ([]string, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_2(&m.recorder.listObjectsExpects, m.ctrl, m, "ListObjects", ctx, bucketName)
+	return gomock.Dispatch3_2(&m.recorder.listObjectsExpects, m.ctrl, m, "ListObjects", ctx, bucketName, prefix)
 }
 
 // ListObjects indicates an expected call of ListObjects.
-func (mr *MockSessionMockRecorder) ListObjects(ctx, bucketName any) *MockSessionListObjectsCall {
+func (mr *MockSessionMockRecorder) ListObjects(ctx, bucketName, prefix any) *MockSessionListObjectsCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, string, []string, error](mr.mock.ctrl.T, mr.mock, "ListObjects", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(bucketName))
+	call := gomock.NewCall3_2[context.Context, string, string, []string, error](mr.mock.ctrl.T, mr.mock, "ListObjects", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(bucketName), gomock.EnsureMatcher(prefix))
 	mr.listObjectsExpects = append(mr.listObjectsExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockSessionListObjectsCall is the typed call wrapper for ListObjects.
-type MockSessionListObjectsCall = gomock.Call2_2[context.Context, string, []string, error]
+type MockSessionListObjectsCall = gomock.Call3_2[context.Context, string, string, []string, error]
 
 // ObjectExists mocks base method.
 func (m *MockSession) ObjectExists(ctx context.Context, bucketName, objectName string) error {


### PR DESCRIPTION
The object store has always been designed as one bucket per controller with per-model key prefixes (juju-<controller-uuid>/<model-uuid>/<hash>), but several places implied or acted like each model had its own bucket. The S3 list call was listing the entire bucket then comparing raw hashes without stripping the namespace prefix, so pruning could misidentify objects from other models. Removing a dead model via RemoveAll was a no-op TODO that suggested deleting the bucket, which would have destroyed all model data on a shared controller bucket. The controller bucket name was also duplicated across the objectstore and drainer manifolds in a way that invited drift.

This change consolidates the physical layout into a single explicit pattern. The S3 listing call now filters by the model namespace prefix and trims it so pruning only sees the raw hashes it expects. RemoveAll lists and deletes only objects under the namespace prefix instead of being a stub. The bucket name is derived once by a shared ControllBucketName helper used by both manifolds. A few comments were updated to stop referring to per-model buckets and to clarify that the apiserver’s model-<uuid> route is a pseudo-bucket for routing, not a real S3 bucket.

We'll then be able to ensure that when a integration to the s3 integrator is called, that it uses the correct bucket. There will be a follow up PR that ensures this is possible.

## QA steps


### S3 setup

I'm using minio here, but that's only because of familiarity and we should probably use something that isn't no longer maintained.

```sh
docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   --user $(id -u):$(id -g) \
   --name minio1 \
   -e "MINIO_ROOT_USER=ROOTUSER" \
   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
   -v ${HOME}/.local/minio/data:/data \
   quay.io/minio/minio server /data --console-address ":9001"
```

```sh
$ docker exec -it <container> bash
$ mc alias set foo http://localhost:9000 ROOTUSER CHANGEME123
$ mc admin info foo
$ mc admin accesskey create foo
# Note down the access keys
```

### Build controller charm

Checkout the following https://github.com/juju/juju-controller/pull/107 and then pack it for use.

```sh
$ charmcraft pack
$ mv juju-controller_ubuntu@24.04-amd64.charm <juju location>
```

### Bootstrap

```sh
$ juju bootstrap lxd src --bootstrap-base=ubuntu@24.04 --controller-charm-path=./juju-controller_ubuntu@24.04-amd64.charm --build-agent
```

Add another model so we can test that:

```sh
$ juju add-model foo
$ juju deploy juju-qa-test
```

Add the s3-integrator so it can drive the draining:

```sh
$ juju switch controller
$ juju deploy s3-integrator
$ juju integrate controller:s3-backend s3-integrator
$ juju config s3-integrator endpoint=<url to minio or S3 compatible>
$ juju run s3-integrator/leader sync-s3-credentials access-key=<access key> secret-key=<secret key>
```

This should start the draining - check `juju debug-log -m controller` for errors.

Alternatively check the db:

```sh
$ juju ssh -m controller 0
$ juju_db_repl
repl (controller)> SELECT * FROM object_store_backend
uuid                                    life_id type_id updated_at
653813f9-2896-5332-8cbe-629a337a56a3    2       0       2026-05-07 10:40:57.846945418 +0000 UTC
f080e651-7c56-4242-8773-260110069191    0       1       2026-05-07 10:40:57.846945418 +0000 UTC
```

We're looking for the life of the file (type_id: 0) to be 2, ensuring it's completed and it's dead.

### Verification

Check the buckets:

```sh
$ mc ls foo
[2026-05-07 10:40:59 UTC]     0B juju-7f618674-29f6-4781-88fb-6e61c6339c42/
```

Check the controller file based object stores are empty:

```sh
$ juju ssh -m controller 0
$ ls -la /var/lib/juju/objectstore
```

Check that we can move into HA (there is a [bug moving into HA](https://github.com/juju/juju-controller/issues/117)):

```sh
$ juju add-unit -m controller controller -n 2
```

Check you can deploy other things:

```sh
$ juju switch foo
$ juju deploy ubuntu
```
