### PR TITLE
feat: return CAAS FQDNs as bind addresses

### DIFF
--- a/domain/network/service/interface.go
+++ b/domain/network/service/interface.go
@@ -213,6 +213,10 @@ type NetworkInfoState interface {
 		ctx context.Context, unitUUID string, endpointNames []string,
 	) ([]networkinternal.EndpointNetworkInfo, error)
 
+	// GetUnitFQDNs retrieves the ordered FQDNs linked to the unit's network
+	// node.
+	GetUnitFQDNs(ctx context.Context, unitUUID string) ([]string, error)
+
 	// GetUnitNetworkInfo retrieves raw unit addresses and selected ingress
 	// addresses for the specified unit when provider networking is not
 	// supported.

--- a/domain/network/service/package_mock_test.go
+++ b/domain/network/service/package_mock_test.go
@@ -60,6 +60,7 @@ type MockStateMockRecorder struct {
 	getUnitAndK8sServiceAddressesExpects        []*gomock.Call2_2[context.Context, unit.UUID, network.SpaceAddresses, error]
 	getUnitEgressSubnetsExpects                 []*gomock.Call2_2[context.Context, string, []string, error]
 	getUnitEndpointNetworkInfoExpects           []*gomock.Call3_2[context.Context, string, []string, []internal.EndpointNetworkInfo, error]
+	getUnitFQDNsExpects                         []*gomock.Call2_2[context.Context, string, []string, error]
 	getUnitNetworkInfoExpects                   []*gomock.Call2_2[context.Context, string, internal.UnitNetworkInfo, error]
 	getUnitPublicAddressForEgressExpects        []*gomock.Call2_2[context.Context, string, string, error]
 	getUnitRelationEndpointNameExpects          []*gomock.Call3_2[context.Context, string, string, string, error]
@@ -594,6 +595,24 @@ func (mr *MockStateMockRecorder) GetUnitEndpointNetworkInfo(ctx, unitUUID, endpo
 
 // MockStateGetUnitEndpointNetworkInfoCall is the typed call wrapper for GetUnitEndpointNetworkInfo.
 type MockStateGetUnitEndpointNetworkInfoCall = gomock.Call3_2[context.Context, string, []string, []internal.EndpointNetworkInfo, error]
+
+// GetUnitFQDNs mocks base method.
+func (m *MockState) GetUnitFQDNs(ctx context.Context, unitUUID string) ([]string, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_2(&m.recorder.getUnitFQDNsExpects, m.ctrl, m, "GetUnitFQDNs", ctx, unitUUID)
+}
+
+// GetUnitFQDNs indicates an expected call of GetUnitFQDNs.
+func (mr *MockStateMockRecorder) GetUnitFQDNs(ctx, unitUUID any) *MockStateGetUnitFQDNsCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_2[context.Context, string, []string, error](mr.mock.ctrl.T, mr.mock, "GetUnitFQDNs", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(unitUUID))
+	mr.getUnitFQDNsExpects = append(mr.getUnitFQDNsExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockStateGetUnitFQDNsCall is the typed call wrapper for GetUnitFQDNs.
+type MockStateGetUnitFQDNsCall = gomock.Call2_2[context.Context, string, []string, error]
 
 // GetUnitNetworkInfo mocks base method.
 func (m *MockState) GetUnitNetworkInfo(ctx context.Context, unitUUID string) (internal.UnitNetworkInfo, error) {

--- a/domain/network/service/unitinfo.go
+++ b/domain/network/service/unitinfo.go
@@ -32,12 +32,22 @@ func (s *ProviderService) GetUnitRelationNetworks(
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
+	if len(relationUUIDs) == 0 {
+		return nil, nil
+	}
+
 	unitUUID, err := s.st.GetUnitUUIDByName(ctx, unitName)
 	if err != nil {
 		return nil, internalerrors.Capture(err)
 	}
 
 	result := make(map[corerelation.UUID]domainnetwork.UnitNetwork, len(relationUUIDs))
+	var (
+		supportsNetworking bool
+		isCaas             bool
+		fqdns              []string
+		propertiesLoaded   bool
+	)
 	for _, relationUUID := range relationUUIDs {
 		endpointName, err := s.st.GetUnitRelationEndpointName(
 			ctx, unitUUID.String(), relationUUID.String(),
@@ -55,15 +65,32 @@ func (s *ProviderService) GetUnitRelationNetworks(
 			return nil, internalerrors.Capture(err)
 		}
 
+		if !propertiesLoaded {
+			supportsNetworking, isCaas, fqdns, err = s.getUnitNetworkProperties(
+				ctx, unitUUID.String(),
+			)
+			if err != nil {
+				return nil, internalerrors.Capture(err)
+			}
+			propertiesLoaded = true
+		}
+
 		infos, err := s.getUnitEndpointNetworks(
 			ctx, unitUUID.String(), []string{endpointName}, egressSubnets,
+			supportsNetworking, isCaas, fqdns,
 		)
 		if err != nil {
 			return nil, internalerrors.Errorf("getting unit endpoint networks: %w", err)
 		}
-		if len(infos) != 1 {
+
+		if num := len(infos); num == 0 {
 			return nil, internalerrors.Errorf(
-				"expected 1 NetworkInfo for unit %q on endpoint %q, got %d",
+				"empty endpoint network info for unit %q on endpoint %q",
+				unitName, endpointName,
+			)
+		} else if num > 1 {
+			return nil, internalerrors.Errorf(
+				"expected exactly one endpoint network info for unit %q on endpoint %q, got %d",
 				unitName, endpointName, len(infos),
 			)
 		}
@@ -98,7 +125,47 @@ func (s *ProviderService) GetUnitEndpointNetworks(
 		return nil, internalerrors.Errorf("getting model egress subnets: %w", err)
 	}
 
-	return s.getUnitEndpointNetworks(ctx, unitUUID.String(), endpointNames, defaultEgressSubnets)
+	supportsNetworking, isCaas, fqdns, err := s.getUnitNetworkProperties(
+		ctx, unitUUID.String(),
+	)
+	if err != nil {
+		return nil, internalerrors.Capture(err)
+	}
+
+	return s.getUnitEndpointNetworks(
+		ctx, unitUUID.String(), endpointNames, defaultEgressSubnets,
+		supportsNetworking, isCaas, fqdns,
+	)
+}
+
+func (s *ProviderService) getUnitNetworkProperties(
+	ctx context.Context, unitUUID string,
+) (bool, bool, []string, error) {
+	supportsNetworking, err := s.supportsNetworking(ctx)
+	if err != nil {
+		return false, false, nil, internalerrors.Errorf(
+			"checking provider networking support: %w", err,
+		)
+	}
+
+	isCaas, err := s.st.IsCaasUnit(ctx, unitUUID)
+	if err != nil {
+		return false, false, nil, internalerrors.Errorf(
+			"checking if unit is caas: %w", err,
+		)
+	}
+
+	var fqdns []string
+	if isCaas {
+		fqdns, err = s.st.GetUnitFQDNs(ctx, unitUUID)
+		if err != nil {
+			return false, false, nil, internalerrors.Errorf(
+				"getting unit FQDNs: %w", err,
+			)
+		}
+	}
+
+	return supportsNetworking, isCaas, fqdns, nil
 }
 
 func (s *ProviderService) getUnitEndpointNetworks(
@@ -106,19 +173,14 @@ func (s *ProviderService) getUnitEndpointNetworks(
 	unitUUID string,
 	endpointNames []string,
 	defaultEgressSubnets []string,
+	supportsNetworking bool,
+	isCaas bool,
+	fqdns []string,
 ) ([]domainnetwork.UnitNetwork, error) {
-	supportsNetworking, err := s.supportsNetworking(ctx)
-	if err != nil {
-		return nil, internalerrors.Errorf("checking provider networking support: %w", err)
-	}
-
-	isCaas, err := s.st.IsCaasUnit(ctx, unitUUID)
-	if err != nil {
-		return nil, internalerrors.Errorf("checking if unit is caas: %w", err)
-	}
-
 	if !supportsNetworking {
-		return s.getUnitEndpointNetworksWithoutProviderNetworking(ctx, unitUUID, endpointNames, isCaas, defaultEgressSubnets)
+		return s.getUnitEndpointNetworksWithoutProviderNetworking(
+			ctx, unitUUID, endpointNames, fqdns, isCaas, defaultEgressSubnets,
+		)
 	}
 
 	endpointNetworks, err := s.st.GetUnitEndpointNetworkInfo(ctx, unitUUID, endpointNames)
@@ -131,6 +193,7 @@ func (s *ProviderService) getUnitEndpointNetworks(
 		info := buildUnitNetworkWithIngressAddresses(
 			endpointNetwork.Addresses,
 			endpointNetwork.IngressAddresses,
+			fqdns,
 			isCaas,
 		)
 		info.EndpointName = endpointNetwork.EndpointName
@@ -195,9 +258,22 @@ func (s *ProviderService) getUnitPublicEgressSubnets(
 func buildUnitNetworkWithIngressAddresses(
 	addresses []networkinternal.UnitAddress,
 	ingressAddresses []string,
+	fqdns []string,
 	isCaas bool,
 ) domainnetwork.UnitNetwork {
 	var devices []domainnetwork.DeviceInfo
+	// TODO: IAAS FQDNs require separate selection and device-association
+	// semantics and will be handled in future work.
+	if isCaas && len(fqdns) > 0 {
+		devices = []domainnetwork.DeviceInfo{{
+			Addresses: transform.Slice(fqdns, func(fqdn string) domainnetwork.AddressInfo {
+				return domainnetwork.AddressInfo{
+					Hostname: fqdn,
+					Value:    fqdn,
+				}
+			}),
+		}}
+	}
 	deviceIndex := make(map[string]int)
 	for _, addr := range addresses {
 		// The purpose of the method is to get connectivity information for
@@ -252,13 +328,20 @@ func subnetsForAddresses(addrs []string) []string {
 }
 
 func (s *ProviderService) getUnitEndpointNetworksWithoutProviderNetworking(
-	ctx context.Context, unitUUID string, endpointNames []string, isCaas bool, defaultEgressSubnets []string,
+	ctx context.Context,
+	unitUUID string,
+	endpointNames []string,
+	fqdns []string,
+	isCaas bool,
+	defaultEgressSubnets []string,
 ) ([]domainnetwork.UnitNetwork, error) {
 	unitNetwork, err := s.st.GetUnitNetworkInfo(ctx, unitUUID)
 	if err != nil {
 		return nil, internalerrors.Errorf("getting unit network info: %w", err)
 	}
-	info := buildUnitNetworkWithIngressAddresses(unitNetwork.Addresses, unitNetwork.IngressAddresses, isCaas)
+	info := buildUnitNetworkWithIngressAddresses(
+		unitNetwork.Addresses, unitNetwork.IngressAddresses, fqdns, isCaas,
+	)
 	info.EgressSubnets = defaultEgressSubnets
 	if len(info.EgressSubnets) == 0 {
 		info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)

--- a/domain/network/service/unitinfo_test.go
+++ b/domain/network/service/unitinfo_test.go
@@ -256,6 +256,62 @@ func (s *infoSuite) TestGetUnitRelationNetworks(c *tc.C) {
 	c.Check(info.EgressSubnets, tc.DeepEquals, []string{"192.168.1.0/24"})
 }
 
+func (s *infoSuite) TestGetUnitRelationNetworksLoadsCaasFQDNsOnce(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := coreunit.Name("mysql/0")
+	unitUUID := coreunit.UUID("unit-uuid-123")
+	relationUUID1 := tc.Must(c, corerelation.NewUUID)
+	relationUUID2 := tc.Must(c, corerelation.NewUUID)
+	endpointName1 := "db"
+	endpointName2 := "server"
+	fqdn := "mysql-0.example.test"
+	providerCalls := 0
+	providerGetter := func(context.Context) (ProviderWithNetworking, error) {
+		providerCalls++
+		return s.providerWithNetworking, nil
+	}
+
+	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetUnitRelationEndpointName(
+		gomock.Any(), unitUUID.String(), relationUUID1.String(),
+	).Return(endpointName1, nil)
+	s.st.EXPECT().GetUnitRelationEndpointName(
+		gomock.Any(), unitUUID.String(), relationUUID2.String(),
+	).Return(endpointName2, nil)
+	s.st.EXPECT().GetRelationEgressSubnets(
+		gomock.Any(), relationUUID1.String(),
+	).Return([]string{"10.0.0.0/24"}, nil)
+	s.st.EXPECT().GetRelationEgressSubnets(
+		gomock.Any(), relationUUID2.String(),
+	).Return([]string{"10.0.1.0/24"}, nil)
+	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
+	s.st.EXPECT().GetUnitFQDNs(
+		gomock.Any(), unitUUID.String(),
+	).Return([]string{fqdn}, nil)
+	s.st.EXPECT().GetUnitEndpointNetworkInfo(
+		gomock.Any(), unitUUID.String(), []string{endpointName1},
+	).Return([]networkinternal.EndpointNetworkInfo{{EndpointName: endpointName1}}, nil)
+	s.st.EXPECT().GetUnitEndpointNetworkInfo(
+		gomock.Any(), unitUUID.String(), []string{endpointName2},
+	).Return([]networkinternal.EndpointNetworkInfo{{EndpointName: endpointName2}}, nil)
+
+	service := NewProviderService(
+		s.st, providerGetter, nil, loggertesting.WrapCheckLog(c),
+	)
+	infoMap, err := service.GetUnitRelationNetworks(
+		c.Context(), unitName, []corerelation.UUID{relationUUID1, relationUUID2},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(infoMap, tc.HasLen, 2)
+	c.Check(providerCalls, tc.Equals, 1)
+	for _, relationUUID := range []corerelation.UUID{relationUUID1, relationUUID2} {
+		c.Assert(infoMap[relationUUID].DeviceInfos, tc.HasLen, 1)
+		c.Check(infoMap[relationUUID].DeviceInfos[0].Addresses, tc.DeepEquals,
+			[]domainnetwork.AddressInfo{{Hostname: fqdn, Value: fqdn}})
+	}
+}
+
 func (s *infoSuite) TestGetUnitRelationNetworksFallsBackToModelEgressSubnets(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -407,6 +463,9 @@ func (s *infoSuite) TestGetUnitEndpointNetworksStateError(c *tc.C) {
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
 	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
+	s.st.EXPECT().GetUnitFQDNs(
+		gomock.Any(), unitUUID.String(),
+	).Return([]string{"controller-0.example.test"}, nil)
 	s.st.EXPECT().GetUnitEndpointNetworkInfo(
 		gomock.Any(), unitUUID.String(), endpointNames,
 	).Return(nil, errors.New("state error"))
@@ -429,6 +488,24 @@ func (s *infoSuite) TestGetUnitEndpointNetworksIsCaasUnitError(c *tc.C) {
 	service := NewProviderService(s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c))
 	_, err := service.GetUnitEndpointNetworks(c.Context(), unitName, []string{"db"})
 	c.Assert(err, tc.ErrorMatches, "checking if unit is caas: boom")
+}
+
+func (s *infoSuite) TestGetUnitEndpointNetworksFQDNError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := coreunit.Name("mysql/0")
+	unitUUID := coreunit.UUID("unit-uuid-123")
+
+	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
+	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
+	s.st.EXPECT().GetUnitFQDNs(
+		gomock.Any(), unitUUID.String(),
+	).Return(nil, errors.New("boom"))
+
+	service := NewProviderService(s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c))
+	_, err := service.GetUnitEndpointNetworks(c.Context(), unitName, []string{"db"})
+	c.Assert(err, tc.ErrorMatches, "getting unit FQDNs: boom")
 }
 
 func (s *infoSuite) TestGetUnitEndpointNetworksGetModelEgressSubnetsError(c *tc.C) {
@@ -520,6 +597,9 @@ func (s *infoSuite) TestGetUnitEndpointNetworksCaasUsesServiceAddressForIngress(
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
 	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
+	s.st.EXPECT().GetUnitFQDNs(
+		gomock.Any(), unitUUID.String(),
+	).Return([]string{"controller-0.example.test"}, nil)
 	s.st.EXPECT().GetUnitEndpointNetworkInfo(
 		gomock.Any(), unitUUID.String(), endpointNames,
 	).Return(stateNetworkInfo, nil)
@@ -531,6 +611,11 @@ func (s *infoSuite) TestGetUnitEndpointNetworksCaasUsesServiceAddressForIngress(
 	c.Check(infos[0], tc.DeepEquals, domainnetwork.UnitNetwork{
 		EndpointName: "db",
 		DeviceInfos: []domainnetwork.DeviceInfo{{
+			Addresses: []domainnetwork.AddressInfo{{
+				Hostname: "controller-0.example.test",
+				Value:    "controller-0.example.test",
+			}},
+		}, {
 			Name:       "eth0",
 			MACAddress: "aa:bb:cc:dd:ee:ff",
 			Addresses: []domainnetwork.AddressInfo{{
@@ -557,7 +642,7 @@ func (s *infoSuite) TestBuildUnitNetworkPreservesDeviceAndAddressOrder(c *tc.C) 
 			corenetwork.EthernetDevice),
 	}
 
-	info := buildUnitNetworkWithIngressAddresses(addresses, nil, false)
+	info := buildUnitNetworkWithIngressAddresses(addresses, nil, nil, false)
 
 	c.Check(info.DeviceInfos, tc.DeepEquals, []domainnetwork.DeviceInfo{{
 		Name:       "eth1",
@@ -592,10 +677,45 @@ func (s *infoSuite) TestBuildUnitNetworkCaasDoesNotEmitEmptyDevices(c *tc.C) {
 			corenetwork.LoopbackDevice),
 	}
 
-	info := buildUnitNetworkWithIngressAddresses(addresses, []string{"10.0.0.2/24"}, true)
+	info := buildUnitNetworkWithIngressAddresses(addresses, []string{"10.0.0.2/24"}, nil, true)
 
 	c.Check(info.DeviceInfos, tc.HasLen, 0)
 	c.Check(info.IngressAddresses, tc.DeepEquals, []string{"10.0.0.2"})
+}
+
+func (s *infoSuite) TestBuildUnitNetworkCaasPrependsFQDNs(c *tc.C) {
+	addresses := []networkinternal.UnitAddress{
+		unitAddress("10.0.0.1", "10.0.0.0/24", "eth0",
+			"aa:bb:cc:dd:ee:01", corenetwork.ScopeMachineLocal,
+			corenetwork.EthernetDevice),
+	}
+
+	info := buildUnitNetworkWithIngressAddresses(
+		addresses, nil, []string{"controller-0.example.test"}, true,
+	)
+
+	c.Check(info.DeviceInfos, tc.DeepEquals, []domainnetwork.DeviceInfo{{
+		Addresses: []domainnetwork.AddressInfo{{
+			Hostname: "controller-0.example.test",
+			Value:    "controller-0.example.test",
+		}},
+	}, {
+		Name:       "eth0",
+		MACAddress: "aa:bb:cc:dd:ee:01",
+		Addresses: []domainnetwork.AddressInfo{{
+			Hostname: "10.0.0.1",
+			Value:    "10.0.0.1",
+			CIDR:     "10.0.0.0/24",
+		}},
+	}})
+}
+
+func (s *infoSuite) TestBuildUnitNetworkIaasIgnoresFQDNs(c *tc.C) {
+	info := buildUnitNetworkWithIngressAddresses(
+		nil, nil, []string{"ignored.example.test"}, false,
+	)
+
+	c.Check(info.DeviceInfos, tc.HasLen, 0)
 }
 
 func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedUsesUnitAddresses(c *tc.C) {
@@ -670,6 +790,9 @@ func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedCaasSkipsServiceAddre
 	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
 	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
 	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
+	s.st.EXPECT().GetUnitFQDNs(
+		gomock.Any(), unitUUID.String(),
+	).Return(nil, nil)
 	s.st.EXPECT().GetUnitNetworkInfo(
 		gomock.Any(), unitUUID.String(),
 	).Return(unitNetworkInfo([]string{"10.0.0.2"}, addresses...), nil)
@@ -690,6 +813,131 @@ func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedCaasSkipsServiceAddre
 		}},
 		IngressAddresses: []string{"10.0.0.2"},
 		EgressSubnets:    []string{"10.0.0.0/24"},
+	}})
+}
+
+func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedCaasPrependsFQDNs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := coreunit.Name("mysql/0")
+	unitUUID := coreunit.UUID("unit-uuid-123")
+	endpointNames := []string{"db"}
+	addresses := []networkinternal.UnitAddress{
+		unitAddress("10.0.0.1", "10.0.0.0/24", "eth0",
+			"aa:bb:cc:dd:ee:01", corenetwork.ScopeMachineLocal,
+			corenetwork.EthernetDevice),
+	}
+
+	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
+	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
+	s.st.EXPECT().GetUnitFQDNs(
+		gomock.Any(), unitUUID.String(),
+	).Return([]string{"controller-0.example.test", "controller-1.example.test"}, nil)
+	s.st.EXPECT().GetUnitNetworkInfo(
+		gomock.Any(), unitUUID.String(),
+	).Return(networkinternal.UnitNetworkInfo{
+		Addresses:        addresses,
+		IngressAddresses: []string{"10.0.0.2"},
+	}, nil)
+
+	service := NewProviderService(s.st, s.notSupportedProviderGetter, nil, loggertesting.WrapCheckLog(c))
+	infos, err := service.GetUnitEndpointNetworks(c.Context(), unitName, endpointNames)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(infos, tc.DeepEquals, []domainnetwork.UnitNetwork{{
+		EndpointName: "db",
+		DeviceInfos: []domainnetwork.DeviceInfo{{
+			Addresses: []domainnetwork.AddressInfo{{
+				Hostname: "controller-0.example.test",
+				Value:    "controller-0.example.test",
+			}, {
+				Hostname: "controller-1.example.test",
+				Value:    "controller-1.example.test",
+			}},
+		}, {
+			Name:       "eth0",
+			MACAddress: "aa:bb:cc:dd:ee:01",
+			Addresses: []domainnetwork.AddressInfo{{
+				Hostname: "10.0.0.1",
+				Value:    "10.0.0.1",
+				CIDR:     "10.0.0.0/24",
+			}},
+		}},
+		IngressAddresses: []string{"10.0.0.2"},
+		EgressSubnets:    []string{"10.0.0.0/24"},
+	}})
+}
+
+func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedCaasUsesFQDNWithoutPodIP(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := coreunit.Name("mysql/0")
+	unitUUID := coreunit.UUID("unit-uuid-123")
+	endpointNames := []string{"db"}
+
+	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return(nil, nil)
+	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
+	s.st.EXPECT().GetUnitFQDNs(
+		gomock.Any(), unitUUID.String(),
+	).Return([]string{"controller-0.example.test"}, nil)
+	s.st.EXPECT().GetUnitNetworkInfo(
+		gomock.Any(), unitUUID.String(),
+	).Return(networkinternal.UnitNetworkInfo{}, nil)
+
+	service := NewProviderService(s.st, s.notSupportedProviderGetter, nil, loggertesting.WrapCheckLog(c))
+	infos, err := service.GetUnitEndpointNetworks(c.Context(), unitName, endpointNames)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(infos, tc.DeepEquals, []domainnetwork.UnitNetwork{{
+		EndpointName: "db",
+		DeviceInfos: []domainnetwork.DeviceInfo{{
+			Addresses: []domainnetwork.AddressInfo{{
+				Hostname: "controller-0.example.test",
+				Value:    "controller-0.example.test",
+			}},
+		}},
+		IngressAddresses: []string{},
+	}})
+}
+
+func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedIaasDoesNotRequestFQDNs(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := coreunit.Name("mysql/0")
+	unitUUID := coreunit.UUID("unit-uuid-123")
+	endpointNames := []string{"db"}
+	addresses := []networkinternal.UnitAddress{
+		unitAddress("192.168.1.10", "192.168.1.0/24", "eth0",
+			"aa:bb:cc:dd:ee:ff", corenetwork.ScopeCloudLocal,
+			corenetwork.EthernetDevice),
+	}
+
+	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"192.168.1.0/24"}, nil)
+	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(false, nil)
+	s.st.EXPECT().GetUnitNetworkInfo(
+		gomock.Any(), unitUUID.String(),
+	).Return(networkinternal.UnitNetworkInfo{
+		Addresses:        addresses,
+		IngressAddresses: []string{"192.168.1.10/24"},
+	}, nil)
+
+	service := NewProviderService(s.st, s.notSupportedProviderGetter, nil, loggertesting.WrapCheckLog(c))
+	infos, err := service.GetUnitEndpointNetworks(c.Context(), unitName, endpointNames)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(infos, tc.DeepEquals, []domainnetwork.UnitNetwork{{
+		EndpointName: "db",
+		DeviceInfos: []domainnetwork.DeviceInfo{{
+			Name:       "eth0",
+			MACAddress: "aa:bb:cc:dd:ee:ff",
+			Addresses: []domainnetwork.AddressInfo{{
+				Hostname: "192.168.1.10",
+				Value:    "192.168.1.10",
+				CIDR:     "192.168.1.0/24",
+			}},
+		}},
+		IngressAddresses: []string{"192.168.1.10"},
+		EgressSubnets:    []string{"192.168.1.0/24"},
 	}})
 }
 

--- a/domain/network/state/package_test.go
+++ b/domain/network/state/package_test.go
@@ -409,6 +409,15 @@ func (s *linkLayerBaseSuite) addK8sService(c *tc.C, nodeUUID, appUUID string) {
 		svcUUID, nodeUUID, appUUID, "provider-id")
 }
 
+func (s *linkLayerBaseSuite) addFQDNAddress(c *tc.C, nodeUUID, address string) {
+	addressUUID := uuid.MustNewUUID().String()
+	s.query(c, `INSERT INTO fqdn_address (uuid, address, scope_id)
+VALUES (?, ?, (SELECT id FROM network_address_scope WHERE name = ?))`,
+		addressUUID, address, corenetwork.ScopeCloudLocal)
+	s.query(c, `INSERT INTO net_node_fqdn_address (net_node_uuid, address_uuid) VALUES (?, ?)`,
+		nodeUUID, addressUUID)
+}
+
 func zeroNilPtr[T comparable](v *T) T {
 	var zero T
 	if v == nil {

--- a/domain/network/state/unitinfo.go
+++ b/domain/network/state/unitinfo.go
@@ -249,6 +249,48 @@ ORDER BY endpoint_name,
 	return infos, nil
 }
 
+// GetUnitFQDNs retrieves the ordered FQDNs linked to the unit's network node.
+func (st *State) GetUnitFQDNs(ctx context.Context, unitUUID string) ([]string, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	type fqdnAddress struct {
+		Address string `db:"address"`
+	}
+
+	ident := entityUUID{UUID: unitUUID}
+	stmt, err := st.Prepare(`
+SELECT fqa.address AS &fqdnAddress.address
+FROM   unit AS u
+JOIN   net_node_fqdn_address AS nnfa
+       ON nnfa.net_node_uuid = u.net_node_uuid
+JOIN   fqdn_address AS fqa ON fqa.uuid = nnfa.address_uuid
+WHERE  u.uuid = $entityUUID.uuid
+ORDER BY fqa.address
+`, fqdnAddress{}, entityUUID{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var fqdns []fqdnAddress
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, ident).GetAll(&fqdns)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("querying unit FQDNs: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	return transform.Slice(fqdns, func(fqdn fqdnAddress) string {
+		return fqdn.Address
+	}), nil
+}
+
 // GetUnitNetworkInfo retrieves raw unit addresses and selected ingress
 // addresses for the specified unit when provider networking is not supported.
 func (st *State) GetUnitNetworkInfo(
@@ -268,7 +310,6 @@ func (st *State) GetUnitNetworkInfo(
 		DeviceType     string         `db:"device_type"`
 		IngressAddress sql.NullString `db:"ingress_address_value"`
 	}
-
 	var rows []unitNetworkInfoRow
 	ident := entityUUID{UUID: unitUUID}
 	stmt, err := st.Prepare(`
@@ -340,7 +381,6 @@ ORDER BY CASE WHEN ingress_address_value IS NULL THEN 1 ELSE 0 END,
 	if err != nil {
 		return networkinternal.UnitNetworkInfo{}, errors.Capture(err)
 	}
-
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, ident).GetAll(&rows)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {

--- a/domain/network/state/unitinfo_test.go
+++ b/domain/network/state/unitinfo_test.go
@@ -4,21 +4,38 @@
 package state
 
 import (
+	"context"
 	"testing"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/collections/transform"
 	"github.com/juju/tc"
 
+	coredatabase "github.com/juju/juju/core/database"
 	corenetwork "github.com/juju/juju/core/network"
 	networkinternal "github.com/juju/juju/domain/network/internal"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
 	"github.com/juju/juju/environs/config"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
 )
 
 type infoSuite struct {
 	linkLayerBaseSuite
 	relationCount int
+}
+
+type retryingTxnRunner struct {
+	coredatabase.TxnRunner
+}
+
+func (r retryingTxnRunner) Txn(
+	ctx context.Context, fn func(context.Context, *sqlair.TX) error,
+) error {
+	if err := r.TxnRunner.Txn(ctx, fn); err != nil {
+		return err
+	}
+	return r.TxnRunner.Txn(ctx, fn)
 }
 
 func TestInfoSuite(t *testing.T) {
@@ -453,6 +470,78 @@ WHERE uuid = ?
 		MACAddress: "00:11:22:33:44:66",
 		DeviceType: corenetwork.VirtualEthernetDevice,
 	}})
+}
+
+func (s *infoSuite) TestGetUnitFQDNsReturnsOrderedUnitFQDNs(c *tc.C) {
+	nodeUUID := s.addNetNode(c)
+	otherNodeUUID := s.addNetNode(c)
+	spaceUUID := corenetwork.AlphaSpaceId.String()
+	charmUUID := s.addCharm(c)
+	appUUID := s.addApplication(c, charmUUID, spaceUUID)
+	unitUUID := s.addUnit(c, appUUID, charmUUID, nodeUUID)
+
+	s.addFQDNAddress(c, nodeUUID, "unit-0.example.test")
+	s.addFQDNAddress(c, nodeUUID, "a-unit-0.example.test")
+	s.addFQDNAddress(c, otherNodeUUID, "other.example.test")
+
+	fqdns, err := s.state.GetUnitFQDNs(c.Context(), string(unitUUID))
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fqdns, tc.DeepEquals, []string{
+		"a-unit-0.example.test",
+		"unit-0.example.test",
+	})
+}
+
+func (s *infoSuite) TestGetUnitFQDNsNoFQDNs(c *tc.C) {
+	nodeUUID := s.addNetNode(c)
+	spaceUUID := corenetwork.AlphaSpaceId.String()
+	charmUUID := s.addCharm(c)
+	appUUID := s.addApplication(c, charmUUID, spaceUUID)
+	unitUUID := s.addUnit(c, appUUID, charmUUID, nodeUUID)
+	fqdns, err := s.state.GetUnitFQDNs(c.Context(), string(unitUUID))
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(fqdns, tc.HasLen, 0)
+}
+
+func (s *infoSuite) TestUnitNetworkQueriesResetResultsOnTransactionRetry(c *tc.C) {
+	nodeUUID := s.addNetNode(c)
+	deviceUUID := s.addLinkLayerDevice(
+		c, nodeUUID, "eth0", "00:11:22:33:44:55", corenetwork.EthernetDevice,
+	)
+	spaceUUID := corenetwork.AlphaSpaceId.String()
+	subnetUUID := s.addSubnet(c, "10.0.0.0/24", spaceUUID)
+	s.addIPAddressWithSubnetAndScope(
+		c, deviceUUID, nodeUUID, subnetUUID, "10.0.0.1", corenetwork.ScopeCloudLocal,
+	)
+	charmUUID := s.addCharm(c)
+	appUUID := s.addApplication(c, charmUUID, spaceUUID)
+	unitUUID := s.addUnit(c, appUUID, charmUUID, nodeUUID)
+	endpointName := "endpoint1"
+	s.addApplicationEndpoint(c, appUUID, charmUUID, endpointName, "")
+	s.addFQDNAddress(c, nodeUUID, "unit-0.example.test")
+
+	runner := retryingTxnRunner{TxnRunner: s.TxnRunner()}
+	state := NewState(
+		func(context.Context) (coredatabase.TxnRunner, error) { return runner, nil },
+		loggertesting.WrapCheckLog(c),
+	)
+	fqdns, err := state.GetUnitFQDNs(c.Context(), string(unitUUID))
+	c.Assert(err, tc.ErrorIsNil)
+	info, err := state.GetUnitNetworkInfo(c.Context(), string(unitUUID))
+	c.Assert(err, tc.ErrorIsNil)
+	endpointInfos, err := state.GetUnitEndpointNetworkInfo(
+		c.Context(), string(unitUUID), []string{endpointName},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(fqdns, tc.DeepEquals, []string{"unit-0.example.test"})
+	c.Check(info.Addresses, tc.HasLen, 1)
+	c.Check(info.IngressAddresses, tc.DeepEquals, []string{"10.0.0.1"})
+	c.Assert(endpointInfos, tc.HasLen, 1)
+	c.Check(endpointInfos[0].Addresses, tc.HasLen, 1)
+	c.Check(endpointInfos[0].IngressAddresses, tc.DeepEquals, []string{"10.0.0.1"})
 }
 
 func (s *infoSuite) TestGetUnitNetworkInfoPrioritisesPrimaryIngress(c *tc.C) {

--- a/internal/worker/uniter/runner/jujuc/network-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/network-get_test.go
@@ -140,6 +140,22 @@ func (s *NetworkGetSuite) createCommand(c *tc.C) cmd.Command {
 		IngressAddresses: []string{"203.0.113.10"},
 		EgressSubnets:    []string{"10.55.0.0/16"},
 	}
+	presetBindings["caas-fqdn"] = params.NetworkInfoResult{
+		Info: []params.NetworkInfo{{
+			Addresses: []params.InterfaceAddress{{
+				Hostname: "controller-0.example.test",
+				Address:  "controller-0.example.test",
+			}},
+		}, {
+			MACAddress:    "00:11:22:33:44:66",
+			InterfaceName: "eth0",
+			Addresses: []params.InterfaceAddress{{
+				Address: "10.55.0.9",
+				CIDR:    "10.55.0.0/24",
+			}},
+		}},
+		IngressAddresses: []string{"10.55.0.2"},
+	}
 	presetBindings["result-error"] = params.NetworkInfoResult{
 		Error: &params.Error{Message: "network info failed"},
 	}
@@ -329,6 +345,39 @@ ingress-addresses:
 		args:    []string{"ingress-egress-only", "--primary-address"},
 		code:    1,
 		out:     `no primary address attached to space for binding "ingress-egress-only"`,
+	}, {
+		summary: "CAAS FQDN is the bind address",
+		args:    []string{"caas-fqdn", "--bind-address"},
+		out:     "controller-0.example.test",
+	}, {
+		summary: "CAAS service address remains the ingress address",
+		args:    []string{"caas-fqdn", "--ingress-address"},
+		out:     "10.55.0.2",
+	}, {
+		summary: "CAAS full output lists FQDN before pod IP",
+		args:    []string{"caas-fqdn"},
+		out: `
+bind-addresses:
+- mac-address: ""
+  interface-name: ""
+  addresses:
+  - hostname: controller-0.example.test
+    value: controller-0.example.test
+    cidr: ""
+    address: controller-0.example.test
+  macaddress: ""
+  interfacename: ""
+- mac-address: 00:11:22:33:44:66
+  interface-name: eth0
+  addresses:
+  - hostname: ""
+    value: 10.55.0.9
+    cidr: 10.55.0.0/24
+    address: 10.55.0.9
+  macaddress: 00:11:22:33:44:66
+  interfacename: eth0
+ingress-addresses:
+- 10.55.0.2`[1:],
 	}, {
 		summary: "explicit ingress and egress information",
 		args:    []string{"ingress-egress", "--ingress-address", "--bind-address", "--egress-subnets"},


### PR DESCRIPTION
Query unit-linked FQDNs only for CAAS units and prepend them as logical bind devices while retaining pod addresses as fallbacks. Keep ingress, egress, and IAAS behavior unchanged.

Add state, service, retry, and network-get coverage, and avoid repeated network property lookups across relations.

~~Requires: https://github.com/juju/juju/pull/22897~~

## QA steps

```
$ juju bootstrap minikube mini
$ juju switch controller
$ juju exec --unit controller/0 -- network-get juju-info
bind-addresses:
- mac-address: ""
  interface-name: ""
  addresses:
  - hostname: controller-0.controller-service-endpoints.controller-mini.svc.cluster.local
    value: controller-0.controller-service-endpoints.controller-mini.svc.cluster.local
    cidr: ""
    address: controller-0.controller-service-endpoints.controller-mini.svc.cluster.local
  macaddress: ""
  interfacename: ""
- mac-address: ""
  interface-name: placeholder for "controller/0" k8s pod
  addresses:
  - hostname: 10.244.0.125
    value: 10.244.0.125
    cidr: 10.244.0.0/24
    address: 10.244.0.125
  macaddress: ""
  interfacename: placeholder for "controller/0" k8s pod
egress-subnets:
- 10.104.83.184/32
ingress-addresses:
- 10.104.83.184

$ juju exec --unit controller/0 -- network-get juju-info --bind-address
controller-0.controller-service-endpoints.controller-mini.svc.cluster.local
```