### PR TITLE
chore: add lxd server vulnerability to ignore list

### DIFF
--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -151,6 +151,9 @@ run_govulncheck() {
 		# LXD daemon vulnerability not client
 		# https://pkg.go.dev/vuln/GO-2026-4595
 		"GO-2026-4595"
+		# LXD daemon vulnerability not client
+		# https://pkg.go.dev/vuln/GO-2026-5306
+		"GO-2026-5306"
 	)
 	ignoreMatcher=$(join "|" "${ignore[@]}")
 


### PR DESCRIPTION
**[GO-2026-5306 (CVE-2026-34179)](https://pkg.go.dev/vuln/GO-2026-5306) — Safe
to ignore in Juju.** This is a server-side privilege escalation in the LXD
daemon's certificate update handler. Juju does not run an LXD server; it
imports the LXD module solely as a client library to communicate with
externally-managed LXD instances. Since the vulnerable code path is never
executed by Juju, the dependency poses no risk.


## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

## Documentation changes

## Links
