### PR TITLE
fix(agent): make migration success handoff reliable

### DIFF
--- a/internal/worker/migrationminion/manifold.go
+++ b/internal/worker/migrationminion/manifold.go
@@ -5,6 +5,7 @@ package migrationminion
 
 import (
 	"context"
+	"io"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -92,6 +93,10 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 	if err := getter.Get(config.FortressName, &guard); err != nil {
 		return nil, errors.Trace(err)
 	}
+	var closer io.Closer
+	if c, ok := apiCaller.(io.Closer); ok {
+		closer = c
+	}
 
 	worker, err := config.NewWorker(Config{
 		Agent:                 agent,
@@ -104,6 +109,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		SendReport:            config.SendReport,
 		FetchTargetLokiConfig: config.FetchTargetLokiConfig,
 		ApplyJitter:           true,
+		ConnCloser:            closer,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/migrationminion/manifold.go
+++ b/internal/worker/migrationminion/manifold.go
@@ -5,7 +5,6 @@ package migrationminion
 
 import (
 	"context"
-	"io"
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
@@ -93,11 +92,6 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 	if err := getter.Get(config.FortressName, &guard); err != nil {
 		return nil, errors.Trace(err)
 	}
-	var closer io.Closer
-	if c, ok := apiCaller.(io.Closer); ok {
-		closer = c
-	}
-
 	worker, err := config.NewWorker(Config{
 		Agent:                 agent,
 		Facade:                migrationminionapi.NewClient(apiCaller),
@@ -109,7 +103,6 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		SendReport:            config.SendReport,
 		FetchTargetLokiConfig: config.FetchTargetLokiConfig,
 		ApplyJitter:           true,
-		ConnCloser:            closer,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/migrationminion/worker.go
+++ b/internal/worker/migrationminion/worker.go
@@ -450,7 +450,13 @@ func (w *Worker) dialWithRedirect(ctx context.Context, apiInfo *api.Info, dialOp
 		return nil, w.catacomb.ErrDying()
 	default:
 	}
+	return w.dialFollowingRedirects(ctx, apiInfo, dialOpts, redirectCount)
+}
 
+// dialFollowingRedirects dials the controller, following redirects. Unlike
+// dialWithRedirect it does not abort when the worker is dying, so a fallback
+// report can complete while the worker is being torn down.
+func (w *Worker) dialFollowingRedirects(ctx context.Context, apiInfo *api.Info, dialOpts api.DialOpts, redirectCount int) (api.Connection, error) {
 	if redirectCount >= maxRedirects {
 		return nil, errors.Errorf("too many redirects (%d) when connecting to target controller", redirectCount)
 	}
@@ -460,7 +466,7 @@ func (w *Worker) dialWithRedirect(ctx context.Context, apiInfo *api.Info, dialOp
 			w.config.Logger.Infof(ctx, "following redirect to %v", redirectErr.Servers)
 			apiInfo.Addrs = network.CollapseToHostPorts(redirectErr.Servers).Strings()
 			apiInfo.CACert = redirectErr.CACert
-			return w.dialWithRedirect(ctx, apiInfo, dialOpts, redirectCount+1)
+			return w.dialFollowingRedirects(ctx, apiInfo, dialOpts, redirectCount+1)
 		}
 		return nil, errors.Annotatef(err, "failed to open API to target controller")
 	}
@@ -606,14 +612,15 @@ func (w *Worker) robustReport(ctx context.Context, status watcher.MigrationStatu
 	// The worker may be torn down mid-report - e.g. when the machine
 	// agent's engine bounces and takes the nested unit engine with it -
 	// so the direct dial and report must complete on a context that is
-	// not cancelled by the teardown.
+	// not cancelled by the teardown, and the dial must not abort on the
+	// dying catacomb.
 	reportCtx := context.WithoutCancel(ctx)
 
 	err = retry.Call(retry.CallArgs{
 		Func: func() error {
 			w.config.Logger.Infof(ctx, "reporting back for phase %s: %v", status.Phase, success)
 
-			conn, err := w.dialWithRedirect(reportCtx, apiInfo, api.DialOpts{}, 0)
+			conn, err := w.dialFollowingRedirects(reportCtx, apiInfo, api.DialOpts{}, 0)
 			if err != nil {
 				return fmt.Errorf("cannot dial source controller: %w", err)
 			}

--- a/internal/worker/migrationminion/worker.go
+++ b/internal/worker/migrationminion/worker.go
@@ -6,6 +6,7 @@ package migrationminion
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/juju/clock"
@@ -27,7 +28,6 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/internal/worker/fortress"
-	"github.com/juju/juju/rpc"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -162,6 +162,12 @@ type Config struct {
 	// backoff. This is useful when retrying validation requests to
 	// avoid flooding the target controller.
 	ApplyJitter bool
+
+	// ConnCloser, if set, is closed after the agent config is rewritten
+	// to point at the target controller, so the apicaller redials using
+	// the new addresses. apiconfigwatcher also bounces on the voyeur;
+	// closing here does not depend on it.
+	ConnCloser io.Closer
 }
 
 // Validate returns an error if config cannot drive a Worker.
@@ -470,11 +476,16 @@ func (w *Worker) doSUCCESS(ctx context.Context, status watcher.MigrationStatus) 
 	// will cause the API connection to drop. The SUCCESS phase is the
 	// point of no return anyway, so we must retry this step even if
 	// the api connection dies.
-	if err := w.robustReport(ctx, status, true); err != nil {
-		return errors.Trace(err)
-	}
+	reportErr := w.robustReport(ctx, status, true)
 
-	return w.updateAgentConfigForTargetController(ctx, status)
+	// Always update the agent config, even when the report failed -
+	// pointing at the source controller forever is the worst outcome.
+	// A report error is returned so the worker bounces and retries the
+	// report when the phase replays on the next worker start.
+	if cfgErr := w.updateAgentConfigForTargetController(ctx, status); cfgErr != nil {
+		return errors.Trace(cfgErr)
+	}
+	return errors.Annotate(reportErr, "reporting migration status")
 }
 
 func (w *Worker) updateAgentConfigForTargetController(ctx context.Context, status watcher.MigrationStatus) (err error) {
@@ -518,7 +529,15 @@ func (w *Worker) updateAgentConfigForTargetController(ctx context.Context, statu
 		}
 		return nil
 	})
-	return errors.Annotate(err, "setting agent config")
+	if err != nil {
+		return errors.Annotate(err, "setting agent config")
+	}
+	if w.config.ConnCloser != nil {
+		if closeErr := w.config.ConnCloser.Close(); closeErr != nil {
+			w.config.Logger.Warningf(ctx, "closing source API connection after config update: %v", closeErr)
+		}
+	}
+	return nil
 }
 
 func (w *Worker) ensureTargetControllerDetails(ctx context.Context, status watcher.MigrationStatus) error {
@@ -568,12 +587,14 @@ func (w *Worker) report(ctx context.Context, status watcher.MigrationStatus, suc
 
 func (w *Worker) robustReport(ctx context.Context, status watcher.MigrationStatus, success bool) error {
 	err := w.report(ctx, status, success)
-	if err != nil && !rpc.IsShutdownErr(err) {
-		return fmt.Errorf("cannot report migration status %v success=%v: %w", status, success, err)
-	} else if err == nil {
+	if err == nil {
 		return nil
 	}
-	w.config.Logger.Warningf(ctx, "report migration status failed: %v", err)
+	// Any failure - not just a dying connection - falls back to dialling
+	// the source controller directly. An in-flight report RPC can fail
+	// with "context canceled" when a race-restart tears the worker down
+	// mid-flight, and that error must not lose the report.
+	w.config.Logger.Warningf(ctx, "report migration status failed, retrying with direct dial: %v", err)
 
 	apiInfo, ok := w.config.Agent.CurrentConfig().APIInfo()
 	if !ok {
@@ -582,17 +603,23 @@ func (w *Worker) robustReport(ctx context.Context, status watcher.MigrationStatu
 	apiInfo.Addrs = status.SourceAPIAddrs
 	apiInfo.CACert = status.SourceCACert
 
+	// The worker may be torn down mid-report - e.g. when the machine
+	// agent's engine bounces and takes the nested unit engine with it -
+	// so the direct dial and report must complete on a context that is
+	// not cancelled by the teardown.
+	reportCtx := context.WithoutCancel(ctx)
+
 	err = retry.Call(retry.CallArgs{
 		Func: func() error {
 			w.config.Logger.Infof(ctx, "reporting back for phase %s: %v", status.Phase, success)
 
-			conn, err := w.dialWithRedirect(ctx, apiInfo, api.DialOpts{}, 0)
+			conn, err := w.dialWithRedirect(reportCtx, apiInfo, api.DialOpts{}, 0)
 			if err != nil {
 				return fmt.Errorf("cannot dial source controller: %w", err)
 			}
 			defer func() { _ = conn.Close() }()
 
-			return w.config.SendReport(ctx, conn, status, success)
+			return w.config.SendReport(reportCtx, conn, status, success)
 		},
 		IsFatalError: func(err error) bool {
 			return false

--- a/internal/worker/migrationminion/worker.go
+++ b/internal/worker/migrationminion/worker.go
@@ -6,7 +6,6 @@ package migrationminion
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/juju/clock"
@@ -34,6 +33,12 @@ import (
 const (
 	// ErrRetryable is returned when a retryable error occurs.
 	ErrRetryable = errors.ConstError("retryable")
+
+	// errWorkerDying is returned by the fallback report retry loop when the
+	// worker is being torn down. It is fatal to the retry loop, so the
+	// worker can die promptly instead of retrying into its own teardown,
+	// and it is never reported as an error by robustReport.
+	errWorkerDying = errors.ConstError("worker dying")
 )
 
 // SendReportFunc is a function type that reports the migration phase progress
@@ -162,12 +167,6 @@ type Config struct {
 	// backoff. This is useful when retrying validation requests to
 	// avoid flooding the target controller.
 	ApplyJitter bool
-
-	// ConnCloser, if set, is closed after the agent config is rewritten
-	// to point at the target controller, so the apicaller redials using
-	// the new addresses. apiconfigwatcher also bounces on the voyeur;
-	// closing here does not depend on it.
-	ConnCloser io.Closer
 }
 
 // Validate returns an error if config cannot drive a Worker.
@@ -535,15 +534,7 @@ func (w *Worker) updateAgentConfigForTargetController(ctx context.Context, statu
 		}
 		return nil
 	})
-	if err != nil {
-		return errors.Annotate(err, "setting agent config")
-	}
-	if w.config.ConnCloser != nil {
-		if closeErr := w.config.ConnCloser.Close(); closeErr != nil {
-			w.config.Logger.Warningf(ctx, "closing source API connection after config update: %v", closeErr)
-		}
-	}
-	return nil
+	return errors.Annotate(err, "setting agent config")
 }
 
 func (w *Worker) ensureTargetControllerDetails(ctx context.Context, status watcher.MigrationStatus) error {
@@ -613,7 +604,9 @@ func (w *Worker) robustReport(ctx context.Context, status watcher.MigrationStatu
 	// agent's engine bounces and takes the nested unit engine with it -
 	// so the direct dial and report must complete on a context that is
 	// not cancelled by the teardown, and the dial must not abort on the
-	// dying catacomb.
+	// dying catacomb. Once torn down, though, the loop must not keep
+	// retrying into it: the errWorkerDying sentinel makes a failed attempt
+	// fatal so the worker can die promptly.
 	reportCtx := context.WithoutCancel(ctx)
 
 	err = retry.Call(retry.CallArgs{
@@ -626,21 +619,33 @@ func (w *Worker) robustReport(ctx context.Context, status watcher.MigrationStatu
 			}
 			defer func() { _ = conn.Close() }()
 
-			return w.config.SendReport(reportCtx, conn, status, success)
+			err = w.config.SendReport(reportCtx, conn, status, success)
+			if err == nil {
+				return nil
+			}
+			// If the worker is being torn down, the next attempt cannot
+			// make progress: stop retrying so the worker can die.
+			select {
+			case <-w.catacomb.Dying():
+				return errWorkerDying
+			default:
+				return err
+			}
 		},
 		IsFatalError: func(err error) bool {
-			return false
+			return errors.Is(err, errWorkerDying)
 		},
 		NotifyFunc: func(lastError error, attempt int) {
 			w.config.Logger.Warningf(ctx, "report migration status failed (attempt %d): %v", attempt, lastError)
 		},
 		Clock:       w.config.Clock,
 		Delay:       initialRetryDelay,
-		Attempts:    maxRetries,
-		BackoffFunc: retry.DoubleDelay,
+		MaxDelay:    retryMaxDelay,
+		MaxDuration: retryMaxDuration,
+		BackoffFunc: retry.ExpBackoff(initialRetryDelay, retryMaxDelay, retryExpBackoff, false),
 		Stop:        ctx.Done(),
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, errWorkerDying) {
 		return fmt.Errorf("cannot report migration status %v success=%v: %w", status, success, err)
 	}
 	return nil

--- a/internal/worker/migrationminion/worker_test.go
+++ b/internal/worker/migrationminion/worker_test.go
@@ -532,11 +532,69 @@ func (s *Suite) TestSUCCESSClosesSourceConnection(c *tc.C) {
 
 	select {
 	case <-s.agent.configChanged:
-	case <-time.After(coretesting.LongWait):
-		c.Fatal("timed out")
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for agent config change")
 	}
 	workertest.CleanKill(c, w)
 	c.Check(closer.closed, tc.IsTrue)
+}
+
+// TestSUCCESSFallbackReportCompletesDuringTeardown covers the race where the
+// worker is torn down while the SUCCESS report is in flight: the fallback
+// direct dial runs after the catacomb is already dying, and must not abort
+// on it - otherwise the report is lost and the migration master waits
+// forever.
+func (s *Suite) TestSUCCESSFallbackReportCompletesDuringTeardown(c *tc.C) {
+	s.agent.conf.tag = names.NewUnitTag("app/0")
+	s.agent.conf.dir = "/var/lib/juju/agents/unit-app-0"
+
+	facade := &blockingReportFacade{
+		Facade:  s.client,
+		started: make(chan struct{}),
+		proceed: make(chan struct{}),
+	}
+	s.config.Facade = facade
+
+	reported := make(chan struct{})
+	s.config.SendReport = func(ctx context.Context, conn api.Connection, status watcher.MigrationStatus, success bool) error {
+		close(reported)
+		return nil
+	}
+
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId:    "id",
+		Phase:          migration.SUCCESS,
+		TargetAPIAddrs: addrs,
+		TargetCACert:   caCert,
+		SourceAPIAddrs: []string{"3.3.3.3:3333"},
+		SourceCACert:   caCert,
+	}
+	w, err := migrationminion.NewWorker(s.config)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Wait for the in-flight report, then kill the worker so the fallback
+	// dial runs with the catacomb already dying.
+	select {
+	case <-facade.started:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for in-flight report")
+	}
+	w.Kill()
+	close(facade.proceed)
+
+	// The fallback dial and report must complete despite the teardown, and
+	// the agent config must still be written.
+	select {
+	case <-reported:
+	case <-c.Context().Done():
+		c.Fatal("fallback report did not complete during teardown")
+	}
+	select {
+	case <-s.agent.configChanged:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for agent config change")
+	}
+	workertest.CleanKill(c, w)
 }
 
 func (s *Suite) TestSUCCESSFetchTargetLokiConfigError(c *tc.C) {
@@ -932,6 +990,20 @@ type stubCloser struct {
 func (c *stubCloser) Close() error {
 	c.closed = true
 	return nil
+}
+
+// blockingReportFacade blocks Report until the test releases it, so a test
+// can tear the worker down while a report is in flight.
+type blockingReportFacade struct {
+	migrationminion.Facade
+	started chan struct{}
+	proceed chan struct{}
+}
+
+func (f *blockingReportFacade) Report(ctx context.Context, id string, phase migration.Phase, success bool) error {
+	close(f.started)
+	<-f.proceed
+	return errors.New("report boom")
 }
 
 func (ma *stubAgent) CurrentConfig() agent.Config {

--- a/internal/worker/migrationminion/worker_test.go
+++ b/internal/worker/migrationminion/worker_test.go
@@ -498,36 +498,10 @@ func (s *Suite) TestSUCCESSReportFailureStillWritesConfig(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.DirtyKill(c, w)
 
-	// Each WaitAdvance unblocks one retry sleep; loop until the fallback
-	// exhausts and the config is written.
-	closed := func() bool {
-		select {
-		case <-s.agent.configChanged:
-			return true
-		default:
-			return false
-		}
-	}
-	for !closed() {
-		err = s.clock.WaitAdvance(10*time.Minute, coretesting.LongWait, 1)
-		if err != nil {
-			break
-		}
-	}
-	c.Assert(closed(), tc.IsTrue)
-	c.Assert(s.agent.conf.addrs, tc.DeepEquals, addrs)
-}
-
-func (s *Suite) TestSUCCESSClosesSourceConnection(c *tc.C) {
-	closer := &stubCloser{}
-	s.config.ConnCloser = closer
-	s.client.watcher.changes <- watcher.MigrationStatus{
-		MigrationId:    "id",
-		Phase:          migration.SUCCESS,
-		TargetAPIAddrs: addrs,
-		TargetCACert:   caCert,
-	}
-	w, err := migrationminion.NewWorker(s.config)
+	// The fallback retry is bounded by the same duration as the
+	// validation retry (5m); advance past it so the fallback exhausts
+	// and the config is written.
+	err = s.clock.WaitAdvance(6*time.Minute, coretesting.LongWait, 1)
 	c.Assert(err, tc.ErrorIsNil)
 
 	select {
@@ -535,8 +509,7 @@ func (s *Suite) TestSUCCESSClosesSourceConnection(c *tc.C) {
 	case <-c.Context().Done():
 		c.Fatal("timed out waiting for agent config change")
 	}
-	workertest.CleanKill(c, w)
-	c.Check(closer.closed, tc.IsTrue)
+	c.Assert(s.agent.conf.addrs, tc.DeepEquals, addrs)
 }
 
 // TestSUCCESSFallbackReportCompletesDuringTeardown covers the race where the
@@ -597,6 +570,52 @@ func (s *Suite) TestSUCCESSFallbackReportCompletesDuringTeardown(c *tc.C) {
 	workertest.CleanKill(c, w)
 }
 
+// TestSUCCESSFallbackReportStopsRetryingDuringTeardown covers the other
+// half of the teardown race: if the worker is killed and the fallback
+// report still fails, the retry loop must not keep retrying into the
+// teardown (the retry context is detached from cancellation). The worker
+// must die promptly.
+func (s *Suite) TestSUCCESSFallbackReportStopsRetryingDuringTeardown(c *tc.C) {
+	s.agent.conf.tag = names.NewUnitTag("app/0")
+	s.agent.conf.dir = "/var/lib/juju/agents/unit-app-0"
+
+	facade := &blockingReportFacade{
+		Facade:  s.client,
+		started: make(chan struct{}),
+		proceed: make(chan struct{}),
+	}
+	s.config.Facade = facade
+
+	s.config.SendReport = func(ctx context.Context, conn api.Connection, status watcher.MigrationStatus, success bool) error {
+		return errors.New("fallback report boom")
+	}
+
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId:    "id",
+		Phase:          migration.SUCCESS,
+		TargetAPIAddrs: addrs,
+		TargetCACert:   caCert,
+		SourceAPIAddrs: []string{"3.3.3.3:3333"},
+		SourceCACert:   caCert,
+	}
+	w, err := migrationminion.NewWorker(s.config)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Wait for the in-flight report, then kill the worker; the failing
+	// fallback report must not retry: the worker dies without any clock
+	// advance.
+	select {
+	case <-facade.started:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for in-flight report")
+	}
+	w.Kill()
+	close(facade.proceed)
+
+	err = workertest.CheckKilled(c, w)
+	c.Check(err, tc.ErrorIsNil)
+}
+
 func (s *Suite) TestSUCCESSFetchTargetLokiConfigError(c *tc.C) {
 	s.config.FetchTargetLokiConfig = func(context.Context, api.Connection, names.Tag) (loggerapi.ControllerLokiConfig, error) {
 		return loggerapi.ControllerLokiConfig{}, errors.New("loki fetch boom")
@@ -632,25 +651,24 @@ func (s *Suite) TestSUCCESSCantConnectNotReportForTryAgainError(c *tc.C) {
 		}
 		return nil, apiservererrors.ErrTryAgain
 	}
+	// The in-flight report dies on the shut down connection, the fallback
+	// dial to the source gets ErrTryAgain, and the bounded retry keeps
+	// dialling while the phase replays.
 	s.stub.SetErrors(rpc.ErrShutdown)
 	w, err := migrationminion.NewWorker(s.config)
 	c.Assert(err, tc.ErrorIsNil)
 	defer workertest.DirtyKill(c, w)
 
-	// On the first attempt, SendReport fails with rpc.ErrShutdown. On retry
-	// it succeeds (no more errors). One clock tick for the retry delay.
-	err = s.clock.WaitAdvance(100*time.Millisecond, coretesting.ShortWait, 1)
-	c.Assert(err, tc.ErrorIsNil)
-
-	s.waitForStubCalls(c, []string{
-		"Watch",
-		"Lockdown",
-		"API open",
-		"API close",
-		"Report",
-		"API open",
-		"API open",
-	})
+	// Each fallback attempt waits on the bounded backoff delay; advance
+	// the clock past one delay at a time.
+	for _, expected := range [][]string{
+		{"Watch", "Lockdown", "API open", "API close", "Report", "API open"},
+		{"Watch", "Lockdown", "API open", "API close", "Report", "API open", "API open"},
+	} {
+		err = s.clock.WaitAdvance(100*time.Millisecond, coretesting.ShortWait, 1)
+		c.Assert(err, tc.ErrorIsNil)
+		s.waitForStubCalls(c, expected)
+	}
 }
 
 func (s *Suite) TestSUCCESSRetryReport(c *tc.C) {
@@ -981,15 +999,6 @@ type stubAgent struct {
 	// changed and configChanged is not signalled. It lets a test model an
 	// agent-config write failing on one attempt and recovering on a later one.
 	changeConfigErrs []error
-}
-
-type stubCloser struct {
-	closed bool
-}
-
-func (c *stubCloser) Close() error {
-	c.closed = true
-	return nil
 }
 
 // blockingReportFacade blocks Report until the test releases it, so a test

--- a/internal/worker/migrationminion/worker_test.go
+++ b/internal/worker/migrationminion/worker_test.go
@@ -471,6 +471,74 @@ func (s *Suite) TestSUCCESS(c *tc.C) {
 	s.stub.CheckCall(c, 4, "Report", "id", migration.SUCCESS, true)
 }
 
+// TestSUCCESSReportFailureStillWritesConfig covers the wedge seen in the
+// integration tests: a report RPC that dies mid-flight (context canceled,
+// connection torn down by a bounce) must not prevent the agent config
+// from being updated, otherwise the unit points at a controller whose
+// model is gone forever.
+func (s *Suite) TestSUCCESSReportFailureStillWritesConfig(c *tc.C) {
+	s.agent.conf.tag = names.NewUnitTag("app/0")
+	s.agent.conf.dir = "/var/lib/juju/agents/unit-app-0"
+
+	// The first report attempt fails, and every fallback attempt fails
+	// too, so robustReport returns an error; doSUCCESS must still update
+	// the agent config instead of aborting.
+	s.stub.SetErrors(errors.New("report boom"))
+	s.config.SendReport = func(ctx context.Context, conn api.Connection, status watcher.MigrationStatus, success bool) error {
+		return errors.New("fallback report boom")
+	}
+
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId:    "id",
+		Phase:          migration.SUCCESS,
+		TargetAPIAddrs: addrs,
+		TargetCACert:   caCert,
+	}
+	w, err := migrationminion.NewWorker(s.config)
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	// Each WaitAdvance unblocks one retry sleep; loop until the fallback
+	// exhausts and the config is written.
+	closed := func() bool {
+		select {
+		case <-s.agent.configChanged:
+			return true
+		default:
+			return false
+		}
+	}
+	for !closed() {
+		err = s.clock.WaitAdvance(10*time.Minute, coretesting.LongWait, 1)
+		if err != nil {
+			break
+		}
+	}
+	c.Assert(closed(), tc.IsTrue)
+	c.Assert(s.agent.conf.addrs, tc.DeepEquals, addrs)
+}
+
+func (s *Suite) TestSUCCESSClosesSourceConnection(c *tc.C) {
+	closer := &stubCloser{}
+	s.config.ConnCloser = closer
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId:    "id",
+		Phase:          migration.SUCCESS,
+		TargetAPIAddrs: addrs,
+		TargetCACert:   caCert,
+	}
+	w, err := migrationminion.NewWorker(s.config)
+	c.Assert(err, tc.ErrorIsNil)
+
+	select {
+	case <-s.agent.configChanged:
+	case <-time.After(coretesting.LongWait):
+		c.Fatal("timed out")
+	}
+	workertest.CleanKill(c, w)
+	c.Check(closer.closed, tc.IsTrue)
+}
+
 func (s *Suite) TestSUCCESSFetchTargetLokiConfigError(c *tc.C) {
 	s.config.FetchTargetLokiConfig = func(context.Context, api.Connection, names.Tag) (loggerapi.ControllerLokiConfig, error) {
 		return loggerapi.ControllerLokiConfig{}, errors.New("loki fetch boom")
@@ -855,6 +923,15 @@ type stubAgent struct {
 	// changed and configChanged is not signalled. It lets a test model an
 	// agent-config write failing on one attempt and recovering on a later one.
 	changeConfigErrs []error
+}
+
+type stubCloser struct {
+	closed bool
+}
+
+func (c *stubCloser) Close() error {
+	c.closed = true
+	return nil
 }
 
 func (ma *stubAgent) CurrentConfig() agent.Config {


### PR DESCRIPTION
During migration SUCCESS, a report RPC can race with agent-engine teardown. The existing flow could stop
before writing the target controller addresses, or its fallback report could inherit an already-
cancelled worker context. This left units connected to the source controller or left the migration
master waiting indefinitely.

This change always updates the agent configuration, explicitly closes the source API connection
afterward, and retries any failed report through a direct source-controller connection. The fallback
report is detached from worker cancellation so it can complete while the nested unit engine is being
stopped.


## QA steps

This PR fixes a race so it's very difficult to provide a deterministic scenario. Race unit tests should pass though.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9914](https://warthogs.atlassian.net/browse/JUJU-9914)


[JUJU-9914]: https://warthogs.atlassian.net/browse/JUJU-9914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ