### PR TITLE
feat: add --show-command flag to juju ssh and scp

### DIFF
--- a/cmd/juju/ssh/scp.go
+++ b/cmd/juju/ssh/scp.go
@@ -158,6 +158,7 @@ func (c *scpCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.sshMachine.SetFlags(f)
 	c.sshContainer.SetFlags(f)
 	f.BoolVar(&c.jump, "jump", false, "Proxy SSH through the Juju controller")
+	c.sshJump.SetFlags(f)
 }
 
 func (c *scpCommand) Info() *cmd.Info {
@@ -179,6 +180,9 @@ func (c *scpCommand) Init(args []string) (err error) {
 	}
 	if c.modelType, err = c.ModelType(context.TODO()); err != nil {
 		return err
+	}
+	if c.sshJump.showCommand && !c.jump {
+		return errors.New("--show-command requires --jump")
 	}
 	if c.jump && c.modelType == model.CAAS {
 		return errors.New("--jump is not supported for scp to Kubernetes targets")

--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -205,6 +205,7 @@ func (c *sshCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.sshContainer.SetFlags(f)
 	f.Var(&c.pty, "pty", "Enable pseudo-tty allocation")
 	f.BoolVar(&c.jump, "jump", false, "Proxy SSH through the Juju controller")
+	c.sshJump.SetFlags(f)
 }
 
 func (c *sshCommand) Info() *cmd.Info {
@@ -226,6 +227,9 @@ func (c *sshCommand) Init(args []string) (err error) {
 	}
 	if c.modelType, err = c.ModelType(context.TODO()); err != nil {
 		return err
+	}
+	if c.sshJump.showCommand && !c.jump {
+		return errors.New("--show-command requires --jump")
 	}
 	// The jump provider is transparent to the model type. The container flag is
 	// registered by the embedded sshContainer, so propagate its value to the

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -9,12 +9,16 @@ package ssh
 
 import (
 	"context"
+	"io"
 	"net"
 	"os"
 	"strconv"
+	"text/template"
 
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
 	"github.com/juju/retry"
+	"github.com/juju/utils/v4"
 	"github.com/juju/utils/v4/ssh"
 	gossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -31,6 +35,10 @@ import (
 
 // finalDestinationUser is the user used on the terminating target.
 const finalDestinationUser = "ubuntu"
+
+const openSSHTemplate = `ssh -o "ProxyCommand=ssh -W %h:%p -p {{.JumpPort}} {{.JumpUser}}@{{.JumpHost}}" {{.DestinationUser}}@{{.VirtualHostname}}{{if .Args}} {{.Args}}{{end}}`
+
+const openSCPTemplate = `scp -o "ProxyCommand=ssh -W %h:%p -p {{.JumpPort}} {{.JumpUser}}@{{.JumpHost}}" {{.Args}}`
 
 // SSHAPIJump is the SSH API client used by the SSH jump provider.
 type SSHAPIJump interface {
@@ -53,6 +61,9 @@ type sshJump struct {
 	target               string
 	args                 []string
 	noHostKeyChecks      bool
+	showCommand          bool
+	sshOutputTemplate    *template.Template
+	scpOutputTemplate    *template.Template
 
 	// jumpUser is the Juju user used to authenticate against the jump server.
 	jumpUser string
@@ -69,6 +80,11 @@ type sshJump struct {
 	hostChecker      jujussh.ReachableChecker
 
 	jumpHostPort int
+}
+
+// SetFlags registers flags specific to the SSH jump provider.
+func (p *sshJump) SetFlags(f *gnuflag.FlagSet) {
+	f.BoolVar(&p.showCommand, "show-command", false, "Print the OpenSSH command instead of executing it")
 }
 
 // initRun initializes the SSH jump provider for a model command.
@@ -109,6 +125,14 @@ func (p *sshJump) initRun(ctx context.Context, mc ModelCommand) error {
 		return errors.Trace(err)
 	}
 	p.jumpUser = account.User
+	p.sshOutputTemplate, err = template.New("ssh-output").Parse(openSSHTemplate)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	p.scpOutputTemplate, err = template.New("scp-output").Parse(openSCPTemplate)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }
 
@@ -323,6 +347,9 @@ func (p *sshJump) ssh(ctx Context, enablePty bool, target *resolvedTarget) error
 	if len(args) == 0 && p.modelType == model.CAAS {
 		args = []string{"exec", "sh"}
 	}
+	if p.showCommand {
+		return p.showSSHCommand(ctx.GetStdout(), target, args)
+	}
 	cmd := ssh.Command(target.userHost(), args, options)
 	cmd.Stdin = ctx.GetStdin()
 	cmd.Stdout = ctx.GetStdout()
@@ -340,11 +367,34 @@ func (p *sshJump) copy(ctx Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if p.showCommand {
+		return p.showSCPCommand(ctx.GetStdout(), targets[0], args)
+	}
 	options, err := p.getSSHOptions(false, targets...)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	return ssh.Copy(args, options)
+}
+
+func (p *sshJump) showSSHCommand(w io.Writer, target *resolvedTarget, args []string) error {
+	return p.sshOutputTemplate.Execute(w, map[string]string{
+		"JumpPort":        strconv.Itoa(p.jumpHostPort),
+		"JumpUser":        target.via.user,
+		"JumpHost":        target.via.host,
+		"DestinationUser": target.user,
+		"VirtualHostname": target.host,
+		"Args":            utils.CommandString(args...),
+	})
+}
+
+func (p *sshJump) showSCPCommand(w io.Writer, proxyTarget *resolvedTarget, args []string) error {
+	return p.scpOutputTemplate.Execute(w, map[string]string{
+		"JumpPort": strconv.Itoa(p.jumpHostPort),
+		"JumpUser": proxyTarget.via.user,
+		"JumpHost": proxyTarget.via.host,
+		"Args":     utils.CommandString(args...),
+	})
 }
 
 func (p *sshJump) setPublicKeyRetryStrategy(_ retry.CallArgs) {}

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -36,9 +36,11 @@ import (
 // finalDestinationUser is the user used on the terminating target.
 const finalDestinationUser = "ubuntu"
 
-const openSSHTemplate = `ssh -o "ProxyCommand=ssh -W %h:%p -p {{.JumpPort}} {{.JumpUser}}@{{.JumpHost}}" {{.DestinationUser}}@{{.VirtualHostname}}{{if .Args}} {{.Args}}{{end}}`
+const openSSHTemplate = `ssh -o "ProxyCommand=ssh -W %h:%p -p {{.JumpPort}} {{.JumpUser}}@{{.JumpHost}}" {{.DestinationUser}}@{{.VirtualHostname}}{{if .Args}} {{.Args}}{{end}}
+`
 
-const openSCPTemplate = `scp -o "ProxyCommand=ssh -W %h:%p -p {{.JumpPort}} {{.JumpUser}}@{{.JumpHost}}" {{.Args}}`
+const openSCPTemplate = `scp -o "ProxyCommand=ssh -W %h:%p -p {{.JumpPort}} {{.JumpUser}}@{{.JumpHost}}" {{.Args}}
+`
 
 // SSHAPIJump is the SSH API client used by the SSH jump provider.
 type SSHAPIJump interface {
@@ -368,6 +370,9 @@ func (p *sshJump) copy(ctx Context) error {
 		return errors.Trace(err)
 	}
 	if p.showCommand {
+		if len(targets) == 0 {
+			return errors.New("at least one remote SCP target is required")
+		}
 		return p.showSCPCommand(ctx.GetStdout(), targets[0], args)
 	}
 	options, err := p.getSSHOptions(false, targets...)

--- a/cmd/juju/ssh/ssh_jump_test.go
+++ b/cmd/juju/ssh/ssh_jump_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	stdtesting "testing"
+	"text/template"
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/collections/set"
@@ -213,6 +214,43 @@ func (s *sshJumpSuite) TestSSHSkipsHostKeyChecking(c *tc.C) {
 	c.Check(strings.Contains(out, "-o ProxyCommand ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %h:%p -p 17022 fred@1.0.0.1"), tc.IsTrue)
 	c.Check(strings.Contains(out, "-o StrictHostKeyChecking no"), tc.IsTrue)
 	c.Check(strings.Contains(out, "-o UserKnownHostsFile /dev/null"), tc.IsTrue)
+}
+
+func (s *sshJumpSuite) TestSSHShowsJumpCommand(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	target := &resolvedTarget{
+		user: finalDestinationUser,
+		host: "resolved-target",
+		via:  &resolvedTarget{user: "fred", host: "1.0.0.1"},
+	}
+	outputTemplate, err := template.New("output").Parse(openSSHTemplate)
+	c.Assert(err, tc.ErrorIsNil)
+	jump := sshJump{
+		args:              []string{"echo", "hello world"},
+		jumpHostPort:      17022,
+		showCommand:       true,
+		sshOutputTemplate: outputTemplate,
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	sshCtx := mocks.NewMockContext(ctrl)
+	sshCtx.EXPECT().GetStdout().Return(buffer)
+
+	c.Assert(jump.ssh(sshCtx, false, target), tc.ErrorIsNil)
+	c.Check(buffer.String(), tc.Equals, "ssh -o \"ProxyCommand=ssh -W %h:%p -p 17022 fred@1.0.0.1\" ubuntu@resolved-target echo \"hello world\"")
+}
+
+func (s *sshJumpSuite) TestCopyShowsJumpCommand(c *tc.C) {
+	outputTemplate, err := template.New("output").Parse(openSCPTemplate)
+	c.Assert(err, tc.ErrorIsNil)
+	jump := sshJump{jumpHostPort: 17022, scpOutputTemplate: outputTemplate}
+	target := &resolvedTarget{via: &resolvedTarget{user: "fred", host: "1.0.0.1"}}
+
+	buffer := bytes.NewBuffer(nil)
+	c.Assert(jump.showSCPCommand(buffer, target, []string{"local file", "ubuntu@machine-0:/remote path"}), tc.ErrorIsNil)
+	c.Check(buffer.String(), tc.Equals, "scp -o \"ProxyCommand=ssh -W %h:%p -p 17022 fred@1.0.0.1\" \"local file\" \"ubuntu@machine-0:/remote path\"")
 }
 
 func (s *sshJumpSuite) TestCopyUsesJumpProxyCommand(c *tc.C) {

--- a/cmd/juju/ssh/ssh_jump_test.go
+++ b/cmd/juju/ssh/ssh_jump_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/tc"
 	gossh "golang.org/x/crypto/ssh"
 
+	"github.com/juju/juju/cmd/cmd/cmdtesting"
 	"github.com/juju/juju/cmd/juju/ssh/mocks"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
@@ -239,7 +240,7 @@ func (s *sshJumpSuite) TestSSHShowsJumpCommand(c *tc.C) {
 	sshCtx.EXPECT().GetStdout().Return(buffer)
 
 	c.Assert(jump.ssh(sshCtx, false, target), tc.ErrorIsNil)
-	c.Check(buffer.String(), tc.Equals, "ssh -o \"ProxyCommand=ssh -W %h:%p -p 17022 fred@1.0.0.1\" ubuntu@resolved-target echo \"hello world\"")
+	c.Check(buffer.String(), tc.Equals, "ssh -o \"ProxyCommand=ssh -W %h:%p -p 17022 fred@1.0.0.1\" ubuntu@resolved-target echo \"hello world\"\n")
 }
 
 func (s *sshJumpSuite) TestCopyShowsJumpCommand(c *tc.C) {
@@ -250,7 +251,46 @@ func (s *sshJumpSuite) TestCopyShowsJumpCommand(c *tc.C) {
 
 	buffer := bytes.NewBuffer(nil)
 	c.Assert(jump.showSCPCommand(buffer, target, []string{"local file", "ubuntu@machine-0:/remote path"}), tc.ErrorIsNil)
-	c.Check(buffer.String(), tc.Equals, "scp -o \"ProxyCommand=ssh -W %h:%p -p 17022 fred@1.0.0.1\" \"local file\" \"ubuntu@machine-0:/remote path\"")
+	c.Check(buffer.String(), tc.Equals, "scp -o \"ProxyCommand=ssh -W %h:%p -p 17022 fred@1.0.0.1\" \"local file\" \"ubuntu@machine-0:/remote path\"\n")
+}
+
+func (s *sshJumpSuite) TestCopyShowsJumpCommandThroughCopy(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	s.sshAPIJump.EXPECT().VirtualHostname(gomock.Any(), "0", nil).Return("machine-0", nil)
+	s.sshAPIJump.EXPECT().PublicHostKeyForTarget(gomock.Any(), "machine-0").Return(params.PublicSSHHostKeyResult{
+		PublicKey: s.hostKey,
+	}, nil)
+	s.sshAPIJump.EXPECT().Close().Return(nil)
+	outputTemplate, err := template.New("output").Parse(openSCPTemplate)
+	c.Assert(err, tc.ErrorIsNil)
+
+	jump := sshJump{
+		args:                 []string{"foo.txt", "0:/tmp/foo.txt"},
+		jumpUser:             "fred",
+		jumpServerHostKey:    s.hostKey,
+		showCommand:          true,
+		scpOutputTemplate:    outputTemplate,
+		sshClient:            s.sshAPIJump,
+		controllersAddresses: []string{"1.0.0.1"},
+		hostChecker:          validAddressesWithPort(17022, "1.0.0.1"),
+		jumpHostPort:         17022,
+	}
+	defer jump.cleanupRun()
+
+	ctx := cmdtesting.Context(c)
+	c.Assert(jump.copy(ctx), tc.ErrorIsNil)
+	c.Check(cmdtesting.Stdout(ctx), tc.Equals, "scp -o \"ProxyCommand=ssh -W %h:%p -p 17022 fred@1.0.0.1\" foo.txt ubuntu@machine-0:/tmp/foo.txt\n")
+}
+
+func (*sshJumpSuite) TestCopyShowCommandRequiresRemoteTarget(c *tc.C) {
+	jump := sshJump{
+		args:        []string{"foo.txt", "bar.txt"},
+		showCommand: true,
+	}
+
+	c.Assert(jump.copy(nil), tc.ErrorMatches, "at least one remote SCP target is required")
 }
 
 func (s *sshJumpSuite) TestCopyUsesJumpProxyCommand(c *tc.C) {

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/debug-code.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/debug-code.md
@@ -20,6 +20,7 @@ juju debug-code [options] <unit name> [hook or action names]
 | `--no-host-key-checks` | false | Skip host key checking (INSECURE) |
 | `--proxy` | false | Proxy through the API server |
 | `--pty` | &lt;auto&gt; | Enable pseudo-tty allocation |
+| `--show-command` | false | Print the OpenSSH command instead of executing it |
 
 ## Examples
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/debug-hooks.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/debug-hooks.md
@@ -21,6 +21,7 @@ juju debug-hooks [options] <unit name> [hook or action names]
 | `--no-host-key-checks` | false | Skip host key checking (INSECURE) |
 | `--proxy` | false | Proxy through the API server |
 | `--pty` | &lt;auto&gt; | Enable pseudo-tty allocation |
+| `--show-command` | false | Print the OpenSSH command instead of executing it |
 
 ## Examples
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/scp.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/scp.md
@@ -18,6 +18,7 @@ juju scp [options] <source> <destination>
 | `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
 | `--no-host-key-checks` | false | Skip host key checking (INSECURE) |
 | `--proxy` | false | Proxy through the API server |
+| `--show-command` | false | Print the OpenSSH command instead of executing it |
 
 ## Examples
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/ssh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/ssh.md
@@ -19,6 +19,7 @@ juju ssh [options] <[user@]target> [openssh options] [command]
 | `--no-host-key-checks` | false | Skip host key checking (INSECURE) |
 | `--proxy` | false | Proxy through the API server |
 | `--pty` | &lt;auto&gt; | Enable pseudo-tty allocation |
+| `--show-command` | false | Print the OpenSSH command instead of executing it |
 
 ## Examples
 


### PR DESCRIPTION
# Description

`juju ssh/scp` commands are just convenience commands around the actual ssh command you can run yourself. With this flag we add the ability to output the ssh command you can copy paste in another machine without the juju CLI.

The implementation is done via a string template because the other potential solution would have been to add a method to `juju/utils` to output the command from the struct, but it has 2 problems:

- the utils lib doesn't always implement the ssh via OpenSSH, and in case it's go we would need to have some shimming code to return the ssh command, probably via a string template
- the actual ssh command we will run is not actually compatible with another machine because we set the `temporary host file + strict host checking` option which ofc we wouldn't have on other machine.

All this to say, the string template is pretty simple, it works for what this flag is thought: "giving you a blueprint command with the virtual hostname and everything, so you can ssh via OpenSSH". All the options you might want to custom your ssh command with, you can just do it by hand. 