### PR TITLE
fix: propagate proxy envvars

### DIFF
--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo/v2"
 	"github.com/juju/names/v6"
+	"github.com/juju/proxy"
 	"github.com/juju/retry"
 	"gopkg.in/yaml.v3"
 	apps "k8s.io/api/apps/v1"
@@ -1237,15 +1238,39 @@ func (c *controllerStack) controllerContainers(setupCmd, machineCmd, controllerI
 			},
 		},
 	}
+	apiContainer.Env = append(apiContainer.Env, proxyEnvironment(c.pcfg.ProxySettings)...)
 	if features := featureflag.AsEnvironmentValue(); features != "" {
-		apiContainer.Env = []core.EnvVar{{
+		apiContainer.Env = append(apiContainer.Env, core.EnvVar{
 			Name:  osenv.JujuFeatureFlagEnvKey,
 			Value: features,
-		}}
+		})
 	}
 
 	containerSpec = append(containerSpec, apiContainer)
 	return containerSpec, nil
+}
+
+// proxyEnvironment returns the container environment variables that configure
+// the jujud process (and the bootstrap-state command it runs) to use the
+// model's proxy settings. The charmhub client used to download the controller
+// charm resolves proxies from the process environment, so these must be set
+// before bootstrap-state runs.
+func proxyEnvironment(settings proxy.Settings) []core.EnvVar {
+	var env []core.EnvVar
+	add := func(name, value string) {
+		if value == "" {
+			return
+		}
+		env = append(env,
+			core.EnvVar{Name: name, Value: value},
+			core.EnvVar{Name: strings.ToUpper(name), Value: value},
+		)
+	}
+	add("http_proxy", settings.Http)
+	add("https_proxy", settings.Https)
+	add("ftp_proxy", settings.Ftp)
+	add("no_proxy", settings.FullNoProxy())
+	return env
 }
 
 // jujudPebbleLayer returns the Pebble layer yaml for running the jujud

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -12,6 +12,7 @@ import (
 	jujuclock "github.com/juju/clock"
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
+	"github.com/juju/proxy"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
 	apps "k8s.io/api/apps/v1"
@@ -349,6 +350,11 @@ func (s *bootstrapSuite) testBootstrap(c *tc.C, enableServiceLinks bool) {
 	s.pcfg.Bootstrap.Timeout = 10 * time.Minute
 	s.pcfg.Bootstrap.ControllerExternalIPs = []string{"10.0.0.1"}
 	s.pcfg.Bootstrap.IgnoreProxy = true
+	s.pcfg.ProxySettings = proxy.Settings{
+		Http:    "http://proxy:3128",
+		Https:   "https://proxy:3128",
+		NoProxy: "localhost,10.0.0.0/8",
+	}
 
 	controllerStacker := s.controllerStackerGetter()
 
@@ -668,10 +674,17 @@ func (s *bootstrapSuite) testBootstrap(c *tc.C, enableServiceLinks bool) {
 			Name:            "api-server",
 			ImagePullPolicy: core.PullIfNotPresent,
 			Image:           "ghcr.io/juju/jujud-operator:" + expectedVersion.String(),
-			Env: []core.EnvVar{{
-				Name:  osenv.JujuFeatureFlagEnvKey,
-				Value: "developer-mode",
-			}},
+			Env: []core.EnvVar{
+				{Name: "JUJU_CONTAINER_NAME", Value: "api-server"},
+				{Name: "PEBBLE_SOCKET", Value: "/charm/container/pebble.socket"},
+				{Name: "http_proxy", Value: "http://proxy:3128"},
+				{Name: "HTTP_PROXY", Value: "http://proxy:3128"},
+				{Name: "https_proxy", Value: "https://proxy:3128"},
+				{Name: "HTTPS_PROXY", Value: "https://proxy:3128"},
+				{Name: "no_proxy", Value: "10.0.0.0/8,localhost"},
+				{Name: "NO_PROXY", Value: "10.0.0.0/8,localhost"},
+				{Name: osenv.JujuFeatureFlagEnvKey, Value: "developer-mode"},
+			},
 			Command: []string{
 				"/bin/sh",
 			},


### PR DESCRIPTION
This wires the controller's proxy settings into the api-server container spec so the jujud process (and the bootstrap-state command it runs) has http_proxy/https_proxy/no_proxy env vars set from the start.

The controller charm is downloaded from Charmhub during bootstrap, before the proxy updater worker can run. That client resolves proxies from the process environment (internal/http/middleware.go), so a proxied environment previously dialed Charmhub directly and timed out. The proxy updater worker itself is left untouched - it still handles runtime config changes and auto-no-proxy.

## QA steps

```sh
$ juju bootstrap --config juju-http-proxy=http://127.0.0.1:1 --config juju-https-proxy=http://127.0.0.1:1 microk8s test
$ microk8s kubectl describe pod -n controller-test controller-0
...
Environment:
      JUJU_CONTAINER_NAME:  api-server
      PEBBLE_SOCKET:        /charm/container/pebble.socket
      http_proxy:           http://127.0.0.1:1
      HTTP_PROXY:           http://127.0.0.1:1
      https_proxy:          http://127.0.0.1:1
      HTTPS_PROXY:          http://127.0.0.1:1
      no_proxy:             127.0.0.1,::1,localhost
      NO_PROXY:             127.0.0.1,::1,localhost
...
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes https://github.com/juju/juju/pull/22894.

