### PR TITLE
fix: migrate application-named offer entities

### DIFF
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -1836,15 +1836,25 @@ func (i *importer) remoteEntities() error {
 		dst: i.st.db(),
 	}
 	offerUUIDByName := make(map[string]string)
+	offersByApplicationName := make(map[string][]applicationOfferDetails)
 	for _, app := range i.model.Applications() {
 		for _, offer := range app.Offers() {
 			offerUUIDByName[offer.OfferName()] = offer.OfferUUID()
+			appName := offer.ApplicationName()
+			offersByApplicationName[appName] = append(
+				offersByApplicationName[appName],
+				applicationOfferDetails{
+					name: offer.OfferName(),
+					uuid: offer.OfferUUID(),
+				},
+			)
 		}
 	}
 	migration.Add(func() error {
 		m := ImportRemoteEntities{}
 		return m.Execute(&applicationOffersStateShim{
-			offerUUIDByName: offerUUIDByName,
+			offerUUIDByName:         offerUUIDByName,
+			offersByApplicationName: offersByApplicationName,
 			stateModelNamspaceShim: stateModelNamspaceShim{
 				Model: migration.src,
 				st:    i.st,

--- a/state/migration_import_tasks.go
+++ b/state/migration_import_tasks.go
@@ -446,7 +446,7 @@ func (im *ImportRemoteEntities) maybeConvertApplicationOffer(
 	}
 	uuid, err := src.OfferUUIDForApp(name)
 	if errors.Is(err, errors.NotFound) {
-		return id, false, nil
+		return id, false, errors.Trace(err)
 	}
 	if err != nil {
 		return id, false, errors.Trace(err)
@@ -475,6 +475,7 @@ type applicationOffersStateShim struct {
 }
 
 type applicationOfferDetails struct {
+	// name is only used for diagnostics, since offersByApplicationName is indexed by name
 	name string
 	uuid string
 }

--- a/state/migration_import_tasks.go
+++ b/state/migration_import_tasks.go
@@ -4,13 +4,13 @@
 package state
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/description/v11"
 	"github.com/juju/errors"
-	"github.com/juju/mgo/v3"
-	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/mgo/v3/txn"
 	"github.com/juju/names/v5"
 
@@ -404,7 +404,11 @@ func (im *ImportRemoteEntities) Execute(src RemoteEntitiesInput, runner Transact
 			ok  bool
 			err error
 		)
-		if id, ok = im.maybeConvertApplicationOffer(src, entity.ID()); !ok {
+		id, ok, err = im.maybeConvertApplicationOffer(src, entity.ID())
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !ok {
 			id, err = im.legacyAppToOffer(entity.ID(), src.OfferUUIDForApp)
 			if err != nil {
 				return errors.Trace(err)
@@ -427,16 +431,27 @@ func (im *ImportRemoteEntities) Execute(src RemoteEntitiesInput, runner Transact
 	return nil
 }
 
-// maybeConvertApplicationOffer returns the offer uuid if an offer name is passed in.
-func (im *ImportRemoteEntities) maybeConvertApplicationOffer(src RemoteEntitiesInput, id string) (string, bool) {
+// maybeConvertApplicationOffer returns the offer uuid if an offer or
+// application name is passed in.
+func (im *ImportRemoteEntities) maybeConvertApplicationOffer(
+	src RemoteEntitiesInput,
+	id string,
+) (string, bool, error) {
 	if !strings.HasPrefix(id, names.ApplicationOfferTagKind+"-") {
-		return id, false
+		return id, false, nil
 	}
-	offerName := strings.TrimPrefix(id, names.ApplicationOfferTagKind+"-")
-	if uuid, ok := src.OfferUUID(offerName); ok {
-		return names.NewApplicationOfferTag(uuid).String(), true
+	name := strings.TrimPrefix(id, names.ApplicationOfferTagKind+"-")
+	if uuid, ok := src.OfferUUID(name); ok {
+		return names.NewApplicationOfferTag(uuid).String(), true, nil
 	}
-	return id, false
+	uuid, err := src.OfferUUIDForApp(name)
+	if errors.Is(err, errors.NotFound) {
+		return id, false, nil
+	}
+	if err != nil {
+		return id, false, errors.Trace(err)
+	}
+	return names.NewApplicationOfferTag(uuid).String(), true, nil
 }
 
 func (im *ImportRemoteEntities) legacyAppToOffer(id string, offerUUIDForApp func(string) (string, error)) (string, error) {
@@ -455,7 +470,13 @@ func (im *ImportRemoteEntities) legacyAppToOffer(id string, offerUUIDForApp func
 type applicationOffersStateShim struct {
 	stateModelNamspaceShim
 
-	offerUUIDByName map[string]string
+	offerUUIDByName         map[string]string
+	offersByApplicationName map[string][]applicationOfferDetails
+}
+
+type applicationOfferDetails struct {
+	name string
+	uuid string
 }
 
 func (s *applicationOffersStateShim) OfferUUID(offerName string) (string, bool) {
@@ -463,22 +484,24 @@ func (s *applicationOffersStateShim) OfferUUID(offerName string) (string, bool) 
 	return uuid, ok
 }
 
-func (a applicationOffersStateShim) OfferUUIDForApp(appName string) (string, error) {
-	applicationOffersCollection, closer, err := a.st.db().GetCollection(applicationOffersC)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	defer closer()
-
-	var doc applicationOfferDoc
-	err = applicationOffersCollection.Find(bson.D{{"application-name", appName}}).One(&doc)
-	if err == mgo.ErrNotFound {
+func (s applicationOffersStateShim) OfferUUIDForApp(appName string) (string, error) {
+	offers := s.offersByApplicationName[appName]
+	switch len(offers) {
+	case 0:
 		return "", errors.NotFoundf("offer for app %q", appName)
+	case 1:
+		return offers[0].uuid, nil
 	}
-	if err != nil {
-		return "", errors.Annotate(err, "getting application offer documents")
+
+	matches := make([]string, len(offers))
+	for i, offer := range offers {
+		matches[i] = fmt.Sprintf("%q (%s)", offer.name, offer.uuid)
 	}
-	return doc.OfferUUID, nil
+	sort.Strings(matches)
+	return "", errors.Errorf(
+		"application %q has multiple offers: %s",
+		appName, strings.Join(matches, ", "),
+	)
 }
 
 // RelationNetworksDescription defines an in-place usage for reading relation networks.

--- a/state/migration_import_tasks_test.go
+++ b/state/migration_import_tasks_test.go
@@ -464,12 +464,11 @@ func (s *MigrationImportTasksSuite) TestImportRemoteEntitiesApplicationOfferNoMa
 		"", errors.NotFoundf("offer for app %q", "missing"))
 
 	runner := NewMockTransactionRunner(ctrl)
-	// No call to RunTransaction for an invalid tag.
+	// No call to RunTransaction when no matching offer exists.
 
 	m := ImportRemoteEntities{}
 	err := m.Execute(model, runner)
-	c.Assert(err, gc.ErrorMatches,
-		`"applicationoffer-missing" is not a valid applicationoffer tag`)
+	c.Assert(err, gc.ErrorMatches, `offer for app "missing" not found`)
 }
 
 func (s *MigrationImportTasksSuite) TestImportRemoteEntitiesWithNoEntities(c *gc.C) {

--- a/state/migration_import_tasks_test.go
+++ b/state/migration_import_tasks_test.go
@@ -361,6 +361,117 @@ func (s *MigrationImportTasksSuite) TestImportRemoteEntities(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *MigrationImportTasksSuite) TestImportRemoteEntitiesApplicationOfferApplicationName(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	entity := s.remoteEntity(ctrl, "applicationoffer-app2", "xxx-yyy-ccc")
+	lookup := applicationOffersStateShim{
+		offersByApplicationName: map[string][]applicationOfferDetails{
+			"app2": {{name: "offer2", uuid: "uuid2"}},
+		},
+	}
+
+	model := NewMockRemoteEntitiesInput(ctrl)
+	model.EXPECT().RemoteEntities().Return([]description.RemoteEntity{entity})
+	model.EXPECT().OfferUUID("app2").Return("", false)
+	model.EXPECT().OfferUUIDForApp("app2").DoAndReturn(lookup.OfferUUIDForApp)
+	model.EXPECT().DocID("applicationoffer-uuid2").Return("doc-uuid2")
+
+	runner := NewMockTransactionRunner(ctrl)
+	runner.EXPECT().RunTransaction([]txn.Op{{
+		C:      remoteEntitiesC,
+		Id:     "doc-uuid2",
+		Assert: txn.DocMissing,
+		Insert: &remoteEntityDoc{
+			DocID: "doc-uuid2",
+			Token: "xxx-yyy-ccc",
+		},
+	}}).Return(nil)
+
+	m := ImportRemoteEntities{}
+	err := m.Execute(model, runner)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MigrationImportTasksSuite) TestImportRemoteEntitiesOfferNameTakesPrecedence(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	entity := s.remoteEntity(ctrl, "applicationoffer-shared-name", "xxx-yyy-ccc")
+
+	model := NewMockRemoteEntitiesInput(ctrl)
+	model.EXPECT().RemoteEntities().Return([]description.RemoteEntity{entity})
+	model.EXPECT().OfferUUID("shared-name").Return("offer-uuid", true)
+	model.EXPECT().DocID("applicationoffer-offer-uuid").Return("doc-offer-uuid")
+
+	runner := NewMockTransactionRunner(ctrl)
+	runner.EXPECT().RunTransaction([]txn.Op{{
+		C:      remoteEntitiesC,
+		Id:     "doc-offer-uuid",
+		Assert: txn.DocMissing,
+		Insert: &remoteEntityDoc{
+			DocID: "doc-offer-uuid",
+			Token: "xxx-yyy-ccc",
+		},
+	}}).Return(nil)
+
+	m := ImportRemoteEntities{}
+	err := m.Execute(model, runner)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *MigrationImportTasksSuite) TestImportRemoteEntitiesApplicationNameAmbiguous(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	entity := NewMockRemoteEntity(ctrl)
+	entity.EXPECT().ID().Return("applicationoffer-app2").AnyTimes()
+	lookup := applicationOffersStateShim{
+		offersByApplicationName: map[string][]applicationOfferDetails{
+			"app2": {
+				{name: "offer-z", uuid: "uuid-z"},
+				{name: "offer-a", uuid: "uuid-a"},
+			},
+		},
+	}
+
+	model := NewMockRemoteEntitiesInput(ctrl)
+	model.EXPECT().RemoteEntities().Return([]description.RemoteEntity{entity})
+	model.EXPECT().OfferUUID("app2").Return("", false)
+	model.EXPECT().OfferUUIDForApp("app2").DoAndReturn(lookup.OfferUUIDForApp)
+
+	runner := NewMockTransactionRunner(ctrl)
+	// No call to RunTransaction when the application name is ambiguous.
+
+	m := ImportRemoteEntities{}
+	err := m.Execute(model, runner)
+	c.Assert(err, gc.ErrorMatches,
+		`application "app2" has multiple offers: "offer-a" \(uuid-a\), "offer-z" \(uuid-z\)`)
+}
+
+func (s *MigrationImportTasksSuite) TestImportRemoteEntitiesApplicationOfferNoMatch(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	entity := NewMockRemoteEntity(ctrl)
+	entity.EXPECT().ID().Return("applicationoffer-missing").AnyTimes()
+
+	model := NewMockRemoteEntitiesInput(ctrl)
+	model.EXPECT().RemoteEntities().Return([]description.RemoteEntity{entity})
+	model.EXPECT().OfferUUID("missing").Return("", false)
+	model.EXPECT().OfferUUIDForApp("missing").Return(
+		"", errors.NotFoundf("offer for app %q", "missing"))
+
+	runner := NewMockTransactionRunner(ctrl)
+	// No call to RunTransaction for an invalid tag.
+
+	m := ImportRemoteEntities{}
+	err := m.Execute(model, runner)
+	c.Assert(err, gc.ErrorMatches,
+		`"applicationoffer-missing" is not a valid applicationoffer tag`)
+}
+
 func (s *MigrationImportTasksSuite) TestImportRemoteEntitiesWithNoEntities(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
Resolve legacy applicationoffer tags containing application names to offer UUIDs during model import. 
This builds up the map of names to offer UUIDs. If it encounters a duplicate, then reject the import, rather than importing something ambiguous. This shouldn't generally be a problem because 2.9 already was ambiguous, so it shouldn't have been done. This is still better than requiring all CMRs to be removed in order to migrate.

## QA steps

 1. Bootstrap a 2.9 controller create 2 models, so that you can have a CMR.

```sh
$ juju-2.9 bootstrap lxd lxd29
$ juju-2.9 add-model -c lxd29 sink
$ juju-2.9add-model -c lxd29 saas
$ juju-2.9 deploy juju-qa-dummy-sink -m lxd29:sink
$ juju-2.9 deploy juju-qa-dummy-source -m lxd29:saas
$ juju-2.9 offer -m lxd29:saas dummy-source
$ juju-2.9 relate lxd29:saas.dummy-source -m lxd29:sink dummy-sink
```

Make sure the saas source and sink are working:
```sh
$ juju-2.9 config -m lxd29:saas dummy-source token=foo
$ juju-2.9 status -m lxd29:sink
```

 2. Bootstrap a 3.6 controller with the changes and migrate the model.

```sh
$ juju-3.6 bootstrap lxd lxd36
$ juju migrate lxd29:sink lxd36
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. You should also
    be able to update the token and see that the CMR is still working

```sh
$ juju debug-log -m lxd36:controller
$ juju debug-log -m lxd36:sink
$ juju-2.9 config -m lxd29:saas dummy-source token=bar
$ juju-3.6 status -m lxd36:sink
```

## Documentation changes

This improves the ability to migrate 2.9 models to a 3.6 controller. We'll also want to make sure that we can further migrate these models to 4.x.

## Links

(there is a github issue, but I still have to look up which one)
