### PR TITLE
fix: restore controller-machine access to the /log endpoint

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -772,14 +772,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	controllerAdminAuthorizer := controllerAdminAuthorizer{
 		controllerTag: names.NewControllerTag(srv.shared.controllerUUID),
 	}
-	var debuglogAuth httpcontext.CompositeAuthorizer = []authentication.Authorizer{
-		tagKindAuthorizer{names.ControllerAgentTagKind},
-		httpcontext.ControllerAuthorizer,
-		controllerAdminAuthorizer,
-		modelPermissionAuthorizer{
-			perm: permission.ReadAccess,
-		},
-	}
+	debuglogAuth := debugLogAuthorizer(controllerAdminAuthorizer)
 	debugLogHandler := srv.monitoredHandler(newDebugLogTailerHandler(
 		httpCtxt,
 		httpAuthenticator,

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -774,6 +774,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 	}
 	var debuglogAuth httpcontext.CompositeAuthorizer = []authentication.Authorizer{
 		tagKindAuthorizer{names.ControllerAgentTagKind},
+		httpcontext.ControllerAuthorizer,
 		controllerAdminAuthorizer,
 		modelPermissionAuthorizer{
 			perm: permission.ReadAccess,

--- a/apiserver/authorizer.go
+++ b/apiserver/authorizer.go
@@ -119,6 +119,24 @@ func (a modelPermissionAuthorizer) Authorize(ctx context.Context, authInfo authe
 	return nil
 }
 
+// debugLogAuthorizer returns the authorizer for the /log endpoint.
+//
+// [httpcontext.ControllerAuthorizer] admits controller machines: the
+// migration-master's LOGTRANSFER phase streams the source model's logs
+// through /log while authenticated as the controller machine agent, which
+// is neither a controller-agent tag nor a user. Workload machines
+// (AuthInfo.Controller == false) remain denied. Do not remove this entry
+// or widen the admission to [names.MachineTagKind], that would reopen the
+// cross-model log disclosure fixed in #22387.
+func debugLogAuthorizer(adminAuth controllerAdminAuthorizer) httpcontext.CompositeAuthorizer {
+	return httpcontext.CompositeAuthorizer{
+		tagKindAuthorizer{names.ControllerAgentTagKind},
+		httpcontext.ControllerAuthorizer,
+		adminAuth,
+		modelPermissionAuthorizer{perm: permission.ReadAccess},
+	}
+}
+
 // ModelAuthorizationInfo provides information to authorizer's about the model
 // that is being used in the authorization request.
 type ModelAuthorizationInfo interface {

--- a/apiserver/authorizerdebuglog_test.go
+++ b/apiserver/authorizerdebuglog_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/juju/names/v6"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/apiserver/authentication"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/internal/uuid"
+)
+
+// debugLogAuthorizerSuite exists to form a set of contract tests for the
+// authorizer composition used by the /log endpoint. It exists to prevent
+// a regression where controller machines were denied access to /log,
+// breaking log transfer during model migration, while ensuring workload
+// machines stay denied.
+type debugLogAuthorizerSuite struct{}
+
+// TestDebugLogAuthorizerSuite runs all of the tests that are apart of
+// the [debugLogAuthorizerSuite].
+func TestDebugLogAuthorizerSuite(t *testing.T) {
+	tc.Run(t, &debugLogAuthorizerSuite{})
+}
+
+func (s *debugLogAuthorizerSuite) authorizer(c *tc.C) authentication.Authorizer {
+	controllerUUID := tc.Must(c, uuid.NewUUID)
+	return debugLogAuthorizer(controllerAdminAuthorizer{
+		controllerTag: names.NewControllerTag(controllerUUID.String()),
+	})
+}
+
+// TestControllerAgentAllowed tests that a controller agent is authorized
+// for the /log endpoint.
+func (s *debugLogAuthorizerSuite) TestControllerAgentAllowed(c *tc.C) {
+	err := s.authorizer(c).Authorize(c.Context(), authentication.AuthInfo{
+		Tag:        names.NewControllerAgentTag("0"),
+		Controller: true,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestControllerMachineAllowed tests that a machine agent for a controller
+// machine is authorized for the /log endpoint. This is the regression guard
+// for the migration-master's LOGTRANSFER phase, which streams the source
+// model's logs through /log while authenticated as the controller machine
+// agent.
+func (s *debugLogAuthorizerSuite) TestControllerMachineAllowed(c *tc.C) {
+	err := s.authorizer(c).Authorize(c.Context(), authentication.AuthInfo{
+		Tag:        names.NewMachineTag("0"),
+		Controller: true,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestWorkloadMachineDenied tests that a machine agent for a workload
+// (non-controller) machine is denied access to the /log endpoint. This
+// guards the security boundary fixed in #22387: admitting all machine tags
+// would reopen the cross-model log disclosure.
+func (s *debugLogAuthorizerSuite) TestWorkloadMachineDenied(c *tc.C) {
+	err := s.authorizer(c).Authorize(c.Context(), authentication.AuthInfo{
+		Tag:        names.NewMachineTag("1"),
+		Controller: false,
+	})
+	c.Assert(err, tc.ErrorIs, apiservererrors.ErrPerm)
+}
+
+// TestOtherAgentTagsDenied tests that agent tags that are neither
+// controller agents nor machines are denied access to the /log endpoint.
+func (s *debugLogAuthorizerSuite) TestOtherAgentTagsDenied(c *tc.C) {
+	authorizer := s.authorizer(c)
+	for _, tag := range []names.Tag{
+		names.NewApplicationTag("foo"),
+		names.NewUnitTag("foo/0"),
+	} {
+		err := authorizer.Authorize(c.Context(), authentication.AuthInfo{
+			Tag: tag,
+		})
+		c.Check(err, tc.ErrorIs, apiservererrors.ErrPerm)
+	}
+}


### PR DESCRIPTION
The debug-log (/log) endpoint authorizer only admits controller-agent tags, controller admins, and users with model read access. The migration-master's LOGTRANSFER phase reads the source model's log stream through this endpoint while running under the controller machine agent, which matches none of these, so log transfer fails with 'authorization failed: permission denied' and the migration never reaches REAP.

Restore the controller-machine authorizer
(httpcontext.ControllerAuthorizer,
gated on AuthInfo.Controller) that 3.6 carries in debuglogAuth. It was dropped from 4.0 during the 3.6->4.0 merge-forward (d96d4b3ab2, #22387), which applied the security fix's removal of MachineTagKind but not its compensating controller-machine authorizer. Workload machine agents (Controller == false) stay denied, so this does not reopen the cross-model
log disclosure fixed in 3.6.

_Note: this was lost in the forward merge https://github.com/juju/juju/pull/22387, so this patch only restores the piece we need._

## QA steps

Nothing to QA here, this will be useful once https://github.com/juju/juju/pull/22899 and https://github.com/juju/juju/pull/22945 lands so we can test the full migration scenario.

