### PR TITLE
fix(storage): thread persistent flag through storage instance status chain

### DIFF
--- a/apiserver/facades/client/client/fullstatus_test.go
+++ b/apiserver/facades/client/client/fullstatus_test.go
@@ -731,11 +731,12 @@ func (s *fullStatusSuite) TestProcessStorageLinksVolumeStorage(c *tc.C) {
 
 	s.statusService.EXPECT().GetAllStorageInstanceStatuses(gomock.Any()).Return(
 		[]service.StorageInstance{{
-			UUID:  storageUUID,
-			ID:    "pgdata/0",
-			Owner: &unitName,
-			Kind:  domainstorage.StorageKindBlock,
-			Life:  corelife.Alive,
+			UUID:       storageUUID,
+			ID:         "pgdata/0",
+			Owner:      &unitName,
+			Kind:       domainstorage.StorageKindBlock,
+			Persistent: true,
+			Life:       corelife.Alive,
 			Status: status.StatusInfo{
 				Status: status.Pending,
 				Since:  &storageSince,
@@ -755,7 +756,7 @@ func (s *fullStatusSuite) TestProcessStorageLinksVolumeStorage(c *tc.C) {
 			ID:         "0",
 			StorageID:  "pgdata/0",
 			Life:       corelife.Alive,
-			Persistent: true,
+			Persistent: false,
 			Status: status.StatusInfo{
 				Status: status.Attached,
 				Since:  &volumeSince,
@@ -786,9 +787,9 @@ func (s *fullStatusSuite) TestProcessStorageLinksVolumeStorage(c *tc.C) {
 	c.Assert(volumes[0].Storage, tc.NotNil)
 	c.Check(volumes[0].Storage.StorageTag, tc.Equals, "storage-pgdata-0")
 	c.Check(volumes[0].Storage.Status.Status, tc.Equals, status.Pending)
-	c.Check(volumes[0].Storage.Persistent, tc.IsFalse)
+	c.Check(volumes[0].Storage.Persistent, tc.IsTrue)
 	c.Check(storage[0].Status.Status, tc.Equals, status.Pending)
-	c.Check(storage[0].Persistent, tc.IsFalse)
+	c.Check(storage[0].Persistent, tc.IsTrue)
 
 	attachment := volumes[0].Storage.Attachments["unit-postgresql-0"]
 	c.Check(attachment.MachineTag, tc.Equals, "machine-0")

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1466,6 +1466,7 @@ func processStorage(
 		details := params.StorageDetails{
 			StorageTag: names.NewStorageTag(v.ID).String(),
 			Life:       v.Life,
+			Persistent: v.Persistent,
 			Status: params.EntityStatus{
 				Status: v.Status.Status,
 				Info:   v.Status.Message,

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -508,6 +508,8 @@ func (a *StorageAPI) ListStorageDetails(
 		retVal.Kind = storageKind
 
 		retVal.Life = si.Life
+		retVal.Persistent = si.Persistent
+
 		retVal.Status = params.EntityStatus{
 			Status: si.Status.Status,
 			Info:   si.Status.Message,

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -23,6 +23,34 @@ func TestStorageSuite(t *testing.T) {
 	tc.Run(t, &storageSuite{})
 }
 
+func (s *storageSuite) TestStub(c *tc.C) {
+	c.Skip(`This suite is missing tests for the following scenerios:
+- ListStorageDetails but retrieving units returns an error (is this a useful test?)
+- ListStorageDetails but retrieving the unit's storage attachements returns an error (is this a useful test?)
+- TestStorageListEmpty
+- TestStorageListFilesystem
+- TestStorageListVolume
+- TestStorageListError
+- TestStorageListInstanceError
+- TestStorageListFilesystemError
+- TestShowStorageEmpty
+- TestShowStorageInvalidTag
+- TestShowStorage
+- TestShowStorageInvalidId
+- TestRemove
+- TestAttach
+- TestImportFilesystem
+- TestImportFilesystemVolumeBacked
+- TestImportFilesystemError
+- TestImportFilesystemNotSupported
+- TestImportFilesystemK8sProvider
+- TestImportFilesystemVolumeBackedNotSupported
+- TestImportValidationErrors
+- TestListStorageAsAdminOnNotOwnedModel
+- TestListStorageAsNonAdminOnNotOwnedModel
+`)
+}
+
 // TestListStorageDetailsPersistent verifies that a block storage instance
 // marked as persistent propagates Persistent=true to the API response, and
 // that a filesystem-kind instance without a backing volume remains false.
@@ -54,6 +82,16 @@ func (s *storageSuite) TestListStorageDetailsPersistent(c *tc.C) {
 
 	details := results.Results[0].Result
 	c.Assert(details, tc.HasLen, 2)
-	c.Check(details[0].Persistent, tc.IsTrue)
-	c.Check(details[1].Persistent, tc.IsFalse)
+
+	findByTag := func(tag string) params.StorageDetails {
+		for _, d := range details {
+			if d.StorageTag == tag {
+				return d
+			}
+		}
+		c.Fatalf("storage detail with tag %q not found", tag)
+		return params.StorageDetails{}
+	}
+	c.Check(findByTag("storage-single-blk-0").Persistent, tc.IsTrue)
+	c.Check(findByTag("storage-single-fs-1").Persistent, tc.IsFalse)
 }

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -1,45 +1,59 @@
 // Copyright 2015 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package storage_test
+package storage
 
 import (
 	"testing"
 
+	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
+
+	corestatus "github.com/juju/juju/core/status"
+	statusservice "github.com/juju/juju/domain/status/service"
+	domainstorage "github.com/juju/juju/domain/storage"
+	"github.com/juju/juju/rpc/params"
 )
 
 type storageSuite struct {
+	baseStorageSuite
 }
 
 func TestStorageSuite(t *testing.T) {
 	tc.Run(t, &storageSuite{})
 }
 
-func (s *storageSuite) TestStub(c *tc.C) {
-	c.Skip(`This suite is missing tests for the following scenerios:
-- ListStorageDetails but retrieving units returns an error (is this a useful test?)
-- ListStorageDetails but retrieving the unit's storage attachements returns an error (is this a useful test?)
-- TestStorageListEmpty
-- TestStorageListFilesystem
-- TestStorageListVolume
-- TestStorageListError
-- TestStorageListInstanceError
-- TestStorageListFilesystemError
-- TestShowStorageEmpty
-- TestShowStorageInvalidTag
-- TestShowStorage
-- TestShowStorageInvalidId
-- TestRemove
-- TestAttach
-- TestImportFilesystem
-- TestImportFilesystemVolumeBacked
-- TestImportFilesystemError
-- TestImportFilesystemNotSupported
-- TestImportFilesystemK8sProvider
-- TestImportFilesystemVolumeBackedNotSupported
-- TestImportValidationErrors
-- TestListStorageAsAdminOnNotOwnedModel
-- TestListStorageAsNonAdminOnNotOwnedModel
-`)
+// TestListStorageDetailsPersistent verifies that a block storage instance
+// marked as persistent propagates Persistent=true to the API response, and
+// that a filesystem-kind instance without a backing volume remains false.
+func (s *storageSuite) TestListStorageDetailsPersistent(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.statusService.EXPECT().GetAllStorageInstanceStatuses(gomock.Any()).Return(
+		[]statusservice.StorageInstance{
+			{
+				ID:         "single-blk/0",
+				Kind:       domainstorage.StorageKindBlock,
+				Persistent: true,
+				Status:     corestatus.StatusInfo{Status: corestatus.Attached},
+			}, {
+				ID:         "single-fs/1",
+				Kind:       domainstorage.StorageKindFilesystem,
+				Persistent: false,
+				Status:     corestatus.StatusInfo{Status: corestatus.Attached},
+			},
+		}, nil,
+	)
+
+	api := s.makeTestAPIForIAASModel(c)
+	results, err := api.ListStorageDetails(c.Context(), params.StorageFilters{
+		Filters: []params.StorageFilter{{}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results.Results, tc.HasLen, 1)
+
+	details := results.Results[0].Result
+	c.Assert(details, tc.HasLen, 2)
+	c.Check(details[0].Persistent, tc.IsTrue)
+	c.Check(details[1].Persistent, tc.IsFalse)
 }

--- a/domain/status/service/storage.go
+++ b/domain/status/service/storage.go
@@ -249,11 +249,12 @@ func (s *Service) transformStorageInstanceResults(
 	storageMap := map[storage.StorageInstanceUUID]*StorageInstance{}
 	for _, dsi := range storageInstances {
 		si := StorageInstance{
-			UUID:  dsi.UUID,
-			ID:    dsi.ID,
-			Kind:  dsi.Kind,
-			Owner: dsi.Owner,
-			Name:  dsi.Name,
+			UUID:       dsi.UUID,
+			ID:         dsi.ID,
+			Kind:       dsi.Kind,
+			Owner:      dsi.Owner,
+			Name:       dsi.Name,
+			Persistent: dsi.Persistent,
 		}
 		var err error
 		si.Life, err = dsi.Life.Value()

--- a/domain/status/service/storage_test.go
+++ b/domain/status/service/storage_test.go
@@ -243,11 +243,12 @@ func (s *storageServiceSuite) TestGetStorageInstanceStatuses(c *tc.C) {
 	}
 	si := []status.StorageInstance{
 		{
-			UUID:  uuids[0],
-			ID:    "12",
-			Owner: new(unit.Name("foo/10")),
-			Life:  life.Alive,
-			Kind:  storage.StorageKindFilesystem,
+			UUID:       uuids[0],
+			ID:         "12",
+			Owner:      new(unit.Name("foo/10")),
+			Life:       life.Alive,
+			Kind:       storage.StorageKindFilesystem,
+			Persistent: true,
 			FilesystemStatus: status.StatusInfo[status.StorageFilesystemStatusType]{
 				Message: "filesystem is attached",
 				Status:  status.StorageFilesystemStatusTypeAttached,
@@ -273,11 +274,12 @@ func (s *storageServiceSuite) TestGetStorageInstanceStatuses(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(res, tc.DeepEquals, []StorageInstance{
 		{
-			UUID:  uuids[0],
-			ID:    "12",
-			Owner: new(unit.Name("foo/10")),
-			Kind:  storage.StorageKindFilesystem,
-			Life:  corelife.Alive,
+			UUID:       uuids[0],
+			ID:         "12",
+			Owner:      new(unit.Name("foo/10")),
+			Kind:       storage.StorageKindFilesystem,
+			Life:       corelife.Alive,
+			Persistent: true,
 			Attachments: map[unit.Name]StorageAttachment{
 				"foo/10": {
 					Life:    corelife.Alive,

--- a/domain/status/service/types.go
+++ b/domain/status/service/types.go
@@ -108,6 +108,7 @@ type StorageInstance struct {
 	Status      status.StatusInfo
 	Attachments map[unit.Name]StorageAttachment
 	Name        string
+	Persistent  bool
 }
 
 // StorageAttachment represents the status of a storage attachment.

--- a/domain/status/state/model/storage.go
+++ b/domain/status/state/model/storage.go
@@ -382,6 +382,9 @@ SELECT &storageInstanceStatusDetails.* FROM (
               si.life_id,
               si.storage_kind_id,
               si.storage_name,
+              -- Persistent is a storage_volume property. A filesystem-kind
+              -- storage instance has no storage_instance_volume row, so sv.
+              -- persistent will always be NULL there and will resolve to false.
               sv.persistent AS persistent,
               u.name AS owner_unit_name,
               svs.status_id AS volume_status_id,
@@ -480,6 +483,9 @@ SELECT &storageInstanceStatusDetails.* FROM (
               si.life_id,
               si.storage_kind_id,
               si.storage_name,
+              -- Persistent is a storage_volume property. A filesystem-kind
+              -- storage instance has no storage_instance_volume row, so sv.
+              -- persistent will always be NULL there and will resolve to false.
               sv.persistent AS persistent,
               u.name AS owner_unit_name,
               svs.status_id AS volume_status_id,

--- a/domain/status/state/model/storage.go
+++ b/domain/status/state/model/storage.go
@@ -382,6 +382,7 @@ SELECT &storageInstanceStatusDetails.* FROM (
               si.life_id,
               si.storage_kind_id,
               si.storage_name,
+              sv.persistent AS persistent,
               u.name AS owner_unit_name,
               svs.status_id AS volume_status_id,
               svs.message AS volume_status_message,
@@ -393,6 +394,7 @@ SELECT &storageInstanceStatusDetails.* FROM (
     LEFT JOIN storage_unit_owner suo ON si.uuid=suo.storage_instance_uuid
     LEFT JOIN unit u ON suo.unit_uuid=u.uuid
     LEFT JOIN storage_instance_volume siv ON si.uuid=siv.storage_instance_uuid
+    LEFT JOIN storage_volume sv ON sv.uuid=siv.storage_volume_uuid
     LEFT JOIN storage_volume_status svs ON siv.storage_volume_uuid=svs.volume_uuid
     LEFT JOIN storage_instance_filesystem sif ON si.uuid=sif.storage_instance_uuid
     LEFT JOIN storage_filesystem_status sfs ON sif.storage_filesystem_uuid=sfs.filesystem_uuid
@@ -436,7 +438,7 @@ SELECT &storageInstanceStatusDetails.* FROM (
 			}
 		}
 		var volStatus status.StatusInfo[status.StorageVolumeStatusType]
-		if v.FilesystemStatusID.Valid {
+		if v.VolumeStatusID.Valid {
 			statusValue, err := status.DecodeStorageVolumeStatus(
 				v.VolumeStatusID.V)
 			if err != nil {
@@ -457,6 +459,7 @@ SELECT &storageInstanceStatusDetails.* FROM (
 			Owner:            owner,
 			FilesystemStatus: fsStatus,
 			VolumeStatus:     volStatus,
+			Persistent:       v.Persistent.Valid && v.Persistent.Bool,
 		}, nil
 	})
 }
@@ -477,6 +480,7 @@ SELECT &storageInstanceStatusDetails.* FROM (
               si.life_id,
               si.storage_kind_id,
               si.storage_name,
+              sv.persistent AS persistent,
               u.name AS owner_unit_name,
               svs.status_id AS volume_status_id,
               svs.message AS volume_status_message,
@@ -488,6 +492,7 @@ SELECT &storageInstanceStatusDetails.* FROM (
     LEFT JOIN storage_unit_owner suo ON si.uuid=suo.storage_instance_uuid
     LEFT JOIN unit u ON suo.unit_uuid=u.uuid
     LEFT JOIN storage_instance_volume siv ON si.uuid=siv.storage_instance_uuid
+    LEFT JOIN storage_volume sv ON sv.uuid=siv.storage_volume_uuid
     LEFT JOIN storage_volume_status svs ON siv.storage_volume_uuid=svs.volume_uuid
     LEFT JOIN storage_instance_filesystem sif ON si.uuid=sif.storage_instance_uuid
     LEFT JOIN storage_filesystem_status sfs ON sif.storage_filesystem_uuid=sfs.filesystem_uuid
@@ -551,6 +556,7 @@ SELECT &storageInstanceStatusDetails.* FROM (
 			Owner:            owner,
 			FilesystemStatus: fsStatus,
 			VolumeStatus:     volStatus,
+			Persistent:       v.Persistent.Valid && v.Persistent.Bool,
 		}, nil
 	})
 }

--- a/domain/status/state/model/storage_test.go
+++ b/domain/status/state/model/storage_test.go
@@ -396,6 +396,51 @@ func (s *storageStatusSuite) NewModelState(c *tc.C) *ModelState {
 	return NewModelState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 }
 
+// TestGetStorageInstancesVolumeStatusWithoutFilesystem verifies that a
+// storage instance with a volume status but no filesystem status still
+// decodes its VolumeStatus correctly.
+func (s *storageStatusSuite) TestGetStorageInstancesVolumeStatusWithoutFilesystem(c *tc.C) {
+	ch0 := s.newCharm(c)
+	s.newCharmStorage(c, ch0, "blk", storage.StorageKindBlock)
+
+	blkPoolUUID := s.newStoragePool(c, "blkpool", "blkpool", nil)
+	s0, _ := s.newStorageInstance(c, ch0, "blk", blkPoolUUID, storage.StorageKindBlock)
+	volUUID, _ := s.newVolumeWithStatus(c, status.StorageVolumeStatusTypeAttached)
+	s.newStorageInstanceVolume(c, s0, volUUID)
+
+	st := s.NewModelState(c)
+	instances, err := st.GetStorageInstances(c.Context(), []storage.StorageInstanceUUID{s0})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(instances, tc.HasLen, 1)
+	c.Check(instances[0].VolumeStatus.Status, tc.Equals, status.StorageVolumeStatusTypeAttached)
+}
+
+// TestGetStorageInstancesPersistent verifies that GetStorageInstances joins
+// storage_volume and returns Persistent=true for a block storage instance
+// backed by a volume with persistent=true.
+func (s *storageStatusSuite) TestGetStorageInstancesPersistent(c *tc.C) {
+	ch0 := s.newCharm(c)
+	s.newCharmStorage(c, ch0, "blk", storage.StorageKindBlock)
+
+	blkPoolUUID := s.newStoragePool(c, "blkpool", "blkpool", nil)
+	s0, _ := s.newStorageInstance(c, ch0, "blk", blkPoolUUID, storage.StorageKindBlock)
+	volUUID, _ := s.newVolume(c)
+	s.newStorageInstanceVolume(c, s0, volUUID)
+
+	_, err := s.DB().ExecContext(
+		c.Context(),
+		`UPDATE storage_volume SET persistent=true WHERE uuid=?`,
+		volUUID.String(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := s.NewModelState(c)
+	instances, err := st.GetStorageInstances(c.Context(), []storage.StorageInstanceUUID{s0})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(instances, tc.HasLen, 1)
+	c.Check(instances[0].Persistent, tc.IsTrue)
+}
+
 func (s *storageStatusSuite) TestGetAllStorageInstancesEmpty(c *tc.C) {
 	st := s.NewModelState(c)
 	res, err := st.GetAllStorageInstances(c.Context())
@@ -442,6 +487,32 @@ func (s *storageStatusSuite) TestGetAllStorageInstances(c *tc.C) {
 			Kind:  storage.StorageKindFilesystem,
 		},
 	})
+}
+
+// TestGetAllStorageInstancesPersistent verifies that the state query joins
+// storage_volume and returns Persistent=true for a block storage instance
+// backed by a volume with persistent=true.
+func (s *storageStatusSuite) TestGetAllStorageInstancesPersistent(c *tc.C) {
+	ch0 := s.newCharm(c)
+	s.newCharmStorage(c, ch0, "blk", storage.StorageKindBlock)
+
+	blkPoolUUID := s.newStoragePool(c, "blkpool", "blkpool", nil)
+	s0, _ := s.newStorageInstance(c, ch0, "blk", blkPoolUUID, storage.StorageKindBlock)
+	volUUID, _ := s.newVolume(c)
+	s.newStorageInstanceVolume(c, s0, volUUID)
+
+	_, err := s.DB().ExecContext(
+		c.Context(),
+		`UPDATE storage_volume SET persistent=true WHERE uuid=?`,
+		volUUID.String(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := s.NewModelState(c)
+	res, err := st.GetAllStorageInstances(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(res, tc.HasLen, 1)
+	c.Check(res[0].Persistent, tc.IsTrue)
 }
 
 func (s *storageStatusSuite) TestGetAllStorageInstanceAttachmentsEmpty(c *tc.C) {

--- a/domain/status/state/model/types.go
+++ b/domain/status/state/model/types.go
@@ -294,6 +294,7 @@ type storageInstanceStatusDetails struct {
 	VolumeStatusID            sql.Null[int]  `db:"volume_status_id"`
 	VolumeStatusMessage       string         `db:"volume_status_message"`
 	VolumeStatusUpdatedAt     *time.Time     `db:"volume_status_updated_at"`
+	Persistent                sql.NullBool   `db:"persistent"`
 }
 
 // storageAttachmentStatusDetails is used to retrieve all required

--- a/domain/status/types.go
+++ b/domain/status/types.go
@@ -82,6 +82,7 @@ type StorageInstance struct {
 	Life             life.Life
 	FilesystemStatus StatusInfo[StorageFilesystemStatusType]
 	VolumeStatus     StatusInfo[StorageVolumeStatusType]
+	Persistent       bool
 }
 
 // StorageAttachment represents the status of a storage attachment.

--- a/tests/suites/storage/persistent_storage.sh
+++ b/tests/suites/storage/persistent_storage.sh
@@ -30,46 +30,42 @@ run_persistent_storage() {
 	echo "Checking total number of storage unit(s)."
 	assert_storage 2 "select(.storage) | .storage | keys | length"
 	echo "Checking names of storage unit(s)."
-	assert_storage "single-blk/0" "$(label 0)"
-	assert_storage "single-fs/1" "$(label 1)"
+	assert_storage 1 ".storage | keys | map(select(test(\"^single-blk/\"))) | length"
+	assert_storage 1 ".storage | keys | map(select(test(\"^single-fs/\"))) | length"
+	BLK_ID=$(juju storage --format json | yq -r '.storage | keys | map(select(test("^single-blk/"))) | .[]')
+	FS_ID=$(juju storage --format json | yq -r '.storage | keys | map(select(test("^single-fs/"))) | .[]')
+	assert_storage "${BLK_ID}" '.storage | keys | .[] | select(test("^single-blk/"))'
+	assert_storage "${FS_ID}" '.storage | keys | .[] | select(test("^single-fs/"))'
 	echo "Check name and total number of storage unit: PASSED."
 
 	#
 	# check type, persistent setting and pool of single block storage unit
 	#
-	# storage type
-	assert_storage "block" "$(kind_name "single-blk" 0)"
-	# persistent setting
+	assert_storage "block" ".storage[\"${BLK_ID}\"][\"kind\"]"
 	echo "Checking persistent setting of single block storage unit"
-	assert_storage true '.storage | ."single-blk/0" | .persistent'
-	# pool storage
-	assert_storage "single-blk/0" '.volumes | ."0" | .storage'
-	# pool setting
-	assert_storage "ebs" '.volumes | ."0" | .pool'
-	# storage status
-	assert_storage "attached" '.volumes | ."0" | .status | .current'
+	assert_storage true ".storage[\"${BLK_ID}\"][\"persistent\"]"
+	assert_storage "${BLK_ID}" '.volumes."0".storage'
+	assert_storage "ebs" '.volumes."0".pool'
+	assert_storage "attached" '.volumes."0".status.current'
 	echo "Check properties of single block device storage unit: PASSED."
 
 	#
 	# check type, persistent setting and pool of single filesystem storage unit
 	#
-	assert_storage "filesystem" "$(kind_name "single-fs" 1)"
-	# persistent setting
+	assert_storage "filesystem" ".storage[\"${FS_ID}\"][\"kind\"]"
 	echo "Checking persistent setting of single filesystem storage unit"
-	assert_storage false '.storage | ."single-fs/1" | .persistent'
-	# pool storage
-	assert_storage "single-blk/0" '.volumes | ."0" | .storage'
-	# pool setting
-	assert_storage "ebs" '.volumes | ."0" | .pool'
-	# storage status
-	assert_storage "attached" '.volumes | ."0" | .status | .current'
+	assert_storage false ".storage[\"${FS_ID}\"][\"persistent\"]"
+	# The sole volume is owned by the block storage instance, not the filesystem.
+	assert_storage "${BLK_ID}" '.volumes."0".storage'
+	assert_storage "ebs" '.volumes."0".pool'
+	assert_storage "attached" '.volumes."0".status.current'
 	echo "Check properties of single filesystem storage unit: PASSED."
 
 	# assert charm removal message for single block and filesystem storage
 	echo "Remove application, check that storage is also removed"
 	removal_msg=$(juju remove-application --no-prompt dummy-storage 2>&1)
-	echo "${removal_msg}" | sed -sn 3p | sed 's/^-//' | check "will remove storage single-fs/1"
-	echo "${removal_msg}" | sed -sn 4p | sed 's/^-//' | check "will detach storage single-blk/0"
+	echo "${removal_msg}" | grep -cE "will remove storage ${FS_ID}" | check 1
+	echo "${removal_msg}" | grep -cE "will detach storage ${BLK_ID}" | check 1
 	#
 	# wait until an update of storage status occurred. Due to the asynchronous nature of Juju,
 	# the status of storage may change from time to time after a Juju CLI is issued, in this test only
@@ -79,47 +75,46 @@ run_persistent_storage() {
 	# status has changed and now we can check for the storage status and assert that indeed the
 	# single filesystem storage unit has been removed successfully.
 	sleep 5 # avoid races, sometimes the storage disappears just after the app
-	assert_storage false '.storage | has("single-fs/1")'
+	assert_storage false ".storage | has(\"${FS_ID}\")"
 
 	echo "Checking total number of storage unit(s)."
 	assert_storage 1 "select(.storage) | .storage | keys | length"
 	echo "Check for existence of single block storage"
-	assert_storage true '.storage | has("single-blk/0")'
-	echo "single-blk/0 found in storage list."
+	assert_storage true ".storage | has(\"${BLK_ID}\")"
+	echo "${BLK_ID} found in storage list."
 
-	echo "Check for existence of single-blk/0 persistent storage after remove-application"
-	assert_storage "single-blk/0" '.volumes | ."0" | .storage'
+	echo "Check for existence of ${BLK_ID} persistent storage after remove-application"
+	assert_storage "${BLK_ID}" '.volumes."0".storage'
 	# storage status
-	assert_storage "detached" '.volumes | ."0" | .status | .current'
-	echo "Check status of persistent storage single-blk/0 after remove-application: PASSED"
+	assert_storage "detached" '.volumes."0".status.current'
+	echo "Check status of persistent storage ${BLK_ID} after remove-application: PASSED"
 
 	# Deploy charm with an existing detached storage
 	juju deploy -m "${model_name}" juju-qa-dummy-storage dummy-storage \
-		--attach-storage single-blk/0
+		--attach-storage "${BLK_ID}"
 	echo "Checking current status of app dummy-storage."
 	# wait for current application-status to be active
 	wait_for "dummy-storage" "$(active_condition "dummy-storage" 0)"
 	# wait for current workload-status to be active
 	wait_for "active" "$(workload_status "dummy-storage" 1).current"
-	# assert storage unit count
 	assert_storage 1 "select(.storage) | .storage | keys | length"
-	echo "Checking existence of single block device storage single-blk/0."
-	assert_storage true '.storage | has("single-blk/0")'
+	echo "Checking existence of single block device storage ${BLK_ID}."
+	assert_storage true ".storage | has(\"${BLK_ID}\")"
 	# assert persistent setting
-	echo "Checking persistent setting of storage unit single-blk/0."
-	assert_storage true '.storage | ."single-blk/0" | .persistent'
+	echo "Checking persistent setting of storage unit ${BLK_ID}."
+	assert_storage true ".storage[\"${BLK_ID}\"][\"persistent\"]"
 	# assert storage status
-	echo "Checking the status of storage single-blk/0 in volumes."
-	assert_storage "attached" '.volumes | ."0" | .status | .current'
+	echo "Checking the status of storage ${BLK_ID} in volumes."
+	assert_storage "attached" '.volumes."0".status.current'
 
 	# remove charm
 	juju remove-application --no-prompt dummy-storage
 	# wait for application to be removed
 	wait_for "{}" ".applications"
 	# persistent storage should remain after remove-application
-	assert_storage true '.storage | has("single-blk/0")'
+	assert_storage true ".storage | has(\"${BLK_ID}\")"
 	# remove storage
-	juju remove-storage single-blk/0
+	juju remove-storage "${BLK_ID}"
 	# wait until an update of storage status occurred. Due to the asynchronous nature of Juju,
 	# the status of storage may change time to time after a Juju CLI issued.
 	# Checking removal of single block device storage {}.


### PR DESCRIPTION
`juju storage --format json` currently reports `persistent: false` for a block-storage volume on 4.x even when `storage_volume.persistent` is `true`. The value is stored correctly in the database, but the read path dropped it before constructing the API response.

This change threads `Persistent` from the state query through the status domain/service layers into `ListStorageDetails` and `juju status --storage`. It also fixes an adjacent by-UUID status-transform guard that incorrectly checked filesystem status before decoding volume status.

## Fly by f89aaf3cd7be8a00e65659b637e1cb4627094ef4

Harden integration test against storage ID reordering
Storage IDs are type-monotonic rather than name-monotonic on 4.0, so
`single-blk/0` and `single-fs/1` are no longer predictable. Replace
hard-coded IDs with prefix-based lookups.

## Follow up
The `DestroyApplication`/`DestroyUnit` facade endpoints return empty
`DestroyedStorage`/`DetachedStorage` slices (TODO from the storage stub).
`juju remove-application` does not report which storage will be removed
or detached. A followup PR will compose the storage provisioning and
storage services to restore classification using `Persistent`.

Reported here: https://github.com/juju/juju/issues/22969

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing — not run in this environment
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~ — no new package or package documentation was introduced

## QA steps

Run aws ci:
`./main.sh -p aws storage test_persistent_storage`

this will fails with 

```
    | Check properties of single filesystem storage unit: PASSED.
    | Remove application, check that storage is also removed
    | 
    | "Expected": 1
    | "Received": 0
```
For an unrelated reason

## Documentation changes

No standalone documentation changes are required. The existing `Persistent` API field is already documented; this change corrects the value returned by the existing API paths.

## Links

**Jira card:** [JUJU-9800](https://warthogs.atlassian.net/browse/JUJU-9800)

[JUJU-9800]: https://warthogs.atlassian.net/browse/JUJU-9800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ