### PR TITLE
refactor: retry pod failures during bootstrap

### DIFF
--- a/cmd/juju/common/cloud.go
+++ b/cmd/juju/common/cloud.go
@@ -66,10 +66,10 @@ func ChooseCloudRegion(cloud jujucloud.Cloud, regionName string) (jujucloud.Regi
 		return cloud.Regions[0], nil
 	}
 	return jujucloud.Region{
-		"", // no region name
-		cloud.Endpoint,
-		cloud.IdentityEndpoint,
-		cloud.StorageEndpoint,
+		Name:             "", // no region name
+		Endpoint:         cloud.Endpoint,
+		IdentityEndpoint: cloud.IdentityEndpoint,
+		StorageEndpoint:  cloud.StorageEndpoint,
 	}, nil
 }
 

--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -163,6 +163,7 @@ func isRetryableErrorMessage(errorMessage string) bool {
 		strings.HasSuffix(errorMessage, "i/o timeout"),
 		strings.HasSuffix(errorMessage, "network is unreachable"),
 		strings.HasSuffix(errorMessage, "deadline exceeded"),
+		strings.HasSuffix(errorMessage, "lost connection to pod"),
 		strings.HasSuffix(errorMessage, "no api connection available"):
 		return true
 	default:

--- a/cmd/juju/common/controller_test.go
+++ b/cmd/juju/common/controller_test.go
@@ -122,6 +122,26 @@ func (s *controllerSuite) TestWaitForAgentAPIReadyRetries(c *tc.C) {
 		})
 	})
 
+	c.Run("K8sLostConnectionToPodRetries", func(c *stdtesting.T) {
+		count := 0
+		tryAPI := func(ctx context.Context, c *modelcmd.ModelCommandBase) error {
+			count++
+			if count == 1 {
+				return errors.New(
+					"unable to connect to API: dial tcp 127.0.0.1:36141: " +
+						"connect: connection refused; proxy error: lost connection to pod",
+				)
+			}
+			return nil
+		}
+		runInCommand(&tc.TBC{TB: c}, func(ctx *cmd.Context, base *modelcmd.ModelCommandBase) {
+			bootstrapCtx := environscmd.BootstrapContext(c.Context(), ctx)
+			err := WaitForAgentInitialisation(bootstrapCtx, base, false, "arthur", tryAPI)
+			tc.Assert(c, err, tc.ErrorIsNil)
+			tc.Check(c, count, tc.Equals, 2)
+		})
+	})
+
 	c.Run("ExhaustedRetries", func(c *stdtesting.T) {
 		count := 0
 		tryAPI := func(ctx context.Context, c *modelcmd.ModelCommandBase) error {


### PR DESCRIPTION
It's possible to loose a pod whilst bootstrapping to k8s, that's ok. What isn't ok, is that fact that we don't retry.


## QA steps

Ensure the github tests pass.