### PR TITLE
fix(sshtunneler): wait for machine host keys

### DIFF
--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -48,9 +48,17 @@ type State interface {
 	// the provisioner after a machine is detached for reprovisioning.
 	NamespaceForWatchMachineReprovision() string
 
+	// NamespaceForWatchMachineSSHHostKeys returns the namespace for watching
+	// machine SSH host key changes.
+	NamespaceForWatchMachineSSHHostKeys() string
+
 	// InitialWatchModelMachineLifeAndStartTimesStatement returns the namespace
 	// and initial statement for watching machine life and agent start times.
 	InitialWatchModelMachineLifeAndStartTimesStatement() (string, string)
+
+	// InitialWatchMachineSSHHostKeysStatement returns the namespace and initial
+	// statement for watching SSH host key changes.
+	InitialWatchMachineSSHHostKeysStatement() (string, string)
 
 	// GetMachineLife returns the life status of the specified machine.
 	// It returns a MachineNotFound if the given machine doesn't exist.

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -48,10 +48,6 @@ type State interface {
 	// the provisioner after a machine is detached for reprovisioning.
 	NamespaceForWatchMachineReprovision() string
 
-	// NamespaceForWatchMachineSSHHostKeys returns the namespace for watching
-	// machine SSH host key changes.
-	NamespaceForWatchMachineSSHHostKeys() string
-
 	// InitialWatchModelMachineLifeAndStartTimesStatement returns the namespace
 	// and initial statement for watching machine life and agent start times.
 	InitialWatchModelMachineLifeAndStartTimesStatement() (string, string)

--- a/domain/machine/service/state_mock_test.go
+++ b/domain/machine/service/state_mock_test.go
@@ -64,6 +64,7 @@ type MockStateMockRecorder struct {
 	getSSHHostKeysExpects                                     []*gomock.Call2_2[context.Context, string, []string, error]
 	getSupportedContainersTypesExpects                        []*gomock.Call2_2[context.Context, string, []string, error]
 	initialMachineContainerLifeStatementExpects               []*gomock.Call0_3[string, string, func(string) string]
+	initialWatchMachineSSHHostKeysStatementExpects            []*gomock.Call0_2[string, string]
 	initialWatchModelMachineLifeAndStartTimesStatementExpects []*gomock.Call0_2[string, string]
 	initialWatchModelMachinesStatementExpects                 []*gomock.Call0_2[string, string]
 	initialWatchStatementExpects                              []*gomock.Call0_2[string, string]
@@ -76,6 +77,7 @@ type MockStateMockRecorder struct {
 	namespaceForWatchMachineCloudInstanceExpects              []*gomock.Call0_1[string]
 	namespaceForWatchMachineRebootExpects                     []*gomock.Call0_1[string]
 	namespaceForWatchMachineReprovisionExpects                []*gomock.Call0_1[string]
+	namespaceForWatchMachineSSHHostKeysExpects                []*gomock.Call0_1[string]
 	requireMachineRebootExpects                               []*gomock.Call2_1[context.Context, machine.UUID, error]
 	setKeepInstanceExpects                                    []*gomock.Call3_1[context.Context, machine.Name, bool, error]
 	setMachineCloudInstanceExpects                            []*gomock.Call6_1[context.Context, string, instance.Id, string, string, *instance.HardwareCharacteristics, error]
@@ -602,6 +604,24 @@ func (mr *MockStateMockRecorder) InitialMachineContainerLifeStatement() *MockSta
 // MockStateInitialMachineContainerLifeStatementCall is the typed call wrapper for InitialMachineContainerLifeStatement.
 type MockStateInitialMachineContainerLifeStatementCall = gomock.Call0_3[string, string, func(string) string]
 
+// InitialWatchMachineSSHHostKeysStatement mocks base method.
+func (m *MockState) InitialWatchMachineSSHHostKeysStatement() (string, string) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_2(&m.recorder.initialWatchMachineSSHHostKeysStatementExpects, m.ctrl, m, "InitialWatchMachineSSHHostKeysStatement")
+}
+
+// InitialWatchMachineSSHHostKeysStatement indicates an expected call of InitialWatchMachineSSHHostKeysStatement.
+func (mr *MockStateMockRecorder) InitialWatchMachineSSHHostKeysStatement() *MockStateInitialWatchMachineSSHHostKeysStatementCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_2[string, string](mr.mock.ctrl.T, mr.mock, "InitialWatchMachineSSHHostKeysStatement")
+	mr.initialWatchMachineSSHHostKeysStatementExpects = append(mr.initialWatchMachineSSHHostKeysStatementExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockStateInitialWatchMachineSSHHostKeysStatementCall is the typed call wrapper for InitialWatchMachineSSHHostKeysStatement.
+type MockStateInitialWatchMachineSSHHostKeysStatementCall = gomock.Call0_2[string, string]
+
 // InitialWatchModelMachineLifeAndStartTimesStatement mocks base method.
 func (m *MockState) InitialWatchModelMachineLifeAndStartTimesStatement() (string, string) {
 	m.ctrl.T.Helper()
@@ -817,6 +837,24 @@ func (mr *MockStateMockRecorder) NamespaceForWatchMachineReprovision() *MockStat
 
 // MockStateNamespaceForWatchMachineReprovisionCall is the typed call wrapper for NamespaceForWatchMachineReprovision.
 type MockStateNamespaceForWatchMachineReprovisionCall = gomock.Call0_1[string]
+
+// NamespaceForWatchMachineSSHHostKeys mocks base method.
+func (m *MockState) NamespaceForWatchMachineSSHHostKeys() string {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.namespaceForWatchMachineSSHHostKeysExpects, m.ctrl, m, "NamespaceForWatchMachineSSHHostKeys")
+}
+
+// NamespaceForWatchMachineSSHHostKeys indicates an expected call of NamespaceForWatchMachineSSHHostKeys.
+func (mr *MockStateMockRecorder) NamespaceForWatchMachineSSHHostKeys() *MockStateNamespaceForWatchMachineSSHHostKeysCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[string](mr.mock.ctrl.T, mr.mock, "NamespaceForWatchMachineSSHHostKeys")
+	mr.namespaceForWatchMachineSSHHostKeysExpects = append(mr.namespaceForWatchMachineSSHHostKeysExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockStateNamespaceForWatchMachineSSHHostKeysCall is the typed call wrapper for NamespaceForWatchMachineSSHHostKeys.
+type MockStateNamespaceForWatchMachineSSHHostKeysCall = gomock.Call0_1[string]
 
 // RequireMachineReboot mocks base method.
 func (m *MockState) RequireMachineReboot(ctx context.Context, uuid machine.UUID) error {

--- a/domain/machine/service/state_mock_test.go
+++ b/domain/machine/service/state_mock_test.go
@@ -77,7 +77,6 @@ type MockStateMockRecorder struct {
 	namespaceForWatchMachineCloudInstanceExpects              []*gomock.Call0_1[string]
 	namespaceForWatchMachineRebootExpects                     []*gomock.Call0_1[string]
 	namespaceForWatchMachineReprovisionExpects                []*gomock.Call0_1[string]
-	namespaceForWatchMachineSSHHostKeysExpects                []*gomock.Call0_1[string]
 	requireMachineRebootExpects                               []*gomock.Call2_1[context.Context, machine.UUID, error]
 	setKeepInstanceExpects                                    []*gomock.Call3_1[context.Context, machine.Name, bool, error]
 	setMachineCloudInstanceExpects                            []*gomock.Call6_1[context.Context, string, instance.Id, string, string, *instance.HardwareCharacteristics, error]
@@ -837,24 +836,6 @@ func (mr *MockStateMockRecorder) NamespaceForWatchMachineReprovision() *MockStat
 
 // MockStateNamespaceForWatchMachineReprovisionCall is the typed call wrapper for NamespaceForWatchMachineReprovision.
 type MockStateNamespaceForWatchMachineReprovisionCall = gomock.Call0_1[string]
-
-// NamespaceForWatchMachineSSHHostKeys mocks base method.
-func (m *MockState) NamespaceForWatchMachineSSHHostKeys() string {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch0_1(&m.recorder.namespaceForWatchMachineSSHHostKeysExpects, m.ctrl, m, "NamespaceForWatchMachineSSHHostKeys")
-}
-
-// NamespaceForWatchMachineSSHHostKeys indicates an expected call of NamespaceForWatchMachineSSHHostKeys.
-func (mr *MockStateMockRecorder) NamespaceForWatchMachineSSHHostKeys() *MockStateNamespaceForWatchMachineSSHHostKeysCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[string](mr.mock.ctrl.T, mr.mock, "NamespaceForWatchMachineSSHHostKeys")
-	mr.namespaceForWatchMachineSSHHostKeysExpects = append(mr.namespaceForWatchMachineSSHHostKeysExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockStateNamespaceForWatchMachineSSHHostKeysCall is the typed call wrapper for NamespaceForWatchMachineSSHHostKeys.
-type MockStateNamespaceForWatchMachineSSHHostKeysCall = gomock.Call0_1[string]
 
 // RequireMachineReboot mocks base method.
 func (m *MockState) RequireMachineReboot(ctx context.Context, uuid machine.UUID) error {

--- a/domain/machine/service/watcher.go
+++ b/domain/machine/service/watcher.go
@@ -293,6 +293,43 @@ func (s *WatchableService) WatchMachineCloudInstances(ctx context.Context, machi
 	)
 }
 
+// WatchMachineSSHHostKeys returns a watcher that emits changes to the SSH
+// host keys for the given machine. The initial event allows callers to query
+// keys that were reported before the watcher was created.
+func (s *WatchableService) WatchMachineSSHHostKeys(ctx context.Context, machineUUID machine.UUID) (watcher.StringsWatcher, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	table, stmt := s.st.InitialWatchMachineSSHHostKeysStatement()
+	return s.watcherFactory.NewNamespaceWatcher(
+		ctx,
+		eventsource.InitialNamespaceChanges(stmt, machineUUID.String()),
+		fmt.Sprintf("machine SSH host keys watcher for %q", machineUUID),
+		eventsource.PredicateFilter(
+			table,
+			changestream.All,
+			eventsource.EqualsPredicate(machineUUID.String()),
+		),
+	)
+}
+
+// WatchSSHHostKeysByMachineName returns a watcher that emits changes to the
+// SSH host keys for the machine identified by its name.
+func (s *WatchableService) WatchSSHHostKeysByMachineName(ctx context.Context, name machine.Name) (watcher.StringsWatcher, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := name.Validate(); err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	machineUUID, err := s.st.GetMachineUUID(ctx, name)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return s.WatchMachineSSHHostKeys(ctx, machineUUID)
+}
+
 // WatchMachineReboot returns a NotifyWatcher that is subscribed to
 // the changes in the machine_requires_reboot table in the model.
 // It raises an event whenever the machine uuid or its parent is

--- a/domain/machine/service/watcher.go
+++ b/domain/machine/service/watcher.go
@@ -293,9 +293,10 @@ func (s *WatchableService) WatchMachineCloudInstances(ctx context.Context, machi
 	)
 }
 
-// WatchMachineSSHHostKeys returns a watcher that emits changes to the SSH
-// host keys for the given machine. The initial event allows callers to query
-// keys that were reported before the watcher was created.
+// WatchMachineSSHHostKeys returns a watcher that emits the machine UUID when
+// the SSH host keys for the given machine change. The initial event allows
+// callers to query keys that were reported before the watcher was created;
+// callers must query the current keys after each notification.
 func (s *WatchableService) WatchMachineSSHHostKeys(ctx context.Context, machineUUID machine.UUID) (watcher.StringsWatcher, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -1481,6 +1481,12 @@ func (*State) NamespaceForWatchMachineCloudInstance() string {
 	return "machine_cloud_instance"
 }
 
+// NamespaceForWatchMachineSSHHostKeys returns the namespace for watching
+// machine SSH host key changes.
+func (*State) NamespaceForWatchMachineSSHHostKeys() string {
+	return "machine_ssh_host_key"
+}
+
 // NamespaceForWatchMachineReprovision returns the namespace used to wake the
 // provisioner after a machine is detached for reprovisioning.
 func (*State) NamespaceForWatchMachineReprovision() string {
@@ -1515,6 +1521,12 @@ func (*State) InitialWatchModelMachinesStatement() (string, string) {
 // statement for watching life and agent start time changes machines.
 func (*State) InitialWatchModelMachineLifeAndStartTimesStatement() (string, string) {
 	return "custom_machine_lifecycle_start_time", "SELECT name FROM machine"
+}
+
+// InitialWatchMachineSSHHostKeysStatement returns the namespace and initial
+// query for watching SSH host key changes for one machine.
+func (*State) InitialWatchMachineSSHHostKeysStatement() (string, string) {
+	return "machine_ssh_host_key", "SELECT DISTINCT machine_uuid FROM machine_ssh_host_key WHERE machine_uuid = ?"
 }
 
 // InitialMachineContainerLifeStatement returns the table and the initial watch

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -1481,12 +1481,6 @@ func (*State) NamespaceForWatchMachineCloudInstance() string {
 	return "machine_cloud_instance"
 }
 
-// NamespaceForWatchMachineSSHHostKeys returns the namespace for watching
-// machine SSH host key changes.
-func (*State) NamespaceForWatchMachineSSHHostKeys() string {
-	return "machine_ssh_host_key"
-}
-
 // NamespaceForWatchMachineReprovision returns the namespace used to wake the
 // provisioner after a machine is detached for reprovisioning.
 func (*State) NamespaceForWatchMachineReprovision() string {

--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -403,6 +403,36 @@ func (s *watcherSuite) TestMachineCloudInstanceWatchWithSet(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
+func (s *watcherSuite) TestMachineSSHHostKeysWatchWithSet(c *tc.C) {
+	res, err := s.svc.AddMachine(c.Context(), domainmachine.AddMachineArgs{
+		Platform: deployment.Platform{
+			Channel: "24.04",
+			OSType:  deployment.Ubuntu,
+		},
+		Nonce: new("nonce-123"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	machineUUID, err := s.svc.GetMachineUUID(c.Context(), res.MachineName)
+	c.Assert(err, tc.ErrorIsNil)
+	err = s.svc.SetSSHHostKeys(c.Context(), machineUUID, []string{"ssh-ed25519 AAAA"})
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.AssertChangeStreamIdle(c, "before watcher start")
+
+	hostKeyWatcher, err := s.svc.WatchMachineSSHHostKeys(c.Context(), machineUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, hostKeyWatcher))
+
+	harness.AddTest(c, func(c *tc.C) {
+		err := s.svc.SetSSHHostKeys(c.Context(), machineUUID, []string{"ssh-ed25519 BBBB"})
+		c.Assert(err, tc.ErrorIsNil)
+	}, func(w watchertest.WatcherC[[]string]) {
+		w.Check(watchertest.SliceAssert([]string{machineUUID.String()}))
+	})
+
+	harness.Run(c, []string{machineUUID.String()})
+}
+
 // TestWatchMachineForReboot tests the functionality of watching machines for reboot.
 // It creates a machine hierarchy with a parent, a child (which will be watched), and a control child.
 // Then it creates a watcher for the child and performs the following assertions:

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -18,7 +18,7 @@ import (
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/objectstore-triggers.gen.go -package=triggers -tables=object_store_metadata_path
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/secret-triggers.gen.go -package=triggers -tables=secret_metadata,secret_rotation,secret_revision,secret_revision_expire,secret_revision_obsolete,secret_reference,secret_deleted_value_ref
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/network-triggers.gen.go -package=triggers -tables=subnet,ip_address
-//go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/machine-triggers.gen.go -package=triggers -tables=machine,machine_lxd_profile,machine_cloud_instance,machine_requires_reboot,machine_reprovision
+//go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/machine-triggers.gen.go -package=triggers -tables=machine,machine_lxd_profile,machine_cloud_instance,machine_requires_reboot,machine_reprovision,machine_ssh_host_key
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/ssh-connection-request-triggers.gen.go -package=triggers -tables=ssh_connection_request
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/application-triggers.gen.go -package=triggers -tables=application,application_config_hash,application_setting,charm,application_scale,port_range,application_exposed_endpoint_space,application_exposed_endpoint_cidr
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/unit-triggers.gen.go -package triggers -tables=unit,unit_principal,unit_resolved
@@ -110,6 +110,7 @@ const (
 	tableRelationNetworkEgress
 	tableModelMigrating
 	tableMachineReprovision
+	tableMachineSSHHostKey
 )
 
 // modelPostPatchFilesByVersion is used to categorise the post patch files
@@ -159,6 +160,7 @@ func ModelDDLForVersion(version semversion.Number) *schema.Schema {
 		triggers.ChangeLogTriggersForMachineCloudInstance("machine_uuid", tableMachineCloudInstance),
 		triggers.ChangeLogTriggersForMachineRequiresReboot("machine_uuid", tableMachineRequireReboot),
 		triggers.ChangeLogTriggersForMachineReprovision("machine_name", tableMachineReprovision),
+		triggers.ChangeLogTriggersForMachineSshHostKey("machine_uuid", tableMachineSSHHostKey),
 		triggers.ChangeLogTriggersForSshConnectionRequest("tunnel_id", tableSSHConnectionRequest),
 		triggers.ChangeLogTriggersForCharm("uuid", tableCharm),
 		triggers.ChangeLogTriggersForUnit("uuid", tableUnit),

--- a/domain/schema/model/triggers/machine-triggers.gen.go
+++ b/domain/schema/model/triggers/machine-triggers.gen.go
@@ -209,3 +209,40 @@ END;`, columnName, namespaceID))
 	}
 }
 
+// ChangeLogTriggersForMachineSshHostKey generates the triggers for the
+// machine_ssh_host_key table.
+func ChangeLogTriggersForMachineSshHostKey(columnName string, namespaceID int) func() schema.Patch {
+	return func() schema.Patch {
+		return schema.MakePatch(fmt.Sprintf(`
+-- insert namespace for MachineSshHostKey
+INSERT INTO change_log_namespace VALUES (%[2]d, 'machine_ssh_host_key', 'MachineSshHostKey changes based on %[1]s');
+
+-- insert trigger for MachineSshHostKey
+CREATE TRIGGER trg_log_machine_ssh_host_key_insert
+AFTER INSERT ON machine_ssh_host_key FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (1, %[2]d, NEW.%[1]s, DATETIME('now', 'utc'));
+END;
+
+-- update trigger for MachineSshHostKey
+CREATE TRIGGER trg_log_machine_ssh_host_key_update
+AFTER UPDATE ON machine_ssh_host_key FOR EACH ROW
+WHEN 
+	NEW.uuid != OLD.uuid OR
+	NEW.machine_uuid != OLD.machine_uuid OR
+	NEW.ssh_key != OLD.ssh_key
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
+END;
+-- delete trigger for MachineSshHostKey
+CREATE TRIGGER trg_log_machine_ssh_host_key_delete
+AFTER DELETE ON machine_ssh_host_key FOR EACH ROW
+BEGIN
+    INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
+    VALUES (4, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));
+END;`, columnName, namespaceID))
+	}
+}
+

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -540,6 +540,9 @@ func (s *modelSchemaSuite) TestModelTriggers(c *tc.C) {
 		"trg_log_machine_requires_reboot_delete",
 		"trg_log_machine_requires_reboot_insert",
 		"trg_log_machine_requires_reboot_update",
+		"trg_log_machine_ssh_host_key_delete",
+		"trg_log_machine_ssh_host_key_insert",
+		"trg_log_machine_ssh_host_key_update",
 
 		"trg_log_machine_reprovision_delete",
 		"trg_log_machine_reprovision_insert",

--- a/internal/sshtunneler/service_mock_test.go
+++ b/internal/sshtunneler/service_mock_test.go
@@ -16,6 +16,7 @@ import (
 	gomock "github.com/canonical/gomock/gomock"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
+	watcher "github.com/juju/juju/core/watcher"
 	ssh "github.com/juju/juju/domain/ssh"
 	ssh0 "golang.org/x/crypto/ssh"
 )
@@ -72,8 +73,9 @@ type MockMachineState struct {
 
 // MockMachineStateMockRecorder is the mock recorder for MockMachineState.
 type MockMachineStateMockRecorder struct {
-	mock                   *MockMachineState
-	machineHostKeysExpects []*gomock.Call3_2[context.Context, string, string, []string, error]
+	mock                        *MockMachineState
+	machineHostKeysExpects      []*gomock.Call3_2[context.Context, string, string, []string, error]
+	watchMachineHostKeysExpects []*gomock.Call3_2[context.Context, string, string, watcher.StringsWatcher, error]
 }
 
 // NewMockMachineState creates a new mock instance.
@@ -105,6 +107,24 @@ func (mr *MockMachineStateMockRecorder) MachineHostKeys(ctx, modelUUID, machineI
 
 // MockMachineStateMachineHostKeysCall is the typed call wrapper for MachineHostKeys.
 type MockMachineStateMachineHostKeysCall = gomock.Call3_2[context.Context, string, string, []string, error]
+
+// WatchMachineHostKeys mocks base method.
+func (m *MockMachineState) WatchMachineHostKeys(ctx context.Context, modelUUID, machineID string) (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch3_2(&m.recorder.watchMachineHostKeysExpects, m.ctrl, m, "WatchMachineHostKeys", ctx, modelUUID, machineID)
+}
+
+// WatchMachineHostKeys indicates an expected call of WatchMachineHostKeys.
+func (mr *MockMachineStateMockRecorder) WatchMachineHostKeys(ctx, modelUUID, machineID any) *MockMachineStateWatchMachineHostKeysCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall3_2[context.Context, string, string, watcher.StringsWatcher, error](mr.mock.ctrl.T, mr.mock, "WatchMachineHostKeys", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(modelUUID), gomock.EnsureMatcher(machineID))
+	mr.watchMachineHostKeysExpects = append(mr.watchMachineHostKeysExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockMachineStateWatchMachineHostKeysCall is the typed call wrapper for WatchMachineHostKeys.
+type MockMachineStateWatchMachineHostKeysCall = gomock.Call3_2[context.Context, string, string, watcher.StringsWatcher, error]
 
 // MockControllerInfo is a mock of ControllerInfo interface.
 type MockControllerInfo struct {

--- a/internal/sshtunneler/tunneler.go
+++ b/internal/sshtunneler/tunneler.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/catacomb"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/model"
@@ -71,9 +73,12 @@ type SSHDial interface {
 }
 
 // Tracker provides methods to create SSH tunnels to machine units.
-// The objects keep track of consumers who have requested tunnels
-// and allows an SSH server to push tunnels to these consumers.
+// The tracker keeps track of consumers who have requested tunnels and allows
+// an SSH server to push tunnels to these consumers. It is also a worker and
+// must be stopped by callers that create it.
 type Tracker struct {
+	catacomb catacomb.Catacomb
+
 	authn        tunnelAuthentication
 	connReqState ConnRequestState
 	machines     MachineState
@@ -113,7 +118,7 @@ func (args *TrackerArgs) validate() error {
 	return nil
 }
 
-// NewTracker creates a new tunnel tracker.
+// NewTracker creates and starts a new tunnel tracker worker.
 func NewTracker(args TrackerArgs) (*Tracker, error) {
 	if err := args.validate(); err != nil {
 		return nil, err
@@ -124,7 +129,7 @@ func NewTracker(args TrackerArgs) (*Tracker, error) {
 		return nil, err
 	}
 
-	return &Tracker{
+	tt := &Tracker{
 		tracker:      make(map[string]chan (net.Conn)),
 		authn:        authn,
 		controller:   args.ControllerInfo,
@@ -132,8 +137,33 @@ func NewTracker(args TrackerArgs) (*Tracker, error) {
 		connReqState: args.ConnRequestState,
 		machines:     args.MachineState,
 		dialer:       args.Dialer,
-	}, nil
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Name: "ssh-tunnel-tracker",
+		Site: &tt.catacomb,
+		Work: tt.loop,
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return tt, nil
 }
+
+func (tt *Tracker) loop() error {
+	<-tt.catacomb.Dying()
+	return tt.catacomb.ErrDying()
+}
+
+// Kill stops the tracker.
+func (tt *Tracker) Kill() {
+	tt.catacomb.Kill(nil)
+}
+
+// Wait blocks until the tracker has completed.
+func (tt *Tracker) Wait() error {
+	return tt.catacomb.Wait()
+}
+
+var _ worker.Worker = (*Tracker)(nil)
 
 // RequestArgs holds the arguments for requesting a tunnel.
 type RequestArgs struct {
@@ -183,6 +213,8 @@ func (tt *Tracker) machineHostKeys(ctx context.Context, req RequestArgs) ([]goss
 // Use context.WithTimeout to control the maximum time to wait for the tunnel
 // to be established.
 func (tt *Tracker) RequestTunnel(ctx context.Context, req RequestArgs) (*gossh.Client, error) {
+	ctx = tt.catacomb.Context(ctx)
+
 	if req.MachineID == "" {
 		return nil, errors.NotValidf("empty MachineID")
 	}
@@ -295,6 +327,8 @@ func (tt *Tracker) AuthenticateTunnel(username, password string) (tunnelID strin
 // to RequestTunnel(). Use context.WithTimeout to control the
 // maximum time to wait.
 func (tt *Tracker) PushTunnel(ctx context.Context, tunnelID string, conn net.Conn) error {
+	ctx = tt.catacomb.Context(ctx)
+
 	recv, ok := tt.get(tunnelID)
 	if !ok {
 		return errors.New("tunnel not found")
@@ -336,6 +370,13 @@ func (tt *Tracker) machineHostKeysWithWatcher(ctx context.Context, req RequestAr
 	if err != nil {
 		return nil, errors.Annotate(err, "watching for machine SSH host keys")
 	}
+	if err := tt.catacomb.Add(hostKeyWatcher); err != nil {
+		return nil, errors.Annotate(err, "adding machine SSH host key watcher")
+	}
+	// Stop the watcher when we exit the scope of this function to avoid
+	// accumulating watchers indefinitely.
+	// We also add it to the catacomb to indicate that this worker
+	// has resources that are pending cleanup.
 	defer func() {
 		hostKeyWatcher.Kill()
 		_ = hostKeyWatcher.Wait()

--- a/internal/sshtunneler/tunneler.go
+++ b/internal/sshtunneler/tunneler.go
@@ -13,20 +13,19 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/juju/retry"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	coressh "github.com/juju/juju/core/ssh"
+	"github.com/juju/juju/core/watcher"
 	domainssh "github.com/juju/juju/domain/ssh"
 	"github.com/juju/juju/internal/pki/ssh"
 	"github.com/juju/juju/internal/uuid"
 )
 
 var (
-	maxTimeout           = 60 * time.Second
-	errNoMachineHostKeys = errors.New("no machine SSH host keys available")
+	maxTimeout = 60 * time.Second
 )
 
 const (
@@ -50,6 +49,9 @@ type MachineState interface {
 	// MachineHostKeys returns the SSH host keys registered for the given
 	// machine in the specified model.
 	MachineHostKeys(ctx context.Context, modelUUID, machineID string) ([]string, error)
+	// WatchMachineHostKeys returns a watcher for SSH host key changes for the
+	// given machine in the specified model. The watcher sends an initial event.
+	WatchMachineHostKeys(ctx context.Context, modelUUID, machineID string) (watcher.StringsWatcher, error)
 }
 
 // ControllerInfo defines an interface to fetch the local controller node's
@@ -305,13 +307,15 @@ func (tt *Tracker) PushTunnel(ctx context.Context, tunnelID string, conn net.Con
 	}
 }
 
-// wait blocks until a TCP tunnel to the target unit is established.
+// wait blocks until a TCP tunnel to the target unit is established and the
+// machine's SSH host keys are available. The context deadline bounds both
+// waits.
 func (tt *Tracker) wait(ctx context.Context, recv chan (net.Conn), privateKey gossh.Signer, req RequestArgs) (*gossh.Client, error) {
 	select {
 	case conn := <-recv:
 		// We now have ownership of the connection, so we should close it
 		// if the SSH dial fails.
-		hostKeys, err := tt.machineHostKeysWithRetry(ctx, req)
+		hostKeys, err := tt.machineHostKeysWithWatcher(ctx, req)
 		if err != nil {
 			conn.Close()
 			return nil, err
@@ -327,32 +331,34 @@ func (tt *Tracker) wait(ctx context.Context, recv chan (net.Conn), privateKey go
 	}
 }
 
-func (tt *Tracker) machineHostKeysWithRetry(ctx context.Context, req RequestArgs) ([]gossh.PublicKey, error) {
-	var hostKeys []gossh.PublicKey
-	strategy := retry.CallArgs{
-		Clock:    tt.clock,
-		Delay:    time.Second,
-		Attempts: -1,
-		Stop:     ctx.Done(),
-		Func: func() error {
-			var err error
-			hostKeys, err = tt.machineHostKeys(ctx, req)
+func (tt *Tracker) machineHostKeysWithWatcher(ctx context.Context, req RequestArgs) ([]gossh.PublicKey, error) {
+	hostKeyWatcher, err := tt.machines.WatchMachineHostKeys(ctx, req.ModelUUID, req.MachineID)
+	if err != nil {
+		return nil, errors.Annotate(err, "watching for machine SSH host keys")
+	}
+	defer func() {
+		hostKeyWatcher.Kill()
+		_ = hostKeyWatcher.Wait()
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, errors.Annotate(ctx.Err(), "waiting for machine SSH host keys")
+		case _, ok := <-hostKeyWatcher.Changes():
+			if !ok {
+				return nil, errors.New("machine SSH host key watcher closed")
+			}
+
+			hostKeys, err := tt.machineHostKeys(ctx, req)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			if len(hostKeys) == 0 {
-				return errNoMachineHostKeys
+			if len(hostKeys) != 0 {
+				return hostKeys, nil
 			}
-			return nil
-		},
-		IsFatalError: func(err error) bool {
-			return !errors.Is(err, errNoMachineHostKeys)
-		},
+		}
 	}
-	if err := retry.Call(strategy); err != nil {
-		return nil, errors.Annotate(err, "waiting for machine SSH host keys")
-	}
-	return hostKeys, nil
 }
 
 func useFixedHostKeys(keys []gossh.PublicKey) gossh.HostKeyCallback {

--- a/internal/sshtunneler/tunneler.go
+++ b/internal/sshtunneler/tunneler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/retry"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/core/model"
@@ -24,7 +25,8 @@ import (
 )
 
 var (
-	maxTimeout = 60 * time.Second
+	maxTimeout           = 60 * time.Second
+	errNoMachineHostKeys = errors.New("no machine SSH host keys available")
 )
 
 const (
@@ -176,8 +178,8 @@ func (tt *Tracker) machineHostKeys(ctx context.Context, req RequestArgs) ([]goss
 
 // RequestTunnel requests a tunnel to a model specific unit.
 //
-// The returned tunnelRequest should be used to wait for the tunnel to be established.
-// See Wait() for more information.
+// Use context.WithTimeout to control the maximum time to wait for the tunnel
+// to be established.
 func (tt *Tracker) RequestTunnel(ctx context.Context, req RequestArgs) (*gossh.Client, error) {
 	if req.MachineID == "" {
 		return nil, errors.NotValidf("empty MachineID")
@@ -218,11 +220,6 @@ func (tt *Tracker) RequestTunnel(ctx context.Context, req RequestArgs) (*gossh.C
 		return nil, err
 	}
 
-	machineHostKeys, err := tt.machineHostKeys(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
 	// Make sure to use an unbuffered channel to ensure someone always
 	// has responsibility of the connection passed around.
 	connRecv := make(chan (net.Conn))
@@ -246,7 +243,7 @@ func (tt *Tracker) RequestTunnel(ctx context.Context, req RequestArgs) (*gossh.C
 		return nil, err
 	}
 
-	return tt.wait(ctx, connRecv, privateKey, machineHostKeys)
+	return tt.wait(ctx, connRecv, privateKey, req)
 }
 
 func (tt *Tracker) add(tunnelID string, recv chan net.Conn) {
@@ -309,19 +306,16 @@ func (tt *Tracker) PushTunnel(ctx context.Context, tunnelID string, conn net.Con
 }
 
 // wait blocks until a TCP tunnel to the target unit is established.
-//
-// It is a mistake not to call Wait() after a successful call to RequestTunnel()
-// as this will leak resources in the tunnel tracker.
-// If the tunnel is no longer required, the caller should call Close() on the
-// returned client.
-//
-// Use context.WithTimeout to control the maximum time to wait for the tunnel
-// to be established.
-func (tt *Tracker) wait(ctx context.Context, recv chan (net.Conn), privateKey gossh.Signer, hostKeys []gossh.PublicKey) (*gossh.Client, error) {
+func (tt *Tracker) wait(ctx context.Context, recv chan (net.Conn), privateKey gossh.Signer, req RequestArgs) (*gossh.Client, error) {
 	select {
 	case conn := <-recv:
 		// We now have ownership of the connection, so we should close it
 		// if the SSH dial fails.
+		hostKeys, err := tt.machineHostKeysWithRetry(ctx, req)
+		if err != nil {
+			conn.Close()
+			return nil, err
+		}
 		sshClient, err := tt.dialer.Dial(conn, defaultUser, privateKey, useFixedHostKeys(hostKeys))
 		if err != nil {
 			conn.Close()
@@ -331,6 +325,34 @@ func (tt *Tracker) wait(ctx context.Context, recv chan (net.Conn), privateKey go
 	case <-ctx.Done():
 		return nil, errors.Annotate(ctx.Err(), "waiting for tunnel")
 	}
+}
+
+func (tt *Tracker) machineHostKeysWithRetry(ctx context.Context, req RequestArgs) ([]gossh.PublicKey, error) {
+	var hostKeys []gossh.PublicKey
+	strategy := retry.CallArgs{
+		Clock:    tt.clock,
+		Delay:    time.Second,
+		Attempts: -1,
+		Stop:     ctx.Done(),
+		Func: func() error {
+			var err error
+			hostKeys, err = tt.machineHostKeys(ctx, req)
+			if err != nil {
+				return err
+			}
+			if len(hostKeys) == 0 {
+				return errNoMachineHostKeys
+			}
+			return nil
+		},
+		IsFatalError: func(err error) bool {
+			return !errors.Is(err, errNoMachineHostKeys)
+		},
+	}
+	if err := retry.Call(strategy); err != nil {
+		return nil, errors.Annotate(err, "waiting for machine SSH host keys")
+	}
+	return hostKeys, nil
 }
 
 func useFixedHostKeys(keys []gossh.PublicKey) gossh.HostKeyCallback {

--- a/internal/sshtunneler/tunneler_test.go
+++ b/internal/sshtunneler/tunneler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
 	coressh "github.com/juju/juju/core/ssh"
+	"github.com/juju/juju/core/watcher/watchertest"
 	domainssh "github.com/juju/juju/domain/ssh"
 	"github.com/juju/juju/internal/pki/test"
 	"github.com/juju/juju/internal/testhelpers"
@@ -92,6 +93,10 @@ func (s *sshTunnelerSuite) TestTunneler(c *tc.C) {
 	)
 	s.machines.EXPECT().MachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		[]string{string(gossh.MarshalAuthorizedKey(sshPublicHostKey))}, nil)
+	hostKeyChanges := make(chan []string, 1)
+	hostKeyChanges <- nil
+	s.machines.EXPECT().WatchMachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		watchertest.NewMockStringsWatcher(hostKeyChanges), nil)
 	s.dialer.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(c net.Conn, s1 string, s2 gossh.Signer, hkc gossh.HostKeyCallback) (*gossh.Client, error) {
 			hostKeyCallback = hkc
@@ -186,6 +191,10 @@ func (s *sshTunnelerSuite) TestTunnelIsClosedWhenDialFails(c *tc.C) {
 	)
 	s.machines.EXPECT().MachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		[]string{string(gossh.MarshalAuthorizedKey(publicHostKey))}, nil)
+	hostKeyChanges := make(chan []string, 1)
+	hostKeyChanges <- nil
+	s.machines.EXPECT().WatchMachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		watchertest.NewMockStringsWatcher(hostKeyChanges), nil)
 	s.dialer.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed-to-connect"))
 	s.clock.EXPECT().Now().AnyTimes().Return(now)
 
@@ -230,19 +239,21 @@ func (s *sshTunnelerSuite) TestTunnelIsClosedWhenDialFails(c *tc.C) {
 	c.Check(mockConn.Bool.Load(), tc.Equals, true)
 }
 
-func (s *sshTunnelerSuite) TestMachineHostKeysWithRetry(c *tc.C) {
+func (s *sshTunnelerSuite) TestMachineHostKeysWithWatcher(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	tunnelTracker := s.newTracker(c)
-	now := time.Now()
 	machineHostKey, err := test.InsecureKeyProfile()
 	c.Assert(err, tc.ErrorIsNil)
 	publicHostKey, err := gossh.NewPublicKey(machineHostKey.Public())
 	c.Assert(err, tc.ErrorIsNil)
 
+	hostKeyChanges := make(chan []string, 2)
+	hostKeyChanges <- nil
+	hostKeyChanges <- nil
+	s.machines.EXPECT().WatchMachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		watchertest.NewMockStringsWatcher(hostKeyChanges), nil)
 	var hostKeyCalls int
-	s.clock.EXPECT().Now().AnyTimes().Return(now)
-	s.clock.EXPECT().After(gomock.Any()).Return(time.After(1 * time.Nanosecond))
 	s.machines.EXPECT().MachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(context.Context, string, string) ([]string, error) {
 			if hostKeyCalls == 0 {
@@ -257,7 +268,7 @@ func (s *sshTunnelerSuite) TestMachineHostKeysWithRetry(c *tc.C) {
 		ControllerNodeID: "0",
 		ModelUUID:        "8419cd78-4993-4c3a-928e-c646226beeee",
 	}
-	hostKeys, err := tunnelTracker.machineHostKeysWithRetry(c.Context(), tunnelReqArgs)
+	hostKeys, err := tunnelTracker.machineHostKeysWithWatcher(c.Context(), tunnelReqArgs)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(hostKeys, tc.HasLen, 1)
 }

--- a/internal/sshtunneler/tunneler_test.go
+++ b/internal/sshtunneler/tunneler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
 	coressh "github.com/juju/juju/core/ssh"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	domainssh "github.com/juju/juju/domain/ssh"
 	"github.com/juju/juju/internal/pki/test"
@@ -59,6 +60,10 @@ func (s *sshTunnelerSuite) newTracker(c *tc.C) *Tracker {
 	}
 	tunnelTracker, err := NewTracker(args)
 	c.Assert(err, tc.ErrorIsNil)
+	c.Cleanup(func() {
+		tunnelTracker.Kill()
+		_ = tunnelTracker.Wait()
+	})
 	return tunnelTracker
 }
 
@@ -155,11 +160,11 @@ func (s *sshTunnelerSuite) TestTunneler(c *tc.C) {
 
 type mockConn struct {
 	net.Conn
-	atomic.Bool
+	wasClosed atomic.Bool
 }
 
 func (m *mockConn) Close() error {
-	m.Bool.Store(true)
+	m.wasClosed.Store(true)
 	return nil
 }
 
@@ -236,7 +241,7 @@ func (s *sshTunnelerSuite) TestTunnelIsClosedWhenDialFails(c *tc.C) {
 	wg.Wait()
 
 	c.Check(tunnelTracker.tracker, tc.HasLen, 0)
-	c.Check(mockConn.Bool.Load(), tc.Equals, true)
+	c.Check(mockConn.wasClosed.Load(), tc.Equals, true)
 }
 
 func (s *sshTunnelerSuite) TestMachineHostKeysWithWatcher(c *tc.C) {
@@ -271,6 +276,111 @@ func (s *sshTunnelerSuite) TestMachineHostKeysWithWatcher(c *tc.C) {
 	hostKeys, err := tunnelTracker.machineHostKeysWithWatcher(c.Context(), tunnelReqArgs)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(hostKeys, tc.HasLen, 1)
+}
+
+func (s *sshTunnelerSuite) TestMachineHostKeysWithWatcherStopsWhenTrackerKilled(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	tunnelTracker := s.newTracker(c)
+	now := time.Now()
+	requestCreated := make(chan struct{})
+	hostKeyChanges := make(chan []string)
+	hostKeyWatcher := watchertest.NewMockStringsWatcher(hostKeyChanges)
+	watcherStarted := make(chan struct{})
+	var sshConnArgs domainssh.SSHConnRequest
+
+	s.clock.EXPECT().Now().Return(now)
+	s.controller.EXPECT().LocalAddresses(gomock.Any(), "0").Return(nil, nil)
+	s.connRequests.EXPECT().InsertSSHConnRequest(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ model.UUID, req domainssh.SSHConnRequest) error {
+			sshConnArgs = req
+			close(requestCreated)
+			return nil
+		})
+	s.machines.EXPECT().WatchMachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, string, string) (watcher.StringsWatcher, error) {
+			close(watcherStarted)
+			return hostKeyWatcher, nil
+		})
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := tunnelTracker.RequestTunnel(c.Context(), RequestArgs{
+			MachineID:        "0",
+			ControllerNodeID: "0",
+			ModelUUID:        "8419cd78-4993-4c3a-928e-c646226beeee",
+		})
+		result <- err
+	}()
+
+	select {
+	case <-requestCreated:
+	case <-c.Context().Done():
+		c.Fatal("tunnel request was not created")
+	}
+
+	conn := &mockConn{}
+	err := tunnelTracker.PushTunnel(c.Context(), sshConnArgs.TunnelID, conn)
+	c.Assert(err, tc.ErrorIsNil)
+
+	select {
+	case <-watcherStarted:
+	case <-c.Context().Done():
+		c.Fatal("machine host key watcher was not started")
+	}
+
+	tunnelTracker.Kill()
+	c.Assert(tunnelTracker.Wait(), tc.ErrorIsNil)
+
+	select {
+	case err := <-result:
+		c.Check(err, tc.ErrorMatches, `waiting for machine SSH host keys: context canceled`)
+	case <-c.Context().Done():
+		c.Fatal("machine host key lookup did not stop")
+	}
+	c.Check(conn.wasClosed.Load(), tc.Equals, true)
+	c.Assert(hostKeyWatcher.Wait(), tc.ErrorIsNil)
+}
+
+func (s *sshTunnelerSuite) TestRequestTunnelStopsWhenTrackerKilled(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	tunnelTracker := s.newTracker(c)
+	now := time.Now()
+	requestCreated := make(chan struct{})
+	s.clock.EXPECT().Now().Return(now)
+	s.controller.EXPECT().LocalAddresses(gomock.Any(), "0").Return(nil, nil)
+	s.connRequests.EXPECT().InsertSSHConnRequest(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, model.UUID, domainssh.SSHConnRequest) error {
+			close(requestCreated)
+			return nil
+		})
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := tunnelTracker.RequestTunnel(c.Context(), RequestArgs{
+			MachineID:        "0",
+			ControllerNodeID: "0",
+			ModelUUID:        "8419cd78-4993-4c3a-928e-c646226beeee",
+		})
+		result <- err
+	}()
+
+	select {
+	case <-requestCreated:
+	case <-c.Context().Done():
+		c.Fatal("tunnel request was not created")
+	}
+
+	tunnelTracker.Kill()
+	c.Assert(tunnelTracker.Wait(), tc.ErrorIsNil)
+
+	select {
+	case err := <-result:
+		c.Check(err, tc.ErrorMatches, `waiting for tunnel: context canceled`)
+	case <-c.Context().Done():
+		c.Fatal("tunnel request did not stop")
+	}
 }
 
 func (s *sshTunnelerSuite) TestGenerateEphemeralSSHKey(c *tc.C) {
@@ -460,6 +570,11 @@ func (s *sshTunnelerSuite) TestNewTunnelTrackerValidation(c *tc.C) {
 	tunnelTracker, err := NewTracker(args)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(tunnelTracker, tc.Not(tc.IsNil))
+	createdTracker := tunnelTracker
+	c.Cleanup(func() {
+		createdTracker.Kill()
+		_ = createdTracker.Wait()
+	})
 
 	// Test case: Missing ConnRequestState
 	args.ConnRequestState = nil

--- a/internal/sshtunneler/tunneler_test.go
+++ b/internal/sshtunneler/tunneler_test.go
@@ -169,6 +169,10 @@ func (s *sshTunnelerSuite) TestTunnelIsClosedWhenDialFails(c *tc.C) {
 	tunnelRequested := make(chan struct{})
 
 	now := time.Now()
+	machineHostKey, err := test.InsecureKeyProfile()
+	c.Assert(err, tc.ErrorIsNil)
+	publicHostKey, err := gossh.NewPublicKey(machineHostKey.Public())
+	c.Assert(err, tc.ErrorIsNil)
 
 	s.controller.EXPECT().LocalAddresses(gomock.Any(), gomock.Any()).Return([]network.SpaceAddress{
 		{MachineAddress: network.NewMachineAddress("1.2.3.4")},
@@ -180,7 +184,8 @@ func (s *sshTunnelerSuite) TestTunnelIsClosedWhenDialFails(c *tc.C) {
 			return nil
 		},
 	)
-	s.machines.EXPECT().MachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
+	s.machines.EXPECT().MachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		[]string{string(gossh.MarshalAuthorizedKey(publicHostKey))}, nil)
 	s.dialer.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed-to-connect"))
 	s.clock.EXPECT().Now().AnyTimes().Return(now)
 
@@ -223,6 +228,38 @@ func (s *sshTunnelerSuite) TestTunnelIsClosedWhenDialFails(c *tc.C) {
 
 	c.Check(tunnelTracker.tracker, tc.HasLen, 0)
 	c.Check(mockConn.Bool.Load(), tc.Equals, true)
+}
+
+func (s *sshTunnelerSuite) TestMachineHostKeysWithRetry(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	tunnelTracker := s.newTracker(c)
+	now := time.Now()
+	machineHostKey, err := test.InsecureKeyProfile()
+	c.Assert(err, tc.ErrorIsNil)
+	publicHostKey, err := gossh.NewPublicKey(machineHostKey.Public())
+	c.Assert(err, tc.ErrorIsNil)
+
+	var hostKeyCalls int
+	s.clock.EXPECT().Now().AnyTimes().Return(now)
+	s.clock.EXPECT().After(gomock.Any()).Return(time.After(1 * time.Nanosecond))
+	s.machines.EXPECT().MachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, string, string) ([]string, error) {
+			if hostKeyCalls == 0 {
+				hostKeyCalls++
+				return []string{}, nil
+			}
+			return []string{string(gossh.MarshalAuthorizedKey(publicHostKey))}, nil
+		}).Times(2)
+
+	tunnelReqArgs := RequestArgs{
+		MachineID:        "0",
+		ControllerNodeID: "0",
+		ModelUUID:        "8419cd78-4993-4c3a-928e-c646226beeee",
+	}
+	hostKeys, err := tunnelTracker.machineHostKeysWithRetry(c.Context(), tunnelReqArgs)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(hostKeys, tc.HasLen, 1)
 }
 
 func (s *sshTunnelerSuite) TestGenerateEphemeralSSHKey(c *tc.C) {
@@ -325,7 +362,6 @@ func (s *sshTunnelerSuite) TestRequestTunnelTimeout(c *tc.C) {
 		{MachineAddress: network.NewMachineAddress("1.2.3.4")},
 	}, nil)
 	s.connRequests.EXPECT().InsertSSHConnRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	s.machines.EXPECT().MachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
 
 	tunnelReqArgs := RequestArgs{
 		MachineID:        "0",
@@ -355,7 +391,6 @@ func (s *sshTunnelerSuite) TestRequestTunnelDeadline(c *tc.C) {
 		{MachineAddress: network.NewMachineAddress("1.2.3.4")},
 	}, nil)
 	s.connRequests.EXPECT().InsertSSHConnRequest(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	s.machines.EXPECT().MachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
 
 	tunnelReqArgs := RequestArgs{
 		MachineID:        "0",
@@ -390,12 +425,6 @@ func (s *sshTunnelerSuite) TestInvalidMachineHostKey(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	tunnelTracker := s.newTracker(c)
-
-	now := time.Now()
-	s.clock.EXPECT().Now().Times(1).Return(now)
-	s.controller.EXPECT().LocalAddresses(gomock.Any(), gomock.Any()).Return([]network.SpaceAddress{
-		{MachineAddress: network.NewMachineAddress("1.2.3.4")},
-	}, nil)
 	s.machines.EXPECT().MachineHostKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"fake-host-key"}, nil)
 
 	tunnelReqArgs := RequestArgs{
@@ -404,7 +433,7 @@ func (s *sshTunnelerSuite) TestInvalidMachineHostKey(c *tc.C) {
 		ModelUUID:        "8419cd78-4993-4c3a-928e-c646226beeee",
 	}
 
-	_, err := tunnelTracker.RequestTunnel(c.Context(), tunnelReqArgs)
+	_, err := tunnelTracker.machineHostKeys(c.Context(), tunnelReqArgs)
 	c.Assert(err, tc.ErrorMatches, "failed to parse machine host key: ssh: no key found")
 }
 

--- a/internal/worker/sshtunneler/service_mock_test.go
+++ b/internal/worker/sshtunneler/service_mock_test.go
@@ -15,6 +15,7 @@ import (
 	gomock "github.com/canonical/gomock/gomock"
 	machine "github.com/juju/juju/core/machine"
 	network "github.com/juju/juju/core/network"
+	watcher "github.com/juju/juju/core/watcher"
 	ssh "github.com/juju/juju/domain/ssh"
 )
 
@@ -70,8 +71,9 @@ type MockMachineService struct {
 
 // MockMachineServiceMockRecorder is the mock recorder for MockMachineService.
 type MockMachineServiceMockRecorder struct {
-	mock                               *MockMachineService
-	getSSHHostKeysByMachineNameExpects []*gomock.Call2_2[context.Context, machine.Name, []string, error]
+	mock                                 *MockMachineService
+	getSSHHostKeysByMachineNameExpects   []*gomock.Call2_2[context.Context, machine.Name, []string, error]
+	watchSSHHostKeysByMachineNameExpects []*gomock.Call2_2[context.Context, machine.Name, watcher.StringsWatcher, error]
 }
 
 // NewMockMachineService creates a new mock instance.
@@ -103,6 +105,24 @@ func (mr *MockMachineServiceMockRecorder) GetSSHHostKeysByMachineName(ctx, name 
 
 // MockMachineServiceGetSSHHostKeysByMachineNameCall is the typed call wrapper for GetSSHHostKeysByMachineName.
 type MockMachineServiceGetSSHHostKeysByMachineNameCall = gomock.Call2_2[context.Context, machine.Name, []string, error]
+
+// WatchSSHHostKeysByMachineName mocks base method.
+func (m *MockMachineService) WatchSSHHostKeysByMachineName(ctx context.Context, name machine.Name) (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_2(&m.recorder.watchSSHHostKeysByMachineNameExpects, m.ctrl, m, "WatchSSHHostKeysByMachineName", ctx, name)
+}
+
+// WatchSSHHostKeysByMachineName indicates an expected call of WatchSSHHostKeysByMachineName.
+func (mr *MockMachineServiceMockRecorder) WatchSSHHostKeysByMachineName(ctx, name any) *MockMachineServiceWatchSSHHostKeysByMachineNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_2[context.Context, machine.Name, watcher.StringsWatcher, error](mr.mock.ctrl.T, mr.mock, "WatchSSHHostKeysByMachineName", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(name))
+	mr.watchSSHHostKeysByMachineNameExpects = append(mr.watchSSHHostKeysByMachineNameExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockMachineServiceWatchSSHHostKeysByMachineNameCall is the typed call wrapper for WatchSSHHostKeysByMachineName.
+type MockMachineServiceWatchSSHHostKeysByMachineNameCall = gomock.Call2_2[context.Context, machine.Name, watcher.StringsWatcher, error]
 
 // MockControllerNodeService is a mock of ControllerNodeService interface.
 type MockControllerNodeService struct {

--- a/internal/worker/sshtunneler/worker.go
+++ b/internal/worker/sshtunneler/worker.go
@@ -10,8 +10,8 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/worker/v5"
+	"github.com/juju/worker/v5/catacomb"
 	gossh "golang.org/x/crypto/ssh"
-	"gopkg.in/tomb.v2"
 
 	coremachine "github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
@@ -77,7 +77,7 @@ type GetMachineServiceFunc = func(ctx context.Context, getter services.DomainSer
 
 // sshTunnelerWorker is a worker that wraps a tunnel tracker singleton.
 type sshTunnelerWorker struct {
-	tomb          tomb.Tomb
+	catacomb      catacomb.Catacomb
 	tunnelTracker *sshtunneler.Tracker
 }
 
@@ -213,19 +213,28 @@ func NewWorker(domainServicesGetter services.DomainServicesGetter, getSSHService
 	}
 
 	w := &sshTunnelerWorker{tunnelTracker: tracker}
-	w.tomb.Go(func() error {
-		<-w.tomb.Dying()
-		return tomb.ErrDying
-	})
+	if err := catacomb.Invoke(catacomb.Plan{
+		Name: "ssh-tunneler",
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{tracker},
+	}); err != nil {
+		return nil, errors.Trace(err)
+	}
 	return w, nil
+}
+
+func (w *sshTunnelerWorker) loop() error {
+	<-w.catacomb.Dying()
+	return w.catacomb.ErrDying()
 }
 
 // Kill is part of the worker.Worker interface.
 func (w *sshTunnelerWorker) Kill() {
-	w.tomb.Kill(nil)
+	w.catacomb.Kill(nil)
 }
 
 // Wait is part of the worker.Worker interface.
 func (w *sshTunnelerWorker) Wait() error {
-	return w.tomb.Wait()
+	return w.catacomb.Wait()
 }

--- a/internal/worker/sshtunneler/worker.go
+++ b/internal/worker/sshtunneler/worker.go
@@ -16,6 +16,7 @@ import (
 	coremachine "github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/watcher"
 	domainssh "github.com/juju/juju/domain/ssh"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/sshtunneler"
@@ -51,6 +52,10 @@ type MachineService interface {
 	// GetSSHHostKeysByMachineName returns the SSH host keys stored for the
 	// machine identified by its name.
 	GetSSHHostKeysByMachineName(ctx context.Context, name coremachine.Name) ([]string, error)
+	// WatchSSHHostKeysByMachineName returns a watcher for SSH host key changes
+	// for the machine identified by its name. The watcher sends an initial
+	// event.
+	WatchSSHHostKeysByMachineName(ctx context.Context, name coremachine.Name) (watcher.StringsWatcher, error)
 }
 
 // ControllerNodeService provides controller-scoped address lookups used to
@@ -138,6 +143,25 @@ func (a *machineStateAdapter) MachineHostKeys(ctx context.Context, modelUUID, ma
 		return nil, errors.Annotatef(err, "getting SSH host keys for machine %q", machineID)
 	}
 	return keys, nil
+}
+
+// WatchMachineHostKeys implements sshtunneler.MachineState.
+func (a *machineStateAdapter) WatchMachineHostKeys(ctx context.Context, modelUUID, machineID string) (watcher.StringsWatcher, error) {
+	parsedUUID := coremodel.UUID(modelUUID)
+	if err := parsedUUID.Validate(); err != nil {
+		return nil, errors.Annotatef(err, "invalid model UUID %q", modelUUID)
+	}
+
+	machineSvc, err := a.getMachineService(ctx, a.domainServicesGetter, parsedUUID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	watcher, err := machineSvc.WatchSSHHostKeysByMachineName(ctx, coremachine.Name(machineID))
+	if err != nil {
+		return nil, errors.Annotatef(err, "watching SSH host keys for machine %q", machineID)
+	}
+	return watcher, nil
 }
 
 // controllerInfoAdapter adapts a ControllerNodeService to the

--- a/internal/worker/sshtunneler/worker_test.go
+++ b/internal/worker/sshtunneler/worker_test.go
@@ -16,6 +16,7 @@ import (
 	coremachine "github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/watcher/watchertest"
 	domainssh "github.com/juju/juju/domain/ssh"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/internal/testhelpers"
@@ -179,6 +180,14 @@ func (s *workerSuite) TestStateAdapterMachineHostKeysRoutedByModelUUID(c *tc.C) 
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(keys, tc.DeepEquals, []string{"ssh-ed25519 AAAA... user@host"})
 	c.Check(calledWithUUID, tc.Equals, coremodel.UUID(modelUUID))
+
+	watcher := watchertest.NewMockStringsWatcher(make(chan []string))
+	s.machineService.EXPECT().WatchSSHHostKeysByMachineName(gomock.Any(), coremachine.Name("0")).Return(watcher, nil)
+	gotWatcher, err := adapter.WatchMachineHostKeys(c.Context(), modelUUID, "0")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(gotWatcher, tc.Equals, watcher)
+	gotWatcher.Kill()
+	_ = gotWatcher.Wait()
 }
 
 // TestStateAdapterMachineHostKeysInvalidModelUUID verifies that an invalid


### PR DESCRIPTION
For the SSH proxy feature, when establishing a reverse tunnel connection to a machine we expect that we know the machine's host keys. The machine's host keys are reported by the machine to Juju by the hostkeyReporter worker. If we don't wait for the worker to report, we may connect without knowing the machine's host key which will result in an error. 

This is only a concern when you attempt to connect to a machine that is still being provisioned. The problem that arises is:
1. User client establishes an SSH connection to the controller.
2. Controller writes to the DB requesting a tunnel to the desired machine.
3. Machine is being provisioned and once ready, establishes a tunnel to the controller.
4. The controller fetches the machine's host keys from the database (an empty list) and tries to establish an SSH connection to the machine over the tunnel.
5. The connection fails because the host keys for the machine are empty as we didn't wait for the HostkeyReporter to do its job.

The alternative to this change is to connect to the machine and ignore host key checking. While this is normally not advised we are connecting to the machine over a reverse tunnel so we've already verified the authenticity of the machine. We could then go one step further and remove the HostkeyWorker entirely as the controller does not SSH to machines directly. But this is a larger change that I have not employed.

The solution employed in this PR is to use a watcher to wait for the machine's host keys to be set. For provisioned machines, the host keys will almost certainly already be populated in the database so we use a StringsWatcher which will fire an initial event prompting us to query the DB. If the machine is busy being provisioned and we have no keys, we rely on the watcher to fire and indicate when we should check again.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Before this change:
1. make install
3. juju bootstrap microk8s test-ssh-initial-connect-fix
4. juju add-model test
5. juju show-model # Get model UUID
6. juju show-controller # Get controller address
7. juju deploy ubuntu
8. ssh -o StrictHostKeyChecking=no -J admin@<controller-ip>:17022 ubuntu@0.<model-uuid>.juju.internal
10. \# Depending on how long your machine takes to provision, you may get a context deadline exceeded error like `failed to connect to machine: waiting for tunnel: context deadline exceeded`. Just try again.
11. \# Once the machine is ready you will likely get a "host key mismatch" error.

After this change:
1. Same as above but now our SSH session starts successfully after the machine has been provisioned.

## Links

**Jira card:** [JUJU-9954](https://warthogs.atlassian.net/browse/JUJU-9954)


[JUJU-9954]: https://warthogs.atlassian.net/browse/JUJU-9954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ