### PR TITLE
feat: juju scp with jump flag

### DIFF
--- a/cmd/juju/ssh/scp.go
+++ b/cmd/juju/ssh/scp.go
@@ -74,6 +74,8 @@ add ` + "`-- -3`" + ` to the command-line arguments.
 To enable transfers to/from machines that do not have internet access, you can use
 the Juju controller as a proxy with the ` + "`--proxy`" + ` option.
 
+To proxy transfers through the controller's SSH server, use the ` + "`--jump`" + ` option.
+
 The SSH host keys of the target are verified by default. To disable this, add
  ` + "`--no-host-key-checks`" + ` option. Using this option is strongly discouraged.
 
@@ -119,6 +121,10 @@ Copy a file (` + "`chunks-inspect`" + `) from ` + "`localhost`" + ` to the ` + "
 in a specific container in a Juju unit running in Kubernetes:
 
     juju scp --container loki chunks-inspect loki-k8s/0:/loki
+
+Copy ` + "`foo.txt`" + ` through the controller SSH server to machine ` + "`0`" + `:
+
+	juju scp --jump foo.txt 0:/tmp/foo.txt
 `
 
 func NewSCPCommand(hostChecker jujussh.ReachableChecker, retryStrategy retry.CallArgs, publicKeyRetryStrategy retry.CallArgs) cmd.Command {
@@ -137,10 +143,12 @@ type scpCommand struct {
 
 	sshMachine
 	sshContainer
+	sshJump
 
 	provider sshProvider
 
 	hostChecker jujussh.ReachableChecker
+	jump        bool
 
 	retryStrategy          retry.CallArgs
 	publicKeyRetryStrategy retry.CallArgs
@@ -149,6 +157,7 @@ type scpCommand struct {
 func (c *scpCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.sshMachine.SetFlags(f)
 	c.sshContainer.SetFlags(f)
+	f.BoolVar(&c.jump, "jump", false, "Proxy SSH through the Juju controller")
 }
 
 func (c *scpCommand) Info() *cmd.Info {
@@ -171,7 +180,10 @@ func (c *scpCommand) Init(args []string) (err error) {
 	if c.modelType, err = c.ModelType(context.TODO()); err != nil {
 		return err
 	}
-	if c.modelType == model.CAAS {
+	if c.jump {
+		c.provider = &c.sshJump
+		c.sshJump.container = c.sshContainer.container
+	} else if c.modelType == model.CAAS {
 		c.provider = &c.sshContainer
 	} else {
 		c.provider = &c.sshMachine

--- a/cmd/juju/ssh/scp.go
+++ b/cmd/juju/ssh/scp.go
@@ -180,9 +180,11 @@ func (c *scpCommand) Init(args []string) (err error) {
 	if c.modelType, err = c.ModelType(context.TODO()); err != nil {
 		return err
 	}
+	if c.jump && c.modelType == model.CAAS {
+		return errors.New("--jump is not supported for scp to Kubernetes targets")
+	}
 	if c.jump {
 		c.provider = &c.sshJump
-		c.sshJump.container = c.sshContainer.container
 	} else if c.modelType == model.CAAS {
 		c.provider = &c.sshContainer
 	} else {

--- a/cmd/juju/ssh/scp.go
+++ b/cmd/juju/ssh/scp.go
@@ -185,6 +185,7 @@ func (c *scpCommand) Init(args []string) (err error) {
 	}
 	if c.jump {
 		c.provider = &c.sshJump
+		c.sshJump.noHostKeyChecks = c.sshMachine.noHostKeyChecks
 	} else if c.modelType == model.CAAS {
 		c.provider = &c.sshContainer
 	} else {

--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -233,6 +233,7 @@ func (c *sshCommand) Init(args []string) (err error) {
 	if c.jump {
 		c.provider = &c.sshJump
 		c.sshJump.container = c.sshContainer.container
+		c.sshJump.noHostKeyChecks = c.sshMachine.noHostKeyChecks
 	} else if c.modelType == model.CAAS {
 		c.provider = &c.sshContainer
 	} else {

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/retry"
@@ -164,6 +163,7 @@ func (p *sshJump) setArgs(args []string) {
 // resolveTarget resolves the target for the SSH jump provider into a virtual
 // hostname to be reached through the controller jump server.
 func (p *sshJump) resolveTarget(ctx context.Context, target string) (*resolvedTarget, error) {
+	user, target := splitUserTarget(target)
 	resolvedTargetName, err := p.maybeResolveLeaderUnit(ctx, target)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -201,14 +201,18 @@ func (p *sshJump) resolveTarget(ctx context.Context, target string) (*resolvedTa
 	if err := p.generateKnownHosts(address.Host(), virtualHostname, targetKeys.PublicKey); err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &resolvedTarget{
+	resolved := &resolvedTarget{
 		user: finalDestinationUser,
 		host: virtualHostname,
 		via: &resolvedTarget{
 			user: p.jumpUser,
 			host: address.Host(),
 		},
-	}, nil
+	}
+	if user != "" {
+		resolved.user = user
+	}
+	return resolved, nil
 }
 
 // generateKnownHosts writes a temporary known_hosts file pinning the jump server
@@ -321,7 +325,7 @@ func (p *sshJump) copy(ctx Context) error {
 		return errors.New("--jump is not supported for scp to Kubernetes targets")
 	}
 
-	args, targets, err := p.expandSCPArgs(ctx, p.args)
+	args, targets, err := expandSCPArgs(ctx, p.args, p.resolveTarget)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -330,38 +334,6 @@ func (p *sshJump) copy(ctx Context) error {
 		return errors.Trace(err)
 	}
 	return ssh.Copy(args, options)
-}
-
-// expandSCPArgs resolves Juju SCP targets to virtual hostnames reachable via
-// the controller jump server and forwards all other arguments unchanged. For
-// example, it rewrites "mysql/0:/var/log/syslog" to
-// "ubuntu@<virtual-hostname>:/var/log/syslog".
-func (p *sshJump) expandSCPArgs(ctx context.Context, args []string) ([]string, []*resolvedTarget, error) {
-	outArgs := make([]string, len(args))
-	var targets []*resolvedTarget
-	for i, arg := range args {
-		parts := strings.SplitN(arg, ":", 2)
-		if strings.HasPrefix(arg, "-") || len(parts) <= 1 {
-			outArgs[i] = arg
-			continue
-		}
-
-		user, targetName := splitUserTarget(parts[0])
-		target, err := p.resolveTarget(ctx, targetName)
-		if err != nil {
-			return nil, nil, errors.Trace(err)
-		}
-		if user != "" {
-			target.user = user
-		}
-		outArg := net.JoinHostPort(target.host, parts[1])
-		if target.user != "" {
-			outArg = target.user + "@" + outArg
-		}
-		outArgs[i] = outArg
-		targets = append(targets, target)
-	}
-	return outArgs, targets, nil
 }
 
 func (p *sshJump) setPublicKeyRetryStrategy(_ retry.CallArgs) {}

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -52,6 +52,7 @@ type sshJump struct {
 	container            string
 	target               string
 	args                 []string
+	noHostKeyChecks      bool
 
 	// jumpUser is the Juju user used to authenticate against the jump server.
 	jumpUser string
@@ -275,25 +276,35 @@ func (p *sshJump) maybePopulateTargetViaField(_ context.Context, _ *resolvedTarg
 	return nil
 }
 
-// getSSHOptions returns SSH options that verify both jump and target host keys.
+// getSSHOptions returns SSH options for the jump server and target.
 func (p *sshJump) getSSHOptions(enablePty bool, targets ...*resolvedTarget) (*ssh.Options, error) {
 	if len(targets) == 0 {
 		return nil, errors.New("at least one SSH target is required")
 	}
+	strictHostKeyChecking := "yes"
+	knownHostsPath := p.knownHostsPath
+	if p.noHostKeyChecks {
+		strictHostKeyChecking = "no"
+		knownHostsPath = os.DevNull
+	}
+
 	var options ssh.Options
 	// -o ProxyCommand is a substitute for the -J option, due to a limitation
-	// in the github.com/juju/utils/v4/ssh package. The inner ssh pins the jump
-	// server host key using the same known_hosts file.
+	// in the github.com/juju/utils/v4/ssh package.
 	options.SetProxyCommand(
 		"ssh",
-		"-o", "StrictHostKeyChecking=yes",
-		"-o", "UserKnownHostsFile="+p.knownHostsPath,
+		"-o", "StrictHostKeyChecking="+strictHostKeyChecking,
+		"-o", "UserKnownHostsFile="+knownHostsPath,
 		"-W", "%h:%p",
 		"-p", strconv.Itoa(p.jumpHostPort),
 		targets[0].via.userHost(),
 	)
-	options.SetStrictHostKeyChecking(ssh.StrictHostChecksYes)
-	options.SetKnownHostsFile(p.knownHostsPath)
+	if p.noHostKeyChecks {
+		options.SetStrictHostKeyChecking(ssh.StrictHostChecksNo)
+	} else {
+		options.SetStrictHostKeyChecking(ssh.StrictHostChecksYes)
+	}
+	options.SetKnownHostsFile(knownHostsPath)
 	if enablePty {
 		options.EnablePTY()
 	}

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/retry"
@@ -223,13 +224,21 @@ func (p *sshJump) generateKnownHosts(jumpHost, virtualHostname string, targetHos
 	if err != nil {
 		return errors.Trace(err)
 	}
-	f, err := os.CreateTemp("", "ssh_known_hosts")
-	if err != nil {
-		return errors.Annotate(err, "creating known hosts file")
+	var f *os.File
+	if p.knownHostsPath == "" {
+		f, err = os.CreateTemp("", "ssh_known_hosts")
+		if err != nil {
+			return errors.Annotate(err, "creating known hosts file")
+		}
+		// This needs to be set here because it's used to cleanup the file.
+		p.knownHostsPath = f.Name()
+	} else {
+		f, err = os.OpenFile(p.knownHostsPath, os.O_APPEND|os.O_WRONLY, 0600)
+		if err != nil {
+			return errors.Annotate(err, "opening known hosts file")
+		}
 	}
 	defer f.Close()
-	// This needs to be set here because it's used to cleanup the file.
-	p.knownHostsPath = f.Name()
 	if _, err := f.WriteString(jumpLine + targetLine); err != nil {
 		return errors.Trace(err)
 	}
@@ -306,9 +315,53 @@ func (p *sshJump) ssh(ctx Context, enablePty bool, target *resolvedTarget) error
 	return cmd.Run()
 }
 
-// copy is not implemented for the SSH jump provider.
-func (p *sshJump) copy(_ Context) error {
-	return errors.NotImplemented
+// copy transfers files through the controller SSH jump server.
+func (p *sshJump) copy(ctx Context) error {
+	if p.modelType == model.CAAS {
+		return errors.New("--jump is not supported for scp to Kubernetes targets")
+	}
+
+	args, targets, err := p.expandSCPArgs(ctx, p.args)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	options, err := p.getSSHOptions(false, targets...)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return ssh.Copy(args, options)
+}
+
+// expandSCPArgs resolves Juju SCP targets to virtual hostnames reachable via
+// the controller jump server and forwards all other arguments unchanged. For
+// example, it rewrites "mysql/0:/var/log/syslog" to
+// "ubuntu@<virtual-hostname>:/var/log/syslog".
+func (p *sshJump) expandSCPArgs(ctx context.Context, args []string) ([]string, []*resolvedTarget, error) {
+	outArgs := make([]string, len(args))
+	var targets []*resolvedTarget
+	for i, arg := range args {
+		parts := strings.SplitN(arg, ":", 2)
+		if strings.HasPrefix(arg, "-") || len(parts) <= 1 {
+			outArgs[i] = arg
+			continue
+		}
+
+		user, targetName := splitUserTarget(parts[0])
+		target, err := p.resolveTarget(ctx, targetName)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		if user != "" {
+			target.user = user
+		}
+		outArg := net.JoinHostPort(target.host, parts[1])
+		if target.user != "" {
+			outArg = target.user + "@" + outArg
+		}
+		outArgs[i] = outArg
+		targets = append(targets, target)
+	}
+	return outArgs, targets, nil
 }
 
 func (p *sshJump) setPublicKeyRetryStrategy(_ retry.CallArgs) {}

--- a/cmd/juju/ssh/ssh_jump_test.go
+++ b/cmd/juju/ssh/ssh_jump_test.go
@@ -6,6 +6,7 @@ package ssh
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	stdtesting "testing"
 
@@ -184,6 +185,75 @@ func (s *sshJumpSuite) TestSSHEnablesPTY(c *tc.C) {
 	err := jump.ssh(sshCtx, true, target)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(strings.Contains(buffer.String(), "-t -t"), tc.IsTrue)
+}
+
+func (s *sshJumpSuite) TestCopyUsesJumpProxyCommand(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	s.sshAPIJump.EXPECT().VirtualHostname(gomock.Any(), "0", nil).Return("machine-0", nil)
+	s.sshAPIJump.EXPECT().PublicHostKeyForTarget(gomock.Any(), "machine-0").Return(params.PublicSSHHostKeyResult{
+		PublicKey: s.hostKey,
+	}, nil)
+	s.sshAPIJump.EXPECT().Close().Return(nil)
+
+	jump := sshJump{
+		args:                 []string{"foo.txt", "0:/tmp/foo.txt"},
+		jumpUser:             "fred",
+		jumpServerHostKey:    s.hostKey,
+		sshClient:            s.sshAPIJump,
+		controllersAddresses: []string{"1.0.0.1"},
+		hostChecker:          validAddressesWithPort(17022, "1.0.0.1"),
+		jumpHostPort:         17022,
+	}
+	defer jump.cleanupRun()
+
+	c.Assert(jump.copy(nil), tc.ErrorIsNil)
+	output, err := os.ReadFile(filepath.Join(s.binDir, "scp.args"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(output), tc.Contains, "-o ProxyCommand ssh -o StrictHostKeyChecking=yes")
+	c.Check(string(output), tc.Contains, "-W %h:%p -p 17022 fred@1.0.0.1")
+	c.Check(string(output), tc.Contains, "foo.txt ubuntu@machine-0:/tmp/foo.txt")
+	c.Check(string(output), tc.Contains, "[1.0.0.1]:17022 ")
+	c.Check(string(output), tc.Contains, "machine-0 ")
+}
+
+func (s *sshJumpSuite) TestCopyPinsAllTargetHostKeys(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	s.sshAPIJump.EXPECT().VirtualHostname(gomock.Any(), "0", nil).Return("machine-0", nil)
+	s.sshAPIJump.EXPECT().PublicHostKeyForTarget(gomock.Any(), "machine-0").Return(params.PublicSSHHostKeyResult{
+		PublicKey: s.hostKey,
+	}, nil)
+	s.sshAPIJump.EXPECT().VirtualHostname(gomock.Any(), "1", nil).Return("machine-1", nil)
+	s.sshAPIJump.EXPECT().PublicHostKeyForTarget(gomock.Any(), "machine-1").Return(params.PublicSSHHostKeyResult{
+		PublicKey: s.hostKey,
+	}, nil)
+	s.sshAPIJump.EXPECT().Close().Return(nil)
+
+	jump := sshJump{
+		args:                 []string{"-3", "0:/tmp/source", "bob@1:/tmp/destination"},
+		jumpUser:             "fred",
+		jumpServerHostKey:    s.hostKey,
+		sshClient:            s.sshAPIJump,
+		controllersAddresses: []string{"1.0.0.1"},
+		hostChecker:          validAddressesWithPort(17022, "1.0.0.1"),
+		jumpHostPort:         17022,
+	}
+	defer jump.cleanupRun()
+
+	c.Assert(jump.copy(nil), tc.ErrorIsNil)
+	output, err := os.ReadFile(filepath.Join(s.binDir, "scp.args"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(output), tc.Contains, "-3 ubuntu@machine-0:/tmp/source bob@machine-1:/tmp/destination")
+	c.Check(string(output), tc.Contains, "machine-0 ")
+	c.Check(string(output), tc.Contains, "machine-1 ")
+}
+
+func (s *sshJumpSuite) TestCopyRejectsCAASTarget(c *tc.C) {
+	jump := sshJump{modelType: "caas"}
+	c.Check(jump.copy(nil), tc.ErrorMatches, "--jump is not supported for scp to Kubernetes targets")
 }
 
 func (s *sshJumpSuite) TestGenerateKnownHostsSupportsIPv6(c *tc.C) {

--- a/cmd/juju/ssh/ssh_jump_test.go
+++ b/cmd/juju/ssh/ssh_jump_test.go
@@ -188,6 +188,33 @@ func (s *sshJumpSuite) TestSSHEnablesPTY(c *tc.C) {
 	c.Check(strings.Contains(buffer.String(), "-t -t"), tc.IsTrue)
 }
 
+func (s *sshJumpSuite) TestSSHSkipsHostKeyChecking(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	target := &resolvedTarget{
+		user: finalDestinationUser,
+		host: "resolved-target",
+		via: &resolvedTarget{
+			user: "fred",
+			host: "1.0.0.1",
+		},
+	}
+	jump := sshJump{jumpHostPort: 17022, noHostKeyChecks: true}
+
+	buffer := bytes.NewBuffer(nil)
+	sshCtx := mocks.NewMockContext(ctrl)
+	sshCtx.EXPECT().GetStdin().Return(bytes.NewBuffer(nil)).AnyTimes()
+	sshCtx.EXPECT().GetStdout().Return(buffer).AnyTimes()
+	sshCtx.EXPECT().GetStderr().Return(buffer).AnyTimes()
+
+	c.Assert(jump.ssh(sshCtx, false, target), tc.ErrorIsNil)
+	out := buffer.String()
+	c.Check(strings.Contains(out, "-o ProxyCommand ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %h:%p -p 17022 fred@1.0.0.1"), tc.IsTrue)
+	c.Check(strings.Contains(out, "-o StrictHostKeyChecking no"), tc.IsTrue)
+	c.Check(strings.Contains(out, "-o UserKnownHostsFile /dev/null"), tc.IsTrue)
+}
+
 func (s *sshJumpSuite) TestCopyUsesJumpProxyCommand(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()

--- a/cmd/juju/ssh/ssh_jump_test.go
+++ b/cmd/juju/ssh/ssh_jump_test.go
@@ -16,6 +16,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/cmd/juju/ssh/mocks"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	pkissh "github.com/juju/juju/internal/pki/ssh"
 	coretesting "github.com/juju/juju/internal/testing"
@@ -106,7 +107,7 @@ func (s *sshJumpSuite) TestResolveTargetPassesContainerForCAAS(c *tc.C) {
 	}, nil)
 
 	jump := sshJump{
-		modelType:            "caas",
+		modelType:            model.CAAS,
 		container:            container,
 		jumpServerHostKey:    s.hostKey,
 		sshClient:            s.sshAPIJump,
@@ -252,7 +253,7 @@ func (s *sshJumpSuite) TestCopyPinsAllTargetHostKeys(c *tc.C) {
 }
 
 func (s *sshJumpSuite) TestCopyRejectsCAASTarget(c *tc.C) {
-	jump := sshJump{modelType: "caas"}
+	jump := sshJump{modelType: model.CAAS}
 	c.Check(jump.copy(nil), tc.ErrorMatches, "--jump is not supported for scp to Kubernetes targets")
 }
 

--- a/cmd/juju/ssh/ssh_machine.go
+++ b/cmd/juju/ssh/ssh_machine.go
@@ -230,7 +230,7 @@ func (c *sshMachine) ssh(ctx Context, enablePty bool, target *resolvedTarget) er
 }
 
 func (c *sshMachine) copy(ctx Context) error {
-	args, targets, err := c.expandSCPArgs(ctx, c.getArgs())
+	args, targets, err := expandSCPArgs(ctx, c.getArgs(), c.resolveTarget)
 	if err != nil {
 		return err
 	}
@@ -257,8 +257,8 @@ func (c *sshMachine) copy(ctx Context) error {
 // expandSCPArgs takes a list of arguments and looks for ones in the form of
 // 0:some/path or application/0:some/path, and translates them into
 // ubuntu@machine:some/path so they can be passed as arguments to scp, and pass
-// the rest verbatim on to scp
-func (c *sshMachine) expandSCPArgs(ctx context.Context, args []string) ([]string, []*resolvedTarget, error) {
+// the rest verbatim on to scp.
+func expandSCPArgs(ctx context.Context, args []string, resolveTarget func(context.Context, string) (*resolvedTarget, error)) ([]string, []*resolvedTarget, error) {
 	outArgs := make([]string, len(args))
 	var targets []*resolvedTarget
 	for i, arg := range args {
@@ -269,7 +269,7 @@ func (c *sshMachine) expandSCPArgs(ctx context.Context, args []string) ([]string
 			continue
 		}
 
-		target, err := c.resolveTarget(ctx, v[0])
+		target, err := resolveTarget(ctx, v[0])
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -64,7 +64,7 @@ var allowedCalls = map[string]set.Strings{
 	"juju/commands/upgradecontroller.go": set.NewStrings("os.Open", "os.RemoveAll"),
 	// ssh is not a whitelisted embedded CLI command.
 	"juju/ssh/ssh_machine.go": set.NewStrings("os.Remove"),
-	"juju/ssh/ssh_jump.go":    set.NewStrings("os.Remove"),
+	"juju/ssh/ssh_jump.go":    set.NewStrings("os.OpenFile", "os.Remove"),
 	// agree is not exposed to shell scripts because it uses PAGER to present terms
 	"juju/agree/agree/agree.go": set.NewStrings("exec.Command", "exec.LookPath"),
 	// Ignore the actual os calls.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/scp.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/scp.md
@@ -14,6 +14,7 @@ juju scp [options] <source> <destination>
 | Flag | Default | Usage |
 | --- | --- | --- |
 | `--container` |  | the container name of the target pod |
+| `--jump` | false | Proxy SSH through the Juju controller |
 | `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
 | `--no-host-key-checks` | false | Skip host key checking (INSECURE) |
 | `--proxy` | false | Proxy through the API server |
@@ -59,6 +60,10 @@ Copy a file (`chunks-inspect`) from `localhost` to the `/loki` directory
 in a specific container in a Juju unit running in Kubernetes:
 
     juju scp --container loki chunks-inspect loki-k8s/0:/loki
+
+Copy `foo.txt` through the controller SSH server to machine `0`:
+
+	juju scp --jump foo.txt 0:/tmp/foo.txt
 
 
 ## Details
@@ -115,6 +120,8 @@ add `-- -3` to the command-line arguments.
 
 To enable transfers to/from machines that do not have internet access, you can use
 the Juju controller as a proxy with the `--proxy` option.
+
+To proxy transfers through the controller's SSH server, use the `--jump` option.
 
 The SSH host keys of the target are verified by default. To disable this, add
  `--no-host-key-checks` option. Using this option is strongly discouraged.


### PR DESCRIPTION
# Description

Implement `juju scp --jump`.

Copying file to CAAS target is more involved and if we want to support it needs some work on the ssh worker as well, so we will handle it in a separate pr.

# QA

juju bootstrap


```
juju add-model test
juju deploy ubuntu
juju add-unit ubuntu -n 1 
echo "ciao ciao" > ./foo.txt
juju scp --jump ./foo.txt 0:/tmp/foo.txt
```

Cross-copy

```
juju ssh --jump 1 cat /tmp/foo.txt
cat: /tmp/foo.txt: No such file or directory
Connection to 1.e9250bd9-3b11-42de-8710-4d2f7b5826f5.juju.local closed.
[12:44:27] ➜  ~ juju scp --jump -- -3 0:/tmp/foo.txt 1:/tmp/foo.txt
[12:44:35] ➜  ~ juju ssh --jump 1 cat /tmp/foo.txt                 
ciao ciao
Connection to 1.e9250bd9-3b11-42de-8710-4d2f7b5826f5.juju.local closed.
```


Check with strace the CLI is just reaching for the controller
```terminal
[12:52:55] ➜  ~ strace -f -yy -e connect juju scp --jump ./foo.txt 0:/tmp/foo1.txt 2>&1 | grep "10\."                                                                   
[pid 978335] connect(3<TCP:[2378332]>, {sa_family=AF_INET, sin_port=htons(17070), sin_addr=inet_addr("10.194.223.111")}, 16) = -1 EINPROGRESS (Operation now in progress)
[pid 978322] connect(7<TCP:[2378334]>, {sa_family=AF_INET, sin_port=htons(17022), sin_addr=inet_addr("10.194.223.111")}, 16) = -1 EINPROGRESS (Operation now in progress)
[pid 978351] connect(4<TCP:[2381593]>, {sa_family=AF_INET, sin_port=htons(17022), sin_addr=inet_addr("10.194.223.111")}, 16) = 0
[12:53:37] ➜  ~ strace -f -yy -e connect juju scp ./foo.txt 0:/tmp/foo2.txt 2>&1 | grep "10\."
[pid 979126] connect(3<TCP:[2384669]>, {sa_family=AF_INET, sin_port=htons(17070), sin_addr=inet_addr("10.194.223.111")}, 16) = -1 EINPROGRESS (Operation now in progress)
[pid 979119] connect(7<TCP:[2364282]>, {sa_family=AF_INET, sin_port=htons(22), sin_addr=inet_addr("10.194.223.59")}, 16 <unfinished ...>
```