### PR TITLE
fix(azure): destroy-controller fails to delete resources in shared resource groups

### DIFF
--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -1919,9 +1919,19 @@ func (env *azureEnviron) Destroy(ctx context.ProviderCallContext) error {
 // DestroyController is specified in the Environ interface.
 func (env *azureEnviron) DestroyController(ctx context.ProviderCallContext, controllerUUID string) error {
 	logger.Debugf("destroying model %q", env.modelName)
-	logger.Debugf("deleting resource groups")
-	if err := env.deleteControllerManagedResourceGroups(ctx, controllerUUID); err != nil {
-		return errors.Trace(err)
+	if env.config.resourceGroupName == "" {
+		logger.Debugf("deleting resource groups")
+		if err := env.deleteControllerManagedResourceGroups(ctx, controllerUUID); err != nil {
+			return errors.Trace(err)
+		}
+	} else {
+		// The controller model may live in a user-specified resource group that
+		// is not tagged with the controller UUID, so it is not picked up by
+		// deleteControllerManagedResourceGroups above. Clean its contents here.
+		logger.Debugf("deleting resources in user-specified resource group %q", env.resourceGroup)
+		if err := env.deleteResourcesInGroup(ctx, env.resourceGroup); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	logger.Debugf("deleting auto managed identities")
 	if err := env.deleteControllerManagedIdentities(ctx, controllerUUID); err != nil {

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -2218,7 +2218,11 @@ func (env *azureEnviron) getModelResources(sdkCtx stdcontext.Context, resourceGr
 func (env *azureEnviron) deleteResources(sdkCtx stdcontext.Context, toDelete []*armresources.GenericResourceExpanded) ([]*armresources.GenericResourceExpanded, error) {
 	logger.Debugf("deleting %d resources", len(toDelete))
 
-	var remainingResources []*armresources.GenericResourceExpanded
+	// Each goroutine below writes to its own pre-sized slice index
+	// so that the shared remainingResources is race-free without a mutex.
+	// This follows the same index-addressed pattern used by cancelResults
+	// in StopInstances and errs in deleteControllerManagedResourceGroups.
+	var remainingResources = make([]*armresources.GenericResourceExpanded, len(toDelete))
 	var wg sync.WaitGroup
 	deleteResults := make([]error, len(toDelete))
 	for i, res := range toDelete {
@@ -2242,7 +2246,7 @@ func (env *azureEnviron) deleteResources(sdkCtx stdcontext.Context, toDelete []*
 				}
 				// If the resource is in use, don't error, just queue it up for another pass.
 				if strings.HasPrefix(errorutils.ErrorCode(err), "InUse") {
-					remainingResources = append(remainingResources, toDelete[i])
+					remainingResources[i] = toDelete[i]
 				} else {
 					deleteResults[i] = errors.Annotatef(err, "deleting resource %q: %v", id, err)
 				}
@@ -2251,6 +2255,14 @@ func (env *azureEnviron) deleteResources(sdkCtx stdcontext.Context, toDelete []*
 		}(i, id)
 	}
 	wg.Wait()
+
+	// Compact the pre-sized slice to remove nil entries before returning.
+	remaining := make([]*armresources.GenericResourceExpanded, 0, len(remainingResources))
+	for _, res := range remainingResources {
+		if res != nil {
+			remaining = append(remaining, res)
+		}
+	}
 
 	var errStrings []string
 	for i, err := range deleteResults {
@@ -2262,7 +2274,7 @@ func (env *azureEnviron) deleteResources(sdkCtx stdcontext.Context, toDelete []*
 	if len(errStrings) > 0 {
 		return nil, errors.Annotate(errors.New(strings.Join(errStrings, "\n")), "deleting resources")
 	}
-	return remainingResources, nil
+	return remaining, nil
 }
 
 // Provider is specified in the Environ interface.

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -2118,14 +2118,19 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.ProviderCallContext,
 
 	// Find all the resources tagged as belonging to this model.
 	filter := fmt.Sprintf("tagName eq '%s' and tagValue eq '%s'", tags.JujuModel, env.config.UUID())
-	resourceItems, err := env.getModelResources(ctx, resourceGroup, filter)
+	resourceItems, err := env.getModelResources(ctx, resourceGroup, filter, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	// Older APIs can ignore the filter above, so query the hard way just in case.
+	var apiVersions map[string]string
 	if len(resourceItems) == 0 {
-		resourceItems, err = env.getModelResources(ctx, resourceGroup, "")
+		apiVersions, err = env.resourceAPIVersions(ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		resourceItems, err = env.getModelResources(ctx, resourceGroup, "", apiVersions)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -2167,12 +2172,19 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.ProviderCallContext,
 		return errors.Annotatef(err, "deleting machine instances %q", instIds)
 	}
 
+	if len(otherResources) > 0 && apiVersions == nil {
+		apiVersions, err = env.resourceAPIVersions(ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	// Loop until all remaining resources are deleted.
 	// For safety, add an upper retry limit; in reality, this will never be hit.
 	remainingResources := otherResources
 	retries := 0
 	for len(remainingResources) > 0 && retries < 10 {
-		remainingResources, err = env.deleteResources(ctx, remainingResources)
+		remainingResources, err = env.deleteResources(ctx, remainingResources, apiVersions)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -2191,7 +2203,7 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.ProviderCallContext,
 	return nil
 }
 
-func (env *azureEnviron) getModelResources(sdkCtx stdcontext.Context, resourceGroup, modelFilter string) ([]*armresources.GenericResourceExpanded, error) {
+func (env *azureEnviron) getModelResources(sdkCtx stdcontext.Context, resourceGroup, modelFilter string, apiVersions map[string]string) ([]*armresources.GenericResourceExpanded, error) {
 	resources, err := env.resourcesClient()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -2209,7 +2221,11 @@ func (env *azureEnviron) getModelResources(sdkCtx stdcontext.Context, resourceGr
 			// If no modelFilter specified, we need to check that the resource
 			// belongs to this model.
 			if modelFilter == "" {
-				fullRes, err := resources.GetByID(sdkCtx, toValue(res.ID), computeAPIVersion, nil)
+				apiVersion, ok := apiVersions[toValue(res.Type)]
+				if !ok {
+					return nil, errors.Errorf("no API version found for resource type %q", toValue(res.Type))
+				}
+				fullRes, err := resources.GetByID(sdkCtx, toValue(res.ID), apiVersion, nil)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
@@ -2223,9 +2239,17 @@ func (env *azureEnviron) getModelResources(sdkCtx stdcontext.Context, resourceGr
 	return resourceItems, nil
 }
 
+func (env *azureEnviron) resourceAPIVersions(ctx context.ProviderCallContext) (map[string]string, error) {
+	providers, err := env.providersClient()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return collectAPIVersions(ctx, providers)
+}
+
 // deleteResources deletes the specified resources, returning any that
 // cannot be deleted because they are in use.
-func (env *azureEnviron) deleteResources(sdkCtx stdcontext.Context, toDelete []*armresources.GenericResourceExpanded) ([]*armresources.GenericResourceExpanded, error) {
+func (env *azureEnviron) deleteResources(sdkCtx stdcontext.Context, toDelete []*armresources.GenericResourceExpanded, apiVersions map[string]string) ([]*armresources.GenericResourceExpanded, error) {
 	logger.Debugf("deleting %d resources", len(toDelete))
 
 	// Each goroutine below writes to its own pre-sized slice index
@@ -2237,16 +2261,21 @@ func (env *azureEnviron) deleteResources(sdkCtx stdcontext.Context, toDelete []*
 	deleteResults := make([]error, len(toDelete))
 	for i, res := range toDelete {
 		id := toValue(res.ID)
+		apiVersion, ok := apiVersions[toValue(res.Type)]
+		if !ok {
+			deleteResults[i] = errors.Errorf("no API version found for resource type %q", toValue(res.Type))
+			continue
+		}
 		logger.Debugf("- deleting resource %q", id)
 		wg.Add(1)
-		go func(i int, id string) {
+		go func(i int, id, apiVersion string) {
 			defer wg.Done()
 			resources, err := env.resourcesClient()
 			if err != nil {
 				deleteResults[i] = err
 				return
 			}
-			poller, err := resources.BeginDeleteByID(sdkCtx, id, computeAPIVersion, nil)
+			poller, err := resources.BeginDeleteByID(sdkCtx, id, apiVersion, nil)
 			if err == nil {
 				_, err = poller.PollUntilDone(sdkCtx, nil)
 			}
@@ -2262,7 +2291,7 @@ func (env *azureEnviron) deleteResources(sdkCtx stdcontext.Context, toDelete []*
 				}
 				return
 			}
-		}(i, id)
+		}(i, id, apiVersion)
 	}
 	wg.Wait()
 

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -1938,7 +1938,8 @@ func (env *azureEnviron) DestroyController(ctx context.ProviderCallContext, cont
 		return errors.Trace(err)
 	}
 	// Resource groups are self-contained and fully encompass
-	// all environ armresources. Once you delete the group, there
+	// all environ armresources. Once the group has been deleted,
+	// or its contents cleaned up for a user-specified group, there
 	// is nothing else to do.
 	return nil
 }
@@ -2204,9 +2205,13 @@ func (env *azureEnviron) getModelResources(
 		return nil, errors.Trace(err)
 	}
 	var resourceItems []*armresources.GenericResourceExpanded
-	pager := resources.NewListByResourceGroupPager(resourceGroup, &armresources.ClientListByResourceGroupOptions{
-		Filter: to.Ptr(modelFilter),
-	})
+	// If no model filter is specified, omit the $filter query parameter
+	// entirely so the resource group is listed without a filter.
+	listOpts := &armresources.ClientListByResourceGroupOptions{}
+	if modelFilter != "" {
+		listOpts.Filter = to.Ptr(modelFilter)
+	}
+	pager := resources.NewListByResourceGroupPager(resourceGroup, listOpts)
 	for pager.More() {
 		next, err := pager.NextPage(sdkCtx)
 		if err != nil {
@@ -2282,7 +2287,7 @@ func (env *azureEnviron) deleteResources(sdkCtx stdcontext.Context, toDelete []*
 				if strings.HasPrefix(errorutils.ErrorCode(err), "InUse") {
 					remainingResources[i] = toDelete[i]
 				} else {
-					deleteResults[i] = errors.Annotatef(err, "deleting resource %q: %v", id, err)
+					deleteResults[i] = errors.Annotatef(err, "deleting resource %q", id)
 				}
 				return
 			}

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -2008,7 +2008,7 @@ func (env *azureEnviron) deleteControllerManagedIdentities(ctx context.ProviderC
 		return errors.Trace(err)
 	}
 	_, err = clientFactory.NewUserAssignedIdentitiesClient().Delete(ctx, env.resourceGroup, identityName, nil)
-	if !errorutils.IsNotFoundError(err) {
+	if err != nil && !errorutils.IsNotFoundError(err) {
 		logger.Warningf("cannot delete managed identity %q: %v", identityName, err)
 	}
 
@@ -2115,7 +2115,7 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.ProviderCallContext,
 
 	// Older APIs can ignore the filter above, so query the hard way just in case.
 	if len(resourceItems) == 0 {
-		resourceItems, err = env.getModelResources(ctx, resourceGroup, filter)
+		resourceItems, err = env.getModelResources(ctx, resourceGroup, "")
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -2116,20 +2116,20 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.ProviderCallContext,
 		err = errorutils.HandleCredentialError(err, ctx)
 	}()
 
+	apiVersions, err := env.resourceAPIVersions(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	// Find all the resources tagged as belonging to this model.
 	filter := fmt.Sprintf("tagName eq '%s' and tagValue eq '%s'", tags.JujuModel, env.config.UUID())
-	resourceItems, err := env.getModelResources(ctx, resourceGroup, filter, nil)
+	resourceItems, err := env.getModelResources(ctx, resourceGroup, filter, apiVersions)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	// Older APIs can ignore the filter above, so query the hard way just in case.
-	var apiVersions map[string]string
 	if len(resourceItems) == 0 {
-		apiVersions, err = env.resourceAPIVersions(ctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
 		resourceItems, err = env.getModelResources(ctx, resourceGroup, "", apiVersions)
 		if err != nil {
 			return errors.Trace(err)
@@ -2172,13 +2172,6 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.ProviderCallContext,
 		return errors.Annotatef(err, "deleting machine instances %q", instIds)
 	}
 
-	if len(otherResources) > 0 && apiVersions == nil {
-		apiVersions, err = env.resourceAPIVersions(ctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-
 	// Loop until all remaining resources are deleted.
 	// For safety, add an upper retry limit; in reality, this will never be hit.
 	remainingResources := otherResources
@@ -2203,7 +2196,9 @@ func (env *azureEnviron) deleteResourcesInGroup(ctx context.ProviderCallContext,
 	return nil
 }
 
-func (env *azureEnviron) getModelResources(sdkCtx stdcontext.Context, resourceGroup, modelFilter string, apiVersions map[string]string) ([]*armresources.GenericResourceExpanded, error) {
+func (env *azureEnviron) getModelResources(
+	sdkCtx stdcontext.Context, resourceGroup, modelFilter string, apiVersions map[string]string,
+) ([]*armresources.GenericResourceExpanded, error) {
 	resources, err := env.resourcesClient()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2217,23 +2217,31 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 		ID:   to.Ptr("networkSecurityGroups/nsg-0"),
 		Name: to.Ptr("nsg-0"),
 		Type: to.Ptr("Microsoft.Network/networkSecurityGroups"),
+	}, {
+		ID:   to.Ptr("networkSecurityGroups/nsg-1"),
+		Name: to.Ptr("nsg-1"),
+		Type: to.Ptr("Microsoft.Network/networkSecurityGroups"),
 	}}
 	resourceListResult := armresources.ResourceListResult{Value: res}
 
 	// When the tag-filtered list returns nothing, deleteResourcesInGroup must
 	// fall back to listing all resources and filtering client-side by tag.
+	// Only resources tagged as belonging to this model are deleted.
 	s.sender = azuretesting.Senders{
 		makeSender(".*/providers", makeNetworkProviderResult()),                            // GET API versions
 		makeSender(".*/resourceGroups/foo/resources.*", armresources.ResourceListResult{}), // GET with filter, empty
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),                // GET without filter
-		makeSender(".*/networkSecurityGroups/nsg-0", armresources.GenericResource{ // GET resource by ID
+		makeSender(".*/networkSecurityGroups/nsg-0", armresources.GenericResource{ // GET resource by ID (model)
 			Tags: map[string]*string{tags.JujuModel: to.Ptr(testing.ModelTag.Id())},
+		}),
+		makeSender(".*/networkSecurityGroups/nsg-1", armresources.GenericResource{ // GET resource by ID (foreign model)
+			Tags: map[string]*string{tags.JujuModel: to.Ptr("00000000-0000-0000-0000-000000000000")},
 		}),
 		makeSender("/networkSecurityGroups/nsg-0", nil), // DELETE
 	}
 	err := env.Destroy(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.requests, gc.HasLen, 5)
+	c.Assert(s.requests, gc.HasLen, 6)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
 	c.Assert(s.requests[1].Method, gc.Equals, "GET")
 	c.Assert(s.requests[1].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
@@ -2241,10 +2249,13 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 		testing.ModelTag.Id(),
 	))
 	c.Assert(s.requests[2].Method, gc.Equals, "GET")
-	c.Assert(s.requests[2].URL.Query().Get("$filter"), gc.Equals, "")
+	_, hasFilter := s.requests[2].URL.Query()["$filter"]
+	c.Assert(hasFilter, jc.IsFalse)
 	c.Assert(s.requests[3].Method, gc.Equals, "GET")
-	c.Assert(s.requests[4].Method, gc.Equals, "DELETE")
-	c.Assert(s.requests[4].URL.Query().Get("api-version"), gc.Equals, "2021-12-01")
+	c.Assert(s.requests[3].URL.Query().Get("api-version"), gc.Equals, "2021-12-01")
+	c.Assert(s.requests[4].Method, gc.Equals, "GET")
+	c.Assert(s.requests[5].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[5].URL.Query().Get("api-version"), gc.Equals, "2021-12-01")
 }
 
 func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *gc.C) {
@@ -2262,29 +2273,84 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *gc
 	}}
 	resourceListResult := armresources.ResourceListResult{Value: res}
 
-	inUseErr0 := newAzureResponseError(c, http.StatusConflict, "InUse", "in use")
-	inUseErr1 := newAzureResponseError(c, http.StatusConflict, "InUse", "in use")
+	inUseErr := newAzureResponseError(c, http.StatusConflict, "InUse", "in use")
 
-	// Two NSG resources; the first pass both return InUse, the
-	// second pass they succeed. This exercises the concurrent
-	// index-addressed write to remainingResources in deleteResources.
+	// On the first pass one NSG is deleted while the other is in use, so the
+	// pre-sized remainingResources slice contains a nil hole that must be
+	// compacted before the second pass retries the in-use resource. The first
+	// DELETE to arrive returns InUse regardless of which NSG it targets.
 	s.sender = azuretesting.Senders{
 		makeSender(".*/providers", makeNetworkProviderResult()),             // GET API versions
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
-		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr0, 1),  // DELETE (InUse), pass 1
-		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr1, 1),  // DELETE (InUse), pass 1
-		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
+		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr, 1),   // DELETE (InUse), pass 1
+		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 1
 		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
 	}
 	err := env.Destroy(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.requests, gc.HasLen, 6)
+	c.Assert(s.requests, gc.HasLen, 5)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
 	c.Assert(s.requests[1].Method, gc.Equals, "GET")
 	c.Assert(s.requests[2].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[3].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[4].Method, gc.Equals, "DELETE")
-	c.Assert(s.requests[5].Method, gc.Equals, "DELETE")
+}
+
+func (s *environSuite) TestDestroyHostedModelCustomResourceGroupMultipleTypes(c *gc.C) {
+	env := s.openEnviron(c,
+		testing.Attrs{"controller-uuid": utils.MustNewUUID().String(), "resource-group-name": "foo"})
+
+	res := []*armresources.GenericResourceExpanded{{
+		ID:   to.Ptr("networkSecurityGroups/nsg-0"),
+		Name: to.Ptr("nsg-0"),
+		Type: to.Ptr("Microsoft.Network/networkSecurityGroups"),
+	}, {
+		ID:   to.Ptr("storageAccounts/sa-0"),
+		Name: to.Ptr("sa-0"),
+		Type: to.Ptr("Microsoft.Storage/storageAccounts"),
+	}}
+	resourceListResult := armresources.ResourceListResult{Value: res}
+
+	providers := armresources.ProviderListResult{Value: []*armresources.Provider{{
+		Namespace: to.Ptr("Microsoft.Network"),
+		ResourceTypes: []*armresources.ProviderResourceType{{
+			ResourceType: to.Ptr("networkSecurityGroups"),
+			APIVersions:  to.SliceOfPtrs("2021-12-01"),
+		}},
+	}, {
+		Namespace: to.Ptr("Microsoft.Storage"),
+		ResourceTypes: []*armresources.ProviderResourceType{{
+			ResourceType: to.Ptr("storageAccounts"),
+			APIVersions:  to.SliceOfPtrs("2023-01-01"),
+		}},
+	}}}
+
+	// The two resources are deleted concurrently, each using the API version
+	// matching its own type.
+	deleteSender := &azuretesting.MockSender{}
+	deleteSender.PathPattern = "(networkSecurityGroups/nsg-0|storageAccounts/sa-0)"
+	deleteSender.AppendResponse(azuretesting.NewResponse()) //nolint:bodyclose
+	deleteSender.AppendResponse(azuretesting.NewResponse()) //nolint:bodyclose
+
+	s.sender = azuretesting.Senders{
+		makeSender(".*/providers", providers),                               // GET API versions
+		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
+		deleteSender,
+	}
+	err := env.Destroy(s.callCtx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.requests, gc.HasLen, 4)
+
+	deleteVersions := make(map[string]string)
+	for _, req := range s.requests {
+		if req.Method == "DELETE" {
+			deleteVersions[req.URL.Path] = req.URL.Query().Get("api-version")
+		}
+	}
+	c.Assert(deleteVersions, jc.DeepEquals, map[string]string{
+		"/networkSecurityGroups/nsg-0": "2021-12-01",
+		"/storageAccounts/sa-0":        "2023-01-01",
+	})
 }
 
 func (s *environSuite) TestDestroyHostedModelWithInvalidCredential(c *gc.C) {
@@ -2439,6 +2505,38 @@ func (s *environSuite) TestDestroyControllerManagedIdentityDeleteError(c *gc.C) 
 		}
 	}
 	c.Check(found, jc.IsTrue)
+}
+
+func (s *environSuite) TestDestroyControllerManagedIdentityDeleteNotFound(c *gc.C) {
+	groups := []*armresources.ResourceGroup{{
+		Name: to.Ptr("group1"),
+	}}
+	result := armresources.ResourceGroupListResult{Value: groups}
+
+	var logWriter loggo.TestWriter
+	writerName := "TestDestroyControllerManagedIdentityDeleteNotFound"
+	c.Assert(loggo.RegisterWriter(writerName, &logWriter), jc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter(writerName)
+	}()
+
+	identityDeleteErr := newAzureResponseError(c, http.StatusNotFound, "NotFound", "not found")
+
+	env := s.openEnviron(c)
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourcegroups", result),                                                // GET
+		makeSender(".*/resourcegroups/group1", nil),                                            // DELETE
+		makeSender(".*/roleDefinitions*", nil),                                                 // GET
+		makeSender(".*/roleAssignments*", nil),                                                 // GET
+		s.makeErrorSender(".*/userAssignedIdentities/juju-controller-*", identityDeleteErr, 1), // DELETE (not found)
+	}
+	err := env.DestroyController(s.callCtx, s.controllerUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.requests, gc.HasLen, 5)
+
+	for _, entry := range logWriter.Log() {
+		c.Check(entry.Message, gc.Not(gc.Matches), ".*cannot delete managed identity.*")
+	}
 }
 
 func (s *environSuite) TestDestroyControllerWithInvalidCredential(c *gc.C) {

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"path"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -23,6 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/juju/clock/testclock"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v5"
 	gitjujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -2241,6 +2243,44 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 	c.Assert(s.requests[3].Method, gc.Equals, "DELETE")
 }
 
+func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *gc.C) {
+	env := s.openEnviron(c,
+		testing.Attrs{"controller-uuid": utils.MustNewUUID().String(), "resource-group-name": "foo"})
+
+	res := []*armresources.GenericResourceExpanded{{
+		ID:   to.Ptr("networkSecurityGroups/nsg-0"),
+		Name: to.Ptr("nsg-0"),
+		Type: to.Ptr("Microsoft.Network/networkSecurityGroups"),
+	}, {
+		ID:   to.Ptr("networkSecurityGroups/nsg-1"),
+		Name: to.Ptr("nsg-1"),
+		Type: to.Ptr("Microsoft.Network/networkSecurityGroups"),
+	}}
+	resourceListResult := armresources.ResourceListResult{Value: res}
+
+	inUseErr0 := newAzureResponseError(c, http.StatusConflict, "InUse", "in use")
+	inUseErr1 := newAzureResponseError(c, http.StatusConflict, "InUse", "in use")
+
+	// Two NSG resources; the first pass both return InUse, the
+	// second pass they succeed. This exercises the concurrent
+	// index-addressed write to remainingResources in deleteResources.
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
+		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr0, 1),  // DELETE (InUse), pass 1
+		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr1, 1),  // DELETE (InUse), pass 1
+		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
+		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
+	}
+	err := env.Destroy(s.callCtx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.requests, gc.HasLen, 5)
+	c.Assert(s.requests[0].Method, gc.Equals, "GET")
+	c.Assert(s.requests[1].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[2].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[3].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[4].Method, gc.Equals, "DELETE")
+}
+
 func (s *environSuite) TestDestroyHostedModelWithInvalidCredential(c *gc.C) {
 	env := s.openEnviron(c, testing.Attrs{"controller-uuid": utils.MustNewUUID().String()})
 	s.createSenderWithUnauthorisedStatusCode(c)
@@ -2292,6 +2332,104 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 	c.Assert(s.requests[4].Method, gc.Equals, "GET")
 	c.Assert(s.requests[5].Method, gc.Equals, "DELETE")
 	c.Assert(path.Base(s.requests[5].URL.Path), gc.Equals, "juju-controller-"+testing.ControllerTag.Id())
+}
+
+func (s *environSuite) TestDestroyControllerCustomResourceGroup(c *gc.C) {
+	env := s.openEnviron(c, testing.Attrs{"resource-group-name": "foo"})
+	resources := armresources.ResourceListResult{
+		Value: []*armresources.GenericResourceExpanded{{
+			ID:   to.Ptr("networkSecurityGroups/nsg-0"),
+			Name: to.Ptr("nsg-0"),
+			Type: to.Ptr("Microsoft.Network/networkSecurityGroups"),
+		}},
+	}
+
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourceGroups/foo/resources.*", resources),     // GET
+		makeSender("/networkSecurityGroups/nsg-0", nil),                // DELETE
+		makeSender(".*/roleDefinitions*", nil),                         // GET
+		makeSender(".*/roleAssignments*", nil),                         // GET
+		makeSender(".*/userAssignedIdentities/juju-controller-*", nil), // DELETE
+	}
+
+	err := env.DestroyController(s.callCtx, s.controllerUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.requests, gc.HasLen, 5)
+	c.Check(s.requests[0].Method, gc.Equals, "GET")
+	c.Check(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
+		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
+		testing.ModelTag.Id(),
+	))
+	c.Check(s.requests[1].Method, gc.Equals, "DELETE")
+	c.Check(s.requests[1].URL.Path, gc.Equals, "/networkSecurityGroups/nsg-0")
+}
+
+func (s *environSuite) TestDestroyControllerManagedIdentityDeleteSuccess(c *gc.C) {
+	groups := []*armresources.ResourceGroup{{
+		Name: to.Ptr("group1"),
+	}}
+	result := armresources.ResourceGroupListResult{Value: groups}
+
+	var logWriter loggo.TestWriter
+	writerName := "TestDestroyControllerManagedIdentityDeleteSuccess"
+	c.Assert(loggo.RegisterWriter(writerName, &logWriter), jc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter(writerName)
+	}()
+
+	env := s.openEnviron(c)
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourcegroups", result),                        // GET
+		makeSender(".*/resourcegroups/group1", nil),                    // DELETE
+		makeSender(".*/roleDefinitions*", nil),                         // GET
+		makeSender(".*/roleAssignments*", nil),                         // GET
+		makeSender(".*/userAssignedIdentities/juju-controller-*", nil), // DELETE (success)
+	}
+	err := env.DestroyController(s.callCtx, s.controllerUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.requests, gc.HasLen, 5)
+
+	for _, entry := range logWriter.Log() {
+		c.Check(entry.Message, gc.Not(gc.Matches), ".*cannot delete managed identity.*")
+	}
+}
+
+func (s *environSuite) TestDestroyControllerManagedIdentityDeleteError(c *gc.C) {
+	groups := []*armresources.ResourceGroup{{
+		Name: to.Ptr("group1"),
+	}}
+	result := armresources.ResourceGroupListResult{Value: groups}
+
+	var logWriter loggo.TestWriter
+	writerName := "TestDestroyControllerManagedIdentityDeleteError"
+	c.Assert(loggo.RegisterWriter(writerName, &logWriter), jc.ErrorIsNil)
+	defer func() {
+		loggo.RemoveWriter(writerName)
+	}()
+
+	identityDeleteErr := newAzureResponseError(c, http.StatusForbidden, "Forbidden", "access denied")
+
+	env := s.openEnviron(c)
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourcegroups", result),                                                // GET
+		makeSender(".*/resourcegroups/group1", nil),                                            // DELETE
+		makeSender(".*/roleDefinitions*", nil),                                                 // GET
+		makeSender(".*/roleAssignments*", nil),                                                 // GET
+		s.makeErrorSender(".*/userAssignedIdentities/juju-controller-*", identityDeleteErr, 1), // DELETE (error)
+	}
+	err := env.DestroyController(s.callCtx, s.controllerUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.requests, gc.HasLen, 5)
+
+	var found bool
+	expectedMsg := `cannot delete managed identity "juju-controller-` + testing.ControllerTag.Id() + `"`
+	for _, entry := range logWriter.Log() {
+		if entry.Level == loggo.WARNING && strings.Contains(entry.Message, expectedMsg) {
+			found = true
+			break
+		}
+	}
+	c.Check(found, jc.IsTrue)
 }
 
 func (s *environSuite) TestDestroyControllerWithInvalidCredential(c *gc.C) {

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2180,6 +2180,7 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *gc.C) {
 	nic0 := makeNetworkInterface("nic-0", "juju-06f00d-0", nic0IPConfiguration)
 
 	s.sender = azuretesting.Senders{
+		makeSender(".*/providers", makeNetworkProviderResult()),                           // GET API versions
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),               // GET
 		makeSenderWithStatus(".*/deployments/juju-06f00d-0/cancel", http.StatusNoContent), // POST
 		s.networkInterfacesSender(nic0),
@@ -2189,7 +2190,6 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *gc.C) {
 		makeSender(".*/networkInterfaces/nic-0", nil),                                                                    // DELETE
 		makeSender(".*/publicIPAddresses/pip-0", nil),                                                                    // DELETE
 		makeSenderWithStatus(".*/deployments/juju-06f00d-0", http.StatusNoContent),                                       // DELETE
-		makeSender(".*/providers", makeNetworkProviderResult()),                                                          // GET
 		s.makeErrorSender("/networkSecurityGroups/nsg-0", newAzureResponseError(c, http.StatusConflict, "InUse", ""), 1), // DELETE
 		makeSender("/networkSecurityGroups/nsg-0", nil),                                                                  // DELETE
 		makeSender(".*/vaults/secret-0", nil),                                                                            // DELETE
@@ -2198,12 +2198,12 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.requests, gc.HasLen, 13)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
-	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
+	c.Assert(s.requests[1].Method, gc.Equals, "GET")
+	c.Assert(s.requests[1].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
-	c.Assert(s.requests[8].Method, gc.Equals, "DELETE")
-	c.Assert(s.requests[9].Method, gc.Equals, "GET")
+	c.Assert(s.requests[9].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[10].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[11].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[12].Method, gc.Equals, "DELETE")
@@ -2223,8 +2223,8 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 	// When the tag-filtered list returns nothing, deleteResourcesInGroup must
 	// fall back to listing all resources and filtering client-side by tag.
 	s.sender = azuretesting.Senders{
-		makeSender(".*/resourceGroups/foo/resources.*", armresources.ResourceListResult{}), // GET with filter, empty
 		makeSender(".*/providers", makeNetworkProviderResult()),                            // GET API versions
+		makeSender(".*/resourceGroups/foo/resources.*", armresources.ResourceListResult{}), // GET with filter, empty
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),                // GET without filter
 		makeSender(".*/networkSecurityGroups/nsg-0", armresources.GenericResource{ // GET resource by ID
 			Tags: map[string]*string{tags.JujuModel: to.Ptr(testing.ModelTag.Id())},
@@ -2235,11 +2235,11 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.requests, gc.HasLen, 5)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
-	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
+	c.Assert(s.requests[1].Method, gc.Equals, "GET")
+	c.Assert(s.requests[1].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
-	c.Assert(s.requests[1].Method, gc.Equals, "GET")
 	c.Assert(s.requests[2].Method, gc.Equals, "GET")
 	c.Assert(s.requests[2].URL.Query().Get("$filter"), gc.Equals, "")
 	c.Assert(s.requests[3].Method, gc.Equals, "GET")
@@ -2269,8 +2269,8 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *gc
 	// second pass they succeed. This exercises the concurrent
 	// index-addressed write to remainingResources in deleteResources.
 	s.sender = azuretesting.Senders{
-		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
 		makeSender(".*/providers", makeNetworkProviderResult()),             // GET API versions
+		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
 		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr0, 1),  // DELETE (InUse), pass 1
 		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr1, 1),  // DELETE (InUse), pass 1
 		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
@@ -2351,8 +2351,8 @@ func (s *environSuite) TestDestroyControllerCustomResourceGroup(c *gc.C) {
 	}
 
 	s.sender = azuretesting.Senders{
+		makeSender(".*/providers", makeNetworkProviderResult()),        // GET API versions
 		makeSender(".*/resourceGroups/foo/resources.*", resources),     // GET
-		makeSender(".*/providers", makeNetworkProviderResult()),        // GET
 		makeSender("/networkSecurityGroups/nsg-0", nil),                // DELETE
 		makeSender(".*/roleDefinitions*", nil),                         // GET
 		makeSender(".*/roleAssignments*", nil),                         // GET
@@ -2363,11 +2363,11 @@ func (s *environSuite) TestDestroyControllerCustomResourceGroup(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.requests, gc.HasLen, 6)
 	c.Check(s.requests[0].Method, gc.Equals, "GET")
-	c.Check(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
+	c.Check(s.requests[1].Method, gc.Equals, "GET")
+	c.Check(s.requests[1].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
-	c.Check(s.requests[1].Method, gc.Equals, "GET")
 	c.Check(s.requests[2].Method, gc.Equals, "DELETE")
 	c.Check(s.requests[2].URL.Path, gc.Equals, "/networkSecurityGroups/nsg-0")
 	c.Check(s.requests[2].URL.Query().Get("api-version"), gc.Equals, "2021-12-01")

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2189,23 +2189,24 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *gc.C) {
 		makeSender(".*/networkInterfaces/nic-0", nil),                                                                    // DELETE
 		makeSender(".*/publicIPAddresses/pip-0", nil),                                                                    // DELETE
 		makeSenderWithStatus(".*/deployments/juju-06f00d-0", http.StatusNoContent),                                       // DELETE
+		makeSender(".*/providers", makeNetworkProviderResult()),                                                          // GET
 		s.makeErrorSender("/networkSecurityGroups/nsg-0", newAzureResponseError(c, http.StatusConflict, "InUse", ""), 1), // DELETE
 		makeSender("/networkSecurityGroups/nsg-0", nil),                                                                  // DELETE
 		makeSender(".*/vaults/secret-0", nil),                                                                            // DELETE
 	}
 	err := env.Destroy(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.requests, gc.HasLen, 12)
+	c.Assert(s.requests, gc.HasLen, 13)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
 	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
-	c.Assert(s.requests[7].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[8].Method, gc.Equals, "DELETE")
-	c.Assert(s.requests[9].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[9].Method, gc.Equals, "GET")
 	c.Assert(s.requests[10].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[11].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[12].Method, gc.Equals, "DELETE")
 }
 
 func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c *gc.C) {
@@ -2223,6 +2224,7 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 	// fall back to listing all resources and filtering client-side by tag.
 	s.sender = azuretesting.Senders{
 		makeSender(".*/resourceGroups/foo/resources.*", armresources.ResourceListResult{}), // GET with filter, empty
+		makeSender(".*/providers", makeNetworkProviderResult()),                            // GET API versions
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),                // GET without filter
 		makeSender(".*/networkSecurityGroups/nsg-0", armresources.GenericResource{ // GET resource by ID
 			Tags: map[string]*string{tags.JujuModel: to.Ptr(testing.ModelTag.Id())},
@@ -2231,16 +2233,18 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c
 	}
 	err := env.Destroy(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.requests, gc.HasLen, 4)
+	c.Assert(s.requests, gc.HasLen, 5)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
 	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
 	c.Assert(s.requests[1].Method, gc.Equals, "GET")
-	c.Assert(s.requests[1].URL.Query().Get("$filter"), gc.Equals, "")
 	c.Assert(s.requests[2].Method, gc.Equals, "GET")
-	c.Assert(s.requests[3].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[2].URL.Query().Get("$filter"), gc.Equals, "")
+	c.Assert(s.requests[3].Method, gc.Equals, "GET")
+	c.Assert(s.requests[4].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[4].URL.Query().Get("api-version"), gc.Equals, "2021-12-01")
 }
 
 func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *gc.C) {
@@ -2266,6 +2270,7 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *gc
 	// index-addressed write to remainingResources in deleteResources.
 	s.sender = azuretesting.Senders{
 		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult), // GET with filter
+		makeSender(".*/providers", makeNetworkProviderResult()),             // GET API versions
 		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr0, 1),  // DELETE (InUse), pass 1
 		s.makeErrorSender("/networkSecurityGroups/nsg-[01]", inUseErr1, 1),  // DELETE (InUse), pass 1
 		makeSender("/networkSecurityGroups/nsg-[01]", nil),                  // DELETE (ok), pass 2
@@ -2273,12 +2278,13 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroupInUseRetry(c *gc
 	}
 	err := env.Destroy(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.requests, gc.HasLen, 5)
+	c.Assert(s.requests, gc.HasLen, 6)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
-	c.Assert(s.requests[1].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[1].Method, gc.Equals, "GET")
 	c.Assert(s.requests[2].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[3].Method, gc.Equals, "DELETE")
 	c.Assert(s.requests[4].Method, gc.Equals, "DELETE")
+	c.Assert(s.requests[5].Method, gc.Equals, "DELETE")
 }
 
 func (s *environSuite) TestDestroyHostedModelWithInvalidCredential(c *gc.C) {
@@ -2346,6 +2352,7 @@ func (s *environSuite) TestDestroyControllerCustomResourceGroup(c *gc.C) {
 
 	s.sender = azuretesting.Senders{
 		makeSender(".*/resourceGroups/foo/resources.*", resources),     // GET
+		makeSender(".*/providers", makeNetworkProviderResult()),        // GET
 		makeSender("/networkSecurityGroups/nsg-0", nil),                // DELETE
 		makeSender(".*/roleDefinitions*", nil),                         // GET
 		makeSender(".*/roleAssignments*", nil),                         // GET
@@ -2354,14 +2361,16 @@ func (s *environSuite) TestDestroyControllerCustomResourceGroup(c *gc.C) {
 
 	err := env.DestroyController(s.callCtx, s.controllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(s.requests, gc.HasLen, 5)
+	c.Assert(s.requests, gc.HasLen, 6)
 	c.Check(s.requests[0].Method, gc.Equals, "GET")
 	c.Check(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
 		testing.ModelTag.Id(),
 	))
-	c.Check(s.requests[1].Method, gc.Equals, "DELETE")
-	c.Check(s.requests[1].URL.Path, gc.Equals, "/networkSecurityGroups/nsg-0")
+	c.Check(s.requests[1].Method, gc.Equals, "GET")
+	c.Check(s.requests[2].Method, gc.Equals, "DELETE")
+	c.Check(s.requests[2].URL.Path, gc.Equals, "/networkSecurityGroups/nsg-0")
+	c.Check(s.requests[2].URL.Query().Get("api-version"), gc.Equals, "2021-12-01")
 }
 
 func (s *environSuite) TestDestroyControllerManagedIdentityDeleteSuccess(c *gc.C) {
@@ -2617,6 +2626,19 @@ func makeProvidersResult() armresources.ProviderListResult {
 		}},
 	}}
 	return armresources.ProviderListResult{Value: providers}
+}
+
+func makeNetworkProviderResult() armresources.ProviderListResult {
+	return armresources.ProviderListResult{Value: []*armresources.Provider{{
+		Namespace: new("Microsoft.Network"),
+		ResourceTypes: []*armresources.ProviderResourceType{{
+			ResourceType: new("networkSecurityGroups"),
+			APIVersions:  to.SliceOfPtrs("2021-12-01"),
+		}, {
+			ResourceType: new("virtualNetworks"),
+			APIVersions:  to.SliceOfPtrs("2021-12-01"),
+		}},
+	}}}
 }
 
 func makeResourcesResult() armresources.ResourceListResult {

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -2206,6 +2206,41 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *gc.C) {
 	c.Assert(s.requests[11].Method, gc.Equals, "DELETE")
 }
 
+func (s *environSuite) TestDestroyHostedModelCustomResourceGroupFilterFallback(c *gc.C) {
+	env := s.openEnviron(c,
+		testing.Attrs{"controller-uuid": utils.MustNewUUID().String(), "resource-group-name": "foo"})
+
+	res := []*armresources.GenericResourceExpanded{{
+		ID:   to.Ptr("networkSecurityGroups/nsg-0"),
+		Name: to.Ptr("nsg-0"),
+		Type: to.Ptr("Microsoft.Network/networkSecurityGroups"),
+	}}
+	resourceListResult := armresources.ResourceListResult{Value: res}
+
+	// When the tag-filtered list returns nothing, deleteResourcesInGroup must
+	// fall back to listing all resources and filtering client-side by tag.
+	s.sender = azuretesting.Senders{
+		makeSender(".*/resourceGroups/foo/resources.*", armresources.ResourceListResult{}), // GET with filter, empty
+		makeSender(".*/resourceGroups/foo/resources.*", resourceListResult),                // GET without filter
+		makeSender(".*/networkSecurityGroups/nsg-0", armresources.GenericResource{ // GET resource by ID
+			Tags: map[string]*string{tags.JujuModel: to.Ptr(testing.ModelTag.Id())},
+		}),
+		makeSender("/networkSecurityGroups/nsg-0", nil), // DELETE
+	}
+	err := env.Destroy(s.callCtx)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.requests, gc.HasLen, 4)
+	c.Assert(s.requests[0].Method, gc.Equals, "GET")
+	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
+		"tagName eq 'juju-model-uuid' and tagValue eq '%s'",
+		testing.ModelTag.Id(),
+	))
+	c.Assert(s.requests[1].Method, gc.Equals, "GET")
+	c.Assert(s.requests[1].URL.Query().Get("$filter"), gc.Equals, "")
+	c.Assert(s.requests[2].Method, gc.Equals, "GET")
+	c.Assert(s.requests[3].Method, gc.Equals, "DELETE")
+}
+
 func (s *environSuite) TestDestroyHostedModelWithInvalidCredential(c *gc.C) {
 	env := s.openEnviron(c, testing.Attrs{"controller-uuid": utils.MustNewUUID().String()})
 	s.createSenderWithUnauthorisedStatusCode(c)


### PR DESCRIPTION
Cherry-picked commits of https://github.com/juju/juju/pull/23035

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

- Bootstrap with custom resrouce-group:

```
❯ juju bootstrap azure/eastus iyigun-test-ctrl \
  --config resource-group-name=iyigun-test-group
[...]

❯ juju destroy-controller --destroy-all-models --no-prompt iyigun-test-ctrl --debug
[...]
14:24:10 DEBUG juju.provider.azure environ.go:206 discovered tenant id: 40a524d9-f848-46d4-a96f-be6df491fe15
14:24:10 WARN  cmd destroy.go:264 This command will destroy the "iyigun-test-ctrl" controller and all its resources
14:24:10 INFO  cmd destroy.go:295 Destroying controller
14:24:10 INFO  cmd destroy.go:370 Waiting for model resources to be reclaimed
14:24:10 INFO  cmd destroy.go:378 All models reclaimed, cleaning up controller machines
14:24:10 DEBUG juju.provider.azure environ.go:1921 destroying model "controller"
14:24:10 DEBUG juju.provider.azure environ.go:1931 deleting resources in user-specified resource group "iyigun-test-group"
14:24:10 DEBUG juju.provider.azure environ.go:2113 deleting all resources in iyigun-test-group
14:24:16 DEBUG juju.provider.azure environ.go:2154 resource to delete: juju-controller (Microsoft.Compute/availabilitySets)
14:24:16 DEBUG juju.provider.azure environ.go:2154 resource to delete: juju-2336a9-0 (Microsoft.Compute/disks)
14:24:16 DEBUG juju.provider.azure environ.go:2154 resource to delete: juju-2336a9-0 (Microsoft.Compute/virtualMachines)
14:24:16 DEBUG juju.provider.azure environ.go:2154 resource to delete: juju-2336a9-0-primary (Microsoft.Network/networkInterfaces)
14:24:16 DEBUG juju.provider.azure environ.go:2154 resource to delete: juju-internal-nsg (Microsoft.Network/networkSecurityGroups)
14:24:16 DEBUG juju.provider.azure environ.go:2154 resource to delete: juju-2336a9-0-public-ip (Microsoft.Network/publicIPAddresses)
14:24:16 DEBUG juju.provider.azure environ.go:2154 resource to delete: juju-internal-network (Microsoft.Network/virtualNetworks)
14:24:16 DEBUG juju.provider.azure environ.go:1245 canceling deployment for instance "juju-2336a9-0"
14:24:16 DEBUG juju.provider.azure environ.go:1318 - canceling deployment "juju-2336a9-0"
14:24:17 DEBUG juju.provider.azure environ.go:1291 deleting instance "juju-2336a9-0"
14:24:17 DEBUG juju.provider.azure environ.go:1365 - deleting virtual machine (juju-2336a9-0)
14:24:18 DEBUG juju.api monitor.go:35 RPC connection died
14:24:18 DEBUG juju.api monitor.go:35 RPC connection died
14:24:58 DEBUG juju.provider.azure environ.go:1376 - deleting OS disk (juju-2336a9-0)
14:24:59 DEBUG juju.provider.azure environ.go:1390 - deleting security rules (juju-2336a9-0)
14:24:59 DEBUG juju.provider.azure environ.go:1398 - deleting network interfaces (juju-2336a9-0)
14:25:01 DEBUG juju.provider.azure environ.go:1417 - deleting public IPs (juju-2336a9-0)
14:25:12 DEBUG juju.provider.azure environ.go:1437 - deleting deployment (juju-2336a9-0)
14:25:28 DEBUG juju.provider.azure environ.go:2248 deleting 3 resources
14:25:28 DEBUG juju.provider.azure environ.go:2264 - deleting resource "/subscriptions/fbcb21ca-f5c1-44d3-bbc0-37889b64b485/resourceGroups/iyigun-test-group/providers/Microsoft.Compute/availabilitySets/juju-controller"
14:25:28 DEBUG juju.provider.azure environ.go:2264 - deleting resource "/subscriptions/fbcb21ca-f5c1-44d3-bbc0-37889b64b485/resourceGroups/iyigun-test-group/providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg"
14:25:28 DEBUG juju.provider.azure environ.go:2264 - deleting resource "/subscriptions/fbcb21ca-f5c1-44d3-bbc0-37889b64b485/resourceGroups/iyigun-test-group/providers/Microsoft.Network/virtualNetworks/juju-internal-network"
14:25:39 DEBUG juju.provider.azure environ.go:2248 deleting 1 resources
14:25:39 DEBUG juju.provider.azure environ.go:2264 - deleting resource "/subscriptions/fbcb21ca-f5c1-44d3-bbc0-37889b64b485/resourceGroups/iyigun-test-group/providers/Microsoft.Network/networkSecurityGroups/juju-internal-nsg"
14:25:41 DEBUG juju.provider.azure environ.go:1936 deleting auto managed identities
14:25:42 DEBUG juju.provider.azure environ.go:1972 found role definition id:
14:25:42 DEBUG juju.provider.azure environ.go:1992 found role assignment id:
14:25:42 INFO  cmd supercommand.go:578 command finished


❯ az resource list --resource-group iyigun-test-group --output table

```

- Bootstrap with default resrouce-group:

```
❯ juju bootstrap azure/eastus iyigun-test-ctrl
[...]

❯ az resource list --resource-group juju-controller-5f05a68f --output table
Name                     ResourceGroup             Location    Type                                     Status
-----------------------  ------------------------  ----------  ---------------------------------------  ---------
juju-controller          juju-controller-5f05a68f  eastus      Microsoft.Compute/availabilitySets       Succeeded
juju-9e3b6b-0-public-ip  juju-controller-5f05a68f  eastus      Microsoft.Network/publicIPAddresses      Succeeded
juju-internal-nsg        juju-controller-5f05a68f  eastus      Microsoft.Network/networkSecurityGroups  Succeeded
juju-internal-network    juju-controller-5f05a68f  eastus      Microsoft.Network/virtualNetworks        Succeeded
juju-9e3b6b-0-primary    juju-controller-5f05a68f  eastus      Microsoft.Network/networkInterfaces      Succeeded
juju-9e3b6b-0            juju-controller-5f05a68f  eastus      Microsoft.Compute/virtualMachines        Succeeded
juju-9e3b6b-0            JUJU-CONTROLLER-5F05A68F  eastus      Microsoft.Compute/disks                  Succeeded

❯ juju destroy-controller --destroy-all-models --no-prompt iyigun-test-ctrl --debug
[...]
14:46:07 DEBUG juju.provider.azure environ.go:206 discovered tenant id: 40a524d9-f848-46d4-a96f-be6df491fe15
14:46:08 DEBUG juju.provider.azure environ.go:2337 legacy resource group name doesn't exist, using short name
14:46:08 WARN  cmd destroy.go:264 This command will destroy the "iyigun-test-ctrl" controller and all its resources
14:46:08 INFO  cmd destroy.go:295 Destroying controller
14:46:09 INFO  cmd destroy.go:370 Waiting for model resources to be reclaimed
14:46:09 INFO  cmd destroy.go:378 All models reclaimed, cleaning up controller machines
14:46:09 DEBUG juju.provider.azure environ.go:1921 destroying model "controller"
14:46:09 DEBUG juju.provider.azure environ.go:1923 deleting resource groups
14:46:11 DEBUG juju.provider.azure environ.go:2057   - deleting resource group "juju-controller-5f05a68f"
14:46:18 DEBUG juju.api monitor.go:35 RPC connection died
14:46:18 DEBUG juju.api monitor.go:35 RPC connection died
14:50:24 DEBUG juju.provider.azure environ.go:1936 deleting auto managed identities
14:50:25 DEBUG juju.provider.azure environ.go:1972 found role definition id:
14:50:26 DEBUG juju.provider.azure environ.go:1992 found role assignment id:
14:50:27 DEBUG juju.rpc server.go:356 error closing codec: write tcp 192.168.1.28:58090->13.92.69.15:17070: write: connection timed out
write tcp 192.168.1.28:58090->13.92.69.15:17070: write: broken pipe
14:50:27 DEBUG juju.rpc server.go:356 error closing codec: write tcp 192.168.1.28:58086->13.92.69.15:17070: write: connection timed out
write tcp 192.168.1.28:58086->13.92.69.15:17070: write: broken pipe
14:50:27 INFO  cmd supercommand.go:578 command finished

❯ az resource list --resource-group juju-controller-5f05a68f --output table
(ResourceGroupNotFound) Resource group 'juju-controller-5f05a68f' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'juju-controller-5f05a68f' could not be found.
```

## Documentation changes

## Links

