### PR TITLE
test(caasadmission): wait for model namespace

### DIFF
--- a/tests/suites/caasadmission/admission.sh
+++ b/tests/suites/caasadmission/admission.sh
@@ -93,6 +93,8 @@ test_new_model_admission() {
 	name=test-$(petname)
 	namespace=${model_name}
 
+	kubectl --kubeconfig "${KUBE_CONFIG}" wait --for=create "namespace/${namespace}" --timeout=60s
+
 	kubectl --kubeconfig "${KUBE_CONFIG}" apply -f - <<EOF
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Wait for the new CAAS model namespace to be created before applying the admission ServiceAccount and RBAC resources.

This removes the race between add-model returning and the Kubernetes provider materialising the namespace, while retaining a bounded 60-second failure.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
cd tests/
./main.sh -v -c microk8s caasadmission
```

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
