### PR TITLE
test(sshserver): address data race in test

### DIFF
--- a/internal/worker/sshserver/handlers/machine/session_test.go
+++ b/internal/worker/sshserver/handlers/machine/session_test.go
@@ -4,7 +4,6 @@
 package machine
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -83,26 +82,20 @@ func (s *machineSuite) TestSessionHandlerPropagatesCommandExitCode(c *tc.C) {
 func (s *machineSuite) TestSessionHandlerProxiesPTYAndWindowChanges(c *tc.C) {
 	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
 	c.Assert(err, tc.ErrorIsNil)
+	ready := make(chan struct{})
 
-	machine := startSSHTestServer(c, &ssh.Server{Handler: func(session ssh.Session) {
-		pty, windowChanges, hasPTY := session.Pty()
-		c.Check(hasPTY, tc.IsTrue)
-		c.Check(pty.Term, tc.Equals, "xterm")
-
-		_, _ = io.WriteString(session, "shell ready\n")
-		var window ssh.Window
-		// This loop terminates when we get what we expect
-		// or when the server is shutdown and windowChanges closes.
-		for {
-			window = <-windowChanges
-			if window.Height == 30 && window.Width == 100 {
-				break
-			}
-		}
-		c.Check(window.Height, tc.Equals, 30)
-		c.Check(window.Width, tc.Equals, 100)
-		_, _ = io.WriteString(session, "shell done\n")
-	}})
+	machine := startSSHTestServer(c, &ssh.Server{
+		PtyCallback: func(_ ssh.Context, pty ssh.Pty) bool {
+			c.Check(pty.Term, tc.Equals, "xterm")
+			c.Check(pty.Window.Height, tc.Equals, 24)
+			c.Check(pty.Window.Width, tc.Equals, 80)
+			return true
+		},
+		Handler: func(session ssh.Session) {
+			close(ready)
+			_, _ = io.WriteString(session, "shell done\n")
+		},
+	})
 
 	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
 	c.Assert(err, tc.ErrorIsNil)
@@ -117,35 +110,17 @@ func (s *machineSuite) TestSessionHandlerProxiesPTYAndWindowChanges(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	defer session.Close()
 
-	stdoutReader, stdoutWriter := io.Pipe()
-	defer stdoutReader.Close()
-	defer stdoutWriter.Close()
-	session.Stdout = stdoutWriter
-	c.Assert(session.RequestPty("xterm", 24, 80, gossh.TerminalModes{}), tc.ErrorIsNil)
+	var stdout bytes.Buffer
+	session.Stdout = &stdout
+
+	err = session.RequestPty("xterm", 24, 80, gossh.TerminalModes{})
+	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(session.Shell(), tc.ErrorIsNil)
 
-	type outputResult struct {
-		message string
-		err     error
-	}
-	outputs := make(chan outputResult, 2)
-	go func() {
-		stdout := bufio.NewReader(stdoutReader)
-		message, err := stdout.ReadString('\n')
-		outputs <- outputResult{message: message, err: err}
-		message, err = stdout.ReadString('\n')
-		outputs <- outputResult{message: message, err: err}
-	}()
-
-	output := <-outputs
-	c.Assert(output.err, tc.ErrorIsNil)
-	c.Check(output.message, tc.Equals, "shell ready\r\n")
+	<-ready
 	c.Assert(session.WindowChange(30, 100), tc.ErrorIsNil)
 	c.Assert(session.Wait(), tc.ErrorIsNil)
-
-	output = <-outputs
-	c.Assert(output.err, tc.ErrorIsNil)
-	c.Check(output.message, tc.Equals, "shell done\r\n")
+	c.Check(stdout.String(), tc.Equals, "shell done\r\n")
 }
 
 func (s *machineSuite) TestSessionHandlerReportsConnectionFailure(c *tc.C) {

--- a/internal/worker/sshserver/handlers/machine/session_test.go
+++ b/internal/worker/sshserver/handlers/machine/session_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 
 	"github.com/gliderlabs/ssh"
 	"github.com/juju/tc"
@@ -117,7 +118,11 @@ func (s *machineSuite) TestSessionHandlerProxiesPTYAndWindowChanges(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(session.Shell(), tc.ErrorIsNil)
 
-	<-ready
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		c.Fatal("timed out waiting for shell to start")
+	}
 	c.Assert(session.WindowChange(30, 100), tc.ErrorIsNil)
 	c.Assert(session.Wait(), tc.ErrorIsNil)
 	c.Check(stdout.String(), tc.Equals, "shell done\r\n")


### PR DESCRIPTION
This change fixes a race in the SSH server proxy handlers. Specifically in `TestSessionHandlerProxiesPTYAndWindowChanges`. The problem almost certainly lies in the Gliderlab's SSH server itself. The relevant snippet from the data race warning is below,
```
WARNING: DATA RACE
Write at 0x00c0001bc4f0 by goroutine 451:
  github.com/gliderlabs/ssh.(*session).handleRequests()
      /home/jenkins/go/pkg/mod/github.com/gliderlabs/ssh@v0.3.8/session.go:351 +0x13d9
  github.com/gliderlabs/ssh.DefaultSessionHandler()
      /home/jenkins/go/pkg/mod/github.com/gliderlabs/ssh@v0.3.8/session.go:106 +0x377
  github.com/gliderlabs/ssh.(*Server).HandleConn.gowrap4()
      /home/jenkins/go/pkg/mod/github.com/gliderlabs/ssh@v0.3.8/server.go:318 +0x86

Previous read at 0x00c0001bc4f0 by goroutine 453:
  github.com/gliderlabs/ssh.(*session).Pty()
      /home/jenkins/go/pkg/mod/github.com/gliderlabs/ssh@v0.3.8/session.go:212 +0x6d
  github.com/juju/juju/internal/worker/sshserver/handlers/machine.(*machineSuite).TestSessionHandlerProxiesPTYAndWindowChanges.func1()
      /home/jenkins/go/src/github.com/juju/juju/internal/worker/sshserver/handlers/machine/session_test.go:88 +0x5a
  github.com/gliderlabs/ssh.(*session).handleRequests.func1()
      /home/jenkins/go/pkg/mod/github.com/gliderlabs/ssh@v0.3.8/session.go:261 +0x49
```

When requesting an SSH session, as opposed to port-forwarding or handling another SSH channel, the server is supposed to respond to requests for window size changes, signals, etc. The Gliderlab's server provides a default implementation for this that receives these requests off a channel and then does the appropriate logic based on the request type. The handler for window-size change does the following,
```go
		case "window-change":
			if sess.pty == nil {
				req.Reply(false, nil)
				continue
			}
			win, ok := parseWinchRequest(req.Payload)
			if ok {
				sess.pty.Window = win // <- session.go:351
				sess.winch <- win
			}
```
Unfortunately modifying `sess.pty` causes a race because calling the session's `Pty()` method does,
```go
func (sess *session) Pty() (Pty, <-chan Window, bool) {
	if sess.pty != nil {
		return *sess.pty, sess.winch, true // <- session.go:212
	}
	return Pty{}, sess.winch, false
}
``` 
Where it returns `sess.pty` which the other handler is modifying at the same time. 

Notice the two line numbers added above and how they correlate with the data race snippet. A proper fix would lie in the Gliderlab's lib and I think would be simply removing the line `sess.pty.Window = win` in effect having the initial window size stay fixed and changes only come down the `winch` channel. I've checked the two most popular forks of the library and neither ([charm bracelet's](https://github.com/charmbracelet/ssh/blob/master/session.go#L390) nor [tailscale's](https://github.com/tailscale/gliderssh/blob/master/session.go)) seem to have resolved the issue.

To fix the issue in the test we simply avoid the use of `Pty()`. In practice I don't expect this would cause any issues, as latency would likely mask any issues or in the worst case you may have an out-dated initial window size.

Running the following surfaces the race before the change and passes after.
```
go test ./internal/worker/sshserver/handlers/machine -run 'TestMachineSuite/TestSessionHandlerProxiesPTYAndWindowChanges' -race -c -o /tmp/machine.test && timeout 31 stress -timeout 30s /tmp/machine.test -test.run 'TestMachineSuite/TestSessionHandlerProxiesPTYAndWindowChanges'
``` 

