### PR TITLE
feat: prototype k8s HA

### DIFF
--- a/apiserver/authentication/agent.go
+++ b/apiserver/authentication/agent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 
+	"github.com/juju/juju/agent"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/machine"
@@ -174,6 +175,24 @@ func (a *agentAuthenticator) authenticateControllerAgent(ctx context.Context, ta
 	// - Any other error, is considered an internal server error.
 
 	valid, err := a.agentPasswordService.MatchesControllerNodePasswordHash(ctx, tag.Id(), credentials)
+	if tag.Id() != agent.BootstrapControllerId &&
+		((err == nil && !valid) || errors.Is(err, controllernodeerrors.NotFound)) {
+		// Prototype CAAS HA onboarding: a new StatefulSet replica starts from
+		// the bootstrap controller's agent configuration. Try its credential
+		// first for compatibility with an unrotated bootstrap config.
+		valid, err = a.agentPasswordService.MatchesControllerNodePasswordHash(
+			ctx, agent.BootstrapControllerId, credentials,
+		)
+	}
+	if tag.Id() != agent.BootstrapControllerId && err == nil && !valid {
+		// The bootstrap controller normally rotates its agent password before a
+		// replica is added. The replica seed therefore uses controller/0's stable
+		// unit credential. The normal password changer immediately replaces it
+		// with credentials for the replica's own controller ID.
+		valid, err = a.agentPasswordService.MatchesUnitPasswordHash(
+			ctx, unit.Name("controller/0"), credentials,
+		)
+	}
 	if errors.Is(err, agentpassworderrors.EmptyPassword) {
 		return nil, errors.Trace(fmt.Errorf("controller node authentication: %w", apiservererrors.ErrBadRequest))
 	} else if errors.Is(err, agentpassworderrors.InvalidPassword) || errors.Is(err, controllernodeerrors.NotFound) {
@@ -202,6 +221,14 @@ func (a *agentAuthenticator) authenticateApplication(ctx context.Context, tag na
 	// - Any other error, is considered an internal server error.
 
 	valid, err := a.agentPasswordService.MatchesApplicationPasswordHash(ctx, appName, credentials)
+	if appName == "controller" && err == nil && !valid {
+		// Prototype CAAS HA onboarding: the bootstrap controller application
+		// does not have an application password. Its extra pods use the
+		// controller/0 unit credential solely to introduce their charm units.
+		valid, err = a.agentPasswordService.MatchesUnitPasswordHash(
+			ctx, unit.Name("controller/0"), credentials,
+		)
+	}
 	if errors.Is(err, agentpassworderrors.EmptyPassword) {
 		return nil, errors.Trace(fmt.Errorf("application authentication: %w", apiservererrors.ErrBadRequest))
 	} else if errors.Is(err, agentpassworderrors.InvalidPassword) || errors.Is(err, applicationerrors.ApplicationNotFound) {

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -253,6 +253,54 @@ func (s *agentAuthenticatorSuite) TestControllerNodeLogin(c *tc.C) {
 	c.Check(authenticatedTag, tc.DeepEquals, authTag)
 }
 
+func (s *agentAuthenticatorSuite) TestControllerNodeLoginUsesBootstrapPasswordForNewNode(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.agentPasswordService.EXPECT().MatchesControllerNodePasswordHash(
+		gomock.Any(), "1", "password",
+	).Return(false, nil)
+	s.agentPasswordService.EXPECT().MatchesControllerNodePasswordHash(
+		gomock.Any(), "0", "password",
+	).Return(true, nil)
+
+	authTag := names.NewControllerAgentTag("1")
+	authenticatorGetter := authentication.NewAgentAuthenticatorGetter(
+		s.agentPasswordService, loggertesting.WrapCheckLog(c),
+	)
+	authenticatedTag, err := authenticatorGetter.Authenticator().Authenticate(
+		c.Context(), authentication.AuthParams{
+			AuthTag:     authTag,
+			Credentials: "password",
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(authenticatedTag, tc.DeepEquals, authTag)
+}
+
+func (s *agentAuthenticatorSuite) TestControllerNodeLoginUsesBootstrapUnitPasswordForNewNode(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.agentPasswordService.EXPECT().MatchesControllerNodePasswordHash(
+		gomock.Any(), "2", "password",
+	).Return(false, controllernodeerrors.NotFound)
+	s.agentPasswordService.EXPECT().MatchesControllerNodePasswordHash(
+		gomock.Any(), "0", "password",
+	).Return(false, nil)
+	s.agentPasswordService.EXPECT().MatchesUnitPasswordHash(
+		gomock.Any(), unit.Name("controller/0"), "password",
+	).Return(true, nil)
+
+	authTag := names.NewControllerAgentTag("2")
+
+	authenticatorGetter := authentication.NewAgentAuthenticatorGetter(s.agentPasswordService, loggertesting.WrapCheckLog(c))
+	authenticatedTag, err := authenticatorGetter.Authenticator().Authenticate(c.Context(), authentication.AuthParams{
+		AuthTag:     authTag,
+		Credentials: "password",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(authenticatedTag, tc.DeepEquals, authTag)
+}
+
 func (s *agentAuthenticatorSuite) TestControllerNodeLoginEmptyCredentials(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -319,6 +367,27 @@ func (s *agentAuthenticatorSuite) TestApplicationLogin(c *tc.C) {
 	s.agentPasswordService.EXPECT().MatchesApplicationPasswordHash(gomock.Any(), "foo", "password").Return(true, nil)
 
 	authTag := names.NewApplicationTag("foo")
+
+	authenticatorGetter := authentication.NewAgentAuthenticatorGetter(s.agentPasswordService, loggertesting.WrapCheckLog(c))
+	authenticatedTag, err := authenticatorGetter.Authenticator().Authenticate(c.Context(), authentication.AuthParams{
+		AuthTag:     authTag,
+		Credentials: "password",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(authenticatedTag, tc.DeepEquals, authTag)
+}
+
+func (s *agentAuthenticatorSuite) TestControllerApplicationLoginUsesBootstrapUnitPassword(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.agentPasswordService.EXPECT().MatchesApplicationPasswordHash(
+		gomock.Any(), "controller", "password",
+	).Return(false, nil)
+	s.agentPasswordService.EXPECT().MatchesUnitPasswordHash(
+		gomock.Any(), unit.Name("controller/0"), "password",
+	).Return(true, nil)
+
+	authTag := names.NewApplicationTag("controller")
 
 	authenticatorGetter := authentication.NewAgentAuthenticatorGetter(s.agentPasswordService, loggertesting.WrapCheckLog(c))
 	authenticatedTag, err := authenticatorGetter.Authenticator().Authenticate(c.Context(), authentication.AuthParams{

--- a/apiserver/facades/agent/agent/agent.go
+++ b/apiserver/facades/agent/agent/agent.go
@@ -296,12 +296,6 @@ func (api *AgentAPI) getOneEntity(ctx context.Context, tag names.Tag) params.Age
 		}
 
 	case names.ControllerAgentTagKind:
-		if tag.(names.ControllerAgentTag).Number() > 0 {
-			return params.AgentGetEntitiesResult{
-				Error: apiservererrors.ServerError(apiservererrors.NotSupportedError(tag, "in HA")),
-			}
-		}
-		// TODO(ha): When we support HA on k8s we may need to implement this.
 		return params.AgentGetEntitiesResult{
 			Life: life.Alive,
 		}

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -19,6 +19,7 @@ import (
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/cmd"
 	"github.com/juju/juju/cmd/modelcmd"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/bootstrap"
 )
@@ -193,7 +194,18 @@ func (c *listControllersCommand) refreshControllerDetails(ctx context.Context, c
 		machineCount += s.TotalMachineCount
 	}
 	details.MachineCount = &machineCount
-	details.ActiveControllerMachineCount, details.ControllerMachineCount = ControllerMachineCounts(controllerModelUUID, modelStatus)
+	activeControllerCount, controllerCount := ControllerMachineCounts(controllerModelUUID, modelStatus)
+	for _, s := range modelStatus {
+		if s.Error == nil && s.UUID == controllerModelUUID && s.ModelType == model.CAAS {
+			machineCount = s.UnitCount
+			details.MachineCount = &machineCount
+			activeControllerCount = s.UnitCount
+			controllerCount = s.UnitCount
+			break
+		}
+	}
+	details.ActiveControllerMachineCount = activeControllerCount
+	details.ControllerMachineCount = controllerCount
 	return c.store.UpdateController(controllerName, *details)
 }
 

--- a/cmd/juju/controller/listcontrollers_test.go
+++ b/cmd/juju/controller/listcontrollers_test.go
@@ -125,6 +125,11 @@ func (s *ListControllersSuite) setupAPIForControllerMachines() {
 					{Id: "2", Status: "active"},
 				},
 			}
+			fakeController.units = map[string]int{"xyz": 3}
+			fakeController.modelTypes = map[string]model.ModelType{
+				"xyz": model.CAAS,
+				"def": model.CAAS,
+			}
 		}
 		return fakeController
 	}
@@ -133,13 +138,11 @@ func (s *ListControllersSuite) setupAPIForControllerMachines() {
 func (s *ListControllersSuite) TestListControllersKnownHAStatus(c *tc.C) {
 	s.createTestClientStore(c)
 	s.setupAPIForControllerMachines()
-	s.expectedOutput = `
-Controller           Model              User   Access     Cloud/Region        Models  Nodes    HA  Version
-aws-test             prod/controller    admin  (unknown)  aws/us-east-1            1      2   2/3  2.0.1      
-k8s-controller       prod/my-k8s-model  admin  superuser  microk8s/localhost       2      4     -  6.6.6      
-mallards*            prod/my-model      admin  superuser  mallards/mallards1       2      4  none  (unknown)  
-mark-test-prodstack  -                  admin  (unknown)  prodstack                -      -     -  (unknown)  
-`[1:]
+	s.expectedOutput = "Controller           Model              User   Access     Cloud/Region        Models  Nodes    HA  Version\n" +
+		"aws-test             prod/controller    admin  (unknown)  aws/us-east-1            1      2   2/3  2.0.1      \n" +
+		"k8s-controller       prod/my-k8s-model  admin  superuser  microk8s/localhost       2      3     3  6.6.6      \n" +
+		"mallards*            prod/my-model      admin  superuser  mallards/mallards1       2      4  none  (unknown)  \n" +
+		"mark-test-prodstack  -                  admin  (unknown)  prodstack                -      -     -  (unknown)  \n"
 	s.assertListControllers(c, "--refresh")
 }
 
@@ -173,10 +176,10 @@ controllers:
     region: localhost
     agent-version: 6.6.6
     model-count: 2
-    node-count: 4
+    node-count: 3
     controller-nodes:
-      active: 1
-      total: 1
+      active: 3
+      total: 3
   mallards:
     current-model: prod/my-model
     user: admin

--- a/cmd/juju/controller/listcontrollersformatters.go
+++ b/cmd/juju/controller/listcontrollersformatters.go
@@ -94,7 +94,11 @@ func formatControllersTabular(writer io.Writer, set ControllerSet, promptRefresh
 			modelCount = fmt.Sprintf("%d", *c.ModelCount)
 		}
 		w.Print(modelName, userName, access, cloudRegion, modelCount, machineCount)
-		controllerMachineInfo, warn := controllerMachineStatus(c.ControllerMachines)
+		controllerMachines := c.ControllerMachines
+		if controllerMachines == nil {
+			controllerMachines = c.ControllerNodes
+		}
+		controllerMachineInfo, warn := controllerMachineStatus(controllerMachines)
 		if warn {
 			w.PrintColor(output.WarningHighlight, controllerMachineInfo)
 		} else {

--- a/cmd/jujuagentd/agent/agent_test.go
+++ b/cmd/jujuagentd/agent/agent_test.go
@@ -238,6 +238,19 @@ func (s *machineControllerStartupValueProviderSuite) TestBootstrapStartupValuesA
 	c.Check(password, tc.Equals, "")
 }
 
+func (s *machineControllerStartupValueProviderSuite) TestBootstrapStartupValuesUseOldPassword(c *tc.C) {
+	apiPort, password := bootstrapStartupValues(&fakeMachineConfig{
+		controllerInfoFound: true,
+		controllerAgentInfo: controller.ControllerAgentInfo{APIPort: 17070},
+		apiInfoFound:        true,
+		apiInfo:             &api.Info{},
+		oldPassword:         "secret",
+	})
+
+	c.Check(apiPort, tc.Equals, 17070)
+	c.Check(password, tc.Equals, "secret")
+}
+
 func (s *machineControllerStartupValueProviderSuite) TestBootstrapStartupValuesReadCurrentAgentConfig(c *tc.C) {
 	apiPort, password := bootstrapStartupValues(&fakeMachineConfig{
 		controllerInfoFound: true,
@@ -273,6 +286,7 @@ type fakeMachineConfig struct {
 	controllerInfoFound   bool
 	apiInfo               *api.Info
 	apiInfoFound          bool
+	oldPassword           string
 }
 
 func (f *fakeMachineConfig) DataDir() string {
@@ -318,6 +332,10 @@ func (f *fakeMachineConfig) APIInfo() (*api.Info, bool) {
 		return f.apiInfo, true
 	}
 	return &api.Info{Password: "password"}, true
+}
+
+func (f *fakeMachineConfig) OldPassword() string {
+	return f.oldPassword
 }
 
 func (f *fakeMachineConfig) Value(key string) string {

--- a/cmd/jujuagentd/agent/machine.go
+++ b/cmd/jujuagentd/agent/machine.go
@@ -782,6 +782,9 @@ func bootstrapStartupValues(config agent.Config) (int, string) {
 	if apiInfo, ok := config.APIInfo(); ok {
 		password = apiInfo.Password
 	}
+	if password == "" {
+		password = config.OldPassword()
+	}
 
 	return apiPort, password
 }

--- a/domain/agentpassword/state/controllerstate.go
+++ b/domain/agentpassword/state/controllerstate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/agentpassword"
-	controllernodeerrors "github.com/juju/juju/domain/controllernode/errors"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -41,14 +40,14 @@ func (s *ControllerState) SetControllerNodePasswordHash(ctx context.Context, id 
 		PasswordHash: passwordHash,
 	}
 
-	query := `
-SELECT COUNT(*) AS &count.count
-FROM controller_node
-WHERE controller_id = $entityPasswordHash.uuid;
+	ensureControllerNodeQuery := `
+INSERT INTO controller_node (controller_id)
+VALUES ($entityPasswordHash.uuid)
+ON CONFLICT (controller_id) DO NOTHING;
 `
-	stmt, err := s.Prepare(query, args, count{})
+	ensureControllerNodeStmt, err := s.Prepare(ensureControllerNodeQuery, args)
 	if err != nil {
-		return errors.Errorf("preparing statement to check if password hash exists: %w", err)
+		return errors.Errorf("preparing statement to ensure controller node exists: %w", err)
 	}
 
 	insertQuery := `
@@ -63,11 +62,8 @@ SET password_hash = $entityPasswordHash.password_hash;
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		var count count
-		if err := tx.Query(ctx, stmt, args).Get(&count); count.Count == 0 {
-			return errors.Errorf("controller node %q: %w", id, controllernodeerrors.NotFound)
-		} else if err != nil {
-			return errors.Errorf("checking if password hash exists: %w", err)
+		if err := tx.Query(ctx, ensureControllerNodeStmt, args).Run(); err != nil {
+			return errors.Errorf("ensuring controller node exists: %w", err)
 		}
 
 		if err := tx.Query(ctx, insertStmt, args).Run(); err != nil {

--- a/domain/agentpassword/state/controllerstate_test.go
+++ b/domain/agentpassword/state/controllerstate_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/domain/agentpassword"
-	controllernodeerrors "github.com/juju/juju/domain/controllernode/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	internalpassword "github.com/juju/juju/internal/password"
 )
@@ -42,13 +41,22 @@ func (s *controllerModelState) TestSetControllerNodePassword(c *tc.C) {
 	c.Assert(hash, tc.Equals, string(passwordHash))
 }
 
-func (s *controllerModelState) TestSetControllerNodePasswordDoesNotExist(c *tc.C) {
+func (s *controllerModelState) TestSetControllerNodePasswordCreatesControllerNode(c *tc.C) {
 	st := NewControllerState(s.TxnRunnerFactory())
 
 	passwordHash := s.genPasswordHash(c)
 
 	err := st.SetControllerNodePasswordHash(c.Context(), "1", passwordHash)
-	c.Assert(err, tc.ErrorIs, controllernodeerrors.NotFound)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var hash string
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT password_hash FROM controller_node_password WHERE controller_id = 1",
+		).Scan(&hash)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(hash, tc.Equals, string(passwordHash))
 }
 
 func (s *controllerModelState) TestMatchesUnitPasswordHash(c *tc.C) {

--- a/domain/network/service/unitinfo.go
+++ b/domain/network/service/unitinfo.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/collections/transform"
 
+	coreapplication "github.com/juju/juju/core/application"
 	corenetwork "github.com/juju/juju/core/network"
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/trace"
@@ -78,6 +79,7 @@ func (s *ProviderService) GetUnitRelationNetworks(
 		infos, err := s.getUnitEndpointNetworks(
 			ctx, unitUUID.String(), []string{endpointName}, egressSubnets,
 			supportsNetworking, isCaas, fqdns,
+			unitName.Application() == coreapplication.ControllerApplicationName,
 		)
 		if err != nil {
 			return nil, internalerrors.Errorf("getting unit endpoint networks: %w", err)
@@ -135,6 +137,7 @@ func (s *ProviderService) GetUnitEndpointNetworks(
 	return s.getUnitEndpointNetworks(
 		ctx, unitUUID.String(), endpointNames, defaultEgressSubnets,
 		supportsNetworking, isCaas, fqdns,
+		unitName.Application() == coreapplication.ControllerApplicationName,
 	)
 }
 
@@ -176,10 +179,12 @@ func (s *ProviderService) getUnitEndpointNetworks(
 	supportsNetworking bool,
 	isCaas bool,
 	fqdns []string,
+	useFQDNIngress bool,
 ) ([]domainnetwork.UnitNetwork, error) {
 	if !supportsNetworking {
 		return s.getUnitEndpointNetworksWithoutProviderNetworking(
 			ctx, unitUUID, endpointNames, fqdns, isCaas, defaultEgressSubnets,
+			useFQDNIngress,
 		)
 	}
 
@@ -196,6 +201,9 @@ func (s *ProviderService) getUnitEndpointNetworks(
 			fqdns,
 			isCaas,
 		)
+		if useFQDNIngress && len(fqdns) > 0 {
+			info.IngressAddresses = []string{fqdns[0]}
+		}
 		info.EndpointName = endpointNetwork.EndpointName
 		info.EgressSubnets = defaultEgressSubnets
 		if len(info.EgressSubnets) == 0 {
@@ -270,6 +278,7 @@ func buildUnitNetworkWithIngressAddresses(
 				return domainnetwork.AddressInfo{
 					Hostname: fqdn,
 					Value:    fqdn,
+					CIDR:     "0.0.0.0/0",
 				}
 			}),
 		}}
@@ -334,6 +343,7 @@ func (s *ProviderService) getUnitEndpointNetworksWithoutProviderNetworking(
 	fqdns []string,
 	isCaas bool,
 	defaultEgressSubnets []string,
+	useFQDNIngress bool,
 ) ([]domainnetwork.UnitNetwork, error) {
 	unitNetwork, err := s.st.GetUnitNetworkInfo(ctx, unitUUID)
 	if err != nil {
@@ -342,6 +352,9 @@ func (s *ProviderService) getUnitEndpointNetworksWithoutProviderNetworking(
 	info := buildUnitNetworkWithIngressAddresses(
 		unitNetwork.Addresses, unitNetwork.IngressAddresses, fqdns, isCaas,
 	)
+	if useFQDNIngress && len(fqdns) > 0 {
+		info.IngressAddresses = []string{fqdns[0]}
+	}
 	info.EgressSubnets = defaultEgressSubnets
 	if len(info.EgressSubnets) == 0 {
 		info.EgressSubnets = subnetsForAddresses(info.IngressAddresses)

--- a/domain/network/service/unitinfo_test.go
+++ b/domain/network/service/unitinfo_test.go
@@ -308,7 +308,7 @@ func (s *infoSuite) TestGetUnitRelationNetworksLoadsCaasFQDNsOnce(c *tc.C) {
 	for _, relationUUID := range []corerelation.UUID{relationUUID1, relationUUID2} {
 		c.Assert(infoMap[relationUUID].DeviceInfos, tc.HasLen, 1)
 		c.Check(infoMap[relationUUID].DeviceInfos[0].Addresses, tc.DeepEquals,
-			[]domainnetwork.AddressInfo{{Hostname: fqdn, Value: fqdn}})
+			[]domainnetwork.AddressInfo{{Hostname: fqdn, Value: fqdn, CIDR: "0.0.0.0/0"}})
 	}
 }
 
@@ -614,6 +614,7 @@ func (s *infoSuite) TestGetUnitEndpointNetworksCaasUsesServiceAddressForIngress(
 			Addresses: []domainnetwork.AddressInfo{{
 				Hostname: "controller-0.example.test",
 				Value:    "controller-0.example.test",
+				CIDR:     "0.0.0.0/0",
 			}},
 		}, {
 			Name:       "eth0",
@@ -627,6 +628,37 @@ func (s *infoSuite) TestGetUnitEndpointNetworksCaasUsesServiceAddressForIngress(
 		IngressAddresses: []string{"10.0.0.2"},
 		EgressSubnets:    []string{"10.0.0.0/24"},
 	})
+}
+
+func (s *infoSuite) TestGetControllerEndpointNetworksCaasUsesFQDNForIngress(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := coreunit.Name("controller/0")
+	unitUUID := coreunit.UUID("unit-uuid-123")
+	endpointNames := []string{"dbcluster"}
+	fqdn := "controller-0.controller-service-endpoints.test.svc.cluster.local"
+
+	s.st.EXPECT().GetUnitUUIDByName(gomock.Any(), unitName).Return(unitUUID, nil)
+	s.st.EXPECT().GetModelEgressSubnets(gomock.Any()).Return([]string{"10.0.0.0/24"}, nil)
+	s.st.EXPECT().IsCaasUnit(gomock.Any(), unitUUID.String()).Return(true, nil)
+	s.st.EXPECT().GetUnitFQDNs(gomock.Any(), unitUUID.String()).Return([]string{fqdn}, nil)
+	s.st.EXPECT().GetUnitEndpointNetworkInfo(
+		gomock.Any(), unitUUID.String(), endpointNames,
+	).Return([]networkinternal.EndpointNetworkInfo{
+		endpointNetworkInfo("dbcluster", []string{"10.0.0.2"}),
+	}, nil)
+
+	service := NewProviderService(s.st, s.networkProviderGetter, nil, loggertesting.WrapCheckLog(c))
+	infos, err := service.GetUnitEndpointNetworks(c.Context(), unitName, endpointNames)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(infos, tc.HasLen, 1)
+	c.Check(infos[0].IngressAddresses, tc.DeepEquals, []string{fqdn})
+	c.Assert(infos[0].DeviceInfos, tc.HasLen, 1)
+	c.Check(infos[0].DeviceInfos[0].Addresses, tc.DeepEquals, []domainnetwork.AddressInfo{{
+		Hostname: fqdn,
+		Value:    fqdn,
+		CIDR:     "0.0.0.0/0",
+	}})
 }
 
 func (s *infoSuite) TestBuildUnitNetworkPreservesDeviceAndAddressOrder(c *tc.C) {
@@ -698,6 +730,7 @@ func (s *infoSuite) TestBuildUnitNetworkCaasPrependsFQDNs(c *tc.C) {
 		Addresses: []domainnetwork.AddressInfo{{
 			Hostname: "controller-0.example.test",
 			Value:    "controller-0.example.test",
+			CIDR:     "0.0.0.0/0",
 		}},
 	}, {
 		Name:       "eth0",
@@ -850,9 +883,11 @@ func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedCaasPrependsFQDNs(c *
 			Addresses: []domainnetwork.AddressInfo{{
 				Hostname: "controller-0.example.test",
 				Value:    "controller-0.example.test",
+				CIDR:     "0.0.0.0/0",
 			}, {
 				Hostname: "controller-1.example.test",
 				Value:    "controller-1.example.test",
+				CIDR:     "0.0.0.0/0",
 			}},
 		}, {
 			Name:       "eth0",
@@ -894,6 +929,7 @@ func (s *infoSuite) TestGetUnitEndpointNetworksNotSupportedCaasUsesFQDNWithoutPo
 			Addresses: []domainnetwork.AddressInfo{{
 				Hostname: "controller-0.example.test",
 				Value:    "controller-0.example.test",
+				CIDR:     "0.0.0.0/0",
 			}},
 		}},
 		IngressAddresses: []string{},

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -61,6 +63,7 @@ const (
 	proxyResourceName           = "proxy"
 	storageName                 = "storage"
 	apiServerScratchStorageName = "apiserver-scratch"
+	controllerConfigSeedDir     = "/var/lib/juju-controller-bootstrap"
 )
 
 const (
@@ -1454,37 +1457,42 @@ func (c *controllerStack) buildContainerSpecForController() (*core.PodSpec, erro
 		jujudEnv = map[string]string{osenv.JujuFeatureFlagEnvKey: featureFlags}
 	}
 
-	setupCmd := ""
-	if c.pcfg.ControllerId == agent.BootstrapControllerId {
-		// only do bootstrap-state on the bootstrap controller - controller-0.
-		bootstrapStateCmd := fmt.Sprintf(
-			"%s bootstrap-state --data-dir $JUJU_DATA_DIR %s --timeout %s",
-			path.Join("$JUJU_TOOLS_DIR", "jujuagentd"),
-			loggingOption,
-			c.timeout.String(),
-		)
-		if featureFlags != "" {
-			bootstrapStateCmd = fmt.Sprintf("%s=%s %s", osenv.JujuFeatureFlagEnvKey, featureFlags, bootstrapStateCmd)
-		}
-		agentConfigPath := path.Join("$JUJU_DATA_DIR", agentConfigRelativePath)
-		if isLocalControllerCharmPath(c.pcfg.Bootstrap.ControllerCharmPath) {
-			charmArchivePath := path.Join("$JUJU_DATA_DIR", "charms", environsbootstrap.ControllerCharmArchive)
-			setupCmd = fmt.Sprintf(
-				"if ! test -e %s; then mkdir -p %s; until test -e %s; do sleep 1; done; %s; fi",
-				agentConfigPath,
-				path.Dir(charmArchivePath),
-				charmArchivePath,
-				bootstrapStateCmd,
-			)
-		} else {
-			setupCmd = fmt.Sprintf("test -e %s || %s", agentConfigPath, bootstrapStateCmd)
-		}
+	// The StatefulSet pod template is shared by every replica. Derive the
+	// controller ID from the pod ordinal and reserve bootstrap-state for
+	// controller-0. Later replicas have their agent config seeded by the charm
+	// init container before this container starts.
+	bootstrapStateCmd := fmt.Sprintf(
+		"%s bootstrap-state --data-dir $JUJU_DATA_DIR %s --timeout %s",
+		path.Join("$JUJU_TOOLS_DIR", "jujuagentd"),
+		loggingOption,
+		c.timeout.String(),
+	)
+	if featureFlags != "" {
+		bootstrapStateCmd = fmt.Sprintf("%s=%s %s", osenv.JujuFeatureFlagEnvKey, featureFlags, bootstrapStateCmd)
 	}
+	agentConfigPath := path.Join("$JUJU_DATA_DIR", agentConfigRelativePath)
+	var bootstrapSetup string
+	if isLocalControllerCharmPath(c.pcfg.Bootstrap.ControllerCharmPath) {
+		charmArchivePath := path.Join("$JUJU_DATA_DIR", "charms", environsbootstrap.ControllerCharmArchive)
+		bootstrapSetup = fmt.Sprintf(
+			"if ! test -e %s; then mkdir -p %s; until test -e %s; do sleep 1; done; %s; fi",
+			agentConfigPath,
+			path.Dir(charmArchivePath),
+			charmArchivePath,
+			bootstrapStateCmd,
+		)
+	} else {
+		bootstrapSetup = fmt.Sprintf("test -e %s || %s", agentConfigPath, bootstrapStateCmd)
+	}
+	setupCmd := fmt.Sprintf(
+		`controller_id="${HOSTNAME##*-}"; if [ "${controller_id}" = "0" ]; then %s; else until test -e "$JUJU_DATA_DIR/agents/controller-${controller_id}/%s"; do sleep 1; done; fi`,
+		bootstrapSetup,
+		agentconstants.AgentConfigFilename,
+	)
 
 	machineCmd := fmt.Sprintf(
-		"%s machine --data-dir $JUJU_DATA_DIR --controller-id %s --log-to-stderr %s",
+		`/bin/sh -c 'controller_id="${HOSTNAME##*-}"; exec %s machine --data-dir "$JUJU_DATA_DIR" --controller-id "${controller_id}" --log-to-stderr %s'`,
 		path.Join("$JUJU_TOOLS_DIR", "jujuagentd"),
-		c.pcfg.ControllerId,
 		loggingOption,
 	)
 
@@ -1552,24 +1560,119 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 	}
 	spec.Containers = append(spec.Containers, containers...)
 
-	agentConfigMount := core.VolumeMount{
-		Name: c.resourceNameVolAgentConf,
-		MountPath: path.Join(
-			c.pcfg.DataDir,
-			constants.TemplateFileNameAgentConf,
-		),
-		SubPath: constants.ControllerUnitAgentConfigFilename,
-	}
 	dataDirMount := core.VolumeMount{
 		Name:      storageName,
 		MountPath: c.pcfg.DataDir,
 	}
+	controllerConfigSeed := core.Container{
+		Name:            "controller-config-seed",
+		ImagePullPolicy: core.PullIfNotPresent,
+		Image:           controllerImage,
+		Command:         []string{"/bin/sh", "-c"},
+		Args: []string{fmt.Sprintf(`
+set -eu
+controller_id="${%s##*-}"
+controller_dir="%s/agents/controller-${controller_id}"
+mkdir -p "${controller_dir}"
+if [ "${controller_id}" = "0" ]; then
+    if [ ! -e "%s/%s" ]; then
+        cp "%s/%s" "%s/%s"
+    fi
+elif [ ! -e "${controller_dir}/%s" ]; then
+    sed -e "s/controller-0/controller-${controller_id}/g" \
+        -e "s/^oldpassword: .*/oldpassword: ${%s}/" "%s/%s" | \
+        sed "/^- localhost:%d$/a- %s:%d" > "${controller_dir}/%s"
+    chmod 600 "${controller_dir}/%s"
+fi
+`,
+			constants.EnvJujuK8sPodName,
+			c.pcfg.DataDir,
+			c.pcfg.DataDir,
+			constants.TemplateFileNameAgentConf,
+			controllerConfigSeedDir,
+			constants.ControllerUnitAgentConfigFilename,
+			c.pcfg.DataDir,
+			constants.TemplateFileNameAgentConf,
+			agentconstants.AgentConfigFilename,
+			constants.EnvJujuK8sUnitPassword,
+			controllerConfigSeedDir,
+			constants.ControllerAgentConfigFilename,
+			c.pcfg.Bootstrap.ControllerAgentInfo.APIPort,
+			c.resourceNameService,
+			c.portAPIServer,
+			agentconstants.AgentConfigFilename,
+			agentconstants.AgentConfigFilename,
+		)},
+		Env: []core.EnvVar{
+			{
+				Name: constants.EnvJujuK8sPodName,
+				ValueFrom: &core.EnvVarSource{
+					FieldRef: &core.ObjectFieldSelector{FieldPath: "metadata.name"},
+				},
+			},
+			{
+				Name: constants.EnvJujuK8sUnitPassword,
+				ValueFrom: &core.EnvVarSource{
+					SecretKeyRef: &core.SecretKeySelector{
+						LocalObjectReference: core.LocalObjectReference{Name: c.appSecretName()},
+						Key:                  constants.EnvJujuK8sUnitPassword,
+					},
+				},
+			},
+		},
+		VolumeMounts: []core.VolumeMount{
+			dataDirMount,
+			{
+				Name:      c.resourceNameVolAgentConf,
+				MountPath: controllerConfigSeedDir,
+				ReadOnly:  true,
+			},
+		},
+		SecurityContext: &core.SecurityContext{
+			RunAsUser:  pointer.Int64(constants.JujuUserID),
+			RunAsGroup: pointer.Int64(constants.JujuGroupID),
+		},
+	}
+	spec.InitContainers = append([]core.Container{controllerConfigSeed}, spec.InitContainers...)
 
 	for i, ct := range spec.InitContainers {
 		if ct.Name != constants.ApplicationInitContainer {
 			continue
 		}
-		ct.VolumeMounts = append(ct.VolumeMounts, agentConfigMount)
+		for j, mount := range ct.VolumeMounts {
+			if mount.MountPath == c.pcfg.DataDir {
+				ct.VolumeMounts = append(ct.VolumeMounts[:j], ct.VolumeMounts[j+1:]...)
+				break
+			}
+		}
+		ct.VolumeMounts = append(ct.VolumeMounts, dataDirMount)
+		ct.Env = append(ct.Env,
+			core.EnvVar{
+				Name:  "JUJU_K8S_APPLICATION",
+				Value: environsbootstrap.ControllerApplicationName,
+			},
+			core.EnvVar{
+				Name:  "JUJU_K8S_MODEL",
+				Value: c.broker.ModelUUID(),
+			},
+			core.EnvVar{
+				Name: "JUJU_K8S_APPLICATION_PASSWORD",
+				ValueFrom: &core.EnvVarSource{
+					SecretKeyRef: &core.SecretKeySelector{
+						LocalObjectReference: core.LocalObjectReference{Name: c.appSecretName()},
+						Key:                  constants.EnvJujuK8sUnitPassword,
+					},
+				},
+			},
+			core.EnvVar{
+				Name:  "JUJU_K8S_CONTROLLER_ADDRESSES",
+				Value: net.JoinHostPort(c.resourceNameService, strconv.Itoa(c.portAPIServer)),
+			},
+			core.EnvVar{
+				Name:  "JUJU_K8S_CONTROLLER_CA_CERT",
+				Value: c.pcfg.APIInfo.CACert,
+			},
+		)
 		ct.Args = append(ct.Args, "--controller")
 		spec.InitContainers[i] = ct
 	}
@@ -1586,7 +1689,7 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 				break
 			}
 		}
-		ct.VolumeMounts = append(ct.VolumeMounts, agentConfigMount, dataDirMount)
+		ct.VolumeMounts = append(ct.VolumeMounts, dataDirMount)
 
 		// Remove probes to prevent controller death.
 		ct.LivenessProbe = nil

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -928,11 +928,6 @@ func (s *bootstrapSuite) TestBootstrap(c *tc.C) {
 					SubPath:   "charm/bin/containeragent",
 				},
 				{
-					Name:      "juju-controller-test-agent-conf",
-					MountPath: "/var/lib/juju/template-agent.conf",
-					SubPath:   "controller-unit-agent.conf",
-				},
-				{
 					Name:      "storage",
 					MountPath: "/var/lib/juju",
 				},
@@ -958,7 +953,7 @@ export JUJU_TOOLS_DIR=$JUJU_DATA_DIR/tools
 mkdir -p $JUJU_TOOLS_DIR
 cp /opt/jujuagentd $JUJU_TOOLS_DIR/jujuagentd
 
-if ! test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf; then mkdir -p $JUJU_DATA_DIR/charms; until test -e $JUJU_DATA_DIR/charms/controller.charm; do sleep 1; done; JUJU_DEV_FEATURE_FLAGS=developer-mode $JUJU_TOOLS_DIR/jujuagentd bootstrap-state --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s; fi
+controller_id="${HOSTNAME##*-}"; if [ "${controller_id}" = "0" ]; then if ! test -e $JUJU_DATA_DIR/agents/controller-0/agent.conf; then mkdir -p $JUJU_DATA_DIR/charms; until test -e $JUJU_DATA_DIR/charms/controller.charm; do sleep 1; done; JUJU_DEV_FEATURE_FLAGS=developer-mode $JUJU_TOOLS_DIR/jujuagentd bootstrap-state --data-dir $JUJU_DATA_DIR --debug --timeout 10m0s; fi; else until test -e "$JUJU_DATA_DIR/agents/controller-${controller_id}/agent.conf"; do sleep 1; done; fi
 
 mkdir -p /var/lib/pebble/default/layers
 cat > /var/lib/pebble/default/layers/001-jujuagentd.yaml <<EOF
@@ -968,7 +963,7 @@ services:
         summary: Juju controller agent
         startup: enabled
         override: replace
-        command: $JUJU_TOOLS_DIR/jujuagentd machine --data-dir $JUJU_DATA_DIR --controller-id 0 --log-to-stderr --debug
+        command: /bin/sh -c 'controller_id="${HOSTNAME##*-}"; exec $JUJU_TOOLS_DIR/jujuagentd machine --data-dir "$JUJU_DATA_DIR" --controller-id "${controller_id}" --log-to-stderr --debug'
         environment:
             JUJU_DEV_FEATURE_FLAGS: developer-mode
 
@@ -1099,6 +1094,61 @@ exec /opt/pebble run --http :38811 --verbose
 		},
 	}
 	statefulSetSpec.Spec.Template.Spec.InitContainers = []core.Container{{
+		Name:            "controller-config-seed",
+		ImagePullPolicy: core.PullIfNotPresent,
+		Image:           "ghcr.io/juju/jujud-operator:" + expectedVersion.String(),
+		Command:         []string{"/bin/sh", "-c"},
+		Args: []string{`
+set -eu
+controller_id="${JUJU_K8S_POD_NAME##*-}"
+controller_dir="/var/lib/juju/agents/controller-${controller_id}"
+mkdir -p "${controller_dir}"
+if [ "${controller_id}" = "0" ]; then
+    if [ ! -e "/var/lib/juju/template-agent.conf" ]; then
+        cp "/var/lib/juju-controller-bootstrap/controller-unit-agent.conf" "/var/lib/juju/template-agent.conf"
+    fi
+elif [ ! -e "${controller_dir}/agent.conf" ]; then
+    sed -e "s/controller-0/controller-${controller_id}/g" \
+        -e "s/^oldpassword: .*/oldpassword: ${JUJU_K8S_UNIT_PASSWORD}/" "/var/lib/juju-controller-bootstrap/controller-agent.conf" | \
+        sed "/^- localhost:456$/a- juju-controller-test-service:17777" > "${controller_dir}/agent.conf"
+    chmod 600 "${controller_dir}/agent.conf"
+fi
+`},
+		Env: []core.EnvVar{
+			{
+				Name: "JUJU_K8S_POD_NAME",
+				ValueFrom: &core.EnvVarSource{
+					FieldRef: &core.ObjectFieldSelector{FieldPath: "metadata.name"},
+				},
+			},
+			{
+				Name: "JUJU_K8S_UNIT_PASSWORD",
+				ValueFrom: &core.EnvVarSource{
+					SecretKeyRef: &core.SecretKeySelector{
+						LocalObjectReference: core.LocalObjectReference{
+							Name: "juju-controller-test-application-config",
+						},
+						Key: "JUJU_K8S_UNIT_PASSWORD",
+					},
+				},
+			},
+		},
+		VolumeMounts: []core.VolumeMount{
+			{
+				Name:      "storage",
+				MountPath: "/var/lib/juju",
+			},
+			{
+				Name:      "juju-controller-test-agent-conf",
+				MountPath: "/var/lib/juju-controller-bootstrap",
+				ReadOnly:  true,
+			},
+		},
+		SecurityContext: &core.SecurityContext{
+			RunAsUser:  pointer.Int64(170),
+			RunAsGroup: pointer.Int64(170),
+		},
+	}, {
 		Name:            "charm-init",
 		ImagePullPolicy: core.PullIfNotPresent,
 		Image:           "ghcr.io/juju/jujud-operator:" + expectedVersion.String(),
@@ -1136,6 +1186,33 @@ exec /opt/pebble run --http :38811 --verbose
 					},
 				},
 			},
+			{
+				Name:  "JUJU_K8S_APPLICATION",
+				Value: "controller",
+			},
+			{
+				Name:  "JUJU_K8S_MODEL",
+				Value: coretesting.ModelTag.Id(),
+			},
+			{
+				Name: "JUJU_K8S_APPLICATION_PASSWORD",
+				ValueFrom: &core.EnvVarSource{
+					SecretKeyRef: &core.SecretKeySelector{
+						LocalObjectReference: core.LocalObjectReference{
+							Name: "juju-controller-test-application-config",
+						},
+						Key: "JUJU_K8S_UNIT_PASSWORD",
+					},
+				},
+			},
+			{
+				Name:  "JUJU_K8S_CONTROLLER_ADDRESSES",
+				Value: "juju-controller-test-service:17777",
+			},
+			{
+				Name:  "JUJU_K8S_CONTROLLER_CA_CERT",
+				Value: coretesting.CACert,
+			},
 		},
 		EnvFrom: []core.EnvFromSource{
 			{
@@ -1148,10 +1225,6 @@ exec /opt/pebble run --http :38811 --verbose
 		},
 		VolumeMounts: []core.VolumeMount{
 			{
-				Name:      "charm-data",
-				MountPath: "/var/lib/juju",
-				SubPath:   "var/lib/juju",
-			}, {
 				Name:      "charm-data",
 				MountPath: "/charm/bin",
 				SubPath:   "charm/bin",
@@ -1172,9 +1245,8 @@ exec /opt/pebble run --http :38811 --verbose
 				MountPath: "/charm/etc/pebble/",
 				SubPath:   "charm/etc/pebble/",
 			}, {
-				Name:      "juju-controller-test-agent-conf",
-				MountPath: "/var/lib/juju/template-agent.conf",
-				SubPath:   "controller-unit-agent.conf",
+				Name:      "storage",
+				MountPath: "/var/lib/juju",
 			},
 		},
 		SecurityContext: &core.SecurityContext{

--- a/internal/worker/caasapplicationprovisioner/application.go
+++ b/internal/worker/caasapplicationprovisioner/application.go
@@ -257,14 +257,8 @@ func (a *appWorker) loop() error {
 				return errors.Trace(err)
 			}
 			if ps.Scaling {
-				if statusOnly {
-					// Clear provisioning state for status only app.
-					err = a.applicationService.SetApplicationScalingState(ctx, name, 0, false)
-					if err != nil {
-						return errors.Trace(err)
-					}
-				} else {
-					scaleChan = a.clock.After(0)
+				scaleChan = a.clock.After(0)
+				if !statusOnly {
 					reconcileDeadChan = a.clock.After(0)
 				}
 			}
@@ -375,10 +369,6 @@ func (a *appWorker) loop() error {
 			}
 			shouldRefresh = false
 		case <-scaleChan:
-			if statusOnly {
-				scaleChan = nil
-				break
-			}
 			if !ready {
 				scaleChan = a.clock.After(retryDelay)
 				shouldRefresh = false

--- a/internal/worker/caasapplicationprovisioner/application_test.go
+++ b/internal/worker/caasapplicationprovisioner/application_test.go
@@ -314,6 +314,10 @@ func (s *ApplicationWorkerSuite) TestWorkerStatusOnly(c *tc.C) {
 	appReplicasChan := make(chan struct{}, 1)
 
 	ops.EXPECT().RefreshOperatorStatus(x, "con-troll-er", s.appUUID, app, x, x, x, x).Return(nil).AnyTimes()
+	ops.EXPECT().EnsureScale(
+		x, "con-troll-er", s.appUUID, app, life.Alive, facade,
+		applicationService, s.logger,
+	).Return(nil).AnyTimes()
 
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationName(x, s.appUUID).Return("con-troll-er", nil),
@@ -328,7 +332,6 @@ func (s *ApplicationWorkerSuite) TestWorkerStatusOnly(c *tc.C) {
 		// handleChange
 		applicationService.EXPECT().GetApplicationLife(x, s.appUUID).Return(life.Alive, nil),
 		applicationService.EXPECT().GetApplicationScalingState(x, "con-troll-er").Return(applicationservice.ScalingState{Scaling: true, ScaleTarget: 1}, nil),
-		applicationService.EXPECT().SetApplicationScalingState(x, "con-troll-er", 0, false).Return(nil),
 		facade.EXPECT().WatchProvisioningInfo(x, "con-troll-er").Return(watchertest.NewMockNotifyWatcher(provisioningInfoChan), nil),
 		app.EXPECT().Watch(x).Return(watchertest.NewMockNotifyWatcher(appChan), nil),
 		app.EXPECT().WatchReplicas().DoAndReturn(func() (watcher.NotifyWatcher, error) {


### PR DESCRIPTION
A series of small changes are needed to get k8s HA up and running. Create a prototype to demonstrate these changes.

Namely:
- Enabled controller applications to use the existing CAAS scale reconciliation path, allowing scale targets to update the Kubernetes StatefulSet without enabling ordinary workload lifecycle management.

- Derived each controller ID from its StatefulSet pod ordinal, ensuring only controller-0 bootstraps while later replicas start as distinct controller agents.
- Added an init container that creates persistent, ordinal-specific controller-agent configurations with a usable initial credential and controller API address.
- Updated charm initialization and volume mounts so scaled pods register as controller units and retain their unit and controller state across restarts.
- Added prototype authentication fallbacks so new controller units and nonzero controller agents can perform their initial API login before rotating to unique credentials.

- Allowed controller agents above ID zero through the Agent API and created missing controller-node records when their passwords are first persisted.
- Allowed machine-agent startup to use oldpassword when a seeded replica does not yet have a current API password.
- Exposed stable per-pod controller FQDNs in the network information consumed by the controller charm, enabling distinct, persistent Dqlite member addresses.
- Updated juju controllers --refresh to derive Kubernetes node and HA counts from controller units rather than machine records.
- Added and updated focused tests covering scale reconciliation, pod-spec generation, authentication, password persistence, network information, and CLI reporting.
