### PR TITLE
refactor: improve robustness of mongo db script

### DIFF
--- a/scripts/mongo-client.sh
+++ b/scripts/mongo-client.sh
@@ -54,8 +54,10 @@ fi
 
 temp_dir=/tmp
 if [[ "${client}" == "/snap/bin/juju-db.mongo" ]]; then
-	temp_dir=/var/snap/juju-db/common
+	temp_dir=/var/snap/juju-db/common/tmp
+	sudo mkdir -p "${temp_dir}"
 fi
+# These must be set before the EXIT trap so nounset does not abort cleanup.
 user_file=""
 password_file=""
 cleanup() {
@@ -73,8 +75,8 @@ trap '{ set +ex; } 2>/dev/null; cleanup' EXIT
 user_file=$(sudo mktemp -p "${temp_dir}" mongo-user.XXXXXX)
 password_file=$(sudo mktemp -p "${temp_dir}" mongo-password.XXXXXX)
 
-sudo awk '/^tag:/ {print $2}' ${conf} | sudo tee "${user_file}" >/dev/null
-sudo awk '/^statepassword:/ {print $2}' ${conf} | sudo tee "${password_file}" >/dev/null
+sudo cat ${conf} | awk '/^tag:/ {print $2}' | sudo tee "${user_file}" >/dev/null
+sudo cat ${conf} | awk '/^statepassword:/ {print $2}' | sudo tee "${password_file}" >/dev/null
 sudo chown root:root "${user_file}" "${password_file}"
 sudo chmod 600 "${user_file}" "${password_file}"
 if ! sudo test -s "${user_file}"; then
@@ -85,6 +87,7 @@ if ! sudo test -s "${password_file}"; then
 	echo "statepassword not found in ${conf}"
 	exit 2
 fi
+# This depends on the legacy mongo shell's cat() helper.
 mongo_auth_js="if (!db.getSiblingDB(\"admin\").auth(cat(\"${user_file}\").trim(), cat(\"${password_file}\").trim())) { print(\"mongo authentication failed\"); quit(3); }"
 
 set -x

--- a/scripts/mongo-client.sh
+++ b/scripts/mongo-client.sh
@@ -36,29 +36,64 @@ if [[ -v SNAP ]] && [[ -n ${SNAP} ]]; then
 fi
 
 read -d '' -r cmds <<'EOF'
-set -x
+set -euo pipefail
 conf=/var/lib/juju/agents/machine-*/agent.conf
-user=$(sudo awk '/^tag:/ {print $2}' ${conf})
-password=$(sudo awk '/^statepassword:/ {print $2}' ${conf})
 
 if [[ -f /snap/bin/juju-db.mongo ]]; then
-    client=/snap/bin/juju-db.mongo
+	client=/snap/bin/juju-db.mongo
 elif [[ -f /usr/lib/juju/mongo*/bin/mongo ]]; then
-    client=/usr/lib/juju/mongo*/bin/mongo
+	client=/usr/lib/juju/mongo*/bin/mongo
 else
-    client=/usr/bin/mongo
+	client=/usr/bin/mongo
 fi
 
 certs=--tlsAllowInvalidCertificates
 if sudo test -f /var/snap/juju-db/common/ca.crt; then
-    certs="--tlsCertificateKeyFile=/var/snap/juju-db/common/server.pem --tlsCAFile=/var/snap/juju-db/common/ca.crt"
+	certs="--tlsCertificateKeyFile=/var/snap/juju-db/common/server.pem --tlsCAFile=/var/snap/juju-db/common/ca.crt"
 fi
 
-exec sudo ${client} localhost:37017/juju \
-    --authenticationDatabase admin \
-    --tls \
-    ${certs} \
-    --username "${user}" --password "${password}"
+temp_dir=/tmp
+if [[ "${client}" == "/snap/bin/juju-db.mongo" ]]; then
+	temp_dir=/var/snap/juju-db/common
+fi
+user_file=""
+password_file=""
+cleanup() {
+	if [[ -n "${user_file}" ]] && sudo test -f "${user_file}"; then
+		sudo truncate -s 0 "${user_file}" || true
+		sudo rm -f "${user_file}" || true
+	fi
+	if [[ -n "${password_file}" ]] && sudo test -f "${password_file}"; then
+		sudo truncate -s 0 "${password_file}" || true
+		sudo rm -f "${password_file}" || true
+	fi
+}
+trap '{ set +ex; } 2>/dev/null; cleanup' EXIT
+
+user_file=$(sudo mktemp -p "${temp_dir}" mongo-user.XXXXXX)
+password_file=$(sudo mktemp -p "${temp_dir}" mongo-password.XXXXXX)
+
+sudo awk '/^tag:/ {print $2}' ${conf} | sudo tee "${user_file}" >/dev/null
+sudo awk '/^statepassword:/ {print $2}' ${conf} | sudo tee "${password_file}" >/dev/null
+sudo chown root:root "${user_file}" "${password_file}"
+sudo chmod 600 "${user_file}" "${password_file}"
+if ! sudo test -s "${user_file}"; then
+	echo "tag not found in ${conf}"
+	exit 2
+fi
+if ! sudo test -s "${password_file}"; then
+	echo "statepassword not found in ${conf}"
+	exit 2
+fi
+mongo_auth_js="if (!db.getSiblingDB(\"admin\").auth(cat(\"${user_file}\").trim(), cat(\"${password_file}\").trim())) { print(\"mongo authentication failed\"); quit(3); }"
+
+set -x
+sudo ${client} localhost:37017/juju \
+	--authenticationDatabase admin \
+	--tls \
+	${certs} \
+	--eval "${mongo_auth_js}" \
+	--shell
 EOF
 
 ${juju} ssh --model controller ${machine} "${cmds}"


### PR DESCRIPTION
Some quality of life tweaks to the mongo db connection script.
Includes:
- lint fixes
- use  set -o pipefail  and clearer failure handling
- mongo auth uses script eval
- reduce verbosity of script; users don't need to see the set up commands

## QA steps

`./scripts/mongo-client.sh`