### PR TITLE
feat(bootstrap): integrate controller snap build into bootstrap

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -733,15 +733,18 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		// should resolve the snap from the store instead and this implicit build
 		// block should be removed.
 		if c.ControllerSnapPath == "" {
+			if !c.BuildSnap {
+				ctx.Warningf("building controller snap and agent from local source; " +
+					"this is temporary and will be replaced by store-based resolution in a future release")
+			}
 			c.BuildSnap = true
-			ctx.Warningf("building controller snap and agent from local source; " +
-				"this is temporary and will be replaced by store-based resolution in a future release")
 		}
 		if c.BuildSnap && c.ControllerSnapPath != "" {
 			c.BuildSnap = false
 			ctx.Warningf("ignoring --build-snap because --controller-snap-path is explicitly provided")
 		}
 		if c.BuildSnap {
+			ctx.Infof("Building controller snap from local source via 'make build-snap'; this may take several minutes...")
 			builtPath, err := bootstrap.BuildControllerSnap(ctx)
 			if err != nil {
 				return errors.Trace(err)
@@ -929,7 +932,6 @@ to create a new model to deploy %sworkloads.
 		BootstrapImage:                c.BootstrapImage,
 		Placement:                     c.Placement,
 		BuildAgent:                    c.BuildAgent,
-		BuildSnap:                     c.BuildSnap,
 		BuildAgentTarball:             sync.BuildAgentTarball,
 		AgentVersion:                  c.AgentVersion,
 		Cloud:                         cloud,

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -429,8 +429,14 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 	}
 
 	if c.ControllerSnapAssertPath != "" {
-		if c.BuildSnap {
-			return errors.New("--controller-snap-assert-path requires --controller-snap-path; it cannot be used with --build-snap")
+		// --controller-snap-assert-path requires --controller-snap-path. When only
+		// --build-snap is set without an explicit path, this combination is
+		// rejected because there is no snap path to associate the assertion with.
+		// When both --build-snap and --controller-snap-path are set, --build-snap
+		// is ignored in Run() and the explicit path + assert path are used.
+		if c.BuildSnap && c.ControllerSnapPath == "" {
+			return errors.New("--controller-snap-assert-path requires --controller-snap-path; " +
+				"it cannot be used with --build-snap")
 		}
 
 		_, err := c.Filesystem().Stat(c.ControllerSnapAssertPath)
@@ -468,9 +474,6 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 	}
 	if c.AgentVersionParam != "" && c.BuildSnap {
 		return errors.New("--agent-version and --build-snap can't be used together")
-	}
-	if c.BuildSnap && c.ControllerSnapPath != "" {
-		return errors.New("--build-snap and --controller-snap-path cannot be used together; use one or the other")
 	}
 	if c.AgentVersionParam != "" && c.BuildAgent {
 		return errors.New("--agent-version and --build-agent can't be used together")
@@ -724,6 +727,20 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	}
 
 	if !isCAASController {
+		// TODO(ice): when --controller-snap-path is not explicitly provided,
+		// building the controller snap from local source is a temporary
+		// workaround. Once the jujud snap is published to the store, the default
+		// should resolve the snap from the store instead and this implicit build
+		// block should be removed.
+		if c.ControllerSnapPath == "" {
+			c.BuildSnap = true
+			ctx.Warningf("building controller snap and agent from local source; " +
+				"this is temporary and will be replaced by store-based resolution in a future release")
+		}
+		if c.BuildSnap && c.ControllerSnapPath != "" {
+			c.BuildSnap = false
+			ctx.Warningf("ignoring --build-snap because --controller-snap-path is explicitly provided")
+		}
 		if c.BuildSnap {
 			builtPath, err := bootstrap.BuildControllerSnap(ctx)
 			if err != nil {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -659,6 +659,11 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		return errors.Trace(err)
 	}
 
+	isCAASController = jujucloud.CloudIsCAAS(cloud)
+	if isCAASController && c.BuildSnap {
+		return errors.NotSupportedf("--build-snap when bootstrapping a k8s controller")
+	}
+
 	// If region is specified by the user, validate it here.
 	// lp#1632735
 	if c.Region != "" {
@@ -719,11 +724,6 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	bootstrapCfg, err := c.bootstrapConfigs(ctx, cloud, provider)
 	if err != nil {
 		return errors.Trace(err)
-	}
-
-	isCAASController = jujucloud.CloudIsCAAS(cloud)
-	if isCAASController && c.BuildSnap {
-		return errors.NotSupportedf("--build-snap when bootstrapping a k8s controller")
 	}
 
 	if !isCAASController {

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -229,6 +229,7 @@ type bootstrapCommand struct {
 	BootstrapBase           string
 	BootstrapImage          string
 	BuildAgent              bool
+	BuildSnap               bool
 	MetadataSource          string
 	Placement               string
 	KeepBrokenEnvironment   bool
@@ -365,6 +366,7 @@ func (c *bootstrapCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.BootstrapBase, "bootstrap-base", "", "Specify the base of the bootstrap machine")
 	f.StringVar(&c.BootstrapImage, "bootstrap-image", "", "Specify the image of the bootstrap machine (requires `--bootstrap-constraints` specifying architecture)")
 	f.BoolVar(&c.BuildAgent, "build-agent", false, "Build local version of agent binary before bootstrapping")
+	f.BoolVar(&c.BuildSnap, "build-snap", false, "Build local controller snap before bootstrapping")
 	f.StringVar(&c.MetadataSource, "metadata-source", "", "Local path to use as agent and/or image metadata source")
 	f.StringVar(&c.Placement, "to", "", "Placement directive indicating an instance to bootstrap")
 	f.BoolVar(&c.KeepBrokenEnvironment, "keep-broken", false,
@@ -427,6 +429,10 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 	}
 
 	if c.ControllerSnapAssertPath != "" {
+		if c.BuildSnap {
+			return errors.New("--controller-snap-assert-path requires --controller-snap-path; it cannot be used with --build-snap")
+		}
+
 		_, err := c.Filesystem().Stat(c.ControllerSnapAssertPath)
 		if err != nil {
 			return errors.Annotatef(err, "--controller-snap-assert-path %q cannot be read", c.ControllerSnapAssertPath)
@@ -459,6 +465,12 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 	}
 	if c.showRegionsForCloud != "" {
 		return cmd.CheckEmpty(args)
+	}
+	if c.AgentVersionParam != "" && c.BuildSnap {
+		return errors.New("--agent-version and --build-snap can't be used together")
+	}
+	if c.BuildSnap && c.ControllerSnapPath != "" {
+		return errors.New("--build-snap and --controller-snap-path cannot be used together; use one or the other")
 	}
 	if c.AgentVersionParam != "" && c.BuildAgent {
 		return errors.New("--agent-version and --build-agent can't be used together")
@@ -707,7 +719,20 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	}
 
 	isCAASController = jujucloud.CloudIsCAAS(cloud)
+	if isCAASController && c.BuildSnap {
+		return errors.NotSupportedf("--build-snap when bootstrapping a k8s controller")
+	}
+
 	if !isCAASController {
+		if c.BuildSnap {
+			builtPath, err := bootstrap.BuildControllerSnap(ctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			c.ControllerSnapPath = builtPath
+			c.BuildAgent = true
+		}
+
 		if bootstrapCfg.bootstrap.ControllerServiceType != "" ||
 			bootstrapCfg.bootstrap.ControllerExternalName != "" ||
 			len(bootstrapCfg.bootstrap.ControllerExternalIPs) > 0 {
@@ -887,6 +912,7 @@ to create a new model to deploy %sworkloads.
 		BootstrapImage:                c.BootstrapImage,
 		Placement:                     c.Placement,
 		BuildAgent:                    c.BuildAgent,
+		BuildSnap:                     c.BuildSnap,
 		BuildAgentTarball:             sync.BuildAgentTarball,
 		AgentVersion:                  c.AgentVersion,
 		Cloud:                         cloud,

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -515,6 +515,18 @@ var bootstrapTests = []bootstrapTest{{
 	info: "missing storage pool type",
 	args: []string{"--storage-pool", "name=test"},
 	err:  `storage pool requires a "type" key to be set not valid`,
+}, {
+	info: "--agent-version with --build-snap",
+	args: []string{"--agent-version", "1.1.0", "--build-snap"},
+	err:  `--agent-version and --build-snap can't be used together`,
+}, {
+	info: "--build-snap with --controller-snap-path",
+	args: []string{"--build-snap", "--controller-snap-path", "/tmp/foo.snap"},
+	err:  `--build-snap and --controller-snap-path cannot be used together; use one or the other`,
+}, {
+	info: "--build-snap with --controller-snap-assert-path",
+	args: []string{"--build-snap", "--controller-snap-assert-path", "/tmp/foo.assert"},
+	err:  `--controller-snap-assert-path requires --controller-snap-path; it cannot be used with --build-snap`,
 }}
 
 func (s *BootstrapSuite) TestRunCloudNameUnknown(c *tc.C) {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2281,6 +2281,7 @@ func (s *BootstrapSuite) TestBootstrapImplicitBuild(c *tc.C) {
 	)
 	c.Assert(err, tc.Equals, cmd.ErrSilent)
 	c.Check(gotArgs.ControllerSnapPath, tc.Equals, tempSnapPath)
+	c.Check(gotArgs.BuildAgent, tc.IsTrue)
 
 	// Verify the WARNING log message.
 	mc := tc.NewMultiChecker()
@@ -2397,6 +2398,32 @@ func (s *BootstrapSuite) TestBootstrapBuildSnapWithAssertPathNoSnapPath(c *tc.C)
 	)
 	c.Assert(err, tc.ErrorMatches,
 		`--controller-snap-assert-path requires --controller-snap-path; it cannot be used with --build-snap`)
+}
+
+// TestBootstrapBuildSnapCAASNotSupported verifies that --build-snap is
+// rejected before any bootstrap work when the target cloud is a Kubernetes
+// (CAAS) cloud.
+func (s *BootstrapSuite) TestBootstrapBuildSnapCAASNotSupported(c *tc.C) {
+	// Patch getBootstrapFuncs so the real kubernetes provider's CloudFinalizer
+	// (which shells out to microk8s/kubeconfig) is skipped. CloudIsCAAS keys
+	// off the cloud type, so this does not affect the check under test.
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &fakeBootstrapFuncs{}
+	})
+
+	cloudsPath := cloud.JujuPersonalCloudsPath()
+	err := os.WriteFile(cloudsPath, []byte(`
+clouds:
+    testk8s:
+        type: kubernetes
+`), 0o644)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = cmdtesting.RunCommand(c, s.newBootstrapCommand(),
+		"testk8s", "devcontroller",
+		"--build-snap",
+	)
+	c.Assert(err, tc.ErrorMatches, `--build-snap when bootstrapping a k8s controller not supported`)
 }
 
 // TestBootstrapIAASRequiresBuildAgent verifies that an IAAS bootstrap with

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -519,14 +519,6 @@ var bootstrapTests = []bootstrapTest{{
 	info: "--agent-version with --build-snap",
 	args: []string{"--agent-version", "1.1.0", "--build-snap"},
 	err:  `--agent-version and --build-snap can't be used together`,
-}, {
-	info: "--build-snap with --controller-snap-path",
-	args: []string{"--build-snap", "--controller-snap-path", "/tmp/foo.snap"},
-	err:  `--build-snap and --controller-snap-path cannot be used together; use one or the other`,
-}, {
-	info: "--build-snap with --controller-snap-assert-path",
-	args: []string{"--build-snap", "--controller-snap-assert-path", "/tmp/foo.assert"},
-	err:  `--controller-snap-assert-path requires --controller-snap-path; it cannot be used with --build-snap`,
 }}
 
 func (s *BootstrapSuite) TestRunCloudNameUnknown(c *tc.C) {
@@ -2258,17 +2250,153 @@ func (s *BootstrapSuite) TestBootstrapControllerSnapPathAlwaysAvailable(c *tc.C)
 	}
 }
 
-// TestBootstrapIAASRequiresSnapPath verifies that an IAAS bootstrap without
-// --controller-snap-path fails in Run() after cloud type is resolved, before
-// any provisioning occurs. The check must not fire for CAAS bootstraps.
-func (s *BootstrapSuite) TestBootstrapIAASRequiresSnapPath(c *tc.C) {
+// TestBootstrapImplicitBuild tests that an IAAS bootstrap without
+// --controller-snap-path triggers the implicit build flow, including the
+// WARNING log message about the temporary behavior.
+func (s *BootstrapSuite) TestBootstrapImplicitBuild(c *tc.C) {
+	s.patchVersion(c)
+	s.tw.Clear()
+
+	var gotArgs bootstrap.BootstrapParams
+	bootstrapFuncs := &fakeBootstrapFuncs{
+		bootstrapF: func(_ environs.BootstrapContext, _ environs.BootstrapEnviron, args bootstrap.BootstrapParams) error {
+			gotArgs = args
+			return errors.New("test error")
+		},
+	}
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return bootstrapFuncs
+	})
+
+	// Patch BuildControllerSnap to return a fake snap file.
+	tempSnapPath := filepath.Join(c.MkDir(), "jujud_4.0.0_amd64.snap")
+	err := os.WriteFile(tempSnapPath, []byte("fake snap"), 0644)
+	c.Assert(err, tc.ErrorIsNil)
+	s.PatchValue(&bootstrap.BuildControllerSnap, func(ctx context.Context) (string, error) {
+		return tempSnapPath, nil
+	})
+
+	_, err = cmdtesting.RunCommand(c, s.newBootstrapCommand(),
+		"dummy", "devcontroller",
+	)
+	c.Assert(err, tc.Equals, cmd.ErrSilent)
+	c.Check(gotArgs.ControllerSnapPath, tc.Equals, tempSnapPath)
+
+	// Verify the WARNING log message.
+	mc := tc.NewMultiChecker()
+	mc.AddExpr(`_.Level`, tc.Equals, tc.ExpectedValue)
+	mc.AddExpr(`_.Message`, tc.Matches, tc.ExpectedValue)
+	mc.AddExpr(`_._`, tc.Ignore)
+	c.Check(s.tw.Log(), tc.OrderedRight[[]loggo.Entry](mc), []loggo.Entry{{
+		Level:   loggo.WARNING,
+		Message: "building controller snap and agent from local source; this is temporary and will be replaced by store-based resolution in a future release",
+	}})
+}
+
+// TestBootstrapExplicitSnapPathBypassesImplicitBuild verifies that when
+// --controller-snap-path is explicitly provided, the implicit build is NOT
+// triggered and the explicit path is used as-is.
+func (s *BootstrapSuite) TestBootstrapExplicitSnapPathBypassesImplicitBuild(c *tc.C) {
+	s.patchVersion(c)
+	s.tw.Clear()
+
+	var gotArgs bootstrap.BootstrapParams
+	bootstrapFuncs := &fakeBootstrapFuncs{
+		bootstrapF: func(_ environs.BootstrapContext, _ environs.BootstrapEnviron, args bootstrap.BootstrapParams) error {
+			gotArgs = args
+			return errors.New("test error")
+		},
+	}
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return bootstrapFuncs
+	})
+
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(),
+		"dummy", "devcontroller",
+		"--controller-snap-path", s.controllerSnapPath,
+		"--build-agent",
+	)
+	c.Assert(err, tc.Equals, cmd.ErrSilent)
+	c.Check(gotArgs.ControllerSnapPath, tc.Equals, s.controllerSnapPath)
+
+	// Verify no implicit build WARNING was logged.
+	for _, entry := range s.tw.Log() {
+		c.Check(entry.Message, tc.Not(tc.Contains), "building controller snap and agent from local source")
+	}
+}
+
+// TestBootstrapBuildSnapIgnoredWithExplicitPath verifies that when both
+// --build-snap and --controller-snap-path are provided, --build-snap is
+// ignored and a warning is logged, and the explicit path is used.
+func (s *BootstrapSuite) TestBootstrapBuildSnapIgnoredWithExplicitPath(c *tc.C) {
+	s.patchVersion(c)
+	s.tw.Clear()
+
+	var gotArgs bootstrap.BootstrapParams
+	bootstrapFuncs := &fakeBootstrapFuncs{
+		bootstrapF: func(_ environs.BootstrapContext, _ environs.BootstrapEnviron, args bootstrap.BootstrapParams) error {
+			gotArgs = args
+			return errors.New("test error")
+		},
+	}
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return bootstrapFuncs
+	})
+
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(),
+		"dummy", "devcontroller",
+		"--build-snap",
+		"--controller-snap-path", s.controllerSnapPath,
+		"--build-agent",
+	)
+	c.Assert(err, tc.Equals, cmd.ErrSilent)
+	c.Check(gotArgs.ControllerSnapPath, tc.Equals, s.controllerSnapPath)
+
+	// Verify the "ignoring --build-snap" warning.
+	mc := tc.NewMultiChecker()
+	mc.AddExpr(`_.Level`, tc.Equals, tc.ExpectedValue)
+	mc.AddExpr(`_.Message`, tc.Matches, tc.ExpectedValue)
+	mc.AddExpr(`_._`, tc.Ignore)
+	c.Check(s.tw.Log(), tc.OrderedRight[[]loggo.Entry](mc), []loggo.Entry{{
+		Level:   loggo.WARNING,
+		Message: "ignoring --build-snap because --controller-snap-path is explicitly provided",
+	}})
+}
+
+// TestBootstrapIAASControllerSnapPathRequired verifies that when all implicit
+// build mechanisms fail (e.g., BuildControllerSnap returns an empty path), the
+// original --controller-snap-path is required error still fires.
+func (s *BootstrapSuite) TestBootstrapIAASControllerSnapPathRequired(c *tc.C) {
 	s.patchVersion(c)
 
-	// IAAS bootstrap without a snap path must fail before provisioning.
+	// Leave BuildControllerSnap unpatched; the real function will fail
+	// (no snapcraft, no source root), which means the implicit build
+	// fails, and the original "required" error will surface.
+	// Instead, patch it to return an empty string to simulate build
+	// success but no path set (should not happen normally, but tests
+	// the fallback).
+	s.PatchValue(&bootstrap.BuildControllerSnap, func(ctx context.Context) (string, error) {
+		return "", nil
+	})
+
 	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
 	)
 	c.Assert(err, tc.ErrorMatches, `--controller-snap-path is required for IAAS bootstrap.*`)
+}
+
+// TestBootstrapBuildSnapWithAssertPathNoSnapPath verifies that
+// --controller-snap-assert-path requires --controller-snap-path when used
+// with --build-snap without an explicit snap path.
+func (s *BootstrapSuite) TestBootstrapBuildSnapWithAssertPathNoSnapPath(c *tc.C) {
+	s.patchVersion(c)
+
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(),
+		"--build-snap",
+		"--controller-snap-assert-path", "/tmp/foo.assert",
+	)
+	c.Assert(err, tc.ErrorMatches,
+		`--controller-snap-assert-path requires --controller-snap-path; it cannot be used with --build-snap`)
 }
 
 // TestBootstrapIAASRequiresBuildAgent verifies that an IAAS bootstrap with

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md
@@ -20,6 +20,7 @@ juju bootstrap [options] [<cloud name>[/region] [<controller name>]]
 | `--bootstrap-constraints` | [] | Specify bootstrap machine constraints |
 | `--bootstrap-image` |  | Specify the image of the bootstrap machine (requires `--bootstrap-constraints` specifying architecture) |
 | `--build-agent` | false | Build local version of agent binary before bootstrapping |
+| `--build-snap` | false | Build local controller snap before bootstrapping |
 | `--clouds` | false | Print the available clouds which can be used to bootstrap a Juju environment |
 | `--config` |  | Specify a controller configuration file, or one or more configuration options. Model config keys only affect the controller model.     (`--config config.yaml [--config key=value ...])` |
 | `--constraints` | [] | Set model constraints |

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -118,10 +118,6 @@ type BootstrapParams struct {
 	// It is an error to specify BuildAgent with a nil BuildAgentTarball.
 	BuildAgent bool
 
-	// BuildSnap reports whether we should build the controller snap local from
-	// source via 'make build-snap' before bootstrapping.
-	BuildSnap bool
-
 	// BuildAgentTarball, if non-nil, is a function that may be used to
 	// build tools to upload. If this is nil, tools uploading will never
 	// take place.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -118,6 +118,10 @@ type BootstrapParams struct {
 	// It is an error to specify BuildAgent with a nil BuildAgentTarball.
 	BuildAgent bool
 
+	// BuildSnap reports whether we should build the controller snap local from
+	// source via 'make build-snap' before bootstrapping.
+	BuildSnap bool
+
 	// BuildAgentTarball, if non-nil, is a function that may be used to
 	// build tools to upload. If this is nil, tools uploading will never
 	// take place.
@@ -245,7 +249,7 @@ func withDefaultControllerConstraints(cons constraints.Value) constraints.Value 
 	// ensure that it has at least 2 cores. Less than 2 cores can cause the
 	// controller to become unresponsive when installing.
 	if !cons.HasCpuCores() && cons.HasVirtType() && *cons.VirtType == instance.VirtTypeMachine {
-		var cores = uint64(2)
+		cores := uint64(2)
 		cons.CpuCores = &cores
 	}
 	return cons
@@ -416,7 +420,8 @@ func bootstrapIAAS(
 	}
 
 	ctx.Verbosef("Loading image metadata")
-	imageMetadata, err := bootstrapImageMetadata(ctx, environ,
+	imageMetadata, err := bootstrapImageMetadata(
+		ctx, environ,
 		ss,
 		&bootstrapBase,
 		bootstrapArchForImageSearch,
@@ -723,8 +728,8 @@ func bootstrapIAAS(
 		cred, err := finalizer.FinaliseBootstrapCredential(
 			ctx,
 			bootstrapParams,
-			args.CloudCredential)
-
+			args.CloudCredential,
+		)
 		if err != nil {
 			return errors.Annotate(err, "finalizing bootstrap credential")
 		}
@@ -826,7 +831,8 @@ func finalizeInstanceBootstrapConfig(
 	}
 
 	authority, err := pki.NewDefaultAuthorityPemCAKey(
-		[]byte(caCert), []byte(args.CAPrivateKey))
+		[]byte(caCert), []byte(args.CAPrivateKey),
+	)
 	if err != nil {
 		return errors.Annotate(err, "loading juju certificate authority")
 	}
@@ -834,7 +840,6 @@ func finalizeInstanceBootstrapConfig(
 	leaf, err := authority.LeafRequestForGroup(pki.DefaultLeafGroup).
 		AddDNSNames(controller.DefaultDNSNames...).
 		Commit()
-
 	if err != nil {
 		return errors.Annotate(err, "make juju default controller cert")
 	}
@@ -898,7 +903,8 @@ func finalizePodBootstrapConfig(
 	}
 
 	authority, err := pki.NewDefaultAuthorityPemCAKey(
-		[]byte(caCert), []byte(args.CAPrivateKey))
+		[]byte(caCert), []byte(args.CAPrivateKey),
+	)
 	if err != nil {
 		return errors.Annotate(err, "loading juju certificate authority")
 	}
@@ -909,7 +915,6 @@ func finalizePodBootstrapConfig(
 	leaf, err := authority.LeafRequestForGroup(pki.DefaultLeafGroup).
 		AddDNSNames(controller.DefaultDNSNames...).
 		Commit()
-
 	if err != nil {
 		return errors.Annotate(err, "make juju default controller cert")
 	}
@@ -985,7 +990,6 @@ func bootstrapImageMetadata(
 	bootstrapImageId string,
 	customImageMetadata *[]*imagemetadata.ImageMetadata,
 ) ([]*imagemetadata.ImageMetadata, error) {
-
 	hasRegion, ok := environ.(simplestreams.HasRegion)
 	if !ok {
 		if bootstrapImageId != "" {
@@ -1075,7 +1079,8 @@ func getBootstrapToolsVersion(ctx context.Context, possibleTools coretools.List)
 	if !isCompatibleVersion(newVersion, jujuversion.Current) {
 		compatibleVersion, compatibleTools := findCompatibleTools(possibleTools, jujuversion.Current)
 		if len(compatibleTools) == 0 {
-			logger.Infof(ctx,
+			logger.Infof(
+				ctx,
 				"failed to find %s agent binaries, will attempt to use %s",
 				jujuversion.Current, newVersion,
 			)

--- a/environs/bootstrap/export_test.go
+++ b/environs/bootstrap/export_test.go
@@ -11,4 +11,7 @@ var (
 	FindBootstrapTools         = findBootstrapTools
 	FindPackagedTools          = findPackagedTools
 	InspectLocalSnapVersion    = inspectLocalSnapVersion
+	SnapArch                   = snapArch
+	BuildCommandFunc           = &buildCommandFunc
+	LookPathFunc               = &lookPathFunc
 )

--- a/environs/bootstrap/snap_build.go
+++ b/environs/bootstrap/snap_build.go
@@ -20,8 +20,6 @@ import (
 const (
 	snapcraftRequiredMessage = "snapcraft is required to build the controller snap; " +
 		"install it with 'sudo snap install snapcraft --classic'"
-	buildSnapProgressMessage = "Building controller snap via make build-snap; " +
-		"this may take several minutes..."
 )
 
 var buildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
@@ -48,6 +46,9 @@ func snapArch(goarch string) string {
 // from the bootstrap command's Run() when --build-snap is set, populating
 // ControllerSnapPath so the existing upload pipeline handles the locally built
 // snap.
+//
+// Declared as a var to allow test injection without a config struct; tests
+// swap the value directly via the exported alias in export_test.go.
 var BuildControllerSnap = func(ctx context.Context) (string, error) {
 	sourceRoot, err := tools.FindJujuSourceRoot()
 	if err != nil {
@@ -58,11 +59,9 @@ var BuildControllerSnap = func(ctx context.Context) (string, error) {
 		return "", errors.New(snapcraftRequiredMessage)
 	}
 
-	logger.Infof(ctx, buildSnapProgressMessage)
-
 	out, err := buildCommandFunc(ctx, sourceRoot, "make", "build-snap")
 	if err != nil {
-		return "", fmt.Errorf(
+		return "", errors.Errorf(
 			"building controller snap failed: %v\n%s\n"+
 				"use --controller-snap-path to supply a pre-built snap instead",
 			err, string(out),
@@ -77,9 +76,9 @@ var BuildControllerSnap = func(ctx context.Context) (string, error) {
 	snapPath := filepath.Join(sourceRoot, expectedFile)
 
 	if _, err := os.Stat(snapPath); err != nil {
-		return "", fmt.Errorf(
-			"controller snap build completed but expected file %q was not found at %s",
-			expectedFile, sourceRoot,
+		return "", errors.Errorf(
+			"controller snap build completed but expected file %q was not found at %s: %v",
+			expectedFile, sourceRoot, err,
 		)
 	}
 

--- a/environs/bootstrap/snap_build.go
+++ b/environs/bootstrap/snap_build.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/juju/errors"
+
+	jujuversion "github.com/juju/juju/core/version"
+	"github.com/juju/juju/environs/tools"
+)
+
+const (
+	snapcraftRequiredMessage = "snapcraft is required to build the controller snap; " +
+		"install it with 'sudo snap install snapcraft --classic'"
+	buildSnapProgressMessage = "Building controller snap via make build-snap; " +
+		"this may take several minutes..."
+)
+
+var buildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	return cmd.CombinedOutput()
+}
+
+var lookPathFunc = exec.LookPath
+
+func snapArch(goarch string) string {
+	switch goarch {
+	case "arm":
+		return "armhf"
+	case "ppc64le":
+		return "ppc64el"
+	default:
+		return goarch
+	}
+}
+
+// BuildControllerSnap builds the controller snap from local source via 'make
+// build-snap' and returns the path to the resulting .snap file. It is called
+// from the bootstrap command's Run() when --build-snap is set, populating
+// ControllerSnapPath so the existing upload pipeline handles the locally built
+// snap.
+func BuildControllerSnap(ctx context.Context) (string, error) {
+	sourceRoot, err := tools.FindJujuSourceRoot()
+	if err != nil {
+		return "", errors.Annotate(err, "cannot locate juju source root")
+	}
+
+	if _, err := lookPathFunc("snapcraft"); err != nil {
+		return "", errors.New(snapcraftRequiredMessage)
+	}
+
+	logger.Infof(ctx, buildSnapProgressMessage)
+
+	out, err := buildCommandFunc(ctx, sourceRoot, "make", "build-snap")
+	if err != nil {
+		return "", fmt.Errorf(
+			"building controller snap failed: %v\n%s\n"+
+				"use --controller-snap-path to supply a pre-built snap instead",
+			err, string(out),
+		)
+	}
+
+	expectedFile := fmt.Sprintf(
+		"jujud_%s_%s.snap",
+		jujuversion.Current.String(),
+		snapArch(runtime.GOARCH),
+	)
+	snapPath := filepath.Join(sourceRoot, expectedFile)
+
+	if _, err := os.Stat(snapPath); err != nil {
+		return "", fmt.Errorf(
+			"controller snap build completed but expected file %q was not found at %s",
+			expectedFile, sourceRoot,
+		)
+	}
+
+	return snapPath, nil
+}

--- a/environs/bootstrap/snap_build.go
+++ b/environs/bootstrap/snap_build.go
@@ -48,7 +48,7 @@ func snapArch(goarch string) string {
 // from the bootstrap command's Run() when --build-snap is set, populating
 // ControllerSnapPath so the existing upload pipeline handles the locally built
 // snap.
-func BuildControllerSnap(ctx context.Context) (string, error) {
+var BuildControllerSnap = func(ctx context.Context) (string, error) {
 	sourceRoot, err := tools.FindJujuSourceRoot()
 	if err != nil {
 		return "", errors.Annotate(err, "cannot locate juju source root")

--- a/environs/bootstrap/snap_build.go
+++ b/environs/bootstrap/snap_build.go
@@ -32,8 +32,6 @@ var lookPathFunc = exec.LookPath
 
 func snapArch(goarch string) string {
 	switch goarch {
-	case "arm":
-		return "armhf"
 	case "ppc64le":
 		return "ppc64el"
 	default:

--- a/environs/bootstrap/snap_build_test.go
+++ b/environs/bootstrap/snap_build_test.go
@@ -59,6 +59,13 @@ func (s *snapBuildSuite) TestBuildControllerSnapSnapcraftNotFound(c *tc.C) {
 		return "", exec.ErrNotFound
 	}
 
+	origFindSourceRoot := tools.FindJujuSourceRoot
+	restoreFindSourceRoot := func() { tools.FindJujuSourceRoot = origFindSourceRoot }
+	defer restoreFindSourceRoot()
+	tools.FindJujuSourceRoot = func() (string, error) {
+		return c.MkDir(), nil
+	}
+
 	_, err := bootstrap.BuildControllerSnap(context.Background())
 	c.Assert(err, tc.ErrorMatches, "snapcraft is required to build the controller snap.*")
 }
@@ -77,6 +84,13 @@ func (s *snapBuildSuite) TestBuildControllerSnapMakeFails(c *tc.C) {
 	defer restoreLookPath()
 	*bootstrap.LookPathFunc = func(file string) (string, error) {
 		return "/usr/bin/snapcraft", nil
+	}
+
+	origFindSourceRoot := tools.FindJujuSourceRoot
+	restoreFindSourceRoot := func() { tools.FindJujuSourceRoot = origFindSourceRoot }
+	defer restoreFindSourceRoot()
+	tools.FindJujuSourceRoot = func() (string, error) {
+		return c.MkDir(), nil
 	}
 
 	_, err := bootstrap.BuildControllerSnap(context.Background())

--- a/environs/bootstrap/snap_build_test.go
+++ b/environs/bootstrap/snap_build_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/tc"
 
+	"github.com/juju/juju/core/version"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/tools"
 	coretesting "github.com/juju/juju/internal/testing"
@@ -114,7 +115,7 @@ func (s *snapBuildSuite) TestBuildControllerSnapFileNotFound(c *tc.C) {
 func (s *snapBuildSuite) TestBuildControllerSnapSuccess(c *tc.C) {
 	tmpDir := c.MkDir()
 
-	snapName := fmt.Sprintf("jujud_%s_%s.snap", "4.1-beta2", runtime.GOARCH)
+	snapName := fmt.Sprintf("jujud_%s_%s.snap", version.Current.String(), bootstrap.SnapArch(runtime.GOARCH))
 	snapPath := filepath.Join(tmpDir, snapName)
 	err := os.WriteFile(snapPath, []byte("fake snap"), 0644)
 	c.Assert(err, tc.ErrorIsNil)

--- a/environs/bootstrap/snap_build_test.go
+++ b/environs/bootstrap/snap_build_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package bootstrap_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/environs/bootstrap"
+	"github.com/juju/juju/environs/tools"
+	coretesting "github.com/juju/juju/internal/testing"
+)
+
+type snapBuildSuite struct {
+	coretesting.BaseSuite
+}
+
+func TestSnapBuildSuite(t *testing.T) {
+	tc.Run(t, &snapBuildSuite{})
+}
+
+func (s *snapBuildSuite) TestSnapArchIdentity(c *tc.C) {
+	c.Check(bootstrap.SnapArch("amd64"), tc.Equals, "amd64")
+	c.Check(bootstrap.SnapArch("arm64"), tc.Equals, "arm64")
+	c.Check(bootstrap.SnapArch("s390x"), tc.Equals, "s390x")
+}
+
+func (s *snapBuildSuite) TestSnapArchMapping(c *tc.C) {
+	c.Check(bootstrap.SnapArch("arm"), tc.Equals, "armhf")
+	c.Check(bootstrap.SnapArch("ppc64le"), tc.Equals, "ppc64el")
+}
+
+func (s *snapBuildSuite) TestSnapArchUnknown(c *tc.C) {
+	c.Check(bootstrap.SnapArch("riscv64"), tc.Equals, "riscv64")
+}
+
+func (s *snapBuildSuite) TestBuildControllerSnapSnapcraftNotFound(c *tc.C) {
+	origBuild := bootstrap.BuildCommandFunc
+	restoreBuild := func() { *bootstrap.BuildCommandFunc = *origBuild }
+	defer restoreBuild()
+
+	*bootstrap.BuildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("should not be called")
+	}
+
+	origLookPath := bootstrap.LookPathFunc
+	restoreLookPath := func() { *bootstrap.LookPathFunc = *origLookPath }
+	defer restoreLookPath()
+	*bootstrap.LookPathFunc = func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+
+	_, err := bootstrap.BuildControllerSnap(context.Background())
+	c.Assert(err, tc.ErrorMatches, "snapcraft is required to build the controller snap.*")
+}
+
+func (s *snapBuildSuite) TestBuildControllerSnapMakeFails(c *tc.C) {
+	origBuild := bootstrap.BuildCommandFunc
+	restoreBuild := func() { *bootstrap.BuildCommandFunc = *origBuild }
+	defer restoreBuild()
+
+	*bootstrap.BuildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte("build output\nbuild failed\n"), fmt.Errorf("exit status 2")
+	}
+
+	origLookPath := bootstrap.LookPathFunc
+	restoreLookPath := func() { *bootstrap.LookPathFunc = *origLookPath }
+	defer restoreLookPath()
+	*bootstrap.LookPathFunc = func(file string) (string, error) {
+		return "/usr/bin/snapcraft", nil
+	}
+
+	_, err := bootstrap.BuildControllerSnap(context.Background())
+	c.Assert(err, tc.ErrorMatches, "building controller snap failed: exit status 2(?s).*")
+}
+
+func (s *snapBuildSuite) TestBuildControllerSnapFileNotFound(c *tc.C) {
+	tmpDir := c.MkDir()
+
+	origBuild := bootstrap.BuildCommandFunc
+	restoreBuild := func() { *bootstrap.BuildCommandFunc = *origBuild }
+	defer restoreBuild()
+
+	*bootstrap.BuildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte("build complete\n"), nil
+	}
+
+	origLookPath := bootstrap.LookPathFunc
+	restoreLookPath := func() { *bootstrap.LookPathFunc = *origLookPath }
+	defer restoreLookPath()
+	*bootstrap.LookPathFunc = func(file string) (string, error) {
+		return "/usr/bin/snapcraft", nil
+	}
+
+	origFindSourceRoot := tools.FindJujuSourceRoot
+	restoreFindSourceRoot := func() { tools.FindJujuSourceRoot = origFindSourceRoot }
+	defer restoreFindSourceRoot()
+	tools.FindJujuSourceRoot = func() (string, error) {
+		return tmpDir, nil
+	}
+
+	_, err := bootstrap.BuildControllerSnap(context.Background())
+	c.Assert(err, tc.ErrorMatches, "controller snap build completed but expected file.*was not found.*")
+}
+
+func (s *snapBuildSuite) TestBuildControllerSnapSuccess(c *tc.C) {
+	tmpDir := c.MkDir()
+
+	snapName := fmt.Sprintf("jujud_%s_%s.snap", "4.1-beta2", runtime.GOARCH)
+	snapPath := filepath.Join(tmpDir, snapName)
+	err := os.WriteFile(snapPath, []byte("fake snap"), 0644)
+	c.Assert(err, tc.ErrorIsNil)
+
+	origBuild := bootstrap.BuildCommandFunc
+	restoreBuild := func() { *bootstrap.BuildCommandFunc = *origBuild }
+	defer restoreBuild()
+
+	buildCalled := false
+	*bootstrap.BuildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		c.Check(dir, tc.Equals, tmpDir)
+		c.Check(name, tc.Equals, "make")
+		c.Check(args, tc.DeepEquals, []string{"build-snap"})
+		buildCalled = true
+		return []byte("build complete\n"), nil
+	}
+
+	origLookPath := bootstrap.LookPathFunc
+	restoreLookPath := func() { *bootstrap.LookPathFunc = *origLookPath }
+	defer restoreLookPath()
+	*bootstrap.LookPathFunc = func(file string) (string, error) {
+		return "/usr/bin/snapcraft", nil
+	}
+
+	origFindSourceRoot := tools.FindJujuSourceRoot
+	restoreFindSourceRoot := func() { tools.FindJujuSourceRoot = origFindSourceRoot }
+	defer restoreFindSourceRoot()
+	tools.FindJujuSourceRoot = func() (string, error) {
+		return tmpDir, nil
+	}
+
+	result, err := bootstrap.BuildControllerSnap(context.Background())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(buildCalled, tc.IsTrue)
+	c.Check(result, tc.Equals, snapPath)
+}

--- a/environs/bootstrap/snap_build_test.go
+++ b/environs/bootstrap/snap_build_test.go
@@ -35,7 +35,6 @@ func (s *snapBuildSuite) TestSnapArchIdentity(c *tc.C) {
 }
 
 func (s *snapBuildSuite) TestSnapArchMapping(c *tc.C) {
-	c.Check(bootstrap.SnapArch("arm"), tc.Equals, "armhf")
 	c.Check(bootstrap.SnapArch("ppc64le"), tc.Equals, "ppc64el")
 }
 

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -52,9 +52,9 @@ func Archive(w io.Writer, dir string) error {
 		logger.Debugf(context.TODO(), "adding entry: %#v", h)
 		// ignore local umask
 		if isExecutable(fi) {
-			h.Mode = 0755
+			h.Mode = 0o755
 		} else {
-			h.Mode = 0644
+			h.Mode = 0o644
 		}
 		err = tarw.WriteHeader(h)
 		if err != nil {
@@ -97,7 +97,7 @@ func tarHeader(i os.FileInfo) *tar.Header {
 		Typeflag:   tar.TypeReg,
 		Name:       i.Name(),
 		Size:       i.Size(),
-		Mode:       int64(i.Mode() & 0777),
+		Mode:       int64(i.Mode() & 0o777),
 		ModTime:    i.ModTime(),
 		AccessTime: i.ModTime(),
 		ChangeTime: i.ModTime(),
@@ -109,7 +109,7 @@ func tarHeader(i os.FileInfo) *tar.Header {
 // isExecutable returns whether the given info
 // represents a regular file executable by (at least) the user.
 func isExecutable(i os.FileInfo) bool {
-	return i.Mode()&(0100|os.ModeType) == 0100
+	return i.Mode()&(0o100|os.ModeType) == 0o100
 }
 
 // closeErrorCheck means that we can ensure that
@@ -249,13 +249,9 @@ func copyExistingJujus(ctx context.Context, dir string) error {
 	return nil
 }
 
-func buildJujus(ctx context.Context, dir string) error {
-	logger.Infof(ctx, "building jujuagentd")
-
-	// Determine if we are in tree of juju and if to prefer
-	// vendor or readonly mod deps.
+// FindJujuSourceRoot locates the juju source tree root via 'go list'.
+var FindJujuSourceRoot = func() (string, error) {
 	var lastErr error
-	var cmdDir string
 	for _, m := range []string{"-mod=vendor", "-mod=readonly"} {
 		var stdout, stderr bytes.Buffer
 		cmd := exec.Command("go", "list", "-json", m, "github.com/juju/juju")
@@ -278,12 +274,17 @@ func buildJujus(ctx context.Context, dir string) error {
 				jujuversion.Current.String(), jujuversion.GitCommit, err)
 			continue
 		}
-		lastErr = nil
-		cmdDir = pkg.Root
-		break
+		return pkg.Root, nil
 	}
-	if lastErr != nil {
-		return lastErr
+	return "", lastErr
+}
+
+func buildJujus(ctx context.Context, dir string) error {
+	logger.Infof(ctx, "building jujuagentd")
+
+	cmdDir, err := FindJujuSourceRoot()
+	if err != nil {
+		return err
 	}
 
 	// Build binaries.
@@ -380,7 +381,7 @@ func bundleTools(
 		}
 		forceVersion = getForceVersion(tvers.Number)
 		logger.Debugf(ctx, "forcing %sversion to %s", officialMsg, forceVersion)
-		if err := os.WriteFile(filepath.Join(dir, "FORCE-VERSION"), []byte(forceVersion.String()), 0666); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "FORCE-VERSION"), []byte(forceVersion.String()), 0o666); err != nil {
 			return semversion.Binary{}, semversion.Number{}, false, "", err
 		}
 	}

--- a/tests/suites/bootstrap/build_snap.sh
+++ b/tests/suites/bootstrap/build_snap.sh
@@ -1,0 +1,160 @@
+# run_build_snap_explicit verifies that --build-snap builds, uploads, and
+# installs the controller snap on a LXD controller.
+#
+# WORKAROUND: Bootstrap is run in the background because it hangs at
+# "Contacting Juju controller" — the juju-controller charm 4.1/stable
+# channel does not yet publish a release for the ubuntu-core/26 base that
+# the snap-built image uses.  The controller machine is provisioned and the
+# snap is installed before the hang, so we poll for the controller to appear
+# in "juju controllers" and then kill the background process.  Once the
+# charm is published, replace the background+poll flow with a direct
+# bootstrap call and verify with "juju status -m controller".
+run_build_snap_explicit() {
+	echo
+
+	local name="test-build-snap-explicit"
+
+	# Capture existing LXD containers to detect new ones after bootstrap.
+	local before
+	before=$(lxc list --format csv -c n 2>/dev/null | sort)
+
+	echo "==> Bootstrapping LXD controller with --build-snap: ${name}"
+
+	# Start bootstrap in the background.  It will hang at the
+	# controller-verification step, but by then the machine is
+	# provisioned and the snap is installed.
+	juju bootstrap lxd "${name}" --build-snap &
+	local bootstrap_pid=$!
+
+	# Poll until the controller appears or 10 minutes elapse.
+	local waited=0
+	while [[ ${waited} -lt 600 ]]; do
+		if juju controllers 2>/dev/null | grep -q "${name}"; then
+			break
+		fi
+		sleep 5
+		waited=$((waited + 5))
+	done
+	echo "${name}" >>"${TEST_DIR}/jujus"
+
+	# Kill the background bootstrap process; it will never complete.
+	kill "${bootstrap_pid}" 2>/dev/null || true
+	wait "${bootstrap_pid}" 2>/dev/null || true
+
+	echo "==> Verifying controller is registered"
+	local controllers_out
+	controllers_out=$(juju controllers 2>/dev/null)
+	check_contains "${controllers_out}" "${name}"
+
+	echo "==> Verifying controller snap was installed on the machine"
+	local after new_container
+	after=$(lxc list --format csv -c n 2>/dev/null | sort)
+	new_container=$(comm -13 <(echo "${before}") <(echo "${after}") | head -1)
+	if [[ -z "${new_container}" ]]; then
+		echo "ERROR: could not find new LXD container for controller ${name}" >&2
+		exit 1
+	fi
+	local snap_list
+	snap_list=$(lxc exec "${new_container}" -- snap list 2>/dev/null)
+	check_contains "${snap_list}" "juju-controller"
+
+	echo "==> Cleaning up controller ${name}..."
+	juju destroy-controller -y "${name}" --destroy-all-models --force --no-prompt 2>&1 || true
+	lxc delete --force "${new_container}" 2>&1 || true
+}
+
+# run_build_snap_implicit verifies that bootstrap without flags
+# implicitly builds, uploads, and installs the controller snap.
+#
+# WORKAROUND: Same background+poll approach as run_build_snap_explicit
+# because of the charm channel issue.  Replace with direct bootstrap and
+# "juju status -m controller" once the charm is published.
+run_build_snap_implicit() {
+	echo
+
+	local name="test-build-snap-implicit"
+
+	# Capture existing LXD containers to detect new ones after bootstrap.
+	local before
+	before=$(lxc list --format csv -c n 2>/dev/null | sort)
+
+	echo "==> Bootstrapping LXD controller without flags (implicit build): ${name}"
+
+	juju bootstrap lxd "${name}" &
+	local bootstrap_pid=$!
+
+	local waited=0
+	while [[ ${waited} -lt 600 ]]; do
+		if juju controllers 2>/dev/null | grep -q "${name}"; then
+			break
+		fi
+		sleep 5
+		waited=$((waited + 5))
+	done
+	echo "${name}" >>"${TEST_DIR}/jujus"
+
+	kill "${bootstrap_pid}" 2>/dev/null || true
+	wait "${bootstrap_pid}" 2>/dev/null || true
+
+	echo "==> Verifying controller is registered"
+	local controllers_out
+	controllers_out=$(juju controllers 2>/dev/null)
+	check_contains "${controllers_out}" "${name}"
+
+	echo "==> Verifying controller snap was installed on the machine"
+	local after new_container
+	after=$(lxc list --format csv -c n 2>/dev/null | sort)
+	new_container=$(comm -13 <(echo "${before}") <(echo "${after}") | head -1)
+	if [[ -z "${new_container}" ]]; then
+		echo "ERROR: could not find new LXD container for controller ${name}" >&2
+		exit 1
+	fi
+	local snap_list
+	snap_list=$(lxc exec "${new_container}" -- snap list 2>/dev/null)
+	check_contains "${snap_list}" "jujud"
+
+	echo "==> Cleaning up controller ${name}..."
+	juju unregister --no-prompt "${name}" 2>&1 || true
+	lxc delete --force "${new_container}" 2>&1 || true
+}
+
+# check_snapcraft verifies that snapcraft is available on $PATH.
+# If not, the test exits 0 from the subshell so that the suite skips
+# gracefully rather than failing.
+check_snapcraft() {
+	if ! command -v snapcraft &>/dev/null; then
+		echo "SKIP: snapcraft not installed (required for build-snap)"
+		exit 0
+	fi
+}
+
+# test_bootstrap_build_snap is the top-level test entry point for the
+# --build-snap integration smoke test.  It validates both explicit
+# --build-snap and implicit (no flags) bootstrap flows end-to-end:
+# building the snap from local source, uploading it to the LXD instance,
+# and verifying installation.
+#
+# The test skips on k8s providers (build-snap is IAAS-only) and when
+# snapcraft is not available.
+test_bootstrap_build_snap() {
+	if [ -n "$(skip 'test_bootstrap_build_snap')" ]; then
+		echo "==> SKIP: asked to skip test_bootstrap_build_snap"
+		return
+	fi
+
+	if [[ ${BOOTSTRAP_PROVIDER:-} == "k8s" || ${BOOTSTRAP_PROVIDER:-} == "microk8s" ]]; then
+		echo "==> TEST SKIPPED: test_bootstrap_build_snap, not supported on k8s controller"
+		return
+	fi
+
+	check_snapcraft
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_build_snap_explicit"
+		run "run_build_snap_implicit"
+	)
+}

--- a/tests/suites/bootstrap/build_snap.sh
+++ b/tests/suites/bootstrap/build_snap.sh
@@ -56,7 +56,7 @@ run_build_snap_explicit() {
 	fi
 	local snap_list
 	snap_list=$(lxc exec "${new_container}" -- snap list 2>/dev/null)
-	check_contains "${snap_list}" "juju-controller"
+	check_contains "${snap_list}" "jujud"
 
 	echo "==> Cleaning up controller ${name}..."
 	juju destroy-controller -y "${name}" --destroy-all-models --force --no-prompt 2>&1 || true
@@ -114,18 +114,19 @@ run_build_snap_implicit() {
 	check_contains "${snap_list}" "jujud"
 
 	echo "==> Cleaning up controller ${name}..."
-	juju unregister --no-prompt "${name}" 2>&1 || true
+	juju destroy-controller -y "${name}" --destroy-all-models --force --no-prompt 2>&1 || true
 	lxc delete --force "${new_container}" 2>&1 || true
 }
 
 # check_snapcraft verifies that snapcraft is available on $PATH.
-# If not, the test exits 0 from the subshell so that the suite skips
-# gracefully rather than failing.
+# It returns a non-zero status when snapcraft is missing so that the caller
+# can skip only the build-snap test rather than exiting the whole runner.
 check_snapcraft() {
 	if ! command -v snapcraft &>/dev/null; then
 		echo "SKIP: snapcraft not installed (required for build-snap)"
-		exit 0
+		return 1
 	fi
+	return 0
 }
 
 # test_bootstrap_build_snap is the top-level test entry point for the
@@ -147,7 +148,9 @@ test_bootstrap_build_snap() {
 		return
 	fi
 
-	check_snapcraft
+	if ! check_snapcraft; then
+		return
+	fi
 
 	(
 		set_verbosity

--- a/tests/suites/bootstrap/task.sh
+++ b/tests/suites/bootstrap/task.sh
@@ -13,4 +13,5 @@ test_bootstrap() {
   test_bootstrap_simplestream
   test_bootstrap_controller_snap_path
   test_bootstrap_controller_snap_path_without_assert
+  test_bootstrap_build_snap
 }


### PR DESCRIPTION
This PR adds a `--build-snap` flag to `juju bootstrap` that builds the
controller snap (`jujud`) from local source and uploads it to the bootstrap
instance. When `--controller-snap-path` is not explicitly provided, the build
is triggered implicitly so that CI and developer workflows work without flag
changes.

The goal is to eliminate the manual `make build-snap` step before bootstrapping
a snap-based controller. Developers and CI can now run `juju bootstrap lxd
<name>` and the controller snap is built, uploaded, and installed
automatically.

**Key behaviors:**
- `juju bootstrap lxd <name>` — implicit build of snap + agent, uploads,
  bootstraps
- `juju bootstrap lxd <name> --build-snap` — explicit opt-in (same result)
- `juju bootstrap lxd <name> --controller-snap-path ./jujud.snap --build-agent`
  — existing path-based flow unchanged
- `--build-snap` auto-enables `--build-agent` for version coupling
- Mutually exclusive with `--agent-version`
- Ignored (with a warning) when `--controller-snap-path` is explicitly provided
- `--controller-snap-assert-path` requires `--controller-snap-path`; it cannot
  be used with `--build-snap` on its own
- Rejected on CAAS (Kubernetes) — build-snap is IAAS-only
- The implicit build is temporary; it will be replaced by store-based
  resolution once the jujud snap is published (JUJU-10106)

**Note:** The integration smoke tests use a background+poll workaround because
the `juju-controller` charm `4.1/stable` channel does not yet publish a release
for the snap-built image base. This will be fixed in a follow-up charm
publishing task.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
❯ make go-install

❯ juju bootstrap lxd ctrl-test \
  --build-snap \
  --controller-charm-path ../juju-controller/juju-controller_ubuntu@24.04-amd64.charm
Building controller snap from local source via 'make build-snap'; this may take several minutes...
Creating Juju controller "ctrl-test" on lxd/default
Inspected local controller snap version 4.1-beta2
Building local Juju agent binary version 4.1-beta2 for amd64 (anchored to controller snap)
To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
Launching controller instance(s) on lxd/default...
 - juju-24876f-0 (arch=amd64)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.159.202.10:22
Connected to 10.159.202.10
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.159.202.10 to verify accessibility...

Bootstrap complete, controller "ctrl-test" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

❯ jst -m controller
Model       Controller  Cloud/Region  Version    Timestamp
controller  ctrl-test   lxd/default   4.1-beta2  10:21:53+02:00

App         Version  Status  Scale  Charm            Channel  Rev  Exposed  Message
controller           active      1  juju-controller             0  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.159.202.10   17022,17070/tcp

Machine  State    Address        Inst id        Base       AZ      Message
0        started  10.159.202.10  juju-24876f-0  ubuntu@26  tuxedo  Running

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer

❯ juju ssh -m controller 0 -- snap list
Name    Version    Rev    Tracking       Publisher    Notes
core26  20260629   462    latest/stable  canonical**  base
jujud   4.1-beta2  x1     -              -            -
snapd   2.76.1     27591  latest/stable  canonical**  snapd
Connection to 10.159.202.10 closed.

❯ juju ssh -m controller 0 -- sudo ls -l /var/snap/jujud/common
total 28
drwxr-xr-x 3 root root 4096 Aug  4 08:19 agents
-rw------- 1 root root 7360 Aug  4 08:19 bootstrap-params
-rw-r--r-- 1 root root  143 Aug  4 08:19 hook.log
lrwxrwxrwx 1 root root   21 Feb  6 07:23 host-os-release -> ../usr/lib/os-release
drwxr-xr-x 2 root root 4096 Aug  4 08:19 locks
drwxr-xr-x 2 root root 4096 Aug  4 08:19 sockets
drwxr-xr-x 3 root root 4096 Aug  4 08:19 var
Connection to 10.159.202.10 closed.
```

## Documentation changes

## Links

**Jira card:** [JUJU-9703](https://warthogs.atlassian.net/browse/JUJU-9703)


[JUJU-9703]: https://warthogs.atlassian.net/browse/JUJU-9703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
