### PR TITLE
fix: GetRemoteSecretContentInfo

### DIFF
--- a/api/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -244,15 +244,17 @@ func (c *Client) GetRemoteSecretContentInfo(uri *coresecrets.URI, revision int, 
 			}
 			// Discharge-required errors are expected: discharge the
 			// macaroon and retry immediately.
-			if params.ErrCode(apiErr) == params.CodeDischargeRequired {
-				mac, err := c.handleDischargeError(apiErr)
-				if err != nil {
-					return errors.Trace(err)
-				}
-				args.Args[0].Macaroons = mac
-				args.Args[0].BakeryVersion = bakery.LatestVersion
-				content, backend, latestRevision, draining, apiErr = apiCall()
+			if params.ErrCode(apiErr) != params.CodeDischargeRequired {
+				return apiErr
 			}
+
+			mac, err := c.handleDischargeError(apiErr)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			args.Args[0].Macaroons = mac
+			args.Args[0].BakeryVersion = bakery.LatestVersion
+			content, backend, latestRevision, draining, apiErr = apiCall()
 			return apiErr
 		},
 		IsFatalError: func(err error) bool {

--- a/api/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -239,24 +239,24 @@ func (c *Client) GetRemoteSecretContentInfo(uri *coresecrets.URI, revision int, 
 	err := retry.Call(retry.CallArgs{
 		Func: func() error {
 			content, backend, latestRevision, draining, apiErr = apiCall()
+			if apiErr == nil {
+				return nil
+			}
+			// Discharge-required errors are expected: discharge the
+			// macaroon and retry immediately.
+			if params.ErrCode(apiErr) == params.CodeDischargeRequired {
+				mac, err := c.handleDischargeError(apiErr)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				args.Args[0].Macaroons = mac
+				args.Args[0].BakeryVersion = bakery.LatestVersion
+				content, backend, latestRevision, draining, apiErr = apiCall()
+			}
 			return apiErr
 		},
 		IsFatalError: func(err error) bool {
-			if errors.IsNotFound(err) || errors.Is(err, apiservererrors.ErrPerm) {
-				return true
-			}
-			if params.ErrCode(apiErr) != params.CodeDischargeRequired {
-				return false
-			}
-			// On error, possibly discharge the macaroon and retry.
-			var mac macaroon.Slice
-			mac, apiErr = c.handleDischargeError(err)
-			if apiErr != nil {
-				return true
-			}
-			args.Args[0].Macaroons = mac
-			args.Args[0].BakeryVersion = bakery.LatestVersion
-			return false
+			return errors.IsNotFound(err) || errors.Is(err, apiservererrors.ErrPerm)
 		},
 		Delay:    retryDelay,
 		Clock:    Clock,

--- a/api/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -92,6 +92,10 @@ func (c *Client) getCachedMacaroon(opName, token string) (macaroon.Slice, bool) 
 
 var Clock retry.Clock = clock.WallClock
 
+// errDischargeFailed is a sentinel error used to mark a failed macaroon
+// discharge as fatal so retry.Call does not retry it.
+var errDischargeFailed = errors.ConstError("discharge failed")
+
 // Account for the fact that the remote controller might be starting up.
 const (
 	numRetries = 3
@@ -250,7 +254,7 @@ func (c *Client) GetRemoteSecretContentInfo(uri *coresecrets.URI, revision int, 
 
 			mac, err := c.handleDischargeError(apiErr)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Wrap(err, errDischargeFailed)
 			}
 			args.Args[0].Macaroons = mac
 			args.Args[0].BakeryVersion = bakery.LatestVersion
@@ -258,7 +262,14 @@ func (c *Client) GetRemoteSecretContentInfo(uri *coresecrets.URI, revision int, 
 			return apiErr
 		},
 		IsFatalError: func(err error) bool {
-			return errors.IsNotFound(err) || errors.Is(err, apiservererrors.ErrPerm)
+			if errors.IsNotFound(err) || errors.Is(err, apiservererrors.ErrPerm) {
+				return true
+			}
+			// A discharge failure should not be retried.
+			if errors.Cause(err) == errDischargeFailed {
+				return true
+			}
+			return false
 		},
 		Delay:    retryDelay,
 		Clock:    Clock,

--- a/api/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -4,13 +4,18 @@
 package crossmodelsecrets_test
 
 import (
+	"context"
+	"encoding/json"
 	"time"
 
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 	"github.com/juju/clock/testclock"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
 
+	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/base/testing"
 	"github.com/juju/juju/api/controller/crossmodelsecrets"
 	apitesting "github.com/juju/juju/api/testing"
@@ -124,6 +129,109 @@ func (s *CrossControllerSuite) TestControllerInfoError(c *gc.C) {
 	c.Assert(content, gc.IsNil)
 	c.Assert(backend, gc.IsNil)
 	c.Assert(attemptCount, gc.Equals, 3)
+}
+
+// mockDischargeAcquirer implements base.MacaroonDischarger for testing
+// macaroon discharge flows.
+type mockDischargeAcquirer struct {
+	base.MacaroonDischarger
+}
+
+func (m *mockDischargeAcquirer) DischargeAll(ctx context.Context, b *bakery.Macaroon) (macaroon.Slice, error) {
+	mac, err := apitesting.NewMacaroon("discharge mac")
+	if err != nil {
+		return nil, err
+	}
+	return macaroon.Slice{mac}, nil
+}
+
+// testLocator resolves any third party location to a known public key.
+type testLocator struct {
+	PublicKey bakery.PublicKey
+}
+
+func (b testLocator) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
+	return bakery.ThirdPartyInfo{
+		PublicKey: b.PublicKey,
+		Version:   bakery.LatestVersion,
+	}, nil
+}
+
+func fillResponse(c *gc.C, resp interface{}, value interface{}) {
+	b, err := json.Marshal(value)
+	c.Assert(err, jc.ErrorIsNil)
+	err = json.Unmarshal(b, resp)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// TestGetRemoteSecretContentInfoDischargeRequired verifies that when the
+// remote controller returns a discharge-required error, the macaroon is
+// discharged and the call is retried immediately within the same Func
+// invocation — without incurring the retry.Call delay.
+func (s *CrossControllerSuite) TestGetRemoteSecretContentInfoDischargeRequired(c *gc.C) {
+	uri := coresecrets.NewURI()
+	key, err := bakery.GenerateKey()
+	c.Assert(err, jc.ErrorIsNil)
+	bk := bakery.New(bakery.BakeryParams{
+		Key:     key,
+		Locator: testLocator{key.Public},
+	})
+	dischargeMacaroon, err := bk.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, []checkers.Caveat{
+		checkers.NeedDeclaredCaveat(checkers.Caveat{
+			Location:  "third party location",
+			Condition: "third party caveat",
+		}),
+	}, bakery.Op{Entity: "secret", Action: "read"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	var (
+		callCount     int
+		dischargedMac macaroon.Slice
+	)
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		var resultErr *params.Error
+		if callCount == 0 {
+			// First call: return a discharge-required error.
+			resultErr = &params.Error{
+				Code: params.CodeDischargeRequired,
+				Info: params.DischargeRequiredErrorInfo{
+					BakeryMacaroon: dischargeMacaroon,
+				}.AsMap(),
+			}
+		} else {
+			// Second call: succeed, and capture the discharged macaroon
+			// that was sent.
+			argParam := arg.(params.GetRemoteSecretContentArgs)
+			dischargedMac = argParam.Args[0].Macaroons
+		}
+		resp := params.SecretContentResults{
+			Results: []params.SecretContentResult{{
+				Error: resultErr,
+				Content: params.SecretContentParams{
+					Data: map[string]string{"key": "value"},
+				},
+				LatestRevision: ptr(1),
+			}},
+		}
+		fillResponse(c, result, resp)
+		callCount++
+		return nil
+	})
+	acquirer := &mockDischargeAcquirer{}
+	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
+	client := crossmodelsecrets.NewClient(callerWithBakery)
+	start := time.Now()
+	content, _, latestRevision, _, err := client.GetRemoteSecretContentInfo(uri, 0, true, false, coretesting.ControllerTag.Id(), "token", 666, nil)
+	elapsed := time.Since(start)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(latestRevision, gc.Equals, 1)
+	c.Check(content.SecretValue.EncodedValues(), gc.DeepEquals, map[string]string{"key": "value"})
+	// Only 2 API calls were made (1st: discharge-required, 2nd: success).
+	c.Check(callCount, gc.Equals, 2)
+	// The discharged macaroon was sent on the second call.
+	c.Assert(dischargedMac, gc.HasLen, 1)
+	c.Assert(dischargedMac[0].Id(), jc.DeepEquals, []byte("discharge mac"))
+	c.Assert(elapsed < crossmodelsecrets.RetryDelay, jc.IsTrue, gc.Commentf("elapsed: %v", elapsed))
 }
 
 func (s *CrossControllerSuite) TestGetSecretAccessScope(c *gc.C) {

--- a/api/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/checkers"
 	"github.com/juju/clock/testclock"
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon.v2"
@@ -220,9 +221,12 @@ func (s *CrossControllerSuite) TestGetRemoteSecretContentInfoDischargeRequired(c
 	acquirer := &mockDischargeAcquirer{}
 	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
 	client := crossmodelsecrets.NewClient(callerWithBakery)
-	start := time.Now()
+	// Patch the retry Clock with a test clock that is never advanced.
+	// The discharge happens inside Func and Clock.After is
+	// never called, so the call completes without advancing the clock.
+	clock := testclock.NewClock(time.Now())
+	s.PatchValue(&crossmodelsecrets.Clock, clock)
 	content, _, latestRevision, _, err := client.GetRemoteSecretContentInfo(uri, 0, true, false, coretesting.ControllerTag.Id(), "token", 666, nil)
-	elapsed := time.Since(start)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(latestRevision, gc.Equals, 1)
 	c.Check(content.SecretValue.EncodedValues(), gc.DeepEquals, map[string]string{"key": "value"})
@@ -231,7 +235,66 @@ func (s *CrossControllerSuite) TestGetRemoteSecretContentInfoDischargeRequired(c
 	// The discharged macaroon was sent on the second call.
 	c.Assert(dischargedMac, gc.HasLen, 1)
 	c.Assert(dischargedMac[0].Id(), jc.DeepEquals, []byte("discharge mac"))
-	c.Assert(elapsed < crossmodelsecrets.RetryDelay, jc.IsTrue, gc.Commentf("elapsed: %v", elapsed))
+}
+
+// failingDischargeAcquirer implements base.MacaroonDischarger for testing
+// macaroon discharge failures.
+type failingDischargeAcquirer struct {
+	base.MacaroonDischarger
+}
+
+func (m *failingDischargeAcquirer) DischargeAll(ctx context.Context, b *bakery.Macaroon) (macaroon.Slice, error) {
+	return nil, errors.New("discharge failed")
+}
+
+// TestGetRemoteSecretContentInfoDischargeFailure verifies that when the
+// macaroon discharge itself fails, the error is treated as fatal and not
+// retried.
+func (s *CrossControllerSuite) TestGetRemoteSecretContentInfoDischargeFailure(c *gc.C) {
+	uri := coresecrets.NewURI()
+	key, err := bakery.GenerateKey()
+	c.Assert(err, jc.ErrorIsNil)
+	bk := bakery.New(bakery.BakeryParams{
+		Key:     key,
+		Locator: testLocator{key.Public},
+	})
+	dischargeMacaroon, err := bk.Oven.NewMacaroon(context.TODO(), bakery.LatestVersion, []checkers.Caveat{
+		checkers.NeedDeclaredCaveat(checkers.Caveat{
+			Location:  "third party location",
+			Condition: "third party caveat",
+		}),
+	}, bakery.Op{Entity: "secret", Action: "read"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	callCount := 0
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		callCount++
+		resp := params.SecretContentResults{
+			Results: []params.SecretContentResult{{
+				Error: &params.Error{
+					Code: params.CodeDischargeRequired,
+					Info: params.DischargeRequiredErrorInfo{
+						BakeryMacaroon: dischargeMacaroon,
+					}.AsMap(),
+				},
+			}},
+		}
+		fillResponse(c, result, resp)
+		return nil
+	})
+	acquirer := &failingDischargeAcquirer{}
+	callerWithBakery := testing.APICallerWithBakery(apiCaller, acquirer)
+	client := crossmodelsecrets.NewClient(callerWithBakery)
+	// Use a test clock that is never advanced. If the discharge failure
+	// were retried, retry.Call would call Clock.After and block forever.
+	clock := testclock.NewClock(time.Now())
+	s.PatchValue(&crossmodelsecrets.Clock, clock)
+	content, _, _, _, err := client.GetRemoteSecretContentInfo(uri, 0, true, false, coretesting.ControllerTag.Id(), "token", 666, nil)
+	c.Check(err, gc.NotNil)
+	c.Check(content, gc.IsNil)
+	// Only 1 API call was made — the discharge failure is fatal and not
+	// retried.
+	c.Check(callCount, gc.Equals, 1)
 }
 
 func (s *CrossControllerSuite) TestGetSecretAccessScope(c *gc.C) {

--- a/api/controller/crossmodelsecrets/export_test.go
+++ b/api/controller/crossmodelsecrets/export_test.go
@@ -1,0 +1,6 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package crossmodelsecrets
+
+const RetryDelay = retryDelay


### PR DESCRIPTION
# Description

Fix #22911

The user reported a delay of 3 seconds to get a secret after 30 secrets.
In reality it wasn't a bug related to the number of secrets, rather a problem with the way we were handling a discharge error in GetRemoteSecretContentInfo. And since the original macaroon expires in 3 minutes, even with 1 single secret is possible to reproduce the issue, if we wait 3+ minutes to try to get the secret.

Basically we were handling the discharge error in the `IsFatalError`, so  we were waiting 3 secs to actually do the API call if we encountered the discharge error.
The better approach is to retry the call on CodeDischargeRequired immidiately and rely on retry.Call for transient errors. This reduces the get-secret time from 3s to ~10ms because when the macaroon expires it's discharged immidiately instead of waiting 3s.

The test is really simple because it checks the test finishes before `crossmodelsecrets.RetryDelay`, if you remove my patch the test will fail. I'd like to use something better like `synctest` but it doesn't play nice with `retry.Call`.

# QA

Clone https://github.com/skourta/cross-model-secret-poc

`charmcraft pack`


```
juju add-model provider       
juju deploy ./cross-model-secret-charm_*.charm secret-provider
juju offer secret-provider:provide-secret
```

```
juju add-model consumer   
juju deploy ./cross-model-secret-charm_*.charm secret-consumer
juju consume repro-fix-1:provider.secret-provider
juju integrate secret-consumer:require-secret secret-provider
```

Then:

```
juju run --model provider secret-provider/leader add-secret name=test1 message=helloworld
```

first get right after the consume:
```
[10:48:00] ➜  cross-model-secret-poc git:(main) ✗ juju run --model consumer secret-consumer/0 get-secret name=test1 
Running operation 1 with 1 task
  - task 2 on unit-secret-consumer-0

Waiting for task 2...
get-secret-ms: "14.75"
message: helloworld
name: test1
```

second get after 4 minutes after the consume before the fix:
```
[9:50:37] ➜  cross-model-secret-poc git:(main) ✗ juju run --model consumer secret-consumer/0 get-secret name=test3
Running operation 25 with 1 task
  - task 26 on unit-secret-consumer-0

Waiting for task 26...
get-secret-ms: "3049.77"
message: helloworld
name: test3
```

After the fix:

```
[10:57:37] ➜  cross-model-secret-poc git:(main) ✗ juju run --model consumer secret-consumer/0 get-secret name=test1
Running operation 9 with 1 task
  - task 10 on unit-secret-consumer-0

Waiting for task 10...
get-secret-ms: "24.37"
message: helloworld
name: test1
```