### PR TITLE
chore: upgrade go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/compute v1.44.0


### PR DESCRIPTION
Fixes following vulnerabilities:

- https://pkg.go.dev/vuln/GO-2026-5026
- https://pkg.go.dev/vuln/GO-2026-5972
- https://pkg.go.dev/vuln/GO-2026-6088
- https://pkg.go.dev/vuln/GO-2026-6089
- https://pkg.go.dev/vuln/GO-2026-6090
- https://pkg.go.dev/vuln/GO-2026-6091
- https://pkg.go.dev/vuln/GO-2026-6218
