### PR TITLE
test(ci): add Azure expose app suite and refactor opened-port checks

### DIFF
--- a/tests/includes/network.sh
+++ b/tests/includes/network.sh
@@ -61,31 +61,27 @@ assert_endpoint_binding_matches() {
 	fi
 }
 
-# assert_opened_ports_output checks that the open-port and opened-ports hook
-# tools behave as expected on the given application unit: it opens a port
-# range for all endpoints, then — when both <endpoint> and
-# <endpoint_port_range> are supplied — opens a port for that specific
-# endpoint. It asserts both the legacy and the --endpoints output formats.
-# Ports are ordered by start port in the output, so expected values are
-# sorted accordingly. Both port ranges must use the same protocol; this
-# helper does not sort or validate across mixed TCP/UDP ranges.
+# _validate_port_args <func_name> [args...]
 #
-# Usage:
-#   assert_opened_ports_output <app_name> <all_endpoints_port_range> \
-#       [<endpoint> <endpoint_port_range>]
-assert_opened_ports_output() {
-	local app_name all_ports endpoint endpoint_ports
-	local exp_legacy exp_endpoints all_start ep_start
+# Validates the argument pattern expected by helpers that accept:
+#   <app_name> <all_endpoints_port_range> [<endpoint> <endpoint_port_range>]
+# Returns 0 when valid, 1 otherwise with an error to stderr.
+_validate_port_args() {
+	local func_name
+	func_name=${1}
+	shift
 
 	if [ "$#" -lt 2 ] || [ "$#" -gt 4 ]; then
-		echo "ERROR: usage: assert_opened_ports_output <app> <all-ports> [<endpoint> <endpoint-ports>]" >&2
+		echo "ERROR: usage: ${func_name} <app> <all-ports> [<endpoint> <endpoint-ports>]" >&2
 		return 1
 	fi
 
+	local app_name all_ports endpoint endpoint_ports
 	app_name=${1:-}
 	all_ports=${2:-}
 	endpoint=${3:-}
 	endpoint_ports=${4:-}
+
 	if [ -z "${app_name}" ] || [ -z "${all_ports}" ]; then
 		echo "ERROR: application and all-endpoints port range are required" >&2
 		return 1
@@ -104,16 +100,59 @@ assert_opened_ports_output() {
 			return 1
 		fi
 	fi
+}
 
-	all_start="${all_ports%%[-\/]*}"
-	if ! [[ ${all_start} =~ ^[0-9]+$ ]]; then
-		echo "ERROR: invalid all-endpoints port range: ${all_ports}" >&2
+# port_range_bounds <port-range>
+#
+# Prints the numeric start and end ports for a port range such as
+# <port>[-<port>][/<protocol>]. The protocol suffix is optional.
+# On failure writes a diagnostic to stderr and returns non-zero.
+port_range_bounds() {
+	local port_range=${1:-}
+	local ports="${port_range%/*}"
+	local from=${ports} to=${ports}
+
+	if [[ ${ports} == *-* ]]; then
+		from=${ports%%-*}
+		to=${ports##*-}
+	fi
+
+	if ! [[ ${from} =~ ^[0-9]+$ && ${to} =~ ^[0-9]+$ ]] || ((from > to)); then
+		echo "ERROR: invalid port range: ${port_range}" >&2
+		return 1
+	fi
+
+	printf '%s %s\n' "${from}" "${to}"
+}
+
+# assert_opened_ports_output checks that the open-port and opened-ports hook
+# tools behave as expected on the given application unit: it opens a port
+# range for all endpoints, then — when both <endpoint> and
+# <endpoint_port_range> are supplied — opens a port for that specific
+# endpoint. It asserts both the legacy and the --endpoints output formats.
+# Ports are ordered by start port in the output, so expected values are
+# sorted accordingly. Both port ranges must use the same protocol; this
+# helper does not sort or validate across mixed TCP/UDP ranges.
+#
+# Usage:
+#   assert_opened_ports_output <app_name> <all_endpoints_port_range> \
+#       [<endpoint> <endpoint_port_range>]
+assert_opened_ports_output() {
+	local app_name all_ports endpoint endpoint_ports
+	local exp_legacy exp_endpoints all_start ep_start
+
+	_validate_port_args "assert_opened_ports_output" "$@" || return 1
+
+	app_name=${1:-}
+	all_ports=${2:-}
+	endpoint=${3:-}
+	endpoint_ports=${4:-}
+
+	if ! all_start=$(port_range_bounds "${all_ports}" | awk '{print $1}'); then
 		return 1
 	fi
 	if [ -n "${endpoint_ports}" ]; then
-		ep_start="${endpoint_ports%%[-\/]*}"
-		if ! [[ ${ep_start} =~ ^[0-9]+$ ]]; then
-			echo "ERROR: invalid endpoint port range: ${endpoint_ports}" >&2
+		if ! ep_start=$(port_range_bounds "${endpoint_ports}" | awk '{print $1}'); then
 			return 1
 		fi
 	fi
@@ -129,8 +168,6 @@ assert_opened_ports_output() {
 	# Build expected outputs sorted by numeric start port, matching the
 	# order produced by opened-ports (sorts by protocol, then by port).
 	if [ -n "${endpoint_ports}" ]; then
-		ep_start="${endpoint_ports%%[-\/]*}"
-		all_start="${all_ports%%[-\/]*}"
 		if [ "${ep_start}" -lt "${all_start}" ]; then
 			exp_legacy="${endpoint_ports} ${all_ports}"
 			exp_endpoints="${endpoint_ports} (${endpoint}) ${all_ports} (*)"

--- a/tests/includes/network.sh
+++ b/tests/includes/network.sh
@@ -60,3 +60,100 @@ assert_endpoint_binding_matches() {
 		exit 1
 	fi
 }
+
+# assert_opened_ports_output checks that the open-port and opened-ports hook
+# tools behave as expected on the given application unit: it opens a port
+# range for all endpoints, then — when both <endpoint> and
+# <endpoint_port_range> are supplied — opens a port for that specific
+# endpoint. It asserts both the legacy and the --endpoints output formats.
+# Ports are ordered by start port in the output, so expected values are
+# sorted accordingly. Both port ranges must use the same protocol; this
+# helper does not sort or validate across mixed TCP/UDP ranges.
+#
+# Usage:
+#   assert_opened_ports_output <app_name> <all_endpoints_port_range> \
+#       [<endpoint> <endpoint_port_range>]
+assert_opened_ports_output() {
+	local app_name all_ports endpoint endpoint_ports
+	local exp_legacy exp_endpoints all_start ep_start
+
+	if [ "$#" -lt 2 ] || [ "$#" -gt 4 ]; then
+		echo "ERROR: usage: assert_opened_ports_output <app> <all-ports> [<endpoint> <endpoint-ports>]" >&2
+		return 1
+	fi
+
+	app_name=${1:-}
+	all_ports=${2:-}
+	endpoint=${3:-}
+	endpoint_ports=${4:-}
+	if [ -z "${app_name}" ] || [ -z "${all_ports}" ]; then
+		echo "ERROR: application and all-endpoints port range are required" >&2
+		return 1
+	fi
+	if { [ -n "${endpoint}" ] && [ -z "${endpoint_ports}" ]; } || \
+		{ [ -z "${endpoint}" ] && [ -n "${endpoint_ports}" ]; }; then
+		echo "ERROR: endpoint and endpoint port range must be supplied together" >&2
+		return 1
+	fi
+
+	# Reject mixed protocols: the current sorter only compares numeric start
+	# ports, which is valid only when both ranges share the same protocol.
+	if [ -n "${endpoint_ports}" ]; then
+		if [ "${all_ports##*/}" != "${endpoint_ports##*/}" ]; then
+			echo "ERROR: this helper only accepts ranges with the same protocol: ${all_ports} vs ${endpoint_ports}" >&2
+			return 1
+		fi
+	fi
+
+	all_start="${all_ports%%[-\/]*}"
+	if ! [[ ${all_start} =~ ^[0-9]+$ ]]; then
+		echo "ERROR: invalid all-endpoints port range: ${all_ports}" >&2
+		return 1
+	fi
+	if [ -n "${endpoint_ports}" ]; then
+		ep_start="${endpoint_ports%%[-\/]*}"
+		if ! [[ ${ep_start} =~ ^[0-9]+$ ]]; then
+			echo "ERROR: invalid endpoint port range: ${endpoint_ports}" >&2
+			return 1
+		fi
+	fi
+
+	echo "==> Checking open/opened-ports hook tools work as expected"
+
+	juju exec --unit "${app_name}/0" "open-port ${all_ports}"
+
+	if [ -n "${endpoint}" ]; then
+		juju exec --unit "${app_name}/0" "open-port ${endpoint_ports} --endpoints ${endpoint}"
+	fi
+
+	# Build expected outputs sorted by numeric start port, matching the
+	# order produced by opened-ports (sorts by protocol, then by port).
+	if [ -n "${endpoint_ports}" ]; then
+		ep_start="${endpoint_ports%%[-\/]*}"
+		all_start="${all_ports%%[-\/]*}"
+		if [ "${ep_start}" -lt "${all_start}" ]; then
+			exp_legacy="${endpoint_ports} ${all_ports}"
+			exp_endpoints="${endpoint_ports} (${endpoint}) ${all_ports} (*)"
+		else
+			exp_legacy="${all_ports} ${endpoint_ports}"
+			exp_endpoints="${all_ports} (*) ${endpoint_ports} (${endpoint})"
+		fi
+	else
+		exp_legacy="${all_ports}"
+		exp_endpoints="${all_ports} (*)"
+	fi
+
+	got=$(juju_exec_output --unit "${app_name}/0" "opened-ports" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
+	if [ "$got" != "$exp_legacy" ]; then
+		# shellcheck disable=SC2046
+		echo $(red "expected opened-ports output to be:\n${exp_legacy}\nGOT:\n${got}")
+		exit 1
+	fi
+
+	got=$(juju_exec_output --unit "${app_name}/0" "opened-ports --endpoints" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
+	if [ "$got" != "$exp_endpoints" ]; then
+		# shellcheck disable=SC2046
+		echo $(red "expected opened-ports output when using --endpoints to be:\n${exp_endpoints}\nGOT:\n${got}")
+		exit 1
+	fi
+}

--- a/tests/includes/network.sh
+++ b/tests/includes/network.sh
@@ -95,7 +95,14 @@ _validate_port_args() {
 	# Reject mixed protocols: the current sorter only compares numeric start
 	# ports, which is valid only when both ranges share the same protocol.
 	if [ -n "${endpoint_ports}" ]; then
-		if [ "${all_ports##*/}" != "${endpoint_ports##*/}" ]; then
+		local all_proto="" endpoint_proto=""
+		if [[ ${all_ports} == */* ]]; then
+			all_proto="${all_ports##*/}"
+		fi
+		if [[ ${endpoint_ports} == */* ]]; then
+			endpoint_proto="${endpoint_ports##*/}"
+		fi
+		if [ "${all_proto}" != "${endpoint_proto}" ]; then
 			echo "ERROR: this helper only accepts ranges with the same protocol: ${all_ports} vs ${endpoint_ports}" >&2
 			return 1
 		fi

--- a/tests/suites/cloud_azure/expose_app.sh
+++ b/tests/suites/cloud_azure/expose_app.sh
@@ -1,0 +1,291 @@
+run_expose_app_azure() {
+	local app_name="ubuntu-lite"
+	local all_ports="1337-1339/tcp"
+	local endpoint="ubuntu"
+	local endpoint_ports="1234/tcp"
+
+	echo
+
+	file="${TEST_DIR}/test-expose-app-azure.log"
+
+	ensure "expose-app-azure" "${file}"
+
+	# Deploy test charm with dual-stack constraint so the machine has both
+	# an IPv4 and an IPv6 address for NSG rule verification.
+	juju deploy "${app_name}" --constraints "ip-family=dual"
+	wait_for "${app_name}" "$(idle_condition "${app_name}")"
+
+	# Open ports and verify hook tool behavior (provider-agnostic).
+	assert_opened_ports_output \
+		"${app_name}" "${all_ports}" "${endpoint}" "${endpoint_ports}"
+
+	# Ensure that CIDRs are correctly generated in Azure NSG rules.
+	assert_ingress_cidrs_for_exposed_app_azure \
+		"${app_name}" "${all_ports}" "${endpoint}" "${endpoint_ports}"
+
+	# Verify IPv4 and IPv6 reachability through the exposed NSG.
+	assert_dual_stack_reachability_for_exposed_app_azure "${app_name}" "${all_ports}"
+
+	destroy_model "expose-app-azure"
+}
+
+assert_ingress_cidrs_for_exposed_app_azure() {
+	local app_name all_ports endpoint endpoint_ports
+	local bounds all_from all_to endpoint_from endpoint_to
+
+	if [ "$#" -lt 2 ] || [ "$#" -gt 4 ]; then
+		echo "ERROR: usage: assert_ingress_cidrs_for_exposed_app_azure <app> <all-ports> [<endpoint> <endpoint-ports>]" >&2
+		return 1
+	fi
+
+	app_name=${1:-}
+	all_ports=${2:-}
+	endpoint=${3:-}
+	endpoint_ports=${4:-}
+	if [ -z "${app_name}" ] || [ -z "${all_ports}" ]; then
+		echo "ERROR: application and all-endpoints port range are required" >&2
+		return 1
+	fi
+	if { [ -n "${endpoint}" ] && [ -z "${endpoint_ports}" ]; } || \
+		{ [ -z "${endpoint}" ] && [ -n "${endpoint_ports}" ]; }; then
+		echo "ERROR: endpoint and endpoint port range must be supplied together" >&2
+		return 1
+	fi
+
+	if ! bounds=$(azure_port_range_bounds "${all_ports}"); then
+		return 1
+	fi
+	read -r all_from all_to <<< "${bounds}"
+	if [ -n "${endpoint}" ]; then
+		if ! bounds=$(azure_port_range_bounds "${endpoint_ports}"); then
+			return 1
+		fi
+		read -r endpoint_from endpoint_to <<< "${bounds}"
+	fi
+
+	echo "==> Checking that expose --to-cidrs works as expected on Azure dual-stack"
+
+	# IPv4-only expose: no IPv6 CIDR is specified anywhere, so no IPv6
+	# source rule may be generated (core firewaller behavior).
+	juju expose "${app_name}" --to-cidrs 10.0.0.0/24,192.168.0.0/24
+
+	echo "==> Waiting for Azure NSG rules to be updated"
+	wait_for_azure_nsg_ingress_cidrs_for_port_range \
+		"${all_from}" "${all_to}" "10.0.0.0/24,192.168.0.0/24" "ipv4"
+
+	# Regression guard, checked only after the IPv4 rules are confirmed
+	# present: the firewaller has then processed the expose, so the
+	# absence of IPv6 rules is meaningful. Let any trailing rule creation
+	# settle first.
+	sleep "${SHORT_TIMEOUT}"
+	echo "==> Regression guard: no IPv6 NSG rules after IPv4-only expose"
+	assert_no_ipv6_nsg_rules_for_port_range "${all_from}" "${all_to}"
+
+	if [ -n "${endpoint}" ]; then
+		# Verify that a subsequent expose overwrites the previous rule for
+		# the same endpoint: first open to the world, then restrict to
+		# specific CIDRs.
+		juju expose "${app_name}" --endpoints "${endpoint}"
+		juju expose "${app_name}" --endpoints "${endpoint}" \
+			--to-cidrs 10.42.0.0/16,2002:0:0:1234::/64
+
+		echo "==> Waiting for Azure NSG rules to be updated"
+		# The all-endpoints range also receives the named endpoint CIDRs.
+		wait_for_azure_nsg_ingress_cidrs_for_port_range \
+			"${all_from}" "${all_to}" \
+			"10.0.0.0/24,10.42.0.0/16,192.168.0.0/24" "ipv4"
+		wait_for_azure_nsg_ingress_cidrs_for_port_range \
+			"${all_from}" "${all_to}" \
+			"2002:0:0:1234::/64" "ipv6"
+
+		# The endpoint-specific range should only use its endpoint CIDRs.
+		wait_for_azure_nsg_ingress_cidrs_for_port_range \
+			"${endpoint_from}" "${endpoint_to}" "10.42.0.0/16" "ipv4"
+		wait_for_azure_nsg_ingress_cidrs_for_port_range \
+			"${endpoint_from}" "${endpoint_to}" \
+			"2002:0:0:1234::/64" "ipv6"
+	fi
+
+	# Destination family check (juju/juju#22758): expose-created rules
+	# must route each source CIDR to a destination of the same family.
+	echo "==> Checking NSG rule destinations match source address family"
+	assert_nsg_rule_destinations_match_source_family
+}
+
+# assert_no_ipv6_nsg_rules_for_port_range fails if any inbound Allow NSG
+# rule for the given port range has an IPv6 source CIDR. It verifies that
+# an IPv4-only expose does not generate IPv6 source rules.
+assert_no_ipv6_nsg_rules_for_port_range() {
+	local from_port="${1}" to_port="${2}"
+	local port_range instance_id rg nsg_name got_v6
+
+	port_range="${from_port}"
+	if [ "${from_port}" != "${to_port}" ]; then
+		port_range="${from_port}-${to_port}"
+	fi
+
+	read -r instance_id rg <<< "$(azure_first_model_instance)"
+	nsg_name=$(azure_nsg_name_for_instance "${rg}" "${instance_id}")
+
+	got_v6=$(az network nsg rule list --resource-group "${rg}" --nsg-name "${nsg_name}" -o yaml 2>/dev/null | \
+		yq -r ".[] | select(.destinationPortRange == \"${port_range}\" and .access == \"Allow\" and .direction == \"Inbound\") | .sourceAddressPrefix | select(test(\":\"))" | sort | paste -sd, -)
+	if [ -n "${got_v6}" ]; then
+		# shellcheck disable=SC2046
+		echo $(red "unexpected IPv6 NSG rule for port range [${from_port},${to_port}]: ${got_v6}")
+		exit 1
+	fi
+}
+
+# assert_nsg_rule_destinations_match_source_family fails if any of this
+# machine's expose-created NSG rules (named machine-<id>-*) does not route
+# its source CIDR to the instance's private address of the same family:
+# the primary IPv4 address for IPv4 sources, the first IPv6 address for
+# IPv6 sources (mirrors the destination selection of juju/juju#22758).
+assert_nsg_rule_destinations_match_source_family() {
+	local machine_id instance_id rg nsg_name nic_v4 nic_v6 rules_yaml bad_v4 bad_v6 mismatched
+
+	machine_id=$(juju show-machine --format json | yq -r '.machines | keys | .[0]')
+	read -r instance_id rg <<< "$(azure_first_model_instance)"
+	nsg_name=$(azure_nsg_name_for_instance "${rg}" "${instance_id}")
+	read -r nic_v4 nic_v6 <<< "$(azure_nic_private_addresses "${rg}" "${instance_id}")"
+
+	rules_yaml=$(az network nsg rule list --resource-group "${rg}" --nsg-name "${nsg_name}" -o yaml 2>/dev/null)
+
+	# Guard against a vacuous pass: if no expose-created rule matches the
+	# machine prefix, there is nothing to validate, so fail loudly.
+	matched=$(printf '%s\n' "${rules_yaml}" | MACHINE_ID="${machine_id}" yq -r \
+		'[.[] | select(.access == "Allow" and .direction == "Inbound") |
+			select(.name | test("^machine-" + strenv(MACHINE_ID) + "-"))] | length')
+	if [ "${matched}" -eq 0 ]; then
+		# shellcheck disable=SC2046
+		echo $(red "no expose-created NSG rules found for machine ${machine_id}; expected machine-${machine_id}-*")
+		exit 1
+	fi
+
+	bad_v4=$(printf '%s\n' "${rules_yaml}" | MACHINE_ID="${machine_id}" NIC="${nic_v4}" yq -r \
+		'.[] | select(.access == "Allow" and .direction == "Inbound") |
+			select(.name | test("^machine-" + strenv(MACHINE_ID) + "-")) |
+			select((.sourceAddressPrefix // "") | test(":") | not) |
+			select((.destinationAddressPrefix // "<none>") != strenv(NIC)) |
+			[.name, .sourceAddressPrefix, (.destinationAddressPrefix // "<none>")] | join(" ")')
+	bad_v6=$(printf '%s\n' "${rules_yaml}" | MACHINE_ID="${machine_id}" NIC="${nic_v6}" yq -r \
+		'.[] | select(.access == "Allow" and .direction == "Inbound") |
+			select(.name | test("^machine-" + strenv(MACHINE_ID) + "-")) |
+			select((.sourceAddressPrefix // "") | test(":")) |
+			select((.destinationAddressPrefix // "<none>") != strenv(NIC)) |
+			[.name, .sourceAddressPrefix, (.destinationAddressPrefix // "<none>")] | join(" ")')
+	mismatched=$(printf '%s\n%s\n' "${bad_v4}" "${bad_v6}" | sed '/^$/d' | sort)
+	if [ -n "${mismatched}" ]; then
+		# shellcheck disable=SC2046
+		echo $(red "NSG rules not routed to the instance's private address of the matching family:\n${mismatched}")
+		exit 1
+	fi
+}
+
+assert_dual_stack_reachability_for_exposed_app_azure() {
+	local app_name all_ports bounds port unit machine_id
+	local unit_ipv4 unit_ipv6
+
+	if [ "$#" -ne 2 ]; then
+		echo "ERROR: usage: assert_dual_stack_reachability_for_exposed_app_azure <app> <all-ports>" >&2
+		return 1
+	fi
+
+	app_name=${1:-}
+	all_ports=${2:-}
+	if [ -z "${app_name}" ] || [ -z "${all_ports}" ]; then
+		echo "ERROR: application and all-endpoints port range are required" >&2
+		return 1
+	fi
+	if ! bounds=$(azure_port_range_bounds "${all_ports}"); then
+		return 1
+	fi
+	port=${bounds%% *}
+	unit="${app_name}/0"
+
+	echo "==> Checking IPv4 and IPv6 reachability through exposed NSG"
+
+	# Expose the all-endpoints rule to the world so the CI runner can probe
+	# the actual port opened above. CIDR behavior was verified separately.
+	juju expose "${app_name}"
+	wait_for "${app_name}" "$(idle_condition "${app_name}")"
+
+	machine_id=$(juju show-unit "${unit}" --format json | UNIT="${unit}" yq -r '.[strenv(UNIT)].machine')
+	if [ -z "${machine_id}" ] || [ "${machine_id}" = "null" ]; then
+		echo "ERROR: no machine found for ${unit}"
+		return 1
+	fi
+	unit_ipv6=$(machine_ipv6 "${machine_id}")
+	unit_ipv4=$(juju show-machine "${machine_id}" --format json |
+		MACHINE_ID="${machine_id}" yq -r '.machines[strenv(MACHINE_ID)]["ip-addresses"][] |
+			select(. | test("^[0-9]+[.]"))' |
+		head -1)
+
+	if [ -z "${unit_ipv6}" ]; then
+		echo "ERROR: no IPv6 address found on machine ${machine_id} (expected dual-stack)"
+		return 1
+	fi
+	if [ -z "${unit_ipv4}" ]; then
+		echo "ERROR: no IPv4 address found on machine ${machine_id}"
+		return 1
+	fi
+
+	if ! ip -6 route show default | grep -q .; then
+		echo "==> ERROR: no IPv6 egress on CI runner, cannot verify IPv6 reachability"
+		return 1
+	fi
+	if ! juju exec --unit "${unit}" -- "command -v python3" >/dev/null 2>&1; then
+		echo "ERROR: python3 is not available on ${unit}"
+		return 1
+	fi
+	if ! azure_upload_tcp_listener "${unit}"; then
+		azure_remove_tcp_listener "${unit}" || true
+		echo "ERROR: could not upload the TCP listener to ${unit}"
+		return 1
+	fi
+
+	# Probe one bounded, one-shot listener per address family. Each retry
+	# starts a fresh listener so a transient connection cannot consume the
+	# only probe while the firewaller propagates the expose rule.
+	echo "==> Probing exposed port ${port} over IPv4 (${unit_ipv4})"
+	if ! azure_probe_tcp_listener "${unit}" "ipv4" "${port}" "${unit_ipv4}"; then
+		azure_remove_tcp_listener "${unit}" || true
+		echo "ERROR: IPv4 connection to ${unit_ipv4}:${port} failed"
+		return 1
+	fi
+
+	echo "==> Probing exposed port ${port} over IPv6 (${unit_ipv6})"
+	if ! azure_probe_tcp_listener "${unit}" "ipv6" "${port}" "${unit_ipv6}"; then
+		azure_remove_tcp_listener "${unit}" || true
+		echo "ERROR: IPv6 connection to [${unit_ipv6}]:${port} failed"
+		return 1
+	fi
+
+	azure_remove_tcp_listener "${unit}" || \
+		echo "WARNING: could not remove the uploaded listener script on ${unit}"
+}
+
+test_expose_app_azure() {
+	if [ "$(skip 'test_expose_app_azure')" ]; then
+		echo "==> TEST SKIPPED: juju expose_app_azure"
+		return
+	fi
+
+	if [ "${BOOTSTRAP_PROVIDER}" != "azure" ]; then
+		echo "==> TEST SKIPPED: expose_app_azure tests, not using azure"
+		return
+	fi
+
+	if [ "$(az account list | yq -r 'length')" -lt 1 ]; then
+		echo "==> TEST SKIPPED: not logged in to Azure cloud"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_expose_app_azure" "$@"
+	)
+}

--- a/tests/suites/cloud_azure/expose_app.sh
+++ b/tests/suites/cloud_azure/expose_app.sh
@@ -33,31 +33,19 @@ assert_ingress_cidrs_for_exposed_app_azure() {
 	local app_name all_ports endpoint endpoint_ports
 	local bounds all_from all_to endpoint_from endpoint_to
 
-	if [ "$#" -lt 2 ] || [ "$#" -gt 4 ]; then
-		echo "ERROR: usage: assert_ingress_cidrs_for_exposed_app_azure <app> <all-ports> [<endpoint> <endpoint-ports>]" >&2
-		return 1
-	fi
+	_validate_port_args "assert_ingress_cidrs_for_exposed_app_azure" "$@" || return 1
 
 	app_name=${1:-}
 	all_ports=${2:-}
 	endpoint=${3:-}
 	endpoint_ports=${4:-}
-	if [ -z "${app_name}" ] || [ -z "${all_ports}" ]; then
-		echo "ERROR: application and all-endpoints port range are required" >&2
-		return 1
-	fi
-	if { [ -n "${endpoint}" ] && [ -z "${endpoint_ports}" ]; } || \
-		{ [ -z "${endpoint}" ] && [ -n "${endpoint_ports}" ]; }; then
-		echo "ERROR: endpoint and endpoint port range must be supplied together" >&2
-		return 1
-	fi
 
-	if ! bounds=$(azure_port_range_bounds "${all_ports}"); then
+	if ! bounds=$(port_range_bounds "${all_ports}"); then
 		return 1
 	fi
 	read -r all_from all_to <<< "${bounds}"
 	if [ -n "${endpoint}" ]; then
-		if ! bounds=$(azure_port_range_bounds "${endpoint_ports}"); then
+		if ! bounds=$(port_range_bounds "${endpoint_ports}"); then
 			return 1
 		fi
 		read -r endpoint_from endpoint_to <<< "${bounds}"
@@ -197,7 +185,7 @@ assert_dual_stack_reachability_for_exposed_app_azure() {
 		echo "ERROR: application and all-endpoints port range are required" >&2
 		return 1
 	fi
-	if ! bounds=$(azure_port_range_bounds "${all_ports}"); then
+	if ! bounds=$(port_range_bounds "${all_ports}"); then
 		return 1
 	fi
 	port=${bounds%% *}

--- a/tests/suites/cloud_azure/expose_app.sh
+++ b/tests/suites/cloud_azure/expose_app.sh
@@ -218,10 +218,6 @@ assert_dual_stack_reachability_for_exposed_app_azure() {
 		return 1
 	fi
 
-	if ! ip -6 route show default | grep -q .; then
-		echo "==> ERROR: no IPv6 egress on CI runner, cannot verify IPv6 reachability"
-		return 1
-	fi
 	if ! juju exec --unit "${unit}" -- "command -v python3" >/dev/null 2>&1; then
 		echo "ERROR: python3 is not available on ${unit}"
 		return 1
@@ -267,6 +263,12 @@ test_expose_app_azure() {
 	if [ "$(az account list | yq -r 'length')" -lt 1 ]; then
 		echo "==> TEST SKIPPED: not logged in to Azure cloud"
 		return
+	fi
+
+	# Require a global IPv6 address before attempting the probe.
+	if ! ip -6 -o addr show scope global | grep -q .; then
+		echo "==> ERROR: no global IPv6 address on CI runner, cannot verify IPv6 reachability"
+		return 1
 	fi
 
 	(

--- a/tests/suites/cloud_azure/helpers.sh
+++ b/tests/suites/cloud_azure/helpers.sh
@@ -1,14 +1,55 @@
 # Azure-specific helper functions used by the cloud_azure test suite.
 # Sourced automatically by run_test via import_subdir_files.
 
+# azure_resource_group_for_instance <instance_id> [<model_name>]
+#
+# Prints the resource group for the given Azure instance id, preferring a
+# scoped az vm show lookup when the (model-)configured resource-group-name
+# is known. Falls back to a subscription-wide az vm list search.
+azure_resource_group_for_instance() {
+	local instance_id=${1}
+	local model_name=${2:-}
+	local rg model_rg
+
+	rg=""
+	if [ -n "${model_name}" ]; then
+		model_rg=$(juju model-config -m "${model_name}" resource-group-name 2>/dev/null || true)
+	else
+		model_rg=$(juju model-config resource-group-name 2>/dev/null || true)
+	fi
+	if [ -n "${model_rg}" ] && [ "${model_rg}" != "null" ]; then
+		rg=$(az vm show --resource-group "${model_rg}" --name "${instance_id}" --query "resourceGroup" -o tsv 2>/dev/null || true)
+	fi
+	if [ -z "${rg}" ]; then
+		rg=$(az vm list -o yaml 2>/dev/null | yq -r ".[] | select(.name == \"${instance_id}\") | .resourceGroup")
+	fi
+
+	echo "${rg}"
+}
+
 # azure_first_model_instance prints "<instance_id> <resource_group>" for
-# the first machine of the current model, discovered via the az CLI.
+# the first machine of the current model, discovered via the az CLI. The
+# result is cached for the lifetime of the test process.
 azure_first_model_instance() {
+	if [ -n "${AZURE_MODEL_INSTANCE_ID:-}" ] && [ -n "${AZURE_MODEL_RG:-}" ]; then
+		echo "${AZURE_MODEL_INSTANCE_ID} ${AZURE_MODEL_RG}"
+		return 0
+	fi
+
 	local machine_id instance_id rg
 
 	machine_id=$(juju show-machine --format json | yq -r '.machines | keys | .[0]')
 	instance_id=$(juju show-machine "${machine_id}" --format json | yq -r ".machines[\"${machine_id}\"][\"instance-id\"]")
-	rg=$(az vm list -o yaml 2>/dev/null | yq -r ".[] | select(.name == \"${instance_id}\") | .resourceGroup")
+	rg=$(azure_resource_group_for_instance "${instance_id}")
+
+	if [ -z "${rg}" ]; then
+		echo "ERROR: could not find resource group for instance ${instance_id}" >&2
+		return 1
+	fi
+
+	AZURE_MODEL_INSTANCE_ID="${instance_id}"
+	AZURE_MODEL_RG="${rg}"
+	export AZURE_MODEL_INSTANCE_ID AZURE_MODEL_RG
 	echo "${instance_id} ${rg}"
 }
 
@@ -90,6 +131,8 @@ wait_for_azure_nsg_ingress_cidrs_for_port_range() {
 	exp_cidrs=${3}
 	cidr_type=${4}
 
+	# Normalize the expected CIDR order to match the sorted output from az.
+	exp_cidrs=$(printf '%s\n' "${exp_cidrs}" | tr ',' '\n' | sort | paste -sd, -)
 	read -r instance_id rg <<< "$(azure_first_model_instance)"
 	nsg_name=$(azure_nsg_name_for_instance "${rg}" "${instance_id}")
 
@@ -122,26 +165,6 @@ wait_for_azure_nsg_ingress_cidrs_for_port_range() {
 	fi
 
 	echo "[+] NSG rules for port range [${from_port}, ${to_port}] and CIDRs ${exp_cidrs} updated"
-}
-
-# azure_port_range_bounds <port-range>
-# Prints the numeric start and end ports. The protocol suffix is optional.
-azure_port_range_bounds() {
-	local port_range=${1:-}
-	local ports="${port_range%/*}"
-	local from=${ports} to=${ports}
-
-	if [[ ${ports} == *-* ]]; then
-		from=${ports%%-*}
-		to=${ports##*-}
-	fi
-
-	if ! [[ ${from} =~ ^[0-9]+$ && ${to} =~ ^[0-9]+$ ]] || (( from > to )); then
-		echo "ERROR: invalid port range: ${port_range}" >&2
-		return 1
-	fi
-
-	printf '%s %s\n' "${from}" "${to}"
 }
 
 # azure_upload_tcp_listener installs a one-shot HTTP listener script on a

--- a/tests/suites/cloud_azure/helpers.sh
+++ b/tests/suites/cloud_azure/helpers.sh
@@ -1,0 +1,288 @@
+# Azure-specific helper functions used by the cloud_azure test suite.
+# Sourced automatically by run_test via import_subdir_files.
+
+# azure_first_model_instance prints "<instance_id> <resource_group>" for
+# the first machine of the current model, discovered via the az CLI.
+azure_first_model_instance() {
+	local machine_id instance_id rg
+
+	machine_id=$(juju show-machine --format json | yq -r '.machines | keys | .[0]')
+	instance_id=$(juju show-machine "${machine_id}" --format json | yq -r ".machines[\"${machine_id}\"][\"instance-id\"]")
+	rg=$(az vm list -o yaml 2>/dev/null | yq -r ".[] | select(.name == \"${instance_id}\") | .resourceGroup")
+	echo "${instance_id} ${rg}"
+}
+
+# azure_nic_name_for_instance <resource_group> <instance_id>
+# Prints the name of the given instance's primary NIC.
+# On failure writes a diagnostic to stderr and returns non-zero.
+azure_nic_name_for_instance() {
+	local rg="${1}" instance_id="${2}"
+	local nic_name
+
+	nic_name=$(az network nic list --resource-group "${rg}" -o yaml 2>/dev/null | \
+		yq -r ".[] | select(.virtualMachine.id | downcase | contains(\"${instance_id}\")) | .name" | head -1)
+	if [ -z "${nic_name}" ]; then
+		echo "ERROR: no NIC found in resource group ${rg} for instance ${instance_id}" >&2
+		return 1
+	fi
+	echo "${nic_name}"
+}
+
+# azure_nic_private_addresses <resource_group> <instance_id>
+# Prints "<ipv4> <ipv6>" for the instance's primary NIC, mirroring the
+# azure provider's destination selection: the IPv4 address of the primary
+# IP configuration, and the address of the first IPv6 configuration
+# (empty when the machine is not dual-stack).
+azure_nic_private_addresses() {
+	local rg="${1}" instance_id="${2}"
+	local nic_name nic_yaml v4 v6
+
+	nic_name=$(azure_nic_name_for_instance "${rg}" "${instance_id}")
+	nic_yaml=$(az network nic show --resource-group "${rg}" --name "${nic_name}" -o yaml 2>/dev/null)
+	# Mirror the provider's destination selection: IPv4 from the primary
+	# IP configuration, IPv6 from the first IPv6 configuration.
+	v4=$(printf '%s\n' "${nic_yaml}" | yq -r '.ipConfigurations[] | select(.primary == true) | .privateIPAddress' | head -1)
+	v6=$(printf '%s\n' "${nic_yaml}" | yq -r '.ipConfigurations[].privateIPAddress | select(test(":"))' | head -1)
+	echo "${v4} ${v6}"
+}
+
+# azure_nsg_name_for_instance <resource_group> <instance_id>
+# Discovers the Azure NSG attached to the given instance's primary NIC.
+# Prefers the NIC-level NSG attachment, falling back to the NIC's subnet
+# when the NIC itself has no NSG (juju 4.x azure provider attaches
+# juju-internal-nsg at the subnet level rather than the NIC).
+# Prints the NSG name on stdout; on failure writes a diagnostic to stderr
+# and returns non-zero so the caller aborts loudly rather than silently.
+azure_nsg_name_for_instance() {
+	local rg="${1}" instance_id="${2}"
+	local nic_name nsg_id subnet_id
+
+	nic_name=$(azure_nic_name_for_instance "${rg}" "${instance_id}")
+	nsg_id=$(az network nic show --resource-group "${rg}" --name "${nic_name}" -o yaml 2>/dev/null | \
+		yq -r '.networkSecurityGroup.id // ""')
+	if [ -z "${nsg_id}" ]; then
+		subnet_id=$(az network nic show --resource-group "${rg}" --name "${nic_name}" -o yaml 2>/dev/null | \
+			yq -r '.ipConfigurations[] | select(.primary == true) | .subnet.id // ""' | head -1)
+		nsg_id=$(az network vnet subnet show --ids "${subnet_id}" -o yaml 2>/dev/null | \
+			yq -r '.networkSecurityGroup.id // ""')
+	fi
+	if [ -z "${nsg_id}" ]; then
+		echo "ERROR: no NSG found on NIC ${nic_name} or its subnet in resource group ${rg}" >&2
+		return 1
+	fi
+	echo "${nsg_id}" | yq -r 'split("/") | .[-1]'
+}
+
+# wait_for_azure_nsg_ingress_cidrs_for_port_range blocks until the expected
+# CIDRs are present in the Azure NSG rules for the specified port range and
+# address family (ipv4 or ipv6). It discovers the resource group and NSG
+# from the first machine in the current model via the az CLI.
+#
+# ```
+# wait_for_azure_nsg_ingress_cidrs_for_port_range <from_port> <to_port> \
+#     <expected_cidrs_csv> <cidr_type:ipv4|ipv6>
+# ```
+wait_for_azure_nsg_ingress_cidrs_for_port_range() {
+	local from_port to_port exp_cidrs cidr_type instance_id rg nsg_name port_range fam_re got_cidrs attempt
+
+	from_port=${1}
+	to_port=${2}
+	exp_cidrs=${3}
+	cidr_type=${4}
+
+	read -r instance_id rg <<< "$(azure_first_model_instance)"
+	nsg_name=$(azure_nsg_name_for_instance "${rg}" "${instance_id}")
+
+	port_range="${from_port}"
+	if [ "${from_port}" != "${to_port}" ]; then
+		port_range="${from_port}-${to_port}"
+	fi
+
+	fam_re="[.]"
+	if [ "${cidr_type}" = "ipv6" ]; then
+		fam_re=":"
+	fi
+
+	attempt=0
+	while [ "${attempt}" -lt 3 ]; do
+		echo "[+] (attempt ${attempt}) polling Azure NSG rules for ${port_range} ${cidr_type}"
+		got_cidrs=$(az network nsg rule list --resource-group "${rg}" --nsg-name "${nsg_name}" -o yaml 2>/dev/null | \
+			yq -r ".[] | select(.destinationPortRange == \"${port_range}\" and .access == \"Allow\" and .direction == \"Inbound\") | .sourceAddressPrefix | select(test(\"${fam_re}\"))" | sort | paste -sd, -)
+		if [ "${got_cidrs}" = "${exp_cidrs}" ]; then
+			break
+		fi
+		sleep "${SHORT_TIMEOUT}"
+		attempt=$((attempt + 1))
+	done
+
+	if [ "${got_cidrs}" != "${exp_cidrs}" ]; then
+		# shellcheck disable=SC2046
+		echo $(red "expected Azure NSG ${cidr_type} CIDRs for range [${from_port}, ${to_port}] to be:\n${exp_cidrs}\nGOT:\n${got_cidrs}")
+		exit 1
+	fi
+
+	echo "[+] NSG rules for port range [${from_port}, ${to_port}] and CIDRs ${exp_cidrs} updated"
+}
+
+# azure_port_range_bounds <port-range>
+# Prints the numeric start and end ports. The protocol suffix is optional.
+azure_port_range_bounds() {
+	local port_range=${1:-}
+	local ports="${port_range%/*}"
+	local from=${ports} to=${ports}
+
+	if [[ ${ports} == *-* ]]; then
+		from=${ports%%-*}
+		to=${ports##*-}
+	fi
+
+	if ! [[ ${from} =~ ^[0-9]+$ && ${to} =~ ^[0-9]+$ ]] || (( from > to )); then
+		echo "ERROR: invalid port range: ${port_range}" >&2
+		return 1
+	fi
+
+	printf '%s %s\n' "${from}" "${to}"
+}
+
+# azure_upload_tcp_listener installs a one-shot HTTP listener script on a
+# unit. The listener binds explicitly to one address family and writes a
+# marker after bind/listen succeeds.
+azure_upload_tcp_listener() {
+	local unit=${1}
+	local listener_script_b64
+
+	listener_script_b64=$(base64 --wrap=0 <<'PYEOF'
+import socket
+import sys
+
+family = sys.argv[1]
+port = int(sys.argv[2])
+ready_path = sys.argv[3]
+
+if family == "ipv4":
+    address_family = socket.AF_INET
+    bind_address = "0.0.0.0"
+elif family == "ipv6":
+    address_family = socket.AF_INET6
+    bind_address = "::"
+else:
+    raise ValueError(f"unsupported address family: {family}")
+
+with socket.socket(address_family, socket.SOCK_STREAM) as server:
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if address_family == socket.AF_INET6:
+        server.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+    server.bind((bind_address, port))
+    server.listen(1)
+    with open(ready_path, "w", encoding="ascii"):
+        pass
+    connection, _ = server.accept()
+    with connection:
+        connection.recv(4096)
+        connection.sendall(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Length: 2\r\n"
+            b"Connection: close\r\n"
+            b"\r\n"
+            b"ok"
+        )
+PYEOF
+	)
+
+	juju exec --unit "${unit}" -- \
+		"printf '%s' '${listener_script_b64}' | base64 -d > /tmp/juju-expose-app-listener.py && chmod 700 /tmp/juju-expose-app-listener.py"
+}
+
+# azure_start_tcp_listener starts the bounded listener for one address family.
+azure_start_tcp_listener() {
+	local unit=${1} family=${2} port=${3}
+	local ready_file pid_file
+
+	ready_file="/tmp/juju-expose-app-listener-${family}-${port}.ready"
+	pid_file="/tmp/juju-expose-app-listener-${family}-${port}.pid"
+
+	juju exec --unit "${unit}" -- \
+		"rm -f ${ready_file} ${pid_file}; nohup timeout 30 python3 /tmp/juju-expose-app-listener.py ${family} ${port} ${ready_file} </dev/null >/dev/null 2>&1 & echo \$! > ${pid_file}"
+}
+
+# azure_wait_for_tcp_listener waits for the listener's bind marker without
+# opening a connection that would consume its one-shot accept.
+azure_wait_for_tcp_listener() {
+	local unit=${1} family=${2} port=${3}
+	local ready_file attempt
+
+	ready_file="/tmp/juju-expose-app-listener-${family}-${port}.ready"
+	attempt=0
+	while [ "${attempt}" -lt 10 ]; do
+		if juju exec --unit "${unit}" -- "test -f ${ready_file}" >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 1
+		attempt=$((attempt + 1))
+	done
+	return 1
+}
+
+# azure_stop_tcp_listener terminates the bounded listener and removes its
+# marker and PID files without matching unrelated processes by name.
+azure_stop_tcp_listener() {
+	local unit=${1} family=${2} port=${3}
+	local ready_file pid_file
+
+	ready_file="/tmp/juju-expose-app-listener-${family}-${port}.ready"
+	pid_file="/tmp/juju-expose-app-listener-${family}-${port}.pid"
+
+	juju exec --unit "${unit}" -- \
+		"if [ -r ${pid_file} ]; then kill \$(cat ${pid_file}) 2>/dev/null || true; fi; rm -f ${pid_file} ${ready_file}"
+}
+
+# azure_probe_tcp_listener retries a fresh one-shot listener while the
+# firewaller propagates the final expose rule.
+azure_probe_tcp_listener() {
+	local unit=${1} family=${2} port=${3} address=${4}
+	local url curl_family probe_out attempt max_attempts
+
+	case ${family} in
+	ipv4)
+		url="http://${address}:${port}/"
+		curl_family="--ipv4"
+		;;
+	ipv6)
+		url="http://[${address}]:${port}/"
+		curl_family="--ipv6"
+		;;
+	*)
+		echo "ERROR: unsupported address family: ${family}" >&2
+		return 1
+		;;
+	esac
+
+	attempt=0
+	max_attempts=6
+	while [ "${attempt}" -lt "${max_attempts}" ]; do
+		if azure_start_tcp_listener "${unit}" "${family}" "${port}" && \
+			azure_wait_for_tcp_listener "${unit}" "${family}" "${port}"; then
+			if probe_out=$(curl --fail --silent --show-error --noproxy '*' \
+				"${curl_family}" --max-time 5 "${url}" 2>&1); then
+				if printf '%s\n' "${probe_out}" | grep -q "ok"; then
+					azure_stop_tcp_listener "${unit}" "${family}" "${port}" || true
+					return 0
+				fi
+			fi
+		fi
+		azure_stop_tcp_listener "${unit}" "${family}" "${port}" || true
+		attempt=$((attempt + 1))
+		if [ "${attempt}" -lt "${max_attempts}" ]; then
+			sleep 1
+		fi
+	done
+	return 1
+}
+
+# azure_remove_tcp_listener removes the uploaded listener script.
+azure_remove_tcp_listener() {
+	local unit=${1}
+
+	juju exec --unit "${unit}" -- \
+		'rm -f /tmp/juju-expose-app-listener.py'
+}

--- a/tests/suites/cloud_azure/helpers.sh
+++ b/tests/suites/cloud_azure/helpers.sh
@@ -61,7 +61,7 @@ azure_nic_name_for_instance() {
 	local nic_name
 
 	nic_name=$(az network nic list --resource-group "${rg}" -o yaml 2>/dev/null | \
-		yq -r ".[] | select(.virtualMachine.id | downcase | contains(\"${instance_id}\")) | .name" | head -1)
+		yq -r ".[] | select(((.virtualMachine.id // \"\") | downcase | split(\"/\") | .[-1]) == (\"${instance_id}\" | downcase)) | .name" | head -1)
 	if [ -z "${nic_name}" ]; then
 		echo "ERROR: no NIC found in resource group ${rg} for instance ${instance_id}" >&2
 		return 1
@@ -147,7 +147,7 @@ wait_for_azure_nsg_ingress_cidrs_for_port_range() {
 	fi
 
 	attempt=0
-	while [ "${attempt}" -lt 3 ]; do
+	while [ "${attempt}" -lt 12 ]; do
 		echo "[+] (attempt ${attempt}) polling Azure NSG rules for ${port_range} ${cidr_type}"
 		got_cidrs=$(az network nsg rule list --resource-group "${rg}" --nsg-name "${nsg_name}" -o yaml 2>/dev/null | \
 			yq -r ".[] | select(.destinationPortRange == \"${port_range}\" and .access == \"Allow\" and .direction == \"Inbound\") | .sourceAddressPrefix | select(test(\"${fam_re}\"))" | sort | paste -sd, -)

--- a/tests/suites/cloud_azure/ip_family.sh
+++ b/tests/suites/cloud_azure/ip_family.sh
@@ -2,11 +2,9 @@ run_ip_family_dual_stack() {
 	(
 		log_file="${TEST_DIR}/ip-family-dual.log"
 
-		# The SSH reachability probes below require IPv6 egress on the CI
-		# runner; fail fast instead of paying for an Azure bootstrap that
-		# cannot be fully verified.
-		if ! ip -6 route show default | grep -q .; then
-			echo "==> ERROR: no IPv6 egress on CI runner, cannot verify SSH reachability"
+		# Require a global IPv6 address before attempting the probe.
+		if ! ip -6 -o addr show scope global | grep -q .; then
+			echo "==> ERROR: no global IPv6 address on CI runner, cannot verify IPv6 reachability"
 			return 1
 		fi
 

--- a/tests/suites/cloud_azure/storage_account_type.sh
+++ b/tests/suites/cloud_azure/storage_account_type.sh
@@ -34,7 +34,7 @@ check_storage_account_type_controller() {
 		echo "ERROR: could not determine controller instance-id for ${controller_name}" >>"${file}"
 		return 1
 	else
-		controller_resource_group=$(az vm list -o yaml 2>/dev/null | yq -r ".[] | select(.name == \"${controller_instance_id}\") | .resourceGroup" 2>/dev/null || true)
+		controller_resource_group=$(azure_resource_group_for_instance "${controller_instance_id}" "controller" 2>/dev/null || true)
 		if [[ -z ${controller_resource_group} || ${controller_resource_group} == "null" ]]; then
 			echo "ERROR: could not find resource group for controller instance-id ${controller_instance_id}" >>"${file}"
 			return 1
@@ -124,7 +124,7 @@ check_storage_account_type_controller() {
 		fi
 
 		# Retrieve the resource group using the instance id.
-		rg=$(az vm list -o yaml 2>/dev/null | yq -r ".[] | select(.name == \"${iid}\") | .resourceGroup" 2>/dev/null || true)
+		rg=$(azure_resource_group_for_instance "${iid}" 2>/dev/null || true)
 		if [[ -z ${rg} || ${rg} == "null" ]]; then
 			echo "ERROR: could not find resource group for instance-id ${iid}" >>"${file}"
 			return 1

--- a/tests/suites/cloud_azure/task.sh
+++ b/tests/suites/cloud_azure/task.sh
@@ -18,4 +18,5 @@ test_cloud_azure() {
 	test_managed_identity
 	test_storage_account_type
 	test_ip_family
+	test_expose_app_azure
 }

--- a/tests/suites/firewall/expose_app.sh
+++ b/tests/suites/firewall/expose_app.sh
@@ -10,38 +10,12 @@ run_expose_app_ec2() {
 	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
 	# Open ports and verify hook tool behavior
-	assert_opened_ports_output
+	assert_opened_ports_output "ubuntu-lite" "1337-1339/tcp" "ubuntu" "1234/tcp"
 
 	# Ensure that CIDRs are correctly generated
 	assert_ingress_cidrs_for_exposed_app
 
 	destroy_model "expose-app"
-}
-
-assert_opened_ports_output() {
-	echo "==> Checking open/opened-ports hook tools work as expected"
-
-	juju exec --unit ubuntu-lite/0 "open-port 1337-1339/tcp"
-	juju exec --unit ubuntu-lite/0 "open-port 1234/tcp --endpoints ubuntu"
-
-	# Test the backwards-compatible version of opened-ports where the output
-	# includes the unique set of opened ports for all endpoints.
-	exp="1234/tcp 1337-1339/tcp"
-	got=$(juju_exec_output --unit ubuntu-lite/0 "opened-ports" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
-	if [ "$got" != "$exp" ]; then
-		# shellcheck disable=SC2046
-		echo $(red "expected opened-ports output to be:\n${exp}\nGOT:\n${got}")
-		exit 1
-	fi
-
-	# Try the new version where we group by endpoint.
-	exp="1234/tcp (ubuntu) 1337-1339/tcp (*)"
-	got=$(juju_exec_output --unit ubuntu-lite/0 "opened-ports --endpoints" | tr '\n' ' ' | sed -e 's/[[:space:]]*$//')
-	if [ "$got" != "$exp" ]; then
-		# shellcheck disable=SC2046
-		echo $(red "expected opened-ports output when using --endpoints to be:\n${exp}\nGOT:\n${got}")
-		exit 1
-	fi
 }
 
 assert_ingress_cidrs_for_exposed_app() {


### PR DESCRIPTION
Add Azure expose CI tests for ipV4 and ipV6.

Add a test which deploy an application on azure, expose it through custom port and cidr, and verify reachability in various condition.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
$ cd tests
$ ./main.sh -p azure cloud_azure test_expose_app_azure
```

## Documentation changes

Test-only CI helper refactor; no CLI, API, or user workflow documentation changes.

## Links

**Jira card:** [JUJU-9972](https://warthogs.atlassian.net/browse/JUJU-9972)


[JUJU-9972]: https://warthogs.atlassian.net/browse/JUJU-9972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ