### PR TITLE
test(hooks): remove invalid machine-agent reboot-execution assertion

### DIFF
--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -86,19 +86,6 @@ run_start_hook_fires_after_reboot() {
 		exit 1
 	fi
 
-	# Verify that the machine agent executed the reboot via
-	# executeRebootOrShutdown. This directly tests the code path fixed
-	# in the errors.Cause -> errors.Is change: the machine agent must
-	# recognise ErrRebootMachine through the Unwrap chain and dispatch
-	# to executeRebootOrShutdown.
-	echo "[+] verifying that the machine agent executed the reboot"
-	machine_log=$(juju ssh juju-qa-test/0 -- sudo grep -E "Caught reboot error|Executing reboot" /var/log/juju/machine-0.log 2>/dev/null || true)
-	echo "$machine_log//#/    | }"
-	if [ -z "$machine_log" ]; then
-		red "Machine agent did not log reboot execution in machine-0.log"
-		exit 1
-	fi
-
 	destroy_model "${model_name}"
 }
 


### PR DESCRIPTION
The reboot test's machine-agent assertion (added in 5938fa7ae4) greps machine-0.log for tokens only produced by a charm-driven juju-reboot. Since the test reboots via sudo reboot now, the grep is always empty and the check fails deterministically on Jenkins.

Remove the invalid assertion, keeping the working reboot detection and uptime checks.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
```sh
cd tests
./main.sh -v hooks
```
Make sure the test passes after the uptime check.


## Documentation changes
N/A

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10274](https://warthogs.atlassian.net/browse/JUJU-10274)


[JUJU-10274]: https://warthogs.atlassian.net/browse/JUJU-10274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ