### PR TITLE
fix(uniter): authorise the caller in SetRelationStatus

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2097,11 +2097,22 @@ func (u *UniterAPI) watchOneRelationUnit(
 // SetRelationStatus updates the status of the specified relations.
 func (u *UniterAPI) SetRelationStatus(ctx context.Context, args params.RelationStatusArgs) (params.ErrorResults, error) {
 	var statusResults params.ErrorResults
+	canAccess, err := u.accessUnit(ctx)
+	if err != nil {
+		return params.ErrorResults{}, err
+	}
 	results := make([]params.ErrorResult, len(args.Args))
 	for i, arg := range args.Args {
 		unitTag, err := names.ParseUnitTag(arg.UnitTag)
 		if err != nil {
 			results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		// The status is recorded against the unit named here, and the
+		// leadership check in the status service is made against that same
+		// name, so the caller has to be that unit.
+		if !canAccess(unitTag) {
+			results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
 			continue
 		}
 		unitName, err := coreunit.NewName(unitTag.Id())
@@ -2132,6 +2143,17 @@ func (u *UniterAPI) oneSetRelationStatus(
 		return internalerrors.Capture(err)
 	}
 
+	// The relation ID is only unique within the model, so it has to be
+	// scoped to the caller the same way the read path does in
+	// getOneRelationById.
+	applicationName, err := u.authApplicationName()
+	if err != nil {
+		return err
+	}
+	if err := u.checkApplicationInRelation(ctx, relationUUID, applicationName); err != nil {
+		return err
+	}
+
 	err = u.statusService.SetRelationStatus(ctx, unitName, relationUUID, status.StatusInfo{
 		Status:  status.Status(relStatus),
 		Message: message,
@@ -2143,6 +2165,27 @@ func (u *UniterAPI) oneSetRelationStatus(
 		return internalerrors.Capture(err)
 	}
 	return nil
+}
+
+// checkApplicationInRelation returns ErrPerm unless the named application is
+// an endpoint of the relation.
+func (u *UniterAPI) checkApplicationInRelation(
+	ctx context.Context,
+	relUUID corerelation.UUID,
+	applicationName string,
+) error {
+	details, err := u.relationService.GetRelationDetails(ctx, relUUID)
+	if errors.Is(err, relationerrors.RelationNotFound) {
+		return apiservererrors.ErrPerm
+	} else if err != nil {
+		return internalerrors.Capture(err)
+	}
+	for _, ep := range details.Endpoints {
+		if ep.ApplicationName == applicationName {
+			return nil
+		}
+	}
+	return apiservererrors.ErrPerm
 }
 
 func (u *UniterAPI) getOneRelationById(ctx context.Context, relID int) (params.RelationResultV2, error) {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2819,6 +2819,7 @@ func (s *uniterRelationSuite) TestSetRelationStatus(c *tc.C) {
 	relID := 42
 	relationUUID := tc.Must(c, corerelation.NewUUID)
 	s.expectGetRelationUUIDByID(relID, relationUUID, nil)
+	s.expectGetRelationDetails(c, relationUUID, relID, names.NewRelationTag("mysql:mysql wordpress:database"))
 	relStatus := status.StatusInfo{
 		Status: status.Joined,
 		Since:  new(s.uniter.clock.Now()),
@@ -2858,6 +2859,53 @@ func (s *uniterRelationSuite) TestSetRelationStatusRelationNotFound(c *tc.C) {
 	relID := 42
 	relationUUID := tc.Must(c, corerelation.NewUUID)
 	s.expectGetRelationUUIDByID(relID, relationUUID, relationerrors.RelationNotFound)
+
+	// act
+	args := params.RelationStatusArgs{Args: []params.RelationStatusArg{{
+		UnitTag:    s.wordpressUnitTag.String(),
+		RelationId: relID,
+		Status:     params.Joined,
+	}}}
+	result, err := s.uniter.SetRelationStatus(c.Context(), args)
+
+	// assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Check(result.Results[0].Error, tc.DeepEquals, apiservertesting.ErrUnauthorized)
+}
+
+// TestSetRelationStatusErrUnauthorized checks that a unit cannot set the
+// relation status on behalf of another unit. The relation is never looked up
+// for the refused unit, so the leadership check that the status service makes
+// against the supplied name is not reached.
+func (s *uniterRelationSuite) TestSetRelationStatusErrUnauthorized(c *tc.C) {
+	// arrange
+	defer s.setupMocks(c).Finish()
+
+	// act
+	args := params.RelationStatusArgs{Args: []params.RelationStatusArg{{
+		UnitTag:    names.NewUnitTag("mysql/0").String(),
+		RelationId: 42,
+		Status:     params.Joined,
+	}}}
+	result, err := s.uniter.SetRelationStatus(c.Context(), args)
+
+	// assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Check(result.Results[0].Error, tc.DeepEquals, apiservertesting.ErrUnauthorized)
+}
+
+// TestSetRelationStatusRelationNotOfCaller checks that a unit cannot set the
+// status of a relation its application is not an endpoint of, since the
+// relation ID is only unique within the model.
+func (s *uniterRelationSuite) TestSetRelationStatusRelationNotOfCaller(c *tc.C) {
+	// arrange
+	defer s.setupMocks(c).Finish()
+	relID := 101
+	relationUUID := tc.Must(c, corerelation.NewUUID)
+	s.expectGetRelationUUIDByID(relID, relationUUID, nil)
+	s.expectGetRelationDetailsUnexpectedAppName(c, relationUUID)
 
 	// act
 	args := params.RelationStatusArgs{Args: []params.RelationStatusArg{{

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2921,6 +2921,88 @@ func (s *uniterRelationSuite) TestSetRelationStatusRelationNotOfCaller(c *tc.C) 
 	c.Check(result.Results[0].Error, tc.DeepEquals, apiservertesting.ErrUnauthorized)
 }
 
+// TestSetRelationStatusRelationDetailsNotFound checks that a relation deleted
+// between the UUID lookup and the details lookup is reported as unauthorized,
+// without reaching the status service.
+func (s *uniterRelationSuite) TestSetRelationStatusRelationDetailsNotFound(c *tc.C) {
+	// arrange
+	defer s.setupMocks(c).Finish()
+	relID := 42
+	relationUUID := tc.Must(c, corerelation.NewUUID)
+	s.expectGetRelationUUIDByID(relID, relationUUID, nil)
+	s.expectGetRelationDetailsNotFound(relationUUID)
+
+	// act
+	args := params.RelationStatusArgs{Args: []params.RelationStatusArg{{
+		UnitTag:    s.wordpressUnitTag.String(),
+		RelationId: relID,
+		Status:     params.Joined,
+	}}}
+	result, err := s.uniter.SetRelationStatus(c.Context(), args)
+
+	// assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Check(result.Results[0].Error, tc.DeepEquals, apiservertesting.ErrUnauthorized)
+}
+
+// TestSetRelationStatusRelationDetailsError checks that an unexpected error
+// from the relation details lookup is surfaced in the per-argument result and
+// the status service is not reached.
+func (s *uniterRelationSuite) TestSetRelationStatusRelationDetailsError(c *tc.C) {
+	// arrange
+	defer s.setupMocks(c).Finish()
+	relID := 42
+	relationUUID := tc.Must(c, corerelation.NewUUID)
+	boom := internalerrors.New("boom")
+	s.expectGetRelationUUIDByID(relID, relationUUID, nil)
+	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relationUUID).Return(relation.RelationDetails{}, boom)
+
+	// act
+	args := params.RelationStatusArgs{Args: []params.RelationStatusArg{{
+		UnitTag:    s.wordpressUnitTag.String(),
+		RelationId: relID,
+		Status:     params.Joined,
+	}}}
+	result, err := s.uniter.SetRelationStatus(c.Context(), args)
+
+	// assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 1)
+	c.Check(result.Results[0].Error, tc.DeepEquals, apiservererrors.ServerError(boom))
+}
+
+// TestSetRelationStatusMixedBatch checks that a refused argument is isolated:
+// the authorized argument succeeds while the one naming another unit gets
+// ErrPerm without any relation or status service call being made for it.
+func (s *uniterRelationSuite) TestSetRelationStatusMixedBatch(c *tc.C) {
+	// arrange
+	defer s.setupMocks(c).Finish()
+	relID := 42
+	relationUUID := tc.Must(c, corerelation.NewUUID)
+	s.expectGetRelationUUIDByID(relID, relationUUID, nil)
+	s.expectGetRelationDetails(c, relationUUID, relID, names.NewRelationTag("mysql:mysql wordpress:database"))
+	relStatus := status.StatusInfo{
+		Status: status.Joined,
+		Since:  new(s.uniter.clock.Now()),
+	}
+	s.expectSetRelationStatus(s.wordpressUnitTag.Id(), relationUUID, relStatus)
+
+	// act: the mocks only expect the calls for the wordpress unit, so any
+	// lookup made for the refused mysql unit fails the test.
+	args := params.RelationStatusArgs{Args: []params.RelationStatusArg{
+		{UnitTag: s.wordpressUnitTag.String(), RelationId: relID, Status: params.Joined},
+		{UnitTag: names.NewUnitTag("mysql/0").String(), RelationId: relID, Status: params.Joined},
+	}}
+	result, err := s.uniter.SetRelationStatus(c.Context(), args)
+
+	// assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result.Results, tc.HasLen, 2)
+	c.Check(result.Results[0].Error, tc.IsNil)
+	c.Check(result.Results[1].Error, tc.DeepEquals, apiservertesting.ErrUnauthorized)
+}
+
 func (s *uniterRelationSuite) TestEnterScopeErrUnauthorized(c *tc.C) {
 	// arrange
 	defer s.setupMocks(c).Finish()


### PR DESCRIPTION
1. `SetRelationStatus` is the only method on this facade that takes a unit tag from the request and never runs it through `u.accessUnit`, so `arg.UnitTag` is used as supplied.
2. `LeadershipService.SetRelationStatus` gates on `WithLeader(unitName.Application(), unitName.String(), ...)`, i.e. against the name in the request rather than the authenticated one, so a non-leader unit can pass its leader's tag to get a leader-only write, and naming another application's leader acts as that application.
3. `oneSetRelationStatus` only checked that the relation exists. `GetRelationUUIDByID` is scoped to the model, not to the caller, so any unit could set the status of any relation in the model, including relations between other applications.

Checking the tag in the loop follows `CommitHookChanges` and `EnterScope`, and the relation is now scoped to the caller's application the way the read path already does it in `getOneRelationById`.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~Integration tests, with comments saying what you're testing~
- [ ] ~doc.go added or updated in changed packages~

## QA steps

```sh
go test ./apiserver/facades/agent/uniter/ -run 'TestUniterRelationSuite/TestSetRelationStatus'
```

`TestSetRelationStatusErrUnauthorized` sends `unit-mysql-0` while authenticated as `wordpress/0`; on the unpatched tree the relation lookup still runs for it. `TestSetRelationStatusRelationNotOfCaller` sets the status of a relation `wordpress` is not an endpoint of; on the unpatched tree `StatusService.SetRelationStatus` is reached. Both fail without this change and pass with it, and the rest of the package stays green.

## Documentation changes

None.

## Links

None.
