### PR TITLE
feat(migration): make the migration flag direction-aware

### DIFF
--- a/apiserver/facades/agent/migrationflag/facade.go
+++ b/apiserver/facades/agent/migrationflag/facade.go
@@ -79,11 +79,11 @@ func (facade *Facade) onePhase(ctx context.Context, tagString string) (string, e
 	if err := facade.auth(ctx, tagString); err != nil {
 		return "", errors.Trace(err)
 	}
-	m, err := facade.modelMigrationService.Migration(ctx)
+	phase, err := facade.modelMigrationService.MigrationPhase(ctx)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	return m.Phase.String(), nil
+	return phase.String(), nil
 }
 
 // Watch returns an id for use with the NotifyWatcher facade, or an
@@ -107,7 +107,7 @@ func (facade *Facade) oneWatch(ctx context.Context, tagString string) (string, e
 	if err := facade.auth(ctx, tagString); err != nil {
 		return "", errors.Trace(err)
 	}
-	w, err := facade.modelMigrationService.WatchMigrationPhase(ctx)
+	w, err := facade.modelMigrationService.WatchMigrationActivity(ctx)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/apiserver/facades/agent/migrationflag/facade_test.go
+++ b/apiserver/facades/agent/migrationflag/facade_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/migrationflag"
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/watcher/watchertest"
-	"github.com/juju/juju/domain/modelmigration"
 	"github.com/juju/juju/internal/testhelpers"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
@@ -100,10 +99,7 @@ func (s *FacadeSuite) TestRejectsNonAgent(c *tc.C) {
 func (s *FacadeSuite) TestPhaseSuccess(c *tc.C) {
 	defer s.setUpMocks(c).Finish()
 
-	mig := modelmigration.Migration{
-		Phase: migration.REAP,
-	}
-	s.modelMigrationService.EXPECT().Migration(gomock.Any()).Return(mig, nil).Times(2)
+	s.modelMigrationService.EXPECT().MigrationPhase(gomock.Any()).Return(migration.REAP, nil).Times(2)
 
 	facade, err := migrationflag.New(
 		s.watcherRegistry,
@@ -127,8 +123,7 @@ func (s *FacadeSuite) TestPhaseSuccess(c *tc.C) {
 func (s *FacadeSuite) TestPhaseErrors(c *tc.C) {
 	defer s.setUpMocks(c).Finish()
 
-	mig := modelmigration.Migration{}
-	s.modelMigrationService.EXPECT().Migration(gomock.Any()).Return(mig, errors.New("ouch"))
+	s.modelMigrationService.EXPECT().MigrationPhase(gomock.Any()).Return(migration.UNKNOWN, errors.New("ouch"))
 	facade, err := migrationflag.New(
 		s.watcherRegistry,
 		authOK,
@@ -166,7 +161,7 @@ func (s *FacadeSuite) TestWatchSuccess(c *tc.C) {
 	w := watchertest.NewMockNotifyWatcher(ch)
 	defer workertest.CleanKill(c, w)
 
-	s.modelMigrationService.EXPECT().WatchMigrationPhase(gomock.Any()).Return(w, nil)
+	s.modelMigrationService.EXPECT().WatchMigrationActivity(gomock.Any()).Return(w, nil)
 	s.watcherRegistry.EXPECT().Register(gomock.Any(), gomock.Any()).Return("123", nil)
 	facade, err := migrationflag.New(
 		s.watcherRegistry,
@@ -188,7 +183,7 @@ func (s *FacadeSuite) TestWatchSuccess(c *tc.C) {
 func (s *FacadeSuite) TestWatchErrors(c *tc.C) {
 	defer s.setUpMocks(c).Finish()
 
-	s.modelMigrationService.EXPECT().WatchMigrationPhase(gomock.Any()).Return(nil, errors.New("blort"))
+	s.modelMigrationService.EXPECT().WatchMigrationActivity(gomock.Any()).Return(nil, errors.New("blort"))
 
 	facade, err := migrationflag.New(
 		s.watcherRegistry,

--- a/apiserver/facades/agent/migrationflag/mocks_test.go
+++ b/apiserver/facades/agent/migrationflag/mocks_test.go
@@ -13,8 +13,8 @@ import (
 	context "context"
 
 	gomock "github.com/canonical/gomock/gomock"
+	migration "github.com/juju/juju/core/migration"
 	watcher "github.com/juju/juju/core/watcher"
-	modelmigration "github.com/juju/juju/domain/modelmigration"
 )
 
 // MockModelMigrationService is a mock of ModelMigrationService interface.
@@ -26,9 +26,9 @@ type MockModelMigrationService struct {
 
 // MockModelMigrationServiceMockRecorder is the mock recorder for MockModelMigrationService.
 type MockModelMigrationServiceMockRecorder struct {
-	mock                       *MockModelMigrationService
-	migrationExpects           []*gomock.Call1_2[context.Context, modelmigration.Migration, error]
-	watchMigrationPhaseExpects []*gomock.Call1_2[context.Context, watcher.NotifyWatcher, error]
+	mock                          *MockModelMigrationService
+	migrationPhaseExpects         []*gomock.Call1_2[context.Context, migration.Phase, error]
+	watchMigrationActivityExpects []*gomock.Call1_2[context.Context, watcher.NotifyWatcher, error]
 }
 
 // NewMockModelMigrationService creates a new mock instance.
@@ -43,38 +43,38 @@ func (m *MockModelMigrationService) EXPECT() *MockModelMigrationServiceMockRecor
 	return m.recorder
 }
 
-// Migration mocks base method.
-func (m *MockModelMigrationService) Migration(ctx context.Context) (modelmigration.Migration, error) {
+// MigrationPhase mocks base method.
+func (m *MockModelMigrationService) MigrationPhase(ctx context.Context) (migration.Phase, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch1_2(&m.recorder.migrationExpects, m.ctrl, m, "Migration", ctx)
+	return gomock.Dispatch1_2(&m.recorder.migrationPhaseExpects, m.ctrl, m, "MigrationPhase", ctx)
 }
 
-// Migration indicates an expected call of Migration.
-func (mr *MockModelMigrationServiceMockRecorder) Migration(ctx any) *MockModelMigrationServiceMigrationCall {
+// MigrationPhase indicates an expected call of MigrationPhase.
+func (mr *MockModelMigrationServiceMockRecorder) MigrationPhase(ctx any) *MockModelMigrationServiceMigrationPhaseCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_2[context.Context, modelmigration.Migration, error](mr.mock.ctrl.T, mr.mock, "Migration", gomock.EnsureMatcher(ctx))
-	mr.migrationExpects = append(mr.migrationExpects, call)
+	call := gomock.NewCall1_2[context.Context, migration.Phase, error](mr.mock.ctrl.T, mr.mock, "MigrationPhase", gomock.EnsureMatcher(ctx))
+	mr.migrationPhaseExpects = append(mr.migrationPhaseExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
-// MockModelMigrationServiceMigrationCall is the typed call wrapper for Migration.
-type MockModelMigrationServiceMigrationCall = gomock.Call1_2[context.Context, modelmigration.Migration, error]
+// MockModelMigrationServiceMigrationPhaseCall is the typed call wrapper for MigrationPhase.
+type MockModelMigrationServiceMigrationPhaseCall = gomock.Call1_2[context.Context, migration.Phase, error]
 
-// WatchMigrationPhase mocks base method.
-func (m *MockModelMigrationService) WatchMigrationPhase(ctx context.Context) (watcher.NotifyWatcher, error) {
+// WatchMigrationActivity mocks base method.
+func (m *MockModelMigrationService) WatchMigrationActivity(ctx context.Context) (watcher.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch1_2(&m.recorder.watchMigrationPhaseExpects, m.ctrl, m, "WatchMigrationPhase", ctx)
+	return gomock.Dispatch1_2(&m.recorder.watchMigrationActivityExpects, m.ctrl, m, "WatchMigrationActivity", ctx)
 }
 
-// WatchMigrationPhase indicates an expected call of WatchMigrationPhase.
-func (mr *MockModelMigrationServiceMockRecorder) WatchMigrationPhase(ctx any) *MockModelMigrationServiceWatchMigrationPhaseCall {
+// WatchMigrationActivity indicates an expected call of WatchMigrationActivity.
+func (mr *MockModelMigrationServiceMockRecorder) WatchMigrationActivity(ctx any) *MockModelMigrationServiceWatchMigrationActivityCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_2[context.Context, watcher.NotifyWatcher, error](mr.mock.ctrl.T, mr.mock, "WatchMigrationPhase", gomock.EnsureMatcher(ctx))
-	mr.watchMigrationPhaseExpects = append(mr.watchMigrationPhaseExpects, call)
+	call := gomock.NewCall1_2[context.Context, watcher.NotifyWatcher, error](mr.mock.ctrl.T, mr.mock, "WatchMigrationActivity", gomock.EnsureMatcher(ctx))
+	mr.watchMigrationActivityExpects = append(mr.watchMigrationActivityExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
-// MockModelMigrationServiceWatchMigrationPhaseCall is the typed call wrapper for WatchMigrationPhase.
-type MockModelMigrationServiceWatchMigrationPhaseCall = gomock.Call1_2[context.Context, watcher.NotifyWatcher, error]
+// MockModelMigrationServiceWatchMigrationActivityCall is the typed call wrapper for WatchMigrationActivity.
+type MockModelMigrationServiceWatchMigrationActivityCall = gomock.Call1_2[context.Context, watcher.NotifyWatcher, error]

--- a/apiserver/facades/agent/migrationflag/service.go
+++ b/apiserver/facades/agent/migrationflag/service.go
@@ -15,7 +15,7 @@ import (
 //
 // Both methods are direction-agnostic: they report a model being imported into
 // this controller as migrating, exactly as they report one being exported from
-// it. That is what keeps a repointed agent's own workers parked between the
+// it. That is what keeps a migrating agent's own workers parked between the
 // moment it starts talking to this controller and the moment the import is
 // committed and the claim released.
 type ModelMigrationService interface {

--- a/apiserver/facades/agent/migrationflag/service.go
+++ b/apiserver/facades/agent/migrationflag/service.go
@@ -6,11 +6,25 @@ package migrationflag
 import (
 	"context"
 
+	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/domain/modelmigration"
 )
 
+// ModelMigrationService supplies the migration phase this facade reports to
+// agents.
+//
+// Both methods are direction-agnostic: they report a model being imported into
+// this controller as migrating, exactly as they report one being exported from
+// it. That is what keeps a repointed agent's own workers parked between the
+// moment it starts talking to this controller and the moment the import is
+// committed and the claim released.
 type ModelMigrationService interface {
-	WatchMigrationPhase(ctx context.Context) (watcher.NotifyWatcher, error)
-	Migration(ctx context.Context) (modelmigration.Migration, error)
+	// WatchMigrationActivity fires on export phase transitions and on import
+	// claim changes, including the claim deletion that makes an imported model
+	// usable.
+	WatchMigrationActivity(ctx context.Context) (watcher.NotifyWatcher, error)
+
+	// MigrationPhase reports the model's migration phase in either direction,
+	// or migration.NONE when the model is not migrating.
+	MigrationPhase(ctx context.Context) (migration.Phase, error)
 }

--- a/apiserver/facades/controller/migrationtarget/domainservices_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/domainservices_mock_test.go
@@ -157,7 +157,7 @@ type MockDomainServicesMockRecorder struct {
 	modelExpects                      []*gomock.Call0_1[*service25.WatchableService]
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
 	modelInfoExpects                  []*gomock.Call0_1[*service25.ProviderModelService]
-	modelMigrationExpects             []*gomock.Call0_1[*service29.Service]
+	modelMigrationExpects             []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects              []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects         []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                    []*gomock.Call0_1[*service31.WatchableService]
@@ -825,7 +825,7 @@ func (mr *MockDomainServicesMockRecorder) ModelInfo() *MockDomainServicesModelIn
 type MockDomainServicesModelInfoCall = gomock.Call0_1[*service25.ProviderModelService]
 
 // ModelMigration mocks base method.
-func (m *MockDomainServices) ModelMigration() *service29.Service {
+func (m *MockDomainServices) ModelMigration() *service29.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelMigrationExpects, m.ctrl, m, "ModelMigration")
 }
@@ -833,14 +833,14 @@ func (m *MockDomainServices) ModelMigration() *service29.Service {
 // ModelMigration indicates an expected call of ModelMigration.
 func (mr *MockDomainServicesMockRecorder) ModelMigration() *MockDomainServicesModelMigrationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service29.Service](mr.mock.ctrl.T, mr.mock, "ModelMigration")
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigration")
 	mr.modelMigrationExpects = append(mr.modelMigrationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
-type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.Service]
+type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockDomainServices) ModelProvider() *service30.Service {

--- a/domain/model/state/controller/state_test.go
+++ b/domain/model/state/controller/state_test.go
@@ -2487,6 +2487,65 @@ func (m *stateSuite) TestImportModel(c *tc.C) {
 	c.Assert(migrationUUID, tc.Not(tc.Equals), "")
 }
 
+// TestImportModelClaimsInImportingPhase asserts that the legacy (v4-v7) import
+// path creates a model_migration_import claim in the *importing* phase.
+//
+// This is a characterisation test for a fact the migration protocol depends on:
+// every import carries a claim, legacy included. Claim existence is therefore
+// not a legacy/v8 discriminator, and legacy imports are frozen and abortable by
+// exactly the same claim phase machine as v8 imports. Code that assumes a
+// missing claim means "legacy" is wrong, and a 3.6 or 4.0 source driving this
+// path would silently take the wrong branch.
+func (m *stateSuite) TestImportModelClaimsInImportingPhase(c *tc.C) {
+	m.createControllerModel(c, m.controllerModelUUID, m.userUUID)
+	m.createModel(c, m.uuid, m.userUUID)
+
+	modelSt := NewState(m.TxnRunnerFactory())
+	testUUID := tc.Must(c, coremodel.NewUUID)
+	err := modelSt.ImportModel(
+		c.Context(),
+		testUUID,
+		coremodel.IAAS,
+		model.GlobalModelCreationArgs{
+			Cloud:       "my-cloud",
+			CloudRegion: "my-region",
+			Credential: corecredential.Key{
+				Cloud: "my-cloud",
+				Owner: usertesting.GenNewName(c, "test-user"),
+				Name:  "foobar",
+			},
+			Name:          "import-phase-test",
+			Qualifier:     "prod",
+			AdminUsers:    []user.UUID{m.userUUID},
+			SecretBackend: juju.BackendName,
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	runner, err := m.TxnRunnerFactory()(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	var phase string
+	err = runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		stmt, err := sqlair.Prepare(`
+SELECT     mmipt.type AS &M.type
+FROM       model_migration_import AS mmi
+JOIN       model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
+WHERE      mmi.model_uuid = $M.model_uuid`, sqlair.M{})
+		if err != nil {
+			return err
+		}
+		result := sqlair.M{}
+		if err := tx.Query(ctx, stmt, sqlair.M{"model_uuid": testUUID.String()}).Get(&result); err != nil {
+			return err
+		}
+		phase = result["type"].(string)
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(phase, tc.Equals, "importing")
+}
+
 func (m *stateSuite) TestImportModelWithSameNameAndOwner(c *tc.C) {
 	m.createControllerModel(c, m.controllerModelUUID, m.userUUID)
 	m.createModel(c, m.uuid, m.userUUID)

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -104,6 +104,10 @@ type ControllerState interface {
 	// sync report changes keyed by migration UUID.
 	NamespaceForWatchMinionSync() string
 
+	// NamespaceForWatchImportClaim returns the changestream namespace for
+	// target-side import claim changes keyed by model UUID.
+	NamespaceForWatchImportClaim() string
+
 	// InsertExport records a new export migration attempt for a model,
 	// returning [modelmigrationerrors.ErrMigrationAlreadyActive] if the model already
 	// has an active export.
@@ -437,9 +441,52 @@ func (s *Service) ModelMigrationMode(ctx context.Context) (modelmigration.Migrat
 	return mode, nil
 }
 
+// MigrationPhase returns the migration phase of this model considering
+// migration in *both* directions:
+//
+//   - a live target-side import claim, in any phase, reports [migration.IMPORT];
+//   - otherwise an active source-side export reports its own phase;
+//   - otherwise [migration.NONE].
+//
+// It exists because [Service.Migration] deliberately reports only exports: the
+// migration master needs export identity and target info, and must never treat
+// an import claim as something it should drive. Callers that only want to know
+// "is this model migrating, either way?" - the migration flag on both the
+// controller and agent sides - must use this instead, so that a target model
+// stays frozen for the whole of an import rather than only during an export.
+//
+// [migration.IMPORT] is reported for every claim phase, including aborting,
+// because none of them make the model usable. Since IMPORT is non-terminal, a
+// flag built on [IsTerminal] reports false and workers stay parked until the
+// claim is gone.
+func (s *Service) MigrationPhase(ctx context.Context) (migration.Phase, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	// GetMigrationMode resolves both tables in one transaction and already
+	// treats any import claim as importing, so it cannot report a stale mix of
+	// the two sides.
+	mode, err := s.controllerState.GetMigrationMode(ctx, s.modelUUID)
+	if err != nil {
+		return migration.UNKNOWN, errors.Capture(err)
+	}
+	if mode == modelmigration.MigrationModeImporting {
+		return migration.IMPORT, nil
+	}
+
+	mig, err := s.Migration(ctx)
+	if err != nil {
+		return migration.UNKNOWN, errors.Capture(err)
+	}
+	return mig.Phase, nil
+}
+
 // Migration returns status about migration of this model. If the model is not
 // currently being migrated, a migration with phase [migration.NONE] is
 // returned.
+//
+// This reports source-side exports only. See [Service.MigrationPhase] for the
+// direction-agnostic read used by the migration flag.
 func (s *Service) Migration(ctx context.Context) (modelmigration.Migration, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -649,6 +696,36 @@ func (s *Service) WatchMigrationPhase(ctx context.Context) (watcher.NotifyWatche
 
 	return s.watchControllerNamespace(
 		ctx, "watch for migration phase change", s.controllerState.NamespaceForWatchPhase(),
+	)
+}
+
+// WatchMigrationActivity returns a notification watcher that fires whenever
+// this model's migration activity changes in either direction: an export phase
+// transition on the source side, or an import claim being created, changing
+// phase, or being deleted on the target side.
+//
+// It is the watcher behind [Service.MigrationPhase], and exists because
+// [Service.WatchMigrationPhase] observes exports only. A target import is
+// invisible to it, so on its own it would never fire when an imported model
+// becomes usable. Claim deletion is exactly that moment, so watching both
+// namespaces is what lets the migration flag unfreeze a target model.
+func (s *Service) WatchMigrationActivity(ctx context.Context) (watcher.NotifyWatcher, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	return s.watcherFactory.NewNotifyWatcher(
+		ctx,
+		"watch for migration activity",
+		eventsource.PredicateFilter(
+			s.controllerState.NamespaceForWatchPhase(),
+			changestream.All,
+			eventsource.EqualsPredicate(s.modelUUID),
+		),
+		eventsource.PredicateFilter(
+			s.controllerState.NamespaceForWatchImportClaim(),
+			changestream.All,
+			eventsource.EqualsPredicate(s.modelUUID),
+		),
 	)
 }
 

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -124,6 +124,11 @@ type ControllerState interface {
 	// GetMigrationMode derives the migration mode for the model.
 	GetMigrationMode(ctx context.Context, modelUUID string) (modelmigration.MigrationMode, error)
 
+	// GetMigrationPhase derives the model's migration phase in both
+	// directions: importing while a target import claim exists, otherwise the
+	// active export's phase, otherwise none.
+	GetMigrationPhase(ctx context.Context, modelUUID string) (migration.Phase, error)
+
 	// SetPhase transitions an export migration to a new phase, enforcing valid
 	// phase transitions with optimistic locking.
 	SetPhase(ctx context.Context, migrationUUID string, newPhase migration.Phase) error
@@ -330,6 +335,37 @@ func NewService(
 	}
 }
 
+// WatchableService provides the means for supporting model migration actions
+// between controllers and the ability to create watchers.
+type WatchableService struct {
+	Service
+}
+
+// NewWatchableService is responsible for constructing a new
+// [WatchableService] to handle model migration tasks with watching
+// capabilities.
+func NewWatchableService(
+	controllerState ControllerState,
+	modelState ModelState,
+	modelUUID string,
+	watcherFactory WatcherFactory,
+	instanceProviderGetter providertracker.ProviderGetter[InstanceProvider],
+	resourceProviderGetter providertracker.ProviderGetter[ResourceProvider],
+	logger logger.Logger,
+) *WatchableService {
+	return &WatchableService{
+		Service: *NewService(
+			controllerState,
+			modelState,
+			modelUUID,
+			watcherFactory,
+			instanceProviderGetter,
+			resourceProviderGetter,
+			logger,
+		),
+	}
+}
+
 // AdoptResources is responsible for taking ownership of the cloud resources of
 // a model when it has been migrated into this controller.
 func (s *Service) AdoptResources(
@@ -463,22 +499,13 @@ func (s *Service) MigrationPhase(ctx context.Context) (migration.Phase, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	// GetMigrationMode resolves both tables in one transaction and already
-	// treats any import claim as importing, so it cannot report a stale mix of
-	// the two sides.
-	mode, err := s.controllerState.GetMigrationMode(ctx, s.modelUUID)
+	// GetMigrationPhase resolves both tables in one transaction, so it cannot
+	// report a stale mix of the two sides.
+	phase, err := s.controllerState.GetMigrationPhase(ctx, s.modelUUID)
 	if err != nil {
 		return migration.UNKNOWN, errors.Capture(err)
 	}
-	if mode == modelmigration.MigrationModeImporting {
-		return migration.IMPORT, nil
-	}
-
-	mig, err := s.Migration(ctx)
-	if err != nil {
-		return migration.UNKNOWN, errors.Capture(err)
-	}
-	return mig.Phase, nil
+	return phase, nil
 }
 
 // Migration returns status about migration of this model. If the model is not
@@ -705,11 +732,14 @@ func (s *Service) WatchMigrationPhase(ctx context.Context) (watcher.NotifyWatche
 // phase, or being deleted on the target side.
 //
 // It is the watcher behind [Service.MigrationPhase], and exists because
-// [Service.WatchMigrationPhase] observes exports only. A target import is
-// invisible to it, so on its own it would never fire when an imported model
-// becomes usable. Claim deletion is exactly that moment, so watching both
-// namespaces is what lets the migration flag unfreeze a target model.
-func (s *Service) WatchMigrationActivity(ctx context.Context) (watcher.NotifyWatcher, error) {
+// [Service.WatchMigrationPhase] observes exports only: a target import is
+// invisible to that watcher, so on its own it would never fire when an
+// imported model becomes usable. Claim deletion is exactly that moment, so
+// watching both namespaces is what lets the migration flag unfreeze a target
+// model. Extending [Service.WatchMigrationPhase] to also observe claims was
+// rejected: it feeds the migration minion, which follows the source's phase
+// machine and must not be woken by target-side claim changes.
+func (s *WatchableService) WatchMigrationActivity(ctx context.Context) (watcher.NotifyWatcher, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -126,8 +126,9 @@ type ControllerState interface {
 
 	// GetMigrationPhase derives the model's migration phase in both
 	// directions: importing while a target import claim exists, otherwise the
-	// active export's phase, otherwise none.
-	GetMigrationPhase(ctx context.Context, modelUUID string) (migration.Phase, error)
+	// active export's phase, otherwise none. The phase is returned as its
+	// name.
+	GetMigrationPhase(ctx context.Context, modelUUID string) (string, error)
 
 	// SetPhase transitions an export migration to a new phase, enforcing valid
 	// phase transitions with optimistic locking.
@@ -501,9 +502,13 @@ func (s *Service) MigrationPhase(ctx context.Context) (migration.Phase, error) {
 
 	// GetMigrationPhase resolves both tables in one transaction, so it cannot
 	// report a stale mix of the two sides.
-	phase, err := s.controllerState.GetMigrationPhase(ctx, s.modelUUID)
+	phaseName, err := s.controllerState.GetMigrationPhase(ctx, s.modelUUID)
 	if err != nil {
 		return migration.UNKNOWN, errors.Capture(err)
+	}
+	phase, ok := migration.ParsePhase(phaseName)
+	if !ok {
+		return migration.UNKNOWN, errors.Errorf("unknown migration phase %q", phaseName)
 	}
 	return phase, nil
 }

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -140,7 +140,7 @@ type MockControllerStateMockRecorder struct {
 	getImportClaimExpects                    []*gomock.Call2_2[context.Context, string, modelmigration0.ImportClaim, error]
 	getImportedOfferUUIDsExpects             []*gomock.Call2_2[context.Context, string, []string, error]
 	getMigrationModeExpects                  []*gomock.Call2_2[context.Context, string, modelmigration0.MigrationMode, error]
-	getMigrationPhaseExpects                 []*gomock.Call2_2[context.Context, string, migration.Phase, error]
+	getMigrationPhaseExpects                 []*gomock.Call2_2[context.Context, string, string, error]
 	getModelUsersForRedirectExpects          []*gomock.Call2_2[context.Context, string, []internal.RedirectUserAccess, error]
 	getSourceControllerInfoExpects           []*gomock.Call1_2[context.Context, internal.SourceControllerInfo, error]
 	importExternalControllersExpects         []*gomock.Call4_1[context.Context, string, string, []internal.ExternalController, error]
@@ -531,7 +531,7 @@ func (mr *MockControllerStateMockRecorder) GetMigrationMode(ctx, modelUUID any) 
 type MockControllerStateGetMigrationModeCall = gomock.Call2_2[context.Context, string, modelmigration0.MigrationMode, error]
 
 // GetMigrationPhase mocks base method.
-func (m *MockControllerState) GetMigrationPhase(ctx context.Context, modelUUID string) (migration.Phase, error) {
+func (m *MockControllerState) GetMigrationPhase(ctx context.Context, modelUUID string) (string, error) {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch2_2(&m.recorder.getMigrationPhaseExpects, m.ctrl, m, "GetMigrationPhase", ctx, modelUUID)
 }
@@ -539,14 +539,14 @@ func (m *MockControllerState) GetMigrationPhase(ctx context.Context, modelUUID s
 // GetMigrationPhase indicates an expected call of GetMigrationPhase.
 func (mr *MockControllerStateMockRecorder) GetMigrationPhase(ctx, modelUUID any) *MockControllerStateGetMigrationPhaseCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, string, migration.Phase, error](mr.mock.ctrl.T, mr.mock, "GetMigrationPhase", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	call := gomock.NewCall2_2[context.Context, string, string, error](mr.mock.ctrl.T, mr.mock, "GetMigrationPhase", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
 	mr.getMigrationPhaseExpects = append(mr.getMigrationPhaseExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerStateGetMigrationPhaseCall is the typed call wrapper for GetMigrationPhase.
-type MockControllerStateGetMigrationPhaseCall = gomock.Call2_2[context.Context, string, migration.Phase, error]
+type MockControllerStateGetMigrationPhaseCall = gomock.Call2_2[context.Context, string, string, error]
 
 // GetModelUsersForRedirect mocks base method.
 func (m *MockControllerState) GetModelUsersForRedirect(ctx context.Context, modelUUID string) ([]internal.RedirectUserAccess, error) {

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -147,6 +147,7 @@ type MockControllerStateMockRecorder struct {
 	insertExportExpects                      []*gomock.Call2_1[context.Context, internal.MigrationSpec, error]
 	insertMinionReportExpects                []*gomock.Call5_1[context.Context, string, migration.Phase, string, bool, error]
 	namespaceForWatchExportExpects           []*gomock.Call0_1[string]
+	namespaceForWatchImportClaimExpects      []*gomock.Call0_1[string]
 	namespaceForWatchMinionSyncExpects       []*gomock.Call0_1[string]
 	namespaceForWatchPhaseExpects            []*gomock.Call0_1[string]
 	secretBackendExistsExpects               []*gomock.Call2_2[context.Context, string, bool, error]
@@ -653,6 +654,24 @@ func (mr *MockControllerStateMockRecorder) NamespaceForWatchExport() *MockContro
 
 // MockControllerStateNamespaceForWatchExportCall is the typed call wrapper for NamespaceForWatchExport.
 type MockControllerStateNamespaceForWatchExportCall = gomock.Call0_1[string]
+
+// NamespaceForWatchImportClaim mocks base method.
+func (m *MockControllerState) NamespaceForWatchImportClaim() string {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.namespaceForWatchImportClaimExpects, m.ctrl, m, "NamespaceForWatchImportClaim")
+}
+
+// NamespaceForWatchImportClaim indicates an expected call of NamespaceForWatchImportClaim.
+func (mr *MockControllerStateMockRecorder) NamespaceForWatchImportClaim() *MockControllerStateNamespaceForWatchImportClaimCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[string](mr.mock.ctrl.T, mr.mock, "NamespaceForWatchImportClaim")
+	mr.namespaceForWatchImportClaimExpects = append(mr.namespaceForWatchImportClaimExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerStateNamespaceForWatchImportClaimCall is the typed call wrapper for NamespaceForWatchImportClaim.
+type MockControllerStateNamespaceForWatchImportClaimCall = gomock.Call0_1[string]
 
 // NamespaceForWatchMinionSync mocks base method.
 func (m *MockControllerState) NamespaceForWatchMinionSync() string {

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -140,6 +140,7 @@ type MockControllerStateMockRecorder struct {
 	getImportClaimExpects                    []*gomock.Call2_2[context.Context, string, modelmigration0.ImportClaim, error]
 	getImportedOfferUUIDsExpects             []*gomock.Call2_2[context.Context, string, []string, error]
 	getMigrationModeExpects                  []*gomock.Call2_2[context.Context, string, modelmigration0.MigrationMode, error]
+	getMigrationPhaseExpects                 []*gomock.Call2_2[context.Context, string, migration.Phase, error]
 	getModelUsersForRedirectExpects          []*gomock.Call2_2[context.Context, string, []internal.RedirectUserAccess, error]
 	getSourceControllerInfoExpects           []*gomock.Call1_2[context.Context, internal.SourceControllerInfo, error]
 	importExternalControllersExpects         []*gomock.Call4_1[context.Context, string, string, []internal.ExternalController, error]
@@ -528,6 +529,24 @@ func (mr *MockControllerStateMockRecorder) GetMigrationMode(ctx, modelUUID any) 
 
 // MockControllerStateGetMigrationModeCall is the typed call wrapper for GetMigrationMode.
 type MockControllerStateGetMigrationModeCall = gomock.Call2_2[context.Context, string, modelmigration0.MigrationMode, error]
+
+// GetMigrationPhase mocks base method.
+func (m *MockControllerState) GetMigrationPhase(ctx context.Context, modelUUID string) (migration.Phase, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_2(&m.recorder.getMigrationPhaseExpects, m.ctrl, m, "GetMigrationPhase", ctx, modelUUID)
+}
+
+// GetMigrationPhase indicates an expected call of GetMigrationPhase.
+func (mr *MockControllerStateMockRecorder) GetMigrationPhase(ctx, modelUUID any) *MockControllerStateGetMigrationPhaseCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_2[context.Context, string, migration.Phase, error](mr.mock.ctrl.T, mr.mock, "GetMigrationPhase", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	mr.getMigrationPhaseExpects = append(mr.getMigrationPhaseExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerStateGetMigrationPhaseCall is the typed call wrapper for GetMigrationPhase.
+type MockControllerStateGetMigrationPhaseCall = gomock.Call2_2[context.Context, string, migration.Phase, error]
 
 // GetModelUsersForRedirect mocks base method.
 func (m *MockControllerState) GetModelUsersForRedirect(ctx context.Context, modelUUID string) ([]internal.RedirectUserAccess, error) {

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -340,6 +340,19 @@ func (s *serviceSuite) service(c *tc.C) *Service {
 	)
 }
 
+// watchableService constructs a WatchableService backed by the suite mocks.
+func (s *serviceSuite) watchableService(c *tc.C) *WatchableService {
+	return NewWatchableService(
+		s.controllerState,
+		s.modelState,
+		s.modelUUID,
+		s.watcherFactory,
+		func(context.Context) (InstanceProvider, error) { return s.instanceProvider, nil },
+		func(context.Context) (ResourceProvider, error) { return s.resourceProvider, nil },
+		loggertesting.WrapCheckLog(c),
+	)
+}
+
 // validTargetInfo returns a TargetInfo that passes validation.
 func (s *serviceSuite) validTargetInfo() migration.TargetInfo {
 	return migration.TargetInfo{
@@ -420,8 +433,8 @@ func (s *serviceSuite) TestMigrationNone(c *tc.C) {
 func (s *serviceSuite) TestMigrationPhaseImportClaimReportsImport(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.controllerState.EXPECT().GetMigrationMode(gomock.Any(), s.modelUUID).Return(
-		modelmigration.MigrationModeImporting, nil)
+	s.controllerState.EXPECT().GetMigrationPhase(gomock.Any(), s.modelUUID).Return(
+		migration.IMPORT, nil)
 
 	phase, err := s.service(c).MigrationPhase(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -436,10 +449,8 @@ func (s *serviceSuite) TestMigrationPhaseImportClaimReportsImport(c *tc.C) {
 func (s *serviceSuite) TestMigrationPhaseExportReportsExportPhase(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.controllerState.EXPECT().GetMigrationMode(gomock.Any(), s.modelUUID).Return(
-		modelmigration.MigrationModeExporting, nil)
-	s.controllerState.EXPECT().GetActiveExport(gomock.Any(), s.modelUUID).Return(
-		modelmigrationinternal.Migration{Phase: migration.QUIESCE}, nil)
+	s.controllerState.EXPECT().GetMigrationPhase(gomock.Any(), s.modelUUID).Return(
+		migration.QUIESCE, nil)
 
 	phase, err := s.service(c).MigrationPhase(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -451,15 +462,25 @@ func (s *serviceSuite) TestMigrationPhaseExportReportsExportPhase(c *tc.C) {
 func (s *serviceSuite) TestMigrationPhaseIdleReportsNone(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.controllerState.EXPECT().GetMigrationMode(gomock.Any(), s.modelUUID).Return(
-		modelmigration.MigrationModeNone, nil)
-	s.controllerState.EXPECT().GetActiveExport(gomock.Any(), s.modelUUID).Return(
-		modelmigrationinternal.Migration{}, modelmigrationerrors.ErrMigrationNotFound)
+	s.controllerState.EXPECT().GetMigrationPhase(gomock.Any(), s.modelUUID).Return(
+		migration.NONE, nil)
 
 	phase, err := s.service(c).MigrationPhase(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(phase, tc.Equals, migration.NONE)
 	c.Check(phase.IsTerminal(), tc.IsTrue)
+}
+
+// TestMigrationPhaseErrorPropagates asserts a state error surfaces with the
+// UNKNOWN phase rather than being mistaken for a real phase answer.
+func (s *serviceSuite) TestMigrationPhaseErrorPropagates(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.controllerState.EXPECT().GetMigrationPhase(gomock.Any(), s.modelUUID).Return(
+		migration.UNKNOWN, errors.New("boom"))
+
+	_, err := s.service(c).MigrationPhase(c.Context())
+	c.Check(err, tc.ErrorMatches, "boom")
 }
 
 // TestWatchMigrationActivityWatchesBothSides asserts the activity watcher
@@ -490,7 +511,7 @@ func (s *serviceSuite) TestWatchMigrationActivityWatchesBothSides(c *tc.C) {
 		},
 	)
 
-	w, err := s.service(c).WatchMigrationActivity(c.Context())
+	w, err := s.watchableService(c).WatchMigrationActivity(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -434,7 +434,7 @@ func (s *serviceSuite) TestMigrationPhaseImportClaimReportsImport(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.controllerState.EXPECT().GetMigrationPhase(gomock.Any(), s.modelUUID).Return(
-		migration.IMPORT, nil)
+		migration.IMPORT.String(), nil)
 
 	phase, err := s.service(c).MigrationPhase(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -450,7 +450,7 @@ func (s *serviceSuite) TestMigrationPhaseExportReportsExportPhase(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.controllerState.EXPECT().GetMigrationPhase(gomock.Any(), s.modelUUID).Return(
-		migration.QUIESCE, nil)
+		migration.QUIESCE.String(), nil)
 
 	phase, err := s.service(c).MigrationPhase(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -463,12 +463,25 @@ func (s *serviceSuite) TestMigrationPhaseIdleReportsNone(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.controllerState.EXPECT().GetMigrationPhase(gomock.Any(), s.modelUUID).Return(
-		migration.NONE, nil)
+		migration.NONE.String(), nil)
 
 	phase, err := s.service(c).MigrationPhase(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(phase, tc.Equals, migration.NONE)
 	c.Check(phase.IsTerminal(), tc.IsTrue)
+}
+
+// TestMigrationPhaseUnparsableErrors asserts a phase name from state that does
+// not parse is an error with the UNKNOWN phase, not silently a wrong answer.
+func (s *serviceSuite) TestMigrationPhaseUnparsableErrors(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.controllerState.EXPECT().GetMigrationPhase(gomock.Any(), s.modelUUID).Return(
+		"NOTAPHASE", nil)
+
+	phase, err := s.service(c).MigrationPhase(c.Context())
+	c.Check(err, tc.ErrorMatches, `unknown migration phase "NOTAPHASE"`)
+	c.Check(phase, tc.Equals, migration.UNKNOWN)
 }
 
 // TestMigrationPhaseErrorPropagates asserts a state error surfaces with the
@@ -477,7 +490,7 @@ func (s *serviceSuite) TestMigrationPhaseErrorPropagates(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.controllerState.EXPECT().GetMigrationPhase(gomock.Any(), s.modelUUID).Return(
-		migration.UNKNOWN, errors.New("boom"))
+		"", errors.New("boom"))
 
 	_, err := s.service(c).MigrationPhase(c.Context())
 	c.Check(err, tc.ErrorMatches, "boom")

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -413,6 +413,96 @@ func (s *serviceSuite) TestMigrationNone(c *tc.C) {
 	c.Check(mig.Phase, tc.Equals, migration.NONE)
 }
 
+// TestMigrationPhaseImportClaimReportsImport asserts that a live target-side
+// import claim reports IMPORT, so a model being imported into this controller
+// is frozen exactly as one being exported from it. Without this, the migration
+// flag would report NONE for a half-imported model and let its workers run.
+func (s *serviceSuite) TestMigrationPhaseImportClaimReportsImport(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.controllerState.EXPECT().GetMigrationMode(gomock.Any(), s.modelUUID).Return(
+		modelmigration.MigrationModeImporting, nil)
+
+	phase, err := s.service(c).MigrationPhase(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(phase, tc.Equals, migration.IMPORT)
+	// IMPORT must be non-terminal, or a flag built on IsTerminal would report
+	// the model as usable while it is still claimed.
+	c.Check(phase.IsTerminal(), tc.IsFalse)
+}
+
+// TestMigrationPhaseExportReportsExportPhase asserts that with no import claim
+// the source-side export phase is reported unchanged.
+func (s *serviceSuite) TestMigrationPhaseExportReportsExportPhase(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.controllerState.EXPECT().GetMigrationMode(gomock.Any(), s.modelUUID).Return(
+		modelmigration.MigrationModeExporting, nil)
+	s.controllerState.EXPECT().GetActiveExport(gomock.Any(), s.modelUUID).Return(
+		modelmigrationinternal.Migration{Phase: migration.QUIESCE}, nil)
+
+	phase, err := s.service(c).MigrationPhase(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(phase, tc.Equals, migration.QUIESCE)
+}
+
+// TestMigrationPhaseIdleReportsNone asserts a model that is neither importing
+// nor exporting reports NONE, which is terminal and therefore unfreezes it.
+func (s *serviceSuite) TestMigrationPhaseIdleReportsNone(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.controllerState.EXPECT().GetMigrationMode(gomock.Any(), s.modelUUID).Return(
+		modelmigration.MigrationModeNone, nil)
+	s.controllerState.EXPECT().GetActiveExport(gomock.Any(), s.modelUUID).Return(
+		modelmigrationinternal.Migration{}, modelmigrationerrors.ErrMigrationNotFound)
+
+	phase, err := s.service(c).MigrationPhase(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(phase, tc.Equals, migration.NONE)
+	c.Check(phase.IsTerminal(), tc.IsTrue)
+}
+
+// TestWatchMigrationActivityWatchesBothSides asserts the activity watcher
+// covers the export phase namespace *and* the import claim namespace, both
+// scoped to this model. Watching exports alone would never fire when a target
+// import claim is deleted - the moment the model becomes usable.
+func (s *serviceSuite) TestWatchMigrationActivityWatchesBothSides(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	var namespaces []string
+	matchesUUID := map[string]bool{}
+	matchesOther := map[string]bool{}
+
+	otherUUID := tc.Must(c, uuid.NewUUID).String()
+	ch := make(chan struct{}, 1)
+	s.controllerState.EXPECT().NamespaceForWatchPhase().Return("model_migration_export_phase")
+	s.controllerState.EXPECT().NamespaceForWatchImportClaim().Return("model_migration_import")
+	s.watcherFactory.EXPECT().NewNotifyWatcher(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, fo eventsource.FilterOption, extra ...eventsource.FilterOption) (watcher.Watcher[struct{}], error) {
+			for _, f := range append([]eventsource.FilterOption{fo}, extra...) {
+				namespaces = append(namespaces, f.Namespace())
+				if pred := f.ChangePredicate(); pred != nil {
+					matchesUUID[f.Namespace()] = pred(s.modelUUID)
+					matchesOther[f.Namespace()] = pred(otherUUID)
+				}
+			}
+			return watchertest.NewMockNotifyWatcher(ch), nil
+		},
+	)
+
+	w, err := s.service(c).WatchMigrationActivity(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	c.Check(namespaces, tc.SameContents, []string{
+		"model_migration_export_phase", "model_migration_import",
+	})
+	for _, ns := range namespaces {
+		c.Check(matchesUUID[ns], tc.IsTrue)
+		c.Check(matchesOther[ns], tc.IsFalse)
+	}
+}
+
 // TestSourceControllerInfoArrangesRawStateAddresses asserts the service
 // arranges raw controller API address rows into the client-facing order.
 func (s *serviceSuite) TestSourceControllerInfoArrangesRawStateAddresses(c *tc.C) {

--- a/domain/modelmigration/state/controller/state.go
+++ b/domain/modelmigration/state/controller/state.go
@@ -142,6 +142,17 @@ func (s *State) NamespaceForWatchMinionSync() string {
 	return "model_migration_export_minion_sync"
 }
 
+// NamespaceForWatchImportClaim returns the changestream namespace that fires
+// when a target-side import claim is created, changes phase, or is deleted,
+// keyed by model UUID.
+//
+// Claim deletion is the moment an imported model becomes usable, so this
+// namespace is what unfreezes the target: see
+// [github.com/juju/juju/domain/modelmigration/service.Service.WatchMigrationActivity].
+func (s *State) NamespaceForWatchImportClaim() string {
+	return "model_migration_import"
+}
+
 // GetActiveExportUUID returns the UUID of the active export migration for the
 // given model. If no active export exists [modelmigrationerrors.ErrMigrationNotFound]
 // is returned.

--- a/domain/modelmigration/state/controller/state.go
+++ b/domain/modelmigration/state/controller/state.go
@@ -148,7 +148,7 @@ func (s *State) NamespaceForWatchMinionSync() string {
 //
 // Claim deletion is the moment an imported model becomes usable, so this
 // namespace is what unfreezes the target: see
-// [github.com/juju/juju/domain/modelmigration/service.Service.WatchMigrationActivity].
+// [github.com/juju/juju/domain/modelmigration/service.WatchableService.WatchMigrationActivity].
 func (s *State) NamespaceForWatchImportClaim() string {
 	return "model_migration_import"
 }
@@ -1010,6 +1010,75 @@ WHERE  model_uuid = $modelUUIDArg.model_uuid
 		return modelmigration.MigrationModeNone, errors.Capture(err)
 	}
 	return mode, nil
+}
+
+// GetMigrationPhase derives the model's migration phase considering migration
+// in both directions: [migration.IMPORT] while a target import claim exists in
+// any phase, otherwise the active export's phase, otherwise [migration.NONE].
+// Both tables are read in one transaction so the answer is never a stale mix
+// of the two sides.
+//
+// The import claim takes precedence over an active export: a model with both
+// is in an inconsistent state, and IMPORT is non-terminal, so consumers that
+// gate work on the phase stay frozen.
+func (s *State) GetMigrationPhase(ctx context.Context, modelUUID string) (migration.Phase, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return migration.UNKNOWN, errors.Capture(err)
+	}
+
+	mUUID := modelUUIDArg{ModelUUID: modelUUID}
+	terminalIDs := terminalPhaseIDs()
+	importStmt, err := s.Prepare(`
+SELECT COUNT(*) AS &countResult.count
+FROM   model_migration_import
+WHERE  model_uuid = $modelUUIDArg.model_uuid
+`, mUUID, countResult{})
+	if err != nil {
+		return migration.UNKNOWN, errors.Capture(err)
+	}
+	exportStmt, err := s.Prepare(`
+SELECT &currentPhase.current_phase_id
+FROM   model_migration_export
+WHERE  model_uuid = $modelUUIDArg.model_uuid
+AND    current_phase_id NOT IN (
+       $terminalPhaseIDArgs.reap_failed_id,
+       $terminalPhaseIDArgs.done_id,
+       $terminalPhaseIDArgs.abort_done_id)
+`, mUUID, terminalIDs, currentPhase{})
+	if err != nil {
+		return migration.UNKNOWN, errors.Capture(err)
+	}
+
+	var phase migration.Phase
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var importCount countResult
+		if err := tx.Query(ctx, importStmt, mUUID).Get(&importCount); err != nil {
+			return errors.Errorf("counting import claims for model %q: %w", modelUUID, err)
+		}
+		if importCount.Count > 0 {
+			phase = migration.IMPORT
+			return nil
+		}
+		var current currentPhase
+		err := tx.Query(ctx, exportStmt, mUUID, terminalIDs).Get(&current)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			phase = migration.NONE
+			return nil
+		} else if err != nil {
+			return errors.Errorf("reading active export phase for model %q: %w", modelUUID, err)
+		}
+		exportPhase, err := modelmigration.Phase(current.CurrentPhaseID).CoreMigrationPhase()
+		if err != nil {
+			return errors.Errorf("translating export phase for model %q: %w", modelUUID, err)
+		}
+		phase = exportPhase
+		return nil
+	})
+	if err != nil {
+		return migration.UNKNOWN, errors.Capture(err)
+	}
+	return phase, nil
 }
 
 // addressesMatch reports whether the persisted addresses equal the supplied

--- a/domain/modelmigration/state/controller/state.go
+++ b/domain/modelmigration/state/controller/state.go
@@ -1015,16 +1015,17 @@ WHERE  model_uuid = $modelUUIDArg.model_uuid
 // GetMigrationPhase derives the model's migration phase considering migration
 // in both directions: [migration.IMPORT] while a target import claim exists in
 // any phase, otherwise the active export's phase, otherwise [migration.NONE].
-// Both tables are read in one transaction so the answer is never a stale mix
-// of the two sides.
+// The phase is returned as its name; constructing the [migration.Phase] is the
+// caller's concern. Both tables are read in one transaction so the answer is
+// never a stale mix of the two sides.
 //
 // The import claim takes precedence over an active export: a model with both
 // is in an inconsistent state, and IMPORT is non-terminal, so consumers that
 // gate work on the phase stay frozen.
-func (s *State) GetMigrationPhase(ctx context.Context, modelUUID string) (migration.Phase, error) {
+func (s *State) GetMigrationPhase(ctx context.Context, modelUUID string) (string, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
-		return migration.UNKNOWN, errors.Capture(err)
+		return "", errors.Capture(err)
 	}
 
 	mUUID := modelUUIDArg{ModelUUID: modelUUID}
@@ -1035,7 +1036,7 @@ FROM   model_migration_import
 WHERE  model_uuid = $modelUUIDArg.model_uuid
 `, mUUID, countResult{})
 	if err != nil {
-		return migration.UNKNOWN, errors.Capture(err)
+		return "", errors.Capture(err)
 	}
 	exportStmt, err := s.Prepare(`
 SELECT &currentPhase.current_phase_id
@@ -1047,23 +1048,23 @@ AND    current_phase_id NOT IN (
        $terminalPhaseIDArgs.abort_done_id)
 `, mUUID, terminalIDs, currentPhase{})
 	if err != nil {
-		return migration.UNKNOWN, errors.Capture(err)
+		return "", errors.Capture(err)
 	}
 
-	var phase migration.Phase
+	var phase string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var importCount countResult
 		if err := tx.Query(ctx, importStmt, mUUID).Get(&importCount); err != nil {
 			return errors.Errorf("counting import claims for model %q: %w", modelUUID, err)
 		}
 		if importCount.Count > 0 {
-			phase = migration.IMPORT
+			phase = migration.IMPORT.String()
 			return nil
 		}
 		var current currentPhase
 		err := tx.Query(ctx, exportStmt, mUUID, terminalIDs).Get(&current)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			phase = migration.NONE
+			phase = migration.NONE.String()
 			return nil
 		} else if err != nil {
 			return errors.Errorf("reading active export phase for model %q: %w", modelUUID, err)
@@ -1072,11 +1073,11 @@ AND    current_phase_id NOT IN (
 		if err != nil {
 			return errors.Errorf("translating export phase for model %q: %w", modelUUID, err)
 		}
-		phase = exportPhase
+		phase = exportPhase.String()
 		return nil
 	})
 	if err != nil {
-		return migration.UNKNOWN, errors.Capture(err)
+		return "", errors.Capture(err)
 	}
 	return phase, nil
 }

--- a/domain/modelmigration/state/controller/state_test.go
+++ b/domain/modelmigration/state/controller/state_test.go
@@ -868,6 +868,52 @@ func (s *stateSuite) TestGetMigrationMode(c *tc.C) {
 	c.Check(mode, tc.Equals, modelmigration.MigrationModeImporting)
 }
 
+// TestGetMigrationPhase asserts the derived phase considers both directions in
+// one read: an import claim reports IMPORT, an active export reports its own
+// phase, neither reports NONE, and a claim takes precedence over an export.
+func (s *stateSuite) TestGetMigrationPhase(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	// No migration: none.
+	phase, err := st.GetMigrationPhase(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(phase, tc.Equals, migration.NONE)
+
+	// Active export: its own phase (exports start in QUIESCE).
+	spec := s.newMigrationSpec()
+	err = st.InsertExport(c.Context(), spec)
+	c.Assert(err, tc.ErrorIsNil)
+	phase, err = st.GetMigrationPhase(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(phase, tc.Equals, migration.QUIESCE)
+
+	// An import claim takes precedence over the active export: a model with
+	// both is inconsistent, and IMPORT keeps it frozen.
+	_, err = s.DB().ExecContext(c.Context(),
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, 'src')",
+		uuid.MustNewUUID().String(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	phase, err = st.GetMigrationPhase(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(phase, tc.Equals, migration.IMPORT)
+
+	// Ending the export leaves the claim reporting IMPORT.
+	err = st.MarkExportEnded(c.Context(), spec.MigrationUUID, migration.DONE)
+	c.Assert(err, tc.ErrorIsNil)
+	phase, err = st.GetMigrationPhase(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(phase, tc.Equals, migration.IMPORT)
+
+	// Deleting the claim - the moment the imported model becomes usable -
+	// reports none.
+	_, err = s.DB().ExecContext(c.Context(),
+		"DELETE FROM model_migration_import WHERE model_uuid = ?", s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	phase, err = st.GetMigrationPhase(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(phase, tc.Equals, migration.NONE)
+}
+
 // TestGetControllerModelInfoIdentity verifies that the model bootstrap
 // identity, credential, the seeded admin model permission and the model secret
 // backend are read back in target-portable form for a model created by the

--- a/domain/modelmigration/state/controller/state_test.go
+++ b/domain/modelmigration/state/controller/state_test.go
@@ -871,13 +871,14 @@ func (s *stateSuite) TestGetMigrationMode(c *tc.C) {
 // TestGetMigrationPhase asserts the derived phase considers both directions in
 // one read: an import claim reports IMPORT, an active export reports its own
 // phase, neither reports NONE, and a claim takes precedence over an export.
+// The phase is returned as its name, parseable with [migration.ParsePhase].
 func (s *stateSuite) TestGetMigrationPhase(c *tc.C) {
 	st := New(s.TxnRunnerFactory(), clock.WallClock)
 
 	// No migration: none.
 	phase, err := st.GetMigrationPhase(c.Context(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(phase, tc.Equals, migration.NONE)
+	c.Check(phase, tc.Equals, migration.NONE.String())
 
 	// Active export: its own phase (exports start in QUIESCE).
 	spec := s.newMigrationSpec()
@@ -885,7 +886,7 @@ func (s *stateSuite) TestGetMigrationPhase(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	phase, err = st.GetMigrationPhase(c.Context(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(phase, tc.Equals, migration.QUIESCE)
+	c.Check(phase, tc.Equals, migration.QUIESCE.String())
 
 	// An import claim takes precedence over the active export: a model with
 	// both is inconsistent, and IMPORT keeps it frozen.
@@ -895,14 +896,14 @@ func (s *stateSuite) TestGetMigrationPhase(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	phase, err = st.GetMigrationPhase(c.Context(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(phase, tc.Equals, migration.IMPORT)
+	c.Check(phase, tc.Equals, migration.IMPORT.String())
 
 	// Ending the export leaves the claim reporting IMPORT.
 	err = st.MarkExportEnded(c.Context(), spec.MigrationUUID, migration.DONE)
 	c.Assert(err, tc.ErrorIsNil)
 	phase, err = st.GetMigrationPhase(c.Context(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(phase, tc.Equals, migration.IMPORT)
+	c.Check(phase, tc.Equals, migration.IMPORT.String())
 
 	// Deleting the claim - the moment the imported model becomes usable -
 	// reports none.
@@ -911,7 +912,7 @@ func (s *stateSuite) TestGetMigrationPhase(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	phase, err = st.GetMigrationPhase(c.Context(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(phase, tc.Equals, migration.NONE)
+	c.Check(phase, tc.Equals, migration.NONE.String())
 }
 
 // TestGetControllerModelInfoIdentity verifies that the model bootstrap

--- a/domain/services/model.go
+++ b/domain/services/model.go
@@ -431,8 +431,8 @@ func (s *ModelServices) SSH() *sshmodelservice.WatchableService {
 
 // ModelMigration returns the model's migration service for supporting migration
 // operations.
-func (s *ModelServices) ModelMigration() *modelmigrationservice.Service {
-	return modelmigrationservice.NewService(
+func (s *ModelServices) ModelMigration() *modelmigrationservice.WatchableService {
+	return modelmigrationservice.NewWatchableService(
 		modelmigrationstatecontroller.New(changestream.NewTxnRunnerFactory(s.controllerDB), s.clock),
 		modelmigrationstatemodel.New(changestream.NewTxnRunnerFactory(s.modelDB), s.modelUUID),
 		s.modelUUID.String(),

--- a/internal/migration/activate_test.go
+++ b/internal/migration/activate_test.go
@@ -82,7 +82,7 @@ func (g activationDomainServicesGetter) ServicesForModel(
 	_ context.Context, modelUUID coremodel.UUID,
 ) (services.DomainServices, error) {
 	return activationDomainServices{
-		modelMigration: modelmigrationservice.NewService(
+		modelMigration: modelmigrationservice.NewWatchableService(
 			migrationclaimstate.New(g.deps.ControllerDB, g.deps.Clock),
 			migrationmodelstate.New(g.deps.ModelDB, modelUUID),
 			modelUUID.String(),
@@ -112,12 +112,12 @@ func (g activationDomainServicesGetter) ServicesForModel(
 type activationDomainServices struct {
 	services.DomainServices
 
-	modelMigration *modelmigrationservice.Service
+	modelMigration *modelmigrationservice.WatchableService
 	model          *modelservice.WatchableService
 	cmr            *crossmodelrelationservice.WatchableService
 }
 
-func (s activationDomainServices) ModelMigration() *modelmigrationservice.Service {
+func (s activationDomainServices) ModelMigration() *modelmigrationservice.WatchableService {
 	return s.modelMigration
 }
 

--- a/internal/migration/domainservices_mock_test.go
+++ b/internal/migration/domainservices_mock_test.go
@@ -157,7 +157,7 @@ type MockDomainServicesMockRecorder struct {
 	modelExpects                      []*gomock.Call0_1[*service25.WatchableService]
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
 	modelInfoExpects                  []*gomock.Call0_1[*service25.ProviderModelService]
-	modelMigrationExpects             []*gomock.Call0_1[*service29.Service]
+	modelMigrationExpects             []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects              []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects         []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                    []*gomock.Call0_1[*service31.WatchableService]
@@ -825,7 +825,7 @@ func (mr *MockDomainServicesMockRecorder) ModelInfo() *MockDomainServicesModelIn
 type MockDomainServicesModelInfoCall = gomock.Call0_1[*service25.ProviderModelService]
 
 // ModelMigration mocks base method.
-func (m *MockDomainServices) ModelMigration() *service29.Service {
+func (m *MockDomainServices) ModelMigration() *service29.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelMigrationExpects, m.ctrl, m, "ModelMigration")
 }
@@ -833,14 +833,14 @@ func (m *MockDomainServices) ModelMigration() *service29.Service {
 // ModelMigration indicates an expected call of ModelMigration.
 func (mr *MockDomainServicesMockRecorder) ModelMigration() *MockDomainServicesModelMigrationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service29.Service](mr.mock.ctrl.T, mr.mock, "ModelMigration")
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigration")
 	mr.modelMigrationExpects = append(mr.modelMigrationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
-type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.Service]
+type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockDomainServices) ModelProvider() *service30.Service {

--- a/internal/services/interface.go
+++ b/internal/services/interface.go
@@ -160,7 +160,7 @@ type ModelDomainServices interface {
 	ModelInfo() *modelservice.ProviderModelService
 	// ModelMigration returns the model's migration service for support
 	// migration operations.
-	ModelMigration() *modelmigrationservice.Service
+	ModelMigration() *modelmigrationservice.WatchableService
 	// ModelSecretBackend returns the model secret backend service.
 	ModelSecretBackend() *secretbackendservice.ModelSecretBackendService
 	// Operation returns the operation service.

--- a/internal/worker/bootstrap/domainservices_mock_test.go
+++ b/internal/worker/bootstrap/domainservices_mock_test.go
@@ -110,7 +110,7 @@ type MockDomainServicesMockRecorder struct {
 	modelExpects                      []*gomock.Call0_1[*service25.WatchableService]
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
 	modelInfoExpects                  []*gomock.Call0_1[*service25.ProviderModelService]
-	modelMigrationExpects             []*gomock.Call0_1[*service29.Service]
+	modelMigrationExpects             []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects              []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects         []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                    []*gomock.Call0_1[*service31.WatchableService]
@@ -778,7 +778,7 @@ func (mr *MockDomainServicesMockRecorder) ModelInfo() *MockDomainServicesModelIn
 type MockDomainServicesModelInfoCall = gomock.Call0_1[*service25.ProviderModelService]
 
 // ModelMigration mocks base method.
-func (m *MockDomainServices) ModelMigration() *service29.Service {
+func (m *MockDomainServices) ModelMigration() *service29.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelMigrationExpects, m.ctrl, m, "ModelMigration")
 }
@@ -786,14 +786,14 @@ func (m *MockDomainServices) ModelMigration() *service29.Service {
 // ModelMigration indicates an expected call of ModelMigration.
 func (mr *MockDomainServicesMockRecorder) ModelMigration() *MockDomainServicesModelMigrationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service29.Service](mr.mock.ctrl.T, mr.mock, "ModelMigration")
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigration")
 	mr.modelMigrationExpects = append(mr.modelMigrationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
-type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.Service]
+type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockDomainServices) ModelProvider() *service30.Service {

--- a/internal/worker/caasapplicationprovisioner/mocks/services_mocks.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/services_mocks.go
@@ -80,7 +80,7 @@ type MockModelDomainServicesMockRecorder struct {
 	keyUpdaterExpects             []*gomock.Call0_1[*service12.WatchableService]
 	machineExpects                []*gomock.Call0_1[*service13.WatchableService]
 	modelInfoExpects              []*gomock.Call0_1[*service14.ProviderModelService]
-	modelMigrationExpects         []*gomock.Call0_1[*service17.Service]
+	modelMigrationExpects         []*gomock.Call0_1[*service17.WatchableService]
 	modelProviderExpects          []*gomock.Call0_1[*service18.Service]
 	modelSecretBackendExpects     []*gomock.Call0_1[*service29.ModelSecretBackendService]
 	networkExpects                []*gomock.Call0_1[*service19.WatchableService]
@@ -474,7 +474,7 @@ func (mr *MockModelDomainServicesMockRecorder) ModelInfo() *MockModelDomainServi
 type MockModelDomainServicesModelInfoCall = gomock.Call0_1[*service14.ProviderModelService]
 
 // ModelMigration mocks base method.
-func (m *MockModelDomainServices) ModelMigration() *service17.Service {
+func (m *MockModelDomainServices) ModelMigration() *service17.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelMigrationExpects, m.ctrl, m, "ModelMigration")
 }
@@ -482,14 +482,14 @@ func (m *MockModelDomainServices) ModelMigration() *service17.Service {
 // ModelMigration indicates an expected call of ModelMigration.
 func (mr *MockModelDomainServicesMockRecorder) ModelMigration() *MockModelDomainServicesModelMigrationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service17.Service](mr.mock.ctrl.T, mr.mock, "ModelMigration")
+	call := gomock.NewCall0_1[*service17.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigration")
 	mr.modelMigrationExpects = append(mr.modelMigrationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockModelDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
-type MockModelDomainServicesModelMigrationCall = gomock.Call0_1[*service17.Service]
+type MockModelDomainServicesModelMigrationCall = gomock.Call0_1[*service17.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockModelDomainServices) ModelProvider() *service18.Service {

--- a/internal/worker/caasfirewaller/mocks/services_mocks.go
+++ b/internal/worker/caasfirewaller/mocks/services_mocks.go
@@ -80,7 +80,7 @@ type MockModelDomainServicesMockRecorder struct {
 	keyUpdaterExpects             []*gomock.Call0_1[*service12.WatchableService]
 	machineExpects                []*gomock.Call0_1[*service13.WatchableService]
 	modelInfoExpects              []*gomock.Call0_1[*service14.ProviderModelService]
-	modelMigrationExpects         []*gomock.Call0_1[*service17.Service]
+	modelMigrationExpects         []*gomock.Call0_1[*service17.WatchableService]
 	modelProviderExpects          []*gomock.Call0_1[*service18.Service]
 	modelSecretBackendExpects     []*gomock.Call0_1[*service29.ModelSecretBackendService]
 	networkExpects                []*gomock.Call0_1[*service19.WatchableService]
@@ -474,7 +474,7 @@ func (mr *MockModelDomainServicesMockRecorder) ModelInfo() *MockModelDomainServi
 type MockModelDomainServicesModelInfoCall = gomock.Call0_1[*service14.ProviderModelService]
 
 // ModelMigration mocks base method.
-func (m *MockModelDomainServices) ModelMigration() *service17.Service {
+func (m *MockModelDomainServices) ModelMigration() *service17.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelMigrationExpects, m.ctrl, m, "ModelMigration")
 }
@@ -482,14 +482,14 @@ func (m *MockModelDomainServices) ModelMigration() *service17.Service {
 // ModelMigration indicates an expected call of ModelMigration.
 func (mr *MockModelDomainServicesMockRecorder) ModelMigration() *MockModelDomainServicesModelMigrationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service17.Service](mr.mock.ctrl.T, mr.mock, "ModelMigration")
+	call := gomock.NewCall0_1[*service17.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigration")
 	mr.modelMigrationExpects = append(mr.modelMigrationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockModelDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
-type MockModelDomainServicesModelMigrationCall = gomock.Call0_1[*service17.Service]
+type MockModelDomainServicesModelMigrationCall = gomock.Call0_1[*service17.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockModelDomainServices) ModelProvider() *service18.Service {

--- a/internal/worker/domainservices/domainservices_mock_test.go
+++ b/internal/worker/domainservices/domainservices_mock_test.go
@@ -484,7 +484,7 @@ type MockModelDomainServicesMockRecorder struct {
 	keyUpdaterExpects             []*gomock.Call0_1[*service21.WatchableService]
 	machineExpects                []*gomock.Call0_1[*service24.WatchableService]
 	modelInfoExpects              []*gomock.Call0_1[*service25.ProviderModelService]
-	modelMigrationExpects         []*gomock.Call0_1[*service29.Service]
+	modelMigrationExpects         []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects          []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects     []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                []*gomock.Call0_1[*service31.WatchableService]
@@ -878,7 +878,7 @@ func (mr *MockModelDomainServicesMockRecorder) ModelInfo() *MockModelDomainServi
 type MockModelDomainServicesModelInfoCall = gomock.Call0_1[*service25.ProviderModelService]
 
 // ModelMigration mocks base method.
-func (m *MockModelDomainServices) ModelMigration() *service29.Service {
+func (m *MockModelDomainServices) ModelMigration() *service29.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelMigrationExpects, m.ctrl, m, "ModelMigration")
 }
@@ -886,14 +886,14 @@ func (m *MockModelDomainServices) ModelMigration() *service29.Service {
 // ModelMigration indicates an expected call of ModelMigration.
 func (mr *MockModelDomainServicesMockRecorder) ModelMigration() *MockModelDomainServicesModelMigrationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service29.Service](mr.mock.ctrl.T, mr.mock, "ModelMigration")
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigration")
 	mr.modelMigrationExpects = append(mr.modelMigrationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockModelDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
-type MockModelDomainServicesModelMigrationCall = gomock.Call0_1[*service29.Service]
+type MockModelDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockModelDomainServices) ModelProvider() *service30.Service {
@@ -1264,7 +1264,7 @@ type MockDomainServicesMockRecorder struct {
 	modelExpects                      []*gomock.Call0_1[*service25.WatchableService]
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
 	modelInfoExpects                  []*gomock.Call0_1[*service25.ProviderModelService]
-	modelMigrationExpects             []*gomock.Call0_1[*service29.Service]
+	modelMigrationExpects             []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects              []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects         []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                    []*gomock.Call0_1[*service31.WatchableService]
@@ -1932,7 +1932,7 @@ func (mr *MockDomainServicesMockRecorder) ModelInfo() *MockDomainServicesModelIn
 type MockDomainServicesModelInfoCall = gomock.Call0_1[*service25.ProviderModelService]
 
 // ModelMigration mocks base method.
-func (m *MockDomainServices) ModelMigration() *service29.Service {
+func (m *MockDomainServices) ModelMigration() *service29.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelMigrationExpects, m.ctrl, m, "ModelMigration")
 }
@@ -1940,14 +1940,14 @@ func (m *MockDomainServices) ModelMigration() *service29.Service {
 // ModelMigration indicates an expected call of ModelMigration.
 func (mr *MockDomainServicesMockRecorder) ModelMigration() *MockDomainServicesModelMigrationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service29.Service](mr.mock.ctrl.T, mr.mock, "ModelMigration")
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigration")
 	mr.modelMigrationExpects = append(mr.modelMigrationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
-type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.Service]
+type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockDomainServices) ModelProvider() *service30.Service {

--- a/internal/worker/migrationflag/manifold_linux.go
+++ b/internal/worker/migrationflag/manifold_linux.go
@@ -84,7 +84,7 @@ func ModelManifold(config ModelManifoldConfig) dependency.Manifold {
 // domainServicesFacade is a local facade adapter that satisfies the Facade
 // interface by reading from domain services directly.
 type domainServicesFacade struct {
-	migrationSvc *modelmigrationservice.Service
+	migrationSvc *modelmigrationservice.WatchableService
 }
 
 // Phase is part of the Facade interface.

--- a/internal/worker/migrationflag/manifold_linux.go
+++ b/internal/worker/migrationflag/manifold_linux.go
@@ -88,15 +88,25 @@ type domainServicesFacade struct {
 }
 
 // Phase is part of the Facade interface.
+//
+// It reads the direction-agnostic phase, so that a model being imported into
+// this controller is reported as migrating just like one being exported from
+// it. Reading only exports would let this controller's model workers run
+// against a half-imported model.
 func (f *domainServicesFacade) Phase(ctx context.Context, _ string) (migration.Phase, error) {
-	mig, err := f.migrationSvc.Migration(ctx)
+	phase, err := f.migrationSvc.MigrationPhase(ctx)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
-	return mig.Phase, nil
+	return phase, nil
 }
 
 // Watch is part of the Facade interface.
+//
+// It watches migration activity in both directions to match Phase. Watching
+// export phases alone would never fire when a target import claim is deleted,
+// which is precisely the moment the flag must flip so the model's workers can
+// start.
 func (f *domainServicesFacade) Watch(ctx context.Context, _ string) (watcher.NotifyWatcher, error) {
-	return f.migrationSvc.WatchMigrationPhase(ctx)
+	return f.migrationSvc.WatchMigrationActivity(ctx)
 }

--- a/internal/worker/migrationflag/util_model_test.go
+++ b/internal/worker/migrationflag/util_model_test.go
@@ -22,7 +22,7 @@ type stubDomainServices struct {
 	services.ModelDomainServices
 }
 
-func (s *stubDomainServices) ModelMigration() *modelmigrationservice.Service {
+func (s *stubDomainServices) ModelMigration() *modelmigrationservice.WatchableService {
 	return nil
 }
 

--- a/internal/worker/modelworkermanager/domainservices_mock_test.go
+++ b/internal/worker/modelworkermanager/domainservices_mock_test.go
@@ -114,7 +114,7 @@ type MockDomainServicesMockRecorder struct {
 	modelExpects                      []*gomock.Call0_1[*service25.WatchableService]
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
 	modelInfoExpects                  []*gomock.Call0_1[*service25.ProviderModelService]
-	modelMigrationExpects             []*gomock.Call0_1[*service29.Service]
+	modelMigrationExpects             []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects              []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects         []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                    []*gomock.Call0_1[*service31.WatchableService]
@@ -782,7 +782,7 @@ func (mr *MockDomainServicesMockRecorder) ModelInfo() *MockDomainServicesModelIn
 type MockDomainServicesModelInfoCall = gomock.Call0_1[*service25.ProviderModelService]
 
 // ModelMigration mocks base method.
-func (m *MockDomainServices) ModelMigration() *service29.Service {
+func (m *MockDomainServices) ModelMigration() *service29.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelMigrationExpects, m.ctrl, m, "ModelMigration")
 }
@@ -790,14 +790,14 @@ func (m *MockDomainServices) ModelMigration() *service29.Service {
 // ModelMigration indicates an expected call of ModelMigration.
 func (mr *MockDomainServicesMockRecorder) ModelMigration() *MockDomainServicesModelMigrationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service29.Service](mr.mock.ctrl.T, mr.mock, "ModelMigration")
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigration")
 	mr.modelMigrationExpects = append(mr.modelMigrationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
-type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.Service]
+type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockDomainServices) ModelProvider() *service30.Service {


### PR DESCRIPTION
This addresses manadart's fortress observation on https://github.com/juju/juju/pull/22899#issuecomment-5069798080: "The target is not equivalently frozen… the 
model-agent migration flag calls Migration(), which only reads active exports. It does not consider 
target import claims." He proposed the invariant migration-inactive = no active export AND no 
uncommitted import claim, noting that "the corresponding watcher needs to observe both export phases 
and model_migration_import."

A protected model worker runs only when the migration flag says the model isn't migrating. That flag 
asks the database a single question, and the question it asked was "does this model have an active 
export?" — that is, is it being sent away from this controller. On a target that row never exists: the
model is arriving. So throughout an import the flag answered "not migrating", and the provisioner, 
firewaller, storage worker and the rest were free to run against a half-written model. Juju 3.6 had no
such gap. It refused to start any worker for a model whose migration mode was importing 
(modelworkermanager.go:286), and that worked because migration mode was one field on the model 
document describing both directions at once. Juju 4.x split that state across an export table and an 
import claim, and only the export half was ever wired up.

This makes the flag ask the better question — is this model migrating in either direction — by 
reporting the non-terminal IMPORT phase whenever a live import claim exists, and extends the watcher 
to observe the claim table as well as export phases. That second part matters as much as the first: 
deleting the claim is the moment an imported model becomes usable, so it is the event that must flip 
the flag and let the workers start. Both copies of the machinery are updated, the controller-side 
worker and the API-served facade; the latter keeps repointed machine and unit agents parked after they
reconnect to the target, and works with unmodified 3.6 and 4.0 agents since all they receive is a 
phase name. manadart also suggested the migration master should actively lock the fortress on the 
target. That is deliberately not here: locking only adds draining of workers already inside, and on a 
target import there are none — the claim is the first write of an import, model.activated is the last,
and workers only start for activated models, so nothing is ever admitted. Happy to add it as 
belt-and-braces if preferred.


## QA steps
Full migrations must still work, and the target's model workers must stay idle during the import. The
import window is short, so widen it with a bigger model. Bootstrap a 3.6 controller (`src36`) and a 
4.1 (this branch) (`dst41`) ones:
```
  juju switch src36 && juju add-model freeze1
  juju deploy juju-qa-test -n 5
  juju migrate src36:freeze1 dst41
```
Then
```
  # While IMPORT is in flight, on a dst41 controller machine:
  juju ssh -m dst41:controller 0 'juju_engine_report' | grep -A3 migration-inactive-flag
  #   -> the flag manifold should be present and reporting false, and the
  #      ifNotMigrating workers (compute-provisioner, firewaller,
  #      storage-provisioner...) should be absent or stopped.

  # A user must not be able to reach the model mid-import:
  juju status -m dst41:freeze1   # expect "migration in progress, model is importing"

  # After completion, the workers must come back:
  juju ssh -m dst41:controller 0 'juju_engine_report' | grep compute-provisioner
  juju switch dst41:freeze1 && juju add-unit juju-qa-test
```
The agent-side half is best checked by confirming no agent errors appear after repoint: `juju debug-log  -m dst41:freeze1 --level ERROR.`


## Links

**Jira card:** [JUJU-9910](https://warthogs.atlassian.net/browse/JUJU-9910)


[JUJU-9910]: https://warthogs.atlassian.net/browse/JUJU-9910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ