### PR TITLE
ci(docs): include docs freshness in the required result check

### DIFF
--- a/.github/workflows/context-tests.yml
+++ b/.github/workflows/context-tests.yml
@@ -209,6 +209,7 @@ jobs:
       - build
       - snap
       - generate
+      - docs
       - client
       - migrate
       - ddl
@@ -230,6 +231,7 @@ jobs:
           if ${{ needs.build.result == 'success' || needs.build.result == 'skipped' }} \
               && ${{ needs.snap.result == 'success' || needs.snap.result == 'skipped' }} \
               && ${{ needs.generate.result == 'success' || needs.generate.result == 'skipped' }} \
+              && ${{ needs.docs.result == 'success' || needs.docs.result == 'skipped' }} \
               && ${{ needs.client.result == 'success' || needs.client.result == 'skipped' }} \
               && ${{ needs.migrate.result == 'success' || needs.migrate.result == 'skipped' }} \
               && ${{ needs.ddl.result == 'success' || needs.ddl.result == 'skipped' }} \


### PR DESCRIPTION
## Problem

The "Autogenerated docs are up to date" freshness gate runs inside the `docs` job, which is only triggered when documentation/generator inputs change. It could not be enforced as a "required" branch-protection status check: GitHub required checks are unconditional, so on any PR that does not touch a docs input the check never reports a status and the merge shows "Expected - Waiting for status to be reported" forever, blocking the PR.

## Fix

Wire the `docs` job into the always-running `result-check` job, exactly as is already done on 3.6. Add `docs` to `result-check`'s `needs` list and to its `if` chain, tolerating a `skipped` result (which is what unrelated PRs produce). This enforces the docs freshness gate through the aggregate check without blocking PRs that make no docs changes, and it means the check can be (re)marked as required in branch protection safely.

## QA steps

- On a PR that changes docs/generator inputs, the docs freshness gate runs and its failure fails `result-check` / "Check Tests Passed".
- On a PR with no docs changes (e.g. an `AGENTS.md`-only change), `docs` is skipped and `result-check` still passes.

## Other

3.6 already has this wiring, so no 3.6 PR is needed.