### PR TITLE
test(spaces_gce): use add_model helper to ensure ssh key is added

### DIFF
--- a/tests/suites/spaces_gce/machines_in_spaces.sh
+++ b/tests/suites/spaces_gce/machines_in_spaces.sh
@@ -4,7 +4,10 @@ run_machines_in_spaces() {
 	echo
 
 	model_name='machines-in-spaces'
-	juju --show-log add-model "$model_name"
+	# add_model ensures the client SSH key is added to the model, which is
+	# required for `juju ssh` (e.g. lines below) since Juju 4.0 no longer
+	# auto-registers the client key when creating a model.
+	add_model "$model_name"
 
 	echo "Setup spaces"
 	juju reload-spaces


### PR DESCRIPTION
In Juju 4.0, SSH keys are no longer automatically added to newly created models. When creating a new model in integration tests via the raw `juju add-model` command rather than the test framework helper `add_model`, the client's SSH public key is not registered in the model. Consequently, subsequent `juju ssh` operations against instances in that model fail with `Permission denied (publickey)`.

This change updates `tests/suites/spaces_gce/machines_in_spaces.sh` to use the `add_model` helper, matching the pattern used across other test suites and ensuring the client's SSH key is added to the model.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [~] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [~] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run the spaces_gce integration test:
```bash
cd tests && ./main.sh spaces_gce test_machines_in_spaces
```

## Documentation changes

None

## Links

**Jira card:** [JUJU-9799](https://warthogs.atlassian.net/browse/JUJU-9799)

[JUJU-9799]: https://warthogs.atlassian.net/browse/JUJU-9799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ