### PR TITLE
feat(sshserver): add metrics

### DIFF
--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -942,6 +942,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			GetControllerSSHService:    sshserver.GetControllerSSHService,
 			GetDomainServicesGetter:    sshserver.GetDomainServicesGetter,
 			GetSSHService:              sshserver.GetSSHService,
+			PrometheusRegisterer:       config.PrometheusRegisterer,
 		})),
 
 		// The ssh tunneler worker runs on the controller machine and creates

--- a/internal/worker/sshserver/handlers/common/doc.go
+++ b/internal/worker/sshserver/handlers/common/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package common contains shared handler interfaces.
+package common

--- a/internal/worker/sshserver/handlers/common/metrics.go
+++ b/internal/worker/sshserver/handlers/common/metrics.go
@@ -1,7 +1,6 @@
 // Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Package common contains shared handler interfaces.
 package common
 
 import "context"

--- a/internal/worker/sshserver/handlers/common/metrics.go
+++ b/internal/worker/sshserver/handlers/common/metrics.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package common contains shared handler interfaces.
+package common
+
+import "context"
+
+// Metrics records metrics for an SSH proxy session.
+type Metrics interface {
+	// ObserveTimeToSession records the time taken to establish a session.
+	ObserveTimeToSession(context.Context)
+}
+
+// NoopMetrics ignores metric observations.
+type NoopMetrics struct{}
+
+// ObserveTimeToSession implements Metrics.
+func (NoopMetrics) ObserveTimeToSession(context.Context) {}

--- a/internal/worker/sshserver/handlers/k8s/k8s.go
+++ b/internal/worker/sshserver/handlers/k8s/k8s.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/virtualhostname"
 	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/common"
 )
 
 // Resolver resolves Kubernetes pod information for a routed destination.
@@ -25,10 +26,11 @@ type Handlers struct {
 	logger      logger.Logger
 	getExecutor func(string) (k8sexec.Executor, error)
 	destination virtualhostname.Info
+	metrics     common.Metrics
 }
 
 // NewHandlers returns handlers for a Kubernetes container target.
-func NewHandlers(destination virtualhostname.Info, resolver Resolver, logger logger.Logger, getExecutor func(string) (k8sexec.Executor, error)) (*Handlers, error) {
+func NewHandlers(destination virtualhostname.Info, resolver Resolver, logger logger.Logger, getExecutor func(string) (k8sexec.Executor, error), metrics common.Metrics) (*Handlers, error) {
 	if resolver == nil {
 		return nil, errors.New("Kubernetes resolver is required")
 	}
@@ -41,10 +43,14 @@ func NewHandlers(destination virtualhostname.Info, resolver Resolver, logger log
 	if destination.Target() != virtualhostname.ContainerTarget {
 		return nil, errors.New("destination must be a container target")
 	}
+	if metrics == nil {
+		return nil, errors.New("metrics collector is required")
+	}
 	return &Handlers{
 		resolver:    resolver,
 		logger:      logger,
 		getExecutor: getExecutor,
 		destination: destination,
+		metrics:     metrics,
 	}, nil
 }

--- a/internal/worker/sshserver/handlers/k8s/k8s_test.go
+++ b/internal/worker/sshserver/handlers/k8s/k8s_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/core/virtualhostname"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/common"
 )
 
 type k8sSuite struct{}
@@ -24,22 +25,22 @@ func (s *k8sSuite) TestNewHandlers(c *tc.C) {
 	destination, err := virtualhostname.NewInfoContainerTarget("8419cd78-4993-4c3a-928e-c646226beeee", "app/0", "workload")
 	c.Assert(err, tc.ErrorIsNil)
 
-	handlers, err := NewHandlers(destination, stubResolver{}, loggertesting.WrapCheckLog(c), stubExecutor)
+	handlers, err := NewHandlers(destination, stubResolver{}, loggertesting.WrapCheckLog(c), stubExecutor, common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(handlers.destination, tc.Equals, destination)
 
-	_, err = NewHandlers(destination, nil, loggertesting.WrapCheckLog(c), stubExecutor)
+	_, err = NewHandlers(destination, nil, loggertesting.WrapCheckLog(c), stubExecutor, common.NoopMetrics{})
 	c.Check(err, tc.ErrorMatches, "Kubernetes resolver is required")
 
-	_, err = NewHandlers(destination, stubResolver{}, nil, stubExecutor)
+	_, err = NewHandlers(destination, stubResolver{}, nil, stubExecutor, common.NoopMetrics{})
 	c.Check(err, tc.ErrorMatches, "logger is required")
 
-	_, err = NewHandlers(destination, stubResolver{}, loggertesting.WrapCheckLog(c), nil)
+	_, err = NewHandlers(destination, stubResolver{}, loggertesting.WrapCheckLog(c), nil, common.NoopMetrics{})
 	c.Check(err, tc.ErrorMatches, "executor is required")
 
 	machine, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
 	c.Assert(err, tc.ErrorIsNil)
-	_, err = NewHandlers(machine, stubResolver{}, loggertesting.WrapCheckLog(c), stubExecutor)
+	_, err = NewHandlers(machine, stubResolver{}, loggertesting.WrapCheckLog(c), stubExecutor, common.NoopMetrics{})
 	c.Check(err, tc.ErrorMatches, "destination must be a container target")
 }
 

--- a/internal/worker/sshserver/handlers/k8s/session.go
+++ b/internal/worker/sshserver/handlers/k8s/session.go
@@ -102,6 +102,7 @@ func (h *Handlers) SessionHandler(session ssh.Session) {
 	// registering nil will unregister the channel from signal sends.
 	defer session.Signals(nil)
 
+	h.metrics.ObserveTimeToSession(session.Context())
 	err = executor.Exec(session.Context(), k8sexec.ExecParams{
 		PodName:       podName,
 		ContainerName: container,

--- a/internal/worker/sshserver/handlers/k8s/session_test.go
+++ b/internal/worker/sshserver/handlers/k8s/session_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/virtualhostname"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/common"
 )
 
 func (s *k8sSuite) TestSessionHandler(c *tc.C) {
@@ -33,7 +34,7 @@ func (s *k8sSuite) TestSessionHandler(c *tc.C) {
 			_, err := io.WriteString(params.Stdout, "test output\n")
 			return err
 		}), nil
-	})
+	}, common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	server := startK8sTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
@@ -71,7 +72,7 @@ func (s *k8sSuite) TestSessionHandlerPreservesRawCommand(c *tc.C) {
 			received = params
 			return nil
 		}), nil
-	})
+	}, common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	server := startK8sTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
@@ -99,7 +100,7 @@ func (s *k8sSuite) TestSessionHandlerStartsDefaultShell(c *tc.C) {
 			received = params
 			return nil
 		}), nil
-	})
+	}, common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	server := startK8sTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
@@ -125,7 +126,7 @@ func (s *k8sSuite) TestSessionHandlerPropagatesExitStatus(c *tc.C) {
 		return executorFunc(func(context.Context, k8sexec.ExecParams, <-chan struct{}) error {
 			return testExitError{status: 3}
 		}), nil
-	})
+	}, common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	server := startK8sTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
@@ -159,7 +160,7 @@ func (s *k8sSuite) TestSessionHandlerForwardsSignal(c *tc.C) {
 				return ctx.Err()
 			}
 		}), nil
-	})
+	}, common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	server := startK8sTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
@@ -182,7 +183,7 @@ func (s *k8sSuite) TestSessionHandlerReportsResolverFailure(c *tc.C) {
 
 	handlers, err := NewHandlers(destination, resolverFunc(func(context.Context, virtualhostname.Info) (string, string, error) {
 		return "", "", errors.New("resolver failed")
-	}), loggertesting.WrapCheckLog(c), stubExecutor)
+	}), loggertesting.WrapCheckLog(c), stubExecutor, common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	server := startK8sTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
@@ -217,7 +218,7 @@ func (s *k8sSuite) TestSessionHandlerWithPTY(c *tc.C) {
 			_, err := io.WriteString(params.Stdout, "final output\n")
 			return err
 		}), nil
-	})
+	}, common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	server := startK8sTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
@@ -258,7 +259,7 @@ func (s *k8sSuite) TestSessionHandlerWithPTYDrainsOutputBeforeErrorExit(c *tc.C)
 			c.Assert(err, tc.ErrorIsNil)
 			return testExitError{status: 3}
 		}), nil
-	})
+	}, common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	server := startK8sTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})

--- a/internal/worker/sshserver/handlers/machine/machine.go
+++ b/internal/worker/sshserver/handlers/machine/machine.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/virtualhostname"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/common"
 )
 
 // SSHConnector establishes SSH clients to machine targets.
@@ -25,10 +26,11 @@ type Handlers struct {
 	connector   SSHConnector
 	logger      logger.Logger
 	destination virtualhostname.Info
+	metrics     common.Metrics
 }
 
 // NewHandlers returns handlers for a machine or machine-unit target.
-func NewHandlers(destination virtualhostname.Info, connector SSHConnector, logger logger.Logger) (*Handlers, error) {
+func NewHandlers(destination virtualhostname.Info, connector SSHConnector, logger logger.Logger, metrics common.Metrics) (*Handlers, error) {
 	if connector == nil {
 		return nil, errors.New("connector is required")
 	}
@@ -39,9 +41,13 @@ func NewHandlers(destination virtualhostname.Info, connector SSHConnector, logge
 		destination.Target() != virtualhostname.UnitTarget {
 		return nil, errors.New("destination must be a machine or unit target")
 	}
+	if metrics == nil {
+		return nil, errors.New("metrics collector is required")
+	}
 	return &Handlers{
 		connector:   connector,
 		logger:      logger,
 		destination: destination,
+		metrics:     metrics,
 	}, nil
 }

--- a/internal/worker/sshserver/handlers/machine/machine_test.go
+++ b/internal/worker/sshserver/handlers/machine/machine_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/core/virtualhostname"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/common"
 )
 
 type machineSuite struct{}
@@ -24,19 +25,19 @@ func (s *machineSuite) TestNewHandlers(c *tc.C) {
 	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
 	c.Assert(err, tc.ErrorIsNil)
 
-	handlers, err := NewHandlers(destination, stubConnector{}, loggertesting.WrapCheckLog(c))
+	handlers, err := NewHandlers(destination, stubConnector{}, loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(handlers.destination, tc.Equals, destination)
 
-	_, err = NewHandlers(destination, nil, loggertesting.WrapCheckLog(c))
+	_, err = NewHandlers(destination, nil, loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Check(err, tc.ErrorMatches, "connector is required")
 
-	_, err = NewHandlers(destination, stubConnector{}, nil)
+	_, err = NewHandlers(destination, stubConnector{}, nil, common.NoopMetrics{})
 	c.Check(err, tc.ErrorMatches, "logger is required")
 
 	container, err := virtualhostname.NewInfoContainerTarget("8419cd78-4993-4c3a-928e-c646226beeee", "app/0", "workload")
 	c.Assert(err, tc.ErrorIsNil)
-	_, err = NewHandlers(container, stubConnector{}, loggertesting.WrapCheckLog(c))
+	_, err = NewHandlers(container, stubConnector{}, loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Check(err, tc.ErrorMatches, "destination must be a machine or unit target")
 }
 

--- a/internal/worker/sshserver/handlers/machine/portforward_test.go
+++ b/internal/worker/sshserver/handlers/machine/portforward_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/core/virtualhostname"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/common"
 )
 
 func (s *machineSuite) TestDirectTCPIPHandler(c *tc.C) {
@@ -32,7 +33,7 @@ func (s *machineSuite) TestDirectTCPIPHandler(c *tc.C) {
 		},
 	}})
 
-	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{
@@ -77,7 +78,7 @@ func (s *machineSuite) TestDirectTCPIPHandlerPreservesHalfClose(c *tc.C) {
 		},
 	}})
 
-	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{
@@ -112,7 +113,7 @@ func (s *machineSuite) TestDirectTCPIPHandlerReportsConnectionFailure(c *tc.C) {
 
 	handlers, err := NewHandlers(destination, connectorFunc(func(context.Context, virtualhostname.Info) (*gossh.Client, error) {
 		return nil, errors.New("connection failed")
-	}), loggertesting.WrapCheckLog(c))
+	}), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{

--- a/internal/worker/sshserver/handlers/machine/proxy.go
+++ b/internal/worker/sshserver/handlers/machine/proxy.go
@@ -56,6 +56,7 @@ func handleProxy[T io.Closer](h *Handlers, ctx context.Context, cfg proxyConfig[
 	})
 	defer stop()
 
+	h.metrics.ObserveTimeToSession(ctx)
 	if err := cfg.run(remote); err != nil {
 		cfg.onError(err)
 	}

--- a/internal/worker/sshserver/handlers/machine/session_test.go
+++ b/internal/worker/sshserver/handlers/machine/session_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/core/virtualhostname"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/common"
 )
 
 func (s *machineSuite) TestSessionHandlerProxiesCommand(c *tc.C) {
@@ -27,7 +28,7 @@ func (s *machineSuite) TestSessionHandlerProxiesCommand(c *tc.C) {
 		_, _ = io.WriteString(session.Stderr(), "warning\n")
 	}})
 
-	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
@@ -60,7 +61,7 @@ func (s *machineSuite) TestSessionHandlerPropagatesCommandExitCode(c *tc.C) {
 		_ = session.Exit(3)
 	}})
 
-	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
@@ -97,7 +98,7 @@ func (s *machineSuite) TestSessionHandlerProxiesPTYAndWindowChanges(c *tc.C) {
 		},
 	})
 
-	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})
@@ -132,7 +133,7 @@ func (s *machineSuite) TestSessionHandlerReportsConnectionFailure(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	handlers, err := NewHandlers(destination, connectorFunc(func(context.Context, virtualhostname.Info) (*gossh.Client, error) {
 		return nil, errors.New("connection failed")
-	}), loggertesting.WrapCheckLog(c))
+	}), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{Handler: handlers.SessionHandler})

--- a/internal/worker/sshserver/handlers/machine/sftp_test.go
+++ b/internal/worker/sshserver/handlers/machine/sftp_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/core/virtualhostname"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/common"
 )
 
 func (s *machineSuite) TestSFTPHandler(c *tc.C) {
@@ -28,7 +29,7 @@ func (s *machineSuite) TestSFTPHandler(c *tc.C) {
 		},
 	}})
 
-	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
@@ -68,7 +69,7 @@ func (s *machineSuite) TestSFTPHandlerProxiesExitStatus(c *tc.C) {
 		"sftp": func(session ssh.Session) { _ = session.Exit(3) },
 	}})
 
-	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
@@ -121,7 +122,7 @@ func (s *machineSuite) TestSFTPHandlerProxiesMachineEOF(c *tc.C) {
 		},
 	}})
 
-	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{
@@ -165,7 +166,7 @@ func (s *machineSuite) TestSFTPHandlerClosesMachineClientWhenClientDisconnects(c
 		},
 	}})
 
-	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c))
+	handlers, err := NewHandlers(destination, connectorForServer(machine), loggertesting.WrapCheckLog(c), common.NoopMetrics{})
 	c.Assert(err, tc.ErrorIsNil)
 
 	controller := startSSHTestServer(c, &ssh.Server{SubsystemHandlers: map[string]ssh.SubsystemHandler{

--- a/internal/worker/sshserver/manifold.go
+++ b/internal/worker/sshserver/manifold.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/dependency"
+	"github.com/prometheus/client_golang/prometheus"
 	gossh "golang.org/x/crypto/ssh"
 
 	corecontroller "github.com/juju/juju/core/controller"
@@ -25,6 +26,7 @@ import (
 	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"
 	"github.com/juju/juju/internal/services"
 	internalTunneler "github.com/juju/juju/internal/sshtunneler"
+	"github.com/juju/juju/internal/worker/common"
 	workerTunneler "github.com/juju/juju/internal/worker/sshtunneler"
 )
 
@@ -110,6 +112,8 @@ type ManifoldConfig struct {
 	GetSSHService GetSSHServiceFunc
 	// Logger is the logger to use for the worker.
 	Logger logger.Logger
+	// PrometheusRegisterer registers SSH server metrics.
+	PrometheusRegisterer prometheus.Registerer
 }
 
 // Validate validates the manifold configuration.
@@ -149,6 +153,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
+	}
+	if config.PrometheusRegisterer == nil {
+		return errors.NotValidf("nil PrometheusRegisterer")
 	}
 	return nil
 }
@@ -193,6 +200,11 @@ func (config ManifoldConfig) startWrapperWorker(ctx context.Context, getter depe
 		return nil, errors.Trace(err)
 	}
 
+	metricsCollector := NewMetricsCollector()
+	if err := config.PrometheusRegisterer.Register(metricsCollector); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	sshService := sshService{
 		controllerSSHService: controllerSSHService,
 		domainServicesGetter: domainServicesGetter,
@@ -208,9 +220,10 @@ func (config ManifoldConfig) startWrapperWorker(ctx context.Context, getter depe
 			resolver:      sshService,
 		},
 		getExecutor: k8sexec.NewInCluster,
+		metrics:     metricsCollector,
 	}
 
-	return config.NewServerWrapperWorker(ServerWrapperWorkerConfig{
+	w, err := config.NewServerWrapperWorker(ServerWrapperWorkerConfig{
 		ControllerConfigService: controllerConfigService,
 		SSHService:              sshService,
 		NewServerWorker:         config.NewServerWorker,
@@ -227,7 +240,15 @@ func (config ManifoldConfig) startWrapperWorker(ctx context.Context, getter depe
 		},
 		ProxyFactory:  proxyFactory,
 		TunnelTracker: tunnelTracker,
+		Metrics:       metricsCollector,
 	})
+	if err != nil {
+		_ = config.PrometheusRegisterer.Unregister(metricsCollector)
+		return nil, errors.Trace(err)
+	}
+	return common.NewCleanupWorker(w, func() {
+		_ = config.PrometheusRegisterer.Unregister(metricsCollector)
+	}), nil
 }
 
 // sshService wraps our ssh domain services to enable two things:

--- a/internal/worker/sshserver/manifold_test.go
+++ b/internal/worker/sshserver/manifold_test.go
@@ -123,7 +123,7 @@ func (s *manifoldSuite) TestConfigValidate(c *tc.C) {
 	cfg = s.newManifoldConfig(c, func(cfg *ManifoldConfig) {
 		cfg.PrometheusRegisterer = nil
 	})
-	c.Check(errors.Is(cfg.Validate(), errors.NotValid), tc.IsTrue)
+	c.Assert(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
 	// Missing GetSSHService.
 	cfg = s.newManifoldConfig(c, func(cfg *ManifoldConfig) {

--- a/internal/worker/sshserver/manifold_test.go
+++ b/internal/worker/sshserver/manifold_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/worker/v5/dependency"
 	dt "github.com/juju/worker/v5/dependency/testing"
 	"github.com/juju/worker/v5/workertest"
+	"github.com/prometheus/client_golang/prometheus"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/controller"
@@ -118,6 +119,12 @@ func (s *manifoldSuite) TestConfigValidate(c *tc.C) {
 	})
 	c.Check(errors.Is(cfg.Validate(), errors.NotValid), tc.IsTrue)
 
+	// Missing Prometheus registerer.
+	cfg = s.newManifoldConfig(c, func(cfg *ManifoldConfig) {
+		cfg.PrometheusRegisterer = nil
+	})
+	c.Check(errors.Is(cfg.Validate(), errors.NotValid), tc.IsTrue)
+
 	// Missing GetSSHService.
 	cfg = s.newManifoldConfig(c, func(cfg *ManifoldConfig) {
 		cfg.GetSSHService = nil
@@ -154,7 +161,8 @@ func (s *manifoldSuite) TestManifoldStart(c *tc.C) {
 			sshServiceCalled = true
 			return s.sshService, nil
 		},
-		Logger: loggertesting.WrapCheckLog(c),
+		Logger:               loggertesting.WrapCheckLog(c),
+		PrometheusRegisterer: prometheus.NewRegistry(),
 	})
 
 	// Check the inputs are as expected
@@ -245,7 +253,8 @@ func (s *manifoldSuite) newManifoldConfig(c *tc.C, modifier func(cfg *ManifoldCo
 		GetSSHService: func(context.Context, services.DomainServicesGetter, model.UUID) (*modelsshservice.WatchableService, error) {
 			return s.sshService, nil
 		},
-		Logger: loggertesting.WrapCheckLog(c),
+		Logger:               loggertesting.WrapCheckLog(c),
+		PrometheusRegisterer: prometheus.NewRegistry(),
 	}
 
 	modifier(cfg)
@@ -279,7 +288,8 @@ func (s *manifoldSuite) TestManifoldMissingDependency(c *tc.C) {
 		GetSSHService: func(context.Context, services.DomainServicesGetter, model.UUID) (*modelsshservice.WatchableService, error) {
 			return s.sshService, nil
 		},
-		Logger: loggertesting.WrapCheckLog(c),
+		Logger:               loggertesting.WrapCheckLog(c),
+		PrometheusRegisterer: prometheus.NewRegistry(),
 	})
 
 	// Check the inputs are as expected

--- a/internal/worker/sshserver/metrics.go
+++ b/internal/worker/sshserver/metrics.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshserver
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const metricsNamespace = "juju_sshserver"
+
+// Collector collects SSH server connection and authentication metrics.
+type Collector struct {
+	connectionCount        prometheus.Gauge
+	connectionDuration     prometheus.Histogram
+	timeToSession          *prometheus.HistogramVec
+	authenticationFailures *prometheus.CounterVec
+}
+
+// NewMetricsCollector returns a collector for an SSH server worker.
+func NewMetricsCollector() *Collector {
+	return &Collector{
+		connectionCount: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "connection_count",
+			Help:      "The number of active connections to the SSH server.",
+		}),
+		connectionDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "connection_duration_seconds",
+			Help:      "The time an SSH connection remains open.",
+			Buckets:   []float64{1, 10, 60, 300, 600, 3600},
+		}),
+		timeToSession: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "time_to_session_seconds",
+			Help:      "The time taken to establish an SSH session.",
+			Buckets:   []float64{0.1, 0.5, 1, 5, 10, 30},
+		}, []string{"model_type"}),
+		authenticationFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "authentication_failures",
+			Help:      "The number of rejected SSH authentication attempts.",
+		}, []string{"auth_method"}),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.connectionCount.Describe(ch)
+	c.connectionDuration.Describe(ch)
+	c.timeToSession.Describe(ch)
+	c.authenticationFailures.Describe(ch)
+}
+
+// Collect implements prometheus.Collector.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.connectionCount.Collect(ch)
+	c.connectionDuration.Collect(ch)
+	c.timeToSession.Collect(ch)
+	c.authenticationFailures.Collect(ch)
+}

--- a/internal/worker/sshserver/proxy.go
+++ b/internal/worker/sshserver/proxy.go
@@ -61,7 +61,7 @@ func (m sessionMetrics) ObserveTimeToSession(ctx context.Context) {
 func (f proxyFactory) New(destination virtualhostname.Info) (ProxyHandlers, error) {
 	modelType := "machine"
 	if destination.Target() == virtualhostname.ContainerTarget {
-		modelType = "kubernetes"
+		modelType = "k8s"
 	}
 	var metrics common.Metrics = sessionMetrics{collector: f.metrics, modelType: modelType}
 

--- a/internal/worker/sshserver/proxy.go
+++ b/internal/worker/sshserver/proxy.go
@@ -4,12 +4,16 @@
 package sshserver
 
 import (
+	"context"
+	"time"
+
 	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/virtualhostname"
 	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"
+	"github.com/juju/juju/internal/worker/sshserver/handlers/common"
 	"github.com/juju/juju/internal/worker/sshserver/handlers/k8s"
 	"github.com/juju/juju/internal/worker/sshserver/handlers/machine"
 )
@@ -36,16 +40,36 @@ type proxyFactory struct {
 	logger      logger.Logger
 	connector   machine.SSHConnector
 	getExecutor func(string) (k8sexec.Executor, error)
+	metrics     *Collector
+}
+
+type sessionMetrics struct {
+	collector *Collector
+	modelType string
+}
+
+func (m sessionMetrics) ObserveTimeToSession(ctx context.Context) {
+	started, ok := ctx.Value(connectionStartTime{}).(time.Time)
+	if !ok {
+		return
+	}
+	m.collector.timeToSession.WithLabelValues(m.modelType).Observe(time.Since(started).Seconds())
 }
 
 // New returns a set of handlers for the given target based
 // on whether the target is a container, unit or machine.
 func (f proxyFactory) New(destination virtualhostname.Info) (ProxyHandlers, error) {
+	modelType := "machine"
+	if destination.Target() == virtualhostname.ContainerTarget {
+		modelType = "kubernetes"
+	}
+	var metrics common.Metrics = sessionMetrics{collector: f.metrics, modelType: modelType}
+
 	switch destination.Target() {
 	case virtualhostname.ContainerTarget:
-		return k8s.NewHandlers(destination, f.k8sResolver, f.logger, f.getExecutor)
+		return k8s.NewHandlers(destination, f.k8sResolver, f.logger, f.getExecutor, metrics)
 	case virtualhostname.MachineTarget, virtualhostname.UnitTarget:
-		return machine.NewHandlers(destination, f.connector, f.logger)
+		return machine.NewHandlers(destination, f.connector, f.logger, metrics)
 	default:
 		return nil, errors.NotValidf("unknown virtual hostname target %d", destination.Target())
 	}

--- a/internal/worker/sshserver/server.go
+++ b/internal/worker/sshserver/server.go
@@ -88,6 +88,9 @@ func (c ServerWorkerConfig) Validate() error {
 	if c.Logger == nil {
 		return errors.NotValidf("missing Logger")
 	}
+	if c.Metrics == nil {
+		return errors.NotValidf("missing Metrics")
+	}
 	if c.JumpHostKey == "" {
 		return errors.NotValidf("empty JumpHostKey")
 	}
@@ -332,7 +335,11 @@ func (s *ServerWorker) reverseTunnelHandler(_ *ssh.Server, conn *gossh.ServerCon
 // connCallback returns a connCallback function that limits the number of concurrent connections.
 func (s *ServerWorker) connCallback() ssh.ConnCallback {
 	return func(ctx ssh.Context, conn net.Conn) net.Conn {
-		ctx.SetValue(connectionStartTime{}, time.Now())
+		// Store the connection start time in the context so we can measure
+		// the time to start the session later in the proxy.
+		now := time.Now()
+		ctx.SetValue(connectionStartTime{}, now)
+
 		current := s.concurrentConnections.Add(1)
 		s.config.Metrics.connectionCount.Inc()
 
@@ -353,14 +360,12 @@ func (s *ServerWorker) connCallback() ssh.ConnCallback {
 			s.concurrentConnections.Add(-1)
 			return conn
 		}
-		go func() {
+		go func(start time.Time) {
 			<-ctx.Done()
 			s.config.Metrics.connectionCount.Dec()
 			s.concurrentConnections.Add(-1)
-			if started, ok := ctx.Value(connectionStartTime{}).(time.Time); ok {
-				s.config.Metrics.connectionDuration.Observe(time.Since(started).Seconds())
-			}
-		}()
+			s.config.Metrics.connectionDuration.Observe(time.Since(start).Seconds())
+		}(now)
 		return conn
 	}
 }

--- a/internal/worker/sshserver/server.go
+++ b/internal/worker/sshserver/server.go
@@ -47,6 +47,8 @@ type Authorizer interface {
 	Authorize(ssh.Context, virtualhostname.Info) (bool, error)
 }
 
+type connectionStartTime struct{}
+
 // ServerWorkerConfig holds the configuration required by the server worker.
 type ServerWorkerConfig struct {
 	// Logger holds the logger for the server.
@@ -77,6 +79,8 @@ type ServerWorkerConfig struct {
 	ProxyFactory ProxyFactory
 	// TunnelTracker accepts incoming reverse SSH tunnel connections.
 	TunnelTracker TunnelTracker
+	// Metrics collects connection and authentication metrics.
+	Metrics *Collector
 }
 
 // Validate validates the workers configuration is as expected.
@@ -188,6 +192,7 @@ func (s *ServerWorker) NewJumpServer() *ssh.Server {
 		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
 			ok, err := s.config.Authenticator.PublicKeyAuthentication(ctx, key)
 			if err != nil {
+				s.config.Metrics.authenticationFailures.WithLabelValues("public_key").Inc()
 				s.config.Logger.Warningf(ctx, "failed to authenticate public key: %v", err)
 				return false
 			}
@@ -196,6 +201,7 @@ func (s *ServerWorker) NewJumpServer() *ssh.Server {
 		PasswordHandler: func(ctx ssh.Context, password string) bool {
 			ok, err := s.config.Authenticator.PasswordAuthentication(ctx, password)
 			if err != nil {
+				s.config.Metrics.authenticationFailures.WithLabelValues("password").Inc()
 				s.config.Logger.Warningf(ctx, "failed to authenticate password: %v", err)
 				return false
 			}
@@ -326,7 +332,9 @@ func (s *ServerWorker) reverseTunnelHandler(_ *ssh.Server, conn *gossh.ServerCon
 // connCallback returns a connCallback function that limits the number of concurrent connections.
 func (s *ServerWorker) connCallback() ssh.ConnCallback {
 	return func(ctx ssh.Context, conn net.Conn) net.Conn {
+		ctx.SetValue(connectionStartTime{}, time.Now())
 		current := s.concurrentConnections.Add(1)
+		s.config.Metrics.connectionCount.Inc()
 
 		if int(current) > s.config.MaxConcurrentConnections {
 			// set the deadline because we don't want to block the connection to write an error.
@@ -341,12 +349,17 @@ func (s *ServerWorker) connCallback() ssh.ConnCallback {
 			// The connection is closed before returning, otherwise
 			// the context is not cancelled and the counter is not decremented.
 			conn.Close()
+			s.config.Metrics.connectionCount.Dec()
 			s.concurrentConnections.Add(-1)
 			return conn
 		}
 		go func() {
 			<-ctx.Done()
+			s.config.Metrics.connectionCount.Dec()
 			s.concurrentConnections.Add(-1)
+			if started, ok := ctx.Value(connectionStartTime{}).(time.Time); ok {
+				s.config.Metrics.connectionDuration.Observe(time.Since(started).Seconds())
+			}
 		}()
 		return conn
 	}
@@ -354,12 +367,11 @@ func (s *ServerWorker) connCallback() ssh.ConnCallback {
 
 // newTerminatingSSHServer creates an embedded SSH server that terminates the
 // user's SSH connection and proxies it to the routed target.
-func (s *ServerWorker) newTerminatingSSHServer(_ ssh.Context, destination virtualhostname.Info) (*ssh.Server, error) {
+func (s *ServerWorker) newTerminatingSSHServer(ctx ssh.Context, destination virtualhostname.Info) (*ssh.Server, error) {
 	handlers, err := s.config.ProxyFactory.New(destination)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
 	server := &ssh.Server{
 		ChannelHandlers: map[string]ssh.ChannelHandler{
 			"session":      ssh.DefaultSessionHandler,

--- a/internal/worker/sshserver/server_test.go
+++ b/internal/worker/sshserver/server_test.go
@@ -85,6 +85,7 @@ func (s *sshServerSuite) newServer(c *tc.C) (*ServerWorker, *bufconn.Listener, f
 		Authorizer:               s.authorizer,
 		ProxyFactory:             s.proxyFactory,
 		TunnelTracker:            s.tunnelTracker,
+		Metrics:                  NewMetricsCollector(),
 	}
 
 	worker, err := NewServerWorker(cfg)
@@ -376,6 +377,7 @@ func (s *sshServerSuite) TestSSHServerMaxConnections(c *tc.C) {
 		Authorizer:               s.authorizer,
 		ProxyFactory:             s.proxyFactory,
 		TunnelTracker:            s.tunnelTracker,
+		Metrics:                  NewMetricsCollector(),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.DirtyKill(c, worker)
@@ -468,6 +470,7 @@ func (s *sshServerSuite) TestSSHWorkerReport(c *tc.C) {
 		Authorizer:               s.authorizer,
 		ProxyFactory:             s.proxyFactory,
 		TunnelTracker:            s.tunnelTracker,
+		Metrics:                  NewMetricsCollector(),
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.DirtyKill(c, worker)

--- a/internal/worker/sshserver/server_test.go
+++ b/internal/worker/sshserver/server_test.go
@@ -201,6 +201,17 @@ func (s *sshServerSuite) TestValidate(c *tc.C) {
 
 	c.Assert(cfg.Validate(), tc.ErrorIs, errors.NotValid)
 
+	// Test no Metrics.
+	s.SetUpMocks(c)
+	cfg = newServerWorkerConfig(l, "jumpHostKey", func(cfg *ServerWorkerConfig) {
+		cfg.Authenticator = s.authenticator
+		cfg.Authorizer = s.authorizer
+		cfg.ProxyFactory = s.proxyFactory
+		cfg.TunnelTracker = s.tunnelTracker
+		cfg.Metrics = nil
+	})
+	c.Assert(cfg.Validate(), tc.ErrorMatches, ".*missing Metrics.*")
+
 	// Test no Logger.
 	cfg = newServerWorkerConfig(l, "Logger", func(cfg *ServerWorkerConfig) {
 		cfg.Logger = nil

--- a/internal/worker/sshserver/worker.go
+++ b/internal/worker/sshserver/worker.go
@@ -66,6 +66,7 @@ type ServerWrapperWorkerConfig struct {
 	Authorizer              Authorizer
 	ProxyFactory            ProxyFactory
 	TunnelTracker           TunnelTracker
+	Metrics                 *Collector
 }
 
 // Validate validates the workers configuration is as expected.
@@ -199,6 +200,7 @@ func (ssw *serverWrapperWorker) loop() error {
 		Authorizer:               ssw.config.Authorizer,
 		ProxyFactory:             ssw.config.ProxyFactory,
 		TunnelTracker:            ssw.config.TunnelTracker,
+		Metrics:                  ssw.config.Metrics,
 	})
 	ssw.addWorkerReporter("ssh-server", srv)
 	if err != nil {

--- a/internal/worker/sshserver/worker.go
+++ b/internal/worker/sshserver/worker.go
@@ -74,6 +74,9 @@ func (c ServerWrapperWorkerConfig) Validate() error {
 	if c.ControllerConfigService == nil {
 		return errors.NotValidf("ControllerConfigService is required")
 	}
+	if c.Metrics == nil {
+		return errors.NotValidf("missing Metrics")
+	}
 	if c.NewServerWorker == nil {
 		return errors.NotValidf("NewSSHServer is required")
 	}

--- a/internal/worker/sshserver/worker_test.go
+++ b/internal/worker/sshserver/worker_test.go
@@ -64,6 +64,16 @@ func (s *workerSuite) TestValidate(c *tc.C) {
 	cfg := newServerWrapperWorkerConfig(c, ctrl, func(cfg *ServerWrapperWorkerConfig) {})
 	c.Assert(cfg.Validate(), tc.IsNil)
 
+	// Test no Metrics.
+	cfg = newServerWrapperWorkerConfig(
+		c,
+		ctrl,
+		func(cfg *ServerWrapperWorkerConfig) {
+			cfg.Metrics = nil
+		},
+	)
+	c.Assert(cfg.Validate(), tc.ErrorMatches, ".*missing Metrics.*")
+
 	// Test no Logger.
 	cfg = newServerWrapperWorkerConfig(
 		c,
@@ -130,6 +140,7 @@ func (s *workerSuite) TestSSHServerWrapperWorkerCanBeKilled(c *tc.C) {
 		ControllerConfigService: controllerConfigService,
 		SSHService:              stubSSHService{jumpHostKey: testHostKey, virtualHostKey: testHostKey},
 		Logger:                  loggertesting.WrapCheckLog(c),
+		Metrics:                 NewMetricsCollector(),
 		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
 			c.Check(swc.JumpHostKey, tc.Equals, testHostKey)
 			return serverWorker, nil
@@ -208,6 +219,7 @@ func (s *workerSuite) TestSSHServerWrapperWorkerRestartsServerWorker(c *tc.C) {
 		ControllerConfigService: controllerConfigService,
 		SSHService:              stubSSHService{jumpHostKey: testHostKey, virtualHostKey: testHostKey},
 		Logger:                  loggertesting.WrapCheckLog(c),
+		Metrics:                 NewMetricsCollector(),
 		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
 			atomic.StoreInt32(&serverStarted, 1)
 			c.Check(swc.Port, tc.Equals, 22)
@@ -296,6 +308,7 @@ func (s *workerSuite) TestSSHServerWrapperWorkerRestartsServerWorkerOnPortChange
 		ControllerConfigService: controllerConfigService,
 		SSHService:              stubSSHService{jumpHostKey: testHostKey, virtualHostKey: testHostKey},
 		Logger:                  loggertesting.WrapCheckLog(c),
+		Metrics:                 NewMetricsCollector(),
 		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
 			c.Check(swc.Port, tc.Equals, 22)
 			c.Check(swc.JumpHostKey, tc.Equals, testHostKey)
@@ -343,6 +356,7 @@ func (s *workerSuite) TestSSHServerWrapperWorkerConfigWatcherClosed(c *tc.C) {
 		ControllerConfigService: controllerConfigService,
 		SSHService:              stubSSHService{jumpHostKey: testHostKey, virtualHostKey: testHostKey},
 		Logger:                  loggertesting.WrapCheckLog(c),
+		Metrics:                 NewMetricsCollector(),
 		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
 			return serverWorker, nil
 		},
@@ -389,6 +403,7 @@ func (s *workerSuite) TestWrapperWorkerReport(c *tc.C) {
 		ControllerConfigService: controllerConfigService,
 		SSHService:              stubSSHService{jumpHostKey: testHostKey, virtualHostKey: testHostKey},
 		Logger:                  loggertesting.WrapCheckLog(c),
+		Metrics:                 NewMetricsCollector(),
 		NewServerWorker: func(swc ServerWorkerConfig) (worker.Worker, error) {
 			return &reportWorker{serverWorker}, nil
 		},

--- a/internal/worker/sshserver/worker_test.go
+++ b/internal/worker/sshserver/worker_test.go
@@ -41,6 +41,7 @@ func newServerWrapperWorkerConfig(
 		ControllerConfigService: NewMockControllerConfigService(ctrl),
 		SSHService:              stubSSHService{jumpHostKey: testHostKey, virtualHostKey: testHostKey},
 		Logger:                  loggertesting.WrapCheckLog(c),
+		Metrics:                 NewMetricsCollector(),
 	}
 	setMockServerDependencies(ctrl, cfg)
 


### PR DESCRIPTION
This change adds metric to the SSH server. In total we add 4 metrics:
- ConnectionCount: The number of active connections.
- ConnectionDuration: The total time an SSH connection was active for.
- TimeToSession: The time taken to establish a session, differentiated by K8s/Machine.
- AuthenticationFailures: A count of the number of times auth failed (access denied does not count as an auth failure), differentiated by auth type (password/public-key).

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Links

**Jira card:** [JUJU-9955](https://warthogs.atlassian.net/browse/JUJU-9955)


[JUJU-9955]: https://warthogs.atlassian.net/browse/JUJU-9955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ