### PR TITLE
feat(migration): add synchronous v8 import abort

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -556,8 +556,8 @@ VALUES (?, 0, 'instance-0')`, machineUUID)
 func (s *loginSuite) beginImport(c *tc.C, modelUUID coremodel.UUID) {
 	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES (?, ?, ?)`,
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES (?, ?, ?, '2026-01-02T03:04:05Z')`,
 			uuid.MustNewUUID().String(), modelUUID.String(), uuid.MustNewUUID().String())
 		return err
 	})

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -214,6 +214,11 @@ type ModelImporter interface {
 	// AdoptResources, the first call a source makes after durably recording
 	// SUCCESS.
 	CommitActivation(ctx context.Context, modelUUID model.UUID, sourceControllerVersion semversion.Number) error
+
+	// AbortModel drives target-side cleanup of a partially imported v8 model,
+	// transitioning its import claim to the aborting phase and undoing the
+	// controller-database import writes. It is idempotent.
+	AbortModel(ctx context.Context, modelUUID model.UUID) error
 }
 
 // ModelMigrationFactory defines an interface for getting a model migrator.

--- a/apiserver/facades/controller/migrationtarget/domain_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/domain_mock_test.go
@@ -228,6 +228,7 @@ type MockModelImporter struct {
 // MockModelImporterMockRecorder is the mock recorder for MockModelImporter.
 type MockModelImporterMockRecorder struct {
 	mock                     *MockModelImporter
+	abortModelExpects        []*gomock.Call2_1[context.Context, model.UUID, error]
 	activateModelExpects     []*gomock.Call2_1[context.Context, migration.ActivateModelArgs, error]
 	commitActivationExpects  []*gomock.Call3_1[context.Context, model.UUID, semversion.Number, error]
 	importModelExpects       []*gomock.Call3_1[context.Context, migration.ImportModelArgs, export.ProjectionView, error]
@@ -245,6 +246,24 @@ func NewMockModelImporter(ctrl *gomock.Controller) *MockModelImporter {
 func (m *MockModelImporter) EXPECT() *MockModelImporterMockRecorder {
 	return m.recorder
 }
+
+// AbortModel mocks base method.
+func (m *MockModelImporter) AbortModel(ctx context.Context, modelUUID model.UUID) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_1(&m.recorder.abortModelExpects, m.ctrl, m, "AbortModel", ctx, modelUUID)
+}
+
+// AbortModel indicates an expected call of AbortModel.
+func (mr *MockModelImporterMockRecorder) AbortModel(ctx, modelUUID any) *MockModelImporterAbortModelCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_1[context.Context, model.UUID, error](mr.mock.ctrl.T, mr.mock, "AbortModel", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	mr.abortModelExpects = append(mr.abortModelExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockModelImporterAbortModelCall is the typed call wrapper for AbortModel.
+type MockModelImporterAbortModelCall = gomock.Call2_1[context.Context, model.UUID, error]
 
 // ActivateModel mocks base method.
 func (m *MockModelImporter) ActivateModel(ctx context.Context, args migration.ActivateModelArgs) error {

--- a/apiserver/facades/controller/migrationtarget/domainservices_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/domainservices_mock_test.go
@@ -158,6 +158,7 @@ type MockDomainServicesMockRecorder struct {
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
 	modelInfoExpects                  []*gomock.Call0_1[*service25.ProviderModelService]
 	modelMigrationExpects             []*gomock.Call0_1[*service29.WatchableService]
+	modelMigrationImportExpects       []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects              []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects         []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                    []*gomock.Call0_1[*service31.WatchableService]
@@ -841,6 +842,24 @@ func (mr *MockDomainServicesMockRecorder) ModelMigration() *MockDomainServicesMo
 
 // MockDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
 type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
+
+// ModelMigrationImport mocks base method.
+func (m *MockDomainServices) ModelMigrationImport() *service29.WatchableService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.modelMigrationImportExpects, m.ctrl, m, "ModelMigrationImport")
+}
+
+// ModelMigrationImport indicates an expected call of ModelMigrationImport.
+func (mr *MockDomainServicesMockRecorder) ModelMigrationImport() *MockDomainServicesModelMigrationImportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigrationImport")
+	mr.modelMigrationImportExpects = append(mr.modelMigrationImportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockDomainServicesModelMigrationImportCall is the typed call wrapper for ModelMigrationImport.
+type MockDomainServicesModelMigrationImportCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockDomainServices) ModelProvider() *service30.Service {

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -64,6 +64,11 @@ type ModelImporter interface {
 	// path, running a durable, idempotent phase machine. It is also safe to
 	// call for legacy (3.6/4.0) imports that have no import claim.
 	ActivateModel(ctx context.Context, args migration.ActivateModelArgs) error
+
+	// AbortModel drives target-side cleanup of a partially imported v8 model,
+	// transitioning its import claim to the aborting phase and undoing the
+	// controller-database import writes. It is idempotent.
+	AbortModel(ctx context.Context, modelUUID coremodel.UUID) error
 }
 
 // CloudService provides a subset of the cloud domain service methods.
@@ -670,14 +675,13 @@ func (api *APIV8) Prechecks(ctx context.Context, args params.SerializedModelV2) 
 }
 
 // Import accepts a v8 model migration envelope, claims the model, bootstraps
-// it and applies the envelope's controller-scoped semantic data. Model-DB
-// content import and activation are not yet part of this path (Tasks 7-10).
+// it and applies the envelope's controller-scoped semantic data.
 //
 // Unlike Prechecks, Import deliberately does NOT re-run the environmental
-// prechecks. Per the spec (WS4a / Task 6) the only work that must precede the
-// first target-side write is schema validation, payload version/decode
-// preparation and the non-empty SourceMigrationUUID check — exactly what
-// importGuard covers. The equivalent collision checks become
+// prechecks. The only work that must precede the first target-side write is
+// schema validation, payload version/decode preparation and the non-empty
+// SourceMigrationUUID check — exactly what importGuard covers. The equivalent
+// collision checks become
 // structural guarded writes inside the real import path (UNIQUE(model_uuid)
 // claim insert, compare-or-insert controller data), so Import does not
 // duplicate the Prechecks routine. This mirrors v7, where Import does not
@@ -694,6 +698,24 @@ func (api *APIV8) Import(ctx context.Context, envelope params.SerializedModelV2)
 	return nil
 }
 
+// Abort drives target-side cleanup of a partially imported v8 model. It shadows
+// the v7 API.Abort (which marks the model for deletion and hands off to the undertaker):
+// on the v8 path, cleanup is owned by the migration abort finalizers. AbortModel
+// undoes the import, stages the model database for deletion, and waits (bounded)
+// for the import claim to be released. A successful return therefore frees the
+// model UUID for an immediate re-migration. A claim that has crossed the
+// activation point of no return is refused.
+func (api *APIV8) Abort(ctx context.Context, args params.ModelArgs) error {
+	modelTag, err := names.ParseModelTag(args.ModelTag)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	api.logger.Debugf(ctx, "Abort v8 migrating model %q", args.ModelTag)
+
+	return errors.Capture(api.modelImporter.AbortModel(ctx, coremodel.UUID(modelTag.Id())))
+}
+
 // importGuard runs the mandatory pre-write checks that must pass before any
 // target-side row is written on the v8 import path: model identity
 // validation (including a non-empty source migration UUID) and the payload
@@ -704,7 +726,7 @@ func (api *APIV8) Import(ctx context.Context, envelope params.SerializedModelV2)
 // There is no runtime controller-schema guard: the v8 import objects are
 // guaranteed present by the time the facade serves requests, because the
 // controllerupgrader manifold gates the apiserver behind completion of the
-// controller-DB schema upgrade (see the migrationtarget v8 spec, §4.6).
+// controller-DB schema upgrade.
 func (api *APIV8) importGuard(ctx context.Context, args params.SerializedModelV2) (export.ProjectionView, *latest.ModelExport, error) {
 	// Model sanity first: nothing else is meaningful without a valid
 	// model identity.

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -711,7 +711,7 @@ func (api *APIV8) Abort(ctx context.Context, args params.ModelArgs) error {
 		return errors.Capture(err)
 	}
 
-	api.logger.Debugf(ctx, "Abort v8 migrating model %q", args.ModelTag)
+	api.logger.Infof(ctx, "Abort v8 migrating model %q", args.ModelTag)
 
 	return errors.Capture(api.modelImporter.AbortModel(ctx, coremodel.UUID(modelTag.Id())))
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_test.go
@@ -510,6 +510,7 @@ func (s *Suite) expectImportModel(c *tc.C) {
 		return migration.NewModelImporter(
 			scope,
 			s.domainServicesGetter,
+			nil,
 			"",
 			loggertesting.WrapCheckLog(c),
 			clock.WallClock,

--- a/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget_v8_test.go
@@ -631,6 +631,44 @@ func (s *v8Suite) TestActivatePropagatesActivateModelError(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "boom")
 }
 
+// TestAbortDelegatesToAbortModel verifies the v8 Abort parses the model tag and
+// delegates to the model importer's AbortModel (not the v7 RemoveMigratingModel
+// path).
+func (s *v8Suite) TestAbortDelegatesToAbortModel(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := model.UUID(uuid.MustNewUUID().String())
+	s.modelImporter.EXPECT().AbortModel(gomock.Any(), modelUUID).Return(nil)
+
+	err := s.mustNewAPIV8(c).Abort(c.Context(), params.ModelArgs{
+		ModelTag: names.NewModelTag(modelUUID.String()).String(),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestAbortPropagatesAbortModelError verifies an error from AbortModel (such as
+// an activation-in-progress conflict) is returned rather than swallowed.
+func (s *v8Suite) TestAbortPropagatesAbortModelError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelImporter.EXPECT().AbortModel(gomock.Any(), gomock.Any()).
+		Return(errors.Errorf("boom"))
+
+	err := s.mustNewAPIV8(c).Abort(c.Context(), params.ModelArgs{
+		ModelTag: names.NewModelTag(uuid.MustNewUUID().String()).String(),
+	})
+	c.Assert(err, tc.ErrorMatches, "boom")
+}
+
+// TestAbortInvalidModelTag verifies a malformed model tag is rejected before any
+// delegation to the model importer.
+func (s *v8Suite) TestAbortInvalidModelTag(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := s.mustNewAPIV8(c).Abort(c.Context(), params.ModelArgs{ModelTag: "not-a-tag"})
+	c.Assert(err, tc.ErrorMatches, `.*"not-a-tag".*`)
+}
+
 // TestV8Registered asserts MigrationTarget v8 is advertised alongside the
 // legacy versions so the new-path source worker can negotiate it.
 func (s *v8Suite) TestV8Registered(c *tc.C) {

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -899,6 +899,7 @@ func (ctx *facadeContext) ModelImporter() facade.ModelImporter {
 	return migration.NewModelImporter(
 		ctx.migrationScope,
 		ctx.r.domainServicesGetter,
+		ctx.r.domainServices,
 		ctx.ControllerUUID(),
 		ctx.Logger(),
 		ctx.r.clock,

--- a/apiserver/services_mock_test.go
+++ b/apiserver/services_mock_test.go
@@ -26,10 +26,11 @@ import (
 	service11 "github.com/juju/juju/domain/macaroon/service"
 	service12 "github.com/juju/juju/domain/model/service"
 	service13 "github.com/juju/juju/domain/modeldefaults/service"
-	service14 "github.com/juju/juju/domain/secretbackend/service"
+	service14 "github.com/juju/juju/domain/modelmigration/service"
+	service15 "github.com/juju/juju/domain/secretbackend/service"
 	controller "github.com/juju/juju/domain/ssh/service/controller"
-	service15 "github.com/juju/juju/domain/tracing/service"
-	service16 "github.com/juju/juju/domain/upgrade/service"
+	service16 "github.com/juju/juju/domain/tracing/service"
+	service17 "github.com/juju/juju/domain/upgrade/service"
 )
 
 // MockControllerDomainServices is a mock of ControllerDomainServices interface.
@@ -57,10 +58,11 @@ type MockControllerDomainServicesMockRecorder struct {
 	macaroonExpects                   []*gomock.Call0_1[*service11.Service]
 	modelExpects                      []*gomock.Call0_1[*service12.WatchableService]
 	modelDefaultsExpects              []*gomock.Call0_1[*service13.Service]
+	modelMigrationImportExpects       []*gomock.Call0_1[*service14.WatchableService]
 	sSHServerHostKeyExpects           []*gomock.Call0_1[*controller.Service]
-	secretBackendExpects              []*gomock.Call0_1[*service14.WatchableService]
-	tracingExpects                    []*gomock.Call0_1[*service15.WatchableService]
-	upgradeExpects                    []*gomock.Call0_1[*service16.WatchableService]
+	secretBackendExpects              []*gomock.Call0_1[*service15.WatchableService]
+	tracingExpects                    []*gomock.Call0_1[*service16.WatchableService]
+	upgradeExpects                    []*gomock.Call0_1[*service17.WatchableService]
 }
 
 // NewMockControllerDomainServices creates a new mock instance.
@@ -345,6 +347,24 @@ func (mr *MockControllerDomainServicesMockRecorder) ModelDefaults() *MockControl
 // MockControllerDomainServicesModelDefaultsCall is the typed call wrapper for ModelDefaults.
 type MockControllerDomainServicesModelDefaultsCall = gomock.Call0_1[*service13.Service]
 
+// ModelMigrationImport mocks base method.
+func (m *MockControllerDomainServices) ModelMigrationImport() *service14.WatchableService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.modelMigrationImportExpects, m.ctrl, m, "ModelMigrationImport")
+}
+
+// ModelMigrationImport indicates an expected call of ModelMigrationImport.
+func (mr *MockControllerDomainServicesMockRecorder) ModelMigrationImport() *MockControllerDomainServicesModelMigrationImportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service14.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigrationImport")
+	mr.modelMigrationImportExpects = append(mr.modelMigrationImportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerDomainServicesModelMigrationImportCall is the typed call wrapper for ModelMigrationImport.
+type MockControllerDomainServicesModelMigrationImportCall = gomock.Call0_1[*service14.WatchableService]
+
 // SSHServerHostKey mocks base method.
 func (m *MockControllerDomainServices) SSHServerHostKey() *controller.Service {
 	m.ctrl.T.Helper()
@@ -364,7 +384,7 @@ func (mr *MockControllerDomainServicesMockRecorder) SSHServerHostKey() *MockCont
 type MockControllerDomainServicesSSHServerHostKeyCall = gomock.Call0_1[*controller.Service]
 
 // SecretBackend mocks base method.
-func (m *MockControllerDomainServices) SecretBackend() *service14.WatchableService {
+func (m *MockControllerDomainServices) SecretBackend() *service15.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.secretBackendExpects, m.ctrl, m, "SecretBackend")
 }
@@ -372,17 +392,17 @@ func (m *MockControllerDomainServices) SecretBackend() *service14.WatchableServi
 // SecretBackend indicates an expected call of SecretBackend.
 func (mr *MockControllerDomainServicesMockRecorder) SecretBackend() *MockControllerDomainServicesSecretBackendCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service14.WatchableService](mr.mock.ctrl.T, mr.mock, "SecretBackend")
+	call := gomock.NewCall0_1[*service15.WatchableService](mr.mock.ctrl.T, mr.mock, "SecretBackend")
 	mr.secretBackendExpects = append(mr.secretBackendExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesSecretBackendCall is the typed call wrapper for SecretBackend.
-type MockControllerDomainServicesSecretBackendCall = gomock.Call0_1[*service14.WatchableService]
+type MockControllerDomainServicesSecretBackendCall = gomock.Call0_1[*service15.WatchableService]
 
 // Tracing mocks base method.
-func (m *MockControllerDomainServices) Tracing() *service15.WatchableService {
+func (m *MockControllerDomainServices) Tracing() *service16.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.tracingExpects, m.ctrl, m, "Tracing")
 }
@@ -390,17 +410,17 @@ func (m *MockControllerDomainServices) Tracing() *service15.WatchableService {
 // Tracing indicates an expected call of Tracing.
 func (mr *MockControllerDomainServicesMockRecorder) Tracing() *MockControllerDomainServicesTracingCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service15.WatchableService](mr.mock.ctrl.T, mr.mock, "Tracing")
+	call := gomock.NewCall0_1[*service16.WatchableService](mr.mock.ctrl.T, mr.mock, "Tracing")
 	mr.tracingExpects = append(mr.tracingExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesTracingCall is the typed call wrapper for Tracing.
-type MockControllerDomainServicesTracingCall = gomock.Call0_1[*service15.WatchableService]
+type MockControllerDomainServicesTracingCall = gomock.Call0_1[*service16.WatchableService]
 
 // Upgrade mocks base method.
-func (m *MockControllerDomainServices) Upgrade() *service16.WatchableService {
+func (m *MockControllerDomainServices) Upgrade() *service17.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.upgradeExpects, m.ctrl, m, "Upgrade")
 }
@@ -408,11 +428,11 @@ func (m *MockControllerDomainServices) Upgrade() *service16.WatchableService {
 // Upgrade indicates an expected call of Upgrade.
 func (mr *MockControllerDomainServicesMockRecorder) Upgrade() *MockControllerDomainServicesUpgradeCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service16.WatchableService](mr.mock.ctrl.T, mr.mock, "Upgrade")
+	call := gomock.NewCall0_1[*service17.WatchableService](mr.mock.ctrl.T, mr.mock, "Upgrade")
 	mr.upgradeExpects = append(mr.upgradeExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesUpgradeCall is the typed call wrapper for Upgrade.
-type MockControllerDomainServicesUpgradeCall = gomock.Call0_1[*service16.WatchableService]
+type MockControllerDomainServicesUpgradeCall = gomock.Call0_1[*service17.WatchableService]

--- a/domain/model/state/controller/state.go
+++ b/domain/model/state/controller/state.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/transform"
@@ -294,11 +295,12 @@ func markModelAsImporting(
 		// This is the legacy import path with no source-side migration UUID;
 		// reuse the import UUID so the NOT NULL diagnostic column is non-empty.
 		SourceMigrationUUID: migrationUUID.String(),
+		UpdatedAt:           time.Now().UTC().Format(time.RFC3339),
 	}
 
 	stmt, err := preparer.Prepare(`
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES ($dbTargetModelMigration.uuid, $dbTargetModelMigration.model_uuid, $dbTargetModelMigration.source_migration_uuid)
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES ($dbTargetModelMigration.uuid, $dbTargetModelMigration.model_uuid, $dbTargetModelMigration.source_migration_uuid, $dbTargetModelMigration.updated_at)
 	`, migrationRecord)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/model/state/controller/state_test.go
+++ b/domain/model/state/controller/state_test.go
@@ -2190,8 +2190,8 @@ func (m *stateSuite) TestCheckModelExistsNotActivated(c *tc.C) {
 
 	err = m.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES (?, ?, ?)`, uuid.MustNewUUID().String(), modelUUID.String(), uuid.MustNewUUID().String())
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES (?, ?, ?, '2026-01-02T03:04:05Z')`, uuid.MustNewUUID().String(), modelUUID.String(), uuid.MustNewUUID().String())
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -2221,8 +2221,8 @@ func (m *stateSuite) TestGetModelConnectionInfoActivatedImporting(c *tc.C) {
 
 	err := m.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES (?, ?, ?)`, uuid.MustNewUUID().String(), m.uuid.String(), uuid.MustNewUUID().String())
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES (?, ?, ?, '2026-01-02T03:04:05Z')`, uuid.MustNewUUID().String(), m.uuid.String(), uuid.MustNewUUID().String())
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/model/state/controller/types.go
+++ b/domain/model/state/controller/types.go
@@ -372,6 +372,8 @@ type dbTargetModelMigration struct {
 	// generated import UUID (matching the upgrade backfill in
 	// 0031-model-migration.PATCH.sql).
 	SourceMigrationUUID string `db:"source_migration_uuid"`
+	// UpdatedAt is when the claim was created, stored as an RFC3339 string.
+	UpdatedAt string `db:"updated_at"`
 }
 
 // dbRedirectModelUUID is a query argument holding a model uuid matched

--- a/domain/modelmigration/errors/errors.go
+++ b/domain/modelmigration/errors/errors.go
@@ -64,4 +64,16 @@ const (
 	// exists for the model. A staged-but-incomplete redirect (completed_at IS
 	// NULL) is not yet active and returns the same error.
 	ErrModelNotRedirected = errors.ConstError("model not redirected")
+
+	// ErrAbortActivating indicates that an abort was attempted on an import
+	// claim that is in the activating phase. Once activation has crossed the
+	// point of no return the model may not be torn down; this is a
+	// non-retryable conflict. The source must retry/continue Activate instead.
+	ErrAbortActivating = errors.ConstError("cannot abort import: activation already in progress")
+
+	// ErrAbortNotFinalizable indicates that abort finalization cannot yet
+	// delete the import claim because cleanup is not provably complete (the
+	// controller model row or its namespace still exists). The caller should
+	// leave the claim in the aborting phase and retry finalization later.
+	ErrAbortNotFinalizable = errors.ConstError("import abort cannot be finalized: cleanup incomplete")
 )

--- a/domain/modelmigration/internal/types.go
+++ b/domain/modelmigration/internal/types.go
@@ -53,6 +53,15 @@ type Migration struct {
 	Target           TargetInfo
 }
 
+// ImportClaimStatus is the state-layer representation of an outstanding
+// target-side import claim.
+type ImportClaimStatus struct {
+	ModelUUID           string
+	SourceMigrationUUID string
+	PhaseType           string
+	UpdatedAt           string
+}
+
 // TargetInfo carries target connection details as persisted by state.
 type TargetInfo struct {
 	ControllerUUID  string

--- a/domain/modelmigration/service/abort.go
+++ b/domain/modelmigration/service/abort.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/trace"
+	"github.com/juju/juju/domain/modelmigration"
+	"github.com/juju/juju/internal/errors"
+)
+
+// These methods are the controller-scoped pass-throughs the v8 abort driver
+// (internal/migration.AbortModelImport) and the abort reconciler call to tear
+// down a partially imported model. They mirror the activation-driver methods in
+// activate.go: input validation and tracing live here, the SQL lives in state.
+
+// SetImportPhaseAborting transitions the model's import claim from the
+// importing phase to the aborting phase. It is idempotent when the claim is
+// already aborting, and returns
+// [modelmigrationerrors.ErrAbortActivating] when the claim has crossed the
+// activation point of no return.
+func (s *Service) SetImportPhaseAborting(ctx context.Context, modelUUID coremodel.UUID) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := modelUUID.Validate(); err != nil {
+		return errors.Errorf("validating model uuid: %w", err)
+	}
+
+	return s.controllerState.SetImportPhaseAborting(ctx, modelUUID.String())
+}
+
+// FinalizeAbortedImport deletes the model's import claim, its FK-dependent
+// companion rows, and its namespace registration once abort cleanup is provably
+// complete. It returns [modelmigrationerrors.ErrAbortNotFinalizable] when
+// cleanup is not yet provable, and is idempotent when no claim exists.
+func (s *Service) FinalizeAbortedImport(ctx context.Context, modelUUID coremodel.UUID) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := modelUUID.Validate(); err != nil {
+		return errors.Errorf("validating model uuid: %w", err)
+	}
+
+	return s.controllerState.FinalizeAbortedImport(ctx, modelUUID.String())
+}
+
+// StageAbortedModelDatabaseDeletion hands the aborted model's dqlite database
+// off to the undertaker's model-database deleter (removing its namespace
+// registration and staging the deletion), so the database is dropped out of
+// band before the claim is finalized. It is idempotent.
+func (s *Service) StageAbortedModelDatabaseDeletion(ctx context.Context, modelUUID coremodel.UUID) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := modelUUID.Validate(); err != nil {
+		return errors.Errorf("validating model uuid: %w", err)
+	}
+
+	return s.controllerState.StageAbortedModelDatabaseDeletion(ctx, modelUUID.String())
+}
+
+// IsModelDying reports whether the model row exists and has left the alive
+// state (it is dying or dead), meaning the generic removal undertaker is
+// already tearing it down, as happens after a v7/legacy abort marked it dead.
+// The v8 abort driver uses this to stand aside from such a model rather than
+// re-driving its own compensation over the undertaker's teardown.
+func (s *Service) IsModelDying(ctx context.Context, modelUUID coremodel.UUID) (bool, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := modelUUID.Validate(); err != nil {
+		return false, errors.Errorf("validating model uuid: %w", err)
+	}
+
+	return s.controllerState.IsModelDying(ctx, modelUUID.String())
+}
+
+// GetAllImportClaims returns a snapshot of every outstanding import claim, for
+// the abort reconciler to scan.
+func (s *Service) GetAllImportClaims(ctx context.Context) ([]modelmigration.ImportClaimStatus, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	return s.controllerState.GetAllImportClaims(ctx)
+}
+
+// IsImportNamespaceRegistered reports whether the model's dqlite namespace is
+// still registered, i.e. whether the model database may still need dropping
+// before abort finalization.
+func (s *Service) IsImportNamespaceRegistered(ctx context.Context, modelUUID coremodel.UUID) (bool, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := modelUUID.Validate(); err != nil {
+		return false, errors.Errorf("validating model uuid: %w", err)
+	}
+
+	return s.controllerState.IsImportNamespaceRegistered(ctx, modelUUID.String())
+}

--- a/domain/modelmigration/service/abort.go
+++ b/domain/modelmigration/service/abort.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/trace"
@@ -63,11 +64,8 @@ func (s *Service) StageAbortedModelDatabaseDeletion(ctx context.Context, modelUU
 	return s.controllerState.StageAbortedModelDatabaseDeletion(ctx, modelUUID.String())
 }
 
-// IsModelDying reports whether the model row exists and has left the alive
-// state (it is dying or dead), meaning the generic removal undertaker is
-// already tearing it down, as happens after a v7/legacy abort marked it dead.
-// The v8 abort driver uses this to stand aside from such a model rather than
-// re-driving its own compensation over the undertaker's teardown.
+// IsModelDying reports whether the model has left the alive state. It returns
+// a model-not-found error when the model does not exist.
 func (s *Service) IsModelDying(ctx context.Context, modelUUID coremodel.UUID) (bool, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -85,7 +83,26 @@ func (s *Service) GetAllImportClaims(ctx context.Context) ([]modelmigration.Impo
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	return s.controllerState.GetAllImportClaims(ctx)
+	rows, err := s.controllerState.GetAllImportClaims(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	claims := make([]modelmigration.ImportClaimStatus, 0, len(rows))
+	for _, row := range rows {
+		updatedAt, err := time.Parse(time.RFC3339, row.UpdatedAt)
+		if err != nil {
+			return nil, errors.Errorf(
+				"parsing import updated_at for model %q: %w", row.ModelUUID, err)
+		}
+		claims = append(claims, modelmigration.ImportClaimStatus{
+			ModelUUID:           row.ModelUUID,
+			SourceMigrationUUID: row.SourceMigrationUUID,
+			Phase:               modelmigration.ImportPhase(row.PhaseType),
+			UpdatedAt:           updatedAt,
+		})
+	}
+	return claims, nil
 }
 
 // IsImportNamespaceRegistered reports whether the model's dqlite namespace is

--- a/domain/modelmigration/service/abort.go
+++ b/domain/modelmigration/service/abort.go
@@ -31,7 +31,11 @@ func (s *Service) SetImportPhaseAborting(ctx context.Context, modelUUID coremode
 		return errors.Errorf("validating model uuid: %w", err)
 	}
 
-	return s.controllerState.SetImportPhaseAborting(ctx, modelUUID.String())
+	return s.controllerState.SetImportPhaseAborting(
+		ctx, modelUUID.String(),
+		modelmigration.ImportPhaseImporting, modelmigration.ImportPhaseAborting,
+		s.clock.Now().UTC().Format(time.RFC3339),
+	)
 }
 
 // FinalizeAbortedImport deletes the model's import claim, its FK-dependent
@@ -64,9 +68,9 @@ func (s *Service) StageAbortedModelDatabaseDeletion(ctx context.Context, modelUU
 	return s.controllerState.StageAbortedModelDatabaseDeletion(ctx, modelUUID.String())
 }
 
-// IsModelDying reports whether the model has left the alive state. It returns
+// IsModelNotAlive reports whether the model has left the alive state. It returns
 // a model-not-found error when the model does not exist.
-func (s *Service) IsModelDying(ctx context.Context, modelUUID coremodel.UUID) (bool, error) {
+func (s *Service) IsModelNotAlive(ctx context.Context, modelUUID coremodel.UUID) (bool, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
@@ -74,7 +78,7 @@ func (s *Service) IsModelDying(ctx context.Context, modelUUID coremodel.UUID) (b
 		return false, errors.Errorf("validating model uuid: %w", err)
 	}
 
-	return s.controllerState.IsModelDying(ctx, modelUUID.String())
+	return s.controllerState.IsModelNotAlive(ctx, modelUUID.String())
 }
 
 // GetAllImportClaims returns a snapshot of every outstanding import claim, for

--- a/domain/modelmigration/service/abort_test.go
+++ b/domain/modelmigration/service/abort_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"github.com/canonical/gomock/gomock"
+	"github.com/juju/tc"
+
+	coreerrors "github.com/juju/juju/core/errors"
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/domain/modelmigration"
+)
+
+// TestSetImportPhaseAborting asserts the transition is delegated to state.
+func (s *serviceSuite) TestSetImportPhaseAborting(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	s.controllerState.EXPECT().SetImportPhaseAborting(gomock.Any(), modelUUID.String()).Return(nil)
+
+	err := s.service(c).SetImportPhaseAborting(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestSetImportPhaseAbortingInvalidModelUUID asserts an invalid model UUID is
+// rejected before any state call.
+func (s *serviceSuite) TestSetImportPhaseAbortingInvalidModelUUID(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := s.service(c).SetImportPhaseAborting(c.Context(), coremodel.UUID("not-a-uuid"))
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}
+
+// TestFinalizeAbortedImport asserts the finalize is delegated to state.
+func (s *serviceSuite) TestFinalizeAbortedImport(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	s.controllerState.EXPECT().FinalizeAbortedImport(gomock.Any(), modelUUID.String()).Return(nil)
+
+	err := s.service(c).FinalizeAbortedImport(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestFinalizeAbortedImportInvalidModelUUID asserts an invalid model UUID is
+// rejected before any state call.
+func (s *serviceSuite) TestFinalizeAbortedImportInvalidModelUUID(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := s.service(c).FinalizeAbortedImport(c.Context(), coremodel.UUID("not-a-uuid"))
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}
+
+// TestStageAbortedModelDatabaseDeletion asserts the staging is delegated to
+// state.
+func (s *serviceSuite) TestStageAbortedModelDatabaseDeletion(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	s.controllerState.EXPECT().StageAbortedModelDatabaseDeletion(gomock.Any(), modelUUID.String()).Return(nil)
+
+	err := s.service(c).StageAbortedModelDatabaseDeletion(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestStageAbortedModelDatabaseDeletionInvalidModelUUID asserts an invalid model
+// UUID is rejected before any state call.
+func (s *serviceSuite) TestStageAbortedModelDatabaseDeletionInvalidModelUUID(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := s.service(c).StageAbortedModelDatabaseDeletion(c.Context(), coremodel.UUID("not-a-uuid"))
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}
+
+// TestGetAllImportClaims asserts the scan is delegated to state and returned
+// unchanged.
+func (s *serviceSuite) TestGetAllImportClaims(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	claims := []modelmigration.ImportClaimStatus{{
+		ModelUUID: tc.Must(c, coremodel.NewUUID).String(),
+		Phase:     modelmigration.ImportPhaseAborting,
+	}}
+	s.controllerState.EXPECT().GetAllImportClaims(gomock.Any()).Return(claims, nil)
+
+	got, err := s.service(c).GetAllImportClaims(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, claims)
+}
+
+// TestIsImportNamespaceRegistered asserts the predicate is delegated to state.
+func (s *serviceSuite) TestIsImportNamespaceRegistered(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	s.controllerState.EXPECT().IsImportNamespaceRegistered(gomock.Any(), modelUUID.String()).Return(true, nil)
+
+	got, err := s.service(c).IsImportNamespaceRegistered(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.IsTrue)
+}
+
+// TestIsImportNamespaceRegisteredInvalidModelUUID asserts an invalid model UUID
+// is rejected before any state call.
+func (s *serviceSuite) TestIsImportNamespaceRegisteredInvalidModelUUID(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	_, err := s.service(c).IsImportNamespaceRegistered(c.Context(), coremodel.UUID("not-a-uuid"))
+	c.Assert(err, tc.ErrorIs, coreerrors.NotValid)
+}

--- a/domain/modelmigration/service/abort_test.go
+++ b/domain/modelmigration/service/abort_test.go
@@ -4,12 +4,15 @@
 package service
 
 import (
+	"time"
+
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 
 	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/modelmigration"
+	modelmigrationinternal "github.com/juju/juju/domain/modelmigration/internal"
 )
 
 // TestSetImportPhaseAborting asserts the transition is delegated to state.
@@ -78,15 +81,21 @@ func (s *serviceSuite) TestStageAbortedModelDatabaseDeletionInvalidModelUUID(c *
 func (s *serviceSuite) TestGetAllImportClaims(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	claims := []modelmigration.ImportClaimStatus{{
+	updatedAt := time.Now().UTC().Truncate(time.Second)
+	rows := []modelmigrationinternal.ImportClaimStatus{{
 		ModelUUID: tc.Must(c, coremodel.NewUUID).String(),
-		Phase:     modelmigration.ImportPhaseAborting,
+		PhaseType: string(modelmigration.ImportPhaseAborting),
+		UpdatedAt: updatedAt.Format(time.RFC3339),
 	}}
-	s.controllerState.EXPECT().GetAllImportClaims(gomock.Any()).Return(claims, nil)
+	s.controllerState.EXPECT().GetAllImportClaims(gomock.Any()).Return(rows, nil)
 
 	got, err := s.service(c).GetAllImportClaims(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(got, tc.DeepEquals, claims)
+	c.Check(got, tc.DeepEquals, []modelmigration.ImportClaimStatus{{
+		ModelUUID: rows[0].ModelUUID,
+		Phase:     modelmigration.ImportPhaseAborting,
+		UpdatedAt: updatedAt,
+	}})
 }
 
 // TestIsImportNamespaceRegistered asserts the predicate is delegated to state.

--- a/domain/modelmigration/service/abort_test.go
+++ b/domain/modelmigration/service/abort_test.go
@@ -20,7 +20,10 @@ func (s *serviceSuite) TestSetImportPhaseAborting(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	modelUUID := tc.Must(c, coremodel.NewUUID)
-	s.controllerState.EXPECT().SetImportPhaseAborting(gomock.Any(), modelUUID.String()).Return(nil)
+	s.controllerState.EXPECT().SetImportPhaseAborting(
+		gomock.Any(), modelUUID.String(),
+		modelmigration.ImportPhaseImporting, modelmigration.ImportPhaseAborting, gomock.Any(),
+	).Return(nil)
 
 	err := s.service(c).SetImportPhaseAborting(c.Context(), modelUUID)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/modelmigration/service/credential_test.go
+++ b/domain/modelmigration/service/credential_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/canonical/gomock/gomock"
+	"github.com/juju/clock"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/cloud"
@@ -59,6 +60,7 @@ func (s *serviceSuite) TestCheckMachinesCredentialError(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).CheckMachines(c.Context())
 	c.Assert(err, tc.ErrorMatches, ".*validating model credential: getting model cloud credential: boom")
@@ -86,6 +88,7 @@ func (s *serviceSuite) TestCheckMachinesRevokedCredential(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).CheckMachines(c.Context())
 	c.Assert(err, tc.ErrorMatches, ".*credential.*revoked.*")
@@ -117,6 +120,7 @@ func (s *serviceSuite) TestCheckMachinesCredentialValidationError(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).CheckMachines(c.Context())
 	c.Assert(err, tc.ErrorMatches, ".*invalid credential.*")
@@ -147,6 +151,7 @@ func (s *serviceSuite) TestCheckMachinesInvalidCredential(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).CheckMachines(c.Context())
 	c.Assert(err, tc.ErrorMatches, `.*credential "default" on cloud "aws" for owner "fred" is not valid: cloud rejected the key.*`)
@@ -174,6 +179,7 @@ func (s *serviceSuite) TestCheckMachinesUnmanagedCloudIgnoresUntrackedInstances(
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).CheckMachines(c.Context())
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -96,6 +96,16 @@ type Service struct {
 // WatcherFactory describes methods for creating watchers used by the
 // [Service].
 type WatcherFactory interface {
+	// NewNamespaceWatcher returns a watcher that emits the initial collection
+	// members followed by changed identifiers in the input namespace.
+	NewNamespaceWatcher(
+		ctx context.Context,
+		initialQuery eventsource.NamespaceQuery,
+		summary string,
+		filterOption eventsource.FilterOption,
+		filterOptions ...eventsource.FilterOption,
+	) (watcher.StringsWatcher, error)
+
 	// NewNotifyWatcher returns a new watcher that filters changes from the
 	// input base watcher's db/queue. A single filter option is required,
 	// though additional filter options can be provided.
@@ -110,6 +120,10 @@ type WatcherFactory interface {
 // ControllerState defines the interface required for accessing the underlying
 // state of the model during migration.
 type ControllerState interface {
+	// InitialWatchImportClaimsStatement returns the changestream namespace and
+	// initial query for target-side import claims, keyed by model UUID.
+	InitialWatchImportClaimsStatement() (string, string)
+
 	// GetKnownSecretBackends returns the subset of the supplied secret backend
 	// UUIDs that exist on the controller, used to detect model secret value
 	// refs that still carry a source-controller-local backend UUID after
@@ -155,6 +169,11 @@ type ControllerState interface {
 	// NamespaceForWatchImportClaim returns the changestream namespace for
 	// target-side import claim changes keyed by model UUID.
 	NamespaceForWatchImportClaim() string
+
+	// NamespaceForWatchModelDatabaseDeletion returns the changestream namespace
+	// for staged model-database deletion changes, keyed by the model's namespace
+	// (its UUID).
+	NamespaceForWatchModelDatabaseDeletion() string
 
 	// InsertExport records a new export migration attempt for a model,
 	// returning [modelmigrationerrors.ErrMigrationAlreadyActive] if the model already
@@ -318,6 +337,40 @@ type ControllerState interface {
 	// deletion, completes the redirect, marks the export DONE, and scrubs
 	// target auth. It fails unless the export is still in phase REAP.
 	CompleteModelRedirectAndPurge(ctx context.Context, migrationUUID, modelUUID string) error
+
+	// SetImportPhaseAborting transitions the model's import claim from the
+	// importing phase to the aborting phase. It is idempotent when the claim is
+	// already aborting and returns
+	// [modelmigrationerrors.ErrAbortActivating] when the claim is activating.
+	SetImportPhaseAborting(ctx context.Context, modelUUID string) error
+
+	// FinalizeAbortedImport deletes the model's import claim, its FK-dependent
+	// companion rows, and its namespace registration once abort cleanup is
+	// provably complete, asserting the claim is aborting and the controller
+	// model identity and namespace mapping are both gone. It returns
+	// [modelmigrationerrors.ErrAbortNotFinalizable] when cleanup is not yet
+	// provable, and is idempotent when no claim exists.
+	FinalizeAbortedImport(ctx context.Context, modelUUID string) error
+
+	// IsModelDying reports whether the model row exists and has left the alive
+	// state (dying or dead), indicating the generic removal undertaker has taken
+	// over teardown after a v7/legacy abort. A missing model row reports false.
+	IsModelDying(ctx context.Context, modelUUID string) (bool, error)
+
+	// GetAllImportClaims returns a snapshot of every outstanding
+	// model_migration_import claim, used by the abort reconciler.
+	GetAllImportClaims(ctx context.Context) ([]modelmigration.ImportClaimStatus, error)
+
+	// IsImportNamespaceRegistered reports whether the model's dqlite namespace
+	// is still registered, i.e. whether the model database may still need
+	// dropping before abort finalization.
+	IsImportNamespaceRegistered(ctx context.Context, modelUUID string) (bool, error)
+
+	// StageAbortedModelDatabaseDeletion removes the aborted model's namespace
+	// registration and stages its dqlite database for deletion by the
+	// undertaker's model-database deleter. It asserts the claim is aborting and
+	// is idempotent.
+	StageAbortedModelDatabaseDeletion(ctx context.Context, modelUUID string) error
 }
 
 // ModelState defines the interface required for accessing the underlying state
@@ -459,6 +512,25 @@ func NewWatchableService(
 			credentialValidator,
 			logger,
 		),
+	}
+}
+
+// NewWatchableImportService constructs a controller-scoped import
+// [WatchableService] with the watchers the migration reconciler needs. It only
+// wires the controller-scoped claim methods and the watcher factory; the
+// regular import path needs no changestream dependency and continues to use
+// [NewImportService].
+func NewWatchableImportService(
+	controllerState ControllerState,
+	watcherFactory WatcherFactory,
+	logger logger.Logger,
+) *WatchableService {
+	return &WatchableService{
+		Service: Service{
+			controllerState: controllerState,
+			watcherFactory:  watcherFactory,
+			logger:          logger,
+		},
 	}
 }
 

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/names/v6"
 	"gopkg.in/macaroon.v2"
@@ -90,6 +91,7 @@ type Service struct {
 	watcherFactory      WatcherFactory
 	credentialValidator CredentialValidator
 	modelUUID           string
+	clock               clock.Clock
 	logger              logger.Logger
 }
 
@@ -339,10 +341,13 @@ type ControllerState interface {
 	CompleteModelRedirectAndPurge(ctx context.Context, migrationUUID, modelUUID string) error
 
 	// SetImportPhaseAborting transitions the model's import claim from the
-	// importing phase to the aborting phase. It is idempotent when the claim is
-	// already aborting and returns
+	// source phase to the target phase, stamping it with the supplied
+	// service-layer timestamp. It is idempotent when the claim is already in
+	// the target phase and returns
 	// [modelmigrationerrors.ErrAbortActivating] when the claim is activating.
-	SetImportPhaseAborting(ctx context.Context, modelUUID string) error
+	SetImportPhaseAborting(
+		ctx context.Context, modelUUID string, source, target modelmigration.ImportPhase, updatedAt string,
+	) error
 
 	// FinalizeAbortedImport deletes the model's import claim, its FK-dependent
 	// companion rows, and its namespace registration once abort cleanup is
@@ -352,9 +357,9 @@ type ControllerState interface {
 	// provable, and is idempotent when no claim exists.
 	FinalizeAbortedImport(ctx context.Context, modelUUID string) error
 
-	// IsModelDying reports whether the model has left the alive state. It returns
+	// IsModelNotAlive reports whether the model has left the alive state. It returns
 	// a model-not-found error when the model does not exist.
-	IsModelDying(ctx context.Context, modelUUID string) (bool, error)
+	IsModelNotAlive(ctx context.Context, modelUUID string) (bool, error)
 
 	// GetAllImportClaims returns a snapshot of every outstanding
 	// model_migration_import claim, used by the abort reconciler.
@@ -450,9 +455,10 @@ type ModelState interface {
 // only needs controller-scoped claim methods. The model-export-only
 // dependencies (modelState, watcherFactory, the provider getters, modelUUID)
 // are intentionally left unset rather than passed as nil by the caller.
-func NewImportService(controllerState ControllerState, logger logger.Logger) *Service {
+func NewImportService(controllerState ControllerState, clock clock.Clock, logger logger.Logger) *Service {
 	return &Service{
 		controllerState: controllerState,
+		clock:           clock,
 		logger:          logger,
 	}
 }
@@ -467,6 +473,7 @@ func NewService(
 	instanceProviderGetter providertracker.ProviderGetter[InstanceProvider],
 	resourceProviderGetter providertracker.ProviderGetter[ResourceProvider],
 	credentialValidator CredentialValidator,
+	clock clock.Clock,
 	logger logger.Logger,
 ) *Service {
 	return &Service{
@@ -477,6 +484,7 @@ func NewService(
 		resourceProviderGetter: resourceProviderGetter,
 		credentialValidator:    credentialValidator,
 		modelUUID:              modelUUID,
+		clock:                  clock,
 		logger:                 logger,
 	}
 }
@@ -498,6 +506,7 @@ func NewWatchableService(
 	instanceProviderGetter providertracker.ProviderGetter[InstanceProvider],
 	resourceProviderGetter providertracker.ProviderGetter[ResourceProvider],
 	credentialValidator CredentialValidator,
+	clock clock.Clock,
 	logger logger.Logger,
 ) *WatchableService {
 	return &WatchableService{
@@ -509,6 +518,7 @@ func NewWatchableService(
 			instanceProviderGetter,
 			resourceProviderGetter,
 			credentialValidator,
+			clock,
 			logger,
 		),
 	}
@@ -522,12 +532,14 @@ func NewWatchableService(
 func NewWatchableImportService(
 	controllerState ControllerState,
 	watcherFactory WatcherFactory,
+	clock clock.Clock,
 	logger logger.Logger,
 ) *WatchableService {
 	return &WatchableService{
 		Service: Service{
 			controllerState: controllerState,
 			watcherFactory:  watcherFactory,
+			clock:           clock,
 			logger:          logger,
 		},
 	}

--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -352,14 +352,13 @@ type ControllerState interface {
 	// provable, and is idempotent when no claim exists.
 	FinalizeAbortedImport(ctx context.Context, modelUUID string) error
 
-	// IsModelDying reports whether the model row exists and has left the alive
-	// state (dying or dead), indicating the generic removal undertaker has taken
-	// over teardown after a v7/legacy abort. A missing model row reports false.
+	// IsModelDying reports whether the model has left the alive state. It returns
+	// a model-not-found error when the model does not exist.
 	IsModelDying(ctx context.Context, modelUUID string) (bool, error)
 
 	// GetAllImportClaims returns a snapshot of every outstanding
 	// model_migration_import claim, used by the abort reconciler.
-	GetAllImportClaims(ctx context.Context) ([]modelmigration.ImportClaimStatus, error)
+	GetAllImportClaims(ctx context.Context) ([]modelmigrationinternal.ImportClaimStatus, error)
 
 	// IsImportNamespaceRegistered reports whether the model's dqlite namespace
 	// is still registered, i.e. whether the model database may still need

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -119,49 +119,57 @@ type MockControllerState struct {
 
 // MockControllerStateMockRecorder is the mock recorder for MockControllerState.
 type MockControllerStateMockRecorder struct {
-	mock                                         *MockControllerState
-	aggregateMinionReportsExpects                []*gomock.Call3_2[context.Context, string, migration.Phase, internal.MinionReports, error]
-	assertImportingExpects                       []*gomock.Call2_1[context.Context, string, error]
-	beginImportExpects                           []*gomock.Call4_2[context.Context, string, string, string, modelmigration0.ImportClaim, error]
-	checkCloudRegionExpects                      []*gomock.Call3_3[context.Context, string, string, bool, bool, error]
-	checkImportModelCollisionExpects             []*gomock.Call4_2[context.Context, string, string, string, modelmigration0.ImportModelCollision, error]
-	completeModelRedirectAndPurgeExpects         []*gomock.Call3_1[context.Context, string, string, error]
-	deleteActivatedImportExpects                 []*gomock.Call2_1[context.Context, string, error]
-	deleteModelImportingStatusExpects            []*gomock.Call2_1[context.Context, string, error]
-	ensureExportOffersExpects                    []*gomock.Call3_1[context.Context, string, []string, error]
-	ensureExternalControllerExistsExpects        []*gomock.Call2_1[context.Context, internal.ExternalController, error]
-	ensureSourceControllerExistsExpects          []*gomock.Call7_1[context.Context, string, string, string, []string, []string, []string, error]
-	externalControllerModelsForImportExpects     []*gomock.Call2_2[context.Context, string, []modelmigration.OffererModel, error]
-	getActiveExportExpects                       []*gomock.Call2_2[context.Context, string, internal.Migration, error]
-	getActiveExportUUIDExpects                   []*gomock.Call2_2[context.Context, string, string, error]
-	getAgentBinaryArchitecturesForVersionExpects []*gomock.Call2_2[context.Context, string, []string, error]
-	getCloudExpects                              []*gomock.Call2_2[context.Context, string, cloud.Cloud, error]
-	getConflictingCloudImageMetadataExpects      []*gomock.Call2_2[context.Context, []modelmigration0.ImportPrecheckImageMetadata, []modelmigration0.CloudImageMetadataConflict, error]
-	getControllerTargetVersionExpects            []*gomock.Call1_2[context.Context, string, error]
-	getCredentialRevokedExpects                  []*gomock.Call4_3[context.Context, string, string, string, bool, bool, error]
-	getDisabledUsersExpects                      []*gomock.Call2_2[context.Context, []string, []string, error]
-	getImportClaimExpects                        []*gomock.Call2_2[context.Context, string, modelmigration0.ImportClaim, error]
-	getImportedOfferUUIDsExpects                 []*gomock.Call2_2[context.Context, string, []string, error]
-	getKnownSecretBackendsExpects                []*gomock.Call2_2[context.Context, []string, []string, error]
-	getMigrationModeExpects                      []*gomock.Call2_2[context.Context, string, modelmigration0.MigrationMode, error]
-	getMigrationPhaseExpects                     []*gomock.Call2_2[context.Context, string, string, error]
-	getModelCloudCredentialExpects               []*gomock.Call2_2[context.Context, string, *modelmigration.ModelCloudCredential, error]
-	getModelUsersForRedirectExpects              []*gomock.Call2_2[context.Context, string, []internal.RedirectUserAccess, error]
-	getSecretBackendReferencesForModelExpects    []*gomock.Call2_2[context.Context, string, map[string]string, error]
-	getSourceControllerInfoExpects               []*gomock.Call1_2[context.Context, internal.SourceControllerInfo, error]
-	importExternalControllersExpects             []*gomock.Call4_1[context.Context, string, string, []internal.ExternalController, error]
-	importOfferPermissionsExpects                []*gomock.Call4_1[context.Context, string, string, []string, error]
-	insertExportExpects                          []*gomock.Call2_1[context.Context, internal.MigrationSpec, error]
-	insertMinionReportExpects                    []*gomock.Call5_1[context.Context, string, migration.Phase, string, bool, error]
-	namespaceForWatchExportExpects               []*gomock.Call0_1[string]
-	namespaceForWatchImportClaimExpects          []*gomock.Call0_1[string]
-	namespaceForWatchMinionSyncExpects           []*gomock.Call0_1[string]
-	namespaceForWatchPhaseExpects                []*gomock.Call0_1[string]
-	secretBackendExistsExpects                   []*gomock.Call2_2[context.Context, string, bool, error]
-	setImportPhaseActivatingExpects              []*gomock.Call2_1[context.Context, string, error]
-	setPhaseExpects                              []*gomock.Call3_1[context.Context, string, migration.Phase, error]
-	setStatusMessageExpects                      []*gomock.Call3_1[context.Context, string, string, error]
-	stageModelRedirectExpects                    []*gomock.Call5_1[context.Context, string, string, internal.RedirectionTarget, []internal.RedirectUserAccess, error]
+	mock                                          *MockControllerState
+	aggregateMinionReportsExpects                 []*gomock.Call3_2[context.Context, string, migration.Phase, internal.MinionReports, error]
+	assertImportingExpects                        []*gomock.Call2_1[context.Context, string, error]
+	beginImportExpects                            []*gomock.Call4_2[context.Context, string, string, string, modelmigration0.ImportClaim, error]
+	checkCloudRegionExpects                       []*gomock.Call3_3[context.Context, string, string, bool, bool, error]
+	checkImportModelCollisionExpects              []*gomock.Call4_2[context.Context, string, string, string, modelmigration0.ImportModelCollision, error]
+	completeModelRedirectAndPurgeExpects          []*gomock.Call3_1[context.Context, string, string, error]
+	deleteActivatedImportExpects                  []*gomock.Call2_1[context.Context, string, error]
+	deleteModelImportingStatusExpects             []*gomock.Call2_1[context.Context, string, error]
+	ensureExportOffersExpects                     []*gomock.Call3_1[context.Context, string, []string, error]
+	ensureExternalControllerExistsExpects         []*gomock.Call2_1[context.Context, internal.ExternalController, error]
+	ensureSourceControllerExistsExpects           []*gomock.Call7_1[context.Context, string, string, string, []string, []string, []string, error]
+	externalControllerModelsForImportExpects      []*gomock.Call2_2[context.Context, string, []modelmigration.OffererModel, error]
+	finalizeAbortedImportExpects                  []*gomock.Call2_1[context.Context, string, error]
+	getActiveExportExpects                        []*gomock.Call2_2[context.Context, string, internal.Migration, error]
+	getActiveExportUUIDExpects                    []*gomock.Call2_2[context.Context, string, string, error]
+	getAgentBinaryArchitecturesForVersionExpects  []*gomock.Call2_2[context.Context, string, []string, error]
+	getAllImportClaimsExpects                     []*gomock.Call1_2[context.Context, []modelmigration0.ImportClaimStatus, error]
+	getCloudExpects                               []*gomock.Call2_2[context.Context, string, cloud.Cloud, error]
+	getConflictingCloudImageMetadataExpects       []*gomock.Call2_2[context.Context, []modelmigration0.ImportPrecheckImageMetadata, []modelmigration0.CloudImageMetadataConflict, error]
+	getControllerTargetVersionExpects             []*gomock.Call1_2[context.Context, string, error]
+	getCredentialRevokedExpects                   []*gomock.Call4_3[context.Context, string, string, string, bool, bool, error]
+	getDisabledUsersExpects                       []*gomock.Call2_2[context.Context, []string, []string, error]
+	getImportClaimExpects                         []*gomock.Call2_2[context.Context, string, modelmigration0.ImportClaim, error]
+	getImportedOfferUUIDsExpects                  []*gomock.Call2_2[context.Context, string, []string, error]
+	getKnownSecretBackendsExpects                 []*gomock.Call2_2[context.Context, []string, []string, error]
+	getMigrationModeExpects                       []*gomock.Call2_2[context.Context, string, modelmigration0.MigrationMode, error]
+	getMigrationPhaseExpects                      []*gomock.Call2_2[context.Context, string, string, error]
+	getModelCloudCredentialExpects                []*gomock.Call2_2[context.Context, string, *modelmigration.ModelCloudCredential, error]
+	getModelUsersForRedirectExpects               []*gomock.Call2_2[context.Context, string, []internal.RedirectUserAccess, error]
+	getSecretBackendReferencesForModelExpects     []*gomock.Call2_2[context.Context, string, map[string]string, error]
+	getSourceControllerInfoExpects                []*gomock.Call1_2[context.Context, internal.SourceControllerInfo, error]
+	importExternalControllersExpects              []*gomock.Call4_1[context.Context, string, string, []internal.ExternalController, error]
+	importOfferPermissionsExpects                 []*gomock.Call4_1[context.Context, string, string, []string, error]
+	initialWatchImportClaimsStatementExpects      []*gomock.Call0_2[string, string]
+	insertExportExpects                           []*gomock.Call2_1[context.Context, internal.MigrationSpec, error]
+	insertMinionReportExpects                     []*gomock.Call5_1[context.Context, string, migration.Phase, string, bool, error]
+	isImportNamespaceRegisteredExpects            []*gomock.Call2_2[context.Context, string, bool, error]
+	isModelDyingExpects                           []*gomock.Call2_2[context.Context, string, bool, error]
+	namespaceForWatchExportExpects                []*gomock.Call0_1[string]
+	namespaceForWatchImportClaimExpects           []*gomock.Call0_1[string]
+	namespaceForWatchMinionSyncExpects            []*gomock.Call0_1[string]
+	namespaceForWatchModelDatabaseDeletionExpects []*gomock.Call0_1[string]
+	namespaceForWatchPhaseExpects                 []*gomock.Call0_1[string]
+	secretBackendExistsExpects                    []*gomock.Call2_2[context.Context, string, bool, error]
+	setImportPhaseAbortingExpects                 []*gomock.Call2_1[context.Context, string, error]
+	setImportPhaseActivatingExpects               []*gomock.Call2_1[context.Context, string, error]
+	setPhaseExpects                               []*gomock.Call3_1[context.Context, string, migration.Phase, error]
+	setStatusMessageExpects                       []*gomock.Call3_1[context.Context, string, string, error]
+	stageAbortedModelDatabaseDeletionExpects      []*gomock.Call2_1[context.Context, string, error]
+	stageModelRedirectExpects                     []*gomock.Call5_1[context.Context, string, string, internal.RedirectionTarget, []internal.RedirectUserAccess, error]
 }
 
 // NewMockControllerState creates a new mock instance.
@@ -392,6 +400,24 @@ func (mr *MockControllerStateMockRecorder) ExternalControllerModelsForImport(ctx
 // MockControllerStateExternalControllerModelsForImportCall is the typed call wrapper for ExternalControllerModelsForImport.
 type MockControllerStateExternalControllerModelsForImportCall = gomock.Call2_2[context.Context, string, []modelmigration.OffererModel, error]
 
+// FinalizeAbortedImport mocks base method.
+func (m *MockControllerState) FinalizeAbortedImport(ctx context.Context, modelUUID string) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_1(&m.recorder.finalizeAbortedImportExpects, m.ctrl, m, "FinalizeAbortedImport", ctx, modelUUID)
+}
+
+// FinalizeAbortedImport indicates an expected call of FinalizeAbortedImport.
+func (mr *MockControllerStateMockRecorder) FinalizeAbortedImport(ctx, modelUUID any) *MockControllerStateFinalizeAbortedImportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "FinalizeAbortedImport", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	mr.finalizeAbortedImportExpects = append(mr.finalizeAbortedImportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerStateFinalizeAbortedImportCall is the typed call wrapper for FinalizeAbortedImport.
+type MockControllerStateFinalizeAbortedImportCall = gomock.Call2_1[context.Context, string, error]
+
 // GetActiveExport mocks base method.
 func (m *MockControllerState) GetActiveExport(ctx context.Context, modelUUID string) (internal.Migration, error) {
 	m.ctrl.T.Helper()
@@ -445,6 +471,24 @@ func (mr *MockControllerStateMockRecorder) GetAgentBinaryArchitecturesForVersion
 
 // MockControllerStateGetAgentBinaryArchitecturesForVersionCall is the typed call wrapper for GetAgentBinaryArchitecturesForVersion.
 type MockControllerStateGetAgentBinaryArchitecturesForVersionCall = gomock.Call2_2[context.Context, string, []string, error]
+
+// GetAllImportClaims mocks base method.
+func (m *MockControllerState) GetAllImportClaims(ctx context.Context) ([]modelmigration0.ImportClaimStatus, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch1_2(&m.recorder.getAllImportClaimsExpects, m.ctrl, m, "GetAllImportClaims", ctx)
+}
+
+// GetAllImportClaims indicates an expected call of GetAllImportClaims.
+func (mr *MockControllerStateMockRecorder) GetAllImportClaims(ctx any) *MockControllerStateGetAllImportClaimsCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall1_2[context.Context, []modelmigration0.ImportClaimStatus, error](mr.mock.ctrl.T, mr.mock, "GetAllImportClaims", gomock.EnsureMatcher(ctx))
+	mr.getAllImportClaimsExpects = append(mr.getAllImportClaimsExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerStateGetAllImportClaimsCall is the typed call wrapper for GetAllImportClaims.
+type MockControllerStateGetAllImportClaimsCall = gomock.Call1_2[context.Context, []modelmigration0.ImportClaimStatus, error]
 
 // GetCloud mocks base method.
 func (m *MockControllerState) GetCloud(ctx context.Context, name string) (cloud.Cloud, error) {
@@ -734,6 +778,24 @@ func (mr *MockControllerStateMockRecorder) ImportOfferPermissions(ctx, modelUUID
 // MockControllerStateImportOfferPermissionsCall is the typed call wrapper for ImportOfferPermissions.
 type MockControllerStateImportOfferPermissionsCall = gomock.Call4_1[context.Context, string, string, []string, error]
 
+// InitialWatchImportClaimsStatement mocks base method.
+func (m *MockControllerState) InitialWatchImportClaimsStatement() (string, string) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_2(&m.recorder.initialWatchImportClaimsStatementExpects, m.ctrl, m, "InitialWatchImportClaimsStatement")
+}
+
+// InitialWatchImportClaimsStatement indicates an expected call of InitialWatchImportClaimsStatement.
+func (mr *MockControllerStateMockRecorder) InitialWatchImportClaimsStatement() *MockControllerStateInitialWatchImportClaimsStatementCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_2[string, string](mr.mock.ctrl.T, mr.mock, "InitialWatchImportClaimsStatement")
+	mr.initialWatchImportClaimsStatementExpects = append(mr.initialWatchImportClaimsStatementExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerStateInitialWatchImportClaimsStatementCall is the typed call wrapper for InitialWatchImportClaimsStatement.
+type MockControllerStateInitialWatchImportClaimsStatementCall = gomock.Call0_2[string, string]
+
 // InsertExport mocks base method.
 func (m *MockControllerState) InsertExport(ctx context.Context, spec internal.MigrationSpec) error {
 	m.ctrl.T.Helper()
@@ -769,6 +831,42 @@ func (mr *MockControllerStateMockRecorder) InsertMinionReport(ctx, migrationUUID
 
 // MockControllerStateInsertMinionReportCall is the typed call wrapper for InsertMinionReport.
 type MockControllerStateInsertMinionReportCall = gomock.Call5_1[context.Context, string, migration.Phase, string, bool, error]
+
+// IsImportNamespaceRegistered mocks base method.
+func (m *MockControllerState) IsImportNamespaceRegistered(ctx context.Context, modelUUID string) (bool, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_2(&m.recorder.isImportNamespaceRegisteredExpects, m.ctrl, m, "IsImportNamespaceRegistered", ctx, modelUUID)
+}
+
+// IsImportNamespaceRegistered indicates an expected call of IsImportNamespaceRegistered.
+func (mr *MockControllerStateMockRecorder) IsImportNamespaceRegistered(ctx, modelUUID any) *MockControllerStateIsImportNamespaceRegisteredCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_2[context.Context, string, bool, error](mr.mock.ctrl.T, mr.mock, "IsImportNamespaceRegistered", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	mr.isImportNamespaceRegisteredExpects = append(mr.isImportNamespaceRegisteredExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerStateIsImportNamespaceRegisteredCall is the typed call wrapper for IsImportNamespaceRegistered.
+type MockControllerStateIsImportNamespaceRegisteredCall = gomock.Call2_2[context.Context, string, bool, error]
+
+// IsModelDying mocks base method.
+func (m *MockControllerState) IsModelDying(ctx context.Context, modelUUID string) (bool, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_2(&m.recorder.isModelDyingExpects, m.ctrl, m, "IsModelDying", ctx, modelUUID)
+}
+
+// IsModelDying indicates an expected call of IsModelDying.
+func (mr *MockControllerStateMockRecorder) IsModelDying(ctx, modelUUID any) *MockControllerStateIsModelDyingCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_2[context.Context, string, bool, error](mr.mock.ctrl.T, mr.mock, "IsModelDying", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	mr.isModelDyingExpects = append(mr.isModelDyingExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerStateIsModelDyingCall is the typed call wrapper for IsModelDying.
+type MockControllerStateIsModelDyingCall = gomock.Call2_2[context.Context, string, bool, error]
 
 // NamespaceForWatchExport mocks base method.
 func (m *MockControllerState) NamespaceForWatchExport() string {
@@ -824,6 +922,24 @@ func (mr *MockControllerStateMockRecorder) NamespaceForWatchMinionSync() *MockCo
 // MockControllerStateNamespaceForWatchMinionSyncCall is the typed call wrapper for NamespaceForWatchMinionSync.
 type MockControllerStateNamespaceForWatchMinionSyncCall = gomock.Call0_1[string]
 
+// NamespaceForWatchModelDatabaseDeletion mocks base method.
+func (m *MockControllerState) NamespaceForWatchModelDatabaseDeletion() string {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.namespaceForWatchModelDatabaseDeletionExpects, m.ctrl, m, "NamespaceForWatchModelDatabaseDeletion")
+}
+
+// NamespaceForWatchModelDatabaseDeletion indicates an expected call of NamespaceForWatchModelDatabaseDeletion.
+func (mr *MockControllerStateMockRecorder) NamespaceForWatchModelDatabaseDeletion() *MockControllerStateNamespaceForWatchModelDatabaseDeletionCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[string](mr.mock.ctrl.T, mr.mock, "NamespaceForWatchModelDatabaseDeletion")
+	mr.namespaceForWatchModelDatabaseDeletionExpects = append(mr.namespaceForWatchModelDatabaseDeletionExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerStateNamespaceForWatchModelDatabaseDeletionCall is the typed call wrapper for NamespaceForWatchModelDatabaseDeletion.
+type MockControllerStateNamespaceForWatchModelDatabaseDeletionCall = gomock.Call0_1[string]
+
 // NamespaceForWatchPhase mocks base method.
 func (m *MockControllerState) NamespaceForWatchPhase() string {
 	m.ctrl.T.Helper()
@@ -859,6 +975,24 @@ func (mr *MockControllerStateMockRecorder) SecretBackendExists(ctx, name any) *M
 
 // MockControllerStateSecretBackendExistsCall is the typed call wrapper for SecretBackendExists.
 type MockControllerStateSecretBackendExistsCall = gomock.Call2_2[context.Context, string, bool, error]
+
+// SetImportPhaseAborting mocks base method.
+func (m *MockControllerState) SetImportPhaseAborting(ctx context.Context, modelUUID string) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_1(&m.recorder.setImportPhaseAbortingExpects, m.ctrl, m, "SetImportPhaseAborting", ctx, modelUUID)
+}
+
+// SetImportPhaseAborting indicates an expected call of SetImportPhaseAborting.
+func (mr *MockControllerStateMockRecorder) SetImportPhaseAborting(ctx, modelUUID any) *MockControllerStateSetImportPhaseAbortingCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "SetImportPhaseAborting", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	mr.setImportPhaseAbortingExpects = append(mr.setImportPhaseAbortingExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerStateSetImportPhaseAbortingCall is the typed call wrapper for SetImportPhaseAborting.
+type MockControllerStateSetImportPhaseAbortingCall = gomock.Call2_1[context.Context, string, error]
 
 // SetImportPhaseActivating mocks base method.
 func (m *MockControllerState) SetImportPhaseActivating(ctx context.Context, modelUUID string) error {
@@ -913,6 +1047,24 @@ func (mr *MockControllerStateMockRecorder) SetStatusMessage(ctx, migrationUUID, 
 
 // MockControllerStateSetStatusMessageCall is the typed call wrapper for SetStatusMessage.
 type MockControllerStateSetStatusMessageCall = gomock.Call3_1[context.Context, string, string, error]
+
+// StageAbortedModelDatabaseDeletion mocks base method.
+func (m *MockControllerState) StageAbortedModelDatabaseDeletion(ctx context.Context, modelUUID string) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_1(&m.recorder.stageAbortedModelDatabaseDeletionExpects, m.ctrl, m, "StageAbortedModelDatabaseDeletion", ctx, modelUUID)
+}
+
+// StageAbortedModelDatabaseDeletion indicates an expected call of StageAbortedModelDatabaseDeletion.
+func (mr *MockControllerStateMockRecorder) StageAbortedModelDatabaseDeletion(ctx, modelUUID any) *MockControllerStateStageAbortedModelDatabaseDeletionCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "StageAbortedModelDatabaseDeletion", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	mr.stageAbortedModelDatabaseDeletionExpects = append(mr.stageAbortedModelDatabaseDeletionExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerStateStageAbortedModelDatabaseDeletionCall is the typed call wrapper for StageAbortedModelDatabaseDeletion.
+type MockControllerStateStageAbortedModelDatabaseDeletionCall = gomock.Call2_1[context.Context, string, error]
 
 // StageModelRedirect mocks base method.
 func (m *MockControllerState) StageModelRedirect(ctx context.Context, migrationUUID, modelUUID string, target internal.RedirectionTarget, users []internal.RedirectUserAccess) error {
@@ -1326,8 +1478,9 @@ type MockWatcherFactory struct {
 
 // MockWatcherFactoryMockRecorder is the mock recorder for MockWatcherFactory.
 type MockWatcherFactoryMockRecorder struct {
-	mock                    *MockWatcherFactory
-	newNotifyWatcherExpects []*gomock.Call3V_2[context.Context, string, eventsource.FilterOption, eventsource.FilterOption, watcher.NotifyWatcher, error]
+	mock                       *MockWatcherFactory
+	newNamespaceWatcherExpects []*gomock.Call4V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error]
+	newNotifyWatcherExpects    []*gomock.Call3V_2[context.Context, string, eventsource.FilterOption, eventsource.FilterOption, watcher.NotifyWatcher, error]
 }
 
 // NewMockWatcherFactory creates a new mock instance.
@@ -1341,6 +1494,25 @@ func NewMockWatcherFactory(ctrl *gomock.Controller) *MockWatcherFactory {
 func (m *MockWatcherFactory) EXPECT() *MockWatcherFactoryMockRecorder {
 	return m.recorder
 }
+
+// NewNamespaceWatcher mocks base method.
+func (m *MockWatcherFactory) NewNamespaceWatcher(ctx context.Context, initialQuery eventsource.NamespaceQuery, summary string, filterOption eventsource.FilterOption, filterOptions ...eventsource.FilterOption) (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch4V_2(&m.recorder.newNamespaceWatcherExpects, m.ctrl, m, "NewNamespaceWatcher", ctx, initialQuery, summary, filterOption, filterOptions...)
+}
+
+// NewNamespaceWatcher indicates an expected call of NewNamespaceWatcher.
+func (mr *MockWatcherFactoryMockRecorder) NewNamespaceWatcher(ctx, initialQuery, summary, filterOption any, filterOptions ...any) *MockWatcherFactoryNewNamespaceWatcherCall {
+	mr.mock.ctrl.T.Helper()
+	varArgs := gomock.EnsureVariadicMatcher(filterOptions)
+	call := gomock.NewCall4V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error](mr.mock.ctrl.T, mr.mock, "NewNamespaceWatcher", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(initialQuery), gomock.EnsureMatcher(summary), gomock.EnsureMatcher(filterOption), varArgs)
+	mr.newNamespaceWatcherExpects = append(mr.newNamespaceWatcherExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockWatcherFactoryNewNamespaceWatcherCall is the typed call wrapper for NewNamespaceWatcher.
+type MockWatcherFactoryNewNamespaceWatcherCall = gomock.Call4V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error]
 
 // NewNotifyWatcher mocks base method.
 func (m *MockWatcherFactory) NewNotifyWatcher(ctx context.Context, summary string, filterOption eventsource.FilterOption, filterOptions ...eventsource.FilterOption) (watcher.NotifyWatcher, error) {

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -157,14 +157,14 @@ type MockControllerStateMockRecorder struct {
 	insertExportExpects                           []*gomock.Call2_1[context.Context, internal.MigrationSpec, error]
 	insertMinionReportExpects                     []*gomock.Call5_1[context.Context, string, migration.Phase, string, bool, error]
 	isImportNamespaceRegisteredExpects            []*gomock.Call2_2[context.Context, string, bool, error]
-	isModelDyingExpects                           []*gomock.Call2_2[context.Context, string, bool, error]
+	isModelNotAliveExpects                        []*gomock.Call2_2[context.Context, string, bool, error]
 	namespaceForWatchExportExpects                []*gomock.Call0_1[string]
 	namespaceForWatchImportClaimExpects           []*gomock.Call0_1[string]
 	namespaceForWatchMinionSyncExpects            []*gomock.Call0_1[string]
 	namespaceForWatchModelDatabaseDeletionExpects []*gomock.Call0_1[string]
 	namespaceForWatchPhaseExpects                 []*gomock.Call0_1[string]
 	secretBackendExistsExpects                    []*gomock.Call2_2[context.Context, string, bool, error]
-	setImportPhaseAbortingExpects                 []*gomock.Call2_1[context.Context, string, error]
+	setImportPhaseAbortingExpects                 []*gomock.Call5_1[context.Context, string, modelmigration0.ImportPhase, modelmigration0.ImportPhase, string, error]
 	setImportPhaseActivatingExpects               []*gomock.Call2_1[context.Context, string, error]
 	setPhaseExpects                               []*gomock.Call3_1[context.Context, string, migration.Phase, error]
 	setStatusMessageExpects                       []*gomock.Call3_1[context.Context, string, string, error]
@@ -850,23 +850,23 @@ func (mr *MockControllerStateMockRecorder) IsImportNamespaceRegistered(ctx, mode
 // MockControllerStateIsImportNamespaceRegisteredCall is the typed call wrapper for IsImportNamespaceRegistered.
 type MockControllerStateIsImportNamespaceRegisteredCall = gomock.Call2_2[context.Context, string, bool, error]
 
-// IsModelDying mocks base method.
-func (m *MockControllerState) IsModelDying(ctx context.Context, modelUUID string) (bool, error) {
+// IsModelNotAlive mocks base method.
+func (m *MockControllerState) IsModelNotAlive(ctx context.Context, modelUUID string) (bool, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_2(&m.recorder.isModelDyingExpects, m.ctrl, m, "IsModelDying", ctx, modelUUID)
+	return gomock.Dispatch2_2(&m.recorder.isModelNotAliveExpects, m.ctrl, m, "IsModelNotAlive", ctx, modelUUID)
 }
 
-// IsModelDying indicates an expected call of IsModelDying.
-func (mr *MockControllerStateMockRecorder) IsModelDying(ctx, modelUUID any) *MockControllerStateIsModelDyingCall {
+// IsModelNotAlive indicates an expected call of IsModelNotAlive.
+func (mr *MockControllerStateMockRecorder) IsModelNotAlive(ctx, modelUUID any) *MockControllerStateIsModelNotAliveCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_2[context.Context, string, bool, error](mr.mock.ctrl.T, mr.mock, "IsModelDying", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
-	mr.isModelDyingExpects = append(mr.isModelDyingExpects, call)
+	call := gomock.NewCall2_2[context.Context, string, bool, error](mr.mock.ctrl.T, mr.mock, "IsModelNotAlive", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	mr.isModelNotAliveExpects = append(mr.isModelNotAliveExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
-// MockControllerStateIsModelDyingCall is the typed call wrapper for IsModelDying.
-type MockControllerStateIsModelDyingCall = gomock.Call2_2[context.Context, string, bool, error]
+// MockControllerStateIsModelNotAliveCall is the typed call wrapper for IsModelNotAlive.
+type MockControllerStateIsModelNotAliveCall = gomock.Call2_2[context.Context, string, bool, error]
 
 // NamespaceForWatchExport mocks base method.
 func (m *MockControllerState) NamespaceForWatchExport() string {
@@ -977,22 +977,22 @@ func (mr *MockControllerStateMockRecorder) SecretBackendExists(ctx, name any) *M
 type MockControllerStateSecretBackendExistsCall = gomock.Call2_2[context.Context, string, bool, error]
 
 // SetImportPhaseAborting mocks base method.
-func (m *MockControllerState) SetImportPhaseAborting(ctx context.Context, modelUUID string) error {
+func (m *MockControllerState) SetImportPhaseAborting(ctx context.Context, modelUUID string, source, target modelmigration0.ImportPhase, updatedAt string) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_1(&m.recorder.setImportPhaseAbortingExpects, m.ctrl, m, "SetImportPhaseAborting", ctx, modelUUID)
+	return gomock.Dispatch5_1(&m.recorder.setImportPhaseAbortingExpects, m.ctrl, m, "SetImportPhaseAborting", ctx, modelUUID, source, target, updatedAt)
 }
 
 // SetImportPhaseAborting indicates an expected call of SetImportPhaseAborting.
-func (mr *MockControllerStateMockRecorder) SetImportPhaseAborting(ctx, modelUUID any) *MockControllerStateSetImportPhaseAbortingCall {
+func (mr *MockControllerStateMockRecorder) SetImportPhaseAborting(ctx, modelUUID, source, target, updatedAt any) *MockControllerStateSetImportPhaseAbortingCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "SetImportPhaseAborting", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	call := gomock.NewCall5_1[context.Context, string, modelmigration0.ImportPhase, modelmigration0.ImportPhase, string, error](mr.mock.ctrl.T, mr.mock, "SetImportPhaseAborting", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID), gomock.EnsureMatcher(source), gomock.EnsureMatcher(target), gomock.EnsureMatcher(updatedAt))
 	mr.setImportPhaseAbortingExpects = append(mr.setImportPhaseAbortingExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerStateSetImportPhaseAbortingCall is the typed call wrapper for SetImportPhaseAborting.
-type MockControllerStateSetImportPhaseAbortingCall = gomock.Call2_1[context.Context, string, error]
+type MockControllerStateSetImportPhaseAbortingCall = gomock.Call5_1[context.Context, string, modelmigration0.ImportPhase, modelmigration0.ImportPhase, string, error]
 
 // SetImportPhaseActivating mocks base method.
 func (m *MockControllerState) SetImportPhaseActivating(ctx context.Context, modelUUID string) error {

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -136,7 +136,7 @@ type MockControllerStateMockRecorder struct {
 	getActiveExportExpects                        []*gomock.Call2_2[context.Context, string, internal.Migration, error]
 	getActiveExportUUIDExpects                    []*gomock.Call2_2[context.Context, string, string, error]
 	getAgentBinaryArchitecturesForVersionExpects  []*gomock.Call2_2[context.Context, string, []string, error]
-	getAllImportClaimsExpects                     []*gomock.Call1_2[context.Context, []modelmigration0.ImportClaimStatus, error]
+	getAllImportClaimsExpects                     []*gomock.Call1_2[context.Context, []internal.ImportClaimStatus, error]
 	getCloudExpects                               []*gomock.Call2_2[context.Context, string, cloud.Cloud, error]
 	getConflictingCloudImageMetadataExpects       []*gomock.Call2_2[context.Context, []modelmigration0.ImportPrecheckImageMetadata, []modelmigration0.CloudImageMetadataConflict, error]
 	getControllerTargetVersionExpects             []*gomock.Call1_2[context.Context, string, error]
@@ -473,7 +473,7 @@ func (mr *MockControllerStateMockRecorder) GetAgentBinaryArchitecturesForVersion
 type MockControllerStateGetAgentBinaryArchitecturesForVersionCall = gomock.Call2_2[context.Context, string, []string, error]
 
 // GetAllImportClaims mocks base method.
-func (m *MockControllerState) GetAllImportClaims(ctx context.Context) ([]modelmigration0.ImportClaimStatus, error) {
+func (m *MockControllerState) GetAllImportClaims(ctx context.Context) ([]internal.ImportClaimStatus, error) {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch1_2(&m.recorder.getAllImportClaimsExpects, m.ctrl, m, "GetAllImportClaims", ctx)
 }
@@ -481,14 +481,14 @@ func (m *MockControllerState) GetAllImportClaims(ctx context.Context) ([]modelmi
 // GetAllImportClaims indicates an expected call of GetAllImportClaims.
 func (mr *MockControllerStateMockRecorder) GetAllImportClaims(ctx any) *MockControllerStateGetAllImportClaimsCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_2[context.Context, []modelmigration0.ImportClaimStatus, error](mr.mock.ctrl.T, mr.mock, "GetAllImportClaims", gomock.EnsureMatcher(ctx))
+	call := gomock.NewCall1_2[context.Context, []internal.ImportClaimStatus, error](mr.mock.ctrl.T, mr.mock, "GetAllImportClaims", gomock.EnsureMatcher(ctx))
 	mr.getAllImportClaimsExpects = append(mr.getAllImportClaimsExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerStateGetAllImportClaimsCall is the typed call wrapper for GetAllImportClaims.
-type MockControllerStateGetAllImportClaimsCall = gomock.Call1_2[context.Context, []modelmigration0.ImportClaimStatus, error]
+type MockControllerStateGetAllImportClaimsCall = gomock.Call1_2[context.Context, []internal.ImportClaimStatus, error]
 
 // GetCloud mocks base method.
 func (m *MockControllerState) GetCloud(ctx context.Context, name string) (cloud.Cloud, error) {

--- a/domain/modelmigration/service/service_test.go
+++ b/domain/modelmigration/service/service_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/canonical/gomock/gomock"
+	"github.com/juju/clock"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
@@ -70,6 +71,7 @@ func (s *serviceSuite) TestAdoptResources(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).AdoptResources(c.Context(), sourceControllerVersion)
 	c.Check(err, tc.ErrorIsNil)
@@ -98,6 +100,7 @@ func (s *serviceSuite) TestAdoptResourcesProviderNotSupported(c *tc.C) {
 		s.instanceProviderGetter(c),
 		resourceGetter,
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).AdoptResources(c.Context(), sourceControllerVersion)
 	c.Check(err, tc.ErrorIsNil)
@@ -127,6 +130,7 @@ func (s *serviceSuite) TestAdoptResourcesProviderNotImplemented(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).AdoptResources(c.Context(), sourceControllerVersion)
 	c.Check(err, tc.ErrorIsNil)
@@ -161,6 +165,7 @@ func (s *serviceSuite) TestMachinesFromProviderNotInModel(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).CheckMachines(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -196,6 +201,7 @@ func (s *serviceSuite) TestMachineInstanceIDsNotInProvider(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).CheckMachines(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
@@ -245,6 +251,7 @@ func (s *serviceSuite) TestWatchForMigration(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	)
 	w, err := svc.WatchForMigration(c.Context())
@@ -276,6 +283,7 @@ func (s *serviceSuite) TestWatchForMigrationError(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	)
 	_, err := svc.WatchForMigration(c.Context())
@@ -357,6 +365,7 @@ func (s *serviceSuite) service(c *tc.C) *Service {
 		func(context.Context) (InstanceProvider, error) { return s.instanceProvider, nil },
 		func(context.Context) (ResourceProvider, error) { return s.resourceProvider, nil },
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	)
 }
@@ -371,6 +380,7 @@ func (s *serviceSuite) watchableService(c *tc.C) *WatchableService {
 		func(context.Context) (InstanceProvider, error) { return s.instanceProvider, nil },
 		func(context.Context) (ResourceProvider, error) { return s.resourceProvider, nil },
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	)
 }

--- a/domain/modelmigration/service/validate_test.go
+++ b/domain/modelmigration/service/validate_test.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"github.com/canonical/gomock/gomock"
+	"github.com/juju/clock"
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/core/semversion"
@@ -28,6 +29,7 @@ func (s *serviceSuite) TestMissingAgentBinaryArchitecturesCAAS(c *tc.C) {
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).MissingAgentBinaryArchitectures(c.Context(), "4.0.1")
 	c.Assert(err, tc.ErrorIsNil)
@@ -73,6 +75,7 @@ func (s *serviceSuite) TestValidateImportedModelRejectsUnitNotInRelation(c *tc.C
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).ValidateImportedModel(c.Context())
 	c.Assert(err, tc.ErrorMatches, `.*unit wordpress/1 hasn't joined relation "wordpress:db mysql:db" yet.*`)
@@ -116,6 +119,7 @@ func (s *serviceSuite) TestValidateImportedModelRelationValidationPasses(c *tc.C
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).ValidateImportedModel(c.Context())
 	c.Check(err, tc.ErrorIsNil)
@@ -148,6 +152,7 @@ func (s *serviceSuite) TestMissingAgentBinaryArchitecturesReportsMissing(c *tc.C
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).MissingAgentBinaryArchitectures(c.Context(), desiredVersion)
 	c.Assert(err, tc.ErrorIsNil)
@@ -175,6 +180,7 @@ func (s *serviceSuite) TestValidateImportedModelRejectsUnknownSecretBackend(c *t
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).ValidateImportedModel(c.Context())
 	c.Check(err, tc.ErrorMatches, ".*secret backend.*source-backend-uuid.*do not exist.*")
@@ -202,6 +208,7 @@ func (s *serviceSuite) TestValidateImportedModelRejectsMissingBackendReference(c
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).ValidateImportedModel(c.Context())
 	c.Check(err, tc.ErrorMatches, ".*missing secret backend references.*rev-1.*")
@@ -230,6 +237,7 @@ func (s *serviceSuite) TestValidateImportedModelRejectsMismatchedBackendReferenc
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).ValidateImportedModel(c.Context())
 	c.Check(err, tc.ErrorMatches, ".*do not match the secret value refs.*rev-1.*")
@@ -293,6 +301,7 @@ func (s *serviceSuite) TestValidateImportedModelSubordinateOnOtherPrincipalPasse
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).ValidateImportedModel(c.Context())
 	c.Check(err, tc.ErrorIsNil)
@@ -336,6 +345,7 @@ func (s *serviceSuite) TestValidateImportedModelRejectsSubordinateNotInOwnRelati
 		s.instanceProviderGetter(c),
 		s.resourceProviderGetter(c),
 		s.credentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	).ValidateImportedModel(c.Context())
 	c.Assert(err, tc.ErrorMatches, `.*unit nrpe/0 hasn't joined relation "nrpe:general-info ubuntu:juju-info" yet.*`)

--- a/domain/modelmigration/service/watcher.go
+++ b/domain/modelmigration/service/watcher.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	"github.com/juju/juju/core/changestream"
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/trace"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
+)
+
+// WatchImportClaims watches every target-side import claim. The collection
+// contains model UUIDs initially and thereafter emits model UUIDs whose claim
+// was inserted, updated, or deleted. Consumers must re-query claim state,
+// since events can be coalesced.
+func (s *WatchableService) WatchImportClaims(ctx context.Context) (watcher.StringsWatcher, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	namespace, initialQuery := s.controllerState.InitialWatchImportClaimsStatement()
+	return s.watcherFactory.NewNamespaceWatcher(
+		ctx,
+		eventsource.InitialNamespaceChanges(initialQuery),
+		"migration import claims watcher",
+		eventsource.NamespaceFilter(namespace, changestream.All),
+	)
+}
+
+// WatchModelDatabaseDeletion returns a notify watcher that fires when the staged
+// model-database deletion for the given model changes, including when the
+// undertaker's model-database deleter removes it after dropping the database.
+// The abort finalization wait uses this to react to the drop completing instead
+// of polling.
+func (s *WatchableService) WatchModelDatabaseDeletion(
+	ctx context.Context, modelUUID coremodel.UUID,
+) (watcher.NotifyWatcher, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	return s.watcherFactory.NewNotifyWatcher(
+		ctx,
+		"model database deletion watcher",
+		eventsource.PredicateFilter(
+			s.controllerState.NamespaceForWatchModelDatabaseDeletion(),
+			changestream.All,
+			eventsource.EqualsPredicate(modelUUID.String()),
+		),
+	)
+}

--- a/domain/modelmigration/state/controller/abort.go
+++ b/domain/modelmigration/state/controller/abort.go
@@ -1,0 +1,463 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/sqlair"
+
+	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/modelmigration"
+	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
+	"github.com/juju/juju/internal/errors"
+)
+
+// These methods implement the target-side v8 import abort claim lifecycle: the
+// importing -> aborting phase transition, the scan the abort reconciler uses to
+// find outstanding claims, the namespace-registration predicate that decides
+// whether the model dqlite database still needs dropping, and the abort
+// finalization that deletes the durable claim once cleanup is provably
+// complete. The compensation of the controller-data rows themselves
+// (permissions, authorized keys, leadership, model identity, ...) is owned by
+// the per-domain services the v8 abort driver calls; this package only owns the
+// migration bookkeeping tables.
+
+// SetImportPhaseAborting transitions the model_migration_import claim for
+// modelUUID from importing to aborting, bumping updated_at. It is idempotent
+// when the claim is already aborting. It returns
+// [modelmigrationerrors.ErrAbortActivating] when the claim is activating (the
+// activation point of no return has been crossed and the model may not be torn
+// down), [modelmigrationerrors.ErrImportNotFound] when no claim exists, and
+// [modelmigrationerrors.ErrPhaseTransitionInvalid] when the phase changed
+// concurrently.
+func (s *State) SetImportPhaseAborting(ctx context.Context, modelUUID string) error {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	mUUID := modelUUIDArg{ModelUUID: modelUUID}
+	phases := importPhaseNames{
+		Target: string(modelmigration.ImportPhaseAborting),
+		Source: string(modelmigration.ImportPhaseImporting),
+	}
+	updateStmt, err := s.Prepare(`
+WITH target_phase AS (
+    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseNames.target
+),
+source_phase AS (
+    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseNames.source
+)
+UPDATE model_migration_import
+SET    phase_type_id = (SELECT id FROM target_phase),
+       updated_at    = DATETIME('now', 'utc')
+WHERE  model_uuid = $modelUUIDArg.model_uuid
+AND    phase_type_id = (SELECT id FROM source_phase)
+`, mUUID, phases)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		claim, err := s.getImportClaim(ctx, tx, modelUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		switch claim.Phase {
+		case modelmigration.ImportPhaseAborting:
+			return nil // idempotent: already aborting
+		case modelmigration.ImportPhaseActivating:
+			return errors.Capture(modelmigrationerrors.ErrAbortActivating)
+		}
+
+		// Phase is importing; CAS to aborting.
+		var outcome sqlair.Outcome
+		if err := tx.Query(ctx, updateStmt, mUUID, phases).Get(&outcome); err != nil {
+			return errors.Errorf("transitioning import to aborting: %w", err)
+		}
+		affected, err := outcome.Result().RowsAffected()
+		if err != nil {
+			return errors.Capture(err)
+		}
+		if affected == 1 {
+			return nil
+		}
+		// The read above saw importing, so the CAS should have matched.
+		// This is unreachable under snapshot isolation: a concurrent
+		// phase change on another node would fail the transaction at
+		// commit time and the framework would retry, at which point the
+		// read would see the new phase. Treat it as a defensive guard.
+		return errors.Errorf(
+			"import phase changed concurrently: %w",
+			modelmigrationerrors.ErrPhaseTransitionInvalid,
+		)
+	})
+}
+
+// checkAbortingState returns nil only while the model_migration_import claim
+// for modelUUID is in the aborting phase. It returns
+// [modelmigrationerrors.ErrImportNotFound] when no claim exists and
+// [modelmigrationerrors.ErrPhaseTransitionInvalid] when a claim exists but is
+// in another phase. It reads the phase rather than filtering to an
+// aborting-only row so those two outcomes stay distinct, which the callers
+// rely on: a missing claim is idempotent success for finalization but an error
+// for staging. It mirrors [State.checkImportingState] for the aborting phase.
+func (s *State) checkAbortingState(ctx context.Context, tx *sqlair.TX, modelUUID string) error {
+	arg := modelUUIDArg{ModelUUID: modelUUID}
+	var row importPhaseRow
+	stmt, err := s.Prepare(`
+SELECT mmipt.type AS &importPhaseRow.phase_type
+FROM   model_migration_import AS mmi
+JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
+WHERE  mmi.model_uuid = $modelUUIDArg.model_uuid
+`, row, arg)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = tx.Query(ctx, stmt, arg).Get(&row)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return errors.Errorf("model %q: %w", modelUUID, modelmigrationerrors.ErrImportNotFound)
+	} else if err != nil {
+		return errors.Errorf("checking import claim phase for model %q: %w", modelUUID, err)
+	}
+	if modelmigration.ImportPhase(row.PhaseType) != modelmigration.ImportPhaseAborting {
+		return errors.Errorf(
+			"model %q import claim is %q, expected aborting: %w", modelUUID, row.PhaseType,
+			modelmigrationerrors.ErrPhaseTransitionInvalid)
+	}
+	return nil
+}
+
+// IsModelDying reports whether the model row for modelUUID exists and has left
+// the alive state (it is dying or dead). The v8 abort driver uses this to
+// detect a model that the generic (legacy) removal undertaker is already
+// tearing down after a v7-protocol abort marked it dead and took the claim's
+// abort lock: in that case the v8 abort compensation and model-database staging
+// must stand aside, because the undertaker owns the teardown of the model, its
+// database and the import claim. A missing model row reports false, so a v8
+// abort re-drive after its own compensation has removed the model row still
+// proceeds to finalization.
+func (s *State) IsModelDying(ctx context.Context, modelUUID string) (bool, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	arg := modelUUIDArg{ModelUUID: modelUUID}
+	stmt, err := s.Prepare(`
+SELECT m.life_id AS &modelLifeRow.life_id
+FROM   model AS m
+WHERE  m.uuid = $modelUUIDArg.model_uuid`, arg, modelLifeRow{})
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	var row modelLifeRow
+	var found bool
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		found = false
+		err := tx.Query(ctx, stmt, arg).Get(&row)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return false, errors.Errorf("reading model life for %q: %w", modelUUID, err)
+	}
+	if !found {
+		return false, nil
+	}
+	// Anything but alive (dying, dead) means the generic removal undertaker
+	// has taken over.
+	return life.Life(row.LifeID) != life.Alive, nil
+}
+
+// GetAllImportClaims returns a snapshot of every outstanding
+// model_migration_import claim. The abort reconciler scans this to find claims
+// in the aborting phase to finalize and stale importing/activating claims to
+// warn about. The table holds at most one row per migrating model and is
+// small, so a full scan is cheap.
+func (s *State) GetAllImportClaims(ctx context.Context) ([]modelmigration.ImportClaimStatus, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	stmt, err := s.Prepare(`
+SELECT mmi.model_uuid AS &importClaimStatusRow.model_uuid,
+       mmi.source_migration_uuid AS &importClaimStatusRow.source_migration_uuid,
+       mmipt.type AS &importClaimStatusRow.phase_type,
+       strftime('%Y-%m-%dT%H:%M:%fZ', mmi.updated_at) AS &importClaimStatusRow.updated_at
+FROM   model_migration_import AS mmi
+JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
+`, importClaimStatusRow{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var rows []importClaimStatusRow
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		rows = nil
+		err := tx.Query(ctx, stmt).GetAll(&rows)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		return nil, errors.Errorf("getting all import claims: %w", err)
+	}
+
+	claims := make([]modelmigration.ImportClaimStatus, 0, len(rows))
+	for _, row := range rows {
+		updatedAt, err := time.Parse(time.RFC3339, row.UpdatedAt)
+		if err != nil {
+			return nil, errors.Errorf(
+				"parsing import updated_at for model %q: %w", row.ModelUUID, err)
+		}
+		claims = append(claims, modelmigration.ImportClaimStatus{
+			ModelUUID:           row.ModelUUID,
+			SourceMigrationUUID: row.SourceMigrationUUID,
+			Phase:               modelmigration.ImportPhase(row.PhaseType),
+			UpdatedAt:           updatedAt,
+		})
+	}
+	return claims, nil
+}
+
+// IsImportNamespaceRegistered reports whether the model's dqlite namespace is
+// still registered in namespace_list. The abort reconciler uses this to decide
+// whether the model database still needs dropping before finalization: a
+// registered namespace means the database may still exist and must be deleted
+// while it can still be reopened, whereas an absent registration means the
+// database was never created (or already dropped) and finalization can proceed.
+func (s *State) IsImportNamespaceRegistered(ctx context.Context, modelUUID string) (bool, error) {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	arg := namespaceArg{Namespace: modelUUID}
+	stmt, err := s.Prepare(`
+SELECT 1 AS &countResult.count
+FROM   namespace_list
+WHERE  namespace = $namespaceArg.namespace
+LIMIT  1
+`, countResult{}, arg)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	var registered bool
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		registered, err = rowExists(ctx, tx, stmt, arg)
+		return err
+	})
+	if err != nil {
+		return false, errors.Errorf(
+			"checking namespace registration for model %q: %w", modelUUID, err)
+	}
+	return registered, nil
+}
+
+// StageAbortedModelDatabaseDeletion hands the aborted model's dqlite database
+// off to the undertaker's model-database deleter, in a single transaction: it
+// removes the model's namespace_list registration (so the deleter no longer
+// treats the model as live and will actually drop the database) and stages a
+// model_database_deletion row keyed by the model UUID. The undertaker drops the
+// database asynchronously and removes the staged row on success;
+// [State.FinalizeAbortedImport] then releases the claim once the staged row is
+// gone.
+//
+// It asserts, in the same transaction, that the claim is in the aborting
+// phase, so a live model's database can never be staged for deletion. It is
+// idempotent: the namespace delete is a no-op once done, and an already-staged
+// deletion is left untouched, so re-driving it (or racing another controller
+// node) is safe. Returns
+// [modelmigrationerrors.ErrImportNotFound] when no claim exists and
+// [modelmigrationerrors.ErrPhaseTransitionInvalid] when the claim is not
+// aborting.
+func (s *State) StageAbortedModelDatabaseDeletion(ctx context.Context, modelUUID string) error {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	nsArg := namespaceArg{Namespace: modelUUID}
+	deleteNamespaceListStmt, err := s.Prepare(`
+DELETE FROM namespace_list
+WHERE  namespace = $namespaceArg.namespace
+`, nsArg)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	stagedDeletionStmt, err := s.Prepare(`
+SELECT 1 AS &countResult.count
+FROM   model_database_deletion
+WHERE  namespace = $namespaceArg.namespace
+LIMIT  1
+`, countResult{}, nsArg)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	stageDeletionStmt, err := s.Prepare(`
+INSERT INTO model_database_deletion (*)
+VALUES ($modelDatabaseDeletion.*)
+`, modelDatabaseDeletion{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := s.checkAbortingState(ctx, tx, modelUUID); err != nil {
+			return errors.Capture(err)
+		}
+
+		if err := tx.Query(ctx, deleteNamespaceListStmt, nsArg).Run(); err != nil {
+			return errors.Errorf("deleting namespace registration: %w", err)
+		}
+		// The deletion is already staged; leave its created_at untouched rather
+		// than rewriting a timestamp that would misreport when it was staged.
+		if staged, err := rowExists(ctx, tx, stagedDeletionStmt, nsArg); err != nil {
+			return errors.Errorf("checking staged model database deletion: %w", err)
+		} else if staged {
+			return nil
+		}
+		if err := tx.Query(ctx, stageDeletionStmt, modelDatabaseDeletion{
+			Namespace: modelUUID,
+			CreatedAt: s.clock.Now().UTC(),
+		}).Run(); err != nil {
+			return errors.Errorf("staging model database deletion: %w", err)
+		}
+		return nil
+	})
+}
+
+// FinalizeAbortedImport deletes the model_migration_import claim and its
+// FK-dependent companion rows (model_migration_import_offer,
+// model_migration_import_external_controller_model) in a single transaction,
+// once abort cleanup is provably complete. It asserts, in the same transaction,
+// that the claim is in the aborting phase, that the controller model identity
+// row and its model_namespace row are both gone, and that no
+// model_database_deletion row is still staged for the model's namespace (which
+// would mean the undertaker has not yet dropped the model database); if any of
+// these does not hold it returns [modelmigrationerrors.ErrAbortNotFinalizable]
+// and makes no deletions, leaving the claim in aborting for a later retry. It
+// is idempotent when no claim exists (already finalized). Returns
+// [modelmigrationerrors.ErrPhaseTransitionInvalid] when a claim exists but is
+// not aborting.
+//
+// The model dqlite database is dropped out of band by the undertaker's
+// model-database deleter after [State.StageAbortedModelDatabaseDeletion] has
+// removed the namespace_list registration and staged the deletion. This method
+// only releases the durable claim, and only once that drop is proven complete
+// (the staged row is gone). The abort reconciler enforces that ordering.
+func (s *State) FinalizeAbortedImport(ctx context.Context, modelUUID string) error {
+	db, err := s.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	mUUID := modelUUIDArg{ModelUUID: modelUUID}
+	nsArg := namespaceArg{Namespace: modelUUID}
+
+	finalizeChecksStmt, err := s.Prepare(`
+WITH model_row AS (
+    SELECT 1 FROM model WHERE uuid = $modelUUIDArg.model_uuid
+),
+model_namespace_row AS (
+    SELECT 1 FROM model_namespace WHERE model_uuid = $modelUUIDArg.model_uuid
+),
+staged_deletion_row AS (
+    SELECT 1 FROM model_database_deletion WHERE namespace = $namespaceArg.namespace
+)
+SELECT EXISTS(SELECT 1 FROM model_row)           AS &abortFinalizeChecks.model_exists,
+       EXISTS(SELECT 1 FROM model_namespace_row) AS &abortFinalizeChecks.namespace_exists,
+       EXISTS(SELECT 1 FROM staged_deletion_row) AS &abortFinalizeChecks.deletion_staged
+`, abortFinalizeChecks{}, mUUID, nsArg)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	deleteOffersStmt, err := s.Prepare(`
+WITH claim AS (
+    SELECT uuid FROM model_migration_import WHERE model_uuid = $modelUUIDArg.model_uuid
+)
+DELETE FROM model_migration_import_offer
+WHERE  migration_uuid IN (SELECT uuid FROM claim)
+`, mUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	deleteECMStmt, err := s.Prepare(`
+WITH claim AS (
+    SELECT uuid FROM model_migration_import WHERE model_uuid = $modelUUIDArg.model_uuid
+)
+DELETE FROM model_migration_import_external_controller_model
+WHERE  migration_uuid IN (SELECT uuid FROM claim)
+`, mUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	deleteClaimStmt, err := s.Prepare(`
+DELETE FROM model_migration_import
+WHERE  model_uuid = $modelUUIDArg.model_uuid
+`, mUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := s.checkAbortingState(ctx, tx, modelUUID); errors.Is(err, modelmigrationerrors.ErrImportNotFound) {
+			return nil // idempotent: already finalized
+		} else if err != nil {
+			return errors.Capture(err)
+		}
+
+		// Finalization predicates, read in a single round trip: the controller
+		// model identity row and its namespace mapping must both be gone, and the
+		// model database must have been dropped by the undertaker (its staged
+		// deletion row cleared), before the claim can be released.
+		var checks abortFinalizeChecks
+		if err := tx.Query(ctx, finalizeChecksStmt, mUUID, nsArg).Get(&checks); err != nil {
+			return errors.Errorf("checking finalization predicates for model %q: %w", modelUUID, err)
+		}
+		if checks.ModelExists {
+			return errors.Errorf(
+				"model %q identity row still present: %w",
+				modelUUID, modelmigrationerrors.ErrAbortNotFinalizable)
+		}
+		if checks.NamespaceExists {
+			return errors.Errorf(
+				"model %q namespace mapping still present: %w",
+				modelUUID, modelmigrationerrors.ErrAbortNotFinalizable)
+		}
+		if checks.DeletionStaged {
+			return errors.Errorf(
+				"model %q database deletion still pending: %w",
+				modelUUID, modelmigrationerrors.ErrAbortNotFinalizable)
+		}
+
+		// Cleanup is proven complete. Remove the claim (companions first, since
+		// their FKs onto the claim do not cascade).
+		if err := tx.Query(ctx, deleteOffersStmt, mUUID).Run(); err != nil {
+			return errors.Errorf("deleting import offer companions: %w", err)
+		}
+		if err := tx.Query(ctx, deleteECMStmt, mUUID).Run(); err != nil {
+			return errors.Errorf("deleting import external controller companions: %w", err)
+		}
+		if err := tx.Query(ctx, deleteClaimStmt, mUUID).Run(); err != nil {
+			return errors.Errorf("deleting aborted import claim: %w", err)
+		}
+		return nil
+	})
+}

--- a/domain/modelmigration/state/controller/abort.go
+++ b/domain/modelmigration/state/controller/abort.go
@@ -10,8 +10,10 @@ import (
 	"github.com/canonical/sqlair"
 
 	"github.com/juju/juju/domain/life"
+	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/modelmigration"
 	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
+	modelmigrationinternal "github.com/juju/juju/domain/modelmigration/internal"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -39,24 +41,25 @@ func (s *State) SetImportPhaseAborting(ctx context.Context, modelUUID string) er
 		return errors.Capture(err)
 	}
 
-	mUUID := modelUUIDArg{ModelUUID: modelUUID}
-	phases := importPhaseNames{
-		Target: string(modelmigration.ImportPhaseAborting),
-		Source: string(modelmigration.ImportPhaseImporting),
+	update := importPhaseUpdate{
+		ModelUUID: modelUUID,
+		Target:    string(modelmigration.ImportPhaseAborting),
+		Source:    string(modelmigration.ImportPhaseImporting),
+		UpdatedAt: s.clock.Now().UTC().Format(time.RFC3339),
 	}
 	updateStmt, err := s.Prepare(`
 WITH target_phase AS (
-    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseNames.target
+    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseUpdate.target
 ),
 source_phase AS (
-    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseNames.source
+    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseUpdate.source
 )
 UPDATE model_migration_import
 SET    phase_type_id = (SELECT id FROM target_phase),
-       updated_at    = DATETIME('now', 'utc')
-WHERE  model_uuid = $modelUUIDArg.model_uuid
+       updated_at    = $importPhaseUpdate.updated_at
+WHERE  model_uuid = $importPhaseUpdate.model_uuid
 AND    phase_type_id = (SELECT id FROM source_phase)
-`, mUUID, phases)
+`, update)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -75,7 +78,7 @@ AND    phase_type_id = (SELECT id FROM source_phase)
 
 		// Phase is importing; CAS to aborting.
 		var outcome sqlair.Outcome
-		if err := tx.Query(ctx, updateStmt, mUUID, phases).Get(&outcome); err != nil {
+		if err := tx.Query(ctx, updateStmt, update).Get(&outcome); err != nil {
 			return errors.Errorf("transitioning import to aborting: %w", err)
 		}
 		affected, err := outcome.Result().RowsAffected()
@@ -85,11 +88,7 @@ AND    phase_type_id = (SELECT id FROM source_phase)
 		if affected == 1 {
 			return nil
 		}
-		// The read above saw importing, so the CAS should have matched.
-		// This is unreachable under snapshot isolation: a concurrent
-		// phase change on another node would fail the transaction at
-		// commit time and the framework would retry, at which point the
-		// read would see the new phase. Treat it as a defensive guard.
+		// Defensively report a phase change when the update does not match.
 		return errors.Errorf(
 			"import phase changed concurrently: %w",
 			modelmigrationerrors.ErrPhaseTransitionInvalid,
@@ -132,15 +131,8 @@ WHERE  mmi.model_uuid = $modelUUIDArg.model_uuid
 	return nil
 }
 
-// IsModelDying reports whether the model row for modelUUID exists and has left
-// the alive state (it is dying or dead). The v8 abort driver uses this to
-// detect a model that the generic (legacy) removal undertaker is already
-// tearing down after a v7-protocol abort marked it dead and took the claim's
-// abort lock: in that case the v8 abort compensation and model-database staging
-// must stand aside, because the undertaker owns the teardown of the model, its
-// database and the import claim. A missing model row reports false, so a v8
-// abort re-drive after its own compensation has removed the model row still
-// proceeds to finalization.
+// IsModelDying reports whether the model has left the alive state. It returns
+// [modelerrors.NotFound] when the model does not exist.
 func (s *State) IsModelDying(ctx context.Context, modelUUID string) (bool, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
@@ -157,24 +149,18 @@ WHERE  m.uuid = $modelUUIDArg.model_uuid`, arg, modelLifeRow{})
 	}
 
 	var row modelLifeRow
-	var found bool
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		found = false
 		err := tx.Query(ctx, stmt, arg).Get(&row)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return nil
+			return modelerrors.NotFound
 		}
-		if err != nil {
-			return err
-		}
-		found = true
-		return nil
+		return err
 	})
+	if errors.Is(err, modelerrors.NotFound) {
+		return false, err
+	}
 	if err != nil {
 		return false, errors.Errorf("reading model life for %q: %w", modelUUID, err)
-	}
-	if !found {
-		return false, nil
 	}
 	// Anything but alive (dying, dead) means the generic removal undertaker
 	// has taken over.
@@ -186,7 +172,7 @@ WHERE  m.uuid = $modelUUIDArg.model_uuid`, arg, modelLifeRow{})
 // in the aborting phase to finalize and stale importing/activating claims to
 // warn about. The table holds at most one row per migrating model and is
 // small, so a full scan is cheap.
-func (s *State) GetAllImportClaims(ctx context.Context) ([]modelmigration.ImportClaimStatus, error) {
+func (s *State) GetAllImportClaims(ctx context.Context) ([]modelmigrationinternal.ImportClaimStatus, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -196,7 +182,7 @@ func (s *State) GetAllImportClaims(ctx context.Context) ([]modelmigration.Import
 SELECT mmi.model_uuid AS &importClaimStatusRow.model_uuid,
        mmi.source_migration_uuid AS &importClaimStatusRow.source_migration_uuid,
        mmipt.type AS &importClaimStatusRow.phase_type,
-       strftime('%Y-%m-%dT%H:%M:%fZ', mmi.updated_at) AS &importClaimStatusRow.updated_at
+	       mmi.updated_at AS &importClaimStatusRow.updated_at
 FROM   model_migration_import AS mmi
 JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
 `, importClaimStatusRow{})
@@ -217,18 +203,13 @@ JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_i
 		return nil, errors.Errorf("getting all import claims: %w", err)
 	}
 
-	claims := make([]modelmigration.ImportClaimStatus, 0, len(rows))
+	claims := make([]modelmigrationinternal.ImportClaimStatus, 0, len(rows))
 	for _, row := range rows {
-		updatedAt, err := time.Parse(time.RFC3339, row.UpdatedAt)
-		if err != nil {
-			return nil, errors.Errorf(
-				"parsing import updated_at for model %q: %w", row.ModelUUID, err)
-		}
-		claims = append(claims, modelmigration.ImportClaimStatus{
+		claims = append(claims, modelmigrationinternal.ImportClaimStatus{
 			ModelUUID:           row.ModelUUID,
 			SourceMigrationUUID: row.SourceMigrationUUID,
-			Phase:               modelmigration.ImportPhase(row.PhaseType),
-			UpdatedAt:           updatedAt,
+			PhaseType:           row.PhaseType,
+			UpdatedAt:           row.UpdatedAt,
 		})
 	}
 	return claims, nil
@@ -311,8 +292,8 @@ LIMIT  1
 		return errors.Capture(err)
 	}
 	stageDeletionStmt, err := s.Prepare(`
-INSERT INTO model_database_deletion (*)
-VALUES ($modelDatabaseDeletion.*)
+INSERT INTO model_database_deletion (namespace, created_at)
+VALUES ($modelDatabaseDeletion.namespace, $modelDatabaseDeletion.created_at)
 `, modelDatabaseDeletion{})
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/modelmigration/state/controller/abort.go
+++ b/domain/modelmigration/state/controller/abort.go
@@ -5,7 +5,6 @@ package controller
 
 import (
 	"context"
-	"time"
 
 	"github.com/canonical/sqlair"
 
@@ -28,14 +27,15 @@ import (
 // migration bookkeeping tables.
 
 // SetImportPhaseAborting transitions the model_migration_import claim for
-// modelUUID from importing to aborting, bumping updated_at. It is idempotent
-// when the claim is already aborting. It returns
-// [modelmigrationerrors.ErrAbortActivating] when the claim is activating (the
-// activation point of no return has been crossed and the model may not be torn
-// down), [modelmigrationerrors.ErrImportNotFound] when no claim exists, and
-// [modelmigrationerrors.ErrPhaseTransitionInvalid] when the phase changed
-// concurrently.
-func (s *State) SetImportPhaseAborting(ctx context.Context, modelUUID string) error {
+// modelUUID from source to target phase, bumping updated_at to the supplied
+// service-layer timestamp. It is idempotent when the claim is already in the
+// target phase. It returns [modelmigrationerrors.ErrAbortActivating] when the
+// claim is activating (the activation point of no return has been crossed and
+// the model may not be torn down) and [modelmigrationerrors.ErrImportNotFound]
+// when no claim exists.
+func (s *State) SetImportPhaseAborting(
+	ctx context.Context, modelUUID string, source, target modelmigration.ImportPhase, updatedAt string,
+) error {
 	db, err := s.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
@@ -43,9 +43,9 @@ func (s *State) SetImportPhaseAborting(ctx context.Context, modelUUID string) er
 
 	update := importPhaseUpdate{
 		ModelUUID: modelUUID,
-		Target:    string(modelmigration.ImportPhaseAborting),
-		Source:    string(modelmigration.ImportPhaseImporting),
-		UpdatedAt: s.clock.Now().UTC().Format(time.RFC3339),
+		Target:    string(target),
+		Source:    string(source),
+		UpdatedAt: updatedAt,
 	}
 	updateStmt, err := s.Prepare(`
 WITH target_phase AS (
@@ -70,29 +70,18 @@ AND    phase_type_id = (SELECT id FROM source_phase)
 			return errors.Capture(err)
 		}
 		switch claim.Phase {
-		case modelmigration.ImportPhaseAborting:
-			return nil // idempotent: already aborting
+		case target:
+			return nil // idempotent: already in the target phase
 		case modelmigration.ImportPhaseActivating:
 			return errors.Capture(modelmigrationerrors.ErrAbortActivating)
 		}
 
-		// Phase is importing; CAS to aborting.
-		var outcome sqlair.Outcome
-		if err := tx.Query(ctx, updateStmt, update).Get(&outcome); err != nil {
+		// The in-transaction read above proved the claim is in the source
+		// phase, so the update must match.
+		if err := tx.Query(ctx, updateStmt, update).Run(); err != nil {
 			return errors.Errorf("transitioning import to aborting: %w", err)
 		}
-		affected, err := outcome.Result().RowsAffected()
-		if err != nil {
-			return errors.Capture(err)
-		}
-		if affected == 1 {
-			return nil
-		}
-		// Defensively report a phase change when the update does not match.
-		return errors.Errorf(
-			"import phase changed concurrently: %w",
-			modelmigrationerrors.ErrPhaseTransitionInvalid,
-		)
+		return nil
 	})
 }
 
@@ -131,9 +120,9 @@ WHERE  mmi.model_uuid = $modelUUIDArg.model_uuid
 	return nil
 }
 
-// IsModelDying reports whether the model has left the alive state. It returns
+// IsModelNotAlive reports whether the model has left the alive state. It returns
 // [modelerrors.NotFound] when the model does not exist.
-func (s *State) IsModelDying(ctx context.Context, modelUUID string) (bool, error) {
+func (s *State) IsModelNotAlive(ctx context.Context, modelUUID string) (bool, error) {
 	db, err := s.DB(ctx)
 	if err != nil {
 		return false, errors.Capture(err)

--- a/domain/modelmigration/state/controller/abort_test.go
+++ b/domain/modelmigration/state/controller/abort_test.go
@@ -1,0 +1,329 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"github.com/juju/clock"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/domain/modelmigration"
+	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
+	"github.com/juju/juju/internal/uuid"
+)
+
+// setImportPhase forces the claim for modelUUID to the given phase id
+// (0=importing, 1=activating, 2=aborting) directly, for arranging test state.
+func (s *stateSuite) setImportPhase(c *tc.C, modelUUID string, phaseID int) {
+	_, err := s.DB().ExecContext(c.Context(),
+		"UPDATE model_migration_import SET phase_type_id = ? WHERE model_uuid = ?",
+		phaseID, modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// insertClaim inserts an importing claim for modelUUID directly and returns its
+// claim UUID.
+func (s *stateSuite) insertClaim(c *tc.C, modelUUID string) string {
+	claimUUID := uuid.MustNewUUID().String()
+	_, err := s.DB().ExecContext(c.Context(),
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		claimUUID, modelUUID, uuid.MustNewUUID().String())
+	c.Assert(err, tc.ErrorIsNil)
+	return claimUUID
+}
+
+func (s *stateSuite) importPhase(c *tc.C, modelUUID string) modelmigration.ImportPhase {
+	claim, err := New(s.TxnRunnerFactory(), clock.WallClock).GetImportClaim(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	return claim.Phase
+}
+
+// TestSetImportPhaseAborting verifies an importing claim transitions to
+// aborting.
+func (s *stateSuite) TestSetImportPhaseAborting(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	_, err := st.BeginImport(c.Context(), s.modelUUID.String(), uuid.MustNewUUID().String(), uuid.MustNewUUID().String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.SetImportPhaseAborting(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(s.importPhase(c, s.modelUUID.String()), tc.Equals, modelmigration.ImportPhaseAborting)
+}
+
+// TestSetImportPhaseAbortingIdempotent verifies a second transition on an
+// already-aborting claim is a no-op success.
+func (s *stateSuite) TestSetImportPhaseAbortingIdempotent(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	_, err := st.BeginImport(c.Context(), s.modelUUID.String(), uuid.MustNewUUID().String(), uuid.MustNewUUID().String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(st.SetImportPhaseAborting(c.Context(), s.modelUUID.String()), tc.ErrorIsNil)
+	c.Assert(st.SetImportPhaseAborting(c.Context(), s.modelUUID.String()), tc.ErrorIsNil)
+	c.Check(s.importPhase(c, s.modelUUID.String()), tc.Equals, modelmigration.ImportPhaseAborting)
+}
+
+// TestSetImportPhaseAbortingFromActivating verifies that aborting is refused
+// once activation has crossed the point of no return.
+func (s *stateSuite) TestSetImportPhaseAbortingFromActivating(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	_, err := st.BeginImport(c.Context(), s.modelUUID.String(), uuid.MustNewUUID().String(), uuid.MustNewUUID().String())
+	c.Assert(err, tc.ErrorIsNil)
+	s.setImportPhase(c, s.modelUUID.String(), 1) // activating
+
+	err = st.SetImportPhaseAborting(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrAbortActivating)
+	c.Check(s.importPhase(c, s.modelUUID.String()), tc.Equals, modelmigration.ImportPhaseActivating)
+}
+
+// TestSetImportPhaseAbortingNoClaim verifies a missing claim reports not found.
+func (s *stateSuite) TestSetImportPhaseAbortingNoClaim(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	err := st.SetImportPhaseAborting(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotFound)
+}
+
+// TestGetAllImportClaims verifies the reconciler scan returns every outstanding
+// claim with its current phase.
+func (s *stateSuite) TestGetAllImportClaims(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	claims, err := st.GetAllImportClaims(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(claims, tc.HasLen, 0)
+
+	sourceUUID := uuid.MustNewUUID().String()
+	_, err = st.BeginImport(c.Context(), s.modelUUID.String(), uuid.MustNewUUID().String(), sourceUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	claims, err = st.GetAllImportClaims(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(claims, tc.HasLen, 1)
+	c.Check(claims[0].ModelUUID, tc.Equals, s.modelUUID.String())
+	c.Check(claims[0].SourceMigrationUUID, tc.Equals, sourceUUID)
+	c.Check(claims[0].Phase, tc.Equals, modelmigration.ImportPhaseImporting)
+	c.Check(claims[0].UpdatedAt.IsZero(), tc.IsFalse)
+
+	err = st.SetImportPhaseAborting(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+
+	claims, err = st.GetAllImportClaims(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(claims, tc.HasLen, 1)
+	c.Check(claims[0].Phase, tc.Equals, modelmigration.ImportPhaseAborting)
+}
+
+// TestIsModelDying verifies the predicate the v8 abort driver uses
+// to stand aside from a model the generic removal undertaker already owns: it is
+// false for an alive model, true once the model is dying or dead, and false for
+// a model that no longer has a row.
+func (s *stateSuite) TestIsModelDying(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	// Alive (the model created in SetUpTest).
+	removing, err := st.IsModelDying(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(removing, tc.IsFalse)
+
+	// Dying.
+	s.setModelLife(c, s.modelUUID.String(), 1)
+	removing, err = st.IsModelDying(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(removing, tc.IsTrue)
+
+	// Dead.
+	s.setModelLife(c, s.modelUUID.String(), 2)
+	removing, err = st.IsModelDying(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(removing, tc.IsTrue)
+
+	// No model row.
+	removing, err = st.IsModelDying(c.Context(), uuid.MustNewUUID().String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(removing, tc.IsFalse)
+}
+
+// setModelLife forces the model's life_id directly, for arranging test state.
+func (s *stateSuite) setModelLife(c *tc.C, modelUUID string, lifeID int) {
+	_, err := s.DB().ExecContext(c.Context(),
+		"UPDATE model SET life_id = ? WHERE uuid = ?", lifeID, modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestIsImportNamespaceRegistered verifies the namespace_list predicate.
+func (s *stateSuite) TestIsImportNamespaceRegistered(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	// s.modelUUID was created as a full model, so its namespace is registered.
+	registered, err := st.IsImportNamespaceRegistered(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(registered, tc.IsTrue)
+
+	// A model UUID that was never created has no namespace registration.
+	registered, err = st.IsImportNamespaceRegistered(c.Context(), uuid.MustNewUUID().String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(registered, tc.IsFalse)
+}
+
+// TestFinalizeAbortedImportModelStillPresent verifies finalization refuses to
+// delete the claim while the controller model identity row still exists, and
+// leaves the claim untouched.
+func (s *stateSuite) TestFinalizeAbortedImportModelStillPresent(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	// s.modelUUID has a live model row.
+	s.insertClaim(c, s.modelUUID.String())
+	s.setImportPhase(c, s.modelUUID.String(), 2) // aborting
+
+	err := st.FinalizeAbortedImport(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrAbortNotFinalizable)
+
+	// The claim is preserved for a later retry.
+	c.Check(s.importPhase(c, s.modelUUID.String()), tc.Equals, modelmigration.ImportPhaseAborting)
+}
+
+// TestFinalizeAbortedImportWrongPhase verifies finalization refuses a claim
+// that is not aborting.
+func (s *stateSuite) TestFinalizeAbortedImportWrongPhase(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	s.insertClaim(c, s.modelUUID.String()) // importing
+
+	err := st.FinalizeAbortedImport(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrPhaseTransitionInvalid)
+}
+
+// TestFinalizeAbortedImportIdempotent verifies finalization is a no-op when no
+// claim exists.
+func (s *stateSuite) TestFinalizeAbortedImportIdempotent(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	err := st.FinalizeAbortedImport(c.Context(), uuid.MustNewUUID().String())
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestStageAbortedModelDatabaseDeletion verifies staging deletes the namespace
+// registration and records a model_database_deletion row for the undertaker.
+func (s *stateSuite) TestStageAbortedModelDatabaseDeletion(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+	db := s.DB()
+
+	modelUUID := uuid.MustNewUUID().String()
+	s.insertClaim(c, modelUUID)
+	s.setImportPhase(c, modelUUID, 2) // aborting
+	_, err := db.ExecContext(c.Context(),
+		"INSERT INTO namespace_list (namespace) VALUES (?)", modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.StageAbortedModelDatabaseDeletion(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The namespace registration is gone and a deletion is staged.
+	var nsCount, delCount int
+	err = db.QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM namespace_list WHERE namespace = ?", modelUUID).Scan(&nsCount)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(nsCount, tc.Equals, 0)
+	err = db.QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM model_database_deletion WHERE namespace = ?", modelUUID).Scan(&delCount)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(delCount, tc.Equals, 1)
+
+	// Staging again is idempotent (the deletion row is upserted).
+	err = st.StageAbortedModelDatabaseDeletion(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	err = db.QueryRowContext(c.Context(),
+		"SELECT COUNT(*) FROM model_database_deletion WHERE namespace = ?", modelUUID).Scan(&delCount)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(delCount, tc.Equals, 1)
+}
+
+// TestStageAbortedModelDatabaseDeletionWrongPhase verifies staging refuses a
+// claim that is not aborting, so a live model's database can never be staged.
+func (s *stateSuite) TestStageAbortedModelDatabaseDeletionWrongPhase(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+
+	s.insertClaim(c, s.modelUUID.String()) // importing
+
+	err := st.StageAbortedModelDatabaseDeletion(c.Context(), s.modelUUID.String())
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrPhaseTransitionInvalid)
+}
+
+// TestFinalizeAbortedImportDeletionPending verifies finalization refuses to
+// release the claim while the model database deletion is still staged (the
+// undertaker has not yet dropped the database).
+func (s *stateSuite) TestFinalizeAbortedImportDeletionPending(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+	db := s.DB()
+
+	// A model UUID with no model row (compensation done) but a still-staged
+	// database deletion.
+	modelUUID := uuid.MustNewUUID().String()
+	s.insertClaim(c, modelUUID)
+	s.setImportPhase(c, modelUUID, 2) // aborting
+	_, err := db.ExecContext(c.Context(),
+		"INSERT INTO model_database_deletion (namespace, created_at) VALUES (?, DATETIME('now'))", modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.FinalizeAbortedImport(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrAbortNotFinalizable)
+
+	// The claim is preserved for a later retry.
+	c.Check(s.importPhase(c, modelUUID), tc.Equals, modelmigration.ImportPhaseAborting)
+}
+
+// TestFinalizeAbortedImport verifies that once the model identity and namespace
+// rows are gone and the database deletion has been completed by the undertaker
+// (no staged row), finalization deletes the companion rows and the claim.
+func (s *stateSuite) TestFinalizeAbortedImport(c *tc.C) {
+	st := New(s.TxnRunnerFactory(), clock.WallClock)
+	db := s.DB()
+
+	// Use a model UUID with no model row (simulating that compensation has
+	// already deleted the identity and namespace mapping) and no staged database
+	// deletion (the undertaker has already dropped the database).
+	modelUUID := uuid.MustNewUUID().String()
+	claimUUID := s.insertClaim(c, modelUUID)
+	s.setImportPhase(c, modelUUID, 2) // aborting
+
+	// Companion rows that must be removed with the claim.
+	offerUUID := uuid.MustNewUUID().String()
+	_, err := db.ExecContext(c.Context(),
+		"INSERT INTO model_migration_import_offer (migration_uuid, offer_uuid) VALUES (?, ?)",
+		claimUUID, offerUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	extCtrlUUID := uuid.MustNewUUID().String()
+	_, err = db.ExecContext(c.Context(),
+		"INSERT INTO external_controller (uuid, alias, ca_cert) VALUES (?, 'other-ctrl', 'CACERT')",
+		extCtrlUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.ExecContext(c.Context(),
+		`INSERT INTO model_migration_import_external_controller_model
+		 (migration_uuid, offerer_model_uuid, controller_uuid) VALUES (?, ?, ?)`,
+		claimUUID, uuid.MustNewUUID().String(), extCtrlUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.FinalizeAbortedImport(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Claim and companions are all gone.
+	tableKeyColumns := map[string]string{
+		"model_migration_import":                           "model_uuid",
+		"model_migration_import_offer":                     "migration_uuid",
+		"model_migration_import_external_controller_model": "migration_uuid",
+	}
+	for table, keyColumn := range tableKeyColumns {
+		key := modelUUID
+		if keyColumn == "migration_uuid" {
+			key = claimUUID
+		}
+		var count int
+		err = db.QueryRowContext(c.Context(),
+			"SELECT COUNT(*) FROM "+table+" WHERE "+keyColumn+" = ?", key).Scan(&count)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Check(count, tc.Equals, 0, tc.Commentf("table %q still has rows", table))
+	}
+}

--- a/domain/modelmigration/state/controller/abort_test.go
+++ b/domain/modelmigration/state/controller/abort_test.go
@@ -29,10 +29,20 @@ func (s *stateSuite) setImportPhase(c *tc.C, modelUUID string, phaseID int) {
 func (s *stateSuite) insertClaim(c *tc.C, modelUUID string) string {
 	claimUUID := uuid.MustNewUUID().String()
 	_, err := s.DB().ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, ?, '2026-01-02T03:04:05Z')",
 		claimUUID, modelUUID, uuid.MustNewUUID().String())
 	c.Assert(err, tc.ErrorIsNil)
 	return claimUUID
+}
+
+// setImportPhaseAborting drives the importing->aborting transition with a
+// fixed timestamp, for arranging test state.
+func (s *stateSuite) setImportPhaseAborting(c *tc.C, st *State, modelUUID string) {
+	c.Assert(st.SetImportPhaseAborting(
+		c.Context(), modelUUID,
+		modelmigration.ImportPhaseImporting, modelmigration.ImportPhaseAborting,
+		"2026-01-02T03:04:05Z",
+	), tc.ErrorIsNil)
 }
 
 func (s *stateSuite) importPhase(c *tc.C, modelUUID string) modelmigration.ImportPhase {
@@ -49,8 +59,7 @@ func (s *stateSuite) TestSetImportPhaseAborting(c *tc.C) {
 	_, err := st.BeginImport(c.Context(), s.modelUUID.String(), uuid.MustNewUUID().String(), uuid.MustNewUUID().String())
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.SetImportPhaseAborting(c.Context(), s.modelUUID.String())
-	c.Assert(err, tc.ErrorIsNil)
+	s.setImportPhaseAborting(c, st, s.modelUUID.String())
 	c.Check(s.importPhase(c, s.modelUUID.String()), tc.Equals, modelmigration.ImportPhaseAborting)
 }
 
@@ -62,8 +71,8 @@ func (s *stateSuite) TestSetImportPhaseAbortingIdempotent(c *tc.C) {
 	_, err := st.BeginImport(c.Context(), s.modelUUID.String(), uuid.MustNewUUID().String(), uuid.MustNewUUID().String())
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Assert(st.SetImportPhaseAborting(c.Context(), s.modelUUID.String()), tc.ErrorIsNil)
-	c.Assert(st.SetImportPhaseAborting(c.Context(), s.modelUUID.String()), tc.ErrorIsNil)
+	s.setImportPhaseAborting(c, st, s.modelUUID.String())
+	s.setImportPhaseAborting(c, st, s.modelUUID.String())
 	c.Check(s.importPhase(c, s.modelUUID.String()), tc.Equals, modelmigration.ImportPhaseAborting)
 }
 
@@ -76,7 +85,11 @@ func (s *stateSuite) TestSetImportPhaseAbortingFromActivating(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	s.setImportPhase(c, s.modelUUID.String(), 1) // activating
 
-	err = st.SetImportPhaseAborting(c.Context(), s.modelUUID.String())
+	err = st.SetImportPhaseAborting(
+		c.Context(), s.modelUUID.String(),
+		modelmigration.ImportPhaseImporting, modelmigration.ImportPhaseAborting,
+		"2026-01-02T03:04:05Z",
+	)
 	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrAbortActivating)
 	c.Check(s.importPhase(c, s.modelUUID.String()), tc.Equals, modelmigration.ImportPhaseActivating)
 }
@@ -85,7 +98,11 @@ func (s *stateSuite) TestSetImportPhaseAbortingFromActivating(c *tc.C) {
 func (s *stateSuite) TestSetImportPhaseAbortingNoClaim(c *tc.C) {
 	st := New(s.TxnRunnerFactory(), clock.WallClock)
 
-	err := st.SetImportPhaseAborting(c.Context(), s.modelUUID.String())
+	err := st.SetImportPhaseAborting(
+		c.Context(), s.modelUUID.String(),
+		modelmigration.ImportPhaseImporting, modelmigration.ImportPhaseAborting,
+		"2026-01-02T03:04:05Z",
+	)
 	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotFound)
 }
 
@@ -111,42 +128,41 @@ func (s *stateSuite) TestGetAllImportClaims(c *tc.C) {
 	_, err = time.Parse(time.RFC3339, claims[0].UpdatedAt)
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.SetImportPhaseAborting(c.Context(), s.modelUUID.String())
-	c.Assert(err, tc.ErrorIsNil)
+	s.setImportPhaseAborting(c, st, s.modelUUID.String())
 
 	claims, err = st.GetAllImportClaims(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(claims, tc.HasLen, 1)
 	c.Check(claims[0].PhaseType, tc.Equals, string(modelmigration.ImportPhaseAborting))
-	_, err = time.Parse(time.RFC3339, claims[0].UpdatedAt)
-	c.Assert(err, tc.ErrorIsNil)
+	// The abort transition stamps the service-supplied timestamp.
+	c.Check(claims[0].UpdatedAt, tc.Equals, "2026-01-02T03:04:05Z")
 }
 
-// TestIsModelDying verifies the predicate the v8 abort driver uses
+// TestIsModelNotAlive verifies the predicate the v8 abort driver uses
 // to stand aside from a model the generic removal undertaker already owns: it is
 // false for an alive model and true once the model is dying or dead.
-func (s *stateSuite) TestIsModelDying(c *tc.C) {
+func (s *stateSuite) TestIsModelNotAlive(c *tc.C) {
 	st := New(s.TxnRunnerFactory(), clock.WallClock)
 
 	// Alive (the model created in SetUpTest).
-	removing, err := st.IsModelDying(c.Context(), s.modelUUID.String())
+	removing, err := st.IsModelNotAlive(c.Context(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(removing, tc.IsFalse)
 
 	// Dying.
 	s.setModelLife(c, s.modelUUID.String(), 1)
-	removing, err = st.IsModelDying(c.Context(), s.modelUUID.String())
+	removing, err = st.IsModelNotAlive(c.Context(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(removing, tc.IsTrue)
 
 	// Dead.
 	s.setModelLife(c, s.modelUUID.String(), 2)
-	removing, err = st.IsModelDying(c.Context(), s.modelUUID.String())
+	removing, err = st.IsModelNotAlive(c.Context(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(removing, tc.IsTrue)
 
 	// No model row.
-	removing, err = st.IsModelDying(c.Context(), uuid.MustNewUUID().String())
+	removing, err = st.IsModelNotAlive(c.Context(), uuid.MustNewUUID().String())
 	c.Assert(err, tc.ErrorIs, modelerrors.NotFound)
 	c.Check(removing, tc.IsFalse)
 }

--- a/domain/modelmigration/state/controller/abort_test.go
+++ b/domain/modelmigration/state/controller/abort_test.go
@@ -4,9 +4,12 @@
 package controller
 
 import (
+	"time"
+
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 
+	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/modelmigration"
 	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
 	"github.com/juju/juju/internal/uuid"
@@ -104,8 +107,9 @@ func (s *stateSuite) TestGetAllImportClaims(c *tc.C) {
 	c.Assert(claims, tc.HasLen, 1)
 	c.Check(claims[0].ModelUUID, tc.Equals, s.modelUUID.String())
 	c.Check(claims[0].SourceMigrationUUID, tc.Equals, sourceUUID)
-	c.Check(claims[0].Phase, tc.Equals, modelmigration.ImportPhaseImporting)
-	c.Check(claims[0].UpdatedAt.IsZero(), tc.IsFalse)
+	c.Check(claims[0].PhaseType, tc.Equals, string(modelmigration.ImportPhaseImporting))
+	_, err = time.Parse(time.RFC3339, claims[0].UpdatedAt)
+	c.Assert(err, tc.ErrorIsNil)
 
 	err = st.SetImportPhaseAborting(c.Context(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
@@ -113,13 +117,14 @@ func (s *stateSuite) TestGetAllImportClaims(c *tc.C) {
 	claims, err = st.GetAllImportClaims(c.Context())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(claims, tc.HasLen, 1)
-	c.Check(claims[0].Phase, tc.Equals, modelmigration.ImportPhaseAborting)
+	c.Check(claims[0].PhaseType, tc.Equals, string(modelmigration.ImportPhaseAborting))
+	_, err = time.Parse(time.RFC3339, claims[0].UpdatedAt)
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 // TestIsModelDying verifies the predicate the v8 abort driver uses
 // to stand aside from a model the generic removal undertaker already owns: it is
-// false for an alive model, true once the model is dying or dead, and false for
-// a model that no longer has a row.
+// false for an alive model and true once the model is dying or dead.
 func (s *stateSuite) TestIsModelDying(c *tc.C) {
 	st := New(s.TxnRunnerFactory(), clock.WallClock)
 
@@ -142,7 +147,7 @@ func (s *stateSuite) TestIsModelDying(c *tc.C) {
 
 	// No model row.
 	removing, err = st.IsModelDying(c.Context(), uuid.MustNewUUID().String())
-	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(err, tc.ErrorIs, modelerrors.NotFound)
 	c.Check(removing, tc.IsFalse)
 }
 

--- a/domain/modelmigration/state/controller/import.go
+++ b/domain/modelmigration/state/controller/import.go
@@ -224,11 +224,17 @@ func (s *State) SetImportPhaseActivating(ctx context.Context, modelUUID string) 
 		Source: string(modelmigration.ImportPhaseImporting),
 	}
 	updateStmt, err := s.Prepare(`
+WITH target_phase AS (
+    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseNames.target
+),
+source_phase AS (
+    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseNames.source
+)
 UPDATE model_migration_import
-SET    phase_type_id = (SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseNames.target),
+SET    phase_type_id = (SELECT id FROM target_phase),
        updated_at    = DATETIME('now', 'utc')
 WHERE  model_uuid = $modelUUIDArg.model_uuid
-AND    phase_type_id = (SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseNames.source)
+AND    phase_type_id = (SELECT id FROM source_phase)
 `, mUUID, phases)
 	if err != nil {
 		return errors.Capture(err)
@@ -280,17 +286,21 @@ func (s *State) DeleteActivatedImport(ctx context.Context, modelUUID string) err
 
 	mUUID := modelUUIDArg{ModelUUID: modelUUID}
 	deleteOffersStmt, err := s.Prepare(`
+WITH claim AS (
+    SELECT uuid FROM model_migration_import WHERE model_uuid = $modelUUIDArg.model_uuid
+)
 DELETE FROM model_migration_import_offer
-WHERE  migration_uuid IN (
-       SELECT uuid FROM model_migration_import WHERE model_uuid = $modelUUIDArg.model_uuid)
+WHERE  migration_uuid IN (SELECT uuid FROM claim)
 	`, mUUID)
 	if err != nil {
 		return errors.Capture(err)
 	}
 	deleteECMStmt, err := s.Prepare(`
+WITH claim AS (
+    SELECT uuid FROM model_migration_import WHERE model_uuid = $modelUUIDArg.model_uuid
+)
 DELETE FROM model_migration_import_external_controller_model
-WHERE  migration_uuid IN (
-       SELECT uuid FROM model_migration_import WHERE model_uuid = $modelUUIDArg.model_uuid)
+WHERE  migration_uuid IN (SELECT uuid FROM claim)
 	`, mUUID)
 	if err != nil {
 		return errors.Capture(err)
@@ -508,7 +518,7 @@ INSERT INTO external_model (*) VALUES ($externalModelArg.*)
 // records each (offerer_model_uuid, controller_uuid) pair into
 // model_migration_import_external_controller_model -- the durable handoff
 // Activate reads to reconcile offerer-controller mappings even after a
-// controller restart (WS9/WS4.1).
+// controller restart.
 func (s *State) ImportExternalControllers(
 	ctx context.Context, modelUUID, claimUUID string, refs []modelmigrationinternal.ExternalController,
 ) error {

--- a/domain/modelmigration/state/controller/import.go
+++ b/domain/modelmigration/state/controller/import.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	"github.com/canonical/sqlair"
 
@@ -48,14 +49,17 @@ func (s *State) BeginImport(
 		return modelmigration.ImportClaim{}, errors.Capture(err)
 	}
 
+	updatedAt := s.clock.Now().UTC()
 	claim := importClaimArg{
 		UUID:                claimUUID,
 		ModelUUID:           modelUUID,
 		SourceMigrationUUID: sourceMigrationUUID,
+		UpdatedAt:           updatedAt.Format(time.RFC3339),
 	}
 	stmt, err := s.Prepare(`
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES ($importClaimArg.uuid, $importClaimArg.model_uuid, $importClaimArg.source_migration_uuid)
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES ($importClaimArg.uuid, $importClaimArg.model_uuid,
+        $importClaimArg.source_migration_uuid, $importClaimArg.updated_at)
 `, claim)
 	if err != nil {
 		return modelmigration.ImportClaim{}, errors.Capture(err)
@@ -80,6 +84,7 @@ VALUES ($importClaimArg.uuid, $importClaimArg.model_uuid, $importClaimArg.source
 		result = modelmigration.ImportClaim{
 			SourceMigrationUUID: sourceMigrationUUID,
 			Phase:               modelmigration.ImportPhaseImporting,
+			UpdatedAt:           updatedAt,
 		}
 		return nil
 	})
@@ -218,24 +223,25 @@ func (s *State) SetImportPhaseActivating(ctx context.Context, modelUUID string) 
 		return errors.Capture(err)
 	}
 
-	mUUID := modelUUIDArg{ModelUUID: modelUUID}
-	phases := importPhaseNames{
-		Target: string(modelmigration.ImportPhaseActivating),
-		Source: string(modelmigration.ImportPhaseImporting),
+	update := importPhaseUpdate{
+		ModelUUID: modelUUID,
+		Target:    string(modelmigration.ImportPhaseActivating),
+		Source:    string(modelmigration.ImportPhaseImporting),
+		UpdatedAt: s.clock.Now().UTC().Format(time.RFC3339),
 	}
 	updateStmt, err := s.Prepare(`
 WITH target_phase AS (
-    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseNames.target
+    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseUpdate.target
 ),
 source_phase AS (
-    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseNames.source
+    SELECT id FROM model_migration_import_phase_type WHERE type = $importPhaseUpdate.source
 )
 UPDATE model_migration_import
 SET    phase_type_id = (SELECT id FROM target_phase),
-       updated_at    = DATETIME('now', 'utc')
-WHERE  model_uuid = $modelUUIDArg.model_uuid
+       updated_at    = $importPhaseUpdate.updated_at
+WHERE  model_uuid = $importPhaseUpdate.model_uuid
 AND    phase_type_id = (SELECT id FROM source_phase)
-`, mUUID, phases)
+`, update)
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -254,7 +260,7 @@ AND    phase_type_id = (SELECT id FROM source_phase)
 
 		// Phase is importing; CAS to activating.
 		var outcome sqlair.Outcome
-		if err := tx.Query(ctx, updateStmt, mUUID, phases).Get(&outcome); err != nil {
+		if err := tx.Query(ctx, updateStmt, update).Get(&outcome); err != nil {
 			return errors.Errorf("transitioning import to activating: %w", err)
 		}
 		affected, err := outcome.Result().RowsAffected()

--- a/domain/modelmigration/state/controller/prechecks.go
+++ b/domain/modelmigration/state/controller/prechecks.go
@@ -304,7 +304,7 @@ func (s *State) getImportClaim(
 	stmt, err := s.Prepare(`
 SELECT mmi.source_migration_uuid AS &importClaimRow.source_migration_uuid,
        mmipt.type AS &importClaimRow.phase_type,
-       strftime('%Y-%m-%dT%H:%M:%fZ', mmi.updated_at) AS &importClaimRow.updated_at
+	       mmi.updated_at AS &importClaimRow.updated_at
 FROM   model_migration_import AS mmi
 JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
 WHERE  mmi.model_uuid = $modelUUIDArg.model_uuid

--- a/domain/modelmigration/state/controller/prechecks_test.go
+++ b/domain/modelmigration/state/controller/prechecks_test.go
@@ -118,7 +118,7 @@ func (s *stateSuite) TestCheckImportModelCollision(c *tc.C) {
 	c.Check(collision.ModelNameExists, tc.IsTrue)
 
 	_, err = db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, ?, '2026-01-02T03:04:05Z')",
 		uuid.MustNewUUID().String(), s.modelUUID, uuid.MustNewUUID().String())
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -143,7 +143,7 @@ func (s *stateSuite) TestGetImportClaim(c *tc.C) {
 	migratingUUID := uuid.MustNewUUID().String()
 	sourceMigrationUUID := uuid.MustNewUUID().String()
 	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, ?, '2026-01-02T03:04:05Z')",
 		migratingUUID, s.modelUUID, sourceMigrationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 

--- a/domain/modelmigration/state/controller/state.go
+++ b/domain/modelmigration/state/controller/state.go
@@ -38,6 +38,13 @@ func New(factory coredatabase.TxnRunnerFactory, clock clock.Clock) *State {
 	}
 }
 
+// InitialWatchImportClaimsStatement returns the changestream namespace and
+// initial query for target-side import claims. Both the initial collection and
+// changelog triggers identify claims by their model UUID.
+func (*State) InitialWatchImportClaimsStatement() (string, string) {
+	return "model_migration_import", "SELECT model_uuid FROM model_migration_import"
+}
+
 // DeleteModelImportingStatus removes the entry from the model_migration_import
 // table in the controller database, indicating that the model import has
 // completed or been aborted.
@@ -151,6 +158,15 @@ func (s *State) NamespaceForWatchMinionSync() string {
 // [github.com/juju/juju/domain/modelmigration/service.WatchableService.WatchMigrationActivity].
 func (s *State) NamespaceForWatchImportClaim() string {
 	return "model_migration_import"
+}
+
+// NamespaceForWatchModelDatabaseDeletion returns the changestream namespace that
+// fires when a staged model-database deletion changes, keyed by the model's
+// namespace (its UUID). The undertaker's model-database deleter removes the
+// staged row once it has dropped the database, so a delete event on this
+// namespace signals that an aborted import may now be finalizable.
+func (s *State) NamespaceForWatchModelDatabaseDeletion() string {
+	return "model_database_deletion"
 }
 
 // GetActiveExportUUID returns the UUID of the active export migration for the

--- a/domain/modelmigration/state/controller/state_reap_test.go
+++ b/domain/modelmigration/state/controller/state_reap_test.go
@@ -263,8 +263,8 @@ func (s *stateSuite) TestCompleteModelRedirectAndPurgeImportClaims(c *tc.C) {
 	claimUUID := uuid.MustNewUUID().String()
 	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
-VALUES (?, ?, ?, (SELECT id FROM model_migration_import_phase_type WHERE type = 'importing'))`,
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id, updated_at)
+VALUES (?, ?, ?, (SELECT id FROM model_migration_import_phase_type WHERE type = 'importing'), '2026-01-02T03:04:05Z')`,
 			claimUUID, s.modelUUID, uuid.MustNewUUID().String())
 		return err
 	})
@@ -299,8 +299,8 @@ func (s *stateSuite) TestCompleteModelRedirectAndPurgeKeepsAbortingClaim(c *tc.C
 	claimUUID := uuid.MustNewUUID().String()
 	err := s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
-VALUES (?, ?, ?, (SELECT id FROM model_migration_import_phase_type WHERE type = 'aborting'))`,
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id, updated_at)
+VALUES (?, ?, ?, (SELECT id FROM model_migration_import_phase_type WHERE type = 'aborting'), '2026-01-02T03:04:05Z')`,
 			claimUUID, s.modelUUID, uuid.MustNewUUID().String())
 		return err
 	})

--- a/domain/modelmigration/state/controller/state_test.go
+++ b/domain/modelmigration/state/controller/state_test.go
@@ -171,7 +171,7 @@ func (s *stateSuite) TestDeleteModelImportingStatusSuccess(c *tc.C) {
 	migratingUUID := uuid.MustNewUUID().String()
 	sourceMigrationUUID := uuid.MustNewUUID().String()
 	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, ?, '2026-01-02T03:04:05Z')",
 		migratingUUID, s.modelUUID, sourceMigrationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -207,7 +207,7 @@ func (s *stateSuite) TestDeleteModelImportingStatusWithCompanions(c *tc.C) {
 	migratingUUID := uuid.MustNewUUID().String()
 	sourceMigrationUUID := uuid.MustNewUUID().String()
 	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, ?, '2026-01-02T03:04:05Z')",
 		migratingUUID, s.modelUUID, sourceMigrationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -332,7 +332,7 @@ func (s *stateSuite) TestDeleteModelImportingStatusVerifyCorrectEntry(c *tc.C) {
 	migratingUUID := uuid.MustNewUUID().String()
 	sourceMigrationUUID := uuid.MustNewUUID().String()
 	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, ?, '2026-01-02T03:04:05Z')",
 		migratingUUID, s.modelUUID, sourceMigrationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -368,7 +368,7 @@ func (s *stateSuite) TestDeleteModelImportingStatusWrongModelUUID(c *tc.C) {
 	migratingUUID := uuid.MustNewUUID().String()
 	sourceMigrationUUID := uuid.MustNewUUID().String()
 	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, ?, '2026-01-02T03:04:05Z')",
 		migratingUUID, s.modelUUID, sourceMigrationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -396,7 +396,7 @@ func (s *stateSuite) TestDeleteModelImportingStatusIdempotent(c *tc.C) {
 	migratingUUID := uuid.MustNewUUID().String()
 	sourceMigrationUUID := uuid.MustNewUUID().String()
 	_, err := db.ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, ?)",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, ?, '2026-01-02T03:04:05Z')",
 		migratingUUID, s.modelUUID, sourceMigrationUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -905,7 +905,7 @@ func (s *stateSuite) TestGetMigrationMode(c *tc.C) {
 	err = st.MarkExportEnded(c.Context(), spec.MigrationUUID, migration.DONE)
 	c.Assert(err, tc.ErrorIsNil)
 	_, err = s.DB().ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, 'src')",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, 'src', '2026-01-02T03:04:05Z')",
 		uuid.MustNewUUID().String(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 	mode, err = st.GetMigrationMode(c.Context(), s.modelUUID.String())
@@ -936,7 +936,7 @@ func (s *stateSuite) TestGetMigrationPhase(c *tc.C) {
 	// An import claim takes precedence over the active export: a model with
 	// both is inconsistent, and IMPORT keeps it frozen.
 	_, err = s.DB().ExecContext(c.Context(),
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, 'src')",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, 'src', '2026-01-02T03:04:05Z')",
 		uuid.MustNewUUID().String(), s.modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 	phase, err = st.GetMigrationPhase(c.Context(), s.modelUUID.String())

--- a/domain/modelmigration/state/controller/types.go
+++ b/domain/modelmigration/state/controller/types.go
@@ -360,8 +360,6 @@ type credentialRevoked struct {
 }
 
 // importClaimRow maps a model_migration_import row joined to its phase type.
-// UpdatedAt is read as text because model_migration_import.updated_at is a
-// TEXT column; the query canonicalises it to RFC3339 via strftime.
 type importClaimRow struct {
 	SourceMigrationUUID string `db:"source_migration_uuid"`
 	PhaseType           string `db:"phase_type"`
@@ -375,6 +373,7 @@ type importClaimArg struct {
 	UUID                string `db:"uuid"`
 	ModelUUID           string `db:"model_uuid"`
 	SourceMigrationUUID string `db:"source_migration_uuid"`
+	UpdatedAt           string `db:"updated_at"`
 }
 
 // importPhaseRow projects only the phase type of a model_migration_import
@@ -385,9 +384,7 @@ type importPhaseRow struct {
 }
 
 // importClaimStatusRow maps a full model_migration_import row (including its
-// model UUID) joined to its phase type, for the abort reconciler's scan of all
-// outstanding claims. UpdatedAt is read as text and canonicalised to RFC3339
-// via strftime, as for importClaimRow.
+// model UUID) joined to its phase type.
 type importClaimStatusRow struct {
 	ModelUUID           string `db:"model_uuid"`
 	SourceMigrationUUID string `db:"source_migration_uuid"`
@@ -401,12 +398,12 @@ type namespaceArg struct {
 	Namespace string `db:"namespace"`
 }
 
-// importPhaseNames binds the source and target phase names of a claim phase
-// transition, so the phase-type IDs are resolved by name from
-// model_migration_import_phase_type rather than inlined as SQL literals.
-type importPhaseNames struct {
-	Target string `db:"target"`
-	Source string `db:"source"`
+// importPhaseUpdate contains the values for an import phase transition.
+type importPhaseUpdate struct {
+	ModelUUID string `db:"model_uuid"`
+	Target    string `db:"target"`
+	Source    string `db:"source"`
+	UpdatedAt string `db:"updated_at"`
 }
 
 // importOfferArg is the insert argument for a model_migration_import_offer

--- a/domain/modelmigration/state/controller/types.go
+++ b/domain/modelmigration/state/controller/types.go
@@ -30,6 +30,12 @@ type importClaimKey struct {
 	ClaimUUID string `db:"claim_uuid"`
 }
 
+// modelLifeRow projects a model row's life id (see
+// [github.com/juju/juju/domain/life]).
+type modelLifeRow struct {
+	LifeID int `db:"life_id"`
+}
+
 // migrationUUIDArg is a query argument holding a migration uuid (the export
 // migration's primary key, referenced as migration_uuid by child tables).
 type migrationUUIDArg struct {
@@ -143,6 +149,17 @@ type addressValue struct {
 // countResult holds a COUNT(*) projection.
 type countResult struct {
 	Count int `db:"count"`
+}
+
+// abortFinalizeChecks projects the three existence predicates
+// FinalizeAbortedImport asserts in a single round trip before releasing an
+// aborted import claim: the controller model identity row, its
+// model_namespace mapping, and any still-staged model_database_deletion for
+// the model's namespace.
+type abortFinalizeChecks struct {
+	ModelExists     bool `db:"model_exists"`
+	NamespaceExists bool `db:"namespace_exists"`
+	DeletionStaged  bool `db:"deletion_staged"`
 }
 
 // cloudImageRow is a custom cloud_image_metadata row with its architecture
@@ -365,6 +382,23 @@ type importClaimArg struct {
 // transaction.
 type importPhaseRow struct {
 	PhaseType string `db:"phase_type"`
+}
+
+// importClaimStatusRow maps a full model_migration_import row (including its
+// model UUID) joined to its phase type, for the abort reconciler's scan of all
+// outstanding claims. UpdatedAt is read as text and canonicalised to RFC3339
+// via strftime, as for importClaimRow.
+type importClaimStatusRow struct {
+	ModelUUID           string `db:"model_uuid"`
+	SourceMigrationUUID string `db:"source_migration_uuid"`
+	PhaseType           string `db:"phase_type"`
+	UpdatedAt           string `db:"updated_at"`
+}
+
+// namespaceArg binds a dqlite namespace name (a model UUID) for existence
+// reads against namespace_list.
+type namespaceArg struct {
+	Namespace string `db:"namespace"`
 }
 
 // importPhaseNames binds the source and target phase names of a claim phase

--- a/domain/modelmigration/types.go
+++ b/domain/modelmigration/types.go
@@ -84,6 +84,25 @@ type ImportClaim struct {
 	UpdatedAt time.Time
 }
 
+// ImportClaimStatus is a full snapshot of a target-side import claim, keyed by
+// its model UUID. The abort reconciler scans all outstanding claims and uses
+// the phase and UpdatedAt to decide which to finalize and which to warn about
+// as stale.
+type ImportClaimStatus struct {
+	// ModelUUID is the UUID of the model the claim belongs to.
+	ModelUUID string
+
+	// SourceMigrationUUID is the migration UUID recorded by the source side.
+	// It is diagnostic only.
+	SourceMigrationUUID string
+
+	// Phase is the claim's current import phase.
+	Phase ImportPhase
+
+	// UpdatedAt is when the claim last changed phase.
+	UpdatedAt time.Time
+}
+
 // ImportClaimConflictError builds the coded AlreadyExists error returned when
 // a v8 import claim attempt finds an existing claim for modelUUID. The
 // message reflects the existing claim's phase: activation-in-progress

--- a/domain/modelmigration/watcher_test.go
+++ b/domain/modelmigration/watcher_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
+	coremodel "github.com/juju/juju/core/model"
 	coremodelmigration "github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -167,6 +168,89 @@ func (s *exportWatcherSuite) TestWatchMinionReports(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
+// TestWatchImportClaims asserts that the target-side import claim watcher
+// returns model UUIDs for its initial collection and all claim mutations.
+func (s *exportWatcherSuite) TestWatchImportClaims(c *tc.C) {
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, coredatabase.ControllerNS)
+	svc := service.NewWatchableImportService(
+		migrationstatecontroller.New(s.controllerDBFactory(), clock.WallClock),
+		domain.NewWatcherFactory(factory, loggertesting.WrapCheckLog(c)),
+		loggertesting.WrapCheckLog(c),
+	)
+
+	// A claim present before the watcher starts must be returned in its initial
+	// collection.
+	s.insertImportClaim(c, s.modelUUID)
+	s.AssertChangeStreamIdle(c, "before watcher start")
+	w, err := svc.WatchImportClaims(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, w))
+	otherModelUUID := uuid.MustNewUUID().String()
+	harness.AddTest(c, func(c *tc.C) {
+		s.insertImportClaim(c, otherModelUUID)
+	}, func(w watchertest.WatcherC[[]string]) {
+		w.Check(watchertest.StringSliceAssert(otherModelUUID))
+	})
+	harness.AddTest(c, func(c *tc.C) {
+		s.setImportClaimPhase(c, otherModelUUID, 1)
+	}, func(w watchertest.WatcherC[[]string]) {
+		w.Check(watchertest.StringSliceAssert(otherModelUUID))
+	})
+	harness.AddTest(c, func(c *tc.C) {
+		s.deleteImportClaim(c, otherModelUUID)
+	}, func(w watchertest.WatcherC[[]string]) {
+		w.Check(watchertest.StringSliceAssert(otherModelUUID))
+	})
+	harness.Run(c, []string{s.modelUUID})
+}
+
+// TestWatchModelDatabaseDeletion asserts the staged model-database deletion
+// watcher fires for the target model's namespace - both when a deletion is
+// staged and when it is removed (the drop completing) - and ignores other
+// models.
+func (s *exportWatcherSuite) TestWatchModelDatabaseDeletion(c *tc.C) {
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, coredatabase.ControllerNS)
+	svc := service.NewWatchableImportService(
+		migrationstatecontroller.New(s.controllerDBFactory(), clock.WallClock),
+		domain.NewWatcherFactory(factory, loggertesting.WrapCheckLog(c)),
+		loggertesting.WrapCheckLog(c),
+	)
+
+	s.AssertChangeStreamIdle(c, "before watcher start")
+	w, err := svc.WatchModelDatabaseDeletion(c.Context(), coremodel.UUID(s.modelUUID))
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, w))
+
+	harness.AddTest(c, func(c *tc.C) {}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertNoChange()
+	})
+
+	// A deletion staged for another model must NOT fire this model's watcher.
+	harness.AddTest(c, func(c *tc.C) {
+		s.stageModelDatabaseDeletion(c, uuid.MustNewUUID().String())
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertNoChange()
+	})
+
+	// Staging this model's deletion fires the watcher.
+	harness.AddTest(c, func(c *tc.C) {
+		s.stageModelDatabaseDeletion(c, s.modelUUID)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	// Removing it (the undertaker having dropped the database) fires again.
+	harness.AddTest(c, func(c *tc.C) {
+		s.removeModelDatabaseDeletion(c, s.modelUUID)
+	}, func(w watchertest.WatcherC[struct{}]) {
+		w.AssertChange()
+	})
+
+	harness.Run(c, struct{}{})
+}
+
 // insertMinionReport records a minion sync row directly.
 func (s *exportWatcherSuite) insertMinionReport(c *tc.C, migrationUUID string, phaseID int, entityKey string, success bool) {
 	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
@@ -223,6 +307,52 @@ func (s *exportWatcherSuite) insertPhase(c *tc.C, migrationUUID string, phaseID 
 INSERT INTO model_migration_export_phase (migration_uuid, model_uuid, phase_id, changed_at)
 VALUES (?, ?, ?, DATETIME('now', 'utc'))`,
 			migrationUUID, s.modelUUID, phaseID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *exportWatcherSuite) insertImportClaim(c *tc.C, modelUUID string) {
+	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
+VALUES (?, ?, 'source-migration-uuid')`, uuid.MustNewUUID().String(), modelUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *exportWatcherSuite) setImportClaimPhase(c *tc.C, modelUUID string, phaseID int) {
+	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+UPDATE model_migration_import
+SET    phase_type_id = ?, updated_at = DATETIME('now', 'utc')
+WHERE  model_uuid = ?`, phaseID, modelUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *exportWatcherSuite) deleteImportClaim(c *tc.C, modelUUID string) {
+	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "DELETE FROM model_migration_import WHERE model_uuid = ?", modelUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *exportWatcherSuite) stageModelDatabaseDeletion(c *tc.C, namespace string) {
+	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			"INSERT INTO model_database_deletion (namespace, created_at) VALUES (?, DATETIME('now', 'utc'))", namespace)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *exportWatcherSuite) removeModelDatabaseDeletion(c *tc.C, namespace string) {
+	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "DELETE FROM model_database_deletion WHERE namespace = ?", namespace)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/modelmigration/watcher_test.go
+++ b/domain/modelmigration/watcher_test.go
@@ -175,6 +175,7 @@ func (s *exportWatcherSuite) TestWatchImportClaims(c *tc.C) {
 	svc := service.NewWatchableImportService(
 		migrationstatecontroller.New(s.controllerDBFactory(), clock.WallClock),
 		domain.NewWatcherFactory(factory, loggertesting.WrapCheckLog(c)),
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	)
 
@@ -214,6 +215,7 @@ func (s *exportWatcherSuite) TestWatchModelDatabaseDeletion(c *tc.C) {
 	svc := service.NewWatchableImportService(
 		migrationstatecontroller.New(s.controllerDBFactory(), clock.WallClock),
 		domain.NewWatcherFactory(factory, loggertesting.WrapCheckLog(c)),
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	)
 
@@ -315,8 +317,8 @@ VALUES (?, ?, ?, DATETIME('now', 'utc'))`,
 func (s *exportWatcherSuite) insertImportClaim(c *tc.C, modelUUID string) {
 	err := s.ControllerTxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES (?, ?, 'source-migration-uuid')`, uuid.MustNewUUID().String(), modelUUID)
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES (?, ?, 'source-migration-uuid', '2026-01-02T03:04:05Z')`, uuid.MustNewUUID().String(), modelUUID)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -381,6 +383,7 @@ func (s *exportWatcherSuite) setupService(c *tc.C, factory domain.WatchableDBFac
 		providertracker.ProviderGetter[service.InstanceProvider](noopInstanceGetter),
 		providertracker.ProviderGetter[service.ResourceProvider](noopResourceGetter),
 		noopCredentialValidator,
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	)
 }

--- a/domain/removal/errors/errors.go
+++ b/domain/removal/errors/errors.go
@@ -93,4 +93,13 @@ const (
 	// and is torn down by aborting the import, which owns the protocol that
 	// proves the model database is gone before the model UUID is released.
 	MigrationImportActive = errors.ConstError("model has an active migration import claim")
+
+	// MigrationImportPastImporting indicates that a model's migration import
+	// claim has reached the activating phase, so the migrating-model abort path
+	// must not tear the model down: activation has crossed the point of no
+	// return and cleanup is owned by the migration activation finalizer, which
+	// preserves the durable claim and the model database until cleanup is
+	// provably complete. (An importing claim is aborted normally; an aborting
+	// claim is a retried abort and is also accepted.)
+	MigrationImportPastImporting = errors.ConstError("model migration import is past the importing phase")
 )

--- a/domain/removal/errors/errors.go
+++ b/domain/removal/errors/errors.go
@@ -93,13 +93,4 @@ const (
 	// and is torn down by aborting the import, which owns the protocol that
 	// proves the model database is gone before the model UUID is released.
 	MigrationImportActive = errors.ConstError("model has an active migration import claim")
-
-	// MigrationImportPastImporting indicates that a model's migration import
-	// claim has reached the activating phase, so the migrating-model abort path
-	// must not tear the model down: activation has crossed the point of no
-	// return and cleanup is owned by the migration activation finalizer, which
-	// preserves the durable claim and the model database until cleanup is
-	// provably complete. (An importing claim is aborted normally; an aborting
-	// claim is a retried abort and is also accepted.)
-	MigrationImportPastImporting = errors.ConstError("model migration import is past the importing phase")
 )

--- a/domain/removal/service/controller.go
+++ b/domain/removal/service/controller.go
@@ -43,7 +43,7 @@ type ControllerState interface {
 
 	// MarkMigratingModelAsDead marks the migrating model with the input UUID as
 	// dead.
-	MarkMigratingModelAsDead(ctx context.Context, modelUUID string) error
+	MarkMigratingModelAsDead(ctx context.Context, modelUUID, updatedAt string) error
 
 	// DeleteModel removes the model with the input UUID from the database.
 	DeleteModel(ctx context.Context, modelUUID string) error

--- a/domain/removal/service/model.go
+++ b/domain/removal/service/model.go
@@ -126,7 +126,10 @@ func (s *Service) RemoveMigratingModel(
 	// controller database. This will cause the undertaker to delete the model
 	// database.
 
-	if err := s.controllerState.MarkMigratingModelAsDead(ctx, modelUUID.String()); err != nil {
+	updatedAt := s.clock.Now().UTC().Format(time.RFC3339)
+	if err := s.controllerState.MarkMigratingModelAsDead(
+		ctx, modelUUID.String(), updatedAt,
+	); err != nil {
 		return errors.Errorf("marking controller model %q as dead: %w", modelUUID, err)
 	}
 

--- a/domain/removal/service/model_test.go
+++ b/domain/removal/service/model_test.go
@@ -416,9 +416,14 @@ func (s *modelSuite) TestRemoveModelNotFoundInBothControllerAndModel(c *tc.C) {
 func (s *modelSuite) TestRemoveMigratingModel(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when)
+
 	cExp := s.controllerState.EXPECT()
 	cExp.IsMigratingModel(gomock.Any(), "some-model-uuid").Return(true, nil)
-	cExp.MarkMigratingModelAsDead(gomock.Any(), "some-model-uuid").Return(nil)
+	cExp.MarkMigratingModelAsDead(
+		gomock.Any(), "some-model-uuid", when.UTC().Format(time.RFC3339),
+	).Return(nil)
 
 	mExp := s.modelState.EXPECT()
 	mExp.IsControllerModel(gomock.Any(), "some-model-uuid").Return(false, nil)

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -40,7 +40,7 @@ type MockControllerDBStateMockRecorder struct {
 	getModelLifeExpects                       []*gomock.Call2_2[context.Context, string, life.Life, error]
 	getModelUUIDsExpects                      []*gomock.Call1_2[context.Context, []string, error]
 	isMigratingModelExpects                   []*gomock.Call2_2[context.Context, string, bool, error]
-	markMigratingModelAsDeadExpects           []*gomock.Call2_1[context.Context, string, error]
+	markMigratingModelAsDeadExpects           []*gomock.Call3_1[context.Context, string, string, error]
 	markModelAsDeadExpects                    []*gomock.Call2_1[context.Context, string, error]
 	modelExistsExpects                        []*gomock.Call2_2[context.Context, string, bool, error]
 	removeSecretBackendReferenceExpects       []*gomock.Call1V_1[context.Context, string, error]
@@ -185,22 +185,22 @@ func (mr *MockControllerDBStateMockRecorder) IsMigratingModel(ctx, modelUUID any
 type MockControllerDBStateIsMigratingModelCall = gomock.Call2_2[context.Context, string, bool, error]
 
 // MarkMigratingModelAsDead mocks base method.
-func (m *MockControllerDBState) MarkMigratingModelAsDead(ctx context.Context, modelUUID string) error {
+func (m *MockControllerDBState) MarkMigratingModelAsDead(ctx context.Context, modelUUID, updatedAt string) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_1(&m.recorder.markMigratingModelAsDeadExpects, m.ctrl, m, "MarkMigratingModelAsDead", ctx, modelUUID)
+	return gomock.Dispatch3_1(&m.recorder.markMigratingModelAsDeadExpects, m.ctrl, m, "MarkMigratingModelAsDead", ctx, modelUUID, updatedAt)
 }
 
 // MarkMigratingModelAsDead indicates an expected call of MarkMigratingModelAsDead.
-func (mr *MockControllerDBStateMockRecorder) MarkMigratingModelAsDead(ctx, modelUUID any) *MockControllerDBStateMarkMigratingModelAsDeadCall {
+func (mr *MockControllerDBStateMockRecorder) MarkMigratingModelAsDead(ctx, modelUUID, updatedAt any) *MockControllerDBStateMarkMigratingModelAsDeadCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "MarkMigratingModelAsDead", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID))
+	call := gomock.NewCall3_1[context.Context, string, string, error](mr.mock.ctrl.T, mr.mock, "MarkMigratingModelAsDead", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID), gomock.EnsureMatcher(updatedAt))
 	mr.markMigratingModelAsDeadExpects = append(mr.markMigratingModelAsDeadExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDBStateMarkMigratingModelAsDeadCall is the typed call wrapper for MarkMigratingModelAsDead.
-type MockControllerDBStateMarkMigratingModelAsDeadCall = gomock.Call2_1[context.Context, string, error]
+type MockControllerDBStateMarkMigratingModelAsDeadCall = gomock.Call3_1[context.Context, string, string, error]
 
 // MarkModelAsDead mocks base method.
 func (m *MockControllerDBState) MarkModelAsDead(ctx context.Context, modelUUID string) error {

--- a/domain/removal/state/controller/model.go
+++ b/domain/removal/state/controller/model.go
@@ -139,38 +139,18 @@ func (st *State) IsMigratingModel(ctx context.Context, mUUID string) (bool, erro
 	return isMigrating, nil
 }
 
-// MarkMigratingModelAsDead marks a migrating model as dead as part of a
-// target-side import abort (the v7/legacy Abort facade path), and, when the
-// model still carries an import claim in the importing phase, transitions that
-// claim to the aborting phase in the *same transaction*.
-//
-// Transitioning the claim to aborting atomically with the mark-dead is what
-// prevents a concurrent activation from resurrecting a just-killed model.
-// Activation compare-and-sets the claim importing->activating before it flips
-// the model row to activated (domain/modelmigration ... SetImportPhaseActivating,
-// domain/model ... Activate, which has no life check). If the abort only marked
-// the model dead and left the claim importing, a stale master driving Activate
-// could still win that CAS and activate the dead model - a split brain where the
-// model is both dead and active. Moving the claim to aborting here makes the
-// activation's own CAS refuse (ErrActivationAborting), so the two operations are
-// mutually exclusive on the claim row.
-//
-// The claim is deliberately left in the aborting phase: the generic model
-// teardown (removeBasicModelData, driven by the undertaker once the model is
-// dead) deletes it once the model has been reaped and its database dropped. A
-// claim that has already crossed the activation point of no return (activating)
-// is refused with MigrationImportPastImporting - an activated model must not be
-// torn down by the abort path.
-//
-// It does not check the current life state before killing, as migrating models
-// can be either alive or dying; it is idempotent once the model is dead.
-func (st *State) MarkMigratingModelAsDead(ctx context.Context, mUUID string) error {
+// MarkMigratingModelAsDead marks a migrating model as dead. An importing claim
+// is moved to aborting in the same transaction to exclude activation, while an
+// activating claim is refused. The operation is idempotent once the model is
+// dead.
+func (st *State) MarkMigratingModelAsDead(ctx context.Context, mUUID, updatedAt string) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
 	}
 
 	modelUUID := entityUUID{UUID: mUUID}
+	abort := migrationImportAbort{ModelUUID: mUUID, UpdatedAt: updatedAt}
 	markDeadStmt, err := st.Prepare(`
 UPDATE model
 SET    life_id = 2
@@ -178,8 +158,7 @@ WHERE  uuid = $entityUUID.uuid`, modelUUID)
 	if err != nil {
 		return errors.Errorf("preparing migrating model life update: %w", err)
 	}
-	// CAS the import claim importing -> aborting. Phase-type ids are resolved by
-	// name so the statement does not depend on their numeric values.
+	// Phase-type ids are resolved by name rather than numeric values.
 	claimToAbortingStmt, err := st.Prepare(`
 WITH aborting_phase AS (
     SELECT id FROM model_migration_import_phase_type WHERE type = 'aborting'
@@ -189,9 +168,9 @@ importing_phase AS (
 )
 UPDATE model_migration_import
 SET    phase_type_id = (SELECT id FROM aborting_phase),
-       updated_at    = DATETIME('now', 'utc')
-WHERE  model_uuid = $entityUUID.uuid
-AND    phase_type_id = (SELECT id FROM importing_phase)`, modelUUID)
+       updated_at    = $migrationImportAbort.updated_at
+WHERE  model_uuid = $migrationImportAbort.model_uuid
+AND    phase_type_id = (SELECT id FROM importing_phase)`, abort)
 	if err != nil {
 		return errors.Errorf("preparing import claim abort transition: %w", err)
 	}
@@ -212,20 +191,14 @@ AND    phase_type_id = (SELECT id FROM importing_phase)`, modelUUID)
 
 		switch phase {
 		case string(modelmigration.ImportPhaseImporting):
-			// Take the abort lock on the claim before killing the model, so a
-			// concurrent activation's importing->activating CAS can no longer
-			// win.
 			var outcome sqlair.Outcome
-			if err := tx.Query(ctx, claimToAbortingStmt, modelUUID).Get(&outcome); err != nil {
+			if err := tx.Query(ctx, claimToAbortingStmt, abort).Get(&outcome); err != nil {
 				return errors.Errorf("transitioning import claim to aborting: %w", err)
 			}
 			if affected, err := outcome.Result().RowsAffected(); err != nil {
 				return errors.Capture(err)
 			} else if affected == 0 {
-				// The read above saw importing; a zero-row CAS means the phase
-				// changed concurrently (an activation raced in between the read
-				// and the update). Refuse rather than kill a model that is being
-				// activated.
+				// Refuse to kill a model whose phase changed concurrently.
 				return errors.Errorf(
 					"model %q migration import left the importing phase concurrently: %w",
 					mUUID, removalerrors.MigrationImportPastImporting)
@@ -441,7 +414,7 @@ WHERE  model_uuid = $entityUUID.uuid;`, modelUUID, count{})
 }
 
 // migratingImportPhase returns the v8 import claim phase for the model, and
-// whether a claim exists at all. A missing claim reports hasClaim=false.
+// whether a claim exists at all.
 func (st *State) migratingImportPhase(ctx context.Context, tx *sqlair.TX, mUUID string) (hasClaim bool, phase string, err error) {
 	modelUUID := entityUUID{UUID: mUUID}
 	stmt, err := st.Prepare(`
@@ -466,50 +439,53 @@ WHERE  mmi.model_uuid = $entityUUID.uuid;`, modelUUID, migrationImportPhase{})
 func (st *State) removeBasicModelData(ctx context.Context, tx *sqlair.TX, mUUID string) error {
 	modelUUIDRec := entityUUID{UUID: mUUID}
 
-	// deletableClaim selects the model's import claim UUID only when the generic
-	// teardown is allowed to release it. The two import companion tables are
-	// keyed by that claim UUID and FK onto model_migration_import, so they must
-	// be deleted before the claim row itself, otherwise the parent delete fails
-	// an enforced foreign-key constraint when an import had recorded offer
-	// permissions or external controllers. All three deletes therefore share
-	// this CTE.
-	//
-	// The claim (and its companions) is deleted here when it is:
-	//   - importing: a legacy v4-v7 abort (whose claims are always importing) or
-	//     normal destruction of a model that never migrated (no claim, so these
-	//     are no-ops); or
-	//   - aborting AND no model-database deletion is still staged for the model's
-	//     namespace: a v7/legacy abort marked the model dead and took the claim's
-	//     abort lock (MarkMigratingModelAsDead), and this undertaker-driven
-	//     teardown owns releasing it. The staged-deletion guard preserves the v8
-	//     invariant that an aborting claim outlives a proven model-database drop:
-	//     if a v8 finalizer has staged the drop, it owns the claim and the
-	//     generic path must not release it early.
-	// An activating claim is never released here - it is owned by the v8
-	// activation finalizer.
-	const deletableClaim = `WITH deletable_claim AS (
-	     SELECT mmi.uuid
-	     FROM   model_migration_import AS mmi
-	     JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
-	     WHERE  mmi.model_uuid = $entityUUID.uuid
-	     AND    (mmipt.type = 'importing'
-	         OR (mmipt.type = 'aborting'
-	             AND NOT EXISTS (SELECT 1 FROM model_database_deletion mdd
-	                             WHERE mdd.namespace = $entityUUID.uuid)))
-	 )
-	 `
-
 	tables := []string{
 		"DELETE FROM model_namespace WHERE model_uuid = $entityUUID.uuid",
 		"DELETE FROM model_secret_backend WHERE model_uuid = $entityUUID.uuid",
 		"DELETE FROM secret_backend_reference WHERE model_uuid = $entityUUID.uuid",
 		"DELETE FROM model_authorized_keys WHERE model_uuid = $entityUUID.uuid",
 		"DELETE FROM model_last_login WHERE model_uuid = $entityUUID.uuid",
-		deletableClaim + `DELETE FROM model_migration_import_offer
+		`WITH deletable_claim AS (
+		     SELECT mmi.uuid
+		     FROM   model_migration_import AS mmi
+		     JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
+		     WHERE  mmi.model_uuid = $entityUUID.uuid
+		     AND    (mmipt.type = 'importing'
+		         OR (mmipt.type = 'aborting'
+		             AND NOT EXISTS (
+		                 SELECT 1
+		                 FROM   model_database_deletion AS mdd
+		                 WHERE  mdd.namespace = $entityUUID.uuid)))
+		 )
+		 DELETE FROM model_migration_import_offer
 		 WHERE migration_uuid IN (SELECT uuid FROM deletable_claim)`,
-		deletableClaim + `DELETE FROM model_migration_import_external_controller_model
+		`WITH deletable_claim AS (
+		     SELECT mmi.uuid
+		     FROM   model_migration_import AS mmi
+		     JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
+		     WHERE  mmi.model_uuid = $entityUUID.uuid
+		     AND    (mmipt.type = 'importing'
+		         OR (mmipt.type = 'aborting'
+		             AND NOT EXISTS (
+		                 SELECT 1
+		                 FROM   model_database_deletion AS mdd
+		                 WHERE  mdd.namespace = $entityUUID.uuid)))
+		 )
+		 DELETE FROM model_migration_import_external_controller_model
 		 WHERE migration_uuid IN (SELECT uuid FROM deletable_claim)`,
-		deletableClaim + `DELETE FROM model_migration_import
+		`WITH deletable_claim AS (
+		     SELECT mmi.uuid
+		     FROM   model_migration_import AS mmi
+		     JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
+		     WHERE  mmi.model_uuid = $entityUUID.uuid
+		     AND    (mmipt.type = 'importing'
+		         OR (mmipt.type = 'aborting'
+		             AND NOT EXISTS (
+		                 SELECT 1
+		                 FROM   model_database_deletion AS mdd
+		                 WHERE  mdd.namespace = $entityUUID.uuid)))
+		 )
+		 DELETE FROM model_migration_import
 		 WHERE model_uuid = $entityUUID.uuid
 		 AND uuid IN (SELECT uuid FROM deletable_claim)`,
 	}

--- a/domain/removal/state/controller/model.go
+++ b/domain/removal/state/controller/model.go
@@ -140,9 +140,10 @@ func (st *State) IsMigratingModel(ctx context.Context, mUUID string) (bool, erro
 }
 
 // MarkMigratingModelAsDead marks a migrating model as dead. An importing claim
-// is moved to aborting in the same transaction to exclude activation, while an
-// activating claim is refused. The operation is idempotent once the model is
-// dead.
+// is moved to aborting in the same transaction, while a claim already in a
+// later phase is left untouched: the model is being removed regardless, so its
+// claim bookkeeping no longer gates that. The operation is idempotent once the
+// model is dead.
 func (st *State) MarkMigratingModelAsDead(ctx context.Context, mUUID, updatedAt string) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -181,38 +182,18 @@ AND    phase_type_id = (SELECT id FROM importing_phase)`, abort)
 			return nil
 		}
 
-		hasClaim, phase, err := st.migratingImportPhase(ctx, tx, mUUID)
+		isMigrating, phase, err := st.migratingImportPhase(ctx, tx, mUUID)
 		if err != nil {
 			return errors.Errorf("checking if model is migrating: %w", err)
 		}
-		if !hasClaim {
+		if !isMigrating {
 			return errors.Errorf("model is not migrating")
 		}
 
-		switch phase {
-		case string(modelmigration.ImportPhaseImporting):
-			var outcome sqlair.Outcome
-			if err := tx.Query(ctx, claimToAbortingStmt, abort).Get(&outcome); err != nil {
+		if phase == string(modelmigration.ImportPhaseImporting) {
+			if err := tx.Query(ctx, claimToAbortingStmt, abort).Run(); err != nil {
 				return errors.Errorf("transitioning import claim to aborting: %w", err)
 			}
-			if affected, err := outcome.Result().RowsAffected(); err != nil {
-				return errors.Capture(err)
-			} else if affected == 0 {
-				// Refuse to kill a model whose phase changed concurrently.
-				return errors.Errorf(
-					"model %q migration import left the importing phase concurrently: %w",
-					mUUID, removalerrors.MigrationImportPastImporting)
-			}
-		case string(modelmigration.ImportPhaseAborting):
-			// A retried abort: the claim is already aborting (this call, or an
-			// earlier one, took the lock). Re-kill the model idempotently and
-			// leave the claim for the undertaker to reap.
-		default:
-			// activating (or any unexpected phase): the model has crossed the
-			// activation point of no return and must not be torn down here.
-			return errors.Errorf(
-				"model %q migration import is %q: %w",
-				mUUID, phase, removalerrors.MigrationImportPastImporting)
 		}
 
 		if err := tx.Query(ctx, markDeadStmt, modelUUID).Run(); err != nil {
@@ -415,7 +396,7 @@ WHERE  model_uuid = $entityUUID.uuid;`, modelUUID, count{})
 
 // migratingImportPhase returns the v8 import claim phase for the model, and
 // whether a claim exists at all.
-func (st *State) migratingImportPhase(ctx context.Context, tx *sqlair.TX, mUUID string) (hasClaim bool, phase string, err error) {
+func (st *State) migratingImportPhase(ctx context.Context, tx *sqlair.TX, mUUID string) (isMigrating bool, phase string, err error) {
 	modelUUID := entityUUID{UUID: mUUID}
 	stmt, err := st.Prepare(`
 SELECT mmipt.type AS &migrationImportPhase.phase
@@ -445,49 +426,14 @@ func (st *State) removeBasicModelData(ctx context.Context, tx *sqlair.TX, mUUID 
 		"DELETE FROM secret_backend_reference WHERE model_uuid = $entityUUID.uuid",
 		"DELETE FROM model_authorized_keys WHERE model_uuid = $entityUUID.uuid",
 		"DELETE FROM model_last_login WHERE model_uuid = $entityUUID.uuid",
-		`WITH deletable_claim AS (
-		     SELECT mmi.uuid
-		     FROM   model_migration_import AS mmi
-		     JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
-		     WHERE  mmi.model_uuid = $entityUUID.uuid
-		     AND    (mmipt.type = 'importing'
-		         OR (mmipt.type = 'aborting'
-		             AND NOT EXISTS (
-		                 SELECT 1
-		                 FROM   model_database_deletion AS mdd
-		                 WHERE  mdd.namespace = $entityUUID.uuid)))
-		 )
-		 DELETE FROM model_migration_import_offer
-		 WHERE migration_uuid IN (SELECT uuid FROM deletable_claim)`,
-		`WITH deletable_claim AS (
-		     SELECT mmi.uuid
-		     FROM   model_migration_import AS mmi
-		     JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
-		     WHERE  mmi.model_uuid = $entityUUID.uuid
-		     AND    (mmipt.type = 'importing'
-		         OR (mmipt.type = 'aborting'
-		             AND NOT EXISTS (
-		                 SELECT 1
-		                 FROM   model_database_deletion AS mdd
-		                 WHERE  mdd.namespace = $entityUUID.uuid)))
-		 )
-		 DELETE FROM model_migration_import_external_controller_model
-		 WHERE migration_uuid IN (SELECT uuid FROM deletable_claim)`,
-		`WITH deletable_claim AS (
-		     SELECT mmi.uuid
-		     FROM   model_migration_import AS mmi
-		     JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
-		     WHERE  mmi.model_uuid = $entityUUID.uuid
-		     AND    (mmipt.type = 'importing'
-		         OR (mmipt.type = 'aborting'
-		             AND NOT EXISTS (
-		                 SELECT 1
-		                 FROM   model_database_deletion AS mdd
-		                 WHERE  mdd.namespace = $entityUUID.uuid)))
-		 )
-		 DELETE FROM model_migration_import
-		 WHERE model_uuid = $entityUUID.uuid
-		 AND uuid IN (SELECT uuid FROM deletable_claim)`,
+		`DELETE FROM model_migration_import_offer
+		 WHERE migration_uuid IN (
+		     SELECT uuid FROM model_migration_import WHERE model_uuid = $entityUUID.uuid)`,
+		`DELETE FROM model_migration_import_external_controller_model
+		 WHERE migration_uuid IN (
+		     SELECT uuid FROM model_migration_import WHERE model_uuid = $entityUUID.uuid)`,
+		`DELETE FROM model_migration_import
+		 WHERE model_uuid = $entityUUID.uuid`,
 	}
 
 	for _, table := range tables {

--- a/domain/removal/state/controller/model.go
+++ b/domain/removal/state/controller/model.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/domain/life"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/domain/modelmigration"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	"github.com/juju/juju/internal/errors"
 )
@@ -138,9 +139,31 @@ func (st *State) IsMigratingModel(ctx context.Context, mUUID string) (bool, erro
 	return isMigrating, nil
 }
 
-// MarkMigratingModelAsDead marks the migrating model with the input UUID as
-// dead. This doesn't check the current life state, as migrating models can be
-// either alive or dying. This will just force death.
+// MarkMigratingModelAsDead marks a migrating model as dead as part of a
+// target-side import abort (the v7/legacy Abort facade path), and, when the
+// model still carries an import claim in the importing phase, transitions that
+// claim to the aborting phase in the *same transaction*.
+//
+// Transitioning the claim to aborting atomically with the mark-dead is what
+// prevents a concurrent activation from resurrecting a just-killed model.
+// Activation compare-and-sets the claim importing->activating before it flips
+// the model row to activated (domain/modelmigration ... SetImportPhaseActivating,
+// domain/model ... Activate, which has no life check). If the abort only marked
+// the model dead and left the claim importing, a stale master driving Activate
+// could still win that CAS and activate the dead model - a split brain where the
+// model is both dead and active. Moving the claim to aborting here makes the
+// activation's own CAS refuse (ErrActivationAborting), so the two operations are
+// mutually exclusive on the claim row.
+//
+// The claim is deliberately left in the aborting phase: the generic model
+// teardown (removeBasicModelData, driven by the undertaker once the model is
+// dead) deletes it once the model has been reaped and its database dropped. A
+// claim that has already crossed the activation point of no return (activating)
+// is refused with MigrationImportPastImporting - an activated model must not be
+// torn down by the abort path.
+//
+// It does not check the current life state before killing, as migrating models
+// can be either alive or dying; it is idempotent once the model is dead.
 func (st *State) MarkMigratingModelAsDead(ctx context.Context, mUUID string) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -148,12 +171,29 @@ func (st *State) MarkMigratingModelAsDead(ctx context.Context, mUUID string) err
 	}
 
 	modelUUID := entityUUID{UUID: mUUID}
-	updateStmt, err := st.Prepare(`
+	markDeadStmt, err := st.Prepare(`
 UPDATE model
 SET    life_id = 2
 WHERE  uuid = $entityUUID.uuid`, modelUUID)
 	if err != nil {
 		return errors.Errorf("preparing migrating model life update: %w", err)
+	}
+	// CAS the import claim importing -> aborting. Phase-type ids are resolved by
+	// name so the statement does not depend on their numeric values.
+	claimToAbortingStmt, err := st.Prepare(`
+WITH aborting_phase AS (
+    SELECT id FROM model_migration_import_phase_type WHERE type = 'aborting'
+),
+importing_phase AS (
+    SELECT id FROM model_migration_import_phase_type WHERE type = 'importing'
+)
+UPDATE model_migration_import
+SET    phase_type_id = (SELECT id FROM aborting_phase),
+       updated_at    = DATETIME('now', 'utc')
+WHERE  model_uuid = $entityUUID.uuid
+AND    phase_type_id = (SELECT id FROM importing_phase)`, modelUUID)
+	if err != nil {
+		return errors.Errorf("preparing import claim abort transition: %w", err)
 	}
 	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if l, err := st.getModelLife(ctx, tx, mUUID); err != nil {
@@ -162,17 +202,49 @@ WHERE  uuid = $entityUUID.uuid`, modelUUID)
 			return nil
 		}
 
-		if migrating, err := st.isModelMigrating(ctx, tx, mUUID); err != nil {
+		hasClaim, phase, err := st.migratingImportPhase(ctx, tx, mUUID)
+		if err != nil {
 			return errors.Errorf("checking if model is migrating: %w", err)
-		} else if !migrating {
+		}
+		if !hasClaim {
 			return errors.Errorf("model is not migrating")
 		}
 
-		err := tx.Query(ctx, updateStmt, modelUUID).Run()
-		if err != nil {
-			return errors.Errorf("marking migrating model as dead: %w", err)
+		switch phase {
+		case string(modelmigration.ImportPhaseImporting):
+			// Take the abort lock on the claim before killing the model, so a
+			// concurrent activation's importing->activating CAS can no longer
+			// win.
+			var outcome sqlair.Outcome
+			if err := tx.Query(ctx, claimToAbortingStmt, modelUUID).Get(&outcome); err != nil {
+				return errors.Errorf("transitioning import claim to aborting: %w", err)
+			}
+			if affected, err := outcome.Result().RowsAffected(); err != nil {
+				return errors.Capture(err)
+			} else if affected == 0 {
+				// The read above saw importing; a zero-row CAS means the phase
+				// changed concurrently (an activation raced in between the read
+				// and the update). Refuse rather than kill a model that is being
+				// activated.
+				return errors.Errorf(
+					"model %q migration import left the importing phase concurrently: %w",
+					mUUID, removalerrors.MigrationImportPastImporting)
+			}
+		case string(modelmigration.ImportPhaseAborting):
+			// A retried abort: the claim is already aborting (this call, or an
+			// earlier one, took the lock). Re-kill the model idempotently and
+			// leave the claim for the undertaker to reap.
+		default:
+			// activating (or any unexpected phase): the model has crossed the
+			// activation point of no return and must not be torn down here.
+			return errors.Errorf(
+				"model %q migration import is %q: %w",
+				mUUID, phase, removalerrors.MigrationImportPastImporting)
 		}
 
+		if err := tx.Query(ctx, markDeadStmt, modelUUID).Run(); err != nil {
+			return errors.Errorf("marking migrating model as dead: %w", err)
+		}
 		return nil
 	}))
 }
@@ -368,8 +440,64 @@ WHERE  model_uuid = $entityUUID.uuid;`, modelUUID, count{})
 	return result.Count > 0, nil
 }
 
+// migratingImportPhase returns the v8 import claim phase for the model, and
+// whether a claim exists at all. A missing claim reports hasClaim=false.
+func (st *State) migratingImportPhase(ctx context.Context, tx *sqlair.TX, mUUID string) (hasClaim bool, phase string, err error) {
+	modelUUID := entityUUID{UUID: mUUID}
+	stmt, err := st.Prepare(`
+SELECT mmipt.type AS &migrationImportPhase.phase
+FROM   model_migration_import AS mmi
+JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
+WHERE  mmi.model_uuid = $entityUUID.uuid;`, modelUUID, migrationImportPhase{})
+	if err != nil {
+		return false, "", errors.Errorf("preparing migrating import phase query: %w", err)
+	}
+
+	var row migrationImportPhase
+	err = tx.Query(ctx, stmt, modelUUID).Get(&row)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return false, "", nil
+	} else if err != nil {
+		return false, "", errors.Errorf("running migrating import phase query: %w", err)
+	}
+	return true, row.Phase, nil
+}
+
 func (st *State) removeBasicModelData(ctx context.Context, tx *sqlair.TX, mUUID string) error {
 	modelUUIDRec := entityUUID{UUID: mUUID}
+
+	// deletableClaim selects the model's import claim UUID only when the generic
+	// teardown is allowed to release it. The two import companion tables are
+	// keyed by that claim UUID and FK onto model_migration_import, so they must
+	// be deleted before the claim row itself, otherwise the parent delete fails
+	// an enforced foreign-key constraint when an import had recorded offer
+	// permissions or external controllers. All three deletes therefore share
+	// this CTE.
+	//
+	// The claim (and its companions) is deleted here when it is:
+	//   - importing: a legacy v4-v7 abort (whose claims are always importing) or
+	//     normal destruction of a model that never migrated (no claim, so these
+	//     are no-ops); or
+	//   - aborting AND no model-database deletion is still staged for the model's
+	//     namespace: a v7/legacy abort marked the model dead and took the claim's
+	//     abort lock (MarkMigratingModelAsDead), and this undertaker-driven
+	//     teardown owns releasing it. The staged-deletion guard preserves the v8
+	//     invariant that an aborting claim outlives a proven model-database drop:
+	//     if a v8 finalizer has staged the drop, it owns the claim and the
+	//     generic path must not release it early.
+	// An activating claim is never released here - it is owned by the v8
+	// activation finalizer.
+	const deletableClaim = `WITH deletable_claim AS (
+	     SELECT mmi.uuid
+	     FROM   model_migration_import AS mmi
+	     JOIN   model_migration_import_phase_type AS mmipt ON mmipt.id = mmi.phase_type_id
+	     WHERE  mmi.model_uuid = $entityUUID.uuid
+	     AND    (mmipt.type = 'importing'
+	         OR (mmipt.type = 'aborting'
+	             AND NOT EXISTS (SELECT 1 FROM model_database_deletion mdd
+	                             WHERE mdd.namespace = $entityUUID.uuid)))
+	 )
+	 `
 
 	tables := []string{
 		"DELETE FROM model_namespace WHERE model_uuid = $entityUUID.uuid",
@@ -377,18 +505,13 @@ func (st *State) removeBasicModelData(ctx context.Context, tx *sqlair.TX, mUUID 
 		"DELETE FROM secret_backend_reference WHERE model_uuid = $entityUUID.uuid",
 		"DELETE FROM model_authorized_keys WHERE model_uuid = $entityUUID.uuid",
 		"DELETE FROM model_last_login WHERE model_uuid = $entityUUID.uuid",
-		// The two import companion tables are keyed by the import claim UUID
-		// and FK onto model_migration_import. They must be deleted before the
-		// claim row itself, otherwise the parent delete fails an enforced
-		// foreign-key constraint when an aborted v8 import had recorded offer
-		// permissions or external controllers.
-		`DELETE FROM model_migration_import_offer
-		 WHERE migration_uuid IN (
-		     SELECT uuid FROM model_migration_import WHERE model_uuid = $entityUUID.uuid)`,
-		`DELETE FROM model_migration_import_external_controller_model
-		 WHERE migration_uuid IN (
-		     SELECT uuid FROM model_migration_import WHERE model_uuid = $entityUUID.uuid)`,
-		"DELETE FROM model_migration_import WHERE model_uuid = $entityUUID.uuid",
+		deletableClaim + `DELETE FROM model_migration_import_offer
+		 WHERE migration_uuid IN (SELECT uuid FROM deletable_claim)`,
+		deletableClaim + `DELETE FROM model_migration_import_external_controller_model
+		 WHERE migration_uuid IN (SELECT uuid FROM deletable_claim)`,
+		deletableClaim + `DELETE FROM model_migration_import
+		 WHERE model_uuid = $entityUUID.uuid
+		 AND uuid IN (SELECT uuid FROM deletable_claim)`,
 	}
 
 	for _, table := range tables {

--- a/domain/removal/state/controller/model_test.go
+++ b/domain/removal/state/controller/model_test.go
@@ -197,6 +197,158 @@ func (s *modelSuite) TestMarkMigratingModelAsDeadAlreadyDead(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestMarkMigratingModelAsDeadTakesAbortLock verifies that marking an importing
+// model dead atomically transitions its import claim to the aborting phase. This
+// is what closes the abort/activate split brain: with the claim in aborting, a
+// concurrent activation's importing->activating compare-and-set can no longer
+// win and resurrect the just-killed model.
+func (s *modelSuite) TestMarkMigratingModelAsDeadTakesAbortLock(c *tc.C) {
+	modelUUID := s.getModelUUID(c)
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		// phase_type_id defaults to 0 (importing).
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
+VALUES ('claim', ?, 'source-migration-uuid')`, modelUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	lifeID, phaseID := s.modelLifeAndClaimPhase(c, modelUUID)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
+	c.Check(phaseID, tc.Equals, 2) // aborting
+}
+
+// TestMarkMigratingModelAsDeadAbortingClaimIsIdempotent verifies that a retried
+// abort, whose claim is already aborting, still marks the model dead and leaves
+// the claim aborting for the undertaker to reap.
+func (s *modelSuite) TestMarkMigratingModelAsDeadAbortingClaimIsIdempotent(c *tc.C) {
+	modelUUID := s.getModelUUID(c)
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
+VALUES ('claim', ?, 'source-migration-uuid', 2)`, modelUUID) // aborting
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	lifeID, phaseID := s.modelLifeAndClaimPhase(c, modelUUID)
+	c.Check(lifeID, tc.Equals, int(life.Dead))
+	c.Check(phaseID, tc.Equals, 2) // still aborting
+}
+
+// TestMarkMigratingModelAsDeadRefusesActivatingClaim verifies that a model whose
+// import claim has reached the activating phase is not marked dead by the abort
+// path: activation has crossed the point of no return and owns the model's
+// teardown, so killing it here would strand an activated model.
+func (s *modelSuite) TestMarkMigratingModelAsDeadRefusesActivatingClaim(c *tc.C) {
+	modelUUID := s.getModelUUID(c)
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
+VALUES ('claim', ?, 'source-migration-uuid', 1)`, modelUUID) // activating
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIs, removalerrors.MigrationImportPastImporting)
+
+	// The model is left alive and the claim untouched.
+	lifeID, phaseID := s.modelLifeAndClaimPhase(c, modelUUID)
+	c.Check(lifeID, tc.Equals, int(life.Alive))
+	c.Check(phaseID, tc.Equals, 1) // still activating
+}
+
+// TestDeleteModelDeletesAbortingClaim verifies the generic (undertaker) removal
+// path reaps an aborting import claim - the abort lock taken by a v7/legacy
+// abort - once the model is torn down and no model-database drop is still
+// staged.
+func (s *modelSuite) TestDeleteModelDeletesAbortingClaim(c *tc.C) {
+	modelUUID := s.getModelUUID(c)
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "UPDATE model SET life_id = 2 WHERE uuid = ?", modelUUID); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
+VALUES ('claim', ?, 'source-migration-uuid', 2)`, modelUUID) // aborting
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err = st.DeleteModel(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(s.claimCount(c, modelUUID), tc.Equals, 0)
+}
+
+// TestDeleteModelPreservesStagedAbortingClaim verifies that when a v8 abort
+// finalizer has staged the model-database drop, the generic removal path leaves
+// the aborting claim in place: the v8 finalizer owns releasing it once the drop
+// is proven complete.
+func (s *modelSuite) TestDeleteModelPreservesStagedAbortingClaim(c *tc.C) {
+	modelUUID := s.getModelUUID(c)
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "UPDATE model SET life_id = 2 WHERE uuid = ?", modelUUID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
+VALUES ('claim', ?, 'source-migration-uuid', 2)`, modelUUID); err != nil { // aborting
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_database_deletion (namespace, created_at)
+VALUES (?, DATETIME('now'))`, modelUUID)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err = st.DeleteModel(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(s.claimCount(c, modelUUID), tc.Equals, 1)
+}
+
+// TestDeleteModelPreservesActivatingClaim verifies the generic removal path
+// never reaps an activating claim - it is owned by the v8 activation finalizer.
+func (s *modelSuite) TestDeleteModelPreservesActivatingClaim(c *tc.C) {
+	modelUUID := s.getModelUUID(c)
+
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "UPDATE model SET life_id = 2 WHERE uuid = ?", modelUUID); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
+VALUES ('claim', ?, 'source-migration-uuid', 1)`, modelUUID) // activating
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err = st.DeleteModel(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(s.claimCount(c, modelUUID), tc.Equals, 1)
+}
+
 func (s *modelSuite) TestMarkModelAsDeadNotFound(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -379,4 +531,30 @@ func (s *modelSuite) getModelUUID(c *tc.C) string {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	return modelUUID
+}
+
+// modelLifeAndClaimPhase returns the model's life_id and its import claim's
+// phase_type_id.
+func (s *modelSuite) modelLifeAndClaimPhase(c *tc.C, modelUUID string) (lifeID, phaseID int) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if err := tx.QueryRowContext(ctx,
+			"SELECT life_id FROM model WHERE uuid = ?", modelUUID).Scan(&lifeID); err != nil {
+			return err
+		}
+		return tx.QueryRowContext(ctx,
+			"SELECT phase_type_id FROM model_migration_import WHERE model_uuid = ?", modelUUID).Scan(&phaseID)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return lifeID, phaseID
+}
+
+// claimCount returns the number of import claims for the model.
+func (s *modelSuite) claimCount(c *tc.C, modelUUID string) int {
+	var count int
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM model_migration_import WHERE model_uuid = ?", modelUUID).Scan(&count)
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return count
 }

--- a/domain/removal/state/controller/model_test.go
+++ b/domain/removal/state/controller/model_test.go
@@ -74,8 +74,8 @@ func (s *modelSuite) TestIsMigratingModel(c *tc.C) {
 	// Set the model as migrating.
 	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES ('foo', ?, 'source-migration-uuid')`, modelUUID)
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES ('foo', ?, 'source-migration-uuid', '2026-01-02T03:04:05Z')`, modelUUID)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -110,8 +110,8 @@ func (s *modelSuite) TestEnsureModelNotAliveUnlessMigratingRefusesMigratingModel
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES ('claim-uuid', ?, 'source-migration-uuid')`, modelUUID)
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES ('claim-uuid', ?, 'source-migration-uuid', '2026-01-02T03:04:05Z')`, modelUUID)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -148,8 +148,8 @@ func (s *modelSuite) TestMarkMigratingModelAsDeadStillAlive(c *tc.C) {
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES ('foo', ?, 'source-migration-uuid')`, modelUUID); err != nil {
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES ('foo', ?, 'source-migration-uuid', '2026-01-02T03:04:05Z')`, modelUUID); err != nil {
 			return err
 		}
 		return nil
@@ -170,8 +170,8 @@ func (s *modelSuite) TestMarkMigratingModelAsDeadDying(c *tc.C) {
 			return err
 		}
 		if _, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES ('foo', ?, 'source-migration-uuid')`, modelUUID); err != nil {
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES ('foo', ?, 'source-migration-uuid', '2026-01-02T03:04:05Z')`, modelUUID); err != nil {
 			return err
 		}
 		return nil
@@ -211,8 +211,8 @@ func (s *modelSuite) TestMarkMigratingModelAsDeadTakesAbortLock(c *tc.C) {
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		// phase_type_id defaults to 0 (importing).
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid)
-VALUES ('claim', ?, 'source-migration-uuid')`, modelUUID)
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at)
+VALUES ('claim', ?, 'source-migration-uuid', '2026-01-02T03:04:05Z')`, modelUUID)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -240,8 +240,8 @@ func (s *modelSuite) TestMarkMigratingModelAsDeadAbortingClaimIsIdempotent(c *tc
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
-VALUES ('claim', ?, 'source-migration-uuid', 2)`, modelUUID) // aborting
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id, updated_at)
+VALUES ('claim', ?, 'source-migration-uuid', 2, '2026-01-02T03:04:05Z')`, modelUUID) // aborting
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -254,28 +254,28 @@ VALUES ('claim', ?, 'source-migration-uuid', 2)`, modelUUID) // aborting
 	c.Check(phaseID, tc.Equals, 2) // still aborting
 }
 
-// TestMarkMigratingModelAsDeadRefusesActivatingClaim verifies that a model whose
-// import claim has reached the activating phase is not marked dead by the abort
-// path: activation has crossed the point of no return and owns the model's
-// teardown, so killing it here would strand an activated model.
-func (s *modelSuite) TestMarkMigratingModelAsDeadRefusesActivatingClaim(c *tc.C) {
+// TestMarkMigratingModelAsDeadKillsActivatingClaim verifies that a model whose
+// import claim has reached the activating phase is still marked dead when asked:
+// removal of the model is not gated on claim bookkeeping. The claim itself is
+// left untouched for the activation finalizer to reap.
+func (s *modelSuite) TestMarkMigratingModelAsDeadKillsActivatingClaim(c *tc.C) {
 	modelUUID := s.getModelUUID(c)
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
-VALUES ('claim', ?, 'source-migration-uuid', 1)`, modelUUID) // activating
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id, updated_at)
+VALUES ('claim', ?, 'source-migration-uuid', 1, '2026-01-02T03:04:05Z')`, modelUUID) // activating
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID, importAbortUpdatedAt)
-	c.Assert(err, tc.ErrorIs, removalerrors.MigrationImportPastImporting)
+	c.Assert(err, tc.ErrorIsNil)
 
-	// The model is left alive and the claim untouched.
+	// The model is dead; the activating claim is left untouched.
 	lifeID, phaseID := s.modelLifeAndClaimPhase(c, modelUUID)
-	c.Check(lifeID, tc.Equals, int(life.Alive))
+	c.Check(lifeID, tc.Equals, int(life.Dead))
 	c.Check(phaseID, tc.Equals, 1) // still activating
 }
 
@@ -291,8 +291,8 @@ func (s *modelSuite) TestDeleteModelDeletesAbortingClaim(c *tc.C) {
 			return err
 		}
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
-VALUES ('claim', ?, 'source-migration-uuid', 2)`, modelUUID) // aborting
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id, updated_at)
+VALUES ('claim', ?, 'source-migration-uuid', 2, '2026-01-02T03:04:05Z')`, modelUUID) // aborting
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -304,11 +304,10 @@ VALUES ('claim', ?, 'source-migration-uuid', 2)`, modelUUID) // aborting
 	c.Check(s.claimCount(c, modelUUID), tc.Equals, 0)
 }
 
-// TestDeleteModelPreservesStagedAbortingClaim verifies that when a v8 abort
-// finalizer has staged the model-database drop, the generic removal path leaves
-// the aborting claim in place: the v8 finalizer owns releasing it once the drop
-// is proven complete.
-func (s *modelSuite) TestDeleteModelPreservesStagedAbortingClaim(c *tc.C) {
+// TestDeleteModelDeletesStagedAbortingClaim verifies that the generic removal
+// path reaps an aborting import claim even when a model-database drop is still
+// staged: removal of the model must not be blocked by migration bookkeeping.
+func (s *modelSuite) TestDeleteModelDeletesStagedAbortingClaim(c *tc.C) {
 	modelUUID := s.getModelUUID(c)
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
@@ -316,8 +315,8 @@ func (s *modelSuite) TestDeleteModelPreservesStagedAbortingClaim(c *tc.C) {
 			return err
 		}
 		if _, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
-VALUES ('claim', ?, 'source-migration-uuid', 2)`, modelUUID); err != nil { // aborting
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id, updated_at)
+VALUES ('claim', ?, 'source-migration-uuid', 2, '2026-01-02T03:04:05Z')`, modelUUID); err != nil { // aborting
 			return err
 		}
 		_, err := tx.ExecContext(ctx, `
@@ -331,12 +330,13 @@ VALUES (?, DATETIME('now'))`, modelUUID)
 	err = st.DeleteModel(c.Context(), modelUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Check(s.claimCount(c, modelUUID), tc.Equals, 1)
+	c.Check(s.claimCount(c, modelUUID), tc.Equals, 0)
 }
 
-// TestDeleteModelPreservesActivatingClaim verifies the generic removal path
-// never reaps an activating claim - it is owned by the v8 activation finalizer.
-func (s *modelSuite) TestDeleteModelPreservesActivatingClaim(c *tc.C) {
+// TestDeleteModelDeletesActivatingClaim verifies the generic removal path reaps
+// an activating claim too: the model is being deleted, so its migration
+// bookkeeping must go with it rather than block removal.
+func (s *modelSuite) TestDeleteModelDeletesActivatingClaim(c *tc.C) {
 	modelUUID := s.getModelUUID(c)
 
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
@@ -344,8 +344,8 @@ func (s *modelSuite) TestDeleteModelPreservesActivatingClaim(c *tc.C) {
 			return err
 		}
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id)
-VALUES ('claim', ?, 'source-migration-uuid', 1)`, modelUUID) // activating
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id, updated_at)
+VALUES ('claim', ?, 'source-migration-uuid', 1, '2026-01-02T03:04:05Z')`, modelUUID) // activating
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -354,7 +354,7 @@ VALUES ('claim', ?, 'source-migration-uuid', 1)`, modelUUID) // activating
 	err = st.DeleteModel(c.Context(), modelUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Check(s.claimCount(c, modelUUID), tc.Equals, 1)
+	c.Check(s.claimCount(c, modelUUID), tc.Equals, 0)
 }
 
 func (s *modelSuite) TestMarkModelAsDeadNotFound(c *tc.C) {
@@ -446,7 +446,7 @@ func (s *modelSuite) TestDeleteMigratingModel(c *tc.C) {
 			return err
 		}
 
-		_, err := tx.ExecContext(ctx, "INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES ('blah', ?, 'source-migration-uuid')", modelUUID)
+		_, err := tx.ExecContext(ctx, "INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES ('blah', ?, 'source-migration-uuid', '2026-01-02T03:04:05Z')", modelUUID)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
@@ -484,7 +484,7 @@ func (s *modelSuite) TestDeleteMigratingModelWithImportCompanions(c *tc.C) {
 			return err
 		}
 		if _, err := tx.ExecContext(ctx,
-			"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, 'source-migration-uuid')",
+			"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, 'source-migration-uuid', '2026-01-02T03:04:05Z')",
 			claimUUID, modelUUID); err != nil {
 			return err
 		}

--- a/domain/removal/state/controller/model_test.go
+++ b/domain/removal/state/controller/model_test.go
@@ -16,6 +16,8 @@ import (
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
+const importAbortUpdatedAt = "2026-08-21T12:00:00Z"
+
 type modelSuite struct {
 	baseSuite
 }
@@ -137,7 +139,7 @@ func (s *modelSuite) TestGetModelUUIDs(c *tc.C) {
 func (s *modelSuite) TestMarkMigratingModelAsDeadNotFound(c *tc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err := st.MarkMigratingModelAsDead(c.Context(), "non-existent-model-uuid")
+	err := st.MarkMigratingModelAsDead(c.Context(), "non-existent-model-uuid", importAbortUpdatedAt)
 	c.Assert(err, tc.ErrorIs, modelerrors.NotFound)
 }
 
@@ -156,7 +158,7 @@ VALUES ('foo', ?, 'source-migration-uuid')`, modelUUID); err != nil {
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID)
+	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID, importAbortUpdatedAt)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -178,7 +180,7 @@ VALUES ('foo', ?, 'source-migration-uuid')`, modelUUID); err != nil {
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID)
+	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID, importAbortUpdatedAt)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -193,7 +195,7 @@ func (s *modelSuite) TestMarkMigratingModelAsDeadAlreadyDead(c *tc.C) {
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID)
+	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID, importAbortUpdatedAt)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -215,12 +217,18 @@ VALUES ('claim', ?, 'source-migration-uuid')`, modelUUID)
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID)
+	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID, importAbortUpdatedAt)
 	c.Assert(err, tc.ErrorIsNil)
 
 	lifeID, phaseID := s.modelLifeAndClaimPhase(c, modelUUID)
 	c.Check(lifeID, tc.Equals, int(life.Dead))
 	c.Check(phaseID, tc.Equals, 2) // aborting
+	var updatedAt string
+	err = s.DB().QueryRowContext(c.Context(),
+		"SELECT updated_at FROM model_migration_import WHERE model_uuid = ?", modelUUID,
+	).Scan(&updatedAt)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(updatedAt, tc.Equals, importAbortUpdatedAt)
 }
 
 // TestMarkMigratingModelAsDeadAbortingClaimIsIdempotent verifies that a retried
@@ -238,7 +246,7 @@ VALUES ('claim', ?, 'source-migration-uuid', 2)`, modelUUID) // aborting
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID)
+	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID, importAbortUpdatedAt)
 	c.Assert(err, tc.ErrorIsNil)
 
 	lifeID, phaseID := s.modelLifeAndClaimPhase(c, modelUUID)
@@ -262,7 +270,7 @@ VALUES ('claim', ?, 'source-migration-uuid', 1)`, modelUUID) // activating
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID)
+	err = st.MarkMigratingModelAsDead(c.Context(), modelUUID, importAbortUpdatedAt)
 	c.Assert(err, tc.ErrorIs, removalerrors.MigrationImportPastImporting)
 
 	// The model is left alive and the claim untouched.

--- a/domain/removal/state/controller/types.go
+++ b/domain/removal/state/controller/types.go
@@ -17,3 +17,9 @@ type entityLife struct {
 type count struct {
 	Count int `db:"count"`
 }
+
+// migrationImportPhase projects the phase name of a model_migration_import
+// claim (importing, activating or aborting).
+type migrationImportPhase struct {
+	Phase string `db:"phase"`
+}

--- a/domain/removal/state/controller/types.go
+++ b/domain/removal/state/controller/types.go
@@ -23,3 +23,9 @@ type count struct {
 type migrationImportPhase struct {
 	Phase string `db:"phase"`
 }
+
+// migrationImportAbort contains the values for aborting an import claim.
+type migrationImportAbort struct {
+	ModelUUID string `db:"model_uuid"`
+	UpdatedAt string `db:"updated_at"`
+}

--- a/domain/schema/controller/sql/0011-model-migration.sql
+++ b/domain/schema/controller/sql/0011-model-migration.sql
@@ -43,7 +43,7 @@ CREATE TABLE model_migration_import (
     model_uuid TEXT NOT NULL,
     source_migration_uuid TEXT NOT NULL,
     phase_type_id INT NOT NULL DEFAULT 0,
-    updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at DATETIME NOT NULL,
     CONSTRAINT fk_model_migration_import_phase_type
     FOREIGN KEY (phase_type_id)
     REFERENCES model_migration_import_phase_type (id)

--- a/domain/schema/controller/sql/0011-model-migration.sql
+++ b/domain/schema/controller/sql/0011-model-migration.sql
@@ -43,7 +43,7 @@ CREATE TABLE model_migration_import (
     model_uuid TEXT NOT NULL,
     source_migration_uuid TEXT NOT NULL,
     phase_type_id INT NOT NULL DEFAULT 0,
-    updated_at TEXT NOT NULL DEFAULT (DATETIME('now', 'utc')),
+    updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%dT%H:%M:%fZ', 'now')),
     CONSTRAINT fk_model_migration_import_phase_type
     FOREIGN KEY (phase_type_id)
     REFERENCES model_migration_import_phase_type (id)

--- a/domain/schema/controller_schema_test.go
+++ b/domain/schema/controller_schema_test.go
@@ -461,7 +461,7 @@ func (s *controllerSchemaSuite) TestVModelStateMigratingForImportPhases(c *tc.C)
 	for _, phaseTypeID := range []int{0, 1, 2} {
 		importUUID := utils.MustNewUUID().String()
 		s.assertExecSQL(c,
-			"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id) VALUES (?, ?, 'source-migration-uuid', ?);",
+			"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id, updated_at) VALUES (?, ?, 'source-migration-uuid', ?, '2026-01-02T03:04:05Z');",
 			importUUID, modelUUID, phaseTypeID)
 		c.Check(migrating(), tc.Equals, 1, tc.Commentf("expected migrating for phase_type_id %d", phaseTypeID))
 
@@ -471,6 +471,6 @@ func (s *controllerSchemaSuite) TestVModelStateMigratingForImportPhases(c *tc.C)
 
 	// A phase_type_id with no lookup row is rejected by the FK.
 	s.assertExecSQLError(c,
-		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id) VALUES (?, ?, 'source-migration-uuid', 99);",
+		"INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, phase_type_id, updated_at) VALUES (?, ?, 'source-migration-uuid', 99, '2026-01-02T03:04:05Z');",
 		"(?s).*FOREIGN KEY constraint failed.*", utils.MustNewUUID().String(), modelUUID)
 }

--- a/domain/services/controller.go
+++ b/domain/services/controller.go
@@ -43,6 +43,8 @@ import (
 	statecontroller "github.com/juju/juju/domain/model/state/controller"
 	modeldefaultsservice "github.com/juju/juju/domain/modeldefaults/service"
 	modeldefaultsstate "github.com/juju/juju/domain/modeldefaults/state"
+	modelmigrationservice "github.com/juju/juju/domain/modelmigration/service"
+	modelmigrationstatecontroller "github.com/juju/juju/domain/modelmigration/state/controller"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	secretbackendstate "github.com/juju/juju/domain/secretbackend/state"
 	sshcontrollerservice "github.com/juju/juju/domain/ssh/service/controller"
@@ -119,6 +121,17 @@ func (s *ControllerServices) Model() *modelservice.WatchableService {
 		},
 		s.clock,
 		logger,
+	)
+}
+
+// ModelMigrationImport returns the controller-scoped model migration import
+// service with watcher support, used by the migration reconciler to complete
+// interrupted target-side import claims.
+func (s *ControllerServices) ModelMigrationImport() *modelmigrationservice.WatchableService {
+	return modelmigrationservice.NewWatchableImportService(
+		modelmigrationstatecontroller.New(changestream.NewTxnRunnerFactory(s.controllerDB), s.clock),
+		s.controllerWatcherFactory("modelmigration"),
+		s.logger.Child("modelmigration"),
 	)
 }
 

--- a/domain/services/controller.go
+++ b/domain/services/controller.go
@@ -131,6 +131,7 @@ func (s *ControllerServices) ModelMigrationImport() *modelmigrationservice.Watch
 	return modelmigrationservice.NewWatchableImportService(
 		modelmigrationstatecontroller.New(changestream.NewTxnRunnerFactory(s.controllerDB), s.clock),
 		s.controllerWatcherFactory("modelmigration"),
+		s.clock,
 		s.logger.Child("modelmigration"),
 	)
 }

--- a/domain/services/model.go
+++ b/domain/services/model.go
@@ -451,6 +451,7 @@ func (s *ModelServices) ModelMigration() *modelmigrationservice.WatchableService
 		modelmigrationservice.NewCredentialValidator(
 			controllerState, modelState, credentialservice.NewCredentialValidator(),
 		),
+		s.clock,
 		s.logger.Child("modelmigration"),
 	)
 }

--- a/domain/status/state/controller/controllerstate_test.go
+++ b/domain/status/state/controller/controllerstate_test.go
@@ -81,7 +81,7 @@ func (s *controllerStateSuite) TestGetModelStatusContextMigrating(c *tc.C) {
 	// Insert a row into model_migration_import to mark the model as migrating.
 	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid) VALUES (?, ?, 'source-migration-uuid')
+INSERT INTO model_migration_import (uuid, model_uuid, source_migration_uuid, updated_at) VALUES (?, ?, 'source-migration-uuid', '2026-01-02T03:04:05Z')
 		`, "migration-uuid-123", modelUUID)
 		return err
 	})

--- a/internal/migration/abort.go
+++ b/internal/migration/abort.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+import (
+	"context"
+	"time"
+
+	"github.com/juju/worker/v5"
+
+	coremodel "github.com/juju/juju/core/model"
+	coremodelmigration "github.com/juju/juju/core/modelmigration"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/domain/modelmigration"
+	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
+	migrationclaimservice "github.com/juju/juju/domain/modelmigration/service"
+	"github.com/juju/juju/internal/errors"
+)
+
+// AbortFinalizeWait bounds how long [WaitAbortFinalized] blocks waiting for the
+// model database to be dropped and the import claim released.
+type AbortFinalizeWait struct {
+	// Delay is the interval between fallback finalization re-checks. The wait is
+	// primarily driven by the model-database-deletion watcher; this re-check
+	// backs it up in case an event is coalesced.
+	Delay time.Duration
+
+	// MaxDuration is the total time budget across all attempts.
+	MaxDuration time.Duration
+}
+
+// DefaultAbortFinalizeWait is the wait applied on the facade Abort path: wait
+// for finalization for up to twenty seconds, re-checking every half second as a
+// fallback to the watcher. The model database is dropped by the undertaker
+// within milliseconds in the normal case, so finalization usually succeeds on
+// the first attempt; the budget only covers a controller node under load.
+var DefaultAbortFinalizeWait = AbortFinalizeWait{
+	Delay:       500 * time.Millisecond,
+	MaxDuration: 20 * time.Second,
+}
+
+// abortFinalizer is the subset of the modelmigration import service that
+// [WaitAbortFinalized] needs: finalize the aborted claim once the database drop
+// is proven, and watch the staged model-database deletion so the wait reacts to
+// the drop completing instead of polling blindly.
+type abortFinalizer interface {
+	// FinalizeAbortedImport deletes the model's import claim once abort cleanup
+	// is provably complete, returning
+	// [modelmigrationerrors.ErrAbortNotFinalizable] while it is not.
+	FinalizeAbortedImport(ctx context.Context, modelUUID coremodel.UUID) error
+
+	// WatchModelDatabaseDeletion fires when the staged model-database deletion
+	// for the model changes, including when the undertaker removes it after
+	// dropping the database.
+	WatchModelDatabaseDeletion(ctx context.Context, modelUUID coremodel.UUID) (watcher.NotifyWatcher, error)
+}
+
+// AbortModelImport drives target-side cleanup of a partially imported v8 model.
+// It is the single entry point for both the facade Abort call and the abort
+// reconciler's retries, and is idempotent and safe to call repeatedly.
+//
+// It transitions the durable model_migration_import claim to the aborting phase
+// (refusing the transition once activation has crossed the point of no return),
+// undoes the controller-database import writes in reverse order via
+// [RemoveOnAbortImport], then hands the model database off to the undertaker's
+// model-database deleter by staging its deletion. It deliberately leaves the
+// claim in the aborting phase: the claim is deleted only once the database drop
+// is proven complete, by [WaitAbortFinalized] on the facade path or the abort
+// reconciler otherwise. Until then the model UUID stays claimed and every
+// concurrent Import keeps seeing a cleanup-in-progress AlreadyExists.
+//
+// deps.ModelDB is not required: the abort compensation writes only to the
+// controller database, and passing a nil ModelDB makes that structural.
+//
+// The modelmigration import service is injected by the caller (the apiserver
+// domain services on the facade path, or the reconciler's own controller-scoped
+// service): this package never builds it from raw database handles.
+//
+// It returns [modelmigrationerrors.ErrAbortActivating] when the claim is
+// activating (a non-retryable conflict: the model must not be torn down after
+// activation has begun), and nil when no claim exists (nothing was imported, or
+// cleanup already finalized).
+//
+// It also returns nil, doing nothing, when the model is already being torn down
+// by the generic removal undertaker (a v7/legacy abort marked it dead and took
+// the claim's abort lock): that path owns the teardown, and re-driving v8
+// compensation over it would race the undertaker.
+func AbortModelImport(ctx context.Context, deps Deps, claim *migrationclaimservice.Service, modelUUID coremodel.UUID) error {
+	c, err := claim.GetImportClaim(ctx, modelUUID)
+	switch {
+	case errors.Is(err, modelmigrationerrors.ErrImportNotFound):
+		// The claim is the first target-side write of an import, so a missing
+		// claim means nothing was imported for this model, or a prior abort has
+		// already finalized cleanup. Either way there is nothing to do.
+		return nil
+	case err != nil:
+		return errors.Errorf("reading import claim for model %q: %w", modelUUID, err)
+	}
+
+	// The model is dying, so the generic removal undertaker already owns its
+	// teardown (a v7/legacy abort marks the model dead and takes the claim's
+	// abort lock). Re-driving v8 compensation over it would race the
+	// undertaker's own DeleteModel/DeleteDB, so leave it alone. A v8 abort
+	// never marks the model dead, so this only fires for the legacy path.
+	if dying, err := claim.IsModelDying(ctx, modelUUID); err != nil {
+		return errors.Errorf("checking model life for %q: %w", modelUUID, err)
+	} else if dying {
+		return nil
+	}
+
+	switch c.Phase {
+	case modelmigration.ImportPhaseActivating:
+		// Not a programming error, and not a race: Activate takes the claim past
+		// the point of no return before it can fail, and the source cannot tell a
+		// failed Activate from one whose reply it never received. Either way its
+		// VALIDATION phase drives ABORT and lands here. Refuse: the model may in
+		// fact be activated, so it must not be torn down.
+		return errors.Errorf("model %q: %w", modelUUID, modelmigrationerrors.ErrAbortActivating)
+	case modelmigration.ImportPhaseImporting:
+		if err := claim.SetImportPhaseAborting(ctx, modelUUID); err != nil {
+			// The claim read above is not part of the transition transaction, so
+			// a concurrent activation may have won the race. SetImportPhaseAborting
+			// re-reads the phase inside its own transaction and reports
+			// ErrAbortActivating itself, so wrapping preserves that sentinel.
+			return errors.Errorf(
+				"transitioning import claim to aborting for model %q: %w", modelUUID, err)
+		}
+	case modelmigration.ImportPhaseAborting:
+		// A previous abort was interrupted before it finalized the claim (or the
+		// reconciler is retrying one); re-drive the idempotent compensation below.
+		deps.Logger.Debugf(ctx,
+			"model %q import claim is already aborting; re-driving abort compensation", modelUUID)
+	default:
+		return errors.Errorf("model %q: unexpected import claim phase %q", modelUUID, c.Phase)
+	}
+
+	// Undo the controller-database import writes in reverse order. This is
+	// idempotent and envelope-free: it derives everything it removes from the
+	// model UUID alone.
+	args := ImportModelArgs{
+		ControllerModelInfo: coremodelmigration.ControllerModelInfo{
+			ModelInfo: coremodelmigration.ModelIdentityInfo{UUID: modelUUID.String()},
+		},
+	}
+	if err := RemoveOnAbortImport(ctx, deps, args); err != nil {
+		return errors.Errorf("removing partial import for model %q: %w", modelUUID, err)
+	}
+
+	// Stage the model database for deletion by the undertaker's model-database
+	// deleter (running on every controller node, so this works from any node).
+	// Staging removes the namespace registration, so a re-drive after the drop
+	// completes sees no registration and skips this; it is idempotent regardless.
+	// A claim that was concurrently finalized reports ErrImportNotFound, which is
+	// success here.
+	if registered, err := claim.IsImportNamespaceRegistered(ctx, modelUUID); err != nil {
+		return errors.Errorf("checking namespace registration for model %q: %w", modelUUID, err)
+	} else if registered {
+		if err := claim.StageAbortedModelDatabaseDeletion(ctx, modelUUID); err != nil &&
+			!errors.Is(err, modelmigrationerrors.ErrImportNotFound) {
+			return errors.Errorf("staging model database deletion for model %q: %w", modelUUID, err)
+		}
+	}
+	return nil
+}
+
+// WaitAbortFinalized blocks until the aborted model's import claim can be
+// finalized (the model database has been dropped by the undertaker and the
+// claim deleted), or the wait timeout occurs. It is called on the facade
+// Abort path so the model UUID is released before the RPC returns, matching the
+// synchronous abort behaviour of earlier Juju releases.
+//
+// The database drop that unblocks finalization happens out of band in the
+// undertaker's model-database deleter, which removes the model's staged
+// deletion row when it is done. This function watches that row and re-attempts
+// finalization when it changes, rather than polling blindly: FinalizeAbortedImport
+// commits successfully every time and reports
+// [modelmigrationerrors.ErrAbortNotFinalizable] as a normal result while the
+// drop is not yet proven, so only the drop event (or the fallback re-check) can
+// make the condition come true. A periodic re-check backs the watcher up in
+// case an event is coalesced.
+//
+// It returns nil only once the claim is gone. If the request context is
+// cancelled or the budget is exhausted, it returns an error and leaves the
+// claim in the aborting phase for a later retry or recovery worker.
+//
+// The modelmigration import service is injected by the caller; deps supplies
+// only the clock and logger for the bounded wait.
+func WaitAbortFinalized(ctx context.Context, deps Deps, claim abortFinalizer, modelUUID coremodel.UUID, wait AbortFinalizeWait) error {
+	// Subscribe before the first finalize attempt so the drop cannot slip
+	// through between a check and the subscription.
+	w, err := claim.WatchModelDatabaseDeletion(ctx, modelUUID)
+	if err != nil {
+		return errors.Errorf("watching model database deletion for model %q: %w", modelUUID, err)
+	}
+	defer func() { _ = worker.Stop(w) }()
+
+	timeout := deps.Clock.After(wait.MaxDuration)
+	for {
+		err := claim.FinalizeAbortedImport(ctx, modelUUID)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, modelmigrationerrors.ErrAbortNotFinalizable) {
+			return errors.Errorf("finalizing aborted import for model %q: %w", modelUUID, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return errors.Capture(ctx.Err())
+		case <-timeout:
+			return errors.Errorf(
+				"timed out finalizing aborted import for model %q: %w",
+				modelUUID, modelmigrationerrors.ErrAbortNotFinalizable,
+			)
+		case _, ok := <-w.Changes():
+			if !ok {
+				return errors.Errorf("model database deletion watcher for model %q closed", modelUUID)
+			}
+		case <-deps.Clock.After(wait.Delay):
+		}
+	}
+}

--- a/internal/migration/abort.go
+++ b/internal/migration/abort.go
@@ -12,15 +12,15 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	coremodelmigration "github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/watcher"
+	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/modelmigration"
 	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
-	migrationclaimservice "github.com/juju/juju/domain/modelmigration/service"
 	"github.com/juju/juju/internal/errors"
 )
 
-// AbortFinalizeWait bounds how long [WaitAbortFinalized] blocks waiting for the
+// abortFinalizeWait bounds how long waitAbortFinalized blocks waiting for the
 // model database to be dropped and the import claim released.
-type AbortFinalizeWait struct {
+type abortFinalizeWait struct {
 	// Delay is the interval between fallback finalization re-checks. The wait is
 	// primarily driven by the model-database-deletion watcher; this re-check
 	// backs it up in case an event is coalesced.
@@ -30,63 +30,29 @@ type AbortFinalizeWait struct {
 	MaxDuration time.Duration
 }
 
-// DefaultAbortFinalizeWait is the wait applied on the facade Abort path: wait
-// for finalization for up to twenty seconds, re-checking every half second as a
-// fallback to the watcher. The model database is dropped by the undertaker
-// within milliseconds in the normal case, so finalization usually succeeds on
-// the first attempt; the budget only covers a controller node under load.
-var DefaultAbortFinalizeWait = AbortFinalizeWait{
+var defaultAbortFinalizeWait = abortFinalizeWait{
 	Delay:       500 * time.Millisecond,
 	MaxDuration: 20 * time.Second,
 }
 
-// abortFinalizer is the subset of the modelmigration import service that
-// [WaitAbortFinalized] needs: finalize the aborted claim once the database drop
-// is proven, and watch the staged model-database deletion so the wait reacts to
-// the drop completing instead of polling blindly.
+// abortFinalizer is the subset of the modelmigration import service needed to
+// finalize an aborted claim after its model database is dropped.
 type abortFinalizer interface {
-	// FinalizeAbortedImport deletes the model's import claim once abort cleanup
-	// is provably complete, returning
-	// [modelmigrationerrors.ErrAbortNotFinalizable] while it is not.
 	FinalizeAbortedImport(ctx context.Context, modelUUID coremodel.UUID) error
-
-	// WatchModelDatabaseDeletion fires when the staged model-database deletion
-	// for the model changes, including when the undertaker removes it after
-	// dropping the database.
 	WatchModelDatabaseDeletion(ctx context.Context, modelUUID coremodel.UUID) (watcher.NotifyWatcher, error)
 }
 
-// AbortModelImport drives target-side cleanup of a partially imported v8 model.
-// It is the single entry point for both the facade Abort call and the abort
-// reconciler's retries, and is idempotent and safe to call repeatedly.
-//
-// It transitions the durable model_migration_import claim to the aborting phase
-// (refusing the transition once activation has crossed the point of no return),
-// undoes the controller-database import writes in reverse order via
-// [RemoveOnAbortImport], then hands the model database off to the undertaker's
-// model-database deleter by staging its deletion. It deliberately leaves the
-// claim in the aborting phase: the claim is deleted only once the database drop
-// is proven complete, by [WaitAbortFinalized] on the facade path or the abort
-// reconciler otherwise. Until then the model UUID stays claimed and every
-// concurrent Import keeps seeing a cleanup-in-progress AlreadyExists.
-//
-// deps.ModelDB is not required: the abort compensation writes only to the
-// controller database, and passing a nil ModelDB makes that structural.
-//
-// The modelmigration import service is injected by the caller (the apiserver
-// domain services on the facade path, or the reconciler's own controller-scoped
-// service): this package never builds it from raw database handles.
-//
-// It returns [modelmigrationerrors.ErrAbortActivating] when the claim is
-// activating (a non-retryable conflict: the model must not be torn down after
-// activation has begun), and nil when no claim exists (nothing was imported, or
-// cleanup already finalized).
-//
-// It also returns nil, doing nothing, when the model is already being torn down
-// by the generic removal undertaker (a v7/legacy abort marked it dead and took
-// the claim's abort lock): that path owns the teardown, and re-driving v8
-// compensation over it would race the undertaker.
-func AbortModelImport(ctx context.Context, deps Deps, claim *migrationclaimservice.Service, modelUUID coremodel.UUID) error {
+type importAbortService interface {
+	GetImportClaim(context.Context, coremodel.UUID) (modelmigration.ImportClaim, error)
+	SetImportPhaseAborting(context.Context, coremodel.UUID) error
+	IsModelDying(context.Context, coremodel.UUID) (bool, error)
+	IsImportNamespaceRegistered(context.Context, coremodel.UUID) (bool, error)
+	StageAbortedModelDatabaseDeletion(context.Context, coremodel.UUID) error
+}
+
+// abortModelImport cleans up a partially imported v8 model. It leaves the
+// durable claim in the aborting phase until the model database is dropped.
+func abortModelImport(ctx context.Context, deps deps, claim importAbortService, modelUUID coremodel.UUID) error {
 	c, err := claim.GetImportClaim(ctx, modelUUID)
 	switch {
 	case errors.Is(err, modelmigrationerrors.ErrImportNotFound):
@@ -98,14 +64,11 @@ func AbortModelImport(ctx context.Context, deps Deps, claim *migrationclaimservi
 		return errors.Errorf("reading import claim for model %q: %w", modelUUID, err)
 	}
 
-	rerun := false
 	switch c.Phase {
 	case modelmigration.ImportPhaseActivating:
 		// Not a programming error, and not a race: Activate takes the claim past
 		// the point of no return before it can fail, and the source cannot tell a
-		// failed Activate from one whose reply it never received. Either way its
-		// VALIDATION phase drives ABORT and lands here. Refuse: the model may in
-		// fact be activated, so it must not be torn down.
+		// failed Activate from one whose reply it never received.
 		return errors.Errorf("model %q: %w", modelUUID, modelmigrationerrors.ErrAbortActivating)
 	case modelmigration.ImportPhaseImporting:
 		if err := claim.SetImportPhaseAborting(ctx, modelUUID); err != nil {
@@ -117,7 +80,8 @@ func AbortModelImport(ctx context.Context, deps Deps, claim *migrationclaimservi
 				"transitioning import claim to aborting for model %q: %w", modelUUID, err)
 		}
 	case modelmigration.ImportPhaseAborting:
-		rerun = true
+		deps.Logger.Debugf(ctx,
+			"model %q import claim is already aborting; re-driving abort compensation", modelUUID)
 	default:
 		return errors.Errorf("model %q: unexpected import claim phase %q", modelUUID, c.Phase)
 	}
@@ -126,17 +90,11 @@ func AbortModelImport(ctx context.Context, deps Deps, claim *migrationclaimservi
 	// catches a legacy abort that won between the initial claim read and the
 	// phase transition. A legacy abort can still begin after this check, but
 	// both cleanup paths are idempotent and converge on the same deletion.
-	if dying, err := claim.IsModelDying(ctx, modelUUID); err != nil {
+	if dying, err := claim.IsModelDying(ctx, modelUUID); err != nil &&
+		!errors.Is(err, modelerrors.NotFound) {
 		return errors.Errorf("checking model life for %q: %w", modelUUID, err)
 	} else if dying {
 		return nil
-	}
-
-	if rerun {
-		// A previous abort was interrupted before it finalized the claim (or the
-		// reconciler is retrying one); re-run the idempotent compensation below.
-		deps.Logger.Debugf(ctx,
-			"model %q import claim is already aborting; re-driving abort compensation", modelUUID)
 	}
 
 	// Undo the controller-database import writes in reverse order. This is
@@ -147,7 +105,7 @@ func AbortModelImport(ctx context.Context, deps Deps, claim *migrationclaimservi
 			ModelInfo: coremodelmigration.ModelIdentityInfo{UUID: modelUUID.String()},
 		},
 	}
-	if err := RemoveOnAbortImport(ctx, deps, args); err != nil {
+	if err := removeOnAbortImport(ctx, deps, args); err != nil {
 		return errors.Errorf("removing partial import for model %q: %w", modelUUID, err)
 	}
 
@@ -168,31 +126,9 @@ func AbortModelImport(ctx context.Context, deps Deps, claim *migrationclaimservi
 	return nil
 }
 
-// WaitAbortFinalized blocks until the aborted model's import claim can be
-// finalized (the model database has been dropped by the undertaker and the
-// claim deleted), or the wait timeout occurs. It is called on the facade
-// Abort path so the model UUID is released before the RPC returns, matching the
-// synchronous abort behaviour of earlier Juju releases.
-//
-// The database drop that unblocks finalization happens out of band in the
-// undertaker's model-database deleter, which removes the model's staged
-// deletion row when it is done. This function watches that row and re-attempts
-// finalization when it changes, rather than polling blindly: FinalizeAbortedImport
-// commits successfully every time and reports
-// [modelmigrationerrors.ErrAbortNotFinalizable] as a normal result while the
-// drop is not yet proven, so only the drop event (or the fallback re-check) can
-// make the condition come true. A periodic re-check backs the watcher up in
-// case an event is coalesced.
-//
-// It returns nil only once the claim is gone. If the request context is
-// cancelled or the budget is exhausted, it returns an error and leaves the
-// claim in the aborting phase for a later retry or recovery worker.
-//
-// The modelmigration import service is injected by the caller; deps supplies
-// only the clock and logger for the bounded wait.
-func WaitAbortFinalized(ctx context.Context, deps Deps, claim abortFinalizer, modelUUID coremodel.UUID, wait AbortFinalizeWait) error {
-	// Subscribe before the first finalize attempt so the drop cannot slip
-	// through between a check and the subscription.
+// waitAbortFinalized waits for the model database drop and releases the aborted
+// import claim, bounded by the supplied duration.
+func waitAbortFinalized(ctx context.Context, deps deps, claim abortFinalizer, modelUUID coremodel.UUID, wait abortFinalizeWait) error {
 	w, err := claim.WatchModelDatabaseDeletion(ctx, modelUUID)
 	if err != nil {
 		return errors.Errorf("watching model database deletion for model %q: %w", modelUUID, err)

--- a/internal/migration/abort.go
+++ b/internal/migration/abort.go
@@ -98,17 +98,7 @@ func AbortModelImport(ctx context.Context, deps Deps, claim *migrationclaimservi
 		return errors.Errorf("reading import claim for model %q: %w", modelUUID, err)
 	}
 
-	// The model is dying, so the generic removal undertaker already owns its
-	// teardown (a v7/legacy abort marks the model dead and takes the claim's
-	// abort lock). Re-driving v8 compensation over it would race the
-	// undertaker's own DeleteModel/DeleteDB, so leave it alone. A v8 abort
-	// never marks the model dead, so this only fires for the legacy path.
-	if dying, err := claim.IsModelDying(ctx, modelUUID); err != nil {
-		return errors.Errorf("checking model life for %q: %w", modelUUID, err)
-	} else if dying {
-		return nil
-	}
-
+	rerun := false
 	switch c.Phase {
 	case modelmigration.ImportPhaseActivating:
 		// Not a programming error, and not a race: Activate takes the claim past
@@ -127,12 +117,26 @@ func AbortModelImport(ctx context.Context, deps Deps, claim *migrationclaimservi
 				"transitioning import claim to aborting for model %q: %w", modelUUID, err)
 		}
 	case modelmigration.ImportPhaseAborting:
-		// A previous abort was interrupted before it finalized the claim (or the
-		// reconciler is retrying one); re-drive the idempotent compensation below.
-		deps.Logger.Debugf(ctx,
-			"model %q import claim is already aborting; re-driving abort compensation", modelUUID)
+		rerun = true
 	default:
 		return errors.Errorf("model %q: unexpected import claim phase %q", modelUUID, c.Phase)
+	}
+
+	// Check model life after taking or observing the claim's abort lock. This
+	// catches a legacy abort that won between the initial claim read and the
+	// phase transition. A legacy abort can still begin after this check, but
+	// both cleanup paths are idempotent and converge on the same deletion.
+	if dying, err := claim.IsModelDying(ctx, modelUUID); err != nil {
+		return errors.Errorf("checking model life for %q: %w", modelUUID, err)
+	} else if dying {
+		return nil
+	}
+
+	if rerun {
+		// A previous abort was interrupted before it finalized the claim (or the
+		// reconciler is retrying one); re-run the idempotent compensation below.
+		deps.Logger.Debugf(ctx,
+			"model %q import claim is already aborting; re-driving abort compensation", modelUUID)
 	}
 
 	// Undo the controller-database import writes in reverse order. This is
@@ -149,7 +153,7 @@ func AbortModelImport(ctx context.Context, deps Deps, claim *migrationclaimservi
 
 	// Stage the model database for deletion by the undertaker's model-database
 	// deleter (running on every controller node, so this works from any node).
-	// Staging removes the namespace registration, so a re-drive after the drop
+	// Staging removes the namespace registration, so a re-run after the drop
 	// completes sees no registration and skips this; it is idempotent regardless.
 	// A claim that was concurrently finalized reports ErrImportNotFound, which is
 	// success here.

--- a/internal/migration/abort.go
+++ b/internal/migration/abort.go
@@ -43,10 +43,27 @@ type abortFinalizer interface {
 }
 
 type importAbortService interface {
+	// GetImportClaim returns the durable import claim for the model, or
+	// [modelmigrationerrors.ErrImportNotFound] when no claim exists.
 	GetImportClaim(context.Context, coremodel.UUID) (modelmigration.ImportClaim, error)
+
+	// SetImportPhaseAborting transitions the model's import claim from
+	// importing to aborting. It returns [modelmigrationerrors.ErrAbortActivating]
+	// when the claim has crossed the activation point of no return.
 	SetImportPhaseAborting(context.Context, coremodel.UUID) error
-	IsModelDying(context.Context, coremodel.UUID) (bool, error)
+
+	// IsModelNotAlive reports whether the model has left the alive state, i.e.
+	// the generic removal undertaker has taken over its teardown.
+	IsModelNotAlive(context.Context, coremodel.UUID) (bool, error)
+
+	// IsImportNamespaceRegistered reports whether the model's dqlite namespace
+	// is still registered, i.e. whether its model database may still need
+	// dropping.
 	IsImportNamespaceRegistered(context.Context, coremodel.UUID) (bool, error)
+
+	// StageAbortedModelDatabaseDeletion removes the model's namespace
+	// registration and stages the model database for deletion by the
+	// undertaker's model-database deleter.
 	StageAbortedModelDatabaseDeletion(context.Context, coremodel.UUID) error
 }
 
@@ -90,10 +107,10 @@ func abortModelImport(ctx context.Context, deps deps, claim importAbortService, 
 	// catches a legacy abort that won between the initial claim read and the
 	// phase transition. A legacy abort can still begin after this check, but
 	// both cleanup paths are idempotent and converge on the same deletion.
-	if dying, err := claim.IsModelDying(ctx, modelUUID); err != nil &&
+	if notAlive, err := claim.IsModelNotAlive(ctx, modelUUID); err != nil &&
 		!errors.Is(err, modelerrors.NotFound) {
 		return errors.Errorf("checking model life for %q: %w", modelUUID, err)
-	} else if dying {
+	} else if notAlive {
 		return nil
 	}
 

--- a/internal/migration/abort_test.go
+++ b/internal/migration/abort_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/juju/clock"
+	"github.com/juju/clock/testclock"
 	"github.com/juju/tc"
 
 	coremodel "github.com/juju/juju/core/model"
@@ -42,7 +43,18 @@ func (s *controllerImportSuite) claimService(c *tc.C) *migrationclaimservice.Ser
 // fallback re-check drives the finalize attempts.
 type waitAbortClaim struct {
 	*migrationclaimservice.Service
-	changes chan struct{}
+	changes       chan struct{}
+	afterFinalize func()
+}
+
+func (w waitAbortClaim) FinalizeAbortedImport(
+	ctx context.Context, modelUUID coremodel.UUID,
+) error {
+	err := w.Service.FinalizeAbortedImport(ctx, modelUUID)
+	if w.afterFinalize != nil {
+		w.afterFinalize()
+	}
+	return err
 }
 
 func (w waitAbortClaim) WatchModelDatabaseDeletion(
@@ -303,4 +315,46 @@ func (s *controllerImportSuite) TestWaitAbortFinalizedPendingDropReturnsError(c 
 	claim, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(claim.Phase, tc.Equals, migrationdomain.ImportPhaseAborting)
+}
+
+// TestWaitAbortFinalizedContextCancelled verifies cancellation interrupts the
+// wait and preserves the aborting claim for a later retry.
+func (s *controllerImportSuite) TestWaitAbortFinalizedContextCancelled(c *tc.C) {
+	modelUUID, _, deps := s.importWithContent(c)
+
+	err := migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	ctx, cancel := context.WithCancel(c.Context())
+	defer cancel()
+	claim := s.waitClaim(c)
+	claim.afterFinalize = cancel
+	deps.Clock = testclock.NewClock(time.Now())
+	err = migration.WaitAbortFinalized(ctx, deps, claim, modelUUID, shortWait)
+	c.Assert(err, tc.ErrorIs, context.Canceled)
+
+	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
+	status, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(status.Phase, tc.Equals, migrationdomain.ImportPhaseAborting)
+}
+
+// TestWaitAbortFinalizedWatcherClosed verifies a dead watcher terminates the
+// wait and preserves the aborting claim for a later retry.
+func (s *controllerImportSuite) TestWaitAbortFinalizedWatcherClosed(c *tc.C) {
+	modelUUID, _, deps := s.importWithContent(c)
+
+	err := migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	claim := s.waitClaim(c)
+	close(claim.changes)
+	deps.Clock = testclock.NewClock(time.Now())
+	err = migration.WaitAbortFinalized(c.Context(), deps, claim, modelUUID, shortWait)
+	c.Assert(err, tc.ErrorMatches, `model database deletion watcher for model ".*" closed`)
+
+	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
+	status, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(status.Phase, tc.Equals, migrationdomain.ImportPhaseAborting)
 }

--- a/internal/migration/abort_test.go
+++ b/internal/migration/abort_test.go
@@ -33,6 +33,7 @@ import (
 func (s *controllerImportSuite) claimService(c *tc.C) *migrationclaimservice.Service {
 	return migrationclaimservice.NewImportService(
 		migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock),
+		clock.WallClock,
 		loggertesting.WrapCheckLog(c),
 	)
 }

--- a/internal/migration/abort_test.go
+++ b/internal/migration/abort_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration_test
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/tc"
+
+	coremodel "github.com/juju/juju/core/model"
+	coremodelmigration "github.com/juju/juju/core/modelmigration"
+	coreuser "github.com/juju/juju/core/user"
+	jujuversion "github.com/juju/juju/core/version"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/domain/export"
+	migrationdomain "github.com/juju/juju/domain/modelmigration"
+	modelmigrationerrors "github.com/juju/juju/domain/modelmigration/errors"
+	migrationclaimservice "github.com/juju/juju/domain/modelmigration/service"
+	migrationclaimstate "github.com/juju/juju/domain/modelmigration/state/controller"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/migration"
+	"github.com/juju/juju/internal/uuid"
+)
+
+// claimService builds the modelmigration import service the abort tests inject
+// into the abort driver, standing in for the apiserver-injected service.
+func (s *controllerImportSuite) claimService(c *tc.C) *migrationclaimservice.Service {
+	return migrationclaimservice.NewImportService(
+		migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock),
+		loggertesting.WrapCheckLog(c),
+	)
+}
+
+// waitAbortClaim wraps the real import Service with a controllable
+// model-database deletion watcher, so the finalize-wait tests can drive
+// WaitAbortFinalized without a changestream. The watcher never fires; the wait's
+// fallback re-check drives the finalize attempts.
+type waitAbortClaim struct {
+	*migrationclaimservice.Service
+	changes chan struct{}
+}
+
+func (w waitAbortClaim) WatchModelDatabaseDeletion(
+	context.Context, coremodel.UUID,
+) (watcher.NotifyWatcher, error) {
+	return watchertest.NewMockNotifyWatcher(w.changes), nil
+}
+
+// waitClaim builds the abortFinalizer the WaitAbortFinalized tests inject: the
+// real import Service plus a stubbed deletion watcher.
+func (s *controllerImportSuite) waitClaim(c *tc.C) waitAbortClaim {
+	return waitAbortClaim{Service: s.claimService(c), changes: make(chan struct{})}
+}
+
+// importWithContent runs a full v8 controller-data import for a fresh model,
+// including an offer permission, and returns the model UUID, the offer UUID it
+// granted, and the deps used, for the abort tests to tear down.
+func (s *controllerImportSuite) importWithContent(c *tc.C) (coremodel.UUID, string, migration.Deps) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	deps, _, _ := s.deps(c, modelUUID)
+
+	offerUUID := uuid.MustNewUUID().String()
+	info := s.baseControllerModelInfo(modelUUID)
+	info.ModelCredential = &coremodelmigration.ModelCloudCredential{
+		Cloud:      s.cloudName,
+		Owner:      coreuser.AdminUserName.Name(),
+		Name:       s.credentialName,
+		AuthType:   "access-key",
+		Attributes: map[string]string{"access-key": "val"},
+	}
+	info.Users = []coremodelmigration.ModelUser{
+		{Name: coreuser.AdminUserName.Name()},
+		{Name: "bob@external", DisplayName: "Bob", External: true},
+	}
+	info.Permissions = []coremodelmigration.ModelPermission{
+		{ObjectType: "model", GrantOn: modelUUID.String(), SubjectName: "bob@external", Access: "read"},
+		{ObjectType: "offer", GrantOn: offerUUID, SubjectName: "bob@external", Access: "consume"},
+	}
+	info.Leaders = []coremodelmigration.ApplicationLeadership{
+		{Application: "myapp", Leader: "myapp/0"},
+	}
+
+	view := export.ProjectionView{AgentTargetVersion: jujuversion.Current}
+	err := migration.ImportControllerModelInfo(c.Context(), deps, uuid.MustNewUUID().String(), info, view)
+	c.Assert(err, tc.ErrorIsNil)
+	return modelUUID, offerUUID, deps
+}
+
+// TestAbortModelImportNoClaim verifies aborting a model with no import claim is
+// a no-op success.
+func (s *controllerImportSuite) TestAbortModelImportNoClaim(c *tc.C) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	deps, _, _ := s.deps(c, modelUUID)
+
+	err := migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestAbortModelImportRemovesPartialImport verifies that aborting an importing
+// model flips the claim to aborting, removes the controller-DB model identity
+// and its model and offer permissions, but preserves the durable claim (which
+// the reconciler finalizes later).
+func (s *controllerImportSuite) TestAbortModelImportRemovesPartialImport(c *tc.C) {
+	modelUUID, offerUUID, deps := s.importWithContent(c)
+
+	// Sanity: the import wrote the model row and at least one offer-scoped
+	// permission row, and the offer was recorded in the ledger.
+	c.Assert(s.rowCount(c, "SELECT COUNT(*) FROM model WHERE uuid = ?", modelUUID.String()), tc.Equals, 1)
+	c.Assert(s.rowCount(c, "SELECT COUNT(*) FROM permission WHERE grant_on = ?", offerUUID) > 0, tc.IsTrue)
+	c.Assert(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_migration_import_offer WHERE offer_uuid = ?", offerUUID), tc.Equals, 1)
+
+	err := migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The claim survives, now in the aborting phase.
+	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
+	claim, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(claim.Phase, tc.Equals, migrationdomain.ImportPhaseAborting)
+
+	// The model identity row is gone.
+	c.Check(s.rowCount(c, "SELECT COUNT(*) FROM model WHERE uuid = ?", modelUUID.String()), tc.Equals, 0)
+	// The model-scoped and offer-scoped permission rows are gone. The offer row
+	// is the one that regressed before the ledger-before-write fence fix: its
+	// grant-on UUID is only discoverable from the offer ledger.
+	c.Check(s.rowCount(c, "SELECT COUNT(*) FROM permission WHERE grant_on = ?", modelUUID.String()), tc.Equals, 0)
+	c.Check(s.rowCount(c, "SELECT COUNT(*) FROM permission WHERE grant_on = ?", offerUUID), tc.Equals, 0)
+
+	// The model database has been handed off to the undertaker: the namespace
+	// registration is gone and a deletion is staged.
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM namespace_list WHERE namespace = ?", modelUUID.String()), tc.Equals, 0)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_database_deletion WHERE namespace = ?", modelUUID.String()), tc.Equals, 1)
+}
+
+// TestAbortModelImportIdempotent verifies aborting twice is safe and leaves the
+// claim in the aborting phase.
+func (s *controllerImportSuite) TestAbortModelImportIdempotent(c *tc.C) {
+	modelUUID, _, deps := s.importWithContent(c)
+
+	c.Assert(migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID), tc.ErrorIsNil)
+	c.Assert(migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID), tc.ErrorIsNil)
+
+	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
+	claim, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(claim.Phase, tc.Equals, migrationdomain.ImportPhaseAborting)
+}
+
+// TestAbortModelImportActivatingRefused verifies aborting a claim that has
+// crossed the activation point of no return is a non-retryable conflict and
+// leaves the model untouched.
+func (s *controllerImportSuite) TestAbortModelImportActivatingRefused(c *tc.C) {
+	modelUUID, _, deps := s.importWithContent(c)
+
+	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
+	c.Assert(claimSt.SetImportPhaseActivating(c.Context(), modelUUID.String()), tc.ErrorIsNil)
+
+	err := migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrAbortActivating)
+
+	// The claim stays activating and the model identity row is untouched.
+	claim, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(claim.Phase, tc.Equals, migrationdomain.ImportPhaseActivating)
+	c.Check(s.rowCount(c, "SELECT COUNT(*) FROM model WHERE uuid = ?", modelUUID.String()), tc.Equals, 1)
+}
+
+// TestAbortModelImportStandsAsideForLegacyRemoval verifies that when a
+// v7/legacy abort has already marked the model dead and taken the claim's abort
+// lock, the v8 abort driver does nothing: it must not re-drive compensation or
+// stage a model-database deletion over the generic undertaker's teardown. This
+// covers the abort reconciler picking up such an aborting claim.
+func (s *controllerImportSuite) TestAbortModelImportStandsAsideForLegacyRemoval(c *tc.C) {
+	modelUUID, _, deps := s.importWithContent(c)
+
+	// Simulate domain/removal MarkMigratingModelAsDead: claim -> aborting and
+	// the model marked dead, in the same spirit as the v7 Abort facade path.
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx,
+			"UPDATE model_migration_import SET phase_type_id = 2 WHERE model_uuid = ?", modelUUID.String()); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx,
+			"UPDATE model SET life_id = 2 WHERE uuid = ?", modelUUID.String())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Nothing was touched: the model row, claim and namespace registration all
+	// remain, and no model-database deletion was staged. The undertaker owns it.
+	c.Check(s.rowCount(c, "SELECT COUNT(*) FROM model WHERE uuid = ?", modelUUID.String()), tc.Equals, 1)
+	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
+	claim, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(claim.Phase, tc.Equals, migrationdomain.ImportPhaseAborting)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM namespace_list WHERE namespace = ?", modelUUID.String()), tc.Equals, 1)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_database_deletion WHERE namespace = ?", modelUUID.String()), tc.Equals, 0)
+}
+
+// shortWait is a tiny finalize-wait budget for the synchronous-finalize tests,
+// polling on the real wall clock so no background clock-advancing goroutine is
+// needed against the live dqlite transactions.
+var shortWait = migration.AbortFinalizeWait{Delay: time.Millisecond, MaxDuration: 50 * time.Millisecond}
+
+// TestWaitAbortFinalized verifies that once the model database has been dropped
+// (staged deletion cleared, standing in for the undertaker), the synchronous
+// finalize deletes the claim so the model UUID is free.
+func (s *controllerImportSuite) TestWaitAbortFinalized(c *tc.C) {
+	modelUUID, _, deps := s.importWithContent(c)
+
+	err := migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Stand in for the undertaker's model-database deleter: clear the staged
+	// deletion row so finalization's predicates pass.
+	err = s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			"DELETE FROM model_database_deletion WHERE namespace = ?", modelUUID.String())
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = migration.WaitAbortFinalized(c.Context(), deps, s.waitClaim(c), modelUUID, shortWait)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The claim is gone, so the model UUID can be claimed by a fresh import.
+	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
+	_, err = claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Check(err, tc.ErrorIs, modelmigrationerrors.ErrImportNotFound)
+}
+
+// TestWaitAbortFinalizedNoClaim verifies finalizing a model with no claim (a
+// prior abort already finalized) is a no-op success.
+func (s *controllerImportSuite) TestWaitAbortFinalizedNoClaim(c *tc.C) {
+	modelUUID := tc.Must(c, coremodel.NewUUID)
+	deps, _, _ := s.deps(c, modelUUID)
+
+	err := migration.WaitAbortFinalized(c.Context(), deps, s.waitClaim(c), modelUUID, shortWait)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestWaitAbortFinalizedPendingDropReturnsError verifies that when the model
+// database has not yet been dropped (staged deletion still present), the
+// bounded wait exhausts its budget with a truthful error and leaves the claim
+// in the aborting phase for recovery.
+func (s *controllerImportSuite) TestWaitAbortFinalizedPendingDropReturnsError(c *tc.C) {
+	modelUUID, _, deps := s.importWithContent(c)
+
+	err := migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The staged deletion row is left in place: the undertaker has not dropped
+	// the database yet, so finalization cannot prove cleanup complete.
+	err = migration.WaitAbortFinalized(c.Context(), deps, s.waitClaim(c), modelUUID, shortWait)
+	c.Assert(err, tc.ErrorIs, modelmigrationerrors.ErrAbortNotFinalizable)
+
+	// The claim survives in the aborting phase for the reconciler to complete.
+	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
+	claim, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(claim.Phase, tc.Equals, migrationdomain.ImportPhaseAborting)
+}

--- a/internal/migration/abort_test.go
+++ b/internal/migration/abort_test.go
@@ -210,6 +210,37 @@ func (s *controllerImportSuite) TestAbortModelImportStandsAsideForLegacyRemoval(
 		"SELECT COUNT(*) FROM model_database_deletion WHERE namespace = ?", modelUUID.String()), tc.Equals, 0)
 }
 
+// TestAbortModelImportChecksLifeAfterTransition verifies model life is checked
+// after transitioning the claim to aborting.
+func (s *controllerImportSuite) TestAbortModelImportChecksLifeAfterTransition(c *tc.C) {
+	modelUUID, _, deps := s.importWithContent(c)
+
+	// Simulate legacy removal marking the model dead in the window where the v8
+	// abort takes the claim's abort lock. A check made before the transition
+	// would miss this update and incorrectly start v8 compensation.
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+CREATE TRIGGER mark_model_dead_after_abort_lock
+AFTER UPDATE OF phase_type_id ON model_migration_import
+BEGIN
+    UPDATE model SET life_id = 2 WHERE uuid = NEW.model_uuid;
+END`)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Legacy removal owns teardown, so v8 compensation and staging did not run.
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model WHERE uuid = ?", modelUUID.String()), tc.Equals, 1)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM namespace_list WHERE namespace = ?", modelUUID.String()), tc.Equals, 1)
+	c.Check(s.rowCount(c,
+		"SELECT COUNT(*) FROM model_database_deletion WHERE namespace = ?", modelUUID.String()), tc.Equals, 0)
+}
+
 // shortWait is a tiny finalize-wait budget for the synchronous-finalize tests,
 // polling on the real wall clock so no background clock-advancing goroutine is
 // needed against the live dqlite transactions.

--- a/internal/migration/abort_test.go
+++ b/internal/migration/abort_test.go
@@ -205,7 +205,6 @@ func (s *controllerImportSuite) TestAbortModelImportStandsAsideForLegacyRemoval(
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
-
 	err = migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -240,6 +239,13 @@ END`)
 		return err
 	})
 	c.Assert(err, tc.ErrorIsNil)
+	defer func() {
+		err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			_, err := tx.ExecContext(ctx, "DROP TRIGGER mark_model_dead_after_abort_lock")
+			return err
+		})
+		c.Check(err, tc.ErrorIsNil)
+	}()
 
 	err = migration.AbortModelImport(c.Context(), deps, s.claimService(c), modelUUID)
 	c.Assert(err, tc.ErrorIsNil)

--- a/internal/migration/activate_test.go
+++ b/internal/migration/activate_test.go
@@ -167,6 +167,7 @@ func (*controllerImportSuite) activateModel(
 			)
 		},
 		activationDomainServicesGetter{deps: deps},
+		nil,
 		"",
 		deps.Logger,
 		deps.Clock,
@@ -565,6 +566,7 @@ func (*controllerImportSuite) commitActivation(
 			return coremodelmigration.NewScope(deps.ControllerDB, deps.ModelDB, nil, nil, modelUUID)
 		},
 		activationDomainServicesGetter{deps: deps, adopted: adopted},
+		nil,
 		"",
 		deps.Logger,
 		deps.Clock,

--- a/internal/migration/activate_test.go
+++ b/internal/migration/activate_test.go
@@ -117,6 +117,7 @@ func (g activationDomainServicesGetter) ServicesForModel(
 			// Credential validation is driven separately by CheckMachines, so
 			// the activation path never reaches the validator.
 			nil,
+			g.deps.Clock,
 			g.deps.Logger,
 		),
 		model: modelservice.NewWatchableService(
@@ -456,7 +457,7 @@ func (s *controllerImportSuite) TestActivateModelReconcilesOffererControllers(c 
 
 	claimSt := migrationclaimstate.New(s.TxnRunnerFactory(), clock.WallClock)
 	claimUUID := s.importClaimUUID(c, modelUUID)
-	err := modelmigrationservice.NewImportService(claimSt, deps.Logger).ImportExternalControllers(
+	err := modelmigrationservice.NewImportService(claimSt, deps.Clock, deps.Logger).ImportExternalControllers(
 		c.Context(), modelUUID, claimUUID,
 		[]coremodelmigration.ExternalController{{
 			UUID:           thirdPartyControllerUUID,

--- a/internal/migration/domainservices_mock_test.go
+++ b/internal/migration/domainservices_mock_test.go
@@ -158,6 +158,7 @@ type MockDomainServicesMockRecorder struct {
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
 	modelInfoExpects                  []*gomock.Call0_1[*service25.ProviderModelService]
 	modelMigrationExpects             []*gomock.Call0_1[*service29.WatchableService]
+	modelMigrationImportExpects       []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects              []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects         []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                    []*gomock.Call0_1[*service31.WatchableService]
@@ -841,6 +842,24 @@ func (mr *MockDomainServicesMockRecorder) ModelMigration() *MockDomainServicesMo
 
 // MockDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
 type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
+
+// ModelMigrationImport mocks base method.
+func (m *MockDomainServices) ModelMigrationImport() *service29.WatchableService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.modelMigrationImportExpects, m.ctrl, m, "ModelMigrationImport")
+}
+
+// ModelMigrationImport indicates an expected call of ModelMigrationImport.
+func (mr *MockDomainServicesMockRecorder) ModelMigrationImport() *MockDomainServicesModelMigrationImportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigrationImport")
+	mr.modelMigrationImportExpects = append(mr.modelMigrationImportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockDomainServicesModelMigrationImportCall is the typed call wrapper for ModelMigrationImport.
+type MockDomainServicesModelMigrationImportCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockDomainServices) ModelProvider() *service30.Service {

--- a/internal/migration/export_test.go
+++ b/internal/migration/export_test.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package migration
+
+type AbortFinalizeWait = abortFinalizeWait
+type Deps = deps
+
+var (
+	AbortModelImport          = abortModelImport
+	ImportControllerModelInfo = importControllerModelInfo
+	RemoveOnAbortImport       = removeOnAbortImport
+	WaitAbortFinalized        = waitAbortFinalized
+)

--- a/internal/migration/import.go
+++ b/internal/migration/import.go
@@ -41,9 +41,9 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
-// Deps bundles the database and ambient dependencies the v8 import
+// deps bundles the database and ambient dependencies the v8 import
 // orchestrator needs, supplied by the caller's migration scope.
-type Deps struct {
+type deps struct {
 	ControllerDB database.TxnRunnerFactory
 	ModelDB      database.TxnRunnerFactory
 	Clock        clock.Clock
@@ -70,7 +70,7 @@ type ImportModelArgs struct {
 	ModelDBPayload *latest.ModelExport
 }
 
-// ImportControllerModelInfo applies the v8 import's controller-scoped semantic
+// importControllerModelInfo applies the v8 import's controller-scoped semantic
 // data to the target controller: the durable model_migration_import claim, the
 // target-local model bootstrap (controller model row + model DB in importing
 // mode), and the users, credential, permissions, authorized keys, secret
@@ -92,9 +92,9 @@ type ImportModelArgs struct {
 // import claim. If a claim already exists for info.ModelInfo.UUID, the returned
 // error wraps [coreerrors.AlreadyExists] (phase-specific wording is supplied by
 // the modelmigration domain).
-func ImportControllerModelInfo(
+func importControllerModelInfo(
 	ctx context.Context,
-	deps Deps,
+	deps deps,
 	sourceMigrationUUID string,
 	info coremodelmigration.ControllerModelInfo,
 	view export.ProjectionView,
@@ -102,13 +102,11 @@ func ImportControllerModelInfo(
 	return newImportCoordinator(deps, sourceMigrationUUID, info, view).Import(ctx)
 }
 
-// RemoveOnAbortImport is the abort seam Task 11 will call from AbortImport. It
-// undoes the controller-DB writes performed by ImportControllerModelInfo in
-// reverse order. Each step is idempotent: it is safe to call RemoveOnAbortImport
-// more than once.
-func RemoveOnAbortImport(
+// removeOnAbortImport undoes the controller-DB writes performed by
+// importControllerModelInfo in reverse order. Each step is idempotent.
+func removeOnAbortImport(
 	ctx context.Context,
-	deps Deps,
+	deps deps,
 	args ImportModelArgs,
 ) error {
 	return newImportCoordinator(
@@ -183,7 +181,7 @@ func (c *importCoordinator) RemoveOnAbort(ctx context.Context) error {
 }
 
 func newImportCoordinator(
-	deps Deps,
+	deps deps,
 	sourceMigrationUUID string,
 	info coremodelmigration.ControllerModelInfo,
 	view export.ProjectionView,
@@ -223,7 +221,7 @@ func newImportCoordinator(
 // deps and svc use either the guarded controller database for forward import,
 // or the ordinary controller database for abort cleanup.
 func newControllerImportOps(
-	deps Deps,
+	deps deps,
 	svc importServices,
 	info coremodelmigration.ControllerModelInfo,
 	view export.ProjectionView,
@@ -379,7 +377,7 @@ func (op *opImportCredential) RemoveOnAbort(_ context.Context) error { return ni
 // ----
 
 type opBootstrapModel struct {
-	deps               Deps
+	deps               deps
 	modelUUID          coremodel.UUID
 	modelUUIDStr       string
 	identity           coremodelmigration.ModelIdentityInfo
@@ -643,7 +641,7 @@ type importServices struct {
 // newImportServices constructs the controller-scoped domain services the v8
 // import driver needs. Each service owns its state and is independent of the
 // others; the import driver is responsible for calling them in FK-safe order.
-func newImportServices(deps Deps, modelUUID coremodel.UUID) importServices {
+func newImportServices(deps deps, modelUUID coremodel.UUID) importServices {
 	return importServices{
 		claim: migrationclaimservice.NewImportService(
 			migrationclaimstate.New(deps.ControllerDB, deps.Clock), deps.Logger,
@@ -678,7 +676,7 @@ func newImportServices(deps Deps, modelUUID coremodel.UUID) importServices {
 // pure orchestration of two existing model-domain service methods.
 func bootstrapImportedModel(
 	ctx context.Context,
-	deps Deps,
+	deps deps,
 	modelUUID coremodel.UUID,
 	identity coremodelmigration.ModelIdentityInfo,
 	credKey corecredential.Key,

--- a/internal/migration/import.go
+++ b/internal/migration/import.go
@@ -644,7 +644,7 @@ type importServices struct {
 func newImportServices(deps deps, modelUUID coremodel.UUID) importServices {
 	return importServices{
 		claim: migrationclaimservice.NewImportService(
-			migrationclaimstate.New(deps.ControllerDB, deps.Clock), deps.Logger,
+			migrationclaimstate.New(deps.ControllerDB, deps.Clock), deps.Clock, deps.Logger,
 		),
 		access: accessservice.NewService(
 			accessstate.NewState(deps.ControllerDB, deps.Clock, deps.Logger), deps.Clock,

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -144,13 +144,20 @@ func (i *ModelImporter) CommitActivation(
 // [github.com/juju/juju/domain/modelmigration/errors.ErrAbortActivating] when
 // activation has already crossed the point of no return.
 func (i *ModelImporter) AbortModel(ctx context.Context, modelUUID coremodel.UUID) error {
+	if i.controllerServices == nil {
+		return internalerrors.New("controller services not configured")
+	}
+	claim := i.controllerServices.ModelMigrationImport()
+	if claim == nil {
+		return internalerrors.New("model migration import service not configured")
+	}
+
 	scope := i.scope(modelUUID)
 	deps := Deps{
 		ControllerDB: scope.ControllerDB(),
 		Clock:        i.clock,
 		Logger:       i.logger,
 	}
-	claim := i.controllerServices.ModelMigrationImport()
 	if err := AbortModelImport(ctx, deps, &claim.Service, modelUUID); err != nil {
 		return err
 	}

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -21,6 +21,7 @@ import (
 	domaincharm "github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/domain/export"
+	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/modelimport"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -46,6 +47,12 @@ type ConfigSchemaSourceProvider = func(environs.CloudService) config.ConfigSchem
 type ModelImporter struct {
 	domainServices services.DomainServicesGetter
 
+	// controllerServices provides the controller-scoped import claim service
+	// (with its watcher) used by the abort path. It is resolved directly rather
+	// than via domainServices.ServicesForModel because abort runs after the
+	// model namespace may have been removed, which would fail model resolution.
+	controllerServices services.ControllerDomainServices
+
 	controllerUUID string
 	scope          modelmigration.ScopeForModel
 	logger         corelogger.Logger
@@ -58,16 +65,18 @@ type ModelImporter struct {
 func NewModelImporter(
 	scope modelmigration.ScopeForModel,
 	domainServices services.DomainServicesGetter,
+	controllerServices services.ControllerDomainServices,
 	controllerUUID string,
 	logger corelogger.Logger,
 	clock clock.Clock,
 ) *ModelImporter {
 	return &ModelImporter{
-		scope:          scope,
-		controllerUUID: controllerUUID,
-		domainServices: domainServices,
-		logger:         logger,
-		clock:          clock,
+		scope:              scope,
+		controllerUUID:     controllerUUID,
+		domainServices:     domainServices,
+		controllerServices: controllerServices,
+		logger:             logger,
+		clock:              clock,
 	}
 }
 
@@ -115,6 +124,39 @@ func (i *ModelImporter) CommitActivation(
 	return commitActivation(ctx, domainServices, modelUUID, sourceControllerVersion)
 }
 
+// AbortModel drives target-side cleanup of a partially imported v8 model. It
+// resolves the controller-database scope for the model UUID and delegates to
+// [AbortModelImport], then blocks (via [WaitAbortFinalized]) until the model
+// database has been dropped and the import claim released, so the model UUID is
+// free when this returns and an immediate re-migration succeeds. The model
+// database is never opened during abort, so no model-DB scope is needed.
+//
+// The controller-scoped modelmigration import service comes from the controller
+// domain services rather than ServicesForModel: the abort path only uses
+// controller-DB state (import claims, namespace registrations, staged
+// deletions), and a re-invocation after a prior partial abort may have already
+// removed the model namespace, which would make ServicesForModel fail.
+//
+// If the claim cannot be finalized within the wait budget, AbortModel returns
+// an error and leaves the claim in the aborting phase for retry or recovery.
+//
+// It returns an error wrapping
+// [github.com/juju/juju/domain/modelmigration/errors.ErrAbortActivating] when
+// activation has already crossed the point of no return.
+func (i *ModelImporter) AbortModel(ctx context.Context, modelUUID coremodel.UUID) error {
+	scope := i.scope(modelUUID)
+	deps := Deps{
+		ControllerDB: scope.ControllerDB(),
+		Clock:        i.clock,
+		Logger:       i.logger,
+	}
+	claim := i.controllerServices.ModelMigrationImport()
+	if err := AbortModelImport(ctx, deps, &claim.Service, modelUUID); err != nil {
+		return err
+	}
+	return WaitAbortFinalized(ctx, deps, claim, modelUUID, DefaultAbortFinalizeWait)
+}
+
 // ImportModel applies a v8 import's controller-scoped semantic data to the
 // target controller. See [ImportControllerModelInfo] for the orchestration;
 // this method only resolves the migration scope for the model UUID and
@@ -144,25 +186,39 @@ func (i *ModelImporter) ImportModel(
 		return internalerrors.Capture(err)
 	}
 
-	if args.ModelDBPayload == nil {
-		return nil
+	if args.ModelDBPayload != nil {
+		// Now that the controller data is applied, rewrite the model-DB payload's
+		// live secret value ref backend UUIDs from the source controller's to the
+		// target's (matched by name) before the insert. An unmapped live revision
+		// is a hard error; no model-DB rows are written.
+		if err := reconcileSecretBackendUUIDs(ctx, deps, args.ControllerModelInfo, args.ModelDBPayload); err != nil {
+			return internalerrors.Errorf(
+				"rewriting secret backend UUIDs for model %q: %w", modelUUID, err)
+		}
+
+		// Model-DB import: insert the transformed, target-version payload into the
+		// model DB. The importer is constructed per import because it binds to the
+		// model DB resolved from the scope for this model UUID (the ModelImporter
+		// itself is not bound to a single model).
+		if err := modelimport.NewImporter(scope.ModelDB()).Import(ctx, args.ModelDBPayload); err != nil {
+			return internalerrors.Errorf("model-DB import for model %q: %w", modelUUID, err)
+		}
 	}
 
-	// Now that the controller data is applied, rewrite the model-DB payload's
-	// live secret value ref backend UUIDs from the source controller's to the
-	// target's (matched by name) before the insert. An unmapped live revision
-	// is a hard error; no model-DB rows are written.
-	if err := reconcileSecretBackendUUIDs(ctx, deps, args.ControllerModelInfo, args.ModelDBPayload); err != nil {
-		return internalerrors.Errorf(
-			"rewriting secret backend UUIDs for model %q: %w", modelUUID, err)
+	// Activate the imported model so it is visible in v_model and connectable by
+	// the migrating model's agents during the source VALIDATION phase. The model
+	// stays gated by the model_migrating flag and the importing import claim until
+	// the target Activate call clears them; activation here only flips
+	// model.activated, mirroring the legacy importModelActivatorOperation. This is
+	// idempotent: a retried import (or the later Activate) tolerates
+	// AlreadyActivated.
+	modelDomainServices, err := i.domainServices.ServicesForModel(ctx, modelUUID)
+	if err != nil {
+		return internalerrors.Errorf("retrieving domain services for model %q: %w", modelUUID, err)
 	}
-
-	// Model-DB import: insert the transformed, target-version payload into the
-	// model DB. The importer is constructed per import because it binds to the
-	// model DB resolved from the scope for this model UUID (the ModelImporter
-	// itself is not bound to a single model).
-	if err := modelimport.NewImporter(scope.ModelDB()).Import(ctx, args.ModelDBPayload); err != nil {
-		return internalerrors.Errorf("model-DB import for model %q: %w", modelUUID, err)
+	if err := modelDomainServices.Model().ActivateModel(ctx, modelUUID); err != nil &&
+		!internalerrors.Is(err, modelerrors.AlreadyActivated) {
+		return internalerrors.Errorf("activating imported model %q: %w", modelUUID, err)
 	}
 	return nil
 }

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -175,6 +175,10 @@ func (i *ModelImporter) AbortModel(ctx context.Context, modelUUID coremodel.UUID
 func (i *ModelImporter) ImportModel(
 	ctx context.Context, args ImportModelArgs, view export.ProjectionView,
 ) error {
+	if i.domainServices == nil {
+		return internalerrors.New("domain services not configured")
+	}
+
 	modelUUID := coremodel.UUID(args.ControllerModelInfo.ModelInfo.UUID)
 	scope := i.scope(modelUUID)
 	deps := Deps{

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -126,7 +126,7 @@ func (i *ModelImporter) CommitActivation(
 
 // AbortModel drives target-side cleanup of a partially imported v8 model. It
 // resolves the controller-database scope for the model UUID and delegates to
-// [AbortModelImport], then blocks (via [WaitAbortFinalized]) until the model
+// abortModelImport, then blocks via waitAbortFinalized until the model
 // database has been dropped and the import claim released, so the model UUID is
 // free when this returns and an immediate re-migration succeeds. The model
 // database is never opened during abort, so no model-DB scope is needed.
@@ -153,19 +153,19 @@ func (i *ModelImporter) AbortModel(ctx context.Context, modelUUID coremodel.UUID
 	}
 
 	scope := i.scope(modelUUID)
-	deps := Deps{
+	deps := deps{
 		ControllerDB: scope.ControllerDB(),
 		Clock:        i.clock,
 		Logger:       i.logger,
 	}
-	if err := AbortModelImport(ctx, deps, &claim.Service, modelUUID); err != nil {
+	if err := abortModelImport(ctx, deps, &claim.Service, modelUUID); err != nil {
 		return err
 	}
-	return WaitAbortFinalized(ctx, deps, claim, modelUUID, DefaultAbortFinalizeWait)
+	return waitAbortFinalized(ctx, deps, claim, modelUUID, defaultAbortFinalizeWait)
 }
 
 // ImportModel applies a v8 import's controller-scoped semantic data to the
-// target controller. See [ImportControllerModelInfo] for the orchestration;
+// target controller. See importControllerModelInfo for the orchestration;
 // this method only resolves the migration scope for the model UUID and
 // delegates.
 //
@@ -181,7 +181,7 @@ func (i *ModelImporter) ImportModel(
 
 	modelUUID := coremodel.UUID(args.ControllerModelInfo.ModelInfo.UUID)
 	scope := i.scope(modelUUID)
-	deps := Deps{
+	deps := deps{
 		ControllerDB: scope.ControllerDB(),
 		ModelDB:      scope.ModelDB(),
 		Clock:        i.clock,
@@ -191,7 +191,7 @@ func (i *ModelImporter) ImportModel(
 	// Apply the controller-scoped data (claim, bootstrap, users, credential,
 	// permissions, secret backend references, ...). Writes only; no return
 	// value beyond the error.
-	if err := ImportControllerModelInfo(
+	if err := importControllerModelInfo(
 		ctx, deps, args.SourceMigrationUUID, args.ControllerModelInfo, view,
 	); err != nil {
 		return internalerrors.Capture(err)

--- a/internal/migration/migration_integration_test.go
+++ b/internal/migration/migration_integration_test.go
@@ -49,7 +49,7 @@ func (s *ExportImportSuite) exportImport(c *tc.C, leaders map[string]string) {
 		return modelmigration.NewScope(nil, nil, nil, nil, tc.Must0(c, model.NewUUID))
 	}
 	importer := migration.NewModelImporter(
-		scope, s.domainServicesGetter,
+		scope, s.domainServicesGetter, nil,
 		"controller-uuid",
 		loggertesting.WrapCheckLog(c),
 		clock.WallClock,

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -56,7 +56,7 @@ func (s *ImportSuite) TestBadBytes(c *tc.C) {
 		return modelmigration.NewScope(nil, nil, nil, nil, tc.Must0(c, model.NewUUID))
 	}
 	importer := migration.NewModelImporter(
-		scope, nil,
+		scope, nil, nil,
 		"controller-uuid",
 		loggertesting.WrapCheckLog(c),
 		clock.WallClock,

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/core/semversion"
 	domaincharm "github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/deployment/charm"
+	"github.com/juju/juju/domain/export"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/testhelpers"
@@ -75,6 +76,18 @@ func (s *ImportSuite) TestAbortModelWithoutControllerServices(c *tc.C) {
 
 	err := importer.AbortModel(c.Context(), model.UUID("model-uuid"))
 	c.Assert(err, tc.ErrorMatches, "controller services not configured")
+}
+
+func (s *ImportSuite) TestImportModelWithoutDomainServices(c *tc.C) {
+	importer := migration.NewModelImporter(
+		nil, nil, nil,
+		"controller-uuid",
+		loggertesting.WrapCheckLog(c),
+		clock.WallClock,
+	)
+
+	err := importer.ImportModel(c.Context(), migration.ImportModelArgs{}, export.ProjectionView{})
+	c.Assert(err, tc.ErrorMatches, "domain services not configured")
 }
 
 const modelYaml = `

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -65,6 +65,18 @@ func (s *ImportSuite) TestBadBytes(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "yaml: unmarshal errors:\n.*")
 }
 
+func (s *ImportSuite) TestAbortModelWithoutControllerServices(c *tc.C) {
+	importer := migration.NewModelImporter(
+		nil, nil, nil,
+		"controller-uuid",
+		loggertesting.WrapCheckLog(c),
+		clock.WallClock,
+	)
+
+	err := importer.AbortModel(c.Context(), model.UUID("model-uuid"))
+	c.Assert(err, tc.ErrorMatches, "controller services not configured")
+}
+
 const modelYaml = `
 cloud: dev
 config:

--- a/internal/migration/modelimporter_test.go
+++ b/internal/migration/modelimporter_test.go
@@ -12,21 +12,17 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/tc"
 
-	"github.com/juju/juju/cloud"
 	coredatabase "github.com/juju/juju/core/database"
 	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	coremodelmigration "github.com/juju/juju/core/modelmigration"
-	coreuser "github.com/juju/juju/core/user"
 	jujuversion "github.com/juju/juju/core/version"
-	accessstate "github.com/juju/juju/domain/access/state"
-	cloudbootstrap "github.com/juju/juju/domain/cloud/bootstrap"
 	"github.com/juju/juju/domain/export"
 	"github.com/juju/juju/domain/export/types/latest"
 	v4_1_0 "github.com/juju/juju/domain/export/types/v4_1_0"
 	modeltesting "github.com/juju/juju/domain/model/state/testing"
 	migrationclaimstate "github.com/juju/juju/domain/modelmigration/state/controller"
-	schematesting "github.com/juju/juju/domain/schema/testing"
+	domainservicestesting "github.com/juju/juju/domain/services/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/uuid"
@@ -36,11 +32,14 @@ import (
 // public method the migrationtarget facade calls. The orchestration itself is
 // covered in this package's direct ImportControllerModelInfo tests; this only
 // proves the delegator resolves the migration scope for the model UUID and
-// wires it through correctly.
+// wires it through correctly, and that it activates the imported model so it is
+// connectable during the source VALIDATION phase.
+//
+// It embeds DomainServicesSuite (rather than a bare schema suite) because
+// ImportModel now resolves real domain services for the model to flip
+// model.activated at the end of the import.
 type modelImporterSuite struct {
-	schematesting.ControllerModelSuite
-
-	cloudName string
+	domainservicestesting.DomainServicesSuite
 }
 
 func TestModelImporterSuite(t *testing.T) {
@@ -48,25 +47,9 @@ func TestModelImporterSuite(t *testing.T) {
 }
 
 func (s *modelImporterSuite) SetUpTest(c *tc.C) {
-	s.ControllerSuite.SetUpTest(c)
-
-	controllerModelUUID := modeltesting.CreateTestModel(c, s.TxnRunnerFactory(), "controller")
-	s.SeedControllerTable(c, controllerModelUUID)
-
-	adminUserUUID := tc.Must(c, coreuser.NewUUID)
-	accessState := accessstate.NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
-	err := accessState.AddUser(c.Context(), adminUserUUID, coreuser.AdminUserName, coreuser.AdminUserName.Name(), false, adminUserUUID)
-	c.Assert(err, tc.ErrorIsNil)
-
-	s.cloudName = "test-cloud"
-	fn := cloudbootstrap.InsertCloud(coreuser.AdminUserName, cloud.Cloud{
-		Name:      s.cloudName,
-		Type:      "ec2",
-		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType},
-	})
-	err = fn(c.Context(), s.ControllerTxnRunner(), s.NoopTxnRunner())
-	c.Assert(err, tc.ErrorIsNil)
-
+	// DomainServicesSuite seeds the controller row, admin user, and
+	// cloud+credential (as s.CloudName), and provisions the model databases.
+	s.DomainServicesSuite.SetUpTest(c)
 	modeltesting.CreateInternalSecretBackend(c, s.ControllerTxnRunner())
 }
 
@@ -81,7 +64,7 @@ func (s *modelImporterSuite) TestImportModel(c *tc.C) {
 	scope := func(coremodel.UUID) coremodelmigration.Scope {
 		return coremodelmigration.NewScope(controllerFactory, modelFactory, nil, nil, modelUUID)
 	}
-	importer := migration.NewModelImporter(scope, nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
+	importer := migration.NewModelImporter(scope, s.ModelDomainServicesGetter(c), nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
 
 	importArgs := migration.ImportModelArgs{
 		SourceMigrationUUID: uuid.MustNewUUID().String(),
@@ -91,7 +74,7 @@ func (s *modelImporterSuite) TestImportModel(c *tc.C) {
 				Name:      "imported-model",
 				Qualifier: "prod",
 				Type:      "iaas",
-				Cloud:     s.cloudName,
+				Cloud:     s.CloudName,
 				Life:      "alive",
 			},
 		},
@@ -101,7 +84,17 @@ func (s *modelImporterSuite) TestImportModel(c *tc.C) {
 	err := importer.ImportModel(c.Context(), importArgs, view)
 	c.Assert(err, tc.ErrorIsNil)
 
-	// The claim landed against the same controller DB the scope resolved to.
+	// The model is activated by the import so the migrating model's agents can
+	// connect to it during VALIDATION. CheckModelExists reads v_model, which
+	// only lists activated models, so a true result proves activation.
+	exists, err := s.ControllerDomainServices(c).Model().CheckModelExists(c.Context(), modelUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(exists, tc.IsTrue)
+
+	// The import claim is still present and importing: activation of the model
+	// row must not have deleted the claim (that happens only in the target
+	// Activate call). It landed against the same controller DB the scope
+	// resolved to.
 	claimSt := migrationclaimstate.New(controllerFactory, clock.WallClock)
 	claim, err := claimSt.GetImportClaim(c.Context(), modelUUID.String())
 	c.Assert(err, tc.ErrorIsNil)
@@ -133,7 +126,7 @@ func (s *modelImporterSuite) TestImportModelNoSecretBackendRewriteRows(c *tc.C) 
 	scope := func(coremodel.UUID) coremodelmigration.Scope {
 		return coremodelmigration.NewScope(controllerFactory, modelFactory, nil, nil, modelUUID)
 	}
-	importer := migration.NewModelImporter(scope, nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
+	importer := migration.NewModelImporter(scope, s.ModelDomainServicesGetter(c), nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
 
 	importArgs := migration.ImportModelArgs{
 		SourceMigrationUUID: uuid.MustNewUUID().String(),
@@ -143,7 +136,7 @@ func (s *modelImporterSuite) TestImportModelNoSecretBackendRewriteRows(c *tc.C) 
 				Name:      "imported-model",
 				Qualifier: "prod",
 				Type:      "iaas",
-				Cloud:     s.cloudName,
+				Cloud:     s.CloudName,
 				Life:      "alive",
 			},
 		},
@@ -230,7 +223,7 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewrite(c *tc.C) {
 	scope := func(coremodel.UUID) coremodelmigration.Scope {
 		return coremodelmigration.NewScope(controllerFactory, modelFactory, nil, nil, modelUUID)
 	}
-	importer := migration.NewModelImporter(scope, nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
+	importer := migration.NewModelImporter(scope, s.ModelDomainServicesGetter(c), nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
 
 	importArgs := migration.ImportModelArgs{
 		SourceMigrationUUID: uuid.MustNewUUID().String(),
@@ -240,7 +233,7 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewrite(c *tc.C) {
 				Name:      "imported-model",
 				Qualifier: "prod",
 				Type:      "iaas",
-				Cloud:     s.cloudName,
+				Cloud:     s.CloudName,
 				Life:      "alive",
 			},
 			SecretBackendRefs: []coremodelmigration.SecretBackendReference{
@@ -319,7 +312,7 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewriteMissingRef(c *tc
 	scope := func(coremodel.UUID) coremodelmigration.Scope {
 		return coremodelmigration.NewScope(controllerFactory, modelFactory, nil, nil, modelUUID)
 	}
-	importer := migration.NewModelImporter(scope, nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
+	importer := migration.NewModelImporter(scope, s.ModelDomainServicesGetter(c), nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
 
 	importArgs := migration.ImportModelArgs{
 		SourceMigrationUUID: uuid.MustNewUUID().String(),
@@ -329,7 +322,7 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewriteMissingRef(c *tc
 				Name:      "imported-model",
 				Qualifier: "prod",
 				Type:      "iaas",
-				Cloud:     s.cloudName,
+				Cloud:     s.CloudName,
 				Life:      "alive",
 			},
 			// Deliberately omit SecretBackendRefs — the revision has no mapping.
@@ -387,7 +380,7 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewriteMissingBackend(c
 	scope := func(coremodel.UUID) coremodelmigration.Scope {
 		return coremodelmigration.NewScope(controllerFactory, modelFactory, nil, nil, modelUUID)
 	}
-	importer := migration.NewModelImporter(scope, nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
+	importer := migration.NewModelImporter(scope, s.ModelDomainServicesGetter(c), nil, "controller-uuid", loggertesting.WrapCheckLog(c), clock.WallClock)
 
 	importArgs := migration.ImportModelArgs{
 		SourceMigrationUUID: uuid.MustNewUUID().String(),
@@ -397,7 +390,7 @@ func (s *modelImporterSuite) TestImportModelSecretBackendRewriteMissingBackend(c
 				Name:      "imported-model",
 				Qualifier: "prod",
 				Type:      "iaas",
-				Cloud:     s.cloudName,
+				Cloud:     s.CloudName,
 				Life:      "alive",
 			},
 			SecretBackendRefs: []coremodelmigration.SecretBackendReference{{

--- a/internal/migration/secretrewrite.go
+++ b/internal/migration/secretrewrite.go
@@ -26,7 +26,7 @@ import (
 // controller CMR references, whose target values are only known at activation.
 func reconcileSecretBackendUUIDs(
 	ctx context.Context,
-	deps Deps,
+	deps deps,
 	info coremodelmigration.ControllerModelInfo,
 	payload *latest.ModelExport,
 ) error {

--- a/internal/services/interface.go
+++ b/internal/services/interface.go
@@ -78,6 +78,10 @@ type ControllerDomainServices interface {
 	ControllerNode() *controllernodeservice.WatchableService
 	// Model returns the model service.
 	Model() *modelservice.WatchableService
+	// ModelMigrationImport returns the controller-scoped model migration import
+	// service, extended with the watchers the migration reconciler uses to drive
+	// interrupted import claims to completion.
+	ModelMigrationImport() *modelmigrationservice.WatchableService
 	//ModelDefaults returns the modeldefaults service.
 	ModelDefaults() *modeldefaultsservice.Service
 	// ExternalController returns the external controller service.

--- a/internal/worker/bootstrap/domainservices_mock_test.go
+++ b/internal/worker/bootstrap/domainservices_mock_test.go
@@ -111,6 +111,7 @@ type MockDomainServicesMockRecorder struct {
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
 	modelInfoExpects                  []*gomock.Call0_1[*service25.ProviderModelService]
 	modelMigrationExpects             []*gomock.Call0_1[*service29.WatchableService]
+	modelMigrationImportExpects       []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects              []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects         []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                    []*gomock.Call0_1[*service31.WatchableService]
@@ -794,6 +795,24 @@ func (mr *MockDomainServicesMockRecorder) ModelMigration() *MockDomainServicesMo
 
 // MockDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
 type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
+
+// ModelMigrationImport mocks base method.
+func (m *MockDomainServices) ModelMigrationImport() *service29.WatchableService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.modelMigrationImportExpects, m.ctrl, m, "ModelMigrationImport")
+}
+
+// ModelMigrationImport indicates an expected call of ModelMigrationImport.
+func (mr *MockDomainServicesMockRecorder) ModelMigrationImport() *MockDomainServicesModelMigrationImportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigrationImport")
+	mr.modelMigrationImportExpects = append(mr.modelMigrationImportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockDomainServicesModelMigrationImportCall is the typed call wrapper for ModelMigrationImport.
+type MockDomainServicesModelMigrationImportCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockDomainServices) ModelProvider() *service30.Service {

--- a/internal/worker/domainservices/domainservices_mock_test.go
+++ b/internal/worker/domainservices/domainservices_mock_test.go
@@ -94,6 +94,7 @@ type MockControllerDomainServicesMockRecorder struct {
 	macaroonExpects                   []*gomock.Call0_1[*service23.Service]
 	modelExpects                      []*gomock.Call0_1[*service25.WatchableService]
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
+	modelMigrationImportExpects       []*gomock.Call0_1[*service29.WatchableService]
 	sSHServerHostKeyExpects           []*gomock.Call0_1[*controller.Service]
 	secretBackendExpects              []*gomock.Call0_1[*service41.WatchableService]
 	tracingExpects                    []*gomock.Call0_1[*service45.WatchableService]
@@ -381,6 +382,24 @@ func (mr *MockControllerDomainServicesMockRecorder) ModelDefaults() *MockControl
 
 // MockControllerDomainServicesModelDefaultsCall is the typed call wrapper for ModelDefaults.
 type MockControllerDomainServicesModelDefaultsCall = gomock.Call0_1[*service28.Service]
+
+// ModelMigrationImport mocks base method.
+func (m *MockControllerDomainServices) ModelMigrationImport() *service29.WatchableService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.modelMigrationImportExpects, m.ctrl, m, "ModelMigrationImport")
+}
+
+// ModelMigrationImport indicates an expected call of ModelMigrationImport.
+func (mr *MockControllerDomainServicesMockRecorder) ModelMigrationImport() *MockControllerDomainServicesModelMigrationImportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigrationImport")
+	mr.modelMigrationImportExpects = append(mr.modelMigrationImportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerDomainServicesModelMigrationImportCall is the typed call wrapper for ModelMigrationImport.
+type MockControllerDomainServicesModelMigrationImportCall = gomock.Call0_1[*service29.WatchableService]
 
 // SSHServerHostKey mocks base method.
 func (m *MockControllerDomainServices) SSHServerHostKey() *controller.Service {
@@ -1265,6 +1284,7 @@ type MockDomainServicesMockRecorder struct {
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
 	modelInfoExpects                  []*gomock.Call0_1[*service25.ProviderModelService]
 	modelMigrationExpects             []*gomock.Call0_1[*service29.WatchableService]
+	modelMigrationImportExpects       []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects              []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects         []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                    []*gomock.Call0_1[*service31.WatchableService]
@@ -1948,6 +1968,24 @@ func (mr *MockDomainServicesMockRecorder) ModelMigration() *MockDomainServicesMo
 
 // MockDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
 type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
+
+// ModelMigrationImport mocks base method.
+func (m *MockDomainServices) ModelMigrationImport() *service29.WatchableService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.modelMigrationImportExpects, m.ctrl, m, "ModelMigrationImport")
+}
+
+// ModelMigrationImport indicates an expected call of ModelMigrationImport.
+func (mr *MockDomainServicesMockRecorder) ModelMigrationImport() *MockDomainServicesModelMigrationImportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigrationImport")
+	mr.modelMigrationImportExpects = append(mr.modelMigrationImportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockDomainServicesModelMigrationImportCall is the typed call wrapper for ModelMigrationImport.
+type MockDomainServicesModelMigrationImportCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockDomainServices) ModelProvider() *service30.Service {

--- a/internal/worker/modelworkermanager/domainservices_mock_test.go
+++ b/internal/worker/modelworkermanager/domainservices_mock_test.go
@@ -115,6 +115,7 @@ type MockDomainServicesMockRecorder struct {
 	modelDefaultsExpects              []*gomock.Call0_1[*service28.Service]
 	modelInfoExpects                  []*gomock.Call0_1[*service25.ProviderModelService]
 	modelMigrationExpects             []*gomock.Call0_1[*service29.WatchableService]
+	modelMigrationImportExpects       []*gomock.Call0_1[*service29.WatchableService]
 	modelProviderExpects              []*gomock.Call0_1[*service30.Service]
 	modelSecretBackendExpects         []*gomock.Call0_1[*service41.ModelSecretBackendService]
 	networkExpects                    []*gomock.Call0_1[*service31.WatchableService]
@@ -798,6 +799,24 @@ func (mr *MockDomainServicesMockRecorder) ModelMigration() *MockDomainServicesMo
 
 // MockDomainServicesModelMigrationCall is the typed call wrapper for ModelMigration.
 type MockDomainServicesModelMigrationCall = gomock.Call0_1[*service29.WatchableService]
+
+// ModelMigrationImport mocks base method.
+func (m *MockDomainServices) ModelMigrationImport() *service29.WatchableService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.modelMigrationImportExpects, m.ctrl, m, "ModelMigrationImport")
+}
+
+// ModelMigrationImport indicates an expected call of ModelMigrationImport.
+func (mr *MockDomainServicesMockRecorder) ModelMigrationImport() *MockDomainServicesModelMigrationImportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service29.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigrationImport")
+	mr.modelMigrationImportExpects = append(mr.modelMigrationImportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockDomainServicesModelMigrationImportCall is the typed call wrapper for ModelMigrationImport.
+type MockDomainServicesModelMigrationImportCall = gomock.Call0_1[*service29.WatchableService]
 
 // ModelProvider mocks base method.
 func (m *MockDomainServices) ModelProvider() *service30.Service {

--- a/rpc/params/migration.go
+++ b/rpc/params/migration.go
@@ -315,7 +315,7 @@ type SecretBackendReference struct {
 // Lease is a model-scoped application-leadership lease. Only the application
 // and its leader travel; the target claims a fresh lease on import, so Start
 // and Expiry are not honoured. Singular-controller leases and lease pins do
-// not travel (see spec §6.2 row 25).
+// not travel.
 type Lease struct {
 	// Type is "application-leadership".
 	Type string `json:"type"`


### PR DESCRIPTION
This adds synchronous target-side abort handling for v8 model migrations. The v8 `MigrationTarget.Abort`
path transitions the durable import claim from importing to aborting, reverses the controller-database
import writes, stages the model database for deletion by the undertaker, waits for the database to be
dropped, and finally releases the claim so the model UUID can be reused. The imported model is also
activated after loading its payload so agents can connect during validation while the migration claim
and migration flag continue to gate normal use.

The abort path uses controller-scoped services because the model namespace may already have been removed
when cleanup is retried. The claim remains in the aborting phase until the controller model, namespace,
and staged-deletion checks prove cleanup is complete; finalization is driven by a deletion watcher with
bounded fallback retries. Abort is idempotent, refuses claims that have crossed into activation, and
stands aside when the legacy removal path already owns a dying model.

This includes the facade wiring, domain service and state operations, deletion watcher triggers, legacy-
removal coordination, and end-to-end unit coverage. ~It depends on #23081, which fences in-flight import
transactions and records offer-cleanup intent before permission writes; #23081 must land before this
change~.

## QA steps
This is a somehow manual and complex QA because we need to ensure a failing (aborting) target, a new integration test is added in https://github.com/juju/juju/pull/23098 anyways.

```
juju bootstrap localhost abort-source --build-agent
juju bootstrap localhost abort-target --build-agent
juju add-model -c abort-source abort-qa
juju model-config -m abort-source:controller \
  'logging-config=#migration=DEBUG'
juju model-config -m abort-source:abort-qa \
  'logging-config=#migration=DEBUG'
juju model-config -m abort-target:controller \
  'logging-config=#migration=DEBUG'
juju deploy -m abort-source:abort-qa ubuntu
juju status -m abort-source:abort-qa
```
Wait until ubuntu/0 is active and idle. Then arm the source controller’s die-in-export wrench:
```
juju ssh -m abort-source:controller controller/0 \
  'sudo mkdir -p /var/lib/juju/wrench &&
   echo "die-in-export" |
   sudo tee /var/lib/juju/wrench/migrationmaster >/dev/null'
juju ssh -m abort-source:controller controller/0 \
  'sudo grep -x "die-in-export" /var/lib/juju/wrench/migrationmaster'
```
Start the migration and wait for abort completion:
```
juju switch abort-source:abort-qa
juju migrate abort-qa abort-target
until juju debug-log -m abort-source:controller --no-tail |
  grep -q 'setting migration phase to ABORTDONE'; do
    sleep 5
done
juju debug-log -m abort-source:controller --no-tail |
  grep -E 'model data transfer failed|aborted, removing model from target controller'
```
Verify the partially imported target model was removed and the source model remains usable:
```
juju models -c abort-target
# abort-qa must not be listed.
juju status -m abort-source:abort-qa
juju add-unit -m abort-source:abort-qa ubuntu
juju status -m abort-source:abort-qa
# Wait for both ubuntu units to become active and idle.
```
Finally, clear the wrench and retry the migration to prove the target claim and model UUID were
released:
```
juju ssh -m abort-source:controller controller/0 \
  'sudo truncate -s 0 /var/lib/juju/wrench/migrationmaster'
juju switch abort-source:abort-qa
juju migrate abort-qa abort-target
until juju models -c abort-target | grep -q abort-qa; do
  sleep 5
done
juju status -m abort-target:abort-qa
juju models -c abort-source
# abort-qa should now exist only on abort-target.
```


## Links


**Jira card:** [JUJU-9910](https://warthogs.atlassian.net/browse/JUJU-9910)


[JUJU-9910]: https://warthogs.atlassian.net/browse/JUJU-9910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ