### PR TITLE
fix(apiremoterelationcaller): follow redirect when external controller not found

### DIFF
--- a/internal/worker/apiremoterelationcaller/manifold.go
+++ b/internal/worker/apiremoterelationcaller/manifold.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	externalcontrollererrors "github.com/juju/juju/domain/externalcontroller/errors"
 	domainmodel "github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/internal/services"
@@ -378,7 +379,7 @@ func (a *apiInfoGetter) getAPIInfoForExternalController(ctx context.Context, mod
 	externalControllerService := services.ExternalController()
 
 	controllerInfo, err := externalControllerService.ControllerForModel(ctx, modelUUID.String())
-	if err != nil && !errors.Is(err, modelerrors.NotFound) {
+	if err != nil && !errors.Is(err, externalcontrollererrors.NotFound) {
 		return api.Info{}, errors.Trace(err)
 	} else if err == nil {
 		return api.Info{

--- a/internal/worker/apiremoterelationcaller/manifold_test.go
+++ b/internal/worker/apiremoterelationcaller/manifold_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	externalcontrollererrors "github.com/juju/juju/domain/externalcontroller/errors"
 	domainmodel "github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/internal/testhelpers"
@@ -346,7 +347,7 @@ func (s *apiInfoSuite) TestGetAPIInfoForModelNonLocalModelRedirected(c *tc.C) {
 	s.modelService.EXPECT().CheckModelExists(gomock.Any(), modelUUID).Return(false, nil)
 
 	s.domainServices.EXPECT().ExternalController().Return(s.externalController)
-	s.externalController.EXPECT().ControllerForModel(gomock.Any(), modelUUID.String()).Return(nil, modelerrors.NotFound)
+	s.externalController.EXPECT().ControllerForModel(gomock.Any(), modelUUID.String()).Return(nil, externalcontrollererrors.NotFound)
 
 	s.modelService.EXPECT().ModelRedirection(gomock.Any(), modelUUID).Return(domainmodel.ModelRedirection{
 		ControllerUUID:  "f47ac10b-58cc-4372-a567-0e02b2c3d479",
@@ -385,7 +386,7 @@ func (s *apiInfoSuite) TestGetAPIInfoForModelNonLocalModelRedirectedNotFound(c *
 	s.modelService.EXPECT().CheckModelExists(gomock.Any(), modelUUID).Return(false, nil)
 
 	s.domainServices.EXPECT().ExternalController().Return(s.externalController)
-	s.externalController.EXPECT().ControllerForModel(gomock.Any(), modelUUID.String()).Return(nil, modelerrors.NotFound)
+	s.externalController.EXPECT().ControllerForModel(gomock.Any(), modelUUID.String()).Return(nil, externalcontrollererrors.NotFound)
 
 	s.modelService.EXPECT().ModelRedirection(gomock.Any(), modelUUID).Return(domainmodel.ModelRedirection{
 		ControllerUUID:  "f47ac10b-58cc-4372-a567-0e02b2c3d479",


### PR DESCRIPTION
_Note: This is part of a series of fixes for the model-migration CI tests._

When a CMR worker cannot find an external controller record, it falls back to the migrated model’s
redirect information. The fallback checked for modelerrors.NotFound, but ControllerForModel actually
returns externalcontrollererrors.NotFound, so the fallback was never reached.

This change checks the error returned by the external-controller domain and allows the worker to read
the migration redirect, register the target controller, and reconnect the CMR consumer after the offerer
model moves.


## QA steps

```
juju bootstrap lxd task15-cmr-src --build-agent
juju bootstrap lxd task15-cmr-consumer --build-agent
juju bootstrap lxd task15-cmr-dst --build-agent

juju add-model -c task15-cmr-src offerer
juju deploy -m task15-cmr-src:offerer juju-qa-dummy-source \
  --base ubuntu@22.04 --config token=before
juju offer -m task15-cmr-src:offerer dummy-source:sink

juju add-model -c task15-cmr-consumer consumer
juju deploy -m task15-cmr-consumer:consumer juju-qa-dummy-sink \
  --base ubuntu@22.04
juju consume -m task15-cmr-consumer:consumer \
  task15-cmr-src:admin/offerer.dummy-source
juju integrate -m task15-cmr-consumer:consumer dummy-sink dummy-source

juju migrate task15-cmr-src:offerer task15-cmr-dst

juju switch task15-cmr-consumer:controller
juju ssh 0 sudo systemctl restart jujud-machine-0.service

juju config -m task15-cmr-dst:offerer dummy-source token=after
juju status -m task15-cmr-consumer:consumer --watch 2s
```
  The consumer’s dummy-sink message should eventually reflect the new after token.

  All targeted package tests passed. The apiserver changes passed -race and 224 stress runs; migration-
  minion passed -race and 48 stress runs. Schema triggers were regenerated successfully with no resulting
  changes.

## Links


**Jira card:** [JUJU-9914](https://warthogs.atlassian.net/browse/JUJU-9914)


[JUJU-9914]: https://warthogs.atlassian.net/browse/JUJU-9914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ