### PR TITLE
feat(sshserver): add authz and authn

### DIFF
--- a/core/ssh/types.go
+++ b/core/ssh/types.go
@@ -3,6 +3,10 @@
 
 package ssh
 
+// ReverseTunnelUser is the username used when machine agents
+// connect to the controller to establish a reverse tunnel.
+const ReverseTunnelUser = "juju-reverse-tunnel"
+
 // PublicKey represents a single public ssh key for a user within a model.
 type PublicKey struct {
 	// Fingerprint is the calculated fingerprint of the ssh key.

--- a/internal/sshtunneler/tunneler.go
+++ b/internal/sshtunneler/tunneler.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	coressh "github.com/juju/juju/core/ssh"
 	domainssh "github.com/juju/juju/domain/ssh"
 	"github.com/juju/juju/internal/pki/ssh"
 	"github.com/juju/juju/internal/uuid"
@@ -27,11 +28,10 @@ var (
 )
 
 const (
-	reverseTunnelUser = "juju-reverse-tunnel"
-	tokenIssuer       = "sshtunneler"
-	tokenSubject      = "reverse-tunnel"
-	tunnelIDClaimKey  = "tunnelID"
-	defaultUser       = "ubuntu"
+	tokenIssuer      = "sshtunneler"
+	tokenSubject     = "reverse-tunnel"
+	tunnelIDClaimKey = "tunnelID"
+	defaultUser      = "ubuntu"
 )
 
 // ConnRequestState defines an interface to write SSH connection requests to
@@ -234,7 +234,7 @@ func (tt *Tracker) RequestTunnel(ctx context.Context, req RequestArgs) (*gossh.C
 		TunnelID:            tunnelID.String(),
 		MachineName:         req.MachineID,
 		Expires:             deadline,
-		SSHUsername:         reverseTunnelUser,
+		SSHUsername:         coressh.ReverseTunnelUser,
 		SSHPassword:         password,
 		ControllerAddresses: controllerAddresses,
 		UnitPort:            0, // Allow the unit worker to determine the port.
@@ -276,7 +276,7 @@ func (tt *Tracker) delete(tunnelID string) {
 // If the request is valid, the provided tunnelID should be
 // stored and provided alongside the network connection to PushTunnel.
 func (tt *Tracker) AuthenticateTunnel(username, password string) (tunnelID string, err error) {
-	if username != reverseTunnelUser {
+	if username != coressh.ReverseTunnelUser {
 		return "", errors.New("invalid username")
 	}
 

--- a/internal/sshtunneler/tunneler_test.go
+++ b/internal/sshtunneler/tunneler_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
+	coressh "github.com/juju/juju/core/ssh"
 	domainssh "github.com/juju/juju/domain/ssh"
 	"github.com/juju/juju/internal/pki/test"
 	"github.com/juju/juju/internal/testhelpers"
@@ -128,7 +129,7 @@ func (s *sshTunnelerSuite) TestTunneler(c *tc.C) {
 	}
 	c.Check(tunnels, tc.HasLen, 1)
 
-	tunnelID, err := tunnelTracker.AuthenticateTunnel(reverseTunnelUser, sshConnArgs.SSHPassword)
+	tunnelID, err := tunnelTracker.AuthenticateTunnel(coressh.ReverseTunnelUser, sshConnArgs.SSHPassword)
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(tunnelID, tc.Equals, tunnels[0])
 
@@ -207,7 +208,7 @@ func (s *sshTunnelerSuite) TestTunnelIsClosedWhenDialFails(c *tc.C) {
 		c.Error("timeout waiting for tunnel request to be processed")
 	}
 
-	tunnelID, err := tunnelTracker.AuthenticateTunnel(reverseTunnelUser, sshConnArgs.SSHPassword)
+	tunnelID, err := tunnelTracker.AuthenticateTunnel(coressh.ReverseTunnelUser, sshConnArgs.SSHPassword)
 	c.Check(err, tc.ErrorIsNil)
 
 	ctx := c.Context()
@@ -248,7 +249,7 @@ func (s *sshTunnelerSuite) TestAuthenticateTunnel(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	s.clock.EXPECT().Now().AnyTimes().Return(now)
-	authTunnelID, err := tunnelTracker.AuthenticateTunnel(reverseTunnelUser, token)
+	authTunnelID, err := tunnelTracker.AuthenticateTunnel(coressh.ReverseTunnelUser, token)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(authTunnelID, tc.Equals, tunnelID)
 }

--- a/internal/worker/sshserver/authentication.go
+++ b/internal/worker/sshserver/authentication.go
@@ -21,9 +21,9 @@ type authenticatedViaPublicKey struct{}
 type userJWT struct{}
 type tunnelIDKey struct{}
 
-const jimmUser = "jimm"
+const externalAuthUser = "external-auth"
 
-// JWTParser parses JIMM's encoded JWT password authentication payload.
+// JWTParser parses a JWT in the password authentication payload.
 type JWTParser interface {
 	// Parse parses the provided JWT string and returns a jwt.Token if valid.
 	Parse(context.Context, string) (jwt.Token, error)
@@ -41,8 +41,8 @@ type UserPublicKeyService interface {
 
 // authenticator implements the Authenticator interface for the SSH server.
 // It handles:
-// 1. Public key authentication by users
-// 2. JWT password authentication for JIMM
+// 1. Public key authentication by users.
+// 2. JWT password authentication for external-auth.
 // 3. Reverse-tunnel authentication for machine agents.
 type authenticator struct {
 	logger        logger.Logger
@@ -70,13 +70,13 @@ func (a authenticator) PublicKeyAuthentication(ctx ssh.Context, key ssh.PublicKe
 
 // PasswordAuthentication implements a password authentication handler.
 // It supports two types of password authentication:
-// 1. Decoding a JWT as the password for JIMM.
+// 1. Decoding a JWT as the password for external-auth.
 // 2. Reverse-tunnel authentication for machine agents.
 func (a authenticator) PasswordAuthentication(ctx ssh.Context, password string) (bool, error) {
 	ctx.SetValue(authenticatedViaPublicKey{}, false)
 
 	switch ctx.User() {
-	case jimmUser:
+	case externalAuthUser:
 		token, err := a.jwtParser.Parse(ctx, password)
 		if err != nil {
 			return false, errors.Annotate(err, "parsing SSH JWT")

--- a/internal/worker/sshserver/authentication.go
+++ b/internal/worker/sshserver/authentication.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/gliderlabs/ssh"
+	"github.com/juju/errors"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	gossh "golang.org/x/crypto/ssh"
 
@@ -51,47 +52,44 @@ type authenticator struct {
 }
 
 // PublicKeyAuthentication implements a public key authentication handler.
-func (a authenticator) PublicKeyAuthentication(ctx ssh.Context, key ssh.PublicKey) bool {
+func (a authenticator) PublicKeyAuthentication(ctx ssh.Context, key ssh.PublicKey) (bool, error) {
 	keys, err := a.publicKeys.PublicKeys(ctx, ctx.User())
 	if err != nil {
-		a.logger.Errorf(ctx, "getting SSH public keys for user %q: %v", ctx.User(), err)
-		return false
+		return false, errors.Annotatef(err, "getting SSH public keys for user %q", ctx.User())
 	}
 
 	for _, authorizedKey := range keys {
 		if bytes.Equal(key.Marshal(), authorizedKey.Marshal()) {
 			ctx.SetValue(authenticatedViaPublicKey{}, true)
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // PasswordAuthentication implements a password authentication handler.
 // It supports two types of password authentication:
 // 1. Decoding a JWT as the password for JIMM.
 // 2. Reverse-tunnel authentication for machine agents.
-func (a authenticator) PasswordAuthentication(ctx ssh.Context, password string) bool {
+func (a authenticator) PasswordAuthentication(ctx ssh.Context, password string) (bool, error) {
 	ctx.SetValue(authenticatedViaPublicKey{}, false)
 
 	switch ctx.User() {
 	case jimmUser:
 		token, err := a.jwtParser.Parse(ctx, password)
 		if err != nil {
-			a.logger.Errorf(ctx, "parsing SSH JWT: %v", err)
-			break
+			return false, errors.Annotate(err, "parsing SSH JWT")
 		}
 		ctx.SetValue(userJWT{}, token)
-		return true
+		return true, nil
 	case coressh.ReverseTunnelUser:
 		tunnelID, err := a.tunnelTracker.AuthenticateTunnel(ctx.User(), password)
 		if err != nil {
-			a.logger.Errorf(ctx, "authenticating reverse SSH tunnel: %v", err)
-			break
+			return false, errors.Annotate(err, "authenticating reverse SSH tunnel")
 		}
 		ctx.SetValue(tunnelIDKey{}, tunnelID)
-		return true
+		return true, nil
 	}
-	return false
+	return false, nil
 }

--- a/internal/worker/sshserver/authentication.go
+++ b/internal/worker/sshserver/authentication.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshserver
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/juju/juju/core/logger"
+)
+
+type authenticatedViaPublicKey struct{}
+
+type userJWT struct{}
+type tunnelIDKey struct{}
+
+const jimmUser = "jimm"
+const reverseTunnelUser = "juju-reverse-tunnel"
+
+// JWTParser parses JIMM's encoded JWT password authentication payload.
+type JWTParser interface {
+	Parse(context.Context, string) (jwt.Token, error)
+}
+
+// TunnelAuthenticator authenticates machine reverse-tunnel connections.
+type TunnelAuthenticator interface {
+	AuthenticateTunnel(username, password string) (string, error)
+}
+
+// UserPublicKeyService retrieves the public keys registered for a user.
+type UserPublicKeyService interface {
+	PublicKeys(context.Context, string) ([]gossh.PublicKey, error)
+}
+
+// TODO(Kian): Remove these once authz and authn are wired into the SSH server.
+var _ Authenticator = authenticator{}
+var _ Authorizer = authorizer{}
+
+type authenticator struct {
+	logger        logger.Logger
+	jwtParser     JWTParser
+	tunnelTracker TunnelAuthenticator
+	publicKeys    UserPublicKeyService
+}
+
+// PublicKeyAuthentication implements a public key authentication handler.
+func (a authenticator) PublicKeyAuthentication(ctx ssh.Context, key ssh.PublicKey) bool {
+	keys, err := a.publicKeys.PublicKeys(ctx, ctx.User())
+	if err != nil {
+		a.logger.Errorf(ctx, "getting SSH public keys for user %q: %v", ctx.User(), err)
+		return false
+	}
+
+	for _, authorizedKey := range keys {
+		if bytes.Equal(key.Marshal(), authorizedKey.Marshal()) {
+			ctx.SetValue(authenticatedViaPublicKey{}, true)
+			return true
+		}
+	}
+
+	return false
+}
+
+// PasswordAuthentication implements a password authentication handler.
+func (a authenticator) PasswordAuthentication(ctx ssh.Context, password string) bool {
+	ctx.SetValue(authenticatedViaPublicKey{}, false)
+
+	switch ctx.User() {
+	case jimmUser:
+		token, err := a.jwtParser.Parse(ctx, password)
+		if err != nil {
+			a.logger.Errorf(ctx, "parsing SSH JWT: %v", err)
+			break
+		}
+		ctx.SetValue(userJWT{}, token)
+		return true
+	case reverseTunnelUser:
+		tunnelID, err := a.tunnelTracker.AuthenticateTunnel(ctx.User(), password)
+		if err != nil {
+			a.logger.Errorf(ctx, "authenticating reverse SSH tunnel: %v", err)
+			break
+		}
+		ctx.SetValue(tunnelIDKey{}, tunnelID)
+		return true
+	}
+	return false
+}

--- a/internal/worker/sshserver/authentication.go
+++ b/internal/worker/sshserver/authentication.go
@@ -12,6 +12,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/logger"
+	coressh "github.com/juju/juju/core/ssh"
 )
 
 type authenticatedViaPublicKey struct{}
@@ -20,10 +21,10 @@ type userJWT struct{}
 type tunnelIDKey struct{}
 
 const jimmUser = "jimm"
-const reverseTunnelUser = "juju-reverse-tunnel"
 
 // JWTParser parses JIMM's encoded JWT password authentication payload.
 type JWTParser interface {
+	// Parse parses the provided JWT string and returns a jwt.Token if valid.
 	Parse(context.Context, string) (jwt.Token, error)
 }
 
@@ -37,10 +38,11 @@ type UserPublicKeyService interface {
 	PublicKeys(context.Context, string) ([]gossh.PublicKey, error)
 }
 
-// TODO(Kian): Remove these once authz and authn are wired into the SSH server.
-var _ Authenticator = authenticator{}
-var _ Authorizer = authorizer{}
-
+// authenticator implements the Authenticator interface for the SSH server.
+// It handles:
+// 1. Public key authentication by users
+// 2. JWT password authentication for JIMM
+// 3. Reverse-tunnel authentication for machine agents.
 type authenticator struct {
 	logger        logger.Logger
 	jwtParser     JWTParser
@@ -67,6 +69,9 @@ func (a authenticator) PublicKeyAuthentication(ctx ssh.Context, key ssh.PublicKe
 }
 
 // PasswordAuthentication implements a password authentication handler.
+// It supports two types of password authentication:
+// 1. Decoding a JWT as the password for JIMM.
+// 2. Reverse-tunnel authentication for machine agents.
 func (a authenticator) PasswordAuthentication(ctx ssh.Context, password string) bool {
 	ctx.SetValue(authenticatedViaPublicKey{}, false)
 
@@ -79,7 +84,7 @@ func (a authenticator) PasswordAuthentication(ctx ssh.Context, password string) 
 		}
 		ctx.SetValue(userJWT{}, token)
 		return true
-	case reverseTunnelUser:
+	case coressh.ReverseTunnelUser:
 		tunnelID, err := a.tunnelTracker.AuthenticateTunnel(ctx.User(), password)
 		if err != nil {
 			a.logger.Errorf(ctx, "authenticating reverse SSH tunnel: %v", err)

--- a/internal/worker/sshserver/authentication_test.go
+++ b/internal/worker/sshserver/authentication_test.go
@@ -43,7 +43,7 @@ func (s *authenticationSuite) TestPasswordAuthenticationRejectsUnexpectedUser(c 
 func (s *authenticationSuite) TestPasswordAuthenticationAcceptsJIMMJWT(c *tc.C) {
 	token, err := jwt.NewBuilder().Subject("alice").Build()
 	c.Assert(err, tc.ErrorIsNil)
-	ctx := &stubAuthenticationContext{user: jimmUser, values: map[any]any{}}
+	ctx := &stubAuthenticationContext{user: externalAuthUser, values: map[any]any{}}
 	parser := &stubJWTParser{token: token}
 
 	auth := authenticator{jwtParser: parser}
@@ -56,7 +56,7 @@ func (s *authenticationSuite) TestPasswordAuthenticationAcceptsJIMMJWT(c *tc.C) 
 }
 
 func (s *authenticationSuite) TestPasswordAuthenticationRejectsInvalidJIMMJWT(c *tc.C) {
-	ctx := &stubAuthenticationContext{user: jimmUser, values: map[any]any{}}
+	ctx := &stubAuthenticationContext{user: externalAuthUser, values: map[any]any{}}
 	parser := &stubJWTParser{err: errors.New("invalid token")}
 
 	auth := authenticator{

--- a/internal/worker/sshserver/authentication_test.go
+++ b/internal/worker/sshserver/authentication_test.go
@@ -34,7 +34,9 @@ func (s *authenticationSuite) TestPasswordAuthenticationRejectsUnexpectedUser(c 
 	auth := authenticator{
 		logger: loggertesting.WrapCheckLog(c),
 	}
-	c.Check(auth.PasswordAuthentication(ctx, "not-a-token"), tc.IsFalse)
+	authenticated, err := auth.PasswordAuthentication(ctx, "not-a-token")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(authenticated, tc.IsFalse)
 	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
 }
 
@@ -45,7 +47,9 @@ func (s *authenticationSuite) TestPasswordAuthenticationAcceptsJIMMJWT(c *tc.C) 
 	parser := &stubJWTParser{token: token}
 
 	auth := authenticator{jwtParser: parser}
-	c.Check(auth.PasswordAuthentication(ctx, "encoded-jwt"), tc.IsTrue)
+	authenticated, err := auth.PasswordAuthentication(ctx, "encoded-jwt")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(authenticated, tc.IsTrue)
 	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
 	c.Check(ctx.values[userJWT{}], tc.Equals, token)
 	c.Check(parser.password, tc.Equals, "encoded-jwt")
@@ -59,7 +63,9 @@ func (s *authenticationSuite) TestPasswordAuthenticationRejectsInvalidJIMMJWT(c 
 		logger:    loggertesting.WrapCheckLog(c),
 		jwtParser: parser,
 	}
-	c.Check(auth.PasswordAuthentication(ctx, "invalid-jwt"), tc.IsFalse)
+	authenticated, err := auth.PasswordAuthentication(ctx, "invalid-jwt")
+	c.Check(err, tc.ErrorMatches, "parsing SSH JWT: invalid token")
+	c.Check(authenticated, tc.IsFalse)
 	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
 	c.Check(ctx.values[userJWT{}], tc.IsNil)
 	c.Check(parser.password, tc.Equals, "invalid-jwt")
@@ -70,7 +76,9 @@ func (s *authenticationSuite) TestPasswordAuthenticationAcceptsReverseTunnel(c *
 	tunnelTracker := &stubTunnelAuthenticator{tunnelID: "tunnel-uuid"}
 
 	auth := authenticator{tunnelTracker: tunnelTracker}
-	c.Check(auth.PasswordAuthentication(ctx, "tunnel-password"), tc.IsTrue)
+	authenticated, err := auth.PasswordAuthentication(ctx, "tunnel-password")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(authenticated, tc.IsTrue)
 	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
 	c.Check(ctx.values[tunnelIDKey{}], tc.Equals, "tunnel-uuid")
 	c.Check(tunnelTracker.username, tc.Equals, coressh.ReverseTunnelUser)
@@ -85,7 +93,9 @@ func (s *authenticationSuite) TestPasswordAuthenticationRejectsInvalidReverseTun
 		logger:        loggertesting.WrapCheckLog(c),
 		tunnelTracker: tunnelTracker,
 	}
-	c.Check(auth.PasswordAuthentication(ctx, "invalid-password"), tc.IsFalse)
+	authenticated, err := auth.PasswordAuthentication(ctx, "invalid-password")
+	c.Check(err, tc.ErrorMatches, "authenticating reverse SSH tunnel: invalid credentials")
+	c.Check(authenticated, tc.IsFalse)
 	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
 	c.Check(ctx.values[tunnelIDKey{}], tc.IsNil)
 	c.Check(tunnelTracker.username, tc.Equals, coressh.ReverseTunnelUser)
@@ -100,7 +110,9 @@ func (s *authenticationSuite) TestPublicKeyAuthenticationAcceptsUsersKey(c *tc.C
 	auth := authenticator{
 		publicKeys: publicKeys,
 	}
-	c.Check(auth.PublicKeyAuthentication(ctx, signer.PublicKey()), tc.IsTrue)
+	authenticated, err := auth.PublicKeyAuthentication(ctx, signer.PublicKey())
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(authenticated, tc.IsTrue)
 	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, true)
 	c.Check(publicKeys.user, tc.Equals, "alice")
 }
@@ -112,7 +124,9 @@ func (s *authenticationSuite) TestPublicKeyAuthenticationRejectsUnauthorizedKey(
 	auth := authenticator{
 		publicKeys: &stubUserPublicKeyService{keys: []gossh.PublicKey{unauthorizedKey}},
 	}
-	c.Check(auth.PublicKeyAuthentication(ctx, newSigner(c).PublicKey()), tc.IsFalse)
+	authenticated, err := auth.PublicKeyAuthentication(ctx, newSigner(c).PublicKey())
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(authenticated, tc.IsFalse)
 	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.IsNil)
 }
 
@@ -123,7 +137,9 @@ func (s *authenticationSuite) TestPublicKeyAuthenticationRejectsKeyLookupError(c
 		logger:     loggertesting.WrapCheckLog(c),
 		publicKeys: &stubUserPublicKeyService{err: errors.New("boom")},
 	}
-	c.Check(auth.PublicKeyAuthentication(ctx, newSigner(c).PublicKey()), tc.IsFalse)
+	authenticated, err := auth.PublicKeyAuthentication(ctx, newSigner(c).PublicKey())
+	c.Check(err, tc.ErrorMatches, "getting SSH public keys for user \\\"alice\\\": boom")
+	c.Check(authenticated, tc.IsFalse)
 	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.IsNil)
 }
 

--- a/internal/worker/sshserver/authentication_test.go
+++ b/internal/worker/sshserver/authentication_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/juju/tc"
+	sshtesting "github.com/juju/utils/v4/ssh/testing"
+	gossh "golang.org/x/crypto/ssh"
+
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/pki/test"
+)
+
+type authenticationSuite struct{}
+
+func TestAuthenticationSuite(t *testing.T) {
+	tc.Run(t, &authenticationSuite{})
+}
+
+func (s *authenticationSuite) TestPasswordAuthenticationRejectsUnexpectedUser(c *tc.C) {
+	ctx := &authenticationContext{user: "alice", values: map[any]any{}}
+	auth := authenticator{
+		logger: loggertesting.WrapCheckLog(c),
+	}
+	c.Check(auth.PasswordAuthentication(ctx, "not-a-token"), tc.IsFalse)
+	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
+}
+
+func (s *authenticationSuite) TestPublicKeyAuthenticationAcceptsUsersKey(c *tc.C) {
+	signer := newSigner(c)
+	ctx := &authenticationContext{user: "alice", values: map[any]any{}}
+	publicKeys := &stubUserPublicKeyService{keys: []gossh.PublicKey{signer.PublicKey()}}
+
+	auth := authenticator{
+		publicKeys: publicKeys,
+	}
+	c.Check(auth.PublicKeyAuthentication(ctx, signer.PublicKey()), tc.IsTrue)
+	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, true)
+	c.Check(publicKeys.user, tc.Equals, "alice")
+}
+
+func (s *authenticationSuite) TestPublicKeyAuthenticationRejectsUnregisteredKey(c *tc.C) {
+	ctx := &authenticationContext{user: "alice", values: map[any]any{}}
+	unregisteredKey := parseAuthorizedKey(c, sshtesting.ValidKeyOne.Key)
+
+	auth := authenticator{
+		publicKeys: &stubUserPublicKeyService{keys: []gossh.PublicKey{unregisteredKey}},
+	}
+	c.Check(auth.PublicKeyAuthentication(ctx, newSigner(c).PublicKey()), tc.IsFalse)
+	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.IsNil)
+}
+
+func (s *authenticationSuite) TestPublicKeyAuthenticationRejectsKeyLookupError(c *tc.C) {
+	ctx := &authenticationContext{user: "alice", values: map[any]any{}}
+
+	auth := authenticator{
+		logger:     loggertesting.WrapCheckLog(c),
+		publicKeys: &stubUserPublicKeyService{err: errors.New("boom")},
+	}
+	c.Check(auth.PublicKeyAuthentication(ctx, newSigner(c).PublicKey()), tc.IsFalse)
+	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.IsNil)
+}
+
+func newSigner(c *tc.C) gossh.Signer {
+	privateKey, err := test.InsecureKeyProfile()
+	c.Assert(err, tc.ErrorIsNil)
+
+	signer, err := gossh.NewSignerFromSigner(privateKey)
+	c.Assert(err, tc.ErrorIsNil)
+	return signer
+}
+
+func parseAuthorizedKey(c *tc.C, key string) gossh.PublicKey {
+	publicKey, _, _, _, err := gossh.ParseAuthorizedKey([]byte(key))
+	c.Assert(err, tc.ErrorIsNil)
+	return publicKey
+}
+
+type stubUserPublicKeyService struct {
+	keys []gossh.PublicKey
+	err  error
+	user string
+}
+
+func (s *stubUserPublicKeyService) PublicKeys(_ context.Context, username string) ([]gossh.PublicKey, error) {
+	s.user = username
+	return s.keys, s.err
+}
+
+type authenticationContext struct {
+	ssh.Context
+	user   string
+	values map[any]any
+}
+
+func (c *authenticationContext) User() string {
+	return c.user
+}
+
+func (c *authenticationContext) SetValue(key, value any) {
+	c.values[key] = value
+}
+
+func (c *authenticationContext) Value(key any) any {
+	return c.values[key]
+}

--- a/internal/worker/sshserver/authentication_test.go
+++ b/internal/worker/sshserver/authentication_test.go
@@ -11,11 +11,17 @@ import (
 	"github.com/gliderlabs/ssh"
 	"github.com/juju/tc"
 	sshtesting "github.com/juju/utils/v4/ssh/testing"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	gossh "golang.org/x/crypto/ssh"
 
+	coressh "github.com/juju/juju/core/ssh"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/pki/test"
 )
+
+// TODO(Kian): Remove these once authz and authn are wired into the SSH server.
+var _ Authenticator = authenticator{}
+var _ Authorizer = authorizer{}
 
 type authenticationSuite struct{}
 
@@ -24,7 +30,7 @@ func TestAuthenticationSuite(t *testing.T) {
 }
 
 func (s *authenticationSuite) TestPasswordAuthenticationRejectsUnexpectedUser(c *tc.C) {
-	ctx := &authenticationContext{user: "alice", values: map[any]any{}}
+	ctx := &stubAuthenticationContext{user: "alice", values: map[any]any{}}
 	auth := authenticator{
 		logger: loggertesting.WrapCheckLog(c),
 	}
@@ -32,9 +38,63 @@ func (s *authenticationSuite) TestPasswordAuthenticationRejectsUnexpectedUser(c 
 	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
 }
 
+func (s *authenticationSuite) TestPasswordAuthenticationAcceptsJIMMJWT(c *tc.C) {
+	token, err := jwt.NewBuilder().Subject("alice").Build()
+	c.Assert(err, tc.ErrorIsNil)
+	ctx := &stubAuthenticationContext{user: jimmUser, values: map[any]any{}}
+	parser := &stubJWTParser{token: token}
+
+	auth := authenticator{jwtParser: parser}
+	c.Check(auth.PasswordAuthentication(ctx, "encoded-jwt"), tc.IsTrue)
+	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
+	c.Check(ctx.values[userJWT{}], tc.Equals, token)
+	c.Check(parser.password, tc.Equals, "encoded-jwt")
+}
+
+func (s *authenticationSuite) TestPasswordAuthenticationRejectsInvalidJIMMJWT(c *tc.C) {
+	ctx := &stubAuthenticationContext{user: jimmUser, values: map[any]any{}}
+	parser := &stubJWTParser{err: errors.New("invalid token")}
+
+	auth := authenticator{
+		logger:    loggertesting.WrapCheckLog(c),
+		jwtParser: parser,
+	}
+	c.Check(auth.PasswordAuthentication(ctx, "invalid-jwt"), tc.IsFalse)
+	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
+	c.Check(ctx.values[userJWT{}], tc.IsNil)
+	c.Check(parser.password, tc.Equals, "invalid-jwt")
+}
+
+func (s *authenticationSuite) TestPasswordAuthenticationAcceptsReverseTunnel(c *tc.C) {
+	ctx := &stubAuthenticationContext{user: coressh.ReverseTunnelUser, values: map[any]any{}}
+	tunnelTracker := &stubTunnelAuthenticator{tunnelID: "tunnel-uuid"}
+
+	auth := authenticator{tunnelTracker: tunnelTracker}
+	c.Check(auth.PasswordAuthentication(ctx, "tunnel-password"), tc.IsTrue)
+	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
+	c.Check(ctx.values[tunnelIDKey{}], tc.Equals, "tunnel-uuid")
+	c.Check(tunnelTracker.username, tc.Equals, coressh.ReverseTunnelUser)
+	c.Check(tunnelTracker.password, tc.Equals, "tunnel-password")
+}
+
+func (s *authenticationSuite) TestPasswordAuthenticationRejectsInvalidReverseTunnel(c *tc.C) {
+	ctx := &stubAuthenticationContext{user: coressh.ReverseTunnelUser, values: map[any]any{}}
+	tunnelTracker := &stubTunnelAuthenticator{err: errors.New("invalid credentials")}
+
+	auth := authenticator{
+		logger:        loggertesting.WrapCheckLog(c),
+		tunnelTracker: tunnelTracker,
+	}
+	c.Check(auth.PasswordAuthentication(ctx, "invalid-password"), tc.IsFalse)
+	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.Equals, false)
+	c.Check(ctx.values[tunnelIDKey{}], tc.IsNil)
+	c.Check(tunnelTracker.username, tc.Equals, coressh.ReverseTunnelUser)
+	c.Check(tunnelTracker.password, tc.Equals, "invalid-password")
+}
+
 func (s *authenticationSuite) TestPublicKeyAuthenticationAcceptsUsersKey(c *tc.C) {
 	signer := newSigner(c)
-	ctx := &authenticationContext{user: "alice", values: map[any]any{}}
+	ctx := &stubAuthenticationContext{user: "alice", values: map[any]any{}}
 	publicKeys := &stubUserPublicKeyService{keys: []gossh.PublicKey{signer.PublicKey()}}
 
 	auth := authenticator{
@@ -45,19 +105,19 @@ func (s *authenticationSuite) TestPublicKeyAuthenticationAcceptsUsersKey(c *tc.C
 	c.Check(publicKeys.user, tc.Equals, "alice")
 }
 
-func (s *authenticationSuite) TestPublicKeyAuthenticationRejectsUnregisteredKey(c *tc.C) {
-	ctx := &authenticationContext{user: "alice", values: map[any]any{}}
-	unregisteredKey := parseAuthorizedKey(c, sshtesting.ValidKeyOne.Key)
+func (s *authenticationSuite) TestPublicKeyAuthenticationRejectsUnauthorizedKey(c *tc.C) {
+	ctx := &stubAuthenticationContext{user: "alice", values: map[any]any{}}
+	unauthorizedKey := parseAuthorizedKey(c, sshtesting.ValidKeyOne.Key)
 
 	auth := authenticator{
-		publicKeys: &stubUserPublicKeyService{keys: []gossh.PublicKey{unregisteredKey}},
+		publicKeys: &stubUserPublicKeyService{keys: []gossh.PublicKey{unauthorizedKey}},
 	}
 	c.Check(auth.PublicKeyAuthentication(ctx, newSigner(c).PublicKey()), tc.IsFalse)
 	c.Check(ctx.values[authenticatedViaPublicKey{}], tc.IsNil)
 }
 
 func (s *authenticationSuite) TestPublicKeyAuthenticationRejectsKeyLookupError(c *tc.C) {
-	ctx := &authenticationContext{user: "alice", values: map[any]any{}}
+	ctx := &stubAuthenticationContext{user: "alice", values: map[any]any{}}
 
 	auth := authenticator{
 		logger:     loggertesting.WrapCheckLog(c),
@@ -82,6 +142,30 @@ func parseAuthorizedKey(c *tc.C, key string) gossh.PublicKey {
 	return publicKey
 }
 
+type stubJWTParser struct {
+	token    jwt.Token
+	err      error
+	password string
+}
+
+func (s *stubJWTParser) Parse(_ context.Context, password string) (jwt.Token, error) {
+	s.password = password
+	return s.token, s.err
+}
+
+type stubTunnelAuthenticator struct {
+	tunnelID string
+	err      error
+	username string
+	password string
+}
+
+func (s *stubTunnelAuthenticator) AuthenticateTunnel(username, password string) (string, error) {
+	s.username = username
+	s.password = password
+	return s.tunnelID, s.err
+}
+
 type stubUserPublicKeyService struct {
 	keys []gossh.PublicKey
 	err  error
@@ -93,20 +177,20 @@ func (s *stubUserPublicKeyService) PublicKeys(_ context.Context, username string
 	return s.keys, s.err
 }
 
-type authenticationContext struct {
+type stubAuthenticationContext struct {
 	ssh.Context
 	user   string
 	values map[any]any
 }
 
-func (c *authenticationContext) User() string {
+func (c *stubAuthenticationContext) User() string {
 	return c.user
 }
 
-func (c *authenticationContext) SetValue(key, value any) {
+func (c *stubAuthenticationContext) SetValue(key, value any) {
 	c.values[key] = value
 }
 
-func (c *authenticationContext) Value(key any) any {
+func (c *stubAuthenticationContext) Value(key any) any {
 	return c.values[key]
 }

--- a/internal/worker/sshserver/authorization.go
+++ b/internal/worker/sshserver/authorization.go
@@ -16,6 +16,7 @@ import (
 
 // AccessService checks local user access to an SSH target.
 type AccessService interface {
+	// HasSSHAccess checks if the given username has SSH access to the specified destination.
 	HasSSHAccess(context.Context, string, virtualhostname.Info) (bool, error)
 }
 
@@ -44,12 +45,13 @@ func (a authorizer) Authorize(ctx ssh.Context, destination virtualhostname.Info)
 
 	token, _ := ctx.Value(userJWT{}).(jwt.Token)
 	if token == nil {
-		a.logger.Errorf(ctx, "SSH JWT is missing from connection context")
+		a.logger.Warningf(ctx, "SSH JWT is missing from connection context")
 		return false
 	}
 
 	claims, ok := token.PrivateClaims()["access"].(map[string]any)
 	if !ok {
+		a.logger.Warningf(ctx, "Invalid SSH JWT token, missing access claim")
 		return false
 	}
 	access, _ := claims["model-"+destination.ModelUUID().String()].(string)

--- a/internal/worker/sshserver/authorization.go
+++ b/internal/worker/sshserver/authorization.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshserver
+
+import (
+	"context"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/virtualhostname"
+)
+
+// AccessService checks local user access to an SSH target.
+type AccessService interface {
+	HasSSHAccess(context.Context, string, virtualhostname.Info) (bool, error)
+}
+
+type authorizer struct {
+	access AccessService
+	logger logger.Logger
+}
+
+// Authorize checks if the SSH connection context is authorized to access the target destination.
+// By this point, we expect the authenticator to have set the authentication method and
+// any relevant claims in the context.
+func (a authorizer) Authorize(ctx ssh.Context, destination virtualhostname.Info) bool {
+	publicKey, ok := ctx.Value(authenticatedViaPublicKey{}).(bool)
+	if !ok {
+		a.logger.Errorf(ctx, "SSH authentication method is missing from connection context")
+		return false
+	}
+	if publicKey {
+		ok, err := a.access.HasSSHAccess(ctx, ctx.User(), destination)
+		if err != nil {
+			a.logger.Errorf(ctx, "checking SSH access: %v", err)
+			return false
+		}
+		return ok
+	}
+
+	token, _ := ctx.Value(userJWT{}).(jwt.Token)
+	if token == nil {
+		a.logger.Errorf(ctx, "SSH JWT is missing from connection context")
+		return false
+	}
+
+	claims, ok := token.PrivateClaims()["access"].(map[string]any)
+	if !ok {
+		return false
+	}
+	access, _ := claims["model-"+destination.ModelUUID().String()].(string)
+	return permission.Access(access).EqualOrGreaterModelAccessThan(permission.AdminAccess)
+}

--- a/internal/worker/sshserver/authorization.go
+++ b/internal/worker/sshserver/authorization.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/gliderlabs/ssh"
+	"github.com/juju/errors"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 
 	"github.com/juju/juju/core/logger"
@@ -28,32 +29,28 @@ type authorizer struct {
 // Authorize checks if the SSH connection context is authorized to access the target destination.
 // By this point, we expect the authenticator to have set the authentication method and
 // any relevant claims in the context.
-func (a authorizer) Authorize(ctx ssh.Context, destination virtualhostname.Info) bool {
+func (a authorizer) Authorize(ctx ssh.Context, destination virtualhostname.Info) (bool, error) {
 	publicKey, ok := ctx.Value(authenticatedViaPublicKey{}).(bool)
 	if !ok {
-		a.logger.Errorf(ctx, "SSH authentication method is missing from connection context")
-		return false
+		return false, errors.New("SSH authentication method is missing from connection context")
 	}
 	if publicKey {
 		ok, err := a.access.HasSSHAccess(ctx, ctx.User(), destination)
 		if err != nil {
-			a.logger.Errorf(ctx, "checking SSH access: %v", err)
-			return false
+			return false, errors.Annotate(err, "checking SSH access")
 		}
-		return ok
+		return ok, nil
 	}
 
 	token, _ := ctx.Value(userJWT{}).(jwt.Token)
 	if token == nil {
-		a.logger.Warningf(ctx, "SSH JWT is missing from connection context")
-		return false
+		return false, errors.New("SSH JWT is missing from connection context")
 	}
 
 	claims, ok := token.PrivateClaims()["access"].(map[string]any)
 	if !ok {
-		a.logger.Warningf(ctx, "Invalid SSH JWT token, missing access claim")
-		return false
+		return false, errors.New("invalid SSH JWT token, missing access claim")
 	}
 	access, _ := claims["model-"+destination.ModelUUID().String()].(string)
-	return permission.Access(access).EqualOrGreaterModelAccessThan(permission.AdminAccess)
+	return permission.Access(access).EqualOrGreaterModelAccessThan(permission.AdminAccess), nil
 }

--- a/internal/worker/sshserver/authorization_test.go
+++ b/internal/worker/sshserver/authorization_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/juju/tc"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/virtualhostname"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type authorizationSuite struct{}
+
+func TestAuthorizationSuite(t *testing.T) {
+	tc.Run(t, &authorizationSuite{})
+}
+
+func (s *authorizationSuite) TestJWTModelAdminAccess(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+	token, err := jwt.NewBuilder().Claim("access", map[string]any{
+		"model-" + destination.ModelUUID().String(): permission.AdminAccess.String(),
+	}).Build()
+	c.Assert(err, tc.ErrorIsNil)
+	ctx := &authenticationContext{values: map[any]any{
+		authenticatedViaPublicKey{}: false,
+		userJWT{}:                   token,
+	}}
+
+	authorizer := authorizer{logger: loggertesting.WrapCheckLog(c)}
+	c.Check(authorizer.Authorize(ctx, destination), tc.IsTrue)
+}
+
+func (s *authorizationSuite) TestPublicKeyAccessAllowed(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+	access := &stubAccessService{allowed: true}
+	ctx := &authenticationContext{user: "alice", values: map[any]any{
+		authenticatedViaPublicKey{}: true,
+	}}
+
+	authorizer := authorizer{access: access, logger: loggertesting.WrapCheckLog(c)}
+	c.Check(authorizer.Authorize(ctx, destination), tc.IsTrue)
+	c.Check(access.username, tc.Equals, "alice")
+	c.Check(access.destination, tc.Equals, destination)
+}
+
+func (s *authorizationSuite) TestPublicKeyAccessDenied(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+	access := &stubAccessService{allowed: false}
+	ctx := &authenticationContext{user: "alice", values: map[any]any{
+		authenticatedViaPublicKey{}: true,
+	}}
+
+	authorizer := authorizer{access: access, logger: loggertesting.WrapCheckLog(c)}
+	c.Check(authorizer.Authorize(ctx, destination), tc.IsFalse)
+	c.Check(access.username, tc.Equals, "alice")
+	c.Check(access.destination, tc.Equals, destination)
+}
+
+func (s *authorizationSuite) TestJWTAccessRejectsNonAdmin(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+	token, err := jwt.NewBuilder().Claim("access", map[string]any{
+		"model-" + destination.ModelUUID().String(): permission.WriteAccess.String(),
+	}).Build()
+	c.Assert(err, tc.ErrorIsNil)
+
+	ctx := &authenticationContext{values: map[any]any{
+		authenticatedViaPublicKey{}: false,
+		userJWT{}:                   token,
+	}}
+	authorizer := authorizer{logger: loggertesting.WrapCheckLog(c)}
+	c.Check(authorizer.Authorize(ctx, destination), tc.IsFalse)
+}
+
+type stubAccessService struct {
+	allowed     bool
+	username    string
+	destination virtualhostname.Info
+}
+
+func (s *stubAccessService) HasSSHAccess(_ context.Context, username string, destination virtualhostname.Info) (bool, error) {
+	s.username = username
+	s.destination = destination
+	return s.allowed, nil
+}

--- a/internal/worker/sshserver/authorization_test.go
+++ b/internal/worker/sshserver/authorization_test.go
@@ -28,7 +28,7 @@ func (s *authorizationSuite) TestJWTModelAdminAccess(c *tc.C) {
 		"model-" + destination.ModelUUID().String(): permission.AdminAccess.String(),
 	}).Build()
 	c.Assert(err, tc.ErrorIsNil)
-	ctx := &authenticationContext{values: map[any]any{
+	ctx := &stubAuthenticationContext{values: map[any]any{
 		authenticatedViaPublicKey{}: false,
 		userJWT{}:                   token,
 	}}
@@ -41,7 +41,7 @@ func (s *authorizationSuite) TestPublicKeyAccessAllowed(c *tc.C) {
 	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
 	c.Assert(err, tc.ErrorIsNil)
 	access := &stubAccessService{allowed: true}
-	ctx := &authenticationContext{user: "alice", values: map[any]any{
+	ctx := &stubAuthenticationContext{user: "alice", values: map[any]any{
 		authenticatedViaPublicKey{}: true,
 	}}
 
@@ -55,7 +55,7 @@ func (s *authorizationSuite) TestPublicKeyAccessDenied(c *tc.C) {
 	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
 	c.Assert(err, tc.ErrorIsNil)
 	access := &stubAccessService{allowed: false}
-	ctx := &authenticationContext{user: "alice", values: map[any]any{
+	ctx := &stubAuthenticationContext{user: "alice", values: map[any]any{
 		authenticatedViaPublicKey{}: true,
 	}}
 
@@ -73,7 +73,21 @@ func (s *authorizationSuite) TestJWTAccessRejectsNonAdmin(c *tc.C) {
 	}).Build()
 	c.Assert(err, tc.ErrorIsNil)
 
-	ctx := &authenticationContext{values: map[any]any{
+	ctx := &stubAuthenticationContext{values: map[any]any{
+		authenticatedViaPublicKey{}: false,
+		userJWT{}:                   token,
+	}}
+	authorizer := authorizer{logger: loggertesting.WrapCheckLog(c)}
+	c.Check(authorizer.Authorize(ctx, destination), tc.IsFalse)
+}
+
+func (s *authorizationSuite) TestJWTAccessRejectsJWTWithMissingAccessClaim(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+	token, err := jwt.NewBuilder().Build()
+	c.Assert(err, tc.ErrorIsNil)
+
+	ctx := &stubAuthenticationContext{values: map[any]any{
 		authenticatedViaPublicKey{}: false,
 		userJWT{}:                   token,
 	}}

--- a/internal/worker/sshserver/authorization_test.go
+++ b/internal/worker/sshserver/authorization_test.go
@@ -5,6 +5,7 @@ package sshserver
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/juju/tc"
@@ -34,7 +35,9 @@ func (s *authorizationSuite) TestJWTModelAdminAccess(c *tc.C) {
 	}}
 
 	authorizer := authorizer{logger: loggertesting.WrapCheckLog(c)}
-	c.Check(authorizer.Authorize(ctx, destination), tc.IsTrue)
+	authorized, err := authorizer.Authorize(ctx, destination)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(authorized, tc.IsTrue)
 }
 
 func (s *authorizationSuite) TestPublicKeyAccessAllowed(c *tc.C) {
@@ -46,7 +49,9 @@ func (s *authorizationSuite) TestPublicKeyAccessAllowed(c *tc.C) {
 	}}
 
 	authorizer := authorizer{access: access, logger: loggertesting.WrapCheckLog(c)}
-	c.Check(authorizer.Authorize(ctx, destination), tc.IsTrue)
+	authorized, err := authorizer.Authorize(ctx, destination)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(authorized, tc.IsTrue)
 	c.Check(access.username, tc.Equals, "alice")
 	c.Check(access.destination, tc.Equals, destination)
 }
@@ -60,7 +65,9 @@ func (s *authorizationSuite) TestPublicKeyAccessDenied(c *tc.C) {
 	}}
 
 	authorizer := authorizer{access: access, logger: loggertesting.WrapCheckLog(c)}
-	c.Check(authorizer.Authorize(ctx, destination), tc.IsFalse)
+	authorized, err := authorizer.Authorize(ctx, destination)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(authorized, tc.IsFalse)
 	c.Check(access.username, tc.Equals, "alice")
 	c.Check(access.destination, tc.Equals, destination)
 }
@@ -78,7 +85,9 @@ func (s *authorizationSuite) TestJWTAccessRejectsNonAdmin(c *tc.C) {
 		userJWT{}:                   token,
 	}}
 	authorizer := authorizer{logger: loggertesting.WrapCheckLog(c)}
-	c.Check(authorizer.Authorize(ctx, destination), tc.IsFalse)
+	authorized, err := authorizer.Authorize(ctx, destination)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(authorized, tc.IsFalse)
 }
 
 func (s *authorizationSuite) TestJWTAccessRejectsJWTWithMissingAccessClaim(c *tc.C) {
@@ -92,11 +101,44 @@ func (s *authorizationSuite) TestJWTAccessRejectsJWTWithMissingAccessClaim(c *tc
 		userJWT{}:                   token,
 	}}
 	authorizer := authorizer{logger: loggertesting.WrapCheckLog(c)}
-	c.Check(authorizer.Authorize(ctx, destination), tc.IsFalse)
+	authorized, err := authorizer.Authorize(ctx, destination)
+	c.Check(err, tc.ErrorMatches, "invalid SSH JWT token, missing access claim")
+	c.Check(authorized, tc.IsFalse)
+}
+
+func (s *authorizationSuite) TestAuthorizeRejectsMissingAuthenticationMethod(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	authorized, err := authorizer{}.Authorize(&stubAuthenticationContext{values: map[any]any{}}, destination)
+	c.Check(err, tc.ErrorMatches, "SSH authentication method is missing from connection context")
+	c.Check(authorized, tc.IsFalse)
+}
+
+func (s *authorizationSuite) TestAuthorizeRejectsMissingJWT(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+	ctx := &stubAuthenticationContext{values: map[any]any{authenticatedViaPublicKey{}: false}}
+
+	authorized, err := authorizer{}.Authorize(ctx, destination)
+	c.Check(err, tc.ErrorMatches, "SSH JWT is missing from connection context")
+	c.Check(authorized, tc.IsFalse)
+}
+
+func (s *authorizationSuite) TestPublicKeyAccessReturnsError(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+	access := &stubAccessService{err: errors.New("boom")}
+	ctx := &stubAuthenticationContext{user: "alice", values: map[any]any{authenticatedViaPublicKey{}: true}}
+
+	authorized, err := (authorizer{access: access}).Authorize(ctx, destination)
+	c.Check(err, tc.ErrorMatches, "checking SSH access: boom")
+	c.Check(authorized, tc.IsFalse)
 }
 
 type stubAccessService struct {
 	allowed     bool
+	err         error
 	username    string
 	destination virtualhostname.Info
 }
@@ -104,5 +146,5 @@ type stubAccessService struct {
 func (s *stubAccessService) HasSSHAccess(_ context.Context, username string, destination virtualhostname.Info) (bool, error) {
 	s.username = username
 	s.destination = destination
-	return s.allowed, nil
+	return s.allowed, s.err
 }

--- a/internal/worker/sshserver/server.go
+++ b/internal/worker/sshserver/server.go
@@ -22,12 +22,19 @@ import (
 
 // SessionHandler is an interface that proxies SSH sessions to a target unit/machine.
 type SessionHandler interface {
+	// Handle proxies the SSH session to the target unit/machine.
 	Handle(s ssh.Session, destination virtualhostname.Info)
 }
 
 // Authenticator authenticates jump SSH connections.
 type Authenticator interface {
+	// PublicKeyAuthentication authenticates a jump SSH connection using a public key.
+	// Returns true if the public key is valid for the user.
+	// Handles auth for user public keys.
 	PublicKeyAuthentication(ssh.Context, ssh.PublicKey) bool
+	// PasswordAuthentication authenticates a jump SSH connection using a password.
+	// Returns true if the password is valid for the user.
+	// Handles auth for JIMM and reverse-tunnel connections.
 	PasswordAuthentication(ssh.Context, string) bool
 }
 

--- a/internal/worker/sshserver/server.go
+++ b/internal/worker/sshserver/server.go
@@ -20,11 +20,20 @@ import (
 	"github.com/juju/juju/core/virtualhostname"
 )
 
-type authenticatedViaPublicKey struct{}
-
 // SessionHandler is an interface that proxies SSH sessions to a target unit/machine.
 type SessionHandler interface {
 	Handle(s ssh.Session, destination virtualhostname.Info)
+}
+
+// Authenticator authenticates jump SSH connections.
+type Authenticator interface {
+	PublicKeyAuthentication(ssh.Context, ssh.PublicKey) bool
+	PasswordAuthentication(ssh.Context, string) bool
+}
+
+// Authorizer checks whether an authenticated user may access a destination.
+type Authorizer interface {
+	Authorize(ssh.Context, virtualhostname.Info) bool
 }
 
 // ServerWorkerConfig holds the configuration required by the server worker.

--- a/internal/worker/sshserver/server.go
+++ b/internal/worker/sshserver/server.go
@@ -34,7 +34,7 @@ type Authenticator interface {
 	PublicKeyAuthentication(ssh.Context, ssh.PublicKey) (bool, error)
 	// PasswordAuthentication authenticates a jump SSH connection using a password.
 	// Returns true if the password is valid for the user.
-	// Handles auth for JIMM and reverse-tunnel connections.
+	// Handles auth for external-auth and reverse-tunnel connections.
 	PasswordAuthentication(ssh.Context, string) (bool, error)
 }
 

--- a/internal/worker/sshserver/server.go
+++ b/internal/worker/sshserver/server.go
@@ -31,16 +31,18 @@ type Authenticator interface {
 	// PublicKeyAuthentication authenticates a jump SSH connection using a public key.
 	// Returns true if the public key is valid for the user.
 	// Handles auth for user public keys.
-	PublicKeyAuthentication(ssh.Context, ssh.PublicKey) bool
+	PublicKeyAuthentication(ssh.Context, ssh.PublicKey) (bool, error)
 	// PasswordAuthentication authenticates a jump SSH connection using a password.
 	// Returns true if the password is valid for the user.
 	// Handles auth for JIMM and reverse-tunnel connections.
-	PasswordAuthentication(ssh.Context, string) bool
+	PasswordAuthentication(ssh.Context, string) (bool, error)
 }
 
 // Authorizer checks whether an authenticated user may access a destination.
 type Authorizer interface {
-	Authorize(ssh.Context, virtualhostname.Info) bool
+	// Authorize checks whether the authenticated user in the SSH connection
+	// context is allowed to access the target destination.
+	Authorize(ssh.Context, virtualhostname.Info) (bool, error)
 }
 
 // ServerWorkerConfig holds the configuration required by the server worker.


### PR DESCRIPTION
This PR introduces an authenticator and authorizer for the SSH server. These components are not yet wired into the SSH server as we do not yet have all their dependencies.

The authenticator authenticates:
1. Users connecting to Juju controllers directly via public key.
2. JIMM connecting via the password handler, where the password is a JWT.
3. Reverse tunnel connection attempts (machine agents) via the password handler.

The authorizer checks that the authenticated user has permission to SSH to the machine based on their model access rights.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Links

**Jira card:** [JUJU-9955](https://warthogs.atlassian.net/browse/JUJU-9955)


[JUJU-9955]: https://warthogs.atlassian.net/browse/JUJU-9955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ