### PR TITLE
feat: harden IAAS snap bootstrap across all controller-snap source modes

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -55,16 +55,16 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          rm -rf snap
-          mkdir -p snap
+          rm -rf snap _build/snap
+          mkdir -p snap _build/snap
           cp -a snaps/juju/. snap/
-          snapcraft --use-lxd
+          snapcraft --use-lxd --output _build/snap
 
       - name: Install snap
         shell: bash
         run: |
           set -euxo pipefail
-          sudo snap install *.snap --dangerous
+          sudo snap install _build/snap/*.snap --dangerous
           # Since we're installing dangerously, we need to
           # manually grant permissions to juju
           sudo snap connect juju:lxd lxd
@@ -124,16 +124,16 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          rm -rf snap
-          mkdir -p snap
+          rm -rf snap _build/snap
+          mkdir -p snap _build/snap
           cp -a snaps/jujud/. snap/
-          snapcraft --use-lxd
+          snapcraft --use-lxd --output _build/snap
 
       - name: Verify snap artifact
         shell: bash
         run: |
           set -euxo pipefail
-          ls -la jujud_*.snap
-          sudo snap install jujud_*.snap --dangerous
+          ls -la _build/snap/jujud_*.snap
+          sudo snap install _build/snap/jujud_*.snap --dangerous
           snap services jujud
           sudo snap remove jujud

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ JUJUD_SNAP_ARCH := $(patsubst ppc64le,ppc64el,$(GOARCH))
 JUJUD_SNAP_VERSION = $(shell sed -n 's/^version: *//p' ${SNAPS_DIR}/jujud/snapcraft.yaml | tr -d '"')
 JUJUD_SNAP_NAME = jujud_$(JUJUD_SNAP_VERSION)_$(JUJUD_SNAP_ARCH).snap
 JUJUD_SNAP_PATH = ${SNAP_BUILD_DIR}/${JUJUD_SNAP_NAME}
+JUJU_SNAP_VERSION = $(shell sed -n 's/^version: *//p' ${SNAPS_DIR}/juju/snapcraft.yaml | tr -d '"')
+JUJU_SNAP_NAME = juju_$(JUJU_SNAP_VERSION)_$(JUJUD_SNAP_ARCH).snap
 
 # Build tags passed to go install/build.
 # Passing no-dqlite will disable building with dqlite.
@@ -621,14 +623,16 @@ juju-snap:
 ## juju-snap: Build the juju snap from snaps/juju/
 	$(call snap_stage,juju)
 	mkdir -p ${SNAP_BUILD_DIR}
-	snapcraft pack --use-lxd --output ${SNAP_BUILD_DIR}
+	snapcraft pack --use-lxd
+	mv ${JUJU_SNAP_NAME} ${SNAP_BUILD_DIR}/
 
 .PHONY: jujud-snap
 jujud-snap:
 ## jujud-snap: Build the jujud controller snap from snaps/jujud/
 	$(call snap_stage,jujud)
 	mkdir -p ${SNAP_BUILD_DIR}
-	snapcraft pack --use-lxd --output ${SNAP_BUILD_DIR}
+	snapcraft pack --use-lxd
+	mv ${JUJUD_SNAP_NAME} ${SNAP_BUILD_DIR}/
 
 .PHONY: jujud-snap-build
 jujud-snap-build:
@@ -654,10 +658,14 @@ jujud-snap-build:
 		if [ "$$(cat ${JUJUD_SNAP_PATCH_DIR}/.rc 2>/dev/null)" != 0 ]; then \
 			cat ${JUJUD_SNAP_PATCH_LOG}; exit 1; \
 		fi; \
-		if $(MAKE) --no-print-directory jujud >> ${JUJUD_SNAP_PATCH_LOG} 2>&1; then \
-			sha256sum "${GO_INSTALL_PATH}/jujud" | cut -d' ' -f1 \
-				> ${JUJUD_SNAP_PATCH_DIR}/.jujud.sha256; \
+		$(MAKE) --no-print-directory jujud >> ${JUJUD_SNAP_PATCH_LOG} 2>&1 \
+			|| { cat ${JUJUD_SNAP_PATCH_LOG}; exit 1; }; \
+		if [ ! -f "$$BASE_SNAP" ]; then \
+			echo "ERROR: expected snap artifact not found at $$BASE_SNAP."; \
+			exit 1; \
 		fi; \
+		sha256sum "${GO_INSTALL_PATH}/jujud" | cut -d' ' -f1 \
+			> ${JUJUD_SNAP_PATCH_DIR}/.jujud.sha256; \
 		echo "Built snap: $$BASE_SNAP"; \
 	fi
 
@@ -926,4 +934,3 @@ docs-%:
 ## docs-run: Build and serve the documentation
 ## docs-clean: Clean the docs build artifacts
 	cd docs && $(MAKE) -f Makefile $* ALLFILES='*.md **/*.md'
-

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ OCI_IMAGE_PLATFORMS ?= linux/$(GOARCH)
 # Multi-snap layout: source-of-truth under snaps/<name>/, staging at snap/
 SNAPS_DIR := snaps
 SNAP_STAGE_DIR := snap
+SNAP_BUILD_DIR := ${BUILD_DIR}/snap
 JUJUD_SNAP_PATCH_DIR := _jujud-snap-patch
 JUJUD_SNAP_PATCH_UNPACK := ${JUJUD_SNAP_PATCH_DIR}/squashfs-root
 JUJUD_SNAP_PATCH_LOG := ${JUJUD_SNAP_PATCH_DIR}/build.log
@@ -85,6 +86,7 @@ JUJUD_SNAP_PATCH_LOG := ${JUJUD_SNAP_PATCH_DIR}/build.log
 JUJUD_SNAP_ARCH := $(patsubst ppc64le,ppc64el,$(GOARCH))
 JUJUD_SNAP_VERSION = $(shell sed -n 's/^version: *//p' ${SNAPS_DIR}/jujud/snapcraft.yaml | tr -d '"')
 JUJUD_SNAP_NAME = jujud_$(JUJUD_SNAP_VERSION)_$(JUJUD_SNAP_ARCH).snap
+JUJUD_SNAP_PATH = ${SNAP_BUILD_DIR}/${JUJUD_SNAP_NAME}
 
 # Build tags passed to go install/build.
 # Passing no-dqlite will disable building with dqlite.
@@ -618,13 +620,15 @@ endef
 juju-snap:
 ## juju-snap: Build the juju snap from snaps/juju/
 	$(call snap_stage,juju)
-	snapcraft pack --use-lxd
+	mkdir -p ${SNAP_BUILD_DIR}
+	snapcraft pack --use-lxd --output ${SNAP_BUILD_DIR}
 
 .PHONY: jujud-snap
 jujud-snap:
 ## jujud-snap: Build the jujud controller snap from snaps/jujud/
 	$(call snap_stage,jujud)
-	snapcraft pack --use-lxd
+	mkdir -p ${SNAP_BUILD_DIR}
+	snapcraft pack --use-lxd --output ${SNAP_BUILD_DIR}
 
 .PHONY: jujud-snap-build
 jujud-snap-build:
@@ -635,7 +639,7 @@ jujud-snap-build:
 # 120) when the build's stdout is a regular file. A pipe keeps stdout valid
 # while still capturing output to the log for display on failure.
 	@set -e; \
-	BASE_SNAP="${JUJUD_SNAP_NAME}"; \
+	BASE_SNAP="${JUJUD_SNAP_PATH}"; \
 	if [ -f "$$BASE_SNAP" ] && [ -z "$$(find ${SNAPS_DIR}/jujud -newer "$$BASE_SNAP" -print -quit 2>/dev/null)" ]; then \
 		echo "Patching controller snap..."; \
 		$(MAKE) --no-print-directory jujud-snap-patch; \
@@ -664,7 +668,7 @@ jujud-snap-patch:
 	mkdir -p ${JUJUD_SNAP_PATCH_DIR}; \
 	$(MAKE) --no-print-directory jujud > ${JUJUD_SNAP_PATCH_LOG} 2>&1 \
 		|| { cat ${JUJUD_SNAP_PATCH_LOG}; exit 1; }; \
-	BASE_SNAP="${JUJUD_SNAP_NAME}"; \
+	BASE_SNAP="${JUJUD_SNAP_PATH}"; \
 	if [ ! -f "$$BASE_SNAP" ]; then \
 		echo "ERROR: no base snap found. Run 'make jujud-snap-build' first to create the base snap artifact."; \
 		exit 1; \

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -822,17 +822,9 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 				return errors.Trace(err)
 			}
 			c.ControllerSnapPath = builtPath
-			c.BuildAgent = true
 		} else if c.ControllerSnapPath != "" {
 			if _, err := c.Filesystem().Stat(c.ControllerSnapPath); err != nil {
 				return errors.Annotatef(err, "--controller-snap-path %q cannot be read", c.ControllerSnapPath)
-			}
-			// --build-agent is mandatory when --controller-snap-path is supplied for
-			// IAAS bootstraps. It provides exact development-version coupling between
-			// the snap and the machine agent.
-			if !c.BuildAgent {
-				return errors.New("--build-agent is required when --controller-snap-path is supplied; " +
-					"it provides exact development-version coupling between the snap and the machine agent")
 			}
 		}
 	}

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -758,7 +758,6 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		return errors.Trace(err)
 	}
 
-	isCAASController = jujucloud.CloudIsCAAS(cloud)
 	if isCAASController && (c.ControllerSnapPath != "" ||
 		c.ControllerSnapAssertPath != "" ||
 		!c.ControllerSnapChannel.Empty() ||

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -437,8 +437,8 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		// --controller-snap-assert-path requires --controller-snap-path. When only
 		// --build-snap is set without an explicit path, this combination is
 		// rejected because there is no snap path to associate the assertion with.
-		// When both --build-snap and --controller-snap-path are set, --build-snap
-		// is ignored in Run() and the explicit path + assert path are used.
+		// When both --build-snap and --controller-snap-path are set, the
+		// combination is rejected in Run().
 		if c.BuildSnap && c.ControllerSnapPath == "" {
 			return errors.New("--controller-snap-assert-path requires --controller-snap-path; " +
 				"it cannot be used with --build-snap")
@@ -486,9 +486,8 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 
 	// Controller-snap source-mode contract: a store mode (channel or revision)
 	// is mutually exclusive with a local snap path, and channel and revision
-	// are mutually exclusive. Store modes force --build-agent and reject an
-	// explicit --agent-version/--auto-upgrade bypass that would detach the
-	// locally built agent from the snap's resolved version.
+	// are mutually exclusive. Store modes no longer force --build-agent;
+	// the snap version is the authoritative anchor for tool selection.
 	isStoreMode := !c.ControllerSnapChannel.Empty() || c.ControllerSnapRevision != ""
 	if isStoreMode {
 		if c.ControllerSnapPath != "" {
@@ -507,7 +506,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 		}
 		if c.AgentVersionParam != "" || c.AutoUpgrade {
 			return errors.New("--agent-version and --auto-upgrade cannot be used with a store-based controller snap;" +
-				" use --build-agent to build the agent anchored to the snap version")
+				" the snap version is the authoritative bootstrap version")
 		}
 	}
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -808,10 +808,6 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 
 		if isStoreMode {
 			c.ControllerSnapStoreMode = true
-			// TODO(ice): Store modes require --build-agent to anchor the locally built
-			// agent to the resolved snap version until machine agent with new
-			// binary name (jujuagentd) is released to simplestreams.
-			c.BuildAgent = true
 		} else if isLocalBuild {
 			ctx.Infof("Building controller snap from local source...")
 			builtPath, err := bootstrap.BuildControllerSnap(ctx, ctx.Stdout, ctx.Stderr)

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -807,6 +807,13 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		}
 
 		if isStoreMode {
+			// The default-store case (no explicit snap flags) is
+			// determined here; Init only rejects --agent-version and
+			// --auto-upgrade for explicit channel/revision inputs.
+			if c.AgentVersionParam != "" || c.AutoUpgrade {
+				return errors.New("--agent-version and --auto-upgrade cannot be used with a store-based controller snap;" +
+					" the snap version is the authoritative bootstrap version")
+			}
 			c.ControllerSnapStoreMode = true
 		} else if isLocalBuild {
 			ctx.Infof("Building controller snap from local source...")

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -758,6 +758,16 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		return errors.Trace(err)
 	}
 
+	isCAASController = jujucloud.CloudIsCAAS(cloud)
+	if isCAASController && (c.ControllerSnapPath != "" ||
+		c.ControllerSnapAssertPath != "" ||
+		!c.ControllerSnapChannel.Empty() ||
+		c.ControllerSnapRevision != "" ||
+		c.ControllerSnapStoreURL != "" ||
+		c.BuildSnap) {
+		return errors.NotSupportedf("controller-snap flags when bootstrapping a Kubernetes controller")
+	}
+
 	if bootstrapCfg.bootstrap.ControllerServiceType != "" ||
 		bootstrapCfg.bootstrap.ControllerExternalName != "" ||
 		len(bootstrapCfg.bootstrap.ControllerExternalIPs) > 0 {
@@ -766,11 +776,19 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 	}
 
 	if !isCAASController {
-		// An explicit local path takes precedence over --build-snap (both are
-		// local modes; this combination is permitted and the path wins).
+		// --build-snap and --controller-snap-path are mutually exclusive
+		// local source modes; the artifact source must be unambiguous.
 		if c.BuildSnap && c.ControllerSnapPath != "" {
-			c.BuildSnap = false
-			ctx.Warningf("ignoring --build-snap because --controller-snap-path is explicitly provided")
+			return errors.New("--build-snap and --controller-snap-path cannot be used together")
+		}
+
+		// All snap source modes use the snap as the version anchor;
+		// --agent-version would silently detach the agent tools from the
+		// selected snap and is rejected for every mode that supplies a
+		// controller snap.
+		if (c.ControllerSnapPath != "" || c.BuildSnap) && c.AgentVersionParam != "" {
+			return errors.New("--agent-version cannot be used with a controller snap;" +
+				" the snap version is the authoritative bootstrap version")
 		}
 
 		// Determine the controller-snap source mode:
@@ -779,7 +797,7 @@ func (c *bootstrapCommand) Run(ctx *cmd.Context) (resultErr error) {
 		//   - channel:      --controller-snap-channel
 		//   - pinned rev:   --controller-snap-revision
 		//   - default:      no snap source flag -> store channel mode,
-		//                    resolving the default <major>.<minor>/edge channel
+		//                    resolving the default latest/edge channel
 		isStoreMode := !c.ControllerSnapChannel.Empty() || c.ControllerSnapRevision != ""
 		isLocalBuild := c.BuildSnap
 		if !isStoreMode && !isLocalBuild && c.ControllerSnapPath == "" {

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2477,6 +2477,29 @@ func (s *BootstrapSuite) TestBootstrapIAASNoSnapSourceDefaultsToStore(c *tc.C) {
 	c.Check(gotArgs.BuildAgent, tc.Equals, false)
 }
 
+// TestBootstrapDefaultStoreModeRejectsAgentVersion verifies that the default
+// store mode (no explicit snap flags) rejects --agent-version and
+// --auto-upgrade. Init's isStoreMode requires explicit channel/revision flags
+// and does not fire for the default case; the rejection must occur in Run
+// after the default store mode is determined.
+func (s *BootstrapSuite) TestBootstrapDefaultStoreModeRejectsAgentVersion(c *tc.C) {
+	s.patchVersion(c)
+
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(),
+		"dummy", "devcontroller",
+		"--agent-version", "1.0.0",
+	)
+	c.Assert(err, tc.ErrorMatches,
+		`--agent-version and --auto-upgrade cannot be used with a store-based controller snap.*`)
+
+	_, err = cmdtesting.RunCommand(c, s.newBootstrapCommand(),
+		"dummy", "devcontroller",
+		"--auto-upgrade",
+	)
+	c.Assert(err, tc.ErrorMatches,
+		`--agent-version and --auto-upgrade cannot be used with a store-based controller snap.*`)
+}
+
 // TestBootstrapBuildSnapWithAssertPathNoSnapPath verifies that
 // --controller-snap-assert-path requires --controller-snap-path when used
 // with --build-snap without an explicit snap path.

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2359,7 +2359,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultStoreMode(c *tc.C) {
 	c.Assert(err, tc.Equals, cmd.ErrSilent)
 	c.Check(gotArgs.ControllerSnapPath, tc.Equals, "")
 	c.Check(gotArgs.ControllerSnapStoreMode, tc.Equals, true)
-	c.Check(gotArgs.BuildAgent, tc.Equals, false)
+	c.Check(gotArgs.BuildAgent, tc.IsFalse)
 }
 
 // TestBootstrapExplicitBuildSnap verifies that an explicit --build-snap builds
@@ -2392,8 +2392,8 @@ func (s *BootstrapSuite) TestBootstrapExplicitBuildSnap(c *tc.C) {
 	)
 	c.Assert(err, tc.Equals, cmd.ErrSilent)
 	c.Check(gotArgs.ControllerSnapPath, tc.Equals, tempSnapPath)
-	c.Check(gotArgs.ControllerSnapStoreMode, tc.Equals, false)
-	c.Check(gotArgs.BuildAgent, tc.Equals, false)
+	c.Check(gotArgs.ControllerSnapStoreMode, tc.IsFalse)
+	c.Check(gotArgs.BuildAgent, tc.IsFalse)
 }
 
 // TestBootstrapExplicitSnapPathBypassesImplicitBuild verifies that when
@@ -2474,7 +2474,7 @@ func (s *BootstrapSuite) TestBootstrapIAASNoSnapSourceDefaultsToStore(c *tc.C) {
 	c.Assert(err, tc.Equals, cmd.ErrSilent)
 	c.Check(gotArgs.ControllerSnapPath, tc.Equals, "")
 	c.Check(gotArgs.ControllerSnapStoreMode, tc.Equals, true)
-	c.Check(gotArgs.BuildAgent, tc.Equals, false)
+	c.Check(gotArgs.BuildAgent, tc.IsFalse)
 }
 
 // TestBootstrapDefaultStoreModeRejectsAgentVersion verifies that the default
@@ -2540,6 +2540,48 @@ clouds:
 	c.Assert(err, tc.ErrorMatches, `--build-snap when bootstrapping a k8s controller not supported`)
 }
 
+// TestBootstrapControllerSnapCAASNotSupported verifies the broader CAAS
+// guard at bootstrap.go:761-767 rejects every controller-snap flag for
+// Kubernetes clouds, not just --build-snap. The guard fires after
+// credential detection, so a credential must be registered for the
+// test cloud.
+func (s *BootstrapSuite) TestBootstrapControllerSnapCAASNotSupported(c *tc.C) {
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return &fakeBootstrapFuncs{}
+	})
+
+	cloudsPath := cloud.JujuPersonalCloudsPath()
+	err := os.WriteFile(cloudsPath, []byte(`
+clouds:
+    testk8s:
+        type: kubernetes
+`), 0o644)
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.store.Credentials = map[string]cloud.CloudCredential{
+		"testk8s": {
+			AuthCredentials: map[string]cloud.Credential{
+				"one": cloud.NewCredential(cloud.UserPassAuthType, map[string]string{
+					"username": "test",
+					"password": "test",
+				}),
+			},
+		},
+	}
+
+	_, err = cmdtesting.RunCommand(c, s.newBootstrapCommand(),
+		"testk8s", "devcontroller",
+		"--controller-snap-path", "/nonexistent/path",
+	)
+	c.Assert(err, tc.ErrorMatches, `controller-snap flags when bootstrapping a Kubernetes controller not supported`)
+
+	_, err = cmdtesting.RunCommand(c, s.newBootstrapCommand(),
+		"testk8s", "devcontroller",
+		"--controller-snap-channel", "4.0/stable",
+	)
+	c.Assert(err, tc.ErrorMatches, `controller-snap flags when bootstrapping a Kubernetes controller not supported`)
+}
+
 // TestBootstrapIAASRequiresBuildAgent verifies that an IAAS bootstrap with
 // --controller-snap-path but without --build-agent is allowed and passes the
 // snap path correctly. The snap version is read from the file and used as the
@@ -2565,8 +2607,8 @@ func (s *BootstrapSuite) TestBootstrapIAASRequiresBuildAgent(c *tc.C) {
 	)
 	c.Assert(err, tc.Equals, cmd.ErrSilent)
 	c.Check(gotArgs.ControllerSnapPath, tc.Equals, s.controllerSnapPath)
-	c.Check(gotArgs.BuildAgent, tc.Equals, false)
-	c.Check(gotArgs.ControllerSnapStoreMode, tc.Equals, false)
+	c.Check(gotArgs.BuildAgent, tc.IsFalse)
+	c.Check(gotArgs.ControllerSnapStoreMode, tc.IsFalse)
 }
 
 // TestBootstrapSnapPathRejectsAgentVersion verifies that

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2359,7 +2359,7 @@ func (s *BootstrapSuite) TestBootstrapDefaultStoreMode(c *tc.C) {
 	c.Assert(err, tc.Equals, cmd.ErrSilent)
 	c.Check(gotArgs.ControllerSnapPath, tc.Equals, "")
 	c.Check(gotArgs.ControllerSnapStoreMode, tc.Equals, true)
-	c.Check(gotArgs.BuildAgent, tc.Equals, true)
+	c.Check(gotArgs.BuildAgent, tc.Equals, false)
 }
 
 // TestBootstrapExplicitBuildSnap verifies that an explicit --build-snap builds
@@ -2474,7 +2474,7 @@ func (s *BootstrapSuite) TestBootstrapIAASNoSnapSourceDefaultsToStore(c *tc.C) {
 	c.Assert(err, tc.Equals, cmd.ErrSilent)
 	c.Check(gotArgs.ControllerSnapPath, tc.Equals, "")
 	c.Check(gotArgs.ControllerSnapStoreMode, tc.Equals, true)
-	c.Check(gotArgs.BuildAgent, tc.Equals, true)
+	c.Check(gotArgs.BuildAgent, tc.Equals, false)
 }
 
 // TestBootstrapBuildSnapWithAssertPathNoSnapPath verifies that

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2393,7 +2393,7 @@ func (s *BootstrapSuite) TestBootstrapExplicitBuildSnap(c *tc.C) {
 	c.Assert(err, tc.Equals, cmd.ErrSilent)
 	c.Check(gotArgs.ControllerSnapPath, tc.Equals, tempSnapPath)
 	c.Check(gotArgs.ControllerSnapStoreMode, tc.Equals, false)
-	c.Check(gotArgs.BuildAgent, tc.Equals, true)
+	c.Check(gotArgs.BuildAgent, tc.Equals, false)
 }
 
 // TestBootstrapExplicitSnapPathBypassesImplicitBuild verifies that when
@@ -2541,17 +2541,32 @@ clouds:
 }
 
 // TestBootstrapIAASRequiresBuildAgent verifies that an IAAS bootstrap with
-// --controller-snap-path but without --build-agent fails in Run() after cloud
-// type is resolved, before any provisioning occurs. The check must not fire
-// for CAAS bootstraps because !isCAASController guards both checks.
+// --controller-snap-path but without --build-agent is allowed and passes the
+// snap path correctly. The snap version is read from the file and used as the
+// tool version anchor; BuildAgentTarball is invoked with build=false for the
+// local-copy fallback when no packaged tools match.
 func (s *BootstrapSuite) TestBootstrapIAASRequiresBuildAgent(c *tc.C) {
 	s.patchVersion(c)
+
+	var gotArgs bootstrap.BootstrapParams
+	bootstrapFuncs := &fakeBootstrapFuncs{
+		bootstrapF: func(_ environs.BootstrapContext, _ environs.BootstrapEnviron, args bootstrap.BootstrapParams) error {
+			gotArgs = args
+			return errors.New("test error")
+		},
+	}
+	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
+		return bootstrapFuncs
+	})
 
 	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
 		"--controller-snap-path", s.controllerSnapPath,
 	)
-	c.Assert(err, tc.ErrorMatches, `--build-agent is required when --controller-snap-path.*`)
+	c.Assert(err, tc.Equals, cmd.ErrSilent)
+	c.Check(gotArgs.ControllerSnapPath, tc.Equals, s.controllerSnapPath)
+	c.Check(gotArgs.BuildAgent, tc.Equals, false)
+	c.Check(gotArgs.ControllerSnapStoreMode, tc.Equals, false)
 }
 
 // TestBootstrapSnapPathRejectsAgentVersion verifies that

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2428,23 +2428,11 @@ func (s *BootstrapSuite) TestBootstrapExplicitSnapPathBypassesImplicitBuild(c *t
 	}
 }
 
-// TestBootstrapBuildSnapIgnoredWithExplicitPath verifies that when both
-// --build-snap and --controller-snap-path are provided, --build-snap is
-// ignored and a warning is logged, and the explicit path is used.
-func (s *BootstrapSuite) TestBootstrapBuildSnapIgnoredWithExplicitPath(c *tc.C) {
+// TestBootstrapBuildSnapRejectedWithExplicitPath verifies that when both
+// --build-snap and --controller-snap-path are provided, the combination is
+// rejected because the artifact source must be unambiguous.
+func (s *BootstrapSuite) TestBootstrapBuildSnapRejectedWithExplicitPath(c *tc.C) {
 	s.patchVersion(c)
-	s.tw.Clear()
-
-	var gotArgs bootstrap.BootstrapParams
-	bootstrapFuncs := &fakeBootstrapFuncs{
-		bootstrapF: func(_ environs.BootstrapContext, _ environs.BootstrapEnviron, args bootstrap.BootstrapParams) error {
-			gotArgs = args
-			return errors.New("test error")
-		},
-	}
-	s.PatchValue(&getBootstrapFuncs, func() BootstrapInterface {
-		return bootstrapFuncs
-	})
 
 	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(),
 		"dummy", "devcontroller",
@@ -2452,18 +2440,7 @@ func (s *BootstrapSuite) TestBootstrapBuildSnapIgnoredWithExplicitPath(c *tc.C) 
 		"--controller-snap-path", s.controllerSnapPath,
 		"--build-agent",
 	)
-	c.Assert(err, tc.Equals, cmd.ErrSilent)
-	c.Check(gotArgs.ControllerSnapPath, tc.Equals, s.controllerSnapPath)
-
-	// Verify the "ignoring --build-snap" warning.
-	mc := tc.NewMultiChecker()
-	mc.AddExpr(`_.Level`, tc.Equals, tc.ExpectedValue)
-	mc.AddExpr(`_.Message`, tc.Matches, tc.ExpectedValue)
-	mc.AddExpr(`_._`, tc.Ignore)
-	c.Check(s.tw.Log(), tc.OrderedRight[[]loggo.Entry](mc), []loggo.Entry{{
-		Level:   loggo.WARNING,
-		Message: "ignoring --build-snap because --controller-snap-path is explicitly provided",
-	}})
+	c.Assert(err, tc.ErrorMatches, `--build-snap and --controller-snap-path cannot be used together`)
 }
 
 // TestBootstrapIAASNoSnapSourceDefaultsToStore verifies that an IAAS bootstrap
@@ -2552,6 +2529,24 @@ func (s *BootstrapSuite) TestBootstrapIAASRequiresBuildAgent(c *tc.C) {
 		"--controller-snap-path", s.controllerSnapPath,
 	)
 	c.Assert(err, tc.ErrorMatches, `--build-agent is required when --controller-snap-path.*`)
+}
+
+// TestBootstrapSnapPathRejectsAgentVersion verifies that
+// --controller-snap-path rejects an explicit --agent-version, because the
+// local snap is the version anchor. The Init-level check catches
+// --agent-version with --build-agent; this Run-level check catches
+// --agent-version without --build-agent (before the build-agent requirement
+// check fires).
+func (s *BootstrapSuite) TestBootstrapSnapPathRejectsAgentVersion(c *tc.C) {
+	s.patchVersion(c)
+
+	_, err := cmdtesting.RunCommand(c, s.newBootstrapCommand(),
+		"dummy", "devcontroller",
+		"--controller-snap-path", s.controllerSnapPath,
+		"--agent-version", "1.0.0",
+	)
+	c.Assert(err, tc.ErrorMatches,
+		`--agent-version cannot be used with a controller snap.*`)
 }
 
 func (s *BootstrapSuite) TestBootstrapSetsControllerOnBase(c *tc.C) {

--- a/cmd/jujud/agent/init_test.go
+++ b/cmd/jujud/agent/init_test.go
@@ -192,7 +192,7 @@ func (s *InitCommandSuite) TestSuccessfulInit(c *tc.C) {
 	c.Check(runtimeStr, tc.Not(tc.Contains), controllerruntimeconfig.TokenSnapData)
 	c.Check(runtimeStr, tc.Not(tc.Contains), controllerruntimeconfig.TokenSnapCommon)
 	c.Check(runtimeStr, tc.Contains, "data-dir: "+snapData)
-	c.Check(runtimeStr, tc.Contains, "log-dir: "+snapCommon+"/var/log/juju")
+	c.Check(runtimeStr, tc.Contains, "log-dir: "+snapCommon+"/logs")
 
 	// Verify runtime.conf file permissions.
 	info, err := os.Stat(runtimeDst)
@@ -254,7 +254,7 @@ func (s *InitCommandSuite) TestTokenResolutionFourPaths(c *tc.C) {
 
 	// Verify the four snap-path fields are resolved.
 	c.Check(resolved.DataDir, tc.Equals, snapData)
-	c.Check(resolved.LogDir, tc.Equals, snapCommon+"/var/log/juju")
+	c.Check(resolved.LogDir, tc.Equals, snapCommon+"/logs")
 	c.Check(resolved.SocketDir, tc.Equals, snapCommon+"/sockets")
 	c.Check(resolved.SharedAgentDir, tc.Equals, snapCommon+"/agents/controller-0")
 
@@ -279,7 +279,7 @@ controller-id: "0"
 controller-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d
 controller-model-uuid: feedface-dead-beef-cafe-c0ffee000000
 data-dir: "@SNAP_DATA@"
-log-dir: "@SNAP_COMMON@/var/log/juju"
+log-dir: "@SNAP_COMMON@/logs"
 socket-dir: "@SNAP_COMMON@/sockets"
 shared-agent-dir: "@SNAP_COMMON@/agents/controller-0"
 api-port: 17070
@@ -328,7 +328,7 @@ func (s *InitCommandSuite) TestCredentialLikeStringPreserved(c *tc.C) {
 		ControllerUUID:       "deadbeef-0bad-400d-8000-4b1d0d06f00d",
 		ControllerModelUUID:  "feedface-dead-beef-cafe-c0ffee000000",
 		DataDir:              controllerruntimeconfig.TokenSnapData,
-		LogDir:               controllerruntimeconfig.TokenSnapCommon + "/var/log/juju",
+		LogDir:               controllerruntimeconfig.TokenSnapCommon + "/logs",
 		SocketDir:            controllerruntimeconfig.TokenSnapCommon + "/sockets",
 		SharedAgentDir:       controllerruntimeconfig.TokenSnapCommon + "/agents/controller-0",
 		APIPort:              17070,

--- a/core/version/version.go
+++ b/core/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "4.1-beta2"
+const version = "4.2-alpha4"
 
 // UserAgentVersion defines a user agent version used for communication for
 // outside resources.

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -584,22 +584,28 @@ func bootstrapIAAS(
 	var availableTools coretools.List
 	if !args.BuildAgent {
 		latestPatchTxt := ""
-		versionTxt := fmt.Sprintf("%v", args.AgentVersion)
-		if args.AgentVersion == nil {
+		lookupVersion := args.AgentVersion
+		if !snapVersion.IsZero() {
+			lookupVersion = &snapVersion
+		}
+		versionTxt := fmt.Sprintf("%v", lookupVersion)
+		if lookupVersion == nil {
 			latestPatchTxt = "latest patch of "
 			versionTxt = fmt.Sprintf("%v.%v", agentVersion.Major, agentVersion.Minor)
 		}
 		ctx.Infof("Looking for %vpackaged Juju agent version %s for %s", latestPatchTxt, versionTxt, bootstrapArch)
 
-		availableTools, err = findPackagedTools(ctx, environ, ss, args.AgentVersion, &bootstrapArch, &bootstrapBase)
+		availableTools, err = findPackagedTools(ctx, environ, ss, lookupVersion, &bootstrapArch, &bootstrapBase)
 		if err != nil && !errors.Is(err, errors.NotFound) {
 			return err
 		}
 		if len(availableTools) != 0 {
-			if args.AgentVersion == nil {
+			if lookupVersion == nil {
 				// If agent version was not specified in the arguments,
 				// we always want the latest/newest available.
 				agentVersion, availableTools = availableTools.Newest()
+			} else if !snapVersion.IsZero() {
+				agentVersion = snapVersion
 			}
 			for _, tool := range availableTools {
 				ctx.Infof("Located Juju agent version %s at %s", tool.Version, tool.URL)
@@ -610,6 +616,17 @@ func bootstrapIAAS(
 	// requested, look for or build a local binary.
 	var builtTools *sync.BuiltAgent
 	if len(availableTools) == 0 && (args.AgentVersion == nil || isCompatibleVersion(*args.AgentVersion, jujuversion.Current)) {
+		// In published-snap modes (store mode), the local-copy fallback is
+		// not invoked; bootstrap fails before provisioning unless
+		// --build-agent is set.
+		if args.ControllerSnapStoreMode && !args.BuildAgent {
+			return errors.Errorf(
+				"no packaged agent binaries match the controller snap version %s for %s/%s; "+
+					"use --build-agent to build from source",
+				snapVersion, bootstrapArch, bootstrapBase.String(),
+			)
+		}
+
 		if args.BuildAgentTarball == nil {
 			return errors.New("cannot build agent binary to upload")
 		}
@@ -680,7 +697,9 @@ func bootstrapIAAS(
 	// agent-version set anyway, to appease FinishInstanceConfig.
 	// In the latter case, setBootstrapTools will later set
 	// agent-version to the correct thing.
-	if args.AgentVersion != nil {
+	if !snapVersion.IsZero() {
+		agentVersion = snapVersion
+	} else if args.AgentVersion != nil {
 		agentVersion = *args.AgentVersion
 	}
 	if cfg, err = cfg.Apply(map[string]any{

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -615,6 +615,10 @@ func bootstrapIAAS(
 	// If there are no prepackaged tools and a specific version has not been
 	// requested, look for or build a local binary.
 	var builtTools *sync.BuiltAgent
+	// args.AgentVersion is guaranteed nil for snap modes by CLI validation
+	// (--agent-version is rejected when a controller snap is supplied).
+	// When not nil, isCompatibleVersion compares against the current client
+	// version to decide whether to build a local binary.
 	if len(availableTools) == 0 && (args.AgentVersion == nil || isCompatibleVersion(*args.AgentVersion, jujuversion.Current)) {
 		// In published-snap modes (store mode), the local-copy fallback is
 		// not invoked; bootstrap fails before provisioning unless

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1334,7 +1334,7 @@ func (s *bootstrapSuite) TestBootstrapControllerSnapPathPackagedToolsMatch(c *tc
 			SnapVersionReader:       s.snapVersionReader(c, snapVersion.String()),
 		})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(buildAgentCalled, tc.IsFalse,
+	c.Check(buildAgentCalled, tc.IsFalse,
 		tc.Commentf("developer mode with packaged tools must not call BuildAgentTarball"))
 }
 
@@ -1384,7 +1384,7 @@ func (s *bootstrapSuite) TestBootstrapControllerSnapPathLocalCopyFallback(c *tc.
 			SnapVersionReader:       s.snapVersionReader(c, snapVersion.String()),
 		})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(capturedBuild, tc.IsFalse,
+	c.Check(capturedBuild, tc.IsFalse,
 		tc.Commentf("local-copy fallback must not build from source"))
 	c.Check(capturedForceVersion, tc.DeepEquals, snapVersion,
 		tc.Commentf("local copy must be forced to the snap version"))
@@ -2152,7 +2152,7 @@ func (s *bootstrapSuite) TestBootstrapStoreModeNoBuildAgentFindsExactTools(c *tc
 			},
 		})
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(buildAgentCalled, tc.IsFalse,
+	c.Check(buildAgentCalled, tc.IsFalse,
 		tc.Commentf("store mode without --build-agent must not call BuildAgentTarball"))
 }
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -2012,3 +2012,97 @@ func (s *BootstrapContextSuite) TestContextDone(c *tc.C) {
 		c.Assert(done, tc.DeepEquals, t.done)
 	}
 }
+
+func (s *bootstrapSuite) TestBootstrapStoreModeNoBuildAgentFindsExactTools(c *tc.C) {
+	// Store mode without --build-agent must find exact published tools
+	// at the snap version without calling BuildAgentTarball.
+	snapVersion := jujuversion.Current.ToPatch()
+	snapDir := c.MkDir()
+	snapPath := filepath.Join(snapDir, "jujud.snap")
+	assertPath := filepath.Join(snapDir, "jujud.assert")
+	c.Assert(os.WriteFile(snapPath, []byte("fake"), 0644), tc.ErrorIsNil)
+	c.Assert(os.WriteFile(assertPath, []byte("assert"), 0644), tc.ErrorIsNil)
+	s.patchSnapReader(c, fmt.Sprintf("name: jujud\nversion: %s\n", snapVersion.String()))
+
+	s.PatchValue(bootstrap.AcquireControllerSnap, func(_ context.Context, _, _, _, _ string, _ int, _ string) (*bootstrap.AcquiredSnap, error) {
+		return &bootstrap.AcquiredSnap{
+			SnapPath:   snapPath,
+			AssertPath: assertPath,
+		}, nil
+	})
+
+	// Patch findTools to return an exact match for the snap version.
+	s.PatchValue(bootstrap.FindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, _ environs.BootstrapEnviron, _ int, _ int, _ []string, filter tools.Filter) (tools.List, error) {
+		c.Check(filter.Number, tc.DeepEquals, snapVersion,
+			tc.Commentf("filter must be anchored to the snap version"))
+		return tools.List{&tools.Tools{
+			Version: semversion.Binary{
+				Number:  snapVersion,
+				Release: "ubuntu",
+				Arch:    "amd64",
+			},
+			URL: "file:///dummy/tools.tgz",
+		}}, nil
+	})
+
+	var buildAgentCalled bool
+	s.PatchValue(&sync.BuildAgentTarball, func(build bool, _ string,
+		_ func(semversion.Number) semversion.Number,
+	) (*sync.BuiltAgent, error) {
+		buildAgentCalled = true
+		return nil, errors.New("unexpected call to BuildAgentTarball")
+	})
+
+	env := newEnviron("foo", useDefaultKeys, nil)
+	ctx := cmdtesting.Context(c)
+	err := bootstrap.Bootstrap(environscmd.BootstrapContext(c.Context(), ctx), env,
+		bootstrap.BootstrapParams{
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             "admin-secret",
+			CAPrivateKey:            coretesting.CAKey,
+			SSHServerHostKey:        coretesting.SSHServerHostKey,
+			SupportedBootstrapBases: supportedJujuBases,
+			ControllerSnapStoreMode: true,
+		})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(buildAgentCalled, tc.IsFalse,
+		tc.Commentf("store mode without --build-agent must not call BuildAgentTarball"))
+}
+
+func (s *bootstrapSuite) TestBootstrapStoreModeNoExactToolsFails(c *tc.C) {
+	// Store mode without --build-agent with no exact published tools
+	// must fail before provisioning with an actionable diagnostic.
+	snapVersion := jujuversion.Current.ToPatch()
+	snapDir := c.MkDir()
+	snapPath := filepath.Join(snapDir, "jujud.snap")
+	assertPath := filepath.Join(snapDir, "jujud.assert")
+	c.Assert(os.WriteFile(snapPath, []byte("fake"), 0644), tc.ErrorIsNil)
+	c.Assert(os.WriteFile(assertPath, []byte("assert"), 0644), tc.ErrorIsNil)
+	s.patchSnapReader(c, fmt.Sprintf("name: jujud\nversion: %s\n", snapVersion.String()))
+
+	s.PatchValue(bootstrap.AcquireControllerSnap, func(_ context.Context, _, _, _, _ string, _ int, _ string) (*bootstrap.AcquiredSnap, error) {
+		return &bootstrap.AcquiredSnap{
+			SnapPath:   snapPath,
+			AssertPath: assertPath,
+		}, nil
+	})
+
+	// Patch findTools to return no matches.
+	s.PatchValue(bootstrap.FindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, _ environs.BootstrapEnviron, _ int, _ int, _ []string, _ tools.Filter) (tools.List, error) {
+		return nil, errors.NotFoundf("no tools")
+	})
+
+	env := newEnviron("foo", useDefaultKeys, nil)
+	ctx := cmdtesting.Context(c)
+	err := bootstrap.Bootstrap(environscmd.BootstrapContext(c.Context(), ctx), env,
+		bootstrap.BootstrapParams{
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             "admin-secret",
+			CAPrivateKey:            coretesting.CAKey,
+			SSHServerHostKey:        coretesting.SSHServerHostKey,
+			SupportedBootstrapBases: supportedJujuBases,
+			ControllerSnapStoreMode: true,
+		})
+	c.Assert(err, tc.ErrorMatches,
+		`no packaged agent binaries match the controller snap version .* use --build-agent to build from source`)
+}

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1144,7 +1144,7 @@ func (s *bootstrapSuite) TestBootstrapControllerSnapPinnedRevision(c *tc.C) {
 		})
 	c.Assert(err, tc.ErrorIsNil)
 
-	c.Assert(gotChannel, tc.Equals, fmt.Sprintf("%d.%d/edge", jujuversion.Current.Major, jujuversion.Current.Minor))
+	c.Assert(gotChannel, tc.Equals, "latest/edge")
 	c.Assert(gotRevision, tc.Equals, 42)
 	c.Assert(env.instanceConfig.Bootstrap.ControllerSnapExpectedVersion, tc.Equals, resolvedVersion.String())
 	c.Assert(env.instanceConfig.Bootstrap.ControllerSnapRevision, tc.Equals, 42)
@@ -1171,9 +1171,9 @@ func (s *bootstrapSuite) TestBootstrapControllerSnapStoreResolveFails(c *tc.C) {
 
 func (s *bootstrapSuite) TestBootstrapControllerSnapDefaultStoreMode(c *tc.C) {
 	// Store mode with an empty channel/revision resolves the default
-	// <major>.<minor>/edge channel via the store client.
+	// latest/edge channel via the store client.
 	resolvedVersion := jujuversion.Current.ToPatch()
-	defaultChannel := fmt.Sprintf("%d.%d/edge", jujuversion.Current.Major, jujuversion.Current.Minor)
+	defaultChannel := "latest/edge"
 
 	var gotChannel string
 	var gotRevision int

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -1293,6 +1293,103 @@ func (s *bootstrapSuite) TestBootstrapControllerSnapLocalUnreadableSnap(c *tc.C)
 	)
 }
 
+func (s *bootstrapSuite) TestBootstrapControllerSnapPathPackagedToolsMatch(c *tc.C) {
+	// A developer-mode controller snap (--controller-snap-path without
+	// --build-agent) that has an exact packaged tools match must select the
+	// published tools and not invoke BuildAgentTarball.
+	snapVersion := jujuversion.Current.ToPatch()
+	snapPath := filepath.Join(c.MkDir(), "jujud.snap")
+	c.Assert(os.WriteFile(snapPath, []byte("snap content"), 0644), tc.ErrorIsNil)
+
+	s.PatchValue(bootstrap.FindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, _ environs.BootstrapEnviron, _ int, _ int, _ []string, filter tools.Filter) (tools.List, error) {
+		c.Check(filter.Number, tc.DeepEquals, snapVersion,
+			tc.Commentf("filter must be anchored to the snap version"))
+		return tools.List{&tools.Tools{
+			Version: semversion.Binary{
+				Number:  snapVersion,
+				Release: "ubuntu",
+				Arch:    "amd64",
+			},
+			URL: "file:///dummy/tools.tgz",
+		}}, nil
+	})
+
+	var buildAgentCalled bool
+	s.PatchValue(&sync.BuildAgentTarball, func(_ bool, _ string,
+		_ func(semversion.Number) semversion.Number,
+	) (*sync.BuiltAgent, error) {
+		buildAgentCalled = true
+		return nil, errors.New("unexpected call to BuildAgentTarball")
+	})
+
+	env := newEnviron("foo", useDefaultKeys, nil)
+	err := bootstrap.Bootstrap(envtesting.BootstrapTestContext(c), env,
+		bootstrap.BootstrapParams{
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             "admin-secret",
+			CAPrivateKey:            coretesting.CAKey,
+			SSHServerHostKey:        coretesting.SSHServerHostKey,
+			SupportedBootstrapBases: supportedJujuBases,
+			ControllerSnapPath:      snapPath,
+			SnapVersionReader:       s.snapVersionReader(c, snapVersion.String()),
+		})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(buildAgentCalled, tc.IsFalse,
+		tc.Commentf("developer mode with packaged tools must not call BuildAgentTarball"))
+}
+
+func (s *bootstrapSuite) TestBootstrapControllerSnapPathLocalCopyFallback(c *tc.C) {
+	// A developer-mode controller snap (--controller-snap-path without
+	// --build-agent) that has no packaged tools match must fall back to
+	// BuildAgentTarball(false, ...) for the local-copy path.
+	s.PatchValue(&arch.HostArch, func() string { return arch.ARM64 })
+	snapVersion := jujuversion.Current.ToPatch()
+	snapPath := filepath.Join(c.MkDir(), "jujud.snap")
+	c.Assert(os.WriteFile(snapPath, []byte("snap content"), 0644), tc.ErrorIsNil)
+
+	// No packaged tools exist.
+	s.PatchValue(bootstrap.FindTools, func(context.Context, envtools.SimplestreamsFetcher, environs.BootstrapEnviron, int, int, []string, tools.Filter) (tools.List, error) {
+		return nil, errors.NotFoundf("tools")
+	})
+
+	var capturedBuild bool
+	var capturedForceVersion semversion.Number
+	s.PatchValue(&sync.BuildAgentTarball, func(build bool, _ string,
+		getForceVersion func(semversion.Number) semversion.Number,
+	) (*sync.BuiltAgent, error) {
+		capturedBuild = build
+		capturedForceVersion = getForceVersion(semversion.Zero)
+		return &sync.BuiltAgent{
+			Dir:      c.MkDir(),
+			Official: true,
+			Version: semversion.Binary{
+				Number:  capturedForceVersion.ToPatch(),
+				Release: "ubuntu",
+				Arch:    "arm64",
+			},
+		}, nil
+	})
+
+	env := newEnviron("foo", useDefaultKeys, nil)
+	ctx := cmdtesting.Context(c)
+	err := bootstrap.Bootstrap(environscmd.BootstrapContext(c.Context(), ctx), env,
+		bootstrap.BootstrapParams{
+			ControllerConfig:        coretesting.FakeControllerConfig(),
+			AdminSecret:             "admin-secret",
+			CAPrivateKey:            coretesting.CAKey,
+			SSHServerHostKey:        coretesting.SSHServerHostKey,
+			SupportedBootstrapBases: supportedJujuBases,
+			ControllerSnapPath:      snapPath,
+			BuildAgentTarball:       sync.BuildAgentTarball,
+			SnapVersionReader:       s.snapVersionReader(c, snapVersion.String()),
+		})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(capturedBuild, tc.IsFalse,
+		tc.Commentf("local-copy fallback must not build from source"))
+	c.Check(capturedForceVersion, tc.DeepEquals, snapVersion,
+		tc.Commentf("local copy must be forced to the snap version"))
+}
+
 func createImageMetadata(c *tc.C) (dir string, _ []*imagemetadata.ImageMetadata) {
 	return createImageMetadataForArch(c, "amd64")
 }
@@ -2017,19 +2114,6 @@ func (s *bootstrapSuite) TestBootstrapStoreModeNoBuildAgentFindsExactTools(c *tc
 	// Store mode without --build-agent must find exact published tools
 	// at the snap version without calling BuildAgentTarball.
 	snapVersion := jujuversion.Current.ToPatch()
-	snapDir := c.MkDir()
-	snapPath := filepath.Join(snapDir, "jujud.snap")
-	assertPath := filepath.Join(snapDir, "jujud.assert")
-	c.Assert(os.WriteFile(snapPath, []byte("fake"), 0644), tc.ErrorIsNil)
-	c.Assert(os.WriteFile(assertPath, []byte("assert"), 0644), tc.ErrorIsNil)
-	s.patchSnapReader(c, fmt.Sprintf("name: jujud\nversion: %s\n", snapVersion.String()))
-
-	s.PatchValue(bootstrap.AcquireControllerSnap, func(_ context.Context, _, _, _, _ string, _ int, _ string) (*bootstrap.AcquiredSnap, error) {
-		return &bootstrap.AcquiredSnap{
-			SnapPath:   snapPath,
-			AssertPath: assertPath,
-		}, nil
-	})
 
 	// Patch findTools to return an exact match for the snap version.
 	s.PatchValue(bootstrap.FindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, _ environs.BootstrapEnviron, _ int, _ int, _ []string, filter tools.Filter) (tools.List, error) {
@@ -2063,6 +2147,9 @@ func (s *bootstrapSuite) TestBootstrapStoreModeNoBuildAgentFindsExactTools(c *tc
 			SSHServerHostKey:        coretesting.SSHServerHostKey,
 			SupportedBootstrapBases: supportedJujuBases,
 			ControllerSnapStoreMode: true,
+			SnapStoreResolver: func(_ context.Context, _, _, _, _ string, _ int) (string, int, error) {
+				return snapVersion.String(), 42, nil
+			},
 		})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(buildAgentCalled, tc.IsFalse,
@@ -2073,19 +2160,6 @@ func (s *bootstrapSuite) TestBootstrapStoreModeNoExactToolsFails(c *tc.C) {
 	// Store mode without --build-agent with no exact published tools
 	// must fail before provisioning with an actionable diagnostic.
 	snapVersion := jujuversion.Current.ToPatch()
-	snapDir := c.MkDir()
-	snapPath := filepath.Join(snapDir, "jujud.snap")
-	assertPath := filepath.Join(snapDir, "jujud.assert")
-	c.Assert(os.WriteFile(snapPath, []byte("fake"), 0644), tc.ErrorIsNil)
-	c.Assert(os.WriteFile(assertPath, []byte("assert"), 0644), tc.ErrorIsNil)
-	s.patchSnapReader(c, fmt.Sprintf("name: jujud\nversion: %s\n", snapVersion.String()))
-
-	s.PatchValue(bootstrap.AcquireControllerSnap, func(_ context.Context, _, _, _, _ string, _ int, _ string) (*bootstrap.AcquiredSnap, error) {
-		return &bootstrap.AcquiredSnap{
-			SnapPath:   snapPath,
-			AssertPath: assertPath,
-		}, nil
-	})
 
 	// Patch findTools to return no matches.
 	s.PatchValue(bootstrap.FindTools, func(_ context.Context, _ envtools.SimplestreamsFetcher, _ environs.BootstrapEnviron, _ int, _ int, _ []string, _ tools.Filter) (tools.List, error) {
@@ -2102,6 +2176,9 @@ func (s *bootstrapSuite) TestBootstrapStoreModeNoExactToolsFails(c *tc.C) {
 			SSHServerHostKey:        coretesting.SSHServerHostKey,
 			SupportedBootstrapBases: supportedJujuBases,
 			ControllerSnapStoreMode: true,
+			SnapStoreResolver: func(_ context.Context, _, _, _, _ string, _ int) (string, int, error) {
+				return snapVersion.String(), 42, nil
+			},
 		})
 	c.Assert(err, tc.ErrorMatches,
 		`no packaged agent binaries match the controller snap version .* use --build-agent to build from source`)

--- a/environs/bootstrap/snap.go
+++ b/environs/bootstrap/snap.go
@@ -5,7 +5,6 @@ package bootstrap
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"strings"
 
@@ -13,7 +12,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/core/semversion"
-	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/domain/deployment/charm"
 	"github.com/juju/juju/internal/snapstore"
 )
@@ -96,7 +94,5 @@ func resolveSnapChannel(channel charm.Channel) string {
 		return channel.String()
 	}
 
-	return fmt.Sprintf(
-		"%d.%d/edge", jujuversion.Current.Major, jujuversion.Current.Minor,
-	)
+	return "latest/edge"
 }

--- a/environs/bootstrap/snap.go
+++ b/environs/bootstrap/snap.go
@@ -81,12 +81,12 @@ func ReadSnapVersion(ctx context.Context, snapPath string) (string, semversion.N
 			"reading controller snap %q: no version found in snap metadata", snapPath)
 	}
 
-	vers, err := snapstore.ParseSnapVersion(raw)
+	v, err := snapstore.ParseSnapVersion(raw)
 	if err != nil {
 		return "", semversion.Zero, errors.Annotatef(err,
 			"reading controller snap %q: cannot parse version %q", snapPath, raw)
 	}
-	return raw, vers, nil
+	return raw, v, nil
 }
 
 func resolveSnapChannel(channel charm.Channel) string {
@@ -94,5 +94,9 @@ func resolveSnapChannel(channel charm.Channel) string {
 		return channel.String()
 	}
 
+	// This should be 4.2/stable but until we have a published version, we
+	// need to use something that exists temporarily. When we published to
+	// 4.2/edge, we can switch this back to 4.2/edge, and then to 4.2/stable.
+	// Until then, we will use latest/edge.
 	return "latest/edge"
 }

--- a/internal/cloudconfig/userdatacfg.go
+++ b/internal/cloudconfig/userdatacfg.go
@@ -802,6 +802,16 @@ func (w *userdataConfig) addControllerSnapInstall() error {
 		w.conf.AddRunCmd(fmt.Sprintf("snap ack %s", assertFile))
 		w.conf.AddRunCmd(fmt.Sprintf("snap install %s", snapFile))
 		logger.Debugf(context.TODO(), "added snap install commands (with assertion) for %q", snapFile)
+
+		if expected := w.icfg.Bootstrap.ControllerSnapExpectedVersion; expected != "" {
+			w.conf.AddRunCmd(cloudinit.LogProgressCmd(
+				"Validating installed controller snap version matches %q", expected,
+			))
+			w.conf.AddRunCmd(fmt.Sprintf(
+				`installed_version=$(snap list %s | awk 'NR>1 {print $2; exit}'); test "$installed_version" = %s || (echo "controller snap version mismatch: expected %s, got $installed_version"; exit 1)`,
+				shquote(bootstrap.ControllerSnapPackageName), shquote(expected), expected,
+			))
+		}
 	} else {
 		w.conf.AddRunCmd(fmt.Sprintf("snap install --dangerous %s", snapFile))
 		logger.Debugf(context.TODO(), "added snap install --dangerous command for %q", snapFile)

--- a/internal/cloudconfig/userdatacfg.go
+++ b/internal/cloudconfig/userdatacfg.go
@@ -802,29 +802,11 @@ func (w *userdataConfig) addControllerSnapInstall() error {
 		w.conf.AddRunCmd(fmt.Sprintf("snap ack %s", assertFile))
 		w.conf.AddRunCmd(fmt.Sprintf("snap install %s", snapFile))
 		logger.Debugf(context.TODO(), "added snap install commands (with assertion) for %q", snapFile)
-
-		if expected := w.icfg.Bootstrap.ControllerSnapExpectedVersion; expected != "" {
-			w.conf.AddRunCmd(cloudinit.LogProgressCmd(
-				"Validating installed controller snap version matches %q", expected,
-			))
-			w.conf.AddRunCmd(fmt.Sprintf(
-				`installed_version=$(snap list %s | awk 'NR>1 {print $2; exit}'); test "$installed_version" = %s || (echo "controller snap version mismatch: expected %s, got $installed_version"; exit 1)`,
-				shquote(bootstrap.ControllerSnapPackageName), shquote(expected), shquote(expected),
-			))
-		}
+		w.addSnapVersionCheck(bootstrap.ControllerSnapPackageName, w.icfg.Bootstrap.ControllerSnapExpectedVersion)
 	} else {
 		w.conf.AddRunCmd(fmt.Sprintf("snap install --dangerous %s", snapFile))
 		logger.Debugf(context.TODO(), "added snap install --dangerous command for %q", snapFile)
-
-		if expected := w.icfg.Bootstrap.ControllerSnapExpectedVersion; expected != "" {
-			w.conf.AddRunCmd(cloudinit.LogProgressCmd(
-				"Validating installed controller snap version matches %q", expected,
-			))
-			w.conf.AddRunCmd(fmt.Sprintf(
-				`installed_version=$(snap list %s | awk 'NR>1 {print $2; exit}'); test "$installed_version" = %s || (echo "controller snap version mismatch: expected %s, got $installed_version"; exit 1)`,
-				shquote(bootstrap.ControllerSnapPackageName), shquote(expected), shquote(expected),
-			))
-		}
+		w.addSnapVersionCheck(bootstrap.ControllerSnapPackageName, w.icfg.Bootstrap.ControllerSnapExpectedVersion)
 	}
 
 	return nil
@@ -855,18 +837,22 @@ func (w *userdataConfig) addControllerSnapStoreInstall() error {
 	))
 	w.conf.AddRunCmd(fmt.Sprintf("snap ack %s", shquote(assertFile)))
 	w.conf.AddRunCmd(fmt.Sprintf("snap install %s", shquote(snapFile)))
-
-	if expected := w.icfg.Bootstrap.ControllerSnapExpectedVersion; expected != "" {
-		w.conf.AddRunCmd(cloudinit.LogProgressCmd(
-			"Validating installed controller snap version matches %q", expected,
-		))
-		w.conf.AddRunCmd(fmt.Sprintf(
-			`installed_version=$(snap list %s | awk 'NR>1 {print $2; exit}'); test "$installed_version" = %s || (echo "controller snap version mismatch: expected %s, got $installed_version"; exit 1)`,
-			shquote(packageName), shquote(expected), expected,
-		))
-	}
+	w.addSnapVersionCheck(packageName, w.icfg.Bootstrap.ControllerSnapExpectedVersion)
 
 	return nil
+}
+
+func (w *userdataConfig) addSnapVersionCheck(packageName, expected string) {
+	if expected == "" {
+		return
+	}
+	w.conf.AddRunCmd(cloudinit.LogProgressCmd(
+		"Validating installed controller snap version matches %q", expected,
+	))
+	w.conf.AddRunCmd(fmt.Sprintf(
+		`installed_version=$(snap list %s | awk 'NR>1 {print $2; exit}'); test "$installed_version" = %s || (echo "controller snap version mismatch: expected %s, got $installed_version"; exit 1)`,
+		shquote(packageName), shquote(expected), shquote(expected),
+	))
 }
 
 func (w *userdataConfig) addDownloadToolsCmds() error {

--- a/internal/cloudconfig/userdatacfg.go
+++ b/internal/cloudconfig/userdatacfg.go
@@ -809,7 +809,7 @@ func (w *userdataConfig) addControllerSnapInstall() error {
 			))
 			w.conf.AddRunCmd(fmt.Sprintf(
 				`installed_version=$(snap list %s | awk 'NR>1 {print $2; exit}'); test "$installed_version" = %s || (echo "controller snap version mismatch: expected %s, got $installed_version"; exit 1)`,
-				shquote(bootstrap.ControllerSnapPackageName), shquote(expected), expected,
+				shquote(bootstrap.ControllerSnapPackageName), shquote(expected), shquote(expected),
 			))
 		}
 	} else {
@@ -822,7 +822,7 @@ func (w *userdataConfig) addControllerSnapInstall() error {
 			))
 			w.conf.AddRunCmd(fmt.Sprintf(
 				`installed_version=$(snap list %s | awk 'NR>1 {print $2; exit}'); test "$installed_version" = %s || (echo "controller snap version mismatch: expected %s, got $installed_version"; exit 1)`,
-				shquote(bootstrap.ControllerSnapPackageName), shquote(expected), expected,
+				shquote(bootstrap.ControllerSnapPackageName), shquote(expected), shquote(expected),
 			))
 		}
 	}

--- a/internal/cloudconfig/userdatacfg_test.go
+++ b/internal/cloudconfig/userdatacfg_test.go
@@ -871,7 +871,7 @@ mkdir -p '/var/lib/juju/snap'
 (cd '/var/lib/juju/snap' && snap download 'jujud' --revision=42 --basename='jujud')
 snap ack '/var/lib/juju/snap/jujud.assert'
 snap install '/var/lib/juju/snap/jujud.snap'
-installed_version=$(snap list 'jujud' | awk 'NR>1 {print $2; exit}'); test "$installed_version" = '4.0.1' || (echo "controller snap version mismatch: expected 4.0.1, got $installed_version"; exit 1`))
+installed_version=$(snap list 'jujud' | awk 'NR>1 {print $2; exit}'); test "$installed_version" = '4.0.1' || (echo "controller snap version mismatch: expected '4.0.1', got $installed_version"; exit 1`))
 	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 
 	// The downloaded revision must be installed from the file, and the

--- a/internal/cloudconfig/userdatacfg_test.go
+++ b/internal/cloudconfig/userdatacfg_test.go
@@ -769,6 +769,31 @@ snap install --dangerous %[1]s`,
 	c.Check(allScripts, tc.Not(tc.Contains), "agents/controller-0/agent.conf")
 }
 
+// TestCloudInitWithLocalControllerSnapAndExpectedVersion verifies that the
+// dangerous install path includes a ControllerSnapExpectedVersion shell check
+// when the expected version is set.
+func (s *cloudinitSuite) TestCloudInitWithLocalControllerSnapAndExpectedVersion(c *tc.C) {
+	snapContent := []byte("fake snap binary content")
+	snapPath := filepath.Join(c.MkDir(), "jujud.snap")
+	err := os.WriteFile(snapPath, snapContent, 0644)
+	c.Assert(err, tc.ErrorIsNil)
+
+	cfg := makeBootstrapConfig(jammy, 0).mutate(func(cfg *testInstanceConfig) {
+		cfg.Bootstrap.ControllerSnapExpectedVersion = "4.0.1"
+		cfg.Bootstrap.ControllerSnapPath = snapPath
+	})
+	base64Content := base64.StdEncoding.EncodeToString(snapContent)
+	snapFile := fmt.Sprintf("/var/lib/juju/snap/%s", bootstrap.ControllerSnapArchive)
+
+	expectedScripts := regexp.QuoteMeta(fmt.Sprintf(`install -D -m 644 /dev/null '%s'
+echo -n %s | base64 -d > '%[1]s'
+snap install --dangerous %[1]s
+installed_version=$(snap list 'jujud' | awk 'NR>1 {print $2; exit}'); test "$installed_version" = '4.0.1' || (echo "controller snap version mismatch: expected '4.0.1', got $installed_version"; exit 1)`,
+		snapFile, base64Content,
+	))
+	checkCloudInitWithContent(c, cfg, expectedScripts, "")
+}
+
 func (s *cloudinitSuite) TestCloudInitWithLocalControllerSnapAndCharm(c *tc.C) {
 	snapContent := []byte("fake snap binary content")
 	dir := c.MkDir()

--- a/internal/cloudconfig/userdatacfg_test.go
+++ b/internal/cloudconfig/userdatacfg_test.go
@@ -845,7 +845,8 @@ func (s *cloudinitSuite) TestCloudInitWithSnapStoreControllerSnapDownloadsRevisi
 mkdir -p '/var/lib/juju/snap'
 (cd '/var/lib/juju/snap' && snap download 'jujud' --revision=42 --basename='jujud')
 snap ack '/var/lib/juju/snap/jujud.assert'
-snap install '/var/lib/juju/snap/jujud.snap'`))
+snap install '/var/lib/juju/snap/jujud.snap'
+installed_version=$(snap list 'jujud' | awk 'NR>1 {print $2; exit}'); test "$installed_version" = '4.0.1' || (echo "controller snap version mismatch: expected 4.0.1, got $installed_version"; exit 1`))
 	checkCloudInitWithContent(c, cfg, expectedScripts, "")
 
 	// The downloaded revision must be installed from the file, and the

--- a/internal/controllerruntimeconfig/config.go
+++ b/internal/controllerruntimeconfig/config.go
@@ -381,7 +381,7 @@ func RenderStagedControllerRuntimeConfig(cfg ControllerRuntimeConfig) StagedCont
 	// credential and non-path fields are left byte-for-byte.
 	staged := StagedControllerRuntimeConfig(cfg)
 	staged.DataDir = TokenSnapData
-	staged.LogDir = TokenSnapCommon + "/var/log/juju"
+	staged.LogDir = TokenSnapCommon + "/logs"
 	staged.SocketDir = TokenSnapCommon + "/sockets"
 	staged.SharedAgentDir = TokenSnapCommon + "/agents/controller-0"
 	return staged

--- a/internal/controllerruntimeconfig/config_test.go
+++ b/internal/controllerruntimeconfig/config_test.go
@@ -543,7 +543,7 @@ func (s *configSuite) TestResolveStagedControllerRuntimeConfig_ResolvesPathField
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(resolved.DataDir, tc.Equals, snapData)
-	c.Check(resolved.LogDir, tc.Equals, snapCommon+"/var/log/juju")
+	c.Check(resolved.LogDir, tc.Equals, snapCommon+"/logs")
 	c.Check(resolved.SocketDir, tc.Equals, snapCommon+"/sockets")
 	c.Check(resolved.SharedAgentDir, tc.Equals, snapCommon+"/agents/controller-0")
 
@@ -560,7 +560,7 @@ func (s *configSuite) TestResolveStagedControllerRuntimeConfig_TokenInCredential
 		"controller-uuid: deadbeef-0bad-400d-8000-4b1d0d06f00d\n" +
 		"controller-model-uuid: feedface-dead-beef-cafe-c0ffee000000\n" +
 		"data-dir: \"@SNAP_DATA@\"\n" +
-		"log-dir: \"@SNAP_COMMON@/var/log/juju\"\n" +
+		"log-dir: \"@SNAP_COMMON@/logs\"\n" +
 		"api-port: 17070\n" +
 		"agent-password: \"@SNAP_DATA@-should-not-be-here\"\n" +
 		"ca-cert: ca-cert-pem\n" +

--- a/internal/snapstore/snapstore.go
+++ b/internal/snapstore/snapstore.go
@@ -227,21 +227,21 @@ func (c *snapStoreClient) doFetchInfo(ctx context.Context, snapName, arch string
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusOK {
+		var info snapInfoResponse
+		if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+			return snapInfoResponse{}, false, jujuerrors.Annotatef(err, "decoding snap store response for %q", snapName)
+		}
+		return info, false, nil
+	}
+
 	if !isRetryableStatusCode(resp.StatusCode) {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return snapInfoResponse{}, false, fmt.Errorf("snap store returned %s for %q: %s", resp.Status, snapName, strings.TrimSpace(string(body)))
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return snapInfoResponse{}, true, fmt.Errorf("snap store returned %s for %q: %s", resp.Status, snapName, strings.TrimSpace(string(body)))
-	}
-
-	var info snapInfoResponse
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return snapInfoResponse{}, false, jujuerrors.Annotatef(err, "decoding snap store response for %q", snapName)
-	}
-	return info, false, nil
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return snapInfoResponse{}, true, fmt.Errorf("snap store returned %s for %q: %s", resp.Status, snapName, strings.TrimSpace(string(body)))
 }
 
 // isRetryableStatusCode reports whether the status code indicates a transient

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -4,7 +4,7 @@
 #if GetEnv('JUJU_VERSION') != ""
 #define MyAppVersion=GetEnv('JUJU_VERSION')
 #else
-#define MyAppVersion="4.1-beta2"
+#define MyAppVersion="4.2-alpha4"
 #endif
 
 #define MyAppName "Juju"

--- a/snaps/juju/snapcraft.yaml
+++ b/snaps/juju/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 4.1-beta2
+version: 4.2-alpha4
 summary: Juju - a model-driven operator lifecycle manager for K8s and machines
 license: AGPL-3.0
 description: |

--- a/snaps/jujud/hooks/install
+++ b/snaps/jujud/hooks/install
@@ -13,8 +13,8 @@ chmod 755 "$SNAP_COMMON/sockets"
 mkdir -p "$SNAP_COMMON/agents/controller-0"
 chmod 755 "$SNAP_COMMON/agents"
 
-mkdir -p "$SNAP_COMMON/var/log/juju"
-chmod 755 "$SNAP_COMMON/var/log/juju"
+mkdir -p "$SNAP_COMMON/logs"
+chmod 755 "$SNAP_COMMON/logs"
 
 mkdir -p "$SNAP_COMMON/.snap-init"
 chmod 755 "$SNAP_COMMON/.snap-init"

--- a/snaps/jujud/snapcraft.yaml
+++ b/snaps/jujud/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: jujud
-version: 4.1-beta2
+version: 4.2-alpha4
 title: Juju Controller
 summary: Juju controller daemon
 description: |


### PR DESCRIPTION
This makes every supported source mode for the standalone controller snap
(`jujud`) operationally robust on IAAS clouds:

- **Local unsigned snap** (`--controller-snap-path`) — installed with
  `--dangerous` and explicit interface connections.
- **Local asserted snap** (`--controller-snap-path` +
  `--controller-snap-assert-path`) — installed with `snap ack` + `snap install
  <file>`, never weakened with `--dangerous`.
- **Channel-selected published snap** (`--controller-snap-channel`) —
  client-acquired from the store before provisioning, installed as a signed file
  on the machine (no machine-side store access).
- **Pinned revision** (`--controller-snap-revision`) — resolved to an exact
  architecture-specific signed artifact on the client before provisioning.
- **Local build** (`--build-snap`) — built before provisioning, follows the
  unsigned-local install path.
- **Default mode** — when no source flag is given, resolves `latest/edge` from
  the store.

Key behaviours established:

1. **Snap version as the authoritative anchor** — the controller snap's
  embedded Juju version drives machine-agent tool selection in every mode.
  Published-snap modes require an exact simplestreams match (or `--build-agent`);
  developer modes fall back to copying `jujuagentd` from beside the client.
2. **Exact installed-version verification** — after every installation
  (dangerous and signed), cloud-init checks that the installed snap version
  matches the inspected artifact, failing bootstrap before initialization on
  mismatch.
3. **Complete source-mode validation** — mutually exclusive flag combinations,
  assertion readability, and CAAS rejection all happen after cloud-type
  classification, returning clear diagnostics before provisioning.
4. **Split-process readiness preserved** — bootstrap success continues to
  require both the controller API and the `jujuagentd` machine agent to be
  ready; API-only success is not accepted.
5. **Dangerous behaviour scoped to unsigned artifacts only** — signed store and
  asserted-local snaps never receive `--dangerous` or dangerous-mode interface
  commands.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
- With snapstore and simplestreams:
- 
```sh
❯ juju bootstrap lxd ctrl-test-1 \
  --controller-charm-path ../juju-controller/juju-controller_ubuntu@24.04-amd64.charm
Creating Juju controller "ctrl-test-1" on lxd/default
Resolved controller snap from channel/revision "latest/edge" (revision 49, version 4.2-alpha3-7ad852d)
Looking for packaged Juju agent version 4.2-alpha3 for amd64
Located Juju agent version 4.2-alpha3-ubuntu-amd64 at https://streams.canonical.com/juju/tools/agent/4.2-alpha3/juju-4.2-alpha3-linux-amd64.tgz
To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
Launching controller instance(s) on lxd/default...
 - juju-f739ab-0 (arch=amd64)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.159.202.161:22
Connected to 10.159.202.161
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.159.202.161 to verify accessibility...

Bootstrap complete, controller "ctrl-test-1" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

❯ jst -m controller
Model       Controller   Cloud/Region  Version     Timestamp
controller  ctrl-test-1  lxd/default   4.2-alpha3  21:06:09+02:00

App         Version  Status  Scale  Charm            Channel  Rev  Exposed  Message
controller           active      1  juju-controller             0  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/0*  active    idle   0        10.159.202.161  17022,17070/tcp

Machine  State    Address         Inst id        Base       AZ      Message
0        started  10.159.202.161  juju-f739ab-0  ubuntu@26  tuxedo  Running

Relation provider     Requirer              Interface  Type  Message
controller:dbcluster  controller:dbcluster  dbcluster  peer

❯ juju add-model m
❯ juju deploy ubuntu

❯ jst
Model  Controller   Cloud/Region  Version     Timestamp
m      ctrl-test-1  lxd/default   4.2-alpha3  21:07:00+02:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  24.04    active      1  ubuntu  latest/stable   79  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.159.202.153

Machine  State    Address         Inst id        Base          AZ      Message
0        started  10.159.202.153  juju-96e7b6-0  ubuntu@24.04  tuxedo  Running

❯ juju ssh -m controller 0 -- snap list
Name    Version             Rev    Tracking       Publisher    Notes
core26  20260629            462    latest/stable  canonical**  base
jujud   4.2-alpha3-7ad852d  49     -              juju-qa      -
snapd   2.76.2              27710  latest/stable  canonical**  snapd
Connection to 10.159.202.161 closed.

ctrl-test-1:m 
❯ snap info jujud | grep latest
  latest/stable:    --
  latest/candidate: --
  latest/beta:      --
  latest/edge:      4.2-alpha3-7ad852d 2026-08-28 (49) 41.7MB -
```

- With local build:
```sh
❯ juju bootstrap lxd ctrl-test \
  --build-agent \
  --controller-charm-path ../juju-controller/juju-controller_ubuntu@24.04-amd64.charm
Creating Juju controller "ctrl-test" on lxd/default
Resolved controller snap from channel/revision "latest/edge" (revision 2, version 4.1-beta2-dda699d)
Building local Juju agent binary version 4.1-beta2 for amd64 (anchored to controller snap)
[...]
Bootstrap complete, controller "ctrl-test" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

❯ juju ssh -m controller 0 -- snap list
Name    Version            Rev    Tracking       Publisher    Notes
core26  20260629           462    latest/stable  canonical**  base
jujud   4.1-beta2-dda699d  2      -              juju-qa      -
snapd   2.76.2             27710  latest/stable  canonical**  snapd
Connection to 10.159.202.98 closed.
```


- With revision:
```sh
❯ make jujud-snap-build
Patching controller snap...
jujud binary unchanged; snap is up to date.

❯ ll _build/snap
Permissions Size User                       Date Modified Git Name
.rw-r--r--   42M iyigun.cevik@canonical.com 24 Aug 18:13   -I  jujud_4.1-beta2_amd64.snap

❯ juju bootstrap lxd ctrl-test --controller-snap-path _build/snap/jujud_4.1-beta2_amd64.snap \
  --controller-charm-path ../juju-controller/juju-controller_ubuntu@24.04-amd64.charm
Creating Juju controller "ctrl-test" on lxd/default
Inspected controller snap version 4.1-beta2
Looking for packaged Juju agent version 4.1-beta2 for amd64
No packaged binary found, preparing local Juju agent binary
[...]
Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

❯ juju ssh -m controller 0 -- snap list
Name    Version    Rev    Tracking       Publisher    Notes
core26  20260629   462    latest/stable  canonical**  base
jujud   4.1-beta2  x1     -              -            -
snapd   2.76.2     27710  latest/stable  canonical**  snapd
Connection to 10.159.202.185 closed.
```

## Documentation changes


## Links

**Jira card:** [JUJU-10158](https://warthogs.atlassian.net/browse/JUJU-10158)


[JUJU-10158]: https://warthogs.atlassian.net/browse/JUJU-10158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ