### PR TITLE
test: fix enable-ha controller test on 4.0

### DIFF
--- a/tests/includes/ha.sh
+++ b/tests/includes/ha.sh
@@ -30,9 +30,9 @@ wait_for_ha() {
 
 	attempt=0
 	# shellcheck disable=SC2143
-	until [[ "$(juju show-controller --format=json | yq -r '.[] | .["controller-machines"] | .[] | select(.["ha-status"] == "ha-enabled") | .["instance-id"]' | wc -l | grep "${amount}")" ]]; do
+	until [[ "$(juju status -m controller --format=json | yq -r '.machines | .[] | select(.["controller-member-status"] == "has-vote") | .["instance-id"]' | wc -l | grep "${amount}")" ]]; do
 		echo "[+] (attempt ${attempt}) polling ha"
-		juju show-controller 2>&1 | yq '.[]["controller-machines"]' | sed 's/^/    | /g'
+		juju status -m controller 2>&1 | sed 's/^/    | /g'
 		sleep "${SHORT_TIMEOUT}"
 		attempt=$((attempt + 1))
 
@@ -46,7 +46,7 @@ wait_for_ha() {
 
 	if [[ ${attempt} -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling ha')"
-		juju show-controller 2>&1 | sed 's/^/    | /g'
+		juju status -m controller 2>&1 | sed 's/^/    | /g'
 
 		sleep "${SHORT_TIMEOUT}"
 	fi

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -87,14 +87,14 @@ run_enable_ha() {
 
 	juju switch enable-ha
 	controller_1=$(juju status -m controller --format json | yq -r '.applications.controller.units["controller/1"].machine')
-	juju remove-machine -m controller "${controller_1}" --force
+	juju remove-machine -m controller "${controller_1}" --force --no-prompt
 	controller_2=$(juju status -m controller --format json | yq -r '.applications.controller.units["controller/2"].machine')
-	juju remove-machine -m controller "${controller_2}" --force
+	juju remove-machine -m controller "${controller_2}" --force --no-prompt
 
 	wait_for_controller_no_leader
 	wait_for_controller_leader
 
-	# Ensure that we have no ha enabled machines.
+	# Ensure that we have no ha enabled machines (this might not be working as intended).
 	juju show-controller --format=json | yq -r '.[] | .["controller-machines"] | (.[] | select(.["instance-id"] == null)) as $i ireduce (0; . + 1)' | grep 0
 
 	destroy_model "enable-ha"


### PR DESCRIPTION
The enable-ha check from the controller test was failing on Juju 4.0 due to the removal of the per-machine ha-status field from`juju show-controller` in f5699833cf, explained in #20030.

Fix: polls the has-vote signal from the `controller-member-status`. Also added the `--no-prompt` flag to `remove-machine` since the interactive confirmation was not suppressed.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju bootstrap lxd test
cd tests
./main.sh -r -l test controller
```
Check if enable-ha passes.

## Documentation changes

No

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10262](https://warthogs.atlassian.net/browse/JUJU-10262)


[JUJU-10262]: https://warthogs.atlassian.net/browse/JUJU-10262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ