### PR TITLE
feat: instance poller integration

### DIFF
--- a/domain/machine/service/provider_test.go
+++ b/domain/machine/service/provider_test.go
@@ -633,6 +633,20 @@ func (s *providerServiceSuite) TestReprovisionMachineInstanceIDError(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `machine "0": instance lookup failed`)
 }
 
+func (s *providerServiceSuite) TestReprovisionMachineMissingInstanceID(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().CheckMachineReprovisioningEligibility(
+		gomock.Any(), machine.Name("0"),
+	).Return(nil)
+	s.state.EXPECT().GetInstanceIDByMachineName(
+		gomock.Any(), machine.Name("0"),
+	).Return("", machineerrors.NotProvisioned)
+
+	err := s.service.ReprovisionMachine(c.Context(), machine.Name("0"))
+	c.Assert(err, tc.ErrorIs, machineerrors.NotProvisioned)
+}
+
 func (s *providerServiceSuite) TestReprovisionMachineAgentPresenceError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -48,8 +48,8 @@ type State interface {
 	// the provisioner after a machine is detached for reprovisioning.
 	NamespaceForWatchMachineReprovision() string
 
-	// InitialWatchModelMachineLifeAndStartTimesStatement returns the namespace and the initial watch
-	// statement for watching life and agent start time changes machines.
+	// InitialWatchModelMachineLifeAndStartTimesStatement returns the namespace
+	// and initial statement for watching machine life and agent start times.
 	InitialWatchModelMachineLifeAndStartTimesStatement() (string, string)
 
 	// GetMachineLife returns the life status of the specified machine.

--- a/domain/machine/service/watcher.go
+++ b/domain/machine/service/watcher.go
@@ -256,7 +256,8 @@ func (s *WatchableService) WatchModelMachines(ctx context.Context) (watcher.Stri
 }
 
 // WatchModelMachineLifeAndStartTimes returns a string watcher that emits
-// machine names for changes to machine life or agent start times.
+// machine names for changes to machine life, agent start times, or
+// reprovisioning state.
 func (s *WatchableService) WatchModelMachineLifeAndStartTimes(ctx context.Context) (watcher.StringsWatcher, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -267,6 +268,10 @@ func (s *WatchableService) WatchModelMachineLifeAndStartTimes(ctx context.Contex
 		eventsource.InitialNamespaceChanges(stmt),
 		"model machine life and start times watcher",
 		eventsource.NamespaceFilter(table, changestream.All),
+		eventsource.NamespaceFilter(
+			s.st.NamespaceForWatchMachineReprovision(),
+			changestream.Changed,
+		),
 	)
 }
 

--- a/domain/machine/state/reprovision.go
+++ b/domain/machine/state/reprovision.go
@@ -340,7 +340,8 @@ WHERE machine_uuid = $entityUUID.uuid`,
 		`
 UPDATE machine
 SET nonce = NULL,
-    hostname = NULL
+    hostname = NULL,
+    agent_started_at = NULL
 WHERE uuid = $entityUUID.uuid`,
 		// Clear the old provider instance association and its observed hardware
 		// characteristics.

--- a/domain/machine/state/reprovision_test.go
+++ b/domain/machine/state/reprovision_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/tc"
 
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain/life"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
@@ -41,6 +42,7 @@ func (s *stateSuite) TestDetachLostMachineCloudInstance(c *tc.C) {
 
 	var (
 		instanceID, displayName, arch, availabilityZone, nonce, hostname sql.Null[string]
+		agentStartedAt                                                   sql.Null[time.Time]
 		machineStatusID, instanceStatusID                                int
 		machineMessage, instanceMessage                                  string
 		machineData, instanceData                                        []byte
@@ -48,11 +50,13 @@ func (s *stateSuite) TestDetachLostMachineCloudInstance(c *tc.C) {
 	db := s.DB()
 	err = db.QueryRowContext(c.Context(), `
 SELECT mci.instance_id, mci.display_name, mci.arch,
-       mci.availability_zone_uuid, m.nonce, m.hostname
+       mci.availability_zone_uuid, m.nonce, m.hostname,
+       m.agent_started_at
 FROM machine AS m
 JOIN machine_cloud_instance AS mci ON m.uuid = mci.machine_uuid
 WHERE m.uuid = ?`, machineUUID.String()).Scan(
 		&instanceID, &displayName, &arch, &availabilityZone, &nonce, &hostname,
+		&agentStartedAt,
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(instanceID.Valid, tc.IsFalse)
@@ -61,6 +65,7 @@ WHERE m.uuid = ?`, machineUUID.String()).Scan(
 	c.Check(availabilityZone.Valid, tc.IsFalse)
 	c.Check(nonce.Valid, tc.IsFalse)
 	c.Check(hostname.Valid, tc.IsFalse)
+	c.Check(agentStartedAt.Valid, tc.IsFalse)
 
 	err = db.QueryRowContext(c.Context(), `
 SELECT ms.status_id, ms.message, ms.data,
@@ -119,6 +124,81 @@ FROM machine_reprovision
 WHERE machine_name = ?`, machineName.String()).Scan(&reprovisionMachineName)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(reprovisionMachineName, tc.Equals, machineName.String())
+}
+
+func (s *stateSuite) TestReplacementPreservesMachineAndUnitIdentity(c *tc.C) {
+	machineUUID, machineName := s.ensureInstance(c)
+	netNodeUUID := s.machineNetNodeUUID(c, machineUUID.String())
+	s.addReprovisionUnit(c, netNodeUUID)
+	s.runQuery(c, `
+UPDATE machine
+SET hostname = ?, agent_started_at = ?
+WHERE uuid = ?`, "old-hostname", time.Now(), machineUUID.String())
+
+	err := s.state.DetachLostMachineCloudInstance(
+		c.Context(), machineName.String(), "123", "reprovisioning requested",
+		nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.state.SetMachineCloudInstance(
+		c.Context(), machineUUID.String(), instance.Id("replacement-instance"),
+		"replacement-display-name", "replacement-nonce",
+		&instance.HardwareCharacteristics{
+			Arch:     new("amd64"),
+			Mem:      new(uint64(2048)),
+			CpuCores: new(uint64(8)),
+			Tags:     new([]string{"replacement-tag"}),
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var (
+		name, preservedNetNode, instanceID, displayName, nonce, arch string
+		mem, cpuCores                                                uint64
+		hostname                                                     sql.Null[string]
+		agentStartedAt                                               sql.Null[time.Time]
+	)
+	err = s.DB().QueryRowContext(c.Context(), `
+SELECT m.name, m.net_node_uuid, mci.instance_id, mci.display_name,
+       m.nonce, mci.arch, mci.mem, mci.cpu_cores, m.hostname,
+       m.agent_started_at
+FROM machine AS m
+JOIN machine_cloud_instance AS mci ON mci.machine_uuid = m.uuid
+WHERE m.uuid = ?`, machineUUID.String()).Scan(
+		&name, &preservedNetNode, &instanceID, &displayName, &nonce, &arch,
+		&mem, &cpuCores, &hostname, &agentStartedAt,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(name, tc.Equals, machineName.String())
+	c.Check(preservedNetNode, tc.Equals, netNodeUUID)
+	c.Check(instanceID, tc.Equals, "replacement-instance")
+	c.Check(displayName, tc.Equals, "replacement-display-name")
+	c.Check(nonce, tc.Equals, "replacement-nonce")
+	c.Check(arch, tc.Equals, "amd64")
+	c.Check(mem, tc.Equals, uint64(2048))
+	c.Check(cpuCores, tc.Equals, uint64(8))
+	c.Check(hostname.Valid, tc.IsFalse)
+	c.Check(agentStartedAt.Valid, tc.IsFalse)
+
+	var unitUUID, unitName, unitNetNode string
+	var unitLife int
+	err = s.DB().QueryRowContext(c.Context(), `
+SELECT uuid, name, life_id, net_node_uuid
+FROM unit
+WHERE uuid = ?`, "reprovision-unit").Scan(
+		&unitUUID, &unitName, &unitLife, &unitNetNode,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(unitUUID, tc.Equals, "reprovision-unit")
+	c.Check(unitName, tc.Equals, "reprovision/0")
+	c.Check(unitLife, tc.Equals, 0)
+	c.Check(unitNetNode, tc.Equals, netNodeUUID)
+	c.Check(s.rowCount(c, "machine_reprovision"), tc.Equals, 0)
+	c.Check(s.rowCountWhere(c, "instance_tag", "machine_uuid = ? AND tag = ?",
+		machineUUID.String(), "replacement-tag"), tc.Equals, 1)
+	c.Check(s.rowCountWhere(c, "instance_tag", "machine_uuid = ? AND tag = ?",
+		machineUUID.String(), "tag1"), tc.Equals, 0)
 }
 
 func (s *stateSuite) TestDetachLostMachineCloudInstanceRechecksLife(c *tc.C) {

--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -294,6 +294,38 @@ func (s *watcherSuite) TestWatchModelMachineLifeStartTimesInitialEvent(c *tc.C) 
 	watcherC.AssertChange(res0.MachineName.String())
 }
 
+func (s *watcherSuite) TestWatchModelMachineLifeStartTimesReprovision(c *tc.C) {
+	res, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			Channel: "24.04",
+			OSType:  deployment.Ubuntu,
+		},
+		Nonce: new("old-nonce"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, err := s.svc.GetMachineUUID(c.Context(), res.MachineName)
+	c.Assert(err, tc.ErrorIsNil)
+	err = s.svc.SetMachineCloudInstance(
+		c.Context(), machineUUID, "old-instance", "old-display-name",
+		"old-nonce", nil,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.AssertChangeStreamIdle(c, "before watcher start")
+
+	watcher, err := s.svc.WatchModelMachineLifeAndStartTimes(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	watcherC := watchertest.NewStringsWatcherC(c, watcher)
+	watcherC.AssertChange(res.MachineName.String())
+
+	err = s.st.DetachLostMachineCloudInstance(
+		c.Context(), res.MachineName.String(), "old-instance",
+		"reprovisioning requested", nil, time.Now(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	watcherC.AssertChange(res.MachineName.String())
+}
+
 func (s *watcherSuite) TestWatchModelMachineLifeStartTimes(c *tc.C) {
 	removalSt := removalstatemodel.NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 

--- a/internal/worker/instancepoller/worker.go
+++ b/internal/worker/instancepoller/worker.go
@@ -298,12 +298,17 @@ func (u *updaterWorker) queueMachineForPolling(ctx context.Context, machineName 
 		return u.setManualMachineRunning(ctx, machineName)
 	}
 
-	// 3. If already being polled, move to short poll group so we
-	// immediately re-check its status on the next interval.
+	// 3. If already being polled, discard cached provider data and move to
+	// the short poll group. Reprovisioning keeps the machine name but changes
+	// its provider instance, so watcher events must force polling info to be
+	// reloaded before the provider is queried again.
 	if entry != nil {
+		oldInstanceID := entry.instanceID
+		entry.instanceID = ""
+		entry.hadDevices = false
 		u.moveEntryToPollGroup(shortPollGroup, entry)
 		if groupType == longPollGroup {
-			u.config.Logger.Debugf(ctx, "moving machine %q (instance ID %q) to short poll group", entry.machineName, entry.instanceID)
+			u.config.Logger.Debugf(ctx, "moving machine %q (instance ID %q) to short poll group", entry.machineName, oldInstanceID)
 		}
 		return nil
 	}

--- a/internal/worker/instancepoller/worker_test.go
+++ b/internal/worker/instancepoller/worker_test.go
@@ -200,6 +200,9 @@ func (s *workerSuite) TestQueueingExistingMachineAlwaysMovesItToShortPollGroup(c
 
 	// Manually move entry to long poll group.
 	entry, _ := updWorker.lookupPolledMachine(machineName)
+	entry.machineUUID = machinetesting.GenUUID(c)
+	entry.instanceID = "old-instance"
+	entry.hadDevices = true
 	entry.shortPollInterval = LongPoll
 	updWorker.pollGroup[longPollGroup][machineName] = entry
 	delete(updWorker.pollGroup[shortPollGroup], machineName)
@@ -210,6 +213,70 @@ func (s *workerSuite) TestQueueingExistingMachineAlwaysMovesItToShortPollGroup(c
 
 	c.Assert(updWorker.pollGroup[shortPollGroup], tc.HasLen, 1, tc.Commentf("machine didn't end up in short poll group"))
 	c.Assert(entry.shortPollInterval, tc.Equals, ShortPoll, tc.Commentf("poll interval was not reset"))
+	c.Check(entry.instanceID, tc.Equals, instance.Id(""))
+	c.Check(entry.hadDevices, tc.IsFalse)
+}
+
+func (s *workerSuite) TestReprovisionedMachinePollsReplacementInstance(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	machineName := machine.Name("0")
+	machineUUID := machinetesting.GenUUID(c)
+	entry := &pollGroupEntry{
+		machineUUID: machineUUID,
+		machineName: machineName,
+		instanceID:  "old-instance",
+		hadDevices:  true,
+	}
+	updWorker.pollGroup[longPollGroup][machineName] = entry
+
+	mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(
+		gomock.Any(), machineName,
+	).Return(life.Alive, false, nil)
+	err := updWorker.queueMachineForPolling(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	entry.shortPollAt = mocked.clock.Now()
+	mocked.machineService.EXPECT().GetPollingInfos(
+		gomock.Any(), []machine.Name{machineName},
+	).Return(domainmachine.PollingInfos{{
+		MachineUUID:         machineUUID,
+		MachineName:         machineName,
+		InstanceID:          "replacement-instance",
+		ExistingDeviceCount: 1,
+	}}, nil)
+	replacement := mocks.NewMockInstance(ctrl)
+	replacement.EXPECT().Status(gomock.Any()).Return(instance.Status{Status: status.Running})
+	mocked.environ.EXPECT().Instances(
+		gomock.Any(), []instance.Id{"replacement-instance"},
+	).Return([]instances.Instance{replacement}, nil)
+	mocked.environ.EXPECT().NetworkInterfaces(
+		gomock.Any(), []instance.Id{"replacement-instance"},
+	).Return([]network.InterfaceInfos{testNetIfs}, nil)
+	mocked.statusService.EXPECT().GetInstanceStatus(
+		gomock.Any(), machineName,
+	).Return(status.StatusInfo{Status: status.Pending}, nil)
+	mocked.statusService.EXPECT().SetInstanceStatus(
+		gomock.Any(), machineName, status.StatusInfo{Status: status.Running},
+	).Return(nil)
+	mocked.machineService.EXPECT().GetMachineLife(
+		gomock.Any(), machineName,
+	).Return(life.Alive, nil)
+	mocked.networkService.EXPECT().SetProviderNetConfig(
+		gomock.Any(), machineUUID, testDevices,
+	).Return(nil)
+	mocked.statusService.EXPECT().GetMachineStatus(
+		gomock.Any(), machineName,
+	).Return(status.StatusInfo{Status: status.Started}, nil)
+
+	err = updWorker.pollGroupMembers(c.Context(), shortPollGroup)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(entry.instanceID, tc.Equals, instance.Id("replacement-instance"))
 }
 
 func (s *workerSuite) TestQueueingExistingMachineThatBecomesManualRemovesItFromPollGroup(c *tc.C) {


### PR DESCRIPTION
Before this change, reprovisioning woke the provisioner but not the instance poller. The poller could continue using the lost machine’s cached provider instance ID and network state, preventing the replacement instance’s status and addresses from appearing correctly in juju status.

This change makes reprovisioning invalidate that cache so the poller reloads the current provider identity before querying the cloud. It also clears stale machine-agent runtime data from the lost instance. The poller must then reload the current instance ID from state before contacting the provider. This ensures that status and network information come from the replacement instance rather than the lost instance.

The old machine agent start time is also cleared during the detach transaction. Previously, the nonce and hostname were removed while agent_started_at remained, leaving runtime evidence from the lost machine attached to an otherwise pending replacement.

## QA steps

```sh
$ juju bootstrap aws/eu-west-2 test
$ juju add-model foo

$ juju deploy juju-qa-dummy-storage machine-storage \
  --storage single-fs=rootfs
```

Record the original machine ID, provider instance ID, addresses, unit name, unit assignment, and storage details.

```sh
$ juju status
$ juju storage
```

Stop the machine agent so Juju no longer considers it present.

```sh
$ juju add-ssh-key <your ssh key>
$ juju ssh 0
sudo systemctl stop 'juju*.service'
exit
```

Delete the backing instance through the provider and wait until it is terminated.

```sh
$ aws ec2 terminate-instances --instance-ids <old-instance-id>
$ aws ec2 wait instance-terminated --instance-ids <old-instance-id>
```

Wait for the machine agent to be reported as unavailable, then request reprovisioning.

```sh
$ juju status
$ juju reprovision-machine 0
$ juju status --watch 2s
```

Verify that machine 0 moves through pending and provisioning before returning to started. Confirm that it has a different provider instance ID and current addresses from the replacement instance.
Verify that the original unit name is unchanged, remains assigned to machine 0, and returns to active/idle. This confirms that the replacement machine agent recreated the unit-agent configuration rather than creating a new Juju unit.

```sh
$ juju status
$ juju ssh 0 -- sudo test \
  -f /var/lib/juju/agents/unit-machine-storage-0/agent.conf
```

## Links


**Jira card:** [JUJU-10183](https://warthogs.atlassian.net/browse/JUJU-10183)


[JUJU-10183]: https://warthogs.atlassian.net/browse/JUJU-10183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ