### PR TITLE
feat: reprovision machine CLI

### DIFF
--- a/api/client/machinemanager/machinemanager.go
+++ b/api/client/machinemanager/machinemanager.go
@@ -130,15 +130,9 @@ func (c *Client) RetryProvisioning(ctx context.Context, all bool, machines ...na
 // ReprovisionMachine requests reprovisioning of a machine whose backing
 // cloud instance is operator-declared lost.
 // The force flag is a data-loss acknowledgement.
-func (c *Client) ReprovisionMachine(ctx context.Context, machine string, force bool) (params.ErrorResult, error) {
-	if !names.IsValidMachine(machine) {
-		return params.ErrorResult{Error: &params.Error{
-			Message: errors.NotValidf("machine ID %q", machine).Error(),
-		}}, nil
-	}
-
+func (c *Client) ReprovisionMachine(ctx context.Context, machine names.MachineTag, force bool) (params.ErrorResult, error) {
 	p := params.ReprovisionMachineArgs{
-		MachineTag: names.NewMachineTag(machine).String(),
+		MachineTag: machine.String(),
 		Force:      force,
 	}
 	var result params.ErrorResult

--- a/api/client/machinemanager/machinemanager.go
+++ b/api/client/machinemanager/machinemanager.go
@@ -126,3 +126,22 @@ func (c *Client) RetryProvisioning(ctx context.Context, all bool, machines ...na
 	err := c.facade.FacadeCall(ctx, "RetryProvisioning", p, &results)
 	return results.Results, err
 }
+
+// ReprovisionMachine requests reprovisioning of a machine whose backing
+// cloud instance is operator-declared lost.
+// The force flag is a data-loss acknowledgement.
+func (c *Client) ReprovisionMachine(ctx context.Context, machine string, force bool) (params.ErrorResult, error) {
+	if !names.IsValidMachine(machine) {
+		return params.ErrorResult{Error: &params.Error{
+			Message: errors.NotValidf("machine ID %q", machine).Error(),
+		}}, nil
+	}
+
+	p := params.ReprovisionMachineArgs{
+		MachineTag: names.NewMachineTag(machine).String(),
+		Force:      force,
+	}
+	var result params.ErrorResult
+	err := c.facade.FacadeCall(ctx, "ReprovisionMachine", p, &result)
+	return result, err
+}

--- a/api/client/machinemanager/machinemanager_test.go
+++ b/api/client/machinemanager/machinemanager_test.go
@@ -308,36 +308,9 @@ func (s *MachinemanagerSuite) TestReprovisionMachine(c *tc.C) {
 		return nil
 	})
 	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
-	result, err := client.ReprovisionMachine(c.Context(), "0", true)
+	result, err := client.ReprovisionMachine(c.Context(), names.NewMachineTag("0"), true)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result, tc.DeepEquals, params.ErrorResult{})
-}
-
-func (s *MachinemanagerSuite) TestReprovisionMachineWithoutForce(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	args := params.ReprovisionMachineArgs{
-		MachineTag: names.NewMachineTag("0").String(),
-		Force:      false,
-	}
-	res := new(params.ErrorResult)
-	ress := params.ErrorResult{
-		Error: &params.Error{Message: "--force is required; reprovisioning will lose root disk, ephemeral disk, charm-local state, and machine-scoped storage data", Code: ""},
-	}
-
-	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
-	mockFacadeCaller.EXPECT().FacadeCall(
-		gomock.Any(), "ReprovisionMachine", args, res,
-	).DoAndReturn(func(_ context.Context, _ string, _ any, resPtr any) error {
-		reflect.ValueOf(resPtr).Elem().Set(reflect.ValueOf(ress))
-		return nil
-	})
-	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
-	result, err := client.ReprovisionMachine(c.Context(), "0", false)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(result.Error, tc.NotNil)
-	c.Check(result.Error.Message, tc.Matches, "--force is required.*")
 }
 
 func (s *MachinemanagerSuite) TestReprovisionMachineError(c *tc.C) {
@@ -355,16 +328,6 @@ func (s *MachinemanagerSuite) TestReprovisionMachineError(c *tc.C) {
 		gomock.Any(), "ReprovisionMachine", args, res,
 	).Return(errors.New("blargh"))
 	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
-	_, err := client.ReprovisionMachine(c.Context(), "0", true)
+	_, err := client.ReprovisionMachine(c.Context(), names.NewMachineTag("0"), true)
 	c.Check(err, tc.ErrorMatches, "blargh")
-}
-
-func (s *MachinemanagerSuite) TestReprovisionMachineInvalidID(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-	client := machinemanager.NewClientFromCaller(nil)
-	result, err := client.ReprovisionMachine(c.Context(), "invalid-id", true)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(result.Error, tc.NotNil)
-	c.Check(result.Error.Message, tc.Matches, "machine ID \"invalid-id\" not valid")
 }

--- a/api/client/machinemanager/machinemanager_test.go
+++ b/api/client/machinemanager/machinemanager_test.go
@@ -288,3 +288,83 @@ func (s *MachinemanagerSuite) TestDestroyMachinesWithParamsNilWait(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, expected)
 }
+
+func (s *MachinemanagerSuite) TestReprovisionMachine(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.ReprovisionMachineArgs{
+		MachineTag: names.NewMachineTag("0").String(),
+		Force:      true,
+	}
+	res := new(params.ErrorResult)
+	ress := params.ErrorResult{}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall(
+		gomock.Any(), "ReprovisionMachine", args, res,
+	).DoAndReturn(func(_ context.Context, _ string, _ any, resPtr any) error {
+		reflect.ValueOf(resPtr).Elem().Set(reflect.ValueOf(ress))
+		return nil
+	})
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
+	result, err := client.ReprovisionMachine(c.Context(), "0", true)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, params.ErrorResult{})
+}
+
+func (s *MachinemanagerSuite) TestReprovisionMachineWithoutForce(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.ReprovisionMachineArgs{
+		MachineTag: names.NewMachineTag("0").String(),
+		Force:      false,
+	}
+	res := new(params.ErrorResult)
+	ress := params.ErrorResult{
+		Error: &params.Error{Message: "--force is required; reprovisioning will lose root disk, ephemeral disk, charm-local state, and machine-scoped storage data", Code: ""},
+	}
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall(
+		gomock.Any(), "ReprovisionMachine", args, res,
+	).DoAndReturn(func(_ context.Context, _ string, _ any, resPtr any) error {
+		reflect.ValueOf(resPtr).Elem().Set(reflect.ValueOf(ress))
+		return nil
+	})
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
+	result, err := client.ReprovisionMachine(c.Context(), "0", false)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Error, tc.NotNil)
+	c.Check(result.Error.Message, tc.Matches, "--force is required.*")
+}
+
+func (s *MachinemanagerSuite) TestReprovisionMachineError(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	args := params.ReprovisionMachineArgs{
+		MachineTag: names.NewMachineTag("0").String(),
+		Force:      true,
+	}
+	res := new(params.ErrorResult)
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall(
+		gomock.Any(), "ReprovisionMachine", args, res,
+	).Return(errors.New("blargh"))
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
+	_, err := client.ReprovisionMachine(c.Context(), "0", true)
+	c.Check(err, tc.ErrorMatches, "blargh")
+}
+
+func (s *MachinemanagerSuite) TestReprovisionMachineInvalidID(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	client := machinemanager.NewClientFromCaller(nil)
+	result, err := client.ReprovisionMachine(c.Context(), "invalid-id", true)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result.Error, tc.NotNil)
+	c.Check(result.Error.Message, tc.Matches, "machine ID \"invalid-id\" not valid")
+}

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -65,7 +65,7 @@ var facadeVersions = facades.FacadeVersions{
 	// Note that this version of Juju does not implement version 10
 	// of the facade, but 3.6 does. Care must be taken not to break
 	// client compatibility with the prior version.
-	"MachineManager":         {10, 11},
+	"MachineManager":         {10, 11, 12},
 	"Machiner":               {5, 6},
 	"MigrationFlag":          {1},
 	"MigrationMaster":        {4, 5},

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -38,6 +38,12 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
+// MachineManagerAPIv11 provides access to the MachineManager API facade for
+// version 11.
+type MachineManagerAPIv11 struct {
+	*MachineManagerAPI
+}
+
 // MachineManagerAPI provides access to the MachineManager API facade.
 type MachineManagerAPI struct {
 	controllerUUID  string
@@ -363,6 +369,17 @@ func (mm *MachineManagerAPI) maybeUpdateInstanceStatus(ctx context.Context, all 
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+// ReprovisionMachine is implemented on the v11 API so a v12 client calling a
+// v11 server gets a not-supported response instead of the v12 implementation.
+func (mm *MachineManagerAPIv11) ReprovisionMachine(context.Context, params.ReprovisionMachineArgs) (params.ErrorResult, error) {
+	return params.ErrorResult{
+		Error: apiservererrors.ParamsErrorf(
+			params.CodeNotSupported,
+			"reprovisioning machines is not supported by this controller",
+		),
+	}, nil
 }
 
 // ReprovisionMachine reprovisions a machine whose backing cloud instance

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -365,6 +365,40 @@ func (mm *MachineManagerAPI) maybeUpdateInstanceStatus(ctx context.Context, all 
 	return nil
 }
 
+// ReprovisionMachine reprovisions a machine whose backing cloud instance
+// is operator-declared lost.
+func (mm *MachineManagerAPI) ReprovisionMachine(ctx context.Context, args params.ReprovisionMachineArgs) (params.ErrorResult, error) {
+	if err := mm.authorizer.CanWrite(ctx); err != nil {
+		return params.ErrorResult{}, err
+	}
+
+	if err := mm.check.ChangeAllowed(ctx); err != nil {
+		return params.ErrorResult{}, errors.Trace(err)
+	}
+
+	machineTag, err := names.ParseMachineTag(args.MachineTag)
+	if err != nil {
+		return params.ErrorResult{Error: apiservererrors.ServerError(err)}, nil
+	}
+
+	if args.Force {
+		mm.logger.Infof(ctx, "reprovisioning requested for machine %q", machineTag.Id())
+	} else {
+		mm.logger.Warningf(ctx, "reprovisioning of machine %q rejected: --force required", machineTag.Id())
+		return params.ErrorResult{
+			Error: apiservererrors.ServerError(errors.Errorf(
+				"--force is required; reprovisioning will lose root disk, ephemeral disk, " +
+					"charm-local state, and machine-scoped storage data",
+			)),
+		}, nil
+	}
+
+	// TODO(juju-9600): Full validation and transactional detach
+	// will be implemented in subsequent tasks (machine eligibility,
+	// agent and provider liveness gates, transactional detach).
+	return params.ErrorResult{}, nil
+}
+
 // DestroyMachineWithParams removes a set of machines from the model.
 func (mm *MachineManagerAPI) DestroyMachineWithParams(ctx context.Context, args params.DestroyMachinesParams) (params.DestroyMachineResults, error) {
 	entities := params.Entities{Entities: make([]params.Entity, len(args.MachineTags))}

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -4,6 +4,7 @@
 package machinemanager
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/juju/tc"
 
 	commonmocks "github.com/juju/juju/apiserver/common/mocks"
+	"github.com/juju/juju/apiserver/facade"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/instance"
@@ -36,6 +38,7 @@ import (
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/rpc/rpcreflect"
 )
 
 type AddMachineManagerSuite struct {
@@ -749,6 +752,33 @@ func (s *ProvisioningMachineManagerSuite) TestReprovisionMachine(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result.Error, tc.IsNil)
+}
+
+func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineV11NotSupported(c *tc.C) {
+	api := &MachineManagerAPIv11{}
+
+	result, err := api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
+		MachineTag: "machine-0",
+		Force:      true,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Error, tc.NotNil)
+	c.Check(result.Error.Code, tc.Equals, params.CodeNotSupported)
+	c.Check(result.Error.Message, tc.Equals, "reprovisioning machines is not supported by this controller")
+}
+
+func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineV11RegisteredType(c *tc.C) {
+	registry := new(facade.Registry)
+	Register(registry)
+
+	goType, err := registry.GetType("MachineManager", 11)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(goType, tc.Equals, reflect.TypeFor[*MachineManagerAPIv11]())
+
+	method, err := rpcreflect.ObjTypeOf(goType).Method("ReprovisionMachine")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(method.Params, tc.Equals, reflect.TypeFor[params.ReprovisionMachineArgs]())
+	c.Check(method.Result, tc.Equals, reflect.TypeFor[params.ErrorResult]())
 }
 
 func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineWithoutForce(c *tc.C) {

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -738,3 +738,54 @@ func (s *ProvisioningMachineManagerSuite) TestRetryProvisioningAll(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(results, tc.DeepEquals, params.ErrorResults{})
 }
+
+func (s *ProvisioningMachineManagerSuite) TestReprovisionMachine(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	result, err := s.api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
+		MachineTag: "machine-0",
+		Force:      true,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Error, tc.IsNil)
+}
+
+func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineWithoutForce(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	result, err := s.api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
+		MachineTag: "machine-0",
+		Force:      false,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Error, tc.NotNil)
+	c.Check(result.Error.Message, tc.Matches, "--force is required.*")
+}
+
+func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineInvalidTag(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	result, err := s.api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
+		MachineTag: "not-a-machine",
+		Force:      true,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Error, tc.NotNil)
+	c.Check(result.Error.Message, tc.Matches, `"not-a-machine" is not a valid tag`)
+}
+
+func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineUnauthorised(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	s.authorizer.Tag = names.NewUserTag("bob")
+
+	_, err := s.api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
+		MachineTag: "machine-0",
+		Force:      true,
+	})
+	c.Assert(err, tc.ErrorMatches, "permission denied")
+}

--- a/apiserver/facades/client/machinemanager/register.go
+++ b/apiserver/facades/client/machinemanager/register.go
@@ -17,15 +17,15 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("MachineManager", 11, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
-		api, err := makeFacade(stdCtx, ctx)
+		api, err := newFacadeV11(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("cannot register machine manager facade: %w", err)
 		}
 		return api, nil
-	}, reflect.TypeFor[*MachineManagerAPI]())
+	}, reflect.TypeFor[*MachineManagerAPIv11]())
 
 	registry.MustRegister("MachineManager", 12, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
-		api, err := makeFacade(stdCtx, ctx)
+		api, err := makeFacade(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("cannot register machine manager facade: %w", err)
 		}
@@ -33,8 +33,16 @@ func Register(registry facade.FacadeRegistry) {
 	}, reflect.TypeFor[*MachineManagerAPI]())
 }
 
+func newFacadeV11(ctx facade.ModelContext) (*MachineManagerAPIv11, error) {
+	api, err := makeFacade(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create machine manager facade: %w", err)
+	}
+	return &MachineManagerAPIv11{MachineManagerAPI: api}, nil
+}
+
 // makeFacade creates a new server-side MachineManager API facade.
-func makeFacade(stdCtx context.Context, ctx facade.ModelContext) (*MachineManagerAPI, error) {
+func makeFacade(ctx facade.ModelContext) (*MachineManagerAPI, error) {
 	// Check the the user is authenticated for this API before creating.
 	if !ctx.Auth().AuthClient() {
 		return nil, apiservererrors.ErrPerm

--- a/apiserver/facades/client/machinemanager/register.go
+++ b/apiserver/facades/client/machinemanager/register.go
@@ -17,7 +17,15 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("MachineManager", 11, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
-		api, err := makeFacadeV11(stdCtx, ctx)
+		api, err := makeFacade(stdCtx, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("cannot register machine manager facade: %w", err)
+		}
+		return api, nil
+	}, reflect.TypeFor[*MachineManagerAPI]())
+
+	registry.MustRegister("MachineManager", 12, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
+		api, err := makeFacade(stdCtx, ctx)
 		if err != nil {
 			return nil, fmt.Errorf("cannot register machine manager facade: %w", err)
 		}
@@ -25,9 +33,8 @@ func Register(registry facade.FacadeRegistry) {
 	}, reflect.TypeFor[*MachineManagerAPI]())
 }
 
-// makeMachineManagerFacadeV11 create a new server-side MachineManager API
-// facade. This is used for facade registration.
-func makeFacadeV11(stdCtx context.Context, ctx facade.ModelContext) (*MachineManagerAPI, error) {
+// makeFacade creates a new server-side MachineManager API facade.
+func makeFacade(stdCtx context.Context, ctx facade.ModelContext) (*MachineManagerAPI, error) {
 	// Check the the user is authenticated for this API before creating.
 	if !ctx.Auth().AuthClient() {
 		return nil, apiservererrors.ErrPerm

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -9685,7 +9685,7 @@
     {
         "Name": "MachineManager",
         "Description": "",
-        "Version": 11,
+        "Version": 12,
         "Schema": {
             "type": "object",
             "properties": {
@@ -9730,6 +9730,17 @@
                         },
                         "Result": {
                             "$ref": "#/definitions/ProvisioningScriptResult"
+                        }
+                    }
+                },
+                "ReprovisionMachine": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ReprovisionMachineArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResult"
                         }
                     }
                 },
@@ -10252,6 +10263,22 @@
                     "additionalProperties": false,
                     "required": [
                         "script"
+                    ]
+                },
+                "ReprovisionMachineArgs": {
+                    "type": "object",
+                    "properties": {
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-tag",
+                        "force"
                     ]
                 },
                 "RetryProvisioningArgs": {

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -414,6 +414,7 @@ func registerCommands(r commandRegistry) {
 	r.Register(machine.NewRemoveCommand())
 	r.Register(machine.NewListMachinesCommand())
 	r.Register(machine.NewShowMachineCommand())
+	r.Register(machine.NewReprovisionMachineCommand())
 
 	// Manage model
 	r.Register(model.NewConfigCommand())

--- a/cmd/juju/commands/main_test.go
+++ b/cmd/juju/commands/main_test.go
@@ -324,6 +324,7 @@ var commandNames = []string{
 	"remove-unit",
 	"remove-user",
 	"rename-space",
+	"reprovision-machine",
 	"resolve",
 	"resolved",
 	"resources",

--- a/cmd/juju/machine/export_test.go
+++ b/cmd/juju/machine/export_test.go
@@ -58,6 +58,20 @@ func NewRemoveCommandForTest(apiRoot api.Connection, machineAPI RemoveMachineAPI
 	return modelcmd.Wrap(command), &RemoveCommand{command}
 }
 
+type ReprovisionMachineCommand struct {
+	*reprovisionMachineCommand
+}
+
+// NewReprovisionMachineCommandForTest returns a ReprovisionMachineCommand
+// with the api provided as specified.
+func NewReprovisionMachineCommandForTest(api ReprovisionMachineAPI) cmd.Command {
+	command := &reprovisionMachineCommand{
+		api: api,
+	}
+	command.SetClientStore(jujuclienttesting.MinimalStore())
+	return modelcmd.Wrap(command)
+}
+
 func NewDisksFlag(disks *[]storage.Directive) *disksFlag {
 	return &disksFlag{disks}
 }

--- a/cmd/juju/machine/reprovisionmachine.go
+++ b/cmd/juju/machine/reprovisionmachine.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/names/v6"
+
+	"github.com/juju/juju/api/client/machinemanager"
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/cmd"
+	"github.com/juju/juju/cmd/juju/block"
+	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/rpc/params"
+)
+
+// NewReprovisionMachineCommand returns a command that reprovisions a machine.
+func NewReprovisionMachineCommand() cmd.Command {
+	return modelcmd.Wrap(&reprovisionMachineCommand{})
+}
+
+type reprovisionMachineCommand struct {
+	modelcmd.ModelCommandBase
+	modelcmd.IAASOnlyCommand
+	machine string
+	force   bool
+	api     ReprovisionMachineAPI
+}
+
+// ReprovisionMachineAPI defines the methods on the client API that the
+// reprovision-machine command calls.
+type ReprovisionMachineAPI interface {
+	Close() error
+	ReprovisionMachine(ctx context.Context, machine string, force bool) (params.ErrorResult, error)
+}
+
+const reprovisionMachineDoc = `
+Reprovision a machine whose backing cloud instance is operator-declared lost.
+This preserves the Juju machine identity and unit assignment and creates a
+replacement cloud instance through the normal provisioning path.
+
+Root disk, ephemeral disk, charm-local state, and machine-scoped storage
+data are NOT recovered. The replacement instance will have empty storage.
+
+The --force flag is required by the server to acknowledge this data loss.
+It does not bypass safety checks.
+
+This command is only supported for top-level, non-controller, IaaS
+provider-backed machines without child container machines or attached
+model-scoped storage.
+`
+
+const reprovisionMachineExamples = `
+    juju reprovision-machine 3 --force
+`
+
+// Info implements Command.Info.
+func (c *reprovisionMachineCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "reprovision-machine",
+		Args:     "<machine>",
+		Purpose:  "Reprovision a machine whose cloud instance has been lost.",
+		Doc:      reprovisionMachineDoc,
+		Examples: reprovisionMachineExamples,
+	})
+}
+
+// SetFlags implements Command.SetFlags.
+func (c *reprovisionMachineCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.ModelCommandBase.SetFlags(f)
+	f.BoolVar(&c.force, "force", false, "Acknowledge that root disk, ephemeral disk, charm-local state, and machine-scoped storage data will be lost")
+}
+
+// Init implements Command.Init.
+func (c *reprovisionMachineCommand) Init(args []string) error {
+	if len(args) == 0 {
+		return errors.Errorf("no machine specified")
+	}
+	if len(args) > 1 {
+		return errors.Errorf("expected exactly one machine, got %d", len(args))
+	}
+
+	machine := args[0]
+	if !names.IsValidMachine(machine) {
+		return errors.Errorf("invalid machine %q", machine)
+	}
+	if names.IsContainerMachine(machine) {
+		return errors.Errorf("invalid machine %q reprovision-machine does not support containers", machine)
+	}
+
+	c.machine = machine
+	return nil
+}
+
+func (c *reprovisionMachineCommand) getAPI(ctx context.Context) (ReprovisionMachineAPI, error) {
+	if c.api != nil {
+		return c.api, nil
+	}
+	root, err := c.NewAPIRoot(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	client := machinemanager.NewClient(root)
+	return client, nil
+}
+
+// Run implements Command.Run.
+func (c *reprovisionMachineCommand) Run(ctx *cmd.Context) error {
+	client, err := c.getAPI(ctx)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	result, err := client.ReprovisionMachine(ctx, c.machine, c.force)
+	if err != nil {
+		if params.IsCodeNotImplemented(err) {
+			return errors.Errorf(
+				"reprovision-machine is not supported by this controller; " +
+					"the controller must be upgraded to a version that supports reprovisioning",
+			)
+		}
+		return block.ProcessBlockedError(err, block.BlockChange)
+	}
+	if result.Error != nil {
+		fmt.Fprintf(ctx.Stderr, "%v\n", result.Error)
+		return nil
+	}
+
+	fmt.Fprintf(ctx.Stdout, "reprovisioning machine %s\n", c.machine)
+	return nil
+}

--- a/cmd/juju/machine/reprovisionmachine.go
+++ b/cmd/juju/machine/reprovisionmachine.go
@@ -128,8 +128,7 @@ func (c *reprovisionMachineCommand) Run(ctx *cmd.Context) error {
 		return block.ProcessBlockedError(err, block.BlockChange)
 	}
 	if result.Error != nil {
-		fmt.Fprintf(ctx.Stderr, "%v\n", result.Error)
-		return nil
+		return result.Error
 	}
 
 	fmt.Fprintf(ctx.Stdout, "reprovisioning machine %s\n", c.machine)

--- a/cmd/juju/machine/reprovisionmachine.go
+++ b/cmd/juju/machine/reprovisionmachine.go
@@ -36,7 +36,7 @@ type reprovisionMachineCommand struct {
 // reprovision-machine command calls.
 type ReprovisionMachineAPI interface {
 	Close() error
-	ReprovisionMachine(ctx context.Context, machine string, force bool) (params.ErrorResult, error)
+	ReprovisionMachine(ctx context.Context, machine names.MachineTag, force bool) (params.ErrorResult, error)
 }
 
 const reprovisionMachineDoc = `
@@ -117,7 +117,7 @@ func (c *reprovisionMachineCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	result, err := client.ReprovisionMachine(ctx, c.machine, c.force)
+	result, err := client.ReprovisionMachine(ctx, names.NewMachineTag(c.machine), c.force)
 	if err != nil {
 		if params.IsCodeNotImplemented(err) {
 			return errors.Errorf(

--- a/cmd/juju/machine/reprovisionmachine_test.go
+++ b/cmd/juju/machine/reprovisionmachine_test.go
@@ -9,6 +9,7 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/errors"
+	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -38,7 +39,7 @@ func (f *fakeReprovisionMachineClient) Close() error {
 	return nil
 }
 
-func (f *fakeReprovisionMachineClient) ReprovisionMachine(ctx context.Context, machine string, force bool) (params.ErrorResult, error) {
+func (f *fakeReprovisionMachineClient) ReprovisionMachine(ctx context.Context, machine names.MachineTag, force bool) (params.ErrorResult, error) {
 	if f.err != nil {
 		return params.ErrorResult{}, f.err
 	}

--- a/cmd/juju/machine/reprovisionmachine_test.go
+++ b/cmd/juju/machine/reprovisionmachine_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine_test
+
+import (
+	"context"
+	"strings"
+	stdtesting "testing"
+
+	"github.com/juju/errors"
+	"github.com/juju/tc"
+
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/cmd/cmd/cmdtesting"
+	"github.com/juju/juju/cmd/juju/machine"
+	"github.com/juju/juju/internal/testing"
+	"github.com/juju/juju/rpc"
+	"github.com/juju/juju/rpc/params"
+)
+
+func TestReprovisionMachineSuite(t *stdtesting.T) {
+	tc.Run(t, &reprovisionMachineSuite{})
+}
+
+type reprovisionMachineSuite struct {
+	testing.FakeJujuXDGDataHomeSuite
+	fake *fakeReprovisionMachineClient
+}
+
+// fakeReprovisionMachineClient mocks the API client for reprovision-machine.
+type fakeReprovisionMachineClient struct {
+	err        error
+	machineErr *params.Error
+}
+
+func (f *fakeReprovisionMachineClient) Close() error {
+	return nil
+}
+
+func (f *fakeReprovisionMachineClient) ReprovisionMachine(ctx context.Context, machine string, force bool) (params.ErrorResult, error) {
+	if f.err != nil {
+		return params.ErrorResult{}, f.err
+	}
+	if f.machineErr != nil {
+		return params.ErrorResult{Error: f.machineErr}, nil
+	}
+	return params.ErrorResult{}, nil
+}
+
+func (s *reprovisionMachineSuite) SetUpTest(c *tc.C) {
+	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
+	s.fake = &fakeReprovisionMachineClient{}
+}
+
+func (s *reprovisionMachineSuite) TestNoArgs(c *tc.C) {
+	command := machine.NewReprovisionMachineCommandForTest(s.fake)
+	_, err := cmdtesting.RunCommand(c, command)
+	c.Check(err, tc.ErrorMatches, "no machine specified")
+}
+
+func (s *reprovisionMachineSuite) TestTooManyArgs(c *tc.C) {
+	command := machine.NewReprovisionMachineCommandForTest(s.fake)
+	_, err := cmdtesting.RunCommand(c, command, "0", "1")
+	c.Check(err, tc.ErrorMatches, "expected exactly one machine, got 2")
+}
+
+func (s *reprovisionMachineSuite) TestInvalidMachine(c *tc.C) {
+	command := machine.NewReprovisionMachineCommandForTest(s.fake)
+	_, err := cmdtesting.RunCommand(c, command, "not-a-machine")
+	c.Check(err, tc.ErrorMatches, `invalid machine "not-a-machine"`)
+}
+
+func (s *reprovisionMachineSuite) TestContainerMachine(c *tc.C) {
+	command := machine.NewReprovisionMachineCommandForTest(s.fake)
+	_, err := cmdtesting.RunCommand(c, command, "0/lxd/0")
+	c.Check(err, tc.ErrorMatches, `invalid machine "0/lxd/0" reprovision-machine does not support containers`)
+}
+
+func (s *reprovisionMachineSuite) TestSuccess(c *tc.C) {
+	command := machine.NewReprovisionMachineCommandForTest(s.fake)
+	ctx, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	c.Check(err, tc.ErrorIsNil)
+	output := cmdtesting.Stdout(ctx)
+	c.Check(strings.TrimSpace(output), tc.Equals, "reprovisioning machine 0")
+}
+
+func (s *reprovisionMachineSuite) TestAPIError(c *tc.C) {
+	s.fake.machineErr = &params.Error{Message: "API error message"}
+	command := machine.NewReprovisionMachineCommandForTest(s.fake)
+	ctx, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	c.Check(err, tc.ErrorIsNil)
+	stderr := cmdtesting.Stderr(ctx)
+	c.Check(strings.TrimSpace(stderr), tc.Equals, "API error message")
+}
+
+func (s *reprovisionMachineSuite) TestBlockedError(c *tc.C) {
+	s.fake.err = apiservererrors.OperationBlockedError("TestBlockReprovisionMachine")
+	command := machine.NewReprovisionMachineCommandForTest(s.fake)
+	_, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	testing.AssertOperationWasBlocked(c, err, ".*TestBlockReprovisionMachine.*")
+}
+
+func (s *reprovisionMachineSuite) TestConnectionError(c *tc.C) {
+	s.fake.err = errors.New("connection refused")
+	command := machine.NewReprovisionMachineCommandForTest(s.fake)
+	_, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	c.Check(err, tc.ErrorMatches, "connection refused")
+}
+
+func (s *reprovisionMachineSuite) TestNotSupported(c *tc.C) {
+	s.fake.err = &rpc.RequestError{
+		Message: `unknown method "ReprovisionMachine" at version 11 for facade type "MachineManager"`,
+		Code:    "not implemented",
+	}
+	command := machine.NewReprovisionMachineCommandForTest(s.fake)
+	_, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	c.Check(err, tc.ErrorMatches,
+		"reprovision-machine is not supported by this controller; "+
+			"the controller must be upgraded to a version that supports reprovisioning")
+}

--- a/cmd/juju/machine/reprovisionmachine_test.go
+++ b/cmd/juju/machine/reprovisionmachine_test.go
@@ -88,10 +88,8 @@ func (s *reprovisionMachineSuite) TestSuccess(c *tc.C) {
 func (s *reprovisionMachineSuite) TestAPIError(c *tc.C) {
 	s.fake.machineErr = &params.Error{Message: "API error message"}
 	command := machine.NewReprovisionMachineCommandForTest(s.fake)
-	ctx, err := cmdtesting.RunCommand(c, command, "0", "--force")
-	c.Check(err, tc.ErrorIsNil)
-	stderr := cmdtesting.Stderr(ctx)
-	c.Check(strings.TrimSpace(stderr), tc.Equals, "API error message")
+	_, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	c.Check(err, tc.ErrorMatches, "API error message")
 }
 
 func (s *reprovisionMachineSuite) TestBlockedError(c *tc.C) {

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/reprovision-machine.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/reprovision-machine.md
@@ -1,0 +1,35 @@
+(command-juju-reprovision-machine)=
+# `juju reprovision-machine`
+## Summary
+Reprovision a machine whose cloud instance has been lost.
+
+## Usage
+```juju reprovision-machine [options] <machine>```
+
+### Options
+| Flag | Default | Usage |
+| --- | --- | --- |
+| `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
+| `--force` | false | Acknowledge that root disk, ephemeral disk, charm-local state, and machine-scoped storage data will be lost |
+| `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
+
+## Examples
+
+    juju reprovision-machine 3 --force
+
+
+## Details
+
+Reprovision a machine whose backing cloud instance is operator-declared lost.
+This preserves the Juju machine identity and unit assignment and creates a
+replacement cloud instance through the normal provisioning path.
+
+Root disk, ephemeral disk, charm-local state, and machine-scoped storage
+data are NOT recovered. The replacement instance will have empty storage.
+
+The --force flag is required by the server to acknowledge this data loss.
+It does not bypass safety checks.
+
+This command is only supported for top-level, non-controller, IaaS
+provider-backed machines without child container machines or attached
+model-scoped storage.

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -839,6 +839,12 @@ type RetryProvisioningArgs struct {
 	All      bool     `json:"all"`
 }
 
+// ReprovisionMachineArgs holds args for reprovisioning a machine.
+type ReprovisionMachineArgs struct {
+	MachineTag string `json:"machine-tag"`
+	Force      bool   `json:"force"`
+}
+
 // ProvisioningNetworkTopology holds a network topology that is based on
 // positive machine space constraints.
 // This is used for creating NICs on instances where the provider is not space


### PR DESCRIPTION
When an IAAS instance backing a Juju machine is lost outside Juju (e.g. OpenStack host failure), operators today must force-remove the machine and its units, then redeploy — losing model identity and unit assignment. This adds the first building block for a recovery path that preserves the Juju machine identity and unit assignment while creating a replacement cloud instance.

It introduces the `juju reprovision-machine <machine> --force` command, plus the matching facade method (v12), API client wrapper, and params types. The --force flag is a data-loss acknowledgement enforced by the server — root disk, ephemeral disk, charm-local state, and machine-scoped storage are not recovered. Older servers that don't support the new facade method get a clear "controller must be upgraded" message rather than a raw RPC error.
The facade currently performs auth, block, and --force checks; the full validation, split-brain gates, and transactional detach will land in follow-up PRs. 


## QA steps

Ignore the error message for now, that will be fixed in the next PR when we have correct validation.

```sh
$ juju bootstrap lxd test
$ juju reprovision-machine -m controller 0
--force is required; reprovisioning will lose root disk, ephemeral disk, charm-local state, and machine-scoped storage data
```

## Links


**Jira card:** [JUJU-10177](https://warthogs.atlassian.net/browse/JUJU-10177)


[JUJU-10177]: https://warthogs.atlassian.net/browse/JUJU-10177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ