### PR TITLE
feat(gce): add support for new disk storage types eg hyperdisk

### DIFF
--- a/docs/reference/cloud/list-of-supported-clouds/google-gce.md
+++ b/docs/reference/cloud/list-of-supported-clouds/google-gce.md
@@ -285,7 +285,7 @@ In addition to generic storage providers, Google GCE provides the following {ref
 
 **Configuration options:**
 
-- `disk-type`: Disk type. Valid values: `pd-standard` (default), `pd-ssd`.
+- `disk-type`: Disk type. Valid values: `pd-standard` (default), `pd-ssd`, `pd-balanced`, `pd-extreme`, `hyperdisk-balanced`, `hyperdisk-balanced-high-availability`, `hyperdisk-extreme`, `hyperdisk-ml`, `hyperdisk-throughput`.
 
 (gce-appendix-example-workflows)=
 ## Appendix: Example workflows

--- a/internal/provider/gce/disks.go
+++ b/internal/provider/gce/disks.go
@@ -194,6 +194,27 @@ func nameVolume(zone string) (string, error) {
 	return volumeName, nil
 }
 
+func isValidDiskType(dt google.DiskType) bool {
+	switch dt {
+	case google.DiskPersistentSSD, google.DiskPersistentStandard, google.DiskPersistentBalanced, google.DiskPersistentExtreme,
+		google.DiskHyperdiskBalanced, google.DiskHyperdiskBalancedHighAvailability, google.DiskHyperdiskML,
+		google.DiskHyperdiskExtreme, google.DiskHyperdiskThroughput:
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidHyperDiskType(dt google.DiskType) bool {
+	switch dt {
+	case google.DiskHyperdiskBalanced, google.DiskHyperdiskBalancedHighAvailability, google.DiskHyperdiskML,
+		google.DiskHyperdiskExtreme, google.DiskHyperdiskThroughput:
+		return true
+	default:
+		return false
+	}
+}
+
 func (v *volumeSource) createOneVolume(ctx context.ProviderCallContext, p storage.VolumeParams, instances instanceCache) (volume *storage.Volume, volumeAttachment *storage.VolumeAttachment, err error) {
 	var volumeName, zone string
 	defer func() {
@@ -219,12 +240,16 @@ func (v *volumeSource) createOneVolume(ctx context.ProviderCallContext, p storag
 	diskType := google.DiskPersistentStandard
 	if val, ok := p.Attributes[diskTypeAttribute].(string); ok {
 		dt := google.DiskType(val)
-		switch dt {
-		case google.DiskPersistentSSD, google.DiskPersistentStandard:
-			diskType = dt
-		case google.DiskLocalSSD:
+		if dt == google.DiskLocalSSD {
 			return nil, nil, errors.NotValidf("local SSD disk storage")
-		default:
+		} else if isValidDiskType(dt) {
+			instanceTypeName := path.Base(inst.GetMachineType())
+			if google.IsLegacyMachineSeries(instanceTypeName) && isValidHyperDiskType(dt) {
+				return nil, nil, errors.NotSupportedf("hyperdisk storage for legacy instance %q", instanceTypeName)
+			}
+			diskType = dt
+		} else {
+			return nil, nil, errors.NotValidf("unknown disk type %q", val)
 		}
 	}
 

--- a/internal/provider/gce/disks_test.go
+++ b/internal/provider/gce/disks_test.go
@@ -250,6 +250,26 @@ func (s *volumeSourceSuite) TestCreateVolumesWithLocalSSD(c *gc.C) {
 	c.Assert(res[0].Error, gc.ErrorMatches, expectedErr)
 }
 
+func (s *volumeSourceSuite) TestCreateVolumesHyperDiskNotSupported(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	s.MockService.EXPECT().Instances(gomock.Any(), "", google.StatusRunning).Return([]*computepb.Instance{{
+		Name:        ptr("inst-0"),
+		Zone:        ptr("path/to/zone"),
+		MachineType: ptr("path/to/zone/n1-standard"),
+	}}, nil)
+
+	s.params[0].Attributes = map[string]interface{}{
+		"disk-type": "hyperdisk-extreme",
+	}
+	source := s.setUpSource(c)
+	res, err := source.CreateVolumes(s.CallCtx, s.params)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(res, gc.HasLen, 1)
+	c.Assert(res[0].Error, gc.ErrorMatches, `hyperdisk storage for legacy instance "n1-standard" not supported`)
+}
+
 func (s *volumeSourceSuite) TestDestroyVolumesInvalidCredentialError(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()

--- a/internal/provider/gce/environ_broker.go
+++ b/internal/provider/gce/environ_broker.go
@@ -223,7 +223,7 @@ func (env *environ) startInstance(
 	}
 	imageURL := imageURLBase + imageID
 
-	disks, err := getDisks(imageURL, os, args.AvailabilityZone, args.Constraints, args.RootDisk)
+	disks, err := getDisks(imageURL, instanceTypeName, os, args.AvailabilityZone, args.Constraints, args.RootDisk)
 	if err != nil {
 		return nil, environs.ZoneIndependentError(err)
 	}
@@ -342,7 +342,7 @@ func getMetadata(args environs.StartInstanceParams, os ostype.OSType) (map[strin
 // the new instances and returns it. This will always include a root
 // disk with characteristics determined by the provides args and
 // constraints.
-func getDisks(imageURL string, os ostype.OSType, zone string, cons constraints.Value, rootDisk *storage.VolumeParams) ([]*computepb.AttachedDisk, error) {
+func getDisks(imageURL, instanceTypeName string, os ostype.OSType, zone string, cons constraints.Value, rootDisk *storage.VolumeParams) ([]*computepb.AttachedDisk, error) {
 	size := common.MinRootDiskSizeGiB(os)
 	if cons.RootDisk != nil && *cons.RootDisk > size {
 		size = common.MiBToGiB(*cons.RootDisk)
@@ -377,13 +377,15 @@ func getDisks(imageURL string, os ostype.OSType, zone string, cons constraints.V
 	if rootDisk != nil {
 		if val, ok := rootDisk.Attributes[diskTypeAttribute].(string); ok && val != "" {
 			dt := google.DiskType(val)
-			switch dt {
-			case google.DiskPersistentSSD, google.DiskPersistentStandard:
+			if dt == google.DiskLocalSSD {
+				return nil, errors.NotValidf("local SSD disk storage")
+			} else if isValidDiskType(dt) {
+				if google.IsLegacyMachineSeries(instanceTypeName) && isValidHyperDiskType(dt) {
+					return nil, errors.NotSupportedf("hyperdisk storage for legacy instance %q", instanceTypeName)
+				}
 				dtStr := formatDiskType(zone, string(dt))
 				disk.InitializeParams.DiskType = &dtStr
-			case google.DiskLocalSSD:
-				return nil, errors.NotValidf("local SSD disk storage")
-			default:
+			} else {
 				return nil, errors.NotValidf("disk type %q for root disk", val)
 			}
 		}
@@ -393,13 +395,15 @@ func getDisks(imageURL string, os ostype.OSType, zone string, cons constraints.V
 		// if it were specified as the root disk source,
 		// otherwise we return an error.
 		dt := google.DiskType(*cons.RootDiskSource)
-		switch dt {
-		case google.DiskPersistentSSD, google.DiskPersistentStandard:
+		if dt == google.DiskLocalSSD {
+			return nil, errors.NotValidf("local SSD disk storage")
+		} else if isValidDiskType(dt) {
+			if google.IsLegacyMachineSeries(instanceTypeName) && isValidHyperDiskType(dt) {
+				return nil, errors.NotSupportedf("hyperdisk storage for legacy instance %q", instanceTypeName)
+			}
 			dtStr := formatDiskType(zone, string(dt))
 			disk.InitializeParams.DiskType = &dtStr
-		case google.DiskLocalSSD:
-			return nil, errors.NotValidf("local SSD disk storage")
-		default:
+		} else {
 			return nil, errors.NotValidf("root disk source %q", dt)
 		}
 	}

--- a/internal/provider/gce/environ_broker_test.go
+++ b/internal/provider/gce/environ_broker_test.go
@@ -767,7 +767,7 @@ func (s *environBrokerSuite) TestGetMetadataOSNotSupported(c *gc.C) {
 
 func (s *environBrokerSuite) TestGetDisks(c *gc.C) {
 	os := ostype.OSTypeForName("ubuntu")
-	diskSpecs, err := gce.GetDisks("image-url", os, "home-zone", s.StartInstArgs.Constraints, nil)
+	diskSpecs, err := gce.GetDisks("image-url", "m4-standard", os, "home-zone", s.StartInstArgs.Constraints, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(diskSpecs, gc.HasLen, 1)
 	diskSpec := diskSpecs[0]
@@ -778,7 +778,7 @@ func (s *environBrokerSuite) TestGetDisks(c *gc.C) {
 
 func (s *environBrokerSuite) TestGetDisksRootDiskSourceValid(c *gc.C) {
 	cons := constraints.MustParse("root-disk-source=pd-ssd")
-	diskSpecs, err := gce.GetDisks("image-url", ostype.Ubuntu, "home-zone", cons, nil)
+	diskSpecs, err := gce.GetDisks("image-url", "m4-standard", ostype.Ubuntu, "home-zone", cons, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(diskSpecs, gc.HasLen, 1)
 	c.Assert(diskSpecs[0].InitializeParams, gc.NotNil)
@@ -787,13 +787,13 @@ func (s *environBrokerSuite) TestGetDisksRootDiskSourceValid(c *gc.C) {
 
 func (s *environBrokerSuite) TestGetDisksRootDiskSourceLocalSSD(c *gc.C) {
 	cons := constraints.MustParse("root-disk-source=local-ssd")
-	_, err := gce.GetDisks("image-url", ostype.Ubuntu, "home-zone", cons, nil)
+	_, err := gce.GetDisks("image-url", "m4-standard", ostype.Ubuntu, "home-zone", cons, nil)
 	c.Assert(err, gc.ErrorMatches, `local SSD disk storage not valid`)
 }
 
 func (s *environBrokerSuite) TestGetDisksRootDiskSourceInvalid(c *gc.C) {
 	cons := constraints.MustParse("root-disk-source=unknown-type")
-	_, err := gce.GetDisks("image-url", ostype.Ubuntu, "home-zone", cons, nil)
+	_, err := gce.GetDisks("image-url", "m4-standard", ostype.Ubuntu, "home-zone", cons, nil)
 	c.Assert(err, gc.ErrorMatches, `root disk source "unknown-type" not valid`)
 }
 
@@ -803,7 +803,7 @@ func (s *environBrokerSuite) TestGetDisksRootDiskAttributesValid(c *gc.C) {
 			"disk-type": "pd-ssd",
 		},
 	}
-	diskSpecs, err := gce.GetDisks("image-url", ostype.Ubuntu, "home-zone", constraints.Value{}, rootDisk)
+	diskSpecs, err := gce.GetDisks("image-url", "m4-standard", ostype.Ubuntu, "home-zone", constraints.Value{}, rootDisk)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(diskSpecs, gc.HasLen, 1)
 	c.Assert(diskSpecs[0].InitializeParams, gc.NotNil)
@@ -817,11 +817,36 @@ func (s *environBrokerSuite) TestGetDisksRootDiskAttributesOverrideConstraint(c 
 		},
 	}
 	cons := constraints.MustParse("root-disk-source=pd-ssd")
-	diskSpecs, err := gce.GetDisks("image-url", ostype.Ubuntu, "home-zone", cons, rootDisk)
+	diskSpecs, err := gce.GetDisks("image-url", "m4-standard", ostype.Ubuntu, "home-zone", cons, rootDisk)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(diskSpecs, gc.HasLen, 1)
 	c.Assert(diskSpecs[0].InitializeParams, gc.NotNil)
 	c.Check(diskSpecs[0].InitializeParams.GetDiskType(), gc.Equals, "zones/home-zone/diskTypes/pd-standard")
+}
+
+func (s *environBrokerSuite) TestGetDisksRootDiskAttributesHyperDisk(c *gc.C) {
+	rootDisk := &storage.VolumeParams{
+		Attributes: map[string]interface{}{
+			"disk-type": "hyperdisk-extreme",
+		},
+	}
+	cons := constraints.MustParse("root-disk-source=test-storage-pool")
+	diskSpecs, err := gce.GetDisks("image-url", "m4-standard", ostype.Ubuntu, "home-zone", cons, rootDisk)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(diskSpecs, gc.HasLen, 1)
+	c.Assert(diskSpecs[0].InitializeParams, gc.NotNil)
+	c.Check(diskSpecs[0].InitializeParams.GetDiskType(), gc.Equals, "zones/home-zone/diskTypes/hyperdisk-extreme")
+}
+
+func (s *environBrokerSuite) TestGetDisksRootDiskAttributesHyperDiskNotSupported(c *gc.C) {
+	rootDisk := &storage.VolumeParams{
+		Attributes: map[string]interface{}{
+			"disk-type": "hyperdisk-extreme",
+		},
+	}
+	cons := constraints.MustParse("root-disk-source=test-storage-pool")
+	_, err := gce.GetDisks("image-url", "n1-standard", ostype.Ubuntu, "home-zone", cons, rootDisk)
+	c.Assert(err, gc.ErrorMatches, `hyperdisk storage for legacy instance "n1-standard" not supported`)
 }
 
 func (s *environBrokerSuite) TestGetDisksRootDiskAttributesLocalSSD(c *gc.C) {
@@ -831,7 +856,7 @@ func (s *environBrokerSuite) TestGetDisksRootDiskAttributesLocalSSD(c *gc.C) {
 		},
 	}
 	cons := constraints.MustParse("root-disk-source=test-storage-pool")
-	_, err := gce.GetDisks("image-url", ostype.Ubuntu, "home-zone", cons, rootDisk)
+	_, err := gce.GetDisks("image-url", "m4-standard", ostype.Ubuntu, "home-zone", cons, rootDisk)
 	c.Assert(err, gc.ErrorMatches, `local SSD disk storage not valid`)
 }
 
@@ -842,7 +867,7 @@ func (s *environBrokerSuite) TestGetDisksRootDiskAttributesInvalidDiskType(c *gc
 		},
 	}
 	cons := constraints.MustParse("root-disk-source=test-storage-pool")
-	_, err := gce.GetDisks("image-url", ostype.Ubuntu, "home-zone", cons, rootDisk)
+	_, err := gce.GetDisks("image-url", "m4-standard", ostype.Ubuntu, "home-zone", cons, rootDisk)
 	c.Assert(err, gc.ErrorMatches, `disk type "unknown-type" for root disk not valid`)
 }
 

--- a/internal/provider/gce/environ_policy.go
+++ b/internal/provider/gce/environ_policy.go
@@ -26,6 +26,17 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 		if !env.checkInstanceType(ctx, args.Constraints) {
 			return errors.Errorf("invalid GCE instance type %q", *args.Constraints.InstanceType)
 		}
+		if args.Constraints.HasRootDiskSource() {
+			instanceTypeName := *args.Constraints.InstanceType
+			dt := google.DiskType(*args.Constraints.RootDiskSource)
+			if dt == google.DiskLocalSSD {
+				return errors.NotValidf("local SSD disk storage")
+			} else if isValidDiskType(dt) {
+				if google.IsLegacyMachineSeries(instanceTypeName) && isValidHyperDiskType(dt) {
+					return errors.NotSupportedf("hyperdisk storage for legacy instance %q", instanceTypeName)
+				}
+			}
+		}
 	}
 
 	vpcLink, autosubnets, err := env.getVpcInfo(ctx)
@@ -55,7 +66,7 @@ var unsupportedConstraints = []string{
 // instance types. See instancetypes.go.
 var instanceTypeConstraints = []string{
 	// TODO: move to a dynamic conflict for arch when gce supports more than amd64
-	//constraints.Arch, // Arches
+	// constraints.Arch, // Arches
 	constraints.Cores,
 	constraints.CpuPower,
 	constraints.Mem,

--- a/internal/provider/gce/environ_policy_test.go
+++ b/internal/provider/gce/environ_policy_test.go
@@ -113,6 +113,30 @@ func (s *environPolSuite) TestPrecheckInstanceInvalidInstanceType(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `.*invalid GCE instance type.*`)
 }
 
+func (s *environPolSuite) TestPrecheckInstanceInvalidRootDiskSource(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+
+	s.MockService.EXPECT().AvailabilityZones(gomock.Any(), "us-east1").Return([]*computepb.Zone{{
+		Name:   ptr("home-zone"),
+		Status: ptr("UP"),
+	}}, nil)
+	s.MockService.EXPECT().ListMachineTypes(gomock.Any(), "home-zone").Return([]*computepb.MachineType{{
+		Id:           ptr(uint64(0)),
+		Name:         ptr("n1-standard-1"),
+		GuestCpus:    ptr(int32(2)),
+		Architecture: ptr("amd64"),
+	}}, nil)
+
+	cons := constraints.MustParse("instance-type=n1-standard-1 root-disk-source=hyperdisk-balanced")
+	err := env.PrecheckInstance(s.CallCtx, environs.PrecheckInstanceParams{
+		Base: version.DefaultSupportedLTSBase(), Constraints: cons})
+
+	c.Assert(err, gc.ErrorMatches, `hyperdisk storage for legacy instance "n1-standard-1" not supported`)
+}
+
 func (s *environPolSuite) TestPrecheckInstanceUnsupportedArch(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()

--- a/internal/provider/gce/internal/google/disks.go
+++ b/internal/provider/gce/internal/google/disks.go
@@ -26,6 +26,14 @@ const (
 	// persistent
 	DiskPersistentStandard DiskType = "pd-standard"
 	DiskPersistentSSD      DiskType = "pd-ssd"
+	DiskPersistentBalanced DiskType = "pd-balanced"
+	DiskPersistentExtreme  DiskType = "pd-extreme"
+	// hyperdisk
+	DiskHyperdiskBalanced                 DiskType = "hyperdisk-balanced"
+	DiskHyperdiskBalancedHighAvailability DiskType = "hyperdisk-balanced-high-availability"
+	DiskHyperdiskML                       DiskType = "hyperdisk-ml"
+	DiskHyperdiskExtreme                  DiskType = "hyperdisk-extreme"
+	DiskHyperdiskThroughput               DiskType = "hyperdisk-throughput"
 	// scratch
 	DiskLocalSSD DiskType = "local-ssd"
 )

--- a/internal/provider/gce/internal/google/instance.go
+++ b/internal/provider/gce/internal/google/instance.go
@@ -6,11 +6,30 @@ package google
 import (
 	"context"
 	"path"
+	"strings"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/juju/errors"
 	"google.golang.org/api/iterator"
 )
+
+// legacyMachineSeries are older v1 or v2 instance families
+// which do not support HyperDisk storage.
+var legacyMachineSeries = []string{
+	"N1-", "N1+GPU-", "E2-", "C2-", "C2D-", "T2A-",
+	"N2-", "N2D-",
+}
+
+// IsLegacyMachineSeries returns true if the instance type is for
+// an older v1 or v2 machine series.
+func IsLegacyMachineSeries(instanceTypeName string) bool {
+	for _, series := range legacyMachineSeries {
+		if strings.HasPrefix(strings.ToUpper(instanceTypeName), series) {
+			return true
+		}
+	}
+	return false
+}
 
 // AvailabilityZones returns the list of availability zones for a given
 // GCE region. If none are found the the list is empty. Any failure in

--- a/tests/suites/cloud_gce/root_disk_source.sh
+++ b/tests/suites/cloud_gce/root_disk_source.sh
@@ -75,16 +75,16 @@ run_root_disk_source() {
 	# Run deploy with no root disk source specified, expect default disk type to be used.
 	assert_root_disk_source_succeed "default" "pd-standard"
 	# Run deploy with root disk source specified as disk type, expect specified disk type to be used.
-	assert_root_disk_source_succeed "disk-type-ssd" "pd-ssd" "root-disk-source=pd-ssd"
+	assert_root_disk_source_succeed "disk-type-hyperdisk" "hyperdisk-balanced" "instance-type=c3-standard-4 root-disk-source=hyperdisk-balanced"
 	assert_root_disk_source_failure "disk-type-local" "root-disk-source=local-ssd" "local SSD disk storage not valid"
 	assert_root_disk_source_failure "disk-type-invalid" "root-disk-source=invalid-disk" 'root disk source ".*" not valid'
 
 	# Create storage pools with different disk types and run deploy with root disk source specified as storage pool, expect disk type of storage pool to be used.
-	juju create-storage-pool ssd-gce gce disk-type=pd-ssd
+	juju create-storage-pool hyperdisk-gce gce disk-type=hyperdisk-balanced
 	juju create-storage-pool local-ssd gce disk-type=pd-ssd
 	juju create-storage-pool local-gce gce disk-type=local-ssd
 	juju create-storage-pool invalid-disk gce disk-type=invalid-disk
-	assert_root_disk_source_succeed "storage-pool-pd-ssd" "pd-ssd" "root-disk-source=ssd-gce"
+	assert_root_disk_source_succeed "storage-pool-hyperdisk-balanced" "hyperdisk-balanced" "instance-type=c3-standard-4 root-disk-source=hyperdisk-gce"
 	assert_root_disk_source_succeed "storage-pool-local-ssd-name" "pd-ssd" "root-disk-source=local-ssd"
 	assert_root_disk_source_failure "storage-pool-local-ssd" "root-disk-source=local-gce" "local SSD disk storage not valid"
 	assert_root_disk_source_failure "storage-pool-invalid" "root-disk-source=invalid-disk" 'disk type ".*" for root disk not valid'


### PR DESCRIPTION
google cloud supports more storage types than juju currently caters for. There's a new class of storage called "hyperdisk" that has been recommended as the default since 2021. We can't switch to it by default for juju 3.6 since it costs approx 2x compared to the current "persistentdisk". So we support it as opt in.

Only newer machine families support hyperdisk so we error if trying to use it with unsupported machine families.
The list of excluded machine families comes from here:
https://docs.cloud.google.com/compute/docs/disks/hyperdisks#machine-type-support

A family is excluded if there are zero hyperdisk types for that family, otherwise it is not blacklisted since there can be 1 valid hyperdisk type that could be used. Just a minimal check is done - sadly there's no API that allows the query needed to do it fully dynamically.

## QA steps

The storage test in the gce cloud shell tests has been updated.

## Documentation changes

updated gce cloud doc

## Links

**Issue:** Fixes #22732.

**Jira card:** [JUJU-10186](https://warthogs.atlassian.net/browse/JUJU-10186)


[JUJU-10186]: https://warthogs.atlassian.net/browse/JUJU-10186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ