### PR TITLE
chore: bump juju version to 4.1-beta3

### DIFF
--- a/core/version/version.go
+++ b/core/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "4.1-beta2"
+const version = "4.1-beta3"
 
 // UserAgentVersion defines a user agent version used for communication for
 // outside resources.

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -4,7 +4,7 @@
 #if GetEnv('JUJU_VERSION') != ""
 #define MyAppVersion=GetEnv('JUJU_VERSION')
 #else
-#define MyAppVersion="4.1-beta2"
+#define MyAppVersion="4.1-beta3"
 #endif
 
 #define MyAppName "Juju"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 4.1-beta2
+version: 4.1-beta3
 summary: Juju - a model-driven operator lifecycle manager for K8s and machines
 license: AGPL-3.0
 description: |


### PR DESCRIPTION
Increase the version number because the tools package for 4.1-beta2 is broken.

## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're te~sting
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

## Documentation changes

## Links
