### PR TITLE
fix(migration): move activation commit point to AdoptResources

### DIFF
--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -203,10 +203,15 @@ type ModelImporter interface {
 	// carried by the import args.
 	ImportModel(ctx context.Context, args migration.ImportModelArgs, view export.ProjectionView) error
 
-	// ActivateModel finalises the activation of a model imported via the v8
-	// path, running a durable, idempotent phase machine. It is also safe to
-	// call for legacy (3.6/4.0) imports that have no import claim.
+	// ActivateModel prepares an imported model for activation without
+	// committing anything, leaving it abortable. Called during the source's
+	// VALIDATION phase, where any failure sends the source to ABORT.
 	ActivateModel(ctx context.Context, args migration.ActivateModelArgs) error
+
+	// CommitActivation records that the source committed the migration and
+	// releases the model for use. Driven by AdoptResources, the first call a
+	// source makes after durably recording SUCCESS.
+	CommitActivation(ctx context.Context, modelUUID model.UUID) error
 }
 
 // ModelMigrationFactory defines an interface for getting a model migrator.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/domain/export"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/services"
@@ -208,10 +209,11 @@ type ModelImporter interface {
 	// VALIDATION phase, where any failure sends the source to ABORT.
 	ActivateModel(ctx context.Context, args migration.ActivateModelArgs) error
 
-	// CommitActivation records that the source committed the migration and
-	// releases the model for use. Driven by AdoptResources, the first call a
-	// source makes after durably recording SUCCESS.
-	CommitActivation(ctx context.Context, modelUUID model.UUID) error
+	// CommitActivation records that the source committed the migration,
+	// releases the model for use and adopts its cloud resources. Driven by
+	// AdoptResources, the first call a source makes after durably recording
+	// SUCCESS.
+	CommitActivation(ctx context.Context, modelUUID model.UUID, sourceControllerVersion semversion.Number) error
 }
 
 // ModelMigrationFactory defines an interface for getting a model migrator.

--- a/apiserver/facades/controller/migrationtarget/domain_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/domain_mock_test.go
@@ -229,6 +229,7 @@ type MockModelImporter struct {
 type MockModelImporterMockRecorder struct {
 	mock                     *MockModelImporter
 	activateModelExpects     []*gomock.Call2_1[context.Context, migration.ActivateModelArgs, error]
+	commitActivationExpects  []*gomock.Call2_1[context.Context, model.UUID, error]
 	importModelExpects       []*gomock.Call3_1[context.Context, migration.ImportModelArgs, export.ProjectionView, error]
 	importModelLegacyExpects []*gomock.Call2_1[context.Context, []byte, error]
 }
@@ -262,6 +263,24 @@ func (mr *MockModelImporterMockRecorder) ActivateModel(ctx, args any) *MockModel
 
 // MockModelImporterActivateModelCall is the typed call wrapper for ActivateModel.
 type MockModelImporterActivateModelCall = gomock.Call2_1[context.Context, migration.ActivateModelArgs, error]
+
+// CommitActivation mocks base method.
+func (m *MockModelImporter) CommitActivation(ctx context.Context, modelUUID model.UUID) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_1(&m.recorder.commitActivationExpects, m.ctrl, m, "CommitActivation", ctx, modelUUID)
+}
+
+// CommitActivation indicates an expected call of CommitActivation.
+func (mr *MockModelImporterMockRecorder) CommitActivation(ctx, modelUUID any) *MockModelImporterCommitActivationCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_1[context.Context, model.UUID, error](mr.mock.ctrl.T, mr.mock, "CommitActivation", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	mr.commitActivationExpects = append(mr.commitActivationExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockModelImporterCommitActivationCall is the typed call wrapper for CommitActivation.
+type MockModelImporterCommitActivationCall = gomock.Call2_1[context.Context, model.UUID, error]
 
 // ImportModel mocks base method.
 func (m *MockModelImporter) ImportModel(ctx context.Context, args migration.ImportModelArgs, view export.ProjectionView) error {

--- a/apiserver/facades/controller/migrationtarget/domain_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/domain_mock_test.go
@@ -229,7 +229,7 @@ type MockModelImporter struct {
 type MockModelImporterMockRecorder struct {
 	mock                     *MockModelImporter
 	activateModelExpects     []*gomock.Call2_1[context.Context, migration.ActivateModelArgs, error]
-	commitActivationExpects  []*gomock.Call2_1[context.Context, model.UUID, error]
+	commitActivationExpects  []*gomock.Call3_1[context.Context, model.UUID, semversion.Number, error]
 	importModelExpects       []*gomock.Call3_1[context.Context, migration.ImportModelArgs, export.ProjectionView, error]
 	importModelLegacyExpects []*gomock.Call2_1[context.Context, []byte, error]
 }
@@ -265,22 +265,22 @@ func (mr *MockModelImporterMockRecorder) ActivateModel(ctx, args any) *MockModel
 type MockModelImporterActivateModelCall = gomock.Call2_1[context.Context, migration.ActivateModelArgs, error]
 
 // CommitActivation mocks base method.
-func (m *MockModelImporter) CommitActivation(ctx context.Context, modelUUID model.UUID) error {
+func (m *MockModelImporter) CommitActivation(ctx context.Context, modelUUID model.UUID, sourceControllerVersion semversion.Number) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_1(&m.recorder.commitActivationExpects, m.ctrl, m, "CommitActivation", ctx, modelUUID)
+	return gomock.Dispatch3_1(&m.recorder.commitActivationExpects, m.ctrl, m, "CommitActivation", ctx, modelUUID, sourceControllerVersion)
 }
 
 // CommitActivation indicates an expected call of CommitActivation.
-func (mr *MockModelImporterMockRecorder) CommitActivation(ctx, modelUUID any) *MockModelImporterCommitActivationCall {
+func (mr *MockModelImporterMockRecorder) CommitActivation(ctx, modelUUID, sourceControllerVersion any) *MockModelImporterCommitActivationCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, model.UUID, error](mr.mock.ctrl.T, mr.mock, "CommitActivation", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	call := gomock.NewCall3_1[context.Context, model.UUID, semversion.Number, error](mr.mock.ctrl.T, mr.mock, "CommitActivation", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID), gomock.EnsureMatcher(sourceControllerVersion))
 	mr.commitActivationExpects = append(mr.commitActivationExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockModelImporterCommitActivationCall is the typed call wrapper for CommitActivation.
-type MockModelImporterCommitActivationCall = gomock.Call2_1[context.Context, model.UUID, error]
+type MockModelImporterCommitActivationCall = gomock.Call3_1[context.Context, model.UUID, semversion.Number, error]
 
 // ImportModel mocks base method.
 func (m *MockModelImporter) ImportModel(ctx context.Context, args migration.ImportModelArgs, view export.ProjectionView) error {

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -55,9 +55,10 @@ type ModelImporter interface {
 	// carried by the import args.
 	ImportModel(ctx context.Context, args migration.ImportModelArgs, view export.ProjectionView) error
 
-	// CommitActivation records that the source committed the migration and
-	// releases the model for use. Driven by AdoptResources.
-	CommitActivation(ctx context.Context, modelUUID coremodel.UUID) error
+	// CommitActivation records that the source committed the migration,
+	// releases the model for use and adopts its cloud resources. Driven by
+	// AdoptResources.
+	CommitActivation(ctx context.Context, modelUUID coremodel.UUID, sourceControllerVersion semversion.Number) error
 
 	// ActivateModel finalises the activation of a model imported via the v8
 	// path, running a durable, idempotent phase machine. It is also safe to
@@ -523,10 +524,6 @@ func (api *API) AdoptResources(ctx context.Context, args params.AdoptResourcesAr
 	}
 
 	modelId := coremodel.UUID(tag.Id())
-	svc, err := api.modelMigrationServiceGetter(ctx, modelId)
-	if err != nil {
-		return errors.Errorf("cannot get model migration service for model %q: %w", modelId, err)
-	}
 
 	// AdoptResources is the first call a source makes after durably recording
 	// SUCCESS, the point from which its phase machine can never reach ABORT. Its
@@ -534,14 +531,13 @@ func (api *API) AdoptResources(ctx context.Context, args params.AdoptResourcesAr
 	// one the wire protocol offers - so committing activation here is what lets
 	// Activate stay abortable. This holds for every facade version: 3.6 and 4.0
 	// sources send it at exactly the same point.
-	if err := api.modelImporter.CommitActivation(ctx, modelId); err != nil {
-		return errors.Errorf("committing activation for model %q: %w", modelId, err)
-	}
-
-	// Adopt last, and let its error surface: the source retries this call, and a
-	// retry finds the model already released and re-runs adoption alone. This
-	// matches 3.6, which released the model before adopting its resources.
-	return svc.AdoptResources(ctx, args.SourceControllerVersion)
+	//
+	// Committing and adopting are one operation on the importer rather than two
+	// calls here, so their order - release the model, then re-tag its resources
+	// - cannot be changed by accident. It is an ordered replayable sequence, not
+	// a transaction: it spans both databases and an external provider call.
+	return errors.Capture(
+		api.modelImporter.CommitActivation(ctx, modelId, args.SourceControllerVersion))
 }
 
 // CheckMachines compares the machines in state with the ones reported

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -55,6 +55,10 @@ type ModelImporter interface {
 	// carried by the import args.
 	ImportModel(ctx context.Context, args migration.ImportModelArgs, view export.ProjectionView) error
 
+	// CommitActivation records that the source committed the migration and
+	// releases the model for use. Driven by AdoptResources.
+	CommitActivation(ctx context.Context, modelUUID coremodel.UUID) error
+
 	// ActivateModel finalises the activation of a model imported via the v8
 	// path, running a durable, idempotent phase machine. It is also safe to
 	// call for legacy (3.6/4.0) imports that have no import claim.
@@ -524,6 +528,19 @@ func (api *API) AdoptResources(ctx context.Context, args params.AdoptResourcesAr
 		return errors.Errorf("cannot get model migration service for model %q: %w", modelId, err)
 	}
 
+	// AdoptResources is the first call a source makes after durably recording
+	// SUCCESS, the point from which its phase machine can never reach ABORT. Its
+	// arrival is therefore the source's commit decision, and the only reliable
+	// one the wire protocol offers - so committing activation here is what lets
+	// Activate stay abortable. This holds for every facade version: 3.6 and 4.0
+	// sources send it at exactly the same point.
+	if err := api.modelImporter.CommitActivation(ctx, modelId); err != nil {
+		return errors.Errorf("committing activation for model %q: %w", modelId, err)
+	}
+
+	// Adopt last, and let its error surface: the source retries this call, and a
+	// retry finds the model already released and re-runs adoption alone. This
+	// matches 3.6, which released the model before adopting its resources.
 	return svc.AdoptResources(ctx, args.SourceControllerVersion)
 }
 

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
@@ -33,6 +33,7 @@ import (
 	v4_0_12 "github.com/juju/juju/domain/export/types/v4_0_12"
 	"github.com/juju/juju/domain/modelmigration"
 	"github.com/juju/juju/internal/errors"
+	internalerrors "github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/uuid"
@@ -644,4 +645,51 @@ func newMacaroon(c *tc.C) *macaroon.Macaroon {
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	return mac
+}
+
+// TestAdoptResourcesCommitsActivationFirst asserts that AdoptResources commits
+// the activation before asking the provider to re-tag anything.
+//
+// AdoptResources is the first call a source makes after durably recording
+// SUCCESS - the point from which its phase machine can never reach ABORT - so
+// its arrival is the source's commit decision, and the only reliable one the
+// wire protocol offers. Committing here is what lets Activate remain abortable.
+// Releasing before adopting also matches 3.6, which released the model in
+// Activate and re-tagged afterwards.
+func (s *v8Suite) TestAdoptResourcesCommitsActivationFirst(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := tc.Must0(c, model.NewUUID)
+	sourceVersion := semversion.MustParse("4.0.12")
+
+	gomock.InOrder(
+		s.modelImporter.EXPECT().CommitActivation(gomock.Any(), modelUUID).Return(nil),
+		s.modelMigrationService.EXPECT().AdoptResources(gomock.Any(), sourceVersion).Return(nil),
+	)
+
+	api := s.mustNewAPIV8(c)
+	err := api.AdoptResources(c.Context(), params.AdoptResourcesArgs{
+		ModelTag:                names.NewModelTag(modelUUID.String()).String(),
+		SourceControllerVersion: sourceVersion,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestAdoptResourcesFailedCommitSkipsProvider asserts the provider is left alone
+// when the commit is refused. A commit is refused only when the model is not the
+// target's to take - it is being aborted, or was never imported here - so
+// re-tagging its cloud resources would be wrong.
+func (s *v8Suite) TestAdoptResourcesFailedCommitSkipsProvider(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := tc.Must0(c, model.NewUUID)
+
+	s.modelImporter.EXPECT().CommitActivation(gomock.Any(), modelUUID).Return(internalerrors.New("boom"))
+
+	api := s.mustNewAPIV8(c)
+	err := api.AdoptResources(c.Context(), params.AdoptResourcesArgs{
+		ModelTag:                names.NewModelTag(modelUUID.String()).String(),
+		SourceControllerVersion: semversion.MustParse("4.0.12"),
+	})
+	c.Check(err, tc.ErrorMatches, ".*committing activation.*boom.*")
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
@@ -33,7 +33,6 @@ import (
 	v4_0_12 "github.com/juju/juju/domain/export/types/v4_0_12"
 	"github.com/juju/juju/domain/modelmigration"
 	"github.com/juju/juju/internal/errors"
-	internalerrors "github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/uuid"
@@ -647,25 +646,23 @@ func newMacaroon(c *tc.C) *macaroon.Macaroon {
 	return mac
 }
 
-// TestAdoptResourcesCommitsActivationFirst asserts that AdoptResources commits
-// the activation before asking the provider to re-tag anything.
+// TestAdoptResourcesCommitsActivation asserts that the AdoptResources RPC is
+// what drives the activation commit, and that it hands the source's version
+// straight through.
 //
 // AdoptResources is the first call a source makes after durably recording
 // SUCCESS - the point from which its phase machine can never reach ABORT - so
 // its arrival is the source's commit decision, and the only reliable one the
-// wire protocol offers. Committing here is what lets Activate remain abortable.
-// Releasing before adopting also matches 3.6, which released the model in
-// Activate and re-tagged afterwards.
-func (s *v8Suite) TestAdoptResourcesCommitsActivationFirst(c *tc.C) {
+// wire protocol offers. Committing here is what lets Activate stay abortable.
+// The ordering within the commit (release the model, then re-tag its
+// resources) is the importer's concern and is asserted there.
+func (s *v8Suite) TestAdoptResourcesCommitsActivation(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	modelUUID := tc.Must0(c, model.NewUUID)
 	sourceVersion := semversion.MustParse("4.0.12")
 
-	gomock.InOrder(
-		s.modelImporter.EXPECT().CommitActivation(gomock.Any(), modelUUID).Return(nil),
-		s.modelMigrationService.EXPECT().AdoptResources(gomock.Any(), sourceVersion).Return(nil),
-	)
+	s.modelImporter.EXPECT().CommitActivation(gomock.Any(), modelUUID, sourceVersion).Return(nil)
 
 	api := s.mustNewAPIV8(c)
 	err := api.AdoptResources(c.Context(), params.AdoptResourcesArgs{
@@ -675,21 +672,21 @@ func (s *v8Suite) TestAdoptResourcesCommitsActivationFirst(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-// TestAdoptResourcesFailedCommitSkipsProvider asserts the provider is left alone
-// when the commit is refused. A commit is refused only when the model is not the
-// target's to take - it is being aborted, or was never imported here - so
-// re-tagging its cloud resources would be wrong.
-func (s *v8Suite) TestAdoptResourcesFailedCommitSkipsProvider(c *tc.C) {
+// TestAdoptResourcesPropagatesCommitError asserts a refused commit surfaces to
+// the source, which retries the call rather than treating it as fatal.
+func (s *v8Suite) TestAdoptResourcesPropagatesCommitError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	modelUUID := tc.Must0(c, model.NewUUID)
+	sourceVersion := semversion.MustParse("4.0.12")
 
-	s.modelImporter.EXPECT().CommitActivation(gomock.Any(), modelUUID).Return(internalerrors.New("boom"))
+	s.modelImporter.EXPECT().CommitActivation(gomock.Any(), modelUUID, sourceVersion).
+		Return(errors.New("boom"))
 
 	api := s.mustNewAPIV8(c)
 	err := api.AdoptResources(c.Context(), params.AdoptResourcesArgs{
 		ModelTag:                names.NewModelTag(modelUUID.String()).String(),
-		SourceControllerVersion: semversion.MustParse("4.0.12"),
+		SourceControllerVersion: sourceVersion,
 	})
-	c.Check(err, tc.ErrorMatches, ".*committing activation.*boom.*")
+	c.Check(err, tc.ErrorMatches, ".*boom.*")
 }

--- a/domain/modelmigration/service/activate.go
+++ b/domain/modelmigration/service/activate.go
@@ -126,6 +126,16 @@ func (s *Service) GetControllerTargetVersion(ctx context.Context) (string, error
 	return s.controllerState.GetControllerTargetVersion(ctx)
 }
 
+// IsModelImporting reports whether the model database still carries its import
+// gate. Used to confirm that a model with no import claim really was released by
+// a completed commit, rather than never imported at all.
+func (s *Service) IsModelImporting(ctx context.Context) (bool, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	return s.modelState.IsModelImporting(ctx)
+}
+
 // DeleteModelImportingStatus clears the model-database import gate, making the
 // model visible once activation completes.
 func (s *Service) DeleteModelImportingStatus(ctx context.Context) error {

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -278,6 +278,10 @@ type ModelState interface {
 	// GetControllerUUID returns the UUID of the controller that owns this
 	// model.
 	GetControllerUUID(context.Context) (string, error)
+
+	// IsModelImporting reports whether the model database still carries its
+	// import gate.
+	IsModelImporting(ctx context.Context) (bool, error)
 	// GetAllInstanceIDs returns all instance IDs from the current model as
 	// juju/collections set.
 	GetAllInstanceIDs(ctx context.Context) (set.Strings, error)

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -834,6 +834,7 @@ type MockModelStateMockRecorder struct {
 	getMigrationAgentsExpects         []*gomock.Call1_2[context.Context, internal.MigrationAgents, error]
 	getModelTargetAgentVersionExpects []*gomock.Call1_2[context.Context, string, error]
 	getOfferUUIDsExpects              []*gomock.Call1_2[context.Context, []string, error]
+	isModelImportingExpects           []*gomock.Call1_2[context.Context, bool, error]
 	setModelTargetAgentVersionExpects []*gomock.Call3_1[context.Context, string, string, error]
 }
 
@@ -956,6 +957,24 @@ func (mr *MockModelStateMockRecorder) GetOfferUUIDs(ctx any) *MockModelStateGetO
 
 // MockModelStateGetOfferUUIDsCall is the typed call wrapper for GetOfferUUIDs.
 type MockModelStateGetOfferUUIDsCall = gomock.Call1_2[context.Context, []string, error]
+
+// IsModelImporting mocks base method.
+func (m *MockModelState) IsModelImporting(ctx context.Context) (bool, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch1_2(&m.recorder.isModelImportingExpects, m.ctrl, m, "IsModelImporting", ctx)
+}
+
+// IsModelImporting indicates an expected call of IsModelImporting.
+func (mr *MockModelStateMockRecorder) IsModelImporting(ctx any) *MockModelStateIsModelImportingCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall1_2[context.Context, bool, error](mr.mock.ctrl.T, mr.mock, "IsModelImporting", gomock.EnsureMatcher(ctx))
+	mr.isModelImportingExpects = append(mr.isModelImportingExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockModelStateIsModelImportingCall is the typed call wrapper for IsModelImporting.
+type MockModelStateIsModelImportingCall = gomock.Call1_2[context.Context, bool, error]
 
 // SetModelTargetAgentVersion mocks base method.
 func (m *MockModelState) SetModelTargetAgentVersion(ctx context.Context, preCondition, toVersion string) error {

--- a/domain/modelmigration/state/model/state.go
+++ b/domain/modelmigration/state/model/state.go
@@ -283,6 +283,36 @@ WHERE  c.source_id < 2
 	return agents, nil
 }
 
+// IsModelImporting reports whether the model database still carries its import
+// gate, which a committed import clears when it releases the model.
+//
+// It is the model-database half of confirming that a model with no import claim
+// really was released by a completed commit, rather than never imported at all.
+func (s *State) IsModelImporting(ctx context.Context) (bool, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return false, errors.Errorf("cannot get database to read importing status: %w", err)
+	}
+
+	arg := entityUUID{UUID: s.modelUUID.String()}
+	stmt, err := s.Prepare(`
+SELECT COUNT(*) AS &importGateCount.count
+FROM   model_migrating
+WHERE  model_uuid = $entityUUID.uuid
+`, arg, importGateCount{})
+	if err != nil {
+		return false, errors.Errorf("preparing importing status statement: %w", err)
+	}
+
+	var c importGateCount
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, stmt, arg).Get(&c)
+	}); err != nil {
+		return false, errors.Errorf("checking if model is importing: %w", err)
+	}
+	return c.Count > 0, nil
+}
+
 // DeleteModelImportingStatus removes the entry from the model_migrating table
 // in the model database, indicating that the model import has completed or been
 // aborted.

--- a/domain/modelmigration/state/model/types.go
+++ b/domain/modelmigration/state/model/types.go
@@ -49,3 +49,8 @@ type setAgentVersionTarget struct {
 	TargetVersion   string `db:"target_version"`
 	PreviousVersion string `db:"previous_version"`
 }
+
+// importGateCount holds a COUNT(*) projection over the model's import gate.
+type importGateCount struct {
+	Count int `db:"count"`
+}

--- a/internal/migration/activate.go
+++ b/internal/migration/activate.go
@@ -46,100 +46,194 @@ type ActivateModelArgs struct {
 	CrossModelUUIDs []string
 }
 
-// activateModel finalises the activation of a model imported via the v8 path.
-// It runs a durable phase machine: importing, activating, then claim deleted,
-// so retrying after a crash at any step resumes safely; every step is
-// idempotent.
+// Migrating a model between two controllers is a commit across two
+// controllers, and only the source can decide its outcome: it is the side that
+// chooses between SUCCESS and ABORT. The target's job is to carry out that
+// decision, never to guess it.
 //
-// Legacy (3.6/4.0) imports set the model_migrating gate but create no
-// model_migration_import claim. When no claim exists, activateModel clears the
-// gate and succeeds, preserving backward compatibility.
-func activateModel(ctx context.Context, domainServices services.DomainServices, args ActivateModelArgs) error {
+// The source's phase machine makes the decision legible. Any error activating
+// the model sends it to ABORT, and it treats the target's cleanup as best
+// effort. But once it durably records SUCCESS it can never reach ABORT again -
+// it only rolls forward, retrying failures. So the target has exactly one
+// reliable commit signal: the first message the source sends after recording
+// SUCCESS, which is AdoptResources.
+//
+// Activation is therefore split in two, with no new RPC and no new error code,
+// so an unmodified 3.6 or 4.0 source speaks the protocol unchanged:
+//
+//	prepareActivation  every fallible, reversible step. Called during
+//	                   VALIDATION, while the source may still abort.
+//	commitActivation   the irreversible transition. Called during SUCCESS, so
+//	                   its arrival is the commit decision.
+
+// prepareActivation performs every fallible, reversible step of activating an
+// imported model, and nothing else.
+//
+// It is 3.6's Activate minus its final act of releasing the model. Each step is
+// idempotent, and every failure leaves the model exactly as it was: claim still
+// importing, gate still closed, workers still parked. That is the point - the
+// source treats any failure here, or a reply it never receives, as a reason to
+// abort, so nothing done here may prevent that abort from succeeding.
+func prepareActivation(ctx context.Context, domainServices services.DomainServices, args ActivateModelArgs) error {
 	modelUUID := args.ModelUUID
-	modelUUIDStr := modelUUID.String()
 
-	// Check for a v8 import claim. A missing claim means legacy import.
+	// Every import creates a claim, legacy ones included, so claim existence
+	// says nothing about which path imported this model.
 	claim, err := domainServices.ModelMigration().GetImportClaim(ctx, modelUUID)
-	hasClaim := err == nil
-	if err != nil && !errors.Is(err, modelmigrationerrors.ErrImportNotFound) {
-		return errors.Errorf("checking import claim for model %q: %w", modelUUIDStr, err)
-	}
-
-	// 1. Transition to activating (v8 only): point of no return.
-	if hasClaim {
-		switch claim.Phase {
-		case modelmigration.ImportPhaseAborting:
-			return errors.Errorf("model %q: %w", modelUUIDStr, modelmigrationerrors.ErrActivationAborting)
-		case modelmigration.ImportPhaseImporting:
-			if err := domainServices.ModelMigration().SetImportPhaseActivating(ctx, modelUUID); err != nil {
-				return errors.Errorf(
-					"transitioning import claim to activating for model %q: %w",
-					modelUUIDStr, err,
-				)
-			}
-		case modelmigration.ImportPhaseActivating:
-			// Idempotent retry: already past the point of no return.
-		default:
-			return errors.Errorf(
-				"model %q: unexpected import claim phase %q",
-				modelUUIDStr, claim.Phase,
-			)
+	switch {
+	case errors.Is(err, modelmigrationerrors.ErrImportNotFound):
+		// No claim: either this model was never imported here, or it was
+		// already committed and released. Only the latter is a success.
+		if committed, err := committedPredicates(ctx, domainServices, modelUUID); err != nil {
+			return errors.Capture(err)
+		} else if committed {
+			return nil
 		}
+		return errors.Errorf("model %q is not importing", modelUUID)
+	case err != nil:
+		return errors.Errorf("reading import claim for model %q: %w", modelUUID, err)
 	}
 
-	// 2. CMR offerer-controller reconciliation: populate
-	// application_remote_offerer.offerer_controller_uuid while the model is
-	// gated. All updates are idempotent so a retry after a crash is safe.
-	if err := reconcileOffererControllers(ctx, domainServices, modelUUID, hasClaim, args); err != nil {
+	switch claim.Phase {
+	case modelmigration.ImportPhaseAborting:
+		// Cleanup has started; the source will abort anyway.
+		return errors.Errorf("model %q: %w", modelUUID, modelmigrationerrors.ErrActivationAborting)
+	case modelmigration.ImportPhaseActivating:
+		// The commit already arrived, so there is nothing left to prepare.
+		// Reporting success beats failing: a stale caller that failed here
+		// would drive an abort the target must then refuse.
+		return nil
+	case modelmigration.ImportPhaseImporting:
+	default:
+		return errors.Errorf("model %q: unexpected import claim phase %q", modelUUID, claim.Phase)
+	}
+
+	if err := reconcileOffererControllers(ctx, domainServices, modelUUID, args); err != nil {
 		return errors.Errorf(
-			"reconciling offerer controller UUIDs for model %q: %w", modelUUIDStr, err,
-		)
+			"reconciling offerer controller UUIDs for model %q: %w", modelUUID, err)
 	}
 
-	// 3. Reconcile the model agent version to match the controller target, if
-	// needed.
-	if err := reconcileModelAgentVersion(ctx, domainServices, modelUUIDStr); err != nil {
+	if err := reconcileModelAgentVersion(ctx, domainServices, modelUUID.String()); err != nil {
 		return errors.Errorf(
-			"reconciling model agent version during activation of model %q: %w",
-			modelUUIDStr, err,
-		)
+			"reconciling model agent version during activation of model %q: %w", modelUUID, err)
 	}
 
-	// 4. Clear the model-DB import gate.
-	// Steps 4 and 5 write to different databases and so cannot share a
-	// transaction, but a crash between them leaves no half-visible model:
-	// visibility gates on model.activated (set in step 5), so until step 5
-	// lands the model stays invisible regardless of the gate. Both steps are
-	// idempotent, so a retry resumes safely.
-	if err := domainServices.ModelMigration().DeleteModelImportingStatus(ctx); err != nil {
-		return errors.Errorf(
-			"clearing import gate for model %q: %w", modelUUIDStr, err,
-		)
+	// Re-check the claim last. Preparation writes only shared controller rows,
+	// using compare-or-insert, so an abort racing it has nothing to undo - but a
+	// caller told preparation succeeded should not then meet a refused commit.
+	if err := domainServices.ModelMigration().AssertImporting(ctx, modelUUID); err != nil {
+		return errors.Errorf("model %q import claim changed during activation: %w", modelUUID, err)
 	}
-
-	// 5. Activate the model row itself in the controller DB. This is a
-	// distinct flag from the migration claim: model_migration_import tracks
-	// the migration's own phase machine, while model.activated is the
-	// generic "model creation is fully complete" flag every model carries
-	// (migrated or not) and is what v_model/CheckModelExists/GetModel gate
-	// on. Without this, the model stays permanently invisible even after the
-	// claim is later deleted. Idempotent: a retry that finds the row already
-	// activated is a success, not an error.
-	if err := domainServices.Model().ActivateModel(ctx, modelUUID); err != nil && !errors.Is(err, modelerrors.AlreadyActivated) {
-		return errors.Errorf("activating model %q: %w", modelUUIDStr, err)
-	}
-
-	// 6. Delete the import claim last (v8 only): after the gate is gone, a
-	// second call with no claim is an idempotent success.
-	if hasClaim {
-		if err := domainServices.ModelMigration().DeleteActivatedImport(ctx, modelUUID); err != nil {
-			return errors.Errorf(
-				"deleting activated import claim for model %q: %w", modelUUIDStr, err,
-			)
-		}
-	}
-
 	return nil
+}
+
+// commitActivation performs the irreversible half of activation: it records
+// that the source committed, then releases the model.
+//
+// It is driven by AdoptResources, which a source sends only after durably
+// recording SUCCESS. Receipt is therefore proof that the source can never abort
+// this migration, which is what makes the transition safe to treat as a point
+// of no return.
+//
+// Releasing before adopting resources matches 3.6, which released the model in
+// Activate and adopted afterwards. An adoption failure does not undo the
+// release: the model is already this controller's, and the source retries
+// AdoptResources until it succeeds.
+func commitActivation(
+	ctx context.Context,
+	domainServices services.DomainServices,
+	modelUUID coremodel.UUID,
+) error {
+	claim, err := domainServices.ModelMigration().GetImportClaim(ctx, modelUUID)
+	switch {
+	case errors.Is(err, modelmigrationerrors.ErrImportNotFound):
+		// The claim is gone: either this commit already completed and its reply
+		// was lost, or the model was never imported here. Only the former may
+		// pass, and it has nothing left to do.
+		committed, err := committedPredicates(ctx, domainServices, modelUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		if !committed {
+			return errors.Errorf("model %q is not importing or activating", modelUUID)
+		}
+		return nil
+	case err != nil:
+		return errors.Errorf("reading import claim for model %q: %w", modelUUID, err)
+	}
+
+	switch claim.Phase {
+	case modelmigration.ImportPhaseAborting:
+		// Unreachable from a correct source: a migration that reached SUCCESS
+		// never drove an abort. Refuse loudly rather than resurrect a model
+		// whose teardown is under way.
+		return errors.Errorf("model %q: cannot commit activation, import is aborting", modelUUID)
+	case modelmigration.ImportPhaseActivating:
+		// An interrupted commit; everything below is idempotent, so resume.
+	case modelmigration.ImportPhaseImporting:
+		// The commit record itself.
+		if err := domainServices.ModelMigration().SetImportPhaseActivating(ctx, modelUUID); err != nil {
+			return errors.Errorf("recording activation commit for model %q: %w", modelUUID, err)
+		}
+	default:
+		return errors.Errorf("model %q: unexpected import claim phase %q", modelUUID, claim.Phase)
+	}
+
+	return releaseModel(ctx, domainServices, modelUUID)
+}
+
+// releaseModel makes a committed model usable and gives up the claim. Every
+// step is idempotent, so a commit interrupted part-way is finished by repeating
+// all of them.
+//
+// Claim deletion is last and is what actually releases the model: it is the
+// change the migration flag watches, so the model's workers start at that
+// moment and not before.
+func releaseModel(
+	ctx context.Context, domainServices services.DomainServices, modelUUID coremodel.UUID,
+) error {
+	if err := domainServices.ModelMigration().DeleteModelImportingStatus(ctx); err != nil {
+		return errors.Errorf("clearing import gate for model %q: %w", modelUUID, err)
+	}
+
+	// model.activated is the generic "model creation is complete" flag every
+	// model carries, distinct from the migration claim. The import sets it so
+	// agents can reach the model during validation, so this is usually a no-op.
+	if err := domainServices.Model().ActivateModel(ctx, modelUUID); err != nil &&
+		!errors.Is(err, modelerrors.AlreadyActivated) {
+		return errors.Errorf("activating model %q: %w", modelUUID, err)
+	}
+
+	if err := domainServices.ModelMigration().DeleteActivatedImport(ctx, modelUUID); err != nil {
+		return errors.Errorf("releasing import claim for model %q: %w", modelUUID, err)
+	}
+	return nil
+}
+
+// committedPredicates reports whether a model with no import claim shows every
+// sign of having been released by a completed commit.
+//
+// A missing claim is ambiguous on its own - it equally describes a model that
+// was never imported and one whose abort finished - so callers that treat it as
+// success must confirm it rather than assume.
+func committedPredicates(
+	ctx context.Context, domainServices services.DomainServices, modelUUID coremodel.UUID,
+) (bool, error) {
+	// CheckModelExists is false for a model that is absent *or* not yet
+	// activated, which is exactly the distinction wanted here.
+	exists, err := domainServices.Model().CheckModelExists(ctx, modelUUID)
+	if err != nil {
+		return false, errors.Errorf("checking model %q exists: %w", modelUUID, err)
+	}
+	if !exists {
+		return false, nil
+	}
+
+	gated, err := domainServices.ModelMigration().IsModelImporting(ctx)
+	if err != nil {
+		return false, errors.Errorf("checking import gate for model %q: %w", modelUUID, err)
+	}
+	return !gated, nil
 }
 
 // reconcileOffererControllers populates
@@ -154,8 +248,7 @@ func activateModel(ctx context.Context, domainServices services.DomainServices, 
 //
 //   - Third-party offerers: applications whose offering model is hosted on a
 //     controller other than the source, recorded in
-//     model_migration_import_external_controller_model during import. Only
-//     present on the v8 path (hasClaim).
+//     model_migration_import_external_controller_model during import.
 //
 // The source controller is registered via EnsureSourceControllerExists
 // (compare-or-insert) rather than the legacy blind upsert. All CMR updates are
@@ -164,7 +257,6 @@ func reconcileOffererControllers(
 	ctx context.Context,
 	domainServices services.DomainServices,
 	modelUUID coremodel.UUID,
-	hasClaim bool,
 	args ActivateModelArgs,
 ) error {
 	if args.SourceControllerUUID == "" {
@@ -203,14 +295,10 @@ func reconcileOffererControllers(
 		}
 	}
 
-	// Third-party offerers (v8 only): mappings recorded during
-	// ImportExternalControllers, read from the companion table. Legacy imports
-	// have no claim and therefore no mappings, so skip the query entirely.
-	if !hasClaim {
-		return nil
-	}
-	// We first retrieve them (from the controller DB) to later be inserted into
-	// the model DB.
+	// Third-party offerers: mappings recorded during ImportExternalControllers,
+	// read from the companion table. A legacy import records none, so this
+	// simply returns nothing for it - there is no need to branch on the import
+	// path, and no way to tell them apart by claim existence anyway.
 	thirdParty, err := domainServices.ModelMigration().ExternalControllerModelsForImport(ctx, modelUUID)
 	if err != nil {
 		return errors.Errorf(

--- a/internal/migration/activate.go
+++ b/internal/migration/activate.go
@@ -128,21 +128,31 @@ func prepareActivation(ctx context.Context, domainServices services.DomainServic
 }
 
 // commitActivation performs the irreversible half of activation: it records
-// that the source committed, then releases the model.
+// that the source committed, releases the model, and adopts its cloud
+// resources.
 //
 // It is driven by AdoptResources, which a source sends only after durably
 // recording SUCCESS. Receipt is therefore proof that the source can never abort
 // this migration, which is what makes the transition safe to treat as a point
 // of no return.
 //
-// Releasing before adopting resources matches 3.6, which released the model in
-// Activate and adopted afterwards. An adoption failure does not undo the
+// This is an ordered, replayable sequence rather than a transaction, and cannot
+// be otherwise: the claim lives in the controller database, the gate in the
+// model database, and resource adoption is a call out to the cloud provider.
+// Each step is idempotent so that a commit interrupted anywhere is finished by
+// repeating all of them - that replayability is what stands in for the
+// atomicity a single database write would have given.
+//
+// The order matters. Releasing before adopting matches 3.6, which released the
+// model in Activate and adopted afterwards, and it keeps model availability
+// independent of the provider. An adoption failure therefore does not undo the
 // release: the model is already this controller's, and the source retries
 // AdoptResources until it succeeds.
 func commitActivation(
 	ctx context.Context,
 	domainServices services.DomainServices,
 	modelUUID coremodel.UUID,
+	sourceControllerVersion semversion.Number,
 ) error {
 	claim, err := domainServices.ModelMigration().GetImportClaim(ctx, modelUUID)
 	switch {
@@ -157,7 +167,9 @@ func commitActivation(
 		if !committed {
 			return errors.Errorf("model %q is not importing or activating", modelUUID)
 		}
-		return nil
+		// Already released by an earlier commit whose reply was lost. Nothing
+		// left to do locally, but the adoption may not have run yet.
+		return adoptResources(ctx, domainServices, modelUUID, sourceControllerVersion)
 	case err != nil:
 		return errors.Errorf("reading import claim for model %q: %w", modelUUID, err)
 	}
@@ -179,7 +191,31 @@ func commitActivation(
 		return errors.Errorf("model %q: unexpected import claim phase %q", modelUUID, claim.Phase)
 	}
 
-	return releaseModel(ctx, domainServices, modelUUID)
+	if err := releaseModel(ctx, domainServices, modelUUID); err != nil {
+		return errors.Capture(err)
+	}
+
+	return adoptResources(ctx, domainServices, modelUUID, sourceControllerVersion)
+}
+
+// adoptResources asks the cloud provider to re-tag the model's resources with
+// this controller, so they are not destroyed when the source controller goes
+// away.
+//
+// It runs last, after the model has already been released, and its error is
+// returned to the source, which retries the whole call. A retry finds no claim,
+// confirms the model was already released, and reaches here again to repeat the
+// adoption alone.
+func adoptResources(
+	ctx context.Context,
+	domainServices services.DomainServices,
+	modelUUID coremodel.UUID,
+	sourceControllerVersion semversion.Number,
+) error {
+	if err := domainServices.ModelMigration().AdoptResources(ctx, sourceControllerVersion); err != nil {
+		return errors.Errorf("adopting cloud resources for model %q: %w", modelUUID, err)
+	}
+	return nil
 }
 
 // releaseModel makes a committed model usable and gives up the claim. Every

--- a/internal/migration/activate_test.go
+++ b/internal/migration/activate_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/domain/export"
 	modelservice "github.com/juju/juju/domain/model/service"
 	modelstatecontroller "github.com/juju/juju/domain/model/state/controller"
+	migrationdomain "github.com/juju/juju/domain/modelmigration"
 	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
 	modelmigrationservice "github.com/juju/juju/domain/modelmigration/service"
 	migrationclaimstate "github.com/juju/juju/domain/modelmigration/state/controller"
@@ -228,10 +229,14 @@ func (s *controllerImportSuite) activationOffererControllerUUID(
 	return got
 }
 
-// TestActivateModelHappyPath verifies the v8 activation state machine: the
-// claim is deleted, the import gate is cleared, the model row is activated and
-// the model agent version is aligned with the controller target.
-func (s *controllerImportSuite) TestActivateModelHappyPath(c *tc.C) {
+// TestActivateModelLeavesModelAbortable is the central guarantee of the
+// protocol: preparing a model must not commit anything.
+//
+// The source calls this during VALIDATION, where any error - or a reply it never
+// receives - sends it to ABORT. If preparation released the model, that abort
+// would arrive at a target that had already handed the model over, and the model
+// would be live on both controllers.
+func (s *controllerImportSuite) TestActivateModelLeavesModelAbortable(c *tc.C) {
 	modelUUID, deps := s.importForActivation(c, "1.0.0")
 
 	err := s.activateModel(c, deps, migration.ActivateModelArgs{
@@ -239,21 +244,84 @@ func (s *controllerImportSuite) TestActivateModelHappyPath(c *tc.C) {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	// The claim is gone.
+	// The claim is untouched and still importing, so an abort still works.
 	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
-	_, err = claimSt.GetImportClaim(c.Context(), modelUUID.String())
-	c.Check(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotFound)
+	claim, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(claim.Phase, tc.Equals, migrationdomain.ImportPhaseImporting)
 
-	// The model row is activated and the gate cleared.
-	c.Check(s.modelActivated(c, modelUUID), tc.IsTrue)
-	c.Check(s.modelGateExists(c, modelUUID), tc.IsFalse)
+	// Nothing was released: the gate is still set and the model not activated.
+	c.Check(s.modelGateExists(c, modelUUID), tc.IsTrue)
+	c.Check(s.modelActivated(c, modelUUID), tc.IsFalse)
 
-	// The agent version was aligned with the controller target.
+	// The fallible work still happened - that is what preparation is for.
 	c.Check(s.modelAgentVersion(c, modelUUID), tc.Equals, jujuversion.Current.String())
 }
 
-// TestActivateModelIdempotent verifies a second activation after a completed
-// one is a no-op success: the model stays activated and no claim reappears.
+// TestCommitActivationReleasesModel verifies the commit does what preparation
+// deliberately did not: clear the gate, activate the model row and give up the
+// claim. Claim deletion is what actually releases the model, so it must be gone.
+func (s *controllerImportSuite) TestCommitActivationReleasesModel(c *tc.C) {
+	modelUUID, deps := s.importForActivation(c, "1.0.0")
+
+	c.Assert(s.activateModel(c, deps, migration.ActivateModelArgs{ModelUUID: modelUUID}), tc.ErrorIsNil)
+	c.Assert(s.commitActivation(c, deps, modelUUID), tc.ErrorIsNil)
+
+	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
+	_, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Check(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotFound)
+
+	c.Check(s.modelActivated(c, modelUUID), tc.IsTrue)
+	c.Check(s.modelGateExists(c, modelUUID), tc.IsFalse)
+}
+
+// TestCommitActivationIsIdempotentAfterRelease verifies a commit retry arriving
+// after the claim is gone succeeds. The source cannot tell a lost reply from a
+// failure, so it will send this call again.
+func (s *controllerImportSuite) TestCommitActivationIsIdempotentAfterRelease(c *tc.C) {
+	modelUUID, deps := s.importForActivation(c, "1.0.0")
+
+	c.Assert(s.activateModel(c, deps, migration.ActivateModelArgs{ModelUUID: modelUUID}), tc.ErrorIsNil)
+	c.Assert(s.commitActivation(c, deps, modelUUID), tc.ErrorIsNil)
+	c.Assert(s.commitActivation(c, deps, modelUUID), tc.ErrorIsNil)
+
+	c.Check(s.modelActivated(c, modelUUID), tc.IsTrue)
+}
+
+// TestCommitActivationWithoutImportFails verifies a commit for a model that was
+// never imported here is refused, rather than a missing claim being read as
+// "already done".
+func (s *controllerImportSuite) TestCommitActivationWithoutImportFails(c *tc.C) {
+	modelUUID, deps := s.importForActivation(c, "1.0.0")
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			"DELETE FROM model_migration_import WHERE model_uuid = ?", modelUUID.String())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The model is neither activated nor ungated, so the predicates fail.
+	err = s.commitActivation(c, deps, modelUUID)
+	c.Check(err, tc.ErrorMatches, ".*is not importing or activating.*")
+}
+
+// TestCommitActivationRefusesAbortingClaim verifies a commit is refused while
+// the model is being torn down. A correct source cannot produce this - a
+// migration that reached SUCCESS never drove an abort - so it fails loudly
+// rather than resurrecting a model whose cleanup is under way.
+func (s *controllerImportSuite) TestCommitActivationRefusesAbortingClaim(c *tc.C) {
+	modelUUID, deps := s.importForActivation(c, "1.0.0")
+	s.setClaimPhase(c, modelUUID, "aborting")
+
+	err := s.commitActivation(c, deps, modelUUID)
+	c.Check(err, tc.ErrorMatches, ".*cannot commit activation, import is aborting.*")
+	c.Check(s.modelActivated(c, modelUUID), tc.IsFalse)
+}
+
+// TestActivateModelIdempotent verifies preparation can be repeated, which a
+// source restarting in VALIDATION will do, and that repeating it still commits
+// nothing.
 func (s *controllerImportSuite) TestActivateModelIdempotent(c *tc.C) {
 	modelUUID, deps := s.importForActivation(c, "1.0.0")
 
@@ -263,27 +331,39 @@ func (s *controllerImportSuite) TestActivateModelIdempotent(c *tc.C) {
 	err = s.activateModel(c, deps, migration.ActivateModelArgs{ModelUUID: modelUUID})
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Check(s.modelActivated(c, modelUUID), tc.IsTrue)
 	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
-	_, err = claimSt.GetImportClaim(c.Context(), modelUUID.String())
-	c.Check(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotFound)
+	claim, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(claim.Phase, tc.Equals, migrationdomain.ImportPhaseImporting)
 }
 
-// TestActivateModelRetryFromActivating verifies that a crash after the claim
-// reached the activating phase resumes to completion on a re-run.
-func (s *controllerImportSuite) TestActivateModelRetryFromActivating(c *tc.C) {
+// TestCommitActivationResumesFromActivating verifies a commit interrupted after
+// its transition is finished by a retry. The source retries AdoptResources until
+// it succeeds, so this is the ordinary recovery path.
+func (s *controllerImportSuite) TestCommitActivationResumesFromActivating(c *tc.C) {
 	modelUUID, deps := s.importForActivation(c, "1.0.0")
 
 	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
 	err := claimSt.SetImportPhaseActivating(c.Context(), modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = s.activateModel(c, deps, migration.ActivateModelArgs{ModelUUID: modelUUID})
+	err = s.commitActivation(c, deps, modelUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(s.modelActivated(c, modelUUID), tc.IsTrue)
 	_, err = claimSt.GetImportClaim(c.Context(), modelUUID.String())
 	c.Check(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotFound)
+}
+
+// TestActivateModelAfterCommitSucceeds verifies a stale preparation arriving
+// after the commit is a no-op success rather than an error. Failing it would
+// push a stale source to ABORT, which the target must then refuse.
+func (s *controllerImportSuite) TestActivateModelAfterCommitSucceeds(c *tc.C) {
+	modelUUID, deps := s.importForActivation(c, "1.0.0")
+	s.setClaimPhase(c, modelUUID, "activating")
+
+	err := s.activateModel(c, deps, migration.ActivateModelArgs{ModelUUID: modelUUID})
+	c.Check(err, tc.ErrorIsNil)
 }
 
 // TestActivateModelUnexpectedImportPhase verifies the defensive switch guard:
@@ -379,23 +459,63 @@ func (s *controllerImportSuite) TestActivateModelAborting(c *tc.C) {
 	c.Check(s.modelActivated(c, modelUUID), tc.IsFalse)
 }
 
-// TestActivateModelLegacyNoClaim verifies a legacy import (import gate set, no
-// v8 claim) still activates: the gate is cleared and the model row activated.
-func (s *controllerImportSuite) TestActivateModelLegacyNoClaim(c *tc.C) {
+// TestActivateAndCommitWithLegacyClaimShape verifies a legacy (v4-v7) import
+// goes through the same prepare/commit protocol as a v8 one.
+//
+// A previous version of this test simulated "legacy" by deleting the import
+// claim. That is not what a legacy import looks like: the legacy path creates a
+// claim in the importing phase, exactly like v8. Claim existence is not a
+// legacy/v8 discriminator, and treating it as one silently put 3.6 and 4.0
+// sources on the wrong path.
+func (s *controllerImportSuite) TestActivateAndCommitWithLegacyClaimShape(c *tc.C) {
 	modelUUID, deps := s.importForActivation(c, "1.0.0")
 
-	// Simulate a legacy import by dropping the v8 claim entirely.
-	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx,
-			"DELETE FROM model_migration_import WHERE model_uuid = ?", modelUUID.String())
-		return err
-	})
+	// The claim a legacy import leaves behind carries no source migration
+	// identity of its own - it reuses its own UUID - but is otherwise identical.
+	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
+	claim, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(claim.Phase, tc.Equals, migrationdomain.ImportPhaseImporting)
 
-	err = s.activateModel(c, deps, migration.ActivateModelArgs{ModelUUID: modelUUID})
-	c.Assert(err, tc.ErrorIsNil)
+	// Preparation leaves it abortable, as for any other import.
+	c.Assert(s.activateModel(c, deps, migration.ActivateModelArgs{ModelUUID: modelUUID}), tc.ErrorIsNil)
+	c.Check(s.modelGateExists(c, modelUUID), tc.IsTrue)
+	c.Check(s.modelActivated(c, modelUUID), tc.IsFalse)
 
+	// The commit releases it.
+	c.Assert(s.commitActivation(c, deps, modelUUID), tc.ErrorIsNil)
 	c.Check(s.modelActivated(c, modelUUID), tc.IsTrue)
 	c.Check(s.modelGateExists(c, modelUUID), tc.IsFalse)
 	c.Check(s.modelAgentVersion(c, modelUUID), tc.Equals, jujuversion.Current.String())
+}
+
+// setClaimPhase forces the model's import claim into the named phase, standing
+// in for a concurrent abort or an already-received commit.
+func (s *controllerImportSuite) setClaimPhase(c *tc.C, modelUUID coremodel.UUID, phase string) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE model_migration_import
+SET    phase_type_id = (
+           SELECT id FROM model_migration_import_phase_type WHERE type = ?)
+WHERE  model_uuid = ?`, phase, modelUUID.String())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// commitActivation drives the commit half of activation, as the target's
+// AdoptResources call does.
+func (*controllerImportSuite) commitActivation(
+	c *tc.C, deps migration.Deps, modelUUID coremodel.UUID,
+) error {
+	importer := migration.NewModelImporter(
+		func(coremodel.UUID) coremodelmigration.Scope {
+			return coremodelmigration.NewScope(deps.ControllerDB, deps.ModelDB, nil, nil, modelUUID)
+		},
+		activationDomainServicesGetter{deps: deps},
+		"",
+		deps.Logger,
+		deps.Clock,
+	)
+	return importer.CommitActivation(c.Context(), modelUUID)
 }

--- a/internal/migration/activate_test.go
+++ b/internal/migration/activate_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	coremodelmigration "github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/semversion"
 	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/crossmodelrelation"
@@ -77,6 +79,23 @@ func (s *controllerImportSuite) importForActivation(
 
 type activationDomainServicesGetter struct {
 	deps migration.Deps
+
+	// adopted records the source controller versions handed to the provider,
+	// so tests can assert whether - and in what state - resource adoption ran.
+	adopted *[]semversion.Number
+}
+
+// recordingResourceProvider stands in for the cloud provider, recording the
+// adoption calls the commit makes instead of tagging anything.
+type recordingResourceProvider struct {
+	adopted *[]semversion.Number
+}
+
+func (p recordingResourceProvider) AdoptResources(
+	_ context.Context, _ string, sourceControllerVersion semversion.Number,
+) error {
+	*p.adopted = append(*p.adopted, sourceControllerVersion)
+	return nil
 }
 
 func (g activationDomainServicesGetter) ServicesForModel(
@@ -89,7 +108,12 @@ func (g activationDomainServicesGetter) ServicesForModel(
 			modelUUID.String(),
 			nil,
 			nil,
-			nil,
+			func(context.Context) (modelmigrationservice.ResourceProvider, error) {
+				if g.adopted == nil {
+					return nil, coreerrors.NotSupported
+				}
+				return recordingResourceProvider{adopted: g.adopted}, nil
+			},
 			g.deps.Logger,
 		),
 		model: modelservice.NewWatchableService(
@@ -265,7 +289,8 @@ func (s *controllerImportSuite) TestCommitActivationReleasesModel(c *tc.C) {
 	modelUUID, deps := s.importForActivation(c, "1.0.0")
 
 	c.Assert(s.activateModel(c, deps, migration.ActivateModelArgs{ModelUUID: modelUUID}), tc.ErrorIsNil)
-	c.Assert(s.commitActivation(c, deps, modelUUID), tc.ErrorIsNil)
+	commitErr, adopted := s.commitActivation(c, deps, modelUUID)
+	c.Assert(commitErr, tc.ErrorIsNil)
 
 	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
 	_, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
@@ -273,6 +298,11 @@ func (s *controllerImportSuite) TestCommitActivationReleasesModel(c *tc.C) {
 
 	c.Check(s.modelActivated(c, modelUUID), tc.IsTrue)
 	c.Check(s.modelGateExists(c, modelUUID), tc.IsFalse)
+
+	// Adoption ran, and ran with the source's version. It happens after the
+	// release, not before: the model's availability must not depend on the
+	// cloud provider being reachable.
+	c.Check(*adopted, tc.DeepEquals, []semversion.Number{sourceVersion})
 }
 
 // TestCommitActivationIsIdempotentAfterRelease verifies a commit retry arriving
@@ -282,8 +312,17 @@ func (s *controllerImportSuite) TestCommitActivationIsIdempotentAfterRelease(c *
 	modelUUID, deps := s.importForActivation(c, "1.0.0")
 
 	c.Assert(s.activateModel(c, deps, migration.ActivateModelArgs{ModelUUID: modelUUID}), tc.ErrorIsNil)
-	c.Assert(s.commitActivation(c, deps, modelUUID), tc.ErrorIsNil)
-	c.Assert(s.commitActivation(c, deps, modelUUID), tc.ErrorIsNil)
+
+	commitErr, adopted := s.commitActivation(c, deps, modelUUID)
+	c.Assert(commitErr, tc.ErrorIsNil)
+	c.Check(*adopted, tc.DeepEquals, []semversion.Number{sourceVersion})
+
+	// The retry finds no claim, confirms the model was already released, and
+	// re-runs the adoption alone - which is the point of retrying, since the
+	// lost reply may have been for a call whose adoption never completed.
+	retryErr, retryAdopted := s.commitActivation(c, deps, modelUUID)
+	c.Assert(retryErr, tc.ErrorIsNil)
+	c.Check(*retryAdopted, tc.DeepEquals, []semversion.Number{sourceVersion})
 
 	c.Check(s.modelActivated(c, modelUUID), tc.IsTrue)
 }
@@ -302,7 +341,7 @@ func (s *controllerImportSuite) TestCommitActivationWithoutImportFails(c *tc.C) 
 	c.Assert(err, tc.ErrorIsNil)
 
 	// The model is neither activated nor ungated, so the predicates fail.
-	err = s.commitActivation(c, deps, modelUUID)
+	err, _ = s.commitActivation(c, deps, modelUUID)
 	c.Check(err, tc.ErrorMatches, ".*is not importing or activating.*")
 }
 
@@ -314,8 +353,11 @@ func (s *controllerImportSuite) TestCommitActivationRefusesAbortingClaim(c *tc.C
 	modelUUID, deps := s.importForActivation(c, "1.0.0")
 	s.setClaimPhase(c, modelUUID, "aborting")
 
-	err := s.commitActivation(c, deps, modelUUID)
+	err, adopted := s.commitActivation(c, deps, modelUUID)
 	c.Check(err, tc.ErrorMatches, ".*cannot commit activation, import is aborting.*")
+	// A refused commit must not re-tag anything: adoption runs only once the
+	// model has become this controller's, and this one has not.
+	c.Check(*adopted, tc.HasLen, 0)
 	c.Check(s.modelActivated(c, modelUUID), tc.IsFalse)
 }
 
@@ -347,7 +389,7 @@ func (s *controllerImportSuite) TestCommitActivationResumesFromActivating(c *tc.
 	err := claimSt.SetImportPhaseActivating(c.Context(), modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = s.commitActivation(c, deps, modelUUID)
+	err, _ = s.commitActivation(c, deps, modelUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(s.modelActivated(c, modelUUID), tc.IsTrue)
@@ -483,7 +525,8 @@ func (s *controllerImportSuite) TestActivateAndCommitWithLegacyClaimShape(c *tc.
 	c.Check(s.modelActivated(c, modelUUID), tc.IsFalse)
 
 	// The commit releases it.
-	c.Assert(s.commitActivation(c, deps, modelUUID), tc.ErrorIsNil)
+	commitErr, _ := s.commitActivation(c, deps, modelUUID)
+	c.Assert(commitErr, tc.ErrorIsNil)
 	c.Check(s.modelActivated(c, modelUUID), tc.IsTrue)
 	c.Check(s.modelGateExists(c, modelUUID), tc.IsFalse)
 	c.Check(s.modelAgentVersion(c, modelUUID), tc.Equals, jujuversion.Current.String())
@@ -503,19 +546,25 @@ WHERE  model_uuid = ?`, phase, modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// sourceVersion stands in for the source controller's version, which the
+// commit hands to the provider when adopting resources.
+var sourceVersion = semversion.MustParse("4.0.12")
+
 // commitActivation drives the commit half of activation, as the target's
-// AdoptResources call does.
+// AdoptResources call does, returning the source versions the provider was
+// asked to adopt with.
 func (*controllerImportSuite) commitActivation(
 	c *tc.C, deps migration.Deps, modelUUID coremodel.UUID,
-) error {
+) (error, *[]semversion.Number) {
+	adopted := &[]semversion.Number{}
 	importer := migration.NewModelImporter(
 		func(coremodel.UUID) coremodelmigration.Scope {
 			return coremodelmigration.NewScope(deps.ControllerDB, deps.ModelDB, nil, nil, modelUUID)
 		},
-		activationDomainServicesGetter{deps: deps},
+		activationDomainServicesGetter{deps: deps, adopted: adopted},
 		"",
 		deps.Logger,
 		deps.Clock,
 	)
-	return importer.CommitActivation(c.Context(), modelUUID)
+	return importer.CommitActivation(c.Context(), modelUUID, sourceVersion), adopted
 }

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -80,9 +80,11 @@ func (i *ModelImporter) ImportModelLegacy(ctx context.Context, bytes []byte) err
 	)
 }
 
-// ActivateModel finalises the activation of a model imported via the v8 path.
-// It resolves the domain services for args.ModelUUID and delegates to the
-// activation driver.
+// ActivateModel prepares an imported model for activation without committing
+// anything: it performs the fallible, reversible work and leaves the model
+// abortable. The source calls this during VALIDATION, where any failure - or a
+// lost reply - sends it to ABORT, so nothing here may prevent that abort from
+// succeeding. See [ModelImporter.CommitActivation] for the other half.
 func (i *ModelImporter) ActivateModel(ctx context.Context, args ActivateModelArgs) error {
 	domainServices, err := i.domainServices.ServicesForModel(ctx, args.ModelUUID)
 	if err != nil {
@@ -90,7 +92,23 @@ func (i *ModelImporter) ActivateModel(ctx context.Context, args ActivateModelArg
 			"retrieving domain services for model %q: %w", args.ModelUUID, err,
 		)
 	}
-	return activateModel(ctx, domainServices, args)
+	return prepareActivation(ctx, domainServices, args)
+}
+
+// CommitActivation crosses the point of no return for an imported model: it
+// records that the source committed, then releases the model for use.
+//
+// It is driven by the target's AdoptResources call, which a source sends only
+// after durably recording SUCCESS - the point from which it can never abort. See
+// activate.go for why that is the only reliable commit signal available.
+func (i *ModelImporter) CommitActivation(ctx context.Context, modelUUID coremodel.UUID) error {
+	domainServices, err := i.domainServices.ServicesForModel(ctx, modelUUID)
+	if err != nil {
+		return internalerrors.Errorf(
+			"retrieving domain services for model %q: %w", modelUUID, err,
+		)
+	}
+	return commitActivation(ctx, domainServices, modelUUID)
 }
 
 // ImportModel applies a v8 import's controller-scoped semantic data to the

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -96,19 +96,23 @@ func (i *ModelImporter) ActivateModel(ctx context.Context, args ActivateModelArg
 }
 
 // CommitActivation crosses the point of no return for an imported model: it
-// records that the source committed, then releases the model for use.
+// records that the source committed, releases the model for use, and adopts its
+// cloud resources.
 //
 // It is driven by the target's AdoptResources call, which a source sends only
 // after durably recording SUCCESS - the point from which it can never abort. See
-// activate.go for why that is the only reliable commit signal available.
-func (i *ModelImporter) CommitActivation(ctx context.Context, modelUUID coremodel.UUID) error {
+// activate.go for why that is the only reliable commit signal available, and
+// why this is an ordered replayable sequence rather than a transaction.
+func (i *ModelImporter) CommitActivation(
+	ctx context.Context, modelUUID coremodel.UUID, sourceControllerVersion semversion.Number,
+) error {
 	domainServices, err := i.domainServices.ServicesForModel(ctx, modelUUID)
 	if err != nil {
 		return internalerrors.Errorf(
 			"retrieving domain services for model %q: %w", modelUUID, err,
 		)
 	}
-	return commitActivation(ctx, domainServices, modelUUID)
+	return commitActivation(ctx, domainServices, modelUUID, sourceControllerVersion)
 }
 
 // ImportModel applies a v8 import's controller-scoped semantic data to the


### PR DESCRIPTION
This is the change @manadart  asked for in https://github.com/juju/juju/pull/22899#issuecomment-5069798080: "The wire path is compatible with
3.6, but the new activation protocol is not failure-safe with a 3.6 source. I would not merge the
current point-of-no-return design." He traced it precisely: the legacy importer creates a real
`model_migration_import` claim, activation treats claim existence as the v8 discriminator and so puts a
3.6 import on the v8 state machine, and from there any failure after the `importing` -> `activating` 
transition is unrecoverable — a 3.6 master sends every activation error to ABORT, the target refuses
to abort an activating claim, and the source proceeds to ABORTDONE and resumes the model locally
anyway. Both controllers end up believing they own the model. He also noted the compatibility test
misses this because it fakes "legacy" by deleting the claim, "which is not what `ImportModelLegacy` 
does."

In 3.6 activation was one field. Activate set the model's migration mode to none, in a single write to
a single database, and the model was released at that instant — there was no intermediate state for a
failure to be caught in. Juju 4.x cannot do that: the claim lives in the controller database and the
gate in the model database, so activation became a sequence, and the durable claim was introduced to
order it. The mistake was where the irreversible step in that sequence was placed. It sat inside
Activate, which the source calls during VALIDATION — a phase it can still abort from. The target was
being asked to commit before the source had decided anything.

Only the source can decide a migration's outcome, and its own phase machine already says so: once it
durably records SUCCESS it can never reach ABORT again, it only rolls forward, retrying failures. The
first message it sends after that point is `AdoptResources()`, which makes that call's arrival a reliable
commit signal — and the only one the existing wire protocol offers. So Activate now only prepares: the 
fallible, idempotent work, leaving the claim importing, the gate closed and the model abortable. 
`AdoptResources()` commits, releases the model, and then adopts cloud
resources — releasing before adopting matches 3.6, and an adoption failure does not undo the release
since the source retries until it succeeds. No new RPC and no new error code, so 3.6 and 4.0 sources
speak this unchanged. Claim existence is also dropped as the legacy/v8 discriminator, and the
compatibility test is replaced with one using the real legacy claim shape. One window is worth stating
plainly: if the source dies after recording SUCCESS but before `AdoptResources()` reaches the target,
both sides stay frozen and an operator must resolve it. That is inherent to a two-controller commit
and no target-side machinery removes it — but it is strictly better than today, where the same window
leaves the model live on both.


## QA steps

Bootstrap 3 controllers (on 3.6, 4.0 and this branch: `src36`, `src40` and `dst41`), then:
```
  # 1. Happy path, both source versions.
  juju switch src36 && juju add-model moveme1 && juju deploy juju-qa-test
  juju migrate src36:moveme1 dst41
  juju switch dst41:moveme1 && juju status && juju add-unit juju-qa-test

  juju switch src40 && juju add-model moveme2 && juju deploy juju-qa-test
  juju migrate src40:moveme2 dst41
  juju switch dst41:moveme2 && juju add-unit juju-qa-test
```
```
  # 2. The regression this fixes: a migration that aborts must leave the
  #    target with nothing, so the same model can be migrated again.
  juju switch src36 && juju add-model moveme3 && juju deploy juju-qa-test
  #    Force a validation failure - stop the unit agent so its minion
  #    report never arrives:
  juju ssh juju-qa-test/0 'sudo systemctl stop jujud-unit-*'
  juju migrate src36:moveme3 dst41
  juju migration-status                    # expect ABORT then ABORTDONE
  juju models -c dst41                     # moveme3 must NOT be listed
  juju switch src36:moveme3 && juju status # source model alive and usable
```
```
  #    Restart the agent and migrate again - the target UUID must be free.
  juju ssh juju-qa-test/0 'sudo systemctl start jujud-unit-*'
  juju migrate src36:moveme3 dst41         # must succeed, not AlreadyExists
```

## Links

**Jira card:** [JUJU-9910](https://warthogs.atlassian.net/browse/JUJU-9910)


[JUJU-9910]: https://warthogs.atlassian.net/browse/JUJU-9910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ