### PR TITLE
docs: fix build warnings from reuse includes and k8s labels

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -327,6 +327,12 @@ new_tab_link_show_external_link_icon = True
 exclude_patterns = [
     "doc-cheat-sheet*",
     "agents/**",
+    "reference/cloud/list-of-supported-clouds/reuse/**",
+    "_build/**",
+    ".sphinx/**",
+    ".venv/**",
+    "venv/**",
+    "__pycache__/**",
 ]
 
 # Adds custom CSS files, located under 'html_static_path'
@@ -347,10 +353,7 @@ html_js_files = [
 
 # Specifies a reST snippet to be appended to each .rst file
 
-rst_epilog = """
-.. include:: /reuse/links.txt
-.. include:: /reuse/substitutions.txt
-"""
+rst_epilog = """"""
 
 # Feedback button at the top; enabled by default
 #

--- a/docs/reference/cloud/list-of-supported-clouds/reuse/k8s/auth-types.md
+++ b/docs/reference/cloud/list-of-supported-clouds/reuse/k8s/auth-types.md
@@ -8,8 +8,6 @@ As for all Kubernetes clouds, credentials are stored in `credentials.yaml` on th
 If using the Juju CLI, you can skip writing this file manually -- `juju add-k8s` can read `kubeconfig` and create the matching credential entry for the selected context.
 ```
 
-(kubernetes-credential-definition)=
-
 ```yaml
 credentials:
   <cloud-name>:
@@ -18,12 +16,10 @@ credentials:
       <auth-attributes>               # fill using one of the mappings below
 ```
 
-(kubernetes-supported-authentication-types)=
 ### Authentication types
 
 As for all Kubernetes clouds, the supported authentication types are:
 
-(kubernetes-auth-clientcertificate)=
 #### `clientcertificate`
 
 Kubernetes client certificate and key.
@@ -32,7 +28,6 @@ Kubernetes client certificate and key.
 - `ClientKeyData`: The Kubernetes certificate key (required).
 - `rbac-id`: The unique ID key name of the RBAC resources (optional).
 
-(kubernetes-auth-oauth2)=
 #### `oauth2`
 
 OAuth2 token authentication.
@@ -40,7 +35,6 @@ OAuth2 token authentication.
 - `Token`: The Kubernetes token (required).
 - `rbac-id`: The unique ID key name of the RBAC resources (optional).
 
-(kubernetes-auth-userpass)=
 #### `userpass`
 
 Username and password authentication.
@@ -48,7 +42,6 @@ Username and password authentication.
 - `username`: The username to authenticate with (required).
 - `password`: The password for the specified username (required).
 
-(kubernetes-auth-certificate)=
 #### `certificate` (legacy)
 
 Kubernetes service account token with certificate.
@@ -57,7 +50,6 @@ Kubernetes service account token with certificate.
 - `Token`: The Kubernetes service account bearer token (required).
 - `rbac-id`: The unique ID key name of the RBAC resources (optional).
 
-(kubernetes-auth-oauth2withcert)=
 #### `oauth2withcert` (legacy)
 
 OAuth2 token with certificate.

--- a/docs/reference/cloud/list-of-supported-clouds/reuse/k8s/controller-service-type.md
+++ b/docs/reference/cloud/list-of-supported-clouds/reuse/k8s/controller-service-type.md
@@ -1,7 +1,5 @@
-(kubernetes-bootstrap-service-type)=
 As for all Kubernetes clouds, the controller service type depends on the host platform.
 
-(kubernetes-bootstrap-service-type)=
 When bootstrapping a controller, Juju creates a Kubernetes `Service` to expose the controller API. The `Service` type depends on the host cloud platform where the Kubernetes cluster is running:
 
 - **`LoadBalancer`**: For managed Kubernetes on public clouds.


### PR DESCRIPTION
Fixes stray build warnings in the 3.6 docs so a clean `make html` doesn't leave contributors doubting their changes.

A clean 3.6 doc build emitted warnings from two sources:

- `docs/conf.py`: the `rst_epilog` referenced `/reuse/links.txt` and `/reuse/substitutions.txt`, which do not exist, producing `InputError` noise on every page; Sphinx also scanned `_build`, the venv, and the shared k8s `reuse/` directory.
- The shared k8s reuse files (`auth-types.md`, `controller-service-type.md`) define `(kubernetes-...)` labels that are duplicated on every cloud page that includes them, producing duplicate-label warnings.

Fix: drop the dead `reuse` `rst_epilog` and exclude the build/venv/reuse dirs in `conf.py`, and remove the k8s label markers from the shared reuse files (no external references target those labels).

Reduces the doc build warning count from 169 (excluding venv/site-packages noise) to 59.

## QA steps

1. From `docs/`, run `make html` — confirm a clean build and no `reuse/links` `InputError` or duplicate-label warnings. (You'll still see those 59 warnings due to issues beyond the scope of this PR.)

## Links

**Jira card:** [JUJU-8573](https://warthogs.atlassian.net/browse/JUJU-8573)


[JUJU-8573]: https://warthogs.atlassian.net/browse/JUJU-8573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ