### PR TITLE
fix(status): allow blocked units in migration precheck

### DIFF
--- a/core/status/present.go
+++ b/core/status/present.go
@@ -67,7 +67,11 @@ func IsUnitWorkloadPresent(status StatusInfo) bool {
 			return false
 		}
 		return true
-	case Blocked, Error, Terminated, Unknown:
+	case Blocked:
+		// Blocked is a recoverable state (e.g. waiting for operator
+		// config) and must not block model migration.
+		return true
+	case Error, Terminated, Unknown:
 		return false
 	default:
 		return false

--- a/core/status/present_test.go
+++ b/core/status/present_test.go
@@ -253,7 +253,7 @@ func (s *viableSuite) TestIsUnitWorkloadPresent(c *tc.C) {
 			status: status.StatusInfo{
 				Status: status.Blocked,
 			},
-			viable: false,
+			viable: true,
 		},
 		{
 			name: "error",

--- a/domain/status/service/service_test.go
+++ b/domain/status/service/service_test.go
@@ -1140,8 +1140,7 @@ func (s *serviceSuite) TestCheckUnitStatusesReadyForMigrationNotReadyWorkload(c 
 
 	err := s.modelService.CheckUnitStatusesReadyForMigration(c.Context())
 	c.Assert(err, tc.ErrorMatches, `(?m).*
-- unit "foo/66\d" workload not active or viable
-- unit "foo/66\d" workload not active or viable`)
+- unit "foo/668" workload not active or viable`)
 }
 
 func (s *serviceSuite) TestCheckUnitStatusesReadyForMigrationNotReadyWorkloadMessage(c *tc.C) {


### PR DESCRIPTION
PR #19080 (https://github.com/juju/juju/pull/19080) replaced migration’s pubsub-based presence checks
with database-backed presence and status checks. As part of that work, workload status became an
explicit migration precheck, but the blocked workload case was not covered. This differs from Juju 3.6,
where migration checked agent presence and status but did not reject units based on workload status.

A blocked workload is not necessarily unhealthy or unsafe to migrate. It commonly indicates a
recoverable state requiring operator action, such as a charm waiting for configuration. This affected
the CMR migration tests, where juju-qa-dummy-source remains blocked until its token is configured even
though its agent is connected and idle.

This change allows blocked workload statuses to pass the migration precheck while continuing to reject
error, terminated, and unknown workloads. The associated status and migration service tests have been
updated to cover this behaviour.


## QA steps

This is the first of a series of PRs that will stabilize model migration CI tests, so nothing can be tested now. Unit tests should pass though.

## Links

**Jira card:** [JUJU-9914](https://warthogs.atlassian.net/browse/JUJU-9914)


[JUJU-9914]: https://warthogs.atlassian.net/browse/JUJU-9914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ