### PR TITLE
test: prevent noopFileWatcher goroutine leak in test changestream

### DIFF
--- a/internal/changestream/testing/changestream.go
+++ b/internal/changestream/testing/changestream.go
@@ -68,10 +68,11 @@ func NewTestWatchableDB(c *tc.C, id string, db database.TxnRunner) *TestWatchabl
 	}
 
 	logger := loggertesting.WrapCheckLog(c)
+	fileWatcher := newNoopFileWatcher()
 	// NewInternalStates handles a zero termDeadline itself (it falls back to
 	// defaultWaitTermTimeout via termDeadline.IsZero()), so passing the zero
 	// time here is safe.
-	stream := stream.NewInternalStates(id, db, newNoopFileWatcher(), clock.WallClock, noopMetrics{}, logger, termDeadline, states)
+	stream := stream.NewInternalStates(id, db, fileWatcher, clock.WallClock, noopMetrics{}, logger, termDeadline, states)
 	mux, err := eventmultiplexer.New(stream, clock.WallClock, noopMetrics{}, logger, signalTimeout)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -87,6 +88,7 @@ func NewTestWatchableDB(c *tc.C, id string, db database.TxnRunner) *TestWatchabl
 		Site: &h.catacomb,
 		Work: h.loop,
 		Init: []worker.Worker{
+			fileWatcher,
 			h.stream,
 			h.mux,
 		},


### PR DESCRIPTION
The TestWatchableDB in changestream testing leaked a noopFileWatcher
goroutine per test because the file watcher was created but never added
to the catacomb's init workers. When the catacomb was killed at cleanup,
the file watcher's tomb remained alive, blocking its goroutine
indefinitely. Over a test suite with many subtests this accumulated and
caused watcher harness tests to miss changestream idle-state reports,
making them flakily time out under CI load.

Fix by adding the noopFileWatcher as an init worker so its lifecycle is
bound to the catacomb and properly cleaned up.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ go test -c -race ./domain/application
❯ stress -timeout 120s ./application.test
```

## Documentation changes

## Links
