### PR TITLE
feat(bootstrap): add fast-path jujud snap patching for dev builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _build/
 _build
 _deps*/
 _deps
+_jujud-snap-patch/
 cmd/juju/juju
 cmd/jujud/jujud
 cmd/builddb/builddb

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,13 @@ OCI_IMAGE_PLATFORMS ?= linux/$(GOARCH)
 # Multi-snap layout: source-of-truth under snaps/<name>/, staging at snap/
 SNAPS_DIR := snaps
 SNAP_STAGE_DIR := snap
+JUJUD_SNAP_PATCH_DIR := _jujud-snap-patch
+JUJUD_SNAP_PATCH_UNPACK := ${JUJUD_SNAP_PATCH_DIR}/squashfs-root
+JUJUD_SNAP_PATCH_LOG := ${JUJUD_SNAP_PATCH_DIR}/build.log
+# Map Go arch to snap arch. Must match snapArch in environs/bootstrap/snap_build.go.
+JUJUD_SNAP_ARCH := $(patsubst ppc64le,ppc64el,$(GOARCH))
+JUJUD_SNAP_VERSION = $(shell sed -n 's/^version: *//p' ${SNAPS_DIR}/jujud/snapcraft.yaml | tr -d '"')
+JUJUD_SNAP_NAME = jujud_$(JUJUD_SNAP_VERSION)_$(JUJUD_SNAP_ARCH).snap
 
 # Build tags passed to go install/build.
 # Passing no-dqlite will disable building with dqlite.
@@ -619,9 +626,83 @@ jujud-snap:
 	$(call snap_stage,jujud)
 	snapcraft pack --use-lxd
 
-.PHONY: build-snap
-build-snap: jujud-snap
-## build-snap: Alias for jujud-snap; produces the jujud controller snap for local bootstrap.
+.PHONY: jujud-snap-build
+jujud-snap-build:
+## jujud-snap-build: Build the jujud controller snap; fast-patch when possible, else full rebuild.
+# The full-build branch pipes snapcraft output through tee rather than
+# redirecting to a plain file: snapcraft's LXD provider spawns snap-confine,
+# which refuses to run ("elevated permissions ... permission escalation", exit
+# 120) when the build's stdout is a regular file. A pipe keeps stdout valid
+# while still capturing output to the log for display on failure.
+	@set -e; \
+	BASE_SNAP="${JUJUD_SNAP_NAME}"; \
+	if [ -f "$$BASE_SNAP" ] && [ -z "$$(find ${SNAPS_DIR}/jujud -newer "$$BASE_SNAP" -print -quit 2>/dev/null)" ]; then \
+		echo "Patching controller snap..."; \
+		$(MAKE) --no-print-directory jujud-snap-patch; \
+	else \
+		echo "Building controller snap from source. This may take a while..."; \
+		rm -rf ${JUJUD_SNAP_PATCH_DIR}; \
+		mkdir -p ${JUJUD_SNAP_PATCH_DIR}; \
+		set +e; \
+		{ $(MAKE) --no-print-directory jujud-snap 2>&1; echo $$? >${JUJUD_SNAP_PATCH_DIR}/.rc; } \
+			| tee ${JUJUD_SNAP_PATCH_LOG} >/dev/null; \
+		set -e; \
+		if [ "$$(cat ${JUJUD_SNAP_PATCH_DIR}/.rc 2>/dev/null)" != 0 ]; then \
+			cat ${JUJUD_SNAP_PATCH_LOG}; exit 1; \
+		fi; \
+		if $(MAKE) --no-print-directory jujud >> ${JUJUD_SNAP_PATCH_LOG} 2>&1; then \
+			sha256sum "${GO_INSTALL_PATH}/jujud" | cut -d' ' -f1 \
+				> ${JUJUD_SNAP_PATCH_DIR}/.jujud.sha256; \
+		fi; \
+		echo "Built snap: $$BASE_SNAP"; \
+	fi
+
+.PHONY: jujud-snap-patch
+jujud-snap-patch:
+## jujud-snap-patch: Fast-patch the base jujud snap with a freshly built jujud binary.
+	@set -e; \
+	mkdir -p ${JUJUD_SNAP_PATCH_DIR}; \
+	$(MAKE) --no-print-directory jujud > ${JUJUD_SNAP_PATCH_LOG} 2>&1 \
+		|| { cat ${JUJUD_SNAP_PATCH_LOG}; exit 1; }; \
+	BASE_SNAP="${JUJUD_SNAP_NAME}"; \
+	if [ ! -f "$$BASE_SNAP" ]; then \
+		echo "ERROR: no base snap found. Run 'make jujud-snap-build' first to create the base snap artifact."; \
+		exit 1; \
+	fi; \
+	JUJUD_BIN="${GO_INSTALL_PATH}/jujud"; \
+	if [ ! -f "$$JUJUD_BIN" ]; then \
+		echo "ERROR: jujud binary not found at $$JUJUD_BIN."; \
+		exit 1; \
+	fi; \
+	JUJUD_SHA="$$(sha256sum "$$JUJUD_BIN" | cut -d' ' -f1)"; \
+	STORED_SHA="$$(cat ${JUJUD_SNAP_PATCH_DIR}/.jujud.sha256 2>/dev/null || true)"; \
+	if [ "$$JUJUD_SHA" = "$$STORED_SHA" ]; then \
+		echo "jujud binary unchanged; snap is up to date."; \
+		exit 0; \
+	fi; \
+	CACHE_SNAP="${JUJUD_SNAP_PATCH_DIR}/base.snap"; \
+	if [ ! -f "$$CACHE_SNAP" ]; then \
+		cp "$$BASE_SNAP" "$$CACHE_SNAP"; \
+	fi; \
+	if [ ! -d ${JUJUD_SNAP_PATCH_UNPACK} ]; then \
+		unsquashfs -d ${JUJUD_SNAP_PATCH_UNPACK} "$$CACHE_SNAP" >> ${JUJUD_SNAP_PATCH_LOG} 2>&1 \
+			|| { cat ${JUJUD_SNAP_PATCH_LOG}; exit 1; }; \
+	fi; \
+	cp "$$JUJUD_BIN" ${JUJUD_SNAP_PATCH_UNPACK}/bin/jujud; \
+	test -L ${JUJUD_SNAP_PATCH_UNPACK}/bin/juju-introspect || \
+		ln -sf jujud ${JUJUD_SNAP_PATCH_UNPACK}/bin/juju-introspect; \
+	if [ ! -x ${JUJUD_SNAP_PATCH_UNPACK}/bin/jujud ]; then \
+		echo "ERROR: jujud binary is not executable."; \
+		exit 1; \
+	fi; \
+	if ! file ${JUJUD_SNAP_PATCH_UNPACK}/bin/jujud | grep -q 'ELF'; then \
+		echo "ERROR: jujud is not a valid ELF binary."; \
+		exit 1; \
+	fi; \
+	snap pack ${JUJUD_SNAP_PATCH_UNPACK} --filename="$$BASE_SNAP" >> ${JUJUD_SNAP_PATCH_LOG} 2>&1 \
+		|| { cat ${JUJUD_SNAP_PATCH_LOG}; exit 1; }; \
+	echo "$$JUJUD_SHA" > ${JUJUD_SNAP_PATCH_DIR}/.jujud.sha256; \
+	echo "Patched snap: $$BASE_SNAP"
 
 .PHONY: install-snap-dependencies
 # Install packages required to develop Juju and run tests. The stable

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -744,8 +744,8 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 			ctx.Warningf("ignoring --build-snap because --controller-snap-path is explicitly provided")
 		}
 		if c.BuildSnap {
-			ctx.Infof("Building controller snap from local source via 'make build-snap'; this may take several minutes...")
-			builtPath, err := bootstrap.BuildControllerSnap(ctx)
+			ctx.Infof("Building controller snap from local source...")
+			builtPath, err := bootstrap.BuildControllerSnap(ctx, ctx.Stdout, ctx.Stderr)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -764,7 +764,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		// absent or unreadable.
 		if c.ControllerSnapPath == "" {
 			return errors.New("--controller-snap-path is required for IAAS bootstrap; " +
-				"build the snap with 'make build-snap' and supply the path")
+				"build the snap with 'make jujud-snap-build' and supply the path")
 		}
 		if _, err := c.Filesystem().Stat(c.ControllerSnapPath); err != nil {
 			return errors.Annotatef(err, "--controller-snap-path %q cannot be read", c.ControllerSnapPath)

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2272,7 +2272,7 @@ func (s *BootstrapSuite) TestBootstrapImplicitBuild(c *tc.C) {
 	tempSnapPath := filepath.Join(c.MkDir(), "jujud_4.0.0_amd64.snap")
 	err := os.WriteFile(tempSnapPath, []byte("fake snap"), 0644)
 	c.Assert(err, tc.ErrorIsNil)
-	s.PatchValue(&bootstrap.BuildControllerSnap, func(ctx context.Context) (string, error) {
+	s.PatchValue(&bootstrap.BuildControllerSnap, func(ctx context.Context, stdout, stderr io.Writer) (string, error) {
 		return tempSnapPath, nil
 	})
 
@@ -2376,7 +2376,7 @@ func (s *BootstrapSuite) TestBootstrapIAASControllerSnapPathRequired(c *tc.C) {
 	// Instead, patch it to return an empty string to simulate build
 	// success but no path set (should not happen normally, but tests
 	// the fallback).
-	s.PatchValue(&bootstrap.BuildControllerSnap, func(ctx context.Context) (string, error) {
+	s.PatchValue(&bootstrap.BuildControllerSnap, func(ctx context.Context, stdout, stderr io.Writer) (string, error) {
 		return "", nil
 	})
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -177,7 +177,7 @@ type BootstrapParams struct {
 	SupportedBootstrapBases []corebase.Base
 
 	// ControllerSnapPath is the path of a local snap file built locally
-	// with 'make build-snap'. In the current phase only the local dangerous
+	// with 'make jujud-snap-build'. In the current phase only the local dangerous
 	// path is active; assertion, channel, and revision paths remain as
 	// optional inputs for future store-install phases.
 	ControllerSnapPath string
@@ -513,7 +513,7 @@ func bootstrapIAAS(
 		if snapCompat.Compare(clientCompat) != 0 {
 			return errors.Errorf(
 				"local snap version %s is not compatible with bootstrap client %s; "+
-					"rebuild the snap with 'make build-snap' to match the current client version",
+					"rebuild the snap with 'make jujud-snap-build' to match the current client version",
 				snapVersion, jujuversion.Current,
 			)
 		}

--- a/environs/bootstrap/snap_build.go
+++ b/environs/bootstrap/snap_build.go
@@ -4,8 +4,10 @@
 package bootstrap
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,10 +24,19 @@ const (
 		"install it with 'sudo snap install snapcraft --classic'"
 )
 
-var buildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+// buildCommandFunc runs the build command, streaming its output live to the
+// supplied writers while also capturing it so callers can include it in an
+// error message. Declared as a var for test injection.
+var buildCommandFunc = func(
+	ctx context.Context, stdout, stderr io.Writer, dir, name string, args ...string,
+) ([]byte, error) {
+	var buf bytes.Buffer
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
-	return cmd.CombinedOutput()
+	cmd.Stdout = io.MultiWriter(stdout, &buf)
+	cmd.Stderr = io.MultiWriter(stderr, &buf)
+	err := cmd.Run()
+	return buf.Bytes(), err
 }
 
 var lookPathFunc = exec.LookPath
@@ -40,14 +51,14 @@ func snapArch(goarch string) string {
 }
 
 // BuildControllerSnap builds the controller snap from local source via 'make
-// build-snap' and returns the path to the resulting .snap file. It is called
+// jujud-snap-build' and returns the path to the resulting .snap file. It is called
 // from the bootstrap command's Run() when --build-snap is set, populating
 // ControllerSnapPath so the existing upload pipeline handles the locally built
-// snap.
+// snap. Build output is streamed live to stdout and stderr.
 //
 // Declared as a var to allow test injection without a config struct; tests
 // swap the value directly via the exported alias in export_test.go.
-var BuildControllerSnap = func(ctx context.Context) (string, error) {
+var BuildControllerSnap = func(ctx context.Context, stdout, stderr io.Writer) (string, error) {
 	sourceRoot, err := tools.FindJujuSourceRoot()
 	if err != nil {
 		return "", errors.Annotate(err, "cannot locate juju source root")
@@ -57,7 +68,7 @@ var BuildControllerSnap = func(ctx context.Context) (string, error) {
 		return "", errors.New(snapcraftRequiredMessage)
 	}
 
-	out, err := buildCommandFunc(ctx, sourceRoot, "make", "build-snap")
+	out, err := buildCommandFunc(ctx, stdout, stderr, sourceRoot, "make", "jujud-snap-build")
 	if err != nil {
 		return "", errors.Errorf(
 			"building controller snap failed: %v\n%s\n"+

--- a/environs/bootstrap/snap_build_test.go
+++ b/environs/bootstrap/snap_build_test.go
@@ -4,8 +4,10 @@
 package bootstrap_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -47,7 +49,7 @@ func (s *snapBuildSuite) TestBuildControllerSnapSnapcraftNotFound(c *tc.C) {
 	restoreBuild := func() { *bootstrap.BuildCommandFunc = *origBuild }
 	defer restoreBuild()
 
-	*bootstrap.BuildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+	*bootstrap.BuildCommandFunc = func(ctx context.Context, stdout, stderr io.Writer, dir, name string, args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("should not be called")
 	}
 
@@ -65,7 +67,7 @@ func (s *snapBuildSuite) TestBuildControllerSnapSnapcraftNotFound(c *tc.C) {
 		return c.MkDir(), nil
 	}
 
-	_, err := bootstrap.BuildControllerSnap(context.Background())
+	_, err := bootstrap.BuildControllerSnap(context.Background(), io.Discard, io.Discard)
 	c.Assert(err, tc.ErrorMatches, "snapcraft is required to build the controller snap.*")
 }
 
@@ -74,7 +76,7 @@ func (s *snapBuildSuite) TestBuildControllerSnapMakeFails(c *tc.C) {
 	restoreBuild := func() { *bootstrap.BuildCommandFunc = *origBuild }
 	defer restoreBuild()
 
-	*bootstrap.BuildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+	*bootstrap.BuildCommandFunc = func(ctx context.Context, stdout, stderr io.Writer, dir, name string, args ...string) ([]byte, error) {
 		return []byte("build output\nbuild failed\n"), fmt.Errorf("exit status 2")
 	}
 
@@ -92,8 +94,8 @@ func (s *snapBuildSuite) TestBuildControllerSnapMakeFails(c *tc.C) {
 		return c.MkDir(), nil
 	}
 
-	_, err := bootstrap.BuildControllerSnap(context.Background())
-	c.Assert(err, tc.ErrorMatches, "building controller snap failed: exit status 2(?s).*")
+	_, err := bootstrap.BuildControllerSnap(context.Background(), io.Discard, io.Discard)
+	c.Assert(err, tc.ErrorMatches, "building controller snap failed: exit status 2(?s).*build failed.*")
 }
 
 func (s *snapBuildSuite) TestBuildControllerSnapFileNotFound(c *tc.C) {
@@ -103,7 +105,7 @@ func (s *snapBuildSuite) TestBuildControllerSnapFileNotFound(c *tc.C) {
 	restoreBuild := func() { *bootstrap.BuildCommandFunc = *origBuild }
 	defer restoreBuild()
 
-	*bootstrap.BuildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+	*bootstrap.BuildCommandFunc = func(ctx context.Context, stdout, stderr io.Writer, dir, name string, args ...string) ([]byte, error) {
 		return []byte("build complete\n"), nil
 	}
 
@@ -121,7 +123,7 @@ func (s *snapBuildSuite) TestBuildControllerSnapFileNotFound(c *tc.C) {
 		return tmpDir, nil
 	}
 
-	_, err := bootstrap.BuildControllerSnap(context.Background())
+	_, err := bootstrap.BuildControllerSnap(context.Background(), io.Discard, io.Discard)
 	c.Assert(err, tc.ErrorMatches, "controller snap build completed but expected file.*was not found.*")
 }
 
@@ -138,11 +140,12 @@ func (s *snapBuildSuite) TestBuildControllerSnapSuccess(c *tc.C) {
 	defer restoreBuild()
 
 	buildCalled := false
-	*bootstrap.BuildCommandFunc = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+	*bootstrap.BuildCommandFunc = func(ctx context.Context, stdout, stderr io.Writer, dir, name string, args ...string) ([]byte, error) {
 		c.Check(dir, tc.Equals, tmpDir)
 		c.Check(name, tc.Equals, "make")
-		c.Check(args, tc.DeepEquals, []string{"build-snap"})
+		c.Check(args, tc.DeepEquals, []string{"jujud-snap-build"})
 		buildCalled = true
+		fmt.Fprint(stdout, "build complete\n")
 		return []byte("build complete\n"), nil
 	}
 
@@ -160,8 +163,10 @@ func (s *snapBuildSuite) TestBuildControllerSnapSuccess(c *tc.C) {
 		return tmpDir, nil
 	}
 
-	result, err := bootstrap.BuildControllerSnap(context.Background())
+	var stdout bytes.Buffer
+	result, err := bootstrap.BuildControllerSnap(context.Background(), &stdout, io.Discard)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(buildCalled, tc.IsTrue)
 	c.Check(result, tc.Equals, snapPath)
+	c.Check(stdout.String(), tc.Equals, "build complete\n")
 }

--- a/tests/suites/bootstrap/build_snap.sh
+++ b/tests/suites/bootstrap/build_snap.sh
@@ -156,7 +156,16 @@ test_bootstrap_build_snap() {
 		set_verbosity
 
 		cd .. || exit
+		# Pin GOBIN so 'make jujud' installs the controller binary to a
+		# known location within the test dir. GO_INSTALL_PATH falls back to
+		# $(go env GOPATH)/bin when GOBIN is unset, but CI runners may not
+		# have a writable GOPATH/bin, so we set it explicitly here.
+		export GOBIN="${TEST_DIR}/gobin"
+		mkdir -p "${GOBIN}"
 
+		# Note: run_build_snap_explicit runs first and produces the base
+		# snap via a full build; run_build_snap_implicit then exercises the
+		# fast-patch path because the artifact already exists.
 		run "run_build_snap_explicit"
 		run "run_build_snap_implicit"
 	)


### PR DESCRIPTION
**Goal:** Make iterating on controller code fast. Any change to Go code
previously required a full `snapcraft pack --use-lxd` run — spinning up an LXD
container, rebuilding dqlite from source, and recompiling everything — which
takes 5–10 minutes before you can bootstrap and test. That cost is paid on
every single iteration, including during `juju bootstrap`, which builds the
snap implicitly.

This brings the common case (Go code changed, snap packaging unchanged) down to
roughly two minutes, dominated by the `jujud` compile itself.

### Approach

Add a fast-patch path that reuses the existing snap instead of rebuilding it:
unpack the artifact, drop in a freshly compiled `jujud`, and repack. Everything
else in the snap — metadata, wrappers, hooks, bundled libraries — is preserved
byte-for-byte from the original build.

Two new Make targets:

- **`make jujud-snap-build`** — the entry point. Picks the fast path when it is
  safe to do so, otherwise performs a full build.
- **`make jujud-snap-patch`** — the fast path on its own.

`make jujud-snap` (full `snapcraft` build) is unchanged and remains available directly.

### Keeping the fast path honest

The fast path is only correct when snap packaging hasn't changed, so
correctness is enforced rather than left to the developer:

- **Staleness detection** — if anything under `snaps/jujud/` (`snapcraft.yaml`,
  hooks, the 17 wrapper scripts) is newer than the existing artifact, a full
  rebuild is forced. Switching branches or editing a wrapper cannot silently
  produce a snap with stale packaging.
- **No-op detection** — if the rebuilt `jujud` is not newer than the snap,
  patching is skipped entirely.
- **Integrity checks** — the binary must exist, be executable, and be a valid
  ELF before the snap is repacked; the `juju-introspect` symlink is verified and
  restored if absent.
- **Pristine base caching** — the original `snapcraft`-produced snap and its
  unpacked tree are cached under the (gitignored) working directory, so repeated
  patches always start from a clean base and never compound. `rm jujud_*.snap`
  forces a full rebuild.

### Behaviour change: `juju bootstrap`

Because IAAS bootstrap builds the controller snap implicitly, bootstrap now
benefits from the fast path automatically — repeat bootstraps against unchanged
packaging are minutes faster. The staleness guard above is what makes this safe
as a default.

Bootstrap output is also much quieter. Verbose build output (Go compile,
`snapcraft`, `unsquashfs`, `snap pack`) goes to a log file, and bootstrap
prints only meaningful progress lines:

```
Building controller snap from local source...
Patching controller snap...
Patched snap: jujud_4.1-beta2_amd64.snap
```

If any build step fails, the full log is dumped before exiting, so nothing is
lost when you actually need it. Build output is written through the command
context's streams rather than the process stdout, so redirection and `--quiet`
behave as expected.


### Notes and limitations

- The patched snap contains the statically linked musl `jujud` from `make
  jujud` rather than the dynamically linked glibc binary from `snapcraft`. This
  is self-contained and transparent to snapd, but it means a patched snap is not
  byte-identical to a `snapcraft`-built one. Use `make jujud-snap` when that
  distinction matters.
- dqlite is not rebuilt on the fast path; a dqlite or packaging change triggers
  a full rebuild via the staleness guard.
- The local build architecture must match the snap's; cross-architecture
  patching is not supported.
- The Make target and the Go code derive the artifact filename independently,
  so the Go→snap architecture mapping is duplicated. It's commented on both
  sides; worth consolidating if a third consumer appears.
- `make build-snap` has been removed in favour of `make jujud-snap-build`,
  aligning the name with the existing `juju-snap` / `jujud-snap` targets.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```bash
# 1. Full build from clean (expect ~5-10 min, quiet output)
❯ rm -f jujud_*.snap && rm -rf _jujud-snap-patch
❯ make jujud-snap-build
Building controller snap from source. This may take a while...
Built snap: jujud_4.1-beta2_amd64.snap # in 32s224ms

# 2. No-op patch (expect "jujud binary unchanged; snap is up to date.")
❯ make jujud-snap-build
Patching controller snap...
jujud binary unchanged; snap is up to date. # in 2s236ms

# 3. Fast patch after a code change (expect ~2 min, "Patched snap: ...")
❯ echo '//nolint' >> cmd/jujud/main.go
❯ make jujud-snap-build
Patching controller snap...
Patched snap: jujud_4.1-beta2_amd64.snap # in in 9s865ms

# 4. Packaging change forces a full rebuild
❯ touch snaps/jujud/local/wrappers/jujud-controller
❯ make jujud-snap-build   # expect "Building controller snap from source..."
Building controller snap from source. This may take a while...
Built snap: jujud_4.1-beta2_amd64.snap # in 32s2ms

# 5. Patched snap installs and the daemon starts
❯ sudo snap install --dangerous jujud_4.1-beta2_amd64.snap
❯ snap services jujud
Service      Startup   Current   Notes
jujud.jujud  disabled  inactive

❯ sudo snap logs jujud -n 5
2026-07-15T19:48:40+02:00 systemd[1]: Started snap.jujud.jujud.service - Service for snap application jujud.jujud.
2026-07-15T19:48:40+02:00 jujud.jujud[1309105]: ERROR cannot read controller runtime config: reading controller runtime config "/var/snap/jujud/x1/agents/controller-0/runtime.conf": open /var/snap/jujud/x1/agents/controller-0/runtime.conf: no such file or directory
2026-07-15T19:48:40+02:00 systemd[1]: snap.jujud.jujud.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
2026-07-15T19:48:40+02:00 systemd[1]: snap.jujud.jujud.service: Failed with result 'exit-code'.
2026-07-15T19:48:40+02:00 systemd[1]: Stopped snap.jujud.jujud.service - Service for snap application jujud.jujud.
# confirm no AppArmor/seccomp denials in dmesg

# 6. Missing base snap is diagnosed clearly
❯ rm -f jujud_*.snap && rm -rf _jujud-snap-patch
❯ make jujud-snap-patch   # expect "ERROR: no base snap found..."
ERROR: no base snap found. Run 'make jujud-snap-build' first to create the base snap artifact.
make: *** [Makefile:664: jujud-snap-patch] Error 1

# 7. Failure diagnostics are surfaced (introduce a deliberate compile error)
❯ `1``   # expect the compiler error printed, non-zero exit

# 8. Bootstrap end-to-end
❯ juju bootstrap lxd ctrl-upgrade-new \
  --build-snap \
  --controller-charm-path ../juju-controller/juju-controller_ubuntu@24.04-amd64.charm
Building controller snap from local source...
Patching controller snap...
jujud binary unchanged; snap is up to date.
Creating Juju controller "ctrl-upgrade-new" on lxd/default
Inspected local controller snap version 4.1-beta2
Building local Juju agent binary version 4.1-beta2 for amd64 (anchored to controller snap)
To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
Launching controller instance(s) on lxd/default...
 - juju-1f61b2-0 (arch=amd64)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.159.202.149:22
Connected to 10.159.202.149
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.159.202.149 to verify accessibility...

Bootstrap complete, controller "ctrl-upgrade-new" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

❯ juju ssh -m controller 0 -- snap list
Name    Version    Rev    Tracking       Publisher    Notes
core26  20260629   462    latest/stable  canonical**  base
jujud   4.1-beta2  x1     -              -            -
snapd   2.76.1     27591  latest/stable  canonical**  snapd
Connection to 10.159.202.149 closed.

❯ jst -m controller
Model       Controller        Cloud/Region  Version    Timestamp
controller  ctrl-upgrade-new  lxd/default   4.1-beta2  20:13:36+02:00

App         Version  Status  Scale  Charm            Channel  Rev  Exposed  Message
controller           active      1  juju-controller             0  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.159.202.149  17022,17070/tcp

Machine  State    Address         Inst id        Base       AZ      Message
0        started  10.159.202.149  juju-1f61b2-0  ubuntu@26  tuxedo  Running

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer
```

## Documentation changes


## Links

**Jira card:** [JUJU-10103](https://warthogs.atlassian.net/browse/JUJU-10103)


[JUJU-10103]: https://warthogs.atlassian.net/browse/JUJU-10103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ