### PR TITLE
fix(azure): destroy-controller fails to delete resources in shared resource groups

### DIFF
--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -2122,14 +2122,19 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.Context, resourceGro
 
 	// Find all the resources tagged as belonging to this model.
 	filter := fmt.Sprintf("tagName eq '%s' and tagValue eq '%s'", tags.JujuModel, env.config.UUID())
-	resourceItems, err := env.getModelResources(ctx, resourceGroup, filter)
+	resourceItems, err := env.getModelResources(ctx, resourceGroup, filter, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	// Older APIs can ignore the filter above, so query the hard way just in case.
+	var apiVersions map[string]string
 	if len(resourceItems) == 0 {
-		resourceItems, err = env.getModelResources(ctx, resourceGroup, "")
+		apiVersions, err = env.resourceAPIVersions(ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		resourceItems, err = env.getModelResources(ctx, resourceGroup, "", apiVersions)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -2171,12 +2176,19 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.Context, resourceGro
 		return errors.Annotatef(err, "deleting machine instances %q", instIds)
 	}
 
+	if len(otherResources) > 0 && apiVersions == nil {
+		apiVersions, err = env.resourceAPIVersions(ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	// Loop until all remaining resources are deleted.
 	// For safety, add an upper retry limit; in reality, this will never be hit.
 	remainingResources := otherResources
 	retries := 0
 	for len(remainingResources) > 0 && retries < 10 {
-		remainingResources, err = env.deleteResources(ctx, remainingResources)
+		remainingResources, err = env.deleteResources(ctx, remainingResources, apiVersions)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -2195,7 +2207,7 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.Context, resourceGro
 	return nil
 }
 
-func (env *azureEnviron) getModelResources(ctx context.Context, resourceGroup, modelFilter string) ([]*armresources.GenericResourceExpanded, error) {
+func (env *azureEnviron) getModelResources(ctx context.Context, resourceGroup, modelFilter string, apiVersions map[string]string) ([]*armresources.GenericResourceExpanded, error) {
 	resources, err := env.resourcesClient()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -2213,7 +2225,11 @@ func (env *azureEnviron) getModelResources(ctx context.Context, resourceGroup, m
 			// If no modelFilter specified, we need to check that the resource
 			// belongs to this model.
 			if modelFilter == "" {
-				fullRes, err := resources.GetByID(ctx, toValue(res.ID), computeAPIVersion, nil)
+				apiVersion, ok := apiVersions[toValue(res.Type)]
+				if !ok {
+					return nil, errors.Errorf("no API version found for resource type %q", toValue(res.Type))
+				}
+				fullRes, err := resources.GetByID(ctx, toValue(res.ID), apiVersion, nil)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
@@ -2227,9 +2243,17 @@ func (env *azureEnviron) getModelResources(ctx context.Context, resourceGroup, m
 	return resourceItems, nil
 }
 
+func (env *azureEnviron) resourceAPIVersions(ctx context.Context) (map[string]string, error) {
+	providers, err := env.providersClient()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return env.collectAPIVersions(ctx, providers)
+}
+
 // deleteResources deletes the specified resources, returning any that
 // cannot be deleted because they are in use.
-func (env *azureEnviron) deleteResources(ctx context.Context, toDelete []*armresources.GenericResourceExpanded) ([]*armresources.GenericResourceExpanded, error) {
+func (env *azureEnviron) deleteResources(ctx context.Context, toDelete []*armresources.GenericResourceExpanded, apiVersions map[string]string) ([]*armresources.GenericResourceExpanded, error) {
 	logger.Debugf(ctx, "deleting %d resources", len(toDelete))
 
 	// Each goroutine below writes to its own pre-sized slice index
@@ -2241,16 +2265,21 @@ func (env *azureEnviron) deleteResources(ctx context.Context, toDelete []*armres
 	deleteResults := make([]error, len(toDelete))
 	for i, res := range toDelete {
 		id := toValue(res.ID)
+		apiVersion, ok := apiVersions[toValue(res.Type)]
+		if !ok {
+			deleteResults[i] = errors.Errorf("no API version found for resource type %q", toValue(res.Type))
+			continue
+		}
 		logger.Debugf(ctx, "- deleting resource %q", id)
 		wg.Add(1)
-		go func(i int, id string) {
+		go func(i int, id, apiVersion string) {
 			defer wg.Done()
 			resources, err := env.resourcesClient()
 			if err != nil {
 				deleteResults[i] = err
 				return
 			}
-			poller, err := resources.BeginDeleteByID(ctx, id, computeAPIVersion, nil)
+			poller, err := resources.BeginDeleteByID(ctx, id, apiVersion, nil)
 			if err == nil {
 				_, err = poller.PollUntilDone(ctx, nil)
 			}
@@ -2266,7 +2295,7 @@ func (env *azureEnviron) deleteResources(ctx context.Context, toDelete []*armres
 				}
 				return
 			}
-		}(i, id)
+		}(i, id, apiVersion)
 	}
 
 	// NOTE (stickupkid): This *could* block forever. Instead we should

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -2011,7 +2011,7 @@ func (env *azureEnviron) deleteControllerManagedIdentities(ctx context.Context, 
 		return errors.Trace(err)
 	}
 	_, err = clientFactory.NewUserAssignedIdentitiesClient().Delete(ctx, env.resourceGroup, identityName, nil)
-	if !errorutils.IsNotFoundError(err) {
+	if err != nil && !errorutils.IsNotFoundError(err) {
 		logger.Warningf(ctx, "cannot delete managed identity %q: %v", identityName, err)
 	}
 
@@ -2119,7 +2119,7 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.Context, resourceGro
 
 	// Older APIs can ignore the filter above, so query the hard way just in case.
 	if len(resourceItems) == 0 {
-		resourceItems, err = env.getModelResources(ctx, resourceGroup, filter)
+		resourceItems, err = env.getModelResources(ctx, resourceGroup, "")
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -2222,7 +2222,11 @@ func (env *azureEnviron) getModelResources(ctx context.Context, resourceGroup, m
 func (env *azureEnviron) deleteResources(ctx context.Context, toDelete []*armresources.GenericResourceExpanded) ([]*armresources.GenericResourceExpanded, error) {
 	logger.Debugf(ctx, "deleting %d resources", len(toDelete))
 
-	var remainingResources []*armresources.GenericResourceExpanded
+	// Each goroutine below writes to its own pre-sized slice index
+	// so that the shared remainingResources is race-free without a mutex.
+	// This follows the same index-addressed pattern used by cancelResults
+	// in StopInstances and errs in deleteControllerManagedResourceGroups.
+	var remainingResources = make([]*armresources.GenericResourceExpanded, len(toDelete))
 	var wg sync.WaitGroup
 	deleteResults := make([]error, len(toDelete))
 	for i, res := range toDelete {
@@ -2246,7 +2250,7 @@ func (env *azureEnviron) deleteResources(ctx context.Context, toDelete []*armres
 				}
 				// If the resource is in use, don't error, just queue it up for another pass.
 				if strings.HasPrefix(errorutils.ErrorCode(err), "InUse") {
-					remainingResources = append(remainingResources, toDelete[i])
+					remainingResources[i] = toDelete[i]
 				} else {
 					deleteResults[i] = errors.Annotatef(err, "deleting resource %q: %v", id, err)
 				}
@@ -2260,6 +2264,14 @@ func (env *azureEnviron) deleteResources(ctx context.Context, toDelete []*armres
 	// context is cancelled.
 	wg.Wait()
 
+	// Compact the pre-sized slice to remove nil entries before returning.
+	remaining := make([]*armresources.GenericResourceExpanded, 0, len(remainingResources))
+	for _, res := range remainingResources {
+		if res != nil {
+			remaining = append(remaining, res)
+		}
+	}
+
 	var errStrings []string
 	for i, err := range deleteResults {
 		if err != nil && !errors.Is(err, errors.NotFound) {
@@ -2270,7 +2282,7 @@ func (env *azureEnviron) deleteResources(ctx context.Context, toDelete []*armres
 	if len(errStrings) > 0 {
 		return nil, errors.Annotate(errors.New(strings.Join(errStrings, "\n")), "deleting resources")
 	}
-	return remainingResources, nil
+	return remaining, nil
 }
 
 // Provider is specified in the Environ interface.

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -2120,20 +2120,20 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.Context, resourceGro
 		_, err = env.MaybeInvalidateCredentialError(ctx, err)
 	}()
 
+	apiVersions, err := env.resourceAPIVersions(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	// Find all the resources tagged as belonging to this model.
 	filter := fmt.Sprintf("tagName eq '%s' and tagValue eq '%s'", tags.JujuModel, env.config.UUID())
-	resourceItems, err := env.getModelResources(ctx, resourceGroup, filter, nil)
+	resourceItems, err := env.getModelResources(ctx, resourceGroup, filter, apiVersions)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	// Older APIs can ignore the filter above, so query the hard way just in case.
-	var apiVersions map[string]string
 	if len(resourceItems) == 0 {
-		apiVersions, err = env.resourceAPIVersions(ctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
 		resourceItems, err = env.getModelResources(ctx, resourceGroup, "", apiVersions)
 		if err != nil {
 			return errors.Trace(err)
@@ -2176,13 +2176,6 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.Context, resourceGro
 		return errors.Annotatef(err, "deleting machine instances %q", instIds)
 	}
 
-	if len(otherResources) > 0 && apiVersions == nil {
-		apiVersions, err = env.resourceAPIVersions(ctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-
 	// Loop until all remaining resources are deleted.
 	// For safety, add an upper retry limit; in reality, this will never be hit.
 	remainingResources := otherResources
@@ -2207,7 +2200,9 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.Context, resourceGro
 	return nil
 }
 
-func (env *azureEnviron) getModelResources(ctx context.Context, resourceGroup, modelFilter string, apiVersions map[string]string) ([]*armresources.GenericResourceExpanded, error) {
+func (env *azureEnviron) getModelResources(
+	ctx context.Context, resourceGroup, modelFilter string, apiVersions map[string]string,
+) ([]*armresources.GenericResourceExpanded, error) {
 	resources, err := env.resourcesClient()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -1941,7 +1941,8 @@ func (env *azureEnviron) DestroyController(ctx context.Context, controllerUUID s
 		return errors.Trace(err)
 	}
 	// Resource groups are self-contained and fully encompass
-	// all environ armresources. Once you delete the group, there
+	// all environ armresources. Once the group has been deleted,
+	// or its contents cleaned up for a user-specified group, there
 	// is nothing else to do.
 	return nil
 }
@@ -2208,9 +2209,13 @@ func (env *azureEnviron) getModelResources(
 		return nil, errors.Trace(err)
 	}
 	var resourceItems []*armresources.GenericResourceExpanded
-	pager := resources.NewListByResourceGroupPager(resourceGroup, &armresources.ClientListByResourceGroupOptions{
-		Filter: new(modelFilter),
-	})
+	// If no model filter is specified, omit the $filter query parameter
+	// entirely so the resource group is listed without a filter.
+	listOpts := &armresources.ClientListByResourceGroupOptions{}
+	if modelFilter != "" {
+		listOpts.Filter = new(modelFilter)
+	}
+	pager := resources.NewListByResourceGroupPager(resourceGroup, listOpts)
 	for pager.More() {
 		next, err := pager.NextPage(ctx)
 		if err != nil {
@@ -2286,7 +2291,7 @@ func (env *azureEnviron) deleteResources(ctx context.Context, toDelete []*armres
 				if strings.HasPrefix(errorutils.ErrorCode(err), "InUse") {
 					remainingResources[i] = toDelete[i]
 				} else {
-					deleteResults[i] = errors.Annotatef(err, "deleting resource %q: %v", id, err)
+					deleteResults[i] = errors.Annotatef(err, "deleting resource %q", id)
 				}
 				return
 			}

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -1922,9 +1922,19 @@ func (env *azureEnviron) Destroy(ctx context.Context) error {
 // DestroyController is specified in the Environ interface.
 func (env *azureEnviron) DestroyController(ctx context.Context, controllerUUID string) error {
 	logger.Debugf(ctx, "destroying model %q", env.modelName)
-	logger.Debugf(ctx, "deleting resource groups")
-	if err := env.deleteControllerManagedResourceGroups(ctx, controllerUUID); err != nil {
-		return errors.Trace(err)
+	if env.config.resourceGroupName == "" {
+		logger.Debugf(ctx, "deleting resource groups")
+		if err := env.deleteControllerManagedResourceGroups(ctx, controllerUUID); err != nil {
+			return errors.Trace(err)
+		}
+	} else {
+		// The controller model may live in a user-specified resource group that
+		// is not tagged with the controller UUID, so it is not picked up by
+		// deleteControllerManagedResourceGroups above. Clean its contents here.
+		logger.Debugf(ctx, "deleting resources in user-specified resource group %q", env.resourceGroup)
+		if err := env.deleteResourcesInGroup(ctx, env.resourceGroup); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	logger.Debugf(ctx, "deleting auto managed identities")
 	if err := env.deleteControllerManagedIdentities(ctx, controllerUUID); err != nil {

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/juju/clock/testclock"
-	"github.com/juju/loggo/v3"
+	"github.com/juju/loggo/v2"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 
@@ -2192,6 +2192,7 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *tc.C) {
 	nic0 := makeNetworkInterface("nic-0", "juju-06f00d-0", nic0IPConfiguration)
 
 	s.sender = azuretesting.Senders{
+		makeSender(".*/providers", makeNetworkProviderResult()),                           // GET API versions
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),               // GET
 		makeSenderWithStatus(".*/deployments/juju-06f00d-0/cancel", http.StatusNoContent), // POST
 		s.networkInterfacesSender(nic0),
@@ -2201,7 +2202,6 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *tc.C) {
 		makeSender(".*/networkInterfaces/nic-0", nil),                                                                    // DELETE
 		makeSender(".*/publicIPAddresses/pip-0", nil),                                                                    // DELETE
 		makeSenderWithStatus(".*/deployments/juju-06f00d-0", http.StatusNoContent),                                       // DELETE
-		makeSender(".*/providers", makeNetworkProviderResult()),                                                          // GET
 		s.makeErrorSender("/networkSecurityGroups/nsg-0", newAzureResponseError(c, http.StatusConflict, "InUse", ""), 1), // DELETE
 		makeSender("/networkSecurityGroups/nsg-0", nil),                                                                  // DELETE
 		makeSender(".*/vaults/secret-0", nil),                                                                            // DELETE
@@ -2210,12 +2210,12 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(s.requests, tc.HasLen, 13)
 	c.Assert(s.requests[0].Method, tc.Equals, "GET")
-	c.Assert(s.requests[0].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
+	c.Assert(s.requests[1].Method, tc.Equals, "GET")
+	c.Assert(s.requests[1].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
-	c.Assert(s.requests[8].Method, tc.Equals, "DELETE")
-	c.Assert(s.requests[9].Method, tc.Equals, "GET")
+	c.Assert(s.requests[9].Method, tc.Equals, "DELETE")
 	c.Assert(s.requests[10].Method, tc.Equals, "DELETE")
 	c.Assert(s.requests[11].Method, tc.Equals, "DELETE")
 	c.Assert(s.requests[12].Method, tc.Equals, "DELETE")
@@ -2235,8 +2235,8 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 	// When the tag-filtered list returns nothing, deleteResourcesInGroup must
 	// fall back to listing all resources and filtering client-side by tag.
 	s.sender = azuretesting.Senders{
-		makeSender(".*/resourceGroups/foo/resources.*", armresources.ResourceListResult{}), // GET with filter, empty
 		makeSender(".*/providers", makeNetworkProviderResult()),                            // GET API versions
+		makeSender(".*/resourceGroups/foo/resources.*", armresources.ResourceListResult{}), // GET with filter, empty
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),                // GET without filter
 		makeSender(".*/networkSecurityGroups/nsg-0", armresources.GenericResource{ // GET resource by ID
 			Tags: map[string]*string{tags.JujuModel: new(testing.ModelTag.Id())},
@@ -2247,11 +2247,11 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(s.requests, tc.HasLen, 5)
 	c.Assert(s.requests[0].Method, tc.Equals, "GET")
-	c.Assert(s.requests[0].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
+	c.Assert(s.requests[1].Method, tc.Equals, "GET")
+	c.Assert(s.requests[1].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
-	c.Assert(s.requests[1].Method, tc.Equals, "GET")
 	c.Assert(s.requests[2].Method, tc.Equals, "GET")
 	c.Assert(s.requests[2].URL.Query().Get("$filter"), tc.Equals, "")
 	c.Assert(s.requests[3].Method, tc.Equals, "GET")
@@ -2281,8 +2281,8 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *tc
 	// second pass they succeed. This exercises the concurrent
 	// index-addressed write to remainingResources in deleteResources.
 	s.sender = azuretesting.Senders{
-		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
 		makeSender(".*/providers", makeNetworkProviderResult()),             // GET API versions
+		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
 		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr0, 1),  // DELETE (InUse), pass 1
 		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr1, 1),  // DELETE (InUse), pass 1
 		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
@@ -2363,8 +2363,8 @@ func (s *environSuite) TestDestroyControllerCustomResourceGroup(c *tc.C) {
 	}
 
 	s.sender = azuretesting.Senders{
+		makeSender(".*/providers", makeNetworkProviderResult()),        // GET API versions
 		makeSender(".*/resourceGroups/foo/resources.*", resources),     // GET
-		makeSender(".*/providers", makeNetworkProviderResult()),        // GET
 		makeSender("/networkSecurityGroups/nsg-0", nil),                // DELETE
 		makeSender(".*/roleDefinitions*", nil),                         // GET
 		makeSender(".*/roleAssignments*", nil),                         // GET
@@ -2375,11 +2375,11 @@ func (s *environSuite) TestDestroyControllerCustomResourceGroup(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(s.requests, tc.HasLen, 6)
 	c.Check(s.requests[0].Method, tc.Equals, "GET")
-	c.Check(s.requests[0].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
+	c.Check(s.requests[1].Method, tc.Equals, "GET")
+	c.Check(s.requests[1].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
-	c.Check(s.requests[1].Method, tc.Equals, "GET")
 	c.Check(s.requests[2].Method, tc.Equals, "DELETE")
 	c.Check(s.requests[2].URL.Path, tc.Equals, "/networkSecurityGroups/nsg-0")
 	c.Check(s.requests[2].URL.Query().Get("api-version"), tc.Equals, "2021-12-01")

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2229,23 +2229,31 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 		ID:   new("networkSecurityGroups/nsg-0"),
 		Name: new("nsg-0"),
 		Type: new("Microsoft.Network/networkSecurityGroups"),
+	}, {
+		ID:   new("networkSecurityGroups/nsg-1"),
+		Name: new("nsg-1"),
+		Type: new("Microsoft.Network/networkSecurityGroups"),
 	}}
 	resourceListResult := armresources.ResourceListResult{Value: res}
 
 	// When the tag-filtered list returns nothing, deleteResourcesInGroup must
 	// fall back to listing all resources and filtering client-side by tag.
+	// Only resources tagged as belonging to this model are deleted.
 	s.sender = azuretesting.Senders{
 		makeSender(".*/providers", makeNetworkProviderResult()),                            // GET API versions
 		makeSender(".*/resourceGroups/foo/resources.*", armresources.ResourceListResult{}), // GET with filter, empty
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),                // GET without filter
-		makeSender(".*/networkSecurityGroups/nsg-0", armresources.GenericResource{ // GET resource by ID
+		makeSender(".*/networkSecurityGroups/nsg-0", armresources.GenericResource{ // GET resource by ID (model)
 			Tags: map[string]*string{tags.JujuModel: new(testing.ModelTag.Id())},
+		}),
+		makeSender(".*/networkSecurityGroups/nsg-1", armresources.GenericResource{ // GET resource by ID (foreign model)
+			Tags: map[string]*string{tags.JujuModel: new("00000000-0000-0000-0000-000000000000")},
 		}),
 		makeSender("/networkSecurityGroups/nsg-0", nil), // DELETE
 	}
 	err := env.Destroy(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(s.requests, tc.HasLen, 5)
+	c.Assert(s.requests, tc.HasLen, 6)
 	c.Assert(s.requests[0].Method, tc.Equals, "GET")
 	c.Assert(s.requests[1].Method, tc.Equals, "GET")
 	c.Assert(s.requests[1].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
@@ -2253,10 +2261,13 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 		testing.ModelTag.Id(),
 	))
 	c.Assert(s.requests[2].Method, tc.Equals, "GET")
-	c.Assert(s.requests[2].URL.Query().Get("$filter"), tc.Equals, "")
+	_, hasFilter := s.requests[2].URL.Query()["$filter"]
+	c.Assert(hasFilter, tc.IsFalse)
 	c.Assert(s.requests[3].Method, tc.Equals, "GET")
-	c.Assert(s.requests[4].Method, tc.Equals, "DELETE")
-	c.Assert(s.requests[4].URL.Query().Get("api-version"), tc.Equals, "2021-12-01")
+	c.Assert(s.requests[3].URL.Query().Get("api-version"), tc.Equals, "2021-12-01")
+	c.Assert(s.requests[4].Method, tc.Equals, "GET")
+	c.Assert(s.requests[5].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[5].URL.Query().Get("api-version"), tc.Equals, "2021-12-01")
 }
 
 func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *tc.C) {
@@ -2274,29 +2285,84 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *tc
 	}}
 	resourceListResult := armresources.ResourceListResult{Value: res}
 
-	inUseErr0 := newAzureResponseError(c, http.StatusConflict, "InUse", "in use")
-	inUseErr1 := newAzureResponseError(c, http.StatusConflict, "InUse", "in use")
+	inUseErr := newAzureResponseError(c, http.StatusConflict, "InUse", "in use")
 
-	// Two NSG resources; the first pass both return InUse, the
-	// second pass they succeed. This exercises the concurrent
-	// index-addressed write to remainingResources in deleteResources.
+	// On the first pass one NSG is deleted while the other is in use, so the
+	// pre-sized remainingResources slice contains a nil hole that must be
+	// compacted before the second pass retries the in-use resource. The first
+	// DELETE to arrive returns InUse regardless of which NSG it targets.
 	s.sender = azuretesting.Senders{
 		makeSender(".*/providers", makeNetworkProviderResult()),             // GET API versions
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
-		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr0, 1),  // DELETE (InUse), pass 1
-		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr1, 1),  // DELETE (InUse), pass 1
-		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
+		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr, 1),   // DELETE (InUse), pass 1
+		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 1
 		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
 	}
 	err := env.Destroy(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(s.requests, tc.HasLen, 6)
+	c.Assert(s.requests, tc.HasLen, 5)
 	c.Assert(s.requests[0].Method, tc.Equals, "GET")
 	c.Assert(s.requests[1].Method, tc.Equals, "GET")
 	c.Assert(s.requests[2].Method, tc.Equals, "DELETE")
 	c.Assert(s.requests[3].Method, tc.Equals, "DELETE")
 	c.Assert(s.requests[4].Method, tc.Equals, "DELETE")
-	c.Assert(s.requests[5].Method, tc.Equals, "DELETE")
+}
+
+func (s *environSuite) TestDestroyHostedModelCustomResourceGroupMultipleTypes(c *tc.C) {
+	env := s.openEnviron(c,
+		testing.Attrs{"controller-uuid": uuid.MustNewUUID().String(), "resource-group-name": "foo"})
+
+	res := []*armresources.GenericResourceExpanded{{
+		ID:   new("networkSecurityGroups/nsg-0"),
+		Name: new("nsg-0"),
+		Type: new("Microsoft.Network/networkSecurityGroups"),
+	}, {
+		ID:   new("storageAccounts/sa-0"),
+		Name: new("sa-0"),
+		Type: new("Microsoft.Storage/storageAccounts"),
+	}}
+	resourceListResult := armresources.ResourceListResult{Value: res}
+
+	providers := armresources.ProviderListResult{Value: []*armresources.Provider{{
+		Namespace: new("Microsoft.Network"),
+		ResourceTypes: []*armresources.ProviderResourceType{{
+			ResourceType: new("networkSecurityGroups"),
+			APIVersions:  to.SliceOfPtrs("2021-12-01"),
+		}},
+	}, {
+		Namespace: new("Microsoft.Storage"),
+		ResourceTypes: []*armresources.ProviderResourceType{{
+			ResourceType: new("storageAccounts"),
+			APIVersions:  to.SliceOfPtrs("2023-01-01"),
+		}},
+	}}}
+
+	// The two resources are deleted concurrently, each using the API version
+	// matching its own type.
+	deleteSender := &azuretesting.MockSender{}
+	deleteSender.PathPattern = "(networkSecurityGroups/nsg-0|storageAccounts/sa-0)"
+	deleteSender.AppendResponse(azuretesting.NewResponse()) //nolint:bodyclose
+	deleteSender.AppendResponse(azuretesting.NewResponse()) //nolint:bodyclose
+
+	s.sender = azuretesting.Senders{
+		makeSender(".*/providers", providers),                               // GET API versions
+		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
+		deleteSender,
+	}
+	err := env.Destroy(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(s.requests, tc.HasLen, 4)
+
+	deleteVersions := make(map[string]string)
+	for _, req := range s.requests {
+		if req.Method == "DELETE" {
+			deleteVersions[req.URL.Path] = req.URL.Query().Get("api-version")
+		}
+	}
+	c.Assert(deleteVersions, tc.DeepEquals, map[string]string{
+		"/networkSecurityGroups/nsg-0": "2021-12-01",
+		"/storageAccounts/sa-0":        "2023-01-01",
+	})
 }
 
 func (s *environSuite) TestDestroyHostedModelWithInvalidCredential(c *tc.C) {
@@ -2451,6 +2517,38 @@ func (s *environSuite) TestDestroyControllerManagedIdentityDeleteError(c *tc.C) 
 		}
 	}
 	c.Check(found, tc.IsTrue)
+}
+
+func (s *environSuite) TestDestroyControllerManagedIdentityDeleteNotFound(c *tc.C) {
+	groups := []*armresources.ResourceGroup{{
+		Name: new("group1"),
+	}}
+	result := armresources.ResourceGroupListResult{Value: groups}
+
+	var logWriter loggo.TestWriter
+	writerName := "TestDestroyControllerManagedIdentityDeleteNotFound"
+	c.Assert(loggo.RegisterWriter(writerName, &logWriter), tc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter(writerName)
+	}()
+
+	identityDeleteErr := newAzureResponseError(c, http.StatusNotFound, "NotFound", "not found")
+
+	env := s.openEnviron(c)
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourcegroups", result),                                                // GET
+		makeSender(".*/resourcegroups/group1", nil),                                            // DELETE
+		makeSender(".*/roleDefinitions*", nil),                                                 // GET
+		makeSender(".*/roleAssignments*", nil),                                                 // GET
+		s.makeErrorSender(".*/userAssignedIdentities/juju-controller-*", identityDeleteErr, 1), // DELETE (not found)
+	}
+	err := env.DestroyController(c.Context(), s.controllerUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(s.requests, tc.HasLen, 5)
+
+	for _, entry := range logWriter.Log() {
+		c.Check(entry.Message, tc.Not(tc.Matches), ".*cannot delete managed identity.*")
+	}
 }
 
 func (s *environSuite) TestDestroyControllerWithInvalidCredential(c *tc.C) {

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"path"
 	"reflect"
+	"strings"
 	stdtesting "testing"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/juju/clock/testclock"
+	"github.com/juju/loggo/v3"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 
@@ -2253,6 +2255,44 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 	c.Assert(s.requests[3].Method, tc.Equals, "DELETE")
 }
 
+func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *tc.C) {
+	env := s.openEnviron(c,
+		testing.Attrs{"controller-uuid": uuid.MustNewUUID().String(), "resource-group-name": "foo"})
+
+	res := []*armresources.GenericResourceExpanded{{
+		ID:   new("networkSecurityGroups/nsg-0"),
+		Name: new("nsg-0"),
+		Type: new("Microsoft.Network/networkSecurityGroups"),
+	}, {
+		ID:   new("networkSecurityGroups/nsg-1"),
+		Name: new("nsg-1"),
+		Type: new("Microsoft.Network/networkSecurityGroups"),
+	}}
+	resourceListResult := armresources.ResourceListResult{Value: res}
+
+	inUseErr0 := newAzureResponseError(c, http.StatusConflict, "InUse", "in use")
+	inUseErr1 := newAzureResponseError(c, http.StatusConflict, "InUse", "in use")
+
+	// Two NSG resources; the first pass both return InUse, the
+	// second pass they succeed. This exercises the concurrent
+	// index-addressed write to remainingResources in deleteResources.
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
+		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr0, 1),  // DELETE (InUse), pass 1
+		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr1, 1),  // DELETE (InUse), pass 1
+		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
+		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
+	}
+	err := env.Destroy(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(s.requests, tc.HasLen, 5)
+	c.Assert(s.requests[0].Method, tc.Equals, "GET")
+	c.Assert(s.requests[1].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[2].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[3].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[4].Method, tc.Equals, "DELETE")
+}
+
 func (s *environSuite) TestDestroyHostedModelWithInvalidCredential(c *tc.C) {
 	env := s.openEnviron(c, testing.Attrs{"controller-uuid": uuid.MustNewUUID().String()})
 	s.createSenderWithUnauthorisedStatusCode(c)
@@ -2304,6 +2344,104 @@ func (s *environSuite) TestDestroyController(c *tc.C) {
 	c.Assert(s.requests[4].Method, tc.Equals, "GET")
 	c.Assert(s.requests[5].Method, tc.Equals, "DELETE")
 	c.Assert(path.Base(s.requests[5].URL.Path), tc.Equals, "juju-controller-"+testing.ControllerTag.Id())
+}
+
+func (s *environSuite) TestDestroyControllerCustomResourceGroup(c *tc.C) {
+	env := s.openEnviron(c, testing.Attrs{"resource-group-name": "foo"})
+	resources := armresources.ResourceListResult{
+		Value: []*armresources.GenericResourceExpanded{{
+			ID:   new("networkSecurityGroups/nsg-0"),
+			Name: new("nsg-0"),
+			Type: new("Microsoft.Network/networkSecurityGroups"),
+		}},
+	}
+
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourceGroups/foo/resources.*", resources),     // GET
+		makeSender("/networkSecurityGroups/nsg-0", nil),                // DELETE
+		makeSender(".*/roleDefinitions*", nil),                         // GET
+		makeSender(".*/roleAssignments*", nil),                         // GET
+		makeSender(".*/userAssignedIdentities/juju-controller-*", nil), // DELETE
+	}
+
+	err := env.DestroyController(c.Context(), s.controllerUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(s.requests, tc.HasLen, 5)
+	c.Check(s.requests[0].Method, tc.Equals, "GET")
+	c.Check(s.requests[0].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
+		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
+		testing.ModelTag.Id(),
+	))
+	c.Check(s.requests[1].Method, tc.Equals, "DELETE")
+	c.Check(s.requests[1].URL.Path, tc.Equals, "/networkSecurityGroups/nsg-0")
+}
+
+func (s *environSuite) TestDestroyControllerManagedIdentityDeleteSuccess(c *tc.C) {
+	groups := []*armresources.ResourceGroup{{
+		Name: new("group1"),
+	}}
+	result := armresources.ResourceGroupListResult{Value: groups}
+
+	var logWriter loggo.TestWriter
+	writerName := "TestDestroyControllerManagedIdentityDeleteSuccess"
+	c.Assert(loggo.RegisterWriter(writerName, &logWriter), tc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter(writerName)
+	}()
+
+	env := s.openEnviron(c)
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourcegroups", result),                        // GET
+		makeSender(".*/resourcegroups/group1", nil),                    // DELETE
+		makeSender(".*/roleDefinitions*", nil),                         // GET
+		makeSender(".*/roleAssignments*", nil),                         // GET
+		makeSender(".*/userAssignedIdentities/juju-controller-*", nil), // DELETE (success)
+	}
+	err := env.DestroyController(c.Context(), s.controllerUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(s.requests, tc.HasLen, 5)
+
+	for _, entry := range logWriter.Log() {
+		c.Check(entry.Message, tc.Not(tc.Matches), ".*cannot delete managed identity.*")
+	}
+}
+
+func (s *environSuite) TestDestroyControllerManagedIdentityDeleteError(c *tc.C) {
+	groups := []*armresources.ResourceGroup{{
+		Name: new("group1"),
+	}}
+	result := armresources.ResourceGroupListResult{Value: groups}
+
+	var logWriter loggo.TestWriter
+	writerName := "TestDestroyControllerManagedIdentityDeleteError"
+	c.Assert(loggo.RegisterWriter(writerName, &logWriter), tc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter(writerName)
+	}()
+
+	identityDeleteErr := newAzureResponseError(c, http.StatusForbidden, "Forbidden", "access denied")
+
+	env := s.openEnviron(c)
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourcegroups", result),                                                // GET
+		makeSender(".*/resourcegroups/group1", nil),                                            // DELETE
+		makeSender(".*/roleDefinitions*", nil),                                                 // GET
+		makeSender(".*/roleAssignments*", nil),                                                 // GET
+		s.makeErrorSender(".*/userAssignedIdentities/juju-controller-*", identityDeleteErr, 1), // DELETE (error)
+	}
+	err := env.DestroyController(c.Context(), s.controllerUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(s.requests, tc.HasLen, 5)
+
+	var found bool
+	expectedMsg := `cannot delete managed identity "juju-controller-` + testing.ControllerTag.Id() + `"`
+	for _, entry := range logWriter.Log() {
+		if entry.Level == loggo.WARNING && strings.Contains(entry.Message, expectedMsg) {
+			found = true
+			break
+		}
+	}
+	c.Check(found, tc.IsTrue)
 }
 
 func (s *environSuite) TestDestroyControllerWithInvalidCredential(c *tc.C) {

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2201,23 +2201,24 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *tc.C) {
 		makeSender(".*/networkInterfaces/nic-0", nil),                                                                    // DELETE
 		makeSender(".*/publicIPAddresses/pip-0", nil),                                                                    // DELETE
 		makeSenderWithStatus(".*/deployments/juju-06f00d-0", http.StatusNoContent),                                       // DELETE
+		makeSender(".*/providers", makeNetworkProviderResult()),                                                          // GET
 		s.makeErrorSender("/networkSecurityGroups/nsg-0", newAzureResponseError(c, http.StatusConflict, "InUse", ""), 1), // DELETE
 		makeSender("/networkSecurityGroups/nsg-0", nil),                                                                  // DELETE
 		makeSender(".*/vaults/secret-0", nil),                                                                            // DELETE
 	}
 	err := env.Destroy(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(s.requests, tc.HasLen, 12)
+	c.Assert(s.requests, tc.HasLen, 13)
 	c.Assert(s.requests[0].Method, tc.Equals, "GET")
 	c.Assert(s.requests[0].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
-	c.Assert(s.requests[7].Method, tc.Equals, "DELETE")
 	c.Assert(s.requests[8].Method, tc.Equals, "DELETE")
-	c.Assert(s.requests[9].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[9].Method, tc.Equals, "GET")
 	c.Assert(s.requests[10].Method, tc.Equals, "DELETE")
 	c.Assert(s.requests[11].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[12].Method, tc.Equals, "DELETE")
 }
 
 func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c *tc.C) {
@@ -2235,6 +2236,7 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 	// fall back to listing all resources and filtering client-side by tag.
 	s.sender = azuretesting.Senders{
 		makeSender(".*/resourceGroups/foo/resources.*", armresources.ResourceListResult{}), // GET with filter, empty
+		makeSender(".*/providers", makeNetworkProviderResult()),                            // GET API versions
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),                // GET without filter
 		makeSender(".*/networkSecurityGroups/nsg-0", armresources.GenericResource{ // GET resource by ID
 			Tags: map[string]*string{tags.JujuModel: new(testing.ModelTag.Id())},
@@ -2243,16 +2245,18 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 	}
 	err := env.Destroy(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(s.requests, tc.HasLen, 4)
+	c.Assert(s.requests, tc.HasLen, 5)
 	c.Assert(s.requests[0].Method, tc.Equals, "GET")
 	c.Assert(s.requests[0].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
 	c.Assert(s.requests[1].Method, tc.Equals, "GET")
-	c.Assert(s.requests[1].URL.Query().Get("$filter"), tc.Equals, "")
 	c.Assert(s.requests[2].Method, tc.Equals, "GET")
-	c.Assert(s.requests[3].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[2].URL.Query().Get("$filter"), tc.Equals, "")
+	c.Assert(s.requests[3].Method, tc.Equals, "GET")
+	c.Assert(s.requests[4].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[4].URL.Query().Get("api-version"), tc.Equals, "2021-12-01")
 }
 
 func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *tc.C) {
@@ -2278,6 +2282,7 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *tc
 	// index-addressed write to remainingResources in deleteResources.
 	s.sender = azuretesting.Senders{
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
+		makeSender(".*/providers", makeNetworkProviderResult()),             // GET API versions
 		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr0, 1),  // DELETE (InUse), pass 1
 		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr1, 1),  // DELETE (InUse), pass 1
 		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
@@ -2285,12 +2290,13 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *tc
 	}
 	err := env.Destroy(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(s.requests, tc.HasLen, 5)
+	c.Assert(s.requests, tc.HasLen, 6)
 	c.Assert(s.requests[0].Method, tc.Equals, "GET")
-	c.Assert(s.requests[1].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[1].Method, tc.Equals, "GET")
 	c.Assert(s.requests[2].Method, tc.Equals, "DELETE")
 	c.Assert(s.requests[3].Method, tc.Equals, "DELETE")
 	c.Assert(s.requests[4].Method, tc.Equals, "DELETE")
+	c.Assert(s.requests[5].Method, tc.Equals, "DELETE")
 }
 
 func (s *environSuite) TestDestroyHostedModelWithInvalidCredential(c *tc.C) {
@@ -2358,6 +2364,7 @@ func (s *environSuite) TestDestroyControllerCustomResourceGroup(c *tc.C) {
 
 	s.sender = azuretesting.Senders{
 		makeSender(".*/resourceGroups/foo/resources.*", resources),     // GET
+		makeSender(".*/providers", makeNetworkProviderResult()),        // GET
 		makeSender("/networkSecurityGroups/nsg-0", nil),                // DELETE
 		makeSender(".*/roleDefinitions*", nil),                         // GET
 		makeSender(".*/roleAssignments*", nil),                         // GET
@@ -2366,14 +2373,16 @@ func (s *environSuite) TestDestroyControllerCustomResourceGroup(c *tc.C) {
 
 	err := env.DestroyController(c.Context(), s.controllerUUID)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(s.requests, tc.HasLen, 5)
+	c.Assert(s.requests, tc.HasLen, 6)
 	c.Check(s.requests[0].Method, tc.Equals, "GET")
 	c.Check(s.requests[0].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
-	c.Check(s.requests[1].Method, tc.Equals, "DELETE")
-	c.Check(s.requests[1].URL.Path, tc.Equals, "/networkSecurityGroups/nsg-0")
+	c.Check(s.requests[1].Method, tc.Equals, "GET")
+	c.Check(s.requests[2].Method, tc.Equals, "DELETE")
+	c.Check(s.requests[2].URL.Path, tc.Equals, "/networkSecurityGroups/nsg-0")
+	c.Check(s.requests[2].URL.Query().Get("api-version"), tc.Equals, "2021-12-01")
 }
 
 func (s *environSuite) TestDestroyControllerManagedIdentityDeleteSuccess(c *tc.C) {
@@ -2629,6 +2638,19 @@ func makeProvidersResult() armresources.ProviderListResult {
 		}},
 	}}
 	return armresources.ProviderListResult{Value: providers}
+}
+
+func makeNetworkProviderResult() armresources.ProviderListResult {
+	return armresources.ProviderListResult{Value: []*armresources.Provider{{
+		Namespace: new("Microsoft.Network"),
+		ResourceTypes: []*armresources.ProviderResourceType{{
+			ResourceType: new("networkSecurityGroups"),
+			APIVersions:  to.SliceOfPtrs("2021-12-01"),
+		}, {
+			ResourceType: new("virtualNetworks"),
+			APIVersions:  to.SliceOfPtrs("2021-12-01"),
+		}},
+	}}}
 }
 
 func makeResourcesResult() armresources.ResourceListResult {

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2218,6 +2218,41 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *tc.C) {
 	c.Assert(s.requests[11].Method, tc.Equals, "DELETE")
 }
 
+func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c *tc.C) {
+	env := s.openEnviron(c,
+		testing.Attrs{"controller-uuid": uuid.MustNewUUID().String(), "resource-group-name": "foo"})
+
+	res := []*armresources.GenericResourceExpanded{{
+		ID:   new("networkSecurityGroups/nsg-0"),
+		Name: new("nsg-0"),
+		Type: new("Microsoft.Network/networkSecurityGroups"),
+	}}
+	resourceListResult := armresources.ResourceListResult{Value: res}
+
+	// When the tag-filtered list returns nothing, deleteResourcesInGroup must
+	// fall back to listing all resources and filtering client-side by tag.
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourceGroups/foo/resources.*", armresources.ResourceListResult{}), // GET with filter, empty
+		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),                // GET without filter
+		makeSender(".*/networkSecurityGroups/nsg-0", armresources.GenericResource{ // GET resource by ID
+			Tags: map[string]*string{tags.JujuModel: new(testing.ModelTag.Id())},
+		}),
+		makeSender("/networkSecurityGroups/nsg-0", nil), // DELETE
+	}
+	err := env.Destroy(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(s.requests, tc.HasLen, 4)
+	c.Assert(s.requests[0].Method, tc.Equals, "GET")
+	c.Assert(s.requests[0].URL.Query().Get("$filter"), tc.Equals, fmt.Sprintf(
+		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
+		testing.ModelTag.Id(),
+	))
+	c.Assert(s.requests[1].Method, tc.Equals, "GET")
+	c.Assert(s.requests[1].URL.Query().Get("$filter"), tc.Equals, "")
+	c.Assert(s.requests[2].Method, tc.Equals, "GET")
+	c.Assert(s.requests[3].Method, tc.Equals, "DELETE")
+}
+
 func (s *environSuite) TestDestroyHostedModelWithInvalidCredential(c *tc.C) {
 	env := s.openEnviron(c, testing.Attrs{"controller-uuid": uuid.MustNewUUID().String()})
 	s.createSenderWithUnauthorisedStatusCode(c)


### PR DESCRIPTION
When testing #23031, I found that `juju destroy-controller` left Juju resources
behind for controllers bootstrapped into a user-specified Azure resource group
(`--config resource-group-name=...`).

This differs from the normal Azure-controller path:

- A normal controller uses a Juju-created, controller-tagged resource group.
  `DestroyController` finds it through `deleteControllerManagedResourceGroups`,
  then `deleteResourceGroup` calls Azure's `ResourceGroupsClient.BeginDelete`.
  Azure recursively removes the group's contents.
- A customer-provided group must be preserved because it can contain non-Juju
  resources or resources belonging to another model. Juju must instead use
  `deleteResourcesInGroup` to select resources by `juju-model-uuid`, stop
  controller instances and their dependent resources, then remove the remaining
  resources individually.

This PR fixes three cleanup failures in that customer-resource-group path:

1. `DestroyController` only discovered resource groups through the
  `juju-controller-uuid` tag in `deleteControllerManagedResourceGroups`.
  Customer-provided groups need not have that tag, so the query returned no
  groups and controller resource cleanup was skipped entirely.

  `DestroyController` now calls `deleteResourcesInGroup` directly for its
  configured `resource-group-name`. The resource group itself remains intact;
  only resources belonging to the controller model are removed.

2. A regression from #12313 broke the fallback used when Azure returns no
  resources for the server-side `juju-model-uuid` tag filter.

  The original implementation retried without a filter and filtered the results
  client-side. Commit 5167e21607 extracted the listing into `getModelResources`,
  but accidentally passed the same tag filter on both calls. When the first
  filtered query returned nothing, the fallback also returned nothing and no
  resources were deleted.

  `deleteResourcesInGroup` now correctly calls `getModelResources` without a
  filter for the fallback, while `getModelResources` verifies the full resource's
  `juju-model-uuid` tag client-side.

3. Generic ARM deletion in `deleteResources` used the hard-coded
   `computeAPIVersion` (`2021-11-01`) for every resource type.

  This worked for Compute resources such as `Microsoft.Compute/availabilitySets`,
  but Azure rejected the same version for `Microsoft.Network/networkSecurityGroups` 
  and `Microsoft.Network/virtualNetworks` with `NoRegisteredProviderFound`.
  Consequently, after the controller VM was removed, the controller NSG and
  VNet remained in the customer resource group.

  `resourceAPIVersions` now obtains the registered API versions through
  `providersClient` and `collectAPIVersions`. `deleteResources` passes the
  version matching each resource's type to `BeginDeleteByID`, and
  `getModelResources` uses the same type-specific version for `GetByID` during
  the unfiltered fallback.

Also fixes two nearby issues:

- Prevent a spurious `cannot delete managed identity` warning after a
  successful managed-identity deletion.
- Remove a data race in `deleteResources`, where concurrent deletions appended
  to a shared dynamic slice without synchronisation.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


```sh
❯ juju bootstrap azure/eastus iyigun-test-ctrl \
  --config resource-group-name=iyigun-test-group \
  --bootstrap-constraints ip-family=dual
[...]

❯ az resource list --resource-group iyigun-test-group --output table
Name                          ResourceGroup      Location    Type                                     Status
----------------------------  -----------------  ----------  ---------------------------------------  ---------
juju-internal-nsg             iyigun-test-group  eastus      Microsoft.Network/networkSecurityGroups  Succeeded
juju-internal-network         iyigun-test-group  eastus      Microsoft.Network/virtualNetworks        Succeeded
juju-6b2107-0-public-ip       iyigun-test-group  eastus      Microsoft.Network/publicIPAddresses      Succeeded
juju-6b2107-0-public-ip-ipv6  iyigun-test-group  eastus      Microsoft.Network/publicIPAddresses      Succeeded
juju-controller               iyigun-test-group  eastus      Microsoft.Compute/availabilitySets       Succeeded
juju-6b2107-0-primary         iyigun-test-group  eastus      Microsoft.Network/networkInterfaces      Succeeded
juju-6b2107-0                 iyigun-test-group  eastus      Microsoft.Compute/virtualMachines        Succeeded
juju-6b2107-0                 IYIGUN-TEST-GROUP  eastus      Microsoft.Compute/disks                  Succeeded

❯ juju destroy-controller --destroy-all-models --no-prompt iyigun-test-ctrl --debug
[...]
16:57:21 DEBUG juju.provider.azure environ.go:214 discovered tenant id: 40a524d9-f848-46d4-a96f-be6df491fe15
16:57:21 WARN  cmd destroy.go:261 This command will destroy the "iyigun-test-ctrl" controller and all its resources
16:57:21 INFO  cmd destroy.go:290 Destroying controller
16:57:21 INFO  cmd destroy.go:365 Waiting for model resources to be reclaimed
16:57:21 INFO  cmd destroy.go:368 Waiting for 0 model, 1 machine, 1 application
16:57:24 INFO  cmd destroy.go:373 All models reclaimed, cleaning up controller machines
16:57:24 DEBUG juju.provider.azure environ.go:2099 destroying model "controller"
16:57:24 DEBUG juju.provider.azure environ.go:2109 deleting resources in user-specified resource group "iyigun-test-group"
16:57:24 DEBUG juju.provider.azure environ.go:2292 deleting all resources in iyigun-test-group
16:57:25 DEBUG juju.provider.azure environ.go:2333 resource to delete: juju-controller (Microsoft.Compute/availabilitySets)
16:57:25 DEBUG juju.provider.azure environ.go:2333 resource to delete: juju-6b2107-0 (Microsoft.Compute/disks)
16:57:25 DEBUG juju.provider.azure environ.go:2333 resource to delete: juju-6b2107-0 (Microsoft.Compute/virtualMachines)
16:57:25 DEBUG juju.provider.azure environ.go:2333 resource to delete: juju-6b2107-0-primary (Microsoft.Network/networkInterfaces)
16:57:25 DEBUG juju.provider.azure environ.go:2333 resource to delete: juju-internal-nsg (Microsoft.Network/networkSecurityGroups)
16:57:25 DEBUG juju.provider.azure environ.go:2333 resource to delete: juju-6b2107-0-public-ip (Microsoft.Network/publicIPAddresses)
16:57:25 DEBUG juju.provider.azure environ.go:2333 resource to delete: juju-6b2107-0-public-ip-ipv6 (Microsoft.Network/publicIPAddresses)
16:57:25 DEBUG juju.provider.azure environ.go:2333 resource to delete: juju-internal-network (Microsoft.Network/virtualNetworks)
16:57:25 DEBUG juju.provider.azure environ.go:1421 canceling deployment for instance "juju-6b2107-0"
16:57:25 DEBUG juju.provider.azure environ.go:1494 - canceling deployment "juju-6b2107-0"
16:57:26 DEBUG juju.provider.azure environ.go:1467 deleting instance "juju-6b2107-0"
16:57:26 DEBUG juju.provider.azure environ.go:1541 - deleting virtual machine (juju-6b2107-0)
16:57:27 DEBUG juju.api monitor.go:40 RPC connection died
16:57:27 DEBUG juju.api monitor.go:40 RPC connection died
16:57:37 DEBUG juju.provider.azure environ.go:1553 - deleting OS disk (juju-6b2107-0)
16:57:38 DEBUG juju.provider.azure environ.go:1568 - deleting security rules (juju-6b2107-0)
16:57:38 DEBUG juju.provider.azure environ.go:1576 - deleting network interfaces (juju-6b2107-0)
16:57:40 DEBUG juju.provider.azure environ.go:1596 - deleting public IPs (juju-6b2107-0)
16:58:03 DEBUG juju.provider.azure environ.go:1617 - deleting deployment (juju-6b2107-0)
16:58:26 DEBUG juju.provider.azure environ.go:2432 deleting 3 resources
16:58:26 DEBUG juju.provider.azure environ.go:2448 - deleting resource "/subscriptions/fbcb21ca-f5c1-44d3-bbc0-37889b64b485/resourceGroups/iyigun-test-group/providers/Microsoft.Compute/availabilitySets/juju-controller"
16:58:26 DEBUG juju.provider.azure environ.go:2448 - deleting resource "/subscriptions/fbcb21ca-f5c1-44d3-bbc0-37889b64b485/resourceGroups/iyigun-test-group/providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg"
16:58:26 DEBUG juju.provider.azure environ.go:2448 - deleting resource "/subscriptions/fbcb21ca-f5c1-44d3-bbc0-37889b64b485/resourceGroups/iyigun-test-group/providers/Microsoft.Network/virtualNetworks/juju-internal-network"
16:58:38 DEBUG juju.provider.azure environ.go:2432 deleting 1 resources
16:58:38 DEBUG juju.provider.azure environ.go:2448 - deleting resource "/subscriptions/fbcb21ca-f5c1-44d3-bbc0-37889b64b485/resourceGroups/iyigun-test-group/providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg"
16:58:39 DEBUG juju.provider.azure environ.go:2114 deleting auto managed identities
16:58:40 DEBUG juju.provider.azure environ.go:2150 found role definition id:
16:58:40 DEBUG juju.provider.azure environ.go:2170 found role assignment id:
16:58:41 INFO  cmd supercommand.go:583 command finished

❯ az resource list --resource-group iyigun-test-group --output table
```


**Bootstrap without custom resource-group:**

```sh

❯ juju bootstrap azure/eastus iyigun-test-ctrl \
  --bootstrap-constraints ip-family=dual
[...]

❯ az resource list --resource-group iyigun-test-group --output table

❯ az resource list --resource-group juju-controller-6cfdfb31 --output table
Name                          ResourceGroup             Location    Type                                     Status
----------------------------  ------------------------  ----------  ---------------------------------------  ---------
juju-99e62c-0-public-ip       juju-controller-6cfdfb31  eastus      Microsoft.Network/publicIPAddresses      Succeeded
juju-internal-nsg             juju-controller-6cfdfb31  eastus      Microsoft.Network/networkSecurityGroups  Succeeded
juju-99e62c-0-public-ip-ipv6  juju-controller-6cfdfb31  eastus      Microsoft.Network/publicIPAddresses      Succeeded
juju-controller               juju-controller-6cfdfb31  eastus      Microsoft.Compute/availabilitySets       Succeeded
juju-internal-network         juju-controller-6cfdfb31  eastus      Microsoft.Network/virtualNetworks        Succeeded
juju-99e62c-0-primary         juju-controller-6cfdfb31  eastus      Microsoft.Network/networkInterfaces      Succeeded
juju-99e62c-0                 juju-controller-6cfdfb31  eastus      Microsoft.Compute/virtualMachines        Succeeded
juju-99e62c-0                 JUJU-CONTROLLER-6CFDFB31  eastus      Microsoft.Compute/disks                  Succeeded

❯ juju destroy-controller --destroy-all-models --no-prompt iyigun-test-ctrl --debug
[...]
17:07:54 DEBUG juju.provider.azure environ.go:214 discovered tenant id: 40a524d9-f848-46d4-a96f-be6df491fe15
17:07:55 DEBUG juju.provider.azure environ.go:2525 legacy resource group name doesn't exist, using short name
17:07:55 WARN  cmd destroy.go:261 This command will destroy the "iyigun-test-ctrl" controller and all its resources
17:07:55 INFO  cmd destroy.go:290 Destroying controller
17:07:56 INFO  cmd destroy.go:365 Waiting for model resources to be reclaimed
17:07:56 INFO  cmd destroy.go:368 Waiting for 0 model, 1 machine, 1 application
17:07:58 INFO  cmd destroy.go:368 Waiting for 0 model, 1 machine, 1 application
17:08:00 INFO  cmd destroy.go:368 Waiting for 0 model, 1 machine, 1 application
17:08:03 INFO  cmd destroy.go:373 All models reclaimed, cleaning up controller machines
17:08:03 DEBUG juju.provider.azure environ.go:2099 destroying model "controller"
17:08:03 DEBUG juju.provider.azure environ.go:2101 deleting resource groups
17:08:03 DEBUG juju.api monitor.go:40 RPC connection died
17:08:03 DEBUG juju.api monitor.go:40 RPC connection died
17:08:03 DEBUG juju.provider.azure environ.go:2235   - deleting resource group "juju-controller-6cfdfb31"
17:12:16 DEBUG juju.provider.azure environ.go:2114 deleting auto managed identities
17:12:17 DEBUG juju.provider.azure environ.go:2150 found role definition id:
17:12:18 DEBUG juju.provider.azure environ.go:2170 found role assignment id:
17:12:18 DEBUG juju.rpc server.go:384 error closing codec: websocket: close sent
write tcp 192.168.1.28:48168->74.151.137.132:17070: write: broken pipe
17:12:18 DEBUG juju.rpc server.go:384 error closing codec: websocket: close sent
write tcp 192.168.1.28:48164->74.151.137.132:17070: write: broken pipe
17:12:18 INFO  cmd supercommand.go:583 command finished

❯ az resource list --resource-group juju-controller-6cfdfb31 --output table
(ResourceGroupNotFound) Resource group 'juju-controller-6cfdfb31' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'juju-controller-6cfdfb31' could not be found.
```

## Documentation changes

## Links

