### PR TITLE
fix: add 26.04 image support to Azure

### DIFF
--- a/core/base/base.go
+++ b/core/base/base.go
@@ -5,6 +5,7 @@ package base
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/juju/charm/v12"
@@ -126,22 +127,21 @@ func (b Base) IsCompatible(other Base) bool {
 
 // ubuntuLTSes lists the Ubuntu LTS releases that
 // this version of Juju knows about
-var ubuntuLTSes = []Base{
-	MakeDefaultBase(UbuntuOS, "20.04"),
-	MakeDefaultBase(UbuntuOS, "22.04"),
-	MakeDefaultBase(UbuntuOS, "24.04"),
-	MakeDefaultBase(UbuntuOS, "26.04"),
+var ubuntuLTSes []Base
+
+func init() {
+	for _, sv := range ubuntuSeries {
+		if !sv.LTS {
+			continue
+		}
+		ubuntuLTSes = append(ubuntuLTSes, MakeDefaultBase(sv.OS, sv.Version))
+	}
 }
 
 // IsUbuntuLTS returns true if this base is a recognised
 // Ubuntu LTS.
 func (b Base) IsUbuntuLTS() bool {
-	for _, ubuntuLTS := range ubuntuLTSes {
-		if b.IsCompatible(ubuntuLTS) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(ubuntuLTSes, b.IsCompatible)
 }
 
 // DisplayString returns the base string ignoring risk.

--- a/core/base/base.go
+++ b/core/base/base.go
@@ -130,6 +130,7 @@ var ubuntuLTSes = []Base{
 	MakeDefaultBase(UbuntuOS, "20.04"),
 	MakeDefaultBase(UbuntuOS, "22.04"),
 	MakeDefaultBase(UbuntuOS, "24.04"),
+	MakeDefaultBase(UbuntuOS, "26.04"),
 }
 
 // IsUbuntuLTS returns true if this base is a recognised

--- a/core/base/base_test.go
+++ b/core/base/base_test.go
@@ -105,6 +105,7 @@ var ubuntuLTS = []Base{
 	MustParseBaseFromString("ubuntu@20.04"),
 	MustParseBaseFromString("ubuntu@22.04"),
 	MustParseBaseFromString("ubuntu@24.04"),
+	MustParseBaseFromString("ubuntu@26.04"),
 	MustParseBaseFromString("ubuntu@24.04/stable"),
 	MustParseBaseFromString("ubuntu@24.04/edge"),
 }


### PR DESCRIPTION
The image lookup for Azure formulates the offer name based on of the Ubuntu version is a LTS.
Thus the offer for 26.04 needs to be "ubuntu-26_04-lts". 
However, the "26.04" version was not marked as a LTS, so the "lts" suffix was left off.

This is a simple patch to record "26.04" as a LTS.

## QA steps

On Azure

`juju add-machine --base ubuntu@26.04`

```
$ juju status
Model       Controller  Cloud/Region     Version   SLA          Timestamp
controller  test2       azure/centralus  3.6.28.2  unsupported  17:21:11+10:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable  361  yes      

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        20.236.243.54   17022,17070/tcp  

Machine  State    Address         Inst id        Base          AZ  Message
0        started  20.236.243.54   juju-bcfc08-0  ubuntu@24.04      
3        started  135.233.77.243  juju-bcfc08-3  ubuntu@26.04      
```

## Links

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #23053.
