### PR TITLE
fix(cmr): make offer creation idempotent for identical offers

### DIFF
--- a/domain/crossmodelrelation/service/offer.go
+++ b/domain/crossmodelrelation/service/offer.go
@@ -14,6 +14,8 @@ import (
 	"github.com/juju/juju/core/offer"
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/trace"
+	"github.com/juju/juju/domain/application/charm"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/crossmodelrelation"
 	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
 	"github.com/juju/juju/internal/errors"
@@ -43,6 +45,14 @@ type ModelOfferState interface {
 		ctx context.Context,
 		offerName string,
 	) (crossmodelrelation.ConsumeDetails, error)
+
+	// GetApplicationEndpointDetails returns the name, role and interface
+	// of the provided endpoints for the given application.
+	GetApplicationEndpointDetails(
+		ctx context.Context,
+		applicationName string,
+		endpoints []string,
+	) ([]crossmodelrelation.OfferEndpoint, error)
 
 	// GetOfferDetails returns the OfferDetail of every offer in the model.
 	// No error is returned if offers are found.
@@ -152,8 +162,11 @@ func (s *Service) CreateOffer(
 		// succeed if the existing offer is identical to the requested one,
 		// that is it offers the same endpoints of the same application.
 		// This keeps creating an offer idempotent.
-		if existingOffer.ApplicationName == args.ApplicationName &&
-			sameOfferEndpoints(existingOffer.Endpoints, args.Endpoints) {
+		same, err := s.isSameOffer(ctx, existingOffer, args)
+		if err != nil {
+			return errors.Errorf("validating against existing offer: %w", err)
+		}
+		if same {
 			return nil
 		}
 		return errors.Errorf("creating offer: offer %q already exists with UUID %q",
@@ -203,16 +216,51 @@ func (s *Service) CreateOffer(
 	return errors.Capture(err)
 }
 
-// sameOfferEndpoints returns true if the offered endpoints and the requested
-// endpoints contain the same endpoint names. The requested endpoints are
-// keyed by endpoint name, the values being optional aliases, which are not
-// persisted as part of the offer.
-func sameOfferEndpoints(offered []crossmodelrelation.OfferEndpoint, requested map[string]string) bool {
+// isSameOffer returns true if the existing offer is for the same
+// application and offers the same endpoints as the requested ones.
+// Requested endpoint aliases are not persisted as part of the offer and
+// are ignored.
+func (s *Service) isSameOffer(
+	ctx context.Context,
+	existingOffer crossmodelrelation.ConsumeDetails,
+	args crossmodelrelation.ApplicationOfferArgs,
+) (bool, error) {
+	if existingOffer.ApplicationName != args.ApplicationName {
+		return false, nil
+	}
+	requested, err := s.modelState.GetApplicationEndpointDetails(
+		ctx, args.ApplicationName, slices.Collect(maps.Keys(args.Endpoints)),
+	)
+	if errors.Is(err, applicationerrors.ApplicationNotFound) ||
+		errors.Is(err, applicationerrors.EndpointNotFound) ||
+		errors.Is(err, crossmodelrelationerrors.MissingEndpoints) {
+		// The requested endpoints cannot be resolved on the application,
+		// so the existing offer differs from the requested one.
+		return false, nil
+	} else if err != nil {
+		return false, errors.Capture(err)
+	}
+	return sameOfferEndpoints(existingOffer.Endpoints, requested), nil
+}
+
+// sameOfferEndpoints returns true if the offered and the requested
+// endpoints contain the same endpoint names, roles and interfaces. The
+// comparison is order-insensitive, no ordering of either slice is assumed.
+func sameOfferEndpoints(offered, requested []crossmodelrelation.OfferEndpoint) bool {
 	if len(offered) != len(requested) {
 		return false
 	}
+	type endpointKey struct {
+		name  string
+		role  charm.RelationRole
+		iface string
+	}
+	existing := make(map[endpointKey]struct{}, len(offered))
 	for _, endpoint := range offered {
-		if _, ok := requested[endpoint.Name]; !ok {
+		existing[endpointKey{name: endpoint.Name, role: endpoint.Role, iface: endpoint.Interface}] = struct{}{}
+	}
+	for _, endpoint := range requested {
+		if _, ok := existing[endpointKey{name: endpoint.Name, role: endpoint.Role, iface: endpoint.Interface}]; !ok {
 			return false
 		}
 	}

--- a/domain/crossmodelrelation/service/offer.go
+++ b/domain/crossmodelrelation/service/offer.go
@@ -37,8 +37,8 @@ type ModelOfferState interface {
 		offer.UUID,
 	) error
 
-	// GetConsumeDetails returns the offer uuid and endpoints necessary to
-	// consume the offer.
+	// GetConsumeDetails returns the offer uuid, application name and
+	// endpoints necessary to consume the offer.
 	GetConsumeDetails(
 		ctx context.Context,
 		offerName string,
@@ -113,8 +113,12 @@ func (s *Service) GetOfferUUIDByRelationUUID(ctx context.Context, relationUUID c
 	return res, nil
 }
 
-// CreateOffer updates an existing offer, or creates a new offer if it does not
-// exist. Permissions are created for a new offer only.
+// CreateOffer creates an offer. Permissions are created for a new offer
+// only. If the offer already exists and offers the same endpoints of the
+// same application, the call is a no-op and succeeds, keeping offer creation
+// idempotent. If the offer exists but differs, an error satisfying
+// [crossmodelrelationerrors.OfferAlreadyExists] is returned, as updating
+// offers is not supported.
 func (s *Service) CreateOffer(
 	ctx context.Context,
 	args crossmodelrelation.ApplicationOfferArgs,
@@ -139,15 +143,21 @@ func (s *Service) CreateOffer(
 		return errors.Capture(err)
 	}
 
-	// Check if the offer already exists.
-	existingOfferUUID, err := s.modelState.GetOfferUUID(ctx, args.OfferName)
+	// Check if the offer already exists by fetching its details.
+	existingOffer, err := s.modelState.GetConsumeDetails(ctx, args.OfferName)
 	if err != nil && !errors.Is(err, crossmodelrelationerrors.OfferNotFound) {
 		return errors.Errorf("creating offer: %w", err)
 	} else if err == nil {
-		// The offer exists, this means that we have to return an error since we
-		// don't support updating offers.
+		// The offer exists. Since updating offers is not supported, only
+		// succeed if the existing offer is identical to the requested one,
+		// that is it offers the same endpoints of the same application.
+		// This keeps creating an offer idempotent.
+		if existingOffer.ApplicationName == args.ApplicationName &&
+			sameOfferEndpoints(existingOffer.Endpoints, args.Endpoints) {
+			return nil
+		}
 		return errors.Errorf("creating offer: offer %q already exists with UUID %q",
-			args.OfferName, existingOfferUUID).Add(crossmodelrelationerrors.OfferAlreadyExists)
+			args.OfferName, existingOffer.OfferUUID).Add(crossmodelrelationerrors.OfferAlreadyExists)
 	}
 
 	endpoints := slices.Collect(maps.Keys(args.Endpoints))
@@ -191,6 +201,22 @@ func (s *Service) CreateOffer(
 	}
 	err = errors.Errorf("creating access for offer %q: %w", args.OfferName, err)
 	return errors.Capture(err)
+}
+
+// sameOfferEndpoints returns true if the offered endpoints and the requested
+// endpoints contain the same endpoint names. The requested endpoints are
+// keyed by endpoint name, the values being optional aliases, which are not
+// persisted as part of the offer.
+func sameOfferEndpoints(offered []crossmodelrelation.OfferEndpoint, requested map[string]string) bool {
+	if len(offered) != len(requested) {
+		return false
+	}
+	for _, endpoint := range offered {
+		if _, ok := requested[endpoint.Name]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // GetConsumeDetails returns the offer uuid and endpoints necessary to

--- a/domain/crossmodelrelation/service/offer.go
+++ b/domain/crossmodelrelation/service/offer.go
@@ -173,7 +173,9 @@ func (s *Service) CreateOffer(
 			args.OfferName, existingOffer.OfferUUID).Add(crossmodelrelationerrors.OfferAlreadyExists)
 	}
 
-	endpoints := slices.Collect(maps.Keys(args.Endpoints))
+	// Sort the endpoint names so offer creation is deterministic regardless
+	// of map iteration order.
+	endpoints := slices.Sorted(maps.Keys(args.Endpoints))
 
 	// Verify the application exists and is not dead before creating the offer,
 	// and that the application endpoints are valid.

--- a/domain/crossmodelrelation/service/offer.go
+++ b/domain/crossmodelrelation/service/offer.go
@@ -162,11 +162,22 @@ func (s *Service) CreateOffer(
 		// succeed if the existing offer is identical to the requested one,
 		// that is it offers the same endpoints of the same application.
 		// This keeps creating an offer idempotent.
-		same, err := s.isSameOffer(ctx, existingOffer, args)
-		if err != nil {
+		//
+		// Resolve the requested endpoints on the application, so they can
+		// be compared against the ones the existing offer exposes.
+		requested, err := s.modelState.GetApplicationEndpointDetails(
+			ctx, args.ApplicationName, slices.Collect(maps.Keys(args.Endpoints)),
+		)
+		if err != nil &&
+			!errors.Is(err, applicationerrors.ApplicationNotFound) &&
+			!errors.Is(err, applicationerrors.EndpointNotFound) &&
+			!errors.Is(err, crossmodelrelationerrors.MissingEndpoints) {
 			return errors.Errorf("validating against existing offer: %w", err)
 		}
-		if same {
+		// The existing offer may be for another application, so the
+		// requested application or its endpoints may not resolve; in
+		// that case the offers differ.
+		if err == nil && isSameOffer(existingOffer, requested, args) {
 			return nil
 		}
 		return errors.Errorf("creating offer: offer %q already exists with UUID %q",
@@ -222,27 +233,13 @@ func (s *Service) CreateOffer(
 // application and offers the same endpoints as the requested ones.
 // Requested endpoint aliases are not persisted as part of the offer and
 // are ignored.
-func (s *Service) isSameOffer(
-	ctx context.Context,
+func isSameOffer(
 	existingOffer crossmodelrelation.ConsumeDetails,
+	requested []crossmodelrelation.OfferEndpoint,
 	args crossmodelrelation.ApplicationOfferArgs,
-) (bool, error) {
-	if existingOffer.ApplicationName != args.ApplicationName {
-		return false, nil
-	}
-	requested, err := s.modelState.GetApplicationEndpointDetails(
-		ctx, args.ApplicationName, slices.Collect(maps.Keys(args.Endpoints)),
-	)
-	if errors.Is(err, applicationerrors.ApplicationNotFound) ||
-		errors.Is(err, applicationerrors.EndpointNotFound) ||
-		errors.Is(err, crossmodelrelationerrors.MissingEndpoints) {
-		// The requested endpoints cannot be resolved on the application,
-		// so the existing offer differs from the requested one.
-		return false, nil
-	} else if err != nil {
-		return false, errors.Capture(err)
-	}
-	return sameOfferEndpoints(existingOffer.Endpoints, requested), nil
+) bool {
+	return existingOffer.ApplicationName == args.ApplicationName &&
+		sameOfferEndpoints(existingOffer.Endpoints, requested)
 }
 
 // sameOfferEndpoints returns true if the offered and the requested

--- a/domain/crossmodelrelation/service/offer_test.go
+++ b/domain/crossmodelrelation/service/offer_test.go
@@ -256,6 +256,8 @@ func (s *offerServiceSuite) TestOfferAlreadyExistsDifferentApplication(c *tc.C) 
 		ApplicationName: "other-application",
 		Endpoints:       []crossmodelrelation.OfferEndpoint{{Name: "db"}},
 	}, nil)
+	s.modelState.EXPECT().GetApplicationEndpointDetails(gomock.Any(), "test-application", []string{"db"}).
+		Return([]crossmodelrelation.OfferEndpoint{{Name: "db", Role: charm.RoleProvider, Interface: "mysql"}}, nil)
 
 	args := crossmodelrelation.ApplicationOfferArgs{
 		ApplicationName: "test-application",

--- a/domain/crossmodelrelation/service/offer_test.go
+++ b/domain/crossmodelrelation/service/offer_test.go
@@ -42,7 +42,7 @@ func (s *offerServiceSuite) TestOfferCreate(c *tc.C) {
 	ownerName := usertesting.GenNewName(c, "admin")
 	ownerUUID := uuid.MustNewUUID()
 
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{}, crossmodelrelationerrors.OfferNotFound)
 	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
 		Return(applicationUUID, nil)
 	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)
@@ -87,7 +87,7 @@ func (s *offerServiceSuite) TestOfferCreateAccessErr(c *tc.C) {
 	ownerName := usertesting.GenNewName(c, "admin")
 	ownerUUID := uuid.MustNewUUID()
 
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{}, crossmodelrelationerrors.OfferNotFound)
 	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
 		Return(applicationUUID, nil)
 	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)
@@ -134,7 +134,7 @@ func (s *offerServiceSuite) TestOfferCreateError(c *tc.C) {
 	ownerName := usertesting.GenNewName(c, "admin")
 	ownerUUID := uuid.MustNewUUID()
 
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{}, crossmodelrelationerrors.OfferNotFound)
 	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
 		Return(applicationUUID, nil)
 	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)
@@ -160,19 +160,59 @@ func (s *offerServiceSuite) TestOfferCreateError(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "creating offer: boom")
 }
 
-// TestOfferAlreadyExists tests that Offer returns an error when an offer
-// with the same name already exists.
-func (s *offerServiceSuite) TestOfferAlreadyExists(c *tc.C) {
+// TestOfferAlreadyExistsIdentical tests that Offer succeeds without
+// creating anything when an identical offer, that is an offer for the same
+// application with the same endpoints, already exists. This keeps creating
+// an offer idempotent.
+func (s *offerServiceSuite) TestOfferAlreadyExistsIdentical(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
 	applicationName := "test-application"
 	offerName := "test-offer"
 	ownerName := usertesting.GenNewName(c, "admin")
-	existingOfferUUID := uuid.MustNewUUID().String()
 
-	// Return an existing offer UUID to simulate the offer already exists
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return(existingOfferUUID, nil)
+	// Return an existing offer identical to the requested one.
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{
+		OfferUUID:       uuid.MustNewUUID().String(),
+		ApplicationName: applicationName,
+		Endpoints: []crossmodelrelation.OfferEndpoint{
+			{Name: "db"},
+			{Name: "db-admin"},
+		},
+	}, nil)
+
+	args := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: applicationName,
+		OfferName:       offerName,
+		Endpoints:       map[string]string{"db-admin": "db-admin", "db": "db"},
+		OwnerName:       ownerName,
+	}
+
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestOfferAlreadyExistsDifferentEndpoints tests that Offer returns an error
+// when an offer with the same name already exists but offers different
+// endpoints, since updating offers is not supported.
+func (s *offerServiceSuite) TestOfferAlreadyExistsDifferentEndpoints(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	applicationName := "test-application"
+	offerName := "test-offer"
+	ownerName := usertesting.GenNewName(c, "admin")
+
+	// Return an existing offer with a different set of endpoints.
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{
+		OfferUUID:       uuid.MustNewUUID().String(),
+		ApplicationName: applicationName,
+		Endpoints:       []crossmodelrelation.OfferEndpoint{{Name: "db-admin"}},
+	}, nil)
 
 	args := crossmodelrelation.ApplicationOfferArgs{
 		ApplicationName: applicationName,
@@ -189,9 +229,42 @@ func (s *offerServiceSuite) TestOfferAlreadyExists(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.OfferAlreadyExists)
 }
 
-// TestOfferGetOfferUUIDError tests that Offer returns an error when
-// GetOfferUUID fails with an error other than OfferNotFound.
-func (s *offerServiceSuite) TestOfferGetOfferUUIDError(c *tc.C) {
+// TestOfferAlreadyExistsDifferentApplication tests that Offer returns an
+// error when an offer with the same name already exists for a different
+// application, since updating offers is not supported.
+func (s *offerServiceSuite) TestOfferAlreadyExistsDifferentApplication(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	offerName := "test-offer"
+	ownerName := usertesting.GenNewName(c, "admin")
+
+	// Return an existing offer for a different application.
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{
+		OfferUUID:       uuid.MustNewUUID().String(),
+		ApplicationName: "other-application",
+		Endpoints:       []crossmodelrelation.OfferEndpoint{{Name: "db"}},
+	}, nil)
+
+	args := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: "test-application",
+		OfferName:       offerName,
+		Endpoints:       map[string]string{"db": "db"},
+		OwnerName:       ownerName,
+	}
+
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, `creating offer: offer "test-offer" already exists with UUID ".*"`)
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.OfferAlreadyExists)
+}
+
+// TestOfferGetConsumeDetailsError tests that Offer returns an error when
+// checking if the offer already exists fails with an error other than
+// OfferNotFound.
+func (s *offerServiceSuite) TestOfferGetConsumeDetailsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
@@ -200,7 +273,7 @@ func (s *offerServiceSuite) TestOfferGetOfferUUIDError(c *tc.C) {
 	ownerName := usertesting.GenNewName(c, "admin")
 
 	// Return a database error when checking if offer exists
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", errors.Errorf("database error"))
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{}, errors.Errorf("database error"))
 
 	args := crossmodelrelation.ApplicationOfferArgs{
 		ApplicationName: applicationName,
@@ -227,7 +300,7 @@ func (s *offerServiceSuite) TestOfferOwnerNotFound(c *tc.C) {
 	applicationUUID := uuid.MustNewUUID().String()
 	ownerName := usertesting.GenNewName(c, "nonexistent")
 
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{}, crossmodelrelationerrors.OfferNotFound)
 	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
 		Return(applicationUUID, nil)
 	// Owner user doesn't exist
@@ -298,7 +371,7 @@ func (s *offerServiceSuite) TestCreateOfferDefaultOfferName(c *tc.C) {
 	ownerUUID := uuid.MustNewUUID()
 
 	// The offer name defaults to the application name.
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), applicationName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), applicationName).Return(crossmodelrelation.ConsumeDetails{}, crossmodelrelationerrors.OfferNotFound)
 	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).Return(applicationUUID, nil)
 	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)
 
@@ -339,7 +412,7 @@ func (s *offerServiceSuite) TestCreateOfferValidateApplicationFails(c *tc.C) {
 	offerName := "test-offer"
 	ownerName := usertesting.GenNewName(c, "admin")
 
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{}, crossmodelrelationerrors.OfferNotFound)
 	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(
 		gomock.Any(), applicationName, []string{"db"},
 	).Return("", errors.Errorf("application is dead"))
@@ -370,7 +443,7 @@ func (s *offerServiceSuite) TestCreateOfferAccessAndDeleteFail(c *tc.C) {
 	ownerName := usertesting.GenNewName(c, "admin")
 	ownerUUID := uuid.MustNewUUID()
 
-	s.modelState.EXPECT().GetOfferUUID(gomock.Any(), offerName).Return("", crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{}, crossmodelrelationerrors.OfferNotFound)
 	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
 		Return(applicationUUID, nil)
 	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)

--- a/domain/crossmodelrelation/service/offer_test.go
+++ b/domain/crossmodelrelation/service/offer_test.go
@@ -16,6 +16,7 @@ import (
 	relationtesting "github.com/juju/juju/core/relation/testing"
 	usertesting "github.com/juju/juju/core/user/testing"
 	"github.com/juju/juju/domain/application/charm"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/crossmodelrelation"
 	crossmodelrelationerrors "github.com/juju/juju/domain/crossmodelrelation/errors"
 	"github.com/juju/juju/internal/errors"
@@ -177,10 +178,18 @@ func (s *offerServiceSuite) TestOfferAlreadyExistsIdentical(c *tc.C) {
 		OfferUUID:       uuid.MustNewUUID().String(),
 		ApplicationName: applicationName,
 		Endpoints: []crossmodelrelation.OfferEndpoint{
-			{Name: "db"},
-			{Name: "db-admin"},
+			{Name: "db", Role: charm.RoleProvider, Interface: "mysql"},
+			{Name: "db-admin", Role: charm.RoleProvider, Interface: "mysql"},
 		},
 	}, nil)
+	// The requested endpoints resolve to the same name, role and interface,
+	// returned in a different order to prove the comparison is
+	// order-insensitive.
+	s.modelState.EXPECT().GetApplicationEndpointDetails(gomock.Any(), applicationName, gomock.Any()).
+		Return([]crossmodelrelation.OfferEndpoint{
+			{Name: "db-admin", Role: charm.RoleProvider, Interface: "mysql"},
+			{Name: "db", Role: charm.RoleProvider, Interface: "mysql"},
+		}, nil)
 
 	args := crossmodelrelation.ApplicationOfferArgs{
 		ApplicationName: applicationName,
@@ -211,8 +220,10 @@ func (s *offerServiceSuite) TestOfferAlreadyExistsDifferentEndpoints(c *tc.C) {
 	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{
 		OfferUUID:       uuid.MustNewUUID().String(),
 		ApplicationName: applicationName,
-		Endpoints:       []crossmodelrelation.OfferEndpoint{{Name: "db-admin"}},
+		Endpoints:       []crossmodelrelation.OfferEndpoint{{Name: "db-admin", Role: charm.RoleProvider, Interface: "mysql"}},
 	}, nil)
+	s.modelState.EXPECT().GetApplicationEndpointDetails(gomock.Any(), applicationName, []string{"db"}).
+		Return([]crossmodelrelation.OfferEndpoint{{Name: "db", Role: charm.RoleProvider, Interface: "mysql"}}, nil)
 
 	args := crossmodelrelation.ApplicationOfferArgs{
 		ApplicationName: applicationName,
@@ -248,6 +259,78 @@ func (s *offerServiceSuite) TestOfferAlreadyExistsDifferentApplication(c *tc.C) 
 
 	args := crossmodelrelation.ApplicationOfferArgs{
 		ApplicationName: "test-application",
+		OfferName:       offerName,
+		Endpoints:       map[string]string{"db": "db"},
+		OwnerName:       ownerName,
+	}
+
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, `creating offer: offer "test-offer" already exists with UUID ".*"`)
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.OfferAlreadyExists)
+}
+
+// TestOfferAlreadyExistsDifferentInterface tests that Offer returns an error
+// when an offer with the same name already exists and offers an endpoint
+// with the same name but a different interface, since updating offers is not
+// supported.
+func (s *offerServiceSuite) TestOfferAlreadyExistsDifferentInterface(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	applicationName := "test-application"
+	offerName := "test-offer"
+	ownerName := usertesting.GenNewName(c, "admin")
+
+	// Return an existing offer whose endpoint has a different interface than
+	// the one the requested endpoint resolves to.
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{
+		OfferUUID:       uuid.MustNewUUID().String(),
+		ApplicationName: applicationName,
+		Endpoints:       []crossmodelrelation.OfferEndpoint{{Name: "db", Role: charm.RoleProvider, Interface: "mysql"}},
+	}, nil)
+	s.modelState.EXPECT().GetApplicationEndpointDetails(gomock.Any(), applicationName, []string{"db"}).
+		Return([]crossmodelrelation.OfferEndpoint{{Name: "db", Role: charm.RoleProvider, Interface: "pgsql"}}, nil)
+
+	args := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: applicationName,
+		OfferName:       offerName,
+		Endpoints:       map[string]string{"db": "db"},
+		OwnerName:       ownerName,
+	}
+
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.ErrorMatches, `creating offer: offer "test-offer" already exists with UUID ".*"`)
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.OfferAlreadyExists)
+}
+
+// TestOfferAlreadyExistsEndpointsNoLongerExist tests that Offer returns an
+// error when an offer with the same name already exists and the requested
+// endpoints no longer resolve on the application, since the offers differ
+// and updating offers is not supported.
+func (s *offerServiceSuite) TestOfferAlreadyExistsEndpointsNoLongerExist(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	applicationName := "test-application"
+	offerName := "test-offer"
+	ownerName := usertesting.GenNewName(c, "admin")
+
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{
+		OfferUUID:       uuid.MustNewUUID().String(),
+		ApplicationName: applicationName,
+		Endpoints:       []crossmodelrelation.OfferEndpoint{{Name: "db", Role: charm.RoleProvider, Interface: "mysql"}},
+	}, nil)
+	s.modelState.EXPECT().GetApplicationEndpointDetails(gomock.Any(), applicationName, []string{"db"}).
+		Return(nil, applicationerrors.EndpointNotFound)
+
+	args := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName: applicationName,
 		OfferName:       offerName,
 		Endpoints:       map[string]string{"db": "db"},
 		OwnerName:       ownerName,

--- a/domain/crossmodelrelation/service/package_mock_test.go
+++ b/domain/crossmodelrelation/service/package_mock_test.go
@@ -144,6 +144,7 @@ type MockModelStateMockRecorder struct {
 	deleteFailedOfferExpects                                                    []*gomock.Call2_1[context.Context, offer.UUID, error]
 	ensureUnitsExistExpects                                                     []*gomock.Call3_1[context.Context, string, []string, error]
 	getAllOffererRelationUUIDsExpects                                           []*gomock.Call1_2[context.Context, []string, error]
+	getApplicationEndpointDetailsExpects                                        []*gomock.Call3_2[context.Context, string, []string, []crossmodelrelation.OfferEndpoint, error]
 	getApplicationNameAndUUIDByOfferUUIDExpects                                 []*gomock.Call2_3[context.Context, string, string, string, error]
 	getConsumeDetailsExpects                                                    []*gomock.Call2_2[context.Context, string, crossmodelrelation.ConsumeDetails, error]
 	getConsumerRelationUUIDsExpects                                             []*gomock.Call1V_2[context.Context, string, []string, error]
@@ -326,6 +327,24 @@ func (mr *MockModelStateMockRecorder) GetAllOffererRelationUUIDs(ctx any) *MockM
 
 // MockModelStateGetAllOffererRelationUUIDsCall is the typed call wrapper for GetAllOffererRelationUUIDs.
 type MockModelStateGetAllOffererRelationUUIDsCall = gomock.Call1_2[context.Context, []string, error]
+
+// GetApplicationEndpointDetails mocks base method.
+func (m *MockModelState) GetApplicationEndpointDetails(ctx context.Context, applicationName string, endpoints []string) ([]crossmodelrelation.OfferEndpoint, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch3_2(&m.recorder.getApplicationEndpointDetailsExpects, m.ctrl, m, "GetApplicationEndpointDetails", ctx, applicationName, endpoints)
+}
+
+// GetApplicationEndpointDetails indicates an expected call of GetApplicationEndpointDetails.
+func (mr *MockModelStateMockRecorder) GetApplicationEndpointDetails(ctx, applicationName, endpoints any) *MockModelStateGetApplicationEndpointDetailsCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall3_2[context.Context, string, []string, []crossmodelrelation.OfferEndpoint, error](mr.mock.ctrl.T, mr.mock, "GetApplicationEndpointDetails", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(applicationName), gomock.EnsureMatcher(endpoints))
+	mr.getApplicationEndpointDetailsExpects = append(mr.getApplicationEndpointDetailsExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockModelStateGetApplicationEndpointDetailsCall is the typed call wrapper for GetApplicationEndpointDetails.
+type MockModelStateGetApplicationEndpointDetailsCall = gomock.Call3_2[context.Context, string, []string, []crossmodelrelation.OfferEndpoint, error]
 
 // GetApplicationNameAndUUIDByOfferUUID mocks base method.
 func (m *MockModelState) GetApplicationNameAndUUIDByOfferUUID(ctx context.Context, offerUUID string) (string, string, error) {

--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -253,6 +253,7 @@ JOIN   application AS a ON ae.application_uuid = a.uuid
 JOIN   charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
 JOIN   charm_relation_role AS crr ON cr.role_id = crr.id
 WHERE  o.name = $name.name
+ORDER BY cr.name
 `, consumeDetail{}, name{})
 	if err != nil {
 		return empty, errors.Errorf("preparing consume detail query: %w", err)
@@ -282,6 +283,70 @@ WHERE  o.name = $name.name
 		ApplicationName: details[0].ApplicationName,
 		Endpoints:       endpoints,
 	}, nil
+}
+
+// GetApplicationEndpointDetails returns the name, role and interface of the
+// provided endpoints for the given application, ordered by endpoint name.
+// Returns applicationerrors.ApplicationNotFound if the application does not
+// exist. Returns an error satisfying
+// [crossmodelrelationerrors.MissingEndpoints] if any of the endpoints do not
+// exist on the application.
+func (st *State) GetApplicationEndpointDetails(
+	ctx context.Context,
+	applicationName string,
+	endpoints []string,
+) ([]crossmodelrelation.OfferEndpoint, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	type names []string
+	stmt, err := st.Prepare(`
+SELECT cr.name      AS &endpointDetail.name,
+       crr.name     AS &endpointDetail.role,
+       cr.interface AS &endpointDetail.interface
+FROM   application_endpoint AS ae
+JOIN   charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
+JOIN   charm_relation_role AS crr ON cr.role_id = crr.id
+WHERE  ae.application_uuid = $uuid.uuid
+AND    cr.name IN ($names[:])
+ORDER BY cr.name
+`, endpointDetail{}, uuid{}, names{})
+	if err != nil {
+		return nil, errors.Errorf("preparing application endpoint details query: %w", err)
+	}
+
+	var details []endpointDetail
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		applicationUUID, _, err := st.getApplicationUUIDAndLife(ctx, tx, applicationName)
+		if err != nil {
+			return errors.Capture(err)
+		}
+
+		err = tx.Query(ctx, stmt, uuid{UUID: applicationUUID}, names(endpoints)).GetAll(&details)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("%q: %w", strings.Join(endpoints, ","), applicationerrors.EndpointNotFound)
+		}
+		return errors.Capture(err)
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	if len(details) != len(endpoints) {
+		return nil, errors.Errorf("not all endpoints found %q for application %q",
+			strings.Join(endpoints, ", "),
+			applicationName,
+		).Add(crossmodelrelationerrors.MissingEndpoints)
+	}
+
+	return transform.Slice(details, func(in endpointDetail) crossmodelrelation.OfferEndpoint {
+		return crossmodelrelation.OfferEndpoint{
+			Name:      in.Name,
+			Role:      in.Role,
+			Interface: in.Interface,
+		}
+	}), nil
 }
 
 // GetOfferDetails returns the OfferDetail of every offer in the model.

--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -229,8 +229,8 @@ func (st *State) GetOfferUUID(ctx context.Context, name string) (string, error) 
 	return offerUUID, err
 }
 
-// GetConsumeDetails returns the offer uuid and endpoints necessary to
-// consume the offer.
+// GetConsumeDetails returns the offer uuid, application name and endpoints
+// necessary to consume the offer.
 // Returns crossmodelrelationerrors.OfferNotFound of the offer is not found.
 func (st *State) GetConsumeDetails(
 	ctx context.Context,
@@ -244,6 +244,7 @@ func (st *State) GetConsumeDetails(
 
 	stmt, err := st.Prepare(`
 SELECT (o.uuid, cr.name, cr.interface, cr.capacity) AS (&consumeDetail.*),
+       a.name   AS &consumeDetail.application_name,
        crr.name AS &consumeDetail.role
 FROM   offer AS o
 JOIN   offer_endpoint AS oe ON o.uuid = oe.offer_uuid
@@ -277,8 +278,9 @@ WHERE  o.name = $name.name
 		}
 	})
 	return crossmodelrelation.ConsumeDetails{
-		OfferUUID: details[0].OfferUUID,
-		Endpoints: endpoints,
+		OfferUUID:       details[0].OfferUUID,
+		ApplicationName: details[0].ApplicationName,
+		Endpoints:       endpoints,
 	}, nil
 }
 

--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -675,6 +675,7 @@ JOIN   charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
 JOIN   relation_status AS rs ON r.uuid = rs.relation_uuid
 JOIN   relation_status_type AS rst ON rs.relation_status_type_id = rst.id
 WHERE  oc.offer_uuid IN ($uuids[:])
+ORDER BY oc.offer_uuid, r.relation_id
 `, offerConnectionDetail{}, uuids{})
 	if err != nil {
 		return nil, errors.Errorf("preparing offer connection detail query: %w", err)

--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -394,6 +394,7 @@ func (st *State) getOfferDetails(ctx context.Context, tx *sqlair.TX) (offerDetai
 	stmt, err := st.Prepare(`
 SELECT &offerDetail.*
 FROM   v_offer_detail
+ORDER BY offer_name, endpoint_name
 `, offerDetail{})
 	if err != nil {
 		return nil, errors.Errorf("preparing offer detail query: %w", err)
@@ -416,6 +417,7 @@ func (st *State) getOfferDetailsForUUIDs(ctx context.Context, tx *sqlair.TX, off
 SELECT &offerDetail.*
 FROM   v_offer_detail
 WHERE  offer_uuid IN ($uuids[:])
+ORDER BY offer_name, endpoint_name
 `, offerDetail{}, uuids{})
 	if err != nil {
 		return nil, errors.Errorf("preparing offer detail for UUID query: %w", err)
@@ -442,6 +444,7 @@ AND    (application_description LIKE $offerFilter.application_description OR $of
 AND    (endpoint_name = $offerFilter.endpoint_name OR $offerFilter.endpoint_name = '')
 AND    (endpoint_role = $offerFilter.endpoint_role OR $offerFilter.endpoint_role = '')
 AND    (endpoint_interface = $offerFilter.endpoint_interface OR $offerFilter.endpoint_interface = '')
+ORDER BY offer_name, endpoint_name
 `, offerDetail{}, offerFilter{})
 	if err != nil {
 		return nil, errors.Errorf("preparing filtered offer detail query: %w", err)
@@ -558,6 +561,7 @@ SELECT ae.application_endpoint_uuid AS &uuid.uuid
 FROM   v_application_endpoint AS ae            
 WHERE  ae.application_uuid = $uuid.uuid
 AND    ae.endpoint_name IN ($dbStrings[:])
+ORDER BY ae.endpoint_name
 `, uuid{}, dbStrings{})
 	if err != nil {
 		return nil, errors.Errorf("preparing application endpoint query: %w", err)

--- a/domain/crossmodelrelation/state/model/offer_test.go
+++ b/domain/crossmodelrelation/state/model/offer_test.go
@@ -235,6 +235,105 @@ func (s *modelOfferSuite) TestDeleteFailedOffer(c *tc.C) {
 	c.Check(s.readOfferEndpoints(c), tc.HasLen, 0)
 }
 
+func (s *modelOfferSuite) TestCreateOfferEndpointsInsertedInNameOrder(c *tc.C) {
+	// Arrange
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relationAlpha := charm.Relation{
+		Name:      "alpha",
+		Role:      charm.RoleProvider,
+		Interface: "alpha",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationAlphaUUID := s.addCharmRelation(c, charmUUID, relationAlpha)
+	relationZed := charm.Relation{
+		Name:      "zed",
+		Role:      charm.RoleRequirer,
+		Interface: "zed",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationZedUUID := s.addCharmRelation(c, charmUUID, relationZed)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	appEndpointAlphaUUID := s.addApplicationEndpoint(c, appUUID, relationAlphaUUID)
+	appEndpointZedUUID := s.addApplicationEndpoint(c, appUUID, relationZedUUID)
+
+	args := crossmodelrelation.CreateOfferArgs{
+		UUID:            tc.Must(c, offer.NewUUID),
+		ApplicationUUID: appUUID.String(),
+		// Request the endpoints in reverse name order.
+		Endpoints: []string{relationZed.Name, relationAlpha.Name},
+		OfferName: "test-offer",
+	}
+
+	// Act
+	err := s.state.CreateOffer(c.Context(), args)
+
+	// Assert — the offer_endpoint rows are inserted in canonical endpoint
+	// name order, regardless of the requested order.
+	c.Assert(err, tc.ErrorIsNil)
+	rows, err := s.DB().QueryContext(c.Context(), `SELECT endpoint_uuid FROM offer_endpoint ORDER BY rowid`)
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { _ = rows.Close() }()
+	var obtained []string
+	for rows.Next() {
+		var endpointUUID string
+		c.Assert(rows.Scan(&endpointUUID), tc.ErrorIsNil)
+		obtained = append(obtained, endpointUUID)
+	}
+	c.Check(obtained, tc.DeepEquals, []string{appEndpointAlphaUUID, appEndpointZedUUID})
+}
+
+// TestGetOfferDetailsDeterministicOrder verifies that offers and their
+// endpoints are returned in canonical name order, regardless of insertion
+// order.
+func (s *modelOfferSuite) TestGetOfferDetailsDeterministicOrder(c *tc.C) {
+	// Arrange — create two offers on the same application, with names and
+	// endpoint associations in reverse canonical order.
+	charmUUID := s.addCharmWithReferenceName(c, "test-charm")
+	s.addCharmMetadataWithDescription(c, charmUUID, "testing application")
+	relationZed := charm.Relation{
+		Name:      "zed",
+		Role:      charm.RoleProvider,
+		Interface: "zed",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationZedUUID := s.addCharmRelation(c, charmUUID, relationZed)
+	relationAlpha := charm.Relation{
+		Name:      "alpha",
+		Role:      charm.RoleProvider,
+		Interface: "alpha",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationAlphaUUID := s.addCharmRelation(c, charmUUID, relationAlpha)
+
+	appUUID := s.addApplication(c, charmUUID, "test-application")
+	appEndpointZedUUID := s.addApplicationEndpoint(c, appUUID, relationZedUUID)
+	appEndpointAlphaUUID := s.addApplicationEndpoint(c, appUUID, relationAlphaUUID)
+
+	s.addOffer(c, "beta-offer", []string{appEndpointZedUUID, appEndpointAlphaUUID})
+	s.addOffer(c, "alpha-offer", []string{appEndpointZedUUID})
+
+	// Act
+	obtained, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{})
+
+	// Assert — offers are ordered by offer name, endpoints by endpoint name.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained, tc.HasLen, 2)
+	c.Check(obtained[0].OfferName, tc.Equals, "alpha-offer")
+	c.Check(obtained[1].OfferName, tc.Equals, "beta-offer")
+	endpointNames := func(endpoints []crossmodelrelation.OfferEndpoint) []string {
+		names := make([]string, len(endpoints))
+		for i, endpoint := range endpoints {
+			names[i] = endpoint.Name
+		}
+		return names
+	}
+	c.Check(endpointNames(obtained[0].Endpoints), tc.DeepEquals, []string{"zed"})
+	c.Check(endpointNames(obtained[1].Endpoints), tc.DeepEquals, []string{"alpha", "zed"})
+}
+
 // TestGetOfferDetailsFilterTwoOffersSameApplication creates two offers for the
 // same application and verifies that filtering by offer name and application
 // name returns only the targeted offer.

--- a/domain/crossmodelrelation/state/model/offer_test.go
+++ b/domain/crossmodelrelation/state/model/offer_test.go
@@ -969,8 +969,9 @@ func (s *modelOfferSuite) setupOfferConnection(c *tc.C) (string, string) {
 
 // addOfferConnectionWithConsumer sets up a complete offer connection scenario
 // including the synthetic remote consumer application. It returns the offer
-// UUID, consumer model UUID, and relation UUID.
-func (s *modelOfferSuite) addOfferConnectionWithConsumer(c *tc.C) (string, string, string) {
+// UUID, consumer model UUID, relation UUID, offerer application UUID and
+// offerer endpoint UUID.
+func (s *modelOfferSuite) addOfferConnectionWithConsumer(c *tc.C) (string, string, string, string, string) {
 	charmUUID := s.addCharm(c)
 	s.addCharmMetadata(c, charmUUID, false)
 	relation := charm.Relation{
@@ -1006,11 +1007,11 @@ INSERT INTO application_remote_consumer
 (offer_connection_uuid, offerer_application_uuid, consumer_application_uuid, consumer_model_uuid, life_id)
 VALUES (?, ?, ?, ?, 0)`, connUUID, appUUID, internaluuid.MustNewUUID().String(), consumerModelUUID)
 
-	return offerUUID.String(), consumerModelUUID, relUUID.String()
+	return offerUUID.String(), consumerModelUUID, relUUID.String(), appUUID.String(), appEndpointUUID
 }
 
 func (s *modelOfferSuite) TestGetOfferConnections(c *tc.C) {
-	offerUUID, consumerModelUUID, relUUID := s.addOfferConnectionWithConsumer(c)
+	offerUUID, consumerModelUUID, relUUID, _, _ := s.addOfferConnectionWithConsumer(c)
 
 	// Set relation status with message and timestamp.
 	s.query(c, `
@@ -1042,7 +1043,7 @@ INSERT INTO relation_network_ingress (relation_uuid, cidr) VALUES (?, '192.168.1
 }
 
 func (s *modelOfferSuite) TestGetOfferConnectionsNullMessageAndTimestamp(c *tc.C) {
-	offerUUID, consumerModelUUID, relUUID := s.addOfferConnectionWithConsumer(c)
+	offerUUID, consumerModelUUID, relUUID, _, _ := s.addOfferConnectionWithConsumer(c)
 
 	// Set relation status with NULL message and NULL updated_at.
 	s.query(c, `
@@ -1063,6 +1064,45 @@ VALUES (?, '0')`, relUUID)
 	c.Check(connections[0].Message, tc.Equals, "")
 	c.Check(connections[0].StatusSince, tc.IsNil)
 	c.Check(connections[0].IngressSubnets, tc.IsNil)
+}
+
+func (s *modelOfferSuite) TestGetOfferConnectionsDeterministicOrder(c *tc.C) {
+	// Arrange — two connections on the same offer; relation IDs are
+	// assigned in insertion order.
+	offerUUID, _, relUUID1, appUUID, appEndpointUUID := s.addOfferConnectionWithConsumer(c)
+	s.query(c, `
+INSERT INTO relation_status (relation_uuid, relation_status_type_id)
+VALUES (?, '0')`, relUUID1)
+
+	relUUID2 := s.addRelation(c)
+	s.addRelationEndpoint(c, relUUID2.String(), appEndpointUUID)
+	connUUID2 := internaluuid.MustNewUUID().String()
+	s.query(c, `
+INSERT INTO offer_connection (uuid, offer_uuid, remote_relation_uuid, username)
+VALUES (?, ?, ?, 'consumer-user')`, connUUID2, offerUUID, relUUID2)
+	synthCharmUUID := s.addCMRCharm(c)
+	s.addCharmMetadata(c, synthCharmUUID, false)
+	s.query(c, `
+INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid)
+VALUES (?, 'remote-consumer-2', 0, ?, ?)`, connUUID2, synthCharmUUID, network.AlphaSpaceId)
+	s.query(c, `
+INSERT INTO application_remote_consumer
+(offer_connection_uuid, offerer_application_uuid, consumer_application_uuid, consumer_model_uuid, life_id)
+VALUES (?, ?, ?, ?, 0)`, connUUID2, appUUID, internaluuid.MustNewUUID().String(), internaluuid.MustNewUUID().String())
+	s.query(c, `
+INSERT INTO relation_status (relation_uuid, relation_status_type_id)
+VALUES (?, '0')`, relUUID2.String())
+
+	// Act
+	connections, err := s.state.GetOfferConnections(c.Context(), []string{offerUUID})
+
+	// Assert — connections are returned ordered by offer UUID and relation ID.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(connections, tc.HasLen, 2)
+	c.Check(connections[0].OfferUUID, tc.Equals, offerUUID)
+	c.Check(connections[0].RelationID, tc.Equals, 0)
+	c.Check(connections[1].OfferUUID, tc.Equals, offerUUID)
+	c.Check(connections[1].RelationID, tc.Equals, 1)
 }
 
 func (s *modelOfferSuite) TestGetOfferConnectionsNoConnections(c *tc.C) {

--- a/domain/crossmodelrelation/state/model/offer_test.go
+++ b/domain/crossmodelrelation/state/model/offer_test.go
@@ -606,16 +606,17 @@ func (s *modelOfferSuite) TestGetConsumeDetails(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(obtained.OfferUUID, tc.Equals, offerUUID.String())
 	c.Check(obtained.ApplicationName, tc.Equals, appName)
-	c.Check(obtained.Endpoints, tc.SameContents, []crossmodelrelation.OfferEndpoint{
+	// Endpoints are returned ordered by endpoint name.
+	c.Check(obtained.Endpoints, tc.DeepEquals, []crossmodelrelation.OfferEndpoint{
 		{
+			Name:      relationTwo.Name,
+			Role:      domaincharm.RoleProvider,
+			Interface: relationTwo.Interface,
+		}, {
 			Name:      relation.Name,
 			Role:      domaincharm.RoleProvider,
 			Interface: relation.Interface,
 			Limit:     4,
-		}, {
-			Name:      relationTwo.Name,
-			Role:      domaincharm.RoleProvider,
-			Interface: relationTwo.Interface,
 		},
 	})
 }
@@ -626,6 +627,101 @@ func (s *modelOfferSuite) TestGetConsumeDetailsNotFound(c *tc.C) {
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.OfferNotFound)
+}
+
+func (s *modelOfferSuite) TestGetApplicationEndpointDetails(c *tc.C) {
+	// Arrange — insert the endpoints in reverse name order to verify the
+	// results are ordered by endpoint name.
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relationZed := charm.Relation{
+		Name:      "zed",
+		Role:      charm.RoleRequirer,
+		Interface: "zed",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationZedUUID := s.addCharmRelation(c, charmUUID, relationZed)
+	relationAlpha := charm.Relation{
+		Name:      "alpha",
+		Role:      charm.RoleProvider,
+		Interface: "alpha",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationAlphaUUID := s.addCharmRelation(c, charmUUID, relationAlpha)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationZedUUID)
+	s.addApplicationEndpoint(c, appUUID, relationAlphaUUID)
+
+	// Act
+	obtained, err := s.state.GetApplicationEndpointDetails(
+		c.Context(), appName, []string{"zed", "alpha"},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtained, tc.DeepEquals, []crossmodelrelation.OfferEndpoint{
+		{
+			Name:      relationAlpha.Name,
+			Role:      domaincharm.RoleProvider,
+			Interface: relationAlpha.Interface,
+		}, {
+			Name:      relationZed.Name,
+			Role:      domaincharm.RoleRequirer,
+			Interface: relationZed.Interface,
+		},
+	})
+}
+
+func (s *modelOfferSuite) TestGetApplicationEndpointDetailsApplicationNotFound(c *tc.C) {
+	// Act
+	_, err := s.state.GetApplicationEndpointDetails(
+		c.Context(), "no-such-app", []string{"db"},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, applicationerrors.ApplicationNotFound)
+}
+
+func (s *modelOfferSuite) TestGetApplicationEndpointDetailsEndpointNotFound(c *tc.C) {
+	// Arrange
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	appName := "test-application"
+	s.addApplication(c, charmUUID, appName)
+
+	// Act
+	_, err := s.state.GetApplicationEndpointDetails(
+		c.Context(), appName, []string{"no-such-endpoint"},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, applicationerrors.EndpointNotFound)
+}
+
+func (s *modelOfferSuite) TestGetApplicationEndpointDetailsMissingEndpoints(c *tc.C) {
+	// Arrange — request two endpoints but only one exists.
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, charmUUID, false)
+	relation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID := s.addCharmRelation(c, charmUUID, relation)
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationUUID)
+
+	// Act
+	_, err := s.state.GetApplicationEndpointDetails(
+		c.Context(), appName, []string{"db", "missing-one"},
+	)
+
+	// Assert
+	c.Assert(err, tc.ErrorIs, crossmodelrelationerrors.MissingEndpoints)
 }
 
 func (s *modelOfferSuite) setupForGetOfferDetails(c *tc.C) []*crossmodelrelation.OfferDetail {

--- a/domain/crossmodelrelation/state/model/offer_test.go
+++ b/domain/crossmodelrelation/state/model/offer_test.go
@@ -605,6 +605,7 @@ func (s *modelOfferSuite) TestGetConsumeDetails(c *tc.C) {
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(obtained.OfferUUID, tc.Equals, offerUUID.String())
+	c.Check(obtained.ApplicationName, tc.Equals, appName)
 	c.Check(obtained.Endpoints, tc.SameContents, []crossmodelrelation.OfferEndpoint{
 		{
 			Name:      relation.Name,

--- a/domain/crossmodelrelation/state/model/remoteapplication.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication.go
@@ -220,7 +220,8 @@ SELECT  a.name AS &remoteApplicationOffererInfo.application_name,
         aro.macaroon AS &remoteApplicationOffererInfo.macaroon
 FROM    application_remote_offerer AS aro
 JOIN    application AS a ON a.uuid = aro.application_uuid
-WHERE   aro.life_id < 2;`
+WHERE   aro.life_id < 2
+ORDER BY a.name;`
 	queryStmt, err := st.Prepare(query, remoteApplicationOffererInfo{})
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -341,7 +342,8 @@ SELECT  a.name AS &remoteApplicationConsumerInfo.application_name,
 FROM    application_remote_consumer AS arc
 JOIN    application AS a ON a.uuid = arc.offer_connection_uuid
 JOIN    offer_connection AS oc ON oc.uuid = arc.offer_connection_uuid
-WHERE   arc.life_id < 2;`
+WHERE   arc.life_id < 2
+ORDER BY a.name;`
 	queryStmt, err := st.Prepare(query, remoteApplicationConsumerInfo{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/crossmodelrelation/state/model/remoteapplication_test.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication_test.go
@@ -399,6 +399,54 @@ func (s *modelRemoteApplicationSuite) TestGetRemoteApplicationOfferers(c *tc.C) 
 	}})
 }
 
+func (s *modelRemoteApplicationSuite) TestGetRemoteApplicationOfferersOrderedByName(c *tc.C) {
+	mac := newMacaroon(c, "encoded macaroon")
+	macBytes := tc.Must(c, mac.MarshalJSON)
+
+	addOfferer := func(applicationName, charmReferenceName string) {
+		ch := charm.Charm{
+			ReferenceName: charmReferenceName,
+			Source:        charm.CMRSource,
+			Metadata: charm.Metadata{
+				Name:        applicationName,
+				Description: "remote offerer application",
+				Provides: map[string]charm.Relation{
+					"db": {
+						Name:      "db",
+						Role:      charm.RoleProvider,
+						Interface: "db",
+						Limit:     1,
+						Scope:     charm.ScopeGlobal,
+					},
+				},
+			},
+		}
+		err := s.state.AddRemoteApplicationOfferer(c.Context(), applicationName, crossmodelrelation.AddRemoteApplicationOffererArgs{
+			ApplicationUUID:       tc.Must(c, internaluuid.NewUUID).String(),
+			CharmUUID:             tc.Must(c, internaluuid.NewUUID).String(),
+			RemoteApplicationUUID: tc.Must(c, internaluuid.NewUUID).String(),
+			OfferUUID:             tc.Must(c, internaluuid.NewUUID).String(),
+			Charm:                 ch,
+			OffererModelUUID:      tc.Must(c, internaluuid.NewUUID).String(),
+			OfferURL:              "controller:qualifier/model." + applicationName,
+			EncodedMacaroon:       macBytes,
+		})
+		c.Assert(err, tc.ErrorIsNil)
+	}
+	// Insert in reverse name order.
+	addOfferer("zed-app", "zed-charm")
+	addOfferer("alpha-app", "alpha-charm")
+
+	results, err := s.state.GetRemoteApplicationOfferers(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Offerers are returned ordered by application name, regardless of
+	// insertion order.
+	c.Assert(results, tc.HasLen, 2)
+	c.Check(results[0].ApplicationName, tc.Equals, "alpha-app")
+	c.Check(results[1].ApplicationName, tc.Equals, "zed-app")
+}
+
 func (s *modelRemoteApplicationSuite) TestGetRemoteApplicationOfferersEmpty(c *tc.C) {
 	// Initially there are no remote application offerers.
 	results, err := s.state.GetRemoteApplicationOfferers(c.Context())
@@ -1096,19 +1144,13 @@ func (s *modelRemoteApplicationSuite) TestGetRemoteApplicationConsumersMultiple(
 
 	results, err := s.state.GetRemoteApplicationConsumers(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(results, tc.HasLen, 2)
 
-	// Order not strictly guaranteed; map by name.
-	found := map[string]crossmodelrelation.RemoteApplicationConsumer{}
-	for _, r := range results {
-		found[r.ApplicationName] = r
-	}
-
-	foo := found["foo"]
-	bar := found["bar"]
-
-	c.Check(foo.OfferUUID, tc.Equals, offerUUID)
-	c.Check(bar.OfferUUID, tc.Equals, offerUUID)
+	// Consumers are returned ordered by application name, regardless of
+	// insertion order.
+	c.Check(results, tc.DeepEquals, []crossmodelrelation.RemoteApplicationConsumer{
+		{ApplicationName: "bar", Life: life.Alive, OfferUUID: offerUUID},
+		{ApplicationName: "foo", Life: life.Alive, OfferUUID: offerUUID},
+	})
 }
 
 func (s *modelRemoteApplicationSuite) TestGetRemoteApplicationConsumersEmpty(c *tc.C) {

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -66,6 +66,14 @@ type consumeDetail struct {
 	EndpointLimit     int                `db:"capacity"`
 }
 
+// endpointDetail contains the name, role and interface of an application
+// endpoint.
+type endpointDetail struct {
+	Name      string             `db:"name"`
+	Role      charm.RelationRole `db:"role"`
+	Interface string             `db:"interface"`
+}
+
 // offerDetail contains the data necessary for create
 // OfferDetail structures
 type offerDetail struct {

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"maps"
 	"slices"
+	"strings"
 	"time"
 
 	corelife "github.com/juju/juju/core/life"
@@ -150,7 +151,13 @@ func (o offerDetails) TransformToOfferDetails() []*crossmodelrelation.OfferDetai
 		converted[details.OfferUUID] = found
 	}
 
-	return slices.Collect(maps.Values(converted))
+	// Return the offers in canonical offer name order, so the result does
+	// not depend on map iteration order.
+	result := slices.Collect(maps.Values(converted))
+	slices.SortFunc(result, func(a, b *crossmodelrelation.OfferDetail) int {
+		return strings.Compare(a.OfferName, b.OfferName)
+	})
+	return result
 }
 
 type setApplicationDetails struct {

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -59,6 +59,7 @@ type offerAndApplicationUUID struct {
 
 type consumeDetail struct {
 	OfferUUID         string             `db:"uuid"`
+	ApplicationName   string             `db:"application_name"`
 	EndpointName      string             `db:"name"`
 	EndpointRole      charm.RelationRole `db:"role"`
 	EndpointInterface string             `db:"interface"`

--- a/domain/crossmodelrelation/types.go
+++ b/domain/crossmodelrelation/types.go
@@ -98,6 +98,10 @@ type OfferDetail struct {
 // ConsumeDetails contains details about a offer which is being consumed.
 type ConsumeDetails struct {
 	OfferUUID string
+
+	// ApplicationName is the name of the application the offer is for.
+	ApplicationName string
+
 	Endpoints []OfferEndpoint
 }
 


### PR DESCRIPTION
Re-deploying a bundle that contains offers (cross-model relations) fails on                            
Juju 4 with `ERROR offer already exists, updating offers is not supported`.                            
Juju 4 removed the offer-update path that existed in Juju 3, but left nothing                          
idempotent in its place: `CreateOffer` rejected creation whenever an offer                             
with the same name already existed, even if the requested offer was identical.                         
This broke any idempotent or re-deploy workflow, and is a regression from                              
Juju 3 (see #22693).                                                                                   
                                                                                                          
This change makes `Service.CreateOffer` idempotent: when an offer with the                             
same name already exists, its details (application name and endpoints) are                             
fetched via `GetConsumeDetails` — which now also returns the application name                          
— and compared against the request. If the existing offer targets the same                             
application with the same set of endpoints, the call succeeds as a no-op,                              
consistent with how re-deploying an already-deployed application behaves. If                           
the offer differs in application or endpoints, the same `OfferAlreadyExists`                           
error as before is returned, since updating offers is still not supported.

## QA steps
Steps taken from #22693:
```
# 1. Create a bundle with an overlay defining an offer:
cat > bundle.yaml << 'EOF'
applications:
  self-signed-certificates:
    charm: self-signed-certificates
    channel: 1/stable
    scale: 1
EOF
cat > overlay.yaml << 'EOF'
applications:
  self-signed-certificates:
    offers:
      ssc-offer:
        endpoints: [certificates]
EOF

# 2. Deploy the bundle the first time (succeeds):
juju deploy ./bundle.yaml --overlay ./overlay.yaml

# 3. Re-deploy the same bundle:
juju deploy ./bundle.yaml --overlay ./overlay.yaml
```
This last step should not fail.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22693.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10044](https://warthogs.atlassian.net/browse/JUJU-10044)


[JUJU-10044]: https://warthogs.atlassian.net/browse/JUJU-10044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ