### PR TITLE
fix: decrement offer connection count

### DIFF
--- a/domain/relation/service/watcher.go
+++ b/domain/relation/service/watcher.go
@@ -796,11 +796,18 @@ func (w *applicationLifeSuspendedStatusWatcher) processChange(
 ) (corerelation.UUID, error) {
 	changedRelationData, err := w.s.st.GetMapperDataForWatchLifeSuspendedStatus(ctx, relUUID, w.appUUID)
 	if errors.Is(err, relationerrors.ApplicationNotFoundForRelation) {
+		if _, seen := w.currentRelations[relUUID]; seen {
+			delete(w.currentRelations, relUUID)
+			return relUUID, nil
+		}
 		relationsIgnored.Add(relUUID.String())
 		return "", continueError
 	} else if errors.Is(err, relationerrors.RelationNotFound) {
+		if _, seen := w.currentRelations[relUUID]; !seen {
+			return "", continueError
+		}
 		delete(w.currentRelations, relUUID)
-		return "", continueError
+		return relUUID, nil
 	} else if err != nil {
 		return "", errors.Capture(err)
 	}

--- a/domain/relation/service/watcher_test.go
+++ b/domain/relation/service/watcher_test.go
@@ -495,6 +495,91 @@ func (s *watcherSuite) TestPrincipalAppNotFoundForUntrackedRelation(c *tc.C) {
 	c.Check(relationsIgnored.Contains(relUUID.String()), tc.IsTrue)
 }
 
+func (s *watcherSuite) TestApplicationRelationRemovedKnown(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	relUUID := testing.GenRelationUUID(c)
+	appID := tc.Must(c, coreapplication.NewUUID)
+
+	s.expectGetMapperDataForWatchLifeSuspendedStatus(
+		relUUID, appID, relation.RelationLifeSuspendedData{}, relationerrors.RelationNotFound,
+	)
+	change := s.expectChanged(ctrl, relUUID)
+
+	watcher := s.getApplicationWatcher(appID)
+	watcher.currentRelations[relUUID] = relation.RelationLifeSuspendedData{
+		Life: life.Alive,
+	}
+
+	relationsIgnored := set.NewStrings()
+	obtained, err := watcher.filterChangeEvents(
+		c.Context(),
+		[]changestream.ChangeEvent{change},
+		relationsIgnored,
+	)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtained, tc.DeepEquals, []string{relUUID.String()})
+	c.Check(watcher.currentRelations, tc.HasLen, 0)
+	c.Check(relationsIgnored.IsEmpty(), tc.IsTrue)
+}
+
+func (s *watcherSuite) TestApplicationNotFoundForTrackedRelation(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	relUUID := testing.GenRelationUUID(c)
+	appID := tc.Must(c, coreapplication.NewUUID)
+
+	s.expectGetMapperDataForWatchLifeSuspendedStatus(
+		relUUID, appID, relation.RelationLifeSuspendedData{}, relationerrors.ApplicationNotFoundForRelation,
+	)
+	change := s.expectChanged(ctrl, relUUID)
+
+	watcher := s.getApplicationWatcher(appID)
+	watcher.currentRelations[relUUID] = relation.RelationLifeSuspendedData{
+		Life: life.Alive,
+	}
+
+	relationsIgnored := set.NewStrings()
+	obtained, err := watcher.filterChangeEvents(
+		c.Context(),
+		[]changestream.ChangeEvent{change},
+		relationsIgnored,
+	)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtained, tc.DeepEquals, []string{relUUID.String()})
+	c.Check(watcher.currentRelations, tc.HasLen, 0)
+	c.Check(relationsIgnored.IsEmpty(), tc.IsTrue)
+}
+
+func (s *watcherSuite) TestApplicationNotFoundForUntrackedRelation(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	relUUID := testing.GenRelationUUID(c)
+	appID := tc.Must(c, coreapplication.NewUUID)
+
+	s.expectGetMapperDataForWatchLifeSuspendedStatus(
+		relUUID, appID, relation.RelationLifeSuspendedData{}, relationerrors.ApplicationNotFoundForRelation,
+	)
+	change := s.expectChanged(ctrl, relUUID)
+
+	watcher := s.getApplicationWatcher(appID)
+	relationsIgnored := set.NewStrings()
+	obtained, err := watcher.filterChangeEvents(
+		c.Context(),
+		[]changestream.ChangeEvent{change},
+		relationsIgnored,
+	)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtained, tc.HasLen, 0)
+	c.Check(relationsIgnored.Contains(relUUID.String()), tc.IsTrue)
+}
+
 func (s *watcherSuite) TestWatchRelationsLifeSuspendedStatusForApplicationApplicationNotFound(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -568,6 +653,17 @@ func (s *watcherSuite) getSubordinateWatcher(principalID, subordinateID coreappl
 func (s *watcherSuite) getPrincipalWatcher(appID coreapplication.UUID) *principalLifeSuspendedStatusWatcher {
 	w := &principalLifeSuspendedStatusWatcher{}
 	w.lifeSuspendedStatusWatcher = lifeSuspendedStatusWatcher[corerelation.Key]{
+		s:                s.service,
+		appUUID:          appID,
+		currentRelations: make(map[corerelation.UUID]relation.RelationLifeSuspendedData),
+		processChange:    w.processChange,
+	}
+	return w
+}
+
+func (s *watcherSuite) getApplicationWatcher(appID coreapplication.UUID) *applicationLifeSuspendedStatusWatcher {
+	w := &applicationLifeSuspendedStatusWatcher{}
+	w.lifeSuspendedStatusWatcher = lifeSuspendedStatusWatcher[corerelation.UUID]{
 		s:                s.service,
 		appUUID:          appID,
 		currentRelations: make(map[corerelation.UUID]relation.RelationLifeSuspendedData),

--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.48.0
 	google.golang.org/api v0.256.0
-	google.golang.org/grpc v1.82.0
+	google.golang.org/grpc v1.82.1
 	gopkg.in/errgo.v1 v1.0.1
 	gopkg.in/httprequest.v1 v1.2.1
 	gopkg.in/ini.v1 v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -940,8 +940,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260715232425-e75dac1f907d/go.
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
When removing multiple relations to the same consumed offer, the offering model could retain one stale offer_connection. This left the offer reporting an incorrect connection count and prevented it from being removed.

The consuming model uses an application relation watcher to notify the CMR worker when relations change. During teardown, the relation endpoints and relation row can be deleted before the watcher processes the changestream event. Previously, if the watcher could no longer find the application endpoint or relation, it removed the relation from its internal state or permanently ignored it without emitting a notification.

As a result, the CMR worker did not receive the removed relation UUID and could not send the final force-cleanup notification to the offering model. The corresponding offer-side relation and offer_connection were therefore left behind.

The watcher now emits the relation UUID when a previously tracked relation loses its endpoints or is no longer found. This allows the CMR worker’s existing removed-relation path to notify the offering model and clean up the connection. Relations that were never tracked by the watcher continue to be ignored.

## QA steps

See: https://github.com/juju/juju/issues/22213

```sh
$ juju add-model source
$ juju deploy juju-qa-dummy-source
$ juju offer dummy-source:sink
$ juju add-model sink
$ juju deploy juju-qa-dummy-sink sink1 
$ juju deploy juju-qa-dummy-sink sink2 
$ juju relate sink1 admin/source.dummy-source
$ juju relate sink2 admin/source.dummy-source
$ juju remove-relation sink1 dummy-source
$ juju remove-relation sink2 dummy-source
$ juju switch source
$ juju status
```

## Links

**Issue:** Fixes https://github.com/juju/juju/issues/22213.

**Jira card:** [JUJU-9644](https://warthogs.atlassian.net/browse/JUJU-9644)


[JUJU-9644]: https://warthogs.atlassian.net/browse/JUJU-9644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ