### PR TITLE
fix(migration): name the controller to upgrade on unsupported payload versions

### DIFF
--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -712,14 +712,11 @@ func (api *APIV8) importGuard(ctx context.Context, args params.SerializedModelV2
 		return export.ProjectionView{}, nil, errors.Capture(err)
 	}
 
-	// Payload-version checks. The newer-than-target check runs before the
-	// decoder registry lookup so a payload from a newer Juju gets the
-	// actionable upgrade message rather than an unknown-version error.
-	targetVersion := export.LatestSupportedPayloadVersion()
-	if args.PayloadVersion.Compare(targetVersion) > 0 {
-		return export.ProjectionView{}, nil, errors.Errorf(
-			"source payload version %q is newer than target %q; upgrade the target controller first %w",
-			args.PayloadVersion, targetVersion, coreerrors.NotSupported)
+	// Payload-version check. It runs before the decoder registry lookup so
+	// every unsupported version gets the actionable upgrade message naming the
+	// controller to move, rather than a bare unknown-version error.
+	if err := export.CheckPayloadVersionSupported(args.PayloadVersion); err != nil {
+		return export.ProjectionView{}, nil, errors.Capture(err)
 	}
 
 	payload, err := export.DecodePayload(args.PayloadVersion, args.Payload)

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
@@ -323,7 +323,8 @@ func (s *v8Suite) TestPrechecksPayloadVersionNewerThanTarget(c *tc.C) {
 }
 
 // TestPrechecksPayloadVersionUnknown verifies that a version at or below the
-// target but unknown to the decoder registry yields a clean error.
+// target but unknown to the decoder registry is rejected with the actionable
+// message telling the operator to upgrade the source controller.
 func (s *v8Suite) TestPrechecksPayloadVersionUnknown(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -332,7 +333,8 @@ func (s *v8Suite) TestPrechecksPayloadVersionUnknown(c *tc.C) {
 
 	err := s.mustNewAPIV8(c).Prechecks(c.Context(), envelope)
 	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
-	c.Check(err, tc.ErrorMatches, `model export payload version "4.0.5": not supported`)
+	c.Check(err, tc.ErrorMatches,
+		`source payload version "4.0.5" predates the 4.0 export format this controller imports \("4.0.12"\); upgrade the source controller in place to the latest 4.0 release, then retry the migration.*`)
 }
 
 // TestPrechecksModelVersionNewerThanController verifies that the model's

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
@@ -337,6 +337,34 @@ func (s *v8Suite) TestPrechecksPayloadVersionUnknown(c *tc.C) {
 		`source payload version "4.0.5" predates the 4.0 export format this controller imports \("4.0.12"\); upgrade the source controller in place to the latest 4.0 release, then retry the migration.*`)
 }
 
+// TestPrechecksPayloadVersionNewerPatchOnKnownLine verifies that a payload
+// using a newer patch on a supported release line advises upgrading the target.
+func (s *v8Suite) TestPrechecksPayloadVersionNewerPatchOnKnownLine(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	envelope := s.makeEnvelope(c, s.validPayload())
+	envelope.PayloadVersion = semversion.MustParse("4.0.13")
+
+	err := s.mustNewAPIV8(c).Prechecks(c.Context(), envelope)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
+	c.Check(err, tc.ErrorMatches,
+		`source payload version "4.0.13" is newer than the 4.0 export format this controller imports \("4.0.12"\); upgrade the target controller first.*`)
+}
+
+// TestPrechecksPayloadVersionBelowFloor verifies that a payload below the
+// import window advises upgrading through the intervening releases first.
+func (s *v8Suite) TestPrechecksPayloadVersionBelowFloor(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	envelope := s.makeEnvelope(c, s.validPayload())
+	envelope.PayloadVersion = semversion.MustParse("3.6.1")
+
+	err := s.mustNewAPIV8(c).Prechecks(c.Context(), envelope)
+	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
+	c.Check(err, tc.ErrorMatches,
+		`source payload version "3.6.1" is older than the oldest export format this controller imports \("4.0.12"\); upgrade the source controller through the intervening releases first.*`)
+}
+
 // TestPrechecksModelVersionNewerThanController verifies that the model's
 // agent version from the payload must not be ahead of the target controller.
 func (s *v8Suite) TestPrechecksModelVersionNewerThanController(c *tc.C) {

--- a/domain/export/payload.go
+++ b/domain/export/payload.go
@@ -53,11 +53,19 @@ func decodeInto[T any](data []byte) (T, error) {
 // error satisfying [coreerrors.NotSupported] when the version is not a known
 // export payload version, and an error satisfying [coreerrors.NotValid] when
 // the bytes cannot be decoded as that version's payload.
+//
+// An unknown version is reported through [CheckPayloadVersionSupported] so the
+// operator is told which controller to upgrade rather than only which version
+// was rejected.
 func DecodePayload(version semversion.Number, data []byte) (any, error) {
 	decode, ok := payloadDecoders[version]
 	if !ok {
+		if err := CheckPayloadVersionSupported(version); err != nil {
+			return nil, errors.Capture(err)
+		}
+		// No decoder found for the version.
 		return nil, errors.Errorf(
-			"model export payload version %q: %w", version, coreerrors.NotSupported)
+			"model export payload version %q has no decoder: %w", version, coreerrors.NotSupported)
 	}
 	payload, err := decode(data)
 	if err != nil {

--- a/domain/export/payload_test.go
+++ b/domain/export/payload_test.go
@@ -71,6 +71,21 @@ func (s *payloadSuite) TestDecodePayloadUnknownVersion(c *tc.C) {
 		`source payload version "4.0.5" predates the 4.0 export format this controller imports \("4.0.12"\); upgrade the source controller in place to the latest 4.0 release, then retry the migration.*`)
 }
 
+// TestDecodePayloadMissingDecoder verifies the fallback error when a supported
+// payload version has no registered decoder.
+func (s *payloadSuite) TestDecodePayloadMissingDecoder(c *tc.C) {
+	originalDecoders := payloadDecoders
+	payloadDecoders = map[semversion.Number]PayloadDecodeFunc{}
+	c.Cleanup(func() {
+		payloadDecoders = originalDecoders
+	})
+
+	_, err := DecodePayload(semversion.MustParse("4.0.12"), []byte("{}"))
+	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
+	c.Check(err, tc.ErrorMatches,
+		`model export payload version "4.0.12" has no decoder.*`)
+}
+
 // TestDecodePayloadMalformedYAML verifies that undecodable bytes yield a
 // NotValid error.
 func (s *payloadSuite) TestDecodePayloadMalformedYAML(c *tc.C) {

--- a/domain/export/payload_test.go
+++ b/domain/export/payload_test.go
@@ -62,11 +62,13 @@ func (s *payloadSuite) TestDecodePayloadRoundTripV410(c *tc.C) {
 }
 
 // TestDecodePayloadUnknownVersion verifies that an unknown payload version
-// yields a clean NotSupported error.
+// yields a NotSupported error naming the controller to upgrade, rather than
+// only the version that was rejected.
 func (s *payloadSuite) TestDecodePayloadUnknownVersion(c *tc.C) {
 	_, err := DecodePayload(semversion.MustParse("4.0.5"), []byte("{}"))
 	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
-	c.Check(err, tc.ErrorMatches, `model export payload version "4.0.5": not supported`)
+	c.Check(err, tc.ErrorMatches,
+		`source payload version "4.0.5" predates the 4.0 export format this controller imports \("4.0.12"\); upgrade the source controller in place to the latest 4.0 release, then retry the migration.*`)
 }
 
 // TestDecodePayloadMalformedYAML verifies that undecodable bytes yield a

--- a/domain/export/version.go
+++ b/domain/export/version.go
@@ -80,16 +80,16 @@ func CheckPayloadVersionSupported(version semversion.Number) error {
 	// On a minor line we do import, but at a different patch. Only one format
 	// per line is supported, so the side holding the older one has to move; an
 	// in-place upgrade to the latest patch of that line needs no migration.
-	if entry, ok := supportedVersionForLine(version); ok {
-		line := fmt.Sprintf("%d.%d", version.Major, version.Minor)
-		if version.Compare(entry) > 0 {
+	if supported, ok := supportedVersionForLine(version); ok {
+		majorMinor := fmt.Sprintf("%d.%d", version.Major, version.Minor)
+		if version.Compare(supported) > 0 {
 			return errors.Errorf(
 				"source payload version %q is newer than the %s export format this controller imports (%q); upgrade the target controller first: %w",
-				version, line, entry, coreerrors.NotSupported)
+				version, majorMinor, supported, coreerrors.NotSupported)
 		}
 		return errors.Errorf(
 			"source payload version %q predates the %s export format this controller imports (%q); upgrade the source controller in place to the latest %s release, then retry the migration: %w",
-			version, line, entry, line, coreerrors.NotSupported)
+			version, majorMinor, supported, majorMinor, coreerrors.NotSupported)
 	}
 
 	// Below the floor: too old to reach this controller in a single hop.

--- a/domain/export/version.go
+++ b/domain/export/version.go
@@ -4,9 +4,12 @@
 package export
 
 import (
+	"fmt"
 	"slices"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/semversion"
+	"github.com/juju/juju/internal/errors"
 )
 
 // exportVersionStrings lists, in ascending order, each semantic version for
@@ -41,4 +44,75 @@ func parseExportVersions(versions []string) []semversion.Number {
 // binary version, and must not be confused with GetControllerTargetVersion.
 func LatestSupportedPayloadVersion() semversion.Number {
 	return slices.MaxFunc(ExportVersions, semversion.Number.Compare)
+}
+
+// OldestSupportedPayloadVersion returns the lowest supported model-export
+// payload schema version: the floor of this controller's import window. A
+// source stamping a payload below this floor cannot be imported directly and
+// has to come up through the intervening releases first.
+func OldestSupportedPayloadVersion() semversion.Number {
+	return slices.MinFunc(ExportVersions, semversion.Number.Compare)
+}
+
+// CheckPayloadVersionSupported reports whether this controller can import a
+// model export payload stamped with the given schema version, returning an
+// error satisfying [coreerrors.NotSupported] when it cannot.
+//
+// The message names the controller the operator has to act on, because that is
+// the one thing the raw version number does not tell them. A source only ever
+// stamps the payload with the export format compiled into its own binary, so a
+// version this controller does not hold means one side is behind the other:
+// either the source is old and must be upgraded, or this controller is and the
+// migration cannot proceed until the target catches up.
+func CheckPayloadVersionSupported(version semversion.Number) error {
+	if slices.Contains(ExportVersions, version) {
+		return nil
+	}
+
+	// Ahead of everything we know: the source runs a newer Juju than this
+	// controller, so the target is the side to move.
+	if latest := LatestSupportedPayloadVersion(); version.Compare(latest) > 0 {
+		return errors.Errorf(
+			"source payload version %q is newer than target %q; upgrade the target controller first: %w",
+			version, latest, coreerrors.NotSupported)
+	}
+
+	// On a minor line we do import, but at a different patch. Only one format
+	// per line is supported, so the side holding the older one has to move; an
+	// in-place upgrade to the latest patch of that line needs no migration.
+	if entry, ok := supportedVersionForLine(version); ok {
+		line := fmt.Sprintf("%d.%d", version.Major, version.Minor)
+		if version.Compare(entry) > 0 {
+			return errors.Errorf(
+				"source payload version %q is newer than the %s export format this controller imports (%q); upgrade the target controller first: %w",
+				version, line, entry, coreerrors.NotSupported)
+		}
+		return errors.Errorf(
+			"source payload version %q predates the %s export format this controller imports (%q); upgrade the source controller in place to the latest %s release, then retry the migration: %w",
+			version, line, entry, line, coreerrors.NotSupported)
+	}
+
+	// Below the floor: too old to reach this controller in a single hop.
+	if oldest := OldestSupportedPayloadVersion(); version.Compare(oldest) < 0 {
+		return errors.Errorf(
+			"source payload version %q is older than the oldest export format this controller imports (%q); upgrade the source controller through the intervening releases first: %w",
+			version, oldest, coreerrors.NotSupported)
+	}
+
+	return errors.Errorf(
+		"model export payload version %q is not one of the export formats this controller imports (%v): %w",
+		version, ExportVersions, coreerrors.NotSupported)
+}
+
+// supportedVersionForLine returns the supported export version sharing the
+// given version's major.minor line, if this controller holds one. At most one
+// entry exists per minor line: the patch at which that line's schema last
+// changed.
+func supportedVersionForLine(version semversion.Number) (semversion.Number, bool) {
+	for _, supported := range ExportVersions {
+		if supported.Major == version.Major && supported.Minor == version.Minor {
+			return supported, true
+		}
+	}
+	return semversion.Number{}, false
 }

--- a/domain/export/version_test.go
+++ b/domain/export/version_test.go
@@ -4,6 +4,7 @@
 package export
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/juju/tc"
@@ -30,7 +31,7 @@ func (s *versionSuite) TestExportVersionsParsed(c *tc.C) {
 // TestLatestSupportedPayloadVersion documents the current highest supported
 // export schema version. Update this when adding a new export payload version.
 func (s *versionSuite) TestLatestSupportedPayloadVersionCurrent(c *tc.C) {
-	c.Assert(
+	c.Check(
 		LatestSupportedPayloadVersion(),
 		tc.Equals,
 		semversion.MustParse("4.1.0"),
@@ -40,11 +41,31 @@ func (s *versionSuite) TestLatestSupportedPayloadVersionCurrent(c *tc.C) {
 // TestOldestSupportedPayloadVersionCurrent documents the floor of the import
 // window. Update this when the oldest supported export version moves.
 func (s *versionSuite) TestOldestSupportedPayloadVersionCurrent(c *tc.C) {
-	c.Assert(
+	c.Check(
 		OldestSupportedPayloadVersion(),
 		tc.Equals,
 		semversion.MustParse("4.0.12"),
 	)
+}
+
+// TestExportVersionsNonEmpty ensures that the support-window helpers have an
+// input to inspect.
+func (s *versionSuite) TestExportVersionsNonEmpty(c *tc.C) {
+	c.Check(len(ExportVersions) > 0, tc.IsTrue)
+}
+
+// TestExportVersionsOnePerMinorLine ensures each export format corresponds to
+// exactly one schema version per major.minor release line.
+func (s *versionSuite) TestExportVersionsOnePerMinorLine(c *tc.C) {
+	versionsByMajorMinor := make(map[string]int)
+	for _, version := range ExportVersions {
+		majorMinor := fmt.Sprintf("%d.%d", version.Major, version.Minor)
+		versionsByMajorMinor[majorMinor]++
+	}
+	for majorMinor, count := range versionsByMajorMinor {
+		c.Check(count, tc.Equals, 1,
+			tc.Commentf("multiple export versions for %s", majorMinor))
+	}
 }
 
 // TestCheckPayloadVersionSupported verifies that every supported export
@@ -70,8 +91,8 @@ func (s *versionSuite) TestCheckPayloadVersionRejections(c *tc.C) {
 		expect:  `source payload version "9.9.9" is newer than target "4.1.0"; upgrade the target controller first.*`,
 	}, {
 		summary: "older patch of a line we import: the source is behind",
-		version: "4.0.6",
-		expect:  `source payload version "4.0.6" predates the 4.0 export format this controller imports \("4.0.12"\); upgrade the source controller in place to the latest 4.0 release, then retry the migration.*`,
+		version: "4.0.11",
+		expect:  `source payload version "4.0.11" predates the 4.0 export format this controller imports \("4.0.12"\); upgrade the source controller in place to the latest 4.0 release, then retry the migration.*`,
 	}, {
 		summary: "newer patch of a line we import: the target is behind on that line",
 		version: "4.0.13",
@@ -88,4 +109,22 @@ func (s *versionSuite) TestCheckPayloadVersionRejections(c *tc.C) {
 		c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
 		c.Check(err, tc.ErrorMatches, test.expect)
 	}
+}
+
+// TestCheckPayloadVersionSupportedSparseVersions verifies that an unsupported
+// version in a gap between supported release lines receives the fallback error.
+func (s *versionSuite) TestCheckPayloadVersionSupportedSparseVersions(c *tc.C) {
+	originalVersions := ExportVersions
+	ExportVersions = []semversion.Number{
+		semversion.MustParse("4.0.12"),
+		semversion.MustParse("4.2.0"),
+	}
+	c.Cleanup(func() {
+		ExportVersions = originalVersions
+	})
+
+	err := CheckPayloadVersionSupported(semversion.MustParse("4.1.5"))
+	c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
+	c.Check(err, tc.ErrorMatches,
+		`model export payload version "4.1.5" is not one of the export formats this controller imports \(\[4.0.12 4.2.0\]\).*`)
 }

--- a/domain/export/version_test.go
+++ b/domain/export/version_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/tc"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/semversion"
 )
 
@@ -34,4 +35,57 @@ func (s *versionSuite) TestLatestSupportedPayloadVersionCurrent(c *tc.C) {
 		tc.Equals,
 		semversion.MustParse("4.1.0"),
 	)
+}
+
+// TestOldestSupportedPayloadVersionCurrent documents the floor of the import
+// window. Update this when the oldest supported export version moves.
+func (s *versionSuite) TestOldestSupportedPayloadVersionCurrent(c *tc.C) {
+	c.Assert(
+		OldestSupportedPayloadVersion(),
+		tc.Equals,
+		semversion.MustParse("4.0.12"),
+	)
+}
+
+// TestCheckPayloadVersionSupported verifies that every supported export
+// version is accepted.
+func (s *versionSuite) TestCheckPayloadVersionSupported(c *tc.C) {
+	for _, version := range ExportVersions {
+		c.Check(CheckPayloadVersionSupported(version), tc.ErrorIsNil,
+			tc.Commentf("export version %q must be supported", version))
+	}
+}
+
+// TestCheckPayloadVersionRejections verifies that each way a payload version
+// can fall outside the import window names the controller the operator has to
+// upgrade.
+func (s *versionSuite) TestCheckPayloadVersionRejections(c *tc.C) {
+	tests := []struct {
+		summary string
+		version string
+		expect  string
+	}{{
+		summary: "newer than every format we hold: the target is behind",
+		version: "9.9.9",
+		expect:  `source payload version "9.9.9" is newer than target "4.1.0"; upgrade the target controller first.*`,
+	}, {
+		summary: "older patch of a line we import: the source is behind",
+		version: "4.0.6",
+		expect:  `source payload version "4.0.6" predates the 4.0 export format this controller imports \("4.0.12"\); upgrade the source controller in place to the latest 4.0 release, then retry the migration.*`,
+	}, {
+		summary: "newer patch of a line we import: the target is behind on that line",
+		version: "4.0.13",
+		expect:  `source payload version "4.0.13" is newer than the 4.0 export format this controller imports \("4.0.12"\); upgrade the target controller first.*`,
+	}, {
+		summary: "below the floor: too old to reach us in one hop",
+		version: "3.6.1",
+		expect:  `source payload version "3.6.1" is older than the oldest export format this controller imports \("4.0.12"\); upgrade the source controller through the intervening releases first.*`,
+	}}
+
+	for _, test := range tests {
+		c.Logf("%s", test.summary)
+		err := CheckPayloadVersionSupported(semversion.MustParse(test.version))
+		c.Assert(err, tc.ErrorIs, coreerrors.NotSupported)
+		c.Check(err, tc.ErrorMatches, test.expect)
+	}
 }


### PR DESCRIPTION
When a model migration is rejected because the source stamped its payload with an export format the 
target does not hold, the operator was told only the number that failed — `model export payload version
"4.0.6": not supported`. That number is the model-export schema version, not a release version, and it
appears nowhere in juju status or juju version, so there was no way to tell from the message whether 
the source controller was too old or the target was too new. In practice this cost real debugging time
on a 4.0 → 4.1 migration where the source controller was simply a stale build.

The target now classifies an out-of-window version against the supported set before rejecting it, and 
names the controller that has to move: a payload from an older patch of a minor line we do import says
to upgrade the source controller in place (an in-place upgrade needs no migration); one from a newer 
patch, or newer than everything we hold, says to upgrade the target; one below the oldest supported 
format says to come up through the intervening releases first. The classification lives in 
`domain/export` next to `ExportVersions`, so the facade's bespoke newer-than-target comparison collapses 
into one call and there is a single authority for what this controller can import.

## QA steps

Bootstrap a target from this branch and a source from 4.0/edge snap (`juju_40`), then deploy ubuntu and attempt migration:
```
juju bootstrap lxd tgt
juju_40 bootstrap lxd src
juju_40 add-model m
juju_40 deploy ubuntu
```
Once it's active attempt migration:
```
juju migrate m tgt
```
You should see on the logs:
```
unit-ubuntu-0: 14:23:40 INFO juju.worker.migrationminion logger-tags:migration migration phase is now: QUIESCE
unit-ubuntu-0: 14:23:40 INFO juju.worker.migrationminion logger-tags:migration reporting back for phase QUIESCE: true
unit-ubuntu-0: 14:23:40 INFO juju.worker.migrationminion logger-tags:migration migration phase is now: IMPORT
unit-ubuntu-0: 14:23:41 INFO juju.worker.migrationminion logger-tags:migration migration phase is now: VALIDATION
```

The model will not be fully migrated because of a ordering issue that will be fixed in the following patch.

## Links


<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9910](https://warthogs.atlassian.net/browse/JUJU-9910)


[JUJU-9910]: https://warthogs.atlassian.net/browse/JUJU-9910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ