### PR TITLE
feat: k8s reconcile from lowest ordinal

### DIFF
--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -72,6 +72,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"StorageProvisioner",
 	"StringsWatcher",
 	"Subnets",
+	"Tracer",
 	"Undertaker",
 	"Uniter",
 	"Upgrader",

--- a/apiserver/restrict_caasmodel_test.go
+++ b/apiserver/restrict_caasmodel_test.go
@@ -30,6 +30,7 @@ func (s *RestrictCAASModelSuite) SetUpSuite(c *tc.C) {
 
 func (s *RestrictCAASModelSuite) TestAllowed(c *tc.C) {
 	s.assertMethod(c, "CAASApplication", 1, "UnitIntroduction")
+	s.assertMethod(c, "Tracer", 1, "GetControllerTracingConfig")
 }
 
 func (s *RestrictCAASModelSuite) TestSubnetsAllowed(c *tc.C) {

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -634,20 +635,12 @@ func reconcileDeadUnitScale(
 	}
 
 	desiredScale := ps.ScaleTarget
-
-	unitScale := 0
-	for unitName := range unitNamesAndLives {
-		nextUnitNumber := unitName.Number() + 1
-		if nextUnitNumber > unitScale {
-			unitScale = nextUnitNumber
-		}
-	}
+	threshold := unitRemovalThreshold(unitNamesAndLives, desiredScale)
 
 	unitsToRemove := 0
-
 	var deadUnits []coreunit.Name
 	for unitName, unitLife := range unitNamesAndLives {
-		if unitName.Number() >= unitScale-desiredScale {
+		if unitName.Number() >= threshold {
 			continue
 		}
 		unitsToRemove++
@@ -684,6 +677,9 @@ func reconcileDeadUnitScale(
 		return tryAgain
 	}
 
+	sort.Slice(deadUnits, func(i, j int) bool {
+		return deadUnits[i].Number() < deadUnits[j].Number()
+	})
 	for _, deadUnit := range deadUnits {
 		logger.Infof(ctx, "removing dead unit %s", deadUnit)
 		if err := facade.RemoveUnit(ctx, string(deadUnit)); err != nil && !errors.Is(err, errors.NotFound) {
@@ -737,15 +733,7 @@ func ensureScale(
 		return err
 	}
 
-	unitScale := 0
-	for unitName := range units {
-		nextUnitNumber := unitName.Number() + 1
-		if nextUnitNumber > unitScale {
-			unitScale = nextUnitNumber
-		}
-	}
-
-	if ps.ScaleTarget >= unitScale {
+	if ps.ScaleTarget >= len(units) {
 		storageUniqueID := appUUID.String()[:6]
 		err := ensureScaleWithFsAttachments(
 			ctx,
@@ -781,9 +769,10 @@ func ensureScale(
 		return nil
 	}
 
+	threshold := unitRemovalThreshold(units, ps.ScaleTarget)
 	var unitsToDestroy []string
 	for unitName, unitLife := range units {
-		if unitName.Number() >= unitScale-ps.ScaleTarget {
+		if unitName.Number() >= threshold {
 			continue
 		}
 		if unitLife == life.Alive {
@@ -807,6 +796,28 @@ func ensureScale(
 
 func getStorageUniqueID(appUUID coreapplication.UUID) string {
 	return appUUID.String()[:6]
+}
+
+// unitRemovalThreshold returns the lowest ordinal that should be kept when
+// scaling down to targetScale units. Unit ordinals lower than the returned
+// threshold are removed, keeping the highest targetScale ordinals. The
+// threshold is derived from the sorted ordinal set rather than assuming
+// ordinals are contiguous (0..N-1), so it remains correct when ordinals are
+// sparse (e.g. 0, 2, 4).
+func unitRemovalThreshold(units map[coreunit.Name]life.Value, targetScale int) int {
+	ordinals := make([]int, 0, len(units))
+	for unitName := range units {
+		ordinals = append(ordinals, unitName.Number())
+	}
+	sort.Ints(ordinals)
+
+	if targetScale >= len(ordinals) {
+		return 0
+	}
+	if targetScale <= 0 {
+		return ordinals[len(ordinals)-1] + 1
+	}
+	return ordinals[len(ordinals)-targetScale]
 }
 
 func setOperatorStatus(

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -634,12 +634,20 @@ func reconcileDeadUnitScale(
 	}
 
 	desiredScale := ps.ScaleTarget
+
+	unitScale := 0
+	for unitName := range unitNamesAndLives {
+		nextUnitNumber := unitName.Number() + 1
+		if nextUnitNumber > unitScale {
+			unitScale = nextUnitNumber
+		}
+	}
+
 	unitsToRemove := 0
 
 	var deadUnits []coreunit.Name
 	for unitName, unitLife := range unitNamesAndLives {
-		if unitName.Number() < desiredScale {
-			// This is a unit we want to keep.
+		if unitName.Number() >= unitScale-desiredScale {
 			continue
 		}
 		unitsToRemove++
@@ -775,8 +783,7 @@ func ensureScale(
 
 	var unitsToDestroy []string
 	for unitName, unitLife := range units {
-		if unitName.Number() < ps.ScaleTarget {
-			// This is a unit we want to keep.
+		if unitName.Number() >= unitScale-ps.ScaleTarget {
 			continue
 		}
 		if unitLife == life.Alive {

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -382,14 +382,13 @@ func (s *OpsSuite) TestReconcileDeadUnitScale(c *tc.C) {
 	defer ctrl.Finish()
 
 	appUUID := tc.Must(c, application.NewUUID)
-	storageUniqueID := appUUID.String()[:6]
 	app := caasmocks.NewMockApplication(ctrl)
 	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
 	applicationService := mocks.NewMockApplicationService(ctrl)
 
 	units := map[unit.Name]life.Value{
-		"test/0": life.Alive,
-		"test/1": life.Dead,
+		"test/0": life.Dead,
+		"test/1": life.Alive,
 	}
 	ps := applicationservice.ScalingState{
 		Scaling:     true,
@@ -400,6 +399,7 @@ func (s *OpsSuite) TestReconcileDeadUnitScale(c *tc.C) {
 			"a",
 		},
 	}
+	storageUniqueID := appUUID.String()[:6]
 	gomock.InOrder(
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(units, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
@@ -407,7 +407,124 @@ func (s *OpsSuite) TestReconcileDeadUnitScale(c *tc.C) {
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
 		app.EXPECT().Scale(1).Return(nil),
 		app.EXPECT().State().Return(appState, nil),
-		facade.EXPECT().RemoveUnit(gomock.Any(), "test/1").Return(nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
+		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
+		appUUID, app, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestReconcileDeadUnitScaleMultipleLowestDead(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appUUID := tc.Must(c, application.NewUUID)
+	storageUniqueID := appUUID.String()[:6]
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Scale down from 4 to 2: test/0 and test/1 are dead and are the
+	// lowest ordinals, so they should be removed.
+	units := map[unit.Name]life.Value{
+		"test/0": life.Dead,
+		"test/1": life.Dead,
+		"test/2": life.Alive,
+		"test/3": life.Alive,
+	}
+	ps := applicationservice.ScalingState{
+		Scaling:     true,
+		ScaleTarget: 2,
+	}
+	appState := caas.ApplicationState{
+		Replicas: []string{
+			"test/2", "test/3",
+		},
+	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(units, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
+		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
+		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
+		app.EXPECT().Scale(2).Return(nil),
+		app.EXPECT().State().Return(appState, nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), gomock.Any()).Return(nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), gomock.Any()).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
+		appUUID, app, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestReconcileDeadUnitScaleLowestNotDead(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appId, _ := application.NewUUID()
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Scale down from 3 to 1: test/0 is alive so it can't be removed
+	// yet. Should be a no-op.
+	units := map[unit.Name]life.Value{
+		"test/0": life.Alive,
+		"test/1": life.Dead,
+		"test/2": life.Alive,
+	}
+	ps := applicationservice.ScalingState{
+		Scaling:     true,
+		ScaleTarget: 1,
+	}
+
+	gomock.InOrder(
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
+		appId, app, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestReconcileDeadUnitScaleAllLowestDead(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appUUID := tc.Must(c, application.NewUUID)
+	storageUniqueID := appUUID.String()[:6]
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Scale down from 3 to 1: test/0 and test/1 are dead, test/2 is kept.
+	units := map[unit.Name]life.Value{
+		"test/0": life.Dead,
+		"test/1": life.Dead,
+		"test/2": life.Alive,
+	}
+	ps := applicationservice.ScalingState{
+		Scaling:     true,
+		ScaleTarget: 1,
+	}
+	appState := caas.ApplicationState{
+		Replicas: []string{
+			"test/2",
+		},
+	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(units, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
+		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
+		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
+		app.EXPECT().Scale(1).Return(nil),
+		app.EXPECT().State().Return(appState, nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), gomock.Any()).Return(nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), gomock.Any()).Return(nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
 	)
 
@@ -457,10 +574,10 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleScaleDownNotAllDead(c *tc.C) {
 
 	// Scale DOWN: 4 current units -> 2 target units, all excess units are dead
 	units := map[unit.Name]life.Value{
-		"test/0": life.Alive,
-		"test/1": life.Dead,
-		"test/2": life.Dead,  // >= target
-		"test/3": life.Alive, // >= target
+		"test/0": life.Alive, // < keep threshold
+		"test/1": life.Dead,  // < keep threshold
+		"test/2": life.Dead,
+		"test/3": life.Alive,
 	}
 	ps := applicationservice.ScalingState{
 		Scaling:     true,
@@ -492,13 +609,12 @@ func (s *OpsSuite) TestEnsureScaleAlive(c *tc.C) {
 		"test/2": life.Dying,
 		"test/3": life.Dead,
 	}
-	unitsToDestroy := []string{"test/1"}
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(1, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 1, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
-		facade.EXPECT().DestroyUnits(gomock.Any(), unitsToDestroy).Return(nil),
+		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
@@ -525,17 +641,166 @@ func (s *OpsSuite) TestEnsureScaleAliveRetry(c *tc.C) {
 		"test/2": life.Dying,
 		"test/3": life.Dead,
 	}
-	unitsToDestroy := []string{"test/1"}
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(10, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
-		facade.EXPECT().DestroyUnits(gomock.Any(), unitsToDestroy).Return(nil),
+		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
 		life.Alive, facade, applicationService, s.logger)
 	c.Assert(err, tc.ErrorMatches, `try again`)
+}
+
+func (s *OpsSuite) TestEnsureScaleAliveScaleDown5To3(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appId, _ := application.NewUUID()
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Scale down from 5 to 3: destroy the lowest 2 ordinals (test/0, test/1).
+	units := map[unit.Name]life.Value{
+		"test/0": life.Alive,
+		"test/1": life.Alive,
+		"test/2": life.Alive,
+		"test/3": life.Alive,
+		"test/4": life.Alive,
+	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(3, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
+		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 3, true).Return(nil),
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
+		life.Alive, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestEnsureScaleAliveScaleDown5To2(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appId, _ := application.NewUUID()
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Scale down from 5 to 2: destroy the lowest 3 ordinals.
+	units := map[unit.Name]life.Value{
+		"test/0": life.Alive,
+		"test/1": life.Alive,
+		"test/2": life.Alive,
+		"test/3": life.Alive,
+		"test/4": life.Alive,
+	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(2, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
+		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1", "test/2"})).Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
+		life.Alive, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestEnsureScaleAliveScaleDown3To1(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appId, _ := application.NewUUID()
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Scale down from 3 to 1: destroy test/0, test/1.
+	units := map[unit.Name]life.Value{
+		"test/0": life.Alive,
+		"test/1": life.Alive,
+		"test/2": life.Alive,
+	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(1, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
+		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 1, true).Return(nil),
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
+		life.Alive, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestEnsureScaleAliveScaleDownMixedLives(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appId, _ := application.NewUUID()
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Scale down from 5 to 2: some units are dying/dead, but only Alive
+	// units in the lowest ordinal range should be destroyed.
+	units := map[unit.Name]life.Value{
+		"test/0": life.Alive,
+		"test/1": life.Dying,
+		"test/2": life.Alive,
+		"test/3": life.Dead,
+		"test/4": life.Alive,
+	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(2, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
+		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/2"})).Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
+		life.Alive, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestEnsureScaleAliveScaleDownNothingToDestroy(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appId, _ := application.NewUUID()
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Scale down from 3 to 1, but the lowest ordinals are already
+	// dying/dead, so there are no Alive units to destroy.
+	ps := applicationservice.ScalingState{
+		Scaling:     true,
+		ScaleTarget: 1,
+	}
+	units := map[unit.Name]life.Value{
+		"test/0": life.Dying,
+		"test/1": life.Dead,
+		"test/2": life.Alive,
+	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(1, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
+		life.Alive, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *OpsSuite) TestEnsureScaleDyingDead(c *tc.C) {

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -450,8 +450,8 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleMultipleLowestDead(c *tc.C) {
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
 		app.EXPECT().Scale(2).Return(nil),
 		app.EXPECT().State().Return(appState, nil),
-		facade.EXPECT().RemoveUnit(gomock.Any(), gomock.Any()).Return(nil),
-		facade.EXPECT().RemoveUnit(gomock.Any(), gomock.Any()).Return(nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), "test/1").Return(nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
 	)
 
@@ -523,8 +523,8 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleAllLowestDead(c *tc.C) {
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
 		app.EXPECT().Scale(1).Return(nil),
 		app.EXPECT().State().Return(appState, nil),
-		facade.EXPECT().RemoveUnit(gomock.Any(), gomock.Any()).Return(nil),
-		facade.EXPECT().RemoveUnit(gomock.Any(), gomock.Any()).Return(nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), "test/1").Return(nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
 	)
 
@@ -582,6 +582,79 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleScaleDownNotAllDead(c *tc.C) {
 	ps := applicationservice.ScalingState{
 		Scaling:     true,
 		ScaleTarget: 2, // Scale down to 2 units
+	}
+
+	gomock.InOrder(
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
+		appId, app, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestReconcileDeadUnitScaleSparseOrdinals(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appUUID := tc.Must(c, application.NewUUID)
+	storageUniqueID := appUUID.String()[:6]
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Ordinals are sparse: {0, 2, 4} (missing 1, 3). Scale down to 2.
+	// Keep the highest 2 ordinals {2, 4}, remove {0}. test/0 is dead.
+	units := map[unit.Name]life.Value{
+		"test/0": life.Dead,
+		"test/2": life.Alive,
+		"test/4": life.Alive,
+	}
+	ps := applicationservice.ScalingState{
+		Scaling:     true,
+		ScaleTarget: 2,
+	}
+	appState := caas.ApplicationState{
+		Replicas: []string{
+			"test/2", "test/4",
+		},
+	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(units, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
+		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
+		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
+		app.EXPECT().Scale(2).Return(nil),
+		app.EXPECT().State().Return(appState, nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
+		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
+		appUUID, app, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestReconcileDeadUnitScaleSparseLowestNotDead(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appId, _ := application.NewUUID()
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Ordinals are sparse: {0, 2, 4}. Scale down to 1.
+	// Keep {4}, remove {0, 2}. test/0 is alive → no-op.
+	units := map[unit.Name]life.Value{
+		"test/0": life.Alive,
+		"test/2": life.Dead,
+		"test/4": life.Dead,
+	}
+	ps := applicationservice.ScalingState{
+		Scaling:     true,
+		ScaleTarget: 1,
 	}
 
 	gomock.InOrder(
@@ -796,6 +869,65 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDownNothingToDestroy(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(1, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
+		life.Alive, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestEnsureScaleAliveScaleDownSparseOrdinals(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appId, _ := application.NewUUID()
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Ordinals are sparse: {0, 2, 4} (missing 1, 3). Scale down to 2.
+	// Keep the highest 2 ordinals {2, 4}, destroy {0}.
+	units := map[unit.Name]life.Value{
+		"test/0": life.Alive,
+		"test/2": life.Alive,
+		"test/4": life.Alive,
+	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(2, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
+		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0"})).Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
+		life.Alive, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestEnsureScaleAliveScaleDownSparseOrdinals2(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appId, _ := application.NewUUID()
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+
+	// Ordinals are sparse: {0, 1, 2, 4} (missing 3). Scale down to 2.
+	// Keep the highest 2 ordinals {2, 4}, destroy {0, 1}.
+	units := map[unit.Name]life.Value{
+		"test/0": life.Alive,
+		"test/1": life.Alive,
+		"test/2": life.Alive,
+		"test/4": life.Alive,
+	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(2, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
+		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,


### PR DESCRIPTION
When reconciling the units during scaling, we previously always scaled from top down - so if you had 0,1,2 and scaled down by one at a time, it would do 0,1 and then 0. This is normally fine, but it doesn't allow you to rollout the oldest unit (or pod in this instance). For instance, if you had new constraints (think affinities) then you'd have to scale to zero, thus removing all pods. This is very unfortunate. Instead, if we scale from bottom up, we can then roll in new units (pods) with new constraints, allowing for a more fluid system.

This was spotted when testing #23076 and wanting to scale back down. 

## QA steps

```sh
$ juju bootstrap microk8s test
$ juju add-model foo
$ juju deploy prometheus-k8s prom -n 3
$ juju remove-unit prom --num-units=2
```

Removes 0, 1.


## Links


**Jira card:** [JUJU-10258](https://warthogs.atlassian.net/browse/JUJU-10258)


[JUJU-10258]: https://warthogs.atlassian.net/browse/JUJU-10258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ