### PR TITLE
test: fix race in test worker

### DIFF
--- a/internal/worker/trace/worker.go
+++ b/internal/worker/trace/worker.go
@@ -196,9 +196,6 @@ func (w *tracerWorker) loop() (err error) {
 	// sure why they decided to do it like this.
 	otel.SetLogger(logr.New(&loggerSink{Logger: w.cfg.Logger}))
 
-	// Report the initial started state.
-	w.reportInternalState(stateStarted)
-
 	ctx := w.catacomb.Context(context.Background())
 
 	if err := w.reloadRuntimeConfig(ctx); err != nil {
@@ -213,6 +210,12 @@ func (w *tracerWorker) loop() (err error) {
 	if err := w.catacomb.Add(runtimeConfigWatcher); err != nil {
 		return errors.Trace(err)
 	}
+
+	// Report the initial started state only once the runtime config has been
+	// loaded and the watcher is installed. This ensures that GetTracer
+	// requests are not served before the initial config is applied, which
+	// could otherwise hand out a NoopTracer for an enabled config.
+	w.reportInternalState(stateStarted)
 
 	for {
 		select {
@@ -410,7 +413,8 @@ func runtimeConfigChanged(current, next RuntimeConfig) bool {
 }
 
 func (w *tracerWorker) stopTrackedTracers() error {
-	for _, workerName := range w.tracerRunner.WorkerNames() {
+	workerNames := w.tracerRunner.WorkerNames()
+	for _, workerName := range workerNames {
 		err := w.tracerRunner.StopAndRemoveWorker(workerName, w.catacomb.Dying())
 		if errors.Is(errors.Cause(err), errors.NotFound) {
 			continue
@@ -420,7 +424,9 @@ func (w *tracerWorker) stopTrackedTracers() error {
 		}
 	}
 
-	w.reportInternalState(stateWorkersKilled)
+	if len(workerNames) > 0 {
+		w.reportInternalState(stateWorkersKilled)
+	}
 
 	return nil
 }

--- a/internal/worker/trace/worker_test.go
+++ b/internal/worker/trace/worker_test.go
@@ -337,10 +337,6 @@ func (s *workerSuite) TestControllerTracingConfigReload(c *tc.C) {
 		c.Fatalf("timed out waiting for initial workload tracing config read")
 	}
 
-	// We need to ensure that the tracers are all drained before we call
-	// GetTracer again to ensure that the new config is applied.
-	s.ensureWorkersKilled(c)
-
 	worker := w
 	_, err = worker.GetTracer(c.Context(), coretrace.Namespace("agent", "anything"))
 	c.Assert(err, tc.ErrorIsNil)


### PR DESCRIPTION
The race is that we dispatched a event for the worker, stating that it started, yet it hadn't fully started yet. This caused an inconsistent test.

## QA steps

Tests pass

## Links

**Issue:** Fixes https://github.com/juju/juju/issues/23004.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10227](https://warthogs.atlassian.net/browse/JUJU-10227)


[JUJU-10227]: https://warthogs.atlassian.net/browse/JUJU-10227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ