### PR TITLE
fix: remove sync.Once and store the pub key in the state

### DIFF
--- a/apiserver/facades/agent/sshsession/facade.go
+++ b/apiserver/facades/agent/sshsession/facade.go
@@ -126,8 +126,8 @@ func (f *Facade) ControllerSSHPort(ctx context.Context) (params.SSHControllerSSH
 
 // ControllerPublicKey returns the marshalled public host key of the controller
 // SSH jump server. The machine agent uses it to pin the host key when
-// reverse-dialling the controller. The public key derivation and caching live
-// in the service, so the facade never handles private key material.
+// reverse-dialling the controller. The public key is derived once at bootstrap
+// and stored in state, so the facade never handles private key material.
 func (f *Facade) ControllerPublicKey(ctx context.Context) (params.SSHControllerPublicKeyResult, error) {
 	publicKey, err := f.controllerSSHHostKeyService.SSHServerHostPublicKey(ctx)
 	if err != nil {

--- a/apiserver/facades/agent/sshsession/facade_test.go
+++ b/apiserver/facades/agent/sshsession/facade_test.go
@@ -144,7 +144,7 @@ func (s *facadeSuite) TestControllerPublicKey(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	// The service derives and caches the public key; the facade simply returns
+	// The public key is stored in state at bootstrap; the facade simply returns
 	// what it is given. Derive the expected bytes from the known private key.
 	signer, err := gossh.ParsePrivateKey([]byte(jujutesting.SSHServerHostKey))
 	c.Assert(err, tc.ErrorIsNil)

--- a/apiserver/facades/agent/sshsession/service.go
+++ b/apiserver/facades/agent/sshsession/service.go
@@ -38,8 +38,7 @@ type ControllerConfigService interface {
 // jump server host key.
 type ControllerSSHHostKeyService interface {
 	// SSHServerHostPublicKey returns the marshalled public host key of the
-	// controller SSH jump server. The service derives it from the private host
-	// key and caches the result, so the facade never handles private key
-	// material and the key is only parsed once.
+	// controller SSH jump server. The public key is derived once at bootstrap
+	// and stored in state, so the facade never handles private key material.
 	SSHServerHostPublicKey(ctx context.Context) ([]byte, error)
 }

--- a/domain/schema/controller/sql/0029-ssh.sql
+++ b/domain/schema/controller/sql/0029-ssh.sql
@@ -15,6 +15,7 @@ CREATE TABLE controller_ssh_host_key (
     id TEXT NOT NULL PRIMARY KEY,
     algorithm_type_id INT NOT NULL,
     ssh_key TEXT NOT NULL,
+    public_key BLOB NOT NULL DEFAULT '',
     CONSTRAINT fk_controller_ssh_host_key_algorithm_type_id
     FOREIGN KEY (algorithm_type_id)
     REFERENCES ssh_key_algorithm_type (id)

--- a/domain/schema/controller/sql/0031-ssh-public-key.sql
+++ b/domain/schema/controller/sql/0031-ssh-public-key.sql
@@ -1,5 +1,0 @@
--- Add a column to store the marshalled public host key alongside the private
--- key. The public key is derived once at bootstrap and stored, so it can be
--- served to clients without re-parsing the private key on every retrieval.
-ALTER TABLE controller_ssh_host_key
-ADD COLUMN public_key BLOB NOT NULL DEFAULT x'';

--- a/domain/schema/controller/sql/0031-ssh-public-key.sql
+++ b/domain/schema/controller/sql/0031-ssh-public-key.sql
@@ -1,0 +1,5 @@
+-- Add a column to store the marshalled public host key alongside the private
+-- key. The public key is derived once at bootstrap and stored, so it can be
+-- served to clients without re-parsing the private key on every retrieval.
+ALTER TABLE controller_ssh_host_key
+ADD COLUMN public_key BLOB NOT NULL DEFAULT x'';

--- a/domain/ssh/bootstrap/bootstrap.go
+++ b/domain/ssh/bootstrap/bootstrap.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/database"
 	coreerrors "github.com/juju/juju/core/errors"
@@ -32,7 +31,7 @@ func InsertInitialSSHServerHostKey(sshServerHostKey string) internaldatabase.Boo
 			return errors.Errorf("determining controller SSH host key algorithm: %w", err)
 		}
 
-		publicKey, err := marshalPublicKey(sshServerHostKey)
+		publicKey, err := pkissh.MarshalPublicKey([]byte(sshServerHostKey))
 		if err != nil {
 			return errors.Errorf("deriving controller SSH host public key: %w", err)
 		}
@@ -81,14 +80,4 @@ func sshKeyAlgorithmTypeID(sshKey string) (int, error) {
 	default:
 		return 0, errors.Errorf("unsupported SSH key algorithm %q", algorithm)
 	}
-}
-
-// marshalPublicKey parses the marshalled private key and returns the
-// marshalled public key derived from it.
-func marshalPublicKey(privateKey string) ([]byte, error) {
-	signer, err := gossh.ParsePrivateKey([]byte(privateKey))
-	if err != nil {
-		return nil, errors.Capture(err)
-	}
-	return signer.PublicKey().Marshal(), nil
 }

--- a/domain/ssh/bootstrap/bootstrap.go
+++ b/domain/ssh/bootstrap/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
+	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/database"
 	coreerrors "github.com/juju/juju/core/errors"
@@ -17,7 +18,9 @@ import (
 )
 
 // InsertInitialSSHServerHostKey inserts the controller jump host key into the
-// controller database during bootstrap.
+// controller database during bootstrap. The marshalled public host key is
+// derived from the private key once here and stored alongside it, so it can be
+// served to clients without re-parsing the private key on every retrieval.
 func InsertInitialSSHServerHostKey(sshServerHostKey string) internaldatabase.BootstrapOpt {
 	return func(ctx context.Context, controller, model database.TxnRunner) error {
 		if sshServerHostKey == "" {
@@ -29,13 +32,19 @@ func InsertInitialSSHServerHostKey(sshServerHostKey string) internaldatabase.Boo
 			return errors.Errorf("determining controller SSH host key algorithm: %w", err)
 		}
 
+		publicKey, err := marshalPublicKey(sshServerHostKey)
+		if err != nil {
+			return errors.Errorf("deriving controller SSH host public key: %w", err)
+		}
+
 		record := controllerSSHHostKey{
 			ID:              domainssh.SSHServerHostKeyUUID,
 			AlgorithmTypeID: algorithmTypeID,
 			SSHKey:          sshServerHostKey,
+			PublicKey:       publicKey,
 		}
 		stmt, err := sqlair.Prepare(`
-INSERT INTO controller_ssh_host_key (id, algorithm_type_id, ssh_key)
+INSERT INTO controller_ssh_host_key (id, algorithm_type_id, ssh_key, public_key)
 VALUES ($controllerSSHHostKey.*)`, controllerSSHHostKey{})
 		if err != nil {
 			return errors.Capture(err)
@@ -54,6 +63,7 @@ type controllerSSHHostKey struct {
 	ID              string `db:"id"`
 	AlgorithmTypeID int    `db:"algorithm_type_id"`
 	SSHKey          string `db:"ssh_key"`
+	PublicKey       []byte `db:"public_key"`
 }
 
 func sshKeyAlgorithmTypeID(sshKey string) (int, error) {
@@ -71,4 +81,14 @@ func sshKeyAlgorithmTypeID(sshKey string) (int, error) {
 	default:
 		return 0, errors.Errorf("unsupported SSH key algorithm %q", algorithm)
 	}
+}
+
+// marshalPublicKey parses the marshalled private key and returns the
+// marshalled public key derived from it.
+func marshalPublicKey(privateKey string) ([]byte, error) {
+	signer, err := gossh.ParsePrivateKey([]byte(privateKey))
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return signer.PublicKey().Marshal(), nil
 }

--- a/domain/ssh/bootstrap/bootstrap_test.go
+++ b/domain/ssh/bootstrap/bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/juju/tc"
+	gossh "golang.org/x/crypto/ssh"
 
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	domainssh "github.com/juju/juju/domain/ssh"
@@ -29,11 +30,17 @@ func (s *bootstrapSuite) TestInsertInitialSSHServerHostKey(c *tc.C) {
 	var (
 		algorithmTypeID int
 		key             string
+		publicKey       []byte
 	)
-	row := s.DB().QueryRow(`SELECT algorithm_type_id, ssh_key FROM controller_ssh_host_key WHERE id = ?`, domainssh.SSHServerHostKeyUUID)
-	c.Assert(row.Scan(&algorithmTypeID, &key), tc.ErrorIsNil)
+	row := s.DB().QueryRow(`SELECT algorithm_type_id, ssh_key, public_key FROM controller_ssh_host_key WHERE id = ?`, domainssh.SSHServerHostKeyUUID)
+	c.Assert(row.Scan(&algorithmTypeID, &key, &publicKey), tc.ErrorIsNil)
 	c.Check(algorithmTypeID, tc.Equals, domainssh.SSHKeyAlgorithmTypeED25519ID)
 	c.Check(key, tc.Equals, jujutesting.SSHServerHostKey)
+
+	// The stored public key must match the one derived from the private key.
+	signer, err := gossh.ParsePrivateKey([]byte(jujutesting.SSHServerHostKey))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(publicKey, tc.DeepEquals, signer.PublicKey().Marshal())
 }
 
 func (s *bootstrapSuite) TestSSHServerHostKeyUUID(c *tc.C) {

--- a/domain/ssh/service/controller/service.go
+++ b/domain/ssh/service/controller/service.go
@@ -5,9 +5,6 @@ package controller
 
 import (
 	"context"
-	"sync"
-
-	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/internal/errors"
@@ -16,14 +13,6 @@ import (
 // Service provides controller-scoped SSH host key workflows.
 type Service struct {
 	state State
-
-	// publicKeyOnce guards the one-time derivation of the marshalled public
-	// host key. The controller SSH host key is set once at bootstrap and is not
-	// rotated, so deriving the public key from it is safe to cache for the
-	// lifetime of the service.
-	publicKeyOnce sync.Once
-	publicKey     []byte
-	publicKeyErr  error
 }
 
 // NewService returns a new controller SSH service.
@@ -44,30 +33,16 @@ func (s *Service) SSHServerHostKey(ctx context.Context) (string, error) {
 }
 
 // SSHServerHostPublicKey returns the marshalled public host key of the
-// controller SSH jump server. It derives the public key from the stored private
-// host key and caches the result, so the private key is fetched from state and
-// parsed only once rather than on every call. The controller SSH host key is
-// set once at bootstrap and is not rotated, so caching for the lifetime of the
-// service is safe.
+// controller SSH jump server. The public key is derived once at bootstrap and
+// stored alongside the private key, so this method simply reads the stored
+// value and never handles private key material.
 func (s *Service) SSHServerHostPublicKey(ctx context.Context) ([]byte, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	s.publicKeyOnce.Do(func() {
-		privateHostKey, err := s.SSHServerHostKey(ctx)
-		if err != nil {
-			s.publicKeyErr = errors.Capture(err)
-			return
-		}
-		signer, err := gossh.ParsePrivateKey([]byte(privateHostKey))
-		if err != nil {
-			s.publicKeyErr = errors.Errorf("parsing controller SSH host key: %w", err)
-			return
-		}
-		s.publicKey = signer.PublicKey().Marshal()
-	})
-	if s.publicKeyErr != nil {
-		return nil, s.publicKeyErr
+	key, err := s.state.GetSSHServerHostPublicKey(ctx)
+	if err != nil {
+		return nil, errors.Errorf("getting controller SSH server host public key: %w", err)
 	}
-	return s.publicKey, nil
+	return key, nil
 }

--- a/domain/ssh/service/controller/service_test.go
+++ b/domain/ssh/service/controller/service_test.go
@@ -38,33 +38,32 @@ func (s *serviceSuite) TestSSHServerHostKeyErrorsWhenMissing(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, context.Canceled)
 }
 
-// TestSSHServerHostPublicKeyDerivesAndCaches checks the public key is derived
-// from the stored private key and that the derivation is cached: the private
-// key is only parsed once, so repeated calls do not re-parse it.
-func (s *serviceSuite) TestSSHServerHostPublicKeyDerivesAndCaches(c *tc.C) {
-	controllerState := &stubControllerState{key: testPrivateKey}
-	svc := controllersshservice.NewService(controllerState)
-
+// TestSSHServerHostPublicKeyReturnsStored checks the public key is returned
+// directly from state without deriving it from the private key.
+func (s *serviceSuite) TestSSHServerHostPublicKeyReturnsStored(c *tc.C) {
 	signer, err := gossh.ParsePrivateKey([]byte(testPrivateKey))
 	c.Assert(err, tc.ErrorIsNil)
 	want := signer.PublicKey().Marshal()
+
+	controllerState := &stubControllerState{
+		key:       testPrivateKey,
+		publicKey: want,
+	}
+	svc := controllersshservice.NewService(controllerState)
 
 	got, err := svc.SSHServerHostPublicKey(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, want)
 
-	// A second call returns the same cached key and does not re-fetch or
-	// re-derive it: the private key is fetched from state exactly once.
-	got2, err := svc.SSHServerHostPublicKey(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(got2, tc.DeepEquals, want)
-	c.Check(controllerState.gets, tc.Equals, 1)
+	// The public key is read from state; the private key is never fetched.
+	c.Check(controllerState.gets, tc.Equals, 0)
+	c.Check(controllerState.publicKeyGets, tc.Equals, 1)
 }
 
-// TestSSHServerHostPublicKeyErrorsWhenMissing checks that a state error fetching
-// the host key is propagated to the caller.
+// TestSSHServerHostPublicKeyErrorsWhenMissing checks that a state error
+// fetching the public key is propagated to the caller.
 func (s *serviceSuite) TestSSHServerHostPublicKeyErrorsWhenMissing(c *tc.C) {
-	svc := controllersshservice.NewService(&stubControllerState{getErr: context.Canceled})
+	svc := controllersshservice.NewService(&stubControllerState{publicKeyGetErr: context.Canceled})
 
 	got, err := svc.SSHServerHostPublicKey(c.Context())
 	c.Check(got, tc.IsNil)
@@ -72,14 +71,22 @@ func (s *serviceSuite) TestSSHServerHostPublicKeyErrorsWhenMissing(c *tc.C) {
 }
 
 type stubControllerState struct {
-	key    string
-	getErr error
-	gets   int
+	key             string
+	getErr          error
+	gets            int
+	publicKey       []byte
+	publicKeyGetErr error
+	publicKeyGets   int
 }
 
 func (s *stubControllerState) GetSSHServerHostKey(_ context.Context) (string, error) {
 	s.gets++
 	return s.key, s.getErr
+}
+
+func (s *stubControllerState) GetSSHServerHostPublicKey(_ context.Context) ([]byte, error) {
+	s.publicKeyGets++
+	return s.publicKey, s.publicKeyGetErr
 }
 
 const testPrivateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\n" +

--- a/domain/ssh/service/controller/state.go
+++ b/domain/ssh/service/controller/state.go
@@ -9,4 +9,10 @@ import "context"
 type State interface {
 	// GetSSHServerHostKey returns the stored controller jump host key.
 	GetSSHServerHostKey(context.Context) (string, error)
+
+	// GetSSHServerHostPublicKey returns the marshalled public host key of the
+	// controller SSH jump server. The public key is derived once at bootstrap
+	// and stored alongside the private key, so this method never handles
+	// private key material.
+	GetSSHServerHostPublicKey(context.Context) ([]byte, error)
 }

--- a/domain/ssh/state/controller/state.go
+++ b/domain/ssh/state/controller/state.go
@@ -60,10 +60,49 @@ WHERE id = $controllerSSHHostKeyID.id`, controllerSSHHostKey{}, controllerSSHHos
 	return key.SSHKey, nil
 }
 
+// GetSSHServerHostPublicKey returns the marshalled public host key of the
+// controller SSH jump server. The public key is derived once at bootstrap and
+// stored alongside the private key, so this method never handles private key
+// material.
+func (st *State) GetSSHServerHostPublicKey(ctx context.Context) ([]byte, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	id := controllerSSHHostKeyID{ID: domainssh.SSHServerHostKeyUUID}
+	stmt, err := st.Prepare(`
+SELECT &controllerSSHHostKey.public_key
+FROM controller_ssh_host_key
+WHERE id = $controllerSSHHostKeyID.id`, controllerSSHHostKey{}, controllerSSHHostKeyID{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var key controllerSSHHostKey
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		key = controllerSSHHostKey{}
+
+		err := tx.Query(ctx, stmt, id).Get(&key)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("controller SSH host key not found").Add(coreerrors.NotFound)
+		}
+		if err != nil {
+			return errors.Errorf("querying controller SSH host public key: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return key.PublicKey, nil
+}
+
 type controllerSSHHostKey struct {
 	ID              string `db:"id"`
 	AlgorithmTypeID int    `db:"algorithm_type_id"`
 	SSHKey          string `db:"ssh_key"`
+	PublicKey       []byte `db:"public_key"`
 }
 
 type controllerSSHHostKeyID struct {

--- a/domain/ssh/state/controller/state_test.go
+++ b/domain/ssh/state/controller/state_test.go
@@ -80,6 +80,24 @@ func (s *stateSuite) TestGetSSHServerHostPublicKeyExisting(c *tc.C) {
 	c.Check(got, tc.DeepEquals, want)
 }
 
+// TestGetSSHServerHostPublicKeyEmpty checks that a row with an empty
+// public_key column returns an empty byte slice without error. This can
+// happen if a row was inserted without deriving the public key.
+func (s *stateSuite) TestGetSSHServerHostPublicKeyEmpty(c *tc.C) {
+	// Insert a row directly with an empty public_key.
+	_, err := s.DB().Exec(
+		`INSERT INTO controller_ssh_host_key (id, algorithm_type_id, ssh_key, public_key) VALUES (?, ?, ?, x'')`,
+		domainssh.SSHServerHostKeyUUID, domainssh.SSHKeyAlgorithmTypeED25519ID, "dummy-key",
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := sshcontrollerstate.NewState(txRunnerFactory(s.ControllerTxnRunner()))
+
+	got, err := st.GetSSHServerHostPublicKey(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, []byte{})
+}
+
 func txRunnerFactory(runner coredatabase.TxnRunner) coredatabase.TxnRunnerFactory {
 	return func(context.Context) (coredatabase.TxnRunner, error) {
 		return runner, nil

--- a/domain/ssh/state/controller/state_test.go
+++ b/domain/ssh/state/controller/state_test.go
@@ -8,6 +8,7 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/tc"
+	gossh "golang.org/x/crypto/ssh"
 
 	coredatabase "github.com/juju/juju/core/database"
 	coreerrors "github.com/juju/juju/core/errors"
@@ -52,6 +53,31 @@ func (s *stateSuite) TestGetSSHServerHostKeyExisting(c *tc.C) {
 	c.Assert(row.Scan(&storedID, &algorithmTypeID), tc.ErrorIsNil)
 	c.Check(storedID, tc.Equals, domainssh.SSHServerHostKeyUUID)
 	c.Check(algorithmTypeID, tc.Equals, domainssh.SSHKeyAlgorithmTypeED25519ID)
+}
+
+func (s *stateSuite) TestGetSSHServerHostPublicKeyMissing(c *tc.C) {
+	st := sshcontrollerstate.NewState(txRunnerFactory(s.ControllerTxnRunner()))
+
+	key, err := st.GetSSHServerHostPublicKey(c.Context())
+	c.Check(key, tc.IsNil)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotFound)
+}
+
+func (s *stateSuite) TestGetSSHServerHostPublicKeyExisting(c *tc.C) {
+	err := sshbootstrap.InsertInitialSSHServerHostKey(jujutesting.SSHServerHostKey)(c.Context(), s.ControllerTxnRunner(), s.NoopTxnRunner())
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := sshcontrollerstate.NewState(txRunnerFactory(s.ControllerTxnRunner()))
+
+	// Derive the expected public key from the same private key that bootstrap
+	// stored, so we can verify the stored value matches.
+	signer, err := gossh.ParsePrivateKey([]byte(jujutesting.SSHServerHostKey))
+	c.Assert(err, tc.ErrorIsNil)
+	want := signer.PublicKey().Marshal()
+
+	got, err := st.GetSSHServerHostPublicKey(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, want)
 }
 
 func txRunnerFactory(runner coredatabase.TxnRunner) coredatabase.TxnRunnerFactory {

--- a/internal/pki/ssh/keys.go
+++ b/internal/pki/ssh/keys.go
@@ -112,3 +112,15 @@ func PrivateKeyAlgorithm(data []byte) (string, error) {
 	}
 	return signer.PublicKey().Type(), nil
 }
+
+// MarshalPublicKey parses a PEM-encoded private key and returns the marshalled
+// public key derived from it. The returned bytes are in the SSH wire format
+// suitable for storage or transmission to clients that need to pin the host
+// key.
+func MarshalPublicKey(privateKey []byte) ([]byte, error) {
+	signer, err := gossh.ParsePrivateKey(privateKey)
+	if err != nil {
+		return nil, errors.Annotate(err, "failed to parse private key")
+	}
+	return signer.PublicKey().Marshal(), nil
+}

--- a/internal/pki/ssh/keys_test.go
+++ b/internal/pki/ssh/keys_test.go
@@ -99,3 +99,24 @@ func (s *KeySuite) TestPrivateKeyAlgorithm_Error(c *tc.C) {
 	_, err := ssh.PrivateKeyAlgorithm([]byte("not a valid key"))
 	c.Assert(err, tc.Not(tc.ErrorIsNil))
 }
+
+// TestMarshalPublicKey checks that the marshalled public key derived from a
+// private key can be parsed back into a valid SSH public key.
+func (s *KeySuite) TestMarshalPublicKey(c *tc.C) {
+	keyStr, err := ssh.NewMarshalledED25519()
+	c.Assert(err, tc.ErrorIsNil)
+
+	marshalled, err := ssh.MarshalPublicKey(keyStr)
+	c.Assert(err, tc.ErrorIsNil)
+
+	publicKey, err := gossh.ParsePublicKey(marshalled)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(publicKey.Type(), tc.Equals, ssh.AlgorithmED25519)
+}
+
+// TestMarshalPublicKeyError checks that an invalid private key produces an
+// error rather than silently returning empty bytes.
+func (s *KeySuite) TestMarshalPublicKeyError(c *tc.C) {
+	_, err := ssh.MarshalPublicKey([]byte("not a valid key"))
+	c.Assert(err, tc.Not(tc.ErrorIsNil))
+}


### PR DESCRIPTION
# Description

Pretty much handling https://github.com/juju/juju/pull/22768#discussion_r3543667848

Storing the key in the state, avoiding the sync.Once or deriving it everytime.

A bit of wiring but the code is very simple.