### PR TITLE
fix(migration): exclude synthetic CMR units from agent-version and status queries

### DIFF
--- a/domain/modelagent/service/service.go
+++ b/domain/modelagent/service/service.go
@@ -80,10 +80,10 @@ type ModelState interface {
 	GetModelTargetAgentVersion(context.Context) (semversion.Number, error)
 
 	// GetUnitsAgentBinaryMetadata reports the agent binary metadata that each
-	// unit in the model is currently running. This is a bulk call to support
-	// operations such as model export where it is expected that the state of a
-	// model stays relatively static over the operation. This function will
-	// never provide enough granularity into what unit fails as part of the
+	// non-synthetic unit in the model is currently running. This is a bulk call
+	// to support operations such as model export where it is expected that the
+	// state of a model stays relatively static over the operation. This function
+	// will never provide enough granularity into what unit fails as part of the
 	// checks.
 	GetUnitsAgentBinaryMetadata(context.Context) (map[coreunit.Name]agentbinary.Metadata, error)
 
@@ -459,18 +459,19 @@ func (s *Service) GetMissingAgentTargetVersions(ctx context.Context) (semversion
 }
 
 // GetUnitsAgentBinaryMetadata returns the agent binary metadata that is running
-// for each unit in the model. This call expects that every unit in the model
-// has their agent binary version set and there exist agent binaries available
-// for each unit and the version that it is running.
+// for each non-synthetic unit in the model. This call expects that every
+// non-synthetic unit has their agent binary version set and there exist agent
+// binaries available for each unit and the version that it is running.
 //
 // This is a bulk call to support operations such as model export where it will
 // never provide enough granularity into what unit fails as part of the checks.
 //
 // The following error types can be expected:
 // - [modelagenterrors.AgentVersionNotSet] when one or more units in the
-// model do not have their agent binary version set.
+// model, excluding synthetic CMR units, do not have their agent binary version
+// set.
 // - [modelagenterrors.MissingAgentBinaries] when the agent binaries don't exist
-// for one or more units in the model.
+// for one or more non-synthetic units in the model.
 func (s *Service) GetUnitsAgentBinaryMetadata(
 	ctx context.Context,
 ) (map[coreunit.Name]agentbinary.Metadata, error) {

--- a/domain/modelagent/state/model/state.go
+++ b/domain/modelagent/state/model/state.go
@@ -736,11 +736,8 @@ LEFT JOIN object_store_metadata AS osm ON abs.object_store_uuid = osm.uuid
 		return nil, errors.Capture(err)
 	}
 
-	// Count only real units: synthetic cross-model-relation units use a
-	// CMR-source charm (charm_source.source_id = 2), have no unit_agent_version
-	// row (and no agent binaries), so they must be excluded or the count mismatch
-	// below wrongly reports "not all units ... have their agent version set" when
-	// a CMR is active. Same charm-source filter as juju/juju#22927.
+	// Exclude synthetic cross-model-relation units: they use a CMR-source charm
+	// (charm_source.source_id = 2) and have no unit_agent_version row.
 	unitCount := rowCount{}
 	stmtUnitCount, err := st.Prepare(`
 SELECT (count(*)) AS (&rowCount.count)
@@ -835,11 +832,8 @@ func (st *State) GetUnitsNotAtTargetAgentVersion(
 		return nil, errors.Capture(err)
 	}
 
-	// Synthetic cross-model-relation units do not run a unit agent (they use a
-	// CMR-source charm, charm_source.source_id = 2), so they never report an
-	// agent version and must be excluded - otherwise an active CMR makes the
-	// migration precheck report a bogus "remote-<uuid>/N" unit as lagging. This
-	// mirrors juju/juju#22927.
+	// Exclude synthetic cross-model-relation units: they use a CMR-source charm
+	// (charm_source.source_id = 2) and never report an agent version.
 	query := `
 WITH agent_units AS (
     SELECT u.uuid AS unit_uuid,

--- a/domain/modelagent/state/model/state.go
+++ b/domain/modelagent/state/model/state.go
@@ -689,16 +689,17 @@ WHERE machine_uuid = $machineUUIDRef.machine_uuid
 }
 
 // GetUnitsAgentBinaryMetadata reports the agent binary metadata that each
-// unit in the model is currently running. This is a bulk call to support
-// operations such as model export where it is expected that the state of a
-// model stays relatively static over the operation. This function will never
-// provide enough granuality into what unit fails as part of the checks.
+// non-synthetic unit in the model is currently running. This is a bulk call to
+// support operations such as model export where it is expected that the state
+// of a model stays relatively static over the operation. This function will
+// never provide enough granularity into what unit fails as part of the checks.
 //
 // The following errors can be expected:
 // - [modelagenterrors.AgentVersionNotSet] when one or more units in
-// the model do not have their agent version set.
+// the model, excluding synthetic CMR units, do not have their agent version
+// set.
 // - [modelagenterrors.MissingAgentBinaries] when the agent binaries don't exist
-// for one or more units in the model.
+// for one or more non-synthetic units in the model.
 func (st *State) GetUnitsAgentBinaryMetadata(
 	ctx context.Context,
 ) (map[coreunit.Name]coreagentbinary.Metadata, error) {
@@ -726,18 +727,20 @@ SELECT    u.name AS &unitAgentBinaryMetadata.name,
           osm.sha_384 AS &unitAgentBinaryMetadata.sha_384
 FROM      unit_agent_version AS uav
 JOIN      unit AS u ON uav.unit_uuid = u.uuid
+JOIN      charm AS c ON c.uuid = u.charm_uuid
 JOIN      architecture AS a ON uav.architecture_id = a.id
 LEFT JOIN v_agent_binary_store AS abs ON (
           uav.version = abs.version
 AND       uav.architecture_id = abs.architecture_id)
 LEFT JOIN object_store_metadata AS osm ON abs.object_store_uuid = osm.uuid
+WHERE     c.source_id < 2
 `, unitAgentBinaryMetadata{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	// Exclude synthetic cross-model-relation units: they use a CMR-source charm
-	// (charm_source.source_id = 2) and have no unit_agent_version row.
+	// Exclude synthetic CMR units from both queries: they do not run unit
+	// agents, but may have stale unit_agent_version rows.
 	unitCount := rowCount{}
 	stmtUnitCount, err := st.Prepare(`
 SELECT (count(*)) AS (&rowCount.count)
@@ -773,7 +776,7 @@ WHERE  c.source_id < 2
 
 	if len(unitBinaryMetadata) != unitCount.Count {
 		return nil, errors.New(
-			"not all units in the model have their agent version set",
+			"not all non-synthetic units in the model have their agent version set",
 		).Add(modelagenterrors.AgentVersionNotSet)
 	}
 

--- a/domain/modelagent/state/model/state.go
+++ b/domain/modelagent/state/model/state.go
@@ -736,10 +736,17 @@ LEFT JOIN object_store_metadata AS osm ON abs.object_store_uuid = osm.uuid
 		return nil, errors.Capture(err)
 	}
 
+	// Count only real units: synthetic cross-model-relation units use a
+	// CMR-source charm (charm_source.source_id = 2), have no unit_agent_version
+	// row (and no agent binaries), so they must be excluded or the count mismatch
+	// below wrongly reports "not all units ... have their agent version set" when
+	// a CMR is active. Same charm-source filter as juju/juju#22927.
 	unitCount := rowCount{}
 	stmtUnitCount, err := st.Prepare(`
 SELECT (count(*)) AS (&rowCount.count)
-FROM   unit
+FROM   unit AS u
+JOIN   charm AS c ON c.uuid = u.charm_uuid
+WHERE  c.source_id < 2
 `, unitCount)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -828,6 +835,11 @@ func (st *State) GetUnitsNotAtTargetAgentVersion(
 		return nil, errors.Capture(err)
 	}
 
+	// Synthetic cross-model-relation units do not run a unit agent (they use a
+	// CMR-source charm, charm_source.source_id = 2), so they never report an
+	// agent version and must be excluded - otherwise an active CMR makes the
+	// migration precheck report a bogus "remote-<uuid>/N" unit as lagging. This
+	// mirrors juju/juju#22927.
 	query := `
 WITH agent_units AS (
     SELECT u.uuid AS unit_uuid,

--- a/domain/modelagent/state/model/state_test.go
+++ b/domain/modelagent/state/model/state_test.go
@@ -732,6 +732,42 @@ func (s *modelStateSuite) TestUnitsNotAtTargetAgentVersionAllUptoDate(c *tc.C) {
 	c.Check(len(list), tc.Equals, 0)
 }
 
+// TestUnitsNotAtTargetAgentVersionExcludesRemoteUnits verifies that synthetic
+// cross-model-relation units are never reported as lagging. Such units use a
+// CMR-source charm (charm_source.source_id = 2) and run no agent, so without the
+// charm-source filter they would be caught by the "unit has no reported version"
+// arm of the query - which made the migration precheck fail on any model with an
+// active CMR. See juju/juju#22927.
+func (s *modelStateSuite) TestUnitsNotAtTargetAgentVersionExcludesRemoteUnits(c *tc.C) {
+	// A real, unreported unit is still reported.
+	s.createTestingApplicationWithName(c, "foo")
+	s.createTestingUnitForApplication(c, "foo")
+
+	// A synthetic remote application and its agentless unit must be excluded.
+	// Mark the charm as CMR source after adding the unit (the application state
+	// rejects adding units to synthetic apps).
+	remoteAppUUID := s.createTestingApplicationWithName(c, "remote-app")
+	s.createTestingUnitForApplication(c, "remote-app")
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE charm
+SET source_id = 2, architecture_id = NULL
+WHERE uuid = (SELECT charm_uuid FROM application WHERE uuid = ?)`,
+			remoteAppUUID.String())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.setModelTargetAgentVersion(c, "4.1.0")
+
+	st := NewState(s.TxnRunnerFactory())
+	list, err := st.GetUnitsNotAtTargetAgentVersion(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(list, tc.DeepEquals, []coreunit.Name{
+		coreunit.Name("foo/0"),
+	})
+}
+
 // TestGetMachinesAgentBinaryMetadataNoMachines is testing that if the model
 // has no machines we get back an empty list of machine agent binary metadata.
 func (s *modelStateSuite) TestGetMachinesAgentBinaryMetadataNoMachines(c *tc.C) {

--- a/domain/modelagent/state/model/state_test.go
+++ b/domain/modelagent/state/model/state_test.go
@@ -734,10 +734,10 @@ func (s *modelStateSuite) TestUnitsNotAtTargetAgentVersionAllUptoDate(c *tc.C) {
 
 // TestUnitsNotAtTargetAgentVersionExcludesRemoteUnits verifies that synthetic
 // cross-model-relation units are never reported as lagging. Such units use a
-// CMR-source charm (charm_source.source_id = 2) and run no agent, so without the
-// charm-source filter they would be caught by the "unit has no reported version"
-// arm of the query - which made the migration precheck fail on any model with an
-// active CMR. See juju/juju#22927.
+// CMR-source charm (charm_source.source_id = 2) and run no agent, so without
+// the charm-source filter they would be caught by the "unit has no reported
+// version" branch of the query. This made the migration precheck fail on any
+// model with an active CMR. See juju/juju#22927.
 func (s *modelStateSuite) TestUnitsNotAtTargetAgentVersionExcludesRemoteUnits(c *tc.C) {
 	// A real, unreported unit is still reported.
 	s.createTestingApplicationWithName(c, "foo")
@@ -992,6 +992,44 @@ func (s *modelStateSuite) TestGetUnitAgentBinaryMetadata(c *tc.C) {
 	data, err := st.GetUnitsAgentBinaryMetadata(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(data, tc.DeepEquals, expected)
+}
+
+// TestGetUnitsAgentBinaryMetadataIgnoresSyntheticCMRUnits verifies that stale
+// agent version records on synthetic CMR units do not cause metadata export to
+// fail or appear in the result.
+func (s *modelStateSuite) TestGetUnitsAgentBinaryMetadataIgnoresSyntheticCMRUnits(c *tc.C) {
+	version := coreagentbinary.Version{
+		Number: semversion.MustParse("4.1.0"),
+		Arch:   corearch.AMD64,
+	}
+	expectedMetadata := s.registerAgentBinary(c, version)
+
+	s.createTestingApplicationWithName(c, "foo")
+	unitUUID := s.createTestingUnitForApplication(c, "foo")
+	s.setUnitAgentVersion(c, unitUUID, version.Number.String())
+
+	remoteAppUUID := s.createTestingApplicationWithName(c, "remote-app")
+	remoteUnitUUID := s.createTestingUnitForApplication(c, "remote-app")
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE charm
+SET source_id = 2, architecture_id = NULL
+WHERE uuid = (SELECT charm_uuid FROM application WHERE uuid = ?)`,
+			remoteAppUUID.String())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Synthetic CMR units do not report agent versions. Create a stale record to
+	// ensure the metadata query and the count query exclude the same population.
+	s.setUnitAgentVersion(c, remoteUnitUUID, version.Number.String())
+
+	st := NewState(s.TxnRunnerFactory())
+	data, err := st.GetUnitsAgentBinaryMetadata(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(data, tc.DeepEquals, map[coreunit.Name]coreagentbinary.Metadata{
+		"foo/0": expectedMetadata,
+	})
 }
 
 // TestGetUnitsAgentBinaryMetadataUnitNotSet is testing that given a set

--- a/domain/modelmigration/state/model/state.go
+++ b/domain/modelmigration/state/model/state.go
@@ -206,12 +206,8 @@ FROM   machine
 	if err != nil {
 		return modelmigrationinternal.MigrationAgents{}, errors.Capture(err)
 	}
-	// Synthetic cross-model-relation units/applications use a CMR-source charm
-	// (charm_source.source_id = 2) and run no agent, so they must be excluded
-	// from the set of agents expected to report during migration - otherwise an
-	// active CMR leaves the phase waiting forever for a report that never comes
-	// ("N succeeded, 1 still to report"). Same charm-source filter as
-	// juju/juju#22927.
+	// Exclude synthetic cross-model-relation units/applications: they use a
+	// CMR-source charm (charm_source.source_id = 2) and run no agent.
 	unitStmt, err := s.Prepare(`
 SELECT &agentName.name
 FROM   unit AS u

--- a/domain/modelmigration/state/model/state.go
+++ b/domain/modelmigration/state/model/state.go
@@ -206,9 +206,17 @@ FROM   machine
 	if err != nil {
 		return modelmigrationinternal.MigrationAgents{}, errors.Capture(err)
 	}
+	// Synthetic cross-model-relation units/applications use a CMR-source charm
+	// (charm_source.source_id = 2) and run no agent, so they must be excluded
+	// from the set of agents expected to report during migration - otherwise an
+	// active CMR leaves the phase waiting forever for a report that never comes
+	// ("N succeeded, 1 still to report"). Same charm-source filter as
+	// juju/juju#22927.
 	unitStmt, err := s.Prepare(`
 SELECT &agentName.name
-FROM   unit
+FROM   unit AS u
+JOIN   charm AS c ON c.uuid = u.charm_uuid
+WHERE  c.source_id < 2
 `, agentName{})
 	if err != nil {
 		return modelmigrationinternal.MigrationAgents{}, errors.Capture(err)
@@ -217,6 +225,8 @@ FROM   unit
 SELECT &agentName.name
 FROM   application AS a
 JOIN   application_agent AS aa ON aa.application_uuid = a.uuid
+JOIN   charm AS c ON c.uuid = a.charm_uuid
+WHERE  c.source_id < 2
 `, agentName{})
 	if err != nil {
 		return modelmigrationinternal.MigrationAgents{}, errors.Capture(err)

--- a/domain/modelmigration/state/model/state_test.go
+++ b/domain/modelmigration/state/model/state_test.go
@@ -215,6 +215,28 @@ func (s *migrationSuite) TestGetMigrationAgentsIAAS(c *tc.C) {
 		unitUUID, "foo/0", appUUID, unitNetNodeUUID, charmUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
+	// A synthetic cross-model-relation unit (CMR-source charm, source_id = 2)
+	// runs no agent and must NOT be an expected migration agent.
+	cmrCharmUUID := uuid.MustNewUUID().String()
+	cmrAppUUID := uuid.MustNewUUID().String()
+	cmrUnitNetNodeUUID := uuid.MustNewUUID().String()
+	cmrUnitUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)",
+		cmrCharmUUID, "remote-app")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, ?, 0, ?, ?)",
+		cmrAppUUID, "remote-app", cmrCharmUUID, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO net_node (uuid) VALUES (?)", cmrUnitNetNodeUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO unit (uuid, name, life_id, application_uuid, net_node_uuid, charm_uuid) VALUES (?, ?, 0, ?, ?, ?)",
+		cmrUnitUUID, "remote-app/0", cmrAppUUID, cmrUnitNetNodeUUID, cmrCharmUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
 	agents, err := New(s.TxnRunnerFactory(), s.modelUUID).GetMigrationAgents(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(agents.Machines, tc.SameContents, []string{"0"})

--- a/domain/modelmigration/state/model/state_test.go
+++ b/domain/modelmigration/state/model/state_test.go
@@ -263,6 +263,23 @@ func (s *caasMigrationSuite) TestGetMigrationAgentsCAAS(c *tc.C) {
 		legacyAppUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
+	// A synthetic CMR application can retain a stale application agent row, but
+	// it does not run an application agent and must be excluded.
+	cmrCharmUUID := uuid.MustNewUUID().String()
+	cmrAppUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)",
+		cmrCharmUUID, "remote-app")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, ?, 0, ?, ?)",
+		cmrAppUUID, "remote-app", cmrCharmUUID, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application_agent (application_uuid) VALUES (?)",
+		cmrAppUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
 	sidecarAppUUID := uuid.MustNewUUID().String()
 	unitNetNodeUUID := uuid.MustNewUUID().String()
 	unitUUID := uuid.MustNewUUID().String()

--- a/domain/status/state/model/modelstate.go
+++ b/domain/status/state/model/modelstate.go
@@ -985,7 +985,22 @@ func (st *ModelState) GetAllUnitWorkloadAgentStatuses(ctx context.Context) (stat
 		return nil, errors.Capture(err)
 	}
 
-	query, err := st.Prepare(`SELECT &workloadAgentStatus.* FROM v_unit_workload_agent_status`, workloadAgentStatus{})
+	// Exclude synthetic cross-model-relation units: they use a CMR-source charm
+	// (charm_source.source_id = 2), have no workload/agent status rows, and both
+	// callers of this method are migration-only (precheck + export). Without this,
+	// an active CMR makes the migration precheck fail with "workload status for
+	// unit remote-<uuid>/N not found". Uses the same charm-source filter as
+	// juju/juju#22927.
+	query, err := st.Prepare(`
+SELECT &workloadAgentStatus.*
+FROM v_unit_workload_agent_status
+WHERE application_uuid NOT IN (
+    SELECT a.uuid
+    FROM application AS a
+    JOIN charm AS c ON c.uuid = a.charm_uuid
+    WHERE c.source_id >= 2
+)
+`, workloadAgentStatus{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/status/state/model/modelstate.go
+++ b/domain/status/state/model/modelstate.go
@@ -976,9 +976,10 @@ WHERE application_uuid = $applicationUUID.uuid
 	return ret, nil
 }
 
-// GetAllUnitWorkloadAgentStatuses retrieves the presence, workload status, and agent status
-// of every unit in the model. Returns an error satisfying [statuserrors.UnitStatusNotFound]
-// if any units do not have statuses.
+// GetAllUnitWorkloadAgentStatuses retrieves the presence, workload status, and
+// agent status of every non-synthetic unit in the model. It returns an error
+// satisfying [statuserrors.UnitStatusNotFound] if any non-synthetic unit does
+// not have statuses.
 func (st *ModelState) GetAllUnitWorkloadAgentStatuses(ctx context.Context) (status.UnitWorkloadAgentStatuses, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -988,14 +989,15 @@ func (st *ModelState) GetAllUnitWorkloadAgentStatuses(ctx context.Context) (stat
 	// Exclude synthetic cross-model-relation units: they use a CMR-source charm
 	// (charm_source.source_id = 2), have no workload/agent status rows.
 	query, err := st.Prepare(`
-SELECT &workloadAgentStatus.*
-FROM v_unit_workload_agent_status
-WHERE application_uuid NOT IN (
-    SELECT a.uuid
-    FROM application AS a
-    JOIN charm AS c ON c.uuid = a.charm_uuid
-    WHERE c.source_id >= 2
+WITH agent_units AS (
+    SELECT u.uuid AS unit_uuid
+    FROM unit AS u
+    JOIN charm AS c ON c.uuid = u.charm_uuid
+    WHERE c.source_id < 2
 )
+SELECT &workloadAgentStatus.*
+FROM v_unit_workload_agent_status AS was
+JOIN agent_units AS au ON au.unit_uuid = was.unit_uuid
 `, workloadAgentStatus{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/status/state/model/modelstate.go
+++ b/domain/status/state/model/modelstate.go
@@ -986,11 +986,7 @@ func (st *ModelState) GetAllUnitWorkloadAgentStatuses(ctx context.Context) (stat
 	}
 
 	// Exclude synthetic cross-model-relation units: they use a CMR-source charm
-	// (charm_source.source_id = 2), have no workload/agent status rows, and both
-	// callers of this method are migration-only (precheck + export). Without this,
-	// an active CMR makes the migration precheck fail with "workload status for
-	// unit remote-<uuid>/N not found". Uses the same charm-source filter as
-	// juju/juju#22927.
+	// (charm_source.source_id = 2), have no workload/agent status rows.
 	query, err := st.Prepare(`
 SELECT &workloadAgentStatus.*
 FROM v_unit_workload_agent_status

--- a/domain/status/state/model/modelstate_test.go
+++ b/domain/status/state/model/modelstate_test.go
@@ -1402,6 +1402,45 @@ func (s *modelStateSuite) TestGetAllFullUnitStatuses(c *tc.C) {
 	c.Check(u3Full.Present, tc.Equals, false)
 }
 
+func (s *modelStateSuite) TestGetAllUnitWorkloadAgentStatusesIgnoresSyntheticCMRUnits(c *tc.C) {
+	_, unitUUIDs := s.createIAASApplicationWithNUnits(c, "foo", 1)
+	unitUUID := unitUUIDs[0]
+	workloadStatus := status.StatusInfo[status.WorkloadStatusType]{
+		Status: status.WorkloadStatusActive,
+		Since:  new(time.Now()),
+	}
+	err := s.state.SetUnitWorkloadStatus(c.Context(), unitUUID, workloadStatus)
+	c.Assert(err, tc.ErrorIsNil)
+
+	agentStatus := status.StatusInfo[status.UnitAgentStatusType]{
+		Status: status.UnitAgentStatusIdle,
+		Since:  new(time.Now()),
+	}
+	err = s.state.SetUnitAgentStatus(c.Context(), unitUUID, agentStatus)
+	c.Assert(err, tc.ErrorIsNil)
+
+	remoteAppUUID, _ := s.createIAASApplicationWithNUnits(c, "remote-app", 1)
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE charm
+SET source_id = 2, architecture_id = NULL
+WHERE uuid = (SELECT charm_uuid FROM application WHERE uuid = ?)`, remoteAppUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	result, err := s.state.GetAllUnitWorkloadAgentStatuses(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.HasLen, 1)
+
+	unitStatus, ok := result["foo/0"]
+	c.Assert(ok, tc.IsTrue)
+	c.Check(unitStatus.WorkloadStatus.Status, tc.Equals, workloadStatus.Status)
+	c.Check(unitStatus.AgentStatus.Status, tc.Equals, agentStatus.Status)
+	_, ok = result["remote-app/0"]
+	c.Check(ok, tc.IsFalse)
+}
+
 func (s *modelStateSuite) TestGetAllApplicationStatusesEmptyModel(c *tc.C) {
 	statuses, err := s.state.GetAllApplicationStatuses(c.Context())
 	c.Assert(err, tc.ErrorIsNil)


### PR DESCRIPTION
When a model has an active cross-model relation, Juju creates "synthetic" units to
represent the remote side. These units do not run an agent, so they have no agent
version and no workload or agent status. Several migration checks queried the units
table without accounting for this, so they treated a synthetic remote unit as if it
were a real one. The effect was that a migration could wrongly report a remote unit
as lagging behind on its agent version, wait forever for a status report that never
comes, or fail outright because a status row does not exist for that unit.

This extends the same charm-source filter already used in #22927 (which fixed the
version precheck) to the remaining query sites: the agent-version count and the
"units not at target version" check, the migration agent list used during export,
and the workload/agent status query. Each of them now skips units whose charm comes
from a cross-model-relation source, so an active CMR no longer blocks or breaks a
migration.

## QA steps


Although migrations 4.0->4.0 are not allowed (and we will add a guard later), this is only done as a simple way to prove that the source prechecks succeed. Later when 4.0->4.1 migrations are fully finished, this won't block.

```
# Source controller and offering model.
juju bootstrap localhost src
juju add-model offering -c src
juju deploy juju-qa-dummy-source --base ubuntu@22.04
juju offer dummy-source:sink

# Consumer model: consume and relate the offer.
juju add-model consuming -c src
juju deploy juju-qa-dummy-sink --base ubuntu@22.04
juju consume src:admin/offering.dummy-source
juju relate dummy-sink dummy-source

# Wait until the offer is connected. 
juju status -m src:offering --format json | \
    jq '.offers["dummy-source"]["active-connected-count"]'
```
```
# Bootstrap a destination controller and migrate the offering model.
juju bootstrap localhost dst
juju migrate src:offering dst
```
Before this change, migration fails during source prechecks with:
```
there exists units in the model that are not running the target agent version
... [remote-<uuid>/0]
```

## Links

**Jira card:** [JUJU-10142](https://warthogs.atlassian.net/browse/JUJU-10142)


[JUJU-10142]: https://warthogs.atlassian.net/browse/JUJU-10142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ