### PR TITLE
fix: allow vault drain token to create secrets when draining from internal backend

### DIFF
--- a/internal/secrets/provider/vault/provider.go
+++ b/internal/secrets/provider/vault/provider.go
@@ -243,11 +243,12 @@ func (p vaultProvider) RestrictedConfig(
 
 	var rules []string
 	if forDrain && (adminUser || accessor.Kind == secrets.ModelAccessor) {
-		// For controller drain worker, we need to be able to update a secret.
-		// Because we may run into a situation that the worker creates a secret in the vault but gets killed/restarted
-		// before it can update the secret to the new backend, we need to allow the worker to update the content
-		// after it's coming up again.
-		rule := fmt.Sprintf(`path "%s/*" {capabilities = ["update"]}`, mountPath)
+		// For controller drain worker, we need to be able to create or update a secret.
+		// When draining from internal backend to vault, the secret does not yet exist in vault,
+		// so we need "create". When the worker creates a secret in vault but gets killed/restarted
+		// before it can update the secret to the new backend, we need to allow the worker to update
+		// the content after it's coming up again.
+		rule := fmt.Sprintf(`path "%s/*" {capabilities = ["create", "update"]}`, mountPath)
 		rules = append(rules, rule)
 	}
 	if adminUser {

--- a/internal/secrets/provider/vault/provider_test.go
+++ b/internal/secrets/provider/vault/provider_test.go
@@ -285,7 +285,7 @@ func (s *providerSuite) TestBackendConfigForDrainController(c *tc.C) {
 			}{}
 			_ = json.Unmarshal(b, &policyReq)
 			c.Assert(policyReq.Policy, tc.Equals, strings.Join([]string{
-				`path "fred-06f00d/*" {capabilities = ["update"]}`,
+				`path "fred-06f00d/*" {capabilities = ["create", "update"]}`,
 				`path "fred-06f00d/*" {capabilities = ["read"]}`,
 			}, "\n"))
 			return &http.Response{


### PR DESCRIPTION
The `test_user_secret_drain` integration test in `secrets_iaas` was failing.
The test creates user secrets, switches the model's secret backend between
vault and internal, and verifies that secrets are correctly drained between
backends in both directions.

The drain from vault to internal worked fine, but the reverse — draining from
internal back to vault — consistently failed. The drain worker would crash-loop
with a 403 Permission Denied error from Vault every time it tried to write a
secret.

**Root cause**

The Vault token policy generated for the drain worker only granted `update`
capability on secret paths. When draining a secret from the internal backend to
Vault, the secret doesn't yet exist in Vault, so the operation is a `create`,
not an `update`. Vault's ACL system rejects creates on paths that only have
update permission, returning 403.

The existing comment and policy were written with only one scenario in mind: a
drain worker that already created a secret in Vault, got killed, and needs to
retry the write on restart (an update). It didn't account for the case where a
secret was created while the internal backend was active and then needs to be
drained to Vault for the first time (a create).

**Fix**

Added `create` to the Vault drain token policy alongside `update`. This covers
both cases: creating new secrets in Vault during drain, and updating existing
ones after a worker restart.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests
./main.sh secrets_iaas test_user_secret_drain
```

## Documentation changes

## Links

