### PR TITLE
fix(schema): emit changestream events for model_migration_import

### DIFF
--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -14,7 +14,7 @@ import (
 
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/cloud-triggers.gen.go -package=triggers -tables=cloud,cloud_ca_cert,cloud_credential,cloud_credential_attribute
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/controller-triggers.gen.go -package=triggers -tables=controller_config,controller_node,external_controller,controller_api_address
-//go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/migration-triggers.gen.go -package=triggers -tables=model_migration_export,model_migration_export_phase,model_migration_export_minion_sync
+//go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/migration-triggers.gen.go -package=triggers -tables=model_migration_export,model_migration_export_phase,model_migration_export_minion_sync,model_migration_import
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/upgrade-triggers.gen.go -package=triggers -tables=upgrade_info,upgrade_info_controller_node
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/objectstore-triggers.gen.go -package=triggers -tables=object_store_metadata_path,object_store_drain_info,object_store_backend
 //go:generate go run ./../../generate/triggergen -db=controller -destination=./controller/triggers/secret-triggers.gen.go -package=triggers -tables=secret_backend_rotation,model_secret_backend
@@ -53,6 +53,7 @@ const (
 	tableModelMigrationExportMinionSync
 	tableWorkloadTracingConfig
 	tableModelDatabaseDeletion
+	tableModelMigrationImport
 )
 
 // controllerPostPatchFilesByVersion is used to categorise the post patch files
@@ -98,6 +99,7 @@ func ControllerDDLForVersion(version semversion.Number) *schema.Schema {
 		triggers.ChangeLogTriggersForModelMigrationExport("model_uuid", tableModelMigrationExport),
 		triggers.ChangeLogTriggersForModelMigrationExportPhase("model_uuid", tableModelMigrationExportPhase),
 		triggers.ChangeLogTriggersForModelMigrationExportMinionSync("migration_uuid", tableModelMigrationExportMinionSync),
+		triggers.ChangeLogTriggersForModelMigrationImport("model_uuid", tableModelMigrationImport),
 		triggers.ChangeLogTriggersForUpgradeInfo("uuid", tableUpgradeInfo),
 		triggers.ChangeLogTriggersForUpgradeInfoControllerNode("upgrade_info_uuid", tableUpgradeInfoControllerNode),
 		triggers.ChangeLogTriggersForObjectStoreMetadataPath("path", tableObjectStoreMetadata),

--- a/domain/schema/controller/triggers/migration-triggers.gen.go
+++ b/domain/schema/controller/triggers/migration-triggers.gen.go
@@ -132,3 +132,42 @@ END;`, columnName, namespaceID))
 	}
 }
 
+// ChangeLogTriggersForModelMigrationImport generates the triggers for the
+// model_migration_import table.
+func ChangeLogTriggersForModelMigrationImport(columnName string, namespaceID int) func() schema.Patch {
+	return func() schema.Patch {
+		return schema.MakePatch(fmt.Sprintf(`
+-- insert namespace for ModelMigrationImport
+INSERT INTO change_log_namespace VALUES (%[2]d, 'model_migration_import', 'ModelMigrationImport changes based on %[1]s');
+
+-- insert trigger for ModelMigrationImport
+CREATE TRIGGER trg_log_model_migration_import_insert
+AFTER INSERT ON model_migration_import FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (1, %[2]d, NEW.%[1]s, DATETIME('now', 'utc'));
+END;
+
+-- update trigger for ModelMigrationImport
+CREATE TRIGGER trg_log_model_migration_import_update
+AFTER UPDATE ON model_migration_import FOR EACH ROW
+WHEN 
+	NEW.uuid != OLD.uuid OR
+	NEW.model_uuid != OLD.model_uuid OR
+	NEW.source_migration_uuid != OLD.source_migration_uuid OR
+	NEW.phase_type_id != OLD.phase_type_id OR
+	NEW.updated_at != OLD.updated_at
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
+END;
+-- delete trigger for ModelMigrationImport
+CREATE TRIGGER trg_log_model_migration_import_delete
+AFTER DELETE ON model_migration_import FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (4, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
+END;`, columnName, namespaceID))
+	}
+}
+

--- a/domain/schema/controller_schema_test.go
+++ b/domain/schema/controller_schema_test.go
@@ -330,6 +330,10 @@ func (s *controllerSchemaSuite) TestControllerTriggers(c *tc.C) {
 		"trg_log_model_migration_export_minion_sync_update",
 		"trg_log_model_migration_export_minion_sync_delete",
 
+		"trg_log_model_migration_import_insert",
+		"trg_log_model_migration_import_update",
+		"trg_log_model_migration_import_delete",
+
 		"trg_log_model_database_deletion_insert",
 		"trg_log_model_database_deletion_update",
 		"trg_log_model_database_deletion_delete",


### PR DESCRIPTION
_Note: This is part of a series of fixes for the model-migration CI tests._

Target agents use `WatchMigrationActivity` to learn when the `model_migration_import` claim is removed and
the migrated model becomes usable. The watcher subscribed to that table’s changestream namespace, but
4.0 did not create the corresponding database triggers, so deleting the claim emitted no event.

This change adds insert, update, and delete changestream triggers for model_migration_import. Workers
gated by the migration-inactive flag are then released when import finishes instead of remaining frozen
on the target controller.

## QA steps
```
juju bootstrap lxd task15-events-src --build-agent
juju bootstrap lxd task15-events-dst --build-agent
juju add-model -c task15-events-src moved
juju deploy -m task15-events-src:moved ubuntu-lite ubuntu
juju status -m task15-events-src:moved --watch 2s

juju migrate task15-events-src:moved task15-events-dst
juju status -m task15-events-dst:moved --watch 2s
juju exec -m task15-events-dst:moved --unit ubuntu/0 -- hostname
```

The migrated unit should resume operation and accept juju exec after import completes.


## Links


**Jira card:** [JUJU-9914](https://warthogs.atlassian.net/browse/JUJU-9914)


[JUJU-9914]: https://warthogs.atlassian.net/browse/JUJU-9914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ