### PR TITLE
fix(removal): refuse generic removal of a migrating model

### DIFF
--- a/domain/removal/errors/errors.go
+++ b/domain/removal/errors/errors.go
@@ -87,4 +87,10 @@ const (
 	// StorageInstanceStillAttached indicates that the storage instance cannot
 	// be removed without force as it still has attachments.
 	StorageInstanceStillAttached = errors.ConstError("storage instance still attached")
+
+	// MigrationImportActive indicates that generic model removal was attempted
+	// on a model that holds a migration import claim. Such a model is mid-import
+	// and is torn down by aborting the import, which owns the protocol that
+	// proves the model database is gone before the model UUID is released.
+	MigrationImportActive = errors.ConstError("model has an active migration import claim")
 )

--- a/domain/removal/service/controller.go
+++ b/domain/removal/service/controller.go
@@ -31,10 +31,12 @@ type ControllerState interface {
 	// GetModelUUIDs retrieves the UUIDs of all models in the controller.
 	GetModelUUIDs(ctx context.Context) ([]string, error)
 
-	// EnsureModelNotAlive ensures that there is no model identified
-	// by the input model UUID, that is still alive. This does not cascade
-	// all entities associated with the model will still be alive.
-	EnsureModelNotAlive(ctx context.Context, modelUUID string, force bool) error
+	// EnsureModelNotAliveUnlessMigrating ensures that there is no model
+	// identified by the input model UUID, that is still alive. This does not
+	// cascade all entities associated with the model will still be alive.
+	// It refuses to begin the removal of a model that holds a migration
+	// import claim.
+	EnsureModelNotAliveUnlessMigrating(ctx context.Context, modelUUID string, force bool) error
 
 	// MarkModelAsDead marks the model with the input UUID as dead.
 	MarkModelAsDead(ctx context.Context, modelUUID string) error
@@ -117,7 +119,7 @@ func (s *Service) removeControllerModel(
 
 	// If the model doesn't exist we can still run this, it just will be a
 	// no-op.
-	if err := s.controllerState.EnsureModelNotAlive(ctx, s.modelUUID.String(), force); err != nil {
+	if err := s.controllerState.EnsureModelNotAliveUnlessMigrating(ctx, s.modelUUID.String(), force); err != nil {
 		return "", errors.Errorf("ensuring controller model %q is not alive: %w", s.modelUUID, err)
 	}
 

--- a/domain/removal/service/controller_test.go
+++ b/domain/removal/service/controller_test.go
@@ -37,7 +37,7 @@ func (s *controllerSuite) TestRemoveController(c *tc.C) {
 	cExp.GetModelUUIDs(gomock.Any()).Return([]string{"model-1"}, nil)
 
 	cExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), s.modelUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), s.modelUUID.String(), false).Return(nil)
 
 	mExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(false, nil)
 	mExp.EnsureModelNotAlive(gomock.Any(), s.modelUUID.String(), false).Return(nil)
@@ -61,7 +61,7 @@ func (s *controllerSuite) TestRemoveControllerModelExists(c *tc.C) {
 	cExp.GetModelUUIDs(gomock.Any()).Return([]string{"model-1"}, nil)
 
 	cExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), s.modelUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), s.modelUUID.String(), false).Return(nil)
 
 	mExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(true, nil)
 	mExp.EnsureModelNotAlive(gomock.Any(), s.modelUUID.String(), false).Return(nil)
@@ -82,7 +82,7 @@ func (s *controllerSuite) TestRemoveControllerModelDoesNotExists(c *tc.C) {
 	cExp.GetModelUUIDs(gomock.Any()).Return([]string{"model-1"}, nil)
 
 	cExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(false, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), s.modelUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), s.modelUUID.String(), false).Return(nil)
 
 	mExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(false, nil)
 
@@ -103,7 +103,7 @@ func (s *controllerSuite) TestRemoveControllerWithForce(c *tc.C) {
 	cExp.GetModelUUIDs(gomock.Any()).Return([]string{"model-1"}, nil)
 
 	cExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), s.modelUUID.String(), true).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), s.modelUUID.String(), true).Return(nil)
 
 	mExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(true, nil)
 	mExp.EnsureModelNotAlive(gomock.Any(), s.modelUUID.String(), true).Return(nil)
@@ -130,7 +130,7 @@ func (s *controllerSuite) TestRemoveControllerEmptyController(c *tc.C) {
 	cExp := s.controllerState.EXPECT()
 	cExp.GetModelUUIDs(gomock.Any()).Return([]string{}, nil)
 	cExp.ModelExists(gomock.Any(), s.modelUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), s.modelUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), s.modelUUID.String(), false).Return(nil)
 
 	modelUUIDs, err := s.newService(c).RemoveController(c.Context(), false, 0)
 	c.Assert(err, tc.ErrorIsNil)
@@ -184,7 +184,7 @@ func (s *controllerSuite) TestExecuteJobForControllerModelWithNoModels(c *tc.C) 
 	cExp := s.controllerState.EXPECT()
 	cExp.GetModelUUIDs(gomock.Any()).Return([]string{}, nil)
 	cExp.ModelExists(gomock.Any(), j.EntityUUID).Return(false, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), j.EntityUUID, false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), j.EntityUUID, false).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIs, removalerrors.RemovalModelRemoved)
@@ -204,7 +204,7 @@ func (s *controllerSuite) TestExecuteJobForControllerModelNotFound(c *tc.C) {
 	cExp := s.controllerState.EXPECT()
 	cExp.GetModelUUIDs(gomock.Any()).Return([]string{j.EntityUUID}, nil)
 	cExp.ModelExists(gomock.Any(), j.EntityUUID).Return(false, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), j.EntityUUID, false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), j.EntityUUID, false).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIs, removalerrors.RemovalModelRemoved)

--- a/domain/removal/service/model.go
+++ b/domain/removal/service/model.go
@@ -164,7 +164,7 @@ func (s *Service) removeModel(
 
 	// If the model doesn't exist we can still run this, it just will be a
 	// no-op.
-	if err := s.controllerState.EnsureModelNotAlive(ctx, modelUUID.String(), force); err != nil {
+	if err := s.controllerState.EnsureModelNotAliveUnlessMigrating(ctx, modelUUID.String(), force); err != nil {
 		return "", errors.Errorf("ensuring model %q is not alive: %w", modelUUID, err)
 	}
 

--- a/domain/removal/service/model_test.go
+++ b/domain/removal/service/model_test.go
@@ -38,7 +38,7 @@ func (s *modelSuite) TestRemoveModelNoForceSuccess(c *tc.C) {
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), false).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
@@ -82,7 +82,7 @@ func (s *modelSuite) TestRemoveModelRetrySchedulesRemovalJobs(c *tc.C) {
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil).Times(2)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil).Times(2)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), false).Return(nil).Times(2)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil).Times(2)
@@ -133,8 +133,8 @@ func (s *modelSuite) TestRemoveModelRetryWithForceSchedulesRemovalJobs(c *tc.C) 
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil).Times(2)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), true).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), true).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil).Times(2)
@@ -198,7 +198,7 @@ func (s *modelSuite) TestRemoveModelNoForceSuccessControllerModel(c *tc.C) {
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), true).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), true).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(true, nil)
@@ -235,7 +235,7 @@ func (s *modelSuite) TestRemoveModelForceNoWaitSuccess(c *tc.C) {
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), true).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), true).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
@@ -258,7 +258,7 @@ func (s *modelSuite) TestRemoveModelForceWaitSuccess(c *tc.C) {
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), true).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), true).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
@@ -287,7 +287,7 @@ func (s *modelSuite) TestRemoveModelNoForceSuccessWithRemoteApplicationOfferer(c
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), false).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
@@ -332,7 +332,7 @@ func (s *modelSuite) TestRemoveModelIgnoresApplicationErrorWithoutRemoteOffererF
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), false).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
@@ -362,7 +362,7 @@ func (s *modelSuite) TestRemoveModelNotFoundInModelButInController(c *tc.C) {
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(true, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), false).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
@@ -384,7 +384,7 @@ func (s *modelSuite) TestRemoveModelNotFoundInControllerButInModel(c *tc.C) {
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(false, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), false).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)
@@ -403,7 +403,7 @@ func (s *modelSuite) TestRemoveModelNotFoundInBothControllerAndModel(c *tc.C) {
 
 	cExp := s.controllerState.EXPECT()
 	cExp.ModelExists(gomock.Any(), mUUID.String()).Return(false, nil)
-	cExp.EnsureModelNotAlive(gomock.Any(), mUUID.String(), false).Return(nil)
+	cExp.EnsureModelNotAliveUnlessMigrating(gomock.Any(), mUUID.String(), false).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), mUUID.String()).Return(false, nil)

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -32,18 +32,18 @@ type MockControllerDBState struct {
 
 // MockControllerDBStateMockRecorder is the mock recorder for MockControllerDBState.
 type MockControllerDBStateMockRecorder struct {
-	mock                                *MockControllerDBState
-	deleteModelExpects                  []*gomock.Call2_1[context.Context, string, error]
-	deleteOfferAccessExpects            []*gomock.Call2_1[context.Context, string, error]
-	ensureModelNotAliveExpects          []*gomock.Call3_1[context.Context, string, bool, error]
-	getActiveModelSecretBackendExpects  []*gomock.Call2_3[context.Context, string, string, *provider.ModelBackendConfig, error]
-	getModelLifeExpects                 []*gomock.Call2_2[context.Context, string, life.Life, error]
-	getModelUUIDsExpects                []*gomock.Call1_2[context.Context, []string, error]
-	isMigratingModelExpects             []*gomock.Call2_2[context.Context, string, bool, error]
-	markMigratingModelAsDeadExpects     []*gomock.Call2_1[context.Context, string, error]
-	markModelAsDeadExpects              []*gomock.Call2_1[context.Context, string, error]
-	modelExistsExpects                  []*gomock.Call2_2[context.Context, string, bool, error]
-	removeSecretBackendReferenceExpects []*gomock.Call1V_1[context.Context, string, error]
+	mock                                      *MockControllerDBState
+	deleteModelExpects                        []*gomock.Call2_1[context.Context, string, error]
+	deleteOfferAccessExpects                  []*gomock.Call2_1[context.Context, string, error]
+	ensureModelNotAliveUnlessMigratingExpects []*gomock.Call3_1[context.Context, string, bool, error]
+	getActiveModelSecretBackendExpects        []*gomock.Call2_3[context.Context, string, string, *provider.ModelBackendConfig, error]
+	getModelLifeExpects                       []*gomock.Call2_2[context.Context, string, life.Life, error]
+	getModelUUIDsExpects                      []*gomock.Call1_2[context.Context, []string, error]
+	isMigratingModelExpects                   []*gomock.Call2_2[context.Context, string, bool, error]
+	markMigratingModelAsDeadExpects           []*gomock.Call2_1[context.Context, string, error]
+	markModelAsDeadExpects                    []*gomock.Call2_1[context.Context, string, error]
+	modelExistsExpects                        []*gomock.Call2_2[context.Context, string, bool, error]
+	removeSecretBackendReferenceExpects       []*gomock.Call1V_1[context.Context, string, error]
 }
 
 // NewMockControllerDBState creates a new mock instance.
@@ -94,23 +94,23 @@ func (mr *MockControllerDBStateMockRecorder) DeleteOfferAccess(ctx, offerUUID an
 // MockControllerDBStateDeleteOfferAccessCall is the typed call wrapper for DeleteOfferAccess.
 type MockControllerDBStateDeleteOfferAccessCall = gomock.Call2_1[context.Context, string, error]
 
-// EnsureModelNotAlive mocks base method.
-func (m *MockControllerDBState) EnsureModelNotAlive(ctx context.Context, modelUUID string, force bool) error {
+// EnsureModelNotAliveUnlessMigrating mocks base method.
+func (m *MockControllerDBState) EnsureModelNotAliveUnlessMigrating(ctx context.Context, modelUUID string, force bool) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch3_1(&m.recorder.ensureModelNotAliveExpects, m.ctrl, m, "EnsureModelNotAlive", ctx, modelUUID, force)
+	return gomock.Dispatch3_1(&m.recorder.ensureModelNotAliveUnlessMigratingExpects, m.ctrl, m, "EnsureModelNotAliveUnlessMigrating", ctx, modelUUID, force)
 }
 
-// EnsureModelNotAlive indicates an expected call of EnsureModelNotAlive.
-func (mr *MockControllerDBStateMockRecorder) EnsureModelNotAlive(ctx, modelUUID, force any) *MockControllerDBStateEnsureModelNotAliveCall {
+// EnsureModelNotAliveUnlessMigrating indicates an expected call of EnsureModelNotAliveUnlessMigrating.
+func (mr *MockControllerDBStateMockRecorder) EnsureModelNotAliveUnlessMigrating(ctx, modelUUID, force any) *MockControllerDBStateEnsureModelNotAliveUnlessMigratingCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall3_1[context.Context, string, bool, error](mr.mock.ctrl.T, mr.mock, "EnsureModelNotAlive", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID), gomock.EnsureMatcher(force))
-	mr.ensureModelNotAliveExpects = append(mr.ensureModelNotAliveExpects, call)
+	call := gomock.NewCall3_1[context.Context, string, bool, error](mr.mock.ctrl.T, mr.mock, "EnsureModelNotAliveUnlessMigrating", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID), gomock.EnsureMatcher(force))
+	mr.ensureModelNotAliveUnlessMigratingExpects = append(mr.ensureModelNotAliveUnlessMigratingExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
-// MockControllerDBStateEnsureModelNotAliveCall is the typed call wrapper for EnsureModelNotAlive.
-type MockControllerDBStateEnsureModelNotAliveCall = gomock.Call3_1[context.Context, string, bool, error]
+// MockControllerDBStateEnsureModelNotAliveUnlessMigratingCall is the typed call wrapper for EnsureModelNotAliveUnlessMigrating.
+type MockControllerDBStateEnsureModelNotAliveUnlessMigratingCall = gomock.Call3_1[context.Context, string, bool, error]
 
 // GetActiveModelSecretBackend mocks base method.
 func (m *MockControllerDBState) GetActiveModelSecretBackend(ctx context.Context, modelUUID string) (string, *provider.ModelBackendConfig, error) {

--- a/domain/removal/state/controller/model.go
+++ b/domain/removal/state/controller/model.go
@@ -49,21 +49,17 @@ WHERE  uuid = $entityUUID.uuid`, modelUUID)
 	return modelExists, errors.Capture(err)
 }
 
-// EnsureModelNotAlive ensures that there is no model identified
-// by the input model UUID, that is still alive. This does not cascade, as
-// it is only used to set the model life to dying.
+// EnsureModelNotAliveUnlessMigrating ensures that there is no model
+// identified by the input model UUID, that is still alive. This does not
+// cascade, as it is only used to set the model life to dying.
 //
-// It refuses to begin generic removal of a model that holds a migration import
+// It refuses to begin the removal of a model that holds a migration import
 // claim. Such a model is mid-import: its rows are still being written, and
 // tearing it down here would race those writes and drop the model database
 // underneath them, while the claim's own cleanup protocol - which proves the
 // database is gone before releasing the model UUID - never runs. The migration
 // abort path owns that teardown and reaches it without this call.
-//
-// The check is inside the transaction that begins removal, so a claim appearing
-// concurrently cannot slip past it. Force is not an escape hatch: the objection
-// is not about the model's contents but about who owns its teardown.
-func (st *State) EnsureModelNotAlive(ctx context.Context, modelUUID string, force bool) error {
+func (st *State) EnsureModelNotAliveUnlessMigrating(ctx context.Context, modelUUID string, force bool) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/removal/state/controller/model.go
+++ b/domain/removal/state/controller/model.go
@@ -52,6 +52,17 @@ WHERE  uuid = $entityUUID.uuid`, modelUUID)
 // EnsureModelNotAlive ensures that there is no model identified
 // by the input model UUID, that is still alive. This does not cascade, as
 // it is only used to set the model life to dying.
+//
+// It refuses to begin generic removal of a model that holds a migration import
+// claim. Such a model is mid-import: its rows are still being written, and
+// tearing it down here would race those writes and drop the model database
+// underneath them, while the claim's own cleanup protocol - which proves the
+// database is gone before releasing the model UUID - never runs. The migration
+// abort path owns that teardown and reaches it without this call.
+//
+// The check is inside the transaction that begins removal, so a claim appearing
+// concurrently cannot slip past it. Force is not an escape hatch: the objection
+// is not about the model's contents but about who owns its teardown.
 func (st *State) EnsureModelNotAlive(ctx context.Context, modelUUID string, force bool) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -68,6 +79,13 @@ func (st *State) EnsureModelNotAlive(ctx context.Context, modelUUID string, forc
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if migrating, err := st.isModelMigrating(ctx, tx, modelUUID); err != nil {
+			return errors.Errorf("checking migration import claim: %w", err)
+		} else if migrating {
+			return errors.Errorf(
+				"model %q is being migrated: %w", modelUUID, removalerrors.MigrationImportActive)
+		}
+
 		// Update the model life to dying.
 		if err := tx.Query(ctx, updateModelLife, eUUID).Run(); err != nil {
 			return errors.Errorf("setting model life to dying: %w", err)

--- a/domain/removal/state/controller/model_test.go
+++ b/domain/removal/state/controller/model_test.go
@@ -83,25 +83,25 @@ VALUES ('foo', ?, 'source-migration-uuid')`, modelUUID)
 	c.Check(isMigrating, tc.IsTrue)
 }
 
-func (s *modelSuite) TestEnsureModelNotAlive(c *tc.C) {
+func (s *modelSuite) TestEnsureModelNotAliveUnlessMigrating(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	modelUUID := s.getModelUUID(c)
 
-	err := st.EnsureModelNotAlive(c.Context(), modelUUID, false)
+	err := st.EnsureModelNotAliveUnlessMigrating(c.Context(), modelUUID, false)
 	c.Assert(err, tc.ErrorIsNil)
 
 	s.checkModelLife(c, modelUUID, life.Dying)
 }
 
-// TestEnsureModelNotAliveRefusesMigratingModel asserts that generic removal
-// cannot begin on a model holding a migration import claim.
+// TestEnsureModelNotAliveUnlessMigratingRefusesMigratingModel asserts that
+// generic removal cannot begin on a model holding a migration import claim.
 //
 // Such a model is mid-import. Marking it dying here would let the undertaker
 // drop the model database underneath the writes still arriving, and would skip
 // the claim protocol that proves the database is actually gone before the model
 // UUID is released. Tearing down a migrating model is the abort path's job.
-func (s *modelSuite) TestEnsureModelNotAliveRefusesMigratingModel(c *tc.C) {
+func (s *modelSuite) TestEnsureModelNotAliveUnlessMigratingRefusesMigratingModel(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	modelUUID := s.getModelUUID(c)
@@ -117,7 +117,7 @@ VALUES ('claim-uuid', ?, 'source-migration-uuid')`, modelUUID)
 	// Force is not an escape hatch: the objection is about who owns the
 	// teardown, not about the model's contents.
 	for _, force := range []bool{false, true} {
-		err := st.EnsureModelNotAlive(c.Context(), modelUUID, force)
+		err := st.EnsureModelNotAliveUnlessMigrating(c.Context(), modelUUID, force)
 		c.Check(err, tc.ErrorIs, removalerrors.MigrationImportActive)
 		s.checkModelLife(c, modelUUID, life.Alive)
 	}

--- a/domain/removal/state/controller/model_test.go
+++ b/domain/removal/state/controller/model_test.go
@@ -94,6 +94,35 @@ func (s *modelSuite) TestEnsureModelNotAlive(c *tc.C) {
 	s.checkModelLife(c, modelUUID, life.Dying)
 }
 
+// TestEnsureModelNotAliveRefusesMigratingModel asserts that generic removal
+// cannot begin on a model holding a migration import claim.
+//
+// Such a model is mid-import. Marking it dying here would let the undertaker
+// drop the model database underneath the writes still arriving, and would skip
+// the claim protocol that proves the database is actually gone before the model
+// UUID is released. Tearing down a migrating model is the abort path's job.
+func (s *modelSuite) TestEnsureModelNotAliveRefusesMigratingModel(c *tc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	modelUUID := s.getModelUUID(c)
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
+VALUES ('claim-uuid', ?, 'source-migration-uuid')`, modelUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Force is not an escape hatch: the objection is about who owns the
+	// teardown, not about the model's contents.
+	for _, force := range []bool{false, true} {
+		err := st.EnsureModelNotAlive(c.Context(), modelUUID, force)
+		c.Check(err, tc.ErrorIs, removalerrors.MigrationImportActive)
+		s.checkModelLife(c, modelUUID, life.Alive)
+	}
+}
+
 func (s *modelSuite) TestGetModelUUIDs(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.48.0
 	google.golang.org/api v0.256.0
-	google.golang.org/grpc v1.82.0
+	google.golang.org/grpc v1.82.1
 	gopkg.in/errgo.v1 v1.0.1
 	gopkg.in/httprequest.v1 v1.2.1
 	gopkg.in/ini.v1 v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -956,8 +956,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260715232425-e75dac1f907d/go.
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
This answers the last sentence of https://github.com/juju/juju/pull/22899#issuecomment-5069798080: "Normal model removal must also 
reject a live import claim; the fortress only controls workers, not controller API mutations." That 
distinction is the whole point. Making the flag claim-aware stops workers touching a model during an 
import. It does nothing about someone calling the API, and juju destroy-model is an API call.

The step that begins ordinary model removal marks the model dying, after which the undertaker tears it
down. That step knew nothing about migration. So running destroy-model against a model in the middle 
of an import simply worked, and did two harmful things at once. It dropped the model's database while 
the import was still writing into it. And it skipped the migration's own cleanup, which is the part
that proves the model database is really gone before the model UUID is released. Releasing that UUID
too early means a later import of the same model can collide with what is left of the last attempt.
Juju 3.6 guarded ordinary model changes with a check that migration mode was none, failing them with
"model is being migrated". Destroying was safer there simply because everything lived in one database
and removal took all of it, so there was no separate model database whose deletion had to be proven
and no claim to release.

Removal now refuses to start while an import claim exists. The check sits inside the transaction that
begins removal rather than in a query beforehand, so a claim appearing in between cannot slip through.
--force does not bypass it, because the objection is not about the model's contents but about which
code owns the teardown. The migration abort path is unaffected, since it reaches the model by a
different route and still tears it down properly. Making a plain destroy-model route into that abort
cleanup, which is what 3.6 effectively allowed, needs the abort engine to route into and so belongs
with that work.


## QA steps

This QA scenario is not straightforward because we need to hit a narrow window when the model is still importing. Bootstrap a 3.6 and a 4.1 (this branch) target controller, then:
```
  juju switch src36 && juju add-model guard1 && juju deploy juju-qa-test -n 5
  juju migrate src36:guard1 dst41
```
While the import is _still running_:
```
  juju destroy-model dst41:guard1 --no-prompt
```
This should fail with: `model has an active migration import claim`.
With force it should fail the same (assuming the migration is still ongoing):
```
  juju destroy-model dst41:guard1 --no-prompt --force
```
Once the migration has finished it is an ordinary model again:
```
  juju destroy-model dst41:guard1 --no-prompt
```
Should succeed.

## Links

**Jira card:** [JUJU-9910](https://warthogs.atlassian.net/browse/JUJU-9910)


[JUJU-9910]: https://warthogs.atlassian.net/browse/JUJU-9910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ