### PR TITLE
fix(relation): map endpoint quota and relation-exists errors to wire codes

### DIFF
--- a/apiserver/common/secrets/drain.go
+++ b/apiserver/common/secrets/drain.go
@@ -169,22 +169,22 @@ func (s *SecretsDrainAPI) ChangeSecretBackend(ctx context.Context, args params.C
 	}
 	for i, arg := range args.Args {
 		err := s.changeSecretBackendForOne(ctx, arg)
-		result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
+		switch {
+		case errors.Is(err, secreterrors.SecretNotFound):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretNotFound,
+				"secret %q not found", arg.URI,
+			)
+		case errors.Is(err, secreterrors.PermissionDenied):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeUnauthorized,
+				"cannot change backend for secret %q: %s", arg.URI, err.Error(),
+			)
+		default:
+			result.Results[i].Error = apiservererrors.ServerError(err)
+		}
 	}
 	return result, nil
-}
-
-// codedSecretError translates well-known secret domain errors into coded
-// params errors at the facade boundary, preserving the message. Other
-// errors are returned unchanged.
-func codedSecretError(err error) error {
-	switch {
-	case errors.Is(err, secreterrors.SecretNotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretNotFound, "%s", err.Error())
-	case errors.Is(err, secreterrors.PermissionDenied):
-		return apiservererrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
-	}
-	return err
 }
 
 func (s *SecretsDrainAPI) changeSecretBackendForOne(ctx context.Context, arg params.ChangeSecretBackendArg) (err error) {

--- a/apiserver/common/secrets/drain.go
+++ b/apiserver/common/secrets/drain.go
@@ -169,11 +169,19 @@ func (s *SecretsDrainAPI) ChangeSecretBackend(ctx context.Context, args params.C
 	}
 	for i, arg := range args.Args {
 		err := s.changeSecretBackendForOne(ctx, arg)
+		// SecretService.ChangeSecretBackend can return SecretNotFound or
+		// PermissionDenied from the management access check, and
+		// SecretRevisionNotFound when looking up the revision UUID.
 		switch {
 		case errors.Is(err, secreterrors.SecretNotFound):
 			result.Results[i].Error = apiservererrors.ParamsErrorf(
 				params.CodeSecretNotFound,
 				"secret %q not found", arg.URI,
+			)
+		case errors.Is(err, secreterrors.SecretRevisionNotFound):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretRevisionNotFound,
+				"secret %q revision %d not found", arg.URI, arg.Revision,
 			)
 		case errors.Is(err, secreterrors.PermissionDenied):
 			result.Results[i].Error = apiservererrors.ParamsErrorf(

--- a/apiserver/common/secrets/drain.go
+++ b/apiserver/common/secrets/drain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/model"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/domain/secret"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	"github.com/juju/juju/rpc/params"
 )
@@ -168,9 +169,22 @@ func (s *SecretsDrainAPI) ChangeSecretBackend(ctx context.Context, args params.C
 	}
 	for i, arg := range args.Args {
 		err := s.changeSecretBackendForOne(ctx, arg)
-		result.Results[i].Error = apiservererrors.ServerError(err)
+		result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
 	}
 	return result, nil
+}
+
+// codedSecretError translates well-known secret domain errors into coded
+// params errors at the facade boundary, preserving the message. Other
+// errors are returned unchanged.
+func codedSecretError(err error) error {
+	switch {
+	case errors.Is(err, secreterrors.SecretNotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretNotFound, "%s", err.Error())
+	case errors.Is(err, secreterrors.PermissionDenied):
+		return apiservererrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
+	}
+	return err
 }
 
 func (s *SecretsDrainAPI) changeSecretBackendForOne(ctx context.Context, arg params.ChangeSecretBackendArg) (err error) {

--- a/apiserver/common/secrets/drain_test.go
+++ b/apiserver/common/secrets/drain_test.go
@@ -4,6 +4,7 @@
 package secrets_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/canonical/gomock/gomock"
@@ -17,6 +18,7 @@ import (
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain/secret"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	backendservice "github.com/juju/juju/domain/secretbackend/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -328,4 +330,39 @@ func (s *secretsDrainSuite) TestWatchSecretBackendChanged(c *tc.C) {
 	c.Assert(result, tc.DeepEquals, params.NotifyWatchResult{
 		NotifyWatcherId: "11",
 	})
+}
+
+func (s *secretsDrainSuite) TestChangeSecretBackendErrorCodes(c *tc.C) {
+	// ChangeSecretBackend fails the management access check with
+	// SecretNotFound or PermissionDenied, and the revision lookup with
+	// SecretRevisionNotFound.
+	for _, t := range []struct {
+		sentinel error
+		code     string
+	}{
+		{secreterrors.SecretNotFound, params.CodeSecretNotFound},
+		{secreterrors.SecretRevisionNotFound, params.CodeSecretRevisionNotFound},
+		{secreterrors.PermissionDenied, params.CodeUnauthorized},
+	} {
+		c.Logf("sentinel %v", t.sentinel)
+		func() {
+			defer s.setup(c).Finish()
+
+			// Arrange:
+			uri := coresecrets.NewURI()
+			s.secretService.EXPECT().ChangeSecretBackend(gomock.Any(), uri, 666, gomock.Any()).
+				Return(fmt.Errorf("boom: %w", t.sentinel))
+
+			// Act:
+			result, err := s.facade.ChangeSecretBackend(c.Context(), params.ChangeSecretBackendArgs{
+				Args: []params.ChangeSecretBackendArg{{URI: uri.String(), Revision: 666}},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(result.Results, tc.HasLen, 1)
+			c.Assert(result.Results[0].Error, tc.NotNil)
+			c.Check(result.Results[0].Error.Code, tc.Equals, t.code)
+		}()
+	}
 }

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -16,7 +16,6 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/upgrade"
 	modelerrors "github.com/juju/juju/domain/model/errors"
-	relationerrors "github.com/juju/juju/domain/relation/errors"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	interrors "github.com/juju/juju/internal/errors"
@@ -194,8 +193,6 @@ func ServerError(err error) *params.Error {
 		code = params.CodeModelNotFound
 	case errors.Is(err, errors.AlreadyExists):
 		code = params.CodeAlreadyExists
-	case errors.Is(err, relationerrors.RelationAlreadyExists):
-		code = params.CodeAlreadyExists
 	case errors.Is(err, secretbackenderrors.AlreadyExists):
 		code = params.CodeSecretBackendAlreadyExists
 	case errors.Is(err, errors.NotAssigned):
@@ -255,8 +252,6 @@ func ServerError(err error) *params.Error {
 			ControllerAlias: redirectError.ControllerAlias,
 		}.AsMap()
 	case errors.Is(err, errors.QuotaLimitExceeded):
-		code = params.CodeQuotaLimitExceeded
-	case errors.Is(err, relationerrors.EndpointQuotaLimitExceeded):
 		code = params.CodeQuotaLimitExceeded
 	case errors.Is(err, errors.NotYetAvailable):
 		code = params.CodeNotYetAvailable

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -16,8 +16,6 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/upgrade"
 	modelerrors "github.com/juju/juju/domain/model/errors"
-	secreterrors "github.com/juju/juju/domain/secret/errors"
-	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	interrors "github.com/juju/juju/internal/errors"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/rpc/params"
@@ -181,20 +179,10 @@ func ServerError(err error) *params.Error {
 		code = params.CodeNotFound
 	case errors.Is(err, errors.UserNotFound):
 		code = params.CodeUserNotFound
-	case errors.Is(err, secreterrors.SecretNotFound):
-		code = params.CodeSecretNotFound
-	case errors.Is(err, secreterrors.SecretRevisionNotFound):
-		code = params.CodeSecretRevisionNotFound
-	case errors.Is(err, secreterrors.SecretConsumerNotFound):
-		code = params.CodeSecretConsumerNotFound
-	case errors.Is(err, secretbackenderrors.NotFound):
-		code = params.CodeSecretBackendNotFound
 	case errors.Is(err, modelerrors.NotFound):
 		code = params.CodeModelNotFound
 	case errors.Is(err, errors.AlreadyExists):
 		code = params.CodeAlreadyExists
-	case errors.Is(err, secretbackenderrors.AlreadyExists):
-		code = params.CodeSecretBackendAlreadyExists
 	case errors.Is(err, errors.NotAssigned):
 		code = params.CodeNotAssigned
 	case errors.Is(err, NoAddressSetError):
@@ -208,8 +196,6 @@ func ServerError(err error) *params.Error {
 		code = params.CodeModelNotFound
 	case errors.Is(err, errors.NotSupported):
 		code = params.CodeNotSupported
-	case errors.Is(err, secretbackenderrors.NotSupported):
-		code = params.CodeSecretBackendNotSupported
 	case errors.Is(err, errors.BadRequest):
 		code = params.CodeBadRequest
 	case errors.Is(err, errors.MethodNotAllowed):
@@ -218,16 +204,10 @@ func ServerError(err error) *params.Error {
 		code = params.CodeNotImplemented
 	case errors.Is(err, errors.Forbidden):
 		code = params.CodeForbidden
-	case errors.Is(err, secretbackenderrors.Forbidden):
-		code = params.CodeSecretBackendForbidden
 	case errors.Is(err, errors.NotValid):
 		code = params.CodeNotValid
-	case errors.Is(err, secretbackenderrors.NotValid):
-		code = params.CodeSecretBackendNotValid
 	case errors.Is(err, IncompatibleBaseError):
 		code = params.CodeIncompatibleBase
-	case errors.Is(err, secreterrors.PermissionDenied):
-		code = params.CodeUnauthorized
 	case errors.As(err, &dischargeRequiredError):
 		code = params.CodeDischargeRequired
 		info = params.DischargeRequiredErrorInfo{

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -16,6 +16,7 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/upgrade"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	relationerrors "github.com/juju/juju/domain/relation/errors"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	interrors "github.com/juju/juju/internal/errors"
@@ -193,6 +194,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeModelNotFound
 	case errors.Is(err, errors.AlreadyExists):
 		code = params.CodeAlreadyExists
+	case errors.Is(err, relationerrors.RelationAlreadyExists):
+		code = params.CodeAlreadyExists
 	case errors.Is(err, secretbackenderrors.AlreadyExists):
 		code = params.CodeSecretBackendAlreadyExists
 	case errors.Is(err, errors.NotAssigned):
@@ -252,6 +255,8 @@ func ServerError(err error) *params.Error {
 			ControllerAlias: redirectError.ControllerAlias,
 		}.AsMap()
 	case errors.Is(err, errors.QuotaLimitExceeded):
+		code = params.CodeQuotaLimitExceeded
+	case errors.Is(err, relationerrors.EndpointQuotaLimitExceeded):
 		code = params.CodeQuotaLimitExceeded
 	case errors.Is(err, errors.NotYetAvailable):
 		code = params.CodeNotYetAvailable

--- a/apiserver/errors/errors_test.go
+++ b/apiserver/errors/errors_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/network"
-	relationerrors "github.com/juju/juju/domain/relation/errors"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/internal/testing"
@@ -118,14 +117,6 @@ var errorTransformTests = []struct {
 	code:       params.CodeAlreadyExists,
 	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeAlreadyExists,
-}, {
-	err:        relationerrors.RelationAlreadyExists,
-	code:       params.CodeAlreadyExists,
-	status:     http.StatusInternalServerError,
-	helperFunc: params.IsCodeAlreadyExists,
-	targetTester: func(e error) bool {
-		return errors.Is(e, errors.AlreadyExists)
-	},
 }, {
 	err:        apiservererrors.ErrUnknownWatcher,
 	code:       params.CodeNotFound,
@@ -236,14 +227,6 @@ var errorTransformTests = []struct {
 	code:       params.CodeQuotaLimitExceeded,
 	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeQuotaLimitExceeded,
-}, {
-	err:        relationerrors.EndpointQuotaLimitExceeded,
-	code:       params.CodeQuotaLimitExceeded,
-	status:     http.StatusInternalServerError,
-	helperFunc: params.IsCodeQuotaLimitExceeded,
-	targetTester: func(e error) bool {
-		return errors.Is(e, errors.QuotaLimitExceeded)
-	},
 }, {
 	err:        errors.NotYetAvailable,
 	code:       params.CodeNotYetAvailable,

--- a/apiserver/errors/errors_test.go
+++ b/apiserver/errors/errors_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/network"
+	relationerrors "github.com/juju/juju/domain/relation/errors"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/internal/testing"
@@ -117,6 +118,14 @@ var errorTransformTests = []struct {
 	code:       params.CodeAlreadyExists,
 	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeAlreadyExists,
+}, {
+	err:        relationerrors.RelationAlreadyExists,
+	code:       params.CodeAlreadyExists,
+	status:     http.StatusInternalServerError,
+	helperFunc: params.IsCodeAlreadyExists,
+	targetTester: func(e error) bool {
+		return errors.Is(e, errors.AlreadyExists)
+	},
 }, {
 	err:        apiservererrors.ErrUnknownWatcher,
 	code:       params.CodeNotFound,
@@ -227,6 +236,14 @@ var errorTransformTests = []struct {
 	code:       params.CodeQuotaLimitExceeded,
 	status:     http.StatusInternalServerError,
 	helperFunc: params.IsCodeQuotaLimitExceeded,
+}, {
+	err:        relationerrors.EndpointQuotaLimitExceeded,
+	code:       params.CodeQuotaLimitExceeded,
+	status:     http.StatusInternalServerError,
+	helperFunc: params.IsCodeQuotaLimitExceeded,
+	targetTester: func(e error) bool {
+		return errors.Is(e, errors.QuotaLimitExceeded)
+	},
 }, {
 	err:        errors.NotYetAvailable,
 	code:       params.CodeNotYetAvailable,

--- a/apiserver/errors/errors_test.go
+++ b/apiserver/errors/errors_test.go
@@ -19,8 +19,6 @@ import (
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/network"
-	secreterrors "github.com/juju/juju/domain/secret/errors"
-	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
 )
@@ -49,31 +47,6 @@ var errorTransformTests = []struct {
 	code:       params.CodeUserNotFound,
 	status:     http.StatusNotFound,
 	helperFunc: params.IsCodeUserNotFound,
-}, {
-	err:        secreterrors.SecretNotFound,
-	code:       params.CodeSecretNotFound,
-	status:     http.StatusNotFound,
-	helperFunc: params.IsCodeSecretNotFound,
-}, {
-	err:        secreterrors.SecretRevisionNotFound,
-	code:       params.CodeSecretRevisionNotFound,
-	status:     http.StatusNotFound,
-	helperFunc: params.IsCodeSecretRevisionNotFound,
-}, {
-	err:        secreterrors.SecretConsumerNotFound,
-	code:       params.CodeSecretConsumerNotFound,
-	status:     http.StatusNotFound,
-	helperFunc: params.IsCodeSecretConsumerNotFound,
-}, {
-	err:        secretbackenderrors.NotFound,
-	code:       params.CodeSecretBackendNotFound,
-	status:     http.StatusNotFound,
-	helperFunc: params.IsCodeSecretBackendNotFound,
-}, {
-	err:        secretbackenderrors.Forbidden,
-	code:       params.CodeSecretBackendForbidden,
-	status:     http.StatusForbidden,
-	helperFunc: params.IsCodeSecretBackendForbidden,
 }, {
 	err:        errors.Unauthorized,
 	code:       params.CodeUnauthorized,

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -579,12 +579,25 @@ func (s *SecretsManagerAPI) GetSecretRevisionContentInfo(ctx context.Context, ar
 		// TODO(wallworld) - if pendingDelete is true, mark the revision for deletion
 		val, valueRef, err := s.secretService.GetSecretValue(ctx, uri, rev, accessor)
 		if err != nil {
-			if errors.Is(err, secreterrors.SecretRevisionNotFound) {
+			// GetSecretValue checks read access before reading the
+			// revision, so it can fail with any of these three.
+			switch {
+			case errors.Is(err, secreterrors.SecretNotFound):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretNotFound,
+					"secret %q not found", arg.URI,
+				)
+			case errors.Is(err, secreterrors.SecretRevisionNotFound):
 				result.Results[i].Error = apiservererrors.ParamsErrorf(
 					params.CodeSecretRevisionNotFound,
 					"getting revision %d of secret %q: %s", rev, arg.URI, err.Error(),
 				)
-			} else {
+			case errors.Is(err, secreterrors.PermissionDenied):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeUnauthorized,
+					"cannot read secret %q: %s", arg.URI, err.Error(),
+				)
+			default:
 				result.Results[i].Error = apiservererrors.ServerError(err)
 			}
 			continue

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretservice "github.com/juju/juju/domain/secret/service"
+	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/secrets"
@@ -67,6 +68,25 @@ type SecretsManagerAPI struct {
 	logger logger.Logger
 }
 
+// codedSecretError translates well-known secret domain errors into coded
+// params errors at the facade boundary, preserving the message. Other
+// errors are returned unchanged.
+func codedSecretError(err error) error {
+	switch {
+	case errors.Is(err, secreterrors.SecretNotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretNotFound, "%s", err.Error())
+	case errors.Is(err, secreterrors.SecretRevisionNotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretRevisionNotFound, "%s", err.Error())
+	case errors.Is(err, secreterrors.SecretConsumerNotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretConsumerNotFound, "%s", err.Error())
+	case errors.Is(err, secretbackenderrors.NotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretBackendNotFound, "%s", err.Error())
+	case errors.Is(err, secreterrors.PermissionDenied):
+		return apiservererrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
+	}
+	return err
+}
+
 // GetSecretBackendConfigs gets the config needed to create a client to secret backends.
 func (s *SecretsManagerAPI) GetSecretBackendConfigs(ctx context.Context, arg params.SecretBackendArgs) (params.SecretBackendConfigResults, error) {
 	if arg.ForDrain {
@@ -77,7 +97,7 @@ func (s *SecretsManagerAPI) GetSecretBackendConfigs(ctx context.Context, arg par
 	}
 	result, activeID, err := s.getSecretBackendConfig(ctx, arg.BackendIDs)
 	if err != nil {
-		return results, errors.Trace(err)
+		return results, codedSecretError(err)
 	}
 	results.ActiveID = activeID
 	results.Results = result
@@ -109,7 +129,7 @@ func (s *SecretsManagerAPI) getBackendConfigForDrain(ctx context.Context, arg pa
 		BackendID: backendID,
 	})
 	if err != nil {
-		return results, errors.Trace(err)
+		return results, codedSecretError(err)
 	}
 	if len(cfgInfo.Configs) == 0 {
 		return results, errors.NotFoundf("no secret backends available")
@@ -244,7 +264,7 @@ func (s *SecretsManagerAPI) GetConsumerSecretsRevisionInfo(ctx context.Context, 
 	for i, uri := range args.URIs {
 		data, latestRevision, err := s.getSecretConsumerInfo(ctx, unitConsumer, uri)
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
+			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
 			continue
 		}
 		result.Results[i] = params.SecretConsumerInfoResult{
@@ -380,7 +400,7 @@ func (s *SecretsManagerAPI) GetSecretContentInfo(ctx context.Context, args param
 	for i, arg := range args.Args {
 		content, backend, draining, err := s.getSecretContent(ctx, arg)
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
+			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
 			continue
 		}
 		contentParams := params.SecretContentParams{}
@@ -524,7 +544,7 @@ func (s *SecretsManagerAPI) GetSecretRevisionContentInfo(ctx context.Context, ar
 		// TODO(wallworld) - if pendingDelete is true, mark the revision for deletion
 		val, valueRef, err := s.secretService.GetSecretValue(ctx, uri, rev, accessor)
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
+			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
 			continue
 		}
 		contentParams := params.SecretContentParams{}
@@ -535,7 +555,7 @@ func (s *SecretsManagerAPI) GetSecretRevisionContentInfo(ctx context.Context, ar
 			}
 			backend, draining, err := s.getBackend(ctx, valueRef.BackendID, accessor, token)
 			if err != nil {
-				result.Results[i].Error = apiservererrors.ServerError(err)
+				result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
 				continue
 			}
 			result.Results[i].BackendConfig = &params.SecretBackendConfigResult{
@@ -812,7 +832,7 @@ func (s *SecretsManagerAPI) SecretsRotated(ctx context.Context, args params.Secr
 	}
 	for i, arg := range args.Args {
 		var result params.ErrorResult
-		result.Error = apiservererrors.ServerError(one(arg))
+		result.Error = apiservererrors.ServerError(codedSecretError(one(arg)))
 		results.Results[i] = result
 	}
 	return results, nil

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -68,25 +68,6 @@ type SecretsManagerAPI struct {
 	logger logger.Logger
 }
 
-// codedSecretError translates well-known secret domain errors into coded
-// params errors at the facade boundary, preserving the message. Other
-// errors are returned unchanged.
-func codedSecretError(err error) error {
-	switch {
-	case errors.Is(err, secreterrors.SecretNotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretNotFound, "%s", err.Error())
-	case errors.Is(err, secreterrors.SecretRevisionNotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretRevisionNotFound, "%s", err.Error())
-	case errors.Is(err, secreterrors.SecretConsumerNotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretConsumerNotFound, "%s", err.Error())
-	case errors.Is(err, secretbackenderrors.NotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretBackendNotFound, "%s", err.Error())
-	case errors.Is(err, secreterrors.PermissionDenied):
-		return apiservererrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
-	}
-	return err
-}
-
 // GetSecretBackendConfigs gets the config needed to create a client to secret backends.
 func (s *SecretsManagerAPI) GetSecretBackendConfigs(ctx context.Context, arg params.SecretBackendArgs) (params.SecretBackendConfigResults, error) {
 	if arg.ForDrain {
@@ -97,7 +78,13 @@ func (s *SecretsManagerAPI) GetSecretBackendConfigs(ctx context.Context, arg par
 	}
 	result, activeID, err := s.getSecretBackendConfig(ctx, arg.BackendIDs)
 	if err != nil {
-		return results, codedSecretError(err)
+		if errors.Is(err, secretbackenderrors.NotFound) {
+			return results, apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendNotFound,
+				"getting config for secret backends %q: %s", arg.BackendIDs, err.Error(),
+			)
+		}
+		return results, errors.Trace(err)
 	}
 	results.ActiveID = activeID
 	results.Results = result
@@ -129,7 +116,13 @@ func (s *SecretsManagerAPI) getBackendConfigForDrain(ctx context.Context, arg pa
 		BackendID: backendID,
 	})
 	if err != nil {
-		return results, codedSecretError(err)
+		if errors.Is(err, secretbackenderrors.NotFound) {
+			return results, apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendNotFound,
+				"getting drain config for secret backend %q: %s", backendID, err.Error(),
+			)
+		}
+		return results, errors.Trace(err)
 	}
 	if len(cfgInfo.Configs) == 0 {
 		return results, errors.NotFoundf("no secret backends available")
@@ -263,8 +256,21 @@ func (s *SecretsManagerAPI) GetConsumerSecretsRevisionInfo(ctx context.Context, 
 	}
 	for i, uri := range args.URIs {
 		data, latestRevision, err := s.getSecretConsumerInfo(ctx, unitConsumer, uri)
-		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
+		switch {
+		case errors.Is(err, secreterrors.SecretNotFound):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretNotFound,
+				"secret %q not found", uri,
+			)
+			continue
+		case errors.Is(err, secreterrors.SecretConsumerNotFound):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretConsumerNotFound,
+				"consumer %q not found for secret %q", unitConsumer.Id(), uri,
+			)
+			continue
+		case err != nil:
+			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
 		result.Results[i] = params.SecretConsumerInfoResult{
@@ -400,7 +406,36 @@ func (s *SecretsManagerAPI) GetSecretContentInfo(ctx context.Context, args param
 	for i, arg := range args.Args {
 		content, backend, draining, err := s.getSecretContent(ctx, arg)
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
+			// The secret is identified by URI or, when looking one up for
+			// the owner, by label.
+			ref := arg.URI
+			if ref == "" {
+				ref = arg.Label
+			}
+			switch {
+			case errors.Is(err, secreterrors.SecretNotFound):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretNotFound,
+					"getting content for secret %q: %s", ref, err.Error(),
+				)
+			case errors.Is(err, secreterrors.SecretRevisionNotFound):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretRevisionNotFound,
+					"getting content for secret %q: %s", ref, err.Error(),
+				)
+			case errors.Is(err, secreterrors.PermissionDenied):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeUnauthorized,
+					"cannot read secret %q: %s", ref, err.Error(),
+				)
+			case errors.Is(err, secretbackenderrors.NotFound):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretBackendNotFound,
+					"getting content for secret %q: %s", ref, err.Error(),
+				)
+			default:
+				result.Results[i].Error = apiservererrors.ServerError(err)
+			}
 			continue
 		}
 		contentParams := params.SecretContentParams{}
@@ -544,7 +579,14 @@ func (s *SecretsManagerAPI) GetSecretRevisionContentInfo(ctx context.Context, ar
 		// TODO(wallworld) - if pendingDelete is true, mark the revision for deletion
 		val, valueRef, err := s.secretService.GetSecretValue(ctx, uri, rev, accessor)
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
+			if errors.Is(err, secreterrors.SecretRevisionNotFound) {
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretRevisionNotFound,
+					"getting revision %d of secret %q: %s", rev, arg.URI, err.Error(),
+				)
+			} else {
+				result.Results[i].Error = apiservererrors.ServerError(err)
+			}
 			continue
 		}
 		contentParams := params.SecretContentParams{}
@@ -555,7 +597,15 @@ func (s *SecretsManagerAPI) GetSecretRevisionContentInfo(ctx context.Context, ar
 			}
 			backend, draining, err := s.getBackend(ctx, valueRef.BackendID, accessor, token)
 			if err != nil {
-				result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
+				if errors.Is(err, secretbackenderrors.NotFound) {
+					result.Results[i].Error = apiservererrors.ParamsErrorf(
+						params.CodeSecretBackendNotFound,
+						"getting backend %q for secret %q: %s",
+						valueRef.BackendID, arg.URI, err.Error(),
+					)
+				} else {
+					result.Results[i].Error = apiservererrors.ServerError(err)
+				}
 				continue
 			}
 			result.Results[i].BackendConfig = &params.SecretBackendConfigResult{
@@ -831,9 +881,21 @@ func (s *SecretsManagerAPI) SecretsRotated(ctx context.Context, args params.Secr
 		})
 	}
 	for i, arg := range args.Args {
-		var result params.ErrorResult
-		result.Error = apiservererrors.ServerError(codedSecretError(one(arg)))
-		results.Results[i] = result
+		err := one(arg)
+		switch {
+		case errors.Is(err, secreterrors.SecretNotFound):
+			results.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretNotFound,
+				"secret %q not found", arg.URI,
+			)
+		case errors.Is(err, secreterrors.PermissionDenied):
+			results.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeUnauthorized,
+				"cannot rotate secret %q: %s", arg.URI, err.Error(),
+			)
+		default:
+			results.Results[i].Error = apiservererrors.ServerError(err)
+		}
 	}
 	return results, nil
 }

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -4,6 +4,7 @@
 package secretsmanager_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretservice "github.com/juju/juju/domain/secret/service"
+	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	"github.com/juju/juju/internal/secrets"
 	"github.com/juju/juju/internal/secrets/provider"
@@ -1387,4 +1389,249 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerMigr
 			},
 		}},
 	})
+}
+
+func (s *SecretsManagerSuite) TestGetSecretBackendConfigsNotFound(c *tc.C) {
+	defer s.setup(c).Finish()
+
+	// Arrange:
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
+	s.secretService.EXPECT().GetReservedSecretIDs(gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.secretBackendService.EXPECT().BackendConfigInfo(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("boom: %w", secretbackenderrors.NotFound))
+
+	// Act:
+	_, err := s.facade.GetSecretBackendConfigs(c.Context(), params.SecretBackendArgs{
+		BackendIDs: []string{"backend-id"},
+	})
+
+	// Assert:
+	pErr, ok := err.(*params.Error)
+	c.Assert(ok, tc.IsTrue)
+	c.Check(pErr.Code, tc.Equals, params.CodeSecretBackendNotFound)
+}
+
+func (s *SecretsManagerSuite) TestGetSecretBackendConfigsForDrainNotFound(c *tc.C) {
+	defer s.setup(c).Finish()
+
+	// Arrange:
+	s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
+	s.secretBackendService.EXPECT().DrainBackendConfigInfo(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("boom: %w", secretbackenderrors.NotFound))
+
+	// Act:
+	_, err := s.facade.GetSecretBackendConfigs(c.Context(), params.SecretBackendArgs{
+		ForDrain:   true,
+		BackendIDs: []string{"backend-id"},
+	})
+
+	// Assert:
+	pErr, ok := err.(*params.Error)
+	c.Assert(ok, tc.IsTrue)
+	c.Check(pErr.Code, tc.Equals, params.CodeSecretBackendNotFound)
+}
+
+// TestGetConsumerSecretsRevisionInfoErrorCodes covers the two sentinels
+// GetSecretConsumerAndLatest documents.
+func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfoErrorCodes(c *tc.C) {
+	for _, t := range []struct {
+		sentinel error
+		code     string
+	}{
+		{secreterrors.SecretNotFound, params.CodeSecretNotFound},
+		{secreterrors.SecretConsumerNotFound, params.CodeSecretConsumerNotFound},
+	} {
+		c.Logf("sentinel %v", t.sentinel)
+		func() {
+			defer s.setup(c).Finish()
+
+			// Arrange:
+			uri := coresecrets.NewURI()
+			s.secretsConsumer.EXPECT().GetSecretConsumerAndLatest(
+				gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"),
+			).Return(nil, 0, fmt.Errorf("boom: %w", t.sentinel))
+
+			// Act:
+			results, err := s.facade.GetConsumerSecretsRevisionInfo(c.Context(), params.GetSecretConsumerInfoArgs{
+				ConsumerTag: "unit-mariadb/0",
+				URIs:        []string{uri.String()},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Assert(results.Results[0].Error, tc.NotNil)
+			c.Check(results.Results[0].Error.Code, tc.Equals, t.code)
+		}()
+	}
+}
+
+// TestGetSecretContentInfoErrorCodes covers every sentinel reachable through
+// getSecretContent: the consumer label/revision lookups and the revision read
+// can fail with SecretNotFound, SecretRevisionNotFound or PermissionDenied,
+// and the backend lookup with secretbackenderrors.NotFound.
+func (s *SecretsManagerSuite) TestGetSecretContentInfoErrorCodes(c *tc.C) {
+	unitName := unittesting.GenNewName(c, "mariadb/0")
+	accessor := secret.SecretAccessor{Kind: secret.UnitAccessor, ID: "mariadb/0"}
+	for _, t := range []struct {
+		about  string
+		expect func(*tc.C, *coresecrets.URI, error)
+		err    error
+		code   string
+	}{{
+		about: "secret not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unitName, uri, "").Return(nil, nil, err)
+		},
+		err:  secreterrors.SecretNotFound,
+		code: params.CodeSecretNotFound,
+	}, {
+		about: "revision not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unitName, uri, "").Return(uri, nil, nil)
+			s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unitName, false, false, nil).Return(668, nil)
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, accessor).Return(nil, nil, err)
+		},
+		err:  secreterrors.SecretRevisionNotFound,
+		code: params.CodeSecretRevisionNotFound,
+	}, {
+		about: "read access denied",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unitName, uri, "").Return(uri, nil, nil)
+			s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unitName, false, false, nil).Return(668, nil)
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, accessor).Return(nil, nil, err)
+		},
+		err:  secreterrors.PermissionDenied,
+		code: params.CodeUnauthorized,
+	}, {
+		about: "backend not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unitName, uri, "").Return(uri, nil, nil)
+			s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unitName, false, false, nil).Return(668, nil)
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, accessor).
+				Return(nil, &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "rev-id"}, nil)
+			s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token)
+			s.secretBackendService.EXPECT().BackendConfigInfo(gomock.Any(), gomock.Any()).Return(nil, err)
+		},
+		err:  secretbackenderrors.NotFound,
+		code: params.CodeSecretBackendNotFound,
+	}} {
+		c.Logf("%s", t.about)
+		func() {
+			defer s.setup(c).Finish()
+
+			// Arrange:
+			uri := coresecrets.NewURI()
+			t.expect(c, uri, fmt.Errorf("boom: %w", t.err))
+
+			// Act:
+			results, err := s.facade.GetSecretContentInfo(c.Context(), params.GetSecretContentArgs{
+				Args: []params.GetSecretContentArg{{URI: uri.String()}},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Assert(results.Results[0].Error, tc.NotNil)
+			c.Check(results.Results[0].Error.Code, tc.Equals, t.code)
+		}()
+	}
+}
+
+// TestGetSecretRevisionContentInfoErrorCodes covers the sentinels GetSecretValue
+// can return plus the backend lookup for external revisions.
+func (s *SecretsManagerSuite) TestGetSecretRevisionContentInfoErrorCodes(c *tc.C) {
+	accessor := secret.SecretAccessor{Kind: secret.UnitAccessor, ID: "mariadb/0"}
+	for _, t := range []struct {
+		about  string
+		expect func(*tc.C, *coresecrets.URI, error)
+		err    error
+		code   string
+	}{{
+		about: "secret not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, accessor).Return(nil, nil, err)
+		},
+		err:  secreterrors.SecretNotFound,
+		code: params.CodeSecretNotFound,
+	}, {
+		about: "revision not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, accessor).Return(nil, nil, err)
+		},
+		err:  secreterrors.SecretRevisionNotFound,
+		code: params.CodeSecretRevisionNotFound,
+	}, {
+		about: "read access denied",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, accessor).Return(nil, nil, err)
+		},
+		err:  secreterrors.PermissionDenied,
+		code: params.CodeUnauthorized,
+	}, {
+		about: "backend not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, accessor).
+				Return(nil, &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "rev-id"}, nil)
+			s.secretBackendService.EXPECT().BackendConfigInfo(gomock.Any(), gomock.Any()).Return(nil, err)
+		},
+		err:  secretbackenderrors.NotFound,
+		code: params.CodeSecretBackendNotFound,
+	}} {
+		c.Logf("%s", t.about)
+		func() {
+			defer s.setup(c).Finish()
+
+			// Arrange: the leadership token is taken up front, before the
+			// revisions are read.
+			s.leadership.EXPECT().LeadershipCheck("mariadb", "mariadb/0").Return(s.token).AnyTimes()
+			uri := coresecrets.NewURI()
+			t.expect(c, uri, fmt.Errorf("boom: %w", t.err))
+
+			// Act:
+			results, err := s.facade.GetSecretRevisionContentInfo(c.Context(), params.SecretRevisionArg{
+				URI:       uri.String(),
+				Revisions: []int{666},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Assert(results.Results[0].Error, tc.NotNil)
+			c.Check(results.Results[0].Error.Code, tc.Equals, t.code)
+		}()
+	}
+}
+
+// TestSecretsRotatedErrorCodes covers the two sentinels the management access
+// check in SecretRotated can return.
+func (s *SecretsManagerSuite) TestSecretsRotatedErrorCodes(c *tc.C) {
+	for _, t := range []struct {
+		sentinel error
+		code     string
+	}{
+		{secreterrors.SecretNotFound, params.CodeSecretNotFound},
+		{secreterrors.PermissionDenied, params.CodeUnauthorized},
+	} {
+		c.Logf("sentinel %v", t.sentinel)
+		func() {
+			defer s.setup(c).Finish()
+
+			// Arrange:
+			uri := coresecrets.NewURI()
+			s.secretTriggers.EXPECT().SecretRotated(gomock.Any(), uri, gomock.Any()).
+				Return(fmt.Errorf("boom: %w", t.sentinel))
+
+			// Act:
+			result, err := s.facade.SecretsRotated(c.Context(), params.SecretRotatedArgs{
+				Args: []params.SecretRotatedArg{{URI: uri.ID, OriginalRevision: 666}},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(result.Results, tc.HasLen, 1)
+			c.Assert(result.Results[0].Error, tc.NotNil)
+			c.Check(result.Results[0].Error.Code, tc.Equals, t.code)
+		}()
+	}
 }

--- a/apiserver/facades/agent/uniter/secrets.go
+++ b/apiserver/facades/agent/uniter/secrets.go
@@ -234,10 +234,10 @@ func (u *UniterAPI) prepareSecretRevokes(
 				u.logger.Infof(ctx, "secret %q no longer exists, skipping revoke", rev.URI)
 				continue
 			}
-			// Map the domain permission error onto the singleton that the
-			// wire layer turns into an unauthorized code.
+			// The accumulated errors are joined and returned to the
+			// wire by CommitHookChanges, so attach the code here.
 			if errors.Is(err, secreterrors.PermissionDenied) {
-				err = apiServerErrors.ErrPerm
+				err = apiServerErrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
 			}
 			revokeErrs = append(revokeErrs, err)
 			continue
@@ -554,10 +554,10 @@ func (u *UniterAPI) prepareSecretDeletes(
 				u.logger.Infof(ctx, "secret %q no longer exists, skipping delete", del.URI)
 				continue
 			}
-			// Map the domain permission error onto the singleton that the
-			// wire layer turns into an unauthorized code.
+			// The accumulated errors are joined and returned to the
+			// wire by CommitHookChanges, so attach the code here.
 			if errors.Is(err, secreterrors.PermissionDenied) {
-				err = apiServerErrors.ErrPerm
+				err = apiServerErrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
 			}
 			deleteErrs = append(deleteErrs, err)
 			continue
@@ -635,10 +635,10 @@ func (u *UniterAPI) prepareSecretUpdates(
 				u.logger.Infof(ctx, "secret %q no longer exists, skipping update", upd.URI)
 				continue
 			}
-			// Map the domain permission error onto the singleton that the
-			// wire layer turns into an unauthorized code.
+			// The accumulated errors are joined and returned to the
+			// wire by CommitHookChanges, so attach the code here.
 			if errors.Is(err, secreterrors.PermissionDenied) {
-				err = apiServerErrors.ErrPerm
+				err = apiServerErrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
 			}
 			updateErrs = append(updateErrs, err)
 			continue

--- a/apiserver/facades/agent/uniter/secrets.go
+++ b/apiserver/facades/agent/uniter/secrets.go
@@ -234,6 +234,11 @@ func (u *UniterAPI) prepareSecretRevokes(
 				u.logger.Infof(ctx, "secret %q no longer exists, skipping revoke", rev.URI)
 				continue
 			}
+			// Map the domain permission error onto the singleton that the
+			// wire layer turns into an unauthorized code.
+			if errors.Is(err, secreterrors.PermissionDenied) {
+				err = apiServerErrors.ErrPerm
+			}
 			revokeErrs = append(revokeErrs, err)
 			continue
 		}
@@ -549,6 +554,11 @@ func (u *UniterAPI) prepareSecretDeletes(
 				u.logger.Infof(ctx, "secret %q no longer exists, skipping delete", del.URI)
 				continue
 			}
+			// Map the domain permission error onto the singleton that the
+			// wire layer turns into an unauthorized code.
+			if errors.Is(err, secreterrors.PermissionDenied) {
+				err = apiServerErrors.ErrPerm
+			}
 			deleteErrs = append(deleteErrs, err)
 			continue
 		}
@@ -624,6 +634,11 @@ func (u *UniterAPI) prepareSecretUpdates(
 			if errors.Is(err, secreterrors.SecretNotFound) {
 				u.logger.Infof(ctx, "secret %q no longer exists, skipping update", upd.URI)
 				continue
+			}
+			// Map the domain permission error onto the singleton that the
+			// wire layer turns into an unauthorized code.
+			if errors.Is(err, secreterrors.PermissionDenied) {
+				err = apiServerErrors.ErrPerm
 			}
 			updateErrs = append(updateErrs, err)
 			continue

--- a/apiserver/facades/agent/uniter/secrets.go
+++ b/apiserver/facades/agent/uniter/secrets.go
@@ -234,10 +234,14 @@ func (u *UniterAPI) prepareSecretRevokes(
 				u.logger.Infof(ctx, "secret %q no longer exists, skipping revoke", rev.URI)
 				continue
 			}
-			// The accumulated errors are joined and returned to the
-			// wire by CommitHookChanges, so attach the code here.
+			// CommitHookChanges joins the accumulated errors and passes
+			// the result to ServerError, which finds the code anywhere in
+			// the chain, so attach it here. Add keeps the domain sentinel
+			// matchable alongside the wire code.
 			if errors.Is(err, secreterrors.PermissionDenied) {
-				err = apiServerErrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
+				err = internalerrors.Errorf("%w", err).Add(
+					apiServerErrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error()),
+				)
 			}
 			revokeErrs = append(revokeErrs, err)
 			continue
@@ -554,10 +558,14 @@ func (u *UniterAPI) prepareSecretDeletes(
 				u.logger.Infof(ctx, "secret %q no longer exists, skipping delete", del.URI)
 				continue
 			}
-			// The accumulated errors are joined and returned to the
-			// wire by CommitHookChanges, so attach the code here.
+			// CommitHookChanges joins the accumulated errors and passes
+			// the result to ServerError, which finds the code anywhere in
+			// the chain, so attach it here. Add keeps the domain sentinel
+			// matchable alongside the wire code.
 			if errors.Is(err, secreterrors.PermissionDenied) {
-				err = apiServerErrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
+				err = internalerrors.Errorf("%w", err).Add(
+					apiServerErrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error()),
+				)
 			}
 			deleteErrs = append(deleteErrs, err)
 			continue
@@ -635,10 +643,14 @@ func (u *UniterAPI) prepareSecretUpdates(
 				u.logger.Infof(ctx, "secret %q no longer exists, skipping update", upd.URI)
 				continue
 			}
-			// The accumulated errors are joined and returned to the
-			// wire by CommitHookChanges, so attach the code here.
+			// CommitHookChanges joins the accumulated errors and passes
+			// the result to ServerError, which finds the code anywhere in
+			// the chain, so attach it here. Add keeps the domain sentinel
+			// matchable alongside the wire code.
 			if errors.Is(err, secreterrors.PermissionDenied) {
-				err = apiServerErrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
+				err = internalerrors.Errorf("%w", err).Add(
+					apiServerErrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error()),
+				)
 			}
 			updateErrs = append(updateErrs, err)
 			continue

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/juju/juju/domain/resolve"
 	resolveerrors "github.com/juju/juju/domain/resolve/errors"
 	domainsecret "github.com/juju/juju/domain/secret"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	domainstorage "github.com/juju/juju/domain/storage"
 	tracingservice "github.com/juju/juju/domain/tracing/service"
 	"github.com/juju/juju/domain/unitstate"
@@ -4233,4 +4234,96 @@ func (s *apiAddresserSuite) setupMocks(c *tc.C) *gomock.Controller {
 		s.watcherRegistry = nil
 	})
 	return ctrl
+}
+
+// TestCommitHookChangesSecretsPermissionDenied checks that a
+// secreterrors.PermissionDenied from the manage-access check is reported with
+// the CodeUnauthorized wire code. The prepare* helpers accumulate errors and
+// join them, so the code is attached to the individual error and has to
+// survive both the join and the ServerError call CommitHookChanges makes.
+func (s *commitHookChangesSuite) TestCommitHookChangesSecretsPermissionDenied(c *tc.C) {
+	uri := coresecrets.NewURI()
+
+	for _, t := range []struct {
+		description string
+		arg         params.CommitHookChangesArg
+		message     string
+	}{{
+		description: "revokes",
+		arg: params.CommitHookChangesArg{
+			SecretRevokes: []params.GrantRevokeSecretArg{{
+				URI:         uri.String(),
+				ScopeTag:    names.NewRelationTag("one:db two:use").String(),
+				SubjectTags: []string{names.NewApplicationTag("two").String()},
+			}},
+		},
+		message: "revoking secrets access: boom: permission denied",
+	}, {
+		description: "deletes",
+		arg: params.CommitHookChangesArg{
+			SecretDeletes: []params.DeleteSecretArg{{URI: uri.String()}},
+		},
+		message: "removing secrets: boom: permission denied",
+	}, {
+		description: "updates",
+		arg: params.CommitHookChangesArg{
+			SecretUpdates: []params.UpdateSecretArg{{
+				URI: uri.String(),
+				UpsertSecretArg: params.UpsertSecretArg{
+					Label: new("label"),
+				},
+			}},
+		},
+		message: "updating secrets: boom: permission denied",
+	}} {
+		c.Logf("test: %s", t.description)
+		func() {
+			// Arrange: the manage access check denies the unit.
+			defer s.setupMocks(c).Finish()
+
+			unitTag := names.NewUnitTag("wordpress/0")
+			s.uniter.accessUnit = func(context.Context) (common.AuthFunc, error) {
+				return func(tag names.Tag) bool { return tag.String() == unitTag.String() }, nil
+			}
+			s.secretService.EXPECT().CheckSecretManageAccess(gomock.Any(), uri, coreunit.Name("wordpress/0")).
+				Return(internalerrors.Errorf("boom: %w", secreterrors.PermissionDenied))
+
+			arg := t.arg
+			arg.Tag = unitTag.String()
+
+			// Act:
+			results, err := s.uniter.CommitHookChanges(c.Context(), params.CommitHookChangesArgs{
+				Args: []params.CommitHookChangesArg{arg},
+			})
+
+			// Assert: the wire code survives the join and ServerError.
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Check(results.Results[0].Error, tc.NotNil)
+			c.Check(results.Results[0].Error.Code, tc.Equals, params.CodeUnauthorized)
+			c.Check(results.Results[0].Error.Message, tc.Equals, t.message)
+		}()
+	}
+}
+
+// TestPrepareSecretPermissionDeniedKeepsSentinel checks that attaching the
+// wire code does not hide the domain sentinel from errors.Is, so callers
+// further up can still match on it.
+func (s *commitHookChangesSuite) TestPrepareSecretPermissionDeniedKeepsSentinel(c *tc.C) {
+	// Arrange:
+	defer s.setupMocks(c).Finish()
+
+	unitName := coreunit.Name("wordpress/0")
+	uri := coresecrets.NewURI()
+	s.secretService.EXPECT().CheckSecretManageAccess(gomock.Any(), uri, unitName).
+		Return(internalerrors.Errorf("boom: %w", secreterrors.PermissionDenied))
+
+	// Act:
+	_, err := s.uniter.prepareSecretDeletes(c.Context(), unitName,
+		[]params.DeleteSecretArg{{URI: uri.String()}})
+
+	// Assert:
+	c.Assert(err, tc.NotNil)
+	c.Check(err, tc.ErrorIs, secreterrors.PermissionDenied)
+	c.Check(params.ErrCode(err), tc.Equals, params.CodeUnauthorized)
 }

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1394,14 +1394,22 @@ func (api *APIBase) AddRelation(ctx context.Context, args params.AddRelation) (_
 		ctx, args.Endpoints[0], args.Endpoints[1], args.ViaCIDRs...,
 	)
 	if err != nil {
-		// Exceeding an endpoint quota is a user error: return a coded,
-		// compact message rather than the full domain error chain.
+		// User errors get a coded, compact message rather than the full
+		// domain error chain.
 		if internalerrors.Is(err, relationerrors.EndpointQuotaLimitExceeded) {
 			return params.AddRelationResults{}, apiservererrors.ParamsErrorf(
 				params.CodeQuotaLimitExceeded,
 				"adding relation between endpoints %q and %q: %s",
 				args.Endpoints[0], args.Endpoints[1],
 				relationerrors.EndpointQuotaLimitExceeded,
+			)
+		}
+		if internalerrors.Is(err, relationerrors.RelationAlreadyExists) {
+			return params.AddRelationResults{}, apiservererrors.ParamsErrorf(
+				params.CodeAlreadyExists,
+				"adding relation between endpoints %q and %q: %s",
+				args.Endpoints[0], args.Endpoints[1],
+				relationerrors.RelationAlreadyExists,
 			)
 		}
 		return params.AddRelationResults{}, internalerrors.Errorf(

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1394,6 +1394,16 @@ func (api *APIBase) AddRelation(ctx context.Context, args params.AddRelation) (_
 		ctx, args.Endpoints[0], args.Endpoints[1], args.ViaCIDRs...,
 	)
 	if err != nil {
+		// Exceeding an endpoint quota is a user error: return a coded,
+		// compact message rather than the full domain error chain.
+		if internalerrors.Is(err, relationerrors.EndpointQuotaLimitExceeded) {
+			return params.AddRelationResults{}, apiservererrors.ParamsErrorf(
+				params.CodeQuotaLimitExceeded,
+				"adding relation between endpoints %q and %q: %s",
+				args.Endpoints[0], args.Endpoints[1],
+				relationerrors.EndpointQuotaLimitExceeded,
+			)
+		}
 		return params.AddRelationResults{}, internalerrors.Errorf(
 			"adding relation between endpoints %q and %q: %w",
 			args.Endpoints[0], args.Endpoints[1], err,

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -719,6 +719,34 @@ func (s *applicationSuite) TestAddRelationEndpointQuotaExceeded(c *tc.C) {
 		`adding relation between endpoints "mattermost" and "postgresql:db": quota limit exceeded`)
 }
 
+// TestAddRelationAlreadyExists ensures that when the relation service reports
+// an already-existing relation, the facade returns a compact, coded params
+// error instead of the full domain error chain.
+func (s *applicationSuite) TestAddRelationAlreadyExists(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	s.setupAPI(c)
+	epStr1 := "mattermost"
+	epStr2 := "postgresql:db"
+	boom := fmt.Errorf("boom: %w", relationerrors.RelationAlreadyExists)
+	s.relationService.EXPECT().AddRelation(gomock.Any(), epStr1, epStr2).Return(
+		relation.Endpoint{}, relation.Endpoint{}, boom,
+	)
+
+	// Act:
+	_, err := s.api.AddRelation(c.Context(), params.AddRelation{
+		Endpoints: []string{"mattermost", "postgresql:db"},
+	})
+
+	// Assert: the error carries the already-exists code and no noisy chain.
+	pErr, ok := err.(*params.Error)
+	c.Assert(ok, tc.IsTrue)
+	c.Check(pErr.Code, tc.Equals, params.CodeAlreadyExists)
+	c.Check(pErr.Message, tc.Equals,
+		`adding relation between endpoints "mattermost" and "postgresql:db": already exists`)
+}
+
 func (s *applicationSuite) TestAddRelationNoEndpointsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -691,6 +691,34 @@ func (s *applicationSuite) TestAddRelationError(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, boom)
 }
 
+// TestAddRelationEndpointQuotaExceeded ensures that when the relation service
+// reports an endpoint quota violation, the facade returns a compact, coded
+// params error instead of the full domain error chain.
+func (s *applicationSuite) TestAddRelationEndpointQuotaExceeded(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	s.setupAPI(c)
+	epStr1 := "mattermost"
+	epStr2 := "postgresql:db"
+	boom := fmt.Errorf("boom: %w", relationerrors.EndpointQuotaLimitExceeded)
+	s.relationService.EXPECT().AddRelation(gomock.Any(), epStr1, epStr2).Return(
+		relation.Endpoint{}, relation.Endpoint{}, boom,
+	)
+
+	// Act:
+	_, err := s.api.AddRelation(c.Context(), params.AddRelation{
+		Endpoints: []string{"mattermost", "postgresql:db"},
+	})
+
+	// Assert: the error carries the quota code and no noisy domain chain.
+	pErr, ok := err.(*params.Error)
+	c.Assert(ok, tc.IsTrue)
+	c.Check(pErr.Code, tc.Equals, params.CodeQuotaLimitExceeded)
+	c.Check(pErr.Message, tc.Equals,
+		`adding relation between endpoints "mattermost" and "postgresql:db": quota limit exceeded`)
+}
+
 func (s *applicationSuite) TestAddRelationNoEndpointsError(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -24,6 +24,7 @@ import (
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	networkerrors "github.com/juju/juju/domain/network/errors"
+	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/environs/config"
 	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/rpc/params"
@@ -418,5 +419,13 @@ func (s *ModelConfigAPI) SetModelSecretBackend(ctx context.Context, arg params.S
 		return params.ErrorResult{}, errors.Trace(err)
 	}
 	err := s.modelSecretBackendService.SetModelSecretBackend(ctx, arg.SecretBackendName)
+	// Translate secret backend domain errors into their wire codes at the
+	// call site, preserving the error message.
+	switch {
+	case internalerrors.Is(err, secretbackenderrors.NotFound):
+		err = apiservererrors.ParamsErrorf(params.CodeSecretBackendNotFound, "%s", err.Error())
+	case internalerrors.Is(err, secretbackenderrors.NotValid):
+		err = apiservererrors.ParamsErrorf(params.CodeSecretBackendNotValid, "%s", err.Error())
+	}
 	return params.ErrorResult{Error: apiservererrors.ServerError(err)}, nil
 }

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -419,13 +419,17 @@ func (s *ModelConfigAPI) SetModelSecretBackend(ctx context.Context, arg params.S
 		return params.ErrorResult{}, errors.Trace(err)
 	}
 	err := s.modelSecretBackendService.SetModelSecretBackend(ctx, arg.SecretBackendName)
-	// Translate secret backend domain errors into their wire codes at the
-	// call site, preserving the error message.
 	switch {
 	case internalerrors.Is(err, secretbackenderrors.NotFound):
-		err = apiservererrors.ParamsErrorf(params.CodeSecretBackendNotFound, "%s", err.Error())
+		err = apiservererrors.ParamsErrorf(
+			params.CodeSecretBackendNotFound,
+			"secret backend %q not found", arg.SecretBackendName,
+		)
 	case internalerrors.Is(err, secretbackenderrors.NotValid):
-		err = apiservererrors.ParamsErrorf(params.CodeSecretBackendNotValid, "%s", err.Error())
+		err = apiservererrors.ParamsErrorf(
+			params.CodeSecretBackendNotValid,
+			"secret backend %q not valid", arg.SecretBackendName,
+		)
 	}
 	return params.ErrorResult{Error: apiservererrors.ServerError(err)}, nil
 }

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -659,7 +659,7 @@ func (s *modelconfigSuite) TestSetModelSecretBackendFailedSecretBackendNotFound(
 		SecretBackendName: "myvault",
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(result.Error, tc.ErrorMatches, "secret backend not found")
+	c.Assert(result.Error, tc.ErrorMatches, `secret backend "myvault" not found`)
 	c.Assert(result.Error.Code, tc.Equals, params.CodeSecretBackendNotFound)
 }
 
@@ -674,7 +674,7 @@ func (s *modelconfigSuite) TestSetModelSecretBackendFailedSecretBackendNotValid(
 		SecretBackendName: "myvault",
 	})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(result.Error, tc.ErrorMatches, "secret backend not valid")
+	c.Assert(result.Error, tc.ErrorMatches, `secret backend "myvault" not valid`)
 	c.Assert(result.Error.Code, tc.Equals, params.CodeSecretBackendNotValid)
 }
 

--- a/apiserver/facades/client/secretbackends/secrets.go
+++ b/apiserver/facades/client/secretbackends/secrets.go
@@ -32,25 +32,6 @@ func (s *SecretBackendsAPI) checkCanAdmin(ctx context.Context) error {
 	return s.authorizer.HasPermission(ctx, permission.SuperuserAccess, names.NewControllerTag(s.controllerUUID))
 }
 
-// codedBackendError translates secret backend domain errors into coded
-// params errors at the facade boundary, preserving the message. Other
-// errors are returned unchanged.
-func codedBackendError(err error) error {
-	switch {
-	case errors.Is(err, secretbackenderrors.AlreadyExists):
-		return apiservererrors.ParamsErrorf(params.CodeSecretBackendAlreadyExists, "%s", err.Error())
-	case errors.Is(err, secretbackenderrors.NotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretBackendNotFound, "%s", err.Error())
-	case errors.Is(err, secretbackenderrors.NotValid):
-		return apiservererrors.ParamsErrorf(params.CodeSecretBackendNotValid, "%s", err.Error())
-	case errors.Is(err, secretbackenderrors.NotSupported):
-		return apiservererrors.ParamsErrorf(params.CodeSecretBackendNotSupported, "%s", err.Error())
-	case errors.Is(err, secretbackenderrors.Forbidden):
-		return apiservererrors.ParamsErrorf(params.CodeSecretBackendForbidden, "%s", err.Error())
-	}
-	return err
-}
-
 // AddSecretBackends adds new secret backends.
 func (s *SecretBackendsAPI) AddSecretBackends(ctx context.Context, args params.AddSecretBackendArgs) (params.ErrorResults, error) {
 	result := params.ErrorResults{
@@ -75,7 +56,25 @@ func (s *SecretBackendsAPI) AddSecretBackends(ctx context.Context, args params.A
 			TokenRotateInterval: arg.TokenRotateInterval,
 			Config:              arg.Config,
 		})
-		result.Results[i].Error = apiservererrors.ServerError(codedBackendError(err))
+		switch {
+		case errors.Is(err, secretbackenderrors.AlreadyExists):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendAlreadyExists,
+				"secret backend %q already exists", arg.Name,
+			)
+		case errors.Is(err, secretbackenderrors.NotValid):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendNotValid,
+				"cannot add secret backend %q: %s", arg.Name, err.Error(),
+			)
+		case errors.Is(err, secretbackenderrors.NotSupported):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendNotSupported,
+				"cannot add secret backend %q: %s", arg.Name, err.Error(),
+			)
+		default:
+			result.Results[i].Error = apiservererrors.ServerError(err)
+		}
 	}
 	return result, nil
 }
@@ -89,7 +88,7 @@ func (s *SecretBackendsAPI) UpdateSecretBackends(ctx context.Context, args param
 		return result, errors.Trace(err)
 	}
 	for i, arg := range args.Args {
-		params := secretbackendservice.UpdateSecretBackendParams{
+		updateParams := secretbackendservice.UpdateSecretBackendParams{
 			UpdateSecretBackendParams: secretbackend.UpdateSecretBackendParams{
 				BackendIdentifier: secretbackend.BackendIdentifier{
 					Name: arg.Name,
@@ -101,10 +100,38 @@ func (s *SecretBackendsAPI) UpdateSecretBackends(ctx context.Context, args param
 			Reset:    arg.Reset,
 		}
 		if len(arg.Config) > 0 {
-			params.Config = arg.Config
+			updateParams.Config = arg.Config
 		}
-		err := s.backendService.UpdateSecretBackend(ctx, params)
-		result.Results[i].Error = apiservererrors.ServerError(codedBackendError(err))
+		err := s.backendService.UpdateSecretBackend(ctx, updateParams)
+		switch {
+		case errors.Is(err, secretbackenderrors.NotFound):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendNotFound,
+				"secret backend %q not found", arg.Name,
+			)
+		case errors.Is(err, secretbackenderrors.AlreadyExists):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendAlreadyExists,
+				"cannot rename secret backend %q: %s", arg.Name, err.Error(),
+			)
+		case errors.Is(err, secretbackenderrors.Forbidden):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendForbidden,
+				"cannot update secret backend %q: %s", arg.Name, err.Error(),
+			)
+		case errors.Is(err, secretbackenderrors.NotValid):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendNotValid,
+				"cannot update secret backend %q: %s", arg.Name, err.Error(),
+			)
+		case errors.Is(err, secretbackenderrors.NotSupported):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendNotSupported,
+				"cannot update secret backend %q: %s", arg.Name, err.Error(),
+			)
+		default:
+			result.Results[i].Error = apiservererrors.ServerError(err)
+		}
 	}
 	return result, nil
 }
@@ -155,15 +182,25 @@ func (s *SecretBackendsAPI) RemoveSecretBackends(ctx context.Context, args param
 				BackendIdentifier: secretbackend.BackendIdentifier{Name: arg.Name},
 				DeleteInUse:       arg.Force,
 			})
-		if errors.Is(err, secretbackenderrors.Forbidden) {
-			err = apiservererrors.ParamsErrorf(
+		switch {
+		case errors.Is(err, secretbackenderrors.Forbidden):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
 				params.CodeNotSupported,
 				"deleting in use secret backend not supported",
 			)
-		} else {
-			err = codedBackendError(err)
+		case errors.Is(err, secretbackenderrors.NotFound):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendNotFound,
+				"secret backend %q not found", arg.Name,
+			)
+		case errors.Is(err, secretbackenderrors.NotValid):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendNotValid,
+				"cannot remove secret backend %q: %s", arg.Name, err.Error(),
+			)
+		default:
+			result.Results[i].Error = apiservererrors.ServerError(err)
 		}
-		result.Results[i].Error = apiservererrors.ServerError(err)
 	}
 	return result, nil
 }

--- a/apiserver/facades/client/secretbackends/secrets.go
+++ b/apiserver/facades/client/secretbackends/secrets.go
@@ -32,6 +32,25 @@ func (s *SecretBackendsAPI) checkCanAdmin(ctx context.Context) error {
 	return s.authorizer.HasPermission(ctx, permission.SuperuserAccess, names.NewControllerTag(s.controllerUUID))
 }
 
+// codedBackendError translates secret backend domain errors into coded
+// params errors at the facade boundary, preserving the message. Other
+// errors are returned unchanged.
+func codedBackendError(err error) error {
+	switch {
+	case errors.Is(err, secretbackenderrors.AlreadyExists):
+		return apiservererrors.ParamsErrorf(params.CodeSecretBackendAlreadyExists, "%s", err.Error())
+	case errors.Is(err, secretbackenderrors.NotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretBackendNotFound, "%s", err.Error())
+	case errors.Is(err, secretbackenderrors.NotValid):
+		return apiservererrors.ParamsErrorf(params.CodeSecretBackendNotValid, "%s", err.Error())
+	case errors.Is(err, secretbackenderrors.NotSupported):
+		return apiservererrors.ParamsErrorf(params.CodeSecretBackendNotSupported, "%s", err.Error())
+	case errors.Is(err, secretbackenderrors.Forbidden):
+		return apiservererrors.ParamsErrorf(params.CodeSecretBackendForbidden, "%s", err.Error())
+	}
+	return err
+}
+
 // AddSecretBackends adds new secret backends.
 func (s *SecretBackendsAPI) AddSecretBackends(ctx context.Context, args params.AddSecretBackendArgs) (params.ErrorResults, error) {
 	result := params.ErrorResults{
@@ -56,7 +75,7 @@ func (s *SecretBackendsAPI) AddSecretBackends(ctx context.Context, args params.A
 			TokenRotateInterval: arg.TokenRotateInterval,
 			Config:              arg.Config,
 		})
-		result.Results[i].Error = apiservererrors.ServerError(err)
+		result.Results[i].Error = apiservererrors.ServerError(codedBackendError(err))
 	}
 	return result, nil
 }
@@ -85,7 +104,7 @@ func (s *SecretBackendsAPI) UpdateSecretBackends(ctx context.Context, args param
 			params.Config = arg.Config
 		}
 		err := s.backendService.UpdateSecretBackend(ctx, params)
-		result.Results[i].Error = apiservererrors.ServerError(err)
+		result.Results[i].Error = apiservererrors.ServerError(codedBackendError(err))
 	}
 	return result, nil
 }
@@ -141,6 +160,8 @@ func (s *SecretBackendsAPI) RemoveSecretBackends(ctx context.Context, args param
 				params.CodeNotSupported,
 				"deleting in use secret backend not supported",
 			)
+		} else {
+			err = codedBackendError(err)
 		}
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}

--- a/apiserver/facades/client/secretbackends/secrets_test.go
+++ b/apiserver/facades/client/secretbackends/secrets_test.go
@@ -91,7 +91,7 @@ func (s *SecretsSuite) TestAddSecretBackends(c *tc.C) {
 		{},
 		{Error: &params.Error{
 			Code:    "secret backend already exists",
-			Message: `secret backend already exists`}},
+			Message: `secret backend "myvault2" already exists`}},
 	})
 }
 
@@ -248,7 +248,7 @@ func (s *SecretsSuite) TestUpdateSecretBackends(c *tc.C) {
 		{},
 		{Error: &params.Error{
 			Code:    "secret backend not found",
-			Message: `secret backend not found`}},
+			Message: `secret backend "not-existing-name" not found`}},
 	})
 }
 

--- a/apiserver/facades/client/secretbackends/secrets_test.go
+++ b/apiserver/facades/client/secretbackends/secrets_test.go
@@ -4,6 +4,7 @@
 package secretbackends
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -334,4 +335,145 @@ func (s *SecretsSuite) TestRemoveSecretBackendsInUse(c *tc.C) {
 			Code:    "not supported",
 			Message: `deleting in use secret backend not supported`}},
 	})
+}
+
+func (s *SecretsSuite) TestAddSecretBackendsErrorCodes(c *tc.C) {
+	for _, t := range []struct {
+		sentinel error
+		code     string
+		message  string
+	}{{
+		sentinel: secretbackenderrors.AlreadyExists,
+		code:     params.CodeSecretBackendAlreadyExists,
+		message:  `secret backend "myvault" already exists`,
+	}, {
+		sentinel: secretbackenderrors.NotValid,
+		code:     params.CodeSecretBackendNotValid,
+		message:  `cannot add secret backend "myvault": boom: secret backend not valid`,
+	}, {
+		sentinel: secretbackenderrors.NotSupported,
+		code:     params.CodeSecretBackendNotSupported,
+		message:  `cannot add secret backend "myvault": boom: secret backend not supported`,
+	}} {
+		func() {
+			// Arrange: the service reports the sentinel wrapped in a chain,
+			// as it would be after travelling back up through the domain.
+			facade, ctrl := s.setup(c)
+			defer ctrl.Finish()
+
+			s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
+			s.mockBackendService.EXPECT().CreateSecretBackend(gomock.Any(), gomock.Any()).
+				Return(fmt.Errorf("boom: %w", t.sentinel))
+
+			// Act:
+			results, err := facade.AddSecretBackends(c.Context(), params.AddSecretBackendArgs{
+				Args: []params.AddSecretBackendArg{{
+					ID:            "backend-id",
+					SecretBackend: params.SecretBackend{Name: "myvault", BackendType: "vault"},
+				}},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Check(results.Results[0].Error, tc.DeepEquals, &params.Error{
+				Code:    t.code,
+				Message: t.message,
+			})
+		}()
+	}
+}
+
+func (s *SecretsSuite) TestUpdateSecretBackendsErrorCodes(c *tc.C) {
+	for _, t := range []struct {
+		sentinel error
+		code     string
+		message  string
+	}{{
+		sentinel: secretbackenderrors.NotFound,
+		code:     params.CodeSecretBackendNotFound,
+		message:  `secret backend "myvault" not found`,
+	}, {
+		sentinel: secretbackenderrors.AlreadyExists,
+		code:     params.CodeSecretBackendAlreadyExists,
+		message:  `cannot rename secret backend "myvault": boom: secret backend already exists`,
+	}, {
+		sentinel: secretbackenderrors.Forbidden,
+		code:     params.CodeSecretBackendForbidden,
+		message:  `cannot update secret backend "myvault": boom: secret backend operation forbidden`,
+	}, {
+		sentinel: secretbackenderrors.NotValid,
+		code:     params.CodeSecretBackendNotValid,
+		message:  `cannot update secret backend "myvault": boom: secret backend not valid`,
+	}, {
+		sentinel: secretbackenderrors.NotSupported,
+		code:     params.CodeSecretBackendNotSupported,
+		message:  `cannot update secret backend "myvault": boom: secret backend not supported`,
+	}} {
+		func() {
+			// Arrange:
+			facade, ctrl := s.setup(c)
+			defer ctrl.Finish()
+
+			s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
+			s.mockBackendService.EXPECT().UpdateSecretBackend(gomock.Any(), gomock.Any()).
+				Return(fmt.Errorf("boom: %w", t.sentinel))
+
+			// Act:
+			results, err := facade.UpdateSecretBackends(c.Context(), params.UpdateSecretBackendArgs{
+				Args: []params.UpdateSecretBackendArg{{Name: "myvault"}},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Check(results.Results[0].Error, tc.DeepEquals, &params.Error{
+				Code:    t.code,
+				Message: t.message,
+			})
+		}()
+	}
+}
+
+func (s *SecretsSuite) TestRemoveSecretBackendsErrorCodes(c *tc.C) {
+	for _, t := range []struct {
+		sentinel error
+		code     string
+		message  string
+	}{{
+		sentinel: secretbackenderrors.Forbidden,
+		code:     params.CodeNotSupported,
+		message:  `deleting in use secret backend not supported`,
+	}, {
+		sentinel: secretbackenderrors.NotFound,
+		code:     params.CodeSecretBackendNotFound,
+		message:  `secret backend "myvault" not found`,
+	}, {
+		sentinel: secretbackenderrors.NotValid,
+		code:     params.CodeSecretBackendNotValid,
+		message:  `cannot remove secret backend "myvault": boom: secret backend not valid`,
+	}} {
+		func() {
+			// Arrange:
+			facade, ctrl := s.setup(c)
+			defer ctrl.Finish()
+
+			s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
+			s.mockBackendService.EXPECT().DeleteSecretBackend(gomock.Any(), gomock.Any()).
+				Return(fmt.Errorf("boom: %w", t.sentinel))
+
+			// Act:
+			results, err := facade.RemoveSecretBackends(c.Context(), params.RemoveSecretBackendArgs{
+				Args: []params.RemoveSecretBackendArg{{Name: "myvault"}},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Check(results.Results[0].Error, tc.DeepEquals, &params.Error{
+				Code:    t.code,
+				Message: t.message,
+			})
+		}()
+	}
 }

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -192,17 +192,25 @@ func (s *SecretsAPI) ListSecrets(ctx context.Context, arg params.ListSecretsArgs
 				rev = *arg.Filter.Revision
 			}
 			val, err := s.secretService.GetSecretContentFromBackend(ctx, m.URI, rev)
-			valueResult := &params.SecretValueResult{
-				Error: apiservererrors.ServerError(err),
-			}
-			if errors.Is(err, secretbackenderrors.NotFound) {
+			valueResult := &params.SecretValueResult{}
+			// GetSecretContentFromBackend collapses a missing secret and a
+			// missing revision into SecretRevisionNotFound, and reports an
+			// unknown external backend as secretbackenderrors.NotFound.
+			switch {
+			case err == nil:
+				valueResult.Data = val.EncodedValues()
+			case errors.Is(err, secreterrors.SecretRevisionNotFound):
+				valueResult.Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretRevisionNotFound,
+					"getting content for secret %q: %s", m.URI, err.Error(),
+				)
+			case errors.Is(err, secretbackenderrors.NotFound):
 				valueResult.Error = apiservererrors.ParamsErrorf(
 					params.CodeSecretBackendNotFound,
 					"getting content for secret %q: %s", m.URI, err.Error(),
 				)
-			}
-			if err == nil {
-				valueResult.Data = val.EncodedValues()
+			default:
+				valueResult.Error = apiservererrors.ServerError(err)
 			}
 			secretResult.Value = valueResult
 		}
@@ -350,7 +358,7 @@ func (s *SecretsAPI) updateSecret(ctx context.Context, arg params.UpdateUserSecr
 			"cannot update secret %q: %s", uri, err.Error(),
 		)
 	}
-	return err
+	return errors.Trace(err)
 }
 
 func (s *SecretsAPI) secretURI(ctx context.Context, uriStr, label string) (*coresecrets.URI, error) {

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -59,6 +59,21 @@ func (s *SecretsAPI) checkCanAdmin(ctx context.Context) error {
 	return apiservererrors.ErrPerm
 }
 
+// codedSecretError translates well-known secret domain errors into coded
+// params errors at the facade boundary, preserving the message. Other
+// errors are returned unchanged.
+func codedSecretError(err error) error {
+	switch {
+	case errors.Is(err, secreterrors.SecretNotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretNotFound, "%s", err.Error())
+	case errors.Is(err, secreterrors.SecretRevisionNotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretRevisionNotFound, "%s", err.Error())
+	case errors.Is(err, secreterrors.PermissionDenied):
+		return apiservererrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
+	}
+	return err
+}
+
 // ListSecrets lists available secrets.
 // If args specifies secret owners, then only charm secrets are queried because user secret don't have owners as such.
 // If no owners are specified, we use the more generic list method when returns all types of secret.
@@ -143,7 +158,7 @@ func (s *SecretsAPI) ListSecrets(ctx context.Context, arg params.ListSecretsArgs
 		}
 		grants, err := s.secretService.GetSecretGrants(ctx, m.URI, coresecrets.RoleView)
 		if err != nil {
-			return result, errors.Trace(err)
+			return result, codedSecretError(err)
 		}
 		for _, g := range grants {
 			accessorTag, err := tagFromSubject(g.Subject)
@@ -186,7 +201,7 @@ func (s *SecretsAPI) ListSecrets(ctx context.Context, arg params.ListSecretsArgs
 			}
 			val, err := s.secretService.GetSecretContentFromBackend(ctx, m.URI, rev)
 			valueResult := &params.SecretValueResult{
-				Error: apiservererrors.ServerError(err),
+				Error: apiservererrors.ServerError(codedSecretError(err)),
 			}
 			if err == nil {
 				valueResult.Data = val.EncodedValues()
@@ -325,7 +340,7 @@ func (s *SecretsAPI) updateSecret(ctx context.Context, arg params.UpdateUserSecr
 		arg.Content.Checksum = checksum
 	}
 	err = s.secretService.UpdateUserSecret(ctx, uri, fromUpsertParams(s.modelUUID, arg.AutoPrune, arg.UpsertSecretArg))
-	return errors.Trace(err)
+	return codedSecretError(err)
 }
 
 func (s *SecretsAPI) secretURI(ctx context.Context, uriStr, label string) (*coresecrets.URI, error) {
@@ -337,7 +352,7 @@ func (s *SecretsAPI) secretURI(ctx context.Context, uriStr, label string) (*core
 	}
 	uri, err := s.secretService.GetUserSecretURIByLabel(ctx, label)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting user secret for label %q", label)
+		return nil, codedSecretError(errors.Annotatef(err, "getting user secret for label %q", label))
 	}
 	return uri, nil
 }
@@ -370,7 +385,7 @@ func (s *SecretsAPI) RemoveSecrets(ctx context.Context, args params.DeleteSecret
 			Revisions: arg.Revisions,
 		})
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
+			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
 			continue
 		}
 	}
@@ -425,7 +440,7 @@ func (s *SecretsAPI) secretsGrantRevoke(ctx context.Context, arg params.GrantRev
 		return nil
 	}
 	for i, appName := range arg.Applications {
-		results.Results[i].Error = apiservererrors.ServerError(one(appName))
+		results.Results[i].Error = apiservererrors.ServerError(codedSecretError(one(appName)))
 	}
 	return results, nil
 }

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -18,6 +18,7 @@ import (
 	domainsecret "github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretservice "github.com/juju/juju/domain/secret/service"
+	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/internal/secrets"
 	"github.com/juju/juju/internal/secrets/provider/kubernetes"
 	"github.com/juju/juju/rpc/params"
@@ -57,21 +58,6 @@ func (s *SecretsAPI) checkCanAdmin(ctx context.Context) error {
 		return nil
 	}
 	return apiservererrors.ErrPerm
-}
-
-// codedSecretError translates well-known secret domain errors into coded
-// params errors at the facade boundary, preserving the message. Other
-// errors are returned unchanged.
-func codedSecretError(err error) error {
-	switch {
-	case errors.Is(err, secreterrors.SecretNotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretNotFound, "%s", err.Error())
-	case errors.Is(err, secreterrors.SecretRevisionNotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretRevisionNotFound, "%s", err.Error())
-	case errors.Is(err, secreterrors.PermissionDenied):
-		return apiservererrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
-	}
-	return err
 }
 
 // ListSecrets lists available secrets.
@@ -158,7 +144,13 @@ func (s *SecretsAPI) ListSecrets(ctx context.Context, arg params.ListSecretsArgs
 		}
 		grants, err := s.secretService.GetSecretGrants(ctx, m.URI, coresecrets.RoleView)
 		if err != nil {
-			return result, codedSecretError(err)
+			if errors.Is(err, secreterrors.SecretNotFound) {
+				return result, apiservererrors.ParamsErrorf(
+					params.CodeSecretNotFound,
+					"secret %q not found", m.URI,
+				)
+			}
+			return result, errors.Trace(err)
 		}
 		for _, g := range grants {
 			accessorTag, err := tagFromSubject(g.Subject)
@@ -201,7 +193,13 @@ func (s *SecretsAPI) ListSecrets(ctx context.Context, arg params.ListSecretsArgs
 			}
 			val, err := s.secretService.GetSecretContentFromBackend(ctx, m.URI, rev)
 			valueResult := &params.SecretValueResult{
-				Error: apiservererrors.ServerError(codedSecretError(err)),
+				Error: apiservererrors.ServerError(err),
+			}
+			if errors.Is(err, secretbackenderrors.NotFound) {
+				valueResult.Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretBackendNotFound,
+					"getting content for secret %q: %s", m.URI, err.Error(),
+				)
 			}
 			if err == nil {
 				valueResult.Data = val.EncodedValues()
@@ -340,7 +338,19 @@ func (s *SecretsAPI) updateSecret(ctx context.Context, arg params.UpdateUserSecr
 		arg.Content.Checksum = checksum
 	}
 	err = s.secretService.UpdateUserSecret(ctx, uri, fromUpsertParams(s.modelUUID, arg.AutoPrune, arg.UpsertSecretArg))
-	return codedSecretError(err)
+	switch {
+	case errors.Is(err, secreterrors.SecretNotFound):
+		return apiservererrors.ParamsErrorf(
+			params.CodeSecretNotFound,
+			"secret %q not found", uri,
+		)
+	case errors.Is(err, secreterrors.PermissionDenied):
+		return apiservererrors.ParamsErrorf(
+			params.CodeUnauthorized,
+			"cannot update secret %q: %s", uri, err.Error(),
+		)
+	}
+	return err
 }
 
 func (s *SecretsAPI) secretURI(ctx context.Context, uriStr, label string) (*coresecrets.URI, error) {
@@ -352,7 +362,13 @@ func (s *SecretsAPI) secretURI(ctx context.Context, uriStr, label string) (*core
 	}
 	uri, err := s.secretService.GetUserSecretURIByLabel(ctx, label)
 	if err != nil {
-		return nil, codedSecretError(errors.Annotatef(err, "getting user secret for label %q", label))
+		if errors.Is(err, secreterrors.SecretNotFound) {
+			return nil, apiservererrors.ParamsErrorf(
+				params.CodeSecretNotFound,
+				"getting user secret for label %q: %s", label, err.Error(),
+			)
+		}
+		return nil, errors.Annotatef(err, "getting user secret for label %q", label)
 	}
 	return uri, nil
 }
@@ -384,9 +400,19 @@ func (s *SecretsAPI) RemoveSecrets(ctx context.Context, args params.DeleteSecret
 			Accessor:  domainsecret.SecretAccessor{Kind: domainsecret.ModelAccessor, ID: s.modelUUID},
 			Revisions: arg.Revisions,
 		})
-		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
-			continue
+		switch {
+		case errors.Is(err, secreterrors.SecretNotFound):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeSecretNotFound,
+				"secret %q not found", uri,
+			)
+		case errors.Is(err, secreterrors.PermissionDenied):
+			result.Results[i].Error = apiservererrors.ParamsErrorf(
+				params.CodeUnauthorized,
+				"cannot remove secret %q: %s", uri, err.Error(),
+			)
+		case err != nil:
+			result.Results[i].Error = apiservererrors.ServerError(err)
 		}
 	}
 	return result, nil
@@ -429,18 +455,30 @@ func (s *SecretsAPI) secretsGrantRevoke(ctx context.Context, arg params.GrantRev
 	}
 
 	one := func(appName string) error {
-		if err := op(ctx, uri, domainsecret.SecretAccessParams{
+		err := op(ctx, uri, domainsecret.SecretAccessParams{
 			Accessor: domainsecret.SecretAccessor{Kind: domainsecret.ModelAccessor, ID: s.modelUUID},
 			Scope:    domainsecret.SecretAccessScope{Kind: domainsecret.ModelAccessScope, ID: s.modelUUID},
 			Subject:  domainsecret.SecretAccessor{Kind: domainsecret.ApplicationAccessor, ID: appName},
 			Role:     coresecrets.RoleView,
-		}); err != nil {
+		})
+		switch {
+		case errors.Is(err, secreterrors.SecretNotFound):
+			return apiservererrors.ParamsErrorf(
+				params.CodeSecretNotFound,
+				"secret %q not found", uri,
+			)
+		case errors.Is(err, secreterrors.PermissionDenied):
+			return apiservererrors.ParamsErrorf(
+				params.CodeUnauthorized,
+				"cannot change access to %q for %q: %s", uri, appName, err.Error(),
+			)
+		case err != nil:
 			return errors.Annotatef(err, "cannot change access to %q for %q", uri, appName)
 		}
 		return nil
 	}
 	for i, appName := range arg.Applications {
-		results.Results[i].Error = apiservererrors.ServerError(codedSecretError(one(appName)))
+		results.Results[i].Error = apiservererrors.ServerError(one(appName))
 	}
 	return results, nil
 }

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -5,6 +5,7 @@ package secrets_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretservice "github.com/juju/juju/domain/secret/service"
+	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/internal/testhelpers"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
@@ -722,4 +724,259 @@ func (s *SecretsSuite) TestRevokeSecretPermissionDenied(c *tc.C) {
 
 	_, err = facade.RevokeSecret(c.Context(), params.GrantRevokeUserSecretArg{Label: "my-secret"})
 	c.Assert(err, tc.ErrorMatches, "permission denied")
+}
+
+func (s *SecretsSuite) TestListSecretsGrantsNotFound(c *tc.C) {
+	// Arrange: GetSecretGrants reports the secret has gone away.
+	defer s.setup(c).Finish()
+
+	s.expectAuthClient()
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.ReadAccess, coretesting.ModelTag).Return(nil)
+
+	uri := coresecrets.NewURI()
+	s.secretService.EXPECT().ListSecrets(gomock.Any(), nil, secret.NilRevision, secret.NilLabels).Return(
+		[]*coresecrets.SecretMetadata{{
+			URI:   uri,
+			Owner: coresecrets.Owner{Kind: coresecrets.ModelOwner, ID: coretesting.ModelTag.Id()},
+		}},
+		[][]*coresecrets.SecretRevisionMetadata{{}},
+		nil,
+	)
+	s.secretService.EXPECT().GetSecretGrants(gomock.Any(), uri, coresecrets.RoleView).
+		Return(nil, fmt.Errorf("boom: %w", secreterrors.SecretNotFound))
+
+	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService, s.modelName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Act:
+	_, err = facade.ListSecrets(c.Context(), params.ListSecretsArgs{})
+
+	// Assert:
+	c.Assert(err, tc.DeepEquals, &params.Error{
+		Code:    params.CodeSecretNotFound,
+		Message: fmt.Sprintf("secret %q not found", uri),
+	})
+}
+
+func (s *SecretsSuite) TestListSecretsRevealErrorCodes(c *tc.C) {
+	for _, t := range []struct {
+		sentinel error
+		code     string
+		message  string
+	}{{
+		sentinel: secreterrors.SecretRevisionNotFound,
+		code:     params.CodeSecretRevisionNotFound,
+		message:  "boom: secret revision not found",
+	}, {
+		sentinel: secretbackenderrors.NotFound,
+		code:     params.CodeSecretBackendNotFound,
+		message:  "boom: secret backend not found",
+	}} {
+		func() {
+			// Arrange: reading the revision content from the backend fails.
+			defer s.setup(c).Finish()
+
+			s.expectAuthClient()
+			s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
+
+			uri := coresecrets.NewURI()
+			s.secretService.EXPECT().ListSecrets(gomock.Any(), nil, secret.NilRevision, secret.NilLabels).Return(
+				[]*coresecrets.SecretMetadata{{
+					URI:            uri,
+					Owner:          coresecrets.Owner{Kind: coresecrets.ModelOwner, ID: coretesting.ModelTag.Id()},
+					LatestRevision: 2,
+				}},
+				[][]*coresecrets.SecretRevisionMetadata{{}},
+				nil,
+			)
+			s.secretService.EXPECT().GetSecretGrants(gomock.Any(), uri, coresecrets.RoleView).Return(nil, nil)
+			s.secretService.EXPECT().GetSecretContentFromBackend(gomock.Any(), uri, 2).
+				Return(nil, fmt.Errorf("boom: %w", t.sentinel))
+
+			facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService, s.modelName)
+			c.Assert(err, tc.ErrorIsNil)
+
+			// Act:
+			results, err := facade.ListSecrets(c.Context(), params.ListSecretsArgs{ShowSecrets: true})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Check(results.Results[0].Value, tc.DeepEquals, &params.SecretValueResult{
+				Error: &params.Error{
+					Code:    t.code,
+					Message: fmt.Sprintf("getting content for secret %q: %s", uri, t.message),
+				},
+			})
+		}()
+	}
+}
+
+func (s *SecretsSuite) TestUpdateSecretsErrorCodes(c *tc.C) {
+	for _, t := range []struct {
+		sentinel error
+		code     string
+		message  string
+	}{{
+		sentinel: secreterrors.SecretNotFound,
+		code:     params.CodeSecretNotFound,
+		message:  "secret %q not found",
+	}, {
+		sentinel: secreterrors.PermissionDenied,
+		code:     params.CodeUnauthorized,
+		message:  "cannot update secret %q: boom: permission denied",
+	}} {
+		func() {
+			// Arrange:
+			defer s.setup(c).Finish()
+
+			s.expectAuthClient()
+			s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
+
+			uri := coresecrets.NewURI()
+			s.secretService.EXPECT().UpdateUserSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(fmt.Errorf("boom: %w", t.sentinel))
+
+			facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService, s.modelName)
+			c.Assert(err, tc.ErrorIsNil)
+
+			// Act:
+			results, err := facade.UpdateSecrets(c.Context(), params.UpdateUserSecretArgs{
+				Args: []params.UpdateUserSecretArg{{
+					URI: uri.String(),
+					UpsertSecretArg: params.UpsertSecretArg{
+						Description: new("this is a user secret."),
+					},
+				}},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Check(results.Results[0].Error, tc.DeepEquals, &params.Error{
+				Code:    t.code,
+				Message: fmt.Sprintf(t.message, uri),
+			})
+		}()
+	}
+}
+
+func (s *SecretsSuite) TestUpdateSecretsLabelNotFound(c *tc.C) {
+	// Arrange: resolving the existing label fails, exercising secretURI.
+	defer s.setup(c).Finish()
+
+	s.expectAuthClient()
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
+	s.secretService.EXPECT().GetUserSecretURIByLabel(gomock.Any(), "my-secret").
+		Return(nil, fmt.Errorf("boom: %w", secreterrors.SecretNotFound))
+
+	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService, s.modelName)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Act:
+	results, err := facade.UpdateSecrets(c.Context(), params.UpdateUserSecretArgs{
+		Args: []params.UpdateUserSecretArg{{
+			ExistingLabel: "my-secret",
+			UpsertSecretArg: params.UpsertSecretArg{
+				Description: new("this is a user secret."),
+			},
+		}},
+	})
+
+	// Assert:
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results.Results, tc.HasLen, 1)
+	c.Check(results.Results[0].Error, tc.DeepEquals, &params.Error{
+		Code:    params.CodeSecretNotFound,
+		Message: `getting user secret for label "my-secret": boom: secret not found`,
+	})
+}
+
+func (s *SecretsSuite) TestRemoveSecretsErrorCodes(c *tc.C) {
+	for _, t := range []struct {
+		sentinel error
+		code     string
+		message  string
+	}{{
+		sentinel: secreterrors.SecretNotFound,
+		code:     params.CodeSecretNotFound,
+		message:  "secret %q not found",
+	}, {
+		sentinel: secreterrors.PermissionDenied,
+		code:     params.CodeUnauthorized,
+		message:  "cannot remove secret %q: boom: permission denied",
+	}} {
+		func() {
+			// Arrange:
+			defer s.setup(c).Finish()
+
+			s.expectAuthClient()
+			s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
+
+			uri := coresecrets.NewURI()
+			s.secretService.EXPECT().DeleteSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(fmt.Errorf("boom: %w", t.sentinel))
+
+			facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService, s.modelName)
+			c.Assert(err, tc.ErrorIsNil)
+
+			// Act:
+			results, err := facade.RemoveSecrets(c.Context(), params.DeleteSecretArgs{
+				Args: []params.DeleteSecretArg{{URI: uri.String()}},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Check(results.Results[0].Error, tc.DeepEquals, &params.Error{
+				Code:    t.code,
+				Message: fmt.Sprintf(t.message, uri),
+			})
+		}()
+	}
+}
+
+func (s *SecretsSuite) TestGrantSecretErrorCodes(c *tc.C) {
+	for _, t := range []struct {
+		sentinel error
+		code     string
+		message  string
+	}{{
+		sentinel: secreterrors.SecretNotFound,
+		code:     params.CodeSecretNotFound,
+		message:  "secret %q not found",
+	}, {
+		sentinel: secreterrors.PermissionDenied,
+		code:     params.CodeUnauthorized,
+		message:  `cannot change access to %q for "gitlab": boom: permission denied`,
+	}} {
+		func() {
+			// Arrange:
+			defer s.setup(c).Finish()
+
+			s.expectAuthClient()
+			s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
+
+			uri := coresecrets.NewURI()
+			s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(fmt.Errorf("boom: %w", t.sentinel))
+
+			facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService, s.modelName)
+			c.Assert(err, tc.ErrorIsNil)
+
+			// Act:
+			results, err := facade.GrantSecret(c.Context(), params.GrantRevokeUserSecretArg{
+				URI:          uri.String(),
+				Applications: []string{"gitlab"},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Check(results.Results[0].Error, tc.DeepEquals, &params.Error{
+				Code:    t.code,
+				Message: fmt.Sprintf(t.message, uri),
+			})
+		}()
+	}
 }

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -817,10 +817,11 @@ func (api *CrossModelRelationsAPIv3) getSecretChanges(ctx context.Context, uriSt
 	}
 	latest, err := api.secretService.GetLatestRevisions(ctx, uris)
 	if err != nil {
-		// Translate the secret domain error into its wire code at the
-		// call site, preserving the message.
 		if internalerrors.Is(err, secreterrors.SecretNotFound) {
-			return nil, apiservererrors.ParamsErrorf(params.CodeSecretNotFound, "%s", err.Error())
+			return nil, apiservererrors.ParamsErrorf(
+				params.CodeSecretNotFound,
+				"getting latest revisions for secrets %q: %s", uriStr, err.Error(),
+			)
 		}
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -35,6 +35,7 @@ import (
 	domainlife "github.com/juju/juju/domain/life"
 	"github.com/juju/juju/domain/relation"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	internalerrors "github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/rpc/params"
 )
@@ -816,6 +817,11 @@ func (api *CrossModelRelationsAPIv3) getSecretChanges(ctx context.Context, uriSt
 	}
 	latest, err := api.secretService.GetLatestRevisions(ctx, uris)
 	if err != nil {
+		// Translate the secret domain error into its wire code at the
+		// call site, preserving the message.
+		if internalerrors.Is(err, secreterrors.SecretNotFound) {
+			return nil, apiservererrors.ParamsErrorf(params.CodeSecretNotFound, "%s", err.Error())
+		}
 		return nil, errors.Trace(err)
 	}
 	changes := make([]params.SecretRevisionChange, len(uris))

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -38,6 +38,7 @@ import (
 	domainlife "github.com/juju/juju/domain/life"
 	domainrelation "github.com/juju/juju/domain/relation"
 	relationerrors "github.com/juju/juju/domain/relation/errors"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -2021,4 +2022,53 @@ func (s *facadeSuite) expectWatchConsumedSecretsChanges(ctrl *gomock.Controller,
 	mockWatcher.EXPECT().Changes().Return(changes)
 	s.crossModelRelationService.EXPECT().WatchRemoteConsumedSecretsChanges(gomock.Any(), appUUID).Return(mockWatcher, nil)
 	return changes
+}
+
+func (s *facadeSuite) TestWatchConsumedSecretsChangesSecretNotFound(c *tc.C) {
+	// Arrange: the watcher reports a URI whose secret has since been removed.
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	testMac, err := macaroon.New([]byte("root"), []byte("id"), "loc", macaroon.LatestVersion)
+	c.Assert(err, tc.ErrorIsNil)
+	offerUUID := tc.Must(c, offer.NewUUID)
+	relUUID := tc.Must(c, corerelation.NewUUID)
+	appUUID := tc.Must(c, application.NewUUID)
+	uri := coresecrets.NewURI()
+
+	s.crossModelAuthContext.EXPECT().Authenticator().Return(s.authenticator)
+	s.crossModelRelationService.EXPECT().GetOfferUUIDByRelationUUID(gomock.Any(), relUUID).Return(offerUUID, nil)
+	s.authenticator.EXPECT().CheckOfferMacaroons(gomock.Any(), s.modelUUID.String(), offerUUID.String(), gomock.Any(), bakery.LatestVersion).
+		Return(nil, nil)
+
+	mockWatcher := NewMockStringsWatcher(ctrl)
+	changes := make(chan []string, 1)
+	changes <- []string{uri.ID}
+	mockWatcher.EXPECT().Changes().Return(changes)
+	mockWatcher.EXPECT().Kill().AnyTimes()
+	mockWatcher.EXPECT().Wait().Return(nil).AnyTimes()
+	s.crossModelRelationService.EXPECT().WatchRemoteConsumedSecretsChanges(gomock.Any(), appUUID).Return(mockWatcher, nil)
+
+	s.secretService.EXPECT().GetLatestRevisions(gomock.Any(), []*coresecrets.URI{uri}).
+		Return(nil, errors.Errorf("boom: %w", secreterrors.SecretNotFound))
+	s.watcherRegistry.EXPECT().Register(gomock.Any(), gomock.Any()).Return("1", nil)
+
+	// Act:
+	results, err := s.api(c).WatchConsumedSecretsChanges(c.Context(), params.WatchRemoteSecretChangesArgs{
+		Args: []params.WatchRemoteSecretChangesArg{{
+			ApplicationToken: appUUID.String(),
+			RelationToken:    relUUID.String(),
+			Macaroons:        macaroon.Slice{testMac},
+			BakeryVersion:    bakery.LatestVersion,
+		}},
+	})
+
+	// Assert: the sentinel is reported with the secret-not-found wire code,
+	// and survives the ServerError call the facade wraps it in.
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results.Results, tc.HasLen, 1)
+	c.Check(results.Results[0].Error, tc.DeepEquals, &params.Error{
+		Code:    params.CodeSecretNotFound,
+		Message: `getting latest revisions for secrets ["` + uri.ID + `"]: boom: secret not found`,
+	})
 }

--- a/apiserver/facades/controller/usersecretsdrain/drain.go
+++ b/apiserver/facades/controller/usersecretsdrain/drain.go
@@ -13,6 +13,8 @@ import (
 	"github.com/juju/juju/core/model"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/domain/secret"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
+	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/secrets"
@@ -29,6 +31,23 @@ type SecretsDrainAPI struct {
 	modelUUID            model.UUID
 	secretBackendService SecretBackendService
 	secretService        SecretService
+}
+
+// codedSecretError translates well-known secret domain errors into coded
+// params errors at the facade boundary, preserving the message. Other
+// errors are returned unchanged.
+func codedSecretError(err error) error {
+	switch {
+	case errors.Is(err, secreterrors.SecretNotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretNotFound, "%s", err.Error())
+	case errors.Is(err, secreterrors.SecretRevisionNotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretRevisionNotFound, "%s", err.Error())
+	case errors.Is(err, secretbackenderrors.NotFound):
+		return apiservererrors.ParamsErrorf(params.CodeSecretBackendNotFound, "%s", err.Error())
+	case errors.Is(err, secreterrors.PermissionDenied):
+		return apiservererrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
+	}
+	return err
 }
 
 // GetSecretBackendConfigs gets the config needed to create a client to secret backends for the drain worker.
@@ -53,7 +72,7 @@ func (s *SecretsDrainAPI) GetSecretBackendConfigs(ctx context.Context, arg param
 		BackendID: backendID,
 	})
 	if err != nil {
-		return results, errors.Trace(err)
+		return results, codedSecretError(err)
 	}
 	if len(cfgInfo.Configs) == 0 {
 		return results, errors.NotFoundf("no secret backends available")
@@ -82,7 +101,7 @@ func (s *SecretsDrainAPI) GetSecretContentInfo(ctx context.Context, args params.
 	for i, arg := range args.Args {
 		content, backend, draining, err := s.getSecretContent(ctx, arg)
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
+			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
 			continue
 		}
 		contentParams := params.SecretContentParams{}
@@ -192,7 +211,7 @@ func (s *SecretsDrainAPI) GetSecretRevisionContentInfo(ctx context.Context, arg 
 			ID:   s.modelUUID.String(),
 		})
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
+			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
 			continue
 		}
 		contentParams := params.SecretContentParams{}
@@ -203,7 +222,7 @@ func (s *SecretsDrainAPI) GetSecretRevisionContentInfo(ctx context.Context, arg 
 			}
 			backend, draining, err := s.getBackend(ctx, valueRef.BackendID)
 			if err != nil {
-				result.Results[i].Error = apiservererrors.ServerError(err)
+				result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
 				continue
 			}
 			result.Results[i].BackendConfig = &params.SecretBackendConfigResult{

--- a/apiserver/facades/controller/usersecretsdrain/drain.go
+++ b/apiserver/facades/controller/usersecretsdrain/drain.go
@@ -90,12 +90,32 @@ func (s *SecretsDrainAPI) GetSecretContentInfo(ctx context.Context, args params.
 	for i, arg := range args.Args {
 		content, backend, draining, err := s.getSecretContent(ctx, arg)
 		if err != nil {
-			if errors.Is(err, secreterrors.SecretRevisionNotFound) {
+			// getSecretContent looks up the secret metadata, reads the
+			// revision value and, for external secrets, resolves the
+			// backend config, so every sentinel those three can return
+			// needs translating here.
+			switch {
+			case errors.Is(err, secreterrors.SecretNotFound):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretNotFound,
+					"getting content for secret %q: %s", arg.URI, err.Error(),
+				)
+			case errors.Is(err, secreterrors.SecretRevisionNotFound):
 				result.Results[i].Error = apiservererrors.ParamsErrorf(
 					params.CodeSecretRevisionNotFound,
 					"getting content for secret %q: %s", arg.URI, err.Error(),
 				)
-			} else {
+			case errors.Is(err, secreterrors.PermissionDenied):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeUnauthorized,
+					"cannot read secret %q: %s", arg.URI, err.Error(),
+				)
+			case errors.Is(err, secretbackenderrors.NotFound):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretBackendNotFound,
+					"getting content for secret %q: %s", arg.URI, err.Error(),
+				)
+			default:
 				result.Results[i].Error = apiservererrors.ServerError(err)
 			}
 			continue
@@ -207,12 +227,25 @@ func (s *SecretsDrainAPI) GetSecretRevisionContentInfo(ctx context.Context, arg 
 			ID:   s.modelUUID.String(),
 		})
 		if err != nil {
-			if errors.Is(err, secreterrors.SecretRevisionNotFound) {
+			// GetSecretValue checks read access before reading the
+			// revision, so it can fail with any of these three.
+			switch {
+			case errors.Is(err, secreterrors.SecretNotFound):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretNotFound,
+					"secret %q not found", arg.URI,
+				)
+			case errors.Is(err, secreterrors.SecretRevisionNotFound):
 				result.Results[i].Error = apiservererrors.ParamsErrorf(
 					params.CodeSecretRevisionNotFound,
 					"getting revision %d of secret %q: %s", rev, arg.URI, err.Error(),
 				)
-			} else {
+			case errors.Is(err, secreterrors.PermissionDenied):
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeUnauthorized,
+					"cannot read secret %q: %s", arg.URI, err.Error(),
+				)
+			default:
 				result.Results[i].Error = apiservererrors.ServerError(err)
 			}
 			continue
@@ -225,7 +258,15 @@ func (s *SecretsDrainAPI) GetSecretRevisionContentInfo(ctx context.Context, arg 
 			}
 			backend, draining, err := s.getBackend(ctx, valueRef.BackendID)
 			if err != nil {
-				result.Results[i].Error = apiservererrors.ServerError(err)
+				if errors.Is(err, secretbackenderrors.NotFound) {
+					result.Results[i].Error = apiservererrors.ParamsErrorf(
+						params.CodeSecretBackendNotFound,
+						"getting backend %q for secret %q: %s",
+						valueRef.BackendID, arg.URI, err.Error(),
+					)
+				} else {
+					result.Results[i].Error = apiservererrors.ServerError(err)
+				}
 				continue
 			}
 			result.Results[i].BackendConfig = &params.SecretBackendConfigResult{

--- a/apiserver/facades/controller/usersecretsdrain/drain.go
+++ b/apiserver/facades/controller/usersecretsdrain/drain.go
@@ -33,23 +33,6 @@ type SecretsDrainAPI struct {
 	secretService        SecretService
 }
 
-// codedSecretError translates well-known secret domain errors into coded
-// params errors at the facade boundary, preserving the message. Other
-// errors are returned unchanged.
-func codedSecretError(err error) error {
-	switch {
-	case errors.Is(err, secreterrors.SecretNotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretNotFound, "%s", err.Error())
-	case errors.Is(err, secreterrors.SecretRevisionNotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretRevisionNotFound, "%s", err.Error())
-	case errors.Is(err, secretbackenderrors.NotFound):
-		return apiservererrors.ParamsErrorf(params.CodeSecretBackendNotFound, "%s", err.Error())
-	case errors.Is(err, secreterrors.PermissionDenied):
-		return apiservererrors.ParamsErrorf(params.CodeUnauthorized, "%s", err.Error())
-	}
-	return err
-}
-
 // GetSecretBackendConfigs gets the config needed to create a client to secret backends for the drain worker.
 func (s *SecretsDrainAPI) GetSecretBackendConfigs(ctx context.Context, arg params.SecretBackendArgs) (params.SecretBackendConfigResults, error) {
 	if len(arg.BackendIDs) > 1 {
@@ -72,7 +55,13 @@ func (s *SecretsDrainAPI) GetSecretBackendConfigs(ctx context.Context, arg param
 		BackendID: backendID,
 	})
 	if err != nil {
-		return results, codedSecretError(err)
+		if errors.Is(err, secretbackenderrors.NotFound) {
+			return results, apiservererrors.ParamsErrorf(
+				params.CodeSecretBackendNotFound,
+				"getting drain config for secret backend %q: %s", backendID, err.Error(),
+			)
+		}
+		return results, errors.Trace(err)
 	}
 	if len(cfgInfo.Configs) == 0 {
 		return results, errors.NotFoundf("no secret backends available")
@@ -101,7 +90,14 @@ func (s *SecretsDrainAPI) GetSecretContentInfo(ctx context.Context, args params.
 	for i, arg := range args.Args {
 		content, backend, draining, err := s.getSecretContent(ctx, arg)
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
+			if errors.Is(err, secreterrors.SecretRevisionNotFound) {
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretRevisionNotFound,
+					"getting content for secret %q: %s", arg.URI, err.Error(),
+				)
+			} else {
+				result.Results[i].Error = apiservererrors.ServerError(err)
+			}
 			continue
 		}
 		contentParams := params.SecretContentParams{}
@@ -211,7 +207,14 @@ func (s *SecretsDrainAPI) GetSecretRevisionContentInfo(ctx context.Context, arg 
 			ID:   s.modelUUID.String(),
 		})
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
+			if errors.Is(err, secreterrors.SecretRevisionNotFound) {
+				result.Results[i].Error = apiservererrors.ParamsErrorf(
+					params.CodeSecretRevisionNotFound,
+					"getting revision %d of secret %q: %s", rev, arg.URI, err.Error(),
+				)
+			} else {
+				result.Results[i].Error = apiservererrors.ServerError(err)
+			}
 			continue
 		}
 		contentParams := params.SecretContentParams{}
@@ -222,7 +225,7 @@ func (s *SecretsDrainAPI) GetSecretRevisionContentInfo(ctx context.Context, arg 
 			}
 			backend, draining, err := s.getBackend(ctx, valueRef.BackendID)
 			if err != nil {
-				result.Results[i].Error = apiservererrors.ServerError(codedSecretError(err))
+				result.Results[i].Error = apiservererrors.ServerError(err)
 				continue
 			}
 			result.Results[i].BackendConfig = &params.SecretBackendConfigResult{

--- a/apiserver/facades/controller/usersecretsdrain/drain_test.go
+++ b/apiserver/facades/controller/usersecretsdrain/drain_test.go
@@ -4,6 +4,7 @@
 package usersecretsdrain_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/canonical/gomock/gomock"
@@ -15,6 +16,8 @@ import (
 	"github.com/juju/juju/core/model"
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/domain/secret"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
+	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	"github.com/juju/juju/internal/secrets/provider"
 	"github.com/juju/juju/internal/testhelpers"
@@ -313,4 +316,161 @@ func (s *drainSuite) TestGetSecretRevisionContentInfoExternal(c *tc.C) {
 			},
 		}},
 	})
+}
+
+func (s *drainSuite) TestGetSecretBackendConfigsNotFound(c *tc.C) {
+	defer s.setup(c).Finish()
+
+	// Arrange:
+	s.secretBackendService.EXPECT().DrainBackendConfigInfo(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("boom: %w", secretbackenderrors.NotFound))
+
+	// Act:
+	_, err := s.facade.GetSecretBackendConfigs(c.Context(), params.SecretBackendArgs{
+		BackendIDs: []string{"backend-id"},
+	})
+
+	// Assert:
+	pErr, ok := err.(*params.Error)
+	c.Assert(ok, tc.IsTrue)
+	c.Check(pErr.Code, tc.Equals, params.CodeSecretBackendNotFound)
+}
+
+// TestGetSecretContentInfoErrorCodes checks every sentinel reachable through
+// getSecretContent: the metadata lookup can fail with SecretNotFound, the
+// revision read with SecretNotFound, SecretRevisionNotFound or
+// PermissionDenied, and the backend lookup with secretbackenderrors.NotFound.
+func (s *drainSuite) TestGetSecretContentInfoErrorCodes(c *tc.C) {
+	accessor := secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
+		ID:   coretesting.ModelTag.Id(),
+	}
+	for _, t := range []struct {
+		about  string
+		expect func(*tc.C, *coresecrets.URI, error)
+		err    error
+		code   string
+	}{{
+		about: "secret metadata not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecret(gomock.Any(), uri).Return(nil, err)
+		},
+		err:  secreterrors.SecretNotFound,
+		code: params.CodeSecretNotFound,
+	}, {
+		about: "revision not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecret(gomock.Any(), uri).
+				Return(&coresecrets.SecretMetadata{URI: uri, LatestRevision: 668}, nil)
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, accessor).Return(nil, nil, err)
+		},
+		err:  secreterrors.SecretRevisionNotFound,
+		code: params.CodeSecretRevisionNotFound,
+	}, {
+		about: "read access denied",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecret(gomock.Any(), uri).
+				Return(&coresecrets.SecretMetadata{URI: uri, LatestRevision: 668}, nil)
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, accessor).Return(nil, nil, err)
+		},
+		err:  secreterrors.PermissionDenied,
+		code: params.CodeUnauthorized,
+	}, {
+		about: "backend not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecret(gomock.Any(), uri).
+				Return(&coresecrets.SecretMetadata{URI: uri, LatestRevision: 668}, nil)
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, accessor).
+				Return(nil, &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "rev-id"}, nil)
+			s.secretBackendService.EXPECT().BackendConfigInfo(gomock.Any(), gomock.Any()).Return(nil, err)
+		},
+		err:  secretbackenderrors.NotFound,
+		code: params.CodeSecretBackendNotFound,
+	}} {
+		c.Logf("%s", t.about)
+		func() {
+			defer s.setup(c).Finish()
+
+			// Arrange:
+			uri := coresecrets.NewURI()
+			t.expect(c, uri, fmt.Errorf("boom: %w", t.err))
+
+			// Act:
+			results, err := s.facade.GetSecretContentInfo(c.Context(), params.GetSecretContentArgs{
+				Args: []params.GetSecretContentArg{{URI: uri.String()}},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Assert(results.Results[0].Error, tc.NotNil)
+			c.Check(results.Results[0].Error.Code, tc.Equals, t.code)
+		}()
+	}
+}
+
+// TestGetSecretRevisionContentInfoErrorCodes checks every sentinel reachable
+// through GetSecretValue plus the backend lookup for external revisions.
+func (s *drainSuite) TestGetSecretRevisionContentInfoErrorCodes(c *tc.C) {
+	accessor := secret.SecretAccessor{
+		Kind: secret.ModelAccessor,
+		ID:   coretesting.ModelTag.Id(),
+	}
+	for _, t := range []struct {
+		about  string
+		expect func(*tc.C, *coresecrets.URI, error)
+		err    error
+		code   string
+	}{{
+		about: "secret not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, accessor).Return(nil, nil, err)
+		},
+		err:  secreterrors.SecretNotFound,
+		code: params.CodeSecretNotFound,
+	}, {
+		about: "revision not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, accessor).Return(nil, nil, err)
+		},
+		err:  secreterrors.SecretRevisionNotFound,
+		code: params.CodeSecretRevisionNotFound,
+	}, {
+		about: "read access denied",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, accessor).Return(nil, nil, err)
+		},
+		err:  secreterrors.PermissionDenied,
+		code: params.CodeUnauthorized,
+	}, {
+		about: "backend not found",
+		expect: func(c *tc.C, uri *coresecrets.URI, err error) {
+			s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, accessor).
+				Return(nil, &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "rev-id"}, nil)
+			s.secretBackendService.EXPECT().BackendConfigInfo(gomock.Any(), gomock.Any()).Return(nil, err)
+		},
+		err:  secretbackenderrors.NotFound,
+		code: params.CodeSecretBackendNotFound,
+	}} {
+		c.Logf("%s", t.about)
+		func() {
+			defer s.setup(c).Finish()
+
+			// Arrange:
+			uri := coresecrets.NewURI()
+			t.expect(c, uri, fmt.Errorf("boom: %w", t.err))
+
+			// Act:
+			results, err := s.facade.GetSecretRevisionContentInfo(c.Context(), params.SecretRevisionArg{
+				URI:       uri.String(),
+				Revisions: []int{666},
+			})
+
+			// Assert:
+			c.Assert(err, tc.ErrorIsNil)
+			c.Assert(results.Results, tc.HasLen, 1)
+			c.Assert(results.Results[0].Error, tc.NotNil)
+			c.Check(results.Results[0].Error.Code, tc.Equals, t.code)
+		}()
+	}
 }


### PR DESCRIPTION
 When you relate an application to an offer that is already related (or when the endpoint only allows one 
 relation), the CLI used to print the whole internal error chain, something like "adding relation between 
 endpoints ...: cannot add relation ...: relation ...: establishing a new relation for ... would exceed   
 its maximum relation limit of 1". Users should just see a short, clear message.                          
                                                                                                          
 The reason this happened is that the state layer marks this failure with a domain error sentinel, but    
 the API server only knew how to translate the juju/errors constant with the same text into a wire error  
 code. Since those are two different Go types, the match never happened, the error crossed the wire with  
 no code at all, and the CLI had nothing to recognize it by — so it printed the raw chained message with  
 every layer's annotation glued together.                                                                 
                                                                                                          
 The fix maps the domain sentinels for quota exceeded and relation already exists to the existing wire    
 codes quota limit exceeded and already exists in the API server error translation, and makes the         
 AddRelation facade return a short coded error for the quota case instead of the full chain. The user now 
 sees "ERROR adding relation between endpoints "postgresql2:database" and "offer-multi": quota limit      
 exceeded". Doing this on the server side means other API clients (pylibjuju, terraform) get the clean    
 error too, and the already-exists mapping also revives the CLI's helpful hint for double integration     
 ("Use 'juju status --relations' ...") which was dead code before.   

## QA steps

```sh                                                                                                    
# Bootstrap a 4.0 controller built from this branch
$ juju bootstrap microk8s qa
$ juju add-model rel-test

# Deploy two apps where the endpoint has a relation limit of 1
$ juju deploy postgresql-k8s postgresql1 --channel 14/stable --trust
$ juju deploy postgresql-k8s postgresql2 --channel 14/stable --trust
$ juju wait-for application postgresql1 --query='status=="active"'
$ juju wait-for application postgresql2 --query='status=="active"'

# Offer the endpoint and relate once (succeeds)
$ juju offer postgresql1:database offer-multi
$ juju integrate postgresql2:database offer-multi

# Relate the same endpoint again — must fail with the short message
$ juju integrate postgresql2:database offer-multi
ERROR adding relation between endpoints "postgresql2:database" and "offer-multi": quota limit exceeded

# Also check the plain double-integration path now shows the friendly hint
$ juju deploy postgresql-test-app --channel latest/edge
$ juju integrate postgresql-test-app:database postgresql1:database
$ juju integrate postgresql-test-app:database postgresql1:database
ERROR ... already exists ...
Use 'juju status --relations' to view the current relations.

# Confirm nothing else broke
$ juju status --relations
$ juju debug-log -m qa:rel-test --replay | grep -i error
 ```                                                                                                      
                                                                                                          
 Any charm with limit: 1 on an endpoint works for the first part (the postgresql-k8s database endpoint is 
 one); only the exact app/endpoint names change. Before this change, the same second integrate printed    
 the full internal chain ending in "would exceed its maximum relation limit of 1".   



## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #21125.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9863](https://warthogs.atlassian.net/browse/JUJU-9863)


[JUJU-9863]: https://warthogs.atlassian.net/browse/JUJU-9863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ