### PR TITLE
feat: trace undertaker

### DIFF
--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -1134,6 +1134,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		undertakerName: ifController(undertaker.Manifold(undertaker.ManifoldConfig{
 			DBAccessorName:            dbAccessorName,
 			DomainServicesName:        domainServicesName,
+			TraceName:                 controllerTraceName,
 			NewWorker:                 undertaker.NewWorker,
 			GetControllerModelService: undertaker.GetControllerModelService,
 			GetRemovalServiceGetter:   undertaker.GetRemovalServiceGetter,

--- a/cmd/jujuagentd/agent/machine/manifolds_test.go
+++ b/cmd/jujuagentd/agent/machine/manifolds_test.go
@@ -53,6 +53,19 @@ func (s *ManifoldsSuite) TestStartFuncsCAAS(c *tc.C) {
 	}))
 }
 
+func (s *ManifoldsSuite) TestDependencyGraphsAreAcyclic(c *tc.C) {
+	config := machine.ManifoldsConfig{
+		Agent:           &mockAgent{},
+		PreUpgradeSteps: preUpgradeSteps,
+	}
+	for _, manifolds := range []dependency.Manifolds{
+		machine.IAASManifolds(config),
+		machine.CAASManifolds(config),
+	} {
+		c.Check(dependency.Validate(manifolds), tc.ErrorIsNil)
+	}
+}
+
 func (*ManifoldsSuite) assertStartFuncs(c *tc.C, manifolds dependency.Manifolds) {
 	for name, manifold := range manifolds {
 		c.Logf("checking %q manifold", name)
@@ -635,6 +648,15 @@ func (*ManifoldsSuite) TestControllerOnlyWorkerDirectInputs(c *tc.C) {
 		c.Assert(ok, tc.IsTrue)
 		checkNotContains(c, apiServerManifold.Inputs, "clock")
 		checkNotContains(c, apiServerManifold.Inputs, "agent")
+
+		undertakerManifold, ok := manifolds["undertaker"]
+		c.Assert(ok, tc.IsTrue)
+		c.Check(undertakerManifold.Inputs, tc.SameContents, []string{
+			"controller-trace",
+			"db-accessor",
+			"domain-services",
+			"is-controller-flag",
+		})
 
 		// external-controller-updater must consume only domain-services directly
 		// (plus the inputs added by the ifNotMigrating and ifPrimaryController

--- a/internal/worker/undertaker/manifold.go
+++ b/internal/worker/undertaker/manifold.go
@@ -14,10 +14,12 @@ import (
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
+	coretrace "github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/removal/service"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/services"
+	workertrace "github.com/juju/juju/internal/worker/trace"
 )
 
 // ControllerModelService is an interface that defines the methods
@@ -72,6 +74,7 @@ type GetDomainServicesGetterFunc func(ctx context.Context, getter dependency.Get
 type ManifoldConfig struct {
 	DBAccessorName            string
 	DomainServicesName        string
+	TraceName                 string
 	Logger                    logger.Logger
 	Clock                     clock.Clock
 	NewWorker                 func(Config) (worker.Worker, error)
@@ -86,6 +89,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.DomainServicesName == "" {
 		return jujuerrors.NotValidf("empty DomainServicesName")
+	}
+	if config.TraceName == "" {
+		return jujuerrors.NotValidf("empty TraceName")
 	}
 	if config.GetRemovalServiceGetter == nil {
 		return jujuerrors.NotValidf("nil GetRemovalServiceGetter")
@@ -112,6 +118,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 		Inputs: []string{
 			config.DBAccessorName,
 			config.DomainServicesName,
+			config.TraceName,
 		},
 		Start: config.start,
 	}
@@ -138,12 +145,23 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		return nil, errors.Capture(err)
 	}
 
+	var tracerGetter workertrace.TracerGetter
+	if err := getter.Get(config.TraceName, &tracerGetter); err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	tracer, err := tracerGetter.GetTracer(ctx, coretrace.Namespace("undertaker", coredatabase.ControllerNS))
+	if err != nil {
+		tracer = coretrace.NoopTracer{}
+	}
+
 	return config.NewWorker(Config{
 		DBDeleter:              dbDeleter,
 		ControllerModelService: controllerModelService,
 		RemovalServiceGetter:   removalServiceGetter,
 		Logger:                 config.Logger,
 		Clock:                  config.Clock,
+		Tracer:                 tracer,
 	})
 }
 

--- a/internal/worker/undertaker/manifold_test.go
+++ b/internal/worker/undertaker/manifold_test.go
@@ -15,7 +15,9 @@ import (
 	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
 
+	coretrace "github.com/juju/juju/core/trace"
 	"github.com/juju/juju/internal/testhelpers"
+	workertrace "github.com/juju/juju/internal/worker/trace"
 )
 
 type manifoldSuite struct {
@@ -43,6 +45,10 @@ func (s *manifoldSuite) TestValidateConfig(c *tc.C) {
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	cfg = s.getConfig()
+	cfg.TraceName = ""
+	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
+
+	cfg = s.getConfig()
 	cfg.NewWorker = nil
 	c.Check(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
@@ -67,6 +73,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 	return ManifoldConfig{
 		DBAccessorName:     "db-accessor",
 		DomainServicesName: "domain-services",
+		TraceName:          "trace",
 		Logger:             s.logger,
 		Clock:              clock.WallClock,
 		NewWorker: func(c Config) (worker.Worker, error) {
@@ -85,11 +92,12 @@ func (s *manifoldSuite) newGetter() dependency.Getter {
 	resources := map[string]any{
 		"db-accessor":     s.dbDeleter,
 		"domain-services": s.controllerModelService,
+		"trace":           stubTracerGetter{},
 	}
 	return dependencytesting.StubGetter(resources)
 }
 
-var expectedInputs = []string{"db-accessor", "domain-services"}
+var expectedInputs = []string{"db-accessor", "domain-services", "trace"}
 
 func (s *manifoldSuite) TestInputs(c *tc.C) {
 	c.Assert(Manifold(s.getConfig()).Inputs, tc.SameContents, expectedInputs)
@@ -101,4 +109,12 @@ func (s *manifoldSuite) TestStart(c *tc.C) {
 	w, err := Manifold(s.getConfig()).Start(c.Context(), s.newGetter())
 	c.Assert(err, tc.ErrorIsNil)
 	workertest.CleanKill(c, w)
+}
+
+type stubTracerGetter struct {
+	workertrace.TracerGetter
+}
+
+func (stubTracerGetter) GetTracer(context.Context, coretrace.TracerNamespace) (coretrace.Tracer, error) {
+	return coretrace.NoopTracer{}, nil
 }

--- a/internal/worker/undertaker/worker.go
+++ b/internal/worker/undertaker/worker.go
@@ -15,6 +15,7 @@ import (
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
+	coretrace "github.com/juju/juju/core/trace"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/internal/errors"
 	internalworker "github.com/juju/juju/internal/worker"
@@ -27,6 +28,7 @@ type Config struct {
 	RemovalServiceGetter   RemovalServiceGetter
 	Logger                 logger.Logger
 	Clock                  clock.Clock
+	Tracer                 coretrace.Tracer
 }
 
 // Worker is the undertaker worker that manages the lifecycle of resources.
@@ -38,6 +40,7 @@ type Worker struct {
 	removalServiceGetter   RemovalServiceGetter
 	logger                 logger.Logger
 	clock                  clock.Clock
+	tracer                 coretrace.Tracer
 }
 
 // NewWorker creates a new instance of the undertaker worker.
@@ -64,6 +67,7 @@ func NewWorker(config Config) (worker.Worker, error) {
 		removalServiceGetter:   config.RemovalServiceGetter,
 		logger:                 config.Logger,
 		clock:                  config.Clock,
+		tracer:                 config.Tracer,
 	}
 
 	if err := catacomb.Invoke(catacomb.Plan{
@@ -158,7 +162,7 @@ func (w *Worker) handleDeadModel(ctx context.Context, mUUID model.UUID) error {
 			return nil, errors.Errorf("getting removal service for model %s: %w", mUUID, err)
 		}
 
-		return newModelWorker(mUUID, removalService, w.dbDeleter), nil
+		return newModelWorker(mUUID, removalService, w.dbDeleter, w.tracer), nil
 	})
 	if err != nil && !errors.Is(err, jujuerrors.AlreadyExists) {
 		return errors.Errorf("starting worker for model %s: %w", mUUID, err)
@@ -173,7 +177,7 @@ func (w *Worker) handlePendingDeletion(ctx context.Context, namespace string) er
 	// key, and the runner guarantees only one of them runs at a time. This is
 	// impossible today, but it means it can never happen in the future either.
 	err := w.runner.StartWorker(ctx, namespace, func(ctx context.Context) (worker.Worker, error) {
-		return newDBDeletionWorker(namespace, w.controllerModelService, w.dbDeleter, w.logger), nil
+		return newDBDeletionWorker(namespace, w.controllerModelService, w.dbDeleter, w.logger, w.tracer), nil
 	})
 	if err != nil && !errors.Is(err, jujuerrors.AlreadyExists) {
 		return errors.Errorf("starting worker for model database deletion %s: %w", namespace, err)
@@ -188,13 +192,20 @@ type modelWorker struct {
 	modelUUID      model.UUID
 	removalService RemovalService
 	dbDeleter      coredatabase.DBDeleter
+	tracer         coretrace.Tracer
 }
 
-func newModelWorker(modelUUID model.UUID, removalService RemovalService, dbDeleter coredatabase.DBDeleter) *modelWorker {
+func newModelWorker(
+	modelUUID model.UUID,
+	removalService RemovalService,
+	dbDeleter coredatabase.DBDeleter,
+	tracer coretrace.Tracer,
+) *modelWorker {
 	w := &modelWorker{
 		modelUUID:      modelUUID,
 		removalService: removalService,
 		dbDeleter:      dbDeleter,
+		tracer:         tracer,
 	}
 
 	w.tomb.Go(w.loop)
@@ -230,7 +241,15 @@ func (w *modelWorker) loop() error {
 	}
 }
 
-func (w *modelWorker) deleteModel(ctx context.Context) error {
+func (w *modelWorker) deleteModel(ctx context.Context) (err error) {
+	ctx, span := coretrace.Start(coretrace.WithTracer(ctx, w.tracer), coretrace.NameFromFunc(),
+		coretrace.WithAttributes(coretrace.StringAttr("undertaker.model.uuid", w.modelUUID.String())),
+	)
+	defer func() {
+		span.RecordError(err)
+		span.End()
+	}()
+
 	if err := w.removalService.DeleteModel(ctx); err != nil && !errors.IsOneOf(err,
 		coredatabase.ErrDBNotFound,
 		modelerrors.NotFound,
@@ -256,6 +275,7 @@ type dbDeletionWorker struct {
 	service   ControllerModelService
 	dbDeleter coredatabase.DBDeleter
 	logger    logger.Logger
+	tracer    coretrace.Tracer
 }
 
 func newDBDeletionWorker(
@@ -263,12 +283,14 @@ func newDBDeletionWorker(
 	service ControllerModelService,
 	dbDeleter coredatabase.DBDeleter,
 	logger logger.Logger,
+	tracer coretrace.Tracer,
 ) *dbDeletionWorker {
 	w := &dbDeletionWorker{
 		namespace: namespace,
 		service:   service,
 		dbDeleter: dbDeleter,
 		logger:    logger,
+		tracer:    tracer,
 	}
 
 	w.tomb.Go(w.loop)
@@ -304,7 +326,15 @@ func (w *dbDeletionWorker) loop() error {
 	}
 }
 
-func (w *dbDeletionWorker) deleteDatabase(ctx context.Context) error {
+func (w *dbDeletionWorker) deleteDatabase(ctx context.Context) (err error) {
+	ctx, span := coretrace.Start(coretrace.WithTracer(ctx, w.tracer), coretrace.NameFromFunc(),
+		coretrace.WithAttributes(coretrace.StringAttr("undertaker.database.namespace", w.namespace)),
+	)
+	defer func() {
+		span.RecordError(err)
+		span.End()
+	}()
+
 	// Delete the model's dqlite database. A not-found database is already
 	// gone, so treat it as success. Any other failure is returned so the
 	// runner restarts this worker with backoff and the staged row survives to

--- a/internal/worker/undertaker/worker_test.go
+++ b/internal/worker/undertaker/worker_test.go
@@ -5,6 +5,7 @@ package undertaker
 
 import (
 	"context"
+	"strings"
 	stdtesting "testing"
 
 	gomock "github.com/canonical/gomock/gomock"
@@ -16,6 +17,7 @@ import (
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/model"
+	coretrace "github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	modelerrors "github.com/juju/juju/domain/model/errors"
@@ -232,6 +234,52 @@ func (s *workerSuite) TestNoPendingDeletions(c *tc.C) {
 	workertest.CleanKill(c, w)
 }
 
+func (s *workerSuite) TestDeleteModelTrace(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	tracer := &recordingTracer{}
+	s.removalService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
+	s.dbDeleter.EXPECT().DeleteDB("model-1").Return(nil)
+
+	w := &modelWorker{
+		modelUUID:      model.UUID("model-1"),
+		removalService: s.removalService,
+		dbDeleter:      s.dbDeleter,
+		tracer:         tracer,
+	}
+	err := w.deleteModel(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	span := tracer.singleSpan(c)
+	c.Check(strings.HasSuffix(span.name, ".deleteModel"), tc.IsTrue)
+	c.Check(span.attributes["undertaker.model.uuid"], tc.Equals, "model-1")
+	c.Check(span.recordedErr, tc.ErrorIsNil)
+	c.Check(span.ended, tc.IsTrue)
+}
+
+func (s *workerSuite) TestDeleteDatabaseTraceError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	tracer := &recordingTracer{}
+	s.dbDeleter.EXPECT().DeleteDB("model-1").Return(errors.Errorf("boom"))
+
+	w := &dbDeletionWorker{
+		namespace: "model-1",
+		service:   s.controllerModelService,
+		dbDeleter: s.dbDeleter,
+		logger:    s.logger,
+		tracer:    tracer,
+	}
+	err := w.deleteDatabase(c.Context())
+	c.Assert(err, tc.ErrorMatches, `deleting database for model "model-1": boom`)
+
+	span := tracer.singleSpan(c)
+	c.Check(strings.HasSuffix(span.name, ".deleteDatabase"), tc.IsTrue)
+	c.Check(span.attributes["undertaker.database.namespace"], tc.Equals, "model-1")
+	c.Check(span.recordedErr, tc.ErrorMatches, `deleting database for model "model-1": boom`)
+	c.Check(span.ended, tc.IsTrue)
+}
+
 func (s *workerSuite) expectWatchModels(ch chan struct{}) {
 	s.controllerModelService.EXPECT().WatchModels(gomock.Any()).DoAndReturn(func(ctx context.Context) (watcher.NotifyWatcher, error) {
 		return watchertest.NewMockNotifyWatcher(ch), nil
@@ -288,5 +336,61 @@ func (s *workerSuite) getConfig() Config {
 		RemovalServiceGetter:   s.removalServiceGetter,
 		Clock:                  clock.WallClock,
 		Logger:                 s.logger,
+		Tracer:                 coretrace.NoopTracer{},
 	}
+}
+
+type recordingTracer struct {
+	spans []*recordingSpan
+}
+
+func (t *recordingTracer) Start(
+	ctx context.Context,
+	name string,
+	options ...coretrace.Option,
+) (context.Context, coretrace.Span) {
+	traceOptions := coretrace.NewTracerOptions()
+	for _, option := range options {
+		option(traceOptions)
+	}
+	attributes := make(map[string]string)
+	for _, attribute := range traceOptions.Attributes() {
+		attributes[attribute.Key()] = attribute.Value()
+	}
+	span := &recordingSpan{
+		name:       name,
+		attributes: attributes,
+	}
+	t.spans = append(t.spans, span)
+	return coretrace.WithSpan(ctx, span), span
+}
+
+func (*recordingTracer) Enabled() bool {
+	return true
+}
+
+func (t *recordingTracer) singleSpan(c *tc.C) *recordingSpan {
+	c.Assert(t.spans, tc.HasLen, 1)
+	return t.spans[0]
+}
+
+type recordingSpan struct {
+	name        string
+	attributes  map[string]string
+	recordedErr error
+	ended       bool
+}
+
+func (*recordingSpan) Scope() coretrace.Scope {
+	return coretrace.NoopScope{}
+}
+
+func (*recordingSpan) AddEvent(string, ...coretrace.Attribute) {}
+
+func (s *recordingSpan) RecordError(err error, _ ...coretrace.Attribute) {
+	s.recordedErr = err
+}
+
+func (s *recordingSpan) End(...coretrace.Attribute) {
+	s.ended = true
 }


### PR DESCRIPTION
This is more a educational PR than a require change. Now that Juju has better trace support, we don't get that support for free. Instead we need to inject it into various workers for them to be traced. There are some workers where seeding the trace is not possible, but those should be few and far between. The likes of the dbaccessor and the changestream are two examples. They can't partake in trace seeding directly, because they're the source of the trace configuration, which would then introduce a cyclic dependency with the trace worker.

The change is simple enough, add the trace worker as a dependency and ensure that we start a trace with the trace worker.

## QA steps

You can either use COS or [docker-compose.yaml](https://gist.github.com/SimonRichardson/8a7421dd91eb0cfbaa4d0ae5df5790c6).

The observability and controller charm is also required from the main branch if using docker-compose, or just the controller charm with COS.

```sh
$ juju bootstrap lxd src --bootstrap-base=ubuntu@24.04 --controller-charm-path=./juju-controller_ubuntu@24.04-amd64.charm --build-agent
$ juju switch controller &&
juju config controller \
    workload-tracing-sample-ratio=1 \
    workload-tracing-tail-sampling-threshold=1ms \
    workload-tracing-insecure-skip-verify=true \
    loki-org-id=tenant1 \
    loki-insecure-skip-verify=true &&
juju deploy ./observability_amd64.charm &&
juju config observability \
    loki-url="http://192.168.0.38:3100/loki/api/v1/push" \
    http-endpoint="http://192.168.0.38:4318/v1/traces" &&
juju integrate controller:loki-push-api observability:loki-push-api &&
juju integrate controller:workload-tracing observability:workload-tracing
```

Then to do the actual test:

```sh
$ juju add-model foo
$ juju deploy ubuntu
$ juju destroy-model foo
```