### PR TITLE
fix: use the correct tag when removing offer artefacts from state

### DIFF
--- a/docs/releasenotes/juju_3.6.x.md
+++ b/docs/releasenotes/juju_3.6.x.md
@@ -443,6 +443,10 @@ You can still bootstrap to an older agent version by explicitly allowing the old
 
 `juju bootstrap lxd --agent-version 3.6.14 --config juju-db-snap-channel 4.4/stable`
 
+**Note:** because the default value of the `juju-db-snap-channel` config is now `4.4.30/stable`, if
+you rely on a snap store proxy to serve snaps to Juju, you will need to seed the store with the updated
+juju-db snap version.
+
 #### Other CVEs
 * fix: [CVE-2026-32691](https://github.com/juju/juju/security/advisories/GHSA-gfgr-6hrj-85ww)
 * fix: [CVE-2026-32692](https://github.com/juju/juju/security/advisories/GHSA-89x7-5m5m-mcmm)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/compute v1.64.0

--- a/internal/worker/remoterelations/relationunitsworker.go
+++ b/internal/worker/remoterelations/relationunitsworker.go
@@ -95,8 +95,10 @@ func (w *relationUnitsWorker) loop() error {
 			return w.catacomb.ErrDying()
 		case change, ok := <-w.rrw.Changes():
 			if !ok {
-				// We are dying.
-				return w.catacomb.ErrDying()
+				// The underlying watcher has shut down, typically because
+				// the relation was removed on the remote side.
+				// Exit cleanly - the parent worker will perform cleanup.
+				return nil
 			}
 			w.logger.Debugf("%v relation units changed for %v: %#v", w.mode, w.relationTag, &change)
 			if isEmpty(change) {

--- a/internal/worker/remoterelations/remoterelationsworker.go
+++ b/internal/worker/remoterelations/remoterelationsworker.go
@@ -84,8 +84,10 @@ func (w *remoteRelationsWorker) loop() error {
 
 		case relChanges, ok := <-w.relationsWatcher.Changes():
 			if !ok {
-				// We are dying.
-				return w.catacomb.ErrDying()
+				// The underlying watcher has shut down, typically because
+				// the relation was removed on the remote side.
+				// Exit cleanly - the parent worker will perform cleanup.
+				return nil
 			}
 			if len(relChanges) == 0 {
 				w.logger.Warningf("relation status watcher event with no changes")

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -449,7 +449,7 @@ func (op *RemoveOfferOperation) internalRemove(offer *crossmodel.ApplicationOffe
 		Remove: true,
 	}, decRefOp)
 	r := op.offerStore.st.RemoteEntities()
-	tokenOps := r.removeRemoteEntityOps(names.NewApplicationTag(offer.OfferName))
+	tokenOps := r.removeRemoteEntityOps(names.NewApplicationOfferTag(offer.OfferUUID))
 	ops = append(ops, tokenOps...)
 	return ops, nil
 }

--- a/state/applicationoffers_test.go
+++ b/state/applicationoffers_test.go
@@ -86,7 +86,7 @@ func (s *applicationOffersSuite) TestEndpoints(c *gc.C) {
 func (s *applicationOffersSuite) TestRemove(c *gc.C) {
 	offer := s.createDefaultOffer(c)
 	r := s.State.RemoteEntities()
-	_, err := r.ExportLocalEntity(names.NewApplicationTag(offer.OfferName))
+	_, err := r.ExportLocalEntity(names.NewApplicationOfferTag(offer.OfferUUID))
 	c.Assert(err, jc.ErrorIsNil)
 
 	sd := state.NewApplicationOffers(s.State)
@@ -95,12 +95,40 @@ func (s *applicationOffersSuite) TestRemove(c *gc.C) {
 	_, err = sd.ApplicationOffer(offer.OfferName)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
-	_, err = r.GetToken(names.NewApplicationTag(offer.OfferName))
+	_, err = r.GetToken(names.NewApplicationOfferTag(offer.OfferUUID))
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 
 	userPerms, err := s.State.GetOfferUsers(offer.OfferUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(userPerms, gc.HasLen, 0)
+}
+
+// TestRemoveKeepsSameNamedApplicationEntity ensures that removing an offer does
+// not delete the remote entity for an application that shares the offer's name.
+func (s *applicationOffersSuite) TestRemoveKeepsSameNamedApplicationEntity(c *gc.C) {
+	sd := state.NewApplicationOffers(s.State)
+	owner := s.Factory.MakeUser(c, nil)
+	offer, err := sd.AddOffer(crossmodel.AddApplicationOfferArgs{
+		OfferName:              "mysql",
+		ApplicationName:        "mysql",
+		ApplicationDescription: "mysql is a db server",
+		Endpoints:              map[string]string{"db": "server"},
+		Owner:                  owner.Name(),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	r := s.State.RemoteEntities()
+	// Simulate the mysql application being a cross-model consumer.
+	appToken, err := r.ExportLocalEntity(names.NewApplicationTag("mysql"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = sd.Remove(offer.OfferName, false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The application entity (and its token) must survive offer removal.
+	gotToken, err := r.GetToken(names.NewApplicationTag("mysql"))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(gotToken, gc.Equals, appToken)
 }
 
 func (s *applicationOffersSuite) TestAddApplicationOffer(c *gc.C) {

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -1019,6 +1019,55 @@ func (s *remoteApplicationSuite) TestDestroyAlsoDeletesSecretConsumerInfo(c *gc.
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
+func (s *remoteApplicationSuite) TestDestroyDoesNotDeletePrefixNamedConsumerInfo(c *gc.C) {
+	ch := s.AddTestingCharm(c, "wordpress")
+	app := s.AddTestingApplication(c, "another", ch)
+	store := state.NewSecrets(s.State)
+	uri := secrets.NewURI()
+	cp := state.CreateSecretParams{
+		Version: 1,
+		Owner:   app.Tag(),
+		UpdateSecretParams: state.UpdateSecretParams{
+			LeaderToken: &fakeToken{},
+			Label:       ptr("label"),
+			Data:        map[string]string{"foo": "bar"},
+		},
+	}
+	_, err := store.CreateSecret(uri, cp)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Remote consumer records for the application being destroyed ("mysql").
+	err = s.State.SaveSecretRemoteConsumer(uri, s.application.Tag(), &secrets.SecretConsumerMetadata{CurrentRevision: 1})
+	c.Assert(err, jc.ErrorIsNil)
+	destroyedUnit := names.NewUnitTag(s.application.Name() + "/0")
+	err = s.State.SaveSecretRemoteConsumer(uri, destroyedUnit, &secrets.SecretConsumerMetadata{CurrentRevision: 1})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Remote consumer records for a different application whose name has
+	// "mysql" as a prefix.
+	siblingApp := names.NewApplicationTag("mysql-root")
+	siblingUnit := names.NewUnitTag("mysql-root/0")
+	err = s.State.SaveSecretRemoteConsumer(uri, siblingApp, &secrets.SecretConsumerMetadata{CurrentRevision: 1})
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.State.SaveSecretRemoteConsumer(uri, siblingUnit, &secrets.SecretConsumerMetadata{CurrentRevision: 1})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.application.Destroy()
+	c.Assert(err, jc.ErrorIsNil)
+
+	// The destroyed application's records are gone.
+	_, err = s.State.GetSecretRemoteConsumer(uri, s.application.Tag())
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	_, err = s.State.GetSecretRemoteConsumer(uri, destroyedUnit)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+
+	// The prefix-named application's records survive.
+	_, err = s.State.GetSecretRemoteConsumer(uri, siblingApp)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.State.GetSecretRemoteConsumer(uri, siblingUnit)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *remoteApplicationSuite) TestDestroyAlsoDeletesSecretPermissions(c *gc.C) {
 	wpEP := []charm.Relation{
 		{Name: "db", Interface: "mysql", Role: charm.RoleRequirer, Scope: charm.ScopeGlobal},

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -2361,7 +2361,8 @@ func (st *State) removeRemoteSecretConsumer(appName string) error {
 	}
 	defer closer()
 
-	match := fmt.Sprintf("(unit|application)-%s(\\/\\d)?", appName)
+	quoted := regexp.QuoteMeta(appName)
+	match := fmt.Sprintf("^(application-%s|unit-%s-[0-9]+)$", quoted, quoted)
 	q := bson.D{{"consumer-tag", bson.D{{"$regex", match}}}}
 	_, err = secretConsumersCollection.Writeable().RemoveAll(q)
 	return err

--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -73,6 +73,109 @@ run_offer_consume() {
 	destroy_model "model-consume"
 }
 
+# This test is for an edge case observed in a Sunbeam deployment (but it could
+# happen in any Juju deployment).
+# Test charms to reproduce the exact scenario don't exist in the charmstore,
+# but an equivalent scenario can be set up using  juju-qa-dummy-source and
+# juju-qa-dummy-sink. A single application in model "yang" (dummy-sink) both:
+#   - consumes an offer from yin (direction 1: yin.dummy-source is offered as
+#     src-offer, and yang.dummy-sink relates to it);
+#   - shares its name with an offer created in yang (direction 2: yang offers
+#     yang.alpha:source as "dummy-sink", consumed by yin.yin-src).
+run_offer_consume_same_app() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# The following ensures that a bootstrap juju exists.
+	file="${TEST_DIR}/test-offer-consume-same-app.log"
+	ensure "yin" "${file}"
+
+	echo "Deploy applications in yin and create the offer"
+	# NB: the dummy-sink charm hard codes reading the token from dummy-source/0,
+	# so the offered token source must keep the name dummy-source.
+	juju deploy juju-qa-dummy-source dummy-source --series jammy
+	# yin-src consumes yang's colliding name offer (direction 2).
+	juju deploy juju-qa-dummy-source yin-src --series jammy
+	juju offer dummy-source:sink src-offer
+
+	wait_for "idle" '.applications["dummy-source"].units["dummy-source/0"]."juju-status".current'
+	wait_for "idle" '.applications["yin-src"].units["yin-src/0"]."juju-status".current'
+
+	echo "Deploy applications in yang"
+	juju add-model yang
+	# dummy-sink is the local consumer whose name will collide with the
+	# direction 2 offer.
+	juju deploy juju-qa-dummy-sink dummy-sink --series jammy
+	# alpha's source endpoint is offered back to yin as dummy-sink.
+	juju deploy juju-qa-dummy-sink alpha --series jammy
+	wait_for "idle" '.applications["dummy-sink"].units["dummy-sink/0"]."juju-status".current'
+	wait_for "idle" '.applications["alpha"].units["alpha/0"]."juju-status".current'
+
+	echo "direction 1: yang.dummy-sink consumes yin.src-offer"
+	juju consume -m yang yin.src-offer
+	juju relate -m yang dummy-sink src-offer
+	juju switch yang
+	wait_for "src-offer" '.applications["dummy-sink"] | .relations.source[0]'
+
+	echo "Verify direction 1: token propagates yin -> yang (phase-one)"
+	juju switch yin
+	juju config dummy-source token=phase-one
+	juju switch yang
+	wait_for "phase-one" '.applications["dummy-sink"].units["dummy-sink/0"]."workload-status".message'
+
+	echo "direction 2: yang offers alpha:source as the colliding name dummy-sink"
+	juju offer yang.alpha:source dummy-sink
+	juju consume -m yin yang.dummy-sink
+	juju relate -m yin yin-src:sink dummy-sink
+	juju switch yin
+	wait_for "dummy-sink" '.applications["yin-src"] | .relations.sink[0]'
+
+	echo "Remove direction 2 relation and offer"
+	juju remove-relation -m yin yin-src:sink dummy-sink
+	juju remove-saas -m yin dummy-sink
+	juju switch yang
+	wait_for null '.offers["dummy-sink"]."total-connected-count"'
+	juju remove-offer yang.dummy-sink -y
+	wait_for null '.offers["dummy-sink"]'
+
+	echo "Add direction 2 back"
+	juju offer yang.alpha:source dummy-sink
+	juju consume -m yin yang.dummy-sink
+	juju relate -m yin yin-src:sink dummy-sink
+	juju switch yin
+	wait_for "dummy-sink" '.applications["yin-src"] | .relations.sink[0]'
+
+	echo "Check direction 1's relation data still flows after adding back the relation"
+	juju config dummy-source token=phase-two
+	juju switch yang
+	wait_for "phase-two" '.applications["dummy-sink"].units["dummy-sink/0"]."workload-status".message'
+
+	echo "tear down direction 1 and confirm yin's offer connection drains"
+	# This is the closest reliable observation possible with the dummy charms.
+	# This check will need to be re-written if the dummy charms ever change.
+	juju remove-relation -m yang dummy-sink src-offer
+	juju remove-saas -m yang src-offer
+	juju switch yin
+	# "Short" timeout so the failure can surface asap.
+	if ! (wait_for null '.offers["src-offer"]."total-connected-count"' 180); then
+		echo "remove-offer yang.dummy-sink did not drain the connection count in 3 minutes"
+		exit 1
+	fi
+	juju remove-offer yin.src-offer -y
+	wait_for null '.offers["src-offer"]'
+
+	echo "Clean up remaining direction 2 state before destroying models"
+	juju remove-relation -m yin yin-src:sink dummy-sink
+	juju remove-saas -m yin dummy-sink
+	juju switch yang
+	wait_for null '.offers["dummy-sink"]."total-connected-count"'
+	juju remove-offer yang.dummy-sink -y
+	wait_for null '.offers["dummy-sink"]'
+
+	destroy_model "yang"
+	destroy_model "yin"
+}
+
 # Previous test's features will be run on multiple controllers
 # where each controller is in a different cloud.
 run_offer_consume_cross_controller() {
@@ -271,6 +374,7 @@ test_offer_consume() {
 		cd .. || exit
 
 		run "run_offer_consume"
+		run "run_offer_consume_same_app"
 		run "run_offer_consume_cross_controller"
 	)
 }

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -64,7 +64,9 @@ run_govulncheck() {
 		"GO-2025-3798"
 		# LXD daemon vulnerability not client
 		# https://pkg.go.dev/vuln/GO-2026-4595
+		# https://pkg.go.dev/vuln/GO-2026-5306
 		"GO-2026-4595"
+		"GO-2026-5306"
 	)
 	ignoreMatcher=$(join "|" "${ignore[@]}")
 


### PR DESCRIPTION
This PR fixes an edge case with an application serving an offer and there being a consumed app with the same SAAS name in the model. To trigger the bug, you remove the offer, which deletes the cross model metadata keyed on the offer name instead of the offer uuid. The deletes the wrong records and things stay broken even when the offer and relation are added back again.

The issue was observed on Sunbeam. The cinder-volume app (in the openstack-machines model) is the one with the dual purpose described above: it offers storage-backend (consumed by k8s cinder), and it consumes database and identity-credentials from k8s (cinder-volume-mysql-router and keystone). Following the repro steps in the bug:
```
#Manually remove CMR integration and offer
juju remove-relation -m openstack cinder:storage-backend cinder-volume:storage-backend
juju remove-saas -m openstack cinder-volume
juju remove-offer admin/openstack-machines.cinder-volume
#Create the offer and integration back
juju switch admin/openstack-machines
juju offer admin/openstack-machines.cinder-volume:storage-backend cinder-volume
juju consume -m openstack admin/openstack-machines.cinder-volume cinder-volume
juju integrate -m openstack cinder:storage-backend cinder-volume:storage-backend
```

the end result is that secret grants are incorrectly removed.

The fix is simple: fix the arg passed to `removeRemoteEntityOps`
`removeRemoteEntityOps(names.NewApplicationOfferTag(offer.OfferUUID))`

There are also a few drive by fixes I discovered when looking through logs and reading the code to diagnose the main issue:
- some child remote relations workers were exiting with ErrDying instead of nil, resulting in a `bad catacomb ErrDying: still alive` error
- removing a remote secret consumer was not properly pinning the regexp

Also includes a drive by release notes tweak.

## QA steps

A shell test is added to set up the edge case scenario using the dummy test charms.

`./main.sh cmr`

## Links

**Issue:** Fixes #23015.

**Jira card:** [JUJU-10126](https://warthogs.atlassian.net/browse/JUJU-10126)


[JUJU-10126]: https://warthogs.atlassian.net/browse/JUJU-10126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ