### PR TITLE
fex: ignore cmr units for model migration readiness

### DIFF
--- a/domain/modelmigration/state/model/state_test.go
+++ b/domain/modelmigration/state/model/state_test.go
@@ -733,50 +733,78 @@ func (s *migrationSuite) TestGetRelationValidationDataExcludesNonAlive(c *tc.C) 
 	c.Check(relations, tc.HasLen, 0)
 }
 
+// addCharm inserts a charm and returns its UUID. A CMR sourced charm is
+// inserted when cmr is true; a locally sourced charm is inserted otherwise.
+func (s *migrationSuite) addCharm(c *tc.C, name string, cmr bool) string {
+	charmUUID := uuid.MustNewUUID().String()
+	var err error
+	if cmr {
+		_, err = s.DB().ExecContext(c.Context(),
+			"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)", charmUUID, name)
+	} else {
+		_, err = s.DB().ExecContext(c.Context(),
+			"INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, ?, 0)", charmUUID, name)
+	}
+	c.Assert(err, tc.ErrorIsNil)
+	return charmUUID
+}
+
+// addCharmRelation inserts a relation endpoint on the given charm and returns
+// its UUID.
+func (s *migrationSuite) addCharmRelation(c *tc.C, charmUUID, name string, roleID int) string {
+	charmRelationUUID := uuid.MustNewUUID().String()
+	_, err := s.DB().ExecContext(c.Context(),
+		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, ?, ?, 0, 'token', false, 1)",
+		charmRelationUUID, charmUUID, name, roleID)
+	c.Assert(err, tc.ErrorIsNil)
+	return charmRelationUUID
+}
+
+// addApplication inserts an application backed by the given charm and returns
+// its UUID.
+func (s *migrationSuite) addApplication(c *tc.C, name, charmUUID string) string {
+	appUUID := uuid.MustNewUUID().String()
+	_, err := s.DB().ExecContext(c.Context(),
+		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, ?, 0, ?, ?)",
+		appUUID, name, charmUUID, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
+	c.Assert(err, tc.ErrorIsNil)
+	return appUUID
+}
+
+// addRelation inserts an alive relation and returns its UUID.
+func (s *migrationSuite) addRelation(c *tc.C, relationID int) string {
+	relationUUID := uuid.MustNewUUID().String()
+	_, err := s.DB().ExecContext(c.Context(),
+		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, 0, ?, 1)",
+		relationUUID, relationID)
+	c.Assert(err, tc.ErrorIsNil)
+	return relationUUID
+}
+
+// addRelationEndpoint links an application endpoint to a relation.
+func (s *migrationSuite) addRelationEndpoint(c *tc.C, relationUUID, appUUID, charmRelationUUID string) {
+	endpointUUID := uuid.MustNewUUID().String()
+	_, err := s.DB().ExecContext(c.Context(),
+		"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
+		endpointUUID, appUUID, charmRelationUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = s.DB().ExecContext(c.Context(),
+		"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
+		uuid.MustNewUUID().String(), relationUUID, endpointUUID)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 // TestGetRelationValidationDataExcludesCMRRelations verifies relations with
 // a cross-model relation (CMR) endpoint are excluded from validation data.
 // CMR consumer relations (offering-model side) are imported by the
 // crossmodelrelation domain, which does not create relation_unit rows, so
 // membership validation cannot apply to them.
 func (s *migrationSuite) TestGetRelationValidationDataExcludesCMRRelations(c *tc.C) {
-	db := s.DB()
-
-	// A CMR relation with a CMR-sourced remote app on one side.
-	// This simulates the offering-model side of a cross-model relation:
-	// dummy-source (local) <-> remote-* (CMR).
-	cmrCharmUUID := uuid.MustNewUUID().String()
-	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)",
-		cmrCharmUUID, "dummy-source-cmr")
-	c.Assert(err, tc.ErrorIsNil)
-
-	cmrCR := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'sink', 0, 0, 'token', false, 1)",
-		cmrCR, cmrCharmUUID)
-	c.Assert(err, tc.ErrorIsNil)
-
-	cmrAppUUID := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'remote-d29ba13b', 0, ?, ?)",
-		cmrAppUUID, cmrCharmUUID, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
-	c.Assert(err, tc.ErrorIsNil)
-
-	cmrRelationUUID := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, 0, 99, 1)",
-		cmrRelationUUID)
-	c.Assert(err, tc.ErrorIsNil)
-
-	cmrEndpointUUID := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
-		cmrEndpointUUID, cmrAppUUID, cmrCR)
-	c.Assert(err, tc.ErrorIsNil)
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
-		uuid.MustNewUUID().String(), cmrRelationUUID, cmrEndpointUUID)
-	c.Assert(err, tc.ErrorIsNil)
+	charmUUID := s.addCharm(c, "remote-d29ba13b", true)
+	charmRelationUUID := s.addCharmRelation(c, charmUUID, "sink", 0)
+	appUUID := s.addApplication(c, "remote-d29ba13b", charmUUID)
+	relationUUID := s.addRelation(c, 99)
+	s.addRelationEndpoint(c, relationUUID, appUUID, charmRelationUUID)
 
 	relations, err := New(s.TxnRunnerFactory(), s.modelUUID).GetRelationValidationData(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -787,184 +815,48 @@ func (s *migrationSuite) TestGetRelationValidationDataExcludesCMRRelations(c *tc
 // when a model has both local and CMR relations, only the local relations
 // are returned for validation.
 func (s *migrationSuite) TestGetRelationValidationDataKeepsLocalWhileExcludingCMR(c *tc.C) {
-	db := s.DB()
+	// Local relation (wordpress:db <-> mysql:db).
+	wpCharm := s.addCharm(c, "wordpress", false)
+	wpRelation := s.addCharmRelation(c, wpCharm, "db", 0)
+	wpApp := s.addApplication(c, "wordpress", wpCharm)
+	myCharm := s.addCharm(c, "mysql", false)
+	myRelation := s.addCharmRelation(c, myCharm, "db", 1)
+	myApp := s.addApplication(c, "mysql", myCharm)
+	localRelation := s.addRelation(c, 7)
+	s.addRelationEndpoint(c, localRelation, wpApp, wpRelation)
+	s.addRelationEndpoint(c, localRelation, myApp, myRelation)
 
-	// --- Local relation (wordpress:db <-> mysql:db) ---
-	localCharmUUID1 := uuid.MustNewUUID().String()
-	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, ?, 0)",
-		localCharmUUID1, "wordpress")
-	c.Assert(err, tc.ErrorIsNil)
-	localCR1 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'db', 0, 0, 'mysql', false, 1)",
-		localCR1, localCharmUUID1)
-	c.Assert(err, tc.ErrorIsNil)
-	localAppUUID1 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'wordpress', 0, ?, ?)",
-		localAppUUID1, localCharmUUID1, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
-	c.Assert(err, tc.ErrorIsNil)
-
-	localCharmUUID2 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, ?, 0)",
-		localCharmUUID2, "mysql")
-	c.Assert(err, tc.ErrorIsNil)
-	localCR2 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'db', 1, 0, 'mysql', false, 1)",
-		localCR2, localCharmUUID2)
-	c.Assert(err, tc.ErrorIsNil)
-	localAppUUID2 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'mysql', 0, ?, ?)",
-		localAppUUID2, localCharmUUID2, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
-	c.Assert(err, tc.ErrorIsNil)
-
-	localRelationUUID := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, 0, 7, 1)",
-		localRelationUUID)
-	c.Assert(err, tc.ErrorIsNil)
-
-	addLocalEndpoint := func(appUUID, charmRelUUID string) {
-		epUUID := uuid.MustNewUUID().String()
-		_, err := db.ExecContext(c.Context(),
-			"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
-			epUUID, appUUID, charmRelUUID)
-		c.Assert(err, tc.ErrorIsNil)
-		_, err = db.ExecContext(c.Context(),
-			"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
-			uuid.MustNewUUID().String(), localRelationUUID, epUUID)
-		c.Assert(err, tc.ErrorIsNil)
-	}
-	addLocalEndpoint(localAppUUID1, localCR1)
-	addLocalEndpoint(localAppUUID2, localCR2)
-
-	// --- CMR relation (dummy-source:sink <-> remote-*:source) ---
-	cmrCharmUUID := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)",
-		cmrCharmUUID, "dummy-source-cmr")
-	c.Assert(err, tc.ErrorIsNil)
-	cmrCR := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'source', 0, 0, 'token', false, 1)",
-		cmrCR, cmrCharmUUID)
-	c.Assert(err, tc.ErrorIsNil)
-	cmrAppUUID := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'remote-d29ba13b', 0, ?, ?)",
-		cmrAppUUID, cmrCharmUUID, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
-	c.Assert(err, tc.ErrorIsNil)
-
-	cmrLocalCharmUUID := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, ?, 0)",
-		cmrLocalCharmUUID, "dummy-source")
-	c.Assert(err, tc.ErrorIsNil)
-	cmrCR2 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'sink', 1, 0, 'token', false, 1)",
-		cmrCR2, cmrLocalCharmUUID)
-	c.Assert(err, tc.ErrorIsNil)
-	cmrLocalAppUUID := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'dummy-source-local', 0, ?, ?)",
-		cmrLocalAppUUID, cmrLocalCharmUUID, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
-	c.Assert(err, tc.ErrorIsNil)
-
-	cmrRelationUUID := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, 0, 99, 1)",
-		cmrRelationUUID)
-	c.Assert(err, tc.ErrorIsNil)
-
-	cmrEP1 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
-		cmrEP1, cmrAppUUID, cmrCR)
-	c.Assert(err, tc.ErrorIsNil)
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
-		uuid.MustNewUUID().String(), cmrRelationUUID, cmrEP1)
-	c.Assert(err, tc.ErrorIsNil)
-
-	cmrEP2 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
-		cmrEP2, cmrLocalAppUUID, cmrCR2)
-	c.Assert(err, tc.ErrorIsNil)
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
-		uuid.MustNewUUID().String(), cmrRelationUUID, cmrEP2)
-	c.Assert(err, tc.ErrorIsNil)
+	// CMR relation (dummy-source:sink <-> remote-*:source).
+	cmrCharm := s.addCharm(c, "remote-d29ba13b", true)
+	cmrRelation := s.addCharmRelation(c, cmrCharm, "source", 0)
+	cmrApp := s.addApplication(c, "remote-d29ba13b", cmrCharm)
+	srcCharm := s.addCharm(c, "dummy-source", false)
+	srcRelation := s.addCharmRelation(c, srcCharm, "sink", 1)
+	srcApp := s.addApplication(c, "dummy-source", srcCharm)
+	cmrRelationUUID := s.addRelation(c, 99)
+	s.addRelationEndpoint(c, cmrRelationUUID, cmrApp, cmrRelation)
+	s.addRelationEndpoint(c, cmrRelationUUID, srcApp, srcRelation)
 
 	relations, err := New(s.TxnRunnerFactory(), s.modelUUID).GetRelationValidationData(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	// Only the local wordpress:db <-> mysql:db relation is returned.
 	c.Assert(relations, tc.HasLen, 1)
-	c.Check(relations[0].UUID, tc.Equals, localRelationUUID)
+	c.Check(relations[0].UUID, tc.Equals, localRelation)
 	c.Check(relations[0].ID, tc.Equals, 7)
 }
 
 // TestGetRelationValidationDataExcludesCMRBothSides verifies a relation
 // where both endpoints are CMR-sourced is excluded from validation data.
 func (s *migrationSuite) TestGetRelationValidationDataExcludesCMRBothSides(c *tc.C) {
-	db := s.DB()
-
-	cmrCharmUUID1 := uuid.MustNewUUID().String()
-	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)",
-		cmrCharmUUID1, "remote-app-1")
-	c.Assert(err, tc.ErrorIsNil)
-	cmrCR1 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'endpoint1', 0, 0, 'token', false, 1)",
-		cmrCR1, cmrCharmUUID1)
-	c.Assert(err, tc.ErrorIsNil)
-	cmrAppUUID1 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'remote-app-1', 0, ?, ?)",
-		cmrAppUUID1, cmrCharmUUID1, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
-	c.Assert(err, tc.ErrorIsNil)
-
-	cmrCharmUUID2 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)",
-		cmrCharmUUID2, "remote-app-2")
-	c.Assert(err, tc.ErrorIsNil)
-	cmrCR2 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'endpoint2', 1, 0, 'token', false, 1)",
-		cmrCR2, cmrCharmUUID2)
-	c.Assert(err, tc.ErrorIsNil)
-	cmrAppUUID2 := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'remote-app-2', 0, ?, ?)",
-		cmrAppUUID2, cmrCharmUUID2, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
-	c.Assert(err, tc.ErrorIsNil)
-
-	cmrRelationUUID := uuid.MustNewUUID().String()
-	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, 0, 99, 1)",
-		cmrRelationUUID)
-	c.Assert(err, tc.ErrorIsNil)
-
-	addCMREndpoint := func(appUUID, charmRelUUID string) {
-		epUUID := uuid.MustNewUUID().String()
-		_, err := db.ExecContext(c.Context(),
-			"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
-			epUUID, appUUID, charmRelUUID)
-		c.Assert(err, tc.ErrorIsNil)
-		_, err = db.ExecContext(c.Context(),
-			"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
-			uuid.MustNewUUID().String(), cmrRelationUUID, epUUID)
-		c.Assert(err, tc.ErrorIsNil)
-	}
-	addCMREndpoint(cmrAppUUID1, cmrCR1)
-	addCMREndpoint(cmrAppUUID2, cmrCR2)
+	charm1 := s.addCharm(c, "remote-app-1", true)
+	relation1 := s.addCharmRelation(c, charm1, "endpoint1", 0)
+	app1 := s.addApplication(c, "remote-app-1", charm1)
+	charm2 := s.addCharm(c, "remote-app-2", true)
+	relation2 := s.addCharmRelation(c, charm2, "endpoint2", 1)
+	app2 := s.addApplication(c, "remote-app-2", charm2)
+	relationUUID := s.addRelation(c, 99)
+	s.addRelationEndpoint(c, relationUUID, app1, relation1)
+	s.addRelationEndpoint(c, relationUUID, app2, relation2)
 
 	relations, err := New(s.TxnRunnerFactory(), s.modelUUID).GetRelationValidationData(c.Context())
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/modelmigration/state/model/state_test.go
+++ b/domain/modelmigration/state/model/state_test.go
@@ -733,7 +733,243 @@ func (s *migrationSuite) TestGetRelationValidationDataExcludesNonAlive(c *tc.C) 
 	c.Check(relations, tc.HasLen, 0)
 }
 
-// TestGetApplicationUnitNamesEmpty verifies no units return an empty map.
+// TestGetRelationValidationDataExcludesCMRRelations verifies relations with
+// a cross-model relation (CMR) endpoint are excluded from validation data.
+// CMR consumer relations (offering-model side) are imported by the
+// crossmodelrelation domain, which does not create relation_unit rows, so
+// membership validation cannot apply to them.
+func (s *migrationSuite) TestGetRelationValidationDataExcludesCMRRelations(c *tc.C) {
+	db := s.DB()
+
+	// A CMR relation with a CMR-sourced remote app on one side.
+	// This simulates the offering-model side of a cross-model relation:
+	// dummy-source (local) <-> remote-* (CMR).
+	cmrCharmUUID := uuid.MustNewUUID().String()
+	_, err := db.ExecContext(c.Context(),
+		"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)",
+		cmrCharmUUID, "dummy-source-cmr")
+	c.Assert(err, tc.ErrorIsNil)
+
+	cmrCR := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'sink', 0, 0, 'token', false, 1)",
+		cmrCR, cmrCharmUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	cmrAppUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'remote-d29ba13b', 0, ?, ?)",
+		cmrAppUUID, cmrCharmUUID, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
+	c.Assert(err, tc.ErrorIsNil)
+
+	cmrRelationUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, 0, 99, 1)",
+		cmrRelationUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	cmrEndpointUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
+		cmrEndpointUUID, cmrAppUUID, cmrCR)
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
+		uuid.MustNewUUID().String(), cmrRelationUUID, cmrEndpointUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	relations, err := New(s.TxnRunnerFactory(), s.modelUUID).GetRelationValidationData(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(relations, tc.HasLen, 0)
+}
+
+// TestGetRelationValidationDataKeepsLocalWhileExcludingCMR verifies that
+// when a model has both local and CMR relations, only the local relations
+// are returned for validation.
+func (s *migrationSuite) TestGetRelationValidationDataKeepsLocalWhileExcludingCMR(c *tc.C) {
+	db := s.DB()
+
+	// --- Local relation (wordpress:db <-> mysql:db) ---
+	localCharmUUID1 := uuid.MustNewUUID().String()
+	_, err := db.ExecContext(c.Context(),
+		"INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, ?, 0)",
+		localCharmUUID1, "wordpress")
+	c.Assert(err, tc.ErrorIsNil)
+	localCR1 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'db', 0, 0, 'mysql', false, 1)",
+		localCR1, localCharmUUID1)
+	c.Assert(err, tc.ErrorIsNil)
+	localAppUUID1 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'wordpress', 0, ?, ?)",
+		localAppUUID1, localCharmUUID1, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
+	c.Assert(err, tc.ErrorIsNil)
+
+	localCharmUUID2 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, ?, 0)",
+		localCharmUUID2, "mysql")
+	c.Assert(err, tc.ErrorIsNil)
+	localCR2 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'db', 1, 0, 'mysql', false, 1)",
+		localCR2, localCharmUUID2)
+	c.Assert(err, tc.ErrorIsNil)
+	localAppUUID2 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'mysql', 0, ?, ?)",
+		localAppUUID2, localCharmUUID2, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
+	c.Assert(err, tc.ErrorIsNil)
+
+	localRelationUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, 0, 7, 1)",
+		localRelationUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	addLocalEndpoint := func(appUUID, charmRelUUID string) {
+		epUUID := uuid.MustNewUUID().String()
+		_, err := db.ExecContext(c.Context(),
+			"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
+			epUUID, appUUID, charmRelUUID)
+		c.Assert(err, tc.ErrorIsNil)
+		_, err = db.ExecContext(c.Context(),
+			"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
+			uuid.MustNewUUID().String(), localRelationUUID, epUUID)
+		c.Assert(err, tc.ErrorIsNil)
+	}
+	addLocalEndpoint(localAppUUID1, localCR1)
+	addLocalEndpoint(localAppUUID2, localCR2)
+
+	// --- CMR relation (dummy-source:sink <-> remote-*:source) ---
+	cmrCharmUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)",
+		cmrCharmUUID, "dummy-source-cmr")
+	c.Assert(err, tc.ErrorIsNil)
+	cmrCR := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'source', 0, 0, 'token', false, 1)",
+		cmrCR, cmrCharmUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	cmrAppUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'remote-d29ba13b', 0, ?, ?)",
+		cmrAppUUID, cmrCharmUUID, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
+	c.Assert(err, tc.ErrorIsNil)
+
+	cmrLocalCharmUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, ?, 0)",
+		cmrLocalCharmUUID, "dummy-source")
+	c.Assert(err, tc.ErrorIsNil)
+	cmrCR2 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'sink', 1, 0, 'token', false, 1)",
+		cmrCR2, cmrLocalCharmUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	cmrLocalAppUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'dummy-source-local', 0, ?, ?)",
+		cmrLocalAppUUID, cmrLocalCharmUUID, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
+	c.Assert(err, tc.ErrorIsNil)
+
+	cmrRelationUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, 0, 99, 1)",
+		cmrRelationUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	cmrEP1 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
+		cmrEP1, cmrAppUUID, cmrCR)
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
+		uuid.MustNewUUID().String(), cmrRelationUUID, cmrEP1)
+	c.Assert(err, tc.ErrorIsNil)
+
+	cmrEP2 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
+		cmrEP2, cmrLocalAppUUID, cmrCR2)
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
+		uuid.MustNewUUID().String(), cmrRelationUUID, cmrEP2)
+	c.Assert(err, tc.ErrorIsNil)
+
+	relations, err := New(s.TxnRunnerFactory(), s.modelUUID).GetRelationValidationData(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	// Only the local wordpress:db <-> mysql:db relation is returned.
+	c.Assert(relations, tc.HasLen, 1)
+	c.Check(relations[0].UUID, tc.Equals, localRelationUUID)
+	c.Check(relations[0].ID, tc.Equals, 7)
+}
+
+// TestGetRelationValidationDataExcludesCMRBothSides verifies a relation
+// where both endpoints are CMR-sourced is excluded from validation data.
+func (s *migrationSuite) TestGetRelationValidationDataExcludesCMRBothSides(c *tc.C) {
+	db := s.DB()
+
+	cmrCharmUUID1 := uuid.MustNewUUID().String()
+	_, err := db.ExecContext(c.Context(),
+		"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)",
+		cmrCharmUUID1, "remote-app-1")
+	c.Assert(err, tc.ErrorIsNil)
+	cmrCR1 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'endpoint1', 0, 0, 'token', false, 1)",
+		cmrCR1, cmrCharmUUID1)
+	c.Assert(err, tc.ErrorIsNil)
+	cmrAppUUID1 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'remote-app-1', 0, ?, ?)",
+		cmrAppUUID1, cmrCharmUUID1, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
+	c.Assert(err, tc.ErrorIsNil)
+
+	cmrCharmUUID2 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, ?, 2)",
+		cmrCharmUUID2, "remote-app-2")
+	c.Assert(err, tc.ErrorIsNil)
+	cmrCR2 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id, interface, optional, capacity) VALUES (?, ?, 'endpoint2', 1, 0, 'token', false, 1)",
+		cmrCR2, cmrCharmUUID2)
+	c.Assert(err, tc.ErrorIsNil)
+	cmrAppUUID2 := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, 'remote-app-2', 0, ?, ?)",
+		cmrAppUUID2, cmrCharmUUID2, "656b4a82-e28c-53d6-a014-f0dd53417eb6")
+	c.Assert(err, tc.ErrorIsNil)
+
+	cmrRelationUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, 0, 99, 1)",
+		cmrRelationUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	addCMREndpoint := func(appUUID, charmRelUUID string) {
+		epUUID := uuid.MustNewUUID().String()
+		_, err := db.ExecContext(c.Context(),
+			"INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, NULL, ?)",
+			epUUID, appUUID, charmRelUUID)
+		c.Assert(err, tc.ErrorIsNil)
+		_, err = db.ExecContext(c.Context(),
+			"INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid) VALUES (?, ?, ?)",
+			uuid.MustNewUUID().String(), cmrRelationUUID, epUUID)
+		c.Assert(err, tc.ErrorIsNil)
+	}
+	addCMREndpoint(cmrAppUUID1, cmrCR1)
+	addCMREndpoint(cmrAppUUID2, cmrCR2)
+
+	relations, err := New(s.TxnRunnerFactory(), s.modelUUID).GetRelationValidationData(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(relations, tc.HasLen, 0)
+}
 func (s *migrationSuite) TestGetApplicationUnitNamesEmpty(c *tc.C) {
 	units, err := New(s.TxnRunnerFactory(), s.modelUUID).GetApplicationUnitNames(c.Context())
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/modelmigration/state/model/validate.go
+++ b/domain/modelmigration/state/model/validate.go
@@ -222,6 +222,11 @@ JOIN   architecture AS a ON a.id = ra.architecture_id
 // needed to validate imported relation-unit consistency before activation. Only
 // alive relations are returned: units legitimately depart a dying or dead
 // relation, so requiring membership there would report false inconsistencies.
+//
+// Relations with a cross-model relation endpoint are excluded: their
+// relation_unit rows are managed outside the standard relation domain and the
+// crossmodelrelation import deliberately does not create them, so membership
+// validation cannot apply.
 func (s *State) GetRelationValidationData(ctx context.Context) ([]modelmigrationinternal.RelationValidationData, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -232,6 +237,16 @@ func (s *State) GetRelationValidationData(ctx context.Context) ([]modelmigration
 SELECT (r.uuid, r.relation_id) AS (&relationValidationRow.*)
 FROM   relation AS r
 WHERE  r.life_id = 0
+AND    NOT EXISTS (
+    SELECT 1
+    FROM   relation_endpoint AS re
+    JOIN   application_endpoint AS ae ON re.endpoint_uuid = ae.uuid
+    JOIN   application AS a ON ae.application_uuid = a.uuid
+    JOIN   charm AS c ON a.charm_uuid = c.uuid
+    JOIN   charm_source AS cs ON c.source_id = cs.id
+    WHERE  re.relation_uuid = r.uuid
+    AND    cs.name = 'cmr'
+)
 `, relationValidationRow{})
 	if err != nil {
 		return nil, errors.Errorf("preparing relation validation data statement: %w", err)
@@ -284,8 +299,8 @@ const containerRelationScope = "container"
 // getRelationEndpoints returns the endpoint rows of every alive relation,
 // grouped by relation UUID and ordered by application name, used to build the
 // readable relation key for validation error messages and to decide which of an
-// application's units are expected in scope. Only alive relations are returned,
-// matching the relations [State.GetRelationValidationData] validates.
+// application's units are expected in scope. Only alive, non-CMR relations are
+// returned, matching the relations [State.GetRelationValidationData] validates.
 func (s *State) getRelationEndpoints(ctx context.Context) (map[string][]relationEndpointRow, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -306,6 +321,16 @@ JOIN   charm_relation_scope AS crs ON cr.scope_id = crs.id
 JOIN   application AS a ON ae.application_uuid = a.uuid
 LEFT JOIN charm_metadata AS cm ON cm.charm_uuid = a.charm_uuid
 WHERE  r.life_id = 0
+AND    NOT EXISTS (
+    SELECT 1
+    FROM   relation_endpoint AS re2
+    JOIN   application_endpoint AS ae2 ON re2.endpoint_uuid = ae2.uuid
+    JOIN   application AS a2 ON ae2.application_uuid = a2.uuid
+    JOIN   charm AS c2 ON a2.charm_uuid = c2.uuid
+    JOIN   charm_source AS cs2 ON c2.source_id = cs2.id
+    WHERE  re2.relation_uuid = r.uuid
+    AND    cs2.name = 'cmr'
+)
 ORDER BY a.name
 `, relationEndpointRow{})
 	if err != nil {

--- a/domain/modelmigration/state/model/validate.go
+++ b/domain/modelmigration/state/model/validate.go
@@ -234,19 +234,19 @@ func (s *State) GetRelationValidationData(ctx context.Context) ([]modelmigration
 	}
 
 	stmt, err := s.Prepare(`
-SELECT (r.uuid, r.relation_id) AS (&relationValidationRow.*)
-FROM   relation AS r
-WHERE  r.life_id = 0
-AND    NOT EXISTS (
-    SELECT 1
+WITH cmr_relations AS (
+    SELECT DISTINCT re.relation_uuid
     FROM   relation_endpoint AS re
     JOIN   application_endpoint AS ae ON re.endpoint_uuid = ae.uuid
     JOIN   application AS a ON ae.application_uuid = a.uuid
     JOIN   charm AS c ON a.charm_uuid = c.uuid
     JOIN   charm_source AS cs ON c.source_id = cs.id
-    WHERE  re.relation_uuid = r.uuid
-    AND    cs.name = 'cmr'
+    WHERE  cs.name = 'cmr'
 )
+SELECT (r.uuid, r.relation_id) AS (&relationValidationRow.*)
+FROM   relation AS r
+WHERE  r.life_id = 0
+AND    r.uuid NOT IN (SELECT relation_uuid FROM cmr_relations)
 `, relationValidationRow{})
 	if err != nil {
 		return nil, errors.Errorf("preparing relation validation data statement: %w", err)
@@ -299,8 +299,9 @@ const containerRelationScope = "container"
 // getRelationEndpoints returns the endpoint rows of every alive relation,
 // grouped by relation UUID and ordered by application name, used to build the
 // readable relation key for validation error messages and to decide which of an
-// application's units are expected in scope. Only alive, non-CMR relations are
-// returned, matching the relations [State.GetRelationValidationData] validates.
+// application's units are expected in scope. CMR filtering is not applied here
+// because the caller [State.GetRelationValidationData] already excludes CMR
+// relations, so only its relation UUIDs are looked up in this map.
 func (s *State) getRelationEndpoints(ctx context.Context) (map[string][]relationEndpointRow, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -321,16 +322,6 @@ JOIN   charm_relation_scope AS crs ON cr.scope_id = crs.id
 JOIN   application AS a ON ae.application_uuid = a.uuid
 LEFT JOIN charm_metadata AS cm ON cm.charm_uuid = a.charm_uuid
 WHERE  r.life_id = 0
-AND    NOT EXISTS (
-    SELECT 1
-    FROM   relation_endpoint AS re2
-    JOIN   application_endpoint AS ae2 ON re2.endpoint_uuid = ae2.uuid
-    JOIN   application AS a2 ON ae2.application_uuid = a2.uuid
-    JOIN   charm AS c2 ON a2.charm_uuid = c2.uuid
-    JOIN   charm_source AS cs2 ON c2.source_id = cs2.id
-    WHERE  re2.relation_uuid = r.uuid
-    AND    cs2.name = 'cmr'
-)
 ORDER BY a.name
 `, relationEndpointRow{})
 	if err != nil {


### PR DESCRIPTION
Migrating a model with cross model relations (CMRs) from 3.6 to 4.0 fails during the target's VALIDATION phase with an error like unit dummy-source/0 hasn't joined relation "dummy-source:sink remote-...:source" yet.
validateRelationConsistency verifies that every alive unit of every application participating in an alive relation has a matching relation_unit row. It read its relations from GetRelationValidationData, which returned all alive relations including CMR relations.

But CMR consumer relations (the offering model side) are imported by the crossmodelrelation domain, which deliberately does not create relation_unit rows for them. The standard relation importer and the status importer both skip these relations, but the validation query did not, so it flagged the local unit as missing from scope and aborted the migration.

The fix updates GetRelationValidationData and getRelationEndpoints to exclude any relation with an endpoint belonging to a CMR sourced application, using the same charm_source.name = 'cmr' join already used by isRemoteRelation in the relation domain.

## QA steps

Deploy 3.6:

```sh
$ juju bootstrap lxd qa-lxd-3-6 
$ juju add-model source
$ juju deploy juju-qa-dummy-source
$ juju config dummy-source token="hello world"
$ juju offer dummy-source:sink
$ juju add-model sink
$ juju consume admin/source.dummy-source
$ juju deploy juju-qa-dummy-sink
$ juju relate dummy-source dummy-sink
```

Deploy 4.0 (i.e. this branch):

```sh
$ juju bootstrap lxd qa-lxd-4-0
$ juju migrate source qa-lxd-4-0
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/issues/23088.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10267](https://warthogs.atlassian.net/browse/JUJU-10267)


[JUJU-10267]: https://warthogs.atlassian.net/browse/JUJU-10267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ