### PR TITLE
feat: detach with machine storage

### DIFF
--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -83,4 +83,12 @@ const (
 	// MachineProviderInstanceRunning describes an error when the provider still
 	// reports the machine's cloud instance as running.
 	MachineProviderInstanceRunning = errors.ConstError("machine provider instance is running")
+
+	// ModelScopedStorageAttached describes an error that occurs during
+	// reprovisioning when model-scoped storage is attached to the machine.
+	ModelScopedStorageAttached = errors.ConstError("model-scoped storage attached to machine")
+
+	// StorageScopeAmbiguous describes an error that occurs during reprovisioning
+	// when Juju cannot safely classify attached storage.
+	StorageScopeAmbiguous = errors.ConstError("storage scope is ambiguous")
 )

--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -91,4 +91,8 @@ const (
 	// StorageScopeAmbiguous describes an error that occurs during reprovisioning
 	// when Juju cannot safely classify attached storage.
 	StorageScopeAmbiguous = errors.ConstError("storage scope is ambiguous")
+
+	// MachineStorageNotAlive describes an error that occurs during
+	// reprovisioning when attached machine storage is not alive.
+	MachineStorageNotAlive = errors.ConstError("machine storage is not alive")
 )

--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -29,7 +29,7 @@ import (
 	"github.com/juju/juju/internal/statushistory"
 )
 
-const reprovisioningStatusMessage = "reprovisioning requested"
+const reprovisioningStatusMessage = "reprovisioning requested; replacement machine-scoped storage will be empty"
 
 // Provider represents an underlying cloud provider.
 type Provider interface {

--- a/domain/machine/service/provider.go
+++ b/domain/machine/service/provider.go
@@ -29,7 +29,7 @@ import (
 	"github.com/juju/juju/internal/statushistory"
 )
 
-const reprovisioningStatusMessage = "reprovisioning requested; replacement machine-scoped storage will be empty"
+const reprovisioningStatusMessage = "reprovisioning requested"
 
 // Provider represents an underlying cloud provider.
 type Provider interface {

--- a/domain/machine/service/provider_test.go
+++ b/domain/machine/service/provider_test.go
@@ -619,6 +619,47 @@ func (s *providerServiceSuite) TestReprovisionMachineAgentPresent(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, machineerrors.MachineAgentPresent)
 }
 
+func (s *providerServiceSuite) TestReprovisionMachineInstanceIDError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().CheckMachineReprovisioningEligibility(
+		gomock.Any(), machine.Name("0"),
+	).Return(nil)
+	s.state.EXPECT().GetInstanceIDByMachineName(
+		gomock.Any(), machine.Name("0"),
+	).Return("", errors.New("instance lookup failed"))
+
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
+	c.Assert(err, tc.ErrorMatches, `machine "0": instance lookup failed`)
+}
+
+func (s *providerServiceSuite) TestReprovisionMachineAgentPresenceError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectReprovisionMachineValidated(c, "i-1234")
+	s.state.EXPECT().IsMachineAgentPresent(
+		gomock.Any(), machine.Name("0"),
+	).Return(false, errors.New("presence lookup failed"))
+
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
+	c.Assert(err, tc.ErrorMatches,
+		`checking machine "0" agent presence: presence lookup failed`)
+}
+
+func (s *providerServiceSuite) TestReprovisionMachineProviderGetterError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectReprovisionMachineValidated(c, "i-1234")
+	s.expectMachineAgentAbsent()
+	s.service.providerGetter = func(context.Context) (Provider, error) {
+		return nil, errors.New("provider unavailable")
+	}
+
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
+	c.Assert(err, tc.ErrorMatches,
+		`getting provider for machine "0" reprovisioning: provider unavailable`)
+}
+
 func (s *providerServiceSuite) TestReprovisionMachineProviderEmptyInstances(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -626,6 +667,48 @@ func (s *providerServiceSuite) TestReprovisionMachineProviderEmptyInstances(c *t
 	s.expectReprovisionMachineValidated(c, instanceID)
 	s.expectMachineAgentAbsent()
 	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return(nil, nil)
+	s.expectMachineDetached()
+
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *providerServiceSuite) TestReprovisionMachineModelScopedStorage(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().CheckMachineReprovisioningEligibility(
+		gomock.Any(), machine.Name("0"),
+	).Return(machineerrors.ModelScopedStorageAttached)
+
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
+	c.Assert(err, tc.ErrorIs, machineerrors.ModelScopedStorageAttached)
+}
+
+func (s *providerServiceSuite) TestReprovisionMachineModelScopedStorageAddedAfterEligibility(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	instanceID := instance.Id("i-1234")
+	s.expectReprovisionMachineValidated(c, instanceID)
+	s.expectMachineAgentAbsent()
+	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return([]instances.Instance{
+		reprovisionInstance{id: instanceID, status: status.Error},
+	}, nil)
+	s.state.EXPECT().DetachLostMachineCloudInstance(
+		gomock.Any(), "0", instanceID.String(), reprovisioningStatusMessage,
+		[]byte(`{"old-instance-id":"i-1234"}`), gomock.Any(),
+	).Return(machineerrors.ModelScopedStorageAttached)
+
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
+	c.Assert(err, tc.ErrorIs, machineerrors.ModelScopedStorageAttached)
+}
+
+func (s *providerServiceSuite) TestReprovisionMachineAgentAbsentNoInstance(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	instanceID := instance.Id("i-1234")
+	s.expectReprovisionMachineValidated(c, instanceID)
+	s.expectMachineAgentAbsent()
+	s.provider.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return(nil, environs.ErrNoInstances)
 	s.expectMachineDetached()
 
 	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
@@ -715,6 +798,26 @@ func (s *providerServiceSuite) TestDetachLostMachineCloudInstanceStatusData(c *t
 	s.statusHistory.EXPECT().RecordStatus(
 		gomock.Any(), domainstatus.MachineInstanceNamespace.WithID("0"), statusInfo,
 	).Return(nil)
+
+	err := s.service.detachLostMachineCloudInstance(
+		c.Context(), machine.Name("0"), instance.Id("i-1234"),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *providerServiceSuite) TestDetachLostMachineCloudInstanceStatusHistoryErrors(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().DetachLostMachineCloudInstance(
+		gomock.Any(), "0", "i-1234", reprovisioningStatusMessage,
+		[]byte(`{"old-instance-id":"i-1234"}`), gomock.Any(),
+	).Return(nil)
+	s.statusHistory.EXPECT().RecordStatus(
+		gomock.Any(), domainstatus.MachineNamespace.WithID("0"), gomock.Any(),
+	).Return(errors.New("machine history failed"))
+	s.statusHistory.EXPECT().RecordStatus(
+		gomock.Any(), domainstatus.MachineInstanceNamespace.WithID("0"), gomock.Any(),
+	).Return(errors.New("instance history failed"))
 
 	err := s.service.detachLostMachineCloudInstance(
 		c.Context(), machine.Name("0"), instance.Id("i-1234"),

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -104,9 +104,9 @@ type State interface {
 	GetMachineLifeAndIsManuallyProvisioned(context.Context, machine.Name) (life.Life, bool, error)
 
 	// CheckMachineReprovisioningEligibility checks machine life, controller
-	// status, manual-provision status, and child-container presence in a
-	// single round-trip. It returns a sentinel error for each ineligible
-	// condition.
+	// status, manual-provision status, child-container presence, and attached
+	// model-scoped storage in a single round-trip. It returns a sentinel error
+	// for each ineligible condition.
 	CheckMachineReprovisioningEligibility(context.Context, machine.Name) error
 
 	// IsMachineAgentPresent returns whether presence exists for the specified

--- a/domain/machine/state/reprovision.go
+++ b/domain/machine/state/reprovision.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"context"
+	"maps"
 	"slices"
 	"time"
 
@@ -20,7 +21,7 @@ import (
 // DetachLostMachineCloudInstance atomically rechecks the critical
 // reprovisioning preconditions, clears stale provider-observed state, and
 // moves the machine and its cloud instance back to pending. Machine-scoped
-// physical storage realization is deleted while logical storage intent is
+// storage is reset to pending while its Juju identity and logical intent are
 // preserved. Unsupported storage is rejected in the same transaction.
 func (st *State) DetachLostMachineCloudInstance(
 	ctx context.Context,
@@ -97,6 +98,7 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 			ctx, tx, volumeTargetStmt, filesystemTargetStmt,
 			reprovisionStorageTargetParams{
 				NetNodeUUID:    target.NetNodeUUID,
+				AliveLifeID:    int(life.Alive),
 				ModelScopeID:   int(domainstorage.ProvisionScopeModel),
 				MachineScopeID: int(domainstorage.ProvisionScopeMachine),
 			},
@@ -116,7 +118,7 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 			return errors.Errorf("clearing block devices: %w", err)
 		}
 
-		if err := st.removeReprovisionStorage(
+		if err := st.resetReprovisionStorage(
 			ctx, tx, storageTargets,
 		); err != nil {
 			return errors.Errorf("clearing machine-scoped storage: %w", err)
@@ -375,9 +377,9 @@ func runReprovisionStatements(
 }
 
 type reprovisionStorageTargets struct {
-	volumes, filesystems                reprovisionUUIDs
-	plans, volumeAttachments            reprovisionUUIDs
-	filesystemAttachments, blockDevices reprovisionUUIDs
+	volumes, filesystems                map[string]struct{}
+	plans, volumeAttachments            map[string]struct{}
+	filesystemAttachments, blockDevices map[string]struct{}
 }
 
 func (st *State) prepareReprovisionStorageTargetStatements() (
@@ -386,13 +388,21 @@ func (st *State) prepareReprovisionStorageTargetStatements() (
 	volumeStmt, err := st.Prepare(`
 WITH volume_targets AS (
     SELECT DISTINCT sv.uuid AS volume_uuid,
+           sv.life_id AS volume_life_id,
            sv.provision_scope_id AS volume_scope_id,
+           siv.storage_instance_uuid AS storage_instance_uuid,
+           si.life_id AS storage_instance_life_id,
            sva.uuid AS attachment_uuid,
+           sva.life_id AS attachment_life_id,
            sva.provision_scope_id AS attachment_scope_id,
            svap.uuid AS plan_uuid,
            svap.provision_scope_id AS plan_scope_id,
            sva.block_device_uuid AS block_device_uuid
     FROM storage_volume AS sv
+    LEFT JOIN storage_instance_volume AS siv
+        ON sv.uuid = siv.storage_volume_uuid
+    LEFT JOIN storage_instance AS si
+        ON siv.storage_instance_uuid = si.uuid
     LEFT JOIN storage_volume_attachment AS sva
         ON sv.uuid = sva.storage_volume_uuid
         AND sva.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
@@ -403,10 +413,22 @@ WITH volume_targets AS (
 ),
 classified_volume_targets AS (
     SELECT vt.volume_uuid,
+           vt.volume_scope_id,
+           vt.storage_instance_uuid,
+           vt.storage_instance_life_id,
            vt.attachment_uuid,
            vt.plan_uuid,
            vt.block_device_uuid,
            CASE
+               WHEN vt.storage_instance_uuid IS NULL OR vt.attachment_uuid IS NULL
+                   THEN TRUE
+               ELSE vt.volume_life_id = $reprovisionStorageTargetParams.alive_life_id
+                   AND vt.attachment_life_id = $reprovisionStorageTargetParams.alive_life_id
+                   AND vt.storage_instance_life_id = $reprovisionStorageTargetParams.alive_life_id
+           END AS all_alive,
+           CASE
+               WHEN vt.storage_instance_uuid IS NULL OR vt.attachment_uuid IS NULL
+                   THEN 'ambiguous'
                WHEN vt.volume_scope_id NOT IN (
                    $reprovisionStorageTargetParams.model_scope_id,
                    $reprovisionStorageTargetParams.machine_scope_id
@@ -424,6 +446,7 @@ classified_volume_targets AS (
     FROM volume_targets AS vt
 )
 SELECT cvt.volume_uuid AS &reprovisionVolumeTarget.volume_uuid,
+       cvt.all_alive AS &reprovisionVolumeTarget.all_alive,
        cvt.scope_class AS &reprovisionVolumeTarget.scope_class,
        cvt.attachment_uuid AS &reprovisionVolumeTarget.attachment_uuid,
        cvt.plan_uuid AS &reprovisionVolumeTarget.plan_uuid,
@@ -435,18 +458,38 @@ FROM classified_volume_targets AS cvt`, reprovisionStorageTargetParams{}, reprov
 	filesystemStmt, err := st.Prepare(`
 WITH filesystem_targets AS (
     SELECT sf.uuid AS filesystem_uuid,
+           sf.life_id AS filesystem_life_id,
            sf.provision_scope_id AS filesystem_scope_id,
+           sif.storage_instance_uuid AS storage_instance_uuid,
+           si.life_id AS storage_instance_life_id,
            sfa.uuid AS attachment_uuid,
+           sfa.life_id AS attachment_life_id,
            sfa.provision_scope_id AS attachment_scope_id
     FROM storage_filesystem AS sf
+    LEFT JOIN storage_instance_filesystem AS sif
+        ON sf.uuid = sif.storage_filesystem_uuid
+    LEFT JOIN storage_instance AS si
+        ON sif.storage_instance_uuid = si.uuid
     JOIN storage_filesystem_attachment AS sfa
         ON sf.uuid = sfa.storage_filesystem_uuid
     WHERE sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 ),
 classified_filesystem_targets AS (
     SELECT ft.filesystem_uuid,
+           ft.filesystem_scope_id,
+           ft.storage_instance_uuid,
+           ft.storage_instance_life_id,
            ft.attachment_uuid,
            CASE
+               WHEN ft.storage_instance_uuid IS NULL
+                   THEN TRUE
+               ELSE ft.filesystem_life_id = $reprovisionStorageTargetParams.alive_life_id
+                   AND ft.attachment_life_id = $reprovisionStorageTargetParams.alive_life_id
+                   AND ft.storage_instance_life_id = $reprovisionStorageTargetParams.alive_life_id
+           END AS all_alive,
+           CASE
+               WHEN ft.storage_instance_uuid IS NULL
+                   THEN 'ambiguous'
                WHEN ft.filesystem_scope_id NOT IN (
                    $reprovisionStorageTargetParams.model_scope_id,
                    $reprovisionStorageTargetParams.machine_scope_id
@@ -460,6 +503,7 @@ classified_filesystem_targets AS (
     FROM filesystem_targets AS ft
 )
 SELECT cft.filesystem_uuid AS &reprovisionFilesystemTarget.filesystem_uuid,
+       cft.all_alive AS &reprovisionFilesystemTarget.all_alive,
        cft.scope_class AS &reprovisionFilesystemTarget.scope_class,
        cft.attachment_uuid AS &reprovisionFilesystemTarget.attachment_uuid
 FROM classified_filesystem_targets AS cft`, reprovisionStorageTargetParams{}, reprovisionFilesystemTarget{})
@@ -469,6 +513,14 @@ FROM classified_filesystem_targets AS cft`, reprovisionStorageTargetParams{}, re
 	return volumeStmt, filesystemStmt, nil
 }
 
+// getReprovisionStorageTargets captures the machine-scoped storage that must
+// be reset before any references are changed. This runs inside the detach
+// transaction so storage cannot change between validation and mutation.
+//
+// Scope and lifecycle are checked from the same rows used to build the target
+// sets. Model-scoped, inconsistent, incomplete, or non-alive storage fails
+// closed. Maps are used because joins may return the same physical entity more
+// than once, while each reset statement must target every UUID only once.
 func (st *State) getReprovisionStorageTargets(
 	ctx context.Context, tx *sqlair.TX,
 	volumeStmt, filesystemStmt *sqlair.Statement,
@@ -483,14 +535,20 @@ func (st *State) getReprovisionStorageTargets(
 		return reprovisionStorageTargets{}, errors.Errorf("querying attached filesystems: %w", err)
 	}
 
-	var targets reprovisionStorageTargets
-	add := func(ids reprovisionUUIDs, value string) reprovisionUUIDs {
-		if slices.Contains(ids, value) {
-			return ids
-		}
-		return append(ids, value)
+	targets := reprovisionStorageTargets{
+		volumes:               make(map[string]struct{}),
+		filesystems:           make(map[string]struct{}),
+		plans:                 make(map[string]struct{}),
+		volumeAttachments:     make(map[string]struct{}),
+		filesystemAttachments: make(map[string]struct{}),
+		blockDevices:          make(map[string]struct{}),
 	}
 	for _, row := range volumeRows {
+		if !row.AllAlive {
+			return reprovisionStorageTargets{}, errors.Errorf(
+				"volume %q: %w", row.VolumeUUID, machineerrors.MachineStorageNotAlive,
+			)
+		}
 		switch row.ScopeClass {
 		case "model":
 			return reprovisionStorageTargets{}, errors.Errorf(
@@ -508,18 +566,23 @@ func (st *State) getReprovisionStorageTargets(
 				row.VolumeUUID, row.ScopeClass, machineerrors.StorageScopeAmbiguous,
 			)
 		}
-		targets.volumes = add(targets.volumes, row.VolumeUUID)
+		targets.volumes[row.VolumeUUID] = struct{}{}
 		if row.AttachmentUUID.Valid {
-			targets.volumeAttachments = add(targets.volumeAttachments, row.AttachmentUUID.V)
+			targets.volumeAttachments[row.AttachmentUUID.V] = struct{}{}
 		}
 		if row.PlanUUID.Valid {
-			targets.plans = add(targets.plans, row.PlanUUID.V)
+			targets.plans[row.PlanUUID.V] = struct{}{}
 		}
 		if row.BlockDeviceUUID.Valid {
-			targets.blockDevices = add(targets.blockDevices, row.BlockDeviceUUID.V)
+			targets.blockDevices[row.BlockDeviceUUID.V] = struct{}{}
 		}
 	}
 	for _, row := range filesystemRows {
+		if !row.AllAlive {
+			return reprovisionStorageTargets{}, errors.Errorf(
+				"filesystem %q: %w", row.FilesystemUUID, machineerrors.MachineStorageNotAlive,
+			)
+		}
 		switch row.ScopeClass {
 		case "model":
 			return reprovisionStorageTargets{}, errors.Errorf(
@@ -537,16 +600,28 @@ func (st *State) getReprovisionStorageTargets(
 				row.FilesystemUUID, row.ScopeClass, machineerrors.StorageScopeAmbiguous,
 			)
 		}
-		targets.filesystems = add(targets.filesystems, row.FilesystemUUID)
-		targets.filesystemAttachments = add(targets.filesystemAttachments, row.AttachmentUUID)
+		targets.filesystems[row.FilesystemUUID] = struct{}{}
+		targets.filesystemAttachments[row.AttachmentUUID] = struct{}{}
 	}
 	return targets, nil
 }
 
-func (st *State) removeReprovisionStorage(
+// resetReprovisionStorage discards provider-observed storage state for the
+// lost machine while preserving Juju storage identities and intent. Volume,
+// filesystem, instance-link, machine-link, and attachment rows remain so the
+// normal provisioner can create empty replacement storage.
+//
+// Provider-specific attachment plans are deleted first. Attachments are then
+// marked unprovisioned before their old block devices are removed. Finally the
+// volume and filesystem provider fields are cleared and their statuses are
+// moved back to pending.
+func (st *State) resetReprovisionStorage(
 	ctx context.Context, tx *sqlair.TX,
 	targets reprovisionStorageTargets,
 ) error {
+	ids := func(values map[string]struct{}) reprovisionUUIDs {
+		return reprovisionUUIDs(slices.Collect(maps.Keys(values)))
+	}
 	run := func(query string, ids reprovisionUUIDs) error {
 		if len(ids) == 0 {
 			return nil
@@ -561,32 +636,85 @@ func (st *State) removeReprovisionStorage(
 		query string
 		ids   reprovisionUUIDs
 	}{
-		{query: `DELETE FROM storage_volume_attachment_plan_attr WHERE attachment_plan_uuid IN ($reprovisionUUIDs[:])`, ids: targets.plans},
-		{query: `DELETE FROM storage_volume_attachment_plan WHERE uuid IN ($reprovisionUUIDs[:])`, ids: targets.plans},
-		{query: `DELETE FROM storage_volume_attachment WHERE uuid IN ($reprovisionUUIDs[:])`, ids: targets.volumeAttachments},
-		{query: `DELETE FROM storage_filesystem_attachment WHERE uuid IN ($reprovisionUUIDs[:])`, ids: targets.filesystemAttachments},
+		// Plan attributes describe the old provider attachment and cannot be
+		// reused.
+		{query: `
+DELETE FROM storage_volume_attachment_plan_attr
+WHERE attachment_plan_uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.plans)},
+		// Attachment plans must be recalculated for the replacement machine.
+		{query: `
+DELETE FROM storage_volume_attachment_plan
+WHERE uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.plans)},
+		// Keep attachment intent, but remove evidence of the old provider
+		// attachment.
+		{query: `
+UPDATE storage_volume_attachment
+SET provider_id = NULL,
+    block_device_uuid = NULL
+WHERE uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.volumeAttachments)},
+		// Keep mount intent, but remove the old provider attachment identifier.
+		{query: `
+UPDATE storage_filesystem_attachment
+SET provider_id = NULL
+WHERE uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.filesystemAttachments)},
+		// Attachment references are now clear, so old block-device links can
+		// be removed.
 		{query: `
 DELETE FROM block_device_link_device
 WHERE block_device_uuid IN ($reprovisionUUIDs[:])
 AND NOT EXISTS (
     SELECT 1 FROM storage_volume_attachment AS sva
     WHERE sva.block_device_uuid = block_device_link_device.block_device_uuid
-)`, ids: targets.blockDevices},
+)`, ids: ids(targets.blockDevices)},
+		// Remove old block-device evidence only when no attachment still
+		// references it.
 		{query: `
 DELETE FROM block_device
 WHERE uuid IN ($reprovisionUUIDs[:])
 AND NOT EXISTS (
     SELECT 1 FROM storage_volume_attachment AS sva
     WHERE sva.block_device_uuid = block_device.uuid
-)`, ids: targets.blockDevices},
-		{query: `DELETE FROM machine_volume WHERE volume_uuid IN ($reprovisionUUIDs[:])`, ids: targets.volumes},
-		{query: `DELETE FROM storage_volume_status WHERE volume_uuid IN ($reprovisionUUIDs[:])`, ids: targets.volumes},
-		{query: `DELETE FROM storage_instance_volume WHERE storage_volume_uuid IN ($reprovisionUUIDs[:])`, ids: targets.volumes},
-		{`DELETE FROM storage_volume WHERE uuid IN ($reprovisionUUIDs[:])`, targets.volumes},
-		{query: `DELETE FROM machine_filesystem WHERE filesystem_uuid IN ($reprovisionUUIDs[:])`, ids: targets.filesystems},
-		{query: `DELETE FROM storage_filesystem_status WHERE filesystem_uuid IN ($reprovisionUUIDs[:])`, ids: targets.filesystems},
-		{query: `DELETE FROM storage_instance_filesystem WHERE storage_filesystem_uuid IN ($reprovisionUUIDs[:])`, ids: targets.filesystems},
-		{query: `DELETE FROM storage_filesystem WHERE uuid IN ($reprovisionUUIDs[:])`, ids: targets.filesystems},
+)`, ids: ids(targets.blockDevices)},
+		// Clear the old provider realization while retaining the Juju volume
+		// identity.
+		{query: `
+UPDATE storage_volume
+SET provider_id = NULL,
+    size_mib = NULL,
+    hardware_id = NULL,
+    wwn = NULL,
+    persistent = NULL,
+    obliterate_on_cleanup = NULL
+WHERE uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.volumes)},
+		// Ensure the retained volume is visible to provisioning as pending work.
+		{query: `
+INSERT INTO storage_volume_status (volume_uuid, status_id, message, updated_at)
+SELECT sv.uuid, 0, 'waiting for replacement machine', NULL
+FROM storage_volume AS sv
+WHERE sv.uuid IN ($reprovisionUUIDs[:])
+ON CONFLICT (volume_uuid) DO UPDATE SET
+    status_id = excluded.status_id,
+    message = excluded.message,
+    updated_at = excluded.updated_at`, ids: ids(targets.volumes)},
+		// Clear the old provider realization while retaining the filesystem
+		// identity.
+		{query: `
+UPDATE storage_filesystem
+SET provider_id = NULL,
+    size_mib = NULL,
+    obliterate_on_cleanup = NULL
+WHERE uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.filesystems)},
+		// Ensure the retained filesystem is visible to provisioning as pending
+		// work.
+		{query: `
+INSERT INTO storage_filesystem_status (filesystem_uuid, status_id, message, updated_at)
+SELECT sf.uuid, 0, 'waiting for replacement machine', NULL
+FROM storage_filesystem AS sf
+WHERE sf.uuid IN ($reprovisionUUIDs[:])
+ON CONFLICT (filesystem_uuid) DO UPDATE SET
+    status_id = excluded.status_id,
+    message = excluded.message,
+    updated_at = excluded.updated_at`, ids: ids(targets.filesystems)},
 	}
 	for _, step := range steps {
 		if err := run(step.query, step.ids); err != nil {

--- a/domain/machine/state/reprovision.go
+++ b/domain/machine/state/reprovision.go
@@ -81,6 +81,10 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 	if err != nil {
 		return errors.Errorf("preparing storage target statements: %w", err)
 	}
+	storageResetStmts, err := st.prepareReprovisionStorageResetStatements()
+	if err != nil {
+		return errors.Errorf("preparing storage reset statements: %w", err)
+	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var target reprovisionDetachTarget
@@ -119,7 +123,7 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 		}
 
 		if err := st.resetReprovisionStorage(
-			ctx, tx, storageTargets,
+			ctx, tx, storageResetStmts, storageTargets,
 		); err != nil {
 			return errors.Errorf("clearing machine-scoped storage: %w", err)
 		}
@@ -456,7 +460,19 @@ FROM classified_volume_targets AS cvt`, reprovisionStorageTargetParams{}, reprov
 		return nil, nil, errors.Capture(err)
 	}
 	filesystemStmt, err := st.Prepare(`
-WITH filesystem_targets AS (
+WITH filesystem_target_uuids AS (
+    SELECT mf.filesystem_uuid
+    FROM machine AS m
+    JOIN machine_filesystem AS mf ON m.uuid = mf.machine_uuid
+    WHERE m.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+
+    UNION
+
+    SELECT sfa.storage_filesystem_uuid
+    FROM storage_filesystem_attachment AS sfa
+    WHERE sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+),
+filesystem_targets AS (
     SELECT sf.uuid AS filesystem_uuid,
            sf.life_id AS filesystem_life_id,
            sf.provision_scope_id AS filesystem_scope_id,
@@ -465,14 +481,15 @@ WITH filesystem_targets AS (
            sfa.uuid AS attachment_uuid,
            sfa.life_id AS attachment_life_id,
            sfa.provision_scope_id AS attachment_scope_id
-    FROM storage_filesystem AS sf
+    FROM filesystem_target_uuids AS ftu
+    JOIN storage_filesystem AS sf ON ftu.filesystem_uuid = sf.uuid
     LEFT JOIN storage_instance_filesystem AS sif
         ON sf.uuid = sif.storage_filesystem_uuid
     LEFT JOIN storage_instance AS si
         ON sif.storage_instance_uuid = si.uuid
-    JOIN storage_filesystem_attachment AS sfa
+    LEFT JOIN storage_filesystem_attachment AS sfa
         ON sf.uuid = sfa.storage_filesystem_uuid
-    WHERE sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+        AND sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 ),
 classified_filesystem_targets AS (
     SELECT ft.filesystem_uuid,
@@ -481,14 +498,14 @@ classified_filesystem_targets AS (
            ft.storage_instance_life_id,
            ft.attachment_uuid,
            CASE
-               WHEN ft.storage_instance_uuid IS NULL
+               WHEN ft.storage_instance_uuid IS NULL OR ft.attachment_uuid IS NULL
                    THEN TRUE
                ELSE ft.filesystem_life_id = $reprovisionStorageTargetParams.alive_life_id
                    AND ft.attachment_life_id = $reprovisionStorageTargetParams.alive_life_id
                    AND ft.storage_instance_life_id = $reprovisionStorageTargetParams.alive_life_id
            END AS all_alive,
            CASE
-               WHEN ft.storage_instance_uuid IS NULL
+               WHEN ft.storage_instance_uuid IS NULL OR ft.attachment_uuid IS NULL
                    THEN 'ambiguous'
                WHEN ft.filesystem_scope_id NOT IN (
                    $reprovisionStorageTargetParams.model_scope_id,
@@ -601,9 +618,117 @@ func (st *State) getReprovisionStorageTargets(
 			)
 		}
 		targets.filesystems[row.FilesystemUUID] = struct{}{}
-		targets.filesystemAttachments[row.AttachmentUUID] = struct{}{}
+		if row.AttachmentUUID.Valid {
+			targets.filesystemAttachments[row.AttachmentUUID.V] = struct{}{}
+		}
 	}
 	return targets, nil
+}
+
+type reprovisionStorageResetStatements struct {
+	planAttrs, plans                         *sqlair.Statement
+	volumeAttachments, filesystemAttachments *sqlair.Statement
+	blockDeviceLinks, blockDevices           *sqlair.Statement
+	volumes, volumeStatuses                  *sqlair.Statement
+	filesystems, filesystemStatuses          *sqlair.Statement
+}
+
+func (st *State) prepareReprovisionStorageResetStatements() (
+	reprovisionStorageResetStatements, error,
+) {
+	var statements reprovisionStorageResetStatements
+	queries := []struct {
+		stmt  **sqlair.Statement
+		query string
+	}{
+		// Plan attributes describe the old provider attachment and cannot be
+		// reused.
+		{stmt: &statements.planAttrs, query: `
+DELETE FROM storage_volume_attachment_plan_attr
+WHERE attachment_plan_uuid IN ($reprovisionUUIDs[:])`},
+		// Attachment plans must be recalculated for the replacement machine.
+		{stmt: &statements.plans, query: `
+DELETE FROM storage_volume_attachment_plan
+WHERE uuid IN ($reprovisionUUIDs[:])`},
+		// Keep attachment intent, but remove evidence of the old provider
+		// attachment.
+		{stmt: &statements.volumeAttachments, query: `
+UPDATE storage_volume_attachment
+SET provider_id = NULL,
+    block_device_uuid = NULL
+WHERE uuid IN ($reprovisionUUIDs[:])`},
+		// Keep mount intent, but remove the old provider attachment identifier.
+		{stmt: &statements.filesystemAttachments, query: `
+UPDATE storage_filesystem_attachment
+SET provider_id = NULL
+WHERE uuid IN ($reprovisionUUIDs[:])`},
+		// Attachment references are now clear, so old block-device links can
+		// be removed.
+		{stmt: &statements.blockDeviceLinks, query: `
+DELETE FROM block_device_link_device
+WHERE block_device_uuid IN ($reprovisionUUIDs[:])
+AND NOT EXISTS (
+    SELECT 1 FROM storage_volume_attachment AS sva
+    WHERE sva.block_device_uuid = block_device_link_device.block_device_uuid
+)`},
+		// Remove old block-device evidence only when no attachment still
+		// references it.
+		{stmt: &statements.blockDevices, query: `
+DELETE FROM block_device
+WHERE uuid IN ($reprovisionUUIDs[:])
+AND NOT EXISTS (
+    SELECT 1 FROM storage_volume_attachment AS sva
+    WHERE sva.block_device_uuid = block_device.uuid
+)`},
+		// Clear the old provider realization while retaining the Juju volume
+		// identity.
+		{stmt: &statements.volumes, query: `
+UPDATE storage_volume
+SET provider_id = NULL,
+    size_mib = NULL,
+    hardware_id = NULL,
+    wwn = NULL,
+    persistent = NULL,
+    obliterate_on_cleanup = NULL
+WHERE uuid IN ($reprovisionUUIDs[:])`},
+		// Ensure the retained volume is visible to provisioning as pending work.
+		{stmt: &statements.volumeStatuses, query: `
+INSERT INTO storage_volume_status (volume_uuid, status_id, message, updated_at)
+SELECT sv.uuid, 0, 'waiting for replacement machine', NULL
+FROM storage_volume AS sv
+WHERE sv.uuid IN ($reprovisionUUIDs[:])
+ON CONFLICT (volume_uuid) DO UPDATE SET
+    status_id = excluded.status_id,
+    message = excluded.message,
+    updated_at = excluded.updated_at`},
+		// Clear the old provider realization while retaining the filesystem
+		// identity.
+		{stmt: &statements.filesystems, query: `
+UPDATE storage_filesystem
+SET provider_id = NULL,
+    size_mib = NULL,
+    obliterate_on_cleanup = NULL
+WHERE uuid IN ($reprovisionUUIDs[:])`},
+		// Ensure the retained filesystem is visible to provisioning as pending
+		// work.
+		{stmt: &statements.filesystemStatuses, query: `
+INSERT INTO storage_filesystem_status (filesystem_uuid, status_id, message, updated_at)
+SELECT sf.uuid, 0, 'waiting for replacement machine', NULL
+FROM storage_filesystem AS sf
+WHERE sf.uuid IN ($reprovisionUUIDs[:])
+ON CONFLICT (filesystem_uuid) DO UPDATE SET
+    status_id = excluded.status_id,
+    message = excluded.message,
+    updated_at = excluded.updated_at`},
+	}
+	for _, item := range queries {
+		stmt, err := st.Prepare(item.query, reprovisionUUIDs{})
+		if err != nil {
+			return reprovisionStorageResetStatements{}, errors.Capture(err)
+		}
+		*item.stmt = stmt
+	}
+	return statements, nil
 }
 
 // resetReprovisionStorage discards provider-observed storage state for the
@@ -617,107 +742,42 @@ func (st *State) getReprovisionStorageTargets(
 // moved back to pending.
 func (st *State) resetReprovisionStorage(
 	ctx context.Context, tx *sqlair.TX,
+	statements reprovisionStorageResetStatements,
 	targets reprovisionStorageTargets,
 ) error {
 	ids := func(values map[string]struct{}) reprovisionUUIDs {
 		return reprovisionUUIDs(slices.Collect(maps.Keys(values)))
 	}
-	run := func(query string, ids reprovisionUUIDs) error {
-		if len(ids) == 0 {
-			return nil
-		}
-		stmt, err := st.Prepare(query, reprovisionUUIDs{})
-		if err != nil {
-			return errors.Capture(err)
-		}
-		return errors.Capture(tx.Query(ctx, stmt, ids).Run())
-	}
+
+	var (
+		plans                 = ids(targets.plans)
+		volumeAttachments     = ids(targets.volumeAttachments)
+		filesystemAttachments = ids(targets.filesystemAttachments)
+		blockDevices          = ids(targets.blockDevices)
+		volumes               = ids(targets.volumes)
+		filesystems           = ids(targets.filesystems)
+	)
+
 	steps := []struct {
-		query string
-		ids   reprovisionUUIDs
+		stmt *sqlair.Statement
+		ids  reprovisionUUIDs
 	}{
-		// Plan attributes describe the old provider attachment and cannot be
-		// reused.
-		{query: `
-DELETE FROM storage_volume_attachment_plan_attr
-WHERE attachment_plan_uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.plans)},
-		// Attachment plans must be recalculated for the replacement machine.
-		{query: `
-DELETE FROM storage_volume_attachment_plan
-WHERE uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.plans)},
-		// Keep attachment intent, but remove evidence of the old provider
-		// attachment.
-		{query: `
-UPDATE storage_volume_attachment
-SET provider_id = NULL,
-    block_device_uuid = NULL
-WHERE uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.volumeAttachments)},
-		// Keep mount intent, but remove the old provider attachment identifier.
-		{query: `
-UPDATE storage_filesystem_attachment
-SET provider_id = NULL
-WHERE uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.filesystemAttachments)},
-		// Attachment references are now clear, so old block-device links can
-		// be removed.
-		{query: `
-DELETE FROM block_device_link_device
-WHERE block_device_uuid IN ($reprovisionUUIDs[:])
-AND NOT EXISTS (
-    SELECT 1 FROM storage_volume_attachment AS sva
-    WHERE sva.block_device_uuid = block_device_link_device.block_device_uuid
-)`, ids: ids(targets.blockDevices)},
-		// Remove old block-device evidence only when no attachment still
-		// references it.
-		{query: `
-DELETE FROM block_device
-WHERE uuid IN ($reprovisionUUIDs[:])
-AND NOT EXISTS (
-    SELECT 1 FROM storage_volume_attachment AS sva
-    WHERE sva.block_device_uuid = block_device.uuid
-)`, ids: ids(targets.blockDevices)},
-		// Clear the old provider realization while retaining the Juju volume
-		// identity.
-		{query: `
-UPDATE storage_volume
-SET provider_id = NULL,
-    size_mib = NULL,
-    hardware_id = NULL,
-    wwn = NULL,
-    persistent = NULL,
-    obliterate_on_cleanup = NULL
-WHERE uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.volumes)},
-		// Ensure the retained volume is visible to provisioning as pending work.
-		{query: `
-INSERT INTO storage_volume_status (volume_uuid, status_id, message, updated_at)
-SELECT sv.uuid, 0, 'waiting for replacement machine', NULL
-FROM storage_volume AS sv
-WHERE sv.uuid IN ($reprovisionUUIDs[:])
-ON CONFLICT (volume_uuid) DO UPDATE SET
-    status_id = excluded.status_id,
-    message = excluded.message,
-    updated_at = excluded.updated_at`, ids: ids(targets.volumes)},
-		// Clear the old provider realization while retaining the filesystem
-		// identity.
-		{query: `
-UPDATE storage_filesystem
-SET provider_id = NULL,
-    size_mib = NULL,
-    obliterate_on_cleanup = NULL
-WHERE uuid IN ($reprovisionUUIDs[:])`, ids: ids(targets.filesystems)},
-		// Ensure the retained filesystem is visible to provisioning as pending
-		// work.
-		{query: `
-INSERT INTO storage_filesystem_status (filesystem_uuid, status_id, message, updated_at)
-SELECT sf.uuid, 0, 'waiting for replacement machine', NULL
-FROM storage_filesystem AS sf
-WHERE sf.uuid IN ($reprovisionUUIDs[:])
-ON CONFLICT (filesystem_uuid) DO UPDATE SET
-    status_id = excluded.status_id,
-    message = excluded.message,
-    updated_at = excluded.updated_at`, ids: ids(targets.filesystems)},
+		{stmt: statements.planAttrs, ids: plans},
+		{stmt: statements.plans, ids: plans},
+		{stmt: statements.volumeAttachments, ids: volumeAttachments},
+		{stmt: statements.filesystemAttachments, ids: filesystemAttachments},
+		{stmt: statements.blockDeviceLinks, ids: blockDevices},
+		{stmt: statements.blockDevices, ids: blockDevices},
+		{stmt: statements.volumes, ids: volumes},
+		{stmt: statements.volumeStatuses, ids: volumes},
+		{stmt: statements.filesystems, ids: filesystems},
+		{stmt: statements.filesystemStatuses, ids: filesystems},
 	}
 	for _, step := range steps {
-		if err := run(step.query, step.ids); err != nil {
+		if len(step.ids) == 0 {
+			continue
+		}
+		if err := tx.Query(ctx, step.stmt, step.ids).Run(); err != nil {
 			return errors.Capture(err)
 		}
 	}

--- a/domain/machine/state/reprovision.go
+++ b/domain/machine/state/reprovision.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/canonical/sqlair"

--- a/domain/machine/state/reprovision.go
+++ b/domain/machine/state/reprovision.go
@@ -390,7 +390,25 @@ func (st *State) prepareReprovisionStorageTargetStatements() (
 	*sqlair.Statement, *sqlair.Statement, error,
 ) {
 	volumeStmt, err := st.Prepare(`
-WITH volume_targets AS (
+WITH volume_target_uuids AS (
+    SELECT mv.volume_uuid
+    FROM machine AS m
+    JOIN machine_volume AS mv ON m.uuid = mv.machine_uuid
+    WHERE m.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+
+    UNION
+
+    SELECT sva.storage_volume_uuid
+    FROM storage_volume_attachment AS sva
+    WHERE sva.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+
+    UNION
+
+    SELECT svap.storage_volume_uuid
+    FROM storage_volume_attachment_plan AS svap
+    WHERE svap.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+),
+volume_targets AS (
     SELECT DISTINCT sv.uuid AS volume_uuid,
            sv.life_id AS volume_life_id,
            sv.provision_scope_id AS volume_scope_id,
@@ -402,7 +420,8 @@ WITH volume_targets AS (
            svap.uuid AS plan_uuid,
            svap.provision_scope_id AS plan_scope_id,
            sva.block_device_uuid AS block_device_uuid
-    FROM storage_volume AS sv
+    FROM volume_target_uuids AS vtu
+    JOIN storage_volume AS sv ON vtu.volume_uuid = sv.uuid
     LEFT JOIN storage_instance_volume AS siv
         ON sv.uuid = siv.storage_volume_uuid
     LEFT JOIN storage_instance AS si
@@ -413,7 +432,6 @@ WITH volume_targets AS (
     LEFT JOIN storage_volume_attachment_plan AS svap
         ON sv.uuid = svap.storage_volume_uuid
         AND svap.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
-    WHERE sva.uuid IS NOT NULL OR svap.uuid IS NOT NULL
 ),
 classified_volume_targets AS (
     SELECT vt.volume_uuid,
@@ -538,6 +556,9 @@ FROM classified_filesystem_targets AS cft`, reprovisionStorageTargetParams{}, re
 // sets. Model-scoped, inconsistent, incomplete, or non-alive storage fails
 // closed. Maps are used because joins may return the same physical entity more
 // than once, while each reset statement must target every UUID only once.
+// machine_volume and machine_filesystem are retained as logical associations;
+// they participate in target discovery so incomplete physical state cannot be
+// skipped.
 func (st *State) getReprovisionStorageTargets(
 	ctx context.Context, tx *sqlair.TX,
 	volumeStmt, filesystemStmt *sqlair.Statement,

--- a/domain/machine/state/reprovision.go
+++ b/domain/machine/state/reprovision.go
@@ -77,7 +77,7 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 	if err != nil {
 		return errors.Errorf("preparing status statements: %w", err)
 	}
-	volumeTargetStmt, filesystemTargetStmt, err := st.prepareReprovisionStorageTargetStatements()
+	storageTargetStmts, err := st.prepareReprovisionStorageTargetStatements()
 	if err != nil {
 		return errors.Errorf("preparing storage target statements: %w", err)
 	}
@@ -99,7 +99,7 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 		}
 
 		storageTargets, err := st.getReprovisionStorageTargets(
-			ctx, tx, volumeTargetStmt, filesystemTargetStmt,
+			ctx, tx, storageTargetStmts,
 			reprovisionStorageTargetParams{
 				NetNodeUUID:    target.NetNodeUUID,
 				AliveLifeID:    int(life.Alive),
@@ -386,11 +386,20 @@ type reprovisionStorageTargets struct {
 	filesystemAttachments, blockDevices map[string]struct{}
 }
 
+type reprovisionStorageTargetStatements struct {
+	volumes, volumeLogicalAttachments         *sqlair.Statement
+	volumeAttachments, volumePlans            *sqlair.Statement
+	filesystems, filesystemLogicalAttachments *sqlair.Statement
+	filesystemAttachments                     *sqlair.Statement
+}
+
 func (st *State) prepareReprovisionStorageTargetStatements() (
-	*sqlair.Statement, *sqlair.Statement, error,
+	reprovisionStorageTargetStatements, error,
 ) {
-	volumeStmt, err := st.Prepare(`
-WITH volume_target_uuids AS (
+	var statements reprovisionStorageTargetStatements
+	var err error
+	statements.volumes, err = st.Prepare(`
+WITH target_volume_uuids AS (
     SELECT mv.volume_uuid
     FROM machine AS m
     JOIN machine_volume AS mv ON m.uuid = mv.machine_uuid
@@ -407,78 +416,66 @@ WITH volume_target_uuids AS (
     SELECT svap.storage_volume_uuid
     FROM storage_volume_attachment_plan AS svap
     WHERE svap.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
-),
-volume_targets AS (
-    SELECT DISTINCT sv.uuid AS volume_uuid,
-           sv.life_id AS volume_life_id,
-           sv.provision_scope_id AS volume_scope_id,
-           siv.storage_instance_uuid AS storage_instance_uuid,
-           si.life_id AS storage_instance_life_id,
-           sva.uuid AS attachment_uuid,
-           sva.life_id AS attachment_life_id,
-           sva.provision_scope_id AS attachment_scope_id,
-           svap.uuid AS plan_uuid,
-           svap.provision_scope_id AS plan_scope_id,
-           sva.block_device_uuid AS block_device_uuid
-    FROM volume_target_uuids AS vtu
-    JOIN storage_volume AS sv ON vtu.volume_uuid = sv.uuid
-    LEFT JOIN storage_instance_volume AS siv
-        ON sv.uuid = siv.storage_volume_uuid
-    LEFT JOIN storage_instance AS si
-        ON siv.storage_instance_uuid = si.uuid
-    LEFT JOIN storage_volume_attachment AS sva
-        ON sv.uuid = sva.storage_volume_uuid
-        AND sva.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
-    LEFT JOIN storage_volume_attachment_plan AS svap
-        ON sv.uuid = svap.storage_volume_uuid
-        AND svap.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
-),
-classified_volume_targets AS (
-    SELECT vt.volume_uuid,
-           vt.volume_scope_id,
-           vt.storage_instance_uuid,
-           vt.storage_instance_life_id,
-           vt.attachment_uuid,
-           vt.plan_uuid,
-           vt.block_device_uuid,
-           CASE
-               WHEN vt.storage_instance_uuid IS NULL OR vt.attachment_uuid IS NULL
-                   THEN TRUE
-               ELSE vt.volume_life_id = $reprovisionStorageTargetParams.alive_life_id
-                   AND vt.attachment_life_id = $reprovisionStorageTargetParams.alive_life_id
-                   AND vt.storage_instance_life_id = $reprovisionStorageTargetParams.alive_life_id
-           END AS all_alive,
-           CASE
-               WHEN vt.storage_instance_uuid IS NULL OR vt.attachment_uuid IS NULL
-                   THEN 'ambiguous'
-               WHEN vt.volume_scope_id NOT IN (
-                   $reprovisionStorageTargetParams.model_scope_id,
-                   $reprovisionStorageTargetParams.machine_scope_id
-               ) THEN 'ambiguous'
-               WHEN vt.attachment_uuid IS NOT NULL
-                   AND vt.attachment_scope_id != vt.volume_scope_id
-                   THEN 'ambiguous'
-               WHEN vt.plan_uuid IS NOT NULL
-                   AND vt.plan_scope_id != vt.volume_scope_id
-                   THEN 'ambiguous'
-               WHEN vt.volume_scope_id = $reprovisionStorageTargetParams.model_scope_id
-                   THEN 'model'
-               ELSE 'machine'
-           END AS scope_class
-    FROM volume_targets AS vt
+
+    UNION
+
+    SELECT siv.storage_volume_uuid
+    FROM storage_attachment AS sa
+    JOIN unit AS u ON sa.unit_uuid = u.uuid
+    JOIN storage_instance_volume AS siv
+        ON sa.storage_instance_uuid = siv.storage_instance_uuid
+    WHERE u.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 )
-SELECT cvt.volume_uuid AS &reprovisionVolumeTarget.volume_uuid,
-       cvt.all_alive AS &reprovisionVolumeTarget.all_alive,
-       cvt.scope_class AS &reprovisionVolumeTarget.scope_class,
-       cvt.attachment_uuid AS &reprovisionVolumeTarget.attachment_uuid,
-       cvt.plan_uuid AS &reprovisionVolumeTarget.plan_uuid,
-       cvt.block_device_uuid AS &reprovisionVolumeTarget.block_device_uuid
-FROM classified_volume_targets AS cvt`, reprovisionStorageTargetParams{}, reprovisionVolumeTarget{})
+SELECT sv.uuid AS &reprovisionStorageEntityTarget.entity_uuid,
+       sv.life_id AS &reprovisionStorageEntityTarget.life_id,
+       sv.provision_scope_id AS &reprovisionStorageEntityTarget.scope_id,
+       siv.storage_instance_uuid AS &reprovisionStorageEntityTarget.storage_instance_uuid,
+       si.life_id AS &reprovisionStorageEntityTarget.storage_instance_life_id
+FROM target_volume_uuids AS tvu
+JOIN storage_volume AS sv ON tvu.volume_uuid = sv.uuid
+LEFT JOIN storage_instance_volume AS siv ON sv.uuid = siv.storage_volume_uuid
+LEFT JOIN storage_instance AS si ON siv.storage_instance_uuid = si.uuid
+`, reprovisionStorageTargetParams{}, reprovisionStorageEntityTarget{})
 	if err != nil {
-		return nil, nil, errors.Capture(err)
+		return reprovisionStorageTargetStatements{}, errors.Capture(err)
 	}
-	filesystemStmt, err := st.Prepare(`
-WITH filesystem_target_uuids AS (
+	statements.volumeLogicalAttachments, err = st.Prepare(`
+SELECT siv.storage_volume_uuid AS &reprovisionStorageLogicalAttachment.entity_uuid,
+       sa.life_id AS &reprovisionStorageLogicalAttachment.life_id
+FROM storage_attachment AS sa
+JOIN unit AS u ON sa.unit_uuid = u.uuid
+JOIN storage_instance_volume AS siv
+    ON sa.storage_instance_uuid = siv.storage_instance_uuid
+WHERE u.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+`, reprovisionStorageTargetParams{}, reprovisionStorageLogicalAttachment{})
+	if err != nil {
+		return reprovisionStorageTargetStatements{}, errors.Capture(err)
+	}
+	statements.volumeAttachments, err = st.Prepare(`
+SELECT sva.uuid AS &reprovisionStoragePhysicalAttachment.uuid,
+       sva.storage_volume_uuid AS &reprovisionStoragePhysicalAttachment.entity_uuid,
+       sva.life_id AS &reprovisionStoragePhysicalAttachment.life_id,
+       sva.provision_scope_id AS &reprovisionStoragePhysicalAttachment.scope_id,
+       sva.block_device_uuid AS &reprovisionStoragePhysicalAttachment.block_device_uuid
+FROM storage_volume_attachment AS sva
+WHERE sva.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+`, reprovisionStorageTargetParams{}, reprovisionStoragePhysicalAttachment{})
+	if err != nil {
+		return reprovisionStorageTargetStatements{}, errors.Capture(err)
+	}
+	statements.volumePlans, err = st.Prepare(`
+SELECT svap.uuid AS &reprovisionStoragePlanTarget.uuid,
+       svap.storage_volume_uuid AS &reprovisionStoragePlanTarget.entity_uuid,
+       svap.life_id AS &reprovisionStoragePlanTarget.life_id,
+       svap.provision_scope_id AS &reprovisionStoragePlanTarget.scope_id
+FROM storage_volume_attachment_plan AS svap
+WHERE svap.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+`, reprovisionStorageTargetParams{}, reprovisionStoragePlanTarget{})
+	if err != nil {
+		return reprovisionStorageTargetStatements{}, errors.Capture(err)
+	}
+	statements.filesystems, err = st.Prepare(`
+WITH target_filesystem_uuids AS (
     SELECT mf.filesystem_uuid
     FROM machine AS m
     JOIN machine_filesystem AS mf ON m.uuid = mf.machine_uuid
@@ -489,63 +486,55 @@ WITH filesystem_target_uuids AS (
     SELECT sfa.storage_filesystem_uuid
     FROM storage_filesystem_attachment AS sfa
     WHERE sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
-),
-filesystem_targets AS (
-    SELECT sf.uuid AS filesystem_uuid,
-           sf.life_id AS filesystem_life_id,
-           sf.provision_scope_id AS filesystem_scope_id,
-           sif.storage_instance_uuid AS storage_instance_uuid,
-           si.life_id AS storage_instance_life_id,
-           sfa.uuid AS attachment_uuid,
-           sfa.life_id AS attachment_life_id,
-           sfa.provision_scope_id AS attachment_scope_id
-    FROM filesystem_target_uuids AS ftu
-    JOIN storage_filesystem AS sf ON ftu.filesystem_uuid = sf.uuid
-    LEFT JOIN storage_instance_filesystem AS sif
-        ON sf.uuid = sif.storage_filesystem_uuid
-    LEFT JOIN storage_instance AS si
-        ON sif.storage_instance_uuid = si.uuid
-    LEFT JOIN storage_filesystem_attachment AS sfa
-        ON sf.uuid = sfa.storage_filesystem_uuid
-        AND sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
-),
-classified_filesystem_targets AS (
-    SELECT ft.filesystem_uuid,
-           ft.filesystem_scope_id,
-           ft.storage_instance_uuid,
-           ft.storage_instance_life_id,
-           ft.attachment_uuid,
-           CASE
-               WHEN ft.storage_instance_uuid IS NULL OR ft.attachment_uuid IS NULL
-                   THEN TRUE
-               ELSE ft.filesystem_life_id = $reprovisionStorageTargetParams.alive_life_id
-                   AND ft.attachment_life_id = $reprovisionStorageTargetParams.alive_life_id
-                   AND ft.storage_instance_life_id = $reprovisionStorageTargetParams.alive_life_id
-           END AS all_alive,
-           CASE
-               WHEN ft.storage_instance_uuid IS NULL OR ft.attachment_uuid IS NULL
-                   THEN 'ambiguous'
-               WHEN ft.filesystem_scope_id NOT IN (
-                   $reprovisionStorageTargetParams.model_scope_id,
-                   $reprovisionStorageTargetParams.machine_scope_id
-               ) THEN 'ambiguous'
-               WHEN ft.attachment_scope_id != ft.filesystem_scope_id
-                   THEN 'ambiguous'
-               WHEN ft.filesystem_scope_id = $reprovisionStorageTargetParams.model_scope_id
-                   THEN 'model'
-               ELSE 'machine'
-           END AS scope_class
-    FROM filesystem_targets AS ft
+
+    UNION
+
+    SELECT sif.storage_filesystem_uuid
+    FROM storage_attachment AS sa
+    JOIN unit AS u ON sa.unit_uuid = u.uuid
+    JOIN storage_instance_filesystem AS sif
+        ON sa.storage_instance_uuid = sif.storage_instance_uuid
+    WHERE u.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 )
-SELECT cft.filesystem_uuid AS &reprovisionFilesystemTarget.filesystem_uuid,
-       cft.all_alive AS &reprovisionFilesystemTarget.all_alive,
-       cft.scope_class AS &reprovisionFilesystemTarget.scope_class,
-       cft.attachment_uuid AS &reprovisionFilesystemTarget.attachment_uuid
-FROM classified_filesystem_targets AS cft`, reprovisionStorageTargetParams{}, reprovisionFilesystemTarget{})
+SELECT sf.uuid AS &reprovisionStorageEntityTarget.entity_uuid,
+       sf.life_id AS &reprovisionStorageEntityTarget.life_id,
+       sf.provision_scope_id AS &reprovisionStorageEntityTarget.scope_id,
+       sif.storage_instance_uuid AS &reprovisionStorageEntityTarget.storage_instance_uuid,
+       si.life_id AS &reprovisionStorageEntityTarget.storage_instance_life_id
+FROM target_filesystem_uuids AS tfu
+JOIN storage_filesystem AS sf ON tfu.filesystem_uuid = sf.uuid
+LEFT JOIN storage_instance_filesystem AS sif
+    ON sf.uuid = sif.storage_filesystem_uuid
+LEFT JOIN storage_instance AS si ON sif.storage_instance_uuid = si.uuid
+`, reprovisionStorageTargetParams{}, reprovisionStorageEntityTarget{})
 	if err != nil {
-		return nil, nil, errors.Capture(err)
+		return reprovisionStorageTargetStatements{}, errors.Capture(err)
 	}
-	return volumeStmt, filesystemStmt, nil
+	statements.filesystemLogicalAttachments, err = st.Prepare(`
+SELECT sif.storage_filesystem_uuid AS &reprovisionStorageLogicalAttachment.entity_uuid,
+       sa.life_id AS &reprovisionStorageLogicalAttachment.life_id
+FROM storage_attachment AS sa
+JOIN unit AS u ON sa.unit_uuid = u.uuid
+JOIN storage_instance_filesystem AS sif
+    ON sa.storage_instance_uuid = sif.storage_instance_uuid
+WHERE u.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+`, reprovisionStorageTargetParams{}, reprovisionStorageLogicalAttachment{})
+	if err != nil {
+		return reprovisionStorageTargetStatements{}, errors.Capture(err)
+	}
+	statements.filesystemAttachments, err = st.Prepare(`
+SELECT sfa.uuid AS &reprovisionStoragePhysicalAttachment.uuid,
+       sfa.storage_filesystem_uuid AS &reprovisionStoragePhysicalAttachment.entity_uuid,
+       sfa.life_id AS &reprovisionStoragePhysicalAttachment.life_id,
+       sfa.provision_scope_id AS &reprovisionStoragePhysicalAttachment.scope_id,
+       NULL AS &reprovisionStoragePhysicalAttachment.block_device_uuid
+FROM storage_filesystem_attachment AS sfa
+WHERE sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+`, reprovisionStorageTargetParams{}, reprovisionStoragePhysicalAttachment{})
+	if err != nil {
+		return reprovisionStorageTargetStatements{}, errors.Capture(err)
+	}
+	return statements, nil
 }
 
 // getReprovisionStorageTargets captures the machine-scoped storage that must
@@ -556,21 +545,64 @@ FROM classified_filesystem_targets AS cft`, reprovisionStorageTargetParams{}, re
 // sets. Model-scoped, inconsistent, incomplete, or non-alive storage fails
 // closed. Maps are used because joins may return the same physical entity more
 // than once, while each reset statement must target every UUID only once.
-// machine_volume and machine_filesystem are retained as logical associations;
-// they participate in target discovery so incomplete physical state cannot be
-// skipped.
+// storage_attachment, machine_volume, and machine_filesystem are retained as
+// logical associations; they participate in target discovery so incomplete
+// physical state cannot be skipped.
 func (st *State) getReprovisionStorageTargets(
 	ctx context.Context, tx *sqlair.TX,
-	volumeStmt, filesystemStmt *sqlair.Statement,
+	statements reprovisionStorageTargetStatements,
 	params reprovisionStorageTargetParams,
 ) (reprovisionStorageTargets, error) {
-	var volumeRows []reprovisionVolumeTarget
-	if err := tx.Query(ctx, volumeStmt, params).GetAll(&volumeRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+	var volumeRows []reprovisionStorageEntityTarget
+	if err := tx.Query(ctx, statements.volumes, params).GetAll(&volumeRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 		return reprovisionStorageTargets{}, errors.Errorf("querying attached volumes: %w", err)
 	}
-	var filesystemRows []reprovisionFilesystemTarget
-	if err := tx.Query(ctx, filesystemStmt, params).GetAll(&filesystemRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+	var volumeLogicalRows []reprovisionStorageLogicalAttachment
+	if err := tx.Query(ctx, statements.volumeLogicalAttachments, params).GetAll(&volumeLogicalRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return reprovisionStorageTargets{}, errors.Errorf("querying logical volume attachments: %w", err)
+	}
+	var volumeAttachmentRows []reprovisionStoragePhysicalAttachment
+	if err := tx.Query(ctx, statements.volumeAttachments, params).GetAll(&volumeAttachmentRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return reprovisionStorageTargets{}, errors.Errorf("querying volume attachments: %w", err)
+	}
+	var volumePlanRows []reprovisionStoragePlanTarget
+	if err := tx.Query(ctx, statements.volumePlans, params).GetAll(&volumePlanRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return reprovisionStorageTargets{}, errors.Errorf("querying volume attachment plans: %w", err)
+	}
+	var filesystemRows []reprovisionStorageEntityTarget
+	if err := tx.Query(ctx, statements.filesystems, params).GetAll(&filesystemRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 		return reprovisionStorageTargets{}, errors.Errorf("querying attached filesystems: %w", err)
+	}
+	var filesystemLogicalRows []reprovisionStorageLogicalAttachment
+	if err := tx.Query(ctx, statements.filesystemLogicalAttachments, params).GetAll(&filesystemLogicalRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return reprovisionStorageTargets{}, errors.Errorf("querying logical filesystem attachments: %w", err)
+	}
+	var filesystemAttachmentRows []reprovisionStoragePhysicalAttachment
+	if err := tx.Query(ctx, statements.filesystemAttachments, params).GetAll(&filesystemAttachmentRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return reprovisionStorageTargets{}, errors.Errorf("querying filesystem attachments: %w", err)
+	}
+
+	logicalAttachments := func(rows []reprovisionStorageLogicalAttachment) map[string][]int {
+		result := make(map[string][]int)
+		for _, row := range rows {
+			result[row.EntityUUID] = append(result[row.EntityUUID], row.LifeID)
+		}
+		return result
+	}
+	physicalAttachments := func(rows []reprovisionStoragePhysicalAttachment) map[string][]reprovisionStoragePhysicalAttachment {
+		result := make(map[string][]reprovisionStoragePhysicalAttachment)
+		for _, row := range rows {
+			result[row.EntityUUID] = append(result[row.EntityUUID], row)
+		}
+		return result
+	}
+	volumeLogical := logicalAttachments(volumeLogicalRows)
+	filesystemLogical := logicalAttachments(filesystemLogicalRows)
+	volumeAttachments := physicalAttachments(volumeAttachmentRows)
+	filesystemAttachments := physicalAttachments(filesystemAttachmentRows)
+	volumePlans := make(map[string][]reprovisionStoragePlanTarget)
+	for _, row := range volumePlanRows {
+		volumePlans[row.EntityUUID] = append(volumePlans[row.EntityUUID], row)
 	}
 
 	targets := reprovisionStorageTargets{
@@ -582,68 +614,105 @@ func (st *State) getReprovisionStorageTargets(
 		blockDevices:          make(map[string]struct{}),
 	}
 	for _, row := range volumeRows {
-		if !row.AllAlive {
-			return reprovisionStorageTargets{}, errors.Errorf(
-				"volume %q: %w", row.VolumeUUID, machineerrors.MachineStorageNotAlive,
-			)
+		attachments := volumeAttachments[row.EntityUUID]
+		plans := volumePlans[row.EntityUUID]
+		if err := validateReprovisionStorageEntity(
+			"volume", row, volumeLogical[row.EntityUUID], attachments, plans, params,
+		); err != nil {
+			return reprovisionStorageTargets{}, errors.Capture(err)
 		}
-		switch row.ScopeClass {
-		case "model":
-			return reprovisionStorageTargets{}, errors.Errorf(
-				"volume %q: %w", row.VolumeUUID, machineerrors.ModelScopedStorageAttached,
-			)
-		case "machine":
-			// An empty Go case exits the switch; it does not fall through.
-		case "ambiguous":
-			return reprovisionStorageTargets{}, errors.Errorf(
-				"volume %q: %w", row.VolumeUUID, machineerrors.StorageScopeAmbiguous,
-			)
-		default:
-			return reprovisionStorageTargets{}, errors.Errorf(
-				"volume %q has unknown scope classification %q: %w",
-				row.VolumeUUID, row.ScopeClass, machineerrors.StorageScopeAmbiguous,
-			)
+		targets.volumes[row.EntityUUID] = struct{}{}
+		for _, attachment := range attachments {
+			targets.volumeAttachments[attachment.UUID] = struct{}{}
+			if attachment.BlockDeviceUUID.Valid {
+				targets.blockDevices[attachment.BlockDeviceUUID.V] = struct{}{}
+			}
 		}
-		targets.volumes[row.VolumeUUID] = struct{}{}
-		if row.AttachmentUUID.Valid {
-			targets.volumeAttachments[row.AttachmentUUID.V] = struct{}{}
-		}
-		if row.PlanUUID.Valid {
-			targets.plans[row.PlanUUID.V] = struct{}{}
-		}
-		if row.BlockDeviceUUID.Valid {
-			targets.blockDevices[row.BlockDeviceUUID.V] = struct{}{}
+		for _, plan := range plans {
+			targets.plans[plan.UUID] = struct{}{}
 		}
 	}
 	for _, row := range filesystemRows {
-		if !row.AllAlive {
-			return reprovisionStorageTargets{}, errors.Errorf(
-				"filesystem %q: %w", row.FilesystemUUID, machineerrors.MachineStorageNotAlive,
-			)
+		attachments := filesystemAttachments[row.EntityUUID]
+		if err := validateReprovisionStorageEntity(
+			"filesystem", row, filesystemLogical[row.EntityUUID], attachments, nil, params,
+		); err != nil {
+			return reprovisionStorageTargets{}, errors.Capture(err)
 		}
-		switch row.ScopeClass {
-		case "model":
-			return reprovisionStorageTargets{}, errors.Errorf(
-				"filesystem %q: %w", row.FilesystemUUID, machineerrors.ModelScopedStorageAttached,
-			)
-		case "machine":
-			// An empty Go case exits the switch; it does not fall through.
-		case "ambiguous":
-			return reprovisionStorageTargets{}, errors.Errorf(
-				"filesystem %q: %w", row.FilesystemUUID, machineerrors.StorageScopeAmbiguous,
-			)
-		default:
-			return reprovisionStorageTargets{}, errors.Errorf(
-				"filesystem %q has unknown scope classification %q: %w",
-				row.FilesystemUUID, row.ScopeClass, machineerrors.StorageScopeAmbiguous,
-			)
-		}
-		targets.filesystems[row.FilesystemUUID] = struct{}{}
-		if row.AttachmentUUID.Valid {
-			targets.filesystemAttachments[row.AttachmentUUID.V] = struct{}{}
+		targets.filesystems[row.EntityUUID] = struct{}{}
+		for _, attachment := range attachments {
+			targets.filesystemAttachments[attachment.UUID] = struct{}{}
 		}
 	}
 	return targets, nil
+}
+
+func validateReprovisionStorageEntity(
+	entityType string,
+	entity reprovisionStorageEntityTarget,
+	logicalAttachmentLives []int,
+	attachments []reprovisionStoragePhysicalAttachment,
+	plans []reprovisionStoragePlanTarget,
+	params reprovisionStorageTargetParams,
+) error {
+	if !entity.StorageInstanceUUID.Valid || !entity.StorageInstanceLifeID.Valid {
+		return errors.Errorf(
+			"%s %q: %w", entityType, entity.EntityUUID,
+			machineerrors.StorageScopeAmbiguous,
+		)
+	}
+	if len(logicalAttachmentLives) == 0 || len(attachments) == 0 {
+		return errors.Errorf(
+			"%s %q: %w", entityType, entity.EntityUUID,
+			machineerrors.StorageScopeAmbiguous,
+		)
+	}
+
+	lifeIDs := []int{entity.LifeID, entity.StorageInstanceLifeID.V}
+	lifeIDs = append(lifeIDs, logicalAttachmentLives...)
+	for _, attachment := range attachments {
+		lifeIDs = append(lifeIDs, attachment.LifeID)
+	}
+	for _, plan := range plans {
+		lifeIDs = append(lifeIDs, plan.LifeID)
+	}
+	for _, lifeID := range lifeIDs {
+		if lifeID != params.AliveLifeID {
+			return errors.Errorf(
+				"%s %q: %w", entityType, entity.EntityUUID,
+				machineerrors.MachineStorageNotAlive,
+			)
+		}
+	}
+
+	if entity.ScopeID != params.ModelScopeID && entity.ScopeID != params.MachineScopeID {
+		return errors.Errorf(
+			"%s %q: %w", entityType, entity.EntityUUID,
+			machineerrors.StorageScopeAmbiguous,
+		)
+	}
+	attachmentScopeIDs := make([]int, 0, len(attachments)+len(plans))
+	for _, attachment := range attachments {
+		attachmentScopeIDs = append(attachmentScopeIDs, attachment.ScopeID)
+	}
+	for _, plan := range plans {
+		attachmentScopeIDs = append(attachmentScopeIDs, plan.ScopeID)
+	}
+	for _, scopeID := range attachmentScopeIDs {
+		if scopeID != entity.ScopeID {
+			return errors.Errorf(
+				"%s %q: %w", entityType, entity.EntityUUID,
+				machineerrors.StorageScopeAmbiguous,
+			)
+		}
+	}
+	if entity.ScopeID == params.ModelScopeID {
+		return errors.Errorf(
+			"%s %q: %w", entityType, entity.EntityUUID,
+			machineerrors.ModelScopedStorageAttached,
+		)
+	}
+	return nil
 }
 
 type reprovisionStorageResetStatements struct {
@@ -676,12 +745,16 @@ WHERE uuid IN ($reprovisionUUIDs[:])`},
 		{stmt: &statements.volumeAttachments, query: `
 UPDATE storage_volume_attachment
 SET provider_id = NULL,
-    block_device_uuid = NULL
+    block_device_uuid = NULL,
+    read_only = NULL
 WHERE uuid IN ($reprovisionUUIDs[:])`},
-		// Keep mount intent, but remove the old provider attachment identifier.
+		// Keep attachment identity, but remove completion data reported for the
+		// old mount.
 		{stmt: &statements.filesystemAttachments, query: `
 UPDATE storage_filesystem_attachment
-SET provider_id = NULL
+SET provider_id = NULL,
+    mount_point = NULL,
+    read_only = NULL
 WHERE uuid IN ($reprovisionUUIDs[:])`},
 		// Attachment references are now clear, so old block-device links can
 		// be removed.

--- a/domain/machine/state/reprovision.go
+++ b/domain/machine/state/reprovision.go
@@ -77,6 +77,10 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 	if err != nil {
 		return errors.Errorf("preparing status statements: %w", err)
 	}
+	storageLifeStmt, err := st.prepareReprovisionStorageLifeStatement()
+	if err != nil {
+		return errors.Errorf("preparing storage lifecycle statement: %w", err)
+	}
 	storageTargetStmts, err := st.prepareReprovisionStorageTargetStatements()
 	if err != nil {
 		return errors.Errorf("preparing storage target statements: %w", err)
@@ -98,14 +102,19 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 			return errors.Capture(err)
 		}
 
+		storageParams := reprovisionStorageTargetParams{
+			NetNodeUUID:    target.NetNodeUUID,
+			AliveLifeID:    int(life.Alive),
+			ModelScopeID:   int(domainstorage.ProvisionScopeModel),
+			MachineScopeID: int(domainstorage.ProvisionScopeMachine),
+		}
+		if err := validateReprovisionStorageLives(
+			ctx, tx, storageLifeStmt, storageParams,
+		); err != nil {
+			return errors.Capture(err)
+		}
 		storageTargets, err := st.getReprovisionStorageTargets(
-			ctx, tx, storageTargetStmts,
-			reprovisionStorageTargetParams{
-				NetNodeUUID:    target.NetNodeUUID,
-				AliveLifeID:    int(life.Alive),
-				ModelScopeID:   int(domainstorage.ProvisionScopeModel),
-				MachineScopeID: int(domainstorage.ProvisionScopeMachine),
-			},
+			ctx, tx, storageTargetStmts, storageParams,
 		)
 		if err != nil {
 			return errors.Capture(err)
@@ -393,6 +402,130 @@ type reprovisionStorageTargetStatements struct {
 	filesystemAttachments                     *sqlair.Statement
 }
 
+func (st *State) prepareReprovisionStorageLifeStatement() (*sqlair.Statement, error) {
+	stmt, err := st.Prepare(`
+WITH target_volume_uuids AS (
+    SELECT mv.volume_uuid
+    FROM machine AS m
+    JOIN machine_volume AS mv ON m.uuid = mv.machine_uuid
+    WHERE m.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+
+    UNION
+
+    SELECT sva.storage_volume_uuid
+    FROM storage_volume_attachment AS sva
+    WHERE sva.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+
+    UNION
+
+    SELECT svap.storage_volume_uuid
+    FROM storage_volume_attachment_plan AS svap
+    WHERE svap.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+
+    UNION
+
+    SELECT siv.storage_volume_uuid
+    FROM storage_attachment AS sa
+    JOIN unit AS u ON sa.unit_uuid = u.uuid
+    JOIN storage_instance_volume AS siv
+        ON sa.storage_instance_uuid = siv.storage_instance_uuid
+    WHERE u.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+),
+target_filesystem_uuids AS (
+    SELECT mf.filesystem_uuid
+    FROM machine AS m
+    JOIN machine_filesystem AS mf ON m.uuid = mf.machine_uuid
+    WHERE m.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+
+    UNION
+
+    SELECT sfa.storage_filesystem_uuid
+    FROM storage_filesystem_attachment AS sfa
+    WHERE sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+
+    UNION
+
+    SELECT sif.storage_filesystem_uuid
+    FROM storage_attachment AS sa
+    JOIN unit AS u ON sa.unit_uuid = u.uuid
+    JOIN storage_instance_filesystem AS sif
+        ON sa.storage_instance_uuid = sif.storage_instance_uuid
+    WHERE u.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+),
+target_storage_instance_uuids AS (
+    SELECT siv.storage_instance_uuid
+    FROM storage_instance_volume AS siv
+    JOIN target_volume_uuids AS tvu ON siv.storage_volume_uuid = tvu.volume_uuid
+
+    UNION
+
+    SELECT sif.storage_instance_uuid
+    FROM storage_instance_filesystem AS sif
+    JOIN target_filesystem_uuids AS tfu
+        ON sif.storage_filesystem_uuid = tfu.filesystem_uuid
+),
+target_storage_lives AS (
+    SELECT 'volume' AS entity_type, sv.uuid AS entity_uuid,
+           sv.life_id AS life_id
+    FROM storage_volume AS sv
+    JOIN target_volume_uuids AS tvu ON sv.uuid = tvu.volume_uuid
+
+    UNION ALL
+
+    SELECT 'filesystem' AS entity_type, sf.uuid AS entity_uuid,
+           sf.life_id AS life_id
+    FROM storage_filesystem AS sf
+    JOIN target_filesystem_uuids AS tfu ON sf.uuid = tfu.filesystem_uuid
+
+    UNION ALL
+
+    SELECT 'storage instance' AS entity_type, si.uuid AS entity_uuid,
+           si.life_id AS life_id
+    FROM storage_instance AS si
+    JOIN target_storage_instance_uuids AS tsiu ON si.uuid = tsiu.storage_instance_uuid
+
+    UNION ALL
+
+    SELECT 'storage attachment' AS entity_type, sa.uuid AS entity_uuid,
+           sa.life_id AS life_id
+    FROM storage_attachment AS sa
+    JOIN target_storage_instance_uuids AS tsiu
+        ON sa.storage_instance_uuid = tsiu.storage_instance_uuid
+
+    UNION ALL
+
+    SELECT 'volume attachment' AS entity_type, sva.uuid AS entity_uuid,
+           sva.life_id AS life_id
+    FROM storage_volume_attachment AS sva
+    JOIN target_volume_uuids AS tvu ON sva.storage_volume_uuid = tvu.volume_uuid
+
+    UNION ALL
+
+    SELECT 'filesystem attachment' AS entity_type, sfa.uuid AS entity_uuid,
+           sfa.life_id AS life_id
+    FROM storage_filesystem_attachment AS sfa
+    JOIN target_filesystem_uuids AS tfu
+        ON sfa.storage_filesystem_uuid = tfu.filesystem_uuid
+
+    UNION ALL
+
+    SELECT 'volume attachment plan' AS entity_type, svap.uuid AS entity_uuid,
+           svap.life_id AS life_id
+    FROM storage_volume_attachment_plan AS svap
+    JOIN target_volume_uuids AS tvu ON svap.storage_volume_uuid = tvu.volume_uuid
+)
+SELECT tsl.entity_type AS &reprovisionStorageLife.entity_type,
+       tsl.entity_uuid AS &reprovisionStorageLife.entity_uuid
+FROM target_storage_lives AS tsl
+WHERE tsl.life_id != $reprovisionStorageTargetParams.alive_life_id
+LIMIT 1
+`, reprovisionStorageTargetParams{}, reprovisionStorageLife{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return stmt, nil
+}
+
 func (st *State) prepareReprovisionStorageTargetStatements() (
 	reprovisionStorageTargetStatements, error,
 ) {
@@ -427,21 +560,17 @@ WITH target_volume_uuids AS (
     WHERE u.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 )
 SELECT sv.uuid AS &reprovisionStorageEntityTarget.entity_uuid,
-       sv.life_id AS &reprovisionStorageEntityTarget.life_id,
        sv.provision_scope_id AS &reprovisionStorageEntityTarget.scope_id,
-       siv.storage_instance_uuid AS &reprovisionStorageEntityTarget.storage_instance_uuid,
-       si.life_id AS &reprovisionStorageEntityTarget.storage_instance_life_id
+       siv.storage_instance_uuid AS &reprovisionStorageEntityTarget.storage_instance_uuid
 FROM target_volume_uuids AS tvu
 JOIN storage_volume AS sv ON tvu.volume_uuid = sv.uuid
 LEFT JOIN storage_instance_volume AS siv ON sv.uuid = siv.storage_volume_uuid
-LEFT JOIN storage_instance AS si ON siv.storage_instance_uuid = si.uuid
 `, reprovisionStorageTargetParams{}, reprovisionStorageEntityTarget{})
 	if err != nil {
 		return reprovisionStorageTargetStatements{}, errors.Capture(err)
 	}
 	statements.volumeLogicalAttachments, err = st.Prepare(`
-SELECT siv.storage_volume_uuid AS &reprovisionStorageLogicalAttachment.entity_uuid,
-       sa.life_id AS &reprovisionStorageLogicalAttachment.life_id
+SELECT siv.storage_volume_uuid AS &reprovisionStorageLogicalAttachment.entity_uuid
 FROM storage_attachment AS sa
 JOIN unit AS u ON sa.unit_uuid = u.uuid
 JOIN storage_instance_volume AS siv
@@ -454,7 +583,6 @@ WHERE u.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 	statements.volumeAttachments, err = st.Prepare(`
 SELECT sva.uuid AS &reprovisionStoragePhysicalAttachment.uuid,
        sva.storage_volume_uuid AS &reprovisionStoragePhysicalAttachment.entity_uuid,
-       sva.life_id AS &reprovisionStoragePhysicalAttachment.life_id,
        sva.provision_scope_id AS &reprovisionStoragePhysicalAttachment.scope_id,
        sva.block_device_uuid AS &reprovisionStoragePhysicalAttachment.block_device_uuid
 FROM storage_volume_attachment AS sva
@@ -466,7 +594,6 @@ WHERE sva.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 	statements.volumePlans, err = st.Prepare(`
 SELECT svap.uuid AS &reprovisionStoragePlanTarget.uuid,
        svap.storage_volume_uuid AS &reprovisionStoragePlanTarget.entity_uuid,
-       svap.life_id AS &reprovisionStoragePlanTarget.life_id,
        svap.provision_scope_id AS &reprovisionStoragePlanTarget.scope_id
 FROM storage_volume_attachment_plan AS svap
 WHERE svap.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
@@ -497,22 +624,18 @@ WITH target_filesystem_uuids AS (
     WHERE u.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 )
 SELECT sf.uuid AS &reprovisionStorageEntityTarget.entity_uuid,
-       sf.life_id AS &reprovisionStorageEntityTarget.life_id,
        sf.provision_scope_id AS &reprovisionStorageEntityTarget.scope_id,
-       sif.storage_instance_uuid AS &reprovisionStorageEntityTarget.storage_instance_uuid,
-       si.life_id AS &reprovisionStorageEntityTarget.storage_instance_life_id
+       sif.storage_instance_uuid AS &reprovisionStorageEntityTarget.storage_instance_uuid
 FROM target_filesystem_uuids AS tfu
 JOIN storage_filesystem AS sf ON tfu.filesystem_uuid = sf.uuid
 LEFT JOIN storage_instance_filesystem AS sif
     ON sf.uuid = sif.storage_filesystem_uuid
-LEFT JOIN storage_instance AS si ON sif.storage_instance_uuid = si.uuid
 `, reprovisionStorageTargetParams{}, reprovisionStorageEntityTarget{})
 	if err != nil {
 		return reprovisionStorageTargetStatements{}, errors.Capture(err)
 	}
 	statements.filesystemLogicalAttachments, err = st.Prepare(`
-SELECT sif.storage_filesystem_uuid AS &reprovisionStorageLogicalAttachment.entity_uuid,
-       sa.life_id AS &reprovisionStorageLogicalAttachment.life_id
+SELECT sif.storage_filesystem_uuid AS &reprovisionStorageLogicalAttachment.entity_uuid
 FROM storage_attachment AS sa
 JOIN unit AS u ON sa.unit_uuid = u.uuid
 JOIN storage_instance_filesystem AS sif
@@ -525,7 +648,6 @@ WHERE u.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 	statements.filesystemAttachments, err = st.Prepare(`
 SELECT sfa.uuid AS &reprovisionStoragePhysicalAttachment.uuid,
        sfa.storage_filesystem_uuid AS &reprovisionStoragePhysicalAttachment.entity_uuid,
-       sfa.life_id AS &reprovisionStoragePhysicalAttachment.life_id,
        sfa.provision_scope_id AS &reprovisionStoragePhysicalAttachment.scope_id,
        NULL AS &reprovisionStoragePhysicalAttachment.block_device_uuid
 FROM storage_filesystem_attachment AS sfa
@@ -537,14 +659,31 @@ WHERE sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 	return statements, nil
 }
 
+// validateReprovisionStorageLives rejects non-alive storage before reset
+// targets are collected or any reprovisioning mutations are run.
+func validateReprovisionStorageLives(
+	ctx context.Context,
+	tx *sqlair.TX,
+	stmt *sqlair.Statement,
+	params reprovisionStorageTargetParams,
+) error {
+	var invalidLife reprovisionStorageLife
+	if err := tx.Query(ctx, stmt, params).Get(&invalidLife); err == nil {
+		return errors.Errorf(
+			"%s %q: %w", invalidLife.EntityType, invalidLife.EntityUUID,
+			machineerrors.MachineStorageNotAlive,
+		)
+	} else if !errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Errorf("validating storage lifecycle: %w", err)
+	}
+	return nil
+}
+
 // getReprovisionStorageTargets captures the machine-scoped storage that must
-// be reset before any references are changed. This runs inside the detach
-// transaction so storage cannot change between validation and mutation.
+// be reset before any references are changed. Model-scoped, inconsistent, or
+// incomplete storage fails closed. Maps ensure each reset statement targets a
+// UUID only once.
 //
-// Scope and lifecycle are checked from the same rows used to build the target
-// sets. Model-scoped, inconsistent, incomplete, or non-alive storage fails
-// closed. Maps are used because joins may return the same physical entity more
-// than once, while each reset statement must target every UUID only once.
 // storage_attachment, machine_volume, and machine_filesystem are retained as
 // logical associations; they participate in target discovery so incomplete
 // physical state cannot be skipped.
@@ -581,11 +720,10 @@ func (st *State) getReprovisionStorageTargets(
 	if err := tx.Query(ctx, statements.filesystemAttachments, params).GetAll(&filesystemAttachmentRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 		return reprovisionStorageTargets{}, errors.Errorf("querying filesystem attachments: %w", err)
 	}
-
-	logicalAttachments := func(rows []reprovisionStorageLogicalAttachment) map[string][]int {
-		result := make(map[string][]int)
+	logicalAttachments := func(rows []reprovisionStorageLogicalAttachment) map[string]int {
+		result := make(map[string]int)
 		for _, row := range rows {
-			result[row.EntityUUID] = append(result[row.EntityUUID], row.LifeID)
+			result[row.EntityUUID]++
 		}
 		return result
 	}
@@ -650,39 +788,22 @@ func (st *State) getReprovisionStorageTargets(
 func validateReprovisionStorageEntity(
 	entityType string,
 	entity reprovisionStorageEntityTarget,
-	logicalAttachmentLives []int,
+	logicalAttachmentCount int,
 	attachments []reprovisionStoragePhysicalAttachment,
 	plans []reprovisionStoragePlanTarget,
 	params reprovisionStorageTargetParams,
 ) error {
-	if !entity.StorageInstanceUUID.Valid || !entity.StorageInstanceLifeID.Valid {
+	if !entity.StorageInstanceUUID.Valid {
 		return errors.Errorf(
 			"%s %q: %w", entityType, entity.EntityUUID,
 			machineerrors.StorageScopeAmbiguous,
 		)
 	}
-	if len(logicalAttachmentLives) == 0 || len(attachments) == 0 {
+	if logicalAttachmentCount == 0 || len(attachments) == 0 {
 		return errors.Errorf(
 			"%s %q: %w", entityType, entity.EntityUUID,
 			machineerrors.StorageScopeAmbiguous,
 		)
-	}
-
-	lifeIDs := []int{entity.LifeID, entity.StorageInstanceLifeID.V}
-	lifeIDs = append(lifeIDs, logicalAttachmentLives...)
-	for _, attachment := range attachments {
-		lifeIDs = append(lifeIDs, attachment.LifeID)
-	}
-	for _, plan := range plans {
-		lifeIDs = append(lifeIDs, plan.LifeID)
-	}
-	for _, lifeID := range lifeIDs {
-		if lifeID != params.AliveLifeID {
-			return errors.Errorf(
-				"%s %q: %w", entityType, entity.EntityUUID,
-				machineerrors.MachineStorageNotAlive,
-			)
-		}
 	}
 
 	if entity.ScopeID != params.ModelScopeID && entity.ScopeID != params.MachineScopeID {

--- a/domain/machine/state/reprovision.go
+++ b/domain/machine/state/reprovision.go
@@ -13,12 +13,15 @@ import (
 	"github.com/juju/juju/domain/life"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	domainstatus "github.com/juju/juju/domain/status"
+	domainstorage "github.com/juju/juju/domain/storage"
 	"github.com/juju/juju/internal/errors"
 )
 
 // DetachLostMachineCloudInstance atomically rechecks the critical
 // reprovisioning preconditions, clears stale provider-observed state, and
-// moves the machine and its cloud instance back to pending.
+// moves the machine and its cloud instance back to pending. Machine-scoped
+// physical storage realization is deleted while logical storage intent is
+// preserved. Unsupported storage is rejected in the same transaction.
 func (st *State) DetachLostMachineCloudInstance(
 	ctx context.Context,
 	mName string,
@@ -73,6 +76,10 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 	if err != nil {
 		return errors.Errorf("preparing status statements: %w", err)
 	}
+	volumeTargetStmt, filesystemTargetStmt, err := st.prepareReprovisionStorageTargetStatements()
+	if err != nil {
+		return errors.Errorf("preparing storage target statements: %w", err)
+	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var target reprovisionDetachTarget
@@ -86,6 +93,18 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 			return errors.Capture(err)
 		}
 
+		storageTargets, err := st.getReprovisionStorageTargets(
+			ctx, tx, volumeTargetStmt, filesystemTargetStmt,
+			reprovisionStorageTargetParams{
+				NetNodeUUID:    target.NetNodeUUID,
+				ModelScopeID:   int(domainstorage.ProvisionScopeModel),
+				MachineScopeID: int(domainstorage.ProvisionScopeMachine),
+			},
+		)
+		if err != nil {
+			return errors.Capture(err)
+		}
+
 		if err := runReprovisionStatements(
 			ctx, tx, networkStmts, netNode{UUID: target.NetNodeUUID},
 		); err != nil {
@@ -96,6 +115,13 @@ GROUP BY   m.uuid, m.net_node_uuid, mci.instance_id, m.life_id
 		if err := runReprovisionStatements(ctx, tx, blockDeviceStmts, machineUUID); err != nil {
 			return errors.Errorf("clearing block devices: %w", err)
 		}
+
+		if err := st.removeReprovisionStorage(
+			ctx, tx, storageTargets,
+		); err != nil {
+			return errors.Errorf("clearing machine-scoped storage: %w", err)
+		}
+
 		if err := runReprovisionStatements(ctx, tx, machineDataStmts, machineUUID); err != nil {
 			return errors.Errorf("clearing stale machine instance data: %w", err)
 		}
@@ -342,6 +368,228 @@ func runReprovisionStatements(
 ) error {
 	for _, stmt := range statements {
 		if err := tx.Query(ctx, stmt, arg).Run(); err != nil {
+			return errors.Capture(err)
+		}
+	}
+	return nil
+}
+
+type reprovisionStorageTargets struct {
+	volumes, filesystems                reprovisionUUIDs
+	plans, volumeAttachments            reprovisionUUIDs
+	filesystemAttachments, blockDevices reprovisionUUIDs
+}
+
+func (st *State) prepareReprovisionStorageTargetStatements() (
+	*sqlair.Statement, *sqlair.Statement, error,
+) {
+	volumeStmt, err := st.Prepare(`
+WITH volume_targets AS (
+    SELECT DISTINCT sv.uuid AS volume_uuid,
+           sv.provision_scope_id AS volume_scope_id,
+           sva.uuid AS attachment_uuid,
+           sva.provision_scope_id AS attachment_scope_id,
+           svap.uuid AS plan_uuid,
+           svap.provision_scope_id AS plan_scope_id,
+           sva.block_device_uuid AS block_device_uuid
+    FROM storage_volume AS sv
+    LEFT JOIN storage_volume_attachment AS sva
+        ON sv.uuid = sva.storage_volume_uuid
+        AND sva.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+    LEFT JOIN storage_volume_attachment_plan AS svap
+        ON sv.uuid = svap.storage_volume_uuid
+        AND svap.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+    WHERE sva.uuid IS NOT NULL OR svap.uuid IS NOT NULL
+),
+classified_volume_targets AS (
+    SELECT vt.volume_uuid,
+           vt.attachment_uuid,
+           vt.plan_uuid,
+           vt.block_device_uuid,
+           CASE
+               WHEN vt.volume_scope_id NOT IN (
+                   $reprovisionStorageTargetParams.model_scope_id,
+                   $reprovisionStorageTargetParams.machine_scope_id
+               ) THEN 'ambiguous'
+               WHEN vt.attachment_uuid IS NOT NULL
+                   AND vt.attachment_scope_id != vt.volume_scope_id
+                   THEN 'ambiguous'
+               WHEN vt.plan_uuid IS NOT NULL
+                   AND vt.plan_scope_id != vt.volume_scope_id
+                   THEN 'ambiguous'
+               WHEN vt.volume_scope_id = $reprovisionStorageTargetParams.model_scope_id
+                   THEN 'model'
+               ELSE 'machine'
+           END AS scope_class
+    FROM volume_targets AS vt
+)
+SELECT cvt.volume_uuid AS &reprovisionVolumeTarget.volume_uuid,
+       cvt.scope_class AS &reprovisionVolumeTarget.scope_class,
+       cvt.attachment_uuid AS &reprovisionVolumeTarget.attachment_uuid,
+       cvt.plan_uuid AS &reprovisionVolumeTarget.plan_uuid,
+       cvt.block_device_uuid AS &reprovisionVolumeTarget.block_device_uuid
+FROM classified_volume_targets AS cvt`, reprovisionStorageTargetParams{}, reprovisionVolumeTarget{})
+	if err != nil {
+		return nil, nil, errors.Capture(err)
+	}
+	filesystemStmt, err := st.Prepare(`
+WITH filesystem_targets AS (
+    SELECT sf.uuid AS filesystem_uuid,
+           sf.provision_scope_id AS filesystem_scope_id,
+           sfa.uuid AS attachment_uuid,
+           sfa.provision_scope_id AS attachment_scope_id
+    FROM storage_filesystem AS sf
+    JOIN storage_filesystem_attachment AS sfa
+        ON sf.uuid = sfa.storage_filesystem_uuid
+    WHERE sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
+),
+classified_filesystem_targets AS (
+    SELECT ft.filesystem_uuid,
+           ft.attachment_uuid,
+           CASE
+               WHEN ft.filesystem_scope_id NOT IN (
+                   $reprovisionStorageTargetParams.model_scope_id,
+                   $reprovisionStorageTargetParams.machine_scope_id
+               ) THEN 'ambiguous'
+               WHEN ft.attachment_scope_id != ft.filesystem_scope_id
+                   THEN 'ambiguous'
+               WHEN ft.filesystem_scope_id = $reprovisionStorageTargetParams.model_scope_id
+                   THEN 'model'
+               ELSE 'machine'
+           END AS scope_class
+    FROM filesystem_targets AS ft
+)
+SELECT cft.filesystem_uuid AS &reprovisionFilesystemTarget.filesystem_uuid,
+       cft.scope_class AS &reprovisionFilesystemTarget.scope_class,
+       cft.attachment_uuid AS &reprovisionFilesystemTarget.attachment_uuid
+FROM classified_filesystem_targets AS cft`, reprovisionStorageTargetParams{}, reprovisionFilesystemTarget{})
+	if err != nil {
+		return nil, nil, errors.Capture(err)
+	}
+	return volumeStmt, filesystemStmt, nil
+}
+
+func (st *State) getReprovisionStorageTargets(
+	ctx context.Context, tx *sqlair.TX,
+	volumeStmt, filesystemStmt *sqlair.Statement,
+	params reprovisionStorageTargetParams,
+) (reprovisionStorageTargets, error) {
+	var volumeRows []reprovisionVolumeTarget
+	if err := tx.Query(ctx, volumeStmt, params).GetAll(&volumeRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return reprovisionStorageTargets{}, errors.Errorf("querying attached volumes: %w", err)
+	}
+	var filesystemRows []reprovisionFilesystemTarget
+	if err := tx.Query(ctx, filesystemStmt, params).GetAll(&filesystemRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return reprovisionStorageTargets{}, errors.Errorf("querying attached filesystems: %w", err)
+	}
+
+	var targets reprovisionStorageTargets
+	add := func(ids reprovisionUUIDs, value string) reprovisionUUIDs {
+		if slices.Contains(ids, value) {
+			return ids
+		}
+		return append(ids, value)
+	}
+	for _, row := range volumeRows {
+		switch row.ScopeClass {
+		case "model":
+			return reprovisionStorageTargets{}, errors.Errorf(
+				"volume %q: %w", row.VolumeUUID, machineerrors.ModelScopedStorageAttached,
+			)
+		case "machine":
+			// An empty Go case exits the switch; it does not fall through.
+		case "ambiguous":
+			return reprovisionStorageTargets{}, errors.Errorf(
+				"volume %q: %w", row.VolumeUUID, machineerrors.StorageScopeAmbiguous,
+			)
+		default:
+			return reprovisionStorageTargets{}, errors.Errorf(
+				"volume %q has unknown scope classification %q: %w",
+				row.VolumeUUID, row.ScopeClass, machineerrors.StorageScopeAmbiguous,
+			)
+		}
+		targets.volumes = add(targets.volumes, row.VolumeUUID)
+		if row.AttachmentUUID.Valid {
+			targets.volumeAttachments = add(targets.volumeAttachments, row.AttachmentUUID.V)
+		}
+		if row.PlanUUID.Valid {
+			targets.plans = add(targets.plans, row.PlanUUID.V)
+		}
+		if row.BlockDeviceUUID.Valid {
+			targets.blockDevices = add(targets.blockDevices, row.BlockDeviceUUID.V)
+		}
+	}
+	for _, row := range filesystemRows {
+		switch row.ScopeClass {
+		case "model":
+			return reprovisionStorageTargets{}, errors.Errorf(
+				"filesystem %q: %w", row.FilesystemUUID, machineerrors.ModelScopedStorageAttached,
+			)
+		case "machine":
+			// An empty Go case exits the switch; it does not fall through.
+		case "ambiguous":
+			return reprovisionStorageTargets{}, errors.Errorf(
+				"filesystem %q: %w", row.FilesystemUUID, machineerrors.StorageScopeAmbiguous,
+			)
+		default:
+			return reprovisionStorageTargets{}, errors.Errorf(
+				"filesystem %q has unknown scope classification %q: %w",
+				row.FilesystemUUID, row.ScopeClass, machineerrors.StorageScopeAmbiguous,
+			)
+		}
+		targets.filesystems = add(targets.filesystems, row.FilesystemUUID)
+		targets.filesystemAttachments = add(targets.filesystemAttachments, row.AttachmentUUID)
+	}
+	return targets, nil
+}
+
+func (st *State) removeReprovisionStorage(
+	ctx context.Context, tx *sqlair.TX,
+	targets reprovisionStorageTargets,
+) error {
+	run := func(query string, ids reprovisionUUIDs) error {
+		if len(ids) == 0 {
+			return nil
+		}
+		stmt, err := st.Prepare(query, reprovisionUUIDs{})
+		if err != nil {
+			return errors.Capture(err)
+		}
+		return errors.Capture(tx.Query(ctx, stmt, ids).Run())
+	}
+	steps := []struct {
+		query string
+		ids   reprovisionUUIDs
+	}{
+		{query: `DELETE FROM storage_volume_attachment_plan_attr WHERE attachment_plan_uuid IN ($reprovisionUUIDs[:])`, ids: targets.plans},
+		{query: `DELETE FROM storage_volume_attachment_plan WHERE uuid IN ($reprovisionUUIDs[:])`, ids: targets.plans},
+		{query: `DELETE FROM storage_volume_attachment WHERE uuid IN ($reprovisionUUIDs[:])`, ids: targets.volumeAttachments},
+		{query: `DELETE FROM storage_filesystem_attachment WHERE uuid IN ($reprovisionUUIDs[:])`, ids: targets.filesystemAttachments},
+		{query: `
+DELETE FROM block_device_link_device
+WHERE block_device_uuid IN ($reprovisionUUIDs[:])
+AND NOT EXISTS (
+    SELECT 1 FROM storage_volume_attachment AS sva
+    WHERE sva.block_device_uuid = block_device_link_device.block_device_uuid
+)`, ids: targets.blockDevices},
+		{query: `
+DELETE FROM block_device
+WHERE uuid IN ($reprovisionUUIDs[:])
+AND NOT EXISTS (
+    SELECT 1 FROM storage_volume_attachment AS sva
+    WHERE sva.block_device_uuid = block_device.uuid
+)`, ids: targets.blockDevices},
+		{query: `DELETE FROM machine_volume WHERE volume_uuid IN ($reprovisionUUIDs[:])`, ids: targets.volumes},
+		{query: `DELETE FROM storage_volume_status WHERE volume_uuid IN ($reprovisionUUIDs[:])`, ids: targets.volumes},
+		{query: `DELETE FROM storage_instance_volume WHERE storage_volume_uuid IN ($reprovisionUUIDs[:])`, ids: targets.volumes},
+		{`DELETE FROM storage_volume WHERE uuid IN ($reprovisionUUIDs[:])`, targets.volumes},
+		{query: `DELETE FROM machine_filesystem WHERE filesystem_uuid IN ($reprovisionUUIDs[:])`, ids: targets.filesystems},
+		{query: `DELETE FROM storage_filesystem_status WHERE filesystem_uuid IN ($reprovisionUUIDs[:])`, ids: targets.filesystems},
+		{query: `DELETE FROM storage_instance_filesystem WHERE storage_filesystem_uuid IN ($reprovisionUUIDs[:])`, ids: targets.filesystems},
+		{query: `DELETE FROM storage_filesystem WHERE uuid IN ($reprovisionUUIDs[:])`, ids: targets.filesystems},
+	}
+	for _, step := range steps {
+		if err := run(step.query, step.ids); err != nil {
 			return errors.Capture(err)
 		}
 	}

--- a/domain/machine/state/reprovision.go
+++ b/domain/machine/state/reprovision.go
@@ -21,8 +21,9 @@ import (
 // DetachLostMachineCloudInstance atomically rechecks the critical
 // reprovisioning preconditions, clears stale provider-observed state, and
 // moves the machine and its cloud instance back to pending. Machine-scoped
-// storage is reset to pending while its Juju identity and logical intent are
-// preserved. Unsupported storage is rejected in the same transaction.
+// storage provider state is reset so the normal provisioning paths can create
+// empty replacement storage while preserving Juju identity and intent.
+// Unsupported storage is rejected in the same transaction.
 func (st *State) DetachLostMachineCloudInstance(
 	ctx context.Context,
 	mName string,
@@ -402,6 +403,8 @@ type reprovisionStorageTargetStatements struct {
 	filesystemAttachments                     *sqlair.Statement
 }
 
+// prepareReprovisionStorageLifeStatement returns a query for the first
+// non-alive lifecycle-managed storage row related to the target machine.
 func (st *State) prepareReprovisionStorageLifeStatement() (*sqlair.Statement, error) {
 	stmt, err := st.Prepare(`
 WITH target_volume_uuids AS (
@@ -659,8 +662,9 @@ WHERE sfa.net_node_uuid = $reprovisionStorageTargetParams.net_node_uuid
 	return statements, nil
 }
 
-// validateReprovisionStorageLives rejects non-alive storage before reset
-// targets are collected or any reprovisioning mutations are run.
+// validateReprovisionStorageLives rejects non-alive storage instances,
+// volumes, filesystems, attachments, and attachment plans before reset targets
+// are collected or any reprovisioning mutations are run.
 func validateReprovisionStorageLives(
 	ctx context.Context,
 	tx *sqlair.TX,
@@ -679,14 +683,14 @@ func validateReprovisionStorageLives(
 	return nil
 }
 
-// getReprovisionStorageTargets captures the machine-scoped storage that must
-// be reset before any references are changed. Model-scoped, inconsistent, or
-// incomplete storage fails closed. Maps ensure each reset statement targets a
-// UUID only once.
+// getReprovisionStorageTargets captures storage associated with the machine
+// after lifecycle validation. Model-scoped, inconsistent, or incomplete
+// storage fails closed. Maps ensure each reset statement targets a UUID only
+// once.
 //
 // storage_attachment, machine_volume, and machine_filesystem are retained as
-// logical associations; they participate in target discovery so incomplete
-// physical state cannot be skipped.
+// Juju associations. They participate in target discovery so incomplete
+// provider state cannot be skipped.
 func (st *State) getReprovisionStorageTargets(
 	ctx context.Context, tx *sqlair.TX,
 	statements reprovisionStorageTargetStatements,
@@ -949,7 +953,7 @@ ON CONFLICT (filesystem_uuid) DO UPDATE SET
 // resetReprovisionStorage discards provider-observed storage state for the
 // lost machine while preserving Juju storage identities and intent. Volume,
 // filesystem, instance-link, machine-link, and attachment rows remain so the
-// normal provisioner can create empty replacement storage.
+// normal provisioning paths can create empty replacement storage.
 //
 // Provider-specific attachment plans are deleted first. Attachments are then
 // marked unprovisioned before their old block devices are removed. Finally the

--- a/domain/machine/state/reprovision_test.go
+++ b/domain/machine/state/reprovision_test.go
@@ -97,8 +97,10 @@ WHERE ms.machine_uuid = ?`, machineUUID.String()).Scan(
 	c.Check(s.rowCountWhere(c, "hostname_address", "uuid = ?", "hostname-uuid"), tc.Equals, 1)
 	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "unreferenced-block"), tc.Equals, 0)
 	c.Check(s.rowCountWhere(c, "block_device_link_device", "block_device_uuid = ?", "unreferenced-block"), tc.Equals, 0)
-	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "referenced-block"), tc.Equals, 1)
-	c.Check(s.rowCountWhere(c, "block_device_link_device", "block_device_uuid = ?", "referenced-block"), tc.Equals, 1)
+	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "referenced-block"), tc.Equals, 0)
+	c.Check(s.rowCountWhere(c, "block_device_link_device", "block_device_uuid = ?", "referenced-block"), tc.Equals, 0)
+	c.Check(s.rowCountWhere(c, "storage_volume", "uuid = ?", "volume-uuid"), tc.Equals, 0)
+	c.Check(s.rowCountWhere(c, "storage_volume_attachment", "uuid = ?", "attachment-uuid"), tc.Equals, 0)
 
 	var name, preservedNetNode string
 	err = db.QueryRowContext(c.Context(),
@@ -159,10 +161,194 @@ func (s *stateSuite) TestDetachLostMachineCloudInstanceRepeated(c *tc.C) {
 	s.checkInstanceID(c, machineUUID.String(), "")
 }
 
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsModelScopedStorage(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumeStorage(c, machineUUID.String(), netNodeUUID, 0, 0)
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.ModelScopedStorageAttached)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCountWhere(c, "storage_volume", "uuid = ?", "storage-volume"), tc.Equals, 1)
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsAmbiguousStorage(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumeStorage(c, machineUUID.String(), netNodeUUID, 1, 0)
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.StorageScopeAmbiguous)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCountWhere(c, "storage_volume", "uuid = ?", "storage-volume"), tc.Equals, 1)
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsModelScopedFilesystem(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionFilesystemStorage(c, machineUUID.String(), netNodeUUID, 0, 0)
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.ModelScopedStorageAttached)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCountWhere(c, "storage_filesystem", "uuid = ?", "storage-filesystem"), tc.Equals, 1)
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsAmbiguousFilesystem(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionFilesystemStorage(c, machineUUID.String(), netNodeUUID, 1, 0)
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.StorageScopeAmbiguous)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCountWhere(c, "storage_filesystem", "uuid = ?", "storage-filesystem"), tc.Equals, 1)
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansVolumeAndPreservesIntent(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumeStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	for _, table := range []string{
+		"storage_volume", "storage_instance_volume", "storage_volume_status",
+		"storage_volume_attachment", "storage_volume_attachment_plan",
+		"storage_volume_attachment_plan_attr", "machine_volume",
+	} {
+		c.Check(s.rowCount(c, table), tc.Equals, 0, tc.Commentf("table %s", table))
+	}
+	for _, table := range []string{
+		"storage_instance", "storage_attachment", "storage_unit_owner",
+	} {
+		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
+	}
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansFilesystemAndPreservesIntent(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionFilesystemStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	for _, table := range []string{
+		"storage_filesystem", "storage_instance_filesystem",
+		"storage_filesystem_status", "storage_filesystem_attachment",
+		"machine_filesystem",
+	} {
+		c.Check(s.rowCount(c, table), tc.Equals, 0, tc.Commentf("table %s", table))
+	}
+	for _, table := range []string{
+		"storage_instance", "storage_attachment", "storage_unit_owner",
+	} {
+		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
+	}
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansPlanOnlyVolume(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumePlanStorage(c, machineUUID.String(), netNodeUUID, 1)
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	for _, table := range []string{
+		"storage_volume", "storage_instance_volume", "storage_volume_status",
+		"storage_volume_attachment_plan", "storage_volume_attachment_plan_attr",
+		"machine_volume",
+	} {
+		c.Check(s.rowCount(c, table), tc.Equals, 0, tc.Commentf("table %s", table))
+	}
+	for _, table := range []string{
+		"storage_instance", "storage_attachment", "storage_unit_owner",
+	} {
+		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
+	}
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstancePreservesOtherMachineStorage(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumeStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
+
+	otherMachineUUID, _ := s.addMachine(c)
+	otherNetNodeUUID := s.machineNetNodeUUID(c, otherMachineUUID.String())
+	s.runQuery(c, `
+INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, 1)`, "other-volume", "other-volume/0")
+	s.runQuery(c, `
+INSERT INTO storage_volume_attachment
+    (uuid, storage_volume_uuid, net_node_uuid, life_id, provision_scope_id)
+VALUES (?, ?, ?, 0, 1)`, "other-volume-attachment", "other-volume", otherNetNodeUUID)
+	s.runQuery(c, "INSERT INTO machine_volume VALUES (?, ?)",
+		otherMachineUUID.String(), "other-volume")
+	s.runQuery(c, `
+INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, 1)`, "other-filesystem", "other-filesystem/0")
+	s.runQuery(c, `
+INSERT INTO storage_filesystem_attachment
+    (uuid, storage_filesystem_uuid, net_node_uuid, provision_scope_id, life_id)
+VALUES (?, ?, ?, 1, 0)`, "other-filesystem-attachment", "other-filesystem",
+		otherNetNodeUUID)
+	s.runQuery(c, "INSERT INTO machine_filesystem VALUES (?, ?)",
+		otherMachineUUID.String(), "other-filesystem")
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	checks := []struct {
+		table  string
+		column string
+		uuid   string
+	}{
+		{table: "storage_volume", column: "uuid", uuid: "other-volume"},
+		{table: "storage_volume_attachment", column: "uuid", uuid: "other-volume-attachment"},
+		{table: "machine_volume", column: "volume_uuid", uuid: "other-volume"},
+		{table: "storage_filesystem", column: "uuid", uuid: "other-filesystem"},
+		{table: "storage_filesystem_attachment", column: "uuid", uuid: "other-filesystem-attachment"},
+		{table: "machine_filesystem", column: "filesystem_uuid", uuid: "other-filesystem"},
+	}
+	for _, check := range checks {
+		c.Check(s.rowCountWhere(c, check.table, check.column+" = ?", check.uuid),
+			tc.Equals, 1, tc.Commentf("table %s", check.table))
+	}
+}
+
 func (s *stateSuite) TestDetachLostMachineCloudInstanceRollsBack(c *tc.C) {
 	machineUUID, machineName := s.ensureInstance(c)
 	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
 	s.addReprovisionNetworkState(c, netNodeUUID)
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumeStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
 	s.runQuery(c, `
 CREATE TRIGGER fail_reprovision_detach
 BEFORE UPDATE ON machine_cloud_instance
@@ -182,6 +368,14 @@ END`)
 	c.Check(s.rowCount(c, "ip_address"), tc.Equals, 1)
 	c.Check(s.rowCount(c, "net_node_fqdn_address"), tc.Equals, 1)
 	c.Check(s.rowCount(c, "net_node_hostname_address"), tc.Equals, 1)
+	for _, table := range []string{
+		"storage_instance", "storage_attachment", "storage_unit_owner",
+		"storage_volume", "storage_instance_volume", "storage_volume_status",
+		"storage_volume_attachment", "storage_volume_attachment_plan",
+		"storage_volume_attachment_plan_attr", "machine_volume",
+	} {
+		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
+	}
 }
 
 func (s *stateSuite) machineNetNodeUUID(c *tc.C, machineUUID string) string {
@@ -248,6 +442,94 @@ INSERT INTO unit
     (uuid, name, life_id, application_uuid, net_node_uuid, charm_uuid)
 VALUES (?, ?, 0, ?, ?, ?)`, "reprovision-unit", "reprovision/0",
 		"reprovision-application", netNodeUUID, "reprovision-charm")
+}
+
+func (s *stateSuite) addReprovisionStorageIntent(c *tc.C, kind int) {
+	s.runQuery(c, "INSERT INTO storage_pool (uuid, name, type) VALUES (?, ?, ?)",
+		"reprovision-pool", "reprovision-pool", "reprovision")
+	s.runQuery(c, `
+INSERT INTO storage_instance
+    (uuid, charm_name, storage_name, storage_kind_id, storage_id, life_id,
+     storage_pool_uuid, requested_size_mib)
+VALUES (?, ?, ?, ?, ?, 0, ?, 1024)`, "storage-instance", "reprovision",
+		"data", kind, "data/0", "reprovision-pool")
+	s.runQuery(c, `
+INSERT INTO storage_attachment (uuid, storage_instance_uuid, unit_uuid, life_id)
+VALUES (?, ?, ?, 0)`, "storage-attachment", "storage-instance", "reprovision-unit")
+	s.runQuery(c, `
+INSERT INTO storage_unit_owner (storage_instance_uuid, unit_uuid)
+VALUES (?, ?)`, "storage-instance", "reprovision-unit")
+}
+
+func (s *stateSuite) addReprovisionVolumeStorage(
+	c *tc.C, machineUUID, netNodeUUID string, volumeScope, attachmentScope int,
+) {
+	s.addReprovisionStorageIntent(c, 0)
+	s.runQuery(c, `
+INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, ?)`, "storage-volume", "storage-volume/0", volumeScope)
+	s.runQuery(c, "INSERT INTO storage_instance_volume VALUES (?, ?)",
+		"storage-instance", "storage-volume")
+	s.runQuery(c, "INSERT INTO storage_volume_status VALUES (?, 3, ?, NULL)",
+		"storage-volume", "attached")
+	s.runQuery(c, "INSERT INTO block_device (uuid, machine_uuid) VALUES (?, ?)",
+		"storage-block", machineUUID)
+	s.runQuery(c, "INSERT INTO block_device_link_device VALUES (?, ?, ?)",
+		"storage-block", machineUUID, "sdc")
+	s.runQuery(c, `
+INSERT INTO storage_volume_attachment
+    (uuid, storage_volume_uuid, net_node_uuid, life_id,
+     provision_scope_id, block_device_uuid)
+VALUES (?, ?, ?, 0, ?, ?)`, "storage-volume-attachment", "storage-volume",
+		netNodeUUID, attachmentScope, "storage-block")
+	s.runQuery(c, `
+INSERT INTO storage_volume_attachment_plan
+    (uuid, storage_volume_uuid, net_node_uuid, life_id, provision_scope_id)
+VALUES (?, ?, ?, 0, ?)`, "storage-volume-plan", "storage-volume",
+		netNodeUUID, attachmentScope)
+	s.runQuery(c, "INSERT INTO storage_volume_attachment_plan_attr VALUES (?, ?, ?)",
+		"storage-volume-plan", "device", "sdc")
+	s.runQuery(c, "INSERT INTO machine_volume VALUES (?, ?)", machineUUID, "storage-volume")
+}
+
+func (s *stateSuite) addReprovisionVolumePlanStorage(
+	c *tc.C, machineUUID, netNodeUUID string, scope int,
+) {
+	s.addReprovisionStorageIntent(c, 0)
+	s.runQuery(c, `
+INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, ?)`, "storage-volume", "storage-volume/0", scope)
+	s.runQuery(c, "INSERT INTO storage_instance_volume VALUES (?, ?)",
+		"storage-instance", "storage-volume")
+	s.runQuery(c, "INSERT INTO storage_volume_status VALUES (?, 0, ?, NULL)",
+		"storage-volume", "pending")
+	s.runQuery(c, `
+INSERT INTO storage_volume_attachment_plan
+    (uuid, storage_volume_uuid, net_node_uuid, life_id, provision_scope_id)
+VALUES (?, ?, ?, 0, ?)`, "storage-volume-plan", "storage-volume", netNodeUUID, scope)
+	s.runQuery(c, "INSERT INTO storage_volume_attachment_plan_attr VALUES (?, ?, ?)",
+		"storage-volume-plan", "device", "sdc")
+	s.runQuery(c, "INSERT INTO machine_volume VALUES (?, ?)", machineUUID, "storage-volume")
+}
+
+func (s *stateSuite) addReprovisionFilesystemStorage(
+	c *tc.C, machineUUID, netNodeUUID string, filesystemScope, attachmentScope int,
+) {
+	s.addReprovisionStorageIntent(c, 1)
+	s.runQuery(c, `
+INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id)
+VALUES (?, ?, 0, ?)`, "storage-filesystem", "storage-filesystem/0", filesystemScope)
+	s.runQuery(c, "INSERT INTO storage_instance_filesystem VALUES (?, ?)",
+		"storage-instance", "storage-filesystem")
+	s.runQuery(c, "INSERT INTO storage_filesystem_status VALUES (?, 3, ?, NULL)",
+		"storage-filesystem", "attached")
+	s.runQuery(c, `
+INSERT INTO storage_filesystem_attachment
+    (uuid, storage_filesystem_uuid, net_node_uuid, provision_scope_id, life_id)
+VALUES (?, ?, ?, ?, 0)`, "storage-filesystem-attachment", "storage-filesystem",
+		netNodeUUID, attachmentScope)
+	s.runQuery(c, "INSERT INTO machine_filesystem VALUES (?, ?)",
+		machineUUID, "storage-filesystem")
 }
 
 func (s *stateSuite) checkInstanceID(c *tc.C, machineUUID, expected string) {

--- a/domain/machine/state/reprovision_test.go
+++ b/domain/machine/state/reprovision_test.go
@@ -306,20 +306,31 @@ func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansVolumeAndPreservesI
 	} {
 		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
 	}
-	var providerID, attachmentProviderID, blockDeviceUUID sql.Null[string]
+	var providerID, hardwareID, wwn sql.Null[string]
+	var attachmentProviderID, blockDeviceUUID sql.Null[string]
+	var sizeMiB sql.Null[int]
+	var persistent sql.Null[bool]
+	var readOnly sql.Null[bool]
 	var volumeStatus int
 	err = s.DB().QueryRowContext(c.Context(), `
-SELECT sv.provider_id, sva.provider_id, sva.block_device_uuid, svs.status_id
+SELECT sv.provider_id, sv.size_mib, sv.hardware_id, sv.wwn, sv.persistent,
+       sva.provider_id, sva.block_device_uuid, sva.read_only, svs.status_id
 FROM storage_volume AS sv
 JOIN storage_volume_attachment AS sva ON sv.uuid = sva.storage_volume_uuid
 JOIN storage_volume_status AS svs ON sv.uuid = svs.volume_uuid
 WHERE sv.uuid = ?`, "storage-volume").Scan(
-		&providerID, &attachmentProviderID, &blockDeviceUUID, &volumeStatus,
+		&providerID, &sizeMiB, &hardwareID, &wwn, &persistent,
+		&attachmentProviderID, &blockDeviceUUID, &readOnly, &volumeStatus,
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(providerID.Valid, tc.IsFalse)
+	c.Check(sizeMiB.Valid, tc.IsFalse)
+	c.Check(hardwareID.Valid, tc.IsFalse)
+	c.Check(wwn.Valid, tc.IsFalse)
+	c.Check(persistent.Valid, tc.IsFalse)
 	c.Check(attachmentProviderID.Valid, tc.IsFalse)
 	c.Check(blockDeviceUUID.Valid, tc.IsFalse)
+	c.Check(readOnly.Valid, tc.IsFalse)
 	c.Check(volumeStatus, tc.Equals, 0)
 	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "storage-block"), tc.Equals, 0)
 
@@ -357,20 +368,27 @@ func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansFilesystemAndPreser
 	} {
 		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
 	}
-	var providerID, attachmentProviderID sql.Null[string]
+	var providerID, attachmentProviderID, mountPoint sql.Null[string]
+	var sizeMiB sql.Null[int]
+	var readOnly sql.Null[bool]
 	var filesystemStatus int
 	err = s.DB().QueryRowContext(c.Context(), `
-SELECT sf.provider_id, sfa.provider_id, sfs.status_id
+SELECT sf.provider_id, sf.size_mib, sfa.provider_id, sfa.mount_point,
+       sfa.read_only, sfs.status_id
 FROM storage_filesystem AS sf
 JOIN storage_filesystem_attachment AS sfa
     ON sf.uuid = sfa.storage_filesystem_uuid
 JOIN storage_filesystem_status AS sfs ON sf.uuid = sfs.filesystem_uuid
 WHERE sf.uuid = ?`, "storage-filesystem").Scan(
-		&providerID, &attachmentProviderID, &filesystemStatus,
+		&providerID, &sizeMiB, &attachmentProviderID, &mountPoint, &readOnly,
+		&filesystemStatus,
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(providerID.Valid, tc.IsFalse)
+	c.Check(sizeMiB.Valid, tc.IsFalse)
 	c.Check(attachmentProviderID.Valid, tc.IsFalse)
+	c.Check(mountPoint.Valid, tc.IsFalse)
+	c.Check(readOnly.Valid, tc.IsFalse)
 	c.Check(filesystemStatus, tc.Equals, 0)
 }
 
@@ -574,9 +592,11 @@ func (s *stateSuite) addReprovisionVolumeStorage(
 	s.addReprovisionStorageIntent(c, 0)
 	s.runQuery(c, `
 INSERT INTO storage_volume
-    (uuid, volume_id, life_id, provision_scope_id, provider_id)
-VALUES (?, ?, 0, ?, ?)`, "storage-volume", "storage-volume/0", volumeScope,
-		"old-volume-provider")
+    (uuid, volume_id, life_id, provision_scope_id, provider_id, size_mib,
+     hardware_id, wwn, persistent)
+VALUES (?, ?, 0, ?, ?, 2048, ?, ?, TRUE)`, "storage-volume",
+		"storage-volume/0", volumeScope, "old-volume-provider", "old-hardware",
+		"old-wwn")
 	s.runQuery(c, "INSERT INTO storage_instance_volume VALUES (?, ?)",
 		"storage-instance", "storage-volume")
 	s.runQuery(c, "INSERT INTO storage_volume_status VALUES (?, 3, ?, NULL)",
@@ -591,6 +611,8 @@ INSERT INTO storage_volume_attachment
      provision_scope_id, provider_id, block_device_uuid)
 VALUES (?, ?, ?, 0, ?, ?, ?)`, "storage-volume-attachment", "storage-volume",
 		netNodeUUID, attachmentScope, "old-attachment-provider", "storage-block")
+	s.runQuery(c, "UPDATE storage_volume_attachment SET read_only = TRUE WHERE uuid = ?",
+		"storage-volume-attachment")
 	s.runQuery(c, `
 INSERT INTO storage_volume_attachment_plan
     (uuid, storage_volume_uuid, net_node_uuid, life_id, provision_scope_id)
@@ -627,8 +649,8 @@ func (s *stateSuite) addReprovisionFilesystemStorage(
 	s.addReprovisionStorageIntent(c, 1)
 	s.runQuery(c, `
 INSERT INTO storage_filesystem
-    (uuid, filesystem_id, life_id, provision_scope_id, provider_id)
-VALUES (?, ?, 0, ?, ?)`, "storage-filesystem", "storage-filesystem/0",
+    (uuid, filesystem_id, life_id, provision_scope_id, provider_id, size_mib)
+VALUES (?, ?, 0, ?, ?, 2048)`, "storage-filesystem", "storage-filesystem/0",
 		filesystemScope, "old-filesystem-provider")
 	s.runQuery(c, "INSERT INTO storage_instance_filesystem VALUES (?, ?)",
 		"storage-instance", "storage-filesystem")
@@ -640,6 +662,10 @@ INSERT INTO storage_filesystem_attachment
      provider_id, life_id)
 VALUES (?, ?, ?, ?, ?, 0)`, "storage-filesystem-attachment", "storage-filesystem",
 		netNodeUUID, attachmentScope, "old-attachment-provider")
+	s.runQuery(c, `
+UPDATE storage_filesystem_attachment
+SET mount_point = ?, read_only = TRUE
+WHERE uuid = ?`, "/old/mount", "storage-filesystem-attachment")
 	s.runQuery(c, "INSERT INTO machine_filesystem VALUES (?, ?)",
 		machineUUID, "storage-filesystem")
 }

--- a/domain/machine/state/reprovision_test.go
+++ b/domain/machine/state/reprovision_test.go
@@ -215,6 +215,22 @@ func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsAmbiguousFilesyste
 	c.Check(s.rowCountWhere(c, "storage_filesystem", "uuid = ?", "storage-filesystem"), tc.Equals, 1)
 }
 
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsFilesystemWithoutAttachment(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionFilesystemStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
+	s.runQuery(c, "DELETE FROM storage_filesystem_attachment WHERE uuid = ?",
+		"storage-filesystem-attachment")
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.StorageScopeAmbiguous)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCountWhere(c, "storage_filesystem", "uuid = ?", "storage-filesystem"), tc.Equals, 1)
+}
+
 func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsNonAliveVolume(c *tc.C) {
 	machineUUID, machineName := s.ensureInstance(c)
 	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())

--- a/domain/machine/state/reprovision_test.go
+++ b/domain/machine/state/reprovision_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain/life"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
+	provisionermodelstate "github.com/juju/juju/domain/provisioner/state/model"
 	domainstatus "github.com/juju/juju/domain/status"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
 func (s *stateSuite) TestDetachLostMachineCloudInstance(c *tc.C) {
@@ -97,10 +99,6 @@ WHERE ms.machine_uuid = ?`, machineUUID.String()).Scan(
 	c.Check(s.rowCountWhere(c, "hostname_address", "uuid = ?", "hostname-uuid"), tc.Equals, 1)
 	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "unreferenced-block"), tc.Equals, 0)
 	c.Check(s.rowCountWhere(c, "block_device_link_device", "block_device_uuid = ?", "unreferenced-block"), tc.Equals, 0)
-	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "referenced-block"), tc.Equals, 0)
-	c.Check(s.rowCountWhere(c, "block_device_link_device", "block_device_uuid = ?", "referenced-block"), tc.Equals, 0)
-	c.Check(s.rowCountWhere(c, "storage_volume", "uuid = ?", "volume-uuid"), tc.Equals, 0)
-	c.Check(s.rowCountWhere(c, "storage_volume_attachment", "uuid = ?", "attachment-uuid"), tc.Equals, 0)
 
 	var name, preservedNetNode string
 	err = db.QueryRowContext(c.Context(),
@@ -217,6 +215,54 @@ func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsAmbiguousFilesyste
 	c.Check(s.rowCountWhere(c, "storage_filesystem", "uuid = ?", "storage-filesystem"), tc.Equals, 1)
 }
 
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsNonAliveVolume(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumeStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
+	s.runQuery(c, "UPDATE storage_volume SET life_id = ? WHERE uuid = ?",
+		life.Dying, "storage-volume")
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.MachineStorageNotAlive)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCount(c, "storage_volume_attachment_plan"), tc.Equals, 1)
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsNonAliveStorageInstance(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumeStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
+	s.runQuery(c, "UPDATE storage_instance SET life_id = ? WHERE uuid = ?",
+		life.Dying, "storage-instance")
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.MachineStorageNotAlive)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCount(c, "storage_volume_attachment_plan"), tc.Equals, 1)
+}
+
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsNonAliveFilesystemAttachment(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionFilesystemStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
+	s.runQuery(c, "UPDATE storage_filesystem_attachment SET life_id = ? WHERE uuid = ?",
+		life.Dying, "storage-filesystem-attachment")
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.MachineStorageNotAlive)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCount(c, "storage_filesystem_attachment"), tc.Equals, 1)
+}
+
 func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansVolumeAndPreservesIntent(c *tc.C) {
 	machineUUID, machineName := s.ensureInstance(c)
 	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
@@ -230,8 +276,12 @@ func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansVolumeAndPreservesI
 
 	for _, table := range []string{
 		"storage_volume", "storage_instance_volume", "storage_volume_status",
-		"storage_volume_attachment", "storage_volume_attachment_plan",
-		"storage_volume_attachment_plan_attr", "machine_volume",
+		"storage_volume_attachment", "machine_volume",
+	} {
+		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
+	}
+	for _, table := range []string{
+		"storage_volume_attachment_plan", "storage_volume_attachment_plan_attr",
 	} {
 		c.Check(s.rowCount(c, table), tc.Equals, 0, tc.Commentf("table %s", table))
 	}
@@ -240,6 +290,32 @@ func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansVolumeAndPreservesI
 	} {
 		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
 	}
+	var providerID, attachmentProviderID, blockDeviceUUID sql.Null[string]
+	var volumeStatus int
+	err = s.DB().QueryRowContext(c.Context(), `
+SELECT sv.provider_id, sva.provider_id, sva.block_device_uuid, svs.status_id
+FROM storage_volume AS sv
+JOIN storage_volume_attachment AS sva ON sv.uuid = sva.storage_volume_uuid
+JOIN storage_volume_status AS svs ON sv.uuid = svs.volume_uuid
+WHERE sv.uuid = ?`, "storage-volume").Scan(
+		&providerID, &attachmentProviderID, &blockDeviceUUID, &volumeStatus,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(providerID.Valid, tc.IsFalse)
+	c.Check(attachmentProviderID.Valid, tc.IsFalse)
+	c.Check(blockDeviceUUID.Valid, tc.IsFalse)
+	c.Check(volumeStatus, tc.Equals, 0)
+	c.Check(s.rowCountWhere(c, "block_device", "uuid = ?", "storage-block"), tc.Equals, 0)
+
+	provisionerState := provisionermodelstate.NewState(
+		s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c),
+	)
+	provisioningInfo, err := provisionerState.GetMachineProvisioningInfo(
+		c.Context(), machineName.String(), false,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(provisioningInfo.VolumeParams, tc.HasLen, 1)
+	c.Check(provisioningInfo.VolumeAttachmentParams, tc.HasLen, 1)
 }
 
 func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansFilesystemAndPreservesIntent(c *tc.C) {
@@ -258,16 +334,31 @@ func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansFilesystemAndPreser
 		"storage_filesystem_status", "storage_filesystem_attachment",
 		"machine_filesystem",
 	} {
-		c.Check(s.rowCount(c, table), tc.Equals, 0, tc.Commentf("table %s", table))
+		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
 	}
 	for _, table := range []string{
 		"storage_instance", "storage_attachment", "storage_unit_owner",
 	} {
 		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
 	}
+	var providerID, attachmentProviderID sql.Null[string]
+	var filesystemStatus int
+	err = s.DB().QueryRowContext(c.Context(), `
+SELECT sf.provider_id, sfa.provider_id, sfs.status_id
+FROM storage_filesystem AS sf
+JOIN storage_filesystem_attachment AS sfa
+    ON sf.uuid = sfa.storage_filesystem_uuid
+JOIN storage_filesystem_status AS sfs ON sf.uuid = sfs.filesystem_uuid
+WHERE sf.uuid = ?`, "storage-filesystem").Scan(
+		&providerID, &attachmentProviderID, &filesystemStatus,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(providerID.Valid, tc.IsFalse)
+	c.Check(attachmentProviderID.Valid, tc.IsFalse)
+	c.Check(filesystemStatus, tc.Equals, 0)
 }
 
-func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansPlanOnlyVolume(c *tc.C) {
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsPlanOnlyVolume(c *tc.C) {
 	machineUUID, machineName := s.ensureInstance(c)
 	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
 	s.addReprovisionUnit(c, netNodeUUID)
@@ -276,20 +367,9 @@ func (s *stateSuite) TestDetachLostMachineCloudInstanceCleansPlanOnlyVolume(c *t
 	err := s.state.DetachLostMachineCloudInstance(
 		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
 	)
-	c.Assert(err, tc.ErrorIsNil)
-
-	for _, table := range []string{
-		"storage_volume", "storage_instance_volume", "storage_volume_status",
-		"storage_volume_attachment_plan", "storage_volume_attachment_plan_attr",
-		"machine_volume",
-	} {
-		c.Check(s.rowCount(c, table), tc.Equals, 0, tc.Commentf("table %s", table))
-	}
-	for _, table := range []string{
-		"storage_instance", "storage_attachment", "storage_unit_owner",
-	} {
-		c.Check(s.rowCount(c, table), tc.Equals, 1, tc.Commentf("table %s", table))
-	}
+	c.Assert(err, tc.ErrorIs, machineerrors.StorageScopeAmbiguous)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCount(c, "storage_volume_attachment_plan"), tc.Equals, 1)
 }
 
 func (s *stateSuite) TestDetachLostMachineCloudInstancePreservesOtherMachineStorage(c *tc.C) {
@@ -421,14 +501,6 @@ VALUES (?, ?, ?, '10.0.0.2/24', 0, 1, 1, 2)`, "address-uuid", netNodeUUID, "devi
 func (s *stateSuite) addReprovisionBlockDeviceState(c *tc.C, machineUUID, netNodeUUID string) {
 	s.runQuery(c, "INSERT INTO block_device (uuid, machine_uuid) VALUES (?, ?)", "unreferenced-block", machineUUID)
 	s.runQuery(c, "INSERT INTO block_device_link_device VALUES (?, ?, ?)", "unreferenced-block", machineUUID, "sda")
-	s.runQuery(c, "INSERT INTO block_device (uuid, machine_uuid) VALUES (?, ?)", "referenced-block", machineUUID)
-	s.runQuery(c, "INSERT INTO block_device_link_device VALUES (?, ?, ?)", "referenced-block", machineUUID, "sdb")
-	s.runQuery(c, "INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id) VALUES (?, ?, 0, 1)", "volume-uuid", "0")
-	s.runQuery(c, `
-INSERT INTO storage_volume_attachment
-    (uuid, storage_volume_uuid, net_node_uuid, life_id,
-     provision_scope_id, block_device_uuid)
-VALUES (?, ?, ?, 0, 1, ?)`, "attachment-uuid", "volume-uuid", netNodeUUID, "referenced-block")
 }
 
 func (s *stateSuite) addReprovisionUnit(c *tc.C, netNodeUUID string) {
@@ -466,8 +538,10 @@ func (s *stateSuite) addReprovisionVolumeStorage(
 ) {
 	s.addReprovisionStorageIntent(c, 0)
 	s.runQuery(c, `
-INSERT INTO storage_volume (uuid, volume_id, life_id, provision_scope_id)
-VALUES (?, ?, 0, ?)`, "storage-volume", "storage-volume/0", volumeScope)
+INSERT INTO storage_volume
+    (uuid, volume_id, life_id, provision_scope_id, provider_id)
+VALUES (?, ?, 0, ?, ?)`, "storage-volume", "storage-volume/0", volumeScope,
+		"old-volume-provider")
 	s.runQuery(c, "INSERT INTO storage_instance_volume VALUES (?, ?)",
 		"storage-instance", "storage-volume")
 	s.runQuery(c, "INSERT INTO storage_volume_status VALUES (?, 3, ?, NULL)",
@@ -479,9 +553,9 @@ VALUES (?, ?, 0, ?)`, "storage-volume", "storage-volume/0", volumeScope)
 	s.runQuery(c, `
 INSERT INTO storage_volume_attachment
     (uuid, storage_volume_uuid, net_node_uuid, life_id,
-     provision_scope_id, block_device_uuid)
-VALUES (?, ?, ?, 0, ?, ?)`, "storage-volume-attachment", "storage-volume",
-		netNodeUUID, attachmentScope, "storage-block")
+     provision_scope_id, provider_id, block_device_uuid)
+VALUES (?, ?, ?, 0, ?, ?, ?)`, "storage-volume-attachment", "storage-volume",
+		netNodeUUID, attachmentScope, "old-attachment-provider", "storage-block")
 	s.runQuery(c, `
 INSERT INTO storage_volume_attachment_plan
     (uuid, storage_volume_uuid, net_node_uuid, life_id, provision_scope_id)
@@ -517,17 +591,20 @@ func (s *stateSuite) addReprovisionFilesystemStorage(
 ) {
 	s.addReprovisionStorageIntent(c, 1)
 	s.runQuery(c, `
-INSERT INTO storage_filesystem (uuid, filesystem_id, life_id, provision_scope_id)
-VALUES (?, ?, 0, ?)`, "storage-filesystem", "storage-filesystem/0", filesystemScope)
+INSERT INTO storage_filesystem
+    (uuid, filesystem_id, life_id, provision_scope_id, provider_id)
+VALUES (?, ?, 0, ?, ?)`, "storage-filesystem", "storage-filesystem/0",
+		filesystemScope, "old-filesystem-provider")
 	s.runQuery(c, "INSERT INTO storage_instance_filesystem VALUES (?, ?)",
 		"storage-instance", "storage-filesystem")
 	s.runQuery(c, "INSERT INTO storage_filesystem_status VALUES (?, 3, ?, NULL)",
 		"storage-filesystem", "attached")
 	s.runQuery(c, `
 INSERT INTO storage_filesystem_attachment
-    (uuid, storage_filesystem_uuid, net_node_uuid, provision_scope_id, life_id)
-VALUES (?, ?, ?, ?, 0)`, "storage-filesystem-attachment", "storage-filesystem",
-		netNodeUUID, attachmentScope)
+    (uuid, storage_filesystem_uuid, net_node_uuid, provision_scope_id,
+     provider_id, life_id)
+VALUES (?, ?, ?, ?, ?, 0)`, "storage-filesystem-attachment", "storage-filesystem",
+		netNodeUUID, attachmentScope, "old-attachment-provider")
 	s.runQuery(c, "INSERT INTO machine_filesystem VALUES (?, ?)",
 		machineUUID, "storage-filesystem")
 }

--- a/domain/machine/state/reprovision_test.go
+++ b/domain/machine/state/reprovision_test.go
@@ -388,6 +388,25 @@ func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsPlanOnlyVolume(c *
 	c.Check(s.rowCount(c, "storage_volume_attachment_plan"), tc.Equals, 1)
 }
 
+func (s *stateSuite) TestDetachLostMachineCloudInstanceRejectsVolumeWithoutAttachmentOrPlan(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumeStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
+	s.runQuery(c, "DELETE FROM storage_volume_attachment_plan_attr")
+	s.runQuery(c, "DELETE FROM storage_volume_attachment_plan")
+	s.runQuery(c, "UPDATE storage_volume_attachment SET block_device_uuid = NULL")
+	s.runQuery(c, "DELETE FROM storage_volume_attachment")
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "message", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIs, machineerrors.StorageScopeAmbiguous)
+	s.checkInstanceID(c, machineUUID.String(), "123")
+	c.Check(s.rowCountWhere(c, "machine_volume", "machine_uuid = ?",
+		machineUUID.String()), tc.Equals, 1)
+}
+
 func (s *stateSuite) TestDetachLostMachineCloudInstancePreservesOtherMachineStorage(c *tc.C) {
 	machineUUID, machineName := s.ensureInstance(c)
 	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -30,6 +30,7 @@ import (
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/network"
 	networkerrors "github.com/juju/juju/domain/network/errors"
+	domainstorage "github.com/juju/juju/domain/storage"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -397,7 +398,8 @@ GROUP BY   m.uuid
 
 // CheckMachineReprovisioningEligibility checks whether the machine identified
 // by name is eligible for reprovisioning. It queries life, controller status,
-// manual-provision status, and child-container presence in a single round-trip.
+// manual-provision status, child-container presence, and model-scoped storage
+// in a single round-trip.
 // It returns a [machineerrors.MachineNotFound] if the machine doesn't exist.
 func (st *State) CheckMachineReprovisioningEligibility(ctx context.Context, mName machine.Name) error {
 	db, err := st.DB(ctx)
@@ -405,29 +407,51 @@ func (st *State) CheckMachineReprovisioningEligibility(ctx context.Context, mNam
 		return errors.Capture(err)
 	}
 
-	machineNameParam := machineName{Name: mName.String()}
+	params := reprovisionEligibilityParams{
+		Name:         mName.String(),
+		ModelScopeID: int(domainstorage.ProvisionScopeModel),
+	}
 	query := `
+WITH model_storage_net_node AS (
+    SELECT sva.net_node_uuid
+    FROM storage_volume_attachment AS sva
+    WHERE sva.provision_scope_id = $reprovisionEligibilityParams.model_scope_id
+
+    UNION
+
+    SELECT svap.net_node_uuid
+    FROM storage_volume_attachment_plan AS svap
+    WHERE svap.provision_scope_id = $reprovisionEligibilityParams.model_scope_id
+
+    UNION
+
+    SELECT sfa.net_node_uuid
+    FROM storage_filesystem_attachment AS sfa
+    WHERE sfa.provision_scope_id = $reprovisionEligibilityParams.model_scope_id
+)
 SELECT     m.life_id AS &reprovisionEligibility.life_id,
            COUNT(mpc.machine_uuid) AS &reprovisionEligibility.is_container,
            COUNT(mic.machine_uuid) AS &reprovisionEligibility.is_controller,
            COUNT(mm.machine_uuid) AS &reprovisionEligibility.is_manual,
-           COUNT(mp.machine_uuid) AS &reprovisionEligibility.has_containers
+           COUNT(mp.machine_uuid) AS &reprovisionEligibility.has_containers,
+           COUNT(msn.net_node_uuid) AS &reprovisionEligibility.has_model_storage
 FROM       machine AS m
 LEFT JOIN  machine_parent AS mpc ON m.uuid = mpc.machine_uuid
 LEFT JOIN  v_machine_is_controller AS mic ON m.uuid = mic.machine_uuid
 LEFT JOIN  machine_manual AS mm ON m.uuid = mm.machine_uuid
 LEFT JOIN  machine_parent AS mp ON m.uuid = mp.parent_uuid
-WHERE      m.name = $machineName.name
+LEFT JOIN  model_storage_net_node AS msn ON m.net_node_uuid = msn.net_node_uuid
+WHERE      m.name = $reprovisionEligibilityParams.name
 GROUP BY   m.uuid
 `
-	queryStmt, err := st.Prepare(query, machineNameParam, reprovisionEligibility{})
+	queryStmt, err := st.Prepare(query, params, reprovisionEligibility{})
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	var result reprovisionEligibility
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, queryStmt, machineNameParam).Get(&result)
+		err := tx.Query(ctx, queryStmt, params).Get(&result)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return machineerrors.MachineNotFound
 		}
@@ -454,6 +478,9 @@ GROUP BY   m.uuid
 	}
 	if result.HasContainers > 0 {
 		return errors.Capture(machineerrors.MachineHasChildContainers)
+	}
+	if result.HasModelStorage > 0 {
+		return errors.Capture(machineerrors.ModelScopedStorageAttached)
 	}
 	return nil
 }

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -1103,6 +1103,56 @@ func (s *stateSuite) TestCheckMachineReprovisioningEligibilityHasChildContainers
 	c.Assert(err, tc.ErrorIs, machineerrors.MachineHasChildContainers)
 }
 
+func (s *stateSuite) TestCheckMachineReprovisioningEligibilityHasModelScopedVolume(c *tc.C) {
+	machineUUID, machineName := s.addMachine(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumeStorage(c, machineUUID.String(), netNodeUUID, 0, 0)
+
+	err := s.state.CheckMachineReprovisioningEligibility(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIs, machineerrors.ModelScopedStorageAttached)
+}
+
+func (s *stateSuite) TestCheckMachineReprovisioningEligibilityHasModelScopedFilesystem(c *tc.C) {
+	machineUUID, machineName := s.addMachine(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionFilesystemStorage(c, machineUUID.String(), netNodeUUID, 0, 0)
+
+	err := s.state.CheckMachineReprovisioningEligibility(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIs, machineerrors.ModelScopedStorageAttached)
+}
+
+func (s *stateSuite) TestCheckMachineReprovisioningEligibilityAllowsMachineScopedVolume(c *tc.C) {
+	machineUUID, machineName := s.addMachine(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumeStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
+
+	err := s.state.CheckMachineReprovisioningEligibility(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *stateSuite) TestCheckMachineReprovisioningEligibilityAllowsMachineScopedFilesystem(c *tc.C) {
+	machineUUID, machineName := s.addMachine(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionFilesystemStorage(c, machineUUID.String(), netNodeUUID, 1, 1)
+
+	err := s.state.CheckMachineReprovisioningEligibility(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *stateSuite) TestCheckMachineReprovisioningEligibilityHasModelScopedVolumePlan(c *tc.C) {
+	machineUUID, machineName := s.addMachine(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.addReprovisionVolumePlanStorage(c, machineUUID.String(), netNodeUUID, 0)
+
+	err := s.state.CheckMachineReprovisioningEligibility(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIs, machineerrors.ModelScopedStorageAttached)
+}
+
 func (s *stateSuite) TestIsMachineAgentPresent(c *tc.C) {
 	machineUUID, machineName := s.addMachine(c)
 	s.runQuery(c, "INSERT INTO machine_agent_presence (machine_uuid) VALUES (?)", machineUUID)

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -551,20 +551,32 @@ type netNode struct {
 	UUID string `db:"net_node_uuid"`
 }
 
-type reprovisionVolumeTarget struct {
-	VolumeUUID      string           `db:"volume_uuid"`
-	AllAlive        bool             `db:"all_alive"`
-	ScopeClass      string           `db:"scope_class"`
-	AttachmentUUID  sql.Null[string] `db:"attachment_uuid"`
-	PlanUUID        sql.Null[string] `db:"plan_uuid"`
+type reprovisionStorageEntityTarget struct {
+	EntityUUID            string           `db:"entity_uuid"`
+	LifeID                int              `db:"life_id"`
+	ScopeID               int              `db:"scope_id"`
+	StorageInstanceUUID   sql.Null[string] `db:"storage_instance_uuid"`
+	StorageInstanceLifeID sql.Null[int]    `db:"storage_instance_life_id"`
+}
+
+type reprovisionStorageLogicalAttachment struct {
+	EntityUUID string `db:"entity_uuid"`
+	LifeID     int    `db:"life_id"`
+}
+
+type reprovisionStoragePhysicalAttachment struct {
+	UUID            string           `db:"uuid"`
+	EntityUUID      string           `db:"entity_uuid"`
+	LifeID          int              `db:"life_id"`
+	ScopeID         int              `db:"scope_id"`
 	BlockDeviceUUID sql.Null[string] `db:"block_device_uuid"`
 }
 
-type reprovisionFilesystemTarget struct {
-	FilesystemUUID string           `db:"filesystem_uuid"`
-	AllAlive       bool             `db:"all_alive"`
-	ScopeClass     string           `db:"scope_class"`
-	AttachmentUUID sql.Null[string] `db:"attachment_uuid"`
+type reprovisionStoragePlanTarget struct {
+	UUID       string `db:"uuid"`
+	EntityUUID string `db:"entity_uuid"`
+	LifeID     int    `db:"life_id"`
+	ScopeID    int    `db:"scope_id"`
 }
 
 type reprovisionUUIDs []string

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -550,3 +550,25 @@ type reprovisionDetachTarget struct {
 type netNode struct {
 	UUID string `db:"net_node_uuid"`
 }
+
+type reprovisionVolumeTarget struct {
+	VolumeUUID      string           `db:"volume_uuid"`
+	ScopeClass      string           `db:"scope_class"`
+	AttachmentUUID  sql.Null[string] `db:"attachment_uuid"`
+	PlanUUID        sql.Null[string] `db:"plan_uuid"`
+	BlockDeviceUUID sql.Null[string] `db:"block_device_uuid"`
+}
+
+type reprovisionFilesystemTarget struct {
+	FilesystemUUID string `db:"filesystem_uuid"`
+	ScopeClass     string `db:"scope_class"`
+	AttachmentUUID string `db:"attachment_uuid"`
+}
+
+type reprovisionUUIDs []string
+
+type reprovisionStorageTargetParams struct {
+	NetNodeUUID    string `db:"net_node_uuid"`
+	ModelScopeID   int    `db:"model_scope_id"`
+	MachineScopeID int    `db:"machine_scope_id"`
+}

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -561,10 +561,10 @@ type reprovisionVolumeTarget struct {
 }
 
 type reprovisionFilesystemTarget struct {
-	FilesystemUUID string `db:"filesystem_uuid"`
-	AllAlive       bool   `db:"all_alive"`
-	ScopeClass     string `db:"scope_class"`
-	AttachmentUUID string `db:"attachment_uuid"`
+	FilesystemUUID string           `db:"filesystem_uuid"`
+	AllAlive       bool             `db:"all_alive"`
+	ScopeClass     string           `db:"scope_class"`
+	AttachmentUUID sql.Null[string] `db:"attachment_uuid"`
 }
 
 type reprovisionUUIDs []string

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -552,22 +552,18 @@ type netNode struct {
 }
 
 type reprovisionStorageEntityTarget struct {
-	EntityUUID            string           `db:"entity_uuid"`
-	LifeID                int              `db:"life_id"`
-	ScopeID               int              `db:"scope_id"`
-	StorageInstanceUUID   sql.Null[string] `db:"storage_instance_uuid"`
-	StorageInstanceLifeID sql.Null[int]    `db:"storage_instance_life_id"`
+	EntityUUID          string           `db:"entity_uuid"`
+	ScopeID             int              `db:"scope_id"`
+	StorageInstanceUUID sql.Null[string] `db:"storage_instance_uuid"`
 }
 
 type reprovisionStorageLogicalAttachment struct {
 	EntityUUID string `db:"entity_uuid"`
-	LifeID     int    `db:"life_id"`
 }
 
 type reprovisionStoragePhysicalAttachment struct {
 	UUID            string           `db:"uuid"`
 	EntityUUID      string           `db:"entity_uuid"`
-	LifeID          int              `db:"life_id"`
 	ScopeID         int              `db:"scope_id"`
 	BlockDeviceUUID sql.Null[string] `db:"block_device_uuid"`
 }
@@ -575,8 +571,12 @@ type reprovisionStoragePhysicalAttachment struct {
 type reprovisionStoragePlanTarget struct {
 	UUID       string `db:"uuid"`
 	EntityUUID string `db:"entity_uuid"`
-	LifeID     int    `db:"life_id"`
 	ScopeID    int    `db:"scope_id"`
+}
+
+type reprovisionStorageLife struct {
+	EntityType string `db:"entity_type"`
+	EntityUUID string `db:"entity_uuid"`
 }
 
 type reprovisionUUIDs []string

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -127,11 +127,17 @@ type machineLifeAndManual struct {
 // reprovisionEligibility holds the results of a compressed eligibility check
 // for reprovisioning.
 type reprovisionEligibility struct {
-	LifeID        life.Life `db:"life_id"`
-	IsContainer   int64     `db:"is_container"`
-	IsController  int64     `db:"is_controller"`
-	IsManual      int64     `db:"is_manual"`
-	HasContainers int64     `db:"has_containers"`
+	LifeID          life.Life `db:"life_id"`
+	IsContainer     int64     `db:"is_container"`
+	IsController    int64     `db:"is_controller"`
+	IsManual        int64     `db:"is_manual"`
+	HasContainers   int64     `db:"has_containers"`
+	HasModelStorage int64     `db:"has_model_storage"`
+}
+
+type reprovisionEligibilityParams struct {
+	Name         string `db:"name"`
+	ModelScopeID int    `db:"model_scope_id"`
 }
 
 // instanceID represents the struct to be used for the instance_id column within

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -553,6 +553,7 @@ type netNode struct {
 
 type reprovisionVolumeTarget struct {
 	VolumeUUID      string           `db:"volume_uuid"`
+	AllAlive        bool             `db:"all_alive"`
 	ScopeClass      string           `db:"scope_class"`
 	AttachmentUUID  sql.Null[string] `db:"attachment_uuid"`
 	PlanUUID        sql.Null[string] `db:"plan_uuid"`
@@ -561,6 +562,7 @@ type reprovisionVolumeTarget struct {
 
 type reprovisionFilesystemTarget struct {
 	FilesystemUUID string `db:"filesystem_uuid"`
+	AllAlive       bool   `db:"all_alive"`
 	ScopeClass     string `db:"scope_class"`
 	AttachmentUUID string `db:"attachment_uuid"`
 }
@@ -569,6 +571,7 @@ type reprovisionUUIDs []string
 
 type reprovisionStorageTargetParams struct {
 	NetNodeUUID    string `db:"net_node_uuid"`
+	AliveLifeID    int    `db:"alive_life_id"`
 	ModelScopeID   int    `db:"model_scope_id"`
 	MachineScopeID int    `db:"machine_scope_id"`
 }


### PR DESCRIPTION
When reprovisioning a machine whose backing instance has been lost, any machine-scoped storage attached to that instance must also be treated as lost. Reusing its provider IDs, attachment plans, or block-device records could make the replacement machine appear to have storage that no longer exists.

Previously, the detach operation cleared the old machine and network provider data but retained storage-related state. It did not classify attached storage or reset its physical provider state. This meant machine-scoped storage could retain information belonging to the lost instance, while model-scoped storage did not prevent reprovisioning.

Reprovisioning now classifies attached volumes and filesystems before proceeding. Model-scoped storage is rejected because safely reattaching storage that may outlive the machine requires a separate recovery flow. Ambiguous, inconsistent, or non-alive storage also fails closed.

For machine-scoped storage, Juju preserves its identity and logical attachment intent while clearing provider-specific state, attachment plans, and old block-device evidence. The storage is returned to pending, allowing normal provisioning to create empty replacement storage for the new instance.

Storage is checked again within the detach transaction so that changes made after the initial eligibility check cannot bypass these safeguards.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model foo
```

Test machine-scoped storage:

```sh
$ juju deploy juju-qa-dummy-storage machine-storage \
  --storage single-fs=rootfs
$ juju storage
```

Stop the Juju services on the machine and delete its backing LXD instance.

```sh
# stop the instance manually
$ juju add-ssh-key <your ssh key>
$ juju ssh 0
$ sudo systemctl stop juju*.service
```

```sh
$ lxc delete <instance id> -f
```

Now retry provisioning:

> [!NOTE]
> This won't create a new instance, as we've not wired up the provisioner task to spot this. So for now you should see that the `instance_id` in the `juju_db_repl` for the `machine_cloud_instance` is `<nil>`.

```sh
$ juju reprovision-machine 0
```

### Model scoped storage

```
$ juju add-model model-storage
$ juju deploy juju-qa-dummy-storage \
  --storage single-fs=lxd
```

Stop the Juju services and delete the backing LXD instance, then run:

```
$ juju reprovision-machine 0
ERROR reprovisioning machine "0": model-scoped storage attached to machine
```



## Links


**Jira card:** [JUJU-10181](https://warthogs.atlassian.net/browse/JUJU-10181)


[JUJU-10181]: https://warthogs.atlassian.net/browse/JUJU-10181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ