### PR TITLE
fix(cli): wait for hosted models to be removed before destroying the controller

### DIFF
--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -360,11 +360,14 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 
 		// Even if we've not just requested for hosted models to be destroyed,
 		// there may be some being destroyed already. We need to wait for them.
-		// Check for both undead models and live machines, as machines may be
-		// in the controller model.
+		// Wait until all hosted models are fully removed from the controller,
+		// not merely dead: cloud resources (e.g. the model's namespace on
+		// Kubernetes) are destroyed after the model is marked dead but before
+		// it is removed. Also wait for live machines, as machines may be in
+		// the controller model.
 		ctx.Infof("Waiting for model resources to be reclaimed")
 		// wait for 2 seconds to let empty hosted models changed from alive to dying.
-		for ; hasUnreclaimedResources(modelStatus); modelStatus = updateStatus(2 * time.Second) {
+		for ; hasUnremovedModels(modelStatus); modelStatus = updateStatus(2 * time.Second) {
 			ctx.Infof("%s", fmtCtrStatus(modelStatus.Controller))
 			for _, model := range modelStatus.Models {
 				ctx.Verbosef("%s", fmtModelStatus(model))

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -36,7 +36,7 @@ import (
 
 // NewDestroyCommand returns a command to destroy a controller.
 func NewDestroyCommand() cmd.Command {
-	cmd := destroyCommand{}
+	cmd := destroyCommand{clock: clock.WallClock}
 	cmd.environsDestroy = environs.Destroy
 	// Even though this command is all about destroying a controller we end up
 	// needing environment endpoints so we can fall back to the client destroy
@@ -59,6 +59,10 @@ type destroyCommand struct {
 	modelTimeout   time.Duration
 	force          bool
 	noWait         bool
+
+	// clock is used to pace the status polling loop while waiting for
+	// the hosted models to be removed.
+	clock clock.Clock
 }
 
 // usageDetails has backticks which we want to keep for markdown processing.
@@ -259,7 +263,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 	}
 
 	ctx.Warningf(destroySysMsg, controllerName)
-	updateStatus := newTimedStatusUpdater(ctx, api, controllerEnviron.Config().UUID(), clock.WallClock)
+	updateStatus := newTimedStatusUpdater(ctx, api, controllerEnviron.Config().UUID(), c.clock)
 	modelStatus := updateStatus(0)
 
 	// check Alive models and --destroy-all-models flag usage
@@ -333,7 +337,7 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 			}
 		}
 
-		updateStatus = newTimedStatusUpdater(ctx, api, controllerEnviron.Config().UUID(), clock.WallClock)
+		updateStatus = newTimedStatusUpdater(ctx, api, controllerEnviron.Config().UUID(), c.clock)
 		modelStatus = updateStatus(0)
 		if !c.destroyModels {
 			if err := c.checkNoAliveHostedModels(modelStatus.Models); err != nil {
@@ -366,9 +370,8 @@ func (c *destroyCommand) Run(ctx *cmd.Context) error {
 		// it is removed. Also wait for live machines, as machines may be in
 		// the controller model.
 		ctx.Infof("Waiting for model resources to be reclaimed")
-		// wait for 2 seconds to let empty hosted models changed from alive to dying.
 		for ; hasUnremovedModels(modelStatus); modelStatus = updateStatus(2 * time.Second) {
-			ctx.Infof("%s", fmtCtrStatus(modelStatus.Controller))
+			ctx.Infof("%s", fmtCtrRemovalStatus(modelStatus.Controller))
 			for _, model := range modelStatus.Models {
 				ctx.Verbosef("%s", fmtModelStatus(model))
 			}

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -68,6 +68,14 @@ type fakeDestroyAPI struct {
 	modelStatus  map[string]base.ModelStatus
 	allModels    []base.UserModel
 	hostedConfig []apicontroller.HostedConfig
+
+	// delayModelRemoval simulates the server-side undertaker taking one extra
+	// poll to reap hosted models after a successful DestroyController.
+	delayModelRemoval       bool
+	destroyCalled           bool
+	reapPending             bool
+	allModelsAfterDestroy   []base.UserModel
+	modelStatusAfterDestroy map[string]base.ModelStatus
 }
 
 func (f *fakeDestroyAPI) Close() error {
@@ -101,7 +109,38 @@ func (f *fakeDestroyAPI) HostedModelConfigs(ctx context.Context) ([]apicontrolle
 
 func (f *fakeDestroyAPI) DestroyController(ctx context.Context, args apicontroller.DestroyControllerParams) error {
 	f.MethodCall(f, "DestroyController", args)
-	return f.NextErr()
+	if err := f.NextErr(); err != nil {
+		return err
+	}
+	f.destroyCalled = true
+	// Simulate the server-side undertaker removing hosted models: with
+	// DestroyModels all hosted models are destroyed and removed; without it,
+	// already-dead models are still reaped in the background.
+	remaining := make([]base.UserModel, 0, len(f.allModels))
+	remainingStatus := make(map[string]base.ModelStatus, len(f.modelStatus))
+	for _, m := range f.allModels {
+		if m.UUID == test1UUID {
+			remaining = append(remaining, m)
+			remainingStatus[m.UUID] = f.modelStatus[m.UUID]
+			continue
+		}
+		status, ok := f.modelStatus[m.UUID]
+		if args.DestroyModels || (ok && status.Life == life.Dead) {
+			continue
+		}
+		remaining = append(remaining, m)
+		remainingStatus[m.UUID] = status
+	}
+	if f.delayModelRemoval {
+		// Hold the reaped lists back so the wait loop observes the dead
+		// model still present for one more poll.
+		f.allModelsAfterDestroy = remaining
+		f.modelStatusAfterDestroy = remainingStatus
+		return nil
+	}
+	f.allModels = remaining
+	f.modelStatus = remainingStatus
+	return nil
 }
 
 func (f *fakeDestroyAPI) ListBlockedModels(ctx context.Context) ([]params.ModelBlockInfo, error) {
@@ -120,6 +159,18 @@ func (f *fakeDestroyAPI) ModelStatus(_ context.Context, tags ...names.ModelTag) 
 
 func (f *fakeDestroyAPI) AllModels(ctx context.Context) ([]base.UserModel, error) {
 	f.MethodCall(f, "AllModels")
+	if f.delayModelRemoval && f.destroyCalled {
+		// Return the pre-reap list once; the reaped lists are applied on
+		// the next poll.
+		f.delayModelRemoval = false
+		f.reapPending = true
+		return f.allModels, f.NextErr()
+	}
+	if f.reapPending {
+		f.reapPending = false
+		f.allModels = f.allModelsAfterDestroy
+		f.modelStatus = f.modelStatusAfterDestroy
+	}
 	return f.allModels, f.NextErr()
 }
 
@@ -310,6 +361,33 @@ func (s *DestroySuite) TestDestroyWithDestroyAllModelsFlag(c *tc.C) {
 		DestroyModels: true,
 	})
 	assertControllerRemovedFromStore(c, "test1", s.store)
+}
+
+func (s *DestroySuite) TestDestroyWaitsForHostedModelRemoval(c *tc.C) {
+	// Simulate the undertaker needing one extra poll to reap the hosted
+	// model after DestroyController returns.
+	s.api.delayModelRemoval = true
+
+	envDestroyCalls := 0
+	destroy := s.environsDestroy
+	s.environsDestroy = func(controllerName string, env environs.ControllerDestroyer, ctx context.Context, store jujuclient.ControllerStore) error {
+		envDestroyCalls++
+		return destroy(controllerName, env, ctx, store)
+	}
+
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--destroy-all-models")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(envDestroyCalls, tc.Equals, 1)
+
+	allModelsCalls := 0
+	for _, call := range s.api.Calls() {
+		if call.FuncName == "AllModels" {
+			allModelsCalls++
+		}
+	}
+	// The wait loop must poll again after DestroyController while the dead
+	// hosted model is still present, and only proceed once it is removed.
+	c.Assert(allModelsCalls >= 3, tc.IsTrue)
 }
 
 func (s *DestroySuite) TestDestroyWithDestroyDestroyStorageFlag(c *tc.C) {

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -69,10 +69,19 @@ type fakeDestroyAPI struct {
 	allModels    []base.UserModel
 	hostedConfig []apicontroller.HostedConfig
 
-	// delayModelRemoval simulates the server-side undertaker taking one extra
-	// poll to reap hosted models after a successful DestroyController.
-	delayModelRemoval       bool
-	destroyCalled           bool
+	// delayModelRemoval simulates the server-side undertaker taking one
+	// extra status poll to remove reaped hosted models from the
+	// controller database after a successful DestroyController.
+	delayModelRemoval bool
+	// delayMachineRemoval simulates machines (for example machines in
+	// the controller model) taking one extra status poll to be removed
+	// after a successful DestroyController.
+	delayMachineRemoval bool
+
+	// The fields below hold the post-destroy state computed by
+	// DestroyController. When either delay is set, that state is only
+	// served from the second status poll after the destroy call.
+	holdStatus              bool
 	reapPending             bool
 	allModelsAfterDestroy   []base.UserModel
 	modelStatusAfterDestroy map[string]base.ModelStatus
@@ -112,7 +121,6 @@ func (f *fakeDestroyAPI) DestroyController(ctx context.Context, args apicontroll
 	if err := f.NextErr(); err != nil {
 		return err
 	}
-	f.destroyCalled = true
 	// Simulate the server-side undertaker removing hosted models: with
 	// DestroyModels all hosted models are destroyed and removed; without it,
 	// already-dead models are still reaped in the background.
@@ -131,11 +139,27 @@ func (f *fakeDestroyAPI) DestroyController(ctx context.Context, args apicontroll
 		remaining = append(remaining, m)
 		remainingStatus[m.UUID] = status
 	}
+	f.allModelsAfterDestroy = remaining
+	f.modelStatusAfterDestroy = remainingStatus
+	if f.delayMachineRemoval {
+		// Machines are torn down after the model reap; serve the reaped
+		// lists with the machines still present for one more poll.
+		cleared := make(map[string]base.ModelStatus, len(remainingStatus))
+		for uuid, status := range remainingStatus {
+			status.HostedMachineCount = 0
+			cleared[uuid] = status
+		}
+		f.allModels = remaining
+		f.modelStatus = remainingStatus
+		f.modelStatusAfterDestroy = cleared
+		f.holdStatus = true
+		return nil
+	}
 	if f.delayModelRemoval {
-		// Hold the reaped lists back so the wait loop observes the dead
-		// model still present for one more poll.
-		f.allModelsAfterDestroy = remaining
-		f.modelStatusAfterDestroy = remainingStatus
+		// The reaped model rows are still present when
+		// DestroyController returns; serve the pre-destroy lists once,
+		// the reaped lists are applied on the next poll.
+		f.holdStatus = true
 		return nil
 	}
 	f.allModels = remaining
@@ -159,10 +183,8 @@ func (f *fakeDestroyAPI) ModelStatus(_ context.Context, tags ...names.ModelTag) 
 
 func (f *fakeDestroyAPI) AllModels(ctx context.Context) ([]base.UserModel, error) {
 	f.MethodCall(f, "AllModels")
-	if f.delayModelRemoval && f.destroyCalled {
-		// Return the pre-reap list once; the reaped lists are applied on
-		// the next poll.
-		f.delayModelRemoval = false
+	if f.holdStatus {
+		f.holdStatus = false
 		f.reapPending = true
 		return f.allModels, f.NextErr()
 	}
@@ -290,9 +312,33 @@ func (s *DestroySuite) runDestroyCommand(c *tc.C, args ...string) (*cmd.Context,
 
 func (s *DestroySuite) newDestroyCommand() cmd.Command {
 	return controller.NewDestroyCommandForTest(
-		s.api, s.store, s.apierror, s.controllerModelConfigAPI,
+		s.api, s.store, s.apierror, s.controllerModelConfigAPI, &mockClock{},
 		s.environsDestroy,
 	)
+}
+
+// countEnvironsDestroy wraps the suite environsDestroy func to count
+// calls to it.
+func (s *DestroySuite) countEnvironsDestroy() *int {
+	calls := new(int)
+	destroy := s.environsDestroy
+	s.environsDestroy = func(controllerName string, env environs.ControllerDestroyer, ctx context.Context, store jujuclient.ControllerStore) error {
+		*calls++
+		return destroy(controllerName, env, ctx, store)
+	}
+	return calls
+}
+
+// allModelsCallCount returns how many times the fake API was asked for
+// the model list.
+func (s *DestroySuite) allModelsCallCount() int {
+	count := 0
+	for _, call := range s.api.Calls() {
+		if call.FuncName == "AllModels" {
+			count++
+		}
+	}
+	return count
 }
 
 func checkControllerExistsInStore(c *tc.C, name string, store jujuclient.ControllerGetter) {
@@ -365,29 +411,69 @@ func (s *DestroySuite) TestDestroyWithDestroyAllModelsFlag(c *tc.C) {
 
 func (s *DestroySuite) TestDestroyWaitsForHostedModelRemoval(c *tc.C) {
 	// Simulate the undertaker needing one extra poll to reap the hosted
-	// model after DestroyController returns.
+	// models after DestroyController returns.
 	s.api.delayModelRemoval = true
 
-	envDestroyCalls := 0
-	destroy := s.environsDestroy
-	s.environsDestroy = func(controllerName string, env environs.ControllerDestroyer, ctx context.Context, store jujuclient.ControllerStore) error {
-		envDestroyCalls++
-		return destroy(controllerName, env, ctx, store)
-	}
-
-	_, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--destroy-all-models")
+	envDestroyCalls := s.countEnvironsDestroy()
+	ctx, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--destroy-all-models")
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(envDestroyCalls, tc.Equals, 1)
+	c.Check(*envDestroyCalls, tc.Equals, 1)
+	// The wait loop must poll again after DestroyController while the
+	// dead hosted models are still present, and only proceed to the
+	// controller teardown once they are removed.
+	c.Check(s.allModelsCallCount() >= 3, tc.IsTrue)
+	// The wait status reports the models that are still present,
+	// including the dead ones awaiting removal.
+	c.Check(cmdtesting.Stderr(ctx), tc.Contains, "Waiting for 2 models")
+}
 
-	allModelsCalls := 0
-	for _, call := range s.api.Calls() {
-		if call.FuncName == "AllModels" {
-			allModelsCalls++
-		}
-	}
-	// The wait loop must poll again after DestroyController while the dead
-	// hosted model is still present, and only proceed once it is removed.
-	c.Assert(allModelsCalls >= 3, tc.IsTrue)
+func (s *DestroySuite) TestDestroyWaitsForHostedModelRemovalWithoutDestroyAllModels(c *tc.C) {
+	// The most common workflow: the models were destroyed beforehand and
+	// are still present in the controller (dead) when destroy-controller
+	// runs. Even without --destroy-all-models the command must wait for
+	// the background reap to finish before tearing the controller down.
+	s.api.delayModelRemoval = true
+
+	envDestroyCalls := s.countEnvironsDestroy()
+	_, err := s.runDestroyCommand(c, "test1", "--no-prompt")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(*envDestroyCalls, tc.Equals, 1)
+	s.api.CheckCall(c, 2, "DestroyController", apicontroller.DestroyControllerParams{})
+	c.Check(s.allModelsCallCount() >= 3, tc.IsTrue)
+}
+
+func (s *DestroySuite) TestDestroyWaitsForDyingHostedModelRemoval(c *tc.C) {
+	// A hosted model caught mid-destruction (dying, not yet dead) is
+	// destroyed along with the rest; the wait loop must hold until it is
+	// removed from the controller, not merely until it is dead.
+	s.api.delayModelRemoval = true
+	status := s.api.modelStatus[test2UUID]
+	status.Life = life.Dying
+	s.api.modelStatus[test2UUID] = status
+
+	envDestroyCalls := s.countEnvironsDestroy()
+	ctx, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--destroy-all-models")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(*envDestroyCalls, tc.Equals, 1)
+	c.Check(s.allModelsCallCount() >= 3, tc.IsTrue)
+	c.Check(cmdtesting.Stderr(ctx), tc.Contains, "Waiting for 2 models")
+}
+
+func (s *DestroySuite) TestDestroyWaitsForHostedMachines(c *tc.C) {
+	// Machines may remain (for example in the controller model) after
+	// the hosted models are gone; the wait loop must hold until they are
+	// removed too.
+	s.api.delayMachineRemoval = true
+	status := s.api.modelStatus[test1UUID]
+	status.HostedMachineCount = 1
+	s.api.modelStatus[test1UUID] = status
+
+	envDestroyCalls := s.countEnvironsDestroy()
+	ctx, err := s.runDestroyCommand(c, "test1", "--no-prompt", "--destroy-all-models")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(*envDestroyCalls, tc.Equals, 1)
+	c.Check(s.allModelsCallCount() >= 3, tc.IsTrue)
+	c.Check(cmdtesting.Stderr(ctx), tc.Contains, "1 machine")
 }
 
 func (s *DestroySuite) TestDestroyWithDestroyDestroyStorageFlag(c *tc.C) {

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -105,8 +105,8 @@ func NewDestroyCommandForTest(
 	store jujuclient.ClientStore,
 	apierr error,
 	controllerModelConfigAPI modelConfigAPI,
+	clock clock.Clock,
 	environsDestroy func(string, environs.ControllerDestroyer, context.Context, jujuclient.ControllerStore) error,
-
 ) cmd.Command {
 	cmd := &destroyCommand{
 		destroyCommandBase: destroyCommandBase{
@@ -115,6 +115,7 @@ func NewDestroyCommandForTest(
 			controllerModelConfigAPI: controllerModelConfigAPI,
 			environsDestroy:          environsDestroy,
 		},
+		clock: clock,
 	}
 	cmd.SetClientStore(store)
 	return modelcmd.WrapController(
@@ -175,6 +176,10 @@ type ModelData modelData
 
 func FmtCtrStatus(data CtrData) string {
 	return fmtCtrStatus(ctrData(data))
+}
+
+func FmtCtrRemovalStatus(data CtrData) string {
+	return fmtCtrRemovalStatus(ctrData(data))
 }
 
 func FmtModelStatus(data ModelData) string {

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -571,6 +571,33 @@ func (s *KillSuite) TestControllerStatus(c *tc.C) {
 
 }
 
+func (s *KillSuite) TestControllerStatusCountsDeadHostedModels(c *tc.C) {
+	s.api.allModels = []base.UserModel{
+		{Name: "admin", UUID: "123", Qualifier: "prod"},
+		{Name: "env1", UUID: "456", Qualifier: "staging"},
+	}
+	s.api.modelStatus = map[string]base.ModelStatus{
+		"123": {
+			UUID:      "123",
+			Life:      life.Alive,
+			Qualifier: "prod",
+		},
+		"456": {
+			UUID:      "456",
+			Life:      life.Dead,
+			Qualifier: "staging",
+		},
+	}
+
+	environmentStatus, err := controller.NewData(c.Context(), s.api, "123")
+	c.Assert(err, tc.ErrorIsNil)
+	// A dead hosted model is still present in the controller and must be
+	// counted so destroy-controller waits for it to be removed.
+	c.Assert(environmentStatus.Controller.HostedModelCount, tc.Equals, 1)
+	// Dead hosted models are still filtered out of the visible model list.
+	c.Assert(environmentStatus.Models, tc.HasLen, 0)
+}
+
 func (s *KillSuite) TestFmtControllerStatus(c *tc.C) {
 	data := controller.CtrData{
 		UUID:               "uuid",

--- a/cmd/juju/controller/kill_test.go
+++ b/cmd/juju/controller/kill_test.go
@@ -591,9 +591,11 @@ func (s *KillSuite) TestControllerStatusCountsDeadHostedModels(c *tc.C) {
 
 	environmentStatus, err := controller.NewData(c.Context(), s.api, "123")
 	c.Assert(err, tc.ErrorIsNil)
-	// A dead hosted model is still present in the controller and must be
-	// counted so destroy-controller waits for it to be removed.
-	c.Assert(environmentStatus.Controller.HostedModelCount, tc.Equals, 1)
+	// A dead hosted model is still present in the controller: it counts
+	// towards the removal wait of destroy-controller, but not towards the
+	// hosted model counts of models still being torn down.
+	c.Assert(environmentStatus.Controller.HostedModelCount, tc.Equals, 0)
+	c.Assert(environmentStatus.Controller.UnremovedModelCount, tc.Equals, 1)
 	// Dead hosted models are still filtered out of the visible model list.
 	c.Assert(environmentStatus.Models, tc.HasLen, 0)
 }
@@ -607,6 +609,20 @@ func (s *KillSuite) TestFmtControllerStatus(c *tc.C) {
 	}
 	out := controller.FmtCtrStatus(data)
 	c.Assert(out, tc.Equals, "Waiting for 3 models, 20 machines, 8 applications")
+}
+
+func (s *KillSuite) TestFmtControllerRemovalStatus(c *tc.C) {
+	// destroy-controller waits for dead-but-present models too, so the
+	// removal status counts them as models being waited for.
+	data := controller.CtrData{
+		UUID:                "uuid",
+		HostedModelCount:    0,
+		UnremovedModelCount: 2,
+		HostedMachineCount:  20,
+		ApplicationCount:    8,
+	}
+	out := controller.FmtCtrRemovalStatus(data)
+	c.Assert(out, tc.Equals, "Waiting for 2 models, 20 machines, 8 applications")
 }
 
 func (s *KillSuite) TestFmtEnvironStatus(c *tc.C) {

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -108,7 +108,7 @@ func newData(ctx context.Context, api destroyControllerAPI, controllerModelUUID 
 	var volumeCount int
 	var filesystemCount int
 	var modelsData []modelData
-	var aliveModelCount int
+	var hostedModelCount int
 	var ctrModelData modelData
 	var applications []base.Application
 	for _, model := range status {
@@ -153,12 +153,12 @@ func newData(ctx context.Context, api destroyControllerAPI, controllerModelUUID 
 		if model.UUID == controllerModelUUID {
 			ctrModelData = modelData
 		} else {
+			hostedModelCount++
 			if model.Life == life.Dead {
 				// Filter out dead, non-controller models.
 				continue
 			}
 			modelsData = append(modelsData, modelData)
-			aliveModelCount++
 			applications = append(applications, model.Applications...)
 		}
 		hostedMachinesCount += model.HostedMachineCount
@@ -169,7 +169,7 @@ func newData(ctx context.Context, api destroyControllerAPI, controllerModelUUID 
 
 	ctrFinalStatus := ctrData{
 		UUID:                 controllerModelUUID,
-		HostedModelCount:     aliveModelCount,
+		HostedModelCount:     hostedModelCount,
 		HostedMachineCount:   hostedMachinesCount,
 		ApplicationCount:     applicationsCount,
 		TotalVolumeCount:     volumeCount,
@@ -186,6 +186,15 @@ func newData(ctx context.Context, api destroyControllerAPI, controllerModelUUID 
 
 func hasUnreclaimedResources(env environmentStatus) bool {
 	return hasUnDeadModels(env.Models) ||
+		env.Controller.HostedMachineCount > 0
+}
+
+// hasUnremovedModels reports whether any hosted models are still present in
+// the controller, regardless of their life. A model remains present until the
+// undertaker has destroyed its cloud resources (for example the model's
+// namespace on Kubernetes) and removed it from the controller database.
+func hasUnremovedModels(env environmentStatus) bool {
+	return env.Controller.HostedModelCount > 0 ||
 		env.Controller.HostedMachineCount > 0
 }
 

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -25,6 +25,14 @@ type ctrData struct {
 	TotalVolumeCount     int
 	TotalFilesystemCount int
 
+	// UnremovedModelCount is the number of hosted models still present
+	// in the controller, regardless of their life: a model remains
+	// present until the undertaker has destroyed its cloud resources
+	// (for example the model's namespace on Kubernetes) and removed it
+	// from the controller database. Unlike HostedModelCount, this
+	// includes models that are already dead.
+	UnremovedModelCount int
+
 	// Model contains controller model data
 	Model modelData
 }
@@ -59,8 +67,9 @@ func newTimedStatusUpdater(ctx *cmd.Context, api destroyControllerAPI, controlle
 			<-clock.After(wait)
 		}
 
-		// If we hit an error, status.HostedModelCount will be 0, the polling
-		// loop will stop and we'll go directly to destroying the model.
+		// If we hit an error, the model and machine counts will be 0,
+		// the polling loop will stop and we'll go directly to
+		// destroying the model.
 		envStatus, err := newData(ctx.Context, api, controllerModelUUID)
 		if err != nil {
 			ctx.Infof("Unable to get the controller summary from the API: %s.", err)
@@ -109,6 +118,7 @@ func newData(ctx context.Context, api destroyControllerAPI, controllerModelUUID 
 	var filesystemCount int
 	var modelsData []modelData
 	var hostedModelCount int
+	var unremovedModelCount int
 	var ctrModelData modelData
 	var applications []base.Application
 	for _, model := range status {
@@ -153,11 +163,12 @@ func newData(ctx context.Context, api destroyControllerAPI, controllerModelUUID 
 		if model.UUID == controllerModelUUID {
 			ctrModelData = modelData
 		} else {
-			hostedModelCount++
+			unremovedModelCount++
 			if model.Life == life.Dead {
 				// Filter out dead, non-controller models.
 				continue
 			}
+			hostedModelCount++
 			modelsData = append(modelsData, modelData)
 			applications = append(applications, model.Applications...)
 		}
@@ -170,6 +181,7 @@ func newData(ctx context.Context, api destroyControllerAPI, controllerModelUUID 
 	ctrFinalStatus := ctrData{
 		UUID:                 controllerModelUUID,
 		HostedModelCount:     hostedModelCount,
+		UnremovedModelCount:  unremovedModelCount,
 		HostedMachineCount:   hostedMachinesCount,
 		ApplicationCount:     applicationsCount,
 		TotalVolumeCount:     volumeCount,
@@ -190,11 +202,12 @@ func hasUnreclaimedResources(env environmentStatus) bool {
 }
 
 // hasUnremovedModels reports whether any hosted models are still present in
-// the controller, regardless of their life. A model remains present until the
-// undertaker has destroyed its cloud resources (for example the model's
-// namespace on Kubernetes) and removed it from the controller database.
+// the controller, regardless of their life, or whether any hosted machines
+// remain. A model remains present until the undertaker has destroyed its
+// cloud resources (for example the model's namespace on Kubernetes) and
+// removed it from the controller database.
 func hasUnremovedModels(env environmentStatus) bool {
-	return env.Controller.HostedModelCount > 0 ||
+	return env.Controller.UnremovedModelCount > 0 ||
 		env.Controller.HostedMachineCount > 0
 }
 
@@ -223,9 +236,23 @@ func s(n int) string {
 	return ""
 }
 
+// fmtCtrStatus returns a status line describing what kill-controller is
+// still waiting for. The model count only includes hosted models that
+// are not yet dead; kill-controller stops waiting once they are dead.
 func fmtCtrStatus(data ctrData) string {
-	modelNo := data.HostedModelCount
-	out := fmt.Sprintf("Waiting for %d model%s", modelNo, s(modelNo))
+	return fmtCtrWaitingStatus(data.HostedModelCount, data)
+}
+
+// fmtCtrRemovalStatus returns a status line describing what
+// destroy-controller is still waiting for. Unlike fmtCtrStatus, the
+// model count includes dead models that are still present, as
+// destroy-controller waits for those to be removed from the controller.
+func fmtCtrRemovalStatus(data ctrData) string {
+	return fmtCtrWaitingStatus(data.UnremovedModelCount, data)
+}
+
+func fmtCtrWaitingStatus(modelCount int, data ctrData) string {
+	out := fmt.Sprintf("Waiting for %d model%s", modelCount, s(modelCount))
 
 	if machineNo := data.HostedMachineCount; machineNo > 0 {
 		out += fmt.Sprintf(", %d machine%s", machineNo, s(machineNo))

--- a/tests/includes/k8s.sh
+++ b/tests/includes/k8s.sh
@@ -26,6 +26,38 @@ kubectl() {
 	esac
 }
 
+# wait_for_namespace_gone polls until the given namespace no longer exists in
+# the cluster. It fails the test if the namespace is still present after the
+# timeout (an integer number of seconds).
+#
+# ```
+# wait_for_namespace_gone <namespace> [<timeout>]
+# ```
+wait_for_namespace_gone() {
+	local name timeout
+
+	name=${1}
+	timeout=${2:-600} # default timeout: 600s = 10m
+
+	attempt=0
+	start_time="$(date -u +%s)"
+	while kubectl get namespace "${name}" >/dev/null 2>&1; do
+		echo "[+] (attempt ${attempt}) polling for namespace ${name} to be removed"
+		sleep "${SHORT_TIMEOUT}"
+
+		elapsed=$(date -u +%s)-$start_time
+		if [[ ${elapsed} -ge ${timeout} ]]; then
+			echo "[-] $(red 'timed out waiting for namespace') $(red "${name}") $(red 'to be removed')"
+			kubectl get namespace "${name}" 2>&1 | sed 's/^/    | /g'
+			exit 1
+		fi
+
+		attempt=$((attempt + 1))
+	done
+
+	echo "[+] $(green 'Namespace removed:') $(green "${name}")"
+}
+
 default_k8s() {
 	if command -v minikube >/dev/null 2>&1 && [[ "Stopped" != "$(minikube status -o json | yq .APIServer)" ]]; then
 		printf "minikube"

--- a/tests/suites/smoke_k8s/destroy.sh
+++ b/tests/suites/smoke_k8s/destroy.sh
@@ -1,0 +1,41 @@
+run_deploy_and_destroy_controller() {
+	echo
+
+	file="${2}"
+
+	ensure "test-deploy-destroy" "${file}"
+
+	juju deploy snappass-test --revision 8 --channel stable
+	wait_for "snappass-test" "$(idle_condition "snappass-test")"
+
+	# Do not destroy the model: the controller teardown must reclaim the
+	# hosted model and its namespace itself.
+	destroy_controller "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+
+	# kill-controller is the forceful escape hatch and does not wait for
+	# hosted model removal, so namespaces may legitimately remain.
+	if [[ ${KILL_CONTROLLER:-} == "true" ]]; then
+		echo "====> KILL_CONTROLLER set, skipping namespace checks"
+		return
+	fi
+
+	wait_for_namespace_gone "test-deploy-destroy"
+	wait_for_namespace_gone "controller-${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+}
+
+test_destroy_controller() {
+	if [ "$(skip 'test_destroy_controller')" ]; then
+		echo "==> TEST SKIPPED: k8s destroy controller tests"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		file="${1}"
+
+		run "run_deploy_and_destroy_controller" "${file}"
+	)
+}

--- a/tests/suites/smoke_k8s/task.sh
+++ b/tests/suites/smoke_k8s/task.sh
@@ -16,4 +16,7 @@ test_smoke_k8s() {
 	test_deploy "${file}"
 
 	destroy_controller "test-smoke-k8s"
+
+	# This test destroys the controller and must run last.
+	test_destroy_controller "${file}"
 }


### PR DESCRIPTION
`juju destroy-controller --destroy-all-models --destroy-storage` on a
Kubernetes controller exits successfully but leaves hosted model namespaces
active forever. The command's "All models reclaimed" predicate only required
hosted models to be **dead**; it then tore down the controller namespace
client-side, killing the controller pod that hosts the undertaker worker
before the undertaker had finished deleting the hosted models' namespaces.
The remaining leak from #22309 (the PV/PVC part was fixed by #21905) is
purely this orphaned namespace race.

In 4.0 a hosted model is removed from the controller database strictly
*after* its cloud resources are destroyed (`removal.Service.DeleteModel`
runs `provider.Destroy`, which for k8s deletes the namespace, before
deleting the model row). This change makes the destroy-controller CLI
wait until every hosted model is fully removed from the controller —
not merely dead — so "model gone from the DB" implies "namespace deletion
completed". This restores the 3.x CLI contract and matches the existing
server-side design, where controller-model removal already waits for
hosted-model DB removal. `kill-controller` deliberately keeps its "wait
for dead, with timeout" semantics as the forceful escape hatch.


## QA steps


Bootstrap a microk8s controller and create a hosted model with a workload (any charm reproduces the leak; the original report used loki-k8s):

```sh
$ juju bootstrap microk8s c
$ juju add-model m
$ juju deploy loki-k8s --trust
 ```                                                                                                      
                                                                                                          
Wait for the deployment to be active, then destroy the controller:                                    
                                                                                                          
 ```sh                                                                                                    
$ juju destroy-controller --destroy-all-models --destroy-storage c
 ```                                                                                                      
                                                                                                          
Reproducer / verification, after the command exits, the hosted model's namespace and any PV/PVC claims must be gone:                                                 
                                                                                                          
 ```sh                                                                                                    
$ microk8s kubectl get ns m      # expect: Error from server (NotFound)
$ microk8s kubectl get pv,pvc -A # expect: no leftover "m/" claims
 ```                                                                                                      
                                                                                                         
## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #22309.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9860](https://warthogs.atlassian.net/browse/JUJU-9860)


[JUJU-9860]: https://warthogs.atlassian.net/browse/JUJU-9860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ