### PR TITLE
fix(tools): make agent binary tarball hash deterministic

### DIFF
--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 
@@ -103,15 +104,23 @@ func copyFile(w io.Writer, file string) error {
 
 // tarHeader returns a tar file header given the file's stat
 // information.
+//
+// Timestamps are pinned to the epoch so that bundling the same content
+// always produces the same archive: bootstrapping two controllers from
+// one tree must yield identical agent binary hashes, or a model migrated
+// between them ends up with two entries for the same version and the
+// provisioner refuses to start new machines ("agent binary info
+// mismatch").
 func tarHeader(i os.FileInfo) *tar.Header {
+	epoch := time.Unix(0, 0).UTC()
 	return &tar.Header{
 		Typeflag:   tar.TypeReg,
 		Name:       i.Name(),
 		Size:       i.Size(),
 		Mode:       int64(i.Mode() & 0777),
-		ModTime:    i.ModTime(),
-		AccessTime: i.ModTime(),
-		ChangeTime: i.ModTime(),
+		ModTime:    epoch,
+		AccessTime: epoch,
+		ChangeTime: epoch,
 		Uname:      "ubuntu",
 		Gname:      "ubuntu",
 	}

--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -139,6 +139,37 @@ func (b *buildSuite) TestArchiveAndSHA256(c *tc.C) {
 	c.Assert(err, tc.Equals, io.EOF)
 }
 
+func (b *buildSuite) TestArchiveDeterministic(c *tc.C) {
+	// The same content bundled at different times (different file mtimes)
+	// must produce byte-identical archives, so two controllers bootstrapped
+	// from the same tree agree on the agent binary hash.
+	write := func() string {
+		dir := c.MkDir()
+		err := os.WriteFile(filepath.Join(dir, "jujuagentd"), []byte("binary"), 0755)
+		c.Assert(err, tc.ErrorIsNil)
+		return dir
+	}
+
+	now := time.Now()
+	old := now.Add(-time.Hour)
+
+	dir1 := write()
+	err := os.Chtimes(dir1+"/jujuagentd", old, old)
+	c.Assert(err, tc.ErrorIsNil)
+	var buf1 bytes.Buffer
+	err = tools.Archive(&buf1, dir1)
+	c.Assert(err, tc.ErrorIsNil)
+
+	dir2 := write()
+	err = os.Chtimes(dir2+"/jujuagentd", now, now)
+	c.Assert(err, tc.ErrorIsNil)
+	var buf2 bytes.Buffer
+	err = tools.Archive(&buf2, dir2)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(buf1.Bytes(), tc.DeepEquals, buf2.Bytes())
+}
+
 func (b *buildSuite) TestGetVersionFromJujud(c *tc.C) {
 	ver := semversion.Binary{
 		Number: semversion.Number{


### PR DESCRIPTION
_Note: This is part of a series of fixes for the model-migration CI tests._

Agent archives included filesystem timestamps in their tar headers. Building the same agent content at
different times could therefore produce different hashes. After migration, the target could contain two
agent binary records for the same version and architecture, causing new machines to fail with an agent
binary info mismatch.

This change uses a fixed epoch timestamp for tar entries, making the resulting archive and SHA256
deterministic when the file contents are unchanged.

__This only affects local built agents (`--build-agent` or falling back to local builds for bootstrap). This could never happen on production controllers.__

## QA steps

```
juju bootstrap lxd task15-tools-src --build-agent
juju bootstrap lxd task15-tools-dst --build-agent
juju add-model -c task15-tools-src moved
juju deploy -m task15-tools-src:moved ubuntu-lite ubuntu
juju status -m task15-tools-src:moved --watch 2s

juju migrate task15-tools-src:moved task15-tools-dst
juju add-unit -m task15-tools-dst:moved ubuntu
juju status -m task15-tools-dst:moved --watch 2s
```
  The added unit should provision without an agent binary mismatch.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
