### PR TITLE
fix(migration): fence v8 import transactions

### DIFF
--- a/domain/access/service/import.go
+++ b/domain/access/service/import.go
@@ -186,8 +186,9 @@ func (s *UserService) ImportLastModelLogins(
 // grouped by offer UUID and written in a single ImportOfferAccess call. Users
 // in inactiveUsers (see [UserService.ImportModelUsers]) are skipped: they have
 // no active target identity to grant live permission state to. It returns the
-// offer UUIDs it processed; the v8 import driver records their cleanup intent
-// before calling this method.
+// offer UUIDs it processed. Callers that must record cleanup intent before
+// these writes should use [OfferUUIDsForImport], which applies the same
+// offer filter.
 //
 // It is called directly by the v8 migration import driver in
 // internal/migration.
@@ -203,8 +204,7 @@ func (s *PermissionService) ImportModelPermissions(
 		return nil, nil
 	}
 
-	offerAccess := make(map[string]map[string]corepermission.Access)
-	var offerUUIDs []string
+	offerAccess, offerUUIDs := collectOfferImportAccess(perms, inactiveUsers)
 
 	for _, p := range perms {
 		if inactiveUsers.Contains(p.SubjectName) {
@@ -228,11 +228,7 @@ func (s *PermissionService) ImportModelPermissions(
 					"granting %q access to %q on model: %w", p.Access, p.SubjectName, err)
 			}
 		case corepermission.Offer:
-			if _, ok := offerAccess[p.GrantOn]; !ok {
-				offerUUIDs = append(offerUUIDs, p.GrantOn)
-				offerAccess[p.GrantOn] = make(map[string]corepermission.Access)
-			}
-			offerAccess[p.GrantOn][p.SubjectName] = corepermission.Access(p.Access)
+			continue
 		default:
 			return nil, errors.Errorf("unknown permission object type %q", p.ObjectType)
 		}
@@ -253,4 +249,38 @@ func (s *PermissionService) ImportModelPermissions(
 	}
 
 	return offerUUIDs, nil
+}
+
+// OfferUUIDsForImport returns the distinct offer UUIDs that
+// [PermissionService.ImportModelPermissions] will write, in first-seen
+// order. Inactive users are skipped. Non-offer object types are ignored so
+// the v8 import driver can record cleanup intent before
+// ImportModelPermissions validates the rest of the envelope.
+func OfferUUIDsForImport(
+	perms []coremodelmigration.ModelPermission, inactiveUsers set.Strings,
+) []string {
+	_, offerUUIDs := collectOfferImportAccess(perms, inactiveUsers)
+	return offerUUIDs
+}
+
+// collectOfferImportAccess groups offer grants the same way
+// ImportModelPermissions writes them: skip inactive users, first-seen
+// offer order, last access wins per subject.
+func collectOfferImportAccess(
+	perms []coremodelmigration.ModelPermission, inactiveUsers set.Strings,
+) (map[string]map[string]corepermission.Access, []string) {
+	offerAccess := make(map[string]map[string]corepermission.Access)
+	var offerUUIDs []string
+	for _, p := range perms {
+		if inactiveUsers.Contains(p.SubjectName) ||
+			corepermission.ObjectType(p.ObjectType) != corepermission.Offer {
+			continue
+		}
+		if _, ok := offerAccess[p.GrantOn]; !ok {
+			offerUUIDs = append(offerUUIDs, p.GrantOn)
+			offerAccess[p.GrantOn] = make(map[string]corepermission.Access)
+		}
+		offerAccess[p.GrantOn][p.SubjectName] = corepermission.Access(p.Access)
+	}
+	return offerAccess, offerUUIDs
 }

--- a/domain/access/service/import.go
+++ b/domain/access/service/import.go
@@ -186,7 +186,8 @@ func (s *UserService) ImportLastModelLogins(
 // grouped by offer UUID and written in a single ImportOfferAccess call. Users
 // in inactiveUsers (see [UserService.ImportModelUsers]) are skipped: they have
 // no active target identity to grant live permission state to. It returns the
-// offer UUIDs granted, for the caller to record against the import claim.
+// offer UUIDs it processed; the v8 import driver records their cleanup intent
+// before calling this method.
 //
 // It is called directly by the v8 migration import driver in
 // internal/migration.

--- a/domain/access/service/import_test.go
+++ b/domain/access/service/import_test.go
@@ -258,6 +258,40 @@ func (s *importServiceSuite) TestImportModelPermissionsEmpty(c *tc.C) {
 	c.Check(offerUUIDs, tc.HasLen, 0)
 }
 
+// TestOfferUUIDsForImport verifies the shared offer filter: inactive
+// users and non-offer object types are skipped, duplicates keep
+// first-seen order.
+func (s *importServiceSuite) TestOfferUUIDsForImport(c *tc.C) {
+	offer1 := uuid.MustNewUUID().String()
+	offer2 := uuid.MustNewUUID().String()
+	got := OfferUUIDsForImport([]coremodelmigration.ModelPermission{{
+		SubjectName: "bob",
+		ObjectType:  string(permission.Offer),
+		GrantOn:     offer1,
+	}, {
+		SubjectName: "bob",
+		ObjectType:  string(permission.Offer),
+		GrantOn:     offer1,
+	}, {
+		SubjectName: "alice",
+		ObjectType:  string(permission.Offer),
+		GrantOn:     offer2,
+	}, {
+		SubjectName: "gone",
+		ObjectType:  string(permission.Offer),
+		GrantOn:     uuid.MustNewUUID().String(),
+	}, {
+		SubjectName: "bob",
+		ObjectType:  string(permission.Model),
+		GrantOn:     "model",
+	}, {
+		SubjectName: "bob",
+		ObjectType:  "invalid",
+		GrantOn:     "x",
+	}}, set.NewStrings("gone"))
+	c.Check(got, tc.DeepEquals, []string{offer1, offer2})
+}
+
 // TestImportLastModelLogins verifies last-login times are set for active users
 // who logged in, and skipped for inactive users or those who never logged in.
 func (s *importServiceSuite) TestImportLastModelLogins(c *tc.C) {

--- a/domain/modelmigration/state/controller/import.go
+++ b/domain/modelmigration/state/controller/import.go
@@ -110,37 +110,19 @@ func (s *State) AssertImporting(ctx context.Context, modelUUID string) error {
 	return nil
 }
 
-// checkImportingState returns nil only while the exact model_migration_import
-// claim is in the importing phase. It runs inside the write-group transaction
-// so the phase check and the write it gates commit atomically.
+// checkImportingState returns nil only while the exact
+// model_migration_import claim is in the importing phase. Companion-table
+// writers keep this check so they stay correct on an unguarded runner;
+// the import coordinator also fences every controller transaction via
+// importTxnRunner using the same query.
 func (s *State) checkImportingState(
 	ctx context.Context, tx *sqlair.TX, modelUUID, claimUUID string,
 ) error {
-	arg := importClaimKey{ModelUUID: modelUUID, ClaimUUID: claimUUID}
-	var row importPhaseRow
-	stmt, err := s.Prepare(`
-SELECT mmipt.type AS &importPhaseRow.phase_type
-FROM   model_migration_import AS mmi
-JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
-WHERE  mmi.model_uuid = $importClaimKey.model_uuid
-AND    mmi.uuid = $importClaimKey.claim_uuid
-`, row, arg)
+	stmt, err := s.Prepare(importPhaseQuery, importPhaseRow{}, importClaimKey{})
 	if err != nil {
 		return errors.Capture(err)
 	}
-
-	err = tx.Query(ctx, stmt, arg).Get(&row)
-	if errors.Is(err, sqlair.ErrNoRows) {
-		return errors.Errorf("model %q: %w", modelUUID, modelmigrationerrors.ErrImportNotFound)
-	} else if err != nil {
-		return errors.Errorf("checking import claim phase for model %q: %w", modelUUID, err)
-	}
-	if modelmigration.ImportPhase(row.PhaseType) != modelmigration.ImportPhaseImporting {
-		return errors.Errorf(
-			"model %q import claim is %q: %w", modelUUID, row.PhaseType,
-			modelmigrationerrors.ErrImportNotImporting)
-	}
-	return nil
+	return assertImportingClaim(ctx, tx, stmt, modelUUID, claimUUID)
 }
 
 // ImportOfferPermissions records the offer UUIDs granted permission during

--- a/domain/modelmigration/state/controller/import.go
+++ b/domain/modelmigration/state/controller/import.go
@@ -111,10 +111,11 @@ func (s *State) AssertImporting(ctx context.Context, modelUUID string) error {
 }
 
 // checkImportingState returns nil only while the exact
-// model_migration_import claim is in the importing phase. Companion-table
-// writers keep this check so they stay correct on an unguarded runner;
-// the import coordinator also fences every controller transaction via
-// importTxnRunner using the same query.
+// model_migration_import claim is in the importing phase. On the guarded
+// forward path the importTxnRunner already asserts the same condition at Txn
+// entry, so this is an intentional double-assertion (belt-and-braces) there;
+// it is the load-bearing assertion for callers that run on an unguarded
+// runner, where it is the only fence.
 func (s *State) checkImportingState(
 	ctx context.Context, tx *sqlair.TX, modelUUID, claimUUID string,
 ) error {

--- a/domain/modelmigration/state/controller/import.go
+++ b/domain/modelmigration/state/controller/import.go
@@ -110,17 +110,20 @@ func (s *State) AssertImporting(ctx context.Context, modelUUID string) error {
 	return nil
 }
 
-// ensureImportingState returns nil only while the model_migration_import claim
-// for modelUUID is in the importing phase, run inside a write-group
-// transaction so the phase check and the write it gates commit atomically.
-func (s *State) ensureImportingState(ctx context.Context, tx *sqlair.TX, modelUUID string) error {
-	arg := modelUUIDArg{ModelUUID: modelUUID}
+// checkImportingState returns nil only while the exact model_migration_import
+// claim is in the importing phase. It runs inside the write-group transaction
+// so the phase check and the write it gates commit atomically.
+func (s *State) checkImportingState(
+	ctx context.Context, tx *sqlair.TX, modelUUID, claimUUID string,
+) error {
+	arg := importClaimKey{ModelUUID: modelUUID, ClaimUUID: claimUUID}
 	var row importPhaseRow
 	stmt, err := s.Prepare(`
 SELECT mmipt.type AS &importPhaseRow.phase_type
 FROM   model_migration_import AS mmi
 JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
-WHERE  mmi.model_uuid = $modelUUIDArg.model_uuid
+WHERE  mmi.model_uuid = $importClaimKey.model_uuid
+AND    mmi.uuid = $importClaimKey.claim_uuid
 `, row, arg)
 	if err != nil {
 		return errors.Capture(err)
@@ -144,9 +147,9 @@ WHERE  mmi.model_uuid = $modelUUIDArg.model_uuid
 // this import claim into model_migration_import_offer, atomically with an
 // importing-phase assertion for modelUUID. AbortImport reads this table to
 // delete the corresponding offer-permission rows without a cross-DB query to
-// the model DB, since the offers themselves live there. The caller is
-// expected to have already written the offer permission rows themselves
-// (owned by the access domain).
+// the model DB, since the offers themselves live there. The caller records
+// this cleanup intent before writing the permission rows owned by the access
+// domain.
 func (s *State) ImportOfferPermissions(
 	ctx context.Context, modelUUID, claimUUID string, offerUUIDs []string,
 ) error {
@@ -168,7 +171,7 @@ VALUES ($importOfferArg.migration_uuid, $importOfferArg.offer_uuid)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		if err := s.ensureImportingState(ctx, tx, modelUUID); err != nil {
+		if err := s.checkImportingState(ctx, tx, modelUUID, claimUUID); err != nil {
 			return errors.Capture(err)
 		}
 		args := make([]importOfferArg, len(offerUUIDs))
@@ -547,7 +550,7 @@ VALUES ($importExternalControllerModelArg.migration_uuid,
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		if err := s.ensureImportingState(ctx, tx, modelUUID); err != nil {
+		if err := s.checkImportingState(ctx, tx, modelUUID, claimUUID); err != nil {
 			return errors.Capture(err)
 		}
 		var mappings []importExternalControllerModelArg

--- a/domain/modelmigration/state/controller/import_guard.go
+++ b/domain/modelmigration/state/controller/import_guard.go
@@ -57,14 +57,12 @@ func NewImportTxnRunnerFactory(
 	}
 }
 
-// importTxnRunner guards SQLair transactions and deliberately rejects
-// standard-library transactions, which cannot share the SQLair assertion.
+// importTxnRunner fences SQLair transactions to an import claim. StdTxn is
+// promoted from the embedded runner and is not fenced, so callers must use Txn.
+// This limitation lasts until the domain runner interface drops StdTxn.
 type importTxnRunner struct {
-	// NOTE: We intentionally embed TxnRunner because we know for sure that only
-	// Txn (and not StdTxn) will be called against this runner.
-	// If StdTxn were called, it would be problematic because it would not share
-	// the SQLair assertion with Txn, but the domain TxnRunner will soon not
-	// include StdTxn.
+	// TxnRunner supplies Dying and, temporarily, StdTxn. The promoted StdTxn
+	// method bypasses the import fence and must not be used with this runner.
 	coredatabase.TxnRunner
 	stmt      *sqlair.Statement
 	modelUUID string

--- a/domain/modelmigration/state/controller/import_guard.go
+++ b/domain/modelmigration/state/controller/import_guard.go
@@ -16,21 +16,25 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
+// importPhaseQuery is the single importing-phase assertion used by both
+// the txn guard and the companion-table write methods.
+const importPhaseQuery = `
+SELECT mmipt.type AS &importPhaseRow.phase_type
+FROM   model_migration_import AS mmi
+JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
+WHERE  mmi.model_uuid = $importClaimKey.model_uuid
+AND    mmi.uuid = $importClaimKey.claim_uuid
+`
+
 // NewImportTxnRunnerFactory returns a transaction runner factory that fences
 // every SQLair transaction to one exact target-side import attempt. The claim
 // assertion and the caller's work execute in the same transaction.
 func NewImportTxnRunnerFactory(
 	factory coredatabase.TxnRunnerFactory, modelUUID, claimUUID string,
 ) coredatabase.TxnRunnerFactory {
-	arg := importClaimKey{ModelUUID: modelUUID, ClaimUUID: claimUUID}
-	row := importPhaseRow{}
-	stmt, prepareErr := sqlair.Prepare(`
-SELECT mmipt.type AS &importPhaseRow.phase_type
-FROM   model_migration_import AS mmi
-JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
-WHERE  mmi.model_uuid = $importClaimKey.model_uuid
-AND    mmi.uuid = $importClaimKey.claim_uuid
-`, row, arg)
+	stmt, prepareErr := sqlair.Prepare(
+		importPhaseQuery, importPhaseRow{}, importClaimKey{},
+	)
 
 	return func(ctx context.Context) (coredatabase.TxnRunner, error) {
 		if prepareErr != nil {
@@ -64,26 +68,10 @@ func (r *importTxnRunner) Txn(
 	ctx context.Context, fn func(context.Context, *sqlair.TX) error,
 ) error {
 	return r.runner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		arg := importClaimKey{ModelUUID: r.modelUUID, ClaimUUID: r.claimUUID}
-		var row importPhaseRow
-		err := tx.Query(ctx, r.stmt, arg).Get(&row)
-		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf(
-				"model %q import claim %q: %w",
-				r.modelUUID, r.claimUUID, modelmigrationerrors.ErrImportNotFound,
-			)
-		} else if err != nil {
-			return errors.Errorf(
-				"checking import claim %q for model %q: %w",
-				r.claimUUID, r.modelUUID, err,
-			)
-		}
-		if modelmigration.ImportPhase(row.PhaseType) != modelmigration.ImportPhaseImporting {
-			return errors.Errorf(
-				"model %q import claim %q is %q: %w",
-				r.modelUUID, r.claimUUID, row.PhaseType,
-				modelmigrationerrors.ErrImportNotImporting,
-			)
+		if err := assertImportingClaim(
+			ctx, tx, r.stmt, r.modelUUID, r.claimUUID,
+		); err != nil {
+			return err
 		}
 		return fn(ctx, tx)
 	})
@@ -100,4 +88,33 @@ func (*importTxnRunner) StdTxn(
 // Dying reports the lifetime of the underlying controller database.
 func (r *importTxnRunner) Dying() <-chan struct{} {
 	return r.runner.Dying()
+}
+
+// assertImportingClaim returns nil only while the exact
+// model_migration_import claim is in the importing phase.
+func assertImportingClaim(
+	ctx context.Context, tx *sqlair.TX, stmt *sqlair.Statement, modelUUID, claimUUID string,
+) error {
+	arg := importClaimKey{ModelUUID: modelUUID, ClaimUUID: claimUUID}
+	var row importPhaseRow
+	err := tx.Query(ctx, stmt, arg).Get(&row)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Errorf(
+			"model %q import claim %q: %w",
+			modelUUID, claimUUID, modelmigrationerrors.ErrImportNotFound,
+		)
+	} else if err != nil {
+		return errors.Errorf(
+			"checking import claim %q for model %q: %w",
+			claimUUID, modelUUID, err,
+		)
+	}
+	if modelmigration.ImportPhase(row.PhaseType) != modelmigration.ImportPhaseImporting {
+		return errors.Errorf(
+			"model %q import claim %q is %q: %w",
+			modelUUID, claimUUID, row.PhaseType,
+			modelmigrationerrors.ErrImportNotImporting,
+		)
+	}
+	return nil
 }

--- a/domain/modelmigration/state/controller/import_guard.go
+++ b/domain/modelmigration/state/controller/import_guard.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/canonical/sqlair"
+
+	coredatabase "github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/domain/modelmigration"
+	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
+	"github.com/juju/juju/internal/errors"
+)
+
+// NewImportTxnRunnerFactory returns a transaction runner factory that fences
+// every SQLair transaction to one exact target-side import attempt. The claim
+// assertion and the caller's work execute in the same transaction.
+func NewImportTxnRunnerFactory(
+	factory coredatabase.TxnRunnerFactory, modelUUID, claimUUID string,
+) coredatabase.TxnRunnerFactory {
+	arg := importClaimKey{ModelUUID: modelUUID, ClaimUUID: claimUUID}
+	row := importPhaseRow{}
+	stmt, prepareErr := sqlair.Prepare(`
+SELECT mmipt.type AS &importPhaseRow.phase_type
+FROM   model_migration_import AS mmi
+JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
+WHERE  mmi.model_uuid = $importClaimKey.model_uuid
+AND    mmi.uuid = $importClaimKey.claim_uuid
+`, row, arg)
+
+	return func(ctx context.Context) (coredatabase.TxnRunner, error) {
+		if prepareErr != nil {
+			return nil, errors.Capture(prepareErr)
+		}
+		runner, err := factory(ctx)
+		if err != nil {
+			return nil, errors.Capture(err)
+		}
+		return &importTxnRunner{
+			runner:    runner,
+			stmt:      stmt,
+			modelUUID: modelUUID,
+			claimUUID: claimUUID,
+		}, nil
+	}
+}
+
+// importTxnRunner guards SQLair transactions and deliberately rejects
+// standard-library transactions, which cannot share the SQLair assertion.
+type importTxnRunner struct {
+	runner    coredatabase.TxnRunner
+	stmt      *sqlair.Statement
+	modelUUID string
+	claimUUID string
+}
+
+// Txn asserts that this exact import attempt is still importing before
+// executing fn in the same transaction.
+func (r *importTxnRunner) Txn(
+	ctx context.Context, fn func(context.Context, *sqlair.TX) error,
+) error {
+	return r.runner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		arg := importClaimKey{ModelUUID: r.modelUUID, ClaimUUID: r.claimUUID}
+		var row importPhaseRow
+		err := tx.Query(ctx, r.stmt, arg).Get(&row)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf(
+				"model %q import claim %q: %w",
+				r.modelUUID, r.claimUUID, modelmigrationerrors.ErrImportNotFound,
+			)
+		} else if err != nil {
+			return errors.Errorf(
+				"checking import claim %q for model %q: %w",
+				r.claimUUID, r.modelUUID, err,
+			)
+		}
+		if modelmigration.ImportPhase(row.PhaseType) != modelmigration.ImportPhaseImporting {
+			return errors.Errorf(
+				"model %q import claim %q is %q: %w",
+				r.modelUUID, r.claimUUID, row.PhaseType,
+				modelmigrationerrors.ErrImportNotImporting,
+			)
+		}
+		return fn(ctx, tx)
+	})
+}
+
+// StdTxn always fails closed because its callback cannot share the SQLair
+// transaction used by the import assertion.
+func (*importTxnRunner) StdTxn(
+	context.Context, func(context.Context, *sql.Tx) error,
+) error {
+	return errors.Errorf("standard transaction for guarded import: %w", coreerrors.NotSupported)
+}
+
+// Dying reports the lifetime of the underlying controller database.
+func (r *importTxnRunner) Dying() <-chan struct{} {
+	return r.runner.Dying()
+}

--- a/domain/modelmigration/state/controller/import_guard.go
+++ b/domain/modelmigration/state/controller/import_guard.go
@@ -5,12 +5,10 @@ package controller
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/canonical/sqlair"
 
 	coredatabase "github.com/juju/juju/core/database"
-	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/domain/modelmigration"
 	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
 	"github.com/juju/juju/internal/errors"
@@ -29,23 +27,29 @@ AND    mmi.uuid = $importClaimKey.claim_uuid
 // NewImportTxnRunnerFactory returns a transaction runner factory that fences
 // every SQLair transaction to one exact target-side import attempt. The claim
 // assertion and the caller's work execute in the same transaction.
+//
+// The phase-assertion statement is prepared eagerly here rather than per
+// transaction. The query is a static constant, so a prepare failure is
+// permanent (replayed from every factory call) and signals a schema mismatch
+// that would defeat every guarded transaction; surfacing it on the first
+// factory use is deliberate rather than a delay.
 func NewImportTxnRunnerFactory(
 	factory coredatabase.TxnRunnerFactory, modelUUID, claimUUID string,
 ) coredatabase.TxnRunnerFactory {
-	stmt, prepareErr := sqlair.Prepare(
-		importPhaseQuery, importPhaseRow{}, importClaimKey{},
-	)
-
 	return func(ctx context.Context) (coredatabase.TxnRunner, error) {
-		if prepareErr != nil {
-			return nil, errors.Capture(prepareErr)
+		stmt, err := sqlair.Prepare(
+			importPhaseQuery, importPhaseRow{}, importClaimKey{},
+		)
+		if err != nil {
+			return nil, errors.Capture(err)
 		}
+
 		runner, err := factory(ctx)
 		if err != nil {
 			return nil, errors.Capture(err)
 		}
 		return &importTxnRunner{
-			runner:    runner,
+			TxnRunner: runner,
 			stmt:      stmt,
 			modelUUID: modelUUID,
 			claimUUID: claimUUID,
@@ -56,7 +60,12 @@ func NewImportTxnRunnerFactory(
 // importTxnRunner guards SQLair transactions and deliberately rejects
 // standard-library transactions, which cannot share the SQLair assertion.
 type importTxnRunner struct {
-	runner    coredatabase.TxnRunner
+	// NOTE: We intentionally embed TxnRunner because we know for sure that only
+	// Txn (and not StdTxn) will be called against this runner.
+	// If StdTxn were called, it would be problematic because it would not share
+	// the SQLair assertion with Txn, but the domain TxnRunner will soon not
+	// include StdTxn.
+	coredatabase.TxnRunner
 	stmt      *sqlair.Statement
 	modelUUID string
 	claimUUID string
@@ -67,7 +76,7 @@ type importTxnRunner struct {
 func (r *importTxnRunner) Txn(
 	ctx context.Context, fn func(context.Context, *sqlair.TX) error,
 ) error {
-	return r.runner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+	return r.TxnRunner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := assertImportingClaim(
 			ctx, tx, r.stmt, r.modelUUID, r.claimUUID,
 		); err != nil {
@@ -75,19 +84,6 @@ func (r *importTxnRunner) Txn(
 		}
 		return fn(ctx, tx)
 	})
-}
-
-// StdTxn always fails closed because its callback cannot share the SQLair
-// transaction used by the import assertion.
-func (*importTxnRunner) StdTxn(
-	context.Context, func(context.Context, *sql.Tx) error,
-) error {
-	return errors.Errorf("standard transaction for guarded import: %w", coreerrors.NotSupported)
-}
-
-// Dying reports the lifetime of the underlying controller database.
-func (r *importTxnRunner) Dying() <-chan struct{} {
-	return r.runner.Dying()
 }
 
 // assertImportingClaim returns nil only while the exact

--- a/domain/modelmigration/state/controller/import_guard.go
+++ b/domain/modelmigration/state/controller/import_guard.go
@@ -36,12 +36,12 @@ AND    mmi.uuid = $importClaimKey.claim_uuid
 func NewImportTxnRunnerFactory(
 	factory coredatabase.TxnRunnerFactory, modelUUID, claimUUID string,
 ) coredatabase.TxnRunnerFactory {
+	stmt, prepareErr := sqlair.Prepare(
+		importPhaseQuery, importPhaseRow{}, importClaimKey{},
+	)
 	return func(ctx context.Context) (coredatabase.TxnRunner, error) {
-		stmt, err := sqlair.Prepare(
-			importPhaseQuery, importPhaseRow{}, importClaimKey{},
-		)
-		if err != nil {
-			return nil, errors.Capture(err)
+		if prepareErr != nil {
+			return nil, errors.Capture(prepareErr)
 		}
 
 		runner, err := factory(ctx)

--- a/domain/modelmigration/state/controller/import_guard_test.go
+++ b/domain/modelmigration/state/controller/import_guard_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/clock"
+	"github.com/juju/tc"
+
+	coreerrors "github.com/juju/juju/core/errors"
+	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
+	"github.com/juju/juju/internal/uuid"
+)
+
+func (s *stateSuite) TestImportTxnRunnerFactory(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+	claimUUID := uuid.MustNewUUID().String()
+	_, err := st.BeginImport(
+		c.Context(), s.modelUUID.String(), claimUUID, uuid.MustNewUUID().String(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	factory := NewImportTxnRunnerFactory(
+		s.TxnRunnerFactory(), s.modelUUID.String(), claimUUID,
+	)
+	runner, err := factory(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	called := false
+	err = runner.Txn(c.Context(), func(context.Context, *sqlair.TX) error {
+		called = true
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(called, tc.IsTrue)
+	c.Check(runner.Dying(), tc.NotNil)
+
+	err = runner.StdTxn(c.Context(), func(context.Context, *sql.Tx) error {
+		c.Fatalf("standard transaction callback must not be called")
+		return nil
+	})
+	c.Check(err, tc.ErrorIs, coreerrors.NotSupported)
+}
+
+func (s *stateSuite) TestImportTxnRunnerFactoryRejectsWrongAttempt(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+	claimUUID := uuid.MustNewUUID().String()
+	_, err := st.BeginImport(
+		c.Context(), s.modelUUID.String(), claimUUID, uuid.MustNewUUID().String(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	for _, test := range []struct {
+		name      string
+		modelUUID string
+		claimUUID string
+	}{
+		{name: "wrong model", modelUUID: uuid.MustNewUUID().String(), claimUUID: claimUUID},
+		{name: "wrong claim", modelUUID: s.modelUUID.String(), claimUUID: uuid.MustNewUUID().String()},
+	} {
+		c.Logf("case %q", test.name)
+		factory := NewImportTxnRunnerFactory(
+			s.TxnRunnerFactory(), test.modelUUID, test.claimUUID,
+		)
+		runner, err := factory(c.Context())
+		c.Assert(err, tc.ErrorIsNil)
+
+		called := false
+		err = runner.Txn(c.Context(), func(context.Context, *sqlair.TX) error {
+			called = true
+			return nil
+		})
+		c.Check(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotFound)
+		c.Check(called, tc.IsFalse)
+	}
+}
+
+func (s *stateSuite) TestImportTxnRunnerFactoryRejectsAborting(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+	claimUUID := uuid.MustNewUUID().String()
+	_, err := st.BeginImport(
+		c.Context(), s.modelUUID.String(), claimUUID, uuid.MustNewUUID().String(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	factory := NewImportTxnRunnerFactory(
+		s.TxnRunnerFactory(), s.modelUUID.String(), claimUUID,
+	)
+	runner, err := factory(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.DB().ExecContext(c.Context(), `
+UPDATE model_migration_import SET phase_type_id = 2 WHERE uuid = ?`, claimUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	called := false
+	err = runner.Txn(c.Context(), func(context.Context, *sqlair.TX) error {
+		called = true
+		return nil
+	})
+	c.Check(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotImporting)
+	c.Check(called, tc.IsFalse)
+}
+
+func (s *stateSuite) TestImportTxnRunnerFactoryRacesAbort(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+	claimUUID := uuid.MustNewUUID().String()
+	_, err := st.BeginImport(
+		c.Context(), s.modelUUID.String(), claimUUID, uuid.MustNewUUID().String(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.DB().ExecContext(c.Context(), `
+CREATE TABLE import_guard_probe (value TEXT NOT NULL)`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	type probe struct {
+		Value string `db:"value"`
+	}
+	insertStmt, err := sqlair.Prepare(`
+INSERT INTO import_guard_probe (value) VALUES ($probe.value)`, probe{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	factory := NewImportTxnRunnerFactory(
+		s.TxnRunnerFactory(), s.modelUUID.String(), claimUUID,
+	)
+	runner, err := factory(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	start := make(chan struct{})
+	writeResult := make(chan error, 1)
+	phaseResult := make(chan error, 1)
+	go func() {
+		<-start
+		writeResult <- runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+			return tx.Query(ctx, insertStmt, probe{Value: "committed"}).Run()
+		})
+	}()
+	go func() {
+		<-start
+		_, err := s.DB().ExecContext(c.Context(), `
+UPDATE model_migration_import SET phase_type_id = 2 WHERE uuid = ?`, claimUUID)
+		phaseResult <- err
+	}()
+	close(start)
+
+	writeErr := <-writeResult
+	phaseErr := <-phaseResult
+	c.Assert(phaseErr, tc.ErrorIsNil)
+
+	var count int
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM import_guard_probe").Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	if writeErr == nil {
+		c.Check(count, tc.Equals, 1)
+	} else {
+		c.Check(writeErr, tc.ErrorIs, modelmigrationerrors.ErrImportNotImporting)
+		c.Check(count, tc.Equals, 0)
+	}
+}

--- a/domain/modelmigration/state/controller/import_guard_test.go
+++ b/domain/modelmigration/state/controller/import_guard_test.go
@@ -5,13 +5,11 @@ package controller
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 
-	coreerrors "github.com/juju/juju/core/errors"
 	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
 	modelmigrationinternal "github.com/juju/juju/domain/modelmigration/internal"
 	"github.com/juju/juju/internal/uuid"
@@ -39,12 +37,6 @@ func (s *stateSuite) TestImportTxnRunnerFactory(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(called, tc.IsTrue)
 	c.Check(runner.Dying(), tc.NotNil)
-
-	err = runner.StdTxn(c.Context(), func(context.Context, *sql.Tx) error {
-		c.Fatalf("standard transaction callback must not be called")
-		return nil
-	})
-	c.Check(err, tc.ErrorIs, coreerrors.NotSupported)
 }
 
 func (s *stateSuite) TestImportTxnRunnerFactoryRejectsWrongAttempt(c *tc.C) {

--- a/domain/modelmigration/state/controller/import_guard_test.go
+++ b/domain/modelmigration/state/controller/import_guard_test.go
@@ -13,6 +13,7 @@ import (
 
 	coreerrors "github.com/juju/juju/core/errors"
 	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
+	modelmigrationinternal "github.com/juju/juju/domain/modelmigration/internal"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -106,7 +107,11 @@ UPDATE model_migration_import SET phase_type_id = 2 WHERE uuid = ?`, claimUUID)
 	c.Check(called, tc.IsFalse)
 }
 
-func (s *stateSuite) TestImportTxnRunnerFactoryRacesAbort(c *tc.C) {
+// TestGuardedCompanionWritesRejectAborting drives ImportOfferPermissions
+// and ImportExternalControllers through the import txn guard after the
+// claim has left importing. The guard must reject both writes before
+// any companion row is committed.
+func (s *stateSuite) TestGuardedCompanionWritesRejectAborting(c *tc.C) {
 	st := New(s.TxnRunnerFactory(), clock.WallClock)
 	claimUUID := uuid.MustNewUUID().String()
 	_, err := st.BeginImport(
@@ -115,51 +120,43 @@ func (s *stateSuite) TestImportTxnRunnerFactoryRacesAbort(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	_, err = s.DB().ExecContext(c.Context(), `
-CREATE TABLE import_guard_probe (value TEXT NOT NULL)`)
-	c.Assert(err, tc.ErrorIsNil)
-
-	type probe struct {
-		Value string `db:"value"`
-	}
-	insertStmt, err := sqlair.Prepare(`
-INSERT INTO import_guard_probe (value) VALUES ($probe.value)`, probe{})
-	c.Assert(err, tc.ErrorIsNil)
-
-	factory := NewImportTxnRunnerFactory(
-		s.TxnRunnerFactory(), s.modelUUID.String(), claimUUID,
-	)
-	runner, err := factory(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
-	start := make(chan struct{})
-	writeResult := make(chan error, 1)
-	phaseResult := make(chan error, 1)
-	go func() {
-		<-start
-		writeResult <- runner.Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
-			return tx.Query(ctx, insertStmt, probe{Value: "committed"}).Run()
-		})
-	}()
-	go func() {
-		<-start
-		_, err := s.DB().ExecContext(c.Context(), `
 UPDATE model_migration_import SET phase_type_id = 2 WHERE uuid = ?`, claimUUID)
-		phaseResult <- err
-	}()
-	close(start)
-
-	writeErr := <-writeResult
-	phaseErr := <-phaseResult
-	c.Assert(phaseErr, tc.ErrorIsNil)
-
-	var count int
-	err = s.DB().QueryRowContext(c.Context(),
-		"SELECT COUNT(*) FROM import_guard_probe").Scan(&count)
 	c.Assert(err, tc.ErrorIsNil)
-	if writeErr == nil {
-		c.Check(count, tc.Equals, 1)
-	} else {
-		c.Check(writeErr, tc.ErrorIs, modelmigrationerrors.ErrImportNotImporting)
-		c.Check(count, tc.Equals, 0)
-	}
+
+	guarded := New(
+		NewImportTxnRunnerFactory(
+			s.TxnRunnerFactory(), s.modelUUID.String(), claimUUID,
+		),
+		clock.WallClock,
+	)
+
+	offerUUID := uuid.MustNewUUID().String()
+	err = guarded.ImportOfferPermissions(
+		c.Context(), s.modelUUID.String(), claimUUID, []string{offerUUID},
+	)
+	c.Check(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotImporting)
+
+	var offerCount int
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?",
+		offerUUID).Scan(&offerCount)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(offerCount, tc.Equals, 0)
+
+	ref := externalController(
+		uuid.MustNewUUID().String(), "third-party", "ca-cert",
+		[]string{"10.0.0.5:17070"}, []string{uuid.MustNewUUID().String()},
+	)
+	err = guarded.ImportExternalControllers(
+		c.Context(), s.modelUUID.String(), claimUUID,
+		[]modelmigrationinternal.ExternalController{ref},
+	)
+	c.Check(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotImporting)
+
+	var controllerCount int
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM external_controller WHERE uuid = ?",
+		ref.UUID).Scan(&controllerCount)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(controllerCount, tc.Equals, 0)
 }

--- a/domain/modelmigration/state/controller/import_guard_test.go
+++ b/domain/modelmigration/state/controller/import_guard_test.go
@@ -160,3 +160,53 @@ UPDATE model_migration_import SET phase_type_id = 2 WHERE uuid = ?`, claimUUID)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(controllerCount, tc.Equals, 0)
 }
+
+// TestGuardedCompanionWritesSucceedWhileImporting drives ImportOfferPermissions
+// and ImportExternalControllers through the import txn guard while the claim
+// is still importing. Both writes must commit, so the guard does not reject a
+// legitimate in-phase write.
+func (s *stateSuite) TestGuardedCompanionWritesSucceedWhileImporting(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+	claimUUID := uuid.MustNewUUID().String()
+	_, err := st.BeginImport(
+		c.Context(), s.modelUUID.String(), claimUUID, uuid.MustNewUUID().String(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	guarded := New(
+		NewImportTxnRunnerFactory(
+			s.TxnRunnerFactory(), s.modelUUID.String(), claimUUID,
+		),
+		clock.WallClock,
+	)
+
+	offerUUID := uuid.MustNewUUID().String()
+	err = guarded.ImportOfferPermissions(
+		c.Context(), s.modelUUID.String(), claimUUID, []string{offerUUID},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var offerCount int
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?",
+		offerUUID).Scan(&offerCount)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(offerCount, tc.Equals, 1)
+
+	ref := externalController(
+		uuid.MustNewUUID().String(), "third-party", "ca-cert",
+		[]string{"10.0.0.5:17070"}, []string{uuid.MustNewUUID().String()},
+	)
+	err = guarded.ImportExternalControllers(
+		c.Context(), s.modelUUID.String(), claimUUID,
+		[]modelmigrationinternal.ExternalController{ref},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var controllerCount int
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM external_controller WHERE uuid = ?",
+		ref.UUID).Scan(&controllerCount)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(controllerCount, tc.Equals, 1)
+}

--- a/domain/modelmigration/state/controller/types.go
+++ b/domain/modelmigration/state/controller/types.go
@@ -29,6 +29,7 @@ type importClaimKey struct {
 	ModelUUID string `db:"model_uuid"`
 	ClaimUUID string `db:"claim_uuid"`
 }
+
 // migrationUUIDArg is a query argument holding a migration uuid (the export
 // migration's primary key, referenced as migration_uuid by child tables).
 type migrationUUIDArg struct {

--- a/domain/modelmigration/state/controller/types.go
+++ b/domain/modelmigration/state/controller/types.go
@@ -24,6 +24,11 @@ type modelUUIDArg struct {
 	ModelUUID string `db:"model_uuid"`
 }
 
+// importClaimKey identifies one exact target-side import attempt.
+type importClaimKey struct {
+	ModelUUID string `db:"model_uuid"`
+	ClaimUUID string `db:"claim_uuid"`
+}
 // migrationUUIDArg is a query argument holding a migration uuid (the export
 // migration's primary key, referenced as migration_uuid by child tables).
 type migrationUUIDArg struct {

--- a/internal/migration/import.go
+++ b/internal/migration/import.go
@@ -29,6 +29,7 @@ import (
 	leaseservice "github.com/juju/juju/domain/lease/service"
 	leasestate "github.com/juju/juju/domain/lease/state"
 	domainmodel "github.com/juju/juju/domain/model"
+	modelerrors "github.com/juju/juju/domain/model/errors"
 	modelservice "github.com/juju/juju/domain/model/service"
 	modelmigrationservice "github.com/juju/juju/domain/model/service/migration"
 	modelstatecontroller "github.com/juju/juju/domain/model/state/controller"
@@ -78,8 +79,10 @@ type ImportModelArgs struct {
 // separate concerns handled outside this package.
 //
 // Each step calls the owning domain's service import method directly. The
-// coordinator constructs the controller-scoped domain services once and
-// orchestrates the call order FK-/dependency-safely.
+// coordinator builds one service bundle with the ordinary controller database
+// for the claim and abort operations, and another with a fenced controller
+// database for the forward operations. It orchestrates the call order
+// FK-/dependency-safely.
 //
 // It writes only controller-database state. Any source→target rewrite of the
 // model-DB payload (e.g. secret backend UUIDs) is read back and applied
@@ -164,8 +167,11 @@ func (c *importCoordinator) Import(ctx context.Context) error {
 	return nil
 }
 
-// RemoveOnAbort runs each op's RemoveOnAbort in reverse registration order,
-// collecting all errors. It is idempotent and safe to call more than once.
+// RemoveOnAbort runs each abort op's RemoveOnAbort in reverse registration
+// order, collecting all errors. The begin op is intentionally excluded: its
+// cleanup is a no-op because the import claim remains the durable anchor until
+// the outer AbortImport flow removes it after compensation. This method is
+// idempotent and safe to call more than once.
 func (c *importCoordinator) RemoveOnAbort(ctx context.Context) error {
 	var errs []error
 	for i := len(c.abortOps) - 1; i >= 0; i-- {
@@ -498,10 +504,15 @@ func (op *opImportAuthorizedKeys) Execute(ctx context.Context, st *importState) 
 	return nil
 }
 
-// RemoveOnAbort deletes all authorized keys stored for the model. The keymanager
-// service already treats this as idempotent.
+// RemoveOnAbort deletes all authorized keys stored for the model. A missing
+// model means an earlier cleanup attempt already removed the model and its key
+// associations, so it is an idempotent success.
 func (op *opImportAuthorizedKeys) RemoveOnAbort(ctx context.Context) error {
-	return op.keymanager.DeleteKeysForModel(ctx)
+	err := op.keymanager.DeleteKeysForModel(ctx)
+	if errors.Is(err, modelerrors.NotFound) {
+		return nil
+	}
+	return errors.Capture(err)
 }
 
 // ----
@@ -615,8 +626,10 @@ func (op *opImportCloudImageMetadata) RemoveOnAbort(_ context.Context) error { r
 // ---- services bundle --------------------------------------------------------
 
 // importServices bundles the controller-scoped domain services the v8 import
-// driver orchestrates. They are constructed once at the start of
-// ImportControllerModelInfo and shared across the import steps.
+// driver orchestrates. The coordinator builds two independent instances: one
+// with the ordinary controller database for the claim and abort operations,
+// and one with the import-guarded controller database for forward operations.
+// Each is constructed once and shared across the steps that use it.
 type importServices struct {
 	claim         *migrationclaimservice.Service
 	access        *accessservice.Service

--- a/internal/migration/import.go
+++ b/internal/migration/import.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
 	coremodelmigration "github.com/juju/juju/core/modelmigration"
+	corepermission "github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/semversion"
 	accessservice "github.com/juju/juju/domain/access/service"
 	accessstate "github.com/juju/juju/domain/access/state"
@@ -138,17 +139,25 @@ type importState struct {
 }
 
 // importCoordinator sequences the controller-DB import steps and exposes both
-// an Import (forward) and a RemoveOnAbort (abort) driver.
+// an Import (forward) and a RemoveOnAbort (abort) driver. Forward operations
+// are constructed after the claim exists so every controller transaction can
+// be fenced to that exact import attempt. Abort operations use the ordinary
+// controller database because they run after the phase becomes aborting.
 type importCoordinator struct {
-	ops []controllerImportOp
+	begin      *opBeginImport
+	newGuarded func(claimUUID string) []controllerImportOp
+	abortOps   []controllerImportOp
 }
 
-// Import runs each op's Execute in registration order, threading importState
-// forward. The first error aborts the sequence; the caller is responsible for
-// calling RemoveOnAbort.
+// Import claims the model, then runs each guarded op's Execute in registration
+// order, threading importState forward. The first error aborts the sequence;
+// the caller is responsible for calling RemoveOnAbort.
 func (c *importCoordinator) Import(ctx context.Context) error {
 	var st importState
-	for _, op := range c.ops {
+	if err := c.begin.Execute(ctx, &st); err != nil {
+		return errors.Capture(err)
+	}
+	for _, op := range c.newGuarded(st.claimUUID) {
 		if err := op.Execute(ctx, &st); err != nil {
 			return errors.Capture(err)
 		}
@@ -160,8 +169,8 @@ func (c *importCoordinator) Import(ctx context.Context) error {
 // collecting all errors. It is idempotent and safe to call more than once.
 func (c *importCoordinator) RemoveOnAbort(ctx context.Context) error {
 	var errs []error
-	for i := len(c.ops) - 1; i >= 0; i-- {
-		if err := c.ops[i].RemoveOnAbort(ctx); err != nil {
+	for i := len(c.abortOps) - 1; i >= 0; i-- {
+		if err := c.abortOps[i].RemoveOnAbort(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -177,7 +186,42 @@ func newImportCoordinator(
 	modelUUIDStr := info.ModelInfo.UUID
 	modelUUID := coremodel.UUID(modelUUIDStr)
 
-	svc := newImportServices(deps, modelUUID)
+	rawServices := newImportServices(deps, modelUUID)
+	begin := &opBeginImport{
+		claim:         rawServices.claim,
+		modelUUID:     modelUUID,
+		modelUUIDStr:  modelUUIDStr,
+		sourceMigUUID: sourceMigrationUUID,
+	}
+	abortOps := newControllerImportOps(deps, rawServices, info, view)
+	newGuarded := func(claimUUID string) []controllerImportOp {
+		guardedDeps := deps
+		guardedDeps.ControllerDB = migrationclaimstate.NewImportTxnRunnerFactory(
+			deps.ControllerDB, modelUUIDStr, claimUUID,
+		)
+		return newControllerImportOps(
+			guardedDeps, newImportServices(guardedDeps, modelUUID), info, view,
+		)
+	}
+
+	return &importCoordinator{
+		begin:      begin,
+		newGuarded: newGuarded,
+		abortOps:   abortOps,
+	}
+}
+
+// newControllerImportOps builds the operations after the durable claim step.
+// deps and svc use either the guarded controller database for forward import,
+// or the ordinary controller database for abort cleanup.
+func newControllerImportOps(
+	deps Deps,
+	svc importServices,
+	info coremodelmigration.ControllerModelInfo,
+	view export.ProjectionView,
+) []controllerImportOp {
+	modelUUIDStr := info.ModelInfo.UUID
+	modelUUID := coremodel.UUID(modelUUIDStr)
 
 	var secretBackendName string
 	if info.SecretBackend != nil {
@@ -185,13 +229,7 @@ func newImportCoordinator(
 	}
 	agentStream := agentStreamFromModelConfig(view)
 
-	ops := []controllerImportOp{
-		&opBeginImport{
-			claim:         svc.claim,
-			modelUUID:     modelUUID,
-			modelUUIDStr:  modelUUIDStr,
-			sourceMigUUID: sourceMigrationUUID,
-		},
+	return []controllerImportOp{
 		&opImportUsers{
 			access:       svc.access,
 			modelUUIDStr: modelUUIDStr,
@@ -255,8 +293,6 @@ func newImportCoordinator(
 			metadata:     info.CloudImageMetadata,
 		},
 	}
-
-	return &importCoordinator{ops: ops}
 }
 
 // ---- per-op structs ---------------------------------------------------------
@@ -404,17 +440,39 @@ type opImportPermissions struct {
 func (op *opImportPermissions) Name() string { return "import-permissions" }
 
 func (op *opImportPermissions) Execute(ctx context.Context, st *importState) error {
-	offerUUIDs, err := op.access.ImportModelPermissions(ctx, op.perms, st.inactiveUsers)
-	if err != nil {
-		return errors.Errorf("applying permissions for model %q import: %w", op.modelUUIDStr, err)
-	}
+	offerUUIDs := offerPermissionUUIDs(op.perms, st.inactiveUsers)
 	if err := op.claim.ImportOfferPermissions(
 		ctx, op.modelUUID, st.claimUUID, offerUUIDs,
 	); err != nil {
 		return errors.Errorf(
 			"recording offer permissions for model %q import: %w", op.modelUUIDStr, err)
 	}
+	if _, err := op.access.ImportModelPermissions(ctx, op.perms, st.inactiveUsers); err != nil {
+		return errors.Errorf("applying permissions for model %q import: %w", op.modelUUIDStr, err)
+	}
 	return nil
+}
+
+// offerPermissionUUIDs returns the distinct offer UUIDs for permissions that
+// may be written by ImportModelPermissions. It mirrors that method's inactive
+// user filtering and preserves first-seen order for deterministic inserts.
+func offerPermissionUUIDs(
+	permissions []coremodelmigration.ModelPermission, inactiveUsers set.Strings,
+) []string {
+	seen := make(map[string]struct{})
+	var result []string
+	for _, permission := range permissions {
+		if inactiveUsers.Contains(permission.SubjectName) ||
+			corepermission.ObjectType(permission.ObjectType) != corepermission.Offer {
+			continue
+		}
+		if _, ok := seen[permission.GrantOn]; ok {
+			continue
+		}
+		seen[permission.GrantOn] = struct{}{}
+		result = append(result, permission.GrantOn)
+	}
+	return result
 }
 
 // RemoveOnAbort deletes the model-scoped and offer-scoped permission rows. Offer

--- a/internal/migration/import.go
+++ b/internal/migration/import.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
 	coremodelmigration "github.com/juju/juju/core/modelmigration"
-	corepermission "github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/semversion"
 	accessservice "github.com/juju/juju/domain/access/service"
 	accessstate "github.com/juju/juju/domain/access/state"
@@ -193,6 +192,9 @@ func newImportCoordinator(
 		modelUUIDStr:  modelUUIDStr,
 		sourceMigUUID: sourceMigrationUUID,
 	}
+	// Abort-path services are a separate bundle from the forward path
+	// and must remain stateless: they must not rely on in-memory state
+	// accumulated during Execute.
 	abortOps := newControllerImportOps(deps, rawServices, info, view)
 	newGuarded := func(claimUUID string) []controllerImportOp {
 		guardedDeps := deps
@@ -440,7 +442,7 @@ type opImportPermissions struct {
 func (op *opImportPermissions) Name() string { return "import-permissions" }
 
 func (op *opImportPermissions) Execute(ctx context.Context, st *importState) error {
-	offerUUIDs := offerPermissionUUIDs(op.perms, st.inactiveUsers)
+	offerUUIDs := accessservice.OfferUUIDsForImport(op.perms, st.inactiveUsers)
 	if err := op.claim.ImportOfferPermissions(
 		ctx, op.modelUUID, st.claimUUID, offerUUIDs,
 	); err != nil {
@@ -451,28 +453,6 @@ func (op *opImportPermissions) Execute(ctx context.Context, st *importState) err
 		return errors.Errorf("applying permissions for model %q import: %w", op.modelUUIDStr, err)
 	}
 	return nil
-}
-
-// offerPermissionUUIDs returns the distinct offer UUIDs for permissions that
-// may be written by ImportModelPermissions. It mirrors that method's inactive
-// user filtering and preserves first-seen order for deterministic inserts.
-func offerPermissionUUIDs(
-	permissions []coremodelmigration.ModelPermission, inactiveUsers set.Strings,
-) []string {
-	seen := make(map[string]struct{})
-	var result []string
-	for _, permission := range permissions {
-		if inactiveUsers.Contains(permission.SubjectName) ||
-			corepermission.ObjectType(permission.ObjectType) != corepermission.Offer {
-			continue
-		}
-		if _, ok := seen[permission.GrantOn]; ok {
-			continue
-		}
-		seen[permission.GrantOn] = struct{}{}
-		result = append(result, permission.GrantOn)
-	}
-	return result
 }
 
 // RemoveOnAbort deletes the model-scoped and offer-scoped permission rows. Offer

--- a/internal/migration/import.go
+++ b/internal/migration/import.go
@@ -441,6 +441,15 @@ type opImportPermissions struct {
 
 func (op *opImportPermissions) Name() string { return "import-permissions" }
 
+// Execute records the offer-permission cleanup intent and then applies the
+// permission grants. Both writes target the controller database, not the
+// model database: op.access is built with deps.ControllerDB, so on the
+// guarded forward path that is the import-guarded runner and
+// ImportModelPermissions' db.Txn asserts the importing phase in the same
+// transaction. The permission write is therefore fenced exactly like the
+// intent write: if the phase flips to aborting between the two, the
+// permission write is rejected and never commits, so abort cannot be left
+// with permission rows to clean up.
 func (op *opImportPermissions) Execute(ctx context.Context, st *importState) error {
 	offerUUIDs := accessservice.OfferUUIDsForImport(op.perms, st.inactiveUsers)
 	if err := op.claim.ImportOfferPermissions(

--- a/internal/migration/import_test.go
+++ b/internal/migration/import_test.go
@@ -293,14 +293,128 @@ func (s *controllerImportSuite) TestImportModelDuplicateClaim(c *tc.C) {
 	c.Check(err, tc.ErrorIs, coreerrors.AlreadyExists)
 }
 
+// TestRemoveOnAbortImportCleansSuccessfulImport verifies that abort
+// compensation removes all imported controller data and remains idempotent.
+// The claim and its companion rows remain until the outer abort flow removes
+// the durable claim anchor.
+func (s *controllerImportSuite) TestRemoveOnAbortImportCleansSuccessfulImport(c *tc.C) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	deps, controllerFactory, _ := s.deps(c, modelUUID)
+
+	sourceMigrationUUID := uuid.MustNewUUID().String()
+	offerUUID := uuid.MustNewUUID().String()
+	info := s.baseControllerModelInfo(modelUUID)
+	info.Users = []coremodelmigration.ModelUser{
+		{Name: "bob@external", External: true},
+	}
+	info.Permissions = []coremodelmigration.ModelPermission{
+		{ObjectType: "model", GrantOn: modelUUID.String(), SubjectName: "bob@external", Access: "read"},
+		{ObjectType: "offer", GrantOn: offerUUID, SubjectName: "bob@external", Access: "consume"},
+	}
+	info.AuthorizedKeys = []coremodelmigration.ModelAuthorizedKey{
+		{
+			Username:  "bob@external",
+			PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4GpCvqUUYUJlx6d1kpUO9k/t4VhSYsf0yE0/QTqDzC bob@host",
+		},
+	}
+	info.Leaders = []coremodelmigration.ApplicationLeadership{
+		{Application: "myapp", Leader: "myapp/0"},
+	}
+
+	err := migration.ImportControllerModelInfo(
+		c.Context(), deps, sourceMigrationUUID, info,
+		export.ProjectionView{AgentTargetVersion: jujuversion.Current},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	importedRows := []struct {
+		name  string
+		query string
+		args  []any
+	}{
+		{
+			name:  "permissions",
+			query: "SELECT COUNT(*) FROM permission WHERE grant_on IN (?, ?)",
+			args:  []any{modelUUID.String(), offerUUID},
+		},
+		{
+			name:  "authorized keys",
+			query: "SELECT COUNT(*) FROM model_authorized_keys WHERE model_uuid = ?",
+			args:  []any{modelUUID.String()},
+		},
+		{
+			name:  "leadership leases",
+			query: "SELECT COUNT(*) FROM lease WHERE model_uuid = ?",
+			args:  []any{modelUUID.String()},
+		},
+		{
+			name:  "model",
+			query: "SELECT COUNT(*) FROM model WHERE uuid = ?",
+			args:  []any{modelUUID.String()},
+		},
+	}
+	for _, row := range importedRows {
+		want := 1
+		if row.name == "permissions" {
+			// Bootstrap also grants the model owner admin access.
+			want = 3
+		}
+		c.Check(s.rowCount(c, row.query, row.args...), tc.Equals, want,
+			tc.Commentf("%s before abort", row.name))
+	}
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?",
+		offerUUID), tc.Equals, 1)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?",
+		modelUUID.String()), tc.Equals, 1)
+
+	_, err = s.DB().ExecContext(c.Context(),
+		"UPDATE model_migration_import SET phase_type_id = 2 WHERE model_uuid = ?",
+		modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	args := migration.ImportModelArgs{
+		SourceMigrationUUID: sourceMigrationUUID,
+		ControllerModelInfo: info,
+	}
+	for attempt := 1; attempt <= 2; attempt++ {
+		err = migration.RemoveOnAbortImport(c.Context(), deps, args)
+		c.Assert(err, tc.ErrorIsNil)
+
+		for _, row := range importedRows {
+			c.Check(s.rowCount(c, row.query, row.args...), tc.Equals, 0,
+				tc.Commentf("%s after abort attempt %d", row.name, attempt))
+		}
+		// The outer abort flow owns the durable claim and its companion rows.
+		c.Check(s.rowCount(c,
+			"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?",
+			offerUUID), tc.Equals, 1)
+		c.Check(s.rowCount(c,
+			"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?",
+			modelUUID.String()), tc.Equals, 1)
+	}
+
+	claimState := migrationclaimstate.New(controllerFactory, clock.WallClock)
+	err = claimState.DeleteModelImportingStatus(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?",
+		offerUUID), tc.Equals, 0)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?",
+		modelUUID.String()), tc.Equals, 0)
+}
+
 // TestImportModelRecordsOfferIntentBeforePermissionFailure verifies that offer
 // cleanup metadata is durable before the access domain starts writing
 // permissions. Duplicate offers are recorded once and permissions for inactive
 // users do not create cleanup intent.
 func (s *controllerImportSuite) TestImportModelRecordsOfferIntentBeforePermissionFailure(c *tc.C) {
 	modelUUID := tc.Must(c, coremodel.NewUUID)
-	deps, _, _ := s.deps(c, modelUUID)
+	deps, controllerFactory, _ := s.deps(c, modelUUID)
 
+	sourceMigrationUUID := uuid.MustNewUUID().String()
 	activeOfferUUID := uuid.MustNewUUID().String()
 	inactiveOfferUUID := uuid.MustNewUUID().String()
 	info := s.baseControllerModelInfo(modelUUID)
@@ -316,7 +430,7 @@ func (s *controllerImportSuite) TestImportModelRecordsOfferIntentBeforePermissio
 	}
 
 	err := migration.ImportControllerModelInfo(
-		c.Context(), deps, uuid.MustNewUUID().String(), info,
+		c.Context(), deps, sourceMigrationUUID, info,
 		export.ProjectionView{AgentTargetVersion: jujuversion.Current},
 	)
 	c.Assert(err, tc.ErrorMatches, `.*unknown permission object type "invalid".*`)
@@ -329,5 +443,34 @@ func (s *controllerImportSuite) TestImportModelRecordsOfferIntentBeforePermissio
 		inactiveOfferUUID), tc.Equals, 0)
 	c.Check(s.rowCount(c,
 		"SELECT COUNT(*) FROM permission WHERE grant_on = ?",
+		activeOfferUUID), tc.Equals, 0)
+
+	_, err = s.DB().ExecContext(c.Context(),
+		"UPDATE model_migration_import SET phase_type_id = 2 WHERE model_uuid = ?",
+		modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = migration.RemoveOnAbortImport(c.Context(), deps, migration.ImportModelArgs{
+		SourceMigrationUUID: sourceMigrationUUID,
+		ControllerModelInfo: info,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM permission WHERE grant_on = ?",
+		activeOfferUUID), tc.Equals, 0)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model WHERE uuid = ?",
+		modelUUID.String()), tc.Equals, 0)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?",
+		activeOfferUUID), tc.Equals, 1)
+
+	// Removing the durable claim is the last outer-abort step and consumes the
+	// cleanup intent after compensation has used it.
+	claimState := migrationclaimstate.New(controllerFactory, clock.WallClock)
+	err = claimState.DeleteModelImportingStatus(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?",
 		activeOfferUUID), tc.Equals, 0)
 }

--- a/internal/migration/import_test.go
+++ b/internal/migration/import_test.go
@@ -131,6 +131,13 @@ func (s *controllerImportSuite) deps(c *tc.C, modelUUID coremodel.UUID) (migrati
 	}, controllerFactory, modelFactory
 }
 
+func (s *controllerImportSuite) rowCount(c *tc.C, query string, args ...any) int {
+	var count int
+	err := s.DB().QueryRowContext(c.Context(), query, args...).Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	return count
+}
+
 func (s *controllerImportSuite) baseControllerModelInfo(modelUUID coremodel.UUID) coremodelmigration.ControllerModelInfo {
 	return coremodelmigration.ControllerModelInfo{
 		ModelInfo: coremodelmigration.ModelIdentityInfo{
@@ -284,4 +291,43 @@ func (s *controllerImportSuite) TestImportModelDuplicateClaim(c *tc.C) {
 
 	err = migration.ImportControllerModelInfo(c.Context(), deps, sourceMigrationUUID, info, view)
 	c.Check(err, tc.ErrorIs, coreerrors.AlreadyExists)
+}
+
+// TestImportModelRecordsOfferIntentBeforePermissionFailure verifies that offer
+// cleanup metadata is durable before the access domain starts writing
+// permissions. Duplicate offers are recorded once and permissions for inactive
+// users do not create cleanup intent.
+func (s *controllerImportSuite) TestImportModelRecordsOfferIntentBeforePermissionFailure(c *tc.C) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	deps, _, _ := s.deps(c, modelUUID)
+
+	activeOfferUUID := uuid.MustNewUUID().String()
+	inactiveOfferUUID := uuid.MustNewUUID().String()
+	info := s.baseControllerModelInfo(modelUUID)
+	info.Users = []coremodelmigration.ModelUser{
+		{Name: "bob@external", External: true},
+		{Name: "alice@external", External: true, Removed: true},
+	}
+	info.Permissions = []coremodelmigration.ModelPermission{
+		{ObjectType: "offer", GrantOn: activeOfferUUID, SubjectName: "bob@external", Access: "consume"},
+		{ObjectType: "offer", GrantOn: activeOfferUUID, SubjectName: "bob@external", Access: "consume"},
+		{ObjectType: "offer", GrantOn: inactiveOfferUUID, SubjectName: "alice@external", Access: "consume"},
+		{ObjectType: "invalid", GrantOn: modelUUID.String(), SubjectName: "bob@external", Access: "read"},
+	}
+
+	err := migration.ImportControllerModelInfo(
+		c.Context(), deps, uuid.MustNewUUID().String(), info,
+		export.ProjectionView{AgentTargetVersion: jujuversion.Current},
+	)
+	c.Assert(err, tc.ErrorMatches, `.*unknown permission object type "invalid".*`)
+
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?",
+		activeOfferUUID), tc.Equals, 1)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?",
+		inactiveOfferUUID), tc.Equals, 0)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM permission WHERE grant_on = ?",
+		activeOfferUUID), tc.Equals, 0)
 }

--- a/internal/migration/import_test.go
+++ b/internal/migration/import_test.go
@@ -294,9 +294,11 @@ func (s *controllerImportSuite) TestImportModelDuplicateClaim(c *tc.C) {
 }
 
 // TestRemoveOnAbortImportCleansSuccessfulImport verifies that abort
-// compensation removes all imported controller data and remains idempotent.
-// The claim and its companion rows remain until the outer abort flow removes
-// the durable claim anchor.
+// compensation removes all imported controller data and remains idempotent,
+// while shared controller-scoped rows (users, credentials, external
+// controllers, cloud image metadata) survive the abort. The claim and its
+// companion rows remain until the outer abort flow removes the durable claim
+// anchor.
 func (s *controllerImportSuite) TestRemoveOnAbortImportCleansSuccessfulImport(c *tc.C) {
 	modelUUID := tc.Must(c, coremodel.NewUUID)
 	deps, controllerFactory, _ := s.deps(c, modelUUID)
@@ -319,6 +321,26 @@ func (s *controllerImportSuite) TestRemoveOnAbortImportCleansSuccessfulImport(c 
 	}
 	info.Leaders = []coremodelmigration.ApplicationLeadership{
 		{Application: "myapp", Leader: "myapp/0"},
+	}
+	extControllerUUID := uuid.MustNewUUID().String()
+	info.ModelCredential = &coremodelmigration.ModelCloudCredential{
+		Cloud:      s.cloudName,
+		Owner:      coreuser.AdminUserName.Name(),
+		Name:       "migrated-cred",
+		AuthType:   string(cloud.AccessKeyAuthType),
+		Attributes: map[string]string{"access-key": "val"},
+	}
+	info.ExternalControllers = []coremodelmigration.ExternalController{
+		{
+			UUID:           extControllerUUID,
+			Alias:          "third-party-controller",
+			CACert:         "ca-cert",
+			Addresses:      []string{"10.0.0.1:17070"},
+			ConsumedModels: []string{uuid.MustNewUUID().String()},
+		},
+	}
+	info.CloudImageMetadata = []coremodelmigration.CloudImageMetadata{
+		{Stream: "released", Region: s.cloudName, Version: "22.04", Arch: "amd64", Source: "custom", Priority: 10, ImageID: "ami-1234"},
 	}
 
 	err := migration.ImportControllerModelInfo(
@@ -369,10 +391,48 @@ func (s *controllerImportSuite) TestRemoveOnAbortImportCleansSuccessfulImport(c 
 		"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?",
 		modelUUID.String()), tc.Equals, 1)
 
+	// Shared controller-scoped rows written by the import. Users,
+	// credentials, external controllers and cloud image metadata are shared
+	// across models: abort must leave them in place.
+	sharedRows := []struct {
+		name  string
+		query string
+		args  []any
+	}{
+		{
+			name:  "cloud credential",
+			query: "SELECT COUNT(*) FROM cloud_credential WHERE name = ?",
+			args:  []any{"migrated-cred"},
+		},
+		{
+			name:  "external controller",
+			query: "SELECT COUNT(*) FROM external_controller WHERE uuid = ?",
+			args:  []any{extControllerUUID},
+		},
+		{
+			name:  "cloud image metadata",
+			query: "SELECT COUNT(*) FROM cloud_image_metadata WHERE image_id = ?",
+			args:  []any{"ami-1234"},
+		},
+	}
+	for _, row := range sharedRows {
+		c.Check(s.rowCount(c, row.query, row.args...), tc.Equals, 1,
+			tc.Commentf("%s before abort", row.name))
+	}
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import_external_controller_model WHERE controller_uuid = ?",
+		extControllerUUID), tc.Equals, 1)
+
 	_, err = s.DB().ExecContext(c.Context(),
 		"UPDATE model_migration_import SET phase_type_id = 2 WHERE model_uuid = ?",
 		modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
+
+	accessSvc := accessservice.NewService(
+		accessstate.NewState(controllerFactory, clock.WallClock, loggertesting.WrapCheckLog(c)),
+		clock.WallClock,
+	)
+	bobName := tc.Must1(c, coreuser.NewName, "bob@external")
 
 	args := migration.ImportModelArgs{
 		SourceMigrationUUID: sourceMigrationUUID,
@@ -393,6 +453,18 @@ func (s *controllerImportSuite) TestRemoveOnAbortImportCleansSuccessfulImport(c 
 		c.Check(s.rowCount(c,
 			"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?",
 			modelUUID.String()), tc.Equals, 1)
+		c.Check(s.rowCount(c,
+			"SELECT COUNT(*) FROM model_migration_import_external_controller_model WHERE controller_uuid = ?",
+			extControllerUUID), tc.Equals, 1)
+
+		// Shared rows survive the abort; bob stays because external users
+		// are controller-level entities.
+		_, err = accessSvc.GetUserByName(c.Context(), bobName)
+		c.Check(err, tc.ErrorIsNil)
+		for _, row := range sharedRows {
+			c.Check(s.rowCount(c, row.query, row.args...), tc.Equals, 1,
+				tc.Commentf("%s after abort attempt %d", row.name, attempt))
+		}
 	}
 
 	claimState := migrationclaimstate.New(controllerFactory, clock.WallClock)
@@ -401,6 +473,104 @@ func (s *controllerImportSuite) TestRemoveOnAbortImportCleansSuccessfulImport(c 
 	c.Check(s.rowCount(c,
 		"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?",
 		offerUUID), tc.Equals, 0)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import_external_controller_model WHERE controller_uuid = ?",
+		extControllerUUID), tc.Equals, 0)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?",
+		modelUUID.String()), tc.Equals, 0)
+
+	// Shared controller-scoped rows survive claim removal as well.
+	_, err = accessSvc.GetUserByName(c.Context(), bobName)
+	c.Check(err, tc.ErrorIsNil)
+	for _, row := range sharedRows {
+		c.Check(s.rowCount(c, row.query, row.args...), tc.Equals, 1,
+			tc.Commentf("%s after claim removal", row.name))
+	}
+}
+
+// TestRemoveOnAbortImportWithoutClaim verifies abort compensation is a safe
+// no-op when nothing was ever imported for the model: no claim, no model row,
+// no companion rows. This is the outer abort flow retrying after the durable
+// claim anchor was already removed.
+func (s *controllerImportSuite) TestRemoveOnAbortImportWithoutClaim(c *tc.C) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	deps, _, _ := s.deps(c, modelUUID)
+
+	args := migration.ImportModelArgs{
+		SourceMigrationUUID: uuid.MustNewUUID().String(),
+		ControllerModelInfo: s.baseControllerModelInfo(modelUUID),
+	}
+	for attempt := 1; attempt <= 2; attempt++ {
+		err := migration.RemoveOnAbortImport(c.Context(), deps, args)
+		c.Assert(err, tc.ErrorIsNil, tc.Commentf("abort attempt %d", attempt))
+
+		c.Check(s.rowCount(c,
+			"SELECT COUNT(*) FROM model WHERE uuid = ?",
+			modelUUID.String()), tc.Equals, 0)
+		c.Check(s.rowCount(c,
+			"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?",
+			modelUUID.String()), tc.Equals, 0)
+		c.Check(s.rowCount(c,
+			"SELECT COUNT(*) FROM model_authorized_keys WHERE model_uuid = ?",
+			modelUUID.String()), tc.Equals, 0)
+	}
+}
+
+// TestRemoveOnAbortImportAfterEarlyFailure verifies abort compensation when
+// the import failed at its first forward step: the durable claim exists, but
+// the model row and every later write group were never created.
+func (s *controllerImportSuite) TestRemoveOnAbortImportAfterEarlyFailure(c *tc.C) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	deps, controllerFactory, _ := s.deps(c, modelUUID)
+
+	sourceMigrationUUID := uuid.MustNewUUID().String()
+	info := s.baseControllerModelInfo(modelUUID)
+	// An invalid username fails import-users, the first forward op, after
+	// the claim was created but before the model row exists.
+	info.Users = []coremodelmigration.ModelUser{
+		{Name: "not-a-valid-user!"},
+	}
+
+	err := migration.ImportControllerModelInfo(
+		c.Context(), deps, sourceMigrationUUID, info,
+		export.ProjectionView{AgentTargetVersion: jujuversion.Current},
+	)
+	c.Assert(err, tc.ErrorMatches, `.*invalid username.*`)
+
+	// The claim exists; the model row was never written.
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?",
+		modelUUID.String()), tc.Equals, 1)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model WHERE uuid = ?",
+		modelUUID.String()), tc.Equals, 0)
+
+	_, err = s.DB().ExecContext(c.Context(),
+		"UPDATE model_migration_import SET phase_type_id = 2 WHERE model_uuid = ?",
+		modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	args := migration.ImportModelArgs{
+		SourceMigrationUUID: sourceMigrationUUID,
+		ControllerModelInfo: info,
+	}
+	for attempt := 1; attempt <= 2; attempt++ {
+		err = migration.RemoveOnAbortImport(c.Context(), deps, args)
+		c.Assert(err, tc.ErrorIsNil, tc.Commentf("abort attempt %d", attempt))
+
+		c.Check(s.rowCount(c,
+			"SELECT COUNT(*) FROM model WHERE uuid = ?",
+			modelUUID.String()), tc.Equals, 0)
+		// The outer abort flow owns the durable claim anchor.
+		c.Check(s.rowCount(c,
+			"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?",
+			modelUUID.String()), tc.Equals, 1)
+	}
+
+	claimState := migrationclaimstate.New(controllerFactory, clock.WallClock)
+	err = claimState.DeleteModelImportingStatus(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
 	c.Check(s.rowCount(c,
 		"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?",
 		modelUUID.String()), tc.Equals, 0)


### PR DESCRIPTION
During a v8 model import, the target controller writes data through several domain services. Abort can
start while an earlier import request is still finishing, so checking the import phase before an
operation is not enough. The phase could change before the operation commits, leaving data behind after
cleanup has already run.

This change adds a transaction runner specifically for import operations. Once the import claim is
created, controller database operations use this runner to verify the exact model and claim are still in
the importing phase within the same transaction as their writes. If the claim has moved to another
phase, the transaction is rejected before those writes are committed.

The change also records offer-permission cleanup intent before importing the permissions. This gives
Abort the information needed to remove permissions even if their import fails partway through.

_Note: this patch originated in this review https://github.com/juju/juju/pull/22970#pullrequestreview-4960187866._

## QA steps

Full migration should continue working, and unit tests should pass. No functional changes.

## Links

**Jira card:** [JUJU-9910](https://warthogs.atlassian.net/browse/JUJU-9910)


[JUJU-9910]: https://warthogs.atlassian.net/browse/JUJU-9910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ