### PR TITLE
fix(migration): ensure external controller records are updated correctly

### DIFF
--- a/.github/workflows/jaas-smoke.yml
+++ b/.github/workflows/jaas-smoke.yml
@@ -17,7 +17,7 @@ jobs:
       - linux
       - x64
       - ${{ (github.repository_owner == 'juju' && 'aws') || (github.repository_owner == 'canonical' && 'noble') }}
-      - large
+      - ${{ (github.repository_owner == 'juju' && 'quad-xlarge') || (github.repository_owner == 'canonical' && 'xlarge') }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/apiserver/common/controllerconfig.go
+++ b/apiserver/common/controllerconfig.go
@@ -101,7 +101,7 @@ func (s *ControllerConfigAPI) getModelControllerInfo(model params.Entity) (param
 	}
 
 	logger.Debugf("found migrated model on another controller, saving the information")
-	_, err = ec.Save(crossmodel.ControllerInfo{
+	err = ec.Save(crossmodel.ControllerInfo{
 		ControllerTag: target.ControllerTag,
 		Alias:         target.ControllerAlias,
 		Addrs:         target.Addrs,

--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -145,7 +145,7 @@ func (s *controllerInfoSuite) TestControllerInfoExternalModel(c *gc.C) {
 		Addrs:         []string{"192.168.1.1:12345"},
 		CACert:        testing.CACert,
 	}
-	_, err := ec.Save(info, modelUUID)
+	err := ec.Save(info, modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	cc := common.NewStateControllerConfig(s.State)
 	results, err := cc.ControllerAPIInfoForModels(params.Entities{

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -2234,7 +2234,7 @@ func (api *APIBase) consumeOne(arg params.ConsumeApplicationArgV5) error {
 		// a different controller.
 		if controllerTag.Id() != api.backend.ControllerTag().Id() {
 			externalControllerUUID = controllerTag.Id()
-			if _, err = api.backend.SaveController(crossmodel.ControllerInfo{
+			if err = api.backend.SaveController(crossmodel.ControllerInfo{
 				ControllerTag: controllerTag,
 				Alias:         arg.ControllerInfo.Alias,
 				Addrs:         arg.ControllerInfo.Addrs,

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -2766,7 +2766,7 @@ func (s *ApplicationSuite) TestConsumeFromExternalController(c *gc.C) {
 		Alias:         "controller-alias",
 		CACert:        coretesting.CACert,
 		Addrs:         []string{"192.168.1.1:1234"},
-	}, coretesting.ModelTag.Id()).Return(nil, nil)
+	}, coretesting.ModelTag.Id()).Return(nil)
 	s.backend.EXPECT().AddRemoteApplication(s.addRemoteApplicationParams).Return(nil, nil)
 
 	results, err := s.api.Consume(s.consumeApplicationArgs)

--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -53,7 +53,7 @@ type Backend interface {
 	Model() (Model, error)
 	Unit(string) (Unit, error)
 	UnitsInError() ([]Unit, error)
-	SaveController(info crossmodel.ControllerInfo, modelUUID string) (ExternalController, error)
+	SaveController(info crossmodel.ControllerInfo, modelUUID string) error
 	ControllerTag() names.ControllerTag
 	ControllerConfig() (controller.Config, error)
 	Resources() Resources
@@ -258,11 +258,9 @@ type modelShim struct {
 	*state.Model
 }
 
-type ExternalController state.ExternalController
-
-func (s stateShim) SaveController(controllerInfo crossmodel.ControllerInfo, modelUUID string) (ExternalController, error) {
+func (s stateShim) SaveController(controllerInfo crossmodel.ControllerInfo, modelUUID string) error {
 	api := state.NewExternalControllers(s.State)
-	return api.Save(controllerInfo, modelUUID)
+	return errors.Trace(api.Save(controllerInfo, modelUUID))
 }
 
 type StorageInterface interface {

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -472,12 +472,11 @@ func (mr *MockBackendMockRecorder) Resources() *gomock.Call {
 }
 
 // SaveController mocks base method.
-func (m *MockBackend) SaveController(arg0 crossmodel.ControllerInfo, arg1 string) (application.ExternalController, error) {
+func (m *MockBackend) SaveController(arg0 crossmodel.ControllerInfo, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveController", arg0, arg1)
-	ret0, _ := ret[0].(application.ExternalController)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // SaveController indicates an expected call of SaveController.

--- a/apiserver/facades/controller/externalcontrollerupdater/externalcontrollerupdater.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/externalcontrollerupdater.go
@@ -94,7 +94,7 @@ func (s *ExternalControllerUpdaterAPI) SetExternalControllerInfo(args params.Set
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		if _, err := s.externalControllers.Save(crossmodel.ControllerInfo{
+		if err := s.externalControllers.Save(crossmodel.ControllerInfo{
 			ControllerTag: controllerTag,
 			Alias:         arg.Info.Alias,
 			Addrs:         arg.Info.Addrs,

--- a/apiserver/facades/controller/externalcontrollerupdater/mock_test.go
+++ b/apiserver/facades/controller/externalcontrollerupdater/mock_test.go
@@ -30,11 +30,11 @@ func (m *mockExternalControllers) Controller(uuid string) (state.ExternalControl
 	return nil, errors.NotFoundf("external controller %q", uuid)
 }
 
-func (m *mockExternalControllers) Save(info crossmodel.ControllerInfo, _ ...string) (state.ExternalController, error) {
+func (m *mockExternalControllers) Save(info crossmodel.ControllerInfo, _ ...string) error {
 	for _, c := range m.controllers {
 		if c.id == info.ControllerTag.Id() {
 			c.info = info
-			return c, nil
+			return nil
 		}
 	}
 	c := &mockExternalController{
@@ -42,7 +42,7 @@ func (m *mockExternalControllers) Save(info crossmodel.ControllerInfo, _ ...stri
 		info: info,
 	}
 	m.controllers = append(m.controllers, c)
-	return c, nil
+	return nil
 }
 
 type mockExternalController struct {

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -410,7 +410,7 @@ func (api *API) Activate(args params.ActivateModelArgs) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		_, err = ec.Save(crossmodel.ControllerInfo{
+		err = ec.Save(crossmodel.ControllerInfo{
 			ControllerTag: cTag,
 			Alias:         args.ControllerAlias,
 			Addrs:         args.SourceAPIAddrs,

--- a/apiserver/facades/controller/remoterelations/interface.go
+++ b/apiserver/facades/controller/remoterelations/interface.go
@@ -102,5 +102,6 @@ func (st stateShim) ApplicationOfferForUUID(offerUUID string) (*crossmodel.Appli
 // If the model UUID is associated with another external controller record,
 // that record will be modified to remove it.
 func (st stateShim) UpdateControllerForModel(controller crossmodel.ControllerInfo, modelUUID string) error {
-	return errors.Trace(state.NewExternalControllers(st.st).SaveAndMoveModels(controller, modelUUID))
+	err := state.NewExternalControllers(st.st).Save(controller, modelUUID)
+	return errors.Trace(err)
 }

--- a/state/externalcontroller.go
+++ b/state/externalcontroller.go
@@ -81,8 +81,7 @@ func (rc *externalController) ControllerInfo() crossmodel.ControllerInfo {
 
 // ExternalControllers instances provide access to external controllers in state.
 type ExternalControllers interface {
-	Save(_ crossmodel.ControllerInfo, modelUUIDs ...string) (ExternalController, error)
-	SaveAndMoveModels(_ crossmodel.ControllerInfo, modelUUIDs ...string) error
+	Save(_ crossmodel.ControllerInfo, modelUUIDs ...string) error
 	Controller(controllerUUID string) (ExternalController, error)
 	ControllerForModel(modelUUID string) (ExternalController, error)
 	Remove(controllerUUID string) error
@@ -105,30 +104,10 @@ func NewExternalControllers(st *State) *externalControllers {
 }
 
 // Save creates or updates an external controller record.
-func (ec *externalControllers) Save(
-	controller crossmodel.ControllerInfo, modelUUIDs ...string,
-) (ExternalController, error) {
-	if err := controller.Validate(); err != nil {
-		return nil, errors.Trace(err)
-	}
-	doc := newExternalControllerDoc(controller)
-	buildTxn := func(int) ([]txn.Op, error) {
-		ops, err := ec.upsertExternalControllerOps(doc, modelUUIDs)
-		return ops, errors.Trace(err)
-	}
-	if err := ec.st.db().Run(buildTxn); err != nil {
-		return nil, errors.Annotate(err, "failed to save external controller")
-	}
-
-	return &externalController{
-		doc: *doc,
-	}, nil
-}
-
-// SaveAndMoveModels is the same as `Save`, but if any of the input model UUIDs
-// are in other external external controllers, those records will be updated
-// to disassociate them.
-func (ec *externalControllers) SaveAndMoveModels(controller crossmodel.ControllerInfo, modelUUIDs ...string) error {
+//
+// If any of the input model UUIDs are in other external controllers,
+// those records will be updated to disassociate them.
+func (ec *externalControllers) Save(controller crossmodel.ControllerInfo, modelUUIDs ...string) error {
 	if err := controller.Validate(); err != nil {
 		return errors.Trace(err)
 	}

--- a/state/externalcontroller_test.go
+++ b/state/externalcontroller_test.go
@@ -37,13 +37,15 @@ func (s *externalControllerSuite) TestSaveInvalidAddress(c *gc.C) {
 		Addrs:         []string{"192.168.1.0"},
 		CACert:        testing.CACert,
 	}
-	_, err := s.externalControllers.Save(controllerInfo)
+	err := s.externalControllers.Save(controllerInfo)
 	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta(`controller api address "192.168.1.0" not valid`))
 }
 
 func (s *externalControllerSuite) TestSaveNoModels(c *gc.C) {
 	controllerInfo := defaultControllerInfo()
-	ec, err := s.externalControllers.Save(controllerInfo)
+	err := s.externalControllers.Save(controllerInfo)
+	c.Assert(err, jc.ErrorIsNil)
+	ec, err := s.externalControllers.Controller(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ec.Id(), gc.Equals, testing.ControllerTag.Id())
 	c.Assert(ec.ControllerInfo(), jc.DeepEquals, controllerInfo)
@@ -54,7 +56,9 @@ func (s *externalControllerSuite) TestSave(c *gc.C) {
 	controllerInfo := defaultControllerInfo()
 	uuid1 := utils.MustNewUUID().String()
 	uuid2 := utils.MustNewUUID().String()
-	ec, err := s.externalControllers.Save(controllerInfo, uuid1, uuid2)
+	err := s.externalControllers.Save(controllerInfo, uuid1, uuid2)
+	c.Assert(err, jc.ErrorIsNil)
+	ec, err := s.externalControllers.Controller(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ec.Id(), gc.Equals, testing.ControllerTag.Id())
 	c.Assert(ec.ControllerInfo(), jc.DeepEquals, controllerInfo)
@@ -64,9 +68,11 @@ func (s *externalControllerSuite) TestSave(c *gc.C) {
 func (s *externalControllerSuite) TestSaveIdempotent(c *gc.C) {
 	controllerInfo := defaultControllerInfo()
 	uuid1 := utils.MustNewUUID().String()
-	_, err := s.externalControllers.Save(controllerInfo, uuid1)
+	err := s.externalControllers.Save(controllerInfo, uuid1)
 	c.Assert(err, jc.ErrorIsNil)
-	ec, err := s.externalControllers.Save(controllerInfo, uuid1)
+	err = s.externalControllers.Save(controllerInfo, uuid1)
+	c.Assert(err, jc.ErrorIsNil)
+	ec, err := s.externalControllers.Controller(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ec.Id(), gc.Equals, testing.ControllerTag.Id())
 	c.Assert(ec.ControllerInfo(), jc.DeepEquals, controllerInfo)
@@ -76,20 +82,20 @@ func (s *externalControllerSuite) TestSaveIdempotent(c *gc.C) {
 func (s *externalControllerSuite) TestUpdateModels(c *gc.C) {
 	controllerInfo := defaultControllerInfo()
 	uuid1 := utils.MustNewUUID().String()
-	_, err := s.externalControllers.Save(controllerInfo, uuid1)
+	err := s.externalControllers.Save(controllerInfo, uuid1)
 	c.Assert(err, jc.ErrorIsNil)
 	uuid2 := utils.MustNewUUID().String()
-	_, err = s.externalControllers.Save(controllerInfo, uuid2)
+	err = s.externalControllers.Save(controllerInfo, uuid2)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertSavedControllerInfo(c, controllerInfo, uuid1, uuid2)
 }
 
-func (s *externalControllerSuite) TestSaveAndMoveModels(c *gc.C) {
+func (s *externalControllerSuite) TestSaveMovesModels(c *gc.C) {
 	// Add a new controller associated with 2 models.
 	oldController := defaultControllerInfo()
 	uuid1 := utils.MustNewUUID().String()
 	uuid2 := utils.MustNewUUID().String()
-	_, err := s.externalControllers.Save(oldController, uuid1, uuid2)
+	err := s.externalControllers.Save(oldController, uuid1, uuid2)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertSavedControllerInfo(c, oldController, uuid1, uuid2)
 
@@ -103,7 +109,7 @@ func (s *externalControllerSuite) TestSaveAndMoveModels(c *gc.C) {
 	}
 
 	uuid3 := utils.MustNewUUID().String()
-	err = s.externalControllers.SaveAndMoveModels(newController, uuid2, uuid3)
+	err = s.externalControllers.Save(newController, uuid2, uuid3)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// New controller is created and associated with models.
@@ -111,24 +117,29 @@ func (s *externalControllerSuite) TestSaveAndMoveModels(c *gc.C) {
 
 	// Old controller is no longer associated with the 2nd model UUID.
 	s.assertSavedControllerInfo(c, oldController, uuid1)
+
+	// The moved model is only associated with the new controller.
+	found, err := s.externalControllers.ControllerForModel(uuid2)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(found.Id(), gc.Equals, newController.ControllerTag.Id())
 }
 
 func (s *externalControllerSuite) TestControllerForModel(c *gc.C) {
 	controllerInfo := defaultControllerInfo()
 	uuid1 := utils.MustNewUUID().String()
 	uuid2 := utils.MustNewUUID().String()
-	ec, err := s.externalControllers.Save(controllerInfo, uuid1, uuid2)
+	err := s.externalControllers.Save(controllerInfo, uuid1, uuid2)
 	c.Assert(err, jc.ErrorIsNil)
 	found, err := s.externalControllers.ControllerForModel(uuid1)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(ec, jc.DeepEquals, found)
+	c.Assert(found.Id(), gc.Equals, controllerInfo.ControllerTag.Id())
 	_, err = s.externalControllers.ControllerForModel("1234")
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 }
 
 func (s *externalControllerSuite) TestController(c *gc.C) {
 	controllerInfo := defaultControllerInfo()
-	_, err := s.externalControllers.Save(controllerInfo)
+	err := s.externalControllers.Save(controllerInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	ec, err := s.externalControllers.Controller(testing.ControllerTag.Id())
@@ -152,7 +163,7 @@ func (s *externalControllerSuite) TestWatchController(c *gc.C) {
 		Addrs:         []string{"192.168.1.0:1234"},
 		CACert:        testing.CACert,
 	}
-	_, err := s.externalControllers.Save(controllerInfo)
+	err := s.externalControllers.Save(controllerInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	w := s.externalControllers.WatchController(testing.ControllerTag.Id())
@@ -164,14 +175,14 @@ func (s *externalControllerSuite) TestWatchController(c *gc.C) {
 
 	// Update the alias, check for one change.
 	controllerInfo.Alias = "alias2"
-	_, err = s.externalControllers.Save(controllerInfo)
+	err = s.externalControllers.Save(controllerInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 
 	// Update the alias and addresses, check for one change.
 	controllerInfo.Alias = "alias3"
 	controllerInfo.Addrs = []string{"192.168.1.1:1234"}
-	_, err = s.externalControllers.Save(controllerInfo)
+	err = s.externalControllers.Save(controllerInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertOneChange()
 }
@@ -183,7 +194,7 @@ func (s *externalControllerSuite) TestWatch(c *gc.C) {
 		Addrs:         []string{"192.168.1.0:1234"},
 		CACert:        testing.CACert,
 	}
-	_, err := s.externalControllers.Save(controllerInfo)
+	err := s.externalControllers.Save(controllerInfo)
 	c.Assert(err, jc.ErrorIsNil)
 
 	w := s.externalControllers.Watch()
@@ -197,7 +208,7 @@ func (s *externalControllerSuite) TestWatch(c *gc.C) {
 	// Update the controller, expect no change. We only get
 	// updated on addition and removal.
 	controllerInfo.Alias = "alias2"
-	_, err = s.externalControllers.Save(controllerInfo)
+	err = s.externalControllers.Save(controllerInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 
@@ -214,7 +225,7 @@ func (s *externalControllerSuite) TestWatch(c *gc.C) {
 	wc.AssertNoChange()
 
 	// Add the controller again, and we should see a change.
-	_, err = s.externalControllers.Save(controllerInfo)
+	err = s.externalControllers.Save(controllerInfo)
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertChange(testing.ControllerTag.Id())
 	wc.AssertNoChange()

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -1162,13 +1162,16 @@ func (s *MigrationExportSuite) TestExternalControllers(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
+	controllerUUID := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
 	service := state.NewExternalControllers(s.State)
-	stCtrl, err := service.Save(crossmodel.ControllerInfo{
+	err = service.Save(crossmodel.ControllerInfo{
 		Addrs:         []string{"10.224.0.1:8080"},
 		Alias:         "magic",
 		CACert:        "magic-ca-cert",
-		ControllerTag: names.NewControllerTag("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+		ControllerTag: names.NewControllerTag(controllerUUID),
 	}, s.Model.UUID(), "af5a9137-934c-4b0c-8317-643b69cf4971")
+	c.Assert(err, jc.ErrorIsNil)
+	stCtrl, err := service.Controller(controllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// We only care for the external controllers
@@ -2802,7 +2805,7 @@ func (s *MigrationExportSuite) TestRemoteApplications(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	service := state.NewExternalControllers(s.State)
-	_, err = service.Save(crossmodel.ControllerInfo{
+	err = service.Save(crossmodel.ControllerInfo{
 		Addrs:         []string{"10.224.0.1:8080"},
 		Alias:         "magic",
 		CACert:        "magic-ca-cert",

--- a/state/migration_import_tasks.go
+++ b/state/migration_import_tasks.go
@@ -431,8 +431,12 @@ func (im *ImportRemoteEntities) Execute(src RemoteEntitiesInput, runner Transact
 	return nil
 }
 
-// maybeConvertApplicationOffer returns the offer uuid if an offer or
-// application name is passed in.
+// maybeConvertApplicationOffer returns the offer uuid if an offer name,
+// application name, or offer UUID is passed in.
+// The id suffix of an "application-offer" entity tag holds either:
+//   - the offer UUID
+//   - an offer name
+//   - the name of the offered application
 func (im *ImportRemoteEntities) maybeConvertApplicationOffer(
 	src RemoteEntitiesInput,
 	id string,
@@ -440,12 +444,22 @@ func (im *ImportRemoteEntities) maybeConvertApplicationOffer(
 	if !strings.HasPrefix(id, names.ApplicationOfferTagKind+"-") {
 		return id, false, nil
 	}
-	name := strings.TrimPrefix(id, names.ApplicationOfferTagKind+"-")
-	if uuid, ok := src.OfferUUID(name); ok {
+	// First check - maybe the tag string is already for an offer UUID.
+	maybeOfferUUID := strings.TrimPrefix(id, names.ApplicationOfferTagKind+"-")
+	if names.IsValidApplicationOffer(maybeOfferUUID) {
+		return id, true, nil
+	}
+	// Second see if we have an offer name.
+	maybeOfferName := maybeOfferUUID
+	if uuid, ok := src.OfferUUID(maybeOfferName); ok {
 		return names.NewApplicationOfferTag(uuid).String(), true, nil
 	}
-	uuid, err := src.OfferUUIDForApp(name)
+	// Last check if we have the offered app name.
+	maybeAppName := maybeOfferName
+	uuid, err := src.OfferUUIDForApp(maybeAppName)
 	if errors.Is(err, errors.NotFound) {
+		// The suffix is not a valid offer UUID, an offer name, or the name of
+		// an offered application, so it cannot be mapped to an offer.
 		return id, false, errors.Trace(err)
 	}
 	if err != nil {

--- a/state/migration_import_tasks_test.go
+++ b/state/migration_import_tasks_test.go
@@ -471,6 +471,33 @@ func (s *MigrationImportTasksSuite) TestImportRemoteEntitiesApplicationOfferNoMa
 	c.Assert(err, gc.ErrorMatches, `offer for app "missing" not found`)
 }
 
+func (s *MigrationImportTasksSuite) TestImportRemoteEntitiesOfferUUID(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	offerUUID := utils.MustNewUUID().String()
+	entity := s.remoteEntity(ctrl, "applicationoffer-"+offerUUID, "xxx-yyy-ccc")
+
+	model := NewMockRemoteEntitiesInput(ctrl)
+	model.EXPECT().RemoteEntities().Return([]description.RemoteEntity{entity})
+	model.EXPECT().DocID("applicationoffer-" + offerUUID).Return("doc-offer-uuid")
+
+	runner := NewMockTransactionRunner(ctrl)
+	runner.EXPECT().RunTransaction([]txn.Op{{
+		C:      remoteEntitiesC,
+		Id:     "doc-offer-uuid",
+		Assert: txn.DocMissing,
+		Insert: &remoteEntityDoc{
+			DocID: "doc-offer-uuid",
+			Token: "xxx-yyy-ccc",
+		},
+	}}).Return(nil)
+
+	m := ImportRemoteEntities{}
+	err := m.Execute(model, runner)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *MigrationImportTasksSuite) TestImportRemoteEntitiesWithNoEntities(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -1129,7 +1129,7 @@ func (s *MigrationImportSuite) TestExternalControllers(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	stateExternalCtrl := state.NewExternalControllers(s.State)
-	crossModelController, err := stateExternalCtrl.Save(crossmodel.ControllerInfo{
+	err = stateExternalCtrl.Save(crossmodel.ControllerInfo{
 		ControllerTag: s.Model.ControllerTag(),
 		Addrs:         []string{"192.168.1.1:8080"},
 		Alias:         "magic",
@@ -1150,7 +1150,7 @@ func (s *MigrationImportSuite) TestExternalControllers(c *gc.C) {
 
 	newCtrl, err := newExternalCtrl.ControllerForModel(s.Model.UUID())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newCtrl.ControllerInfo(), jc.DeepEquals, crossModelController.ControllerInfo())
+	c.Assert(newCtrl.ControllerInfo(), jc.DeepEquals, stateExternalController.ControllerInfo())
 
 	newExternalController, err := newSt.ExternalControllerForModel(s.Model.UUID())
 	c.Assert(err, jc.ErrorIsNil)
@@ -2788,7 +2788,7 @@ func (s *MigrationImportSuite) TestRemoteApplications(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	service := state.NewExternalControllers(s.State)
-	_, err = service.Save(crossmodel.ControllerInfo{
+	err = service.Save(crossmodel.ControllerInfo{
 		ControllerTag: s.Model.ControllerTag(),
 		Addrs:         []string{"192.168.1.1:8080"},
 		Alias:         "magic",
@@ -2867,7 +2867,7 @@ func (s *MigrationImportSuite) TestRemoteApplicationsConsumerProxy(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	service := state.NewExternalControllers(s.State)
-	_, err = service.Save(crossmodel.ControllerInfo{
+	err = service.Save(crossmodel.ControllerInfo{
 		ControllerTag: s.Model.ControllerTag(),
 		Addrs:         []string{"192.168.1.1:8080"},
 		Alias:         "magic",

--- a/state/remoteapplication_test.go
+++ b/state/remoteapplication_test.go
@@ -799,7 +799,7 @@ func (s *remoteApplicationSuite) TestDestroySimple(c *gc.C) {
 
 func (s *remoteApplicationSuite) TestDestroyRemovesExternalController(c *gc.C) {
 	ec := state.NewExternalControllers(s.State)
-	_, err := ec.Save(crossmodel.ControllerInfo{
+	err := ec.Save(crossmodel.ControllerInfo{
 		ControllerTag: names.NewControllerTag(s.externalControllerUUID),
 		Addrs:         []string{"10.0.0.1:17070"},
 	})
@@ -822,7 +822,7 @@ func (s *remoteApplicationSuite) TestDestroyDoesNotRemoveExternalController(c *g
 	c.Assert(rc, gc.Equals, 2)
 
 	ec := state.NewExternalControllers(s.State)
-	_, err = ec.Save(crossmodel.ControllerInfo{
+	err = ec.Save(crossmodel.ControllerInfo{
 		ControllerTag: names.NewControllerTag(s.externalControllerUUID),
 		Addrs:         []string{"10.0.0.1:17070"},
 	})

--- a/tests/suites/cmr/offer_consume_migrate.sh
+++ b/tests/suites/cmr/offer_consume_migrate.sh
@@ -1,0 +1,142 @@
+# A scenario to test external controller record updates:
+#  1. A consumer model consumes two offers hosted by an offering controller.
+#     The consumer's record of the offering controller has both
+#     offered model UUIDs associated with it.
+#  2. The consumer removes the saas for the first offer. The external
+#     controller record on the consumer is retained (the second offer is
+#     still consumed) and still lists the migrated model's UUID.
+#  3. The offering model is migrated to a third controller.
+#  4. The consumer consumes the offer again, this time from the new
+#     controller, and relates to it.
+run_offer_consume_migrate() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# The following ensures that a bootstrap juju exists.
+	file="${TEST_DIR}/test-offer-consume-migrate.log"
+	ensure "model-offer-migrate" "${file}"
+
+	echo "Bootstrap consumer and migration target controllers"
+	bootstrap_alt_controller "cmr-consume"
+	bootstrap_alt_controller "cmr-migrate"
+
+	echo "Deploy two offered applications on the offering controller"
+	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+	add_model "model-offer-1"
+	juju deploy juju-qa-dummy-source --series jammy
+	juju offer dummy-source:sink offer-one
+	wait_for "dummy-source" "$(idle_condition "dummy-source")"
+
+	add_model "model-offer-2"
+	juju deploy juju-qa-dummy-source --series jammy
+	juju offer dummy-source:sink offer-two
+	wait_for "dummy-source" "$(idle_condition "dummy-source")"
+
+	echo "Deploy workload in the consumer model and consume both offers"
+	juju switch "cmr-consume"
+	add_model "model-consume"
+	juju deploy juju-qa-dummy-sink --series jammy
+
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink")"
+
+	juju consume "${BOOTSTRAPPED_JUJU_CTRL_NAME}:admin/model-offer-1.offer-one"
+	juju relate dummy-sink offer-one
+	# Wait for relation joined before migrating.
+	wait_for "offer-one" '.applications["dummy-sink"] | .relations.source[0]'
+
+	# Keep the offering controller's external controller record on the
+	# consumer alive. The external controller record also holds the
+	# model-offer-1 model UUID until it is explicitly moved.
+	juju consume "${BOOTSTRAPPED_JUJU_CTRL_NAME}:admin/model-offer-2.offer-two"
+
+	echo "Remove the offer-one saas, then migrate its offering model"
+	juju remove-relation dummy-sink offer-one
+	juju remove-saas offer-one
+	# The offer-two saas is retained, so the offering controller record persists.
+	wait_for null '.applications["dummy-sink"] | .relations'
+	wait_for null '.["application-endpoints"]["offer-one"]'
+
+	# The cross-model relation must be fully torn down on the offering side as
+	# well, otherwise migration prechecks fail with a unit "hasn't joined
+	# relation" error (see the workaround in model/migration.sh).
+	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}:model-offer-1"
+	wait_for null '.relations'
+	wait_for null '.offers["offer-one"]."total-connected-count"'
+
+	# The offering model is migrated to a new controller. The consumer has no
+	# saas for offer-one any more, so nothing updates its external controller info
+	# via a migration redirect.
+	echo "Migrate the offering model to the new controller"
+	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+	if ! migrate_out=$(juju migrate "model-offer-1" "cmr-migrate" 2>&1); then
+		echo "$(red 'migrate failed')"
+		echo "${migrate_out}" | sed 's/^/    | /'
+		exit 1
+	fi
+
+	# Wait for the model to appear on the target controller.
+	echo "Wait for the model to appear on the target controller"
+	attempt=0
+	until [ "$(juju models --controller cmr-migrate --format=json 2>/dev/null | yq -r '.models[] | .["short-name"]' | grep -E '^model-offer-1$')" ]; do
+		echo "[+] (attempt ${attempt}) waiting for migration of model-offer-1 to cmr-migrate"
+		juju models --controller cmr-migrate 2>/dev/null | sed 's/^/    | /'
+		sleep 5
+		attempt=$((attempt + 1))
+		if [ "${attempt}" -ge 120 ]; then
+			echo "$(red 'timed out waiting for model-offer-1 to migrate to cmr-migrate')"
+			exit 1
+		fi
+	done
+
+	echo "Re-consume the offer from the new controller"
+	juju switch "cmr-consume:model-consume"
+	juju consume "cmr-migrate:admin/model-offer-1.offer-one"
+	juju relate dummy-sink offer-one
+	wait_for "offer-one" '.applications["dummy-sink"] | .relations.source[0]'
+
+	echo "Verify data still flows through the re-created saas"
+	# Change the dummy-source config for "token" and check that the change
+	# is represented in the consuming model's dummy-sink unit.
+	juju switch "cmr-migrate:model-offer-1"
+	juju config dummy-source token=yeah-boi
+	juju switch "cmr-consume:model-consume"
+	wait_for "yeah-boi" "$(workload_status "dummy-sink" 0).message"
+
+	echo "Clean up"
+	# Offers must be removed before controller destruction will work.
+	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
+	juju switch "cmr-consume:model-consume"
+	juju remove-relation dummy-sink offer-one
+	juju remove-saas offer-one
+	juju remove-saas offer-two
+
+	juju switch "cmr-migrate:model-offer-1"
+	wait_for null '.offers["offer-one"]."total-connected-count"'
+	juju remove-offer "cmr-migrate:admin/model-offer-1.offer-one" --force -y
+
+	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}:model-offer-2"
+	wait_for null '.offers["offer-two"]."total-connected-count"'
+	juju remove-offer "${BOOTSTRAPPED_JUJU_CTRL_NAME}:admin/model-offer-2.offer-two" --force -y
+
+	destroy_controller "cmr-consume"
+	destroy_controller "cmr-migrate"
+
+	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+	destroy_model "model-offer-1"
+	destroy_model "model-offer-2"
+}
+
+test_offer_consume_migrate() {
+	if [ "$(skip 'test_offer_consume_migrate')" ]; then
+		echo "==> TEST SKIPPED: offer consume migrate"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_offer_consume_migrate"
+	)
+}

--- a/tests/suites/cmr/task.sh
+++ b/tests/suites/cmr/task.sh
@@ -12,13 +12,14 @@ test_cmr() {
 	# Only bootstrap the shared controller when at least one test that uses it
 	# will run. This avoids an unnecessary bootstrap/destroy cycle when only
 	# test_offer_find_external_user is selected (it manages its own controller).
-	if [ -z "$(skip 'test_offer_consume' 'test_offer_find_non_admin')" ]; then
+	if [ -z "$(skip 'test_offer_consume' 'test_offer_find_non_admin' 'test_offer_consume_migrate')" ]; then
 		file="${TEST_DIR}/test-cmr.log"
 
 		bootstrap "test-cmr" "${file}"
 
 		test_offer_consume
 		test_offer_find_non_admin
+		test_offer_consume_migrate
 
 		destroy_controller "test-cmr"
 	fi


### PR DESCRIPTION
Includes a fix for a regression introduced in https://github.com/juju/juju/pull/22999

When an offer from a model is consumed after that model has migrated to a new controller, Save() previously only added the model UUID to the new controller's record without removing it from the record of the controller that used to host it. The model ended up associated with two external controllers and lookups failed with:
 "expected 1 controller with model <uuid>, got 2".

Now, there was a method added `SaveAndMoveModels()` which did the right thing but not all call sites to the buggy `Save()` we updated. So this PR simply removes `Save()` and renames `SaveAndMoveModels()`.

The regression: maybeConvertApplicationOffer() now fast-paths "application-offer-<offerUUID>" tags and imports them unchanged, while still resolving offer-name and application-name keyed tags from older exports. Previously such models aborted with "remoteentities: offer for app <uuid> not found", which also broke migration of models with active relations.

The regression is causing "test_model_migration_saas_external" shell test to fail.

Includes drive by jaas smoke test backport from 4.0

## QA steps

See the shell test that is added: `run_offer_consume_migrate`

`./main.sh -v -p lxd cmr`

The above also tests the regression.

## Links

**Issue:** Fixes #23078.

