### PR TITLE
fix: concurrent unit removal with storage

### DIFF
--- a/cmd/juju/application/removeunit.go
+++ b/cmd/juju/application/removeunit.go
@@ -94,7 +94,7 @@ const removeUnitExamples = `
 
     juju remove-unit wordpress/2 --force --no-wait
 
-	juju remove-unit wordpress --num-units 2
+    juju remove-unit wordpress --num-units 2
 `
 
 var removeUnitMsgNoDryRun = `

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/remove-unit.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/remove-unit.md
@@ -32,7 +32,7 @@ juju remove-unit [options] <unit> [...] | <application>
 
     juju remove-unit wordpress/2 --force --no-wait
 
-	juju remove-unit wordpress --num-units 2
+    juju remove-unit wordpress --num-units 2
 
 
 ## Details

--- a/internal/worker/uniter/remotestate/storagewatcher.go
+++ b/internal/worker/uniter/remotestate/storagewatcher.go
@@ -141,5 +141,8 @@ func (s *storageAttachmentWatcher) Wait() error {
 }
 
 func (s *storageAttachmentWatcher) scopedContext() (context.Context, context.CancelFunc) {
-	return context.WithCancel(s.catacomb.Context(context.Background()))
+	// Detach from the catacomb so a teardown of the worker tree does not
+	// cancel an in-flight storage read; the loop observes catacomb.Dying()
+	// directly for shutdown. Values are preserved, cancellation is dropped.
+	return context.WithCancel(context.WithoutCancel(s.catacomb.Context(context.Background())))
 }

--- a/internal/worker/uniter/remotestate/watcher.go
+++ b/internal/worker/uniter/remotestate/watcher.go
@@ -1322,5 +1322,9 @@ func (w *RemoteStateWatcher) markShutdown() {
 }
 
 func (w *RemoteStateWatcher) scopedContext() (context.Context, context.CancelFunc) {
-	return context.WithCancel(w.catacomb.Context(context.Background()))
+	// Detach from the catacomb so a teardown of the worker tree does not
+	// cancel an in-flight remote-state read; the loop observes
+	// catacomb.Dying() directly for shutdown. Values are preserved,
+	// cancellation is dropped.
+	return context.WithCancel(context.WithoutCancel(w.catacomb.Context(context.Background())))
 }

--- a/internal/worker/uniter/remotestate/watcher_internal_test.go
+++ b/internal/worker/uniter/remotestate/watcher_internal_test.go
@@ -7,6 +7,7 @@ import (
 	stdtesting "testing"
 
 	"github.com/juju/tc"
+	"github.com/juju/worker/v5/catacomb"
 
 	"github.com/juju/juju/internal/testing"
 )
@@ -39,4 +40,78 @@ func (s *WatcherInternalSuite) TestDeleteSecretSignal(c *tc.C) {
 	c.Assert(w.current.ObsoleteSecretRevisions, tc.DeepEquals, map[string][]int{
 		"secret:9m4e2mr0ui3e8a215n4g": {666},
 	})
+}
+
+func (s *WatcherInternalSuite) TestScopedContextDetachedFromCatacomb(c *tc.C) {
+	var w RemoteStateWatcher
+	err := catacomb.Invoke(catacomb.Plan{
+		Name: "remote-state-watcher",
+		Site: &w.catacomb,
+		Work: func() error {
+			<-w.catacomb.Dying()
+			return w.catacomb.ErrDying()
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	ctx, cancel := w.scopedContext()
+	defer cancel()
+
+	w.catacomb.Kill(nil)
+	select {
+	case <-w.catacomb.Dead():
+	case <-c.Context().Done():
+		c.Fatal("catacomb did not die")
+	}
+
+	// The context must survive the catacomb's death so that an in-flight
+	// operation (e.g. a storage-detaching hook) is not cancelled by teardown.
+	select {
+	case <-ctx.Done():
+		c.Fatal("scoped context should not be cancelled by catacomb death")
+	default:
+	}
+
+	cancel()
+	select {
+	case <-ctx.Done():
+	default:
+		c.Fatal("scoped context should be cancelled by its cancel func")
+	}
+}
+
+func (s *WatcherInternalSuite) TestStorageWatcherScopedContextDetachedFromCatacomb(c *tc.C) {
+	var sw storageAttachmentWatcher
+	err := catacomb.Invoke(catacomb.Plan{
+		Name: "storage-attachment-watcher",
+		Site: &sw.catacomb,
+		Work: func() error {
+			<-sw.catacomb.Dying()
+			return sw.catacomb.ErrDying()
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	ctx, cancel := sw.scopedContext()
+	defer cancel()
+
+	sw.catacomb.Kill(nil)
+	select {
+	case <-sw.catacomb.Dead():
+	case <-c.Context().Done():
+		c.Fatal("catacomb did not die")
+	}
+
+	select {
+	case <-ctx.Done():
+		c.Fatal("scoped context should not be cancelled by catacomb death")
+	default:
+	}
+
+	cancel()
+	select {
+	case <-ctx.Done():
+	default:
+		c.Fatal("scoped context should be cancelled by its cancel func")
+	}
 }

--- a/internal/worker/uniter/resolver/loop.go
+++ b/internal/worker/uniter/resolver/loop.go
@@ -37,6 +37,12 @@ type LoopConfig struct {
 	CharmDirGuard fortress.Guard
 	CharmDir      string
 	Logger        logger.Logger
+
+	// Abort, when non-nil, signals that the loop should exit with
+	// ErrLoopAborted. It is typically wired to the worker's catacomb Dying
+	// channel so that a teardown of the worker tree aborts the loop without
+	// cancelling the context used by in-flight operations.
+	Abort <-chan struct{}
 }
 
 // Loop repeatedly waits for remote state changes, feeding the local and
@@ -48,8 +54,8 @@ type LoopConfig struct {
 // be called when a change is anticipated (i.e. due to ErrWaiting).
 //
 // The resolver loop can be controlled in the following ways:
-//   - if the "abort" channel is signalled, then the loop will
-//     exit with ErrLoopAborted
+//   - if the context is cancelled, or the "abort" channel is signalled,
+//     then the loop will exit with ErrLoopAborted
 //   - if the resolver returns ErrWaiting, then no operations
 //     will be executed until the remote state has changed
 //     again
@@ -165,6 +171,8 @@ func Loop(ctx context.Context, cfg LoopConfig, localState *LocalState) error {
 
 		select {
 		case <-ctx.Done():
+			return ErrLoopAborted
+		case <-cfg.Abort:
 			return ErrLoopAborted
 		case <-cfg.Watcher.RemoteStateChanged():
 		case <-fire:

--- a/internal/worker/uniter/resolver/loop_test.go
+++ b/internal/worker/uniter/resolver/loop_test.go
@@ -33,6 +33,7 @@ type LoopSuite struct {
 	charmURL  string
 	charmDir  string
 	onIdle    func() error
+	abort     <-chan struct{}
 }
 
 func TestLoopSuite(t *stdtesting.T) {
@@ -50,6 +51,7 @@ func (s *LoopSuite) SetUpTest(c *tc.C) {
 	s.opFactory = &mockOpFactory{}
 	s.executor = &mockOpExecutor{}
 	s.charmURL = "ch:trusty/mysql-1"
+	s.abort = nil
 }
 
 func (s *LoopSuite) loop(c *tc.C) func(context.Context) (resolver.LocalState, error) {
@@ -65,6 +67,7 @@ func (s *LoopSuite) loop(c *tc.C) func(context.Context) (resolver.LocalState, er
 			OnIdle:        s.onIdle,
 			CharmDir:      s.charmDir,
 			CharmDirGuard: &mockCharmDirGuard{},
+			Abort:         s.abort,
 			Logger:        loggertesting.WrapCheckLog(c),
 		}, &localState)
 		return localState, err
@@ -74,6 +77,17 @@ func (s *LoopSuite) loop(c *tc.C) func(context.Context) (resolver.LocalState, er
 func (s *LoopSuite) TestAbort(c *tc.C) {
 	ctx, cancel := context.WithCancel(c.Context())
 	cancel()
+
+	_, err := s.loop(c)(ctx)
+	c.Assert(err, tc.Equals, resolver.ErrLoopAborted)
+}
+
+func (s *LoopSuite) TestAbortChannel(c *tc.C) {
+	abort := make(chan struct{})
+	close(abort)
+	s.abort = abort
+
+	ctx := c.Context()
 
 	_, err := s.loop(c)(ctx)
 	c.Assert(err, tc.Equals, resolver.ErrLoopAborted)

--- a/internal/worker/uniter/scopedcontext_test.go
+++ b/internal/worker/uniter/scopedcontext_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package uniter
+
+import (
+	stdtesting "testing"
+
+	"github.com/juju/tc"
+	"github.com/juju/worker/v5/catacomb"
+
+	"github.com/juju/juju/internal/testing"
+)
+
+type ScopedContextSuite struct {
+	testing.BaseSuite
+}
+
+func TestScopedContextSuite(t *stdtesting.T) {
+	tc.Run(t, &ScopedContextSuite{})
+}
+
+// TestScopedContextDetachedFromCatacomb asserts that the loop's scoped context
+// is not cancelled when the uniter's catacomb dies. This is what allows an
+// in-flight hook (for example, a storage-detaching hook during unit removal)
+// to complete and write its state instead of failing with context canceled.
+func (s *ScopedContextSuite) TestScopedContextDetachedFromCatacomb(c *tc.C) {
+	var u Uniter
+	err := catacomb.Invoke(catacomb.Plan{
+		Name: "uniter",
+		Site: &u.catacomb,
+		Work: func() error {
+			<-u.catacomb.Dying()
+			return u.catacomb.ErrDying()
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	ctx, cancel := u.scopedContext()
+	defer cancel()
+
+	u.catacomb.Kill(nil)
+	select {
+	case <-u.catacomb.Dead():
+	case <-c.Context().Done():
+		c.Fatal("catacomb did not die")
+	}
+
+	select {
+	case <-ctx.Done():
+		c.Fatal("scoped context should not be cancelled by catacomb death")
+	default:
+	}
+
+	cancel()
+	select {
+	case <-ctx.Done():
+	default:
+		c.Fatal("scoped context should be cancelled by its cancel func")
+	}
+}

--- a/internal/worker/uniter/uniter.go
+++ b/internal/worker/uniter/uniter.go
@@ -484,6 +484,7 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				OnIdle:        onIdle,
 				CharmDirGuard: u.charmDirGuard,
 				CharmDir:      u.paths.State.CharmDir,
+				Abort:         u.catacomb.Dying(),
 				Logger:        u.logger.Child("resolver"),
 			}, &localState)
 
@@ -953,7 +954,13 @@ func (u *Uniter) Report(ctx stdcontext.Context) map[string]any {
 // scopedContext returns a context that is in the scope of the worker lifetime.
 // It returns a cancellable context that is cancelled when the action has
 // completed.
+//
+// The context is detached from the uniter's catacomb so that a teardown of the
+// worker tree (for example, when the unit is removed) does not cancel an
+// in-flight operation such as a hook. Values are preserved, but the catacomb's
+// cancellation is dropped; the returned cancel func still allows the loop to
+// scope the context's lifetime itself.
 func (u *Uniter) scopedContext() (stdcontext.Context, stdcontext.CancelFunc) {
-	ctx, cancel := stdcontext.WithCancel(u.catacomb.Context(stdcontext.Background()))
-	return ctx, cancel
+	base := stdcontext.WithoutCancel(u.catacomb.Context(stdcontext.Background()))
+	return stdcontext.WithCancel(base)
 }


### PR DESCRIPTION
Concurrent unit removal tears down each departing unit, which kills the uniter's worker tree and cancels any context derived from its catacomb. When a hook is mid flight, that cancellation makes the operation fail while writing its state, so the departing unit transiently enters an error state from a storage detaching hook that its own teardown canceled. This is a regression from threading a cancelable context through the state write.

The fix detaches the uniter's scoped context from its catacomb using `context.WithoutCancel`, keeping values like tracing but dropping the catacomb's cancellation. A new abort channel wired to the catacomb's dying channel still lets the resolver loop detect teardown and exit cleanly after the current operation completes. The same detachment is applied to the storage attachment watcher and remote state watcher, which produced the parallel refreshing storage details symptom. Regression tests verify the abort channel and that the scoped context survives catacomb death while honoring its own cancel function.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model foo
$ juju deploy testcharms/charms/dummy-storage/dummy-storage_amd64.charm
```

We need a script to ensure we race.

```sh
#!/bin/bash

set -euo pipefail

app=dummy-storage
for i in 1 2; do
  juju remove-unit "$app/$i" --no-prompt --destroy-storage &
done
wait
```

Ensure it's executable and run it, when everything is deployed.

It should teardown without context.Cancelled errors.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/22971.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10201](https://warthogs.atlassian.net/browse/JUJU-10201)


[JUJU-10201]: https://warthogs.atlassian.net/browse/JUJU-10201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ