### PR TITLE
feat: add support for image-id constraint on google cloud

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -618,7 +618,7 @@ func (api *ProvisionerAPI) constructImageConstraint(m *state.Machine, env enviro
 		lookup.CloudSpec = spec
 	}
 
-	return imagemetadata.NewImageConstraint(lookup, cons.ImageID)
+	return imagemetadata.NewImageConstraint(lookup)
 }
 
 // findImageMetadata returns all image metadata or an error fetching them.
@@ -661,9 +661,6 @@ func (api *ProvisionerAPI) imageMetadataFromState(constraint *imagemetadata.Imag
 		Arches:   constraint.Arches,
 		Region:   constraint.Region,
 		Stream:   constraint.Stream,
-	}
-	if constraint.ImageID != nil {
-		filter.ImageID = *constraint.ImageID
 	}
 	stored, err := api.st.CloudImageMetadataStorage.FindMetadata(filter)
 	if err != nil {

--- a/docs/reference/cloud/list-of-supported-clouds/google-gce.md
+++ b/docs/reference/cloud/list-of-supported-clouds/google-gce.md
@@ -200,6 +200,7 @@ The constraints `instance-type` and `[cores, cpu-power, mem]` are mutually exclu
 - {ref}`constraint-container`
 - {ref}`constraint-cores`
 - {ref}`constraint-cpu-power`
+- {ref}`constraint-image-id`. Starting with Juju 3.6.28. Valid values: A GCE image ID.
 - {ref}`constraint-instance-role`. Valid values: A service account email.
 - {ref}`constraint-instance-type`. Valid values: Any GCE machine type. Default: `n1-standard-1`.
 - {ref}`constraint-mem`

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -969,7 +969,7 @@ func bootstrapImageMetadata(
 	imageConstraint, err := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: region,
 		Stream:    environ.Config().ImageStream(),
-	}, nil)
+	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1131,7 +1131,7 @@ func setPrivateMetadataSources(fetcher imagemetadata.SimplestreamsFetcher, metad
 	dataSource := fetcher.NewDataSource(dataSourceConfig)
 
 	// Read the image metadata, as we'll want to upload it to the environment.
-	imageConstraint, err := imagemetadata.NewImageConstraint(simplestreams.LookupParams{}, nil)
+	imageConstraint, err := imagemetadata.NewImageConstraint(simplestreams.LookupParams{})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/environs/imagedownloads/simplestreams.go
+++ b/environs/imagedownloads/simplestreams.go
@@ -171,7 +171,7 @@ func One(fetcher imagemetadata.SimplestreamsFetcher, arch, release, stream, ftyp
 			Arches:   []string{arch},
 			Releases: []string{release},
 			Stream:   stream,
-		}, nil,
+		},
 	)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/environs/imagedownloads/simplestreams_test.go
+++ b/environs/imagedownloads/simplestreams_test.go
@@ -77,7 +77,7 @@ func (*Suite) TestFetchManyDefaultFilter(c *gc.C) {
 			Arches:   []string{"amd64", "arm64", "ppc64el"},
 			Releases: []string{"16.04"},
 			Stream:   "released",
-		}, nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	got, resolveInfo, err := Fetch(ss, tds, constraints, nil)
@@ -104,7 +104,7 @@ func (*Suite) TestFetchManyDefaultFilterAndCustomImageDownloadURL(c *gc.C) {
 			Arches:   []string{"amd64", "arm64", "ppc64el"},
 			Releases: []string{"16.04"},
 			Stream:   "released",
-		}, nil,
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	got, resolveInfo, err := Fetch(ss, tds, constraints, nil)

--- a/environs/imagemetadata/generate.go
+++ b/environs/imagemetadata/generate.go
@@ -46,7 +46,7 @@ func MergeAndWriteMetadata(fetcher SimplestreamsFetcher,
 func readMetadata(fetcher SimplestreamsFetcher, metadataStore storage.Storage) ([]*ImageMetadata, error) {
 	// Read any existing metadata so we can merge the new tools metadata with what's there.
 	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", metadataStore, storage.BaseImagesPath, simplestreams.EXISTING_CLOUD_DATA, false)
-	imageConstraint, err := NewImageConstraint(simplestreams.LookupParams{}, nil)
+	imageConstraint, err := NewImageConstraint(simplestreams.LookupParams{})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/environs/imagemetadata/generate_test.go
+++ b/environs/imagemetadata/generate_test.go
@@ -37,7 +37,7 @@ func assertFetch(c *gc.C, ss *simplestreams.Simplestreams, stor storage.Storage,
 		CloudSpec: simplestreams.CloudSpec{region, endpoint},
 		Releases:  []string{version},
 		Arches:    []string{arch},
-	}, nil)
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	dataSource := storage.NewStorageSimpleStreamsDataSource("test datasource", stor, "images", simplestreams.DEFAULT_CLOUD_DATA, false)
 	metadata, _, err := imagemetadata.Fetch(ss, []simplestreams.DataSource{dataSource}, cons)

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -135,10 +135,9 @@ func OfficialDataSources(dataSourceFactory simplestreams.DataSourceFactory, stre
 // ImageConstraint defines criteria used to find an image metadata record.
 type ImageConstraint struct {
 	simplestreams.LookupParams
-	ImageID *string
 }
 
-func NewImageConstraint(params simplestreams.LookupParams, imageID *string) (*ImageConstraint, error) {
+func NewImageConstraint(params simplestreams.LookupParams) (*ImageConstraint, error) {
 	if len(params.Releases) == 0 {
 		workloadVersions, err := corebase.AllWorkloadVersions()
 		if err != nil {
@@ -149,7 +148,7 @@ func NewImageConstraint(params simplestreams.LookupParams, imageID *string) (*Im
 	if len(params.Arches) == 0 {
 		params.Arches = arch.AllSupportedArches
 	}
-	return &ImageConstraint{LookupParams: params, ImageID: imageID}, nil
+	return &ImageConstraint{LookupParams: params}, nil
 }
 
 const (
@@ -245,10 +244,6 @@ func Fetch(fetcher SimplestreamsFetcher, sources []simplestreams.DataSource, con
 	if err != nil {
 		return nil, resolveInfo, err
 	}
-	// TODO - we want to refactor to allow image-id filtering.
-	// We could filter on cons.ImageID here but that would prevent
-	// users from being able to force Juju to use an image not
-	// included in the published metadata.
 	metadata := make([]*ImageMetadata, len(items))
 	for i, md := range items {
 		metadata[i] = md.(*ImageMetadata)

--- a/environs/imagemetadata/simplestreams_test.go
+++ b/environs/imagemetadata/simplestreams_test.go
@@ -80,7 +80,7 @@ func Test(t *stdtesting.T) {
 			CloudSpec: testData.validCloudSpec,
 			Releases:  []string{"12.10"},
 			Arches:    []string{"amd64"},
-		}, nil)
+		})
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -98,7 +98,7 @@ func registerSimpleStreamsTests(t *stdtesting.T) {
 		},
 		Releases: []string{"12.04"},
 		Arches:   []string{"amd64", "arm"},
-	}, nil)
+	})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -323,7 +323,7 @@ func (s *simplestreamsSuite) TestFetch(c *gc.C) {
 			CloudSpec: cloudSpec,
 			Releases:  []string{"12.04"},
 			Arches:    t.arches,
-		}, nil)
+		})
 		c.Assert(err, jc.ErrorIsNil)
 		// Add invalid datasource and check later that resolveInfo is correct.
 		invalidSource := sstesting.InvalidDataSource(s.RequireSigned)
@@ -353,7 +353,7 @@ func (s *productSpecSuite) TestIdWithDefaultStream(c *gc.C) {
 	imageConstraint, err := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		Releases: []string{"12.04"},
 		Arches:   []string{"amd64"},
-	}, nil)
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	for _, stream := range []string{"", "released"} {
 		imageConstraint.Stream = stream
@@ -368,7 +368,7 @@ func (s *productSpecSuite) TestId(c *gc.C) {
 		Releases: []string{"12.04"},
 		Arches:   []string{"amd64"},
 		Stream:   "daily",
-	}, nil)
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	ids, err := imageConstraint.ProductIds()
 	c.Assert(err, jc.ErrorIsNil)
@@ -380,24 +380,13 @@ func (s *productSpecSuite) TestIdMultiArch(c *gc.C) {
 		Releases: []string{"12.04"},
 		Arches:   []string{"amd64", "arm64"},
 		Stream:   "daily",
-	}, nil)
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	ids, err := imageConstraint.ProductIds()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ids, gc.DeepEquals, []string{
 		"com.ubuntu.cloud.daily:server:12.04:amd64",
 		"com.ubuntu.cloud.daily:server:12.04:arm64"})
-}
-
-func (s *productSpecSuite) TestImageID(c *gc.C) {
-	imageID := "ami-0a116fa7c861dd5f9"
-	imageConstraint, err := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
-		Releases: []string{"12.04"},
-		Arches:   []string{"amd64"},
-		Stream:   "pro",
-	}, &imageID)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*imageConstraint.ImageID, gc.Equals, imageID)
 }
 
 type signedSuite struct {
@@ -434,7 +423,7 @@ func (s *signedSuite) TestSignedImageMetadata(c *gc.C) {
 		},
 		Releases: []string{"12.04"},
 		Arches:   []string{"amd64"},
-	}, nil)
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	images, resolveInfo, err := imagemetadata.Fetch(ss, []simplestreams.DataSource{signedSource}, imageConstraint)
 	c.Assert(err, jc.ErrorIsNil)
@@ -464,7 +453,7 @@ func (s *signedSuite) TestSignedImageMetadataInvalidSignature(c *gc.C) {
 		},
 		Releases: []string{"12.04"},
 		Arches:   []string{"amd64"},
-	}, nil)
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	imagemetadata.SetSigningPublicKey(s.origKey)
 	_, _, err = imagemetadata.Fetch(ss, []simplestreams.DataSource{signedSource}, imageConstraint)

--- a/environs/imagemetadata/validation.go
+++ b/environs/imagemetadata/validation.go
@@ -34,7 +34,7 @@ func ValidateImageMetadata(fetcher SimplestreamsFetcher, params *simplestreams.M
 		Releases: []string{params.Release},
 		Arches:   params.Architectures,
 		Stream:   params.Stream,
-	}, nil)
+	})
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/environs/instances/image_test.go
+++ b/environs/instances/image_test.go
@@ -327,7 +327,7 @@ func (s *imageSuite) TestFindInstanceSpec(c *gc.C) {
 			CloudSpec: simplestreams.CloudSpec{t.region, "ep"},
 			Releases:  []string{"12.04"},
 			Stream:    t.stream,
-		}, nil)
+		})
 		c.Assert(err, jc.ErrorIsNil)
 		dataSource := simplestreams.NewDataSource(simplestreams.Config{
 			Description:          "test",
@@ -372,12 +372,11 @@ func (s *imageSuite) TestFindInstanceSpec(c *gc.C) {
 }
 
 func (s *imageSuite) TestFindInstanceSpecWithImageID(c *gc.C) {
-	imageId := "ami-00000011"
 	cons, err := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"us-east-1", "ep"},
 		Releases:  []string{"12.04"},
 		Arches:    []string{"amd64"},
-	}, &imageId)
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
 	dataSource := simplestreams.NewDataSource(simplestreams.Config{
@@ -410,7 +409,7 @@ func (s *imageSuite) TestFindInstanceSpecWithImageID(c *gc.C) {
 	}, instanceTypes)
 
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(spec.Image.Id, gc.Equals, imageId)
+	c.Assert(spec.Image.Id, gc.Equals, "ami-00000011")
 	c.Assert(spec.InstanceType, gc.DeepEquals, instanceTypes[0])
 }
 
@@ -428,7 +427,7 @@ func (s *imageSuite) TestFindInstanceSpecShouldChooseNonSEV(c *gc.C) {
 	cons, err := imagemetadata.NewImageConstraint(simplestreams.LookupParams{
 		CloudSpec: simplestreams.CloudSpec{"test", "ep"},
 		Releases:  []string{"12.04"},
-	}, nil)
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	dataSource := simplestreams.NewDataSource(simplestreams.Config{
 		Description:          "test",

--- a/internal/provider/ec2/environ.go
+++ b/internal/provider/ec2/environ.go
@@ -633,9 +633,17 @@ func (e *environ) StartInstance(
 		return nil, errors.Trace(err)
 	}
 
+	imageMetadata := args.ImageMetadata
+	if args.Constraints.HasImageID() {
+		imageMetadata, err = e.resolveImageIDMetadata(ctx, args)
+		if err != nil {
+			return nil, wrapError(err)
+		}
+	}
+
 	spec, err := findInstanceSpec(
 		args.InstanceConfig.IsController(),
-		args.ImageMetadata,
+		imageMetadata,
 		instanceTypes,
 		&instances.InstanceConstraint{
 			Region:      e.cloud.Region,
@@ -695,11 +703,6 @@ func (e *environ) StartInstance(
 	rootVolumeTags[tagName] = hostname + "-root"
 	volumeTags := CreateTagSpecification(types.ResourceTypeVolume, rootVolumeTags)
 
-	imageID := aws.String(spec.Image.Id)
-	if args.Constraints.HasImageID() {
-		imageID = aws.String(*args.Constraints.ImageID)
-	}
-
 	var instResp *ec2.RunInstancesOutput
 	commonRunArgs := &ec2.RunInstancesInput{
 		MinCount:            aws.Int32(1),
@@ -708,7 +711,7 @@ func (e *environ) StartInstance(
 		InstanceType:        types.InstanceType(spec.InstanceType.Name),
 		SecurityGroupIds:    groupIDs,
 		BlockDeviceMappings: blockDeviceMappings,
-		ImageId:             imageID,
+		ImageId:             aws.String(spec.Image.Id),
 		MetadataOptions: &types.InstanceMetadataOptionsRequest{
 			HttpEndpoint: types.InstanceMetadataEndpointStateEnabled,
 			// By forcing HTTP tokens here we move all created instances over to

--- a/internal/provider/ec2/image.go
+++ b/internal/provider/ec2/image.go
@@ -4,9 +4,12 @@
 package ec2
 
 import (
+	"github.com/juju/errors"
 	"github.com/kr/pretty"
 
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 )
@@ -73,4 +76,20 @@ func withDefaultNonControllerConstraints(cons constraints.Value) constraints.Val
 		cons.CpuPower = instances.CpuPower(100)
 	}
 	return cons
+}
+
+func (e *environ) resolveImageIDMetadata(
+	_ context.ProviderCallContext,
+	args environs.StartInstanceParams,
+) ([]*imagemetadata.ImageMetadata, error) {
+	arch, err := args.Tools.OneArch()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// TODO(wallyworld 2026-08-04): Resolve and validate image-id via DescribeImages.
+	return []*imagemetadata.ImageMetadata{{
+		Id:   *args.Constraints.ImageID,
+		Arch: arch,
+	}}, nil
 }

--- a/internal/provider/gce/environ.go
+++ b/internal/provider/gce/environ.go
@@ -47,6 +47,8 @@ type ComputeService interface {
 	ListMachineTypes(ctx stdcontext.Context, zone string) ([]*computepb.MachineType, error)
 	// MachineType retrieves the machine type definition for the specified instance type.
 	MachineType(ctx stdcontext.Context, zone, instanceType string) (*computepb.MachineType, error)
+	// ImageByProject retrieves image metadata for the specified image in the specified project.
+	ImageByProject(ctx stdcontext.Context, project, image string) (*computepb.Image, error)
 
 	// Firewalls returns the firewalls with the given prefix.
 	Firewalls(ctx stdcontext.Context, prefix string) ([]*computepb.Firewall, error)

--- a/internal/provider/gce/environ_broker.go
+++ b/internal/provider/gce/environ_broker.go
@@ -74,18 +74,27 @@ func (env *environ) buildInstanceSpec(ctx context.ProviderCallContext, args envi
 		return nil, errors.Trace(err)
 	}
 
-	arch, err := args.Tools.OneArch()
+	agentArch, err := args.Tools.OneArch()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	imageMetadata := args.ImageMetadata
+	if args.Constraints.HasImageID() {
+		imageMetadata, err = env.resolveImageIDMetadata(ctx, args)
+		if err != nil {
+			return nil, google.HandleCredentialError(errors.Trace(err), ctx)
+		}
+	}
+
 	spec, err := env.findInstanceSpec(
 		&instances.InstanceConstraint{
 			Region:      env.cloud.Region,
 			Base:        args.InstanceConfig.Base,
-			Arch:        arch,
+			Arch:        agentArch,
 			Constraints: args.Constraints,
 		},
-		args.ImageMetadata,
+		imageMetadata,
 		instTypesAndCosts.InstanceTypes,
 	)
 	return spec, errors.Trace(err)
@@ -217,11 +226,10 @@ func (env *environ) startInstance(
 		hostname,
 	}
 
-	imageURLBase, err := env.imageURLBase(os)
+	imageURL, err := env.imageURL(os, imageID)
 	if err != nil {
 		return nil, environs.ZoneIndependentError(err)
 	}
-	imageURL := imageURLBase + imageID
 
 	disks, err := getDisks(imageURL, instanceTypeName, os, args.AvailabilityZone, args.Constraints, args.RootDisk)
 	if err != nil {

--- a/internal/provider/gce/environ_broker_test.go
+++ b/internal/provider/gce/environ_broker_test.go
@@ -717,6 +717,115 @@ func (s *environBrokerSuite) TestBuildInstanceSpec(c *gc.C) {
 	})
 }
 
+func (s *environBrokerSuite) TestBuildInstanceSpecWithImageID(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+	s.StartInstArgs.Constraints = constraints.MustParse("instance-type=n1-standard-1 image-id=ubuntu-2204-jammy-v20260803")
+
+	s.expectImageMetadata()
+	s.MockService.EXPECT().ImageByProject(gomock.Any(), "ubuntu-os-cloud", "ubuntu-2204-jammy-v20260803").Return(&computepb.Image{
+		Name:         ptr("ubuntu-2204-jammy-v20260803"),
+		Architecture: ptr("X86_64"),
+	}, nil)
+
+	spec, err := gce.BuildInstanceSpec(env, s.CallCtx, s.StartInstArgs)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spec.Image.Id, gc.Equals, "projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20260803")
+	c.Check(spec.Image.Arch, gc.Equals, "amd64")
+}
+
+func (s *environBrokerSuite) TestBuildInstanceSpecWithImageIDFullReference(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+	s.StartInstArgs.Constraints = constraints.MustParse("instance-type=n1-standard-1 image-id=projects/custom-images/global/images/custom-ubuntu")
+
+	s.expectImageMetadata()
+	s.MockService.EXPECT().ImageByProject(gomock.Any(), "custom-images", "custom-ubuntu").Return(&computepb.Image{
+		Name:         ptr("custom-ubuntu"),
+		Architecture: ptr("X86_64"),
+	}, nil)
+
+	spec, err := gce.BuildInstanceSpec(env, s.CallCtx, s.StartInstArgs)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spec.Image.Id, gc.Equals, "projects/custom-images/global/images/custom-ubuntu")
+}
+
+func (s *environBrokerSuite) TestBuildInstanceSpecWithImageIDAndMatchingArchConstraint(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+	s.StartInstArgs.Constraints = constraints.MustParse("instance-type=n1-standard-1 arch=amd64 image-id=ubuntu-2204-jammy-v20260803")
+
+	s.expectImageMetadata()
+	s.MockService.EXPECT().ImageByProject(gomock.Any(), "ubuntu-os-cloud", "ubuntu-2204-jammy-v20260803").Return(&computepb.Image{
+		Name:         ptr("ubuntu-2204-jammy-v20260803"),
+		Architecture: ptr("X86_64"),
+	}, nil)
+
+	spec, err := gce.BuildInstanceSpec(env, s.CallCtx, s.StartInstArgs)
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(spec.Image.Arch, gc.Equals, "amd64")
+}
+
+func (s *environBrokerSuite) TestBuildInstanceSpecWithImageIDAndMismatchedArchConstraint(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+	s.StartInstArgs.Constraints = constraints.MustParse("instance-type=n1-standard-1 arch=amd64 image-id=ubuntu-2204-jammy-v20260803")
+
+	s.expectImageMetadata()
+	s.MockService.EXPECT().ImageByProject(gomock.Any(), "ubuntu-os-cloud", "ubuntu-2204-jammy-v20260803").Return(&computepb.Image{
+		Name:         ptr("ubuntu-2204-jammy-v20260803"),
+		Architecture: ptr("ARM64"),
+	}, nil)
+
+	_, err := gce.BuildInstanceSpec(env, s.CallCtx, s.StartInstArgs)
+
+	c.Assert(err, gc.ErrorMatches, `image "ubuntu-2204-jammy-v20260803" has architecture "arm64" but agent requires "amd64"`)
+}
+
+func (s *environBrokerSuite) TestBuildInstanceSpecWithImageIDUnsupportedArch(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+	s.StartInstArgs.Constraints = constraints.MustParse("instance-type=n1-standard-1 image-id=ubuntu-2204-jammy-v20260803")
+
+	s.expectImageMetadata()
+	s.MockService.EXPECT().ImageByProject(gomock.Any(), "ubuntu-os-cloud", "ubuntu-2204-jammy-v20260803").Return(&computepb.Image{
+		Name:         ptr("ubuntu-2204-jammy-v20260803"),
+		Architecture: ptr("unsupported"),
+	}, nil)
+
+	_, err := gce.BuildInstanceSpec(env, s.CallCtx, s.StartInstArgs)
+
+	c.Assert(err, gc.ErrorMatches, `getting image "ubuntu-2204-jammy-v20260803": unsupported image architecture "unsupported"`)
+}
+
+func (s *environBrokerSuite) TestBuildInstanceSpecWithImageIDNotFound(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+	s.StartInstArgs.Constraints = constraints.MustParse("instance-type=n1-standard-1 image-id=ubuntu-2204-jammy-v20260803")
+
+	s.expectImageMetadata()
+	s.MockService.EXPECT().ImageByProject(gomock.Any(), "ubuntu-os-cloud", "ubuntu-2204-jammy-v20260803").Return(nil, errors.New("not found"))
+
+	_, err := gce.BuildInstanceSpec(env, s.CallCtx, s.StartInstArgs)
+
+	c.Assert(err, gc.ErrorMatches, `getting image "ubuntu-2204-jammy-v20260803": not found`)
+}
+
 func (s *environBrokerSuite) TestFindInstanceSpec(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()

--- a/internal/provider/gce/environ_policy.go
+++ b/internal/provider/gce/environ_policy.go
@@ -59,7 +59,6 @@ func (env *environ) PrecheckInstance(ctx context.ProviderCallContext, args envir
 var unsupportedConstraints = []string{
 	constraints.Tags,
 	constraints.VirtType,
-	constraints.ImageID,
 }
 
 // instanceTypeConstraints defines the fields defined on each of the

--- a/internal/provider/gce/environ_policy_test.go
+++ b/internal/provider/gce/environ_policy_test.go
@@ -379,6 +379,23 @@ func (s *environPolSuite) TestConstraintsValidatorUnsupported(c *gc.C) {
 	c.Assert(unsupported, jc.SameContents, []string{"tags", "virt-type"})
 }
 
+func (s *environPolSuite) TestConstraintsValidatorImageIDSupported(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+
+	s.expectConstraintsCalls()
+
+	validator, err := env.ConstraintsValidator(s.CallCtx)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons := constraints.MustParse("arch=amd64 image-id=ubuntu-2204-jammy-v20260803")
+	unsupported, err := validator.Validate(cons)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unsupported, gc.HasLen, 0)
+}
+
 func (s *environPolSuite) TestConstraintsValidatorVocabInstType(c *gc.C) {
 	ctrl := s.SetupMocks(c)
 	defer ctrl.Finish()

--- a/internal/provider/gce/export_test.go
+++ b/internal/provider/gce/export_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/os/ostype"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
@@ -69,4 +70,24 @@ func GetHardwareCharacteristics(env *environ, spec *instances.InstanceSpec, inst
 
 func HasAccelerator(env *environ, ctx context.ProviderCallContext, zone string, instanceType string) (bool, error) {
 	return env.hasAccelerator(ctx, zone, instanceType)
+}
+
+func ImageURL(env *environ, osName, imageID string) (string, error) {
+	return env.imageURL(ostype.OSTypeForName(osName), imageID)
+}
+
+func SplitProjectImagePath(imagePath string) (string, string, bool) {
+	return splitProjectImagePath(imagePath)
+}
+
+func ConvertImageArch(gceArch string) (string, error) {
+	return convertImageArch(gceArch)
+}
+
+func ResolveImageIDMetadata(env *environ, ctx context.ProviderCallContext, args environs.StartInstanceParams) ([]*imagemetadata.ImageMetadata, error) {
+	return env.resolveImageIDMetadata(ctx, args)
+}
+
+func ParseImageIDReference(env *environ, os, imageID string) (string, string, error) {
+	return env.parseImageIDReference(os, imageID)
 }

--- a/internal/provider/gce/gcemock_test.go
+++ b/internal/provider/gce/gcemock_test.go
@@ -188,6 +188,21 @@ func (mr *MockComputeServiceMockRecorder) Firewalls(arg0, arg1 any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Firewalls", reflect.TypeOf((*MockComputeService)(nil).Firewalls), arg0, arg1)
 }
 
+// ImageByProject mocks base method.
+func (m *MockComputeService) ImageByProject(arg0 context.Context, arg1, arg2 string) (*computepb.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImageByProject", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*computepb.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImageByProject indicates an expected call of ImageByProject.
+func (mr *MockComputeServiceMockRecorder) ImageByProject(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageByProject", reflect.TypeOf((*MockComputeService)(nil).ImageByProject), arg0, arg1, arg2)
+}
+
 // Instance mocks base method.
 func (m *MockComputeService) Instance(arg0 context.Context, arg1, arg2 string) (*computepb.Instance, error) {
 	m.ctrl.T.Helper()

--- a/internal/provider/gce/image.go
+++ b/internal/provider/gce/image.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gce
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/juju/errors"
+
+	corearch "github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/os/ostype"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/imagemetadata"
+)
+
+func (env *environ) resolveImageIDMetadata(ctx context.ProviderCallContext, args environs.StartInstanceParams) ([]*imagemetadata.ImageMetadata, error) {
+	imageID := *args.Constraints.ImageID
+	project, imageName, err := env.parseImageIDReference(args.InstanceConfig.Base.OS, imageID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	image, err := env.gce.ImageByProject(ctx, project, imageName)
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting image %q", imageID)
+	}
+
+	imageArch, err := convertImageArch(image.GetArchitecture())
+	if err != nil {
+		return nil, errors.Annotatef(err, "getting image %q", imageID)
+	}
+	requiredArch, err := args.Tools.OneArch()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if imageArch != requiredArch {
+		return nil, errors.Errorf("image %q has architecture %q but agent requires %q", imageID, imageArch, requiredArch)
+	}
+
+	return []*imagemetadata.ImageMetadata{{
+		Id:       imageRef(project, imageName),
+		Arch:     imageArch,
+		VirtType: virtType,
+	}}, nil
+}
+
+func (env *environ) parseImageIDReference(os string, imageID string) (string, string, error) {
+	if project, imageName, ok := splitProjectImagePath(imageID); ok && imageName != "" {
+		return project, imageName, nil
+	}
+
+	imageURLBase, err := env.imageURLBase(ostype.OSTypeForName(os))
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+	project, _, ok := splitProjectImagePath(imageURLBase)
+	if !ok || project == "" {
+		return "", "", errors.Errorf("invalid image base path %q", imageURLBase)
+	}
+	return project, imageID, nil
+}
+
+func splitProjectImagePath(imagePath string) (string, string, bool) {
+	normalizedPath := strings.TrimPrefix(imagePath, "/")
+	if parsedURL, err := url.Parse(imagePath); err == nil && parsedURL.Scheme != "" {
+		normalizedPath = strings.TrimPrefix(parsedURL.Path, "/")
+	}
+
+	parts := strings.Split(normalizedPath, "/")
+	for i := 0; i+3 < len(parts); i++ {
+		if parts[i] != "projects" || parts[i+2] != "global" || parts[i+3] != "images" {
+			continue
+		}
+		project := parts[i+1]
+		imageName := ""
+		if i+4 < len(parts) {
+			imageName = parts[i+4]
+		}
+		return project, imageName, project != ""
+	}
+	return "", "", false
+}
+
+func imageRef(project, imageName string) string {
+	return fmt.Sprintf("projects/%s/global/images/%s", project, imageName)
+}
+
+func convertImageArch(gceArch string) (string, error) {
+	switch strings.ToUpper(gceArch) {
+	case "ARM64":
+		return corearch.ARM64, nil
+	case "X86_64":
+		return corearch.AMD64, nil
+	default:
+		return "", errors.Errorf("unsupported image architecture %q", gceArch)
+	}
+}
+
+func (env *environ) imageURL(os ostype.OSType, imageID string) (string, error) {
+	if strings.HasPrefix(imageID, "projects/") ||
+		strings.HasPrefix(imageID, "https://") {
+		return imageID, nil
+	}
+
+	imageURLBase, err := env.imageURLBase(os)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return imageURLBase + imageID, nil
+}

--- a/internal/provider/gce/image_test.go
+++ b/internal/provider/gce/image_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package gce_test
+
+import (
+	"cloud.google.com/go/compute/apiv1/computepb"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/internal/provider/gce"
+	coretools "github.com/juju/juju/tools"
+)
+
+type imageSuite struct {
+	gce.BaseSuite
+}
+
+var _ = gc.Suite(&imageSuite{})
+
+func (s *imageSuite) TestConvertImageArchARM64(c *gc.C) {
+	arch, err := gce.ConvertImageArch("ARM64")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(arch, gc.Equals, "arm64")
+}
+
+func (s *imageSuite) TestConvertImageArchX86_64(c *gc.C) {
+	arch, err := gce.ConvertImageArch("X86_64")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(arch, gc.Equals, "amd64")
+}
+
+func (s *imageSuite) TestConvertImageArchX86_64LowerCase(c *gc.C) {
+	arch, err := gce.ConvertImageArch("x86_64")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(arch, gc.Equals, "amd64")
+}
+
+func (s *imageSuite) TestConvertImageArchMixedCase(c *gc.C) {
+	arch, err := gce.ConvertImageArch("Arm64")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(arch, gc.Equals, "arm64")
+}
+
+func (s *imageSuite) TestConvertImageArchUnsupported(c *gc.C) {
+	_, err := gce.ConvertImageArch("ppc64")
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, "unsupported image architecture.*")
+}
+
+func (s *imageSuite) TestConvertImageArchEmpty(c *gc.C) {
+	_, err := gce.ConvertImageArch("")
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, "unsupported image architecture.*")
+}
+
+func (s *imageSuite) TestSplitProjectImagePathWithFullPath(c *gc.C) {
+	project, imageName, ok := gce.SplitProjectImagePath("projects/my-project/global/images/my-image")
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(project, gc.Equals, "my-project")
+	c.Assert(imageName, gc.Equals, "my-image")
+}
+
+func (s *imageSuite) TestSplitProjectImagePathWithLeadingSlash(c *gc.C) {
+	project, imageName, ok := gce.SplitProjectImagePath("/projects/my-project/global/images/my-image")
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(project, gc.Equals, "my-project")
+	c.Assert(imageName, gc.Equals, "my-image")
+}
+
+func (s *imageSuite) TestSplitProjectImagePathWithURL(c *gc.C) {
+	project, imageName, ok := gce.SplitProjectImagePath(
+		"https://www.googleapis.com/compute/v1/projects/my-project/global/images/my-image",
+	)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(project, gc.Equals, "my-project")
+	c.Assert(imageName, gc.Equals, "my-image")
+}
+
+func (s *imageSuite) TestSplitProjectImagePathWithoutImageName(c *gc.C) {
+	project, imageName, ok := gce.SplitProjectImagePath("projects/my-project/global/images/")
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(project, gc.Equals, "my-project")
+	c.Assert(imageName, gc.Equals, "")
+}
+
+func (s *imageSuite) TestSplitProjectImagePathInvalidFormat(c *gc.C) {
+	_, _, ok := gce.SplitProjectImagePath("invalid/path")
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *imageSuite) TestSplitProjectImagePathEmpty(c *gc.C) {
+	_, _, ok := gce.SplitProjectImagePath("")
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *imageSuite) TestSplitProjectImagePathNoProject(c *gc.C) {
+	_, _, ok := gce.SplitProjectImagePath("projects//global/images/my-image")
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *imageSuite) TestResolveImageIDMetadata(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+
+	imageID := "projects/ubuntu-os-cloud/global/images/ubuntu-2204-lts"
+	imageName := "ubuntu-2204-lts"
+	project := "ubuntu-os-cloud"
+
+	s.MockService.EXPECT().ImageByProject(gomock.Any(), project, imageName).Return(&computepb.Image{
+		Architecture: new("X86_64"),
+	}, nil)
+
+	args := s.StartInstArgs
+	args.Constraints = constraints.Value{ImageID: &imageID}
+	args.Tools = []*coretools.Tools{{
+		Version: version.Binary{Arch: arch.AMD64, Release: "ubuntu"},
+		URL:     "https://example.org",
+	}}
+
+	metadata, err := gce.ResolveImageIDMetadata(env, s.CallCtx, args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.HasLen, 1)
+	c.Assert(metadata[0].Id, gc.Equals, imageID)
+	c.Assert(metadata[0].Arch, gc.Equals, arch.AMD64)
+}
+
+func (s *imageSuite) TestResolveImageIDMetadataArchMismatch(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+
+	imageID := "projects/ubuntu-os-cloud/global/images/ubuntu-2204-arm64"
+	imageName := "ubuntu-2204-arm64"
+	project := "ubuntu-os-cloud"
+
+	s.MockService.EXPECT().ImageByProject(gomock.Any(), project, imageName).Return(&computepb.Image{
+		Architecture: new("ARM64"),
+	}, nil)
+
+	args := s.StartInstArgs
+	args.Constraints = constraints.Value{ImageID: &imageID}
+	args.Tools = []*coretools.Tools{{
+		Version: version.Binary{Arch: arch.AMD64, Release: "ubuntu"},
+		URL:     "https://example.org",
+	}}
+
+	_, err := gce.ResolveImageIDMetadata(env, s.CallCtx, args)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, ".*has architecture.*requires.*")
+}
+
+func (s *imageSuite) TestParseImageIDReferenceWithFullPath(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+
+	project, imageName, err := gce.ParseImageIDReference(env, "ubuntu", "projects/my-project/global/images/my-image")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(project, gc.Equals, "my-project")
+	c.Assert(imageName, gc.Equals, "my-image")
+}
+
+func (s *imageSuite) TestImageURL(c *gc.C) {
+	ctrl := s.SetupMocks(c)
+	defer ctrl.Finish()
+
+	env := s.SetupEnv(c, s.MockService)
+
+	url, err := gce.ImageURL(env, "ubuntu", "ubuntu-2204-jammy-v20260803")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(url, gc.Equals, "projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20260803")
+
+	url, err = gce.ImageURL(env, "ubuntu", "projects/custom-images/global/images/custom-ubuntu")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(url, gc.Equals, "projects/custom-images/global/images/custom-ubuntu")
+}

--- a/internal/provider/gce/internal/google/conn.go
+++ b/internal/provider/gce/internal/google/conn.go
@@ -26,6 +26,7 @@ type Connection struct {
 	zones        *compute.ZonesClient
 	instances    *compute.InstancesClient
 	machineTypes *compute.MachineTypesClient
+	images       *compute.ImagesClient
 	disks        *compute.DisksClient
 	firewalls    *compute.FirewallsClient
 	networks     *compute.NetworksClient
@@ -61,6 +62,10 @@ func Connect(ctx context.Context, connCfg ConnectionConfig, creds *Credentials) 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	images, err := newRESTClient(ctx, tokenSource, connCfg.HTTPClient, compute.NewImagesRESTClient)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	disks, err := newRESTClient(ctx, tokenSource, connCfg.HTTPClient, compute.NewDisksRESTClient)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -83,6 +88,7 @@ func Connect(ctx context.Context, connCfg ConnectionConfig, creds *Credentials) 
 		zones:        zones,
 		instances:    instances,
 		machineTypes: machineTypes,
+		images:       images,
 		disks:        disks,
 		firewalls:    firewalls,
 		networks:     networks,

--- a/internal/provider/gce/internal/google/instance.go
+++ b/internal/provider/gce/internal/google/instance.go
@@ -239,6 +239,15 @@ func (c *Connection) MachineType(ctx context.Context, zone, instanceType string)
 	})
 }
 
+// ImageByProject retrieves the image metadata for the specified project and image name.
+func (c *Connection) ImageByProject(ctx context.Context, project, image string) (*computepb.Image, error) {
+	img, err := c.images.Get(ctx, &computepb.GetImageRequest{
+		Project: project,
+		Image:   image,
+	})
+	return img, errors.Trace(err)
+}
+
 func (c *Connection) updateInstanceMetadata(ctx context.Context, instance *computepb.Instance, key, value string) error {
 	metadata := instance.GetMetadata()
 	existingItem := findMetadataItem(metadata.GetItems(), key)

--- a/internal/provider/openstack/image.go
+++ b/internal/provider/openstack/image.go
@@ -7,6 +7,8 @@ import (
 	"github.com/go-goose/goose/v5/nova"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 )
@@ -95,4 +97,20 @@ func findInstanceSpec(
 		spec.InstanceType.VirtType = &spec.Image.VirtType
 	}
 	return spec, nil
+}
+
+func (e *Environ) resolveImageIDMetadata(
+	_ context.ProviderCallContext,
+	args environs.StartInstanceParams,
+) ([]*imagemetadata.ImageMetadata, error) {
+	arch, err := args.Tools.OneArch()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// TODO(wallyworld 2026-08-04): Resolve and validate image-id via Glance API.
+	return []*imagemetadata.ImageMetadata{{
+		Id:   *args.Constraints.ImageID,
+		Arch: arch,
+	}}, nil
 }

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -1091,12 +1091,21 @@ func (e *Environ) startInstance(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	imageMetadata := args.ImageMetadata
+	if args.Constraints.HasImageID() {
+		imageMetadata, err = e.resolveImageIDMetadata(ctx, args)
+		if err != nil {
+			return nil, environs.ZoneIndependentError(err)
+		}
+	}
+
 	spec, err := findInstanceSpec(e, instances.InstanceConstraint{
 		Region:      e.cloud().Region,
 		Base:        args.InstanceConfig.Base,
 		Arch:        arch,
 		Constraints: args.Constraints,
-	}, args.ImageMetadata)
+	}, imageMetadata)
 	if err != nil {
 		return nil, environs.ZoneIndependentError(err)
 	}
@@ -1618,14 +1627,12 @@ func (e *Environ) configureRootDisk(_ context.ProviderCallContext, args environs
 	}
 	switch rootDiskSource {
 	case rootDiskSourceLocal:
-		if args.Constraints.HasImageID() {
-			runOpts.ImageId = *args.Constraints.ImageID
-		} else {
-			runOpts.ImageId = spec.Image.Id
-		}
+		runOpts.ImageId = spec.Image.Id
 	case rootDiskSourceVolume:
+		// Only preserve image-id for volume-backed roots when image-id was
+		// explicitly requested; local roots always need the image recorded.
 		if args.Constraints.HasImageID() {
-			runOpts.ImageId = *args.Constraints.ImageID
+			runOpts.ImageId = spec.Image.Id
 		}
 		size := uint64(0)
 		if args.Constraints.HasRootDisk() {

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -244,7 +244,7 @@ func SetImageMetadata(env environs.Environ, fetcher imagemetadata.SimplestreamsF
 		Releases:  release,
 		Arches:    arches,
 		Stream:    env.Config().ImageStream(),
-	}, nil)
+	})
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/state/cloudimagemetadata/image.go
+++ b/state/cloudimagemetadata/image.go
@@ -388,14 +388,6 @@ func buildSearchClauses(criteria MetadataFilter) bson.D {
 		all = append(all, bson.DocElem{"root_storage_type", criteria.RootStorageType})
 	}
 
-	// TODO - we want to refactor to allow image-id filtering.
-	// We could filter on cons.ImageID here but that would prevent
-	// users from being able to force Juju to use an image not
-	// included in the published metadata.
-	// if criteria.ImageID != "" {
-	//	all = append(all, bson.DocElem{"image_id", criteria.ImageID})
-	//}
-
 	if len(all.Map()) == 0 {
 		return nil
 	}
@@ -425,9 +417,6 @@ type MetadataFilter struct {
 
 	// RootStorageType stores storage type.
 	RootStorageType string `json:"root-storage-type,omitempty"`
-
-	// ImageID stores the image id.
-	ImageID string `json:"image-id,omitempty"`
 }
 
 // SupportedArchitectures implements Storage.SupportedArchitectures.

--- a/tests/includes/gce_image_creation.sh
+++ b/tests/includes/gce_image_creation.sh
@@ -1,0 +1,30 @@
+create_gce_image_and_wait_available() {
+	local source_image_family source_image_project image_name
+	source_image_family="${1:-ubuntu-2404-lts-amd64}"
+	source_image_project="${2:-ubuntu-os-cloud}"
+
+	image_name="juju-constraints-$(date +%s)-$RANDOM"
+
+	gcloud compute images create "${image_name}" \
+		--source-image-family "${source_image_family}" \
+		--source-image-project "${source_image_project}" \
+		--quiet >/dev/null
+
+	echo "${image_name}" >>"${TEST_DIR}/gce-images"
+	echo "${image_name}"
+}
+
+run_cleanup_gce_image() {
+	set +e
+
+	if [[ -f "${TEST_DIR}/gce-images" ]]; then
+		echo "====> Cleaning up GCE images"
+		while read -r gce_image; do
+			gcloud compute images delete "${gce_image}" --quiet >>"${TEST_DIR}/gcloud_cleanup"
+		done <"${TEST_DIR}/gce-images"
+	fi
+
+	set_verbosity
+
+	echo "====> Completed cleaning up gce images"
+}

--- a/tests/suites/constraints/constraints_gce.sh
+++ b/tests/suites/constraints/constraints_gce.sh
@@ -1,6 +1,7 @@
 test_gce_pro_image() {
 	local release_name="$1"
 	local release_version=""
+	local name file
 
 	case "$release_name" in
 	jammy) release_version="22.04" ;;
@@ -10,6 +11,10 @@ test_gce_pro_image() {
 		return 1
 		;;
 	esac
+
+	name="constraints-gce-pro-image-${release_name}"
+	file="${TEST_DIR}/constraints-gce-pro-image-${release_name}.txt"
+	ensure "${name}" "${file}"
 
 	echo "Testing Ubuntu Pro ${release_name} (${release_version}) image on GCE..."
 
@@ -45,6 +50,45 @@ test_gce_pro_image() {
 		--format="json" | yq -r '.[0].sourceImage | split("/") | .[-1]')
 
 	test "$image_id" = "$source_image_id"
+
+	destroy_model "${name}"
+}
+
+test_gce_image_id_constraint() {
+	local name file
+
+	name="constraints-gce-image-id"
+	file="${TEST_DIR}/constraints-gce-image-id.txt"
+	ensure "${name}" "${file}"
+
+	echo "Testing image-id constraint with a custom GCE image..."
+
+	add_clean_func "run_cleanup_gce_image"
+
+	local project_id custom_image image_ref
+	project_id="$(gcloud config get-value project)"
+	custom_image="$(create_gce_image_and_wait_available)"
+	image_ref="projects/${project_id}/global/images/${custom_image}"
+
+	echo "Deploy 2 machines with different constraints"
+	juju add-machine --constraints "cores=2"
+	juju add-machine --constraints "image-id=${image_ref}"
+
+	wait_for_machine_agent_status "0" "started"
+	wait_for_machine_agent_status "1" "started"
+
+	echo "Ensure machine 0 has 2 cores"
+	machine0_hardware="$(juju machines --format json | yq -r '.["machines"]["0"]["hardware"]')"
+	check_contains "${machine0_hardware}" "cores=2"
+
+	echo "Ensure machine 1 uses the correct image ID from image-id constraint"
+	instance_id="$(juju show-machine 1 --format json | yq -r '.["machines"]["1"]["instance-id"]')"
+	az="$(juju show-machine 1 --format yaml | yq -r '.machines["1"].hardware' | tr ' ' '\n' | grep 'availability-zone' | cut -d= -f2)"
+	source_image_id="$(gcloud compute disks describe "${instance_id}" --zone "${az}" --format='value(sourceImage)' | awk -F/ '{print $NF}')"
+
+	echo "${source_image_id}" | check "${custom_image}"
+
+	destroy_model "${name}"
 }
 
 run_constraints_gce() {
@@ -54,13 +98,6 @@ run_constraints_gce() {
 	echo "==> Checking for dependencies"
 	check_dependencies gcloud
 
-	name="constraints-gce"
-
-	file="${TEST_DIR}/constraints-gce.txt"
-
-	ensure "${name}" "${file}"
-
 	test_gce_pro_image noble
-
-	destroy_model "${name}"
+	test_gce_image_id_constraint
 }


### PR DESCRIPTION
This PR adds support for using the "image-id" constraint on the google provider. The constraint is currently only supported on aws and openstack.

In doing this work, a flaw is identified in the current aws and openstack implementation. The workflow is essentially:
- read all image metadata matching any arch, mem, other relevant constraints
- ignore that result and just use the supplied image-id
- no checks are done that the image-id refers to an image consistent with the other constraints

For gce, a better approach is used:
- use the image-id and cloud sdk to query image metadata
- ensure the image is compatible with any other relevant constraints
- do not do an irrelevant metadata query and throw away the results

For AWS and Openstack, a slight tweak is done to add in a stub `resolveImageIDMetadata()` method with the same signature as that introduced for gce and for now effectively sticks with the current limitations but is open for extension later to match what gce does.

An existing TODO around filtering on image-id was removed as the approach is not relevant or necessary. Also the simplestreams image constraint does not need image-id.

## QA steps

New constraints shell test is added

`./main.sh -v -p gce constraints`

## Documentation changes

update gce cloud doc

## Links

**Issue:** Fixes #21581.

**Jira card:** [JUJU-9160](https://warthogs.atlassian.net/browse/JUJU-9160)


[JUJU-9160]: https://warthogs.atlassian.net/browse/JUJU-9160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ