### PR TITLE
fix(agent): wire safe mode controller config ready lock

### DIFF
--- a/cmd/jujuagentd/agent/agent_test.go
+++ b/cmd/jujuagentd/agent/agent_test.go
@@ -336,3 +336,7 @@ func (f *fakeMachineConfig) Tag() names.Tag {
 	}
 	return names.NewMachineTag("0")
 }
+
+func (*fakeMachineConfig) Model() names.ModelTag {
+	return names.NewModelTag("mock-model-uuid")
+}

--- a/cmd/jujuagentd/agent/safemode.go
+++ b/cmd/jujuagentd/agent/safemode.go
@@ -35,6 +35,7 @@ import (
 	internallogger "github.com/juju/juju/internal/logger"
 	internalworker "github.com/juju/juju/internal/worker"
 	"github.com/juju/juju/internal/worker/dbaccessor"
+	"github.com/juju/juju/internal/worker/gate"
 	jujunames "github.com/juju/juju/juju/names"
 	"github.com/juju/juju/rpc/params"
 )
@@ -307,6 +308,7 @@ func (a *SafeModeMachineAgent) makeEngineCreator(
 			AgentConfigChanged:      a.configChangedVal,
 			NewDBWorkerFunc:         a.newDBWorkerFunc,
 			ControllerStartupValues: startupValueProvider,
+			ControllerUnlocker:      gate.NewLock(),
 			ControllerID:            a.Tag().Id(),
 			LogDir:                  agentConfig.LogDir(),
 			ConfigChangeSocketPath:  path.Join(agentConfig.DataDir(), "configchange.socket"),

--- a/cmd/jujuagentd/agent/safemode.go
+++ b/cmd/jujuagentd/agent/safemode.go
@@ -308,11 +308,19 @@ func (a *SafeModeMachineAgent) makeEngineCreator(
 			AgentConfigChanged:      a.configChangedVal,
 			NewDBWorkerFunc:         a.newDBWorkerFunc,
 			ControllerStartupValues: startupValueProvider,
-			ControllerUnlocker:      gate.NewLock(),
-			ControllerID:            a.Tag().Id(),
-			LogDir:                  agentConfig.LogDir(),
-			ConfigChangeSocketPath:  path.Join(agentConfig.DataDir(), "configchange.socket"),
-			Clock:                   clock.WallClock,
+			// Safe mode is only meaningful on a controller, where the
+			// controller-agent-config manifold unlocks this once the socket
+			// listener starts (see controlleragentconfig.Manifold). On a
+			// hypothetical non-controller run the manifold is gated behind
+			// ifController and the lock stays locked, but that is harmless:
+			// no safe-mode worker consumes the gate - it exists only to
+			// satisfy controller-agent-config validation - so there is no
+			// machine-agent-style explicit `if !isController { Unlock() }`.
+			ControllerUnlocker:     gate.NewLock(),
+			ControllerID:           a.Tag().Id(),
+			LogDir:                 agentConfig.LogDir(),
+			ConfigChangeSocketPath: path.Join(agentConfig.DataDir(), "configchange.socket"),
+			Clock:                  clock.WallClock,
 		}
 
 		manifolds := safemode.Manifolds(manifoldsCfg)

--- a/cmd/jujuagentd/agent/safemode/manifolds.go
+++ b/cmd/jujuagentd/agent/safemode/manifolds.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/internal/worker/agent"
 	"github.com/juju/juju/internal/worker/controlleragentconfig"
 	"github.com/juju/juju/internal/worker/dbaccessor"
+	"github.com/juju/juju/internal/worker/gate"
 	"github.com/juju/juju/internal/worker/querylogger"
 	"github.com/juju/juju/internal/worker/stateconfigwatcher"
 	"github.com/juju/juju/internal/worker/terminationworker"
@@ -46,6 +47,12 @@ type ManifoldsConfig struct {
 
 	// ConfigChangeSocketPath is the path to the config-change reload socket.
 	ConfigChangeSocketPath string
+
+	// ControllerUnlocker is passed to the controller agent config manifold.
+	// It is unlocked once the configchange.socket exists. Safe mode has no
+	// dependent waiting on this signal, but the unlocker must be non-nil to
+	// satisfy the controlleragentconfig manifold.
+	ControllerUnlocker gate.Unlocker
 
 	// Clock supplies timekeeping services to various workers.
 	Clock clock.Clock
@@ -81,6 +88,7 @@ func Manifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:            internallogger.GetLogger("juju.worker.controlleragentconfig"),
 			NewSocketListener: controlleragentconfig.NewSocketListener,
 			SocketName:        config.ConfigChangeSocketPath,
+			ReadyUnlocker:     config.ControllerUnlocker,
 		})),
 
 		// The stateconfigwatcher manifold watches the machine agent's

--- a/cmd/jujuagentd/agent/safemode/manifolds_test.go
+++ b/cmd/jujuagentd/agent/safemode/manifolds_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/dependency"
+	dependencytesting "github.com/juju/worker/v5/dependency/testing"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/agenttest"
+	"github.com/juju/juju/agent/engine"
 	"github.com/juju/juju/cmd/jujuagentd/agent/safemode"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/internal/testing"
@@ -135,6 +137,26 @@ func (s *ManifoldsSuite) TestManifoldsDependencies(c *tc.C) {
 		}),
 		expectedManifoldsWithDependencies,
 	)
+}
+
+// TestControllerAgentConfigRequiresUnlocker verifies the safemode wiring
+// must supply a non-nil ControllerUnlocker: without it the
+// controller-agent-config manifold fails validation with a nil
+// ReadyUnlocker error instead of starting.
+func (s *ManifoldsSuite) TestControllerAgentConfigRequiresUnlocker(c *tc.C) {
+	manifolds := safemode.Manifolds(safemode.ManifoldsConfig{
+		Agent:                  &mockAgent{},
+		ControllerID:           "0",
+		ConfigChangeSocketPath: "configchange.socket",
+	})
+
+	getter := dependencytesting.StubGetter(map[string]any{
+		"is-controller-flag": engine.NewStaticFlagWorker(true),
+	})
+
+	worker, err := manifolds["controller-agent-config"].Start(c.Context(), getter)
+	c.Check(worker, tc.IsNil)
+	c.Assert(err, tc.ErrorMatches, ".*nil ReadyUnlocker.*")
 }
 
 var expectedManifoldsWithDependencies = map[string][]string{

--- a/cmd/jujuagentd/agent/safemode/manifolds_test.go
+++ b/cmd/jujuagentd/agent/safemode/manifolds_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/cmd/jujuagentd/agent/safemode"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/internal/testing"
+	"github.com/juju/juju/internal/worker/gate"
 )
 
 type ManifoldsSuite struct {
@@ -34,7 +35,8 @@ func (s *ManifoldsSuite) SetUpTest(c *tc.C) {
 
 func (s *ManifoldsSuite) TestStartFuncs(c *tc.C) {
 	s.assertStartFuncs(c, safemode.Manifolds(safemode.ManifoldsConfig{
-		Agent: &mockAgent{},
+		Agent:              &mockAgent{},
+		ControllerUnlocker: gate.NewLock(),
 	}))
 }
 
@@ -48,7 +50,8 @@ func (*ManifoldsSuite) assertStartFuncs(c *tc.C, manifolds dependency.Manifolds)
 func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 	s.assertManifoldNames(c,
 		safemode.Manifolds(safemode.ManifoldsConfig{
-			Agent: &mockAgent{},
+			Agent:              &mockAgent{},
+			ControllerUnlocker: gate.NewLock(),
 		}),
 		[]string{
 			"agent",
@@ -73,7 +76,8 @@ func (*ManifoldsSuite) assertManifoldNames(c *tc.C, manifolds dependency.Manifol
 
 func (*ManifoldsSuite) TestSingularGuardsUsed(c *tc.C) {
 	manifolds := safemode.Manifolds(safemode.ManifoldsConfig{
-		Agent: &mockAgent{},
+		Agent:              &mockAgent{},
+		ControllerUnlocker: gate.NewLock(),
 	})
 
 	// Explicitly guarded by ifController.
@@ -126,7 +130,8 @@ func checkNotContains(c *tc.C, names []string, seek string) {
 func (s *ManifoldsSuite) TestManifoldsDependencies(c *tc.C) {
 	agenttest.AssertManifoldsDependencies(c,
 		safemode.Manifolds(safemode.ManifoldsConfig{
-			Agent: &mockAgent{},
+			Agent:              &mockAgent{},
+			ControllerUnlocker: gate.NewLock(),
 		}),
 		expectedManifoldsWithDependencies,
 	)

--- a/cmd/jujuagentd/agent/safemode_test.go
+++ b/cmd/jujuagentd/agent/safemode_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package agent
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/juju/names/v6"
+	"github.com/juju/tc"
+	"github.com/juju/utils/v4/voyeur"
+	"github.com/juju/worker/v5/dependency"
+	"github.com/juju/worker/v5/workertest"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/semversion"
+)
+
+type safeModeEngineSuite struct{}
+
+func TestSafeModeEngineSuite(t *testing.T) {
+	tc.Run(t, &safeModeEngineSuite{})
+}
+
+func (*safeModeEngineSuite) TestControllerAgentConfigStarts(c *tc.C) {
+	config := &fakeMachineConfig{
+		dataDir: c.MkDir(),
+		logDir:  c.MkDir(),
+		tag:     names.NewControllerAgentTag("0"),
+		controllerAgentInfo: controller.ControllerAgentInfo{
+			Cert:       "controller-cert",
+			PrivateKey: "controller-key",
+		},
+	}
+	agent := &SafeModeMachineAgent{
+		AgentConfigWriter: &fakeMachineAgentConfigWriter{config: config},
+		agentTag:          config.Tag(),
+		configChangedVal:  voyeur.NewValue(true),
+	}
+
+	engineWorker, err := agent.makeEngineCreator("", semversion.Zero)(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.CleanKill(c, engineWorker)
+
+	engine, ok := engineWorker.(*dependency.Engine)
+	c.Assert(ok, tc.IsTrue)
+
+	for {
+		report := engine.Report(c.Context())
+		manifolds := report[dependency.KeyManifolds].(map[string]interface{})
+		controllerConfig := manifolds["controller-agent-config"].(map[string]interface{})
+		if err, ok := controllerConfig[dependency.KeyError]; ok &&
+			strings.Contains(fmt.Sprint(err), "nil ReadyUnlocker") {
+			c.Fatalf("controller-agent-config did not start: %v", err)
+		}
+		if controllerConfig[dependency.KeyState] == "started" {
+			return
+		}
+		runtime.Gosched()
+	}
+}

--- a/cmd/jujuagentd/agent/safemode_test.go
+++ b/cmd/jujuagentd/agent/safemode_test.go
@@ -50,8 +50,8 @@ func (*safeModeEngineSuite) TestControllerAgentConfigStarts(c *tc.C) {
 
 	for {
 		report := engine.Report(c.Context())
-		manifolds := report[dependency.KeyManifolds].(map[string]interface{})
-		controllerConfig := manifolds["controller-agent-config"].(map[string]interface{})
+		manifolds := report[dependency.KeyManifolds].(map[string]any)
+		controllerConfig := manifolds["controller-agent-config"].(map[string]any)
 		if err, ok := controllerConfig[dependency.KeyError]; ok &&
 			strings.Contains(fmt.Sprint(err), "nil ReadyUnlocker") {
 			c.Fatalf("controller-agent-config did not start: %v", err)


### PR DESCRIPTION
Safe mode did not supply the required readiness unlocker to the
`controlleragentconfig` manifold. As a result, the manifold rejected its
configuration and the safe-mode agent could not start.

This change:

- Creates a controller config unlocker when building the safe-mode engine.
- Passes the unlocker through the safe-mode manifold configuration to
  `controlleragentconfig`.
- Uses the narrow `gate.Unlocker` dependency, since safe mode has no worker
  that waits on this readiness signal.
- Adds an engine-level regression test confirming the controller agent config
  manifold starts, and fails on the previous `nil ReadyUnlocker` error.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap and enter into safe mode:

```sh
❯ juju bootstrap lxd ctrl-test

❯ juju ssh -m controller 0
Welcome to Ubuntu 24.04.4 LTS (GNU/Linux 7.0.0-28-generic x86_64)

ubuntu@juju-5232b7-0:~$ sudo systemctl stop jujuagentd-machine-0.service

ubuntu@juju-5232b7-0:~$ sudo /var/lib/juju/tools/machine-0/jujuagentd safe-mode --machine-id 0

Running in safe mode.
---------------------

This is a special mode of operation that allows you to have single node
only access to the database. This is useful if you have a database that is
corrupt and you want to recover data from it.

This will only stand up the minimum set of services required to allow
you to connect to the database and perform recovery operations.

Use at your own risk.
```

Validate db accessor is working:

```sh
❯ export CONTAINER=$(juju machines -m controller --format yaml | yq '.machines["0"].hostname')

❯ lxc exec $CONTAINER -- /bin/bash
root@juju-5232b7-0:~# tail /var/log/juju/machine-0.log
2026-08-05 16:15:01 INFO juju.security securitylog.go:424 {"datetime":"2026-08-05T16:15:01.708263328Z","appid":"juju.controller","event":"authn_login_success:user-admin","level":"INFO","description":"User user-admin has successfully logged in"}
2026-08-05 16:15:07 INFO juju.security securitylog.go:424 {"datetime":"2026-08-05T16:15:07.254440803Z","appid":"juju.controller","event":"authn_login_success:user-admin","level":"INFO","description":"User user-admin has successfully logged in"}
2026-08-05 16:15:32 INFO juju.security securitylog.go:424 {"datetime":"2026-08-05T16:15:32.624745257Z","appid":"juju.controller","event":"authn_login_success:user-admin","level":"INFO","description":"User user-admin has successfully logged in"}
2026-08-05 16:15:33 INFO juju.security securitylog.go:424 {"datetime":"2026-08-05T16:15:33.14703701Z","appid":"juju.controller","event":"authn_login_success:user-admin","level":"INFO","description":"User user-admin has successfully logged in"}
2026-08-05 16:15:43 INFO juju.security securitylog.go:424 {"datetime":"2026-08-05T16:15:43.718242446Z","appid":"juju.controller","event":"authn_login_success:user-admin","level":"INFO","description":"User user-admin has successfully logged in"}
2026-08-05 16:15:58 INFO juju.security securitylog.go:424 {"datetime":"2026-08-05T16:15:58.49431892Z","appid":"juju.controller","event":"authn_login_success:user-admin","level":"INFO","description":"User user-admin has successfully logged in"}
2026-08-05 16:16:05 INFO juju.security securitylog.go:424 {"datetime":"2026-08-05T16:16:05.360303898Z","appid":"juju.controller","event":"authn_login_success:user-admin","level":"INFO","description":"User user-admin has successfully logged in"}
2026-08-05 16:16:34 INFO juju.security securitylog.go:424 {"datetime":"2026-08-05T16:16:34.326411535Z","appid":"juju.controller","event":"authn_login_success:user-admin","level":"INFO","description":"User user-admin has successfully logged in"}
2026-08-05 16:16:50 INFO juju.security securitylog.go:424 {"datetime":"2026-08-05T16:16:50.484159415Z","appid":"juju.controller","event":"authn_login_success:user-admin","level":"INFO","description":"User user-admin has successfully logged in"}
2026-08-05 16:17:50 INFO juju.security securitylog.go:424 {"datetime":"2026-08-05T16:17:50.98049791Z","appid":"juju.controller","event":"authn_login_success:user-admin","level":"INFO","description":"User user-admin has successfully logged in"}

root@juju-5232b7-0:~# sudo /var/lib/juju/tools/machine-0/jujuagentd db-repl --machine-id 0

Running DB REPL.
----------------

This is a DB REPL (Read-Eval-Print Loop) environment.

You can run arbitrary code here, including code that can modify the
state of the system. Be careful!

Type '.help' for help.

repl (controller)> select * from model;
uuid					activated	cloud_uuid				cloud_region_uuid			cloud_credential_uuid		model_type_id	life_id	name		qualifier	
ce00b93f-262a-480b-8f7c-4920425232b7	true		73dc2fd3-1285-4bf0-8da9-b21acbe35e97	bf2284a5-0f6d-46fb-8d4a-bdeb6569dc52	fa8e5fcb-022e-4871-8d89-ad1acb92d26e	0		0	controller	admin		
```

## Documentation changes

## Links

