### PR TITLE
fix: drop authorized-keys from model config for 3.x clients

### DIFF
--- a/domain/modelconfig/import_integration_test.go
+++ b/domain/modelconfig/import_integration_test.go
@@ -66,6 +66,7 @@ func (s *importSuite) SetUpTest(c *tc.C) {
 		config.ModelValidator(),
 		service.ProviderModelConfigGetter(),
 		st,
+		loggertesting.WrapCheckLog(c),
 	)
 
 	// Initialise required model config entries.

--- a/domain/modelconfig/modelconfig_test.go
+++ b/domain/modelconfig/modelconfig_test.go
@@ -148,7 +148,7 @@ func (s *modelConfigSuite) TestModelConfigService(c *tc.C) {
 	st := state.NewState(modelTxnRunnerFactory)
 	svc := service.NewService(defaults, config.ModelValidator(), func(context.Context, string) (service.ModelConfigProvider, error) {
 		return modelConfigProvider{}, nil
-	}, st)
+	}, st, loggertesting.WrapCheckLog(c))
 
 	cfg, err := svc.ModelConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -248,7 +248,7 @@ func (s *modelConfigSuite) TestWatchModelConfigService(c *tc.C) {
 	factory := domain.NewWatcherFactory(
 		changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, s.modelID.String()),
 		loggertesting.WrapCheckLog(c))
-	svc := service.NewWatchableService(defaults, config.ModelValidator(), nil, st, factory)
+	svc := service.NewWatchableService(defaults, config.ModelValidator(), nil, st, factory, loggertesting.WrapCheckLog(c))
 
 	watcher, err := svc.Watch(c.Context())
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/modelconfig/modelmigration/import.go
+++ b/domain/modelconfig/modelmigration/import.go
@@ -72,7 +72,9 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 		i.defaultsProvider,
 		config.NoControllerAttributesValidator(),
 		service.ProviderModelConfigGetter(),
-		st)
+		st,
+		i.logger,
+	)
 	return nil
 }
 

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
@@ -21,10 +22,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/configschema"
 	"github.com/juju/juju/internal/errors"
-	internallogger "github.com/juju/juju/internal/logger"
 )
-
-var logger = internallogger.GetLogger("juju.domain.modelconfig")
 
 // ModelDefaultsProvider is responsible for providing the default config values
 // for a model.
@@ -104,6 +102,7 @@ type Service struct {
 	modelValidator                config.Validator
 	modelConfigProviderGetterFunc ModelConfigProviderFunc
 	st                            State
+	logger                        logger.Logger
 }
 
 // NewService creates a new ModelConfig service.
@@ -112,12 +111,14 @@ func NewService(
 	modelValidator config.Validator,
 	modelConfigProviderGetterFunc ModelConfigProviderFunc,
 	st State,
+	logger logger.Logger,
 ) *Service {
 	return &Service{
 		defaultsProvider:              defaultsProvider,
 		modelValidator:                modelValidator,
 		modelConfigProviderGetterFunc: modelConfigProviderGetterFunc,
 		st:                            st,
+		logger:                        logger,
 	}
 }
 
@@ -330,7 +331,7 @@ func (s *Service) SetModelConfig(
 	// rather than rejecting it.
 	if _, ok := cfgCopy[config.AuthorizedKeysKey]; ok {
 		delete(cfgCopy, config.AuthorizedKeysKey)
-		logger.Debugf(ctx, "dropping deprecated %s from model config (SSH keys are managed separately in juju 4.x)", config.AuthorizedKeysKey)
+		s.logger.Infof(ctx, "dropping deprecated %s from model config (SSH keys are managed separately in juju 4.x)", config.AuthorizedKeysKey)
 	}
 
 	for k, v := range defaults {
@@ -524,6 +525,7 @@ func NewWatchableService(
 	modelConfigProviderGetterFunc ModelConfigProviderFunc,
 	st State,
 	watcherFactory WatcherFactory,
+	logger logger.Logger,
 ) *WatchableService {
 	return &WatchableService{
 		Service: Service{
@@ -531,6 +533,7 @@ func NewWatchableService(
 			modelValidator:                modelValidator,
 			modelConfigProviderGetterFunc: modelConfigProviderGetterFunc,
 			st:                            st,
+			logger:                        logger,
 		},
 		watcherFactory: watcherFactory,
 	}

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -21,7 +21,10 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/configschema"
 	"github.com/juju/juju/internal/errors"
+	internallogger "github.com/juju/juju/internal/logger"
 )
+
+var logger = internallogger.GetLogger("juju.domain.modelconfig")
 
 // ModelDefaultsProvider is responsible for providing the default config values
 // for a model.
@@ -325,7 +328,10 @@ func (s *Service) SetModelConfig(
 	// compatibility with juju 3.x clients, which always include it when
 	// creating a model, so drop it before validation and persistence
 	// rather than rejecting it.
-	delete(cfgCopy, config.AuthorizedKeysKey)
+	if _, ok := cfgCopy[config.AuthorizedKeysKey]; ok {
+		delete(cfgCopy, config.AuthorizedKeysKey)
+		logger.Debugf(ctx, "dropping deprecated %s from model config (SSH keys are managed separately in juju 4.x)", config.AuthorizedKeysKey)
+	}
 
 	for k, v := range defaults {
 		applyVal := v.ApplyStrategy(cfgCopy[k])

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -320,6 +320,13 @@ func (s *Service) SetModelConfig(
 	cfgCopy := make(map[string]any, len(cfg))
 	maps.Copy(cfgCopy, cfg)
 
+	// authorized-keys is not valid model config in juju 4.x (SSH keys are
+	// managed separately). It is only ever present here for backward
+	// compatibility with juju 3.x clients, which always include it when
+	// creating a model, so drop it before validation and persistence
+	// rather than rejecting it.
+	delete(cfgCopy, config.AuthorizedKeysKey)
+
 	for k, v := range defaults {
 		applyVal := v.ApplyStrategy(cfgCopy[k])
 		if applyVal != nil {

--- a/domain/modelconfig/service/service_test.go
+++ b/domain/modelconfig/service/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/configschema"
 	"github.com/juju/juju/internal/errors"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
 type ModelDefaultsProviderFunc func(context.Context) (modeldefaults.Defaults, error)
@@ -71,7 +72,7 @@ func (s *serviceSuite) TestGetModelConfigContainsAgentInformation(c *tc.C) {
 
 	s.mockModelConfigProvider.EXPECT().ConfigSchema().Return(schema.Fields{})
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState, loggertesting.WrapCheckLog(c))
 	cfg, err := svc.ModelConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(cfg.AgentStream(), tc.Equals, coreagentbinary.AgentStreamReleased.String())
@@ -100,7 +101,7 @@ func (s *serviceSuite) TestModelConfigValuesSupportsMapValues(c *tc.C) {
 		}, nil
 	}
 
-	svc := NewService(defaults, config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	svc := NewService(defaults, config.ModelValidator(), s.modelConfigProviderFunc, s.mockState, loggertesting.WrapCheckLog(c))
 	values, err := svc.ModelConfigValues(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(values[config.ResourceTagsKey].Source, tc.Equals, config.JujuModelConfigSource)
@@ -123,7 +124,7 @@ func (s *serviceSuite) TestUpdateModelConfigAgentStream(c *tc.C) {
 
 	s.mockModelConfigProvider.EXPECT().ConfigSchema().Return(schema.Fields{})
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState, loggertesting.WrapCheckLog(c))
 	err := svc.UpdateModelConfig(
 		c.Context(),
 		map[string]any{
@@ -159,7 +160,7 @@ func (s *serviceSuite) TestUpdateModelConfigNoAgentStreamChange(c *tc.C) {
 
 	s.mockModelConfigProvider.EXPECT().ConfigSchema().Return(schema.Fields{})
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState, loggertesting.WrapCheckLog(c))
 	err := svc.UpdateModelConfig(
 		c.Context(),
 		map[string]any{
@@ -189,7 +190,7 @@ func (s *serviceSuite) TestGetModelConfigSchema(c *tc.C) {
 
 	s.mockModelConfigProvider.EXPECT().Schema().Return(schema)
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState, loggertesting.WrapCheckLog(c))
 	res, err := svc.GetModelConfigSchemaForCloudType(c.Context(), "anytype")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(res, tc.DeepEquals, schema)
@@ -205,7 +206,7 @@ func (s *serviceSuite) TestGetModelConfigSchemaProviderDoesntSuppport(c *tc.C) {
 	defaultSchema, err := config.Schema(nil)
 	c.Assert(err, tc.ErrorIsNil)
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), providerGetter, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), providerGetter, s.mockState, loggertesting.WrapCheckLog(c))
 	res, err := svc.GetModelConfigSchemaForCloudType(c.Context(), "sometype")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(res, tc.DeepEquals, defaultSchema)
@@ -236,7 +237,7 @@ func (s *serviceSuite) TestModelConfigWithProviderSchemaCoercion(c *tc.C) {
 		},
 	)
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState, loggertesting.WrapCheckLog(c))
 	cfg, err := svc.ModelConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -260,7 +261,7 @@ func (s *serviceSuite) TestModelConfigWithoutProviderGetter(c *tc.C) {
 		}, nil,
 	)
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), nil, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), nil, s.mockState, loggertesting.WrapCheckLog(c))
 	_, err := svc.ModelConfig(c.Context())
 	c.Check(err, tc.ErrorMatches, "coercing provider config attributes:.*no model config provider getter")
 }
@@ -284,7 +285,7 @@ func (s *serviceSuite) TestModelConfigWithProviderNotFound(c *tc.C) {
 		return nil, errors.Errorf("unknown cloud type %q", "unknown").Add(coreerrors.NotFound)
 	}
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), providerGetter, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), providerGetter, s.mockState, loggertesting.WrapCheckLog(c))
 	_, err := svc.ModelConfig(c.Context())
 	c.Check(err, tc.ErrorMatches, `coercing provider config attributes:.*unknown cloud type "unknown"`)
 }
@@ -305,7 +306,7 @@ func (s *serviceSuite) TestModelConfigWithProviderEmptySchema(c *tc.C) {
 
 	s.mockModelConfigProvider.EXPECT().ConfigSchema().Return(schema.Fields{})
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState, loggertesting.WrapCheckLog(c))
 	cfg, err := svc.ModelConfig(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(cfg.Name(), tc.Equals, "wallyworld")
@@ -336,7 +337,7 @@ func (s *serviceSuite) TestSetModelConfig(c *tc.C) {
 		"logging-config": "<root>=INFO",
 	})
 
-	svc := NewService(defaults, config.ModelValidator(), nil, s.mockState)
+	svc := NewService(defaults, config.ModelValidator(), nil, s.mockState, loggertesting.WrapCheckLog(c))
 	err := svc.SetModelConfig(c.Context(), attrs)
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -362,7 +363,7 @@ func (s *serviceSuite) TestSetModelConfigDropsAuthorizedKeys(c *tc.C) {
 			return nil
 		})
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState, loggertesting.WrapCheckLog(c))
 	err := svc.SetModelConfig(c.Context(), attrs)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -390,7 +391,7 @@ func (s *serviceSuite) TestModelConfigWithEmptyCloudType(c *tc.C) {
 		}, nil,
 	)
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState, loggertesting.WrapCheckLog(c))
 	_, err := svc.ModelConfig(c.Context())
 	// Even though type is empty string, config.New requires a valid type
 	c.Check(err, tc.ErrorMatches, ".*empty type in model configuration.*")
@@ -414,7 +415,7 @@ func (s *serviceSuite) TestModelConfigWithProviderReturnsNotSupportedError(c *tc
 		return nil, errors.Errorf("unsupported").Add(coreerrors.NotSupported)
 	}
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), providerGetter, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), providerGetter, s.mockState, loggertesting.WrapCheckLog(c))
 	_, err := svc.ModelConfig(c.Context())
 	c.Check(err, tc.ErrorMatches, "coercing provider config attributes:.*provider not found or doesn't support config schema")
 }
@@ -437,7 +438,7 @@ func (s *serviceSuite) TestModelConfigWithProviderReturnsOtherError(c *tc.C) {
 		return nil, errors.Errorf("some other error")
 	}
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), providerGetter, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), providerGetter, s.mockState, loggertesting.WrapCheckLog(c))
 	_, err := svc.ModelConfig(c.Context())
 	c.Check(err, tc.ErrorMatches, "coercing provider config attributes:.*some other error")
 }
@@ -462,7 +463,7 @@ func (s *serviceSuite) TestModelConfigCoercionError(c *tc.C) {
 		},
 	)
 
-	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState, loggertesting.WrapCheckLog(c))
 	_, err := svc.ModelConfig(c.Context())
 	c.Check(err, tc.ErrorMatches, `.*coercing provider config attributes:.*provider-bool.*`)
 }

--- a/domain/modelconfig/service/service_test.go
+++ b/domain/modelconfig/service/service_test.go
@@ -341,6 +341,36 @@ func (s *serviceSuite) TestSetModelConfig(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestSetModelConfigDropsAuthorizedKeys verifies that authorized-keys
+// supplied in model config is accepted (for backward compatibility with juju
+// 3.x clients) but is dropped before persistence: it is not stored in model
+// config. In juju 4.x SSH keys are managed separately.
+func (s *serviceSuite) TestSetModelConfigDropsAuthorizedKeys(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	attrs := map[string]any{
+		config.NameKey:           "wallyworld",
+		config.UUIDKey:           "a677bdfd-3c96-46b2-912f-38e25faceaf7",
+		config.TypeKey:           "sometype",
+		config.AuthorizedKeysKey: "ssh-rsa AAAAB3NzaC1yc2E comment",
+	}
+
+	var persisted map[string]string
+	s.mockState.EXPECT().SetModelConfig(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, cfg map[string]string) error {
+			persisted = cfg
+			return nil
+		})
+
+	svc := NewService(noopDefaultsProvider(), config.ModelValidator(), s.modelConfigProviderFunc, s.mockState)
+	err := svc.SetModelConfig(c.Context(), attrs)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// authorized-keys is not stored in the model config.
+	_, ok := persisted[config.AuthorizedKeysKey]
+	c.Check(ok, tc.IsFalse)
+}
+
 // TestModelConfigWithEmptyCloudType checks that ModelConfig handles the case
 // where cloud type is empty string by converting without coercion.
 func (s *serviceSuite) TestModelConfigWithEmptyCloudType(c *tc.C) {

--- a/domain/modelconfig/service/service_test.go
+++ b/domain/modelconfig/service/service_test.go
@@ -369,6 +369,11 @@ func (s *serviceSuite) TestSetModelConfigDropsAuthorizedKeys(c *tc.C) {
 	// authorized-keys is not stored in the model config.
 	_, ok := persisted[config.AuthorizedKeysKey]
 	c.Check(ok, tc.IsFalse)
+
+	// the other supplied attributes are still persisted.
+	c.Check(persisted[config.NameKey], tc.Equals, "wallyworld")
+	c.Check(persisted[config.UUIDKey], tc.Equals, "a677bdfd-3c96-46b2-912f-38e25faceaf7")
+	c.Check(persisted[config.TypeKey], tc.Equals, "sometype")
 }
 
 // TestModelConfigWithEmptyCloudType checks that ModelConfig handles the case

--- a/domain/services/model.go
+++ b/domain/services/model.go
@@ -236,6 +236,8 @@ func (s *ModelServices) AgentProvisioner() *agentprovisionerservice.Service {
 
 // Config returns the model's configuration service.
 func (s *ModelServices) Config() *modelconfigservice.WatchableService {
+	logger := s.logger.Child("modelconfig")
+
 	defaultsProvider := modeldefaultsservice.NewService(
 		modeldefaultsservice.ProviderModelConfigGetter(),
 		modeldefaultsstate.NewState(
@@ -249,6 +251,7 @@ func (s *ModelServices) Config() *modelconfigservice.WatchableService {
 		modelconfigservice.ProviderModelConfigGetter(),
 		st,
 		s.modelWatcherFactory("modelconfig"),
+		logger,
 	)
 }
 


### PR DESCRIPTION
> Note: This PR should be merged into both `4.0` and `main`

A juju 3.6 client always includes authorized-keys in the model config it sends when creating a model. In juju 4.x SSH keys are managed separately, so authorized-keys is not valid model config and is rejected by ModelValidator, breaking "juju add-model" against a 4.x controller from an older client.

Drop authorized-keys in the modelconfig service SetModelConfig before validation and persistence. This tolerates the legacy attribute for backward compatibility without storing dead config.

`UpdateModelConfig` still rejects `authorized-keys` which is intentional. Currently it's possible to update model config from 3.6 cli to 4.x controller it only fails if you try to update `authorized-keys` since after 4.0 that attribute was moved separately and is no longer part of model config

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

 1. Bootstrap a 4.0 controller.

 2. Use 3.6 CLI to add model

 3. Verify that it doesn't result in failure and model is created
 
## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #23050.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10243](https://warthogs.atlassian.net/browse/JUJU-10243)


[JUJU-10243]: https://warthogs.atlassian.net/browse/JUJU-10243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ