### PR TITLE
fix: wait for configchange.socket before deployer starts on every machine

### DIFF
--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -494,10 +494,16 @@ func (a *MachineAgent) Run(ctx *cmd.Context) (err error) {
 
 	a.upgradeDBLock = internalupgrade.NewLock(agentConfig, jujuversion.Current)
 	a.upgradeStepsLock = internalupgrade.NewLock(agentConfig, jujuversion.Current)
+	// The controller agent config ready lock is created locked and is only
+	// unlocked by the controlleragentconfig worker, once its
+	// configchange.socket listener is serving. The controlleragentconfig
+	// manifold runs on every machine, so the deployer (which waits on this
+	// lock) does not start until the socket exists, regardless of whether
+	// this machine is a controller. If the socket listener cannot be
+	// started the worker keeps erroring and the deployer stays blocked,
+	// which is deliberate: deploying the controller charm without the
+	// socket would fail its install hook anyway.
 	a.controllerAgentConfigReadyLock = gate.NewLock()
-	if _, isController := agentConfig.ControllerAgentInfo(); !isController {
-		a.controllerAgentConfigReadyLock.Unlock()
-	}
 
 	createEngine := a.makeEngineCreator(agentName, agentConfig.UpgradedToVersion(), logSink)
 	if err := a.createJujudSymlinks(agentConfig.DataDir()); err != nil {

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -175,9 +175,9 @@ type ManifoldsConfig struct {
 
 	// ControllerAgentConfigReadyLock is passed to the controller agent
 	// config ready gate to coordinate the deployer with the
-	// controlleragentconfig worker. On controller machines the deployer
-	// must not start until the configchange.socket exists; on
-	// non-controller machines the caller pre-unlocks this lock.
+	// controlleragentconfig worker. The controlleragentconfig worker runs
+	// on every machine and unlocks this lock once the configchange.socket
+	// is serving, so the deployer never starts before the socket exists.
 	ControllerAgentConfigReadyLock gate.Lock
 
 	// NewDBWorkerFunc returns a tracked db worker.
@@ -336,8 +336,9 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		// controllerAgentConfigReadyGateName/FlagName coordinate the deployer
 		// with the controlleragentconfig worker. The deployer must not start
-		// on controller machines until the configchange.socket is available.
-		// On non-controller machines the lock is pre-unlocked by the caller.
+		// until the configchange.socket is available. The lock is unlocked by
+		// the controlleragentconfig worker on every machine, so the deployer
+		// always waits for the socket, regardless of controller status.
 		controllerAgentConfigReadyGateName: gate.ManifoldEx(config.ControllerAgentConfigReadyLock),
 		controllerAgentConfigReadyFlagName: gate.FlagManifold(gate.FlagManifoldConfig{
 			GateName:  controllerAgentConfigReadyGateName,
@@ -362,15 +363,20 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		isControllerFlagName: util.IsControllerFlagManifold(stateConfigWatcherName, true),
 
 		// Controller agent config manifold watches the controller
-		// agent config and bounces if it changes.
-		controllerAgentConfigName: ifController(controlleragentconfig.Manifold(controlleragentconfig.ManifoldConfig{
+		// agent config and bounces if it changes. It deliberately runs
+		// on every machine (not just controllers) so that it creates
+		// configchange.socket and unlocks controllerAgentConfigReadyLock
+		// before the deployer starts. A machine may be promoted to a
+		// controller later, and the controller charm's install hook
+		// connects to that socket, so it must already exist.
+		controllerAgentConfigName: controlleragentconfig.Manifold(controlleragentconfig.ManifoldConfig{
 			AgentName:         agentName,
 			Clock:             config.Clock,
 			Logger:            internallogger.GetLogger("juju.worker.controlleragentconfig"),
 			NewSocketListener: controlleragentconfig.NewSocketListener,
 			SocketName:        path.Join(agentConfig.DataDir(), "configchange.socket"),
 			ReadyUnlocker:     config.ControllerAgentConfigReadyLock,
-		})),
+		}),
 
 		// The stateconfigwatcher manifold watches the machine agent's
 		// configuration and reports if state serving info is
@@ -1143,11 +1149,10 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 		// The deployer worker is primarily for deploying and recalling unit
 		// agents, according to changes in a set of state units; and for the
 		// final removal of its agents' units from state when they are no
-		// longer needed. On controller machines it must also wait until the
-		// controlleragentconfig socket is ready (controllerAgentConfigReadyFlag)
-		// so the controller charm's install hook can reach the socket. On
-		// non-controller machines that flag is pre-unlocked.
-		deployerName: ifControllerAgentConfigNeededAndReady(ifFullyUpgraded(deployer.Manifold(deployer.ManifoldConfig{
+		// longer needed. It must wait until the controlleragentconfig socket
+		// is ready (controllerAgentConfigReadyFlag) so that the controller
+		// charm's install hook (on a promoted machine) can reach the socket.
+		deployerName: ifControllerAgentConfigReady(ifFullyUpgraded(deployer.Manifold(deployer.ManifoldConfig{
 			AgentName:      agentName,
 			APICallerName:  apiCallerName,
 			FlightRecorder: config.FlightRecorder,
@@ -1417,18 +1422,16 @@ var ifControllerProxyReady = engine.Housing{
 	},
 }.Decorate
 
-// ifControllerAgentConfigNeededAndReady gates a manifold on two conditions:
-// "needed"  — the machine is a controller, so configchange.socket must exist
-//
-//	before the gated worker starts (e.g. the controller charm's
-//	install hook connects to it); on non-controller machines the gate
-//	lock is pre-unlocked by the caller, making this a no-op there.
-//
-// "ready"   — the controlleragentconfig worker has started its socket listener,
-//
-//	meaning configchange.socket is on disk (created synchronously
-//	inside NewWorker before the manifold reports as running).
-var ifControllerAgentConfigNeededAndReady = engine.Housing{
+// ifControllerAgentConfigReady gates a manifold on the configchange.socket
+// being ready. The gated worker must not start before the socket exists on
+// disk (e.g. the controller charm's install hook connects to it). The
+// controlleragentconfig manifold is not gated on ifController, so the socket
+// is created on every machine and the lock is unlocked by that worker,
+// meaning gated workers always wait for the socket regardless of controller
+// status. "ready" means the controlleragentconfig worker has started its socket
+// listener, i.e. configchange.socket is on disk (created synchronously inside
+// NewWorker before the manifold reports as running).
+var ifControllerAgentConfigReady = engine.Housing{
 	Flags: []string{
 		controllerAgentConfigReadyFlagName,
 	},

--- a/cmd/jujud-controller/agent/machine/manifolds_test.go
+++ b/cmd/jujud-controller/agent/machine/manifolds_test.go
@@ -364,7 +364,6 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *tc.C) {
 	controllerWorkers := set.NewStrings(
 		"api-remote-caller",
 		"certificate-watcher",
-		"controller-agent-config",
 		"controller-proxy-config-updater",
 		"controller-proxy-ready-flag",
 		"controller-proxy-ready-gate",
@@ -909,8 +908,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 
 	"controller-agent-config": {
 		"agent",
-		"is-controller-flag",
-		"state-config-watcher",
 	},
 
 	"controller-agent-config-ready-gate": {},
@@ -2078,8 +2075,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 
 	"controller-agent-config": {
 		"agent",
-		"is-controller-flag",
-		"state-config-watcher",
 	},
 
 	"controller-agent-config-ready-gate": {},

--- a/internal/worker/controlleragentconfig/manifold.go
+++ b/internal/worker/controlleragentconfig/manifold.go
@@ -91,6 +91,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				SocketName:        config.SocketName,
 			})
 			if err != nil {
+				config.Logger.Warningf(ctx,
+					"controller agent config socket listener failed to start on %q, dependents will not start: %v",
+					config.SocketName, err)
 				return nil, errors.Trace(err)
 			}
 

--- a/tests/suites/unmanaged/deploy_unmanaged.sh
+++ b/tests/suites/unmanaged/deploy_unmanaged.sh
@@ -46,7 +46,7 @@ unmanaged_deploy() {
 	juju add-unit -m controller controller -n 2 --to "1,2" 2>&1 | tee "${TEST_DIR}/enable-ha.log"
 	wait_for "controller" "$(active_condition "controller" 0)"
 
-	machine_base=$(juju machines --format=json | jq -r '.machines | .["0"] | (.base.name+"@"+.base.channel)')
+	machine_base=$(juju machines --format=json | yq -r '.["machines"]["0"]["base"] | .name + "@" + .channel')
 
 	if [[ -z ${machine_base} ]]; then
 		echo "machine 0 has invalid base"


### PR DESCRIPTION
If a machine isn't a controller, the controlleragentconfig worker isn't running, so configchange.socket is never created. When that machine is later promoted to a controller, the deployer starts and deploys the controller unit, whose install hook connects to configchange.socket — but the socket doesn't exist yet, so the hook fails.

With this fix we run controlleragentconfig on every machine, because we don't know which machine might become a controller later. The worker creates and serves the socket and unlocks the controller-agent-config-ready lock once it's listening, so the deployer always waits for the socket regardless of controller status.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests
./main.sh -v -p lxd unmanaged test_deploy_unmanaged
```

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10268](https://warthogs.atlassian.net/browse/JUJU-10268)


[JUJU-10268]: https://warthogs.atlassian.net/browse/JUJU-10268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ