### PR TITLE
feat(ssh): implement scp for k8s pods via proxy

### DIFF
--- a/cmd/juju/ssh/scp.go
+++ b/cmd/juju/ssh/scp.go
@@ -184,12 +184,12 @@ func (c *scpCommand) Init(args []string) (err error) {
 	if c.sshJump.showCommand && !c.jump {
 		return errors.New("--show-command requires --jump")
 	}
-	if c.jump && c.modelType == model.CAAS {
-		c.sshJump.container = c.sshContainer.container
-	}
 	if c.jump {
 		c.provider = &c.sshJump
 		c.sshJump.noHostKeyChecks = c.sshMachine.noHostKeyChecks
+		if c.modelType == model.CAAS {
+			c.sshJump.container = c.sshContainer.container
+		}
 	} else if c.modelType == model.CAAS {
 		c.provider = &c.sshContainer
 	} else {

--- a/cmd/juju/ssh/scp.go
+++ b/cmd/juju/ssh/scp.go
@@ -185,7 +185,7 @@ func (c *scpCommand) Init(args []string) (err error) {
 		return errors.New("--show-command requires --jump")
 	}
 	if c.jump && c.modelType == model.CAAS {
-		return errors.New("--jump is not supported for scp to Kubernetes targets")
+		c.sshJump.container = c.sshContainer.container
 	}
 	if c.jump {
 		c.provider = &c.sshJump

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -414,38 +414,27 @@ func (p *sshJump) copyCAAS(ctx Context) error {
 	if len(args) > 2 {
 		return errors.New("only one source and one destination are allowed for a k8s application")
 	}
+	for _, arg := range args {
+		if strings.HasPrefix(arg, ":") {
+			return errors.New("target must match format: [pod[/container]:]path")
+		}
+	}
 
-	srcPath, srcTarget, err := p.expandCaasScpArg(ctx, args[0])
+	_, targets, err := expandSCPArgs(ctx, args, p.resolveTarget)
 	if err != nil {
 		return err
 	}
-	destPath, destTarget, err := p.expandCaasScpArg(ctx, args[1])
-	if err != nil {
-		return err
-	}
-	if (srcTarget == nil) == (destTarget == nil) {
+	if len(targets) != 1 {
 		return errors.New("copy either from a pod to the client or from the client to a pod")
 	}
 
-	if srcTarget != nil {
-		return p.copyFromCAAS(srcPath, srcTarget, destPath)
+	target := targets[0]
+	_, srcPath, srcIsRemote := strings.Cut(args[0], ":")
+	if srcIsRemote && !strings.HasPrefix(args[0], "-") {
+		return p.copyFromCAAS(srcPath, target, args[1])
 	}
-	return p.copyToCAAS(ctx, srcPath, destTarget, destPath)
-}
-
-func (p *sshJump) expandCaasScpArg(ctx context.Context, arg string) (string, *resolvedTarget, error) {
-	i := strings.Index(arg, ":")
-	if i == -1 {
-		return arg, nil, nil
-	}
-	if i == 0 {
-		return "", nil, errors.New("target must match format: [pod[/container]:]path")
-	}
-	target, err := p.resolveTarget(ctx, arg[:i])
-	if err != nil {
-		return "", nil, err
-	}
-	return arg[i+1:], target, nil
+	_, destPath, _ := strings.Cut(args[1], ":")
+	return p.copyToCAAS(ctx, args[0], target, destPath)
 }
 
 func (p *sshJump) copyToCAAS(ctx Context, srcPath string, destTarget *resolvedTarget, destPath string) error {

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -484,7 +484,10 @@ func (p *sshJump) copyToCAAS(ctx Context, srcPath string, destTarget *resolvedTa
 	if err := <-tarErr; err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(cmdErr)
+	if cmdErr == nil {
+		return nil
+	}
+	return annotateRemoteCommandError(cmdErr, stderr.String())
 }
 
 func (p *sshJump) copyFromCAAS(srcPath string, srcTarget *resolvedTarget, destPath string) error {
@@ -522,10 +525,17 @@ func (p *sshJump) copyFromCAAS(srcPath string, srcTarget *resolvedTarget, destPa
 	_ = reader.Close()
 	err = <-cmdErr
 	if errors.Is(err, io.ErrClosedPipe) {
-		// Closing the reader after the complete archive has been consumed can
-		// make the SSH command's stdout copier report a closed pipe even though
-		// the remote tar command completed successfully.
+		// The archive has been completely consumed if unTarAll returned nil.
+		// Closing the reader then can make the SSH stdout copier report a
+		// closed pipe even though tar completed successfully.
 		return nil
+	}
+	return annotateRemoteCommandError(err, stderr.String())
+}
+
+func annotateRemoteCommandError(err error, stderr string) error {
+	if stderr = strings.TrimSpace(stderr); stderr != "" {
+		return errors.Annotatef(err, "remote tar command failed: %s", stderr)
 	}
 	return errors.Trace(err)
 }

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -8,11 +8,16 @@
 package ssh
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"io"
 	"net"
 	"os"
+	"path"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"text/template"
 
 	"github.com/juju/errors"
@@ -362,7 +367,7 @@ func (p *sshJump) ssh(ctx Context, enablePty bool, target *resolvedTarget) error
 // copy transfers files through the controller SSH jump server.
 func (p *sshJump) copy(ctx Context) error {
 	if p.modelType == model.CAAS {
-		return errors.New("--jump is not supported for scp to Kubernetes targets")
+		return p.copyCAAS(ctx)
 	}
 
 	args, targets, err := expandSCPArgs(ctx, p.args, p.resolveTarget)
@@ -400,6 +405,301 @@ func (p *sshJump) showSCPCommand(w io.Writer, proxyTarget *resolvedTarget, args 
 		"JumpHost": proxyTarget.via.host,
 		"Args":     utils.CommandString(args...),
 	})
+}
+
+func (p *sshJump) copyCAAS(ctx Context) error {
+	args := p.args
+	if len(args) < 2 {
+		return errors.New("source and destination are required")
+	}
+	if len(args) > 2 {
+		return errors.New("only one source and one destination are allowed for a k8s application")
+	}
+
+	srcPath, srcTarget, err := p.expandCaasScpArg(ctx, args[0])
+	if err != nil {
+		return err
+	}
+	destPath, destTarget, err := p.expandCaasScpArg(ctx, args[1])
+	if err != nil {
+		return err
+	}
+	if (srcTarget == nil) == (destTarget == nil) {
+		return errors.New("copy either from a pod to the client or from the client to a pod")
+	}
+
+	if srcTarget != nil {
+		return p.copyFromCAAS(srcPath, srcTarget, destPath)
+	}
+	return p.copyToCAAS(ctx, srcPath, destTarget, destPath)
+}
+
+func (p *sshJump) expandCaasScpArg(ctx context.Context, arg string) (string, *resolvedTarget, error) {
+	i := strings.Index(arg, ":")
+	if i == -1 {
+		return arg, nil, nil
+	}
+	if i == 0 {
+		return "", nil, errors.New("target must match format: [pod[/container]:]path")
+	}
+	target, err := p.resolveTarget(ctx, arg[:i])
+	if err != nil {
+		return "", nil, err
+	}
+	return arg[i+1:], target, nil
+}
+
+func (p *sshJump) copyToCAAS(ctx Context, srcPath string, destTarget *resolvedTarget, destPath string) error {
+	if _, err := os.Stat(srcPath); err != nil {
+		return errors.Errorf("%q does not exist on local", srcPath)
+	}
+	if destPath != "/" && strings.HasSuffix(destPath, "/") {
+		destPath = strings.TrimSuffix(destPath, "/")
+	}
+
+	if err := p.checkRemotePathIsDir(destTarget, destPath); err == nil {
+		destPath = path.Join(destPath, path.Base(srcPath))
+	}
+
+	options, err := p.getSSHOptions(false, destTarget)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	cmd := ssh.Command(destTarget.userHost(), []string{"tar", "-xmf", "-", "-C", path.Dir(destPath)}, options)
+	cmd.Stdin = reader
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	tarErr := make(chan error, 1)
+	go func() {
+		err := makeTar(srcPath, destPath, writer)
+		_ = writer.CloseWithError(err)
+		tarErr <- err
+	}()
+	cmdErr := cmd.Run()
+	_ = reader.Close()
+	if err := <-tarErr; err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(cmdErr)
+}
+
+func (p *sshJump) copyFromCAAS(srcPath string, srcTarget *resolvedTarget, destPath string) error {
+	options, err := p.getSSHOptions(false, srcTarget)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	cmd := ssh.Command(srcTarget.userHost(), []string{"tar", "cf", "-", srcPath}, options)
+	cmd.Stdout = writer
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	cmdErr := make(chan error, 1)
+	go func() {
+		err := cmd.Run()
+		_ = writer.CloseWithError(err)
+		cmdErr <- err
+	}()
+
+	prefix := getPrefix(srcPath)
+	prefix = path.Clean(prefix)
+	// remove extraneous path shortcuts - these could occur if a path contained extra "../"
+	// and attempted to navigate beyond "/" in a remote filesystem.
+	prefix = stripPathShortcuts(prefix)
+	untarErr := unTarAll(srcPath, reader, destPath, prefix)
+	if untarErr != nil {
+		_ = reader.Close()
+		<-cmdErr
+		return errors.Trace(untarErr)
+	}
+	// Close the reader after untarring is complete to end the SSH session.
+	_ = reader.Close()
+	err = <-cmdErr
+	if errors.Is(err, io.ErrClosedPipe) {
+		// Closing the reader after the complete archive has been consumed can
+		// make the SSH command's stdout copier report a closed pipe even though
+		// the remote tar command completed successfully.
+		return nil
+	}
+	return errors.Trace(err)
+}
+
+func getPrefix(file string) string {
+	// tar strips the leading '/' if it's there, so we will too.
+	return strings.TrimLeft(file, "/")
+}
+
+func makeTar(srcPath, destPath string, writer io.Writer) error {
+	tarWriter := tar.NewWriter(writer)
+	defer tarWriter.Close()
+	srcPath = path.Clean(srcPath)
+	destPath = path.Clean(destPath)
+	return recursiveTar(path.Dir(srcPath), path.Base(srcPath), path.Dir(destPath), path.Base(destPath), tarWriter)
+}
+
+// Based on code from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp/cp.go
+func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *tar.Writer) error {
+	srcPath := path.Join(srcBase, srcFile)
+	matchedPaths, err := filepath.Glob(srcPath)
+	if err != nil {
+		return err
+	}
+	for _, fpath := range matchedPaths {
+		stat, err := os.Lstat(fpath)
+		if err != nil {
+			return err
+		}
+		if stat.IsDir() {
+			files, err := os.ReadDir(fpath)
+			if err != nil {
+				return err
+			}
+			if len(files) == 0 {
+				// case empty directory.
+				hdr, _ := tar.FileInfoHeader(stat, fpath)
+				hdr.Name = destFile
+				if err := tw.WriteHeader(hdr); err != nil {
+					return err
+				}
+			}
+			for _, f := range files {
+				if err := recursiveTar(srcBase, path.Join(srcFile, f.Name()), destBase, path.Join(destFile, f.Name()), tw); err != nil {
+					return err
+				}
+			}
+			return nil
+		} else if stat.Mode()&os.ModeSymlink != 0 {
+			// case soft link.
+			hdr, _ := tar.FileInfoHeader(stat, fpath)
+			target, err := os.Readlink(fpath)
+			if err != nil {
+				return err
+			}
+			hdr.Linkname = target
+			hdr.Name = destFile
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+		} else if stat.Mode()&os.ModeSocket != 0 {
+			logger.Warningf(context.TODO(), "socket file %q ignored", fpath)
+		} else {
+			// case regular file or other file type like pipe.
+			hdr, err := tar.FileInfoHeader(stat, fpath)
+			if err != nil {
+				return err
+			}
+			hdr.Name = destFile
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			f, err := os.Open(fpath)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(tw, f); err != nil {
+				_ = f.Close()
+				return err
+			}
+			return f.Close()
+		}
+	}
+	return nil
+}
+
+func unTarAll(srcPath string, reader io.Reader, destDir, prefix string) error {
+	tarReader := tar.NewReader(reader)
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if err != io.EOF {
+				return errors.Trace(err)
+			}
+			break
+		}
+		// All the files will start with the prefix, which is the directory where
+		// they were located on the pod, we need to strip down that prefix, but
+		// if the prefix is missing it means the tar was tampered with.
+		// For the case where prefix is empty we need to ensure that the path
+		// is not absolute, which also indicates the tar file was tampered with.
+		if !strings.HasPrefix(header.Name, prefix) {
+			return errors.New("tar contents corrupted")
+		}
+		destFileName := filepath.Join(destDir, header.Name[len(prefix):])
+		if !isDestRelative(destDir, destFileName) {
+			logger.Warningf(context.TODO(), "file %q is outside target destination, skipping", destFileName)
+			continue
+		}
+		// basic file information.
+		mode := header.FileInfo().Mode()
+		baseName := filepath.Dir(destFileName)
+		if err := os.MkdirAll(baseName, 0755); err != nil {
+			return errors.Trace(err)
+		}
+		if header.FileInfo().IsDir() {
+			if err := os.MkdirAll(destFileName, 0755); err != nil {
+				return errors.Trace(err)
+			}
+			continue
+		}
+		if mode&os.ModeSymlink != 0 {
+			logger.Warningf(context.TODO(), "skipping symlink: %q -> %q", destFileName, header.Linkname)
+			continue
+		}
+		outFile, err := os.Create(destFileName)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if _, err := io.Copy(outFile, tarReader); err != nil {
+			_ = outFile.Close()
+			return errors.Trace(err)
+		}
+		if err := outFile.Close(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func stripPathShortcuts(p string) string {
+	newPath := path.Clean(p)
+	trimmed := strings.TrimPrefix(newPath, "../")
+	for trimmed != newPath {
+		newPath = trimmed
+		trimmed = strings.TrimPrefix(newPath, "../")
+	}
+	if newPath == "." || newPath == ".." {
+		newPath = ""
+	}
+	if len(newPath) > 0 && newPath[0] == '/' {
+		return newPath[1:]
+	}
+	return newPath
+}
+
+func isDestRelative(base, dest string) bool {
+	relative, err := filepath.Rel(base, dest)
+	if err != nil {
+		return false
+	}
+	return relative == "." || relative == stripPathShortcuts(relative)
+}
+
+func (p *sshJump) checkRemotePathIsDir(target *resolvedTarget, path string) error {
+	options, err := p.getSSHOptions(false, target)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	cmd := ssh.Command(target.userHost(), []string{"test", "-d", path}, options)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	return cmd.Run()
 }
 
 func (p *sshJump) setPublicKeyRetryStrategy(_ retry.CallArgs) {}

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -407,6 +407,9 @@ func (p *sshJump) showSCPCommand(w io.Writer, proxyTarget *resolvedTarget, args 
 }
 
 func (p *sshJump) copyCAAS(ctx Context) error {
+	if p.showCommand {
+		return errors.New("--show-command is not supported for Kubernetes pod file transfers; use juju ssh with tar instead")
+	}
 	args := p.args
 	if len(args) < 2 {
 		return errors.New("source and destination are required")

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -8,14 +8,12 @@
 package ssh
 
 import (
-	"archive/tar"
 	"bytes"
 	"context"
 	"io"
 	"net"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
@@ -34,6 +32,7 @@ import (
 	controllerapi "github.com/juju/juju/api/controller/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/internal/filecopy"
 	jujussh "github.com/juju/juju/internal/network/ssh"
 	"github.com/juju/juju/rpc/params"
 )
@@ -475,7 +474,7 @@ func (p *sshJump) copyToCAAS(ctx Context, srcPath string, destTarget *resolvedTa
 
 	tarErr := make(chan error, 1)
 	go func() {
-		err := makeTar(srcPath, destPath, writer)
+		err := filecopy.MakeTar(srcPath, destPath, writer)
 		_ = writer.CloseWithError(err)
 		tarErr <- err
 	}()
@@ -510,12 +509,7 @@ func (p *sshJump) copyFromCAAS(srcPath string, srcTarget *resolvedTarget, destPa
 		cmdErr <- err
 	}()
 
-	prefix := getPrefix(srcPath)
-	prefix = path.Clean(prefix)
-	// remove extraneous path shortcuts - these could occur if a path contained extra "../"
-	// and attempted to navigate beyond "/" in a remote filesystem.
-	prefix = stripPathShortcuts(prefix)
-	untarErr := unTarAll(srcPath, reader, destPath, prefix)
+	untarErr := filecopy.UntarAll(srcPath, reader, destPath)
 	if untarErr != nil {
 		_ = reader.Close()
 		<-cmdErr
@@ -525,7 +519,7 @@ func (p *sshJump) copyFromCAAS(srcPath string, srcTarget *resolvedTarget, destPa
 	_ = reader.Close()
 	err = <-cmdErr
 	if errors.Is(err, io.ErrClosedPipe) {
-		// The archive has been completely consumed if unTarAll returned nil.
+		// The archive has been completely consumed if UntarAll returned nil.
 		// Closing the reader then can make the SSH stdout copier report a
 		// closed pipe even though tar completed successfully.
 		return nil
@@ -538,166 +532,6 @@ func annotateRemoteCommandError(err error, stderr string) error {
 		return errors.Annotatef(err, "remote tar command failed: %s", stderr)
 	}
 	return errors.Trace(err)
-}
-
-func getPrefix(file string) string {
-	// tar strips the leading '/' if it's there, so we will too.
-	return strings.TrimLeft(file, "/")
-}
-
-func makeTar(srcPath, destPath string, writer io.Writer) error {
-	tarWriter := tar.NewWriter(writer)
-	defer tarWriter.Close()
-	srcPath = path.Clean(srcPath)
-	destPath = path.Clean(destPath)
-	return recursiveTar(path.Dir(srcPath), path.Base(srcPath), path.Dir(destPath), path.Base(destPath), tarWriter)
-}
-
-// Based on code from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp/cp.go
-func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *tar.Writer) error {
-	srcPath := path.Join(srcBase, srcFile)
-	matchedPaths, err := filepath.Glob(srcPath)
-	if err != nil {
-		return err
-	}
-	for _, fpath := range matchedPaths {
-		stat, err := os.Lstat(fpath)
-		if err != nil {
-			return err
-		}
-		if stat.IsDir() {
-			files, err := os.ReadDir(fpath)
-			if err != nil {
-				return err
-			}
-			if len(files) == 0 {
-				// case empty directory.
-				hdr, _ := tar.FileInfoHeader(stat, fpath)
-				hdr.Name = destFile
-				if err := tw.WriteHeader(hdr); err != nil {
-					return err
-				}
-			}
-			for _, f := range files {
-				if err := recursiveTar(srcBase, path.Join(srcFile, f.Name()), destBase, path.Join(destFile, f.Name()), tw); err != nil {
-					return err
-				}
-			}
-			return nil
-		} else if stat.Mode()&os.ModeSymlink != 0 {
-			// case soft link.
-			hdr, _ := tar.FileInfoHeader(stat, fpath)
-			target, err := os.Readlink(fpath)
-			if err != nil {
-				return err
-			}
-			hdr.Linkname = target
-			hdr.Name = destFile
-			if err := tw.WriteHeader(hdr); err != nil {
-				return err
-			}
-		} else if stat.Mode()&os.ModeSocket != 0 {
-			logger.Warningf(context.TODO(), "socket file %q ignored", fpath)
-		} else {
-			// case regular file or other file type like pipe.
-			hdr, err := tar.FileInfoHeader(stat, fpath)
-			if err != nil {
-				return err
-			}
-			hdr.Name = destFile
-			if err := tw.WriteHeader(hdr); err != nil {
-				return err
-			}
-			f, err := os.Open(fpath)
-			if err != nil {
-				return err
-			}
-			if _, err := io.Copy(tw, f); err != nil {
-				_ = f.Close()
-				return err
-			}
-			return f.Close()
-		}
-	}
-	return nil
-}
-
-func unTarAll(srcPath string, reader io.Reader, destDir, prefix string) error {
-	tarReader := tar.NewReader(reader)
-	for {
-		header, err := tarReader.Next()
-		if err != nil {
-			if err != io.EOF {
-				return errors.Trace(err)
-			}
-			break
-		}
-		// All the files will start with the prefix, which is the directory where
-		// they were located on the pod, we need to strip down that prefix, but
-		// if the prefix is missing it means the tar was tampered with.
-		// For the case where prefix is empty we need to ensure that the path
-		// is not absolute, which also indicates the tar file was tampered with.
-		if !strings.HasPrefix(header.Name, prefix) {
-			return errors.New("tar contents corrupted")
-		}
-		destFileName := filepath.Join(destDir, header.Name[len(prefix):])
-		if !isDestRelative(destDir, destFileName) {
-			logger.Warningf(context.TODO(), "file %q is outside target destination, skipping", destFileName)
-			continue
-		}
-		// basic file information.
-		mode := header.FileInfo().Mode()
-		baseName := filepath.Dir(destFileName)
-		if err := os.MkdirAll(baseName, 0755); err != nil {
-			return errors.Trace(err)
-		}
-		if header.FileInfo().IsDir() {
-			if err := os.MkdirAll(destFileName, 0755); err != nil {
-				return errors.Trace(err)
-			}
-			continue
-		}
-		if mode&os.ModeSymlink != 0 {
-			logger.Warningf(context.TODO(), "skipping symlink: %q -> %q", destFileName, header.Linkname)
-			continue
-		}
-		outFile, err := os.Create(destFileName)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if _, err := io.Copy(outFile, tarReader); err != nil {
-			_ = outFile.Close()
-			return errors.Trace(err)
-		}
-		if err := outFile.Close(); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
-func stripPathShortcuts(p string) string {
-	newPath := path.Clean(p)
-	trimmed := strings.TrimPrefix(newPath, "../")
-	for trimmed != newPath {
-		newPath = trimmed
-		trimmed = strings.TrimPrefix(newPath, "../")
-	}
-	if newPath == "." || newPath == ".." {
-		newPath = ""
-	}
-	if len(newPath) > 0 && newPath[0] == '/' {
-		return newPath[1:]
-	}
-	return newPath
-}
-
-func isDestRelative(base, dest string) bool {
-	relative, err := filepath.Rel(base, dest)
-	if err != nil {
-		return false
-	}
-	return relative == "." || relative == stripPathShortcuts(relative)
 }
 
 func (p *sshJump) checkRemotePathIsDir(target *resolvedTarget, path string) error {

--- a/cmd/juju/ssh/ssh_jump_test.go
+++ b/cmd/juju/ssh/ssh_jump_test.go
@@ -363,6 +363,15 @@ func (s *sshJumpSuite) TestCopyCAASArgValidation(c *tc.C) {
 	c.Check(jump.copy(nil), tc.ErrorMatches, "target must match format: \\[pod\\[/container\\]:\\]path")
 }
 
+func (s *sshJumpSuite) TestCopyCAASShowCommandNotSupported(c *tc.C) {
+	jump := sshJump{
+		modelType:   model.CAAS,
+		showCommand: true,
+	}
+
+	c.Check(jump.copy(nil), tc.ErrorMatches, "--show-command is not supported for Kubernetes pod file transfers; use juju ssh with tar instead")
+}
+
 func (s *sshJumpSuite) TestCopyToCAAS(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()

--- a/cmd/juju/ssh/ssh_jump_test.go
+++ b/cmd/juju/ssh/ssh_jump_test.go
@@ -357,9 +357,52 @@ func (s *sshJumpSuite) TestCopyPinsAllTargetHostKeys(c *tc.C) {
 	c.Check(string(output), tc.Contains, "machine-1 ")
 }
 
-func (s *sshJumpSuite) TestCopyRejectsCAASTarget(c *tc.C) {
-	jump := sshJump{modelType: model.CAAS}
-	c.Check(jump.copy(nil), tc.ErrorMatches, "--jump is not supported for scp to Kubernetes targets")
+func (s *sshJumpSuite) TestCopyCAASArgValidation(c *tc.C) {
+	jump := sshJump{modelType: model.CAAS, args: []string{"source", ":target"}}
+	c.Check(jump.copy(nil), tc.ErrorMatches, "target must match format: \\[pod\\[/container\\]:\\]path")
+}
+
+func (s *sshJumpSuite) TestCopyToCAAS(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	sshScript := `#!/bin/bash
+{
+    echo "$@"
+    cat >/dev/null
+} >> "$0.args"
+`
+	err := os.WriteFile(filepath.Join(s.binDir, "ssh"), []byte(sshScript), 0777)
+	c.Assert(err, tc.ErrorIsNil)
+
+	srcPath := filepath.Join(c.MkDir(), "source")
+	err = os.WriteFile(srcPath, []byte("test data"), 0600)
+	c.Assert(err, tc.ErrorIsNil)
+
+	s.sshAPIJump.EXPECT().VirtualHostname(gomock.Any(), "0", gomock.Any()).Return("pod-0", nil)
+	s.sshAPIJump.EXPECT().PublicHostKeyForTarget(gomock.Any(), "pod-0").Return(params.PublicSSHHostKeyResult{
+		PublicKey: s.hostKey,
+	}, nil)
+
+	jump := sshJump{
+		modelType:            model.CAAS,
+		container:            "charm",
+		args:                 []string{srcPath, "0:/tmp/destination"},
+		jumpUser:             "fred",
+		jumpServerHostKey:    s.hostKey,
+		sshClient:            s.sshAPIJump,
+		controllersAddresses: []string{"1.0.0.1"},
+		hostChecker:          validAddressesWithPort(17022, "1.0.0.1"),
+		jumpHostPort:         17022,
+	}
+	defer jump.cleanupRun()
+	s.sshAPIJump.EXPECT().Close().Return(nil)
+
+	c.Assert(jump.copy(nil), tc.ErrorIsNil)
+	output, err := os.ReadFile(filepath.Join(s.binDir, "ssh.args"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(output), tc.Contains, "ubuntu@pod-0 test -d /tmp/destination")
+	c.Check(string(output), tc.Contains, "ubuntu@pod-0 tar -xmf - -C /tmp")
 }
 
 func (s *sshJumpSuite) TestGenerateKnownHostsSupportsIPv6(c *tc.C) {

--- a/cmd/juju/ssh/ssh_jump_test.go
+++ b/cmd/juju/ssh/ssh_jump_test.go
@@ -4,6 +4,7 @@
 package ssh
 
 import (
+	"archive/tar"
 	"bytes"
 	"os"
 	"path/filepath"
@@ -403,6 +404,97 @@ func (s *sshJumpSuite) TestCopyToCAAS(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(string(output), tc.Contains, "ubuntu@pod-0 test -d /tmp/destination")
 	c.Check(string(output), tc.Contains, "ubuntu@pod-0 tar -xmf - -C /tmp")
+}
+
+func (s *sshJumpSuite) TestCopyToCAASReportsRemoteStderr(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	sshScript := `#!/bin/bash
+if [[ "$*" == *"test -d"* ]]; then
+    exit 1
+fi
+cat >/dev/null
+echo "permission denied" >&2
+exit 1
+`
+	err := os.WriteFile(filepath.Join(s.binDir, "ssh"), []byte(sshScript), 0777)
+	c.Assert(err, tc.ErrorIsNil)
+
+	srcPath := filepath.Join(c.MkDir(), "source")
+	err = os.WriteFile(srcPath, []byte("test data"), 0600)
+	c.Assert(err, tc.ErrorIsNil)
+
+	jump := sshJump{
+		jumpHostPort:    17022,
+		noHostKeyChecks: true,
+	}
+	target := &resolvedTarget{
+		user: finalDestinationUser,
+		host: "pod-0",
+		via: &resolvedTarget{
+			user: "fred",
+			host: "1.0.0.1",
+		},
+	}
+
+	err = jump.copyToCAAS(nil, srcPath, target, "/tmp/destination")
+	c.Check(err, tc.ErrorMatches, ".*permission denied.*")
+}
+
+func (s *sshJumpSuite) TestCopyFromCAAS(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	sshScript := `#!/bin/bash
+echo "$@" >> "$0.args"
+cat "$0.archive"
+`
+	err := os.WriteFile(filepath.Join(s.binDir, "ssh"), []byte(sshScript), 0777)
+	c.Assert(err, tc.ErrorIsNil)
+
+	const content = "test data"
+	var archive bytes.Buffer
+	tarWriter := tar.NewWriter(&archive)
+	err = tarWriter.WriteHeader(&tar.Header{
+		Name: "remote/source",
+		Mode: 0600,
+		Size: int64(len(content)),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = tarWriter.Write([]byte(content))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(tarWriter.Close(), tc.ErrorIsNil)
+	err = os.WriteFile(filepath.Join(s.binDir, "ssh.archive"), archive.Bytes(), 0600)
+	c.Assert(err, tc.ErrorIsNil)
+
+	destPath := filepath.Join(c.MkDir(), "destination")
+	s.sshAPIJump.EXPECT().VirtualHostname(gomock.Any(), "0", gomock.Any()).Return("pod-0", nil)
+	s.sshAPIJump.EXPECT().PublicHostKeyForTarget(gomock.Any(), "pod-0").Return(params.PublicSSHHostKeyResult{
+		PublicKey: s.hostKey,
+	}, nil)
+
+	jump := sshJump{
+		modelType:            model.CAAS,
+		container:            "charm",
+		args:                 []string{"0:/remote/source", destPath},
+		jumpUser:             "fred",
+		jumpServerHostKey:    s.hostKey,
+		sshClient:            s.sshAPIJump,
+		controllersAddresses: []string{"1.0.0.1"},
+		hostChecker:          validAddressesWithPort(17022, "1.0.0.1"),
+		jumpHostPort:         17022,
+	}
+	defer jump.cleanupRun()
+	s.sshAPIJump.EXPECT().Close().Return(nil)
+
+	c.Assert(jump.copy(nil), tc.ErrorIsNil)
+	result, err := os.ReadFile(destPath)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(result), tc.Equals, content)
+	output, err := os.ReadFile(filepath.Join(s.binDir, "ssh.args"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(output), tc.Contains, "ubuntu@pod-0 tar cf - /remote/source")
 }
 
 func (s *sshJumpSuite) TestGenerateKnownHostsSupportsIPv6(c *tc.C) {

--- a/cmd/package_test.go
+++ b/cmd/package_test.go
@@ -64,7 +64,7 @@ var allowedCalls = map[string]set.Strings{
 	"juju/commands/upgradecontroller.go": set.NewStrings("os.Open", "os.RemoveAll"),
 	// ssh is not a whitelisted embedded CLI command.
 	"juju/ssh/ssh_machine.go": set.NewStrings("os.Remove"),
-	"juju/ssh/ssh_jump.go":    set.NewStrings("os.OpenFile", "os.Remove"),
+	"juju/ssh/ssh_jump.go":    set.NewStrings("os.Create", "os.Lstat", "os.Open", "os.Stat", "os.OpenFile", "os.Remove"),
 	// agree is not exposed to shell scripts because it uses PAGER to present terms
 	"juju/agree/agree/agree.go": set.NewStrings("exec.Command", "exec.LookPath"),
 	// Ignore the actual os calls.

--- a/internal/filecopy/copy.go
+++ b/internal/filecopy/copy.go
@@ -1,0 +1,208 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filecopy
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/errors"
+
+	internallogger "github.com/juju/juju/internal/logger"
+)
+
+var logger = internallogger.GetLogger("juju.internal.filecopy")
+
+// MakeTar writes srcPath to writer as a tar archive rooted at destPath.
+//
+// This is based on code from
+// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp/cp.go.
+func MakeTar(srcPath, destPath string, writer io.Writer) error {
+	tarWriter := tar.NewWriter(writer)
+	defer tarWriter.Close()
+	srcPath = path.Clean(srcPath)
+	destPath = path.Clean(destPath)
+	return recursiveTar(path.Dir(srcPath), path.Base(srcPath), path.Dir(destPath), path.Base(destPath), tarWriter)
+}
+
+// recursiveTar is based on code from
+// https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp/cp.go.
+func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *tar.Writer) error {
+	srcPath := path.Join(srcBase, srcFile)
+	matchedPaths, err := filepath.Glob(srcPath)
+	if err != nil {
+		return err
+	}
+	for _, fpath := range matchedPaths {
+		stat, err := os.Lstat(fpath)
+		if err != nil {
+			return err
+		}
+		if stat.IsDir() {
+			files, err := os.ReadDir(fpath)
+			if err != nil {
+				return err
+			}
+			if len(files) == 0 {
+				// case empty directory.
+				hdr, _ := tar.FileInfoHeader(stat, fpath)
+				hdr.Name = destFile
+				if err := tw.WriteHeader(hdr); err != nil {
+					return err
+				}
+			}
+			for _, f := range files {
+				if err := recursiveTar(srcBase, path.Join(srcFile, f.Name()), destBase, path.Join(destFile, f.Name()), tw); err != nil {
+					return err
+				}
+			}
+			return nil
+		} else if stat.Mode()&os.ModeSymlink != 0 {
+			// case soft link.
+			hdr, _ := tar.FileInfoHeader(stat, fpath)
+			target, err := os.Readlink(fpath)
+			if err != nil {
+				return err
+			}
+
+			hdr.Linkname = target
+			hdr.Name = destFile
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+		} else if stat.Mode()&os.ModeSocket != 0 {
+			logger.Warningf(context.TODO(), "socket file %q ignored", fpath)
+		} else {
+			// case regular file or other file type like pipe.
+			hdr, err := tar.FileInfoHeader(stat, fpath)
+			if err != nil {
+				return err
+			}
+			hdr.Name = destFile
+
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+
+			f, err := os.Open(fpath)
+			if err != nil {
+				return err
+			}
+
+			if _, err := io.Copy(tw, f); err != nil {
+				_ = f.Close()
+				return err
+			}
+			return f.Close()
+		}
+	}
+	return nil
+}
+
+// UntarAll extracts an archive created from srcPath into destDir.
+func UntarAll(srcPath string, reader io.Reader, destDir string) error {
+	prefix := getPrefix(srcPath)
+	prefix = path.Clean(prefix)
+	// Remove extraneous path shortcuts - these could occur if a path contained
+	// extra "../" and attempted to navigate beyond "/" in a remote filesystem.
+	prefix = stripPathShortcuts(prefix)
+
+	tarReader := tar.NewReader(reader)
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if err != io.EOF {
+				return errors.Trace(err)
+			}
+			break
+		}
+
+		// All the files will start with the prefix, which is the directory where
+		// they were located on the pod, we need to strip down that prefix, but
+		// if the prefix is missing it means the tar was tampered with.
+		// For the case where prefix is empty we need to ensure that the path
+		// is not absolute, which also indicates that the tar was tampered with.
+		if !strings.HasPrefix(header.Name, prefix) {
+			return errors.New("tar contents corrupted")
+		}
+
+		mode := header.FileInfo().Mode()
+		destFileName := filepath.Join(destDir, header.Name[len(prefix):])
+		if !isDestRelative(destDir, destFileName) {
+			logger.Warningf(context.TODO(), "file %q is outside target destination, skipping", destFileName)
+			continue
+		}
+
+		baseName := filepath.Dir(destFileName)
+		if err := os.MkdirAll(baseName, 0755); err != nil {
+			return errors.Trace(err)
+		}
+		if header.FileInfo().IsDir() {
+			if err := os.MkdirAll(destFileName, 0755); err != nil {
+				return errors.Trace(err)
+			}
+			continue
+		}
+
+		if mode&os.ModeSymlink != 0 {
+			logger.Warningf(context.TODO(), "skipping symlink: %q -> %q", destFileName, header.Linkname)
+			continue
+		}
+		outFile, err := os.Create(destFileName)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if _, err := io.Copy(outFile, tarReader); err != nil {
+			_ = outFile.Close()
+			return errors.Trace(err)
+		}
+		if err := outFile.Close(); err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	return nil
+}
+
+func getPrefix(file string) string {
+	// tar strips the leading '/' if it's there, so we will too.
+	return strings.TrimLeft(file, "/")
+}
+
+// stripPathShortcuts removes any leading or trailing "../" from a given path.
+func stripPathShortcuts(p string) string {
+	newPath := path.Clean(p)
+	trimmed := strings.TrimPrefix(newPath, "../")
+
+	for trimmed != newPath {
+		newPath = trimmed
+		trimmed = strings.TrimPrefix(newPath, "../")
+	}
+
+	// trim leftover {".", ".."}
+	if newPath == "." || newPath == ".." {
+		newPath = ""
+	}
+
+	if len(newPath) > 0 && string(newPath[0]) == "/" {
+		return newPath[1:]
+	}
+
+	return newPath
+}
+
+// isDestRelative returns true if dest is pointing outside the base directory,
+// false otherwise.
+func isDestRelative(base, dest string) bool {
+	relative, err := filepath.Rel(base, dest)
+	if err != nil {
+		return false
+	}
+	return relative == "." || relative == stripPathShortcuts(relative)
+}

--- a/internal/filecopy/copy.go
+++ b/internal/filecopy/copy.go
@@ -1,5 +1,14 @@
 // Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
+//
+// Portions of this file are derived from Kubernetes:
+// Copyright 2016 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0.
+// You may obtain a copy of the License at:
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Original source:
+// https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
 
 package filecopy
 

--- a/internal/filecopy/copy_test.go
+++ b/internal/filecopy/copy_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package filecopy
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/juju/tc"
+)
+
+type fileCopySuite struct{}
+
+func TestFileCopySuite(t *testing.T) {
+	tc.Run(t, &fileCopySuite{})
+}
+
+func (s *fileCopySuite) TestMakeTarFile(c *tc.C) {
+	source := filepath.Join(c.MkDir(), "source")
+	c.Assert(os.WriteFile(source, []byte("file contents"), 0644), tc.ErrorIsNil)
+
+	var archive bytes.Buffer
+	c.Assert(MakeTar(source, "/target/file", &archive), tc.ErrorIsNil)
+
+	reader := tar.NewReader(&archive)
+	header, err := reader.Next()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(header.Name, tc.Equals, "file")
+	c.Check(header.FileInfo().Mode().IsRegular(), tc.IsTrue)
+	contents, err := io.ReadAll(reader)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(contents), tc.Equals, "file contents")
+
+	_, err = reader.Next()
+	c.Check(err, tc.ErrorIs, io.EOF)
+}
+
+func (s *fileCopySuite) TestMakeTarDirectory(c *tc.C) {
+	source := filepath.Join(c.MkDir(), "source")
+	c.Assert(os.MkdirAll(filepath.Join(source, "nested"), 0755), tc.ErrorIsNil)
+	c.Assert(os.Mkdir(filepath.Join(source, "empty"), 0755), tc.ErrorIsNil)
+	c.Assert(os.WriteFile(filepath.Join(source, "file"), []byte("file"), 0644), tc.ErrorIsNil)
+	c.Assert(os.WriteFile(filepath.Join(source, "nested", "file"), []byte("nested"), 0644), tc.ErrorIsNil)
+	c.Assert(os.Symlink("file", filepath.Join(source, "link")), tc.ErrorIsNil)
+
+	var archive bytes.Buffer
+	c.Assert(MakeTar(source, "/target/", &archive), tc.ErrorIsNil)
+
+	entries := readTarEntries(c, &archive)
+	c.Check(len(entries), tc.Equals, 4)
+
+	c.Check(entries["target/file"].contents, tc.Equals, "file")
+	c.Check(entries["target/nested/file"].contents, tc.Equals, "nested")
+	c.Check(entries["target/empty"].typeflag, tc.Equals, byte(tar.TypeDir))
+	c.Check(entries["target/link"].typeflag, tc.Equals, byte(tar.TypeSymlink))
+	c.Check(entries["target/link"].linkname, tc.Equals, "file")
+}
+
+func (s *fileCopySuite) TestUntarAll(c *tc.C) {
+	archive := makeTarArchive(c, []tarEntry{
+		{name: "remote/root/file", contents: "file contents"},
+		{name: "remote/root/nested/", typeflag: tar.TypeDir},
+		{name: "remote/root/nested/file", contents: "nested contents"},
+		{name: "remote/root/link", typeflag: tar.TypeSymlink, linkname: "../../outside"},
+		{name: "remote/root/../escape", contents: "must not be extracted"},
+	})
+
+	destRoot := c.MkDir()
+	dest := filepath.Join(destRoot, "dest")
+	c.Assert(UntarAll("/remote/root", bytes.NewReader(archive), dest), tc.ErrorIsNil)
+
+	contents, err := os.ReadFile(filepath.Join(dest, "file"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(contents), tc.Equals, "file contents")
+	contents, err = os.ReadFile(filepath.Join(dest, "nested", "file"))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(contents), tc.Equals, "nested contents")
+
+	_, err = os.Lstat(filepath.Join(dest, "link"))
+	c.Check(err, tc.ErrorIs, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(destRoot, "escape"))
+	c.Check(err, tc.ErrorIs, os.ErrNotExist)
+}
+
+func (s *fileCopySuite) TestUntarAllRejectsCorruptArchive(c *tc.C) {
+	archive := makeTarArchive(c, []tarEntry{{name: "other/file", contents: "contents"}})
+	c.Check(
+		UntarAll("/remote/root", bytes.NewReader(archive), c.MkDir()),
+		tc.ErrorMatches,
+		"tar contents corrupted",
+	)
+
+	c.Check(
+		UntarAll("/remote/root", bytes.NewReader([]byte("not a tar")), c.MkDir()),
+		tc.ErrorMatches,
+		"unexpected EOF",
+	)
+}
+
+func (s *fileCopySuite) TestGetPrefix(c *tc.C) {
+	tests := []struct {
+		path   string
+		expect string
+	}{
+		{path: "/var/lib/juju", expect: "var/lib/juju"},
+		{path: "var/lib/juju", expect: "var/lib/juju"},
+		{path: "////", expect: ""},
+	}
+	for _, test := range tests {
+		c.Check(getPrefix(test.path), tc.Equals, test.expect)
+	}
+}
+
+func (s *fileCopySuite) TestStripPathShortcuts(c *tc.C) {
+	tests := []struct {
+		path   string
+		expect string
+	}{
+		{path: "../file", expect: "file"},
+		{path: "../../file", expect: "file"},
+		{path: "a/../../file", expect: "file"},
+		{path: "/file", expect: "file"},
+		{path: ".", expect: ""},
+		{path: "..", expect: ""},
+	}
+	for _, test := range tests {
+		c.Check(stripPathShortcuts(test.path), tc.Equals, test.expect)
+	}
+}
+
+func (s *fileCopySuite) TestIsDestRelative(c *tc.C) {
+	base := filepath.Join(c.MkDir(), "base")
+	tests := []struct {
+		dest   string
+		expect bool
+	}{
+		{dest: base, expect: true},
+		{dest: filepath.Join(base, "file"), expect: true},
+		{dest: filepath.Join(base, "nested", "file"), expect: true},
+		{dest: filepath.Join(base, "..", "outside"), expect: false},
+		{dest: filepath.Join(base, "nested", "..", "..", "outside"), expect: false},
+	}
+	for _, test := range tests {
+		c.Check(isDestRelative(base, test.dest), tc.Equals, test.expect)
+	}
+}
+
+type tarEntry struct {
+	name     string
+	contents string
+	typeflag byte
+	linkname string
+}
+
+func makeTarArchive(c *tc.C, entries []tarEntry) []byte {
+	var archive bytes.Buffer
+	tw := tar.NewWriter(&archive)
+	for _, entry := range entries {
+		header := &tar.Header{
+			Name:     entry.name,
+			Mode:     0644,
+			Size:     int64(len(entry.contents)),
+			Typeflag: entry.typeflag,
+			Linkname: entry.linkname,
+		}
+		if entry.typeflag == tar.TypeDir {
+			header.Mode = 0755
+			header.Size = 0
+		}
+		c.Assert(tw.WriteHeader(header), tc.ErrorIsNil)
+		if entry.typeflag == 0 {
+			_, err := io.WriteString(tw, entry.contents)
+			c.Assert(err, tc.ErrorIsNil)
+		}
+	}
+	c.Assert(tw.Close(), tc.ErrorIsNil)
+	return archive.Bytes()
+}
+
+func readTarEntries(c *tc.C, archive io.Reader) map[string]tarEntry {
+	entries := make(map[string]tarEntry)
+	reader := tar.NewReader(archive)
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		c.Assert(err, tc.ErrorIsNil)
+		contents, err := io.ReadAll(reader)
+		c.Assert(err, tc.ErrorIsNil)
+		entries[header.Name] = tarEntry{
+			name:     header.Name,
+			contents: string(contents),
+			typeflag: header.Typeflag,
+			linkname: header.Linkname,
+		}
+	}
+	return entries
+}

--- a/internal/filecopy/doc.go
+++ b/internal/filecopy/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package filecopy contains the tar archive handling used by
+// the Kubernetes provider and Juju client for SCP to K8s pods.
+package filecopy

--- a/internal/provider/kubernetes/exec/copy.go
+++ b/internal/provider/kubernetes/exec/copy.go
@@ -294,7 +294,7 @@ func unTarAll(src FileResource, reader io.Reader, destDir, prefix string) error 
 
 		// All the files will start with the prefix, which is the directory where
 		// they were located on the pod, we need to strip down that prefix, but
-		// if the prefix is missing it means the tar was tempered with.
+		// if the prefix is missing it means the tar was tampered with.
 		// For the case where prefix is empty we need to ensure that the path
 		// is not absolute, which also indicates the tar file was tampered with.
 		if !strings.HasPrefix(header.Name, prefix) {

--- a/internal/provider/kubernetes/exec/copy.go
+++ b/internal/provider/kubernetes/exec/copy.go
@@ -4,17 +4,16 @@
 package exec
 
 import (
-	"archive/tar"
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/internal/filecopy"
 )
 
 // FileResource holds all the necessary parameters for the source or destination of a copy request.
@@ -90,49 +89,7 @@ func (c client) copyFromPod(ctx context.Context, params CopyParams, cancel <-cha
 			logger.Errorf(context.TODO(), "make tar %q failed: %v", src.Path, err)
 		}
 	}()
-	prefix := getPrefix(src.Path)
-	prefix = path.Clean(prefix)
-	// remove extraneous path shortcuts - these could occur if a path contained extra "../"
-	// and attempted to navigate beyond "/" in a remote filesystem.
-	prefix = stripPathShortcuts(prefix)
-	return unTarAll(src, reader, dest.Path, prefix)
-}
-
-func getPrefix(file string) string {
-	// tar strips the leading '/' if it's there, so we will too.
-	return strings.TrimLeft(file, "/")
-}
-
-// stripPathShortcuts removes any leading or trailing "../" from a given path.
-func stripPathShortcuts(p string) string {
-	newPath := path.Clean(p)
-	trimmed := strings.TrimPrefix(newPath, "../")
-
-	for trimmed != newPath {
-		newPath = trimmed
-		trimmed = strings.TrimPrefix(newPath, "../")
-	}
-
-	// trim leftover {".", ".."}
-	if newPath == "." || newPath == ".." {
-		newPath = ""
-	}
-
-	if len(newPath) > 0 && string(newPath[0]) == "/" {
-		return newPath[1:]
-	}
-
-	return newPath
-}
-
-// isDestRelative returns true if dest is pointing outside the base directory,
-// false otherwise.
-func isDestRelative(base, dest string) bool {
-	relative, err := filepath.Rel(base, dest)
-	if err != nil {
-		return false
-	}
-	return relative == "." || relative == stripPathShortcuts(relative)
+	return filecopy.UntarAll(src.Path, reader, dest.Path)
 }
 
 // this is inspired by kubectl cmd package.
@@ -159,7 +116,7 @@ func (c client) copyToPod(ctx context.Context, params CopyParams, cancel <-chan 
 	go func() {
 		defer writer.Close()
 
-		if err := makeTar(src.Path, dest.Path, writer); err != nil {
+		if err := filecopy.MakeTar(src.Path, dest.Path, writer); err != nil {
 			logger.Errorf(context.TODO(), "make tar %q failed: %v", src.Path, err)
 		}
 	}()
@@ -197,146 +154,4 @@ func (c client) checkRemotePathIsDir(ctx context.Context, rec FileResource, canc
 		Stderr:        &stderr,
 	}
 	return errors.Trace(c.Exec(ctx, execParams, cancel))
-}
-
-// Based on code from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp/cp.go
-func makeTar(srcPath, destPath string, writer io.Writer) error {
-	tarWriter := tar.NewWriter(writer)
-	defer tarWriter.Close()
-	srcPath = path.Clean(srcPath)
-	destPath = path.Clean(destPath)
-	return recursiveTar(path.Dir(srcPath), path.Base(srcPath), path.Dir(destPath), path.Base(destPath), tarWriter)
-}
-
-// Based on code from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp/cp.go
-func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *tar.Writer) error {
-	srcPath := path.Join(srcBase, srcFile)
-	matchedPaths, err := filepath.Glob(srcPath)
-	if err != nil {
-		return err
-	}
-	for _, fpath := range matchedPaths {
-		stat, err := os.Lstat(fpath)
-		if err != nil {
-			return err
-		}
-		if stat.IsDir() {
-			files, err := os.ReadDir(fpath)
-			if err != nil {
-				return err
-			}
-			if len(files) == 0 {
-				// case empty directory.
-				hdr, _ := tar.FileInfoHeader(stat, fpath)
-				hdr.Name = destFile
-				if err := tw.WriteHeader(hdr); err != nil {
-					return err
-				}
-			}
-			for _, f := range files {
-				if err := recursiveTar(srcBase, path.Join(srcFile, f.Name()), destBase, path.Join(destFile, f.Name()), tw); err != nil {
-					return err
-				}
-			}
-			return nil
-		} else if stat.Mode()&os.ModeSymlink != 0 {
-			// case soft link.
-			hdr, _ := tar.FileInfoHeader(stat, fpath)
-			target, err := os.Readlink(fpath)
-			if err != nil {
-				return err
-			}
-
-			hdr.Linkname = target
-			hdr.Name = destFile
-			if err := tw.WriteHeader(hdr); err != nil {
-				return err
-			}
-		} else if stat.Mode()&os.ModeSocket != 0 {
-			logger.Warningf(context.TODO(), "socket file %q ignored", fpath)
-		} else {
-			// case regular file or other file type like pipe.
-			hdr, err := tar.FileInfoHeader(stat, fpath)
-			if err != nil {
-				return err
-			}
-			hdr.Name = destFile
-
-			if err := tw.WriteHeader(hdr); err != nil {
-				return err
-			}
-
-			f, err := os.Open(fpath)
-			if err != nil {
-				return err
-			}
-
-			if _, err := io.Copy(tw, f); err != nil {
-				_ = f.Close()
-				return err
-			}
-			return f.Close()
-		}
-	}
-	return nil
-}
-
-func unTarAll(src FileResource, reader io.Reader, destDir, prefix string) error {
-	tarReader := tar.NewReader(reader)
-	for {
-		header, err := tarReader.Next()
-		if err != nil {
-			if err != io.EOF {
-				return errors.Trace(err)
-			}
-			break
-		}
-
-		// All the files will start with the prefix, which is the directory where
-		// they were located on the pod, we need to strip down that prefix, but
-		// if the prefix is missing it means the tar was tampered with.
-		// For the case where prefix is empty we need to ensure that the path
-		// is not absolute, which also indicates the tar file was tampered with.
-		if !strings.HasPrefix(header.Name, prefix) {
-			return errors.New("tar contents corrupted")
-		}
-
-		// basic file information.
-		mode := header.FileInfo().Mode()
-		destFileName := filepath.Join(destDir, header.Name[len(prefix):])
-
-		if !isDestRelative(destDir, destFileName) {
-			logger.Warningf(context.TODO(), "file %q is outside target destination, skipping", destFileName)
-			continue
-		}
-
-		baseName := filepath.Dir(destFileName)
-		if err := os.MkdirAll(baseName, 0755); err != nil {
-			return errors.Trace(err)
-		}
-		if header.FileInfo().IsDir() {
-			if err := os.MkdirAll(destFileName, 0755); err != nil {
-				return errors.Trace(err)
-			}
-			continue
-		}
-
-		if mode&os.ModeSymlink != 0 {
-			logger.Warningf(context.TODO(), "skipping symlink: %q -> %q", destFileName, header.Linkname)
-			continue
-		}
-		outFile, err := os.Create(destFileName)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if _, err := io.Copy(outFile, tarReader); err != nil {
-			_ = outFile.Close()
-			return errors.Trace(err)
-		}
-		if err := outFile.Close(); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
This PR implements the `juju scp` command for K8s targets when using the `--jump` flag. Currently `juju scp --jump` command works for machine targets by using sftp, but this is not possible for K8s. Instead, we copy the same implementation that is used without the `--jump` flag which is to use `tar` to move files/directories to/from K8s pods. This is the same implementation as `kubectl cp`, see it's help text for more info.

The Kubernetes provider already implements the logic (itself partially lifted from the K8s codebase) for this but eventually we would like to avoid importing provider logic into the client. So we instead copy/paste this logic into the client. So `juju scp --jump` now establishes an SSH connection to the controller, for a K8s target, this opens a session into the target pod/container and the client will then execute `tar` over that connection to copy files.

It's worth noting that there are now 2 places where we use the Kubernete's provider's copy logic:
1. During bootstrap, if the user supplies the `--controller-charm-path` to upload a custom controller charm archive into the controller pod during bootstrap. This is a workaround for testing and could be avoided by building the controller OCI image with the custom charm code.
2. For connecting to 3.6 controllers. Since the Juju 4 client must be compatible with older controllers, we must carry the old SSH logic.   

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. make install
2. make microk8s-operator-update
3. echo hello > test.txt
4. juju bootstrap microk8s test-ssh-scp
5. juju add-model test
6. juju deploy grafana-k8s
7. /# wait for unit to be ready
8. /# verify you can shell into the unit 
9. juju ssh --jump grafana-k8s/0
10. echo hello > test.txt
11. juju scp --jump ./test.txt grafana-k8s/0:/tmp/test.txt
12. juju ssh --jump grafana-k8s/0 cat /tmp/test.txt
13. juju scp --jump grafana-k8s/0:/tmp/test.txt ./remote-file.txt
14. cat ./remote-file.txt

## Links

**Jira card:** [JUJU-10275](https://warthogs.atlassian.net/browse/JUJU-10275)


[JUJU-10275]: https://warthogs.atlassian.net/browse/JUJU-10275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ