### PR TITLE
fix: connection removed model

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -1224,6 +1224,13 @@ func (srv *Server) serveConn(
 		return nil, errors.Annotatef(err, "checking model %q availability", modelUUID)
 	}
 
+	// Close the connection when the model it serves is removed from this
+	// controller, whether destroyed or deleted by a migration's REAP phase
+	// after migrating away, so that its agents and clients reconnect to the
+	// model's new location.
+	srv.watchServedModelRemoval(ctx, conn, domainServices.Model(),
+		srv.shared.controllerDomainServices.Model(), modelUUID)
+
 	tracer, err := srv.shared.tracerGetter.GetTracer(
 		ctx,
 		coretrace.Namespace("apiserver", modelUUID.String()),

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -1227,9 +1227,12 @@ func (srv *Server) serveConn(
 	// Close the connection when the model it serves is removed from this
 	// controller, whether destroyed or deleted by a migration's REAP phase
 	// after migrating away, so that its agents and clients reconnect to the
-	// model's new location.
-	srv.watchServedModelRemoval(ctx, conn, domainServices.Model(),
-		srv.shared.controllerDomainServices.Model(), modelUUID)
+	// model's new location. A connection to a model that is already gone
+	// exists only to answer a redirect, so it is not watched.
+	if modelConn.connectable {
+		srv.watchServedModelRemoval(ctx, conn, domainServices.Model(),
+			srv.shared.controllerDomainServices.Model(), modelUUID)
+	}
 
 	tracer, err := srv.shared.tracerGetter.GetTracer(
 		ctx,

--- a/apiserver/modelremoval.go
+++ b/apiserver/modelremoval.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"context"
+
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/watcher"
+	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/internal/errors"
+)
+
+// ModelRemovalWatchService creates watchers that emit when a model changes.
+// It is satisfied by the controller-scoped *modelservice.WatchableService.
+type ModelRemovalWatchService interface {
+	// WatchModel returns a watcher that emits an event if the model changes.
+	WatchModel(ctx context.Context, modelUUID coremodel.UUID) (watcher.NotifyWatcher, error)
+}
+
+// servedConnection is the subset of *rpc.Conn needed by the model removal
+// watch. It exists so the watch can be unit tested without a full RPC
+// connection.
+type servedConnection interface {
+	// Dead returns a channel that is closed when the connection dies.
+	Dead() <-chan struct{}
+	// Close closes the connection. Closing an already dead or closed
+	// connection is not an error.
+	Close() error
+}
+
+// watchServedModelRemoval arranges for conn to be closed when the model it
+// serves is removed from this controller. Model removal happens when a model
+// is destroyed or when a migration's REAP phase deletes it after migrating
+// away; agents and clients must then reconnect, dialling the addresses the
+// migration wrote into their configuration.
+//
+// The watch is best-effort: if it cannot be established the connection is
+// served without it, as it always has been.
+func (srv *Server) watchServedModelRemoval(
+	ctx context.Context,
+	conn servedConnection,
+	modelService ModelService,
+	watchService ModelRemovalWatchService,
+	modelUUID coremodel.UUID,
+) {
+	watch, err := watchService.WatchModel(ctx, modelUUID)
+	if err != nil {
+		logger.Warningf(ctx,
+			"cannot watch model %q for removal; connection will not be closed on model removal: %v",
+			modelUUID, err,
+		)
+		return
+	}
+	go srv.runModelRemovalWatch(ctx, conn, modelService, watch, modelUUID)
+}
+
+// runModelRemovalWatch closes conn once the model it serves no longer exists
+// on this controller. It returns when the connection dies, the context is
+// cancelled, or the watcher stops.
+func (srv *Server) runModelRemovalWatch(
+	ctx context.Context,
+	conn servedConnection,
+	modelService ModelService,
+	watch watcher.NotifyWatcher,
+	modelUUID coremodel.UUID,
+) {
+	defer func() {
+		watch.Kill()
+		_ = watch.Wait()
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-conn.Dead():
+			return
+		case _, ok := <-watch.Changes():
+			if !ok {
+				logger.Warningf(ctx,
+					"removal watcher for model %q stopped; connection will not be closed on model removal",
+					modelUUID,
+				)
+				return
+			}
+			if _, err := modelIsConnectable(ctx, modelService, modelUUID); errors.Is(err, modelerrors.NotFound) {
+				logger.Infof(ctx, "model %q has been removed, closing connection", modelUUID)
+				_ = conn.Close()
+				return
+			}
+			// The model still exists, or the check failed transiently;
+			// keep watching.
+		}
+	}
+}

--- a/apiserver/modelremoval.go
+++ b/apiserver/modelremoval.go
@@ -85,8 +85,9 @@ func (srv *Server) runModelRemovalWatch(
 				)
 				return
 			}
-			if _, err := modelIsConnectable(ctx, modelService, modelUUID); errors.Is(err, modelerrors.NotFound) {
-				logger.Infof(ctx, "model %q has been removed, closing connection", modelUUID)
+			connInfo, err := modelIsConnectable(ctx, modelService, modelUUID)
+			if errors.Is(err, modelerrors.NotFound) || (err == nil && !connInfo.connectable) {
+				logger.Warningf(ctx, "model %q has been removed, closing connection", modelUUID)
 				_ = conn.Close()
 				return
 			}

--- a/apiserver/modelremoval_test.go
+++ b/apiserver/modelremoval_test.go
@@ -198,3 +198,24 @@ func (s *modelRemovalSuite) TestUnrelatedModelChangeKeepsWatching(c *tc.C) {
 	<-conn.closed
 	<-done
 }
+
+// TestUnactivatedModelClosesConnection covers destroy-model: the
+// model row may still exist but is no longer connectable. The
+// connection must still be closed so agents do not linger.
+func (s *modelRemovalSuite) TestUnactivatedModelClosesConnection(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
+		Return(model.ModelConnectionInfo{Activated: false}, nil)
+
+	conn := newFakeServedConnection()
+	srv := &Server{}
+
+	changes := make(chan struct{}, 1)
+	changes <- struct{}{}
+	watch := watchertest.NewMockNotifyWatcher(changes)
+	done := runWatch(srv, c.Context(), conn, s.modelService, watch, s.modelUUID)
+
+	<-conn.closed
+	<-done
+}

--- a/apiserver/modelremoval_test.go
+++ b/apiserver/modelremoval_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/canonical/gomock/gomock"
+	"github.com/juju/tc"
+
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/domain/model"
+	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/internal/uuid"
+)
+
+type modelRemovalSuite struct {
+	modelService *MockModelService
+	modelUUID    coremodel.UUID
+}
+
+func TestModelRemovalSuite(t *testing.T) {
+	tc.Run(t, &modelRemovalSuite{})
+}
+
+func (s *modelRemovalSuite) setupMocks(c *tc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.modelService = NewMockModelService(ctrl)
+	s.modelUUID = coremodel.UUID(uuid.MustNewUUID().String())
+	return ctrl
+}
+
+// fakeServedConnection implements servedConnection, recording closure and
+// letting tests drive the dead channel.
+type fakeServedConnection struct {
+	dead      chan struct{}
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newFakeServedConnection() *fakeServedConnection {
+	return &fakeServedConnection{
+		dead:   make(chan struct{}),
+		closed: make(chan struct{}),
+	}
+}
+
+func (f *fakeServedConnection) Dead() <-chan struct{} {
+	return f.dead
+}
+
+func (f *fakeServedConnection) Close() error {
+	f.closeOnce.Do(func() { close(f.closed) })
+	return nil
+}
+
+func (f *fakeServedConnection) isClosed() bool {
+	select {
+	case <-f.closed:
+		return true
+	default:
+		return false
+	}
+}
+
+// stubModelRemovalWatchService returns a fixed watcher or error from
+// WatchModel.
+type stubModelRemovalWatchService struct {
+	watch watcher.NotifyWatcher
+	err   error
+}
+
+func (s stubModelRemovalWatchService) WatchModel(context.Context, coremodel.UUID) (watcher.NotifyWatcher, error) {
+	return s.watch, s.err
+}
+
+// runWatch drives runModelRemovalWatch in a goroutine and returns a channel
+// that is closed when it returns.
+func runWatch(srv *Server, ctx context.Context, conn servedConnection, modelService ModelService, watch watcher.NotifyWatcher, modelUUID coremodel.UUID) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.runModelRemovalWatch(ctx, conn, modelService, watch, modelUUID)
+	}()
+	return done
+}
+
+// TestWatchNotStartedWhenWatcherCreationFails pins the best-effort contract:
+// if the removal watcher cannot be created, the connection is served without
+// it, exactly as connections always have been.
+func (s *modelRemovalSuite) TestWatchNotStartedWhenWatcherCreationFails(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	conn := newFakeServedConnection()
+	srv := &Server{}
+
+	// The model service must not be consulted when there is no watcher.
+	srv.watchServedModelRemoval(c.Context(), conn, s.modelService,
+		stubModelRemovalWatchService{err: errors.New("boom")}, s.modelUUID)
+
+	c.Assert(conn.isClosed(), tc.IsFalse)
+}
+
+// TestNoRemovalEventLeavesConnectionOpen verifies that a quiet watcher never
+// closes the connection, and that cancelling the connection's context stops
+// the watch goroutine.
+func (s *modelRemovalSuite) TestNoRemovalEventLeavesConnectionOpen(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	ctx, cancel := context.WithCancel(c.Context())
+	conn := newFakeServedConnection()
+	srv := &Server{}
+
+	watch := watchertest.NewMockNotifyWatcher(make(chan struct{}))
+	done := runWatch(srv, ctx, conn, s.modelService, watch, s.modelUUID)
+
+	cancel()
+	<-done
+
+	c.Assert(conn.isClosed(), tc.IsFalse)
+}
+
+// TestDeadConnectionStopsWatch verifies that the watch ends with the
+// connection without closing it: nothing may outlive the connection.
+func (s *modelRemovalSuite) TestDeadConnectionStopsWatch(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	conn := newFakeServedConnection()
+	srv := &Server{}
+
+	watch := watchertest.NewMockNotifyWatcher(make(chan struct{}))
+	done := runWatch(srv, c.Context(), conn, s.modelService, watch, s.modelUUID)
+
+	close(conn.dead)
+	<-done
+
+	c.Assert(conn.isClosed(), tc.IsFalse)
+}
+
+// TestModelRemovalClosesConnection is the migration REAP case: the model row
+// disappears from the controller, the watcher fires, the model lookup reports
+// not found, and the connection is closed so agents reconnect to the target
+// controller.
+func (s *modelRemovalSuite) TestModelRemovalClosesConnection(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
+		Return(model.ModelConnectionInfo{}, modelerrors.NotFound)
+
+	conn := newFakeServedConnection()
+	srv := &Server{}
+
+	changes := make(chan struct{}, 1)
+	changes <- struct{}{}
+	watch := watchertest.NewMockNotifyWatcher(changes)
+
+	srv.watchServedModelRemoval(c.Context(), conn, s.modelService,
+		stubModelRemovalWatchService{watch: watch}, s.modelUUID)
+
+	<-conn.closed
+}
+
+// TestUnrelatedModelChangeKeepsWatching verifies that a model change which is
+// not a removal - the model is still connectable - does not close the
+// connection, and that a later removal still does.
+func (s *modelRemovalSuite) TestUnrelatedModelChangeKeepsWatching(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	firstCheck := make(chan struct{})
+	gomock.InOrder(
+		s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
+			DoAndReturn(func(context.Context, coremodel.UUID) (model.ModelConnectionInfo, error) {
+				close(firstCheck)
+				return model.ModelConnectionInfo{Activated: true}, nil
+			}),
+		s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
+			Return(model.ModelConnectionInfo{}, modelerrors.NotFound),
+	)
+
+	conn := newFakeServedConnection()
+	srv := &Server{}
+
+	changes := make(chan struct{})
+	watch := watchertest.NewMockNotifyWatcher(changes)
+	done := runWatch(srv, c.Context(), conn, s.modelService, watch, s.modelUUID)
+
+	changes <- struct{}{}
+	<-firstCheck
+	c.Assert(conn.isClosed(), tc.IsFalse)
+
+	changes <- struct{}{}
+	<-conn.closed
+	<-done
+}

--- a/core/status/present.go
+++ b/core/status/present.go
@@ -67,7 +67,11 @@ func IsUnitWorkloadPresent(status StatusInfo) bool {
 			return false
 		}
 		return true
-	case Blocked, Error, Terminated, Unknown:
+	case Blocked:
+		// Blocked is a recoverable state (e.g. waiting for operator
+		// config) and must not block model migration.
+		return true
+	case Error, Terminated, Unknown:
 		return false
 	default:
 		return false

--- a/core/status/present_test.go
+++ b/core/status/present_test.go
@@ -253,7 +253,7 @@ func (s *viableSuite) TestIsUnitWorkloadPresent(c *tc.C) {
 			status: status.StatusInfo{
 				Status: status.Blocked,
 			},
-			viable: false,
+			viable: true,
 		},
 		{
 			name: "error",

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -14,7 +14,7 @@ import (
 
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/cloud-triggers.gen.go -package=triggers -tables=cloud,cloud_ca_cert,cloud_credential,cloud_credential_attribute
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/controller-triggers.gen.go -package=triggers -tables=controller_config,controller_node,external_controller,controller_api_address
-//go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/migration-triggers.gen.go -package=triggers -tables=model_migration_export,model_migration_export_phase,model_migration_export_minion_sync
+//go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/migration-triggers.gen.go -package=triggers -tables=model_migration_export,model_migration_export_phase,model_migration_export_minion_sync,model_migration_import
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/upgrade-triggers.gen.go -package=triggers -tables=upgrade_info,upgrade_info_controller_node
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/objectstore-triggers.gen.go -package=triggers -tables=object_store_metadata_path,object_store_drain_info,object_store_backend
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/secret-triggers.gen.go -package=triggers -tables=secret_backend_rotation,model_secret_backend
@@ -53,6 +53,7 @@ const (
 	tableModelMigrationExportMinionSync
 	tableWorkloadTracingConfig
 	tableModelDatabaseDeletion
+	tableModelMigrationImport
 )
 
 // controllerPostPatchFilesByVersion is used to categorise the post patch files
@@ -98,6 +99,7 @@ func ControllerDDLForVersion(version semversion.Number) *schema.Schema {
 		triggers.ChangeLogTriggersForModelMigrationExport("model_uuid", tableModelMigrationExport),
 		triggers.ChangeLogTriggersForModelMigrationExportPhase("model_uuid", tableModelMigrationExportPhase),
 		triggers.ChangeLogTriggersForModelMigrationExportMinionSync("migration_uuid", tableModelMigrationExportMinionSync),
+		triggers.ChangeLogTriggersForModelMigrationImport("model_uuid", tableModelMigrationImport),
 		triggers.ChangeLogTriggersForUpgradeInfo("uuid", tableUpgradeInfo),
 		triggers.ChangeLogTriggersForUpgradeInfoControllerNode("upgrade_info_uuid", tableUpgradeInfoControllerNode),
 		triggers.ChangeLogTriggersForObjectStoreMetadataPath("path", tableObjectStoreMetadata),

--- a/domain/schema/controller/triggers/migration-triggers.gen.go
+++ b/domain/schema/controller/triggers/migration-triggers.gen.go
@@ -132,3 +132,42 @@ END;`, columnName, namespaceID))
 	}
 }
 
+// ChangeLogTriggersForModelMigrationImport generates the triggers for the
+// model_migration_import table.
+func ChangeLogTriggersForModelMigrationImport(columnName string, namespaceID int) func() schema.Patch {
+	return func() schema.Patch {
+		return schema.MakePatch(fmt.Sprintf(`
+-- insert namespace for ModelMigrationImport
+INSERT INTO change_log_namespace VALUES (%[2]d, 'model_migration_import', 'ModelMigrationImport changes based on %[1]s');
+
+-- insert trigger for ModelMigrationImport
+CREATE TRIGGER trg_log_model_migration_import_insert
+AFTER INSERT ON model_migration_import FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (1, %[2]d, NEW.%[1]s, DATETIME('now', 'utc'));
+END;
+
+-- update trigger for ModelMigrationImport
+CREATE TRIGGER trg_log_model_migration_import_update
+AFTER UPDATE ON model_migration_import FOR EACH ROW
+WHEN 
+	NEW.uuid != OLD.uuid OR
+	NEW.model_uuid != OLD.model_uuid OR
+	NEW.source_migration_uuid != OLD.source_migration_uuid OR
+	NEW.phase_type_id != OLD.phase_type_id OR
+	NEW.updated_at != OLD.updated_at
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
+END;
+-- delete trigger for ModelMigrationImport
+CREATE TRIGGER trg_log_model_migration_import_delete
+AFTER DELETE ON model_migration_import FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (4, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
+END;`, columnName, namespaceID))
+	}
+}
+

--- a/domain/schema/controller_schema_test.go
+++ b/domain/schema/controller_schema_test.go
@@ -330,6 +330,10 @@ func (s *controllerSchemaSuite) TestControllerTriggers(c *tc.C) {
 		"trg_log_model_migration_export_minion_sync_update",
 		"trg_log_model_migration_export_minion_sync_delete",
 
+		"trg_log_model_migration_import_insert",
+		"trg_log_model_migration_import_update",
+		"trg_log_model_migration_import_delete",
+
 		"trg_log_model_database_deletion_insert",
 		"trg_log_model_database_deletion_update",
 		"trg_log_model_database_deletion_delete",

--- a/domain/status/service/service_test.go
+++ b/domain/status/service/service_test.go
@@ -1140,8 +1140,7 @@ func (s *serviceSuite) TestCheckUnitStatusesReadyForMigrationNotReadyWorkload(c 
 
 	err := s.modelService.CheckUnitStatusesReadyForMigration(c.Context())
 	c.Assert(err, tc.ErrorMatches, `(?m).*
-- unit "foo/66\d" workload not active or viable
-- unit "foo/66\d" workload not active or viable`)
+- unit "foo/668" workload not active or viable`)
 }
 
 func (s *serviceSuite) TestCheckUnitStatusesReadyForMigrationNotReadyWorkloadMessage(c *tc.C) {

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 
@@ -103,15 +104,23 @@ func copyFile(w io.Writer, file string) error {
 
 // tarHeader returns a tar file header given the file's stat
 // information.
+//
+// Timestamps are pinned to the epoch so that bundling the same content
+// always produces the same archive: bootstrapping two controllers from
+// one tree must yield identical agent binary hashes, or a model migrated
+// between them ends up with two entries for the same version and the
+// provisioner refuses to start new machines ("agent binary info
+// mismatch").
 func tarHeader(i os.FileInfo) *tar.Header {
+	epoch := time.Unix(0, 0).UTC()
 	return &tar.Header{
 		Typeflag:   tar.TypeReg,
 		Name:       i.Name(),
 		Size:       i.Size(),
 		Mode:       int64(i.Mode() & 0777),
-		ModTime:    i.ModTime(),
-		AccessTime: i.ModTime(),
-		ChangeTime: i.ModTime(),
+		ModTime:    epoch,
+		AccessTime: epoch,
+		ChangeTime: epoch,
 		Uname:      "ubuntu",
 		Gname:      "ubuntu",
 	}

--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -139,6 +139,37 @@ func (b *buildSuite) TestArchiveAndSHA256(c *tc.C) {
 	c.Assert(err, tc.Equals, io.EOF)
 }
 
+func (b *buildSuite) TestArchiveDeterministic(c *tc.C) {
+	// The same content bundled at different times (different file mtimes)
+	// must produce byte-identical archives, so two controllers bootstrapped
+	// from the same tree agree on the agent binary hash.
+	write := func() string {
+		dir := c.MkDir()
+		err := os.WriteFile(filepath.Join(dir, "jujuagentd"), []byte("binary"), 0755)
+		c.Assert(err, tc.ErrorIsNil)
+		return dir
+	}
+
+	now := time.Now()
+	old := now.Add(-time.Hour)
+
+	dir1 := write()
+	err := os.Chtimes(dir1+"/jujuagentd", old, old)
+	c.Assert(err, tc.ErrorIsNil)
+	var buf1 bytes.Buffer
+	err = tools.Archive(&buf1, dir1)
+	c.Assert(err, tc.ErrorIsNil)
+
+	dir2 := write()
+	err = os.Chtimes(dir2+"/jujuagentd", now, now)
+	c.Assert(err, tc.ErrorIsNil)
+	var buf2 bytes.Buffer
+	err = tools.Archive(&buf2, dir2)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(buf1.Bytes(), tc.DeepEquals, buf2.Bytes())
+}
+
 func (b *buildSuite) TestGetVersionFromJujud(c *tc.C) {
 	ver := semversion.Binary{
 		Number: semversion.Number{

--- a/internal/worker/apiremoterelationcaller/manifold.go
+++ b/internal/worker/apiremoterelationcaller/manifold.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	externalcontrollererrors "github.com/juju/juju/domain/externalcontroller/errors"
 	domainmodel "github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/internal/services"
@@ -378,7 +379,7 @@ func (a *apiInfoGetter) getAPIInfoForExternalController(ctx context.Context, mod
 	externalControllerService := services.ExternalController()
 
 	controllerInfo, err := externalControllerService.ControllerForModel(ctx, modelUUID.String())
-	if err != nil && !errors.Is(err, modelerrors.NotFound) {
+	if err != nil && !errors.Is(err, externalcontrollererrors.NotFound) {
 		return api.Info{}, errors.Trace(err)
 	} else if err == nil {
 		return api.Info{

--- a/internal/worker/apiremoterelationcaller/manifold_test.go
+++ b/internal/worker/apiremoterelationcaller/manifold_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	externalcontrollererrors "github.com/juju/juju/domain/externalcontroller/errors"
 	domainmodel "github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/internal/testhelpers"
@@ -346,7 +347,7 @@ func (s *apiInfoSuite) TestGetAPIInfoForModelNonLocalModelRedirected(c *tc.C) {
 	s.modelService.EXPECT().CheckModelExists(gomock.Any(), modelUUID).Return(false, nil)
 
 	s.domainServices.EXPECT().ExternalController().Return(s.externalController)
-	s.externalController.EXPECT().ControllerForModel(gomock.Any(), modelUUID.String()).Return(nil, modelerrors.NotFound)
+	s.externalController.EXPECT().ControllerForModel(gomock.Any(), modelUUID.String()).Return(nil, externalcontrollererrors.NotFound)
 
 	s.modelService.EXPECT().ModelRedirection(gomock.Any(), modelUUID).Return(domainmodel.ModelRedirection{
 		ControllerUUID:  "f47ac10b-58cc-4372-a567-0e02b2c3d479",
@@ -385,7 +386,7 @@ func (s *apiInfoSuite) TestGetAPIInfoForModelNonLocalModelRedirectedNotFound(c *
 	s.modelService.EXPECT().CheckModelExists(gomock.Any(), modelUUID).Return(false, nil)
 
 	s.domainServices.EXPECT().ExternalController().Return(s.externalController)
-	s.externalController.EXPECT().ControllerForModel(gomock.Any(), modelUUID.String()).Return(nil, modelerrors.NotFound)
+	s.externalController.EXPECT().ControllerForModel(gomock.Any(), modelUUID.String()).Return(nil, externalcontrollererrors.NotFound)
 
 	s.modelService.EXPECT().ModelRedirection(gomock.Any(), modelUUID).Return(domainmodel.ModelRedirection{
 		ControllerUUID:  "f47ac10b-58cc-4372-a567-0e02b2c3d479",

--- a/internal/worker/migrationminion/manifold.go
+++ b/internal/worker/migrationminion/manifold.go
@@ -5,6 +5,7 @@ package migrationminion
 
 import (
 	"context"
+	"io"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -92,6 +93,10 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 	if err := getter.Get(config.FortressName, &guard); err != nil {
 		return nil, errors.Trace(err)
 	}
+	var closer io.Closer
+	if c, ok := apiCaller.(io.Closer); ok {
+		closer = c
+	}
 
 	worker, err := config.NewWorker(Config{
 		Agent:                 agent,
@@ -104,6 +109,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		SendReport:            config.SendReport,
 		FetchTargetLokiConfig: config.FetchTargetLokiConfig,
 		ApplyJitter:           true,
+		ConnCloser:            closer,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/migrationminion/worker.go
+++ b/internal/worker/migrationminion/worker.go
@@ -603,17 +603,23 @@ func (w *Worker) robustReport(ctx context.Context, status watcher.MigrationStatu
 	apiInfo.Addrs = status.SourceAPIAddrs
 	apiInfo.CACert = status.SourceCACert
 
+	// The worker may be torn down mid-report - e.g. when the machine
+	// agent's engine bounces and takes the nested unit engine with it -
+	// so the direct dial and report must complete on a context that is
+	// not cancelled by the teardown.
+	reportCtx := context.WithoutCancel(ctx)
+
 	err = retry.Call(retry.CallArgs{
 		Func: func() error {
 			w.config.Logger.Infof(ctx, "reporting back for phase %s: %v", status.Phase, success)
 
-			conn, err := w.dialWithRedirect(ctx, apiInfo, api.DialOpts{}, 0)
+			conn, err := w.dialWithRedirect(reportCtx, apiInfo, api.DialOpts{}, 0)
 			if err != nil {
 				return fmt.Errorf("cannot dial source controller: %w", err)
 			}
 			defer func() { _ = conn.Close() }()
 
-			return w.config.SendReport(ctx, conn, status, success)
+			return w.config.SendReport(reportCtx, conn, status, success)
 		},
 		IsFatalError: func(err error) bool {
 			return false

--- a/internal/worker/migrationminion/worker.go
+++ b/internal/worker/migrationminion/worker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/internal/worker/fortress"
-	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -476,18 +475,17 @@ func (w *Worker) doSUCCESS(ctx context.Context, status watcher.MigrationStatus) 
 	// Report first because the config update that's about to happen
 	// will cause the API connection to drop. The SUCCESS phase is the
 	// point of no return anyway, so we must retry this step even if
-	// the api connection dies. If the report fails, still update the
-	// agent config: pointing at the source controller forever is worse
-	// than a late report, and the report is retried when the phase
-	// replays on the next worker start.
+	// the api connection dies.
 	reportErr := w.robustReport(ctx, status, true)
-	if reportErr != nil {
-		w.config.Logger.Warningf(ctx,
-			"reporting migration phase %s failed, updating agent config anyway: %v",
-			status.Phase, reportErr)
-	}
 
-	return w.updateAgentConfigForTargetController(ctx, status)
+	// Always update the agent config, even when the report failed -
+	// pointing at the source controller forever is the worst outcome.
+	// A report error is returned so the worker bounces and retries the
+	// report when the phase replays on the next worker start.
+	if cfgErr := w.updateAgentConfigForTargetController(ctx, status); cfgErr != nil {
+		return errors.Trace(cfgErr)
+	}
+	return errors.Annotate(reportErr, "reporting migration status")
 }
 
 func (w *Worker) updateAgentConfigForTargetController(ctx context.Context, status watcher.MigrationStatus) (err error) {
@@ -589,12 +587,14 @@ func (w *Worker) report(ctx context.Context, status watcher.MigrationStatus, suc
 
 func (w *Worker) robustReport(ctx context.Context, status watcher.MigrationStatus, success bool) error {
 	err := w.report(ctx, status, success)
-	if err != nil && !rpc.IsShutdownErr(err) {
-		return fmt.Errorf("cannot report migration status %v success=%v: %w", status, success, err)
-	} else if err == nil {
+	if err == nil {
 		return nil
 	}
-	w.config.Logger.Warningf(ctx, "report migration status failed: %v", err)
+	// Any failure - not just a dying connection - falls back to dialling
+	// the source controller directly. An in-flight report RPC can fail
+	// with "context canceled" when a race-restart tears the worker down
+	// mid-flight, and that error must not lose the report.
+	w.config.Logger.Warningf(ctx, "report migration status failed, retrying with direct dial: %v", err)
 
 	apiInfo, ok := w.config.Agent.CurrentConfig().APIInfo()
 	if !ok {

--- a/internal/worker/migrationminion/worker.go
+++ b/internal/worker/migrationminion/worker.go
@@ -476,9 +476,15 @@ func (w *Worker) doSUCCESS(ctx context.Context, status watcher.MigrationStatus) 
 	// Report first because the config update that's about to happen
 	// will cause the API connection to drop. The SUCCESS phase is the
 	// point of no return anyway, so we must retry this step even if
-	// the api connection dies.
-	if err := w.robustReport(ctx, status, true); err != nil {
-		return errors.Trace(err)
+	// the api connection dies. If the report fails, still update the
+	// agent config: pointing at the source controller forever is worse
+	// than a late report, and the report is retried when the phase
+	// replays on the next worker start.
+	reportErr := w.robustReport(ctx, status, true)
+	if reportErr != nil {
+		w.config.Logger.Warningf(ctx,
+			"reporting migration phase %s failed, updating agent config anyway: %v",
+			status.Phase, reportErr)
 	}
 
 	return w.updateAgentConfigForTargetController(ctx, status)

--- a/internal/worker/migrationminion/worker.go
+++ b/internal/worker/migrationminion/worker.go
@@ -6,6 +6,7 @@ package migrationminion
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/juju/clock"
@@ -162,6 +163,12 @@ type Config struct {
 	// backoff. This is useful when retrying validation requests to
 	// avoid flooding the target controller.
 	ApplyJitter bool
+
+	// ConnCloser, if set, is closed after the agent config is rewritten
+	// to point at the target controller, so the apicaller redials using
+	// the new addresses. apiconfigwatcher also bounces on the voyeur;
+	// closing here does not depend on it.
+	ConnCloser io.Closer
 }
 
 // Validate returns an error if config cannot drive a Worker.
@@ -518,7 +525,15 @@ func (w *Worker) updateAgentConfigForTargetController(ctx context.Context, statu
 		}
 		return nil
 	})
-	return errors.Annotate(err, "setting agent config")
+	if err != nil {
+		return errors.Annotate(err, "setting agent config")
+	}
+	if w.config.ConnCloser != nil {
+		if closeErr := w.config.ConnCloser.Close(); closeErr != nil {
+			w.config.Logger.Warningf(ctx, "closing source API connection after config update: %v", closeErr)
+		}
+	}
+	return nil
 }
 
 func (w *Worker) ensureTargetControllerDetails(ctx context.Context, status watcher.MigrationStatus) error {

--- a/internal/worker/migrationminion/worker_test.go
+++ b/internal/worker/migrationminion/worker_test.go
@@ -471,6 +471,27 @@ func (s *Suite) TestSUCCESS(c *tc.C) {
 	s.stub.CheckCall(c, 4, "Report", "id", migration.SUCCESS, true)
 }
 
+func (s *Suite) TestSUCCESSClosesSourceConnection(c *tc.C) {
+	closer := &stubCloser{}
+	s.config.ConnCloser = closer
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId:    "id",
+		Phase:          migration.SUCCESS,
+		TargetAPIAddrs: addrs,
+		TargetCACert:   caCert,
+	}
+	w, err := migrationminion.NewWorker(s.config)
+	c.Assert(err, tc.ErrorIsNil)
+
+	select {
+	case <-s.agent.configChanged:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out")
+	}
+	workertest.CleanKill(c, w)
+	c.Check(closer.closed, tc.IsTrue)
+}
+
 func (s *Suite) TestSUCCESSFetchTargetLokiConfigError(c *tc.C) {
 	s.config.FetchTargetLokiConfig = func(context.Context, api.Connection, names.Tag) (loggerapi.ControllerLokiConfig, error) {
 		return loggerapi.ControllerLokiConfig{}, errors.New("loki fetch boom")
@@ -855,6 +876,15 @@ type stubAgent struct {
 	// changed and configChanged is not signalled. It lets a test model an
 	// agent-config write failing on one attempt and recovering on a later one.
 	changeConfigErrs []error
+}
+
+type stubCloser struct {
+	closed bool
+}
+
+func (c *stubCloser) Close() error {
+	c.closed = true
+	return nil
 }
 
 func (ma *stubAgent) CurrentConfig() agent.Config {

--- a/internal/worker/migrationminion/worker_test.go
+++ b/internal/worker/migrationminion/worker_test.go
@@ -471,6 +471,38 @@ func (s *Suite) TestSUCCESS(c *tc.C) {
 	s.stub.CheckCall(c, 4, "Report", "id", migration.SUCCESS, true)
 }
 
+// TestSUCCESSReportFailureStillWritesConfig covers the wedge seen in the
+// integration tests: a report RPC that dies mid-flight (context canceled,
+// connection torn down by a bounce) must not prevent the agent config
+// from being updated, otherwise the unit points at a controller whose
+// model is gone forever.
+func (s *Suite) TestSUCCESSReportFailureStillWritesConfig(c *tc.C) {
+	s.agent.conf.tag = names.NewUnitTag("app/0")
+	s.agent.conf.dir = "/var/lib/juju/agents/unit-app-0"
+
+	// The first report attempt fails with a non-shutdown error, so
+	// robustReport returns immediately; doSUCCESS must still update the
+	// agent config instead of aborting.
+	s.stub.SetErrors(errors.New("report boom"))
+
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId:    "id",
+		Phase:          migration.SUCCESS,
+		TargetAPIAddrs: addrs,
+		TargetCACert:   caCert,
+	}
+	w, err := migrationminion.NewWorker(s.config)
+	c.Assert(err, tc.ErrorIsNil)
+
+	select {
+	case <-s.agent.configChanged:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out")
+	}
+	workertest.CleanKill(c, w)
+	c.Assert(s.agent.conf.addrs, tc.DeepEquals, addrs)
+}
+
 func (s *Suite) TestSUCCESSClosesSourceConnection(c *tc.C) {
 	closer := &stubCloser{}
 	s.config.ConnCloser = closer

--- a/internal/worker/migrationminion/worker_test.go
+++ b/internal/worker/migrationminion/worker_test.go
@@ -480,10 +480,13 @@ func (s *Suite) TestSUCCESSReportFailureStillWritesConfig(c *tc.C) {
 	s.agent.conf.tag = names.NewUnitTag("app/0")
 	s.agent.conf.dir = "/var/lib/juju/agents/unit-app-0"
 
-	// The first report attempt fails with a non-shutdown error, so
-	// robustReport returns immediately; doSUCCESS must still update the
-	// agent config instead of aborting.
+	// The first report attempt fails, and every fallback attempt fails
+	// too, so robustReport returns an error; doSUCCESS must still update
+	// the agent config instead of aborting.
 	s.stub.SetErrors(errors.New("report boom"))
+	s.config.SendReport = func(ctx context.Context, conn api.Connection, status watcher.MigrationStatus, success bool) error {
+		return errors.New("fallback report boom")
+	}
 
 	s.client.watcher.changes <- watcher.MigrationStatus{
 		MigrationId:    "id",
@@ -493,13 +496,25 @@ func (s *Suite) TestSUCCESSReportFailureStillWritesConfig(c *tc.C) {
 	}
 	w, err := migrationminion.NewWorker(s.config)
 	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
 
-	select {
-	case <-s.agent.configChanged:
-	case <-time.After(coretesting.LongWait):
-		c.Fatal("timed out")
+	// Each WaitAdvance unblocks one retry sleep; loop until the fallback
+	// exhausts and the config is written.
+	closed := func() bool {
+		select {
+		case <-s.agent.configChanged:
+			return true
+		default:
+			return false
+		}
 	}
-	workertest.CleanKill(c, w)
+	for !closed() {
+		err = s.clock.WaitAdvance(10*time.Minute, coretesting.LongWait, 1)
+		if err != nil {
+			break
+		}
+	}
+	c.Assert(closed(), tc.IsTrue)
 	c.Assert(s.agent.conf.addrs, tc.DeepEquals, addrs)
 }
 


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
