### PR TITLE
feat: detach operation

### DIFF
--- a/api/client/machinemanager/machinemanager.go
+++ b/api/client/machinemanager/machinemanager.go
@@ -129,11 +129,9 @@ func (c *Client) RetryProvisioning(ctx context.Context, all bool, machines ...na
 
 // ReprovisionMachine requests reprovisioning of a machine whose backing
 // cloud instance is operator-declared lost.
-// The force flag is a data-loss acknowledgement.
-func (c *Client) ReprovisionMachine(ctx context.Context, machine names.MachineTag, force bool) (params.ErrorResult, error) {
+func (c *Client) ReprovisionMachine(ctx context.Context, machine names.MachineTag) (params.ErrorResult, error) {
 	p := params.ReprovisionMachineArgs{
 		MachineTag: machine.String(),
-		Force:      force,
 	}
 	var result params.ErrorResult
 	err := c.facade.FacadeCall(ctx, "ReprovisionMachine", p, &result)

--- a/api/client/machinemanager/machinemanager_test.go
+++ b/api/client/machinemanager/machinemanager_test.go
@@ -295,7 +295,6 @@ func (s *MachinemanagerSuite) TestReprovisionMachine(c *tc.C) {
 
 	args := params.ReprovisionMachineArgs{
 		MachineTag: names.NewMachineTag("0").String(),
-		Force:      true,
 	}
 	res := new(params.ErrorResult)
 	ress := params.ErrorResult{}
@@ -308,7 +307,7 @@ func (s *MachinemanagerSuite) TestReprovisionMachine(c *tc.C) {
 		return nil
 	})
 	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
-	result, err := client.ReprovisionMachine(c.Context(), names.NewMachineTag("0"), true)
+	result, err := client.ReprovisionMachine(c.Context(), names.NewMachineTag("0"))
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result, tc.DeepEquals, params.ErrorResult{})
 }
@@ -319,7 +318,6 @@ func (s *MachinemanagerSuite) TestReprovisionMachineError(c *tc.C) {
 
 	args := params.ReprovisionMachineArgs{
 		MachineTag: names.NewMachineTag("0").String(),
-		Force:      true,
 	}
 	res := new(params.ErrorResult)
 
@@ -328,6 +326,6 @@ func (s *MachinemanagerSuite) TestReprovisionMachineError(c *tc.C) {
 		gomock.Any(), "ReprovisionMachine", args, res,
 	).Return(errors.New("blargh"))
 	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
-	_, err := client.ReprovisionMachine(c.Context(), names.NewMachineTag("0"), true)
+	_, err := client.ReprovisionMachine(c.Context(), names.NewMachineTag("0"))
 	c.Check(err, tc.ErrorMatches, "blargh")
 }

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -428,7 +428,7 @@ func (mm *MachineManagerAPI) ReprovisionMachine(ctx context.Context, args params
 		}, nil
 	}
 
-	if err := mm.machineService.ReprovisionMachine(ctx, machineName, args.Force); err != nil {
+	if err := mm.machineService.ReprovisionMachine(ctx, machineName); err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}, nil
 	}
 

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -755,11 +755,10 @@ func (s *ProvisioningMachineManagerSuite) TestReprovisionMachine(c *tc.C) {
 
 	s.modelMigrationService.EXPECT().ModelMigrationMode(gomock.Any()).Return(modelmigration.MigrationModeNone, nil)
 	s.upgradeService.EXPECT().IsUpgrading(gomock.Any()).Return(false, nil)
-	s.machineService.EXPECT().ReprovisionMachine(gomock.Any(), coremachine.Name("0"), true).Return(nil)
+	s.machineService.EXPECT().ReprovisionMachine(gomock.Any(), coremachine.Name("0")).Return(nil)
 
 	result, err := s.api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
 		MachineTag: "machine-0",
-		Force:      true,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result.Error, tc.IsNil)
@@ -770,7 +769,6 @@ func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineV11NotSupported(
 
 	result, err := api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
 		MachineTag: "machine-0",
-		Force:      true,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result.Error, tc.NotNil)
@@ -800,7 +798,6 @@ func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineMigrationInProgr
 
 	result, err := s.api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
 		MachineTag: "machine-0",
-		Force:      true,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result.Error, tc.NotNil)
@@ -816,7 +813,6 @@ func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineUpgradeInProgres
 
 	result, err := s.api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
 		MachineTag: "machine-0",
-		Force:      true,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result.Error, tc.NotNil)
@@ -829,11 +825,10 @@ func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineServiceError(c *
 
 	s.modelMigrationService.EXPECT().ModelMigrationMode(gomock.Any()).Return(modelmigration.MigrationModeNone, nil)
 	s.upgradeService.EXPECT().IsUpgrading(gomock.Any()).Return(false, nil)
-	s.machineService.EXPECT().ReprovisionMachine(gomock.Any(), coremachine.Name("0"), true).Return(errors.New("not eligible"))
+	s.machineService.EXPECT().ReprovisionMachine(gomock.Any(), coremachine.Name("0")).Return(errors.New("not eligible"))
 
 	result, err := s.api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
 		MachineTag: "machine-0",
-		Force:      true,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result.Error, tc.NotNil)
@@ -846,7 +841,6 @@ func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineInvalidTag(c *tc
 
 	result, err := s.api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
 		MachineTag: "not-a-machine",
-		Force:      true,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(result.Error, tc.NotNil)
@@ -861,7 +855,6 @@ func (s *ProvisioningMachineManagerSuite) TestReprovisionMachineUnauthorised(c *
 
 	_, err := s.api.ReprovisionMachine(c.Context(), params.ReprovisionMachineArgs{
 		MachineTag: "machine-0",
-		Force:      true,
 	})
 	c.Assert(err, tc.ErrorMatches, "permission denied")
 }

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -218,7 +218,7 @@ type MockMachineServiceMockRecorder struct {
 	getMachineBaseExpects             []*gomock.Call2_2[context.Context, machine.Name, base.Base, error]
 	getMachineContainersExpects       []*gomock.Call2_2[context.Context, machine.UUID, []machine.Name, error]
 	getMachineUUIDExpects             []*gomock.Call2_2[context.Context, machine.Name, machine.UUID, error]
-	reprovisionMachineExpects         []*gomock.Call3_1[context.Context, machine.Name, bool, error]
+	reprovisionMachineExpects         []*gomock.Call2_1[context.Context, machine.Name, error]
 	setKeepInstanceExpects            []*gomock.Call3_1[context.Context, machine.Name, bool, error]
 	shouldKeepInstanceExpects         []*gomock.Call2_2[context.Context, machine.Name, bool, error]
 }
@@ -362,22 +362,22 @@ func (mr *MockMachineServiceMockRecorder) GetMachineUUID(arg0, arg1 any) *MockMa
 type MockMachineServiceGetMachineUUIDCall = gomock.Call2_2[context.Context, machine.Name, machine.UUID, error]
 
 // ReprovisionMachine mocks base method.
-func (m *MockMachineService) ReprovisionMachine(arg0 context.Context, arg1 machine.Name, arg2 bool) error {
+func (m *MockMachineService) ReprovisionMachine(arg0 context.Context, arg1 machine.Name) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch3_1(&m.recorder.reprovisionMachineExpects, m.ctrl, m, "ReprovisionMachine", arg0, arg1, arg2)
+	return gomock.Dispatch2_1(&m.recorder.reprovisionMachineExpects, m.ctrl, m, "ReprovisionMachine", arg0, arg1)
 }
 
 // ReprovisionMachine indicates an expected call of ReprovisionMachine.
-func (mr *MockMachineServiceMockRecorder) ReprovisionMachine(arg0, arg1, arg2 any) *MockMachineServiceReprovisionMachineCall {
+func (mr *MockMachineServiceMockRecorder) ReprovisionMachine(arg0, arg1 any) *MockMachineServiceReprovisionMachineCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall3_1[context.Context, machine.Name, bool, error](mr.mock.ctrl.T, mr.mock, "ReprovisionMachine", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
+	call := gomock.NewCall2_1[context.Context, machine.Name, error](mr.mock.ctrl.T, mr.mock, "ReprovisionMachine", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
 	mr.reprovisionMachineExpects = append(mr.reprovisionMachineExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockMachineServiceReprovisionMachineCall is the typed call wrapper for ReprovisionMachine.
-type MockMachineServiceReprovisionMachineCall = gomock.Call3_1[context.Context, machine.Name, bool, error]
+type MockMachineServiceReprovisionMachineCall = gomock.Call2_1[context.Context, machine.Name, error]
 
 // SetKeepInstance mocks base method.
 func (m *MockMachineService) SetKeepInstance(ctx context.Context, machineName machine.Name, keep bool) error {

--- a/apiserver/facades/client/machinemanager/services.go
+++ b/apiserver/facades/client/machinemanager/services.go
@@ -98,10 +98,10 @@ type MachineService interface {
 	AllMachineNames(context.Context) ([]coremachine.Name, error)
 
 	// ReprovisionMachine validates that a machine is eligible for
-	// reprovisioning. The force flag acknowledges data loss.
+	// reprovisioning.
 	// It returns an error if the machine does not meet the eligibility
 	// criteria.
-	ReprovisionMachine(context.Context, coremachine.Name, bool) error
+	ReprovisionMachine(context.Context, coremachine.Name) error
 
 	// GetInstanceTypesFetcher returns the instance types fetcher.
 	GetInstanceTypesFetcher(context.Context) (environs.InstanceTypesFetcher, error)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -10268,17 +10268,13 @@
                 "ReprovisionMachineArgs": {
                     "type": "object",
                     "properties": {
-                        "force": {
-                            "type": "boolean"
-                        },
                         "machine-tag": {
                             "type": "string"
                         }
                     },
                     "additionalProperties": false,
                     "required": [
-                        "machine-tag",
-                        "force"
+                        "machine-tag"
                     ]
                 },
                 "RetryProvisioningArgs": {

--- a/cmd/juju/machine/reprovisionmachine.go
+++ b/cmd/juju/machine/reprovisionmachine.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/gnuflag"
 	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/api/client/machinemanager"
@@ -28,7 +27,6 @@ type reprovisionMachineCommand struct {
 	modelcmd.ModelCommandBase
 	modelcmd.IAASOnlyCommand
 	machine string
-	force   bool
 	api     ReprovisionMachineAPI
 }
 
@@ -36,7 +34,7 @@ type reprovisionMachineCommand struct {
 // reprovision-machine command calls.
 type ReprovisionMachineAPI interface {
 	Close() error
-	ReprovisionMachine(ctx context.Context, machine names.MachineTag, force bool) (params.ErrorResult, error)
+	ReprovisionMachine(ctx context.Context, machine names.MachineTag) (params.ErrorResult, error)
 }
 
 const reprovisionMachineDoc = `
@@ -47,16 +45,13 @@ replacement cloud instance through the normal provisioning path.
 Root disk, ephemeral disk, charm-local state, and machine-scoped storage
 data are NOT recovered. The replacement instance will have empty storage.
 
-The --force flag is required by the server to acknowledge this data loss.
-It does not bypass safety checks.
-
 This command is only supported for top-level, non-controller, IaaS
 provider-backed machines without child container machines or attached
 model-scoped storage.
 `
 
 const reprovisionMachineExamples = `
-    juju reprovision-machine 3 --force
+    juju reprovision-machine 3
 `
 
 // Info implements Command.Info.
@@ -68,12 +63,6 @@ func (c *reprovisionMachineCommand) Info() *cmd.Info {
 		Doc:      reprovisionMachineDoc,
 		Examples: reprovisionMachineExamples,
 	})
-}
-
-// SetFlags implements Command.SetFlags.
-func (c *reprovisionMachineCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.ModelCommandBase.SetFlags(f)
-	f.BoolVar(&c.force, "force", false, "Acknowledge that root disk, ephemeral disk, charm-local state, and machine-scoped storage data will be lost")
 }
 
 // Init implements Command.Init.
@@ -117,7 +106,7 @@ func (c *reprovisionMachineCommand) Run(ctx *cmd.Context) error {
 	}
 	defer client.Close()
 
-	result, err := client.ReprovisionMachine(ctx, names.NewMachineTag(c.machine), c.force)
+	result, err := client.ReprovisionMachine(ctx, names.NewMachineTag(c.machine))
 	if err != nil {
 		if params.IsCodeNotImplemented(err) {
 			return errors.Errorf(

--- a/cmd/juju/machine/reprovisionmachine_test.go
+++ b/cmd/juju/machine/reprovisionmachine_test.go
@@ -39,7 +39,7 @@ func (f *fakeReprovisionMachineClient) Close() error {
 	return nil
 }
 
-func (f *fakeReprovisionMachineClient) ReprovisionMachine(ctx context.Context, machine names.MachineTag, force bool) (params.ErrorResult, error) {
+func (f *fakeReprovisionMachineClient) ReprovisionMachine(ctx context.Context, machine names.MachineTag) (params.ErrorResult, error) {
 	if f.err != nil {
 		return params.ErrorResult{}, f.err
 	}
@@ -78,9 +78,15 @@ func (s *reprovisionMachineSuite) TestContainerMachine(c *tc.C) {
 	c.Check(err, tc.ErrorMatches, `invalid machine "0/lxd/0" reprovision-machine does not support containers`)
 }
 
+func (s *reprovisionMachineSuite) TestForceFlagRemoved(c *tc.C) {
+	command := machine.NewReprovisionMachineCommandForTest(s.fake)
+	_, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	c.Check(err, tc.ErrorMatches, `option provided but not defined: --force`)
+}
+
 func (s *reprovisionMachineSuite) TestSuccess(c *tc.C) {
 	command := machine.NewReprovisionMachineCommandForTest(s.fake)
-	ctx, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	ctx, err := cmdtesting.RunCommand(c, command, "0")
 	c.Check(err, tc.ErrorIsNil)
 	output := cmdtesting.Stdout(ctx)
 	c.Check(strings.TrimSpace(output), tc.Equals, "reprovisioning machine 0")
@@ -89,21 +95,21 @@ func (s *reprovisionMachineSuite) TestSuccess(c *tc.C) {
 func (s *reprovisionMachineSuite) TestAPIError(c *tc.C) {
 	s.fake.machineErr = &params.Error{Message: "API error message"}
 	command := machine.NewReprovisionMachineCommandForTest(s.fake)
-	_, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	_, err := cmdtesting.RunCommand(c, command, "0")
 	c.Check(err, tc.ErrorMatches, "API error message")
 }
 
 func (s *reprovisionMachineSuite) TestBlockedError(c *tc.C) {
 	s.fake.err = apiservererrors.OperationBlockedError("TestBlockReprovisionMachine")
 	command := machine.NewReprovisionMachineCommandForTest(s.fake)
-	_, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	_, err := cmdtesting.RunCommand(c, command, "0")
 	testing.AssertOperationWasBlocked(c, err, ".*TestBlockReprovisionMachine.*")
 }
 
 func (s *reprovisionMachineSuite) TestConnectionError(c *tc.C) {
 	s.fake.err = errors.New("connection refused")
 	command := machine.NewReprovisionMachineCommandForTest(s.fake)
-	_, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	_, err := cmdtesting.RunCommand(c, command, "0")
 	c.Check(err, tc.ErrorMatches, "connection refused")
 }
 
@@ -113,7 +119,7 @@ func (s *reprovisionMachineSuite) TestNotSupported(c *tc.C) {
 		Code:    "not implemented",
 	}
 	command := machine.NewReprovisionMachineCommandForTest(s.fake)
-	_, err := cmdtesting.RunCommand(c, command, "0", "--force")
+	_, err := cmdtesting.RunCommand(c, command, "0")
 	c.Check(err, tc.ErrorMatches,
 		"reprovision-machine is not supported by this controller; "+
 			"the controller must be upgraded to a version that supports reprovisioning")

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/reprovision-machine.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/reprovision-machine.md
@@ -10,12 +10,11 @@ Reprovision a machine whose cloud instance has been lost.
 | Flag | Default | Usage |
 | --- | --- | --- |
 | `-B`, `--no-browser-login` | false | Do not use web browser for authentication |
-| `--force` | false | Acknowledge that root disk, ephemeral disk, charm-local state, and machine-scoped storage data will be lost |
 | `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
 
 ## Examples
 
-    juju reprovision-machine 3 --force
+    juju reprovision-machine 3
 
 
 ## Details
@@ -26,9 +25,6 @@ replacement cloud instance through the normal provisioning path.
 
 Root disk, ephemeral disk, charm-local state, and machine-scoped storage
 data are NOT recovered. The replacement instance will have empty storage.
-
-The --force flag is required by the server to acknowledge this data loss.
-It does not bypass safety checks.
 
 This command is only supported for top-level, non-controller, IaaS
 provider-backed machines without child container machines or attached

--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -48,6 +48,10 @@ const (
 	// when adding cloud instance on a machine that already exists.
 	MachineCloudInstanceAlreadyExists = errors.ConstError("machine cloud instance already exists")
 
+	// MachineCloudInstanceChanged describes an error that occurs when the
+	// machine's cloud instance changes during a reprovisioning request.
+	MachineCloudInstanceChanged = errors.ConstError("machine cloud instance changed")
+
 	// InvalidMachineConstraints describes an error that occurs when the
 	// machine constraints are not valid. This happens when if the
 	// provided space constraints do not exist or the container type is not

--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	"github.com/juju/clock"
@@ -22,9 +23,13 @@ import (
 	domainmachine "github.com/juju/juju/domain/machine"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	domainstatus "github.com/juju/juju/domain/status"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/statushistory"
 )
+
+const reprovisioningStatusMessage = "reprovisioning requested"
 
 // Provider represents an underlying cloud provider.
 type Provider interface {
@@ -88,14 +93,64 @@ func (s *ProviderService) ReprovisionMachine(ctx context.Context, machineName ma
 	if err != nil && !errors.Is(err, environs.ErrNoInstances) && !errors.Is(err, environs.ErrPartialInstances) {
 		return errors.Errorf("checking provider instance %q for machine %q: %w", instanceID, machineName, err)
 	}
+
+	// If the provider returns no instance, there is nothing to do.
 	if len(instances) == 0 || instances[0] == nil {
 		return nil
 	}
 
+	// If the provider reports that the instance is running, then there isn't
+	// anything we should do.
 	providerStatus := instances[0].Status(ctx)
 	if providerStatus.Status == corestatus.Running {
 		return errors.Errorf("machine %q instance %q: %w", machineName, instanceID, machineerrors.MachineProviderInstanceRunning)
 	}
+	return s.detachLostMachineCloudInstance(ctx, machineName, instanceID)
+}
+
+// detachLostMachineCloudInstance atomically clears provider-observed state for
+// a lost machine instance and moves the machine back to pending. The expected
+// instance ID prevents detaching a replacement that appeared after the
+// provider liveness check.
+func (s *ProviderService) detachLostMachineCloudInstance(
+	ctx context.Context,
+	machineName machine.Name,
+	expectedInstanceID instance.Id,
+) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	statusData := map[string]any{
+		"old-instance-id": expectedInstanceID.String(),
+	}
+	encodedStatusData, err := json.Marshal(statusData)
+	if err != nil {
+		return errors.Errorf("encoding reprovisioning status data: %w", err)
+	}
+
+	now := s.clock.Now().UTC()
+	if err := s.st.DetachLostMachineCloudInstance(
+		ctx, machineName.String(), expectedInstanceID.String(), reprovisioningStatusMessage,
+		encodedStatusData, now,
+	); err != nil {
+		return errors.Errorf("detaching lost cloud instance for machine %q: %w", machineName, err)
+	}
+
+	statusInfo := corestatus.StatusInfo{
+		Status:  corestatus.Pending,
+		Message: reprovisioningStatusMessage,
+		Data:    statusData,
+		Since:   &now,
+	}
+	for _, namespace := range []statushistory.Namespace{
+		domainstatus.MachineNamespace.WithID(machineName.String()),
+		domainstatus.MachineInstanceNamespace.WithID(machineName.String()),
+	} {
+		if err := s.statusHistory.RecordStatus(ctx, namespace, statusInfo); err != nil {
+			s.logger.Warningf(ctx, "recording reprovisioning status history: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -68,7 +68,7 @@ func NewProviderService(
 
 // ReprovisionMachine validates that the machine identified by name is eligible
 // for reprovisioning, then applies the split-brain prevention liveness gates.
-func (s *ProviderService) ReprovisionMachine(ctx context.Context, machineName machine.Name, force bool) error {
+func (s *ProviderService) ReprovisionMachine(ctx context.Context, machineName machine.Name) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -94,9 +94,10 @@ func (s *ProviderService) ReprovisionMachine(ctx context.Context, machineName ma
 		return errors.Errorf("checking provider instance %q for machine %q: %w", instanceID, machineName, err)
 	}
 
-	// If the provider returns no instance, there is nothing to do.
+	// If the provider reports that the instance is missing, then we can safely
+	// detach the instance and move the machine back to pending.
 	if len(instances) == 0 || instances[0] == nil {
-		return nil
+		return s.detachLostMachineCloudInstance(ctx, machineName, instanceID)
 	}
 
 	// If the provider reports that the instance is running, then there isn't

--- a/domain/machine/service/provider_test.go
+++ b/domain/machine/service/provider_test.go
@@ -6,9 +6,11 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/clock"
+	"github.com/juju/clock/testclock"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/core/arch"
@@ -524,6 +526,57 @@ func (s *providerServiceSuite) TestReprovisionMachineProviderNoInstance(c *tc.C)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *providerServiceSuite) TestReprovisionMachineDetachError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	instanceID := instance.Id("i-1234")
+	s.expectReprovisionMachineValidated(c, instanceID)
+	s.expectMachineAgentAbsent()
+	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return([]instances.Instance{
+		reprovisionInstance{id: instanceID, status: status.Error},
+	}, nil)
+	statusData := []byte(`{"old-instance-id":"i-1234"}`)
+	s.state.EXPECT().DetachLostMachineCloudInstance(
+		gomock.Any(), "0", instanceID.String(), reprovisioningStatusMessage,
+		statusData, gomock.Any(),
+	).Return(errors.New("detach failed"))
+
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"), true)
+	c.Assert(err, tc.ErrorMatches, `detaching lost cloud instance for machine "0": detach failed`)
+}
+
+func (s *providerServiceSuite) TestDetachLostMachineCloudInstanceStatusData(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	s.service.clock = testclock.NewClock(now)
+	statusData := map[string]any{
+		"old-instance-id": "i-1234",
+	}
+	encodedStatusData := []byte(`{"old-instance-id":"i-1234"}`)
+	statusInfo := status.StatusInfo{
+		Status:  status.Pending,
+		Message: reprovisioningStatusMessage,
+		Data:    statusData,
+		Since:   &now,
+	}
+	s.state.EXPECT().DetachLostMachineCloudInstance(
+		gomock.Any(), "0", "i-1234",
+		reprovisioningStatusMessage, encodedStatusData, now,
+	).Return(nil)
+	s.statusHistory.EXPECT().RecordStatus(
+		gomock.Any(), domainstatus.MachineNamespace.WithID("0"), statusInfo,
+	).Return(nil)
+	s.statusHistory.EXPECT().RecordStatus(
+		gomock.Any(), domainstatus.MachineInstanceNamespace.WithID("0"), statusInfo,
+	).Return(nil)
+
+	err := s.service.detachLostMachineCloudInstance(
+		c.Context(), machine.Name("0"), instance.Id("i-1234"),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *providerServiceSuite) TestReprovisionMachineProviderPartialNoInstance(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -556,6 +609,7 @@ func (s *providerServiceSuite) TestReprovisionMachineProviderNonRunningStatuses(
 			s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return([]instances.Instance{
 				reprovisionInstance{id: instanceID, status: providerStatus},
 			}, nil)
+			s.expectMachineDetached()
 
 			err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"), true)
 			c.Assert(err, tc.ErrorIsNil)
@@ -570,6 +624,20 @@ func (s *providerServiceSuite) expectReprovisionMachineValidated(c *tc.C, instan
 
 func (s *providerServiceSuite) expectMachineAgentAbsent() {
 	s.state.EXPECT().IsMachineAgentPresent(gomock.Any(), machine.Name("0")).Return(false, nil)
+}
+
+func (s *providerServiceSuite) expectMachineDetached() {
+	statusData := []byte(`{"old-instance-id":"i-1234"}`)
+	s.state.EXPECT().DetachLostMachineCloudInstance(
+		gomock.Any(), "0", "i-1234",
+		reprovisioningStatusMessage, statusData, gomock.Any(),
+	).Return(nil)
+	s.statusHistory.EXPECT().RecordStatus(
+		gomock.Any(), domainstatus.MachineNamespace.WithID("0"), gomock.Any(),
+	).Return(nil)
+	s.statusHistory.EXPECT().RecordStatus(
+		gomock.Any(), domainstatus.MachineInstanceNamespace.WithID("0"), gomock.Any(),
+	).Return(nil)
 }
 
 type reprovisionInstance struct {

--- a/domain/machine/service/provider_test.go
+++ b/domain/machine/service/provider_test.go
@@ -472,7 +472,7 @@ func (s *providerServiceSuite) TestReprovisionMachineAgentPresent(c *tc.C) {
 	s.expectReprovisionMachineValidated(c, "i-1234")
 	s.state.EXPECT().IsMachineAgentPresent(gomock.Any(), machine.Name("0")).Return(true, nil)
 
-	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"), true)
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 	c.Assert(err, tc.ErrorIs, machineerrors.MachineAgentPresent)
 }
 
@@ -484,7 +484,7 @@ func (s *providerServiceSuite) TestReprovisionMachineAgentAbsentNoInstance(c *tc
 	s.expectMachineAgentAbsent()
 	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return(nil, environs.ErrNoInstances)
 
-	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"), true)
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -498,7 +498,7 @@ func (s *providerServiceSuite) TestReprovisionMachineProviderRunning(c *tc.C) {
 		reprovisionInstance{id: instanceID, status: status.Running},
 	}, nil)
 
-	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"), true)
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 	c.Assert(err, tc.ErrorIs, machineerrors.MachineProviderInstanceRunning)
 }
 
@@ -510,7 +510,7 @@ func (s *providerServiceSuite) TestReprovisionMachineProviderLookupError(c *tc.C
 	s.expectMachineAgentAbsent()
 	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return(nil, errors.New("provider lookup failed"))
 
-	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"), true)
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 	c.Assert(err, tc.ErrorMatches, `checking provider instance "i-1234" for machine "0": provider lookup failed`)
 }
 
@@ -522,7 +522,7 @@ func (s *providerServiceSuite) TestReprovisionMachineProviderNoInstance(c *tc.C)
 	s.expectMachineAgentAbsent()
 	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return(nil, environs.ErrNoInstances)
 
-	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"), true)
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -541,7 +541,7 @@ func (s *providerServiceSuite) TestReprovisionMachineDetachError(c *tc.C) {
 		statusData, gomock.Any(),
 	).Return(errors.New("detach failed"))
 
-	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"), true)
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 	c.Assert(err, tc.ErrorMatches, `detaching lost cloud instance for machine "0": detach failed`)
 }
 
@@ -585,7 +585,7 @@ func (s *providerServiceSuite) TestReprovisionMachineProviderPartialNoInstance(c
 	s.expectMachineAgentAbsent()
 	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return([]instances.Instance{nil}, environs.ErrPartialInstances)
 
-	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"), true)
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -611,7 +611,7 @@ func (s *providerServiceSuite) TestReprovisionMachineProviderNonRunningStatuses(
 			}, nil)
 			s.expectMachineDetached()
 
-			err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"), true)
+			err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 			c.Assert(err, tc.ErrorIsNil)
 		}()
 	}

--- a/domain/machine/service/provider_test.go
+++ b/domain/machine/service/provider_test.go
@@ -476,13 +476,14 @@ func (s *providerServiceSuite) TestReprovisionMachineAgentPresent(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, machineerrors.MachineAgentPresent)
 }
 
-func (s *providerServiceSuite) TestReprovisionMachineAgentAbsentNoInstance(c *tc.C) {
+func (s *providerServiceSuite) TestReprovisionMachineProviderEmptyInstances(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	instanceID := instance.Id("i-1234")
 	s.expectReprovisionMachineValidated(c, instanceID)
 	s.expectMachineAgentAbsent()
-	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return(nil, environs.ErrNoInstances)
+	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return(nil, nil)
+	s.expectMachineDetached()
 
 	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 	c.Assert(err, tc.ErrorIsNil)
@@ -521,6 +522,7 @@ func (s *providerServiceSuite) TestReprovisionMachineProviderNoInstance(c *tc.C)
 	s.expectReprovisionMachineValidated(c, instanceID)
 	s.expectMachineAgentAbsent()
 	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return(nil, environs.ErrNoInstances)
+	s.expectMachineDetached()
 
 	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 	c.Assert(err, tc.ErrorIsNil)
@@ -584,6 +586,7 @@ func (s *providerServiceSuite) TestReprovisionMachineProviderPartialNoInstance(c
 	s.expectReprovisionMachineValidated(c, instanceID)
 	s.expectMachineAgentAbsent()
 	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return([]instances.Instance{nil}, environs.ErrPartialInstances)
+	s.expectMachineDetached()
 
 	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/clock"
 	"github.com/juju/collections/transform"
@@ -76,6 +77,12 @@ type State interface {
 	// SetMachineCloudInstance sets an entry in the machine cloud instance table
 	// along with the instance tags and the link to a lxd profile if any.
 	SetMachineCloudInstance(context.Context, string, instance.Id, string, string, *instance.HardwareCharacteristics) error
+
+	// DetachLostMachineCloudInstance atomically clears the provider-observed
+	// state for a lost machine instance and moves the machine back to pending.
+	DetachLostMachineCloudInstance(
+		context.Context, string, string, string, []byte, time.Time,
+	) error
 
 	// SetRunningAgentBinaryVersion sets the running agent version for the
 	// machine. A MachineNotFound error will be returned if the machine does not

--- a/domain/machine/service/state_mock_test.go
+++ b/domain/machine/service/state_mock_test.go
@@ -224,7 +224,7 @@ func (mr *MockStateMockRecorder) CountMachinesInSpace(ctx, spUUID any) *MockStat
 type MockStateCountMachinesInSpaceCall = gomock.Call2_2[context.Context, string, int64, error]
 
 // DetachLostMachineCloudInstance mocks base method.
-func (m *MockState) DetachLostMachineCloudInstance(arg0 context.Context, arg1 string, arg2 string, arg3 string, arg4 []byte, arg5 time.Time) error {
+func (m *MockState) DetachLostMachineCloudInstance(arg0 context.Context, arg1, arg2, arg3 string, arg4 []byte, arg5 time.Time) error {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch6_1(&m.recorder.detachLostMachineCloudInstanceExpects, m.ctrl, m, "DetachLostMachineCloudInstance", arg0, arg1, arg2, arg3, arg4, arg5)
 }

--- a/domain/machine/service/state_mock_test.go
+++ b/domain/machine/service/state_mock_test.go
@@ -11,6 +11,7 @@ package service
 
 import (
 	context "context"
+	time "time"
 
 	gomock "github.com/canonical/gomock/gomock"
 	agentbinary "github.com/juju/juju/core/agentbinary"
@@ -42,6 +43,7 @@ type MockStateMockRecorder struct {
 	checkMachineReprovisioningEligibilityExpects              []*gomock.Call2_1[context.Context, machine.Name, error]
 	clearMachineRebootExpects                                 []*gomock.Call2_1[context.Context, machine.UUID, error]
 	countMachinesInSpaceExpects                               []*gomock.Call2_2[context.Context, string, int64, error]
+	detachLostMachineCloudInstanceExpects                     []*gomock.Call6_1[context.Context, string, string, string, []byte, time.Time, error]
 	getAllProvisionedMachineInstanceIDExpects                 []*gomock.Call1_2[context.Context, map[machine.Name]string, error]
 	getHardwareCharacteristicsExpects                         []*gomock.Call2_2[context.Context, string, instance.HardwareCharacteristics, error]
 	getInstanceIDExpects                                      []*gomock.Call2_2[context.Context, string, string, error]
@@ -220,6 +222,24 @@ func (mr *MockStateMockRecorder) CountMachinesInSpace(ctx, spUUID any) *MockStat
 
 // MockStateCountMachinesInSpaceCall is the typed call wrapper for CountMachinesInSpace.
 type MockStateCountMachinesInSpaceCall = gomock.Call2_2[context.Context, string, int64, error]
+
+// DetachLostMachineCloudInstance mocks base method.
+func (m *MockState) DetachLostMachineCloudInstance(arg0 context.Context, arg1 string, arg2 string, arg3 string, arg4 []byte, arg5 time.Time) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch6_1(&m.recorder.detachLostMachineCloudInstanceExpects, m.ctrl, m, "DetachLostMachineCloudInstance", arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// DetachLostMachineCloudInstance indicates an expected call of DetachLostMachineCloudInstance.
+func (mr *MockStateMockRecorder) DetachLostMachineCloudInstance(arg0, arg1, arg2, arg3, arg4, arg5 any) *MockStateDetachLostMachineCloudInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall6_1[context.Context, string, string, string, []byte, time.Time, error](mr.mock.ctrl.T, mr.mock, "DetachLostMachineCloudInstance", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2), gomock.EnsureMatcher(arg3), gomock.EnsureMatcher(arg4), gomock.EnsureMatcher(arg5))
+	mr.detachLostMachineCloudInstanceExpects = append(mr.detachLostMachineCloudInstanceExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockStateDetachLostMachineCloudInstanceCall is the typed call wrapper for DetachLostMachineCloudInstance.
+type MockStateDetachLostMachineCloudInstanceCall = gomock.Call6_1[context.Context, string, string, string, []byte, time.Time, error]
 
 // GetAllProvisionedMachineInstanceID mocks base method.
 func (m *MockState) GetAllProvisionedMachineInstanceID(ctx context.Context) (map[machine.Name]string, error) {

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -201,7 +201,7 @@ WHERE machine_uuid=$instanceData.machine_uuid
 UPDATE machine
 SET    nonce = $machineNonce.nonce
 WHERE  uuid = $machineNonce.machine_uuid
-AND    nonce IS NULL OR nonce = ''
+AND    (nonce IS NULL OR nonce = '')
 `, mNonce)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -221,6 +221,32 @@ func (s *stateSuite) TestSetInstanceDataEmptyDisplayName(c *tc.C) {
 	c.Check(displayName.Valid, tc.IsFalse)
 }
 
+func (s *stateSuite) TestSetInstanceDataNonceOnlyUpdatesTargetMachine(c *tc.C) {
+	otherMachineUUID, _ := s.addMachine(c)
+	s.runQuery(c, "UPDATE machine SET nonce = '' WHERE uuid = ?", otherMachineUUID.String())
+	targetMachineUUID, _ := s.addMachine(c)
+
+	err := s.state.SetMachineCloudInstance(
+		c.Context(), targetMachineUUID.String(), instance.Id("1"), "",
+		"replacement-nonce", &instance.HardwareCharacteristics{},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var otherNonce, targetNonce sql.Null[string]
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT nonce FROM machine WHERE uuid = ?", otherMachineUUID.String(),
+	).Scan(&otherNonce)
+	c.Assert(err, tc.ErrorIsNil)
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT nonce FROM machine WHERE uuid = ?", targetMachineUUID.String(),
+	).Scan(&targetNonce)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(otherNonce.V, tc.Equals, "")
+	c.Check(otherNonce.Valid, tc.IsTrue)
+	c.Check(targetNonce.V, tc.Equals, "replacement-nonce")
+	c.Check(targetNonce.Valid, tc.IsTrue)
+}
+
 func (s *stateSuite) TestSetInstanceDataEmptyUniqueIndex(c *tc.C) {
 	// Ensure that setting empty instance IDs and display names does not
 	// violate the unique index on the machine_cloud_instance table.

--- a/domain/machine/state/reprovision.go
+++ b/domain/machine/state/reprovision.go
@@ -1,0 +1,348 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/sqlair"
+
+	"github.com/juju/juju/domain/life"
+	machineerrors "github.com/juju/juju/domain/machine/errors"
+	domainstatus "github.com/juju/juju/domain/status"
+	"github.com/juju/juju/internal/errors"
+)
+
+// DetachLostMachineCloudInstance atomically rechecks the critical
+// reprovisioning preconditions, clears stale provider-observed state, and
+// moves the machine and its cloud instance back to pending.
+func (st *State) DetachLostMachineCloudInstance(
+	ctx context.Context,
+	mName string,
+	expectedInstanceID string,
+	statusMessage string,
+	statusData []byte,
+	updatedAt time.Time,
+) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	machineNameParam := machineName{Name: mName}
+	targetStmt, err := st.Prepare(`
+SELECT     m.uuid AS &reprovisionDetachTarget.machine_uuid,
+           m.net_node_uuid AS &reprovisionDetachTarget.net_node_uuid,
+           mci.instance_id AS &reprovisionDetachTarget.instance_id,
+           m.life_id AS &reprovisionDetachTarget.life_id,
+           COUNT(DISTINCT mapr.machine_uuid) AS &reprovisionDetachTarget.agent_present
+FROM       machine AS m
+JOIN       machine_cloud_instance AS mci ON m.uuid = mci.machine_uuid
+LEFT JOIN  machine_agent_presence AS mapr ON m.uuid = mapr.machine_uuid
+WHERE      m.name = $machineName.name
+GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
+`, machineNameParam, reprovisionDetachTarget{})
+	if err != nil {
+		return errors.Errorf("preparing reprovision detach target query: %w", err)
+	}
+
+	machineStatusID, err := domainstatus.EncodeMachineStatus(domainstatus.MachineStatusPending)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	instanceStatusID, err := domainstatus.EncodeCloudInstanceStatus(domainstatus.InstanceStatusPending)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	networkStmts, err := st.prepareReprovisionNetworkStatements()
+	if err != nil {
+		return errors.Errorf("preparing network cleanup statements: %w", err)
+	}
+	blockDeviceStmts, err := st.prepareReprovisionBlockDeviceStatements()
+	if err != nil {
+		return errors.Errorf("preparing block device cleanup statements: %w", err)
+	}
+	machineDataStmts, err := st.prepareReprovisionMachineDataStatements()
+	if err != nil {
+		return errors.Errorf("preparing machine data cleanup statements: %w", err)
+	}
+	machineStatusStmt, instanceStatusStmt, err := st.prepareReprovisionStatusStatements()
+	if err != nil {
+		return errors.Errorf("preparing status statements: %w", err)
+	}
+
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var target reprovisionDetachTarget
+		if err := tx.Query(ctx, targetStmt, machineNameParam).Get(&target); errors.Is(err, sqlair.ErrNoRows) {
+			return machineerrors.MachineNotFound
+		} else if err != nil {
+			return errors.Errorf("querying reprovision detach target %q: %w", mName, err)
+		}
+
+		if err := validateReprovisionDetachTarget(target, expectedInstanceID); err != nil {
+			return errors.Capture(err)
+		}
+
+		if err := runReprovisionStatements(
+			ctx, tx, networkStmts, netNode{UUID: target.NetNodeUUID},
+		); err != nil {
+			return errors.Errorf("clearing network state: %w", err)
+		}
+
+		machineUUID := entityUUID{UUID: target.UUID}
+		if err := runReprovisionStatements(ctx, tx, blockDeviceStmts, machineUUID); err != nil {
+			return errors.Errorf("clearing block devices: %w", err)
+		}
+		if err := runReprovisionStatements(ctx, tx, machineDataStmts, machineUUID); err != nil {
+			return errors.Errorf("clearing stale machine instance data: %w", err)
+		}
+
+		statusValue := setMachineStatus{
+			MachineUUID: target.UUID,
+			StatusID:    machineStatusID,
+			Message:     statusMessage,
+			Data:        statusData,
+			Updated:     &updatedAt,
+		}
+		if err := tx.Query(ctx, machineStatusStmt, statusValue).Run(); err != nil {
+			return errors.Errorf("setting reprovisioning machine status: %w", err)
+		}
+		statusValue.StatusID = instanceStatusID
+		if err := tx.Query(ctx, instanceStatusStmt, statusValue).Run(); err != nil {
+			return errors.Errorf("setting reprovisioning instance status: %w", err)
+		}
+		return nil
+	})
+}
+
+func validateReprovisionDetachTarget(target reprovisionDetachTarget, expectedInstanceID string) error {
+	if target.LifeID != life.Alive {
+		return machineerrors.MachineNotAlive
+	}
+	if target.AgentPresent > 0 {
+		return machineerrors.MachineAgentPresent
+	}
+	if !target.InstanceID.Valid || target.InstanceID.V == "" {
+		return machineerrors.NotProvisioned
+	}
+	if target.InstanceID.V != expectedInstanceID {
+		return machineerrors.MachineCloudInstanceChanged
+	}
+	return nil
+}
+
+func (st *State) prepareReprovisionNetworkStatements() ([]*sqlair.Statement, error) {
+	queries := []string{
+		// Delete provider identifiers for IP addresses observed on the old
+		// machine instance.
+		`
+WITH target_addresses AS (
+    SELECT ipa.uuid AS address_uuid
+    FROM ip_address AS ipa
+    WHERE ipa.net_node_uuid = $netNode.net_node_uuid
+)
+DELETE FROM provider_ip_address
+WHERE address_uuid IN (
+    SELECT ta.address_uuid FROM target_addresses AS ta
+)`,
+		// Delete all IP addresses associated with the machine net node.
+		`
+DELETE FROM ip_address
+WHERE net_node_uuid = $netNode.net_node_uuid`,
+		// Delete parent-child relationships for the old link-layer devices.
+		`
+WITH target_devices AS (
+    SELECT lld.uuid AS device_uuid
+    FROM link_layer_device AS lld
+    WHERE lld.net_node_uuid = $netNode.net_node_uuid
+)
+DELETE FROM link_layer_device_parent
+WHERE device_uuid IN (
+    SELECT td.device_uuid FROM target_devices AS td
+)
+OR parent_uuid IN (
+    SELECT td.device_uuid FROM target_devices AS td
+)`,
+		// Delete provider identifiers for the old link-layer devices.
+		`
+WITH target_devices AS (
+    SELECT lld.uuid AS device_uuid
+    FROM link_layer_device AS lld
+    WHERE lld.net_node_uuid = $netNode.net_node_uuid
+)
+DELETE FROM provider_link_layer_device
+WHERE device_uuid IN (
+    SELECT td.device_uuid FROM target_devices AS td
+)`,
+		// Delete DNS search domains reported for the old link-layer devices.
+		`
+WITH target_devices AS (
+    SELECT lld.uuid AS device_uuid
+    FROM link_layer_device AS lld
+    WHERE lld.net_node_uuid = $netNode.net_node_uuid
+)
+DELETE FROM link_layer_device_dns_domain
+WHERE device_uuid IN (
+    SELECT td.device_uuid FROM target_devices AS td
+)`,
+		// Delete DNS server addresses reported for the old link-layer devices.
+		`
+WITH target_devices AS (
+    SELECT lld.uuid AS device_uuid
+    FROM link_layer_device AS lld
+    WHERE lld.net_node_uuid = $netNode.net_node_uuid
+)
+DELETE FROM link_layer_device_dns_address
+WHERE device_uuid IN (
+    SELECT td.device_uuid FROM target_devices AS td
+)`,
+		// Delete routes reported for the old link-layer devices.
+		`
+WITH target_devices AS (
+    SELECT lld.uuid AS device_uuid
+    FROM link_layer_device AS lld
+    WHERE lld.net_node_uuid = $netNode.net_node_uuid
+)
+DELETE FROM link_layer_device_route
+WHERE device_uuid IN (
+    SELECT td.device_uuid FROM target_devices AS td
+)`,
+		// Delete the old link-layer devices after their references are removed.
+		`
+DELETE FROM link_layer_device
+WHERE net_node_uuid = $netNode.net_node_uuid`,
+		// Delete FQDN associations observed for the old machine instance.
+		`
+DELETE FROM net_node_fqdn_address
+WHERE net_node_uuid = $netNode.net_node_uuid`,
+		// Delete hostname associations observed for the old machine instance.
+		`
+DELETE FROM net_node_hostname_address
+WHERE net_node_uuid = $netNode.net_node_uuid`,
+	}
+	return st.prepareReprovisionStatements(queries, netNode{})
+}
+
+func (st *State) prepareReprovisionBlockDeviceStatements() ([]*sqlair.Statement, error) {
+	queries := []string{
+		// Delete device links for old block devices that are not referenced by
+		// a storage volume attachment.
+		`
+WITH unreferenced_block_devices AS (
+    SELECT bd.uuid
+    FROM block_device AS bd
+    LEFT JOIN storage_volume_attachment AS sva
+    ON bd.uuid = sva.block_device_uuid
+    WHERE bd.machine_uuid = $entityUUID.uuid
+    AND sva.uuid IS NULL
+)
+DELETE FROM block_device_link_device
+WHERE block_device_uuid IN (
+    SELECT uuid FROM unreferenced_block_devices
+)`,
+		// Delete old block devices that are safe to remove because no storage
+		// volume attachment references them.
+		`
+WITH attached_block_devices AS (
+    SELECT sva.block_device_uuid
+    FROM storage_volume_attachment AS sva
+    WHERE sva.block_device_uuid IS NOT NULL
+)
+DELETE FROM block_device
+WHERE machine_uuid = $entityUUID.uuid
+AND uuid NOT IN (
+    SELECT block_device_uuid FROM attached_block_devices
+)`,
+	}
+	return st.prepareReprovisionStatements(queries, entityUUID{})
+}
+
+func (st *State) prepareReprovisionMachineDataStatements() ([]*sqlair.Statement, error) {
+	queries := []string{
+		// Delete provider tags reported for the old machine instance.
+		`
+DELETE FROM instance_tag
+WHERE machine_uuid = $entityUUID.uuid`,
+		// Clear runtime identity data reported by the old machine instance.
+		`
+UPDATE machine
+SET nonce = NULL,
+    hostname = NULL
+WHERE uuid = $entityUUID.uuid`,
+		// Clear the old provider instance association and its observed hardware
+		// characteristics.
+		`
+UPDATE machine_cloud_instance
+SET instance_id = NULL,
+    display_name = NULL,
+    arch = NULL,
+    availability_zone_uuid = NULL,
+    cpu_cores = NULL,
+    cpu_power = NULL,
+    mem = NULL,
+    root_disk = NULL,
+    root_disk_source = NULL,
+    virt_type = NULL
+WHERE machine_uuid = $entityUUID.uuid`,
+	}
+	return st.prepareReprovisionStatements(queries, entityUUID{})
+}
+
+func (st *State) prepareReprovisionStatusStatements() (*sqlair.Statement, *sqlair.Statement, error) {
+	// Move the machine agent status back to pending and record the
+	// reprovisioning context.
+	machineStatusStmt, err := st.Prepare(`
+INSERT INTO machine_status (*)
+VALUES ($setMachineStatus.*)
+ON CONFLICT (machine_uuid)
+DO UPDATE SET
+    status_id = excluded.status_id,
+    message = excluded.message,
+    updated_at = excluded.updated_at,
+    data = excluded.data
+`, setMachineStatus{})
+	if err != nil {
+		return nil, nil, errors.Capture(err)
+	}
+	// Move the cloud instance status back to pending and record the
+	// reprovisioning context.
+	instanceStatusStmt, err := st.Prepare(`
+UPDATE machine_cloud_instance_status
+SET status_id = $setMachineStatus.status_id,
+    message = $setMachineStatus.message,
+    data = $setMachineStatus.data,
+    updated_at = $setMachineStatus.updated_at
+WHERE machine_uuid = $setMachineStatus.machine_uuid
+`, setMachineStatus{})
+	if err != nil {
+		return nil, nil, errors.Capture(err)
+	}
+	return machineStatusStmt, instanceStatusStmt, nil
+}
+
+func (st *State) prepareReprovisionStatements(
+	queries []string, typeSample any,
+) ([]*sqlair.Statement, error) {
+	statements := make([]*sqlair.Statement, len(queries))
+	for i, query := range queries {
+		stmt, err := st.Prepare(query, typeSample)
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		statements[i] = stmt
+	}
+	return statements, nil
+}
+
+func runReprovisionStatements(
+	ctx context.Context, tx *sqlair.TX, statements []*sqlair.Statement, arg any,
+) error {
+	for _, stmt := range statements {
+		if err := tx.Query(ctx, stmt, arg).Run(); err != nil {
+			return errors.Capture(err)
+		}
+	}
+	return nil
+}

--- a/domain/machine/state/reprovision_test.go
+++ b/domain/machine/state/reprovision_test.go
@@ -82,14 +82,19 @@ WHERE ms.machine_uuid = ?`, machineUUID.String()).Scan(
 		"instance_tag",
 		"provider_ip_address",
 		"ip_address",
+		"link_layer_device_parent",
 		"provider_link_layer_device",
 		"link_layer_device_dns_domain",
 		"link_layer_device_dns_address",
 		"link_layer_device_route",
 		"link_layer_device",
+		"net_node_fqdn_address",
+		"net_node_hostname_address",
 	} {
 		c.Check(s.rowCount(c, table), tc.Equals, 0, tc.Commentf("table %s", table))
 	}
+	c.Check(s.rowCountWhere(c, "fqdn_address", "uuid = ?", "fqdn-uuid"), tc.Equals, 1)
+	c.Check(s.rowCountWhere(c, "hostname_address", "uuid = ?", "hostname-uuid"), tc.Equals, 1)
 	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "unreferenced-block"), tc.Equals, 0)
 	c.Check(s.rowCountWhere(c, "block_device_link_device", "block_device_uuid = ?", "unreferenced-block"), tc.Equals, 0)
 	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "referenced-block"), tc.Equals, 1)
@@ -172,8 +177,11 @@ END`)
 	c.Assert(err, tc.ErrorMatches, ".*detach failed.*")
 	s.checkInstanceID(c, machineUUID.String(), "123")
 	c.Check(s.rowCount(c, "instance_tag"), tc.Equals, 2)
-	c.Check(s.rowCount(c, "link_layer_device"), tc.Equals, 1)
+	c.Check(s.rowCount(c, "link_layer_device"), tc.Equals, 2)
+	c.Check(s.rowCount(c, "link_layer_device_parent"), tc.Equals, 1)
 	c.Check(s.rowCount(c, "ip_address"), tc.Equals, 1)
+	c.Check(s.rowCount(c, "net_node_fqdn_address"), tc.Equals, 1)
+	c.Check(s.rowCount(c, "net_node_hostname_address"), tc.Equals, 1)
 }
 
 func (s *stateSuite) machineNetNodeUUID(c *tc.C, machineUUID string) string {
@@ -190,6 +198,12 @@ func (s *stateSuite) addReprovisionNetworkState(c *tc.C, netNodeUUID string) {
 INSERT INTO link_layer_device
     (uuid, net_node_uuid, name, device_type_id, virtual_port_type_id)
 VALUES (?, ?, 'eth0', 2, 0)`, "device-uuid", netNodeUUID)
+	s.runQuery(c, `
+INSERT INTO link_layer_device
+    (uuid, net_node_uuid, name, device_type_id, virtual_port_type_id)
+VALUES (?, ?, 'eth1', 2, 0)`, "child-device-uuid", netNodeUUID)
+	s.runQuery(c, "INSERT INTO link_layer_device_parent VALUES (?, ?)",
+		"child-device-uuid", "device-uuid")
 	s.runQuery(c, "INSERT INTO provider_link_layer_device VALUES (?, ?)", "provider-device", "device-uuid")
 	s.runQuery(c, "INSERT INTO link_layer_device_dns_domain VALUES (?, ?)", "device-uuid", "example.test")
 	s.runQuery(c, "INSERT INTO link_layer_device_dns_address VALUES (?, ?)", "device-uuid", "10.0.0.2")
@@ -200,6 +214,14 @@ INSERT INTO ip_address
      config_type_id, origin_id, scope_id)
 VALUES (?, ?, ?, '10.0.0.2/24', 0, 1, 1, 2)`, "address-uuid", netNodeUUID, "device-uuid")
 	s.runQuery(c, "INSERT INTO provider_ip_address VALUES (?, ?)", "provider-address", "address-uuid")
+	s.runQuery(c, "INSERT INTO fqdn_address VALUES (?, ?, ?)",
+		"fqdn-uuid", "machine.example.test", 1)
+	s.runQuery(c, "INSERT INTO net_node_fqdn_address VALUES (?, ?)",
+		netNodeUUID, "fqdn-uuid")
+	s.runQuery(c, "INSERT INTO hostname_address VALUES (?, ?, ?)",
+		"hostname-uuid", "machine", 0)
+	s.runQuery(c, "INSERT INTO net_node_hostname_address VALUES (?, ?)",
+		netNodeUUID, "hostname-uuid")
 }
 
 func (s *stateSuite) addReprovisionBlockDeviceState(c *tc.C, machineUUID, netNodeUUID string) {

--- a/domain/machine/state/reprovision_test.go
+++ b/domain/machine/state/reprovision_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/domain/life"
+	machineerrors "github.com/juju/juju/domain/machine/errors"
+	domainstatus "github.com/juju/juju/domain/status"
+)
+
+func (s *stateSuite) TestDetachLostMachineCloudInstance(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionNetworkState(c, netNodeUUID)
+	s.addReprovisionBlockDeviceState(c, machineUUID.String(), netNodeUUID)
+	s.addReprovisionUnit(c, netNodeUUID)
+	preservedCounts := map[string]int{
+		"application":        s.rowCount(c, "application"),
+		"unit":               s.rowCount(c, "unit"),
+		"machine_platform":   s.rowCount(c, "machine_platform"),
+		"machine_constraint": s.rowCount(c, "machine_constraint"),
+		"machine_placement":  s.rowCount(c, "machine_placement"),
+	}
+
+	updatedAt := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	statusData := []byte(`{"old-instance-id":"123"}`)
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123",
+		"reprovisioning requested", statusData, updatedAt,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var (
+		instanceID, displayName, arch, availabilityZone, nonce, hostname sql.Null[string]
+		machineStatusID, instanceStatusID                                int
+		machineMessage, instanceMessage                                  string
+		machineData, instanceData                                        []byte
+	)
+	db := s.DB()
+	err = db.QueryRowContext(c.Context(), `
+SELECT mci.instance_id, mci.display_name, mci.arch,
+       mci.availability_zone_uuid, m.nonce, m.hostname
+FROM machine AS m
+JOIN machine_cloud_instance AS mci ON m.uuid = mci.machine_uuid
+WHERE m.uuid = ?`, machineUUID.String()).Scan(
+		&instanceID, &displayName, &arch, &availabilityZone, &nonce, &hostname,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(instanceID.Valid, tc.IsFalse)
+	c.Check(displayName.Valid, tc.IsFalse)
+	c.Check(arch.Valid, tc.IsFalse)
+	c.Check(availabilityZone.Valid, tc.IsFalse)
+	c.Check(nonce.Valid, tc.IsFalse)
+	c.Check(hostname.Valid, tc.IsFalse)
+
+	err = db.QueryRowContext(c.Context(), `
+SELECT ms.status_id, ms.message, ms.data,
+       mcis.status_id, mcis.message, mcis.data
+FROM machine_status AS ms
+JOIN machine_cloud_instance_status AS mcis
+  ON ms.machine_uuid = mcis.machine_uuid
+WHERE ms.machine_uuid = ?`, machineUUID.String()).Scan(
+		&machineStatusID, &machineMessage, &machineData,
+		&instanceStatusID, &instanceMessage, &instanceData,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(machineStatusID, tc.Equals, int(domainstatus.MachineStatusPending))
+	c.Check(instanceStatusID, tc.Equals, int(domainstatus.InstanceStatusPending))
+	c.Check(machineMessage, tc.Equals, "reprovisioning requested")
+	c.Check(instanceMessage, tc.Equals, "reprovisioning requested")
+	c.Check(machineData, tc.DeepEquals, statusData)
+	c.Check(instanceData, tc.DeepEquals, statusData)
+
+	for _, table := range []string{
+		"instance_tag",
+		"provider_ip_address",
+		"ip_address",
+		"provider_link_layer_device",
+		"link_layer_device_dns_domain",
+		"link_layer_device_dns_address",
+		"link_layer_device_route",
+		"link_layer_device",
+	} {
+		c.Check(s.rowCount(c, table), tc.Equals, 0, tc.Commentf("table %s", table))
+	}
+	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "unreferenced-block"), tc.Equals, 0)
+	c.Check(s.rowCountWhere(c, "block_device_link_device", "block_device_uuid = ?", "unreferenced-block"), tc.Equals, 0)
+	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "referenced-block"), tc.Equals, 1)
+	c.Check(s.rowCountWhere(c, "block_device_link_device", "block_device_uuid = ?", "referenced-block"), tc.Equals, 1)
+
+	var name, preservedNetNode string
+	err = db.QueryRowContext(c.Context(),
+		"SELECT name, net_node_uuid FROM machine WHERE uuid = ?", machineUUID.String(),
+	).Scan(&name, &preservedNetNode)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(name, tc.Equals, machineName.String())
+	c.Check(preservedNetNode, tc.Equals, netNodeUUID)
+	for table, count := range preservedCounts {
+		c.Check(s.rowCount(c, table), tc.Equals, count, tc.Commentf("table %s", table))
+	}
+	c.Check(s.rowCountWhere(c, "unit", "net_node_uuid = ?", netNodeUUID), tc.Equals, 1)
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRechecksLife(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	s.runQuery(c, "UPDATE machine SET life_id = ? WHERE uuid = ?", life.Dying, machineUUID.String())
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.MachineNotAlive)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRechecksPresence(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	s.runQuery(c, "INSERT INTO machine_agent_presence (machine_uuid) VALUES (?)", machineUUID.String())
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.MachineAgentPresent)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRechecksInstance(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "old-instance", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.MachineCloudInstanceChanged)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRepeated(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.NotProvisioned)
+	s.checkInstanceID(c, machineUUID.String(), "")
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRollsBack(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionNetworkState(c, netNodeUUID)
+	s.runQuery(c, `
+CREATE TRIGGER fail_reprovision_detach
+BEFORE UPDATE ON machine_cloud_instance
+WHEN NEW.instance_id IS NULL
+BEGIN
+    SELECT RAISE(ABORT, 'detach failed');
+END`)
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorMatches, ".*detach failed.*")
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCount(c, "instance_tag"), tc.Equals, 2)
+	c.Check(s.rowCount(c, "link_layer_device"), tc.Equals, 1)
+	c.Check(s.rowCount(c, "ip_address"), tc.Equals, 1)
+}
+
+func (s *stateSuite) machineNetNodeUUID(c *tc.C, machineUUID string) string {
+	var netNodeUUID string
+	err := s.DB().QueryRowContext(c.Context(),
+		"SELECT net_node_uuid FROM machine WHERE uuid = ?", machineUUID,
+	).Scan(&netNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	return netNodeUUID
+}
+
+func (s *stateSuite) addReprovisionNetworkState(c *tc.C, netNodeUUID string) {
+	s.runQuery(c, `
+INSERT INTO link_layer_device
+    (uuid, net_node_uuid, name, device_type_id, virtual_port_type_id)
+VALUES (?, ?, 'eth0', 2, 0)`, "device-uuid", netNodeUUID)
+	s.runQuery(c, "INSERT INTO provider_link_layer_device VALUES (?, ?)", "provider-device", "device-uuid")
+	s.runQuery(c, "INSERT INTO link_layer_device_dns_domain VALUES (?, ?)", "device-uuid", "example.test")
+	s.runQuery(c, "INSERT INTO link_layer_device_dns_address VALUES (?, ?)", "device-uuid", "10.0.0.2")
+	s.runQuery(c, "INSERT INTO link_layer_device_route VALUES (?, ?, ?, ?)", "device-uuid", "0.0.0.0/0", "10.0.0.1", 1)
+	s.runQuery(c, `
+INSERT INTO ip_address
+    (uuid, net_node_uuid, device_uuid, address_value, type_id,
+     config_type_id, origin_id, scope_id)
+VALUES (?, ?, ?, '10.0.0.2/24', 0, 1, 1, 2)`, "address-uuid", netNodeUUID, "device-uuid")
+	s.runQuery(c, "INSERT INTO provider_ip_address VALUES (?, ?)", "provider-address", "address-uuid")
+}
+
+func (s *stateSuite) addReprovisionBlockDeviceState(c *tc.C, machineUUID, netNodeUUID string) {
+	s.runQuery(c, "INSERT INTO block_device (uuid, machine_uuid) VALUES (?, ?)", "unreferenced-block", machineUUID)
+	s.runQuery(c, "INSERT INTO block_device_link_device VALUES (?, ?, ?)", "unreferenced-block", machineUUID, "sda")
+	s.runQuery(c, "INSERT INTO block_device (uuid, machine_uuid) VALUES (?, ?)", "referenced-block", machineUUID)
+	s.runQuery(c, "INSERT INTO block_device_link_device VALUES (?, ?, ?)", "referenced-block", machineUUID, "sdb")
+	s.runQuery(c, "INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id) VALUES (?, ?, 0, 1)", "volume-uuid", "0")
+	s.runQuery(c, `
+INSERT INTO storage_volume_attachment
+    (uuid, storage_volume_uuid, net_node_uuid, life_id,
+     provision_scope_id, block_device_uuid)
+VALUES (?, ?, ?, 0, 1, ?)`, "attachment-uuid", "volume-uuid", netNodeUUID, "referenced-block")
+}
+
+func (s *stateSuite) addReprovisionUnit(c *tc.C, netNodeUUID string) {
+	s.runQuery(c, "INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 0)", "reprovision-charm", "reprovision")
+	s.runQuery(c, "INSERT INTO charm_metadata (charm_uuid, name, subordinate) VALUES (?, ?, false)", "reprovision-charm", "reprovision")
+	s.runQuery(c, `
+INSERT INTO application (uuid, charm_uuid, name, life_id, space_uuid)
+VALUES (?, ?, ?, 0, ?)`, "reprovision-application", "reprovision-charm", "reprovision", network.AlphaSpaceId)
+	s.runQuery(c, `
+INSERT INTO unit
+    (uuid, name, life_id, application_uuid, net_node_uuid, charm_uuid)
+VALUES (?, ?, 0, ?, ?, ?)`, "reprovision-unit", "reprovision/0",
+		"reprovision-application", netNodeUUID, "reprovision-charm")
+}
+
+func (s *stateSuite) checkInstanceID(c *tc.C, machineUUID, expected string) {
+	var instanceID sql.Null[string]
+	err := s.DB().QueryRowContext(c.Context(),
+		"SELECT instance_id FROM machine_cloud_instance WHERE machine_uuid = ?", machineUUID,
+	).Scan(&instanceID)
+	c.Assert(err, tc.ErrorIsNil)
+	if expected == "" {
+		c.Check(instanceID.Valid, tc.IsFalse)
+		return
+	}
+	c.Check(instanceID.V, tc.Equals, expected)
+	c.Check(instanceID.Valid, tc.IsTrue)
+}
+
+func (s *stateSuite) rowCount(c *tc.C, table string) int {
+	return s.rowCountWhere(c, table, "1 = 1")
+}
+
+func (s *stateSuite) rowCountWhere(c *tc.C, table, where string, args ...any) int {
+	var count int
+	err := s.DB().QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM "+table+" WHERE "+where, args...,
+	).Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	return count
+}

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -532,3 +532,15 @@ type sshHostKey struct {
 	MachineUUID string `db:"machine_uuid"`
 	Key         string `db:"ssh_key"`
 }
+
+type reprovisionDetachTarget struct {
+	UUID         string           `db:"machine_uuid"`
+	NetNodeUUID  string           `db:"net_node_uuid"`
+	InstanceID   sql.Null[string] `db:"instance_id"`
+	LifeID       life.Life        `db:"life_id"`
+	AgentPresent int64            `db:"agent_present"`
+}
+
+type netNode struct {
+	UUID string `db:"net_node_uuid"`
+}

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -842,7 +842,6 @@ type RetryProvisioningArgs struct {
 // ReprovisionMachineArgs holds args for reprovisioning a machine.
 type ReprovisionMachineArgs struct {
 	MachineTag string `json:"machine-tag"`
-	Force      bool   `json:"force"`
 }
 
 // ProvisioningNetworkTopology holds a network topology that is based on


### PR DESCRIPTION
Previously, reprovisioning stopped after validating the request and checking whether the old cloud instance was still running. It did not safely detach the lost instance or reset its provider-derived state.

Now, a confirmed lost instance is detached transactionally. Stale network, block-device, machine, and status data is cleared while preserving the machine identity, assigned units, and storage-backed block devices. The transaction rechecks the machine’s life, agent presence, and instance ID to avoid racing with a replacement instance.

This should ultimately move into the model workers rather than remain in the API request path. Reprovisioning is a model-level workflow involving provider calls and several state transitions; workers can serialize it with provisioning, retry transient failures, and continue after controller restarts. The API should record intent, while the workers perform and reconcile the operation.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju reprovision-machine -m controller 0
ERROR reprovisioning machine "0": machine is a controller machine
$ juju add-model foo
$ juju deploy juju-qa-test
$ juju reprovision-machine 0
ERROR machine "0": machine agent is still present

# stop the instance manually
$ juju add-ssh-key <your ssh key>
$ juju ssh 0
$ sudo systemctl stop juju*.service

# now test it again
$ juju reprovision-machine 0
ERROR machine "0" instance "juju-4e3558-0": machine provider instance is running

# delete it from the provider
$ juju reprovision-machine 0
reprovisioning machine 0
```


## Links


**Jira card:** [JUJU-10180](https://warthogs.atlassian.net/browse/JUJU-10180)


[JUJU-10180]: https://warthogs.atlassian.net/browse/JUJU-10180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ