### PR TITLE
fix: add diagnostics for OAuth connection retries

### DIFF
--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -263,6 +263,10 @@ func (c *statusCommand) getStatus(ctx context.Context, includeStorage bool) (*pa
 	})
 }
 
+func (c *statusCommand) logStatusAttemptFailure(ctx context.Context, attempt, attempts int, err error) {
+	logger.Debugf(ctx, "status request attempt %d/%d failed (status API client cached: %t): %v", attempt, attempts, c.statusAPI != nil, err)
+}
+
 func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 	showIntegrations := c.integrations || c.relations
 	showStorage := c.storage
@@ -286,18 +290,18 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 	status, err := c.getStatus(ctx, showStorage)
 	if err != nil && !modelcmd.IsModelMigratedError(err) {
 		attempts := c.retryCount + 1
-		logger.Debugf(context.TODO(), "status request attempt %d/%d failed (API client initialized: %t): %v", 1, attempts, c.statusAPI != nil, err)
+		c.logStatusAttemptFailure(ctx, 1, attempts, err)
 		for i := 0; i < c.retryCount; i++ {
 			// fun bit - make sure a new api connection is used for each new call
 			c.SetModelAPI(nil)
-			logger.Debugf(context.TODO(), "retrying status request, attempt %d/%d, after %s", i+2, attempts, c.retryDelay)
+			logger.Debugf(ctx, "retrying status request, attempt %d/%d, after %s", i+2, attempts, c.retryDelay)
 			// Wait for a bit before retries.
 			<-c.clock.After(c.retryDelay)
 			status, err = c.getStatus(ctx, showStorage)
 			if err == nil || modelcmd.IsModelMigratedError(err) {
 				break
 			}
-			logger.Debugf(context.TODO(), "status request attempt %d/%d failed (API client initialized: %t): %v", i+2, attempts, c.statusAPI != nil, err)
+			c.logStatusAttemptFailure(ctx, i+2, attempts, err)
 		}
 	}
 

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -285,15 +285,19 @@ func (c *statusCommand) runStatus(ctx *cmd.Context) error {
 	// Always attempt to get the status at least once, and retry if it fails.
 	status, err := c.getStatus(ctx, showStorage)
 	if err != nil && !modelcmd.IsModelMigratedError(err) {
+		attempts := c.retryCount + 1
+		logger.Debugf(context.TODO(), "status request attempt %d/%d failed (API client initialized: %t): %v", 1, attempts, c.statusAPI != nil, err)
 		for i := 0; i < c.retryCount; i++ {
 			// fun bit - make sure a new api connection is used for each new call
 			c.SetModelAPI(nil)
+			logger.Debugf(context.TODO(), "retrying status request, attempt %d/%d, after %s", i+2, attempts, c.retryDelay)
 			// Wait for a bit before retries.
 			<-c.clock.After(c.retryDelay)
 			status, err = c.getStatus(ctx, showStorage)
 			if err == nil || modelcmd.IsModelMigratedError(err) {
 				break
 			}
+			logger.Debugf(context.TODO(), "status request attempt %d/%d failed (API client initialized: %t): %v", i+2, attempts, c.statusAPI != nil, err)
 		}
 	}
 

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -250,11 +250,11 @@ func (c *CommandBase) NewAPIRootWithDialOpts(
 		param.DialOpts = *dialOpts
 	}
 	initialSessionToken := param.AccountDetails.SessionToken
-	logger.Debugf(context.TODO(), "opening API connection for controller %q and model %q using login provider %T (session token present: %t)",
+	logger.Debugf(ctx, "opening API connection for controller %q and model %q using login provider %T (session token present: %t)",
 		controllerName, modelName, param.DialOpts.LoginProvider, initialSessionToken != "")
 	conn, err := juju.NewAPIConnection(ctx, param)
 	refreshedSessionToken := param.AccountDetails.SessionToken != initialSessionToken
-	logger.Debugf(context.TODO(), "API connection result for controller %q and model %q (error: %v; session token refreshed: %t; refreshed token persistence requires a successful connection)",
+	logger.Debugf(ctx, "API connection result for controller %q and model %q (error: %v; session token refreshed: %t; refreshed session token persistence depends on connection success)",
 		controllerName, modelName, err, refreshedSessionToken)
 	if modelName != "" && params.ErrCode(err) == params.CodeModelNotFound {
 		return nil, c.missingModelError(store, controllerName, modelName)

--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -249,7 +249,13 @@ func (c *CommandBase) NewAPIRootWithDialOpts(
 	if dialOpts != nil {
 		param.DialOpts = *dialOpts
 	}
+	initialSessionToken := param.AccountDetails.SessionToken
+	logger.Debugf(context.TODO(), "opening API connection for controller %q and model %q using login provider %T (session token present: %t)",
+		controllerName, modelName, param.DialOpts.LoginProvider, initialSessionToken != "")
 	conn, err := juju.NewAPIConnection(ctx, param)
+	refreshedSessionToken := param.AccountDetails.SessionToken != initialSessionToken
+	logger.Debugf(context.TODO(), "API connection result for controller %q and model %q (error: %v; session token refreshed: %t; refreshed token persistence requires a successful connection)",
+		controllerName, modelName, err, refreshedSessionToken)
 	if modelName != "" && params.ErrCode(err) == params.CodeModelNotFound {
 		return nil, c.missingModelError(store, controllerName, modelName)
 	}

--- a/juju/api.go
+++ b/juju/api.go
@@ -135,7 +135,7 @@ func NewAPIConnection(ctx context.Context, args NewAPIConnectionParams) (_ api.C
 		authTag != nil &&
 		args.AccountDetails.User != "" &&
 		args.AccountDetails.User != authTag.Id() {
-		logger.Debugf(context.TODO(), "rejecting API connection because authenticated user %q differs from expected user %q", authTag.Id(), args.AccountDetails.User)
+		logger.Debugf(ctx, "rejecting API connection because authenticated user %q differs from expected user %q", authTag.Id(), args.AccountDetails.User)
 		return nil, errors.Unauthorizedf("attempted login as %q for user %q", authTag.Id(), args.AccountDetails.User)
 	}
 

--- a/juju/api.go
+++ b/juju/api.go
@@ -130,11 +130,13 @@ func NewAPIConnection(ctx context.Context, args NewAPIConnectionParams) (_ api.C
 	// This only applies if the user was explicitly set.
 	// Logging in via an external auth provider is allowed with specifying a
 	// user in the args - that comes from the provider.
+	authTag := st.AuthTag()
 	if args.AccountDetails != nil &&
-		st.AuthTag() != nil &&
+		authTag != nil &&
 		args.AccountDetails.User != "" &&
-		args.AccountDetails.User != st.AuthTag().Id() {
-		return nil, errors.Unauthorizedf("attempted login as %q for user %q", st.AuthTag().Id(), args.AccountDetails.User)
+		args.AccountDetails.User != authTag.Id() {
+		logger.Debugf(context.TODO(), "rejecting API connection because authenticated user %q differs from expected user %q", authTag.Id(), args.AccountDetails.User)
+		return nil, errors.Unauthorizedf("attempted login as %q for user %q", authTag.Id(), args.AccountDetails.User)
 	}
 
 	// Update API addresses if they've changed. Error is non-fatal.


### PR DESCRIPTION
## Summary

- Log `juju status` retry attempts and whether the API client was initialized.
- Log OIDC connection attempts without exposing session-token values.
- Log when a refreshed session token cannot be persisted because API connection setup failed.
- Log authenticated-user and expected-user mismatches before rejecting the connection.

These diagnostics make repeated OAuth prompts traceable to the status retry loop and post-login identity validation.

## Test plan

- `go test ./juju ./cmd/juju/status ./cmd/internal/loginprovider`
- `go test ./cmd/modelcmd`
- `git diff --check`
