### PR TITLE
feat(ssh): use tailscale fork of gliderlabs/ssh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.10.1
-	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-delve/delve v1.26.1
 	github.com/go-goose/goose/v5 v5.1.7
 	github.com/go-logr/logr v1.4.3
@@ -100,6 +99,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/rs/xid v1.6.0
+	github.com/tailscale/gliderssh v0.3.4-0.20260716005906-1a0f895faf28
 	github.com/vallerion/rscanner v0.0.0-20230822073625-4f90454447a3
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vmware/govmomi v0.34.1

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,6 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
-github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
 github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-delve/delve v1.26.1 h1:V1F0hzAjXCpsBP+I/E6fVUTLC/ZBSs1YWUb8cTtIWFE=
@@ -707,6 +705,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tailscale/gliderssh v0.3.4-0.20260716005906-1a0f895faf28 h1:Azz5ILxxVsHN/KjIu3wkJPAmmtiijucZw4Ax5Ye8n+s=
+github.com/tailscale/gliderssh v0.3.4-0.20260716005906-1a0f895faf28/go.mod h1:wn16Km1EZOX4UEAyaZa3dBwfFGOJ7neck40NcwosJUw=
 github.com/testcontainers/testcontainers-go v0.15.0 h1:3Ex7PUGFv0b2bBsdOv6R42+SK2qoZnWBd21LvZYhUtQ=
 github.com/testcontainers/testcontainers-go v0.15.0/go.mod h1:PkohMRH2X8Hib0IWtifVexDfLPVT+tb5E9hsf7cW12w=
 github.com/vallerion/rscanner v0.0.0-20230822073625-4f90454447a3 h1:PURv1WVac+xnJevO1IGtFdvlWcnqOdMjP5T0zgJuC5I=

--- a/internal/worker/sshserver/authentication.go
+++ b/internal/worker/sshserver/authentication.go
@@ -7,9 +7,9 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
 	"github.com/lestrrat-go/jwx/v3/jwt"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/logger"

--- a/internal/worker/sshserver/authentication_test.go
+++ b/internal/worker/sshserver/authentication_test.go
@@ -8,10 +8,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/tc"
 	sshtesting "github.com/juju/utils/v4/ssh/testing"
 	"github.com/lestrrat-go/jwx/v3/jwt"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 
 	coressh "github.com/juju/juju/core/ssh"

--- a/internal/worker/sshserver/authorization.go
+++ b/internal/worker/sshserver/authorization.go
@@ -6,9 +6,9 @@ package sshserver
 import (
 	"context"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
 	"github.com/lestrrat-go/jwx/v3/jwt"
+	ssh "github.com/tailscale/gliderssh"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/permission"

--- a/internal/worker/sshserver/handlers/k8s/portforward.go
+++ b/internal/worker/sshserver/handlers/k8s/portforward.go
@@ -4,7 +4,7 @@
 package k8s
 
 import (
-	"github.com/gliderlabs/ssh"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 )
 

--- a/internal/worker/sshserver/handlers/k8s/session.go
+++ b/internal/worker/sshserver/handlers/k8s/session.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/creack/pty"
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
+	ssh "github.com/tailscale/gliderssh"
 
 	"github.com/juju/juju/core/logger"
 	k8sexec "github.com/juju/juju/internal/provider/kubernetes/exec"

--- a/internal/worker/sshserver/handlers/k8s/session_test.go
+++ b/internal/worker/sshserver/handlers/k8s/session_test.go
@@ -10,8 +10,8 @@ import (
 	"io"
 	"syscall"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/tc"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/virtualhostname"

--- a/internal/worker/sshserver/handlers/k8s/sftp.go
+++ b/internal/worker/sshserver/handlers/k8s/sftp.go
@@ -3,7 +3,7 @@
 
 package k8s
 
-import "github.com/gliderlabs/ssh"
+import ssh "github.com/tailscale/gliderssh"
 
 // SFTPHandler rejects SFTP, which is unsupported for Kubernetes targets.
 func (*Handlers) SFTPHandler() ssh.SubsystemHandler {

--- a/internal/worker/sshserver/handlers/k8s/utils_test.go
+++ b/internal/worker/sshserver/handlers/k8s/utils_test.go
@@ -6,8 +6,8 @@ package k8s
 import (
 	"context"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/tc"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 	"google.golang.org/grpc/test/bufconn"
 	"k8s.io/client-go/kubernetes"

--- a/internal/worker/sshserver/handlers/machine/portforward.go
+++ b/internal/worker/sshserver/handlers/machine/portforward.go
@@ -9,8 +9,8 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 )
 

--- a/internal/worker/sshserver/handlers/machine/portforward_test.go
+++ b/internal/worker/sshserver/handlers/machine/portforward_test.go
@@ -8,8 +8,8 @@ import (
 	"errors"
 	"io"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/tc"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/virtualhostname"

--- a/internal/worker/sshserver/handlers/machine/proxy.go
+++ b/internal/worker/sshserver/handlers/machine/proxy.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"sync"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -63,14 +63,17 @@ func handleProxy[T io.Closer](h *Handlers, ctx context.Context, cfg proxyConfig[
 }
 
 func (h *Handlers) handleError(session ssh.Session, err error) {
-	h.logger.Errorf(session.Context(), "machine proxy failure: %v", err)
-	writeError(session, err)
-
+	// An exit error indicates that proxying was successful,
+	// but the remote process exited with a non-zero status.
+	// Any other error indicates a failure in the proxying process itself.
 	var exitErr *gossh.ExitError
 	if errors.As(err, &exitErr) {
 		_ = session.Exit(exitErr.ExitStatus())
 		return
 	}
+
+	h.logger.Errorf(session.Context(), "machine proxy failure: %v", err)
+	writeError(session, err)
 	_ = session.Exit(1)
 }
 

--- a/internal/worker/sshserver/handlers/machine/session.go
+++ b/internal/worker/sshserver/handlers/machine/session.go
@@ -6,8 +6,8 @@ package machine
 import (
 	"context"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -48,14 +48,7 @@ func setupShellOrCommand(userSession ssh.Session, machineSession *gossh.Session)
 		return machineSession.Start(userSession.RawCommand())
 	}
 
-	// The Gliderlabs SSH server does not currently forward terminal modes.
-	// See https://github.com/gliderlabs/ssh/issues/98 and
-	// https://github.com/gliderlabs/ssh/pull/210.
-	// This will impact terminal behaviour for interactive sessions but can be
-	// addressed by using the above patches in a fork of the Gliderlabs SSH server.
-	if err := machineSession.RequestPty(pty.Term, pty.Window.Height, pty.Window.Width, gossh.TerminalModes{
-		gossh.ECHO: 1,
-	}); err != nil {
+	if err := machineSession.RequestPty(pty.Term, pty.Window.Height, pty.Window.Width, pty.Modes); err != nil {
 		return err
 	}
 	if err := machineSession.Shell(); err != nil {

--- a/internal/worker/sshserver/handlers/machine/session_test.go
+++ b/internal/worker/sshserver/handlers/machine/session_test.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 	"io"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/tc"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/virtualhostname"

--- a/internal/worker/sshserver/handlers/machine/sftp.go
+++ b/internal/worker/sshserver/handlers/machine/sftp.go
@@ -6,8 +6,8 @@ package machine
 import (
 	"context"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/logger"

--- a/internal/worker/sshserver/handlers/machine/sftp_test.go
+++ b/internal/worker/sshserver/handlers/machine/sftp_test.go
@@ -6,9 +6,9 @@ package machine
 import (
 	"io"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/tc"
 	"github.com/pkg/sftp"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/virtualhostname"

--- a/internal/worker/sshserver/handlers/machine/utils_test.go
+++ b/internal/worker/sshserver/handlers/machine/utils_test.go
@@ -6,8 +6,8 @@ package machine
 import (
 	"context"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/tc"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 	"google.golang.org/grpc/test/bufconn"
 

--- a/internal/worker/sshserver/proxy.go
+++ b/internal/worker/sshserver/proxy.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
+	ssh "github.com/tailscale/gliderssh"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/virtualhostname"

--- a/internal/worker/sshserver/server.go
+++ b/internal/worker/sshserver/server.go
@@ -11,9 +11,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
 	"github.com/juju/worker/v5"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 	"gopkg.in/tomb.v2"
 
@@ -192,14 +192,17 @@ func NewServerWorker(config ServerWorkerConfig) (worker.Worker, error) {
 func (s *ServerWorker) NewJumpServer() *ssh.Server {
 	server := ssh.Server{
 		ConnCallback: s.connCallback(),
-		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) bool {
+		PublicKeyHandler: func(ctx ssh.Context, key ssh.PublicKey) error {
 			ok, err := s.config.Authenticator.PublicKeyAuthentication(ctx, key)
 			if err != nil {
 				s.config.Metrics.authenticationFailures.WithLabelValues("public_key").Inc()
 				s.config.Logger.Warningf(ctx, "failed to authenticate public key: %v", err)
-				return false
+				return err
 			}
-			return ok
+			if !ok {
+				return errors.New("rejected invalid public key")
+			}
+			return nil
 		},
 		PasswordHandler: func(ctx ssh.Context, password string) bool {
 			ok, err := s.config.Authenticator.PasswordAuthentication(ctx, password)

--- a/internal/worker/sshserver/server_test.go
+++ b/internal/worker/sshserver/server_test.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/canonical/gomock/gomock"
-	"github.com/gliderlabs/ssh"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
+	ssh "github.com/tailscale/gliderssh"
 	gossh "golang.org/x/crypto/ssh"
 	"google.golang.org/grpc/test/bufconn"
 

--- a/internal/worker/sshserver/service_mock_test.go
+++ b/internal/worker/sshserver/service_mock_test.go
@@ -14,10 +14,10 @@ import (
 	net "net"
 
 	gomock "github.com/canonical/gomock/gomock"
-	ssh "github.com/gliderlabs/ssh"
 	controller "github.com/juju/juju/controller"
 	virtualhostname "github.com/juju/juju/core/virtualhostname"
 	watcher "github.com/juju/juju/core/watcher"
+	ssh "github.com/tailscale/gliderssh"
 )
 
 // MockControllerConfigService is a mock of ControllerConfigService interface.


### PR DESCRIPTION
This change switches our dependency on the gliderlabs/ssh module to the fork at tailscale/ssh which is better maintained and also includes some improvements where it handles terminal modes.

One change the tailscale fork makes is the signature for the PublicKey auth handler - instead of returning a bool, it returns an error.

There is also one small drive-by tweak in `internal/worker/sshserver/handlers/machine/proxy.go` where we were writing an error to stderr unnecessarily.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

As in #23006 

1. make install
2. juju bootstrap localhost test-ssh
3. juju add-model test
4. juju deploy ubuntu
5. \# Wait for the unit to become active
6. juju add-ssh-key "$(cat ~/.ssh/id_rsa.pub)" # Or wherever your SSH key lives
7. ssh -o StrictHostKeyChecking=no -J admin@\<controller-ip\>:17022 ubuntu@0.\<model-uuid\>.juju.internal