### PR TITLE
fix(controlsocket): use fresh password for GetUserByAuth on UserAlreadyExists

### DIFF
--- a/internal/worker/controlsocket/worker.go
+++ b/internal/worker/controlsocket/worker.go
@@ -275,7 +275,7 @@ func (w *Worker) handleAddMetricsUser(resp http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	code, err := w.addMetricsUser(ctx, parsedBody.Username, auth.NewPassword(parsedBody.Password))
+	code, err := w.addMetricsUser(ctx, parsedBody.Username, parsedBody.Password)
 	if err != nil {
 		w.writeErrorResponse(ctx, resp, code, err)
 		return
@@ -284,7 +284,7 @@ func (w *Worker) handleAddMetricsUser(resp http.ResponseWriter, req *http.Reques
 	w.writeResponse(ctx, resp, code, infof("created user %q", parsedBody.Username))
 }
 
-func (w *Worker) addMetricsUser(ctx context.Context, username string, password auth.Password) (int, error) {
+func (w *Worker) addMetricsUser(ctx context.Context, username string, rawPassword string) (int, error) {
 	validatedName, err := validateMetricsUsername(username)
 	if err != nil {
 		return http.StatusBadRequest, err
@@ -301,10 +301,11 @@ func (w *Worker) addMetricsUser(ctx context.Context, username string, password a
 		Key:        w.controllerModelUUID.String(),
 	}
 
+	addPassword := auth.NewPassword(rawPassword)
 	_, _, err = w.accessService.AddUser(ctx, service.AddUserArg{
 		Name:        validatedName,
 		DisplayName: validatedName.Name(),
-		Password:    &password,
+		Password:    &addPassword,
 		CreatorUUID: creatorUser.UUID,
 		Permission: permission.AccessSpec{
 			Target: controllerModelID,
@@ -312,11 +313,13 @@ func (w *Worker) addMetricsUser(ctx context.Context, username string, password a
 		},
 	})
 	if internalerrors.Is(err, usererrors.UserAlreadyExists) {
-		// Retrieve existing user
-		user, err := w.accessService.GetUserByAuth(ctx, validatedName, password)
+		// Retrieve existing user. A fresh auth.Password must be constructed
+		// because AddUser hashes and destroys the password passed to it.
+		authPassword := auth.NewPassword(rawPassword)
+		user, err := w.accessService.GetUserByAuth(ctx, validatedName, authPassword)
 		if err != nil {
 			return http.StatusInternalServerError,
-				fmt.Errorf("retrieving existing user %q: %v", username, err)
+				fmt.Errorf("retrieving existing user %q: %w", username, err)
 		}
 
 		// We want this operation to be idempotent, but at the same time, this
@@ -335,7 +338,7 @@ func (w *Worker) addMetricsUser(ctx context.Context, username string, password a
 		accessLevel, err := w.accessService.ReadUserAccessLevelForTarget(ctx, validatedName, controllerModelID)
 		if err != nil {
 			return http.StatusInternalServerError,
-				fmt.Errorf("retrieving existing user %q: %v", username, err)
+				fmt.Errorf("retrieving existing user %q: %w", username, err)
 		} else if accessLevel != permission.ReadAccess {
 			return http.StatusNotFound, fmt.Errorf(
 				"unexpected permission for user %q, expected %q, got %q",

--- a/internal/worker/controlsocket/worker_test.go
+++ b/internal/worker/controlsocket/worker_test.go
@@ -311,6 +311,92 @@ func (s *workerSuite) TestMetricsUsersAddIdempotent(c *tc.C) {
 	})
 }
 
+// TestMetricsUsersAddAlreadyExistsPasswordNotDestroyed verifies that when
+// AddUser returns UserAlreadyExists, the password passed to GetUserByAuth is
+// a fresh, non-destroyed instance. The real AddUser implementation hashes and
+// destroys the password via auth.HashPassword, so reusing the same password
+// instance would result in ErrPasswordDestroyed.
+func (s *workerSuite) TestMetricsUsersAddAlreadyExistsPasswordNotDestroyed(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), usertesting.GenNewName(c, userCreator)).Return(coreuser.User{
+		UUID: coreuser.UUID("deadbeef"),
+	}, nil)
+	s.accessService.EXPECT().AddUser(gomock.Any(), service.AddUserArg{
+		Name:        s.metricsUserName,
+		DisplayName: "juju-metrics-r0",
+		Password:    new(auth.NewPassword("bar")),
+		CreatorUUID: coreuser.UUID("deadbeef"),
+		Permission: permission.AccessSpec{
+			Target: s.controllerModelID,
+			Access: permission.ReadAccess,
+		},
+	}).DoAndReturn(func(ctx context.Context, arg service.AddUserArg) (coreuser.UUID, []byte, error) {
+		// Simulate the real AddUser which hashes and destroys the password.
+		if arg.Password != nil {
+			arg.Password.Destroy()
+		}
+		return coreuser.UUID("foobar"), nil, usererrors.UserAlreadyExists
+	})
+	// GetUserByAuth must receive a fresh, non-destroyed password.
+	s.accessService.EXPECT().GetUserByAuth(gomock.Any(), s.metricsUserName, auth.NewPassword("bar")).Return(coreuser.User{
+		CreatorName: usertesting.GenNewName(c, userCreator),
+	}, nil)
+	s.accessService.EXPECT().ReadUserAccessLevelForTarget(gomock.Any(), s.metricsUserName, s.controllerModelID).Return(
+		permission.ReadAccess, nil,
+	)
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"username":"juju-metrics-r0","password":"bar"}`,
+		statusCode: http.StatusOK, // succeed as a no-op
+		response:   `.*created user \\\"juju-metrics-r0\\\".*`,
+	})
+}
+
+// TestMetricsUsersAddAlreadyExistsGetByAuthError verifies that when AddUser
+// returns UserAlreadyExists and the subsequent GetUserByAuth call fails, the
+// handler responds with HTTP 500 and surfaces the error from GetUserByAuth.
+func (s *workerSuite) TestMetricsUsersAddAlreadyExistsGetByAuthError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.accessService.EXPECT().GetUserByName(gomock.Any(), usertesting.GenNewName(c, userCreator)).Return(coreuser.User{
+		UUID: coreuser.UUID("deadbeef"),
+	}, nil)
+	s.accessService.EXPECT().AddUser(gomock.Any(), service.AddUserArg{
+		Name:        s.metricsUserName,
+		DisplayName: "juju-metrics-r0",
+		Password:    new(auth.NewPassword("bar")),
+		CreatorUUID: coreuser.UUID("deadbeef"),
+		Permission: permission.AccessSpec{
+			Target: s.controllerModelID,
+			Access: permission.ReadAccess,
+		},
+	}).Return(coreuser.UUID("foobar"), nil, usererrors.UserAlreadyExists)
+	s.accessService.EXPECT().GetUserByAuth(gomock.Any(), s.metricsUserName, auth.NewPassword("bar")).Return(
+		coreuser.User{}, errors.New("boom"),
+	)
+
+	socket := s.newSocket(c)
+
+	w := s.newWorker(c, socket)
+	defer workertest.CleanKill(c, w)
+
+	s.runHandlerTest(c, socket, handlerTest{
+		method:     http.MethodPost,
+		endpoint:   "/metrics-users",
+		body:       `{"username":"juju-metrics-r0","password":"bar"}`,
+		statusCode: http.StatusInternalServerError,
+		response:   `.*retrieving existing user.*`,
+	})
+}
+
 func (s *workerSuite) TestMetricsUsersRemoveInvalidMethod(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/tests/suites/controllercharm/prometheus.sh
+++ b/tests/suites/controllercharm/prometheus.sh
@@ -19,7 +19,7 @@ run_prometheus() {
 	juju status -m controller --format json | yq -r "$(active_condition "controller")" | check "controller"
 	juju status --format json | yq -r "$(active_condition "prometheus-k8s")" | check "prometheus-k8s"
 
-	juju remove-application prometheus-k8s --destroy-storage \
+	juju remove-application prometheus-k8s --destroy-storage --no-prompt \
 		--force --no-wait # TODO: remove these flags once storage bug is fixed
 	destroy_controller "${MODEL_NAME}"
 }
@@ -75,10 +75,10 @@ run_prometheus_multiple_units() {
 	# Ensure p1 is still healty
 	wait_for "p1" "$(active_condition "p1" 0)"
 
-	juju remove-application p1 --destroy-storage \
-		--force --no-wait --no-prompt # TODO: remove these flags once storage bug is fixed
-	juju remove-application p2 --destroy-storage \
-		--force --no-wait --no-prompt # TODO: remove these flags once storage bug is fixed
+	juju remove-application p1 --destroy-storage --no-prompt \
+		--force --no-wait # TODO: remove these flags once storage bug is fixed
+	juju remove-application p2 --destroy-storage --no-prompt \
+		--force --no-wait # TODO: remove these flags once storage bug is fixed
 	destroy_controller "${MODEL_NAME}"
 }
 
@@ -111,8 +111,8 @@ run_prometheus_cross_controller() {
 	juju status -m controller --format json | yq -r "$(active_condition "controller")" | check "controller"
 	juju status --format json | yq -r "$(active_condition "prometheus-k8s")" | check "prometheus-k8s"
 
-	juju remove-application prometheus-k8s --destroy-storage \
-		--force --no-wait --no-prompt # TODO: remove these flags once storage bug is fixed
+	juju remove-application prometheus-k8s --destroy-storage --no-prompt \
+		--force --no-wait # TODO: remove these flags once storage bug is fixed
 	destroy_controller "${PROMETHEUS_MODEL_NAME}"
 }
 


### PR DESCRIPTION
## Description

When `AddUser` returns `UserAlreadyExists`, the `auth.Password` passed to it has already been hashed and destroyed by `auth.HashPassword` (which calls `p.Destroy()` via `defer`). Reusing that same password instance for the subsequent `GetUserByAuth` call results in `ErrPasswordDestroyed` and an HTTP 500 response, breaking the idempotency of `POST /metrics-users`.

`addMetricsUser` now accepts the raw password string and constructs separate `auth.Password` instances for `AddUser` and `GetUserByAuth`.

Also adds `--no-prompt` to `remove-application` calls in the prometheus controller charm test suite to avoid interactive prompts in CI.

## Root cause

In `internal/worker/controlsocket/worker.go`, `addMetricsUser` took a single `auth.Password`:
```go
_, _, err = w.accessService.AddUser(ctx, service.AddUserArg{
    Password: &password, // AddUser hashes and destroys this
    ...
})
if internalerrors.Is(err, usererrors.UserAlreadyExists) {
    user, err := w.accessService.GetUserByAuth(ctx, validatedName, password)
    // password is destroyed here -> ErrPasswordDestroyed -> HTTP 500
}
```

The existing unit tests did not catch this because `accessService` was mocked with GoMock and did not execute the real `HashPassword` which zeroes the bytes.

## Fix

```go
addPassword := auth.NewPassword(rawPassword)
_, _, err = w.accessService.AddUser(ctx, service.AddUserArg{
    Password: &addPassword,
    ...
})
if internalerrors.Is(err, usererrors.UserAlreadyExists) {
    authPassword := auth.NewPassword(rawPassword) // fresh instance
    user, err := w.accessService.GetUserByAuth(ctx, validatedName, authPassword)
}
```

## Related controller charm PR

The juju-controller charm-side fix is in **[juju/juju-controller PR #133](https://github.com/juju/juju-controller/pull/133)**.

## Testing

- `go test ./internal/worker/controlsocket/...` — 24 tests pass (including new `TestMetricsUsersAddAlreadyExistsPasswordNotDestroyed` which simulates `AddUser` destroying the password via `DoAndReturn`).

## QA steps

**End-to-end validation with companion PR:**

1. Bootstrap a controller on microk8s with the agent built from this PR.
2. On the deployed controller, copy `src/controlsocket.py` and `src/charm.py` from [juju/juju-controller PR #133](https://github.com/juju/juju-controller/pull/133).
3. Run the reproduce steps from [juju/juju-controller #130](https://github.com/juju/juju-controller/issues/130):
   ```bash
   juju offer controller.controller:metrics-endpoint
   juju deploy prometheus-k8s --channel 1/stable --trust
   juju relate prometheus-k8s admin/controller.controller
   ```
4. **Verify:** The controller SAAS stays `active` after ~5 s (not `error`), and `check_prometheus_targets` passes without retry timeout.

## JIRA

[JUJU-10266](https://warthogs.atlassian.net/browse/JUJU-10266)

[JUJU-10266]: https://warthogs.atlassian.net/browse/JUJU-10266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ