### PR TITLE
chore: autofill login code

### DIFF
--- a/api/sessiontokenloginprovider.go
+++ b/api/sessiontokenloginprovider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/juju/errors"
 
@@ -125,8 +126,16 @@ func (p *sessionTokenLoginProvider) initiateDeviceLogin(ctx context.Context, cal
 		return errors.Trace(err)
 	}
 
+	verificationURI, err := verificationURIWithUserCode(
+		deviceResult.VerificationURI,
+		deviceResult.UserCode,
+	)
+	if err != nil {
+		return errors.Annotate(err, "building verification URL")
+	}
+
 	// We print the verification URL and the user code.
-	err = p.printOutput("Please visit %s and enter code %s to log in.", deviceResult.VerificationURI, deviceResult.UserCode)
+	err = p.printOutput("Please visit %s to log in.", verificationURI)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -145,6 +154,19 @@ func (p *sessionTokenLoginProvider) initiateDeviceLogin(ctx context.Context, cal
 	p.tokenCallback(sessionTokenResult.SessionToken)
 
 	return nil
+}
+
+func verificationURIWithUserCode(verificationURI, userCode string) (string, error) {
+	uri, err := url.Parse(verificationURI)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	query := uri.Query()
+	query.Set("user_code", userCode)
+	uri.RawQuery = query.Encode()
+
+	return uri.String(), nil
 }
 
 func (p *sessionTokenLoginProvider) login(ctx context.Context, caller base.APICaller) (*LoginResultParams, error) {

--- a/api/sessiontokenloginprovider_test.go
+++ b/api/sessiontokenloginprovider_test.go
@@ -143,7 +143,7 @@ func (s *sessionTokenLoginProviderProviderSuite) TestSessionTokenLogin(c *tc.C) 
 	c.Assert(err, tc.ErrorIsNil)
 	defer func() { _ = apiState.Close() }()
 
-	c.Check(output.String(), tc.Equals, "Please visit http://localhost:8080/test-verification and enter code 1234567 to log in.\n")
+	c.Check(output.String(), tc.Equals, "Please visit http://localhost:8080/test-verification?user_code=1234567 to log in.\n")
 	c.Check(obtainedSessionToken, tc.Equals, sessionToken)
 	c.Check(err, tc.ErrorIsNil)
 }


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->
Simple change autofilling the login code field instead of requiring the user to copy paste it every time.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] ~Comments saying why design decisions were made~
- [x] ~Go unit tests, with comments saying what you're testing~
- [x] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
1. `juju login <jaas-instance> -c i-love-jazz`
2. See the login message with the code in the query parameters, if the link is clicked the page opens with the link filled

