### PR TITLE
feat(sshserver): add machine handlers

### DIFF
--- a/internal/worker/sshserver/handlers/machine/doc.go
+++ b/internal/worker/sshserver/handlers/machine/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package machine provides SSH handlers for machine and machine-unit targets.
+// It is used by the SSH proxy to route SSH sessions, local forwarding,
+// and SFTP requests to the appropriate machine target.
+package machine

--- a/internal/worker/sshserver/handlers/machine/machine.go
+++ b/internal/worker/sshserver/handlers/machine/machine.go
@@ -1,7 +1,6 @@
 // Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Package machine provides SSH handlers for machine and machine-unit targets.
 package machine
 
 import (

--- a/internal/worker/sshserver/handlers/machine/machine.go
+++ b/internal/worker/sshserver/handlers/machine/machine.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package machine provides SSH handlers for machine and machine-unit targets.
+package machine
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/virtualhostname"
+)
+
+// SSHConnector establishes SSH clients to machine targets.
+type SSHConnector interface {
+	// Connect establishes an SSH client to the given target.
+	// If the target is not a machine or machine unit, an error is returned.
+	Connect(context.Context, virtualhostname.Info) (*gossh.Client, error)
+}
+
+// Handlers provides SSH channel handlers for a machine target.
+type Handlers struct {
+	connector   SSHConnector
+	logger      logger.Logger
+	destination virtualhostname.Info
+}
+
+// NewHandlers returns handlers for a machine or machine-unit target.
+func NewHandlers(destination virtualhostname.Info, connector SSHConnector, logger logger.Logger) (*Handlers, error) {
+	if connector == nil {
+		return nil, errors.New("connector is required")
+	}
+	if logger == nil {
+		return nil, errors.New("logger is required")
+	}
+	if destination.Target() != virtualhostname.MachineTarget &&
+		destination.Target() != virtualhostname.UnitTarget {
+		return nil, errors.New("destination must be a machine or unit target")
+	}
+	return &Handlers{
+		connector:   connector,
+		logger:      logger,
+		destination: destination,
+	}, nil
+}

--- a/internal/worker/sshserver/handlers/machine/machine_test.go
+++ b/internal/worker/sshserver/handlers/machine/machine_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/juju/tc"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/juju/juju/core/virtualhostname"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type machineSuite struct{}
+
+func TestMachineSuite(t *testing.T) {
+	tc.Run(t, &machineSuite{})
+}
+
+func (s *machineSuite) TestNewHandlers(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	handlers, err := NewHandlers(destination, stubConnector{}, loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(handlers.destination, tc.Equals, destination)
+
+	_, err = NewHandlers(destination, nil, loggertesting.WrapCheckLog(c))
+	c.Check(err, tc.ErrorMatches, "connector is required")
+
+	_, err = NewHandlers(destination, stubConnector{}, nil)
+	c.Check(err, tc.ErrorMatches, "logger is required")
+
+	container, err := virtualhostname.NewInfoContainerTarget("8419cd78-4993-4c3a-928e-c646226beeee", "app/0", "workload")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = NewHandlers(container, stubConnector{}, loggertesting.WrapCheckLog(c))
+	c.Check(err, tc.ErrorMatches, "destination must be a machine or unit target")
+}
+
+type stubConnector struct{}
+
+func (stubConnector) Connect(context.Context, virtualhostname.Info) (*gossh.Client, error) {
+	return nil, nil
+}

--- a/internal/worker/sshserver/handlers/machine/portforward.go
+++ b/internal/worker/sshserver/handlers/machine/portforward.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"sync"
+
+	"github.com/gliderlabs/ssh"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+type localForwardChannelData struct {
+	DestAddr   string
+	DestPort   uint32
+	OriginAddr string
+	OriginPort uint32
+}
+
+type halfCloseConn interface {
+	net.Conn
+	CloseWrite() error
+}
+
+// DirectTCPIPHandler returns a handler for the DirectTCPIP channel type.
+// This handler is used for local port forwarding. While the handler is similar
+// to the default DirectTCPIPHandler, it first connects to the target machine
+// machine and proxies the port forwarding request through the machine's SSH server.
+func (h *Handlers) DirectTCPIPHandler() ssh.ChannelHandler {
+	return func(_ *ssh.Server, _ *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
+		data := localForwardChannelData{}
+		if err := gossh.Unmarshal(newChan.ExtraData(), &data); err != nil {
+			_ = newChan.Reject(gossh.ConnectionFailed, "parsing forward data: "+err.Error())
+			return
+		}
+
+		client, err := h.connector.Connect(ctx, h.destination)
+		if err != nil {
+			_ = newChan.Reject(gossh.ConnectionFailed, fmt.Sprintf("connecting to machine: %v", err))
+			return
+		}
+		defer client.Close()
+
+		destination := net.JoinHostPort(data.DestAddr, strconv.FormatUint(uint64(data.DestPort), 10))
+		connection, err := client.DialContext(ctx, "tcp", destination)
+		if err != nil {
+			_ = newChan.Reject(gossh.ConnectionFailed, fmt.Sprintf("dialling target: %v", err))
+			return
+		}
+
+		halfCloseConnection, ok := connection.(halfCloseConn)
+		if !ok {
+			_ = connection.Close()
+			_ = newChan.Reject(gossh.ConnectionFailed, "target connection does not support half-close")
+			return
+		}
+
+		channel, requests, err := newChan.Accept()
+		if err != nil {
+			_ = connection.Close()
+			return
+		}
+		defer channel.Close()
+		defer halfCloseConnection.Close()
+
+		stop := context.AfterFunc(ctx, func() {
+			_ = channel.Close()
+			_ = halfCloseConnection.Close()
+		})
+		defer stop()
+
+		go gossh.DiscardRequests(requests)
+		proxy(channel, halfCloseConnection)
+	}
+}
+
+func proxy(channel gossh.Channel, connection halfCloseConn) {
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		_, _ = io.Copy(channel, connection)
+		_ = channel.CloseWrite()
+	})
+	wg.Go(func() {
+		_, _ = io.Copy(connection, channel)
+		_ = connection.CloseWrite()
+	})
+	wg.Wait()
+}

--- a/internal/worker/sshserver/handlers/machine/portforward.go
+++ b/internal/worker/sshserver/handlers/machine/portforward.go
@@ -37,12 +37,14 @@ func (h *Handlers) DirectTCPIPHandler() ssh.ChannelHandler {
 	return func(_ *ssh.Server, _ *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
 		var data localForwardChannelData
 		if err := gossh.Unmarshal(newChan.ExtraData(), &data); err != nil {
+			h.logger.Debugf(ctx, "failed to parse local forward channel data: %v", err)
 			_ = newChan.Reject(gossh.ConnectionFailed, "parsing forward data: "+err.Error())
 			return
 		}
 
 		client, err := h.connector.Connect(ctx, h.destination)
 		if err != nil {
+			h.logger.Debugf(ctx, "failed to connect to machine: %v", err)
 			_ = newChan.Reject(gossh.ConnectionFailed, fmt.Sprintf("connecting to machine: %v", err))
 			return
 		}
@@ -51,12 +53,14 @@ func (h *Handlers) DirectTCPIPHandler() ssh.ChannelHandler {
 		destination := net.JoinHostPort(data.DestAddr, strconv.FormatUint(uint64(data.DestPort), 10))
 		connection, err := client.DialContext(ctx, "tcp", destination)
 		if err != nil {
+			h.logger.Debugf(ctx, "failed to dial target %q: %v", destination, err)
 			_ = newChan.Reject(gossh.ConnectionFailed, fmt.Sprintf("dialling target: %v", err))
 			return
 		}
 
 		halfCloseConnection, ok := connection.(halfCloseConn)
 		if !ok {
+			h.logger.Debugf(ctx, "target connection does not support half-close")
 			_ = connection.Close()
 			_ = newChan.Reject(gossh.ConnectionFailed, "target connection does not support half-close")
 			return
@@ -64,6 +68,7 @@ func (h *Handlers) DirectTCPIPHandler() ssh.ChannelHandler {
 
 		channel, requests, err := newChan.Accept()
 		if err != nil {
+			h.logger.Debugf(ctx, "failed to accept channel: %v", err)
 			_ = connection.Close()
 			return
 		}

--- a/internal/worker/sshserver/handlers/machine/portforward.go
+++ b/internal/worker/sshserver/handlers/machine/portforward.go
@@ -5,13 +5,12 @@ package machine
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net"
 	"strconv"
-	"sync"
 
 	"github.com/gliderlabs/ssh"
+	"github.com/juju/errors"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -30,9 +29,9 @@ type halfCloseConn interface {
 }
 
 // DirectTCPIPHandler returns a handler for the DirectTCPIP channel type.
-// This handler is used for local port forwarding. While the handler is similar
-// to the default DirectTCPIPHandler, it first connects to the target machine
-// machine and proxies the port forwarding request through the machine's SSH server.
+// This handler is used for local port forwarding. The newChan is the user's
+// SSH channel to the controller, and the handler will create a new connection
+// to the target machine and proxy data between the two connections.
 func (h *Handlers) DirectTCPIPHandler() ssh.ChannelHandler {
 	return func(_ *ssh.Server, _ *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
 		var data localForwardChannelData
@@ -42,59 +41,45 @@ func (h *Handlers) DirectTCPIPHandler() ssh.ChannelHandler {
 			return
 		}
 
-		client, err := h.connector.Connect(ctx, h.destination)
-		if err != nil {
-			h.logger.Debugf(ctx, "failed to connect to machine: %v", err)
-			_ = newChan.Reject(gossh.ConnectionFailed, fmt.Sprintf("connecting to machine: %v", err))
-			return
-		}
-		defer client.Close()
-
 		destination := net.JoinHostPort(data.DestAddr, strconv.FormatUint(uint64(data.DestPort), 10))
-		connection, err := client.DialContext(ctx, "tcp", destination)
-		if err != nil {
-			h.logger.Debugf(ctx, "failed to dial target %q: %v", destination, err)
-			_ = newChan.Reject(gossh.ConnectionFailed, fmt.Sprintf("dialling target: %v", err))
-			return
-		}
+		accepted := false
+		handleProxy(h, ctx, proxyConfig[halfCloseConn]{
+			createRemote: func(ctx context.Context, client *gossh.Client) (halfCloseConn, error) {
+				connection, err := client.DialContext(ctx, "tcp", destination)
+				if err != nil {
+					return nil, err
+				}
+				halfCloseConnection, ok := connection.(halfCloseConn)
+				if !ok {
+					_ = connection.Close()
+					return nil, errors.New("target connection does not support half-close")
+				}
 
-		halfCloseConnection, ok := connection.(halfCloseConn)
-		if !ok {
-			h.logger.Debugf(ctx, "target connection does not support half-close")
-			_ = connection.Close()
-			_ = newChan.Reject(gossh.ConnectionFailed, "target connection does not support half-close")
-			return
-		}
+				return halfCloseConnection, nil
+			},
+			run: func(remote halfCloseConn) error {
+				channel, requests, err := newChan.Accept()
+				if err != nil {
+					return err
+				}
+				accepted = true
+				stop := context.AfterFunc(ctx, func() {
+					_ = channel.Close()
+				})
+				defer stop()
 
-		channel, requests, err := newChan.Accept()
-		if err != nil {
-			h.logger.Debugf(ctx, "failed to accept channel: %v", err)
-			_ = connection.Close()
-			return
-		}
-		defer channel.Close()
-		defer halfCloseConnection.Close()
-
-		stop := context.AfterFunc(ctx, func() {
-			_ = channel.Close()
-			_ = halfCloseConnection.Close()
+				go gossh.DiscardRequests(requests)
+				proxyStreams(channel, remote)
+				_ = channel.Close()
+				return nil
+			},
+			onError: func(err error) {
+				h.logger.Debugf(ctx, "machine proxy failure: %v", err)
+				if accepted {
+					return
+				}
+				_ = newChan.Reject(gossh.ConnectionFailed, err.Error())
+			},
 		})
-		defer stop()
-
-		go gossh.DiscardRequests(requests)
-		proxy(channel, halfCloseConnection)
 	}
-}
-
-func proxy(channel gossh.Channel, connection halfCloseConn) {
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		_, _ = io.Copy(channel, connection)
-		_ = channel.CloseWrite()
-	})
-	wg.Go(func() {
-		_, _ = io.Copy(connection, channel)
-		_ = connection.CloseWrite()
-	})
-	wg.Wait()
 }

--- a/internal/worker/sshserver/handlers/machine/portforward.go
+++ b/internal/worker/sshserver/handlers/machine/portforward.go
@@ -15,6 +15,8 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 )
 
+// localForwardChannelData mirrors the unexported
+// gossh.localForwardChannelData from x/crypto/ssh.
 type localForwardChannelData struct {
 	DestAddr   string
 	DestPort   uint32
@@ -23,7 +25,7 @@ type localForwardChannelData struct {
 }
 
 type halfCloseConn interface {
-	net.Conn
+	io.ReadWriteCloser
 	CloseWrite() error
 }
 
@@ -33,7 +35,7 @@ type halfCloseConn interface {
 // machine and proxies the port forwarding request through the machine's SSH server.
 func (h *Handlers) DirectTCPIPHandler() ssh.ChannelHandler {
 	return func(_ *ssh.Server, _ *gossh.ServerConn, newChan gossh.NewChannel, ctx ssh.Context) {
-		data := localForwardChannelData{}
+		var data localForwardChannelData
 		if err := gossh.Unmarshal(newChan.ExtraData(), &data); err != nil {
 			_ = newChan.Reject(gossh.ConnectionFailed, "parsing forward data: "+err.Error())
 			return

--- a/internal/worker/sshserver/handlers/machine/portforward.go
+++ b/internal/worker/sshserver/handlers/machine/portforward.go
@@ -42,7 +42,11 @@ func (h *Handlers) DirectTCPIPHandler() ssh.ChannelHandler {
 		}
 
 		destination := net.JoinHostPort(data.DestAddr, strconv.FormatUint(uint64(data.DestPort), 10))
+
+		// Delay accepting the channel until we have successfully connected to the target
+		// machine so that we can send the user an error message if the connection fails.
 		accepted := false
+
 		handleProxy(h, ctx, proxyConfig[halfCloseConn]{
 			createRemote: func(ctx context.Context, client *gossh.Client) (halfCloseConn, error) {
 				connection, err := client.DialContext(ctx, "tcp", destination)
@@ -62,6 +66,8 @@ func (h *Handlers) DirectTCPIPHandler() ssh.ChannelHandler {
 				if err != nil {
 					return err
 				}
+				defer channel.Close()
+
 				accepted = true
 				stop := context.AfterFunc(ctx, func() {
 					_ = channel.Close()
@@ -70,7 +76,6 @@ func (h *Handlers) DirectTCPIPHandler() ssh.ChannelHandler {
 
 				go gossh.DiscardRequests(requests)
 				proxyStreams(channel, remote)
-				_ = channel.Close()
 				return nil
 			},
 			onError: func(err error) {

--- a/internal/worker/sshserver/handlers/machine/portforward_test.go
+++ b/internal/worker/sshserver/handlers/machine/portforward_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/juju/tc"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/juju/juju/core/virtualhostname"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+func (s *machineSuite) TestDirectTCPIPHandler(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	machine := startSSHTestServer(c, &ssh.Server{ChannelHandlers: map[string]ssh.ChannelHandler{
+		"direct-tcpip": func(_ *ssh.Server, _ *gossh.ServerConn, channel gossh.NewChannel, _ ssh.Context) {
+			connection, requests, err := channel.Accept()
+			if err != nil {
+				return
+			}
+			defer connection.Close()
+			go gossh.DiscardRequests(requests)
+			_, _ = connection.Write([]byte("Hello world"))
+		},
+	}})
+
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{
+		LocalPortForwardingCallback: func(ssh.Context, string, uint32) bool { return true },
+		ChannelHandlers: map[string]ssh.ChannelHandler{
+			"direct-tcpip": handlers.DirectTCPIPHandler(),
+		},
+	})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+	defer client.Close()
+
+	connection, err := client.Dial("tcp", "localhost:8080")
+	c.Assert(err, tc.ErrorIsNil)
+	defer connection.Close()
+
+	response, err := io.ReadAll(connection)
+
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(response, tc.DeepEquals, []byte("Hello world"))
+}
+
+func (s *machineSuite) TestDirectTCPIPHandlerPreservesHalfClose(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	machine := startSSHTestServer(c, &ssh.Server{ChannelHandlers: map[string]ssh.ChannelHandler{
+		"direct-tcpip": func(_ *ssh.Server, _ *gossh.ServerConn, channel gossh.NewChannel, _ ssh.Context) {
+			connection, requests, err := channel.Accept()
+			if err != nil {
+				return
+			}
+			defer connection.Close()
+			go gossh.DiscardRequests(requests)
+
+			request, err := io.ReadAll(connection)
+			if err != nil {
+				return
+			}
+			_, _ = connection.Write(append([]byte("response: "), request...))
+		},
+	}})
+
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{
+		LocalPortForwardingCallback: func(ssh.Context, string, uint32) bool { return true },
+		ChannelHandlers: map[string]ssh.ChannelHandler{
+			"direct-tcpip": handlers.DirectTCPIPHandler(),
+		},
+	})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+	defer client.Close()
+
+	connection, err := client.Dial("tcp", "localhost:8080")
+	c.Assert(err, tc.ErrorIsNil)
+	defer connection.Close()
+
+	_, err = connection.Write([]byte("request"))
+	c.Assert(err, tc.ErrorIsNil)
+	closeWriter, ok := connection.(interface{ CloseWrite() error })
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(closeWriter.CloseWrite(), tc.ErrorIsNil)
+
+	response, err := io.ReadAll(connection)
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(response, tc.DeepEquals, []byte("response: request"))
+}
+
+func (s *machineSuite) TestDirectTCPIPHandlerReportsConnectionFailure(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	handlers, err := NewHandlers(destination, connectorFunc(func(context.Context, virtualhostname.Info) (*gossh.Client, error) {
+		return nil, errors.New("connection failed")
+	}), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{
+		LocalPortForwardingCallback: func(ssh.Context, string, uint32) bool { return true },
+		ChannelHandlers: map[string]ssh.ChannelHandler{
+			"direct-tcpip": handlers.DirectTCPIPHandler(),
+		},
+	})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+	defer client.Close()
+
+	_, err = client.Dial("tcp", "localhost:8080")
+
+	c.Check(err, tc.ErrorMatches, `ssh: rejected: connect failed \(connecting to machine: connection failed\)`)
+}

--- a/internal/worker/sshserver/handlers/machine/portforward_test.go
+++ b/internal/worker/sshserver/handlers/machine/portforward_test.go
@@ -128,5 +128,5 @@ func (s *machineSuite) TestDirectTCPIPHandlerReportsConnectionFailure(c *tc.C) {
 
 	_, err = client.Dial("tcp", "localhost:8080")
 
-	c.Check(err, tc.ErrorMatches, `ssh: rejected: connect failed \(connecting to machine: connection failed\)`)
+	c.Check(err, tc.ErrorMatches, `ssh: rejected: connect failed \(failed to connect to machine: connection failed\)`)
 }

--- a/internal/worker/sshserver/handlers/machine/proxy.go
+++ b/internal/worker/sshserver/handlers/machine/proxy.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/juju/errors"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+type proxyConfig[T io.Closer] struct {
+	// createRemote takes an SSH connection to a remote machine and
+	//  returns a protocol specific object for proxying the user's request.
+	createRemote func(context.Context, *gossh.Client) (T, error)
+	// run performs the handler-specific proxy operation.
+	run func(T) error
+	// onError handles errors produced during the proxy lifecycle.
+	onError func(error)
+}
+
+// handleProxy is a generic helper for implementing SSH handlers that proxy to a remote machine.
+// It performs the following steps:
+// 1. Establishes an SSH connection to the target machine.
+// 2. Creates a protocol-specific object for proxying the user's request.
+// 3. Runs the handler-specific proxy operation.
+// 4. Handles any errors that occur during the proxy lifecycle.
+func handleProxy[T io.Closer](h *Handlers, ctx context.Context, cfg proxyConfig[T]) {
+	client, err := h.connector.Connect(ctx, h.destination)
+	if err != nil {
+		cfg.onError(errors.Annotate(err, "failed to connect to machine"))
+		return
+	}
+	defer client.Close()
+
+	remote, err := cfg.createRemote(ctx, client)
+	if err != nil {
+		cfg.onError(errors.Annotate(err, "failed to create remote proxy"))
+		return
+	}
+	defer remote.Close()
+
+	// Tear down both connections when the context is done.
+	// This context is the user's SSH connection context, so when
+	// the user disconnects, we will close the connection to the machine.
+	stop := context.AfterFunc(ctx, func() {
+		_ = client.Close()
+		_ = remote.Close()
+	})
+	defer stop()
+
+	if err := cfg.run(remote); err != nil {
+		cfg.onError(err)
+	}
+}
+
+func (h *Handlers) handleError(session ssh.Session, err error) {
+	h.logger.Errorf(session.Context(), "machine proxy failure: %v", err)
+	_, _ = session.Stderr().Write([]byte(err.Error() + "\n"))
+
+	var exitErr *gossh.ExitError
+	if errors.As(err, &exitErr) {
+		_ = session.Exit(exitErr.ExitStatus())
+		return
+	}
+	_ = session.Exit(1)
+}
+
+// proxyStreams proxies data between two streams and attempts
+// to close the write side of each stream when there is no more
+// data to read from the other stream.
+// See https://github.com/golang/go/issues/35892 for a scenario
+// where this is relevant.
+func proxyStreams(left, right io.ReadWriteCloser) {
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		_, _ = io.Copy(left, right)
+		closeWrite(left)
+	})
+	wg.Go(func() {
+		_, _ = io.Copy(right, left)
+		closeWrite(right)
+	})
+	wg.Wait()
+}
+
+func closeWrite(closer io.ReadWriteCloser) {
+	if halfCloser, ok := closer.(interface{ CloseWrite() error }); ok {
+		_ = halfCloser.CloseWrite()
+		return
+	}
+	_ = closer.Close()
+}

--- a/internal/worker/sshserver/handlers/machine/proxy.go
+++ b/internal/worker/sshserver/handlers/machine/proxy.go
@@ -13,6 +13,9 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 )
 
+// proxyConfig provides an abstraction around an SSH proxy
+// handler to ensure consistent connection management,
+// error handling, logging and eventually monitoring.
 type proxyConfig[T io.Closer] struct {
 	// createRemote takes an SSH connection to a remote machine and
 	//  returns a protocol specific object for proxying the user's request.

--- a/internal/worker/sshserver/handlers/machine/session.go
+++ b/internal/worker/sshserver/handlers/machine/session.go
@@ -16,6 +16,12 @@ func (h *Handlers) SessionHandler(session ssh.Session) {
 	handleError := func(err error) {
 		h.logger.Errorf(session.Context(), "machine session proxy failure: %v", err)
 		_, _ = session.Stderr().Write([]byte(err.Error() + "\n"))
+
+		var exitErr *gossh.ExitError
+		if errors.As(err, &exitErr) {
+			_ = session.Exit(exitErr.ExitStatus())
+			return
+		}
 		_ = session.Exit(1)
 	}
 

--- a/internal/worker/sshserver/handlers/machine/session.go
+++ b/internal/worker/sshserver/handlers/machine/session.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"context"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/juju/errors"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// SessionHandler proxies a shell or command session to the target machine.
+func (h *Handlers) SessionHandler(session ssh.Session) {
+	handleError := func(err error) {
+		h.logger.Errorf(session.Context(), "machine session proxy failure: %v", err)
+		_, _ = session.Stderr().Write([]byte(err.Error() + "\n"))
+		_ = session.Exit(1)
+	}
+
+	client, err := h.connector.Connect(session.Context(), h.destination)
+	if err != nil {
+		handleError(errors.Annotate(err, "connecting to machine"))
+		return
+	}
+	defer client.Close()
+	stop := context.AfterFunc(session.Context(), func() {
+		_ = client.Close()
+	})
+	defer stop()
+
+	machineSession, err := client.NewSession()
+	if err != nil {
+		handleError(errors.Annotate(err, "creating SSH session to machine"))
+		return
+	}
+	defer machineSession.Close()
+
+	machineSession.Stdin = session
+	machineSession.Stdout = session
+	machineSession.Stderr = session.Stderr()
+
+	if err := setupShellOrCommand(session, machineSession); err != nil {
+		handleError(err)
+		return
+	}
+	if err := machineSession.Wait(); err != nil {
+		handleError(errors.Annotate(err, "waiting for SSH session to machine"))
+	}
+}
+
+func setupShellOrCommand(userSession ssh.Session, machineSession *gossh.Session) error {
+	pty, windowChanges, hasPTY := userSession.Pty()
+	if !hasPTY {
+		return machineSession.Start(userSession.RawCommand())
+	}
+
+	// The Gliderlabs SSH server does not currently forward terminal modes.
+	// See https://github.com/gliderlabs/ssh/issues/98 and
+	// https://github.com/gliderlabs/ssh/pull/210.
+	// This will impact terminal behaviour for interactive sessions but can be
+	// addressed by using the above patches in a fork of the Gliderlabs SSH server.
+	if err := machineSession.RequestPty(pty.Term, pty.Window.Height, pty.Window.Width, gossh.TerminalModes{
+		gossh.ECHO: 1,
+	}); err != nil {
+		return err
+	}
+	if err := machineSession.Shell(); err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case <-userSession.Context().Done():
+				return
+			case window, ok := <-windowChanges:
+				if !ok {
+					return
+				}
+				_ = machineSession.WindowChange(window.Height, window.Width)
+			}
+		}
+	}()
+	return nil
+}

--- a/internal/worker/sshserver/handlers/machine/session.go
+++ b/internal/worker/sshserver/handlers/machine/session.go
@@ -12,48 +12,34 @@ import (
 )
 
 // SessionHandler proxies a shell or command session to the target machine.
+// The session is the user's SSH session, and createRemote creates a an
+// SSH session to the target machine.
 func (h *Handlers) SessionHandler(session ssh.Session) {
-	handleError := func(err error) {
-		h.logger.Errorf(session.Context(), "machine session proxy failure: %v", err)
-		_, _ = session.Stderr().Write([]byte(err.Error() + "\n"))
+	handleProxy(h, session.Context(), proxyConfig[*gossh.Session]{
+		createRemote: func(_ context.Context, client *gossh.Client) (*gossh.Session, error) {
+			machineSession, err := client.NewSession()
+			if err != nil {
+				return nil, err
+			}
 
-		var exitErr *gossh.ExitError
-		if errors.As(err, &exitErr) {
-			_ = session.Exit(exitErr.ExitStatus())
-			return
-		}
-		_ = session.Exit(1)
-	}
-
-	client, err := h.connector.Connect(session.Context(), h.destination)
-	if err != nil {
-		handleError(errors.Annotate(err, "connecting to machine"))
-		return
-	}
-	defer client.Close()
-	stop := context.AfterFunc(session.Context(), func() {
-		_ = client.Close()
+			machineSession.Stdin = session
+			machineSession.Stdout = session
+			machineSession.Stderr = session.Stderr()
+			if err := setupShellOrCommand(session, machineSession); err != nil {
+				_ = machineSession.Close()
+				return nil, err
+			}
+			return machineSession, nil
+		},
+		run: func(remote *gossh.Session) error {
+			err := remote.Wait()
+			if err == nil {
+				return nil
+			}
+			return errors.Annotate(err, "waiting for SSH session to machine")
+		},
+		onError: func(err error) { h.handleError(session, err) },
 	})
-	defer stop()
-
-	machineSession, err := client.NewSession()
-	if err != nil {
-		handleError(errors.Annotate(err, "creating SSH session to machine"))
-		return
-	}
-	defer machineSession.Close()
-
-	machineSession.Stdin = session
-	machineSession.Stdout = session
-	machineSession.Stderr = session.Stderr()
-
-	if err := setupShellOrCommand(session, machineSession); err != nil {
-		handleError(err)
-		return
-	}
-	if err := machineSession.Wait(); err != nil {
-		handleError(errors.Annotate(err, "waiting for SSH session to machine"))
-	}
 }
 
 func setupShellOrCommand(userSession ssh.Session, machineSession *gossh.Session) error {
@@ -85,6 +71,7 @@ func setupShellOrCommand(userSession ssh.Session, machineSession *gossh.Session)
 				if !ok {
 					return
 				}
+				// Forward window size changes for responsive terminal behaviour.
 				_ = machineSession.WindowChange(window.Height, window.Width)
 			}
 		}

--- a/internal/worker/sshserver/handlers/machine/session_test.go
+++ b/internal/worker/sshserver/handlers/machine/session_test.go
@@ -4,6 +4,7 @@
 package machine
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -89,9 +90,18 @@ func (s *machineSuite) TestSessionHandlerProxiesPTYAndWindowChanges(c *tc.C) {
 		c.Check(pty.Term, tc.Equals, "xterm")
 
 		_, _ = io.WriteString(session, "shell ready\n")
-		window := <-windowChanges
+		var window ssh.Window
+		// This loop terminates when we get what we expect
+		// or when the server is shutdown and windowChanges closes.
+		for {
+			window = <-windowChanges
+			if window.Height == 30 && window.Width == 100 {
+				break
+			}
+		}
 		c.Check(window.Height, tc.Equals, 30)
 		c.Check(window.Width, tc.Equals, 100)
+		_, _ = io.WriteString(session, "shell done\n")
 	}})
 
 	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
@@ -107,14 +117,35 @@ func (s *machineSuite) TestSessionHandlerProxiesPTYAndWindowChanges(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	defer session.Close()
 
-	var stdout bytes.Buffer
-	session.Stdout = &stdout
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer stdoutReader.Close()
+	defer stdoutWriter.Close()
+	session.Stdout = stdoutWriter
 	c.Assert(session.RequestPty("xterm", 24, 80, gossh.TerminalModes{}), tc.ErrorIsNil)
 	c.Assert(session.Shell(), tc.ErrorIsNil)
+
+	type outputResult struct {
+		message string
+		err     error
+	}
+	outputs := make(chan outputResult, 2)
+	go func() {
+		stdout := bufio.NewReader(stdoutReader)
+		message, err := stdout.ReadString('\n')
+		outputs <- outputResult{message: message, err: err}
+		message, err = stdout.ReadString('\n')
+		outputs <- outputResult{message: message, err: err}
+	}()
+
+	output := <-outputs
+	c.Assert(output.err, tc.ErrorIsNil)
+	c.Check(output.message, tc.Equals, "shell ready\r\n")
 	c.Assert(session.WindowChange(30, 100), tc.ErrorIsNil)
 	c.Assert(session.Wait(), tc.ErrorIsNil)
 
-	c.Check(stdout.String(), tc.Equals, "shell ready\r\n")
+	output = <-outputs
+	c.Assert(output.err, tc.ErrorIsNil)
+	c.Check(output.message, tc.Equals, "shell done\r\n")
 }
 
 func (s *machineSuite) TestSessionHandlerReportsConnectionFailure(c *tc.C) {

--- a/internal/worker/sshserver/handlers/machine/session_test.go
+++ b/internal/worker/sshserver/handlers/machine/session_test.go
@@ -172,5 +172,5 @@ func (s *machineSuite) TestSessionHandlerReportsConnectionFailure(c *tc.C) {
 	err = session.Run("echo hello")
 
 	c.Check(err, tc.ErrorMatches, "Process exited with status 1")
-	c.Check(stderr.String(), tc.Equals, "connecting to machine: connection failed\n")
+	c.Check(stderr.String(), tc.Equals, "failed to connect to machine: connection failed\n")
 }

--- a/internal/worker/sshserver/handlers/machine/session_test.go
+++ b/internal/worker/sshserver/handlers/machine/session_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/juju/tc"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/juju/juju/core/virtualhostname"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+func (s *machineSuite) TestSessionHandlerProxiesCommand(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	machine := startSSHTestServer(c, &ssh.Server{Handler: func(session ssh.Session) {
+		c.Check(session.RawCommand(), tc.Equals, "echo hello")
+		_, _ = io.WriteString(session, "hello\n")
+		_, _ = io.WriteString(session.Stderr(), "warning\n")
+	}})
+
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+	defer client.Close()
+
+	session, err := client.NewSession()
+	c.Assert(err, tc.ErrorIsNil)
+	defer session.Close()
+
+	var stdout, stderr bytes.Buffer
+	session.Stdout = &stdout
+	session.Stderr = &stderr
+
+	err = session.Run("echo hello")
+
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(stdout.String(), tc.Equals, "hello\n")
+	c.Check(stderr.String(), tc.Equals, "warning\n")
+}
+
+func (s *machineSuite) TestSessionHandlerReportsConnectionFailure(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+	handlers, err := NewHandlers(destination, connectorFunc(func(context.Context, virtualhostname.Info) (*gossh.Client, error) {
+		return nil, errors.New("connection failed")
+	}), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+	defer client.Close()
+
+	session, err := client.NewSession()
+	c.Assert(err, tc.ErrorIsNil)
+	defer session.Close()
+
+	var stderr bytes.Buffer
+	session.Stderr = &stderr
+
+	err = session.Run("echo hello")
+
+	c.Check(err, tc.ErrorMatches, "Process exited with status 1")
+	c.Check(stderr.String(), tc.Equals, "connecting to machine: connection failed\n")
+}

--- a/internal/worker/sshserver/handlers/machine/session_test.go
+++ b/internal/worker/sshserver/handlers/machine/session_test.go
@@ -51,6 +51,72 @@ func (s *machineSuite) TestSessionHandlerProxiesCommand(c *tc.C) {
 	c.Check(stderr.String(), tc.Equals, "warning\n")
 }
 
+func (s *machineSuite) TestSessionHandlerPropagatesCommandExitCode(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	machine := startSSHTestServer(c, &ssh.Server{Handler: func(session ssh.Session) {
+		c.Check(session.RawCommand(), tc.Equals, "exit 3")
+		_ = session.Exit(3)
+	}})
+
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+	defer client.Close()
+
+	session, err := client.NewSession()
+	c.Assert(err, tc.ErrorIsNil)
+	defer session.Close()
+
+	err = session.Run("exit 3")
+	var exitErr *gossh.ExitError
+	c.Assert(errors.As(err, &exitErr), tc.IsTrue)
+	c.Check(exitErr.ExitStatus(), tc.Equals, 3)
+}
+
+func (s *machineSuite) TestSessionHandlerProxiesPTYAndWindowChanges(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	machine := startSSHTestServer(c, &ssh.Server{Handler: func(session ssh.Session) {
+		pty, windowChanges, hasPTY := session.Pty()
+		c.Check(hasPTY, tc.IsTrue)
+		c.Check(pty.Term, tc.Equals, "xterm")
+
+		_, _ = io.WriteString(session, "shell ready\n")
+		window := <-windowChanges
+		c.Check(window.Height, tc.Equals, 30)
+		c.Check(window.Width, tc.Equals, 100)
+	}})
+
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+	defer client.Close()
+
+	session, err := client.NewSession()
+	c.Assert(err, tc.ErrorIsNil)
+	defer session.Close()
+
+	var stdout bytes.Buffer
+	session.Stdout = &stdout
+	c.Assert(session.RequestPty("xterm", 24, 80, gossh.TerminalModes{}), tc.ErrorIsNil)
+	c.Assert(session.Shell(), tc.ErrorIsNil)
+	c.Assert(session.WindowChange(30, 100), tc.ErrorIsNil)
+	c.Assert(session.Wait(), tc.ErrorIsNil)
+
+	c.Check(stdout.String(), tc.Equals, "shell ready\r\n")
+}
+
 func (s *machineSuite) TestSessionHandlerReportsConnectionFailure(c *tc.C) {
 	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
 	c.Assert(err, tc.ErrorIsNil)

--- a/internal/worker/sshserver/handlers/machine/sftp.go
+++ b/internal/worker/sshserver/handlers/machine/sftp.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/juju/errors"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/juju/juju/core/logger"
+)
+
+// SFTPHandler proxies the SFTP subsystem to the target machine.
+func (h *Handlers) SFTPHandler() ssh.SubsystemHandler {
+	return func(session ssh.Session) {
+		handleError := func(err error) {
+			h.logger.Errorf(session.Context(), "SFTP proxy failure: %v", err)
+			_, _ = session.Stderr().Write([]byte(err.Error() + "\n"))
+			_ = session.Exit(1)
+		}
+
+		client, err := h.connector.Connect(session.Context(), h.destination)
+		if err != nil {
+			handleError(errors.Annotate(err, "connecting to machine"))
+			return
+		}
+		defer client.Close()
+
+		machineChannel, machineRequests, err := client.OpenChannel("session", nil)
+		if err != nil {
+			handleError(errors.Annotate(err, "opening machine session"))
+			return
+		}
+		defer machineChannel.Close()
+
+		// Note that we don't call `session.Close()` in this function.
+		// The routine copying *from* session will return once the
+		// session is closed. Closing session is handled by
+		// `proxyRequests` in order to propagate the exit code
+		// back to the client.
+
+		stop := context.AfterFunc(session.Context(), func() {
+			_ = machineChannel.Close()
+		})
+		defer stop()
+
+		// This routine is cleaned up when machineRequests channel closes
+		// which occurs when machineChannel is closed.
+		go proxyRequests(session, machineRequests, h.logger)
+
+		if err := requestSubsystem(machineChannel, "sftp"); err != nil {
+			handleError(errors.Annotate(err, "requesting SFTP subsystem"))
+			return
+		}
+
+		var wg sync.WaitGroup
+
+		wg.Go(func() {
+			_, _ = io.Copy(machineChannel, session)
+			_ = machineChannel.CloseWrite()
+		})
+		wg.Go(func() {
+			_, _ = io.Copy(session, machineChannel)
+			_ = session.CloseWrite()
+		})
+		wg.Wait()
+	}
+}
+
+// proxyReqs proxies SSH requests (things like signals, etc) from the
+// connection to the machine back to the client, relaying only those messages
+// that do not require a reply. This matches the behaviour of the x/crypto/ssh
+// `DiscardRequests` function with the addition of the proxying logic.
+// When the reqs channel is closed, this indicates that the connection
+// to the machine has ended, so we also close the client's session.
+//
+// This ensures that the client receives the correct exit codes when
+// proxying sftp connections. Otherwise, the client can successfully
+// send/receive files but end up with a non-zero exit code.
+func proxyRequests(session ssh.Session, requests <-chan *gossh.Request, logger logger.Logger) {
+	for request := range requests {
+		if request.WantReply {
+			// This handles keepalives and matches OpenSSH's behaviour.
+			_ = request.Reply(false, nil)
+			continue
+		}
+		if _, err := session.SendRequest(request.Type, false, request.Payload); err != nil {
+			logger.Errorf(session.Context(), "sending SFTP request %q: %v", request.Type, err)
+		}
+	}
+	_ = session.Close()
+}
+
+type subsystemRequest struct {
+	Subsystem string
+}
+
+// requestSubsystem requests the association of a subsystem with the session on the remote host.
+// A subsystem is a predefined command that runs in the background when the ssh session is initiated
+func requestSubsystem(channel gossh.Channel, subsystem string) error {
+	ok, err := channel.SendRequest("subsystem", true, gossh.Marshal(&subsystemRequest{Subsystem: subsystem}))
+	if err == nil && !ok {
+		return errors.New("ssh: subsystem request failed")
+	}
+	return err
+}

--- a/internal/worker/sshserver/handlers/machine/sftp.go
+++ b/internal/worker/sshserver/handlers/machine/sftp.go
@@ -5,8 +5,6 @@ package machine
 
 import (
 	"context"
-	"io"
-	"sync"
 
 	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
@@ -58,17 +56,7 @@ func (h *Handlers) SFTPHandler() ssh.SubsystemHandler {
 			return
 		}
 
-		var wg sync.WaitGroup
-
-		wg.Go(func() {
-			_, _ = io.Copy(machineChannel, session)
-			_ = machineChannel.CloseWrite()
-		})
-		wg.Go(func() {
-			_, _ = io.Copy(session, machineChannel)
-			_ = session.CloseWrite()
-		})
-		wg.Wait()
+		proxy(machineChannel, session)
 	}
 }
 

--- a/internal/worker/sshserver/handlers/machine/sftp.go
+++ b/internal/worker/sshserver/handlers/machine/sftp.go
@@ -16,48 +16,30 @@ import (
 // SFTPHandler proxies the SFTP subsystem to the target machine.
 func (h *Handlers) SFTPHandler() ssh.SubsystemHandler {
 	return func(session ssh.Session) {
-		handleError := func(err error) {
-			h.logger.Errorf(session.Context(), "SFTP proxy failure: %v", err)
-			_, _ = session.Stderr().Write([]byte(err.Error() + "\n"))
-			_ = session.Exit(1)
-		}
-
-		client, err := h.connector.Connect(session.Context(), h.destination)
-		if err != nil {
-			handleError(errors.Annotate(err, "connecting to machine"))
-			return
-		}
-		defer client.Close()
-
-		machineChannel, machineRequests, err := client.OpenChannel("session", nil)
-		if err != nil {
-			handleError(errors.Annotate(err, "opening machine session"))
-			return
-		}
-		defer machineChannel.Close()
-
-		// Note that we don't call `session.Close()` in this function.
-		// The routine copying *from* session will return once the
-		// session is closed. Closing session is handled by
-		// `proxyRequests` in order to propagate the exit code
-		// back to the client.
-
-		stop := context.AfterFunc(session.Context(), func() {
-			_ = machineChannel.Close()
+		handleProxy(h, session.Context(), proxyConfig[*sftpProxy]{
+			createRemote: func(_ context.Context, client *gossh.Client) (*sftpProxy, error) {
+				machineChannel, machineRequests, err := client.OpenChannel("session", nil)
+				if err != nil {
+					return nil, err
+				}
+				return &sftpProxy{Channel: machineChannel, requests: machineRequests}, nil
+			},
+			run: func(machine *sftpProxy) error {
+				if err := requestSubsystem(machine.Channel, "sftp"); err != nil {
+					return errors.Annotate(err, "requesting SFTP subsystem")
+				}
+				go proxyRequests(session, machine.requests, h.logger)
+				proxyStreams(machine.Channel, session)
+				return nil
+			},
+			onError: func(err error) { h.handleError(session, err) },
 		})
-		defer stop()
-
-		// This routine is cleaned up when machineRequests channel closes
-		// which occurs when machineChannel is closed.
-		go proxyRequests(session, machineRequests, h.logger)
-
-		if err := requestSubsystem(machineChannel, "sftp"); err != nil {
-			handleError(errors.Annotate(err, "requesting SFTP subsystem"))
-			return
-		}
-
-		proxy(machineChannel, session)
 	}
+}
+
+type sftpProxy struct {
+	gossh.Channel
+	requests <-chan *gossh.Request
 }
 
 // proxyReqs proxies SSH requests (things like signals, etc) from the

--- a/internal/worker/sshserver/handlers/machine/sftp_test.go
+++ b/internal/worker/sshserver/handlers/machine/sftp_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"io"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/juju/tc"
+	"github.com/pkg/sftp"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/juju/juju/core/virtualhostname"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+func (s *machineSuite) TestSFTPHandler(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	machine := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
+		"sftp": func(session ssh.Session) {
+			server := sftp.NewRequestServer(session, sftp.InMemHandler())
+			if err := server.Serve(); err == io.EOF {
+				_ = server.Close()
+			}
+		},
+	}})
+
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
+		"sftp": handlers.SFTPHandler(),
+	}})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+	defer client.Close()
+
+	sftpClient, err := sftp.NewClient(client)
+	c.Assert(err, tc.ErrorIsNil)
+	defer sftpClient.Close()
+
+	file, err := sftpClient.Create("testfile.txt")
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = file.Write([]byte("Hello, SFTP!"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(file.Close(), tc.ErrorIsNil)
+
+	file, err = sftpClient.Open("testfile.txt")
+	c.Assert(err, tc.ErrorIsNil)
+	defer file.Close()
+
+	contents, err := io.ReadAll(file)
+
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(string(contents), tc.Equals, "Hello, SFTP!")
+}
+
+func (s *machineSuite) TestSFTPHandlerProxiesExitStatus(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	machine := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
+		"sftp": func(session ssh.Session) { _ = session.Exit(3) },
+	}})
+
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
+		"sftp": handlers.SFTPHandler(),
+	}})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+	defer client.Close()
+
+	channel, requests, err := client.OpenChannel("session", nil)
+	c.Assert(err, tc.ErrorIsNil)
+	defer channel.Close()
+
+	exitCode := make(chan uint32, 1)
+	requestsDone := make(chan struct{})
+	go func() {
+		defer close(requestsDone)
+		for request := range requests {
+			if request.WantReply {
+				_ = request.Reply(false, nil)
+			}
+			if request.Type != "exit-status" {
+				continue
+			}
+			var payload struct{ Code uint32 }
+			if err := gossh.Unmarshal(request.Payload, &payload); err == nil {
+				exitCode <- payload.Code
+			}
+		}
+	}()
+
+	c.Assert(requestSubsystem(channel, "sftp"), tc.ErrorIsNil)
+
+	<-requestsDone
+	c.Check(<-exitCode, tc.Equals, uint32(3))
+}
+
+func (s *machineSuite) TestSFTPHandlerProxiesMachineEOF(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	machineClose := make(chan struct{})
+	defer close(machineClose)
+	machine := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
+		"sftp": func(session ssh.Session) {
+			_, _ = session.Write([]byte("response"))
+			_ = session.CloseWrite()
+			<-machineClose
+		},
+	}})
+
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
+		"sftp": handlers.SFTPHandler(),
+	}})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+	defer client.Close()
+
+	channel, _, err := client.OpenChannel("session", nil)
+	c.Assert(err, tc.ErrorIsNil)
+	defer channel.Close()
+	c.Assert(requestSubsystem(channel, "sftp"), tc.ErrorIsNil)
+
+	response := make(chan []byte, 1)
+	go func() {
+		data, _ := io.ReadAll(channel)
+		response <- data
+	}()
+
+	select {
+	case data := <-response:
+		c.Check(data, tc.DeepEquals, []byte("response"))
+	case <-c.Context().Done():
+		c.Fatal("machine EOF was not proxied to the client")
+	}
+}
+
+func (s *machineSuite) TestSFTPHandlerClosesMachineClientWhenClientDisconnects(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	machineSessionStarted := make(chan struct{})
+	machineSessionStopped := make(chan struct{})
+	machine := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
+		"sftp": func(session ssh.Session) {
+			close(machineSessionStarted)
+			<-session.Context().Done()
+			close(machineSessionStopped)
+		},
+	}})
+
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	c.Assert(err, tc.ErrorIsNil)
+
+	controller := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
+		"sftp": handlers.SFTPHandler(),
+	}})
+
+	client, err := controller.client()
+	c.Assert(err, tc.ErrorIsNil)
+
+	channel, _, err := client.OpenChannel("session", nil)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(requestSubsystem(channel, "sftp"), tc.ErrorIsNil)
+
+	select {
+	case <-machineSessionStarted:
+	case <-c.Context().Done():
+		c.Fatal("machine SFTP session did not start")
+	}
+
+	c.Assert(client.Close(), tc.ErrorIsNil)
+
+	select {
+	case <-machineSessionStopped:
+	case <-c.Context().Done():
+		c.Fatal("machine SFTP session was not closed after client disconnect")
+	}
+}

--- a/internal/worker/sshserver/handlers/machine/utils_test.go
+++ b/internal/worker/sshserver/handlers/machine/utils_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package machine
+
+import (
+	"context"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/juju/tc"
+	gossh "golang.org/x/crypto/ssh"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/juju/juju/core/virtualhostname"
+)
+
+type connectorFunc func(context.Context, virtualhostname.Info) (*gossh.Client, error)
+
+func (f connectorFunc) Connect(ctx context.Context, destination virtualhostname.Info) (*gossh.Client, error) {
+	return f(ctx, destination)
+}
+
+type sshTestServer struct {
+	listener *bufconn.Listener
+}
+
+func startSSHTestServer(c *tc.C, server *ssh.Server) *sshTestServer {
+	listener := bufconn.Listen(1024)
+	c.Cleanup(func() { listener.Close() })
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	return &sshTestServer{listener: listener}
+}
+
+func (s *sshTestServer) client() (*gossh.Client, error) {
+	conn, err := s.listener.Dial()
+	if err != nil {
+		return nil, err
+	}
+	sshConn, channels, requests, err := gossh.NewClientConn(conn, "", &gossh.ClientConfig{
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return gossh.NewClient(sshConn, channels, requests), nil
+}
+
+func connectorForServer(server *sshTestServer) SSHConnector {
+	return connectorFunc(func(context.Context, virtualhostname.Info) (*gossh.Client, error) {
+		return server.client()
+	})
+}

--- a/internal/worker/sshserver/proxy.go
+++ b/internal/worker/sshserver/proxy.go
@@ -11,14 +11,16 @@ import (
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/virtualhostname"
-	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"
 	"github.com/juju/juju/internal/worker/sshserver/handlers/machine"
 )
 
 // ProxyHandlers provide session, local forwarding, and SFTP handling for a target.
 type ProxyHandlers interface {
+	// SessionHandler returns a handler for proxying SSH commands/terminal sessions.
 	SessionHandler(ssh.Session)
+	// DirectTCPIPHandler returns a handler for proxying SSH local forwarding requests.
 	DirectTCPIPHandler() ssh.ChannelHandler
+	// SFTPHandler returns a handler for proxying SFTP requests.
 	SFTPHandler() ssh.SubsystemHandler
 }
 
@@ -28,12 +30,13 @@ type ProxyFactory interface {
 }
 
 type proxyFactory struct {
-	logger      logger.Logger
-	connector   machine.SSHConnector
-	getExecutor func(string) (k8sexec.Executor, error)
+	logger    logger.Logger
+	connector machine.SSHConnector
 }
 
-func (f proxyFactory) New(_ context.Context, destination virtualhostname.Info) (ProxyHandlers, error) {
+// New returns a set of handlers for the given target based
+// on whether the target is a container, unit or machine.
+func (f proxyFactory) New(destination virtualhostname.Info) (ProxyHandlers, error) {
 	switch destination.Target() {
 	case virtualhostname.ContainerTarget:
 		return nil, errors.NotImplemented

--- a/internal/worker/sshserver/proxy.go
+++ b/internal/worker/sshserver/proxy.go
@@ -4,8 +4,6 @@
 package sshserver
 
 import (
-	"context"
-
 	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
 
@@ -22,11 +20,6 @@ type ProxyHandlers interface {
 	DirectTCPIPHandler() ssh.ChannelHandler
 	// SFTPHandler returns a handler for proxying SFTP requests.
 	SFTPHandler() ssh.SubsystemHandler
-}
-
-// ProxyFactory creates handlers for a routed SSH target.
-type ProxyFactory interface {
-	New(context.Context, virtualhostname.Info) (ProxyHandlers, error)
 }
 
 type proxyFactory struct {

--- a/internal/worker/sshserver/proxy.go
+++ b/internal/worker/sshserver/proxy.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshserver
+
+import (
+	"context"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/virtualhostname"
+	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/machine"
+)
+
+// ProxyHandlers provide session, local forwarding, and SFTP handling for a target.
+type ProxyHandlers interface {
+	SessionHandler(ssh.Session)
+	DirectTCPIPHandler() ssh.ChannelHandler
+	SFTPHandler() ssh.SubsystemHandler
+}
+
+// ProxyFactory creates handlers for a routed SSH target.
+type ProxyFactory interface {
+	New(context.Context, virtualhostname.Info) (ProxyHandlers, error)
+}
+
+type proxyFactory struct {
+	logger      logger.Logger
+	connector   machine.SSHConnector
+	getExecutor func(string) (k8sexec.Executor, error)
+}
+
+func (f proxyFactory) New(_ context.Context, destination virtualhostname.Info) (ProxyHandlers, error) {
+	switch destination.Target() {
+	case virtualhostname.ContainerTarget:
+		return nil, errors.NotImplemented
+	case virtualhostname.MachineTarget, virtualhostname.UnitTarget:
+		return machine.NewHandlers(destination, f.connector, f.logger)
+	default:
+		return nil, errors.NotValidf("unknown virtual hostname target %d", destination.Target())
+	}
+}

--- a/internal/worker/sshserver/proxy_test.go
+++ b/internal/worker/sshserver/proxy_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshserver
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/virtualhostname"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/machine"
+)
+
+type proxySuite struct{}
+
+func TestProxySuite(t *testing.T) {
+	tc.Run(t, &proxySuite{})
+}
+
+func (s *proxySuite) TestNewSelectsMachineHandlers(c *tc.C) {
+	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
+	c.Assert(err, tc.ErrorIsNil)
+
+	handlers, err := (proxyFactory{
+		logger:    loggertesting.WrapCheckLog(c),
+		connector: proxyConnector{},
+	}).New(c.Context(), destination)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(handlers, tc.FitsTypeOf, &machine.Handlers{})
+}
+
+type proxyConnector struct {
+	machine.SSHConnector
+}

--- a/internal/worker/sshserver/proxy_test.go
+++ b/internal/worker/sshserver/proxy_test.go
@@ -26,7 +26,7 @@ func (s *proxySuite) TestNewSelectsMachineHandlers(c *tc.C) {
 	handlers, err := (proxyFactory{
 		logger:    loggertesting.WrapCheckLog(c),
 		connector: proxyConnector{},
-	}).New(c.Context(), destination)
+	}).New(destination)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(handlers, tc.FitsTypeOf, &machine.Handlers{})
 }


### PR DESCRIPTION
This change adds several SSH machine handlers:
- Session handler for interactive shells and single commands
- SFTP for file transfer
- DirectTCPIP for port-forwarding

These handlers and the associated comments are lifted from the `feature/ssh` branch and updated with some changes as discussed in  https://github.com/juju/juju/pull/22895 to handle half-closed TCP connections where the sending/receiving side may be closed before the other. See https://github.com/golang/go/issues/35892 and https://go-review.googlesource.com/c/go/+/637939 for more discussion.

The tests are fairly thorough in that they create a test SSH server and verify a client <-> proxy handlers <-> test-server.

A follow-up PR will introduce the Kubernetes handlers and a further follow-up will wire this into the SSH server.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Links

**Jira card:** [JUJU-9955](https://warthogs.atlassian.net/browse/JUJU-9955)


[JUJU-9955]: https://warthogs.atlassian.net/browse/JUJU-9955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ