### PR TITLE
test(sshserver): address flakey window size test

### DIFF
--- a/internal/worker/sshserver/handlers/machine/session.go
+++ b/internal/worker/sshserver/handlers/machine/session.go
@@ -52,6 +52,18 @@ func setupShellOrCommand(userSession ssh.Session, machineSession *gossh.Session)
 		return err
 	}
 
+	// Start the command or shell before forwarding window size changes, to avoid a
+	// race condition where the remote shell is not ready to receive window size changes.
+	var err error
+	if command := userSession.RawCommand(); command != "" {
+		err = machineSession.Start(command)
+	} else {
+		err = machineSession.Shell()
+	}
+	if err != nil {
+		return err
+	}
+
 	go func() {
 		for {
 			select {
@@ -66,9 +78,5 @@ func setupShellOrCommand(userSession ssh.Session, machineSession *gossh.Session)
 			}
 		}
 	}()
-
-	if command := userSession.RawCommand(); command != "" {
-		return machineSession.Start(command)
-	}
-	return machineSession.Shell()
+	return nil
 }

--- a/internal/worker/sshserver/handlers/machine/session_test.go
+++ b/internal/worker/sshserver/handlers/machine/session_test.go
@@ -117,17 +117,19 @@ func (s *machineSuite) TestSessionHandlerPropagatesCommandExitCode(c *tc.C) {
 func (s *machineSuite) TestSessionHandlerProxiesPTYAndWindowChanges(c *tc.C) {
 	destination, err := virtualhostname.NewInfoMachineTarget("8419cd78-4993-4c3a-928e-c646226beeee", "0")
 	c.Assert(err, tc.ErrorIsNil)
-	ready := make(chan struct{})
+	ptyCalled := make(chan struct{})
+	sessionStarted := make(chan struct{})
 
 	machine := startSSHTestServer(c, &ssh.Server{
 		PtyCallback: func(_ ssh.Context, pty ssh.Pty) bool {
 			c.Check(pty.Term, tc.Equals, "xterm")
 			c.Check(pty.Window.Height, tc.Equals, 24)
 			c.Check(pty.Window.Width, tc.Equals, 80)
+			close(ptyCalled)
 			return true
 		},
 		Handler: func(session ssh.Session) {
-			close(ready)
+			close(sessionStarted)
 			_, _ = io.WriteString(session, "shell done\n")
 		},
 	})
@@ -153,11 +155,17 @@ func (s *machineSuite) TestSessionHandlerProxiesPTYAndWindowChanges(c *tc.C) {
 	c.Assert(session.Shell(), tc.ErrorIsNil)
 
 	select {
-	case <-ready:
+	case <-ptyCalled:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for pty callback to be called")
+	}
+	c.Assert(session.WindowChange(30, 100), tc.ErrorIsNil)
+
+	select {
+	case <-sessionStarted:
 	case <-c.Context().Done():
 		c.Fatal("timed out waiting for shell to start")
 	}
-	c.Assert(session.WindowChange(30, 100), tc.ErrorIsNil)
 	c.Assert(session.Wait(), tc.ErrorIsNil)
 	c.Check(stdout.String(), tc.Equals, "shell done\r\n")
 }


### PR DESCRIPTION
Addresses a flakey test `TestSessionHandlerProxiesPTYAndWindowChanges`.

In https://github.com/juju/juju/pull/23096 we made a slight tweak to start the shell/command _after_ starting the window size proxying routine. That seems to be the root cause for the flakey test. To address this we simply start the shell/command first then send window size changes.

After the above fix I encountered a very seldom test failure when running the test with `stress` which required a small tweak in the test itself to ensure the test server does not end the session before we've run our window size check.

Verified with,
```
go test ./internal/worker/sshserver/handlers/machine -c -race -o /tmp/machine.test && timeout 60s stress /tmp/machine.test -test.run '^TestMachineSuite$/^TestSessionHandlerProxiesPTYAndWindowChanges$'
```