### PR TITLE
feat: S3 bucket and region

### DIFF
--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -1000,6 +1000,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		objectStoreServicesName: objectstoreservices.Manifold(objectstoreservices.ManifoldConfig{
 			ChangeStreamName:             changeStreamName,
+			ControllerUUID:               config.ControllerUUID,
 			Clock:                        config.Clock,
 			Logger:                       internallogger.GetLogger("juju.worker.objectstoreservices"),
 			NewWorker:                    objectstoreservices.NewWorker,

--- a/core/objectstore/objectstore.go
+++ b/core/objectstore/objectstore.go
@@ -73,7 +73,8 @@ type WriteSession interface {
 // BucketSession provides additional access to the object store. This allows
 // the manipulation of buckets.
 type BucketSession interface {
-	// CreateBucket creates a bucket in the object store based on the bucket name.
+	// CreateBucket ensures that a bucket with the supplied name exists in the
+	// object store.
 	CreateBucket(ctx context.Context, bucketName string) error
 }
 

--- a/domain/objectstore/controller_info_test.go
+++ b/domain/objectstore/controller_info_test.go
@@ -1,0 +1,6 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package objectstore_test
+
+const testControllerUUID = "00000000-0000-4000-8000-000000000000"

--- a/domain/objectstore/object_store_integration_test.go
+++ b/domain/objectstore/object_store_integration_test.go
@@ -36,7 +36,7 @@ func (s *integrationSuite) newService() *service.Service {
 }
 
 func (s *integrationSuite) newDrainingService() *service.WatchableDrainingService {
-	return service.NewWatchableDrainingService(s.newState(), nil)
+	return service.NewWatchableDrainingService(s.newState(), nil, testControllerUUID)
 }
 
 // TestPutAndGetMetadata verifies that metadata can be stored and retrieved
@@ -460,7 +460,7 @@ func (s *integrationSuite) TestMetadataPersistsThroughBackendTransition(c *tc.C)
 // state so tests can call state methods directly for setup.
 func (s *integrationSuite) newDrainingServiceWithState() (*service.WatchableDrainingService, *state.State) {
 	st := s.newState()
-	svc := service.NewWatchableDrainingService(st, nil)
+	svc := service.NewWatchableDrainingService(st, nil, testControllerUUID)
 	return svc, st
 }
 

--- a/domain/objectstore/object_store_integration_test.go
+++ b/domain/objectstore/object_store_integration_test.go
@@ -221,9 +221,9 @@ func (s *integrationSuite) TestTransitionBackendToS3(c *tc.C) {
 	c.Check(phaseInfo.ActiveBackendUUID, tc.Equals, newBackend.UUID)
 }
 
-// TestTransitionBackendToS3AlreadyInProgress verifies that attempting to
-// transition while a drain is already in progress returns the expected error.
-func (s *integrationSuite) TestTransitionBackendToS3AlreadyInProgress(c *tc.C) {
+// TestTransitionBackendToS3Idempotent verifies that repeating the same
+// transition while its drain is in progress succeeds without changing it.
+func (s *integrationSuite) TestTransitionBackendToS3Idempotent(c *tc.C) {
 	svc := s.newDrainingService()
 
 	creds := domainobjectstore.S3Credentials{
@@ -235,8 +235,32 @@ func (s *integrationSuite) TestTransitionBackendToS3AlreadyInProgress(c *tc.C) {
 	err := svc.TransitionBackendToS3(c.Context(), creds)
 	c.Assert(err, tc.ErrorIsNil)
 
-	// Second call should fail because draining is already in progress.
+	// The same request is already being fulfilled by the active drain.
 	err = svc.TransitionBackendToS3(c.Context(), creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	phaseInfo, err := svc.GetDrainingPhaseInfo(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(phaseInfo.Phase, tc.Equals, objectstore.PhaseDraining)
+}
+
+// TestTransitionBackendToS3AlreadyInProgress verifies that a different S3
+// configuration cannot replace one whose drain is still in progress.
+func (s *integrationSuite) TestTransitionBackendToS3AlreadyInProgress(c *tc.C) {
+	svc := s.newDrainingService()
+
+	err := svc.TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = svc.TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
+		Endpoint:  "https://other.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	})
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrDrainingAlreadyInProgress)
 }
 

--- a/domain/objectstore/service/service.go
+++ b/domain/objectstore/service/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
-	domaincontroller "github.com/juju/juju/domain/controller"
 	domainobjectstore "github.com/juju/juju/domain/objectstore"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/internal/errors"
@@ -145,13 +144,6 @@ type WatcherFactory interface {
 		filter eventsource.FilterOption,
 		filterOpts ...eventsource.FilterOption,
 	) (watcher.NotifyWatcher, error)
-}
-
-// ControllerInfoService describes the controller information needed by the
-// object store service.
-type ControllerInfoService interface {
-	// GetControllerInfo returns information about the current controller.
-	GetControllerInfo(ctx context.Context) (domaincontroller.ControllerInfo, error)
 }
 
 // Service provides the API for working with the objectstore.
@@ -449,17 +441,13 @@ func (s *WatchableService) Watch(ctx context.Context) (watcher.StringsWatcher, e
 // and the ability to create watchers and drain the object store.
 type WatchableDrainingService struct {
 	WatchableService
-	st                DrainingState
-	controllerService ControllerInfoService
+	st             DrainingState
+	controllerUUID string
 }
 
 // NewWatchableDrainingService returns a new service reference wrapping the
 // input state.
-func NewWatchableDrainingService(st DrainingState, watcherFactory WatcherFactory, controllerService ...ControllerInfoService) *WatchableDrainingService {
-	var controllerInfoService ControllerInfoService
-	if len(controllerService) > 0 {
-		controllerInfoService = controllerService[0]
-	}
+func NewWatchableDrainingService(st DrainingState, watcherFactory WatcherFactory, controllerUUID string) *WatchableDrainingService {
 	return &WatchableDrainingService{
 		WatchableService: WatchableService{
 			Service: Service{
@@ -467,8 +455,8 @@ func NewWatchableDrainingService(st DrainingState, watcherFactory WatcherFactory
 			},
 			watcherFactory: watcherFactory,
 		},
-		st:                st,
-		controllerService: controllerInfoService,
+		st:             st,
+		controllerUUID: controllerUUID,
 	}
 }
 
@@ -637,6 +625,13 @@ func (s *WatchableDrainingService) TransitionBackendToS3(ctx context.Context, cr
 	if err := credential.Validate(); err != nil {
 		return errors.Errorf("validating S3 credentials: %w", err)
 	}
+	if credential.Bucket == "" {
+		bucket, err := s.defaultS3Bucket()
+		if err != nil {
+			return errors.Errorf("getting default S3 bucket: %w", err)
+		}
+		credential.Bucket = bucket
+	}
 
 	backendUUID, err := objectstore.NewUUID()
 	if err != nil {
@@ -652,6 +647,17 @@ func (s *WatchableDrainingService) TransitionBackendToS3(ctx context.Context, cr
 		return errors.Errorf("transitioning backend to S3: %w", err)
 	}
 	return nil
+}
+
+func (s *WatchableDrainingService) defaultS3Bucket() (string, error) {
+	if s.controllerUUID == "" {
+		return "", errors.Errorf("empty controller UUID")
+	}
+	bucket := fmt.Sprintf("juju-%s", s.controllerUUID)
+	if _, err := objectstore.ParseObjectStoreBucketName(bucket); err != nil {
+		return "", errors.Capture(err)
+	}
+	return bucket, nil
 }
 
 // WatchObjectStoreBackend returns a watcher that watches the object store

--- a/domain/objectstore/service/service.go
+++ b/domain/objectstore/service/service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"math/rand/v2"
 	"regexp"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
+	domaincontroller "github.com/juju/juju/domain/controller"
 	domainobjectstore "github.com/juju/juju/domain/objectstore"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/internal/errors"
@@ -143,6 +145,13 @@ type WatcherFactory interface {
 		filter eventsource.FilterOption,
 		filterOpts ...eventsource.FilterOption,
 	) (watcher.NotifyWatcher, error)
+}
+
+// ControllerInfoService describes the controller information needed by the
+// object store service.
+type ControllerInfoService interface {
+	// GetControllerInfo returns information about the current controller.
+	GetControllerInfo(ctx context.Context) (domaincontroller.ControllerInfo, error)
 }
 
 // Service provides the API for working with the objectstore.
@@ -440,12 +449,17 @@ func (s *WatchableService) Watch(ctx context.Context) (watcher.StringsWatcher, e
 // and the ability to create watchers and drain the object store.
 type WatchableDrainingService struct {
 	WatchableService
-	st DrainingState
+	st                DrainingState
+	controllerService ControllerInfoService
 }
 
 // NewWatchableDrainingService returns a new service reference wrapping the
 // input state.
-func NewWatchableDrainingService(st DrainingState, watcherFactory WatcherFactory) *WatchableDrainingService {
+func NewWatchableDrainingService(st DrainingState, watcherFactory WatcherFactory, controllerService ...ControllerInfoService) *WatchableDrainingService {
+	var controllerInfoService ControllerInfoService
+	if len(controllerService) > 0 {
+		controllerInfoService = controllerService[0]
+	}
 	return &WatchableDrainingService{
 		WatchableService: WatchableService{
 			Service: Service{
@@ -453,7 +467,8 @@ func NewWatchableDrainingService(st DrainingState, watcherFactory WatcherFactory
 			},
 			watcherFactory: watcherFactory,
 		},
-		st: st,
+		st:                st,
+		controllerService: controllerInfoService,
 	}
 }
 
@@ -506,6 +521,12 @@ type BackendInfo struct {
 	Type objectstore.BackendType
 
 	// Endpoint, AccessKey, SecretKey, and Region are only used for S3 backend.
+	Bucket *string
+
+	// Region is the region for the S3 backend.
+	Region *string
+
+	// Endpoint is the endpoint for the S3 backend.
 	Endpoint *string
 
 	// AccessKey is not returned for security reasons, but it is expected to be
@@ -526,6 +547,8 @@ func (s BackendInfo) S3Credentials() (domainobjectstore.S3Credentials, bool) {
 	}
 
 	return domainobjectstore.S3Credentials{
+		Bucket:    deref(s.Bucket),
+		Region:    deref(s.Region),
 		Endpoint:  deref(s.Endpoint),
 		AccessKey: deref(s.AccessKey),
 		SecretKey: deref(s.SecretKey),
@@ -569,6 +592,8 @@ func (s *WatchableDrainingService) GetActiveObjectStoreBackend(ctx context.Conte
 	return BackendInfo{
 		UUID:      objectstore.UUID(backendInfo.UUID),
 		Type:      objectstore.BackendType(backendInfo.ObjectStoreType),
+		Bucket:    backendInfo.Bucket,
+		Region:    backendInfo.Region,
 		Endpoint:  backendInfo.Endpoint,
 		AccessKey: backendInfo.AccessKey,
 		SecretKey: backendInfo.SecretKey,
@@ -592,6 +617,8 @@ func (s *WatchableDrainingService) GetObjectStoreBackend(ctx context.Context, uu
 	return BackendInfo{
 		UUID:      objectstore.UUID(backendInfo.UUID),
 		Type:      objectstore.BackendType(backendInfo.ObjectStoreType),
+		Bucket:    backendInfo.Bucket,
+		Region:    backendInfo.Region,
 		Endpoint:  backendInfo.Endpoint,
 		AccessKey: backendInfo.AccessKey,
 		SecretKey: backendInfo.SecretKey,

--- a/domain/objectstore/service/service_test.go
+++ b/domain/objectstore/service/service_test.go
@@ -30,6 +30,8 @@ type serviceSuite struct {
 	watcherFactory *MockWatcherFactory
 }
 
+const testControllerUUID = "00000000-0000-4000-8000-000000000000"
+
 func TestServiceSuite(t *testing.T) {
 	tc.Run(t, &serviceSuite{})
 }
@@ -464,7 +466,7 @@ func (s *drainingServiceSuite) TestSetDrainingPhase(c *tc.C) {
 
 	s.state.EXPECT().TransitionDrainingPhase(gomock.Any(), tc.Bind(tc.IsNonZeroUUID), newPhase).Return(nil)
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).SetDrainingPhase(c.Context(), newPhase)
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).SetDrainingPhase(c.Context(), newPhase)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -475,7 +477,7 @@ func (s *drainingServiceSuite) TestSetDrainingPhaseCompleted(c *tc.C) {
 
 	s.state.EXPECT().TransitionDrainingPhase(gomock.Any(), tc.Bind(tc.IsNonZeroUUID), newPhase).Return(nil)
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).SetDrainingPhase(c.Context(), newPhase)
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).SetDrainingPhase(c.Context(), newPhase)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -484,7 +486,7 @@ func (s *drainingServiceSuite) TestSetDrainingPhaseInvalid(c *tc.C) {
 
 	phase := objectstore.Phase("invalid")
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).SetDrainingPhase(c.Context(), phase)
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).SetDrainingPhase(c.Context(), phase)
 	c.Assert(err, tc.ErrorMatches, "invalid phase \"invalid\"")
 }
 
@@ -495,7 +497,7 @@ func (s *drainingServiceSuite) TestSetDrainingPhaseError(c *tc.C) {
 
 	s.state.EXPECT().TransitionDrainingPhase(gomock.Any(), tc.Bind(tc.IsNonZeroUUID), newPhase).Return(errors.Errorf("boom"))
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).SetDrainingPhase(c.Context(), newPhase)
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).SetDrainingPhase(c.Context(), newPhase)
 	c.Assert(err, tc.ErrorMatches, `.*boom`)
 }
 
@@ -510,7 +512,7 @@ func (s *drainingServiceSuite) TestGetDrainingPhase(c *tc.C) {
 		Phase: phase.String(),
 	}, nil)
 
-	p, err := NewWatchableDrainingService(s.state, s.watcherFactory).GetDrainingPhase(c.Context())
+	p, err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).GetDrainingPhase(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(p, tc.Equals, phase)
 }
@@ -521,7 +523,7 @@ func (s *drainingServiceSuite) TestGetDrainingPhaseNotFoundReturnsUnknown(c *tc.
 	s.state.EXPECT().GetActiveDrainingInfo(gomock.Any()).
 		Return(domainobjectstore.DrainingInfo{}, objectstoreerrors.ErrDrainingPhaseNotFound)
 
-	p, err := NewWatchableDrainingService(s.state, s.watcherFactory).GetDrainingPhase(c.Context())
+	p, err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).GetDrainingPhase(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(p, tc.Equals, objectstore.PhaseUnknown)
 }
@@ -532,7 +534,7 @@ func (s *drainingServiceSuite) TestGetDrainingPhaseError(c *tc.C) {
 	s.state.EXPECT().GetActiveDrainingInfo(gomock.Any()).
 		Return(domainobjectstore.DrainingInfo{}, errors.Errorf("boom"))
 
-	_, err := NewWatchableDrainingService(s.state, s.watcherFactory).GetDrainingPhase(c.Context())
+	_, err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).GetDrainingPhase(c.Context())
 	c.Assert(err, tc.ErrorMatches, `.*boom`)
 }
 
@@ -543,14 +545,14 @@ func (s *drainingServiceSuite) TestRemoveMetadata(c *tc.C) {
 
 	s.state.EXPECT().RemoveMetadata(gomock.Any(), key).Return(nil)
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).RemoveMetadata(c.Context(), key)
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).RemoveMetadata(c.Context(), key)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *drainingServiceSuite) TestRemoveMetadataEmptyPath(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).RemoveMetadata(c.Context(), "")
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).RemoveMetadata(c.Context(), "")
 	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrEmptyPath)
 }
 
@@ -562,7 +564,7 @@ func (s *drainingServiceSuite) TestGetActiveObjectStoreBackend(c *tc.C) {
 		ObjectStoreType: "file",
 	}, nil)
 
-	info, err := NewWatchableDrainingService(s.state, s.watcherFactory).GetActiveObjectStoreBackend(c.Context())
+	info, err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).GetActiveObjectStoreBackend(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(info.Type, tc.Equals, objectstore.FileBackend)
 	c.Check(info.UUID, tc.Equals, objectstore.UUID("backend-uuid"))
@@ -621,7 +623,24 @@ func (s *drainingServiceSuite) TestTransitionBackendToS3Success(c *tc.C) {
 
 	s.state.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any(), gomock.Any(), creds).Return(nil)
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), creds)
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).TransitionBackendToS3(c.Context(), creds)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *drainingServiceSuite) TestTransitionBackendToS3DefaultBucket(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	creds := domainobjectstore.S3Credentials{
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	}
+	expected := creds
+	expected.Bucket = "juju-" + testControllerUUID
+
+	s.state.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any(), gomock.Any(), expected).Return(nil)
+
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).TransitionBackendToS3(c.Context(), creds)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -634,16 +653,18 @@ func (s *drainingServiceSuite) TestTransitionBackendToS3StateError(c *tc.C) {
 		SecretKey: "secret-key",
 	}
 
-	s.state.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any(), gomock.Any(), creds).Return(errors.New("boom"))
+	expected := creds
+	expected.Bucket = "juju-" + testControllerUUID
+	s.state.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any(), gomock.Any(), expected).Return(errors.New("boom"))
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), creds)
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).TransitionBackendToS3(c.Context(), creds)
 	c.Assert(err, tc.ErrorMatches, ".*boom.*")
 }
 
 func (s *drainingServiceSuite) TestTransitionBackendToS3MissingEndpoint(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
 		AccessKey: "access-key",
 		SecretKey: "secret-key",
 	})
@@ -653,7 +674,7 @@ func (s *drainingServiceSuite) TestTransitionBackendToS3MissingEndpoint(c *tc.C)
 func (s *drainingServiceSuite) TestTransitionBackendToS3InvalidBucket(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
 		Bucket:    "bad_bucket",
 		Endpoint:  "https://s3.example.com",
 		AccessKey: "access-key",
@@ -665,7 +686,7 @@ func (s *drainingServiceSuite) TestTransitionBackendToS3InvalidBucket(c *tc.C) {
 func (s *drainingServiceSuite) TestTransitionBackendToS3MissingAccessKey(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
 		Endpoint:  "https://s3.example.com",
 		SecretKey: "secret-key",
 	})
@@ -675,7 +696,7 @@ func (s *drainingServiceSuite) TestTransitionBackendToS3MissingAccessKey(c *tc.C
 func (s *drainingServiceSuite) TestTransitionBackendToS3MissingSecretKey(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
 		Endpoint:  "https://s3.example.com",
 		AccessKey: "access-key",
 	})
@@ -685,7 +706,7 @@ func (s *drainingServiceSuite) TestTransitionBackendToS3MissingSecretKey(c *tc.C
 func (s *drainingServiceSuite) TestTransitionBackendToS3EmptyCredentials(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{})
+	err := NewWatchableDrainingService(s.state, s.watcherFactory, testControllerUUID).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{})
 	c.Assert(err, tc.ErrorMatches, ".*endpoint is required.*")
 }
 

--- a/domain/objectstore/service/service_test.go
+++ b/domain/objectstore/service/service_test.go
@@ -612,6 +612,8 @@ func (s *drainingServiceSuite) TestTransitionBackendToS3Success(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	creds := domainobjectstore.S3Credentials{
+		Bucket:    "test-bucket",
+		Region:    "us-east-1",
 		Endpoint:  "https://s3.example.com",
 		AccessKey: "access-key",
 		SecretKey: "secret-key",
@@ -646,6 +648,18 @@ func (s *drainingServiceSuite) TestTransitionBackendToS3MissingEndpoint(c *tc.C)
 		SecretKey: "secret-key",
 	})
 	c.Assert(err, tc.ErrorMatches, ".*endpoint is required.*")
+}
+
+func (s *drainingServiceSuite) TestTransitionBackendToS3InvalidBucket(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := NewWatchableDrainingService(s.state, s.watcherFactory).TransitionBackendToS3(c.Context(), domainobjectstore.S3Credentials{
+		Bucket:    "bad_bucket",
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	})
+	c.Assert(err, tc.ErrorMatches, `.*bucket: bucket name "bad_bucket": invalid characters.*`)
 }
 
 func (s *drainingServiceSuite) TestTransitionBackendToS3MissingAccessKey(c *tc.C) {

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -775,6 +775,8 @@ func (s *State) GetObjectStoreBackend(ctx context.Context, uuid string) (domaino
 		TypeID    int              `db:"type_id"`
 		TypeValue string           `db:"type"`
 		LifeID    life.Life        `db:"life_id"`
+		Bucket    sql.Null[string] `db:"bucket"`
+		Region    sql.Null[string] `db:"region"`
 		Endpoint  sql.Null[string] `db:"endpoint"`
 		AccessKey sql.Null[string] `db:"static_key"`
 		SecretKey sql.Null[string] `db:"static_secret"`
@@ -808,6 +810,8 @@ WHERE uuid = $backendInfo.uuid`, backendInfo{})
 		UUID:            info.UUID,
 		ObjectStoreType: info.TypeValue,
 		LifeID:          info.LifeID,
+		Bucket:          nullableOrNil(info.Bucket),
+		Region:          nullableOrNil(info.Region),
 		Endpoint:        nullableOrNil(info.Endpoint),
 		AccessKey:       nullableOrNil(info.AccessKey),
 		SecretKey:       nullableOrNil(info.SecretKey),
@@ -833,6 +837,8 @@ func (s *State) GetActiveObjectStoreBackend(ctx context.Context) (domainobjectst
 		TypeID    int              `db:"type_id"`
 		TypeValue string           `db:"type"`
 		LifeID    life.Life        `db:"life_id"`
+		Bucket    sql.Null[string] `db:"bucket"`
+		Region    sql.Null[string] `db:"region"`
 		Endpoint  sql.Null[string] `db:"endpoint"`
 		AccessKey sql.Null[string] `db:"static_key"`
 		SecretKey sql.Null[string] `db:"static_secret"`
@@ -866,6 +872,8 @@ WHERE life_id = 0`, backendInfo{})
 		UUID:            info.UUID,
 		ObjectStoreType: info.TypeValue,
 		LifeID:          info.LifeID,
+		Bucket:          nullableOrNil(info.Bucket),
+		Region:          nullableOrNil(info.Region),
 		Endpoint:        nullableOrNil(info.Endpoint),
 		AccessKey:       nullableOrNil(info.AccessKey),
 		SecretKey:       nullableOrNil(info.SecretKey),
@@ -898,6 +906,8 @@ func (s *State) TransitionBackendToS3(ctx context.Context, bUUID, dUUID string, 
 
 	type s3Credentials struct {
 		UUID      string `db:"object_store_backend_uuid"`
+		Bucket    string `db:"bucket"`
+		Region    string `db:"region"`
 		Endpoint  string `db:"endpoint"`
 		AccessKey string `db:"static_key"`
 		SecretKey string `db:"static_secret"`
@@ -916,6 +926,8 @@ func (s *State) TransitionBackendToS3(ctx context.Context, bUUID, dUUID string, 
 
 	s3Creds := s3Credentials{
 		UUID:      bUUID,
+		Bucket:    credential.Bucket,
+		Region:    credential.Region,
 		Endpoint:  credential.Endpoint,
 		AccessKey: credential.AccessKey,
 		SecretKey: credential.SecretKey,
@@ -955,6 +967,8 @@ VALUES ($newBackend.uuid, 0, 1, $newBackend.updated_at)`, backend)
 	s3InsertStmt, err := s.Prepare(`
 INSERT INTO object_store_backend_s3_credential (
     object_store_backend_uuid, 
+    bucket,
+    region,
     endpoint, 
     static_key, 
     static_secret

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -786,7 +786,7 @@ func (s *State) GetObjectStoreBackend(ctx context.Context, uuid string) (domaino
 SELECT &backendInfo.*
 FROM object_store_backend
 JOIN object_store_backend_type ON object_store_backend.type_id = object_store_backend_type.id
-LEFT JOIN object_store_backend_s3_credential ON object_store_backend.uuid = object_store_backend_s3_credential.object_store_backend_uuid
+LEFT JOIN object_store_backend_s3_config ON object_store_backend.uuid = object_store_backend_s3_config.object_store_backend_uuid
 WHERE uuid = $backendInfo.uuid`, backendInfo{})
 	if err != nil {
 		return domainobjectstore.BackendInfo{}, errors.Errorf("preparing select object store backend statement: %w", err)
@@ -848,7 +848,7 @@ func (s *State) GetActiveObjectStoreBackend(ctx context.Context) (domainobjectst
 SELECT &backendInfo.*
 FROM object_store_backend
 JOIN object_store_backend_type ON object_store_backend.type_id = object_store_backend_type.id
-LEFT JOIN object_store_backend_s3_credential ON object_store_backend.uuid = object_store_backend_s3_credential.object_store_backend_uuid
+LEFT JOIN object_store_backend_s3_config ON object_store_backend.uuid = object_store_backend_s3_config.object_store_backend_uuid
 WHERE life_id = 0`, backendInfo{})
 	if err != nil {
 		return domainobjectstore.BackendInfo{}, errors.Errorf("preparing select active object store backend statement: %w", err)
@@ -892,8 +892,8 @@ WHERE life_id = 0`, backendInfo{})
 //
 // This method returns the following errors:
 //   - [objectstoreerrors.ErrDrainingAlreadyInProgress]: if there is already an
-//     active draining phase, as we don't want to update the backend information
-//     while we're in the middle of a draining process.
+//     active draining phase with different S3 configuration. Repeating the
+//     transition with the same configuration is an idempotent success.
 //   - [objectstoreerrors.ErrBackendAlreadyExists]: if there is already a
 //     backend with the specified uuid.
 //   - [objectstoreerrors.ErrBackendTransitionNotSupported]: if the current
@@ -949,6 +949,21 @@ WHERE di.phase_type_id < 2`, count{})
 		return errors.Errorf("preparing select draining phase statement: %w", err)
 	}
 
+	getDrainingS3ConfigStmt, err := s.Prepare(`
+SELECT c.object_store_backend_uuid AS &s3Credentials.object_store_backend_uuid,
+       c.bucket AS &s3Credentials.bucket,
+       c.region AS &s3Credentials.region,
+       c.endpoint AS &s3Credentials.endpoint,
+       c.static_key AS &s3Credentials.static_key,
+       c.static_secret AS &s3Credentials.static_secret
+FROM object_store_drain_info AS di
+JOIN object_store_backend_s3_config AS c
+  ON di.to_backend_uuid = c.object_store_backend_uuid
+WHERE di.phase_type_id < 2`, s3Credentials{})
+	if err != nil {
+		return errors.Errorf("preparing select draining S3 configuration statement: %w", err)
+	}
+
 	setBackendDyingStmt, err := s.Prepare(`
 UPDATE object_store_backend
 SET life_id = 1, updated_at = $newBackend.updated_at
@@ -965,7 +980,7 @@ VALUES ($newBackend.uuid, 0, 1, $newBackend.updated_at)`, backend)
 	}
 
 	s3InsertStmt, err := s.Prepare(`
-INSERT INTO object_store_backend_s3_credential (
+INSERT INTO object_store_backend_s3_config (
     object_store_backend_uuid, 
     bucket,
     region,
@@ -1013,11 +1028,23 @@ WHERE b.life_id = 0`, activeBackend{})
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// Ensure that we're not currently in a draining phase, as we don't want
 		// to update the backend information while we're in the middle of a
-		// draining process.
+		// draining process. An identical request is already satisfied by the
+		// in-progress transition, so treat it as an idempotent success.
 		var phaseCount count
 		if err := tx.Query(ctx, getPhaseInfoStmt).Get(&phaseCount); err != nil {
 			return errors.Errorf("checking draining phase: %w", err)
 		} else if phaseCount.Count > 0 {
+			var current s3Credentials
+			if err := tx.Query(ctx, getDrainingS3ConfigStmt).Get(&current); err != nil {
+				return errors.Errorf("getting draining S3 configuration: %w", err)
+			}
+			if current.Bucket == s3Creds.Bucket &&
+				current.Region == s3Creds.Region &&
+				current.Endpoint == s3Creds.Endpoint &&
+				current.AccessKey == s3Creds.AccessKey &&
+				current.SecretKey == s3Creds.SecretKey {
+				return nil
+			}
 			return objectstoreerrors.ErrDrainingAlreadyInProgress
 		}
 
@@ -1117,7 +1144,7 @@ WHERE uuid = $backendType.uuid`, backendType{})
 	}
 
 	deleteStmt, err := s.Prepare(`
-DELETE FROM object_store_backend_s3_credential
+DELETE FROM object_store_backend_s3_config
 WHERE object_store_backend_uuid = $backendType.uuid`, backendType{})
 	if err != nil {
 		return errors.Errorf("preparing delete credentials statement: %w", err)

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -688,6 +688,8 @@ func (s *stateSuite) TestGetActiveDrainingInfo(c *tc.C) {
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
+		Bucket:    "test-bucket",
+		Region:    "us-east-1",
 		Endpoint:  "https://s3.example.com",
 		AccessKey: "access-key",
 		SecretKey: "secret-key",
@@ -931,7 +933,7 @@ func (s *stateSuite) TestTransitionBackendToS3(c *tc.C) {
 
 	var lifeID, typeID int
 	var dyingTypeID int
-	var endpoint, accessKey, secretKey string
+	var bucket, region, endpoint, accessKey, secretKey string
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
 SELECT life_id, type_id FROM object_store_backend
@@ -948,10 +950,10 @@ WHERE life_id = 1`)
 		}
 
 		row = tx.QueryRowContext(ctx, `
-SELECT endpoint, static_key, static_secret
+SELECT bucket, region, endpoint, static_key, static_secret
 FROM object_store_backend_s3_credential
 WHERE object_store_backend_uuid = ?`, backendUUID)
-		if err := row.Scan(&endpoint, &accessKey, &secretKey); err != nil {
+		if err := row.Scan(&bucket, &region, &endpoint, &accessKey, &secretKey); err != nil {
 			return errors.Errorf("querying backend credentials: %w", err)
 		}
 
@@ -964,6 +966,8 @@ WHERE object_store_backend_uuid = ?`, backendUUID)
 
 	c.Check(dyingTypeID, tc.Equals, 0)
 
+	c.Check(bucket, tc.Equals, creds.Bucket)
+	c.Check(region, tc.Equals, creds.Region)
 	c.Check(endpoint, tc.Equals, creds.Endpoint)
 	c.Check(accessKey, tc.Equals, creds.AccessKey)
 	c.Check(secretKey, tc.Equals, creds.SecretKey)
@@ -1091,6 +1095,8 @@ WHERE life_id = 0`)
 	c.Check(info.UUID, tc.Equals, activeUUID)
 	c.Check(info.ObjectStoreType, tc.Equals, "file")
 	c.Check(info.LifeID, tc.Equals, life.Alive)
+	c.Check(info.Bucket, tc.IsNil)
+	c.Check(info.Region, tc.IsNil)
 	c.Check(info.Endpoint, tc.IsNil)
 	c.Check(info.AccessKey, tc.IsNil)
 	c.Check(info.SecretKey, tc.IsNil)
@@ -1101,6 +1107,8 @@ func (s *stateSuite) TestGetActiveObjectStoreBackendS3(c *tc.C) {
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
+		Bucket:    "test-bucket",
+		Region:    "us-east-1",
 		Endpoint:  "https://s3.example.com",
 		AccessKey: "access-key",
 		SecretKey: "secret-key",
@@ -1114,6 +1122,10 @@ func (s *stateSuite) TestGetActiveObjectStoreBackendS3(c *tc.C) {
 	c.Check(info.UUID, tc.Equals, backendUUID)
 	c.Check(info.ObjectStoreType, tc.Equals, "s3")
 	c.Check(info.LifeID, tc.Equals, life.Alive)
+	c.Assert(info.Bucket, tc.NotNil)
+	c.Check(*info.Bucket, tc.Equals, creds.Bucket)
+	c.Assert(info.Region, tc.NotNil)
+	c.Check(*info.Region, tc.Equals, creds.Region)
 	c.Assert(info.Endpoint, tc.NotNil)
 	c.Check(*info.Endpoint, tc.Equals, creds.Endpoint)
 	c.Assert(info.AccessKey, tc.NotNil)

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -831,6 +831,8 @@ func (s *stateSuite) TestTransitionBackendToS3CalledTwice(c *tc.C) {
 
 	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
 	creds := domainobjectstore.S3Credentials{
+		Bucket:    "test-bucket",
+		Region:    "us-east-1",
 		Endpoint:  "https://s3.example.com",
 		AccessKey: "access-key",
 		SecretKey: "secret-key",
@@ -839,13 +841,76 @@ func (s *stateSuite) TestTransitionBackendToS3CalledTwice(c *tc.C) {
 	err := st.TransitionBackendToS3(c.Context(), backendUUID, "drain-uuid", creds)
 	c.Assert(err, tc.ErrorIsNil)
 
-	// Force the old backend to be marked as dead.
-	s.markBackendAsDead(c, "653813f9-2896-5332-8cbe-629a337a56a3")
+	// A repeated request has newly generated backend and drain UUIDs, but is
+	// already satisfied by the in-progress transition.
+	err = st.TransitionBackendToS3(c.Context(),
+		tc.Must(c, coreobjectstore.NewUUID).String(), "drain-uuid-2", creds)
+	c.Assert(err, tc.ErrorIsNil)
 
-	// The second call fails because the draining phase is already active
-	// from the first call.
-	err = st.TransitionBackendToS3(c.Context(), backendUUID, "drain-uuid-2", creds)
-	c.Assert(err, tc.ErrorIs, objectstoreerrors.ErrDrainingAlreadyInProgress)
+	var backendCount, drainCount, configCount int
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM object_store_backend`).Scan(&backendCount); err != nil {
+			return err
+		}
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM object_store_drain_info`).Scan(&drainCount); err != nil {
+			return err
+		}
+		return tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM object_store_backend_s3_config`).Scan(&configCount)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(backendCount, tc.Equals, 2)
+	c.Check(drainCount, tc.Equals, 1)
+	c.Check(configCount, tc.Equals, 1)
+}
+
+func (s *stateSuite) TestTransitionBackendToS3CalledWhileDrainingWithDifferentConfig(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock)
+
+	backendUUID := tc.Must(c, coreobjectstore.NewUUID).String()
+	creds := domainobjectstore.S3Credentials{
+		Bucket:    "test-bucket",
+		Region:    "us-east-1",
+		Endpoint:  "https://s3.example.com",
+		AccessKey: "access-key",
+		SecretKey: "secret-key",
+	}
+	err := st.TransitionBackendToS3(c.Context(), backendUUID, "drain-uuid", creds)
+	c.Assert(err, tc.ErrorIsNil)
+
+	tests := []struct {
+		name  string
+		creds domainobjectstore.S3Credentials
+	}{
+		{name: "bucket", creds: domainobjectstore.S3Credentials{
+			Bucket: "other-bucket", Region: creds.Region, Endpoint: creds.Endpoint,
+			AccessKey: creds.AccessKey, SecretKey: creds.SecretKey,
+		}},
+		{name: "region", creds: domainobjectstore.S3Credentials{
+			Bucket: creds.Bucket, Region: "eu-west-1", Endpoint: creds.Endpoint,
+			AccessKey: creds.AccessKey, SecretKey: creds.SecretKey,
+		}},
+		{name: "endpoint", creds: domainobjectstore.S3Credentials{
+			Bucket: creds.Bucket, Region: creds.Region, Endpoint: "https://other.example.com",
+			AccessKey: creds.AccessKey, SecretKey: creds.SecretKey,
+		}},
+		{name: "access key", creds: domainobjectstore.S3Credentials{
+			Bucket: creds.Bucket, Region: creds.Region, Endpoint: creds.Endpoint,
+			AccessKey: "other-access-key", SecretKey: creds.SecretKey,
+		}},
+		{name: "secret key", creds: domainobjectstore.S3Credentials{
+			Bucket: creds.Bucket, Region: creds.Region, Endpoint: creds.Endpoint,
+			AccessKey: creds.AccessKey, SecretKey: "other-secret-key",
+		}},
+	}
+	for _, test := range tests {
+		err := st.TransitionBackendToS3(c.Context(),
+			tc.Must(c, coreobjectstore.NewUUID).String(), "other-drain-uuid", test.creds)
+		c.Check(err, tc.ErrorIs, objectstoreerrors.ErrDrainingAlreadyInProgress,
+			tc.Commentf("changed field: %s", test.name))
+	}
 }
 
 func (s *stateSuite) TestTransitionBackendToS3FromS3NotSupported(c *tc.C) {
@@ -951,7 +1016,7 @@ WHERE life_id = 1`)
 
 		row = tx.QueryRowContext(ctx, `
 SELECT bucket, region, endpoint, static_key, static_secret
-FROM object_store_backend_s3_credential
+FROM object_store_backend_s3_config
 WHERE object_store_backend_uuid = ?`, backendUUID)
 		if err := row.Scan(&bucket, &region, &endpoint, &accessKey, &secretKey); err != nil {
 			return errors.Errorf("querying backend credentials: %w", err)
@@ -1006,7 +1071,7 @@ WHERE uuid = ?`, seedBackendUUID)
 		}
 
 		row = tx.QueryRowContext(ctx, `
-SELECT COUNT(*) FROM object_store_backend_s3_credential
+SELECT COUNT(*) FROM object_store_backend_s3_config
 WHERE object_store_backend_uuid = ?`, seedBackendUUID)
 		if err := row.Scan(&credsCount); err != nil {
 			return errors.Errorf("counting drained backend credentials: %w", err)
@@ -1064,7 +1129,7 @@ WHERE uuid = ?`, seedBackendUUID)
 		}
 
 		row = tx.QueryRowContext(ctx, `
-SELECT COUNT(*) FROM object_store_backend_s3_credential
+SELECT COUNT(*) FROM object_store_backend_s3_config
 WHERE object_store_backend_uuid = ?`, seedBackendUUID)
 		if err := row.Scan(&credsCount); err != nil {
 			return errors.Errorf("counting drained backend credentials: %w", err)

--- a/domain/objectstore/types.go
+++ b/domain/objectstore/types.go
@@ -5,6 +5,7 @@ package objectstore
 
 import (
 	coreerrors "github.com/juju/juju/core/errors"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/internal/errors"
 )
@@ -23,6 +24,10 @@ type Metadata struct {
 
 // S3Credentials represents the credentials for the s3 object store.
 type S3Credentials struct {
+	// Bucket is the bucket for the object store.
+	Bucket string
+	// Region is the region for the object store.
+	Region string
 	// Endpoint is the endpoint for the object store.
 	Endpoint string
 	// AccessKey is the access key for the object store.
@@ -33,6 +38,11 @@ type S3Credentials struct {
 
 // Validate validates the S3Credentials.
 func (s S3Credentials) Validate() error {
+	if s.Bucket != "" {
+		if _, err := coreobjectstore.ParseObjectStoreBucketName(s.Bucket); err != nil {
+			return errors.Errorf("bucket: %w", err)
+		}
+	}
 	if s.Endpoint == "" {
 		return errors.New("endpoint is required").Add(coreerrors.NotValid)
 	}
@@ -72,6 +82,12 @@ type BackendInfo struct {
 	ObjectStoreType string
 
 	// Endpoint, AccessKey, SecretKey, and Region are only used for S3 backend.
+	Bucket *string
+
+	// Region is the region for the S3 backend.
+	Region *string
+
+	// Endpoint is the endpoint for the S3 backend.
 	Endpoint *string
 
 	// AccessKey is the access key for the S3 backend. It is expected to be set

--- a/domain/objectstore/watcher_test.go
+++ b/domain/objectstore/watcher_test.go
@@ -133,6 +133,7 @@ func (s *watcherSuite) TestWatchDraining(c *tc.C) {
 		domain.NewWatcherFactory(factory,
 			loggertesting.WrapCheckLog(c),
 		),
+		testControllerUUID,
 	)
 	watcher, err := svc.WatchDraining(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -179,6 +180,7 @@ func (s *watcherSuite) TestWatchObjectStoreBackend(c *tc.C) {
 		domain.NewWatcherFactory(factory,
 			loggertesting.WrapCheckLog(c),
 		),
+		testControllerUUID,
 	)
 
 	s.AssertChangeStreamIdle(c, "before watcher start")
@@ -222,6 +224,7 @@ func (s *watcherSuite) TestWatchDrainingFullLifecycle(c *tc.C) {
 		domain.NewWatcherFactory(factory,
 			loggertesting.WrapCheckLog(c),
 		),
+		testControllerUUID,
 	)
 
 	// Verify the initial state: no draining in progress.
@@ -298,6 +301,7 @@ func (s *watcherSuite) TestWatchDrainingTransitionToError(c *tc.C) {
 		domain.NewWatcherFactory(factory,
 			loggertesting.WrapCheckLog(c),
 		),
+		testControllerUUID,
 	)
 
 	watcher, err := svc.WatchDraining(c.Context())

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -79,6 +79,8 @@ CREATE UNIQUE INDEX idx_singleton_object_store_backend_life_id_dying ON object_s
 
 CREATE TABLE object_store_backend_s3_credential (
     object_store_backend_uuid TEXT NOT NULL PRIMARY KEY,
+    bucket TEXT,
+    region TEXT,
     endpoint TEXT NOT NULL,
     static_key TEXT NOT NULL,
     static_secret TEXT NOT NULL,

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -77,14 +77,14 @@ CREATE UNIQUE INDEX idx_singleton_object_store_backend_type_id ON object_store_b
 CREATE UNIQUE INDEX idx_singleton_object_store_backend_life_id_alive ON object_store_backend ((1)) WHERE life_id = 0;
 CREATE UNIQUE INDEX idx_singleton_object_store_backend_life_id_dying ON object_store_backend ((1)) WHERE life_id = 1;
 
-CREATE TABLE object_store_backend_s3_credential (
+CREATE TABLE object_store_backend_s3_config (
     object_store_backend_uuid TEXT NOT NULL PRIMARY KEY,
     bucket TEXT,
     region TEXT,
     endpoint TEXT NOT NULL,
     static_key TEXT NOT NULL,
     static_secret TEXT NOT NULL,
-    CONSTRAINT fk_object_store_backend_uuid_s3_credential_object_store_uuid
+    CONSTRAINT fk_object_store_backend_uuid_s3_config_object_store_uuid
     FOREIGN KEY (object_store_backend_uuid)
     REFERENCES object_store_backend (uuid)
 );

--- a/domain/schema/controller_schema_test.go
+++ b/domain/schema/controller_schema_test.go
@@ -164,7 +164,7 @@ func (s *controllerSchemaSuite) TestControllerTables(c *tc.C) {
 		"upgrade_state_type",
 
 		// Object store metadata
-		"object_store_backend_s3_credential",
+		"object_store_backend_s3_config",
 		"object_store_backend_type",
 		"object_store_backend",
 		"object_store_drain_info",

--- a/domain/services/objectstore.go
+++ b/domain/services/objectstore.go
@@ -25,7 +25,8 @@ import (
 type ObjectStoreServices struct {
 	modelServiceFactoryBase
 
-	clock clock.Clock
+	clock          clock.Clock
+	controllerUUID string
 }
 
 // NewObjectStoreServices returns a new set of services for the usage of the
@@ -33,6 +34,7 @@ type ObjectStoreServices struct {
 func NewObjectStoreServices(
 	controllerDB changestream.WatchableDBFactory,
 	modelDB changestream.WatchableDBFactory,
+	controllerUUID string,
 	clock clock.Clock,
 	logger logger.Logger,
 ) *ObjectStoreServices {
@@ -44,7 +46,8 @@ func NewObjectStoreServices(
 			},
 			modelDB: modelDB,
 		},
-		clock: clock,
+		clock:          clock,
+		controllerUUID: controllerUUID,
 	}
 }
 
@@ -77,6 +80,7 @@ func (s *ObjectStoreServices) AgentObjectStore() *objectstoreservice.WatchableDr
 	return objectstoreservice.NewWatchableDrainingService(
 		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.clock),
 		s.controllerWatcherFactory("objectstore"),
+		s.controllerUUID,
 	)
 }
 

--- a/domain/services/testing/suite.go
+++ b/domain/services/testing/suite.go
@@ -324,6 +324,7 @@ func (s *DomainServicesSuite) ObjectStoreServicesGetter(c *tc.C) ObjectStoreServ
 		return domainservices.NewObjectStoreServices(
 			databasetesting.ConstFactory(s.TxnRunner()),
 			databasetesting.ConstFactory(s.ModelTxnRunner(c, modelUUID.String())),
+			jujutesting.ControllerTag.Id(),
 			clock.WallClock,
 			loggertesting.WrapCheckLog(c),
 		)

--- a/internal/objectstore/s3objectstore.go
+++ b/internal/objectstore/s3objectstore.go
@@ -706,6 +706,8 @@ func (t *s3ObjectStore) remove(ctx context.Context, path string) error {
 }
 
 func (t *s3ObjectStore) filePath(hash string) string {
+	// S3 object keys always use forward slashes, so do not use
+	// filepath.Join here because its separator depends on the host OS.
 	return fmt.Sprintf("%s/%s", t.namespace, hash)
 }
 

--- a/internal/objectstore/s3objectstore_test.go
+++ b/internal/objectstore/s3objectstore_test.go
@@ -49,6 +49,84 @@ func TestS3ObjectStoreSuite(t *stdtesting.T) {
 	})
 }
 
+func (s *s3ObjectStoreSuite) TestFilePathUsesNamespace(c *tc.C) {
+	for _, test := range []struct {
+		namespace string
+		hash      string
+		expected  string
+	}{
+		{
+			namespace: "model-uuid",
+			hash:      "abc123",
+			expected:  "model-uuid/abc123",
+		}, {
+			namespace: "controller",
+			hash:      "def456",
+			expected:  "controller/def456",
+		}, {
+			namespace: "01234567-89ab-cdef-0123-456789abcdef",
+			hash:      "fedcba",
+			expected:  "01234567-89ab-cdef-0123-456789abcdef/fedcba",
+		},
+	} {
+		store := &s3ObjectStore{namespace: test.namespace}
+		c.Check(store.filePath(test.hash), tc.Equals, test.expected)
+	}
+}
+
+func (s *s3ObjectStoreSuite) TestPutFileCreatesNamespacedObjectKey(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	for _, namespace := range []string{
+		"model-uuid",
+		"controller",
+		"01234567-89ab-cdef-0123-456789abcdef",
+	} {
+		s.session.EXPECT().PutObject(
+			gomock.Any(), defaultBucketName, namespace+"/object-sha",
+			gomock.Any(), "s3-hash",
+		).DoAndReturn(func(_ context.Context, _, _ string, body io.Reader, _ string) error {
+			content, err := io.ReadAll(body)
+			c.Assert(err, tc.ErrorIsNil)
+			c.Check(string(content), tc.Equals, "some content")
+			return nil
+		})
+
+		store := &s3ObjectStore{
+			client:     s.client,
+			rootBucket: defaultBucketName,
+			namespace:  namespace,
+		}
+		err := store.putFile(
+			c.Context(), strings.NewReader("some content"),
+			"object-sha", "s3-hash",
+		)
+		c.Assert(err, tc.ErrorIsNil)
+	}
+}
+
+func (s *s3ObjectStoreSuite) TestDeleteObjectUsesNamespace(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	for _, namespace := range []string{
+		"model-uuid",
+		"controller",
+		"01234567-89ab-cdef-0123-456789abcdef",
+	} {
+		s.session.EXPECT().DeleteObject(
+			gomock.Any(), defaultBucketName, namespace+"/object-sha",
+		).Return(nil)
+
+		store := &s3ObjectStore{
+			client:     s.client,
+			rootBucket: defaultBucketName,
+			namespace:  namespace,
+		}
+		err := store.deleteObject(c.Context(), "object-sha")
+		c.Assert(err, tc.ErrorIsNil)
+	}
+}
+
 func (s *s3ObjectStoreSuite) TestGetMetadataNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -720,11 +798,14 @@ func (s *s3ObjectStoreSuite) TestRemoveDoesNotDeleteSharedHash(c *tc.C) {
 func (s *s3ObjectStoreSuite) TestRemoveAll(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	otherModelObject := "limbo/baz"
 	objects := map[string]bool{
-		filePath("foo"):  true,
-		filePath("bar"):  true,
-		otherModelObject: true,
+		filePath("foo"):        true,
+		filePath("bar"):        true,
+		"limbo/foo":            true,
+		"limbo/bar":            true,
+		"inferior/foo":         true,
+		"controller/foo":       true,
+		"another-model/shared": true,
 	}
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
@@ -741,6 +822,7 @@ func (s *s3ObjectStoreSuite) TestRemoveAll(c *tc.C) {
 	)
 	s.session.EXPECT().DeleteObject(gomock.Any(), defaultBucketName, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _, object string) error {
+			c.Check(strings.HasPrefix(object, "inferi/"), tc.IsTrue)
 			delete(objects, object)
 			return nil
 		},
@@ -757,7 +839,11 @@ func (s *s3ObjectStoreSuite) TestRemoveAll(c *tc.C) {
 	err := store.RemoveAll(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(objects, tc.DeepEquals, map[string]bool{
-		otherModelObject: true,
+		"limbo/foo":            true,
+		"limbo/bar":            true,
+		"inferior/foo":         true,
+		"controller/foo":       true,
+		"another-model/shared": true,
 	})
 
 	workertest.CleanKill(c, store)

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -126,8 +126,9 @@ func defaultOptions() *options {
 // objectsClient is a Juju shim around the AWS S3 client,
 // which Juju uses to drive it's object store requirents
 type S3Client struct {
-	logger logger.Logger
-	client *s3.Client
+	logger       logger.Logger
+	client       *s3.Client
+	bucketRegion string
 }
 
 // NewS3Client returns a new s3Caller client for accessing the object store.
@@ -147,6 +148,7 @@ func NewS3Client(endpoint string, httpClient HTTPClient, credentials Credentials
 	}
 
 	region, err := resolveRegion(o.region, endpoint)
+	bucketRegion := region
 	if err != nil {
 		if credentials.Kind() == StaticCredentialsKind {
 			o.logger.Warningf(context.Background(),
@@ -190,7 +192,8 @@ func NewS3Client(endpoint string, httpClient HTTPClient, credentials Credentials
 		client: s3.NewFromConfig(cfg, func(o *s3.Options) {
 			o.UsePathStyle = true
 		}),
-		logger: o.logger,
+		logger:       o.logger,
+		bucketRegion: bucketRegion,
 	}, nil
 }
 
@@ -329,15 +332,35 @@ func (c *S3Client) DeleteObject(ctx context.Context, bucketName, objectName stri
 	return nil
 }
 
-// CreateBucket creates a bucket in the object store based on the bucket name.
+// CreateBucket ensures that a bucket with the supplied name exists in the
+// object store.
 func (c *S3Client) CreateBucket(ctx context.Context, bucketName string) error {
-	c.logger.Tracef(ctx, "creating bucket %s in s3 storage", bucketName)
+	c.logger.Tracef(ctx, "ensuring bucket %s exists in s3 storage", bucketName)
 
-	_, err := c.client.CreateBucket(ctx,
-		&s3.CreateBucketInput{
-			Bucket:                     aws.String(bucketName),
-			ObjectLockEnabledForBucket: aws.Bool(true),
-		})
+	_, err := c.client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err == nil {
+		return nil
+	}
+	if err = handleError(err); !errors.Is(err, errors.NotFound) {
+		return errors.Annotatef(err, "checking if bucket %s exists using S3 client", bucketName)
+	}
+
+	input := &s3.CreateBucketInput{
+		Bucket:                     aws.String(bucketName),
+		ObjectLockEnabledForBucket: aws.Bool(true),
+	}
+	// AWS requires an explicit location constraint when creating a bucket
+	// outside us-east-1. S3-compatible stores with a configured region receive
+	// the same standard S3 field.
+	if c.bucketRegion != "" && c.bucketRegion != awsGlobalEndpointRegion {
+		input.CreateBucketConfiguration = &types.CreateBucketConfiguration{
+			LocationConstraint: types.BucketLocationConstraint(c.bucketRegion),
+		}
+	}
+
+	_, err = c.client.CreateBucket(ctx, input)
 	if err != nil {
 		if err := handleError(err); err != nil {
 			return errors.Trace(err)

--- a/internal/s3client/client_test.go
+++ b/internal/s3client/client_test.go
@@ -165,20 +165,92 @@ func (s *s3ClientSuite) TestListObjectsWithPrefix(c *tc.C) {
 }
 
 func (s *s3ClientSuite) TestCreateBucket(c *tc.C) {
+	var requests int
 	url, httpClient, cleanup := s.setupServer(c, func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.Method, tc.Equals, http.MethodPut)
+		requests++
 		c.Check(r.URL.Path, tc.Equals, "/bucket")
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		c.Check(r.Method, tc.Equals, http.MethodPut)
 
 		// Ensure the bucket is created with object lock enabled.
 		c.Check(r.Header.Get("x-amz-bucket-object-lock-enabled"), tc.Equals, "true")
+		body, err := io.ReadAll(r.Body)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Check(string(body), tc.Contains,
+			"<LocationConstraint>eu-west-1</LocationConstraint>")
 	})
 	defer cleanup()
 
-	client, err := NewS3Client(url, httpClient, AnonymousCredentials{})
+	client, err := NewS3Client(url, httpClient, AnonymousCredentials{},
+		WithRegion("eu-west-1"))
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = client.CreateBucket(c.Context(), "bucket")
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(requests, tc.Equals, 2)
+}
+
+func (s *s3ClientSuite) TestCreateBucketAlreadyExists(c *tc.C) {
+	var requests int
+	url, httpClient, cleanup := s.setupServer(c, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		c.Check(r.Method, tc.Equals, http.MethodHead)
+		c.Check(r.URL.Path, tc.Equals, "/bucket")
+		w.WriteHeader(http.StatusOK)
+	})
+	defer cleanup()
+
+	client, err := NewS3Client(url, httpClient, AnonymousCredentials{},
+		WithRegion("eu-west-1"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = client.CreateBucket(c.Context(), "bucket")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(requests, tc.Equals, 1)
+}
+
+func (s *s3ClientSuite) TestCreateBucketInUSEastOneOmitsLocationConstraint(c *tc.C) {
+	url, httpClient, cleanup := s.setupServer(c, func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.Path, tc.Equals, "/bucket")
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		c.Check(r.Method, tc.Equals, http.MethodPut)
+		body, err := io.ReadAll(r.Body)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Check(string(body), tc.Equals, "")
+	})
+	defer cleanup()
+
+	client, err := NewS3Client(url, httpClient, AnonymousCredentials{},
+		WithRegion("us-east-1"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = client.CreateBucket(c.Context(), "bucket")
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *s3ClientSuite) TestCreateBucketDoesNotCreateWhenExistenceCheckFails(c *tc.C) {
+	var requests int
+	url, httpClient, cleanup := s.setupServer(c, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		c.Check(r.Method, tc.Equals, http.MethodHead)
+		c.Check(r.URL.Path, tc.Equals, "/bucket")
+		w.WriteHeader(http.StatusForbidden)
+	})
+	defer cleanup()
+
+	client, err := NewS3Client(url, httpClient, AnonymousCredentials{},
+		WithRegion("eu-west-1"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = client.CreateBucket(c.Context(), "bucket")
+	c.Assert(err, tc.ErrorIs, errors.Forbidden)
+	c.Check(requests, tc.Equals, 1)
 }
 
 func (s *s3ClientSuite) TestRegionFromEndpoint(c *tc.C) {

--- a/internal/worker/controlsocket/worker.go
+++ b/internal/worker/controlsocket/worker.go
@@ -308,6 +308,8 @@ func (w *Worker) registerHandlers(r *mux.Router) {
 	// with the following format:
 	//
 	// {
+	//   "bucket": <string>,
+	//   "region": <string>,
 	//   "endpoint": <string>,
 	//   "access_key": <string>,
 	//   "secret_key": <string>,
@@ -567,6 +569,8 @@ func (w *Worker) handleSetWorkloadTracingConfig(resp http.ResponseWriter, req *h
 }
 
 type s3CredentialsRequest struct {
+	Bucket    string `json:"bucket"`
+	Region    string `json:"region"`
 	Endpoint  string `json:"endpoint"`
 	AccessKey string `json:"access_key"`
 	SecretKey string `json:"secret_key"`
@@ -593,6 +597,8 @@ func (w *Worker) handleAddS3Credentials(resp http.ResponseWriter, req *http.Requ
 	}
 
 	if err := w.objectStoreService.TransitionBackendToS3(ctx, domainobjectstore.S3Credentials{
+		Bucket:    parsedBody.Bucket,
+		Region:    parsedBody.Region,
 		Endpoint:  parsedBody.Endpoint,
 		AccessKey: parsedBody.AccessKey,
 		SecretKey: parsedBody.SecretKey,

--- a/internal/worker/controlsocket/worker.go
+++ b/internal/worker/controlsocket/worker.go
@@ -303,8 +303,8 @@ func (w *Worker) registerHandlers(r *mux.Router) {
 	r.Handle("/workload-tracing-config", w.withMetrics("/workload-tracing-config", w.handleJSONPost(w.handleSetWorkloadTracingConfig))).
 		Methods(http.MethodPost)
 
-	// s3-credentials endpoint for managing object store credentials when S3 is
-	// used as the backend. This is a POST endpoint that accepts a JSON body
+	// s3-config endpoint for managing the object store configuration when S3
+	// is used as the backend. This is a POST endpoint that accepts a JSON body
 	// with the following format:
 	//
 	// {
@@ -316,10 +316,10 @@ func (w *Worker) registerHandlers(r *mux.Router) {
 	// }
 	//
 	// The worker will update the object store configuration with the provided
-	// S3 credentials.
-	r.Handle("/s3-credentials", w.withMetrics("/s3-credentials", w.handleJSONPost(w.handleAddS3Credentials))).
+	// S3 configuration.
+	r.Handle("/s3-config", w.withMetrics("/s3-config", w.handleJSONPost(w.handleSetS3Config))).
 		Methods(http.MethodPost)
-	r.Handle("/s3-credentials", w.withMetrics("/s3-credentials", http.HandlerFunc(w.handleRemoveS3Credentials))).
+	r.Handle("/s3-config", w.withMetrics("/s3-config", http.HandlerFunc(w.handleRemoveS3Config))).
 		Methods(http.MethodDelete)
 
 	// loki-endpoint endpoint for managing the Loki push API endpoint. This
@@ -568,7 +568,7 @@ func (w *Worker) handleSetWorkloadTracingConfig(resp http.ResponseWriter, req *h
 	w.writeResponse(ctx, resp, http.StatusOK, "updated workload tracing config")
 }
 
-type s3CredentialsRequest struct {
+type s3ConfigRequest struct {
 	Bucket    string `json:"bucket"`
 	Region    string `json:"region"`
 	Endpoint  string `json:"endpoint"`
@@ -576,10 +576,10 @@ type s3CredentialsRequest struct {
 	SecretKey string `json:"secret_key"`
 }
 
-func (w *Worker) handleAddS3Credentials(resp http.ResponseWriter, req *http.Request) {
+func (w *Worker) handleSetS3Config(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	var parsedBody s3CredentialsRequest
+	var parsedBody s3ConfigRequest
 	if err := json.NewDecoder(req.Body).Decode(&parsedBody); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		switch {
@@ -603,21 +603,21 @@ func (w *Worker) handleAddS3Credentials(resp http.ResponseWriter, req *http.Requ
 		AccessKey: parsedBody.AccessKey,
 		SecretKey: parsedBody.SecretKey,
 	}); internalerrors.Is(err, coreerrors.NotValid) {
-		w.writeErrorResponse(ctx, resp, http.StatusBadRequest, internalerrors.Errorf("invalid S3 credentials: %w", err))
+		w.writeErrorResponse(ctx, resp, http.StatusBadRequest, internalerrors.Errorf("invalid S3 config: %w", err))
 		return
 	} else if err != nil {
-		w.writeErrorResponse(ctx, resp, http.StatusInternalServerError, internalerrors.Errorf("saving S3 credentials: %w", err))
+		w.writeErrorResponse(ctx, resp, http.StatusInternalServerError, internalerrors.Errorf("saving S3 config: %w", err))
 		return
 	}
 
-	w.writeResponse(ctx, resp, http.StatusOK, infof("updated S3 credentials"))
+	w.writeResponse(ctx, resp, http.StatusOK, infof("updated S3 config"))
 }
 
-func (w *Worker) handleRemoveS3Credentials(resp http.ResponseWriter, req *http.Request) {
+func (w *Worker) handleRemoveS3Config(resp http.ResponseWriter, req *http.Request) {
 	// We currently don't allow you to move to another s3 provider. This will
 	// be fixed in future requests.
 	w.writeErrorResponse(req.Context(), resp, http.StatusNotImplemented,
-		internalerrors.New("removing s3 credentials is not supported at this time"))
+		internalerrors.New("removing S3 config is not supported at this time"))
 }
 
 type lokiEndpointRequest struct {

--- a/internal/worker/controlsocket/worker_test.go
+++ b/internal/worker/controlsocket/worker_test.go
@@ -1094,6 +1094,8 @@ func (s *workerSuite) TestAddS3CredentialsSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.objectStoreService.EXPECT().TransitionBackendToS3(gomock.Any(), domainobjectstore.S3Credentials{
+		Bucket:    "test-bucket",
+		Region:    "us-east-1",
 		Endpoint:  "https://example.com",
 		AccessKey: "foo",
 		SecretKey: "bar",
@@ -1107,7 +1109,7 @@ func (s *workerSuite) TestAddS3CredentialsSuccess(c *tc.C) {
 	s.runHandlerTest(c, socket, handlerTest{
 		method:     http.MethodPost,
 		endpoint:   "/s3-credentials",
-		body:       `{"endpoint":"https://example.com","access_key":"foo","secret_key":"bar"}`,
+		body:       `{"bucket":"test-bucket","region":"us-east-1","endpoint":"https://example.com","access_key":"foo","secret_key":"bar"}`,
 		statusCode: http.StatusOK,
 		response:   ".*updated S3 credentials.*",
 	})

--- a/internal/worker/controlsocket/worker_test.go
+++ b/internal/worker/controlsocket/worker_test.go
@@ -1005,7 +1005,7 @@ func (s *workerSuite) TestWorkloadTracingConfigServiceError(c *tc.C) {
 	})
 }
 
-func (s *workerSuite) TestAddS3CredentialsInvalidMethod(c *tc.C) {
+func (s *workerSuite) TestSetS3ConfigInvalidMethod(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	socket := s.newSocket(c)
@@ -1015,13 +1015,13 @@ func (s *workerSuite) TestAddS3CredentialsInvalidMethod(c *tc.C) {
 
 	s.runHandlerTest(c, socket, handlerTest{
 		method:     http.MethodGet,
-		endpoint:   "/s3-credentials",
+		endpoint:   "/s3-config",
 		statusCode: http.StatusMethodNotAllowed,
 		ignoreBody: true,
 	})
 }
 
-func (s *workerSuite) TestAddS3CredentialsMissingBody(c *tc.C) {
+func (s *workerSuite) TestS3CredentialsEndpointRemoved(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	socket := s.newSocket(c)
@@ -1032,12 +1032,29 @@ func (s *workerSuite) TestAddS3CredentialsMissingBody(c *tc.C) {
 	s.runHandlerTest(c, socket, handlerTest{
 		method:     http.MethodPost,
 		endpoint:   "/s3-credentials",
+		body:       `{}`,
+		statusCode: http.StatusNotFound,
+		ignoreBody: true,
+	})
+}
+
+func (s *workerSuite) TestSetS3ConfigMissingBody(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/s3-config",
 		statusCode: http.StatusBadRequest,
 		response:   ".*missing request body.*",
 	})
 }
 
-func (s *workerSuite) TestAddS3CredentialsPayloadTooLarge(c *tc.C) {
+func (s *workerSuite) TestSetS3ConfigPayloadTooLarge(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	socket := s.newSocket(c)
@@ -1047,14 +1064,14 @@ func (s *workerSuite) TestAddS3CredentialsPayloadTooLarge(c *tc.C) {
 
 	s.runHandlerTest(c, socket, handlerTest{
 		method:     http.MethodPost,
-		endpoint:   "/s3-credentials",
+		endpoint:   "/s3-config",
 		body:       strings.Repeat("a", maxPayloadBytes+1),
 		statusCode: http.StatusRequestEntityTooLarge,
 		response:   ".*must not exceed.*",
 	})
 }
 
-func (s *workerSuite) TestAddS3CredentialsInvalidJSON(c *tc.C) {
+func (s *workerSuite) TestSetS3ConfigInvalidJSON(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	socket := s.newSocket(c)
@@ -1064,14 +1081,14 @@ func (s *workerSuite) TestAddS3CredentialsInvalidJSON(c *tc.C) {
 
 	s.runHandlerTest(c, socket, handlerTest{
 		method:     http.MethodPost,
-		endpoint:   "/s3-credentials",
+		endpoint:   "/s3-config",
 		body:       `{"Endpoint":`,
 		statusCode: http.StatusBadRequest,
 		response:   ".*request body is not valid JSON.*",
 	})
 }
 
-func (s *workerSuite) TestAddS3CredentialsServiceError(c *tc.C) {
+func (s *workerSuite) TestSetS3ConfigServiceError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.objectStoreService.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any()).Return(errors.New("boom"))
@@ -1083,14 +1100,14 @@ func (s *workerSuite) TestAddS3CredentialsServiceError(c *tc.C) {
 
 	s.runHandlerTest(c, socket, handlerTest{
 		method:     http.MethodPost,
-		endpoint:   "/s3-credentials",
+		endpoint:   "/s3-config",
 		body:       `{"endpoint":"https://example.com","access_key":"foo","secret_key":"bar"}`,
 		statusCode: http.StatusInternalServerError,
-		response:   ".*saving S3 credentials.*boom.*",
+		response:   ".*saving S3 config.*boom.*",
 	})
 }
 
-func (s *workerSuite) TestAddS3CredentialsSuccess(c *tc.C) {
+func (s *workerSuite) TestSetS3ConfigSuccess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.objectStoreService.EXPECT().TransitionBackendToS3(gomock.Any(), domainobjectstore.S3Credentials{
@@ -1108,14 +1125,14 @@ func (s *workerSuite) TestAddS3CredentialsSuccess(c *tc.C) {
 
 	s.runHandlerTest(c, socket, handlerTest{
 		method:     http.MethodPost,
-		endpoint:   "/s3-credentials",
+		endpoint:   "/s3-config",
 		body:       `{"bucket":"test-bucket","region":"us-east-1","endpoint":"https://example.com","access_key":"foo","secret_key":"bar"}`,
 		statusCode: http.StatusOK,
-		response:   ".*updated S3 credentials.*",
+		response:   ".*updated S3 config.*",
 	})
 }
 
-func (s *workerSuite) TestAddS3CredentialsNotValid(c *tc.C) {
+func (s *workerSuite) TestSetS3ConfigNotValid(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.objectStoreService.EXPECT().TransitionBackendToS3(gomock.Any(), gomock.Any()).Return(
@@ -1129,14 +1146,14 @@ func (s *workerSuite) TestAddS3CredentialsNotValid(c *tc.C) {
 
 	s.runHandlerTest(c, socket, handlerTest{
 		method:     http.MethodPost,
-		endpoint:   "/s3-credentials",
+		endpoint:   "/s3-config",
 		body:       `{"endpoint":"https://example.com","access_key":"foo","secret_key":"bar"}`,
 		statusCode: http.StatusBadRequest,
-		response:   ".*invalid S3 credentials.*",
+		response:   ".*invalid S3 config.*",
 	})
 }
 
-func (s *workerSuite) TestRemoveS3CredentialsNotImplemented(c *tc.C) {
+func (s *workerSuite) TestRemoveS3ConfigNotImplemented(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	socket := s.newSocket(c)
@@ -1146,13 +1163,13 @@ func (s *workerSuite) TestRemoveS3CredentialsNotImplemented(c *tc.C) {
 
 	s.runHandlerTest(c, socket, handlerTest{
 		method:     http.MethodDelete,
-		endpoint:   "/s3-credentials",
+		endpoint:   "/s3-config",
 		statusCode: http.StatusNotImplemented,
-		response:   ".*removing s3 credentials is not supported.*",
+		response:   ".*removing S3 config is not supported.*",
 	})
 }
 
-func (s *workerSuite) TestAddS3CredentialsUnsupportedContentType(c *tc.C) {
+func (s *workerSuite) TestSetS3ConfigUnsupportedContentType(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	socket := s.newSocket(c)
@@ -1162,7 +1179,7 @@ func (s *workerSuite) TestAddS3CredentialsUnsupportedContentType(c *tc.C) {
 
 	s.runHandlerTest(c, socket, handlerTest{
 		method:      http.MethodPost,
-		endpoint:    "/s3-credentials",
+		endpoint:    "/s3-config",
 		body:        `{"endpoint":"https://example.com","access_key":"foo","secret_key":"bar"}`,
 		contentType: "text/plain",
 		statusCode:  http.StatusUnsupportedMediaType,

--- a/internal/worker/httpserver/worker.go
+++ b/internal/worker/httpserver/worker.go
@@ -179,7 +179,10 @@ func (w *Worker) loop() error {
 		ConnContext:  recordRawFd,
 	}
 
+	serveStopped := make(chan struct{})
 	go func() {
+		defer close(serveStopped)
+
 		err := server.Serve(tls.NewListener(w.listener, w.config.TLSConfig))
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			w.logger.Errorf(ctx, "server finished with error %v", err)
@@ -203,6 +206,11 @@ func (w *Worker) loop() error {
 		if err := w.listener.Close(); err != nil {
 			w.logger.Errorf(ctx, "error closing listener: %v", err)
 		}
+
+		// Shutdown normally causes Serve to return, but closing the listener
+		// also unblocks it when Shutdown fails. Do not let the worker finish
+		// while the serving goroutine can still use worker-owned resources.
+		<-serveStopped
 	}()
 
 	shutDownCtx, cancel := context.WithTimeout(context.Background(), ShutdownTimeout)

--- a/internal/worker/objectstore/worker.go
+++ b/internal/worker/objectstore/worker.go
@@ -397,7 +397,10 @@ func (w *objectStoreWorker) initObjectStore(ctx context.Context, namespace strin
 			metadataService = w.cfg.ModelMetadataServiceGetter.ForModelUUID(modelUUID)
 		}
 
-		rootBucket := w.rootBucketName(backendInfo)
+		rootBucket, err := w.rootBucketName(backendInfo)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 
 		objectStore, err := w.cfg.NewObjectStoreWorker(
 			ctx,
@@ -442,11 +445,14 @@ func (w *objectStoreWorker) initObjectStore(ctx context.Context, namespace strin
 	return errors.Trace(err)
 }
 
-func (w *objectStoreWorker) rootBucketName(backendInfo objectstoreservice.BackendInfo) string {
-	if backendInfo.Type == objectstore.S3Backend && backendInfo.Bucket != nil && *backendInfo.Bucket != "" {
-		return *backendInfo.Bucket
+func (w *objectStoreWorker) rootBucketName(backendInfo objectstoreservice.BackendInfo) (string, error) {
+	if backendInfo.Type != objectstore.S3Backend {
+		return w.cfg.RootBucket, nil
 	}
-	return w.cfg.RootBucket
+	if backendInfo.Bucket == nil || *backendInfo.Bucket == "" {
+		return "", errors.NotValidf("empty S3 bucket")
+	}
+	return *backendInfo.Bucket, nil
 }
 
 // Report returns a map of internal state for the worker.

--- a/internal/worker/objectstore/worker.go
+++ b/internal/worker/objectstore/worker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
 	coretrace "github.com/juju/juju/core/trace"
+	objectstoreservice "github.com/juju/juju/domain/objectstore/service"
 	internalobjectstore "github.com/juju/juju/internal/objectstore"
 	internalworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/apiremotecaller"
@@ -396,12 +397,14 @@ func (w *objectStoreWorker) initObjectStore(ctx context.Context, namespace strin
 			metadataService = w.cfg.ModelMetadataServiceGetter.ForModelUUID(modelUUID)
 		}
 
+		rootBucket := w.rootBucketName(backendInfo)
+
 		objectStore, err := w.cfg.NewObjectStoreWorker(
 			ctx,
 			backendInfo.Type,
 			namespace,
 			internalobjectstore.WithRootDir(w.cfg.RootDir),
-			internalobjectstore.WithRootBucket(w.cfg.RootBucket),
+			internalobjectstore.WithRootBucket(rootBucket),
 			internalobjectstore.WithS3Client(w.cfg.S3Client),
 			internalobjectstore.WithAPIRemoveCallers(w.cfg.APIRemoteCaller),
 			internalobjectstore.WithMetadataService(metadataService),
@@ -437,6 +440,13 @@ func (w *objectStoreWorker) initObjectStore(ctx context.Context, namespace strin
 		return nil
 	}
 	return errors.Trace(err)
+}
+
+func (w *objectStoreWorker) rootBucketName(backendInfo objectstoreservice.BackendInfo) string {
+	if backendInfo.Type == objectstore.S3Backend && backendInfo.Bucket != nil && *backendInfo.Bucket != "" {
+		return *backendInfo.Bucket
+	}
+	return w.cfg.RootBucket
 }
 
 // Report returns a map of internal state for the worker.

--- a/internal/worker/objectstoredrainer/drainer.go
+++ b/internal/worker/objectstoredrainer/drainer.go
@@ -335,5 +335,7 @@ func (w *drainWorker) objectAlreadyExists(ctx context.Context, hash string) erro
 }
 
 func (w *drainWorker) filePath(hash string) string {
+	// S3 object keys always use forward slashes, so do not use
+	// filepath.Join here because its separator depends on the host OS.
 	return fmt.Sprintf("%s/%s", w.namespace, hash)
 }

--- a/internal/worker/objectstoredrainer/drainer_test.go
+++ b/internal/worker/objectstoredrainer/drainer_test.go
@@ -242,6 +242,52 @@ func (s *drainerSuite) TestDrainFilePut(c *tc.C) {
 	c.Assert(reader.Closed(), tc.IsTrue)
 }
 
+func (s *drainerSuite) TestDrainFileCreatesNamespacedObjectKey(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	const content = "some content"
+	s3Hash := s.calculateBase64SHA256(c, content)
+
+	for _, namespace := range []string{
+		"model-uuid",
+		"controller",
+		"01234567-89ab-cdef-0123-456789abcdef",
+	} {
+		reader := &readCloser{Reader: strings.NewReader(content)}
+		s.hashFileSystemAccessor.EXPECT().HashExists(
+			gomock.Any(), "object-sha",
+		).Return(nil)
+		s.s3Session.EXPECT().ObjectExists(
+			gomock.Any(), defaultBucketName, namespace+"/object-sha",
+		).Return(errors.NotFoundf("not found"))
+		s.hashFileSystemAccessor.EXPECT().GetByHash(
+			gomock.Any(), "object-sha",
+		).Return(reader, int64(len(content)), nil)
+		s.s3Session.EXPECT().PutObject(
+			gomock.Any(), defaultBucketName, namespace+"/object-sha",
+			gomock.Any(), s3Hash,
+		).DoAndReturn(func(_ context.Context, _, _ string, body io.Reader, _ string) error {
+			got, err := io.ReadAll(body)
+			c.Assert(err, tc.ErrorIsNil)
+			c.Check(string(got), tc.Equals, content)
+			return nil
+		})
+
+		store := &drainWorker{
+			rootBucket: defaultBucketName,
+			namespace:  namespace,
+			fileSystem: s.hashFileSystemAccessor,
+			client:     &client{s3Session: s.s3Session},
+			logger:     s.logger,
+		}
+		err := store.drainFile(
+			c.Context(), "/path", "object-sha", int64(len(content)),
+		)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Check(reader.Closed(), tc.IsTrue)
+	}
+}
+
 func (s *drainerSuite) TestComputeS3Hash(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/internal/worker/objectstoredrainer/package_test.go
+++ b/internal/worker/objectstoredrainer/package_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/core/logger"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
+	objectstoreservice "github.com/juju/juju/domain/objectstore/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
 )
@@ -48,6 +50,11 @@ func (s *baseSuite) setupMocks(c *tc.C) *gomock.Controller {
 
 	s.guard = NewMockGuard(ctrl)
 	s.guardService = NewMockDrainingService(ctrl)
+	bucket := "test-bucket"
+	s.guardService.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(objectstoreservice.BackendInfo{
+		Type:   coreobjectstore.S3Backend,
+		Bucket: &bucket,
+	}, nil).AnyTimes()
 
 	s.objectStoreService = NewMockObjectStoreService(ctrl)
 	s.objectStoreServicesGetter = NewMockObjectStoreServicesGetter(ctrl)

--- a/internal/worker/objectstoredrainer/worker.go
+++ b/internal/worker/objectstoredrainer/worker.go
@@ -315,8 +315,14 @@ func (w *Worker) loop() error {
 			// another. For now, we just log that we're in the draining phase
 			// from file to s3.
 
+			rootBucketName, err := w.activeRootBucketName(ctx)
+			if err != nil {
+				_ = w.drainingService.SetDrainingPhase(ctx, objectstore.PhaseError)
+				return errors.Errorf("getting active root bucket name: %w", err)
+			}
+
 			// Drain the agent binary object store, then drain all the models.
-			if err := w.drainAgentBinaries(ctx); err != nil {
+			if err := w.drainAgentBinaries(ctx, rootBucketName); err != nil {
 				_ = w.drainingService.SetDrainingPhase(ctx, objectstore.PhaseError)
 				return errors.Errorf("draining agent binaries: %w", err)
 			}
@@ -336,7 +342,7 @@ func (w *Worker) loop() error {
 				continue
 			}
 
-			signal, err := w.drainModels(ctx, uniqueNamespaces)
+			signal, err := w.drainModels(ctx, uniqueNamespaces, rootBucketName)
 			if err != nil {
 				_ = w.drainingService.SetDrainingPhase(ctx, objectstore.PhaseError)
 				return errors.Errorf("draining models: %w", err)
@@ -355,7 +361,7 @@ func (w *Worker) loop() error {
 	}
 }
 
-func (w *Worker) drainAgentBinaries(ctx context.Context) error {
+func (w *Worker) drainAgentBinaries(ctx context.Context, rootBucketName string) error {
 	w.logger.Infof(ctx, "draining controller agent binaries")
 	signal := make(chan drainResult, 1)
 
@@ -367,7 +373,7 @@ func (w *Worker) drainAgentBinaries(ctx context.Context) error {
 			fileSystem,
 			w.client,
 			w.controllerObjectStoreService,
-			w.rootBucketName,
+			rootBucketName,
 			namespace,
 			w.selectFileHash,
 			w.clock,
@@ -399,7 +405,7 @@ func (w *Worker) drainAgentBinaries(ctx context.Context) error {
 
 // drainModels starts a worker for each model in the state and waits for them
 // to complete. It signals the completion of each worker through a channel.
-func (w *Worker) drainModels(ctx context.Context, namespaces []string) (<-chan drainResult, error) {
+func (w *Worker) drainModels(ctx context.Context, namespaces []string, rootBucketName string) (<-chan drainResult, error) {
 	signal := make(chan drainResult, len(namespaces))
 	for _, namespace := range namespaces {
 		w.logger.Infof(ctx, "draining model %q", namespace)
@@ -412,7 +418,7 @@ func (w *Worker) drainModels(ctx context.Context, namespaces []string) (<-chan d
 				fileSystem,
 				w.client,
 				metadataService.ObjectStore(),
-				w.rootBucketName,
+				rootBucketName,
 				namespace,
 				w.selectFileHash,
 				w.clock,
@@ -427,6 +433,17 @@ func (w *Worker) drainModels(ctx context.Context, namespaces []string) (<-chan d
 		}
 	}
 	return signal, nil
+}
+
+func (w *Worker) activeRootBucketName(ctx context.Context) (string, error) {
+	backendInfo, err := w.drainingService.GetActiveObjectStoreBackend(ctx)
+	if err != nil {
+		return "", errors.Errorf("getting active object store backend: %w", err)
+	}
+	if backendInfo.Type == objectstore.S3Backend && backendInfo.Bucket != nil && *backendInfo.Bucket != "" {
+		return *backendInfo.Bucket, nil
+	}
+	return w.rootBucketName, nil
 }
 
 // waitForDraining waits for all the draining workers to complete. It will

--- a/internal/worker/objectstoredrainer/worker.go
+++ b/internal/worker/objectstoredrainer/worker.go
@@ -440,10 +440,13 @@ func (w *Worker) activeRootBucketName(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", errors.Errorf("getting active object store backend: %w", err)
 	}
-	if backendInfo.Type == objectstore.S3Backend && backendInfo.Bucket != nil && *backendInfo.Bucket != "" {
-		return *backendInfo.Bucket, nil
+	if backendInfo.Type != objectstore.S3Backend {
+		return w.rootBucketName, nil
 	}
-	return w.rootBucketName, nil
+	if backendInfo.Bucket == nil || *backendInfo.Bucket == "" {
+		return "", errors.Errorf("empty S3 bucket").Add(coreerrors.NotValid)
+	}
+	return *backendInfo.Bucket, nil
 }
 
 // waitForDraining waits for all the draining workers to complete. It will

--- a/internal/worker/objectstoredrainer/worker_test.go
+++ b/internal/worker/objectstoredrainer/worker_test.go
@@ -567,16 +567,29 @@ func (s *workerSuite) TestDrainingPhaseError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	draining := make(chan struct{}, 1)
+	phases := make(chan objectstore.Phase, 2)
+	done := make(chan struct{})
 	s.guardService.EXPECT().WatchDraining(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.Watcher[struct{}], error) {
 		return watchertest.NewMockNotifyWatcher(draining), nil
 	})
-	// Return PhaseError — the worker should log and continue (not die).
-	s.guardService.EXPECT().GetDrainingPhase(gomock.Any()).Return(objectstore.PhaseError, nil)
+	s.guardService.EXPECT().GetDrainingPhase(gomock.Any()).DoAndReturn(func(context.Context) (objectstore.Phase, error) {
+		select {
+		case phase := <-phases:
+			return phase, nil
+		case <-c.Context().Done():
+			return "", c.Context().Err()
+		}
+	}).AnyTimes()
+	s.guard.EXPECT().Unlock(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
+		defer close(done)
+		return nil
+	})
 
 	w := s.newWorker(c)
 	defer workertest.DirtyKill(c, w)
 
 	// Trigger draining watcher.
+	phases <- objectstore.PhaseError
 	select {
 	case draining <- struct{}{}:
 	case <-c.Context().Done():
@@ -585,13 +598,7 @@ func (s *workerSuite) TestDrainingPhaseError(c *tc.C) {
 
 	// Give the worker time to process. If it didn't crash, it's still alive.
 	// Send another event with PhaseCompleted to verify it kept looping.
-	s.guardService.EXPECT().GetDrainingPhase(gomock.Any()).Return(objectstore.PhaseCompleted, nil)
-	done := make(chan struct{})
-	s.guard.EXPECT().Unlock(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
-		defer close(done)
-		return nil
-	})
-
+	phases <- objectstore.PhaseCompleted
 	select {
 	case draining <- struct{}{}:
 	case <-c.Context().Done():

--- a/internal/worker/objectstores3caller/manifold.go
+++ b/internal/worker/objectstores3caller/manifold.go
@@ -19,7 +19,7 @@ import (
 )
 
 // NewClientFunc is a function that returns a new S3 client.
-type NewClientFunc = func(endpoint string, client s3client.HTTPClient, creds s3client.Credentials, logger logger.Logger) (objectstore.Session, error)
+type NewClientFunc = func(endpoint string, client s3client.HTTPClient, creds s3client.Credentials, region string, logger logger.Logger) (objectstore.Session, error)
 
 // GetObjectStoreServiceFunc is a helper function that gets a service from
 // the manifold.
@@ -134,9 +134,10 @@ func outputWorker(in worker.Worker) (objectstore.Client, error) {
 }
 
 // NewS3Client returns a new S3 client based on the supplied dependencies.
-func NewS3Client(endpoint string, client s3client.HTTPClient, creds s3client.Credentials, logger logger.Logger) (objectstore.Session, error) {
+func NewS3Client(endpoint string, client s3client.HTTPClient, creds s3client.Credentials, region string, logger logger.Logger) (objectstore.Session, error) {
 	return s3client.NewS3Client(endpoint, client, creds,
 		s3client.WithLogger(logger),
+		s3client.WithRegion(region),
 		s3client.WithMaxAttempts(10),
 		s3client.WithRateLimiting(false),
 	)

--- a/internal/worker/objectstores3caller/manifold_test.go
+++ b/internal/worker/objectstores3caller/manifold_test.go
@@ -73,7 +73,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
 		HTTPClientName:          "http-client",
 		ObjectStoreServicesName: "object-store-services",
-		NewClient: func(string, s3client.HTTPClient, s3client.Credentials, logger.Logger) (objectstore.Session, error) {
+		NewClient: func(string, s3client.HTTPClient, s3client.Credentials, string, logger.Logger) (objectstore.Session, error) {
 			return s.session, nil
 		},
 		Logger: s.logger,

--- a/internal/worker/objectstores3caller/package_test.go
+++ b/internal/worker/objectstores3caller/package_test.go
@@ -66,10 +66,12 @@ func (s *baseSuite) expectHTTPClient(c *tc.C) {
 
 func (s *baseSuite) expectGetActiveBackendS3(c *tc.C) {
 	endpoint := "https://s3.example.com"
+	region := "us-east-1"
 	accessKey := "access-key"
 	secretKey := "secret-key"
 	s.objectStoreService.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).Return(objectstoreservice.BackendInfo{
 		Type:      "s3",
+		Region:    &region,
 		Endpoint:  &endpoint,
 		AccessKey: &accessKey,
 		SecretKey: &secretKey,

--- a/internal/worker/objectstores3caller/worker.go
+++ b/internal/worker/objectstores3caller/worker.go
@@ -200,6 +200,7 @@ func (w *s3Worker) makeNewClient(ctx context.Context) (objectstore.Session, erro
 			Key:    credentials.AccessKey,
 			Secret: credentials.SecretKey,
 		},
+		credentials.Region,
 		w.config.Logger,
 	)
 	if err != nil {

--- a/internal/worker/objectstores3caller/worker_test.go
+++ b/internal/worker/objectstores3caller/worker_test.go
@@ -366,7 +366,7 @@ func (s *workerSuite) getConfig() workerConfig {
 	return workerConfig{
 		ObjectStoreService: s.objectStoreService,
 		HTTPClient:         s.httpClient,
-		NewClient: func(string, s3client.HTTPClient, s3client.Credentials, logger.Logger) (objectstore.Session, error) {
+		NewClient: func(string, s3client.HTTPClient, s3client.Credentials, string, logger.Logger) (objectstore.Session, error) {
 			atomic.AddInt64(&s.sessionRefCount, 1)
 			return s.session, nil
 		},
@@ -376,6 +376,7 @@ func (s *workerSuite) getConfig() workerConfig {
 
 func (s *workerSuite) expectGetActiveBackendS3WithDone(done chan struct{}) {
 	endpoint := "https://s3.example.com"
+	region := "us-east-1"
 	accessKey := "access-key"
 	secretKey := "secret-key"
 	s.objectStoreService.EXPECT().GetActiveObjectStoreBackend(gomock.Any()).
@@ -383,6 +384,7 @@ func (s *workerSuite) expectGetActiveBackendS3WithDone(done chan struct{}) {
 			defer close(done)
 			return objectstoreservice.BackendInfo{
 				Type:      "s3",
+				Region:    &region,
 				Endpoint:  &endpoint,
 				AccessKey: &accessKey,
 				SecretKey: &secretKey,

--- a/internal/worker/objectstoreservices/manifold.go
+++ b/internal/worker/objectstoreservices/manifold.go
@@ -24,6 +24,7 @@ import (
 // worker in a dependency.Engine.
 type ManifoldConfig struct {
 	ChangeStreamName string
+	ControllerUUID   string
 	Clock            clock.Clock
 	Logger           logger.Logger
 	NewWorker        func(Config) (worker.Worker, error)
@@ -42,6 +43,7 @@ type ManifoldConfig struct {
 type ObjectStoreServicesGetterFn func(
 	ObjectStoreServicesFn,
 	changestream.WatchableDBGetter,
+	string,
 	clock.Clock,
 	logger.Logger,
 ) services.ObjectStoreServicesGetter
@@ -50,6 +52,7 @@ type ObjectStoreServicesGetterFn func(
 type ObjectStoreServicesFn func(
 	coremodel.UUID,
 	changestream.WatchableDBGetter,
+	string,
 	clock.Clock,
 	logger.Logger,
 ) services.ObjectStoreServices
@@ -58,6 +61,9 @@ type ObjectStoreServicesFn func(
 func (config ManifoldConfig) Validate() error {
 	if config.ChangeStreamName == "" {
 		return errors.NotValidf("empty ChangeStreamName")
+	}
+	if config.ControllerUUID == "" {
+		return errors.NotValidf("empty ControllerUUID")
 	}
 	if config.Clock == nil {
 		return errors.NotValidf("nil Clock")
@@ -104,6 +110,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		Logger:                       config.Logger,
 		NewObjectStoreServicesGetter: config.NewObjectStoreServicesGetter,
 		NewObjectStoreServices:       config.NewObjectStoreServices,
+		ControllerUUID:               config.ControllerUUID,
 	})
 }
 
@@ -133,12 +140,14 @@ func (config ManifoldConfig) output(in worker.Worker, out any) error {
 func NewObjectStoreServicesGetter(
 	newObjectStoreServices ObjectStoreServicesFn,
 	dbGetter changestream.WatchableDBGetter,
+	controllerUUID string,
 	clock clock.Clock,
 	logger logger.Logger,
 ) services.ObjectStoreServicesGetter {
 	return &domainServicesGetter{
 		newObjectStoreServices: newObjectStoreServices,
 		dbGetter:               dbGetter,
+		controllerUUID:         controllerUUID,
 		clock:                  clock,
 		logger:                 logger,
 	}
@@ -148,12 +157,14 @@ func NewObjectStoreServicesGetter(
 func NewObjectStoreServices(
 	modelUUID coremodel.UUID,
 	dbGetter changestream.WatchableDBGetter,
+	controllerUUID string,
 	clock clock.Clock,
 	logger logger.Logger,
 ) services.ObjectStoreServices {
 	return domainservicefactory.NewObjectStoreServices(
 		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, coredatabase.ControllerNS),
 		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, modelUUID.String()),
+		controllerUUID,
 		clock,
 		logger,
 	)

--- a/internal/worker/objectstoreservices/manifold_test.go
+++ b/internal/worker/objectstoreservices/manifold_test.go
@@ -67,6 +67,7 @@ func (s *manifoldSuite) TestStart(c *tc.C) {
 
 	manifold := Manifold(ManifoldConfig{
 		ChangeStreamName:             "changestream",
+		ControllerUUID:               "controller-uuid",
 		Clock:                        clock.WallClock,
 		Logger:                       s.logger,
 		NewWorker:                    NewWorker,
@@ -90,6 +91,7 @@ func (s *manifoldSuite) TestStartUsesWallClock(c *tc.C) {
 	var workerConfig Config
 	manifold := Manifold(ManifoldConfig{
 		ChangeStreamName: "changestream",
+		ControllerUUID:   "controller-uuid",
 		Clock:            clock.WallClock,
 		Logger:           s.logger,
 		NewWorker: func(cfg Config) (worker.Worker, error) {
@@ -110,6 +112,7 @@ func (s *manifoldSuite) TestOutputObjectStoreServicesGetter(c *tc.C) {
 
 	w, err := NewWorker(Config{
 		DBGetter:                     s.dbGetter,
+		ControllerUUID:               "controller-uuid",
 		Clock:                        clock.WallClock,
 		Logger:                       s.logger,
 		NewObjectStoreServices:       NewObjectStoreServices,
@@ -130,6 +133,7 @@ func (s *manifoldSuite) TestOutputInvalid(c *tc.C) {
 
 	w, err := NewWorker(Config{
 		DBGetter:                     s.dbGetter,
+		ControllerUUID:               "controller-uuid",
 		Clock:                        clock.WallClock,
 		Logger:                       s.logger,
 		NewObjectStoreServices:       NewObjectStoreServices,
@@ -148,15 +152,16 @@ func (s *manifoldSuite) TestOutputInvalid(c *tc.C) {
 func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
 		ChangeStreamName: "changestream",
+		ControllerUUID:   "controller-uuid",
 		Clock:            clock.WallClock,
 		Logger:           s.logger,
 		NewWorker: func(Config) (worker.Worker, error) {
 			return nil, nil
 		},
-		NewObjectStoreServices: func(model.UUID, changestream.WatchableDBGetter, clock.Clock, logger.Logger) services.ObjectStoreServices {
+		NewObjectStoreServices: func(model.UUID, changestream.WatchableDBGetter, string, clock.Clock, logger.Logger) services.ObjectStoreServices {
 			return nil
 		},
-		NewObjectStoreServicesGetter: func(ObjectStoreServicesFn, changestream.WatchableDBGetter, clock.Clock, logger.Logger) services.ObjectStoreServicesGetter {
+		NewObjectStoreServicesGetter: func(ObjectStoreServicesFn, changestream.WatchableDBGetter, string, clock.Clock, logger.Logger) services.ObjectStoreServicesGetter {
 			return nil
 		},
 	}

--- a/internal/worker/objectstoreservices/worker.go
+++ b/internal/worker/objectstoreservices/worker.go
@@ -23,6 +23,8 @@ type Config struct {
 	Clock  clock.Clock
 	Logger logger.Logger
 
+	ControllerUUID string
+
 	NewObjectStoreServicesGetter ObjectStoreServicesGetterFn
 	NewObjectStoreServices       ObjectStoreServicesFn
 }
@@ -37,6 +39,9 @@ func (config Config) Validate() error {
 	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
+	}
+	if config.ControllerUUID == "" {
+		return errors.NotValidf("empty ControllerUUID")
 	}
 	if config.NewObjectStoreServices == nil {
 		return errors.NotValidf("nil NewObjectStoreServices")
@@ -57,6 +62,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		servicesGetter: config.NewObjectStoreServicesGetter(
 			config.NewObjectStoreServices,
 			config.DBGetter,
+			config.ControllerUUID,
 			config.Clock,
 			config.Logger,
 		),
@@ -110,6 +116,7 @@ type objectStoreServices struct {
 type domainServicesGetter struct {
 	newObjectStoreServices ObjectStoreServicesFn
 	dbGetter               changestream.WatchableDBGetter
+	controllerUUID         string
 	clock                  clock.Clock
 	logger                 logger.Logger
 }
@@ -120,7 +127,7 @@ type domainServicesGetter struct {
 func (s *domainServicesGetter) ServicesForModel(modelUUID coremodel.UUID) services.ObjectStoreServices {
 	return &objectStoreServices{
 		ObjectStoreServices: s.newObjectStoreServices(
-			modelUUID, s.dbGetter, s.clock, s.logger,
+			modelUUID, s.dbGetter, s.controllerUUID, s.clock, s.logger,
 		),
 	}
 }

--- a/internal/worker/objectstoreservices/worker_test.go
+++ b/internal/worker/objectstoreservices/worker_test.go
@@ -51,6 +51,10 @@ func (s *workerSuite) TestValidateConfig(c *tc.C) {
 	cfg = s.getConfig()
 	cfg.NewObjectStoreServicesGetter = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
+	cfg.ControllerUUID = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 }
 
 func (s *workerSuite) getConfig() Config {
@@ -58,10 +62,13 @@ func (s *workerSuite) getConfig() Config {
 		DBGetter: s.dbGetter,
 		Clock:    clock.WallClock,
 		Logger:   s.logger,
-		NewObjectStoreServices: func(coremodel.UUID, changestream.WatchableDBGetter, clock.Clock, logger.Logger) services.ObjectStoreServices {
+
+		ControllerUUID: "controller-uuid",
+
+		NewObjectStoreServices: func(coremodel.UUID, changestream.WatchableDBGetter, string, clock.Clock, logger.Logger) services.ObjectStoreServices {
 			return s.objectStoreServices
 		},
-		NewObjectStoreServicesGetter: func(ObjectStoreServicesFn, changestream.WatchableDBGetter, clock.Clock, logger.Logger) services.ObjectStoreServicesGetter {
+		NewObjectStoreServicesGetter: func(ObjectStoreServicesFn, changestream.WatchableDBGetter, string, clock.Clock, logger.Logger) services.ObjectStoreServicesGetter {
 			return s.objectStoreServicesGetter
 		},
 	}

--- a/testcharms/charms/s3/charmcraft.yaml
+++ b/testcharms/charms/s3/charmcraft.yaml
@@ -1,0 +1,15 @@
+type: charm
+base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:
+  s390x:
+parts:
+  include:
+    plugin: dump
+    source: .
+    prime:
+      - config.yaml
+      - hooks
+      - manifest.yaml
+      - metadata.yaml

--- a/testcharms/charms/s3/config.yaml
+++ b/testcharms/charms/s3/config.yaml
@@ -1,0 +1,21 @@
+options:
+  bucket:
+    type: string
+    default: ""
+    description: S3 bucket name advertised to Juju.
+  region:
+    type: string
+    default: ""
+    description: S3 region advertised to Juju.
+  endpoint:
+    type: string
+    default: ""
+    description: S3-compatible endpoint advertised to Juju.
+  static_key:
+    type: string
+    default: ""
+    description: Static access key advertised to Juju.
+  static_secret:
+    type: string
+    default: ""
+    description: Static secret key advertised to Juju.

--- a/testcharms/charms/s3/hooks/config-changed
+++ b/testcharms/charms/s3/hooks/config-changed
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+for relation_id in $(relation-ids s3-credentials); do
+    "$(dirname "$0")/publish-s3-config" "${relation_id}"
+done
+
+status-set active "published S3 config"

--- a/testcharms/charms/s3/hooks/install
+++ b/testcharms/charms/s3/hooks/install
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+status-set active "ready"

--- a/testcharms/charms/s3/hooks/publish-s3-config
+++ b/testcharms/charms/s3/hooks/publish-s3-config
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+if ! is-leader; then
+    status-set waiting "waiting for leader to publish S3 config"
+    exit 0
+fi
+
+bucket="$(config-get bucket)"
+region="$(config-get region)"
+endpoint="$(config-get endpoint)"
+static_key="$(config-get static_key)"
+static_secret="$(config-get static_secret)"
+relation_id="${1:-}"
+
+relation_args=""
+if [ -n "${relation_id}" ]; then
+    relation_args="-r ${relation_id}"
+fi
+
+# shellcheck disable=SC2086
+relation-set ${relation_args} --app \
+    bucket="${bucket}" \
+    region="${region}" \
+    endpoint="${endpoint}" \
+    access-key="${static_key}" \
+    secret-key="${static_secret}"
+
+status-set active "published S3 config"

--- a/testcharms/charms/s3/hooks/s3-credentials-relation-changed
+++ b/testcharms/charms/s3/hooks/s3-credentials-relation-changed
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+"$(dirname "$0")/publish-s3-config"

--- a/testcharms/charms/s3/hooks/s3-credentials-relation-joined
+++ b/testcharms/charms/s3/hooks/s3-credentials-relation-joined
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+"$(dirname "$0")/publish-s3-config"

--- a/testcharms/charms/s3/hooks/start
+++ b/testcharms/charms/s3/hooks/start
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+status-set active "ready"

--- a/testcharms/charms/s3/manifest.yaml
+++ b/testcharms/charms/s3/manifest.yaml
@@ -1,0 +1,5 @@
+bases:
+  - architectures:
+      - amd64
+    channel: '24.04'
+    name: ubuntu

--- a/testcharms/charms/s3/metadata.yaml
+++ b/testcharms/charms/s3/metadata.yaml
@@ -1,0 +1,11 @@
+name: s3
+maintainer: Juju QA <juju-qa@canonical.com>
+summary: Test S3-compatible configuration provider
+description: |
+  Test charm that publishes S3-compatible configuration over the s3
+  relation interface.
+provides:
+  s3-credentials:
+    interface: s3
+series:
+  - noble


### PR DESCRIPTION
Previously, S3 backend state only carried the endpoint and credentials, while workers relied on separately wired bucket defaults and inferred regions. The API also exposed this incomplete configuration through /s3-credentials.

 Now bucket and region are persisted with the backend and flow through the object-store services into the model workers, S3 caller, and drainer. The endpoint is renamed to /s3-config to reflect that it returns the complete S3 configuration and to align with juju-controller PR 126.

Keeping this configuration in the model-worker path ensures every worker follows the active backend while preserving model isolation. One controller-scoped bucket is used, with objects stored as <model-uuid>/<object-sha>. Tests verify namespaced uploads and ensure removing one model cannot remove another model’s objects.

## QA steps

You can test with minio or aws, or similar. I tested with aws directly this time. So you'll need to setup a user and a bucket in aws with the correct permissions. The bucket must support versioning and locking.

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "BucketAccess",
      "Effect": "Allow",
      "Action": [
        "s3:CreateBucket",
        "s3:ListBucket",
        "s3:GetBucketLocation",
        "s3:PutBucketVersioning",
        "s3:PutBucketObjectLockConfiguration"
      ],
      "Resource": "arn:aws:s3:::<bucket name>"
    },
    {
      "Sid": "ObjectAccess",
      "Effect": "Allow",
      "Action": [
        "s3:GetObject",
        "s3:PutObject",
        "s3:DeleteObject",
        "s3:PutObjectRetention",
        "s3:PutObjectLegalHold",
        "s3:BypassGovernanceRetention"
      ],
      "Resource": "arn:aws:s3:::<bucket name>/*"
    }
  ]
}
```

Additionally, you'll need the controller charm from https://github.com/juju/juju-controller/pull/126 which supports buckets and regions.

```sh
$ juju bootstrap lxd test --bootstrap-base=ubuntu@24.04 --controller-charm-path=./juju-controller_ubuntu@24.04-amd64.charm

$ juju add-model foo && juju deploy ubuntu &&
juju add-model bar && juju deploy juju-qa-test &&
juju switch controller && juju deploy ./testcharms/charms/s3/s3_amd64.charm

$ juju config s3 bucket="<bucket name>" \
               region="<region for regional buckets>" \
               endpoint="<s3 url>" \
               static_key="<static key>" \
               static_secret="<secret - which is only for the s3 charm>"

$ juju integrate controller:s3-backend s3:s3-credentials
```

This should drain.

--------

Things which are missing that will be done in a follow up:

 - [ ] Remove orphan objects after the drain
 - [ ] Allow the breaking of a relation if the drain is stuck in an error state