### PR TITLE
fix: allow vault drain token to create secrets when draining from internal backend

### DIFF
--- a/secrets/provider/vault/provider.go
+++ b/secrets/provider/vault/provider.go
@@ -254,11 +254,12 @@ func (p vaultProvider) RestrictedConfig(
 
 	var rules []string
 	if forDrain && (adminUser || consumer.Kind() == names.ModelTagKind) {
-		// For controller drain worker, we need to be able to update a secret.
-		// Because we may run into a situation that the worker creates a secret in the vault but gets killed/restarted
-		// before it can update the secret to the new backend, we need to allow the worker to update the content
-		// after it's coming up again.
-		rule := fmt.Sprintf(`path "%s/*" {capabilities = ["update"]}`, mountPath)
+		// For controller drain worker, we need to be able to create or update a secret.
+		// When draining from internal backend to vault, the secret does not yet exist in vault,
+		// so we need "create". When the worker creates a secret in vault but gets killed/restarted
+		// before it can update the secret to the new backend, we need to allow the worker to update
+		// the content after it's coming up again.
+		rule := fmt.Sprintf(`path "%s/*" {capabilities = ["create", "update"]}`, mountPath)
 		rules = append(rules, rule)
 	}
 	if adminUser {

--- a/secrets/provider/vault/provider_test.go
+++ b/secrets/provider/vault/provider_test.go
@@ -453,7 +453,91 @@ func (s *providerSuite) TestBackendConfigNonAdmin(c *gc.C) {
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
 }
 
-func (s *providerSuite) TestBackendConfigForDrain(c *gc.C) {
+func (s *providerSuite) TestBackendConfigForDrainController(c *gc.C) {
+	ctrl, newVaultClient := s.newVaultClient(c, nil)
+	defer ctrl.Finish()
+
+	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+		func(req *http.Request) (*http.Response, error) {
+			c.Assert(req.URL.String(), gc.Equals, `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`)
+			c.Assert(req.Method, gc.Equals, http.MethodGet)
+			return &http.Response{
+				Request:    req,
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(`{"errors":[]}`)),
+			}, nil
+		},
+	)
+	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+		func(req *http.Request) (*http.Response, error) {
+			c.Assert(req.URL.String(), gc.Equals, `http://vault-ip:8200/v1/sys/policies/acl/fred-06f00d-some-uuid`)
+			c.Assert(req.Method, gc.Equals, http.MethodPut)
+			b, _ := ioutil.ReadAll(req.Body)
+			defer req.Body.Close()
+			policyReq := struct {
+				Policy string
+			}{}
+			_ = json.Unmarshal(b, &policyReq)
+			c.Assert(policyReq.Policy, gc.Equals, strings.Join([]string{
+				`path "fred-06f00d/*" {capabilities = ["create", "update"]}`,
+			}, "\n"))
+			return &http.Response{
+				Request:    req,
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(nil),
+			}, nil
+		},
+	)
+	s.mockRoundTripper.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(
+		func(req *http.Request) (*http.Response, error) {
+			c.Assert(req.URL.String(), gc.Equals, `http://vault-ip:8200/v1/auth/token/create`)
+			b, _ := ioutil.ReadAll(req.Body)
+			defer req.Body.Close()
+			tokenReq := api.TokenCreateRequest{}
+			_ = json.Unmarshal(b, &tokenReq)
+			c.Assert(tokenReq, jc.DeepEquals, api.TokenCreateRequest{
+				Policies:        []string{"fred-06f00d-some-uuid"},
+				Metadata:        map[string]string{"juju-issued-token-uuid": "some-uuid"},
+				TTL:             "10m",
+				NoDefaultPolicy: true,
+			})
+			return &http.Response{
+				Request:    req,
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"auth": {"client_token": "foo"}}`)),
+			}, nil
+		},
+	)
+
+	s.PatchValue(&jujuvault.NewVaultClient, newVaultClient)
+	p, err := provider.Provider(jujuvault.BackendType)
+	c.Assert(err, jc.ErrorIsNil)
+
+	adminCfg := &provider.ModelBackendConfig{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig: provider.BackendConfig{
+			BackendType: "vault",
+			Config: map[string]any{
+				"endpoint":        "http://vault-ip:8200/",
+				"namespace":       "ns",
+				"token":           "vault-token",
+				"ca-cert":         coretesting.CACert,
+				"tls-server-name": "tls-server",
+			},
+		},
+	}
+	issuedTokenUUID := "some-uuid"
+	cfg, err := p.RestrictedConfig(
+		adminCfg, true, true, issuedTokenUUID,
+		coretesting.ModelTag, nil, nil, nil,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg.Config["token"], gc.Equals, "foo")
+}
+
+func (s *providerSuite) TestBackendConfigForDrainUnit(c *gc.C) {
 	ctrl, newVaultClient := s.newVaultClient(c, nil)
 	defer ctrl.Finish()
 


### PR DESCRIPTION
Cherry-pick of the commit for the `4.0` branch: #23048

Test was missing in `3.6` branch so I added it as well.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests
./main.sh secrets_iaas test_user_secret_drain
```


## Documentation changes

## Links

