### PR TITLE
fix: API addresses from virtual Ethernet devices

### DIFF
--- a/domain/network/service/interface.go
+++ b/domain/network/service/interface.go
@@ -124,12 +124,12 @@ type NetConfigState interface {
 	// - [uniterrors.UnitNotFound] if the unit does not exist.
 	GetUnitAndK8sServiceAddresses(ctx context.Context, uuid coreunit.UUID) (network.SpaceAddresses, error)
 
-	// GetControllerAPIAddresses returns the addresses which can be used as
-	// controller API addresses for the specified unit.
+	// GetControllerAPIAddresses returns controller API address candidates for
+	// the specified unit, including the supplying device type.
 	//
 	// The following errors may be returned:
 	// - [uniterrors.UnitNotFound] if the unit does not exist.
-	GetControllerAPIAddresses(ctx context.Context, uuid coreunit.UUID) (network.SpaceAddresses, error)
+	GetControllerAPIAddresses(ctx context.Context, uuid string) (domainnetwork.ControllerAPIAddresses, error)
 
 	// GetUnitAddresses returns the addresses of the specified unit.
 	//
@@ -147,7 +147,7 @@ type NetConfigState interface {
 	// The following errors may be returned:
 	// - [applicationerrors.UnitNotFound] if the unit does not exist or is not
 	//   a controller application unit.
-	GetControllerUnitUUIDByName(context.Context, coreunit.Name) (coreunit.UUID, error)
+	GetControllerUnitUUIDByName(context.Context, string) (string, error)
 
 	// GetUnitUUIDByName returns the UUID for the named unit, returning an
 	// error satisfying [applicationerrors.UnitNotFound] if the unit doesn't

--- a/domain/network/service/package_mock_test.go
+++ b/domain/network/service/package_mock_test.go
@@ -42,8 +42,8 @@ type MockStateMockRecorder struct {
 	getAllSpacesExpects                         []*gomock.Call1_2[context.Context, network.SpaceInfos, error]
 	getAllSubnetsExpects                        []*gomock.Call1_2[context.Context, network.SubnetInfos, error]
 	getContainerNetworkingMethodExpects         []*gomock.Call1_2[context.Context, string, error]
-	getControllerAPIAddressesExpects            []*gomock.Call2_2[context.Context, unit.UUID, network.SpaceAddresses, error]
-	getControllerUnitUUIDByNameExpects          []*gomock.Call2_2[context.Context, unit.Name, unit.UUID, error]
+	getControllerAPIAddressesExpects            []*gomock.Call2_2[context.Context, string, network0.ControllerAPIAddresses, error]
+	getControllerUnitUUIDByNameExpects          []*gomock.Call2_2[context.Context, string, string, error]
 	getMachineAppBindingsExpects                []*gomock.Call2_2[context.Context, string, []internal.SpaceName, error]
 	getMachineNetNodeUUIDExpects                []*gomock.Call2_2[context.Context, string, string, error]
 	getMachineSpaceConstraintsExpects           []*gomock.Call2_3[context.Context, string, []internal.SpaceName, []internal.SpaceName, error]
@@ -271,7 +271,7 @@ func (mr *MockStateMockRecorder) GetContainerNetworkingMethod(ctx any) *MockStat
 type MockStateGetContainerNetworkingMethodCall = gomock.Call1_2[context.Context, string, error]
 
 // GetControllerAPIAddresses mocks base method.
-func (m *MockState) GetControllerAPIAddresses(ctx context.Context, uuid unit.UUID) (network.SpaceAddresses, error) {
+func (m *MockState) GetControllerAPIAddresses(ctx context.Context, uuid string) (network0.ControllerAPIAddresses, error) {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch2_2(&m.recorder.getControllerAPIAddressesExpects, m.ctrl, m, "GetControllerAPIAddresses", ctx, uuid)
 }
@@ -279,17 +279,17 @@ func (m *MockState) GetControllerAPIAddresses(ctx context.Context, uuid unit.UUI
 // GetControllerAPIAddresses indicates an expected call of GetControllerAPIAddresses.
 func (mr *MockStateMockRecorder) GetControllerAPIAddresses(ctx, uuid any) *MockStateGetControllerAPIAddressesCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, unit.UUID, network.SpaceAddresses, error](mr.mock.ctrl.T, mr.mock, "GetControllerAPIAddresses", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(uuid))
+	call := gomock.NewCall2_2[context.Context, string, network0.ControllerAPIAddresses, error](mr.mock.ctrl.T, mr.mock, "GetControllerAPIAddresses", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(uuid))
 	mr.getControllerAPIAddressesExpects = append(mr.getControllerAPIAddressesExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockStateGetControllerAPIAddressesCall is the typed call wrapper for GetControllerAPIAddresses.
-type MockStateGetControllerAPIAddressesCall = gomock.Call2_2[context.Context, unit.UUID, network.SpaceAddresses, error]
+type MockStateGetControllerAPIAddressesCall = gomock.Call2_2[context.Context, string, network0.ControllerAPIAddresses, error]
 
 // GetControllerUnitUUIDByName mocks base method.
-func (m *MockState) GetControllerUnitUUIDByName(arg0 context.Context, arg1 unit.Name) (unit.UUID, error) {
+func (m *MockState) GetControllerUnitUUIDByName(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch2_2(&m.recorder.getControllerUnitUUIDByNameExpects, m.ctrl, m, "GetControllerUnitUUIDByName", arg0, arg1)
 }
@@ -297,14 +297,14 @@ func (m *MockState) GetControllerUnitUUIDByName(arg0 context.Context, arg1 unit.
 // GetControllerUnitUUIDByName indicates an expected call of GetControllerUnitUUIDByName.
 func (mr *MockStateMockRecorder) GetControllerUnitUUIDByName(arg0, arg1 any) *MockStateGetControllerUnitUUIDByNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, unit.Name, unit.UUID, error](mr.mock.ctrl.T, mr.mock, "GetControllerUnitUUIDByName", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
+	call := gomock.NewCall2_2[context.Context, string, string, error](mr.mock.ctrl.T, mr.mock, "GetControllerUnitUUIDByName", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
 	mr.getControllerUnitUUIDByNameExpects = append(mr.getControllerUnitUUIDByNameExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockStateGetControllerUnitUUIDByNameCall is the typed call wrapper for GetControllerUnitUUIDByName.
-type MockStateGetControllerUnitUUIDByNameCall = gomock.Call2_2[context.Context, unit.Name, unit.UUID, error]
+type MockStateGetControllerUnitUUIDByNameCall = gomock.Call2_2[context.Context, string, string, error]
 
 // GetMachineAppBindings mocks base method.
 func (m *MockState) GetMachineAppBindings(ctx context.Context, machineUUID string) ([]internal.SpaceName, error) {

--- a/domain/network/service/unitaddress.go
+++ b/domain/network/service/unitaddress.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/unit"
+	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -91,27 +92,83 @@ func (s *Service) GetUnitPublicAddresses(ctx context.Context, unitName unit.Name
 	return matchedAddrs, nil
 }
 
-// GetControllerAPIAddresses returns all addresses which can be used for
-// API addresses for the specified unit. local-machine scoped addresses
-// will not be returned.
+// GetControllerAPIAddresses returns addresses which can be used for API
+// addresses for the specified unit. Local-machine scoped addresses will
+// not be returned. Non-virtual Ethernet addresses are preferred, with virtual
+// Ethernet addresses retained as a fallback. If a management space is
+// configured, its candidates are selected independently so that it is always
+// honoured.
 //
 // The following errors may be returned:
 //   - [applicationerrors.UnitNotFound] if the unit does not exist or is
 //     not a controller application unit.
 //   - [network.NoAddressError] if the unit has no suitable API addresses.
-func (s *Service) GetControllerAPIAddresses(ctx context.Context, unitName unit.Name) (network.SpaceAddresses, error) {
-	unitUUID, err := s.st.GetControllerUnitUUIDByName(ctx, unitName)
+func (s *Service) GetControllerAPIAddresses(
+	ctx context.Context,
+	unitName unit.Name,
+	managementSpace *network.SpaceInfo,
+) (network.SpaceAddresses, error) {
+	unitUUID, err := s.st.GetControllerUnitUUIDByName(ctx, unitName.String())
 	if err != nil {
-		return nil, errors.Capture(err)
-	}
-	addrs, err := s.st.GetControllerAPIAddresses(ctx, unitUUID)
-	if err != nil {
-		return nil, errors.Capture(err)
+		return nil, errors.Errorf("getting controller unit UUID for %q: %w", unitName, err)
 	}
 
+	candidates, err := s.st.GetControllerAPIAddresses(ctx, unitUUID)
+	if err != nil {
+		return nil, errors.Errorf("getting API addresses for %q: %w", unitName, err)
+	}
+
+	addrs := selectControllerAPIAddresses(candidates, managementSpace)
 	if len(addrs) == 0 {
 		return nil, network.NoAddressError("API")
 	}
 
 	return addrs, nil
+}
+
+// selectControllerAPIAddresses selects the preferred client addresses from all
+// candidates. When a management space is configured, its preferred addresses
+// are added to the selection so that agent connectivity honours the explicit
+// operator choice.
+func selectControllerAPIAddresses(
+	candidates domainnetwork.ControllerAPIAddresses,
+	managementSpace *network.SpaceInfo,
+) network.SpaceAddresses {
+	selected := make([]bool, len(candidates))
+	markPreferredControllerAPIAddresses(candidates, nil, selected)
+	if managementSpace != nil {
+		markPreferredControllerAPIAddresses(candidates, &managementSpace.ID, selected)
+	}
+
+	result := make(network.SpaceAddresses, 0, len(candidates))
+	for i, candidate := range candidates {
+		if selected[i] {
+			result = append(result, candidate.SpaceAddress)
+		}
+	}
+	return result
+}
+
+func markPreferredControllerAPIAddresses(
+	candidates domainnetwork.ControllerAPIAddresses,
+	spaceUUID *network.SpaceUUID,
+	selected []bool,
+) {
+	hasNonVeth := false
+	for _, candidate := range candidates {
+		if (spaceUUID == nil || candidate.SpaceID == *spaceUUID) &&
+			candidate.DeviceType != domainnetwork.DeviceTypeVeth {
+			hasNonVeth = true
+			break
+		}
+	}
+
+	for i, candidate := range candidates {
+		if spaceUUID != nil && candidate.SpaceID != *spaceUUID {
+			continue
+		}
+		if !hasNonVeth || candidate.DeviceType != domainnetwork.DeviceTypeVeth {
+			selected[i] = true
+		}
+	}
 }

--- a/domain/network/service/unitaddress.go
+++ b/domain/network/service/unitaddress.go
@@ -108,6 +108,9 @@ func (s *Service) GetControllerAPIAddresses(
 	unitName unit.Name,
 	managementSpace *network.SpaceInfo,
 ) (network.SpaceAddresses, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
 	unitUUID, err := s.st.GetControllerUnitUUIDByName(ctx, unitName.String())
 	if err != nil {
 		return nil, errors.Errorf("getting controller unit UUID for %q: %w", unitName, err)

--- a/domain/network/service/unitaddress_test.go
+++ b/domain/network/service/unitaddress_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/unit"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
@@ -420,50 +421,95 @@ func (s *unitAddressSuite) TestGetPublicAddressesNoAddresses(c *tc.C) {
 	c.Assert(err, tc.Satisfies, network.IsNoAddressError)
 }
 
-func (s *unitAddressSuite) TestGetControllerAPIAddresses(c *tc.C) {
+func (s *unitAddressSuite) TestGetControllerAPIAddressesPrefersNonVeth(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
 	unitName := unit.Name("foo/0")
-	unitAddresses := network.SpaceAddresses{
-		{
-			SpaceID: network.AlphaSpaceId,
-			MachineAddress: network.MachineAddress{
-				Value:      "2001:DB8::/32",
-				ConfigType: network.ConfigStatic,
-				Type:       network.IPv6Address,
-				Scope:      network.ScopePublic,
-			},
-		},
-		{
-			SpaceID: network.AlphaSpaceId,
-			MachineAddress: network.MachineAddress{
-				Value:      "10.0.0.2/24",
-				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv4Address,
-				Scope:      network.ScopePublic,
-			},
-		},
-		{
-			SpaceID: network.AlphaSpaceId,
-			MachineAddress: network.MachineAddress{
-				Value:      "54.32.1.3/24",
-				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv4Address,
-				Scope:      network.ScopeCloudLocal,
-			},
-		},
+	candidates := domainnetwork.ControllerAPIAddresses{
+		newControllerAPIAddress("10.0.0.1", "space-0", domainnetwork.DeviceTypeVeth),
+		newControllerAPIAddress("10.0.0.2", "space-0", domainnetwork.DeviceTypeEthernet),
 	}
 
-	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName).Return("foo", nil)
-	s.st.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.UUID("foo")).Return(unitAddresses, nil)
+	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName.String()).Return("foo", nil)
+	s.st.EXPECT().GetControllerAPIAddresses(gomock.Any(), "foo").Return(candidates, nil)
 
 	// Act
-	addrs, err := s.service(c).GetControllerAPIAddresses(c.Context(), unitName)
+	addrs, err := s.service(c).GetControllerAPIAddresses(c.Context(), unitName, nil)
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(addrs, tc.DeepEquals, unitAddresses)
+	c.Check(addrs, tc.DeepEquals, network.SpaceAddresses{candidates[1].SpaceAddress})
+}
+
+func (s *unitAddressSuite) TestGetControllerAPIAddressesFallsBackToVeth(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unit.Name("foo/0")
+	candidates := domainnetwork.ControllerAPIAddresses{
+		newControllerAPIAddress("10.0.0.1", "space-0", domainnetwork.DeviceTypeVeth),
+		newControllerAPIAddress("10.0.0.2", "space-1", domainnetwork.DeviceTypeVeth),
+	}
+
+	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName.String()).Return("foo", nil)
+	s.st.EXPECT().GetControllerAPIAddresses(gomock.Any(), "foo").Return(candidates, nil)
+
+	addrs, err := s.service(c).GetControllerAPIAddresses(c.Context(), unitName, nil)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(addrs, tc.DeepEquals, network.SpaceAddresses{
+		candidates[0].SpaceAddress,
+		candidates[1].SpaceAddress,
+	})
+}
+
+func (s *unitAddressSuite) TestGetControllerAPIAddressesHonoursManagementSpace(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unit.Name("foo/0")
+	candidates := domainnetwork.ControllerAPIAddresses{
+		newControllerAPIAddress("10.0.0.1", "management", domainnetwork.DeviceTypeVeth),
+		newControllerAPIAddress("10.0.0.2", "management", domainnetwork.DeviceTypeEthernet),
+		newControllerAPIAddress("10.1.0.1", "other", domainnetwork.DeviceTypeEthernet),
+	}
+	managementSpace := &network.SpaceInfo{ID: "management"}
+
+	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName.String()).Return("foo", nil)
+	s.st.EXPECT().GetControllerAPIAddresses(gomock.Any(), "foo").Return(candidates, nil)
+
+	addrs, err := s.service(c).GetControllerAPIAddresses(
+		c.Context(), unitName, managementSpace,
+	)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(addrs, tc.DeepEquals, network.SpaceAddresses{
+		candidates[1].SpaceAddress,
+		candidates[2].SpaceAddress,
+	})
+}
+
+func (s *unitAddressSuite) TestGetControllerAPIAddressesFallsBackToVethInManagementSpace(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	unitName := unit.Name("foo/0")
+	candidates := domainnetwork.ControllerAPIAddresses{
+		newControllerAPIAddress("10.0.0.1", "management", domainnetwork.DeviceTypeVeth),
+		newControllerAPIAddress("10.1.0.1", "other", domainnetwork.DeviceTypeEthernet),
+	}
+	managementSpace := &network.SpaceInfo{ID: "management"}
+
+	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName.String()).Return("foo", nil)
+	s.st.EXPECT().GetControllerAPIAddresses(gomock.Any(), "foo").Return(candidates, nil)
+
+	addrs, err := s.service(c).GetControllerAPIAddresses(
+		c.Context(), unitName, managementSpace,
+	)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(addrs, tc.DeepEquals, network.SpaceAddresses{
+		candidates[0].SpaceAddress,
+		candidates[1].SpaceAddress,
+	})
 }
 
 func (s *unitAddressSuite) TestGetControllerAPIAddressesNoAddresses(c *tc.C) {
@@ -471,11 +517,11 @@ func (s *unitAddressSuite) TestGetControllerAPIAddressesNoAddresses(c *tc.C) {
 
 	// Arrange
 	unitName := unit.Name("foo/0")
-	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName).Return(unit.UUID("foo"), nil)
-	s.st.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.UUID("foo")).Return(network.SpaceAddresses{}, nil)
+	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName.String()).Return("foo", nil)
+	s.st.EXPECT().GetControllerAPIAddresses(gomock.Any(), "foo").Return(domainnetwork.ControllerAPIAddresses{}, nil)
 
 	// Act
-	_, err := s.service(c).GetControllerAPIAddresses(c.Context(), unitName)
+	_, err := s.service(c).GetControllerAPIAddresses(c.Context(), unitName, nil)
 
 	// Assert
 	c.Assert(err, tc.Satisfies, network.IsNoAddressError)
@@ -486,10 +532,10 @@ func (s *unitAddressSuite) TestGetControllerAPIAddressesUnitNotFound(c *tc.C) {
 
 	// Arrange
 	unitName := unit.Name("foo/0")
-	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName).Return(unit.UUID("foo"), applicationerrors.UnitNotFound)
+	s.st.EXPECT().GetControllerUnitUUIDByName(gomock.Any(), unitName.String()).Return("foo", applicationerrors.UnitNotFound)
 
 	// Act
-	_, err := s.service(c).GetControllerAPIAddresses(c.Context(), unitName)
+	_, err := s.service(c).GetControllerAPIAddresses(c.Context(), unitName, nil)
 
 	// Assert
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
@@ -661,4 +707,20 @@ func (s *unitAddressSuite) TestGetUnitPrivateAddressNoAddress(c *tc.C) {
 
 	_, err := s.service(c).GetUnitPrivateAddress(c.Context(), unitName)
 	c.Assert(err, tc.Satisfies, network.IsNoAddressError)
+}
+
+func newControllerAPIAddress(
+	value string,
+	spaceUUID network.SpaceUUID,
+	deviceType domainnetwork.DeviceType,
+) domainnetwork.ControllerAPIAddress {
+	return domainnetwork.ControllerAPIAddress{
+		SpaceAddress: network.SpaceAddress{
+			SpaceID: spaceUUID,
+			MachineAddress: network.MachineAddress{
+				Value: value,
+			},
+		},
+		DeviceType: deviceType,
+	}
 }

--- a/domain/network/state/address.go
+++ b/domain/network/state/address.go
@@ -20,14 +20,14 @@ func (st *State) GetNetNodeAddresses(ctx context.Context, nodeUUID string) (core
 		return nil, errors.Capture(err)
 	}
 
-	var address []spaceAddress
+	var address []SpaceAddress
 	ident := entityUUID{UUID: nodeUUID}
 	stmt, err := st.Prepare(`
-SELECT    &spaceAddress.*
+SELECT    &SpaceAddress.*
 FROM      v_ip_address_with_names AS ipa
 LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid
 WHERE     net_node_uuid = $entityUUID.uuid
-`, spaceAddress{}, entityUUID{})
+`, SpaceAddress{}, entityUUID{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -644,6 +644,31 @@ type spaceAddress struct {
 	SubnetCIDR sql.NullString `db:"cidr"`
 }
 
+type controllerAPIAddress struct {
+	Value      string         `db:"address_value"`
+	ConfigType string         `db:"config_type_name"`
+	Type       string         `db:"type_name"`
+	Origin     string         `db:"origin_name"`
+	Scope      string         `db:"scope_name"`
+	DeviceUUID string         `db:"device_uuid"`
+	SpaceUUID  sql.NullString `db:"space_uuid"`
+	SubnetCIDR sql.NullString `db:"cidr"`
+	DeviceType int            `db:"device_type_id"`
+}
+
+func (a controllerAPIAddress) toSpaceAddress() spaceAddress {
+	return spaceAddress{
+		Value:      a.Value,
+		ConfigType: a.ConfigType,
+		Type:       a.Type,
+		Origin:     a.Origin,
+		Scope:      a.Scope,
+		DeviceUUID: a.DeviceUUID,
+		SpaceUUID:  a.SpaceUUID,
+		SubnetCIDR: a.SubnetCIDR,
+	}
+}
+
 // spaceConstraint represents a space name/UUID pair and its
 // role as a constraint (whether included or excluded).
 type spaceConstraint struct {

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -633,7 +633,9 @@ func (subs subnetGroups) subnetForIP(ip net.IP) (string, error) {
 	return matches[0], nil
 }
 
-type spaceAddress struct {
+// SpaceAddress represents an address joined with its space and subnet details.
+// It is exported so SQLair can reflect it when embedded in query result types.
+type SpaceAddress struct {
 	Value      string         `db:"address_value"`
 	ConfigType string         `db:"config_type_name"`
 	Type       string         `db:"type_name"`
@@ -645,28 +647,8 @@ type spaceAddress struct {
 }
 
 type controllerAPIAddress struct {
-	Value      string         `db:"address_value"`
-	ConfigType string         `db:"config_type_name"`
-	Type       string         `db:"type_name"`
-	Origin     string         `db:"origin_name"`
-	Scope      string         `db:"scope_name"`
-	DeviceUUID string         `db:"device_uuid"`
-	SpaceUUID  sql.NullString `db:"space_uuid"`
-	SubnetCIDR sql.NullString `db:"cidr"`
-	DeviceType int            `db:"device_type_id"`
-}
-
-func (a controllerAPIAddress) toSpaceAddress() spaceAddress {
-	return spaceAddress{
-		Value:      a.Value,
-		ConfigType: a.ConfigType,
-		Type:       a.Type,
-		Origin:     a.Origin,
-		Scope:      a.Scope,
-		DeviceUUID: a.DeviceUUID,
-		SpaceUUID:  a.SpaceUUID,
-		SubnetCIDR: a.SubnetCIDR,
-	}
+	SpaceAddress
+	DeviceType int `db:"device_type_id"`
 }
 
 // spaceConstraint represents a space name/UUID pair and its

--- a/domain/network/state/unitaddress.go
+++ b/domain/network/state/unitaddress.go
@@ -14,6 +14,7 @@ import (
 	coreunit "github.com/juju/juju/core/unit"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	domainlife "github.com/juju/juju/domain/life"
+	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -59,87 +60,94 @@ WHERE     ua.unit_uuid = $entityUUID.uuid
 	return encodeIPAddresses(address)
 }
 
-// GetControllerAPIAddresses returns the addresses which can be used as
+// GetControllerAPIAddresses returns address candidates which can be used as
 // controller API addresses for the specified unit.
 //
 // The addresses are taken from the union of the net node UUIDs of the cloud
 // service (if any) and the net node UUIDs of the unit, where each net node has
 // an associated address.
 //
-// Addresses belonging to virtual Ethernet devices are excluded because those
-// devices are not suitable for advertised ingress.
+// Machine-local addresses are excluded because they are not suitable for
+// advertised ingress. Device types are returned with the addresses so that the
+// service can prefer non-virtual Ethernet devices while retaining a fallback.
 //
 // The following errors may be returned:
 // - [uniterrors.UnitNotFound] if the unit does not exist.
-func (st *State) GetControllerAPIAddresses(ctx context.Context, uuid coreunit.UUID) (corenetwork.SpaceAddresses, error) {
+func (st *State) GetControllerAPIAddresses(
+	ctx context.Context, unitUUID string,
+) (domainnetwork.ControllerAPIAddresses, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
-	var address []spaceAddress
-	ident := entityUUID{UUID: uuid.String()}
+	ident := entityUUID{UUID: unitUUID}
+
 	type apiAddressFilter struct {
-		DeviceTypeName string `db:"device_type_name"`
-		ScopeName      string `db:"scope_name"`
+		ScopeName string `db:"scope_name"`
 	}
 	filter := apiAddressFilter{
-		DeviceTypeName: corenetwork.VirtualEthernetDevice.String(),
-		ScopeName:      corenetwork.ScopeMachineLocal.String(),
+		ScopeName: corenetwork.ScopeMachineLocal.String(),
 	}
+
 	queryUnitAPIAddressesStmt, err := st.Prepare(`
 WITH unit_net_node AS (
-    SELECT ks.net_node_uuid
+    SELECT ks.net_node_uuid AS net_node_uuid
     FROM   unit AS u
     JOIN   application AS app ON u.application_uuid = app.uuid
     JOIN   k8s_service AS ks ON app.uuid = ks.application_uuid
     WHERE  u.uuid = $entityUUID.uuid
     UNION
-    SELECT u.net_node_uuid
+    SELECT u.net_node_uuid AS net_node_uuid
     FROM   unit AS u
     WHERE  u.uuid = $entityUUID.uuid
 )
-SELECT ipa.address_value AS &spaceAddress.address_value,
-       iact.name AS &spaceAddress.config_type_name,
-       iat.name AS &spaceAddress.type_name,
-       iao.name AS &spaceAddress.origin_name,
-       ias.name AS &spaceAddress.scope_name,
-       ipa.device_uuid AS &spaceAddress.device_uuid,
-       sn.space_uuid AS &spaceAddress.space_uuid,
-       sn.cidr AS &spaceAddress.cidr
+SELECT ipa.address_value AS &controllerAPIAddress.address_value,
+       iact.name AS &controllerAPIAddress.config_type_name,
+       iat.name AS &controllerAPIAddress.type_name,
+       iao.name AS &controllerAPIAddress.origin_name,
+       ias.name AS &controllerAPIAddress.scope_name,
+       ipa.device_uuid AS &controllerAPIAddress.device_uuid,
+       sn.space_uuid AS &controllerAPIAddress.space_uuid,
+       sn.cidr AS &controllerAPIAddress.cidr,
+       lld.device_type_id AS &controllerAPIAddress.device_type_id
 FROM   unit_net_node AS unn
 JOIN   ip_address AS ipa ON unn.net_node_uuid = ipa.net_node_uuid
 JOIN   link_layer_device AS lld
        ON ipa.device_uuid = lld.uuid
        AND unn.net_node_uuid = lld.net_node_uuid
-JOIN   link_layer_device_type AS lldt ON lld.device_type_id = lldt.id
 JOIN   ip_address_config_type AS iact ON ipa.config_type_id = iact.id
 JOIN   ip_address_type AS iat ON ipa.type_id = iat.id
 JOIN   ip_address_origin AS iao ON ipa.origin_id = iao.id
 JOIN   ip_address_scope AS ias ON ipa.scope_id = ias.id
 LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid
-WHERE  lldt.name != $apiAddressFilter.device_type_name
-AND    ias.name != $apiAddressFilter.scope_name
-`, spaceAddress{}, entityUUID{}, apiAddressFilter{})
+WHERE  ias.name != $apiAddressFilter.scope_name
+`, controllerAPIAddress{}, entityUUID{}, apiAddressFilter{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
 
+	var addresses []controllerAPIAddress
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		address = nil
+		addresses = nil
 		if err := st.checkUnitNotDead(ctx, tx, ident); err != nil {
 			return errors.Capture(err)
 		}
-		err := tx.Query(ctx, queryUnitAPIAddressesStmt, ident, filter).GetAll(&address)
+		err := tx.Query(ctx, queryUnitAPIAddressesStmt, ident, filter).GetAll(&addresses)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("querying API addresses for unit %q: %w", uuid, err)
+			return errors.Errorf("querying unit addresses: %w", err)
 		}
 		return nil
 	})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
-	return encodeIPAddresses(address)
+
+	addrs, err := encodeControllerAPIAddresses(addresses)
+	if err != nil {
+		return nil, errors.Errorf("encoding API addresses: %q", err)
+	}
+	return addrs, nil
 }
 
 // GetUnitAddresses returns the addresses of the specified unit.
@@ -188,7 +196,7 @@ WHERE     u.uuid = $entityUUID.uuid
 // The following errors may be returned:
 //   - [applicationerrors.UnitNotFound] if the unit does not exist or is not
 //     a controller application unit.
-func (st *State) GetControllerUnitUUIDByName(ctx context.Context, name coreunit.Name) (coreunit.UUID, error) {
+func (st *State) GetControllerUnitUUIDByName(ctx context.Context, name string) (string, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return "", errors.Capture(err)
@@ -204,15 +212,16 @@ WHERE  u.name = $unitName.name
 		return "", errors.Errorf("preparing query: %w", err)
 	}
 
-	var uuid coreunit.UUID
+	var uuid string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		unitName := unitName{Name: name}
+		uuid = ""
+		unitName := unitName{Name: coreunit.Name(name)}
 		unitUUID := entityUUID{}
 		err = tx.Query(ctx, query, unitName).Get(&unitUUID)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("unit %q not found", name).Add(applicationerrors.UnitNotFound)
+			return applicationerrors.UnitNotFound
 		}
-		uuid = coreunit.UUID(unitUUID.UUID)
+		uuid = unitUUID.String()
 		return errors.Capture(err)
 	})
 	if err != nil {
@@ -308,6 +317,21 @@ func encodeIPAddresses(addresses []spaceAddress) (corenetwork.SpaceAddresses, er
 			return nil, errors.Capture(err)
 		}
 		res[i] = encodedIP
+	}
+	return res, nil
+}
+
+func encodeControllerAPIAddresses(addresses []controllerAPIAddress) (domainnetwork.ControllerAPIAddresses, error) {
+	res := make(domainnetwork.ControllerAPIAddresses, len(addresses))
+	for i, addr := range addresses {
+		encodedIP, err := encodeIPAddress(addr.toSpaceAddress())
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		res[i] = domainnetwork.ControllerAPIAddress{
+			SpaceAddress: encodedIP,
+			DeviceType:   domainnetwork.DeviceType(addr.DeviceType),
+		}
 	}
 	return res, nil
 }

--- a/domain/network/state/unitaddress.go
+++ b/domain/network/state/unitaddress.go
@@ -145,7 +145,7 @@ WHERE  ias.name != $apiAddressFilter.scope_name
 
 	addrs, err := encodeControllerAPIAddresses(addresses)
 	if err != nil {
-		return nil, errors.Errorf("encoding API addresses: %q", err)
+		return nil, errors.Errorf("encoding API addresses: %w", err)
 	}
 	return addrs, nil
 }

--- a/domain/network/state/unitaddress.go
+++ b/domain/network/state/unitaddress.go
@@ -33,13 +33,13 @@ func (st *State) GetUnitAndK8sServiceAddresses(ctx context.Context, uuid coreuni
 		return nil, errors.Capture(err)
 	}
 
-	var address []spaceAddress
+	var address []SpaceAddress
 	ident := entityUUID{UUID: uuid.String()}
 	queryUnitPublicAddressesStmt, err := st.Prepare(`
-SELECT &spaceAddress.*
+SELECT &SpaceAddress.*
 FROM v_all_unit_address AS ua
 WHERE     ua.unit_uuid = $entityUUID.uuid
-`, spaceAddress{}, entityUUID{})
+`, SpaceAddress{}, entityUUID{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -160,16 +160,16 @@ func (st *State) GetUnitAddresses(ctx context.Context, uuid coreunit.UUID) (core
 		return nil, errors.Capture(err)
 	}
 
-	var address []spaceAddress
+	var address []SpaceAddress
 	ident := entityUUID{UUID: uuid.String()}
 	queryUnitPublicAddressesStmt, err := st.Prepare(`
-SELECT    &spaceAddress.*
+SELECT    &SpaceAddress.*
 FROM      unit u
 JOIN      link_layer_device AS lld ON u.net_node_uuid = lld.net_node_uuid
 JOIN      v_ip_address_with_names AS ipa ON lld.uuid = ipa.device_uuid
 LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid
 WHERE     u.uuid = $entityUUID.uuid
-`, spaceAddress{}, entityUUID{})
+`, SpaceAddress{}, entityUUID{})
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -309,7 +309,7 @@ WHERE uuid = $entityUUID.uuid;
 	}
 }
 
-func encodeIPAddresses(addresses []spaceAddress) (corenetwork.SpaceAddresses, error) {
+func encodeIPAddresses(addresses []SpaceAddress) (corenetwork.SpaceAddresses, error) {
 	res := make(corenetwork.SpaceAddresses, len(addresses))
 	for i, addr := range addresses {
 		encodedIP, err := encodeIPAddress(addr)
@@ -324,7 +324,7 @@ func encodeIPAddresses(addresses []spaceAddress) (corenetwork.SpaceAddresses, er
 func encodeControllerAPIAddresses(addresses []controllerAPIAddress) (domainnetwork.ControllerAPIAddresses, error) {
 	res := make(domainnetwork.ControllerAPIAddresses, len(addresses))
 	for i, addr := range addresses {
-		encodedIP, err := encodeIPAddress(addr.toSpaceAddress())
+		encodedIP, err := encodeIPAddress(addr.SpaceAddress)
 		if err != nil {
 			return nil, errors.Capture(err)
 		}
@@ -336,7 +336,7 @@ func encodeControllerAPIAddresses(addresses []controllerAPIAddress) (domainnetwo
 	return res, nil
 }
 
-func encodeIPAddress(address spaceAddress) (corenetwork.SpaceAddress, error) {
+func encodeIPAddress(address SpaceAddress) (corenetwork.SpaceAddress, error) {
 	spaceUUID := corenetwork.AlphaSpaceId
 	if address.SpaceUUID.Valid {
 		spaceUUID = corenetwork.SpaceUUID(address.SpaceUUID.String)

--- a/domain/network/state/unitaddress_test.go
+++ b/domain/network/state/unitaddress_test.go
@@ -12,6 +12,7 @@ import (
 	corenetwork "github.com/juju/juju/core/network"
 	coreunit "github.com/juju/juju/core/unit"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -140,7 +141,7 @@ func (s *unitAddressSuite) TestGetUnitAndK8sServiceAddressesNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
-func (s *unitAddressSuite) TestGetControllerAPIAddressesExcludesVeth(c *tc.C) {
+func (s *unitAddressSuite) TestGetControllerAPIAddressesReturnsDeviceTypes(c *tc.C) {
 	// Arrange
 	nodeUUID := s.addNetNode(c)
 	ethDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
@@ -176,24 +177,42 @@ func (s *unitAddressSuite) TestGetControllerAPIAddressesExcludesVeth(c *tc.C) {
 	unitUUID := s.addUnit(c, appUUID, charmUUID, nodeUUID)
 
 	// Act
-	addr, err := s.state.GetControllerAPIAddresses(c.Context(), unitUUID)
+	addr, err := s.state.GetControllerAPIAddresses(c.Context(), unitUUID.String())
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(addr, tc.DeepEquals, corenetwork.SpaceAddresses{{
-		SpaceID: corenetwork.SpaceUUID(spaceUUID),
-		Origin:  corenetwork.OriginProvider,
-		MachineAddress: corenetwork.MachineAddress{
-			Value:      "10.0.0.1",
-			CIDR:       cidr,
-			Type:       corenetwork.IPv4Address,
-			Scope:      corenetwork.ScopeCloudLocal,
-			ConfigType: corenetwork.ConfigStatic,
+	c.Check(addr, tc.SameContents, domainnetwork.ControllerAPIAddresses{
+		{
+			SpaceAddress: corenetwork.SpaceAddress{
+				SpaceID: corenetwork.SpaceUUID(spaceUUID),
+				Origin:  corenetwork.OriginProvider,
+				MachineAddress: corenetwork.MachineAddress{
+					Value:      "10.0.0.1",
+					CIDR:       cidr,
+					Type:       corenetwork.IPv4Address,
+					Scope:      corenetwork.ScopeCloudLocal,
+					ConfigType: corenetwork.ConfigStatic,
+				},
+			},
+			DeviceType: domainnetwork.DeviceTypeEthernet,
+		}, {
+			SpaceAddress: corenetwork.SpaceAddress{
+				SpaceID: corenetwork.SpaceUUID(spaceUUID),
+				Origin:  corenetwork.OriginProvider,
+				MachineAddress: corenetwork.MachineAddress{
+					Value:      "10.0.0.2",
+					CIDR:       cidr,
+					Type:       corenetwork.IPv4Address,
+					Scope:      corenetwork.ScopeCloudLocal,
+					ConfigType: corenetwork.ConfigStatic,
+				},
+			},
+			DeviceType: domainnetwork.DeviceTypeVeth,
 		},
-	}})
+	})
 }
 
-func (s *unitAddressSuite) TestGetControllerAPIAddressesExcludesK8sServiceVeth(c *tc.C) {
+func (s *unitAddressSuite) TestGetControllerAPIAddressesIncludesK8sServicePlaceholder(c *tc.C) {
 	// Arrange
 	podNodeUUID := s.addNetNode(c)
 	podDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
@@ -202,14 +221,13 @@ func (s *unitAddressSuite) TestGetControllerAPIAddressesExcludesK8sServiceVeth(c
 	)
 
 	svcNodeUUID := s.addNetNode(c)
-	svcVethDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
-		c, svcNodeUUID, "veth0", "00:11:22:33:44:66",
-		corenetwork.VirtualEthernetDevice,
-	)
-	svcEthDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
-		c, svcNodeUUID, "eth1", "00:11:22:33:44:77",
+	svcDeviceUUID := s.linkLayerBaseSuite.addLinkLayerDevice(
+		c, svcNodeUUID, "placeholder", "00:11:22:33:44:66",
 		corenetwork.EthernetDevice,
 	)
+	// Kubernetes service devices are placeholders without a discovered type.
+	s.query(c, `UPDATE link_layer_device SET device_type_id = 0 WHERE uuid = ?`,
+		svcDeviceUUID)
 
 	spaceUUID := s.addSpace(c)
 	subnetUUID, cidr := s.addsubnet(c, spaceUUID)
@@ -218,11 +236,7 @@ func (s *unitAddressSuite) TestGetControllerAPIAddressesExcludesK8sServiceVeth(c
 		corenetwork.ScopeMachineLocal,
 	)
 	s.addIPAddressWithSubnetAndScope(
-		c, svcVethDeviceUUID, svcNodeUUID, subnetUUID, "10.0.0.2",
-		corenetwork.ScopeCloudLocal,
-	)
-	s.addIPAddressWithSubnetAndScope(
-		c, svcEthDeviceUUID, svcNodeUUID, subnetUUID, "10.0.0.3",
+		c, svcDeviceUUID, svcNodeUUID, subnetUUID, "10.0.0.2",
 		corenetwork.ScopeCloudLocal,
 	)
 
@@ -232,20 +246,23 @@ func (s *unitAddressSuite) TestGetControllerAPIAddressesExcludesK8sServiceVeth(c
 	s.addK8sService(c, svcNodeUUID, appUUID)
 
 	// Act
-	addr, err := s.state.GetControllerAPIAddresses(c.Context(), unitUUID)
+	addr, err := s.state.GetControllerAPIAddresses(c.Context(), unitUUID.String())
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(addr, tc.SameContents, corenetwork.SpaceAddresses{{
-		SpaceID: corenetwork.SpaceUUID(spaceUUID),
-		Origin:  corenetwork.OriginProvider,
-		MachineAddress: corenetwork.MachineAddress{
-			Value:      "10.0.0.3",
-			CIDR:       cidr,
-			Type:       corenetwork.IPv4Address,
-			Scope:      corenetwork.ScopeCloudLocal,
-			ConfigType: corenetwork.ConfigStatic,
+	c.Check(addr, tc.SameContents, domainnetwork.ControllerAPIAddresses{{
+		SpaceAddress: corenetwork.SpaceAddress{
+			SpaceID: corenetwork.SpaceUUID(spaceUUID),
+			Origin:  corenetwork.OriginProvider,
+			MachineAddress: corenetwork.MachineAddress{
+				Value:      "10.0.0.2",
+				CIDR:       cidr,
+				Type:       corenetwork.IPv4Address,
+				Scope:      corenetwork.ScopeCloudLocal,
+				ConfigType: corenetwork.ConfigStatic,
+			},
 		},
+		DeviceType: domainnetwork.DeviceTypeUnknown,
 	}})
 }
 
@@ -310,11 +327,11 @@ func (s *unitAddressSuite) TestGetControllerUnitUUIDByName(c *tc.C) {
 	unitUUID := s.addUnit(c, appUUID, charmUUID, nodeUUID)
 
 	// Act:
-	uuid, err := s.state.GetControllerUnitUUIDByName(c.Context(), coreunit.Name(unitUUID))
+	uuid, err := s.state.GetControllerUnitUUIDByName(c.Context(), unitUUID.String())
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(uuid, tc.Equals, unitUUID)
+	c.Check(uuid, tc.Equals, unitUUID.String())
 }
 
 func (s *unitAddressSuite) TestGetControllerUnitUUIDByNameNotFound(c *tc.C) {

--- a/domain/network/state/unitinfo.go
+++ b/domain/network/state/unitinfo.go
@@ -85,7 +85,7 @@ func (st *State) GetUnitEndpointNetworkInfo(
 	}
 
 	type names []string
-	type InSpaceAddress spaceAddress
+	type InSpaceAddress SpaceAddress
 	type endpointNetworkInfoRow struct {
 		EndpointName string `db:"endpoint_name"`
 		InSpaceAddress
@@ -223,7 +223,7 @@ ORDER BY endpoint_name,
 	for _, row := range rows {
 		info := infosByEndpoint[row.EndpointName]
 
-		encodedIP, err := encodeIPAddress(spaceAddress(row.InSpaceAddress))
+		encodedIP, err := encodeIPAddress(SpaceAddress(row.InSpaceAddress))
 		if err != nil {
 			return nil, errors.Capture(err)
 		}
@@ -260,7 +260,7 @@ func (st *State) GetUnitNetworkInfo(
 		return networkinternal.UnitNetworkInfo{}, errors.Capture(err)
 	}
 
-	type InSpaceAddress spaceAddress
+	type InSpaceAddress SpaceAddress
 	type unitNetworkInfoRow struct {
 		InSpaceAddress
 		Device         string         `db:"name"`
@@ -354,7 +354,7 @@ ORDER BY CASE WHEN ingress_address_value IS NULL THEN 1 ELSE 0 END,
 
 	info := networkinternal.UnitNetworkInfo{}
 	for _, row := range rows {
-		encodedIP, err := encodeIPAddress(spaceAddress(row.InSpaceAddress))
+		encodedIP, err := encodeIPAddress(SpaceAddress(row.InSpaceAddress))
 		if err != nil {
 			return networkinternal.UnitNetworkInfo{}, errors.Capture(err)
 		}

--- a/domain/network/types.go
+++ b/domain/network/types.go
@@ -60,6 +60,17 @@ type NetInterface struct {
 	// here and handled by network config updates if they become pertinent.
 }
 
+// ControllerAPIAddress is an address that can be advertised for a controller,
+// together with the type of device that supplies it.
+type ControllerAPIAddress struct {
+	network.SpaceAddress
+	DeviceType DeviceType
+}
+
+// ControllerAPIAddresses is a collection of controller API address
+// candidates.
+type ControllerAPIAddresses []ControllerAPIAddress
+
 // DeviceToBridge indicates a device on a known machine that should be bridged
 // in order to provision a container or virtual machine on it with appropriate
 // network connectivity.

--- a/internal/worker/apiaddresssetter/package_mocks_test.go
+++ b/internal/worker/apiaddresssetter/package_mocks_test.go
@@ -217,7 +217,7 @@ type MockNetworkService struct {
 // MockNetworkServiceMockRecorder is the mock recorder for MockNetworkService.
 type MockNetworkServiceMockRecorder struct {
 	mock                             *MockNetworkService
-	getControllerAPIAddressesExpects []*gomock.Call2_2[context.Context, unit.Name, network.SpaceAddresses, error]
+	getControllerAPIAddressesExpects []*gomock.Call3_2[context.Context, unit.Name, *network.SpaceInfo, network.SpaceAddresses, error]
 	spaceByNameExpects               []*gomock.Call2_2[context.Context, network.SpaceName, *network.SpaceInfo, error]
 }
 
@@ -234,22 +234,22 @@ func (m *MockNetworkService) EXPECT() *MockNetworkServiceMockRecorder {
 }
 
 // GetControllerAPIAddresses mocks base method.
-func (m *MockNetworkService) GetControllerAPIAddresses(ctx context.Context, unitName unit.Name) (network.SpaceAddresses, error) {
+func (m *MockNetworkService) GetControllerAPIAddresses(ctx context.Context, unitName unit.Name, managementSpace *network.SpaceInfo) (network.SpaceAddresses, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_2(&m.recorder.getControllerAPIAddressesExpects, m.ctrl, m, "GetControllerAPIAddresses", ctx, unitName)
+	return gomock.Dispatch3_2(&m.recorder.getControllerAPIAddressesExpects, m.ctrl, m, "GetControllerAPIAddresses", ctx, unitName, managementSpace)
 }
 
 // GetControllerAPIAddresses indicates an expected call of GetControllerAPIAddresses.
-func (mr *MockNetworkServiceMockRecorder) GetControllerAPIAddresses(ctx, unitName any) *MockNetworkServiceGetControllerAPIAddressesCall {
+func (mr *MockNetworkServiceMockRecorder) GetControllerAPIAddresses(ctx, unitName, managementSpace any) *MockNetworkServiceGetControllerAPIAddressesCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, unit.Name, network.SpaceAddresses, error](mr.mock.ctrl.T, mr.mock, "GetControllerAPIAddresses", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(unitName))
+	call := gomock.NewCall3_2[context.Context, unit.Name, *network.SpaceInfo, network.SpaceAddresses, error](mr.mock.ctrl.T, mr.mock, "GetControllerAPIAddresses", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(unitName), gomock.EnsureMatcher(managementSpace))
 	mr.getControllerAPIAddressesExpects = append(mr.getControllerAPIAddressesExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockNetworkServiceGetControllerAPIAddressesCall is the typed call wrapper for GetControllerAPIAddresses.
-type MockNetworkServiceGetControllerAPIAddressesCall = gomock.Call2_2[context.Context, unit.Name, network.SpaceAddresses, error]
+type MockNetworkServiceGetControllerAPIAddressesCall = gomock.Call3_2[context.Context, unit.Name, *network.SpaceInfo, network.SpaceAddresses, error]
 
 // SpaceByName mocks base method.
 func (m *MockNetworkService) SpaceByName(ctx context.Context, name network.SpaceName) (*network.SpaceInfo, error) {

--- a/internal/worker/apiaddresssetter/worker.go
+++ b/internal/worker/apiaddresssetter/worker.go
@@ -64,14 +64,19 @@ type ApplicationService interface {
 // NetworkService is the interface that is used to interact with the
 // network spaces/subnets.
 type NetworkService interface {
-	// GetControllerAPIAddresses returns all addresses which can be used for
-	// API addresses for the specified unit. local-machine scoped addresses
-	// will not be returned.
+	// GetControllerAPIAddresses returns the preferred addresses which can be
+	// used as API addresses for the specified unit, honouring the management
+	// space when one is configured. Local-machine scoped addresses will not be
+	// returned.
 	//
 	// The following errors may be returned:
 	// - [uniterrors.UnitNotFound] if the unit does not exist
 	// - [network.NoAddressError] if the unit has no api address associated
-	GetControllerAPIAddresses(ctx context.Context, unitName unit.Name) (network.SpaceAddresses, error)
+	GetControllerAPIAddresses(
+		ctx context.Context,
+		unitName unit.Name,
+		managementSpace *network.SpaceInfo,
+	) (network.SpaceAddresses, error)
 	// SpaceByName returns a space from state that matches the input name. If the
 	// space is not found, an error is returned matching
 	// [github.com/juju/juju/domain/network/errors.SpaceNotFound].
@@ -349,7 +354,7 @@ func (w *apiAddressSetterWorker) updateAPIAddresses(ctx context.Context) error {
 		if err != nil {
 			return errors.Capture(err)
 		}
-		addrs, err := w.config.NetworkService.GetControllerAPIAddresses(ctx, unitName)
+		addrs, err := w.config.NetworkService.GetControllerAPIAddresses(ctx, unitName, mgmtSpace)
 		if err != nil {
 			return errors.Capture(err)
 		}

--- a/internal/worker/apiaddresssetter/worker_test.go
+++ b/internal/worker/apiaddresssetter/worker_test.go
@@ -135,7 +135,7 @@ func (s *workerSuite) TestNewControllerNode(c *tc.C) {
 	sp := &network.SpaceInfo{
 		ID: "space0",
 	}
-	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1")).Return(addrs, nil)
+	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1"), sp).Return(addrs, nil)
 	s.networkService.EXPECT().SpaceByName(gomock.Any(), network.SpaceName("space0")).Return(sp, nil)
 	// Synchronization point to ensure the worker processes the event.
 	sync := make(chan struct{})
@@ -222,7 +222,7 @@ func (s *workerSuite) TestUnchangedControllerNodes(c *tc.C) {
 	sp := &network.SpaceInfo{
 		ID: "space0",
 	}
-	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1")).Return(addrs, nil).Times(1)
+	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1"), sp).Return(addrs, nil).Times(1)
 	s.networkService.EXPECT().SpaceByName(gomock.Any(), network.SpaceName("space0")).Return(sp, nil).Times(1)
 
 	sync := make(chan struct{})
@@ -311,7 +311,7 @@ func (s *workerSuite) TestConfigChange(c *tc.C) {
 	sp0 := &network.SpaceInfo{
 		ID: "space0",
 	}
-	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1")).Return(addrs, nil)
+	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1"), sp0).Return(addrs, nil)
 	s.networkService.EXPECT().SpaceByName(gomock.Any(), network.SpaceName("space0")).Return(sp0, nil)
 	// Synchronization point to ensure the worker processes the event.
 	sync := make(chan struct{})
@@ -334,7 +334,7 @@ func (s *workerSuite) TestConfigChange(c *tc.C) {
 	sp1 := &network.SpaceInfo{
 		ID: "space1",
 	}
-	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1")).Return(addrs, nil)
+	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1"), sp1).Return(addrs, nil)
 	s.networkService.EXPECT().SpaceByName(gomock.Any(), network.SpaceName("space1")).Return(sp1, nil)
 	args2 := controllernode.SetAPIAddressArgs{
 		MgmtSpace: sp1,
@@ -432,7 +432,7 @@ func (s *workerSuite) TestNodeAddressChange(c *tc.C) {
 	sp0 := &network.SpaceInfo{
 		ID: "space0",
 	}
-	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1")).Return(addrs, nil)
+	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1"), sp0).Return(addrs, nil)
 	s.networkService.EXPECT().SpaceByName(gomock.Any(), network.SpaceName("space0")).Return(sp0, nil).MaxTimes(2)
 	// Synchronization point to ensure the worker processes the event.
 	sync := make(chan struct{})
@@ -456,7 +456,7 @@ func (s *workerSuite) TestNodeAddressChange(c *tc.C) {
 			SpaceID: "space0",
 		},
 	}
-	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1")).Return(newAddrs, nil)
+	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1"), sp0).Return(newAddrs, nil)
 	// Synchronization point to ensure the worker processes the config event.
 	addrSync := make(chan struct{})
 	newHP := network.SpaceAddressesWithPort(newAddrs, 17070)


### PR DESCRIPTION
The change made under https://github.com/juju/juju/pull/22767 was not correct. In LXD containers, all configured NICs are VETH devices, so it is not correct to omit them.

Fortunately, the fallback from filtering agent addresses by a configured management space is to include all addresses when none result, so this was not a breaking change, however it needs fixing in order for management space configuration to be honoured.

The rules for API addresses used by agents are now as follows:
- If `juju-mgmt-space` is configured in controller config, we honour it unconditionally (addresses on VETH devices may be included).
- If no management space is configured, we will use only addresses from non-VETH devices if they exist.
- If there is no management space and only addresses from VETH devices, we will use those.

## QA steps

#23031 needs to land before we can properly test setting the management space. Regressions can be tested for by:
- Simple deployment on LXD (containers) to verify that we get addresses.
- Repetition of the QA from #22767 to filter VETH when ETH devices are present.
