### PR TITLE
refactor(apiserver): build tools URLs with net/url

### DIFF
--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -5,7 +5,7 @@ package common
 
 import (
 	"context"
-	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -406,15 +406,7 @@ func (t *toolsURLGetter) ToolsURLs(ctx context.Context, v semversion.Binary) ([]
 	}
 	var urls []string
 	for _, addr := range addrs {
-		serverRoot := fmt.Sprintf("https://%s/model/%s", addr, t.modelUUID)
-		url := ToolsURL(serverRoot, v.String())
-		urls = append(urls, url)
+		urls = append(urls, (&url.URL{Scheme: "https", Host: addr}).JoinPath("model", t.modelUUID, "tools", v.String()).String())
 	}
 	return urls, nil
-}
-
-// ToolsURL returns a tools URL pointing the API server
-// specified by the "serverRoot".
-func ToolsURL(serverRoot string, v string) string {
-	return fmt.Sprintf("%s/tools/%s", serverRoot, v)
 }

--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -6,6 +6,8 @@ package common_test
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"path"
 	"strings"
 	"testing"
 
@@ -345,4 +347,36 @@ func (s *getUrlSuite) TestToolsURLGetter(c *tc.C) {
 	c.Assert(urls, tc.DeepEquals, []string{
 		"https://0.1.2.3:1234/model/my-uuid/tools/" + current.String(),
 	})
+}
+
+// TestToolsURLGetterPlusInPathSegment asserts that a "+" in the version string
+// is emitted literally in the tools URL path.
+func (s *getUrlSuite) TestToolsURLGetterPlusInPathSegment(c *tc.C) {
+	defer s.setup(c).Finish()
+
+	addrs := []string{"0.1.2.3:1234"}
+	s.apiHostPortsGetter.EXPECT().GetAllAPIAddressesForAgents(gomock.Any()).Return(addrs, nil)
+
+	// Release is stored verbatim on Binary, so it can carry a "+" directly.
+	vers := semversion.Binary{
+		Number:  semversion.MustParse("4.0.0"),
+		Release: "ubuntu+lts",
+		Arch:    "amd64",
+	}
+	c.Assert(vers.String(), tc.Equals, "4.0.0-ubuntu+lts-amd64")
+
+	g := common.NewToolsURLGetter("my-uuid", s.apiHostPortsGetter)
+	urls, err := g.ToolsURLs(c.Context(), vers)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(urls, tc.HasLen, 1)
+
+	c.Check(urls[0], tc.Equals,
+		"https://0.1.2.3:1234/model/my-uuid/tools/4.0.0-ubuntu+lts-amd64")
+	// Query-style encoding would have produced "%2B" here.
+	c.Check(strings.Contains(urls[0], "%2B"), tc.IsFalse)
+
+	// A client parsing the URL must recover the exact version string.
+	parsed, err := url.Parse(urls[0])
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(path.Base(parsed.Path), tc.Equals, vers.String())
 }

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -368,25 +368,32 @@ func (h *toolsUploadHandler) processPost(r *http.Request) (tools.Tools, error) {
 		return tools.Tools{}, internalerrors.Capture(err)
 	}
 
-	serverRoot, err := h.getServerRoot(r, query)
+	serverRoot, err := h.getServerRoot(r)
 	if err != nil {
 		return tools.Tools{}, internalerrors.Capture(err)
 	}
 
 	return tools.Tools{
 		Version: parsedBinaryVersion,
-		URL:     common.ToolsURL(serverRoot, parsedBinaryVersion.String()),
+		URL:     serverRoot.JoinPath("tools", parsedBinaryVersion.String()).String(),
 		SHA256:  sha,
 		Size:    size,
 	}, nil
 }
 
-func (h *toolsUploadHandler) getServerRoot(r *http.Request, query url.Values) (string, error) {
+func (h *toolsUploadHandler) getServerRoot(r *http.Request) (*url.URL, error) {
 	modelUUID, valid := httpcontext.RequestModelUUID(r.Context())
 	if !valid {
-		return "", errors.BadRequestf("invalid model UUID")
+		return nil, errors.BadRequestf("invalid model UUID")
 	}
-	return fmt.Sprintf("https://%s/model/%s", r.Host, modelUUID), nil
+
+	u := &url.URL{
+		Scheme: "https",
+		Host:   r.Host,
+		Path:   "/model/" + modelUUID,
+	}
+
+	return u, nil
 }
 
 // handleUpload uploads the tools data from the reader to env storage as the specified version.

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -248,3 +248,50 @@ func (s *toolsSuite) TestUploadAgentBinary(c *tc.C) {
 		Size:    9,
 	})
 }
+
+// TestUploadAgentBinaryPlusInPathSegment asserts that a "+" in the uploaded
+// binary version appears literally in the tools URL returned to the client.
+func (s *toolsSuite) TestUploadAgentBinaryPlusInPathSegment(c *tc.C) {
+	defer s.SetUpMocks(c).Finish()
+
+	body := strings.NewReader("123456789")
+	handler := newToolsUploadHandler(s.blockCheckGetter, s.agentBinaryStoreGetter)
+	res := httptest.NewRecorder()
+	// "%2B" in the query decodes to a literal "+" in the release component.
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"https://10.0.0.1:17070/tools?binaryVersion=4.0.0-ubuntu%2Blts-amd64",
+		body,
+	)
+	req.Header.Add("Content-Type", "application/x-tar-gz")
+
+	modelUUID := tc.Must0(c, coremodel.NewUUID)
+	ctx := httpcontext.SetContextModelUUID(req.Context(), modelUUID)
+	req = req.WithContext(ctx)
+
+	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil)
+	s.agentBinaryStore.EXPECT().AddAgentBinaryWithSHA256(
+		gomock.Any(),
+		gomock.Any(),
+		coreagentbinary.Version{
+			Number: semversion.MustParse("4.0.0"),
+			Arch:   corearch.AMD64,
+		},
+		int64(9),
+		"15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+	).Return(nil)
+
+	handler.ServeHTTP(res, req)
+
+	toolsResponse := s.assertResponse(c, res.Result(), http.StatusOK)
+	c.Assert(toolsResponse.Error, tc.IsNil)
+	c.Assert(toolsResponse.ToolsList, tc.HasLen, 1)
+
+	agentTools := toolsResponse.ToolsList[0]
+	c.Check(agentTools.Version, tc.Equals, semversion.MustParseBinary("4.0.0-ubuntu+lts-amd64"))
+	c.Check(agentTools.URL, tc.Equals, fmt.Sprintf(
+		"https://10.0.0.1:17070/model/%s/tools/4.0.0-ubuntu+lts-amd64", modelUUID,
+	))
+	// Query-style encoding would have produced "%2B" here.
+	c.Check(strings.Contains(agentTools.URL, "%2B"), tc.IsFalse)
+}


### PR DESCRIPTION
Replace fmt.Sprintf string formatting with the `net/url` package when building agent binary (tools) URLs. The upload handler and the tools URL getter now assemble a `url.URL` and append path segments through JoinPath.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
`go test -race ./apiserver/ ./apiserver/common/`

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes
N/A
<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22910.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10172](https://warthogs.atlassian.net/browse/JUJU-10172)


[JUJU-10172]: https://warthogs.atlassian.net/browse/JUJU-10172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ