### PR TITLE
fix: prototype check of support for OVS networking

### DIFF
--- a/api/common/cloudcred/package_test.go
+++ b/api/common/cloudcred/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cloudcred
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -20,6 +20,7 @@ const (
 	nic            = "nic"
 	nicTypeBridged = "bridged"
 	nicTypeMACVLAN = "macvlan"
+	nicTypeOVN     = "ovn"
 	netTypeBridge  = "bridge"
 )
 
@@ -224,10 +225,10 @@ func (s *Server) verifyNICsWithAPI(nics map[string]device) error {
 
 	// No nics with a nictype of nicTypeBridged, nicTypeMACVLAN was found.
 	return errors.Errorf(
-		"no network device found with nictype %q or %q"+
+		"no network device found with nictype %q, %q, or %q"+
 			"\n\tthe following devices were checked: %s"+
-			"\nReconfigure lxd to use a network of type %q or %q.",
-		nicTypeBridged, nicTypeMACVLAN, strings.Join(checked, ", "), nicTypeBridged, nicTypeMACVLAN)
+			"\nReconfigure lxd to use a network of type %q, %q, or %q.",
+		nicTypeBridged, nicTypeMACVLAN, nicTypeOVN, strings.Join(checked, ", "), nicTypeBridged, nicTypeMACVLAN, nicTypeOVN)
 }
 
 // generateNICDeviceName attempts to generate a new NIC device name that is not
@@ -265,11 +266,11 @@ func getProfileNICs(profile *api.Profile) map[string]device {
 }
 
 func isValidNICType(nic device) bool {
-	return nic["nictype"] == nicTypeBridged || nic["nictype"] == nicTypeMACVLAN
+	return nic["nictype"] == nicTypeBridged || nic["nictype"] == nicTypeMACVLAN || nic["nictype"] == nicTypeOVN
 }
 
 func isValidNetworkType(net *api.Network) bool {
-	return net.Type == netTypeBridge || net.Type == nicTypeMACVLAN
+	return net.Type == netTypeBridge || net.Type == nicTypeMACVLAN || net.Type == nicTypeOVN
 }
 
 // NetworkName returns the network name from the

--- a/container/lxd/network.go
+++ b/container/lxd/network.go
@@ -20,8 +20,9 @@ const (
 	nic            = "nic"
 	nicTypeBridged = "bridged"
 	nicTypeMACVLAN = "macvlan"
-	nicTypeOVN     = "ovn"
 	netTypeBridge  = "bridge"
+	netTypeMACVLAN = "macvlan"
+	netTypeOVN     = "ovn"
 )
 
 // device is a type alias for profile devices.
@@ -30,6 +31,11 @@ type device = map[string]string
 // LocalBridgeName returns the name of the local LXD network bridge.
 func (s *Server) LocalBridgeName() string {
 	return s.localBridgeName
+}
+
+// LocalNetworkType returns the type of the local LXD network.
+func (s *Server) LocalNetworkType() string {
+	return s.localNetworkType
 }
 
 // EnableHTTPSListener configures LXD to listen for HTTPS requests, rather than
@@ -160,6 +166,7 @@ func (s *Server) ensureDefaultNetworking(profile *api.Profile, eTag string) erro
 	}
 
 	s.localBridgeName = network.DefaultLXDBridge
+	s.localNetworkType = net.Type
 
 	nicName := generateNICDeviceName(profile)
 	if nicName == "" {
@@ -190,6 +197,44 @@ func (s *Server) ensureDefaultNetworking(profile *api.Profile, eTag string) erro
 // verifyNICsWithAPI uses the LXD network API to check if one of the input NIC
 // devices is suitable for LXD to work with Juju.
 func (s *Server) verifyNICsWithAPI(nics map[string]device) error {
+	net, netName, checked, err := s.findUsableNetwork(nics)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if net == nil {
+		// No nics with a nictype of nicTypeBridged, nicTypeMACVLAN was found.
+		return errors.Errorf(
+			"no network device found with nictype %q or %q"+
+				"\n\tthe following devices were checked: %s"+
+				"\nReconfigure lxd to use a network of type %q or %q.",
+			nicTypeBridged, nicTypeMACVLAN, strings.Join(checked, ", "), nicTypeBridged, nicTypeMACVLAN)
+	}
+
+	logger.Tracef("found usable network device with parent %q", netName)
+	s.localBridgeName = netName
+	s.localNetworkType = net.Type
+	return nil
+}
+
+// DefaultNetwork returns the managed network used by a NIC in the default
+// profile.
+func (s *Server) DefaultNetwork() (*api.Network, error) {
+	profile, _, err := s.GetProfile("default")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	net, _, _, err := s.findUsableNetwork(getProfileNICs(profile))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if net == nil {
+		return nil, errors.NotFoundf("usable network in profile %q", profile.Name)
+	}
+	return net, nil
+}
+
+func (s *Server) findUsableNetwork(nics map[string]device) (*api.Network, string, []string, error) {
 	checked := make([]string, 0, len(nics))
 	for name, nic := range nics {
 		checked = append(checked, name)
@@ -207,7 +252,7 @@ func (s *Server) verifyNICsWithAPI(nics map[string]device) error {
 
 		net, _, err := s.GetNetwork(netName)
 		if err != nil {
-			return errors.Annotatef(err, "retrieving network %q", netName)
+			return nil, "", checked, errors.Annotatef(err, "retrieving network %q", netName)
 		}
 
 		// Versions of the LXD profile prior to 3.22 have a "nictype" member
@@ -219,16 +264,9 @@ func (s *Server) verifyNICsWithAPI(nics map[string]device) error {
 		}
 
 		logger.Tracef("found usable network device %q with parent %q", name, netName)
-		s.localBridgeName = netName
-		return nil
+		return net, netName, checked, nil
 	}
-
-	// No nics with a nictype of nicTypeBridged, nicTypeMACVLAN was found.
-	return errors.Errorf(
-		"no network device found with nictype %q, %q, or %q"+
-			"\n\tthe following devices were checked: %s"+
-			"\nReconfigure lxd to use a network of type %q, %q, or %q.",
-		nicTypeBridged, nicTypeMACVLAN, nicTypeOVN, strings.Join(checked, ", "), nicTypeBridged, nicTypeMACVLAN, nicTypeOVN)
+	return nil, "", checked, nil
 }
 
 // generateNICDeviceName attempts to generate a new NIC device name that is not
@@ -266,11 +304,11 @@ func getProfileNICs(profile *api.Profile) map[string]device {
 }
 
 func isValidNICType(nic device) bool {
-	return nic["nictype"] == nicTypeBridged || nic["nictype"] == nicTypeMACVLAN || nic["nictype"] == nicTypeOVN
+	return nic["nictype"] == nicTypeBridged || nic["nictype"] == nicTypeMACVLAN
 }
 
 func isValidNetworkType(net *api.Network) bool {
-	return net.Type == netTypeBridge || net.Type == nicTypeMACVLAN || net.Type == nicTypeOVN
+	return net.Type == netTypeBridge || net.Type == netTypeMACVLAN || net.Type == netTypeOVN
 }
 
 // NetworkName returns the network name from the

--- a/container/lxd/network_forward.go
+++ b/container/lxd/network_forward.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	stderrors "errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/juju/errors"
+)
+
+const (
+	forwardControllerUUIDKey = "user.juju-controller-uuid"
+	forwardInstanceIDKey     = "user.juju-instance-id"
+)
+
+// EnsureControllerNetworkForward allocates an external IPv4 address and
+// forwards the supplied TCP ports to a controller instance.
+func (s *Server) EnsureControllerNetworkForward(
+	networkName, controllerUUID, instanceID, targetAddress string,
+	ports []int,
+) (string, error) {
+	forwardPut := controllerNetworkForward(controllerUUID, instanceID, targetAddress, ports)
+
+	forward, eTag, err := s.getControllerNetworkForward(networkName, controllerUUID, instanceID)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if forward != nil {
+		op, err := s.UpdateNetworkForward(networkName, forward.ListenAddress, forwardPut, eTag)
+		if err := WaitOp(op, err); err != nil {
+			return "", errors.Annotate(err, "updating controller network forward")
+		}
+		return forward.ListenAddress, nil
+	}
+
+	op, err := s.CreateNetworkForward(networkName, api.NetworkForwardsPost{
+		ListenAddress:     "0.0.0.0",
+		NetworkForwardPut: forwardPut,
+	})
+	if err := WaitOp(op, err); err != nil {
+		return "", errors.Annotate(err, "creating controller network forward")
+	}
+
+	forward, _, err = s.getControllerNetworkForward(networkName, controllerUUID, instanceID)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if forward == nil {
+		return "", errors.NotFoundf("allocated controller network forward")
+	}
+	return forward.ListenAddress, nil
+}
+
+// ControllerNetworkForwardAddress returns the allocated address for a
+// controller instance.
+func (s *Server) ControllerNetworkForwardAddress(
+	networkName, controllerUUID, instanceID string,
+) (string, bool, error) {
+	forward, _, err := s.getControllerNetworkForward(networkName, controllerUUID, instanceID)
+	if err != nil {
+		return "", false, errors.Trace(err)
+	}
+	if forward == nil {
+		return "", false, nil
+	}
+	return forward.ListenAddress, true, nil
+}
+
+// DeleteControllerNetworkForwards deletes forwards for a controller. If
+// instanceID is non-empty, only forwards for that instance are deleted.
+func (s *Server) DeleteControllerNetworkForwards(
+	networkName, controllerUUID, instanceID string,
+) error {
+	forwards, err := s.GetNetworkForwards(networkName)
+	if err != nil {
+		return errors.Annotate(err, "listing controller network forwards")
+	}
+
+	var deleteErrors []error
+	for _, forward := range forwards {
+		if !isControllerNetworkForward(forward, controllerUUID, instanceID) {
+			continue
+		}
+		op, err := s.DeleteNetworkForward(networkName, forward.ListenAddress)
+		if err := WaitOp(op, err); err != nil {
+			deleteErrors = append(deleteErrors, errors.Annotatef(
+				err, "deleting controller network forward %q", forward.ListenAddress))
+		}
+	}
+	return stderrors.Join(deleteErrors...)
+}
+
+func (s *Server) getControllerNetworkForward(
+	networkName, controllerUUID, instanceID string,
+) (*api.NetworkForward, string, error) {
+	forwards, err := s.GetNetworkForwards(networkName)
+	if err != nil {
+		return nil, "", errors.Annotate(err, "listing controller network forwards")
+	}
+	for _, forward := range forwards {
+		if !isControllerNetworkForward(forward, controllerUUID, instanceID) {
+			continue
+		}
+		current, eTag, err := s.GetNetworkForward(networkName, forward.ListenAddress)
+		return current, eTag, errors.Trace(err)
+	}
+	return nil, "", nil
+}
+
+func isControllerNetworkForward(
+	forward api.NetworkForward, controllerUUID, instanceID string,
+) bool {
+	if controllerUUID != "" && forward.Config[forwardControllerUUIDKey] != controllerUUID {
+		return false
+	}
+	return instanceID == "" || forward.Config[forwardInstanceIDKey] == instanceID
+}
+
+func controllerNetworkForward(
+	controllerUUID, instanceID, targetAddress string, ports []int,
+) api.NetworkForwardPut {
+	uniquePorts := make(map[int]struct{}, len(ports))
+	for _, port := range ports {
+		if port > 0 {
+			uniquePorts[port] = struct{}{}
+		}
+	}
+	ports = make([]int, 0, len(uniquePorts))
+	for port := range uniquePorts {
+		ports = append(ports, port)
+	}
+	sort.Ints(ports)
+
+	portStrings := make([]string, len(ports))
+	for i, port := range ports {
+		portStrings[i] = strconv.Itoa(port)
+	}
+
+	return api.NetworkForwardPut{
+		Description: fmt.Sprintf("Juju controller %s instance %s", controllerUUID, instanceID),
+		Config: map[string]string{
+			forwardControllerUUIDKey: controllerUUID,
+			forwardInstanceIDKey:     instanceID,
+		},
+		Ports: []api.NetworkForwardPort{{
+			Protocol:      "tcp",
+			ListenPort:    strings.Join(portStrings, ","),
+			TargetAddress: targetAddress,
+		}},
+	}
+}

--- a/container/lxd/network_forward_test.go
+++ b/container/lxd/network_forward_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd_test
+
+import (
+	"errors"
+
+	lxdapi "github.com/canonical/lxd/shared/api"
+	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/container/lxd"
+	lxdtesting "github.com/juju/juju/container/lxd/testing"
+)
+
+type networkForwardSuite struct {
+	lxdtesting.BaseSuite
+}
+
+var _ = gc.Suite(&networkForwardSuite{})
+
+func (s *networkForwardSuite) TestEnsureControllerNetworkForwardCreates(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	client := s.NewMockServer(ctrl)
+	forwardPut := lxdapi.NetworkForwardPut{
+		Description: "Juju controller controller-uuid instance instance-id",
+		Config: map[string]string{
+			"user.juju-controller-uuid": "controller-uuid",
+			"user.juju-instance-id":     "instance-id",
+		},
+		Ports: []lxdapi.NetworkForwardPort{{
+			Protocol:      "tcp",
+			ListenPort:    "22,17070",
+			TargetAddress: "10.241.0.2",
+		}},
+	}
+	allocated := lxdapi.NetworkForward{
+		ListenAddress: "10.19.2.22",
+		Description:   forwardPut.Description,
+		Config:        forwardPut.Config,
+		Ports:         forwardPut.Ports,
+	}
+	createOp := lxdtesting.NewMockOperation(ctrl)
+
+	gomock.InOrder(
+		client.EXPECT().GetNetworkForwards("network-name").Return(nil, nil),
+		client.EXPECT().CreateNetworkForward("network-name", lxdapi.NetworkForwardsPost{
+			ListenAddress:     "0.0.0.0",
+			NetworkForwardPut: forwardPut,
+		}).Return(createOp, nil),
+		createOp.EXPECT().Wait().Return(nil),
+		client.EXPECT().GetNetworkForwards("network-name").Return([]lxdapi.NetworkForward{allocated}, nil),
+		client.EXPECT().GetNetworkForward("network-name", "10.19.2.22").Return(&allocated, lxdtesting.ETag, nil),
+	)
+
+	server, err := lxd.NewServer(client)
+	c.Assert(err, jc.ErrorIsNil)
+
+	address, err := server.EnsureControllerNetworkForward(
+		"network-name", "controller-uuid", "instance-id", "10.241.0.2",
+		[]int{17070, 22, 17070},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(address, gc.Equals, "10.19.2.22")
+}
+
+func (s *networkForwardSuite) TestEnsureControllerNetworkForwardUpdates(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	client := s.NewMockServer(ctrl)
+	existing := lxdapi.NetworkForward{
+		ListenAddress: "10.19.2.22",
+		Config: map[string]string{
+			"user.juju-controller-uuid": "controller-uuid",
+			"user.juju-instance-id":     "instance-id",
+		},
+	}
+	expected := lxdapi.NetworkForwardPut{
+		Description: "Juju controller controller-uuid instance instance-id",
+		Config: map[string]string{
+			"user.juju-controller-uuid": "controller-uuid",
+			"user.juju-instance-id":     "instance-id",
+		},
+		Ports: []lxdapi.NetworkForwardPort{{
+			Protocol:      "tcp",
+			ListenPort:    "22,17070",
+			TargetAddress: "10.241.0.3",
+		}},
+	}
+	updateOp := lxdtesting.NewMockOperation(ctrl)
+
+	gomock.InOrder(
+		client.EXPECT().GetNetworkForwards("network-name").Return([]lxdapi.NetworkForward{existing}, nil),
+		client.EXPECT().GetNetworkForward("network-name", "10.19.2.22").Return(&existing, lxdtesting.ETag, nil),
+		client.EXPECT().UpdateNetworkForward("network-name", "10.19.2.22", expected, lxdtesting.ETag).Return(updateOp, nil),
+		updateOp.EXPECT().Wait().Return(nil),
+	)
+
+	server, err := lxd.NewServer(client)
+	c.Assert(err, jc.ErrorIsNil)
+
+	address, err := server.EnsureControllerNetworkForward(
+		"network-name", "controller-uuid", "instance-id", "10.241.0.3",
+		[]int{22, 17070},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(address, gc.Equals, "10.19.2.22")
+}
+
+func (s *networkForwardSuite) TestControllerNetworkForwardAddressNotFound(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	client := s.NewMockServer(ctrl)
+	client.EXPECT().GetNetworkForwards("network-name").Return(nil, nil)
+
+	server, err := lxd.NewServer(client)
+	c.Assert(err, jc.ErrorIsNil)
+
+	address, found, err := server.ControllerNetworkForwardAddress(
+		"network-name", "controller-uuid", "instance-id",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(found, jc.IsFalse)
+	c.Check(address, gc.Equals, "")
+}
+
+func (s *networkForwardSuite) TestDeleteControllerNetworkForwards(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	client := s.NewMockServer(ctrl)
+	forwards := []lxdapi.NetworkForward{{
+		ListenAddress: "10.19.2.22",
+		Config: map[string]string{
+			"user.juju-controller-uuid": "controller-uuid",
+			"user.juju-instance-id":     "instance-id",
+		},
+	}, {
+		ListenAddress: "10.19.2.23",
+		Config: map[string]string{
+			"user.juju-controller-uuid": "other-controller",
+			"user.juju-instance-id":     "other-instance",
+		},
+	}}
+	deleteOp := lxdtesting.NewMockOperation(ctrl)
+
+	client.EXPECT().GetNetworkForwards("network-name").Return(forwards, nil)
+	client.EXPECT().DeleteNetworkForward("network-name", "10.19.2.22").Return(deleteOp, nil)
+	deleteOp.EXPECT().Wait().Return(nil)
+
+	server, err := lxd.NewServer(client)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = server.DeleteControllerNetworkForwards("network-name", "controller-uuid", "")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *networkForwardSuite) TestDeleteControllerNetworkForwardsReportsErrors(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	client := s.NewMockServer(ctrl)
+	forward := lxdapi.NetworkForward{
+		ListenAddress: "10.19.2.22",
+		Config: map[string]string{
+			"user.juju-controller-uuid": "controller-uuid",
+			"user.juju-instance-id":     "instance-id",
+		},
+	}
+
+	client.EXPECT().GetNetworkForwards("network-name").Return([]lxdapi.NetworkForward{forward}, nil)
+	client.EXPECT().DeleteNetworkForward("network-name", "10.19.2.22").Return(nil, errors.New("boom"))
+
+	server, err := lxd.NewServer(client)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = server.DeleteControllerNetworkForwards("network-name", "controller-uuid", "")
+	c.Assert(err, gc.ErrorMatches, `deleting controller network forward "10.19.2.22": boom`)
+}

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -208,9 +208,9 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentBadNicType(c *gc.C) {
 
 	err = jujuSvr.VerifyNetworkDevice(profile, "")
 	c.Assert(err, gc.ErrorMatches,
-		`profile "default": no network device found with nictype "bridged" or "macvlan"\n`+
+		`profile "default": no network device found with nictype "bridged", "macvlan", or "ovn"\n`+
 			`\tthe following devices were checked: eth0\n`+
-			`Reconfigure lxd to use a network of type "bridged" or "macvlan".`)
+			`Reconfigure lxd to use a network of type "bridged", "macvlan", or "ovn".`)
 }
 
 // Juju used to fail when IPv6 was enabled on the lxd network. This test now

--- a/container/lxd/network_test.go
+++ b/container/lxd/network_test.go
@@ -144,6 +144,29 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentValid(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *networkSuite) TestVerifyNetworkDevicePresentValidOVN(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServerWithExtensions(ctrl, "network")
+
+	profile := defaultProfileWithNIC()
+	profile.Devices["eth0"]["network"] = "ovn-network"
+	net := &lxdapi.Network{
+		Name:    "ovn-network",
+		Managed: true,
+		Type:    "ovn",
+	}
+	cSvr.EXPECT().GetNetwork("ovn-network").Return(net, "", nil)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = jujuSvr.VerifyNetworkDevice(profile, "")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(jujuSvr.LocalBridgeName(), gc.Equals, "ovn-network")
+	c.Check(jujuSvr.LocalNetworkType(), gc.Equals, "ovn")
+}
+
 func (s *networkSuite) TestVerifyNetworkDevicePresentValidLegacy(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -208,9 +231,9 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentBadNicType(c *gc.C) {
 
 	err = jujuSvr.VerifyNetworkDevice(profile, "")
 	c.Assert(err, gc.ErrorMatches,
-		`profile "default": no network device found with nictype "bridged", "macvlan", or "ovn"\n`+
+		`profile "default": no network device found with nictype "bridged" or "macvlan"\n`+
 			`\tthe following devices were checked: eth0\n`+
-			`Reconfigure lxd to use a network of type "bridged", "macvlan", or "ovn".`)
+			`Reconfigure lxd to use a network of type "bridged" or "macvlan".`)
 }
 
 // Juju used to fail when IPv6 was enabled on the lxd network. This test now

--- a/container/lxd/server.go
+++ b/container/lxd/server.go
@@ -30,7 +30,8 @@ type Server struct {
 	clusterAPISupport bool
 	storageAPISupport bool
 
-	localBridgeName string
+	localBridgeName  string
+	localNetworkType string
 
 	clock clock.Clock
 }

--- a/internal/provider/lxd/environ.go
+++ b/internal/provider/lxd/environ.go
@@ -262,6 +262,10 @@ func (env *environ) DestroyController(ctx context.ProviderCallContext, controlle
 			return errors.Annotate(err, "destroying LXD filesystems for controller")
 		}
 	}
+	if err := env.deleteControllerNetworkForwards(controllerUUID, ""); err != nil {
+		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		return errors.Annotate(err, "deleting controller network forwards")
+	}
 	return nil
 }
 

--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	stderrors "errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -47,6 +48,31 @@ func (env *environ) StartInstance(
 			_ = args.StatusCallback(status.ProvisioningError, err.Error(), nil)
 		}
 		return nil, errors.Trace(err)
+	}
+	if args.InstanceConfig.IsController() {
+		err := env.ensureControllerNetworkForward(
+			ctx, container, args.InstanceConfig, args.ControllerUUID,
+		)
+		if err != nil {
+			if deleteErr := env.deleteControllerNetworkForwards(
+				args.ControllerUUID, container.Name,
+			); deleteErr != nil {
+				logger.Errorf(
+					"deleting network forward after controller provisioning failure: %v",
+					deleteErr,
+				)
+			}
+			if removeErr := env.server().RemoveContainer(container.Name); removeErr != nil {
+				logger.Errorf(
+					"removing controller %q after network forward failure: %v",
+					container.Name, removeErr,
+				)
+			}
+			if args.StatusCallback != nil {
+				_ = args.StatusCallback(status.ProvisioningError, err.Error(), nil)
+			}
+			return nil, errors.Annotate(err, "creating controller network forward")
+		}
 	}
 	logger.Infof("started instance %q", container.Name)
 	inst := newInstance(container, env)
@@ -481,5 +507,12 @@ func (env *environ) StopInstances(ctx context.ProviderCallContext, instances ...
 		return errors.Trace(err)
 	}
 
-	return nil
+	var cleanupErrors []error
+	for _, name := range names {
+		if err := env.deleteControllerNetworkForwards("", name); err != nil {
+			cleanupErrors = append(cleanupErrors, errors.Annotatef(
+				err, "deleting network forward for instance %q", name))
+		}
+	}
+	return stderrors.Join(cleanupErrors...)
 }

--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -4,6 +4,7 @@
 package lxd_test
 
 import (
+	stdcontext "context"
 	"fmt"
 	"reflect"
 
@@ -37,6 +38,7 @@ var _ = gc.Suite(&environBrokerSuite{})
 func (s *environBrokerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.callCtx = &context.CloudCallContext{
+		Context: stdcontext.Background(),
 		InvalidateCredentialFunc: func(string) error {
 			s.invalidCredential = true
 			return nil
@@ -79,6 +81,7 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil)
 
 	// Check that no custom devices were passed - vanilla cloud-init.
 	check := func(spec containerlxd.ContainerSpec) bool {
@@ -107,10 +110,75 @@ func (s *environBrokerSuite) TestStartInstanceDefaultNIC(c *gc.C) {
 	c.Assert(*res.Hardware.AvailabilityZone, jc.DeepEquals, "node01")
 }
 
+func (s *environBrokerSuite) TestStartControllerInstanceWithOVN(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+
+	args := s.GetStartInstanceArgs(c)
+	containerName := "juju-controller-machine-0"
+	container := &containerlxd.Container{
+		Instance: api.Instance{
+			Name:     containerName,
+			Location: "node01",
+		},
+	}
+	ovnNetwork := &api.Network{
+		Name: "arbitrary-network-name",
+		Type: "ovn",
+		Config: map[string]string{
+			"ipv4.address": "10.241.0.1/16",
+		},
+	}
+	internalAddress := network.NewMachineAddress(
+		"10.241.0.2",
+		network.WithScope(network.ScopeCloudLocal),
+	).AsProviderAddress()
+	controllerConfig := args.InstanceConfig.ControllerConfig
+
+	gomock.InOrder(
+		svr.EXPECT().HostArch().Return(arch.AMD64),
+		svr.EXPECT().FindImage(
+			gomock.Any(),
+			corebase.MakeDefaultBase("ubuntu", "24.04"),
+			arch.AMD64,
+			api.InstanceTypeContainer,
+			gomock.Any(),
+			true,
+			gomock.Any(),
+		).Return(containerlxd.SourcedImage{}, nil),
+		svr.EXPECT().ServerVersion().Return("3.10.0"),
+		svr.EXPECT().GetNICsFromProfile("default").Return(s.defaultProfile.Devices, nil),
+		svr.EXPECT().CreateContainerFromSpec(gomock.Any()).Return(container, nil),
+		svr.EXPECT().DefaultNetwork().Return(ovnNetwork, nil),
+		svr.EXPECT().ContainerAddresses(containerName).Return(
+			network.ProviderAddresses{internalAddress}, nil,
+		),
+		svr.EXPECT().EnsureControllerNetworkForward(
+			ovnNetwork.Name,
+			args.ControllerUUID,
+			containerName,
+			internalAddress.Value,
+			[]int{
+				controllerConfig.SSHServerPort(),
+				controllerConfig.APIPort(),
+				controllerConfig.ControllerAPIPort(),
+			},
+		).Return("10.19.2.22", nil),
+		svr.EXPECT().HostArch().Return(arch.AMD64),
+	)
+
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
+	res, err := env.StartInstance(s.callCtx, args)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+}
+
 func (s *environBrokerSuite) TestStartInstanceUseZoneFromServerNameWhenContainerLocationIsNone(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil)
 
 	// Check that no custom devices were passed - vanilla cloud-init.
 	check := func(spec containerlxd.ContainerSpec) bool {
@@ -145,6 +213,7 @@ func (s *environBrokerSuite) TestStartInstanceNonDefaultNIC(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil)
 
 	nics := map[string]map[string]string{
 		"eno9": {
@@ -188,6 +257,7 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil)
 
 	profileNICs := map[string]map[string]string{
 		"eno9": {
@@ -294,6 +364,7 @@ func (s *environBrokerSuite) TestStartInstanceWithPlacementAvailable(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil)
 
 	target := lxdtesting.NewMockInstanceServer(ctrl)
 	tExp := target.EXPECT()
@@ -427,6 +498,7 @@ func (s *environBrokerSuite) TestStartInstanceWithZoneConstraintsAvailable(c *gc
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil)
 
 	target := lxdtesting.NewMockInstanceServer(ctrl)
 	tExp := target.EXPECT()
@@ -542,6 +614,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraints(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil)
 
 	// Check that the constraints were passed through to spec.Config.
 	check := func(spec containerlxd.ContainerSpec) bool {
@@ -593,6 +666,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndCustomNICs(c *gc
 	defer ctrl.Finish()
 
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil)
 
 	nics := map[string]map[string]string{
 		"eno9": {
@@ -649,6 +723,7 @@ func (s *environBrokerSuite) TestStartInstanceWithConstraintsAndVirtType(c *gc.C
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil)
 
 	// Check that the constraints were passed through to spec.Config.
 	check := func(spec containerlxd.ContainerSpec) bool {
@@ -695,6 +770,7 @@ func (s *environBrokerSuite) TestStartInstanceWithCharmLXDProfile(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil)
 
 	// Check that the lxd profile name was passed through to spec.Config.
 	check := func(spec containerlxd.ContainerSpec) bool {
@@ -771,11 +847,38 @@ func (s *environBrokerSuite) TestStopInstances(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	svr := lxd.NewMockServer(ctrl)
+	svr.EXPECT().DefaultNetwork().Return(&api.Network{Type: "bridge"}, nil).Times(2)
 
 	svr.EXPECT().RemoveContainers([]string{"juju-f75cba-1", "juju-f75cba-2"})
 
 	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
 	err := env.StopInstances(s.callCtx, "juju-f75cba-1", "juju-f75cba-2", "not-in-namespace-so-ignored")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *environBrokerSuite) TestStopInstancesDeletesOVNForwards(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	svr := lxd.NewMockServer(ctrl)
+	network := &api.Network{
+		Name: "arbitrary-network-name",
+		Type: "ovn",
+	}
+
+	gomock.InOrder(
+		svr.EXPECT().RemoveContainers([]string{"juju-f75cba-1", "juju-f75cba-2"}),
+		svr.EXPECT().DefaultNetwork().Return(network, nil),
+		svr.EXPECT().DeleteControllerNetworkForwards(
+			network.Name, "", "juju-f75cba-1",
+		).Return(nil),
+		svr.EXPECT().DefaultNetwork().Return(network, nil),
+		svr.EXPECT().DeleteControllerNetworkForwards(
+			network.Name, "", "juju-f75cba-2",
+		).Return(nil),
+	)
+
+	env := s.NewEnviron(c, svr, nil, environscloudspec.CloudSpec{})
+	err := env.StopInstances(s.callCtx, "juju-f75cba-1", "juju-f75cba-2")
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/internal/provider/lxd/environ_test.go
+++ b/internal/provider/lxd/environ_test.go
@@ -308,6 +308,7 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 		{"GetStoragePoolVolumes", []interface{}{"juju"}},
 		{"DeleteStoragePoolVolume", []interface{}{"juju", "custom", "ours"}},
 		{"GetStoragePoolVolumes", []interface{}{"juju-zfs"}},
+		{"DefaultNetwork", []interface{}{}},
 	})
 }
 

--- a/internal/provider/lxd/export_test.go
+++ b/internal/provider/lxd/export_test.go
@@ -17,6 +17,7 @@ var (
 	NewInstance     = newInstance
 	GetCertificates = getCertificates
 	ParseAPIVersion = parseAPIVersion
+	EnsureHTTPSHost = ensureHTTPSHost
 )
 
 func NewProviderWithMocks(

--- a/internal/provider/lxd/instance.go
+++ b/internal/provider/lxd/instance.go
@@ -58,5 +58,22 @@ func (i *environInstance) Status(ctx context.ProviderCallContext) instance.Statu
 // Addresses implements instances.Instance.
 func (i *environInstance) Addresses(_ context.ProviderCallContext) (network.ProviderAddresses, error) {
 	addrs, err := i.env.server().ContainerAddresses(i.container.Name)
-	return addrs, errors.Trace(err)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	controllerUUID, ok := isController(i.container)
+	if !ok {
+		return addrs, nil
+	}
+	address, found, err := i.env.controllerNetworkForwardAddress(
+		controllerUUID, i.container.Name,
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if found {
+		addrs = append(addrs, controllerForwardAddress(address))
+	}
+	return addrs, nil
 }

--- a/internal/provider/lxd/instance_test.go
+++ b/internal/provider/lxd/instance_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/context"
 	"github.com/juju/juju/internal/provider/lxd"
 )
@@ -45,4 +46,27 @@ func (s *instanceSuite) TestAddresses(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(addresses, jc.DeepEquals, s.Addresses)
+}
+
+func (s *instanceSuite) TestAddressesIncludesOVNForward(c *gc.C) {
+	s.Client.NetworkType = "ovn"
+	s.Client.NetworkForwardAddr = "10.19.2.22"
+
+	addresses, err := s.Instance.Addresses(context.NewEmptyCloudCallContext())
+	c.Assert(err, jc.ErrorIsNil)
+
+	expected := append(
+		s.Addresses,
+		network.NewMachineAddress(
+			"10.19.2.22",
+			network.WithScope(network.ScopePublic),
+		).AsProviderAddress(),
+	)
+	c.Check(addresses, jc.DeepEquals, expected)
+	s.Stub.CheckCallNames(
+		c,
+		"ContainerAddresses",
+		"DefaultNetwork",
+		"ControllerNetworkForwardAddress",
+	)
 }

--- a/internal/provider/lxd/network_forward.go
+++ b/internal/provider/lxd/network_forward.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+import (
+	"net"
+	"time"
+
+	lxdapi "github.com/canonical/lxd/shared/api"
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/retry"
+
+	"github.com/juju/juju/cloudconfig/instancecfg"
+	"github.com/juju/juju/container/lxd"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/environs/context"
+	"github.com/juju/juju/environs/tags"
+)
+
+const controllerAddressTimeout = 5 * time.Minute
+
+func (env *environ) ensureControllerNetworkForward(
+	ctx context.ProviderCallContext,
+	container *lxd.Container,
+	instanceConfig *instancecfg.InstanceConfig,
+	controllerUUID string,
+) error {
+	network, ok, err := env.ovnNetwork()
+	if err != nil || !ok {
+		return errors.Trace(err)
+	}
+
+	targetAddress, err := env.waitForControllerAddress(ctx, container.Name, network)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	controllerConfig := instanceConfig.ControllerConfig
+	ports := []int{
+		controllerConfig.SSHServerPort(),
+		controllerConfig.APIPort(),
+		controllerConfig.ControllerAPIPort(),
+	}
+	_, err = env.server().EnsureControllerNetworkForward(
+		network.Name, controllerUUID, container.Name, targetAddress, ports,
+	)
+	return errors.Trace(err)
+}
+
+func (env *environ) controllerNetworkForwardAddress(
+	controllerUUID, instanceID string,
+) (string, bool, error) {
+	network, ok, err := env.ovnNetwork()
+	if err != nil || !ok {
+		return "", false, errors.Trace(err)
+	}
+	return env.server().ControllerNetworkForwardAddress(
+		network.Name, controllerUUID, instanceID,
+	)
+}
+
+func (env *environ) deleteControllerNetworkForwards(
+	controllerUUID, instanceID string,
+) error {
+	network, ok, err := env.ovnNetwork()
+	if err != nil || !ok {
+		return errors.Trace(err)
+	}
+	return errors.Trace(env.server().DeleteControllerNetworkForwards(
+		network.Name, controllerUUID, instanceID,
+	))
+}
+
+func (env *environ) ovnNetwork() (*lxdapi.Network, bool, error) {
+	network, err := env.server().DefaultNetwork()
+	if err != nil {
+		return nil, false, errors.Trace(err)
+	}
+	return network, network.Type == "ovn", nil
+}
+
+func (env *environ) waitForControllerAddress(
+	ctx context.ProviderCallContext,
+	instanceID string,
+	network *lxdapi.Network,
+) (string, error) {
+	_, subnet, err := net.ParseCIDR(network.Config["ipv4.address"])
+	if err != nil {
+		return "", errors.Annotatef(
+			err, "parsing IPv4 address for OVN network %q", network.Name)
+	}
+
+	var targetAddress string
+	err = retry.Call(retry.CallArgs{
+		Func: func() error {
+			addresses, err := env.server().ContainerAddresses(instanceID)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			targetAddress = addressInSubnet(addresses, subnet)
+			if targetAddress == "" {
+				return errors.NotFoundf(
+					"controller address in OVN network %q", network.Name)
+			}
+			return nil
+		},
+		Delay:       time.Second,
+		Attempts:    retry.UnlimitedAttempts,
+		MaxDuration: controllerAddressTimeout,
+		Clock:       clock.WallClock,
+		Stop:        ctx.Done(),
+	})
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", errors.Trace(ctx.Err())
+		}
+		return "", errors.Trace(retry.LastError(err))
+	}
+	return targetAddress, nil
+}
+
+func addressInSubnet(addresses network.ProviderAddresses, subnet *net.IPNet) string {
+	for _, address := range addresses {
+		ip := net.ParseIP(address.Value)
+		if ip != nil && ip.To4() != nil && subnet.Contains(ip) {
+			return ip.String()
+		}
+	}
+	return ""
+}
+
+func controllerForwardAddress(address string) network.ProviderAddress {
+	return network.NewMachineAddress(
+		address,
+		network.WithScope(network.ScopePublic),
+	).AsProviderAddress()
+}
+
+func isController(container *lxd.Container) (string, bool) {
+	controllerUUID := container.Metadata(tags.JujuController)
+	return controllerUUID, container.Metadata(tags.JujuIsController) == "true"
+}

--- a/internal/provider/lxd/package_mock_test.go
+++ b/internal/provider/lxd/package_mock_test.go
@@ -75,6 +75,22 @@ func (mr *MockServerMockRecorder) ContainerAddresses(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerAddresses", reflect.TypeOf((*MockServer)(nil).ContainerAddresses), arg0)
 }
 
+// ControllerNetworkForwardAddress mocks base method.
+func (m *MockServer) ControllerNetworkForwardAddress(arg0, arg1, arg2 string) (string, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerNetworkForwardAddress", arg0, arg1, arg2)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ControllerNetworkForwardAddress indicates an expected call of ControllerNetworkForwardAddress.
+func (mr *MockServerMockRecorder) ControllerNetworkForwardAddress(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerNetworkForwardAddress", reflect.TypeOf((*MockServer)(nil).ControllerNetworkForwardAddress), arg0, arg1, arg2)
+}
+
 // CreateCertificate mocks base method.
 func (m *MockServer) CreateCertificate(arg0 api.CertificatesPost) error {
 	m.ctrl.T.Helper()
@@ -174,6 +190,21 @@ func (mr *MockServerMockRecorder) CreateVolume(arg0, arg1, arg2 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockServer)(nil).CreateVolume), arg0, arg1, arg2)
 }
 
+// DefaultNetwork mocks base method.
+func (m *MockServer) DefaultNetwork() (*api.Network, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DefaultNetwork")
+	ret0, _ := ret[0].(*api.Network)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DefaultNetwork indicates an expected call of DefaultNetwork.
+func (mr *MockServerMockRecorder) DefaultNetwork() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultNetwork", reflect.TypeOf((*MockServer)(nil).DefaultNetwork))
+}
+
 // DeleteCertificate mocks base method.
 func (m *MockServer) DeleteCertificate(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -186,6 +217,20 @@ func (m *MockServer) DeleteCertificate(arg0 string) error {
 func (mr *MockServerMockRecorder) DeleteCertificate(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCertificate", reflect.TypeOf((*MockServer)(nil).DeleteCertificate), arg0)
+}
+
+// DeleteControllerNetworkForwards mocks base method.
+func (m *MockServer) DeleteControllerNetworkForwards(arg0, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteControllerNetworkForwards", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteControllerNetworkForwards indicates an expected call of DeleteControllerNetworkForwards.
+func (mr *MockServerMockRecorder) DeleteControllerNetworkForwards(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteControllerNetworkForwards", reflect.TypeOf((*MockServer)(nil).DeleteControllerNetworkForwards), arg0, arg1, arg2)
 }
 
 // DeleteProfile mocks base method.
@@ -229,6 +274,21 @@ func (m *MockServer) EnableHTTPSListener() error {
 func (mr *MockServerMockRecorder) EnableHTTPSListener() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableHTTPSListener", reflect.TypeOf((*MockServer)(nil).EnableHTTPSListener))
+}
+
+// EnsureControllerNetworkForward mocks base method.
+func (m *MockServer) EnsureControllerNetworkForward(arg0, arg1, arg2, arg3 string, arg4 []int) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureControllerNetworkForward", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnsureControllerNetworkForward indicates an expected call of EnsureControllerNetworkForward.
+func (mr *MockServerMockRecorder) EnsureControllerNetworkForward(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureControllerNetworkForward", reflect.TypeOf((*MockServer)(nil).EnsureControllerNetworkForward), arg0, arg1, arg2, arg3, arg4)
 }
 
 // EnsureDefaultStorage mocks base method.
@@ -596,6 +656,20 @@ func (m *MockServer) LocalBridgeName() string {
 func (mr *MockServerMockRecorder) LocalBridgeName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalBridgeName", reflect.TypeOf((*MockServer)(nil).LocalBridgeName))
+}
+
+// LocalNetworkType mocks base method.
+func (m *MockServer) LocalNetworkType() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LocalNetworkType")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// LocalNetworkType indicates an expected call of LocalNetworkType.
+func (mr *MockServerMockRecorder) LocalNetworkType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalNetworkType", reflect.TypeOf((*MockServer)(nil).LocalNetworkType))
 }
 
 // Name mocks base method.

--- a/internal/provider/lxd/server.go
+++ b/internal/provider/lxd/server.go
@@ -47,6 +47,11 @@ type Server interface {
 	DeleteCertificate(fingerprint string) (err error)
 	CreateClientCertificate(certificate *lxd.Certificate) error
 	LocalBridgeName() string
+	LocalNetworkType() string
+	DefaultNetwork() (*lxdapi.Network, error)
+	EnsureControllerNetworkForward(networkName, controllerUUID, instanceID, targetAddress string, ports []int) (string, error)
+	ControllerNetworkForwardAddress(networkName, controllerUUID, instanceID string) (string, bool, error)
+	DeleteControllerNetworkForwards(networkName, controllerUUID, instanceID string) error
 	AliveContainers(prefix string) ([]lxd.Container, error)
 	ContainerAddresses(name string) ([]network.ProviderAddress, error)
 	RemoveContainer(name string) error
@@ -292,14 +297,31 @@ func (s *serverFactory) initLocalServer() (Server, error) {
 }
 
 func (s *serverFactory) bootstrapLocalServer(svr Server) (Server, string, error) {
-	// select the server bridge name, so that we can then try and select
-	// the hostAddress from the current interfaceAddress
-	bridgeName := svr.LocalBridgeName()
-	hostAddress, err := s.interfaceAddress.InterfaceAddress(bridgeName)
-	if err != nil {
-		return nil, "", errors.Trace(err)
+	var hostAddress string
+	if svr.LocalNetworkType() == "ovn" {
+		server, _, err := svr.GetServer()
+		if err != nil {
+			return nil, "", errors.Trace(err)
+		}
+		if clusterAddress, _ := server.Config["cluster.https_address"].(string); clusterAddress != "" {
+			hostAddress, err = addressHost(clusterAddress)
+			if err != nil {
+				return nil, "", errors.Annotate(err, "parsing LXD cluster address")
+			}
+		}
+	} else {
+		// Select the server bridge name, so that we can then select the host
+		// address from the current interface address.
+		bridgeName := svr.LocalBridgeName()
+		var err error
+		hostAddress, err = s.interfaceAddress.InterfaceAddress(bridgeName)
+		if err != nil {
+			return nil, "", errors.Trace(err)
+		}
 	}
-	hostAddress = lxd.EnsureHTTPS(hostAddress)
+	if hostAddress != "" {
+		hostAddress = ensureHTTPSHost(hostAddress)
+	}
 
 	// The following retry mechanism is required for newer LXD versions, where
 	// the new lxd client doesn't propagate the EnableHTTPSListener quick enough
@@ -321,6 +343,9 @@ func (s *serverFactory) bootstrapLocalServer(svr Server) (Server, string, error)
 			}
 
 			connInfoAddresses = cInfo.Addresses
+			if hostAddress == "" {
+				hostAddress = firstIPv4Host(cInfo.Addresses)
+			}
 			for _, addr := range cInfo.Addresses {
 				if strings.HasPrefix(addr, hostAddress+":") {
 					hostAddress = addr
@@ -354,6 +379,37 @@ func (s *serverFactory) bootstrapLocalServer(svr Server) (Server, string, error)
 	}
 
 	return svr, hostAddress, nil
+}
+
+func addressHost(address string) (string, error) {
+	parsed, err := url.Parse(lxd.EnsureHTTPS(address))
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if parsed.Hostname() == "" {
+		return "", errors.NotValidf("LXD address %q", address)
+	}
+	return parsed.Hostname(), nil
+}
+
+func firstIPv4Host(addresses []string) string {
+	for _, address := range addresses {
+		host, err := addressHost(address)
+		if err != nil {
+			continue
+		}
+		if ip := net.ParseIP(host); ip != nil && ip.To4() != nil {
+			return lxd.EnsureHTTPS(host)
+		}
+	}
+	return ""
+}
+
+func ensureHTTPSHost(host string) string {
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+		host = "[" + host + "]"
+	}
+	return lxd.EnsureHTTPS(host)
 }
 
 func (s *serverFactory) bootstrapRemoteServer(svr Server) error {

--- a/internal/provider/lxd/server_integration_test.go
+++ b/internal/provider/lxd/server_integration_test.go
@@ -52,6 +52,7 @@ func (s *serverIntegrationSuite) TestLocalServer(c *gc.C) {
 		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
+		server.EXPECT().LocalNetworkType().Return("bridge"),
 		server.EXPECT().LocalBridgeName().Return(bridgeName),
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
@@ -90,6 +91,7 @@ func (s *serverIntegrationSuite) TestLocalServerRetrySemantics(c *gc.C) {
 		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
+		server.EXPECT().LocalNetworkType().Return("bridge"),
 		server.EXPECT().LocalBridgeName().Return(bridgeName),
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(emptyConnectionInfo, nil),
@@ -126,6 +128,7 @@ func (s *serverIntegrationSuite) TestLocalServerRetrySemanticsFailure(c *gc.C) {
 	server.EXPECT().GetProfile("default").Return(profile, etag, nil).Times(31)
 	server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil).Times(31)
 	server.EXPECT().EnableHTTPSListener().Return(nil).Times(31)
+	server.EXPECT().LocalNetworkType().Return("bridge")
 	server.EXPECT().LocalBridgeName().Return(bridgeName)
 	interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil)
 	server.EXPECT().GetConnectionInfo().Return(emptyConnectionInfo, nil).Times(30)
@@ -156,6 +159,7 @@ func (s *serverIntegrationSuite) TestLocalServerWithInvalidAPIVersion(c *gc.C) {
 		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
+		server.EXPECT().LocalNetworkType().Return("bridge"),
 		server.EXPECT().LocalBridgeName().Return(bridgeName),
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
@@ -307,6 +311,7 @@ func (s *serverIntegrationSuite) TestLocalServerWithStorageNotSupported(c *gc.C)
 		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
+		server.EXPECT().LocalNetworkType().Return("bridge"),
 		server.EXPECT().LocalBridgeName().Return(bridgeName),
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
@@ -339,6 +344,7 @@ func (s *serverIntegrationSuite) TestRemoteServerWithEmptyEndpointYieldsLocalSer
 		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
 		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
 		server.EXPECT().EnableHTTPSListener().Return(nil),
+		server.EXPECT().LocalNetworkType().Return("bridge"),
 		server.EXPECT().LocalBridgeName().Return(bridgeName),
 		interfaceAddr.EXPECT().InterfaceAddress(bridgeName).Return(hostAddress, nil),
 		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
@@ -351,6 +357,75 @@ func (s *serverIntegrationSuite) TestRemoteServerWithEmptyEndpointYieldsLocalSer
 	svr, err := factory.RemoteServer(lxd.CloudSpec{})
 	c.Assert(svr, gc.Not(gc.IsNil))
 	c.Assert(err, gc.IsNil)
+}
+
+func (s *serverIntegrationSuite) TestLocalServerWithOVN(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	profile := &api.Profile{}
+	etag := "etag"
+	hostAddress := "10.19.2.11"
+	serverInfo := &api.Server{
+		ServerUntrusted: api.ServerUntrusted{
+			Config: map[string]interface{}{
+				"cluster.https_address": hostAddress + ":8443",
+			},
+		},
+	}
+	connectionInfo := &client.ConnectionInfo{
+		Addresses: []string{
+			"https://" + hostAddress + ":8443",
+		},
+	}
+
+	factory, server, _ := lxd.NewLocalServerFactory(ctrl)
+
+	gomock.InOrder(
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
+		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
+		server.EXPECT().EnableHTTPSListener().Return(nil),
+		server.EXPECT().LocalNetworkType().Return("ovn"),
+		server.EXPECT().GetServer().Return(serverInfo, etag, nil),
+		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
+		server.EXPECT().StorageSupported().Return(false),
+		server.EXPECT().ServerVersion().Return("5.2"),
+	)
+
+	svr, err := factory.LocalServer()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(svr, gc.Equals, server)
+}
+
+func (s *serverIntegrationSuite) TestLocalServerWithOVNUsesAdvertisedAddress(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	profile := &api.Profile{}
+	etag := "etag"
+	hostAddress := "10.19.2.11"
+	connectionInfo := &client.ConnectionInfo{
+		Addresses: []string{
+			"https://" + hostAddress + ":8443",
+		},
+	}
+
+	factory, server, _ := lxd.NewLocalServerFactory(ctrl)
+
+	gomock.InOrder(
+		server.EXPECT().GetProfile("default").Return(profile, etag, nil),
+		server.EXPECT().VerifyNetworkDevice(profile, etag).Return(nil),
+		server.EXPECT().EnableHTTPSListener().Return(nil),
+		server.EXPECT().LocalNetworkType().Return("ovn"),
+		server.EXPECT().GetServer().Return(&api.Server{}, etag, nil),
+		server.EXPECT().GetConnectionInfo().Return(connectionInfo, nil),
+		server.EXPECT().StorageSupported().Return(false),
+		server.EXPECT().ServerVersion().Return("5.2"),
+	)
+
+	svr, err := factory.LocalServer()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(svr, gc.Equals, server)
 }
 
 func (s *serverIntegrationSuite) TestRemoteServer(c *gc.C) {

--- a/internal/provider/lxd/server_test.go
+++ b/internal/provider/lxd/server_test.go
@@ -36,6 +36,10 @@ func (s *serverSuite) TestParseAPIVersion(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `minor version number  b not valid`)
 }
 
+func (s *serverSuite) TestEnsureHTTPSHostIPv6(c *gc.C) {
+	c.Check(EnsureHTTPSHost("2001:db8::1"), gc.Equals, "https://[2001:db8::1]")
+}
+
 func (s *serverSuite) TestValidateAPIVersion(c *gc.C) {
 	err := ValidateAPIVersion("5.0")
 	c.Check(err, jc.ErrorIsNil)

--- a/internal/provider/lxd/testing_test.go
+++ b/internal/provider/lxd/testing_test.go
@@ -397,6 +397,8 @@ type StubClient struct {
 	NetworkNames       []string
 	NetworkState       map[string]api.NetworkState
 	ProfileNames       []string
+	NetworkType        string
+	NetworkForwardAddr string
 }
 
 func (conn *StubClient) FilterContainers(prefix string, statuses ...string) ([]lxd.Container, error) {
@@ -485,6 +487,45 @@ func (conn *StubClient) UpdateContainerConfig(container string, cfg map[string]s
 func (conn *StubClient) LocalBridgeName() string {
 	conn.AddCall("LocalBridgeName")
 	return "test-bridge"
+}
+
+func (conn *StubClient) LocalNetworkType() string {
+	return conn.NetworkType
+}
+
+func (conn *StubClient) DefaultNetwork() (*api.Network, error) {
+	conn.AddCall("DefaultNetwork")
+	return &api.Network{
+		Name: "test-network",
+		Type: conn.NetworkType,
+		Config: map[string]string{
+			"ipv4.address": "10.0.0.1/24",
+		},
+	}, conn.NextErr()
+}
+
+func (conn *StubClient) EnsureControllerNetworkForward(
+	networkName, controllerUUID, instanceID, targetAddress string, ports []int,
+) (string, error) {
+	conn.AddCall(
+		"EnsureControllerNetworkForward",
+		networkName, controllerUUID, instanceID, targetAddress, ports,
+	)
+	return conn.NetworkForwardAddr, conn.NextErr()
+}
+
+func (conn *StubClient) ControllerNetworkForwardAddress(
+	networkName, controllerUUID, instanceID string,
+) (string, bool, error) {
+	conn.AddCall("ControllerNetworkForwardAddress", networkName, controllerUUID, instanceID)
+	return conn.NetworkForwardAddr, conn.NetworkForwardAddr != "", conn.NextErr()
+}
+
+func (conn *StubClient) DeleteControllerNetworkForwards(
+	networkName, controllerUUID, instanceID string,
+) error {
+	conn.AddCall("DeleteControllerNetworkForwards", networkName, controllerUUID, instanceID)
+	return conn.NextErr()
 }
 
 func (conn *StubClient) GetProfile(name string) (*api.Profile, string, error) {


### PR DESCRIPTION
Quick Prototype, not ready for merging.


<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
