### PR TITLE
fix: agent-stream and agent-version keys could leak to the model config if model-defaults were provided during bootstrap

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -435,7 +435,7 @@ func (m *ModelManagerAPI) agentStreamFromModelDefaults(
 ) (coreagentbinary.AgentStream, error) {
 	defaults, err := m.modelDefaultsService.ModelDefaults(ctx, modelUUID)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", internalerrors.Capture(err)
 	}
 
 	attr, ok := defaults[config.AgentStreamKey]

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -404,7 +404,9 @@ func (m *ModelManagerAPI) createModelInfo(
 	// If the user has supplied an agent stream and not target agent version.
 	if suppliedAgentVersion == semversion.Zero &&
 		suppliedAgentStream != coreagentbinary.AgentStream("") {
-		// TODO: We don't have a way to set just the agent stream.
+		return modelInfoService.CreateModelWithAgentStream(
+			ctx, suppliedAgentStream,
+		)
 	}
 
 	// If the user has supplied nothing.

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -388,7 +388,7 @@ func (m *ModelManagerAPI) createModelInfo(
 
 	// If the user has not supplied an agent stream, check the model
 	// defaults for one.
-	if suppliedAgentStream == coreagentbinary.AgentStream("") {
+	if suppliedAgentStream.IsZero() {
 		modelDefaultStream, err := m.agentStreamFromModelDefaults(ctx, modelUUID)
 		if err != nil {
 			return err
@@ -398,7 +398,7 @@ func (m *ModelManagerAPI) createModelInfo(
 
 	// If the user has supplied both a target agent version and agent stream
 	if suppliedAgentVersion != semversion.Zero &&
-		suppliedAgentStream != coreagentbinary.AgentStream("") {
+		!suppliedAgentStream.IsZero() {
 		return modelInfoService.CreateModelWithAgentVersionStream(
 			ctx, suppliedAgentVersion, suppliedAgentStream,
 		)
@@ -406,7 +406,7 @@ func (m *ModelManagerAPI) createModelInfo(
 
 	// If the user has supplied a target agent version but no agent stream
 	if suppliedAgentVersion != semversion.Zero &&
-		suppliedAgentStream == coreagentbinary.AgentStream("") {
+		suppliedAgentStream.IsZero() {
 		return modelInfoService.CreateModelWithAgentVersion(
 			ctx, suppliedAgentVersion,
 		)
@@ -414,7 +414,7 @@ func (m *ModelManagerAPI) createModelInfo(
 
 	// If the user has supplied an agent stream and not target agent version.
 	if suppliedAgentVersion == semversion.Zero &&
-		suppliedAgentStream != coreagentbinary.AgentStream("") {
+		!suppliedAgentStream.IsZero() {
 		return modelInfoService.CreateModelWithAgentStream(
 			ctx, suppliedAgentStream,
 		)

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -306,7 +306,7 @@ func (m *ModelManagerAPI) CreateModel(ctx context.Context, args params.ModelCrea
 	// modelInfoCreate will be calling one of the Create* funcs on the model
 	// info service. When handling the error we need to handle the total set of
 	// possibilities.
-	err = m.createModelInfo(ctx, args.Config, modelDomainServices.ModelInfo())
+	err = m.createModelInfo(ctx, args.Config, modelUUID, modelDomainServices.ModelInfo())
 	switch {
 	case errors.Is(err, modelerrors.AlreadyExists):
 		return result, apiservererrors.ParamsErrorf(
@@ -353,6 +353,7 @@ func (m *ModelManagerAPI) CreateModel(ctx context.Context, args params.ModelCrea
 func (m *ModelManagerAPI) createModelInfo(
 	ctx context.Context,
 	configArgs map[string]any,
+	modelUUID coremodel.UUID,
 	modelInfoService ModelInfoService,
 ) error {
 	suppliedAgentVersion := semversion.Zero
@@ -385,6 +386,16 @@ func (m *ModelManagerAPI) createModelInfo(
 		delete(configArgs, config.AgentStreamKey)
 	}
 
+	// If the user has not supplied an agent stream, check the model
+	// defaults for one.
+	if suppliedAgentStream == coreagentbinary.AgentStream("") {
+		modelDefaultStream, err := m.agentStreamFromModelDefaults(ctx, modelUUID)
+		if err != nil {
+			return err
+		}
+		suppliedAgentStream = modelDefaultStream
+	}
+
 	// If the user has supplied both a target agent version and agent stream
 	if suppliedAgentVersion != semversion.Zero &&
 		suppliedAgentStream != coreagentbinary.AgentStream("") {
@@ -409,8 +420,34 @@ func (m *ModelManagerAPI) createModelInfo(
 		)
 	}
 
-	// If the user has supplied nothing.
+	// If the user has supplied nothing and no cloud default exists.
 	return modelInfoService.CreateModel(ctx)
+}
+
+// agentStreamFromModelDefaults reads the model defaults for the given model
+// and returns the agent stream value if one is set. The region default
+// takes priority over the cloud-level (controller) default, which in turn
+// takes priority over the schema default. If no default is set, an empty
+// stream is returned.
+func (m *ModelManagerAPI) agentStreamFromModelDefaults(
+	ctx context.Context,
+	modelUUID coremodel.UUID,
+) (coreagentbinary.AgentStream, error) {
+	defaults, err := m.modelDefaultsService.ModelDefaults(ctx, modelUUID)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	attr, ok := defaults[config.AgentStreamKey]
+	if !ok {
+		return "", nil
+	}
+
+	if streamStr, ok := attr.Value().(string); ok && streamStr != "" {
+		return coreagentbinary.AgentStream(streamStr), nil
+	}
+
+	return "", nil
 }
 
 func (m *ModelManagerAPI) dumpModel(ctx context.Context, args params.Entity) ([]byte, error) {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -443,6 +443,34 @@ func (s *modelManagerSuite) TestCreateModelWithTargetControllerSet(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, `target-controller parameter is only supported on JAAS`)
 }
 
+func (s *modelManagerSuite) TestCreateModelArgsWithAgentStream(c *tc.C) {
+	ctrl := s.setUpAPI(c)
+	defer ctrl.Finish()
+
+	cloudCredental := credential.Key{
+		Cloud: "dummy",
+		Owner: coreuser.AdminUserName,
+		Name:  "some-credential",
+	}
+	args := params.ModelCreateArgs{
+		Name:      "foo",
+		Qualifier: "admin",
+		Config: map[string]any{
+			"bar":                 "baz",
+			config.AgentStreamKey: "released",
+		},
+		CloudTag:           "cloud-dummy",
+		CloudRegion:        "qux",
+		CloudCredentialTag: "cloudcred-dummy_admin_some-credential",
+	}
+
+	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
+	s.modelInfoService.EXPECT().CreateModelWithAgentStream(gomock.Any(), coreagentbinary.AgentStreamReleased).Return(nil)
+
+	_, err := s.api.CreateModel(c.Context(), args)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersionAndStream(c *tc.C) {
 	ctrl := s.setUpAPI(c)
 	defer ctrl.Finish()

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -475,6 +475,47 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentStream(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestCreateModelArgsWithAgentVersionAndCloudDefaultStream is testing
+// that when the user supplies only an agent version (no stream) but a
+// cloud default for agent-stream exists, the model is created with both
+// the supplied version and the cloud default stream via
+// CreateModelWithAgentVersionStream.
+func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersionAndCloudDefaultStream(c *tc.C) {
+	ctrl := s.setUpAPI(c)
+	defer ctrl.Finish()
+
+	cloudCredental := credential.Key{
+		Cloud: "dummy",
+		Owner: coreuser.AdminUserName,
+		Name:  "some-credential",
+	}
+	args := params.ModelCreateArgs{
+		Name:      "foo",
+		Qualifier: "admin",
+		Config: map[string]any{
+			"bar":                  "baz",
+			config.AgentVersionKey: jujuversion.Current.String(),
+		},
+		CloudTag:           "cloud-dummy",
+		CloudRegion:        "qux",
+		CloudCredentialTag: "cloudcred-dummy_admin_some-credential",
+	}
+
+	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
+	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).
+		Return(modeldefaults.Defaults{
+			config.AgentStreamKey: {
+				Controller: "testing",
+			},
+		}, nil)
+	s.modelInfoService.EXPECT().CreateModelWithAgentVersionStream(
+		gomock.Any(), jujuversion.Current, coreagentbinary.AgentStreamTesting,
+	).Return(nil)
+
+	_, err := s.api.CreateModel(c.Context(), args)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 // TestCreateModelArgsWithAgentStreamFromCloudDefaults is testing that when
 // the user does not supply an agent stream, but a cloud default for
 // agent-stream exists, the model is created with the cloud default stream.

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -363,6 +363,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithCloud(c *tc.C) {
 	}
 
 	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
+	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
 	s.modelInfoService.EXPECT().CreateModel(gomock.Any()).Return(nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
@@ -379,6 +380,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *tc.C) {
 	}
 
 	s.expectCreateModel(c, ctrl, args, credential.Key{Cloud: "dummy", Owner: coreuser.AdminUserName, Name: "some-credential"}, "dummy", "dummy-region")
+	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
 	s.modelInfoService.EXPECT().CreateModel(gomock.Any()).Return(nil)
 	s.modelService.EXPECT().DefaultCloudCredentialKeyForOwner(gomock.Any(), usertesting.GenNewName(c, "admin"), "dummy").Return(credential.Key{Name: "some-credential", Cloud: "dummy", Owner: usertesting.GenNewName(c, "admin")}, nil)
 
@@ -396,6 +398,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultCredentialAdmin(c *tc.C) {
 	}
 
 	s.expectCreateModel(c, ctrl, args, credential.Key{Cloud: "dummy", Owner: coreuser.AdminUserName, Name: "some-credential"}, "dummy", "dummy-region")
+	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
 	s.modelInfoService.EXPECT().CreateModel(gomock.Any()).Return(nil)
 	s.modelService.EXPECT().DefaultCloudCredentialKeyForOwner(gomock.Any(), usertesting.GenNewName(c, "admin"), "dummy").Return(credential.Key{Name: "some-credential", Cloud: "dummy", Owner: usertesting.GenNewName(c, "admin")}, nil)
 
@@ -425,6 +428,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersion(c *tc.C) {
 	}
 
 	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
+	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
 	s.modelInfoService.EXPECT().CreateModelWithAgentVersion(gomock.Any(), jujuversion.Current).Return(nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
@@ -466,6 +470,45 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentStream(c *tc.C) {
 
 	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
 	s.modelInfoService.EXPECT().CreateModelWithAgentStream(gomock.Any(), coreagentbinary.AgentStreamReleased).Return(nil)
+
+	_, err := s.api.CreateModel(c.Context(), args)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestCreateModelArgsWithAgentStreamFromCloudDefaults is testing that when
+// the user does not supply an agent stream, but a cloud default for
+// agent-stream exists, the model is created with the cloud default stream.
+func (s *modelManagerSuite) TestCreateModelArgsWithAgentStreamFromCloudDefaults(c *tc.C) {
+	ctrl := s.setUpAPI(c)
+	defer ctrl.Finish()
+
+	cloudCredental := credential.Key{
+		Cloud: "dummy",
+		Owner: coreuser.AdminUserName,
+		Name:  "some-credential",
+	}
+	args := params.ModelCreateArgs{
+		Name:      "foo",
+		Qualifier: "admin",
+		Config: map[string]any{
+			"bar": "baz",
+		},
+		CloudTag:           "cloud-dummy",
+		CloudRegion:        "qux",
+		CloudCredentialTag: "cloudcred-dummy_admin_some-credential",
+	}
+
+	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
+	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).
+		Return(modeldefaults.Defaults{
+			config.AgentStreamKey: {
+				Controller: "testing",
+			},
+		}, nil)
+
+	s.modelInfoService.EXPECT().CreateModelWithAgentStream(
+		gomock.Any(), coreagentbinary.AgentStreamTesting,
+	).Return(nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)

--- a/apiserver/facades/client/modelmanager/service_mock_test.go
+++ b/apiserver/facades/client/modelmanager/service_mock_test.go
@@ -14,6 +14,7 @@ import (
 	time "time"
 
 	gomock "github.com/canonical/gomock/gomock"
+
 	modelmanager "github.com/juju/juju/apiserver/facades/client/modelmanager"
 	agentbinary "github.com/juju/juju/core/agentbinary"
 	assumes "github.com/juju/juju/core/assumes"
@@ -606,6 +607,7 @@ type MockModelInfoService struct {
 type MockModelInfoServiceMockRecorder struct {
 	mock                                     *MockModelInfoService
 	createModelExpects                       []*gomock.Call1_1[context.Context, error]
+	createModelWithAgentStreamExpects        []*gomock.Call2_1[context.Context, agentbinary.AgentStream, error]
 	createModelWithAgentVersionExpects       []*gomock.Call2_1[context.Context, semversion.Number, error]
 	createModelWithAgentVersionStreamExpects []*gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
 	getModelInfoExpects                      []*gomock.Call1_2[context.Context, model.ModelInfo, error]
@@ -644,6 +646,24 @@ func (mr *MockModelInfoServiceMockRecorder) CreateModel(arg0 any) *MockModelInfo
 
 // MockModelInfoServiceCreateModelCall is the typed call wrapper for CreateModel.
 type MockModelInfoServiceCreateModelCall = gomock.Call1_1[context.Context, error]
+
+// CreateModelWithAgentStream mocks base method.
+func (m *MockModelInfoService) CreateModelWithAgentStream(arg0 context.Context, arg1 agentbinary.AgentStream) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_1(&m.recorder.createModelWithAgentStreamExpects, m.ctrl, m, "CreateModelWithAgentStream", arg0, arg1)
+}
+
+// CreateModelWithAgentStream indicates an expected call of CreateModelWithAgentStream.
+func (mr *MockModelInfoServiceMockRecorder) CreateModelWithAgentStream(arg0, arg1 any) *MockModelInfoServiceCreateModelWithAgentStreamCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_1[context.Context, agentbinary.AgentStream, error](mr.mock.ctrl.T, mr.mock, "CreateModelWithAgentStream", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
+	mr.createModelWithAgentStreamExpects = append(mr.createModelWithAgentStreamExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockModelInfoServiceCreateModelWithAgentStreamCall is the typed call wrapper for CreateModelWithAgentStream.
+type MockModelInfoServiceCreateModelWithAgentStreamCall = gomock.Call2_1[context.Context, agentbinary.AgentStream, error]
 
 // CreateModelWithAgentVersion mocks base method.
 func (m *MockModelInfoService) CreateModelWithAgentVersion(arg0 context.Context, arg1 semversion.Number) error {

--- a/apiserver/facades/client/modelmanager/service_mock_test.go
+++ b/apiserver/facades/client/modelmanager/service_mock_test.go
@@ -488,6 +488,7 @@ type MockModelDefaultsService struct {
 type MockModelDefaultsServiceMockRecorder struct {
 	mock                             *MockModelDefaultsService
 	cloudDefaultsExpects             []*gomock.Call2_2[context.Context, string, modeldefaults.ModelDefaultAttributes, error]
+	modelDefaultsExpects             []*gomock.Call2_2[context.Context, model.UUID, modeldefaults.Defaults, error]
 	removeCloudDefaultsExpects       []*gomock.Call3_1[context.Context, string, []string, error]
 	removeCloudRegionDefaultsExpects []*gomock.Call4_1[context.Context, string, string, []string, error]
 	updateCloudDefaultsExpects       []*gomock.Call3_1[context.Context, string, map[string]any, error]
@@ -523,6 +524,24 @@ func (mr *MockModelDefaultsServiceMockRecorder) CloudDefaults(ctx, cloudName any
 
 // MockModelDefaultsServiceCloudDefaultsCall is the typed call wrapper for CloudDefaults.
 type MockModelDefaultsServiceCloudDefaultsCall = gomock.Call2_2[context.Context, string, modeldefaults.ModelDefaultAttributes, error]
+
+// ModelDefaults mocks base method.
+func (m *MockModelDefaultsService) ModelDefaults(ctx context.Context, uuid model.UUID) (modeldefaults.Defaults, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_2(&m.recorder.modelDefaultsExpects, m.ctrl, m, "ModelDefaults", ctx, uuid)
+}
+
+// ModelDefaults indicates an expected call of ModelDefaults.
+func (mr *MockModelDefaultsServiceMockRecorder) ModelDefaults(ctx, uuid any) *MockModelDefaultsServiceModelDefaultsCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_2[context.Context, model.UUID, modeldefaults.Defaults, error](mr.mock.ctrl.T, mr.mock, "ModelDefaults", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(uuid))
+	mr.modelDefaultsExpects = append(mr.modelDefaultsExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockModelDefaultsServiceModelDefaultsCall is the typed call wrapper for ModelDefaults.
+type MockModelDefaultsServiceModelDefaultsCall = gomock.Call2_2[context.Context, model.UUID, modeldefaults.Defaults, error]
 
 // RemoveCloudDefaults mocks base method.
 func (m *MockModelDefaultsService) RemoveCloudDefaults(ctx context.Context, cloudName string, removeAttrs []string) error {

--- a/apiserver/facades/client/modelmanager/service_mock_test.go
+++ b/apiserver/facades/client/modelmanager/service_mock_test.go
@@ -14,7 +14,6 @@ import (
 	time "time"
 
 	gomock "github.com/canonical/gomock/gomock"
-
 	modelmanager "github.com/juju/juju/apiserver/facades/client/modelmanager"
 	agentbinary "github.com/juju/juju/core/agentbinary"
 	assumes "github.com/juju/juju/core/assumes"

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -138,6 +138,10 @@ type ModelService interface {
 // ModelDefaultsService defines a interface for interacting with the model
 // defaults.
 type ModelDefaultsService interface {
+	// ModelDefaults returns the default attribute details for a specified
+	// model.
+	ModelDefaults(ctx context.Context, uuid coremodel.UUID) (modeldefaults.Defaults, error)
+
 	// CloudDefaults returns the default attribute details for a specified
 	// cloud.
 	CloudDefaults(ctx context.Context, cloudName string) (modeldefaults.ModelDefaultAttributes, error)

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -173,6 +173,12 @@ type ModelInfoService interface {
 	// initialised.
 	CreateModelWithAgentVersion(context.Context, semversion.Number) error
 
+	// CreateModelWithAgentStream is responsible for creating a new model within
+	// the model database using the specified agent stream. Upon creating the
+	// model any information required in the model's provider will be
+	// initialised.
+	CreateModelWithAgentStream(context.Context, agentbinary.AgentStream) error
+
 	// CreateModelWithAgentVersionStream is responsible for creating a new model
 	// within the model database using the specified agent version and agent
 	// stream. Upon creating the model any information required in the model's

--- a/core/agentbinary/types.go
+++ b/core/agentbinary/types.go
@@ -75,6 +75,11 @@ func (v Version) Validate() error {
 	return nil
 }
 
+// IsZero specifies whether the agent stream is a zero value.
+func (a AgentStream) IsZero() bool {
+	return a == AgentStreamZero
+}
+
 // String returns the agent stream as a string. This  function implements the
 // stringer interface.
 func (a AgentStream) String() string {

--- a/domain/model/bootstrap/bootstrap.go
+++ b/domain/model/bootstrap/bootstrap.go
@@ -173,7 +173,7 @@ func CreateLocalModelRecordWithAgentStream(
 			return errors.Errorf("getting model for id %q: %w", id, err)
 		}
 
-		if agentStream == coreagentbinary.AgentStreamZero {
+		if agentStream.IsZero() {
 			agentStream = coreagentbinary.AgentStreamReleased
 		}
 

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -457,7 +457,6 @@ func (s *ModelService) CreateModelWithAgentVersion(
 // The following error types can be expected to be returned:
 // - [modelerrors.AlreadyExists] when the model uuid is already in use.
 // - [coreerrors.NotValid] when the agent stream is not valid.
-// supported.
 func (s *ModelService) CreateModelWithAgentStream(
 	ctx context.Context,
 	agentStream agentbinary.AgentStream,

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -451,6 +451,24 @@ func (s *ModelService) CreateModelWithAgentVersion(
 	return s.CreateModelWithAgentVersionStream(ctx, agentVersion, defaultAgentStream)
 }
 
+// CreateModelWithAgentStream is responsible for creating a new model within
+// the model database using the specified agent stream.
+//
+// The following error types can be expected to be returned:
+// - [modelerrors.AlreadyExists] when the model uuid is already in use.
+// - [coreerrors.NotValid] when the agent stream is not valid.
+// supported.
+func (s *ModelService) CreateModelWithAgentStream(
+	ctx context.Context,
+	agentStream agentbinary.AgentStream,
+) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	defaultAgentVersion, _ := agentVersionSelector()
+	return s.CreateModelWithAgentVersionStream(ctx, defaultAgentVersion, agentStream)
+}
+
 // CreateModelWithAgentVersionStream is responsible for creating a new model
 // within the model database, using the input agent version and agent stream.
 //

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -389,6 +389,78 @@ func (s *modelServiceSuite) TestCreateModelForVersionInvalidStream(c *tc.C) {
 	c.Check(err, tc.ErrorIs, modelerrors.AgentStreamNotValid)
 }
 
+// TestCreateModelWithAgentStream is testing that when
+// [ModelService.CreateModelWithAgentStream] is called with a valid agent
+// stream, the model is created with the current Juju version and the
+// supplied stream.
+func (s *modelServiceSuite) TestCreateModelWithAgentStream(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	controllerUUID := uuid.MustNewUUID()
+	modelUUID := tc.Must0(c, coremodel.NewUUID)
+
+	s.mockControllerState.EXPECT().GetModelSeedInformation(gomock.Any(), modelUUID).Return(coremodel.ModelInfo{
+		UUID:           modelUUID,
+		ControllerUUID: controllerUUID,
+		Name:           "my-awesome-model",
+		Qualifier:      "prod",
+		Cloud:          "aws",
+		CloudType:      "ec2",
+		CloudRegion:    "myregion",
+		Type:           coremodel.IAAS,
+	}, nil)
+	s.mockModelState.EXPECT().Create(gomock.Any(), model.ModelDetailArgs{
+		UUID:               modelUUID,
+		ControllerUUID:     controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		AgentStream:        domainagentbinary.AgentStreamTesting,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+	}).Return(nil)
+
+	svc := NewModelService(
+		modelUUID,
+		s.mockControllerState,
+		s.mockModelState,
+		s.environVersionProviderGetter(),
+		DefaultAgentBinaryFinder(),
+	)
+	err := svc.CreateModelWithAgentStream(
+		c.Context(),
+		agentbinary.AgentStreamTesting,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestCreateModelWithAgentStreamInvalidStream is testing that when
+// [ModelService.CreateModelWithAgentStream] is called with an agent stream
+// that isn't understood or supported we get back an error that satisfies
+// [modelerrors.AgentStreamNotValid].
+func (s *modelServiceSuite) TestCreateModelWithAgentStreamInvalidStream(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := tc.Must0(c, coremodel.NewUUID)
+	s.mockControllerState.EXPECT().GetModelSeedInformation(gomock.Any(), modelUUID).Return(coremodel.ModelInfo{}, nil)
+
+	svc := NewModelService(
+		modelUUID,
+		s.mockControllerState,
+		s.mockModelState,
+		s.environVersionProviderGetter(),
+		DefaultAgentBinaryFinder(),
+	)
+	err := svc.CreateModelWithAgentStream(
+		c.Context(),
+		agentbinary.AgentStream("bad stream"),
+	)
+	c.Check(err, tc.ErrorIs, modelerrors.AgentStreamNotValid)
+}
+
 func (s *modelServiceSuite) TestGetEnvironVersion(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()

--- a/domain/modelconfig/import_integration_test.go
+++ b/domain/modelconfig/import_integration_test.go
@@ -122,11 +122,15 @@ func (s *importSuite) TestImportModelConfig(c *tc.C) {
 	defaultBase, _ := storedConfig.DefaultBase()
 	c.Check(defaultBase, tc.Equals, "ubuntu@20.04")
 
+	// agent-version and agent-stream are no longer stored in
+	// model_config; they are stored in the agent_version table. The
+	// v_model_config view synthesizes them from agent_version, which is
+	// not populated in this test, so the values are empty.
 	agentVersion, _ := storedConfig.AgentVersion()
-	c.Check(agentVersion.String(), tc.Equals, "7.8.9")
+	c.Check(agentVersion.String(), tc.Equals, "0.0.0")
 
 	agentStream := storedConfig.AgentStream()
-	c.Check(agentStream, tc.Equals, "candidate")
+	c.Check(agentStream, tc.Equals, "")
 
 	defaults := config.ConfigDefaults()
 

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -346,12 +346,22 @@ func (s *Service) SetModelConfig(
 		return errors.Errorf("constructing new model config with model defaults: %w", err)
 	}
 
-	_, err = s.validatorForSetModelConfig().Validate(ctx, setCfg, nil)
+	// Agent stream and version are not model config values. They are
+	// stored in the agent_version table and should never be written to
+	// model_config. The AggregateValidator for SetModelConfig accepts a
+	// nil pointer for old config in Validate(), so we cannot technically
+	// add AgentStreamChange() or AgentVersionChange() validation.
+	strippedCfg, err := setCfg.Remove([]string{config.AgentStreamKey, config.AgentVersionKey})
+	if err != nil {
+		return errors.Errorf("removing agent version and stream keys from model config: %w", err)
+	}
+
+	_, err = s.validatorForSetModelConfig().Validate(ctx, strippedCfg, nil)
 	if err != nil {
 		return errors.Errorf("validating model config to set for model: %w", err)
 	}
 
-	rawCfg, err := CoerceConfigForStorage(setCfg.AllAttrs())
+	rawCfg, err := CoerceConfigForStorage(strippedCfg.AllAttrs())
 	if err != nil {
 		return errors.Errorf("coercing model config for storage: %w", err)
 	}

--- a/domain/modelconfig/service/service_test.go
+++ b/domain/modelconfig/service/service_test.go
@@ -377,6 +377,50 @@ func (s *serviceSuite) TestSetModelConfigDropsAuthorizedKeys(c *tc.C) {
 	c.Check(persisted[config.TypeKey], tc.Equals, "sometype")
 }
 
+// TestSetModelConfigStripsAgentStreamAndVersion verifies that
+// SetModelConfig strips agent-stream and agent-version from the
+// config before persisting to state. These values belong in the
+// agent_version table and must never be written to model_config.
+func (s *serviceSuite) TestSetModelConfigStripsAgentStreamAndVersion(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	var defaults ModelDefaultsProviderFunc = func(_ context.Context) (modeldefaults.Defaults, error) {
+		return modeldefaults.Defaults{
+			config.AgentStreamKey: modeldefaults.DefaultAttributeValue{
+				Controller: "testing",
+			},
+			config.AgentVersionKey: modeldefaults.DefaultAttributeValue{
+				Controller: "4.0.15",
+			},
+			"foo": modeldefaults.DefaultAttributeValue{
+				Controller: "bar",
+			},
+		}, nil
+	}
+
+	attrs := map[string]any{
+		"name":          "tugudd",
+		"uuid":          "a677bdfd-3c96-46b2-912f-38e25faceaf7",
+		"type":          "sometype",
+		"agent-stream":  "proposed",
+		"agent-version": "4.0.14",
+	}
+
+	// The stored config must not contain agent-stream or agent-version.
+	// The cloud default "foo=bar" should still be applied.
+	s.mockState.EXPECT().SetModelConfig(gomock.Any(), map[string]string{
+		"name":           "tugudd",
+		"uuid":           "a677bdfd-3c96-46b2-912f-38e25faceaf7",
+		"type":           "sometype",
+		"foo":            "bar",
+		"logging-config": "<root>=INFO",
+	})
+
+	svc := NewService(defaults, config.ModelValidator(), nil, s.mockState, loggertesting.WrapCheckLog(c))
+	err := svc.SetModelConfig(c.Context(), attrs)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 // TestModelConfigWithEmptyCloudType checks that ModelConfig handles the case
 // where cloud type is empty string by converting without coercion.
 func (s *serviceSuite) TestModelConfigWithEmptyCloudType(c *tc.C) {

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -185,6 +185,7 @@ var modelPostPatchFilesByVersion = []struct {
 	version: semversion.MustParse("4.0.15"),
 	files: []string{
 		"0062-storage-filesystem-provider-id-unique.PATCH.sql",
+		"0063-agent-stream-cleanup.PATCH.sql",
 	},
 }}
 

--- a/domain/schema/model/sql/0063-agent-stream-cleanup.PATCH.sql
+++ b/domain/schema/model/sql/0063-agent-stream-cleanup.PATCH.sql
@@ -1,0 +1,6 @@
+-- Remove agent-stream and agent-version keys from model_config.
+-- These values are stored in the agent_version table and are
+-- synthesized by the v_model_config view. Storing them in model_config
+-- causes the view to return conflicting rows.
+DELETE FROM model_config
+WHERE "key" IN ('agent-stream', 'agent-version');


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->
Two keys were progressively removed from model-config: `agent-version` and `agent-stream`. In Juju 4, agent version is stored in a separate table with the agent stream ID attached. The `model-config` command displays the KVs gathered from the view `v_model_config`, which is created by unioning the `model_config` and `agent_version` tables. Ideally, these two keys should never reach the `model_config` table, and in most parts of the code, this was ensured. However, when adding a new model with a model-default provided for agent-stream when bootstrapping, the agent-stream key would leak by means of fetching data from the `cloud_defaults` table. On top of that, the models ignore the model default for agent-stream and resort to the default agent-stream from the code.

Fixed by removing both keys from the model defaults during model creation. The models also try to fetch the agent-stream from model defaults if none was supplied by the user. The additional SQL patch deletes the stale keys from the model config. During model migration, the keys are retrieved from the model config and directly inserted into the `agent_version` table, thus omitting having it on `model_config`.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

```sh
juju bootstrap lxd test --model-default agent-stream=testing
juju add-model m
juju model-config # should be testing
juju model-config agent-stream=released
juju model-config # should be released
```
Additional steps:
```sh
juju switch test:controller
juju ssh 0
juju_db_repl
```
```sql
.open <modelUUID>
SELECT * FROM model_config WHERE key = 'agent-stream' # should be empty
SELECT * FROM agent_version # stream_id should be 2 before change and 0 after
```

## Documentation changes
N/A

<!-- How it affects user workflow (CLI or API). -->

## Links

**Issue:** Fixes #22956.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10192](https://warthogs.atlassian.net/browse/JUJU-10192)


[JUJU-10192]: https://warthogs.atlassian.net/browse/JUJU-10192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ