### PR TITLE
fix: run lease-expiry worker on all controller nodes

### DIFF
--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -691,7 +691,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 
 		// The lease expiry worker constantly deletes
 		// leases with an expiry time in the past.
-		leaseExpiryName: ifPrimaryController(leaseexpiry.Manifold(leaseexpiry.ManifoldConfig{
+		leaseExpiryName: ifController(leaseexpiry.Manifold(leaseexpiry.ManifoldConfig{
 			ClockName:      clockName,
 			DBAccessorName: dbAccessorName,
 			TraceName:      traceName,

--- a/cmd/jujud-controller/agent/machine/manifolds_test.go
+++ b/cmd/jujud-controller/agent/machine/manifolds_test.go
@@ -372,6 +372,7 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *tc.C) {
 		"file-notify-watcher",
 		"is-primary-controller-flag",
 		"jwt-parser",
+		"lease-expiry",
 		"query-logger",
 		"ssh-server",
 		"undertaker",
@@ -387,7 +388,6 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *tc.C) {
 		"api-address-setter",
 		"change-stream-pruner",
 		"external-controller-updater",
-		"lease-expiry",
 		"secret-backend-rotate",
 	)
 
@@ -1159,8 +1159,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"controller-agent-config",
 		"db-accessor",
 		"is-controller-flag",
-		"is-primary-controller-flag",
-		"lease-manager",
 		"query-logger",
 		"state-config-watcher",
 		"trace",
@@ -2294,8 +2292,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"controller-agent-config",
 		"db-accessor",
 		"is-controller-flag",
-		"is-primary-controller-flag",
-		"lease-manager",
 		"query-logger",
 		"state-config-watcher",
 		"trace",

--- a/domain/lease/modelmigration/import.go
+++ b/domain/lease/modelmigration/import.go
@@ -57,7 +57,7 @@ func (i *importOperation) Name() string {
 // Setup is called before the operation is executed. It should return an
 // error if the operation cannot be performed.
 func (o *importOperation) Setup(scope modelmigration.Scope) error {
-	o.service = service.NewService(state.NewState(scope.ControllerDB(), o.logger))
+	o.service = service.NewService(state.NewState(scope.ControllerDB()))
 	return nil
 }
 

--- a/domain/lease/service/service.go
+++ b/domain/lease/service/service.go
@@ -23,7 +23,6 @@ type State interface {
 	PinLease(context.Context, lease.Key, string) error
 	UnpinLease(context.Context, lease.Key, string) error
 	Pinned(context.Context) (map[lease.Key][]string, error)
-	ExpireLeases(context.Context) error
 }
 
 // Service provides the API for working with external controllers.
@@ -133,13 +132,4 @@ func (s *Service) Pinned(ctx context.Context) (map[lease.Key][]string, error) {
 	defer span.End()
 
 	return s.st.Pinned(ctx)
-}
-
-// ExpireLeases ensures that all leases that have expired are deleted from
-// the store.
-func (s *Service) ExpireLeases(ctx context.Context) error {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-
-	return s.st.ExpireLeases(ctx)
 }

--- a/domain/lease/service/service_test.go
+++ b/domain/lease/service/service_test.go
@@ -184,16 +184,6 @@ func (s *serviceSuite) TestPinned(c *tc.C) {
 	c.Assert(got, tc.DeepEquals, expected)
 }
 
-func (s *serviceSuite) TestExpireLeases(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.state.EXPECT().ExpireLeases(gomock.Any()).Return(nil)
-
-	service := NewService(s.state)
-	err := service.ExpireLeases(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-}
-
 func (s *serviceSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 

--- a/domain/lease/service/state_mock_test.go
+++ b/domain/lease/service/state_mock_test.go
@@ -27,16 +27,15 @@ type MockState struct {
 
 // MockStateMockRecorder is the mock recorder for MockState.
 type MockStateMockRecorder struct {
-	mock                *MockState
-	claimLeaseExpects   []*gomock.Call4_1[context.Context, uuid.UUID, lease.Key, lease.Request, error]
-	expireLeasesExpects []*gomock.Call1_1[context.Context, error]
-	extendLeaseExpects  []*gomock.Call3_1[context.Context, lease.Key, lease.Request, error]
-	leaseGroupExpects   []*gomock.Call3_2[context.Context, string, string, map[lease.Key]lease.Info, error]
-	leasesExpects       []*gomock.Call1V_2[context.Context, lease.Key, map[lease.Key]lease.Info, error]
-	pinLeaseExpects     []*gomock.Call3_1[context.Context, lease.Key, string, error]
-	pinnedExpects       []*gomock.Call1_2[context.Context, map[lease.Key][]string, error]
-	revokeLeaseExpects  []*gomock.Call3_1[context.Context, lease.Key, string, error]
-	unpinLeaseExpects   []*gomock.Call3_1[context.Context, lease.Key, string, error]
+	mock               *MockState
+	claimLeaseExpects  []*gomock.Call4_1[context.Context, uuid.UUID, lease.Key, lease.Request, error]
+	extendLeaseExpects []*gomock.Call3_1[context.Context, lease.Key, lease.Request, error]
+	leaseGroupExpects  []*gomock.Call3_2[context.Context, string, string, map[lease.Key]lease.Info, error]
+	leasesExpects      []*gomock.Call1V_2[context.Context, lease.Key, map[lease.Key]lease.Info, error]
+	pinLeaseExpects    []*gomock.Call3_1[context.Context, lease.Key, string, error]
+	pinnedExpects      []*gomock.Call1_2[context.Context, map[lease.Key][]string, error]
+	revokeLeaseExpects []*gomock.Call3_1[context.Context, lease.Key, string, error]
+	unpinLeaseExpects  []*gomock.Call3_1[context.Context, lease.Key, string, error]
 }
 
 // NewMockState creates a new mock instance.
@@ -68,24 +67,6 @@ func (mr *MockStateMockRecorder) ClaimLease(arg0, arg1, arg2, arg3 any) *MockSta
 
 // MockStateClaimLeaseCall is the typed call wrapper for ClaimLease.
 type MockStateClaimLeaseCall = gomock.Call4_1[context.Context, uuid.UUID, lease.Key, lease.Request, error]
-
-// ExpireLeases mocks base method.
-func (m *MockState) ExpireLeases(arg0 context.Context) error {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch1_1(&m.recorder.expireLeasesExpects, m.ctrl, m, "ExpireLeases", arg0)
-}
-
-// ExpireLeases indicates an expected call of ExpireLeases.
-func (mr *MockStateMockRecorder) ExpireLeases(arg0 any) *MockStateExpireLeasesCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_1[context.Context, error](mr.mock.ctrl.T, mr.mock, "ExpireLeases", gomock.EnsureMatcher(arg0))
-	mr.expireLeasesExpects = append(mr.expireLeasesExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockStateExpireLeasesCall is the typed call wrapper for ExpireLeases.
-type MockStateExpireLeasesCall = gomock.Call1_1[context.Context, error]
 
 // ExtendLease mocks base method.
 func (m *MockState) ExtendLease(arg0 context.Context, arg1 lease.Key, arg2 lease.Request) error {

--- a/domain/lease/state/state.go
+++ b/domain/lease/state/state.go
@@ -12,7 +12,6 @@ import (
 	coredatabase "github.com/juju/juju/core/database"
 	coreerrors "github.com/juju/juju/core/errors"
 	corelease "github.com/juju/juju/core/lease"
-	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/errors"
@@ -22,14 +21,12 @@ import (
 // State describes retrieval and persistence methods for storage.
 type State struct {
 	*domain.StateBase
-	logger logger.Logger
 }
 
 // NewState returns a new state reference.
-func NewState(factory coredatabase.TxnRunnerFactory, logger logger.Logger) *State {
+func NewState(factory coredatabase.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
-		logger:    logger,
 	}
 }
 
@@ -430,76 +427,4 @@ ORDER BY l.uuid;`, Lease{}, LeasePin{})
 		return nil
 	})
 	return result, errors.Capture(err)
-}
-
-// ExpireLeases (lease.Store) deletes all leases that have expired, from the
-// store. This method is intended to be called periodically by a worker.
-func (s *State) ExpireLeases(ctx context.Context) error {
-	db, err := s.DB(ctx)
-	if err != nil {
-		return errors.Capture(err)
-	}
-
-	// This is split into two queries to avoid a write transaction preventing
-	// other writers from writing to the db, even if there is no writes
-	// occurring.
-	count := Count{}
-	countStmt, err := s.Prepare(`
-SELECT COUNT(*) AS &Count.num FROM lease WHERE expiry < datetime('now');
-`, count)
-	if err != nil {
-		return errors.Errorf("preparing select expired count statement: %w", err)
-	}
-
-	deleteStmt, err := s.Prepare(`
-DELETE FROM lease WHERE uuid in (
-	SELECT l.uuid 
-	FROM   lease l LEFT JOIN lease_pin p ON l.uuid = p.lease_uuid
-	WHERE  p.uuid IS NULL
-	AND    l.expiry < datetime('now')
-);`)
-	if err != nil {
-		return errors.Errorf("preparing delete lease statement: %w", err)
-	}
-
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, countStmt).Get(&count)
-		if database.IsErrRetryable(err) {
-			return nil
-		} else if err != nil {
-			return errors.Capture(err)
-		}
-
-		// Nothing to do here, so return early.
-		if count.Num == 0 {
-			return nil
-		}
-
-		var outcome sqlair.Outcome
-		err = tx.Query(ctx, deleteStmt).Get(&outcome)
-		if err != nil {
-			// TODO (manadart 2022-12-15): This incarnation of the worker runs on
-			// all controller nodes. Retryable errors are those that occur due to
-			// locking or other contention. We know we will retry very soon,
-			// so just log and indicate success for these cases.
-			// Rethink this if the worker cardinality changes to be singular.
-			if database.IsErrRetryable(err) {
-				s.logger.Debugf(ctx, "ignoring error during lease expiry: %s", err.Error())
-				return nil
-			}
-			return errors.Capture(err)
-		}
-
-		expired, err := outcome.Result().RowsAffected()
-		if err != nil {
-			return errors.Capture(err)
-		}
-
-		if expired > 0 {
-			s.logger.Infof(ctx, "expired %d leases", expired)
-		}
-
-		return nil
-	})
-	return errors.Capture(err)
 }

--- a/domain/lease/state/state_test.go
+++ b/domain/lease/state/state_test.go
@@ -13,7 +13,6 @@ import (
 	corelease "github.com/juju/juju/core/lease"
 	"github.com/juju/juju/domain/lease/state"
 	schematesting "github.com/juju/juju/domain/schema/testing"
-	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -30,7 +29,7 @@ func TestStateSuite(t *testing.T) {
 func (s *stateSuite) SetUpTest(c *tc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
-	s.store = state.NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	s.store = state.NewState(s.TxnRunnerFactory())
 }
 
 func (s *stateSuite) TestClaimLeaseSuccessAndLeaseQueries(c *tc.C) {
@@ -254,35 +253,4 @@ func (s *stateSuite) TestLeaseOperationCancellation(c *tc.C) {
 
 	err := s.store.ClaimLease(ctx, uuid.MustNewUUID(), key, req)
 	c.Assert(err, tc.ErrorMatches, "context canceled")
-}
-
-func (s *stateSuite) TestWorkerDeletesExpiredLeases(c *tc.C) {
-	// Insert 2 leases, one with an expiry time in the past,
-	// another in the future.
-	q := `
-INSERT INTO lease (uuid, lease_type_id, model_uuid, name, holder, start, expiry)
-VALUES (?, 1, 'some-model-uuid', ?, ?, datetime('now'), datetime('now', ?))`[1:]
-
-	stmt, err := s.DB().Prepare(q)
-	c.Assert(err, tc.ErrorIsNil)
-
-	defer stmt.Close()
-
-	_, err = stmt.Exec(uuid.MustNewUUID().String(), "postgresql", "postgresql/0", "+2 minutes")
-	c.Assert(err, tc.ErrorIsNil)
-
-	_, err = stmt.Exec(uuid.MustNewUUID().String(), "redis", "redis/0", "-2 minutes")
-	c.Assert(err, tc.ErrorIsNil)
-
-	err = s.store.ExpireLeases(c.Context())
-	c.Assert(err, tc.ErrorIsNil)
-
-	// Only the postgresql lease (expiring in the future) should remain.
-	row := s.DB().QueryRow("SELECT name FROM LEASE")
-	var name string
-	err = row.Scan(&name)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(row.Err(), tc.ErrorIsNil)
-
-	c.Check(name, tc.Equals, "postgresql")
 }

--- a/domain/lease/state/types.go
+++ b/domain/lease/state/types.go
@@ -48,11 +48,6 @@ type LeasePin struct {
 	EntityID string `db:"entity_id"`
 }
 
-// Count is used count leases.
-type Count struct {
-	Num int `db:"num"`
-}
-
 // leadership represents a single row from the leadership table for
 // applications.
 type leadership struct {

--- a/internal/worker/dbaccessor/tracker.go
+++ b/internal/worker/dbaccessor/tracker.go
@@ -234,6 +234,19 @@ func (w *trackedDBWorker) StdTxn(ctx context.Context, fn func(context.Context, *
 	})
 }
 
+// StdTxnNoRetry executes the input function against the tracked database
+// within a standard library transaction. No retries are attempted.
+func (w *trackedDBWorker) StdTxnNoRetry(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	return w.runNoRetry(ctx, func(db *sqlair.DB) error {
+		// Tie the worker tomb to the context, so that if the worker dies, we
+		// can correctly kill the transaction via the context. The context will
+		// now have the correct reason for the death of the transaction. Either
+		// the tomb died or the context was cancelled.
+		ctx = corecontext.WithSourceableError(w.tomb.Context(ctx), w)
+		return errors.Trace(database.StdTxn(ctx, db.PlainDB(), fn))
+	})
+}
+
 // Dying returns a channel that is closed when the database connection
 // is no longer usable. This can be used to detect when the database is
 // shutting down or has been closed.
@@ -247,40 +260,52 @@ func (w *trackedDBWorker) Err() error {
 }
 
 func (w *trackedDBWorker) run(ctx context.Context, fn func(*sqlair.DB) error) error {
+	ctx = w.prepareRunContext(ctx)
+
+	// Retry so long as the tomb and the context are valid.
+	return database.Retry(ctx, func() error {
+		w.metrics.TxnRetries.WithLabelValues(w.namespace).Inc()
+		return w.runAttempt(ctx, fn)
+	})
+}
+
+func (w *trackedDBWorker) runNoRetry(ctx context.Context, fn func(*sqlair.DB) error) error {
+	ctx = w.prepareRunContext(ctx)
+	return w.runAttempt(ctx, fn)
+}
+
+func (w *trackedDBWorker) prepareRunContext(ctx context.Context) context.Context {
 	w.metrics.TxnRequests.WithLabelValues(w.namespace).Inc()
 
-	// Tie the tomb to the context for the retry semantics.
+	// Tie the tomb to the transaction context.
 	ctx = corecontext.WithSourceableError(w.tomb.Context(ctx), w)
 
 	// Inject the metrics into the context for the txn.
-	ctx = txn.WithMetrics(ctx, w.dbTxnMetrics)
+	return txn.WithMetrics(ctx, w.dbTxnMetrics)
+}
 
-	// Retry the so long as the tomb and the context are valid.
-	return database.Retry(ctx, func() (err error) {
-		begin := w.clock.Now()
-		w.metrics.TxnRetries.WithLabelValues(w.namespace).Inc()
-		w.metrics.DBRequests.WithLabelValues(w.namespace).Inc()
-		defer w.meterDBOpResult(begin, err)
+func (w *trackedDBWorker) runAttempt(ctx context.Context, fn func(*sqlair.DB) error) (err error) {
+	begin := w.clock.Now()
+	w.metrics.DBRequests.WithLabelValues(w.namespace).Inc()
+	defer w.meterDBOpResult(begin, err)
 
-		// The underlying db could be swapped out if the database becomes
-		// stale.
-		w.mutex.RLock()
-		db := w.db
-		w.mutex.RUnlock()
+	// The underlying db could be swapped out if the database becomes stale.
+	w.mutex.RLock()
+	db := w.db
+	w.mutex.RUnlock()
 
-		// If we ever get a nil database, then ensure we return an error,
-		// rather than potentially causing panics down the line.
-		if db == nil {
-			return errors.NotFoundf("database")
-		}
+	// If we ever get a nil database, then ensure we return an error, rather
+	// than potentially causing panics down the line.
+	if db == nil {
+		return errors.NotFoundf("database")
+	}
 
-		// Don't execute the function if we know the context is already done.
-		if err := ctx.Err(); err != nil {
-			return errors.Trace(err)
-		}
+	// Don't execute the function if we know the context is already done.
+	if err := ctx.Err(); err != nil {
+		return errors.Trace(err)
+	}
 
-		return fn(db)
-	})
+	return fn(db)
 }
 
 // meterDBOpResults decrements the active DB operation count,

--- a/internal/worker/dbaccessor/tracker_test.go
+++ b/internal/worker/dbaccessor/tracker_test.go
@@ -119,14 +119,13 @@ func (s *trackedDBWorkerSuite) TestWorkerStdTxnNoRetry(c *tc.C) {
 	})
 	c.Assert(ok, tc.IsTrue)
 
-	attempts := 0
-	err = runner.StdTxnNoRetry(c.Context(), func(_ context.Context, tx *sql.Tx) error {
-		c.Check(tx, tc.NotNil)
-		attempts++
+	var attempts atomic.Int64
+	err = runner.StdTxnNoRetry(c.Context(), func(context.Context, *sql.Tx) error {
+		attempts.Add(1)
 		return sqlite3.ErrBusy
 	})
 	c.Check(err, tc.ErrorIs, sqlite3.ErrBusy)
-	c.Check(attempts, tc.Equals, 1)
+	c.Check(attempts.Load(), tc.Equals, int64(1))
 
 	workertest.CleanKill(c, w)
 }

--- a/internal/worker/dbaccessor/tracker_test.go
+++ b/internal/worker/dbaccessor/tracker_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	"github.com/juju/worker/v5/workertest"
+	"github.com/mattn/go-sqlite3"
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/internal/testhelpers"
@@ -97,6 +98,35 @@ func (s *trackedDBWorkerSuite) TestWorkerDBIsNotNil(c *tc.C) {
 		return nil
 	})
 	c.Assert(err, tc.ErrorIsNil)
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *trackedDBWorkerSuite) TestWorkerStdTxnNoRetry(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectClock()
+	defer s.expectTimer(0)()
+
+	s.dbApp.EXPECT().Open(gomock.Any(), "controller").Return(s.DB(), nil)
+
+	w, err := s.newTrackedDBWorker(c, defaultPingDBFunc)
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	runner, ok := w.(interface {
+		StdTxnNoRetry(context.Context, func(context.Context, *sql.Tx) error) error
+	})
+	c.Assert(ok, tc.IsTrue)
+
+	attempts := 0
+	err = runner.StdTxnNoRetry(c.Context(), func(_ context.Context, tx *sql.Tx) error {
+		c.Check(tx, tc.NotNil)
+		attempts++
+		return sqlite3.ErrBusy
+	})
+	c.Check(err, tc.ErrorIs, sqlite3.ErrBusy)
+	c.Check(attempts, tc.Equals, 1)
 
 	workertest.CleanKill(c, w)
 }

--- a/internal/worker/lease/manifold.go
+++ b/internal/worker/lease/manifold.go
@@ -43,7 +43,7 @@ type ManifoldConfig struct {
 	LogDir               string
 	PrometheusRegisterer prometheus.Registerer
 	NewWorker            func(ManagerConfig) (worker.Worker, error)
-	NewStore             func(database.DBGetter, logger.Logger) lease.Store
+	NewStore             func(database.DBGetter) lease.Store
 	NewSecretaryFinder   func(string) lease.SecretaryFinder
 }
 
@@ -115,7 +115,7 @@ func (s *manifoldState) start(ctx context.Context, getter dependency.Getter) (wo
 		tracer = coretrace.NoopTracer{}
 	}
 
-	store := s.config.NewStore(dbGetter, s.config.Logger)
+	store := s.config.NewStore(dbGetter)
 
 	controllerUUID := currentConfig.Controller().Id()
 	w, err := s.config.NewWorker(ManagerConfig{
@@ -170,7 +170,7 @@ func NewWorker(config ManagerConfig) (worker.Worker, error) {
 }
 
 // NewStore returns a new lease store based on the input config.
-func NewStore(dbGetter database.DBGetter, logger logger.Logger) lease.Store {
+func NewStore(dbGetter database.DBGetter) lease.Store {
 	factory := database.NewTxnRunnerFactoryForNamespace(dbGetter.GetDB, database.ControllerNS)
-	return service.NewService(state.NewState(factory, logger))
+	return service.NewService(state.NewState(factory))
 }

--- a/internal/worker/lease/manifold_test.go
+++ b/internal/worker/lease/manifold_test.go
@@ -12,7 +12,6 @@ import (
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/lease"
-	"github.com/juju/juju/core/logger"
 )
 
 type manifoldSuite struct {
@@ -69,7 +68,7 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		NewWorker: func(mc ManagerConfig) (worker.Worker, error) {
 			return nil, nil
 		},
-		NewStore: func(coredatabase.DBGetter, logger.Logger) lease.Store {
+		NewStore: func(coredatabase.DBGetter) lease.Store {
 			return nil
 		},
 		NewSecretaryFinder: func(s string) lease.SecretaryFinder {

--- a/internal/worker/leaseexpiry/manifold.go
+++ b/internal/worker/leaseexpiry/manifold.go
@@ -15,8 +15,6 @@ import (
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/logger"
 	coretrace "github.com/juju/juju/core/trace"
-	"github.com/juju/juju/domain/lease/service"
-	"github.com/juju/juju/domain/lease/state"
 	"github.com/juju/juju/internal/worker/trace"
 )
 
@@ -30,7 +28,7 @@ type ManifoldConfig struct {
 	Logger logger.Logger
 
 	NewWorker func(Config) (worker.Worker, error)
-	NewStore  func(database.DBGetter, logger.Logger) lease.ExpiryStore
+	NewStore  func(context.Context, database.DBGetter, logger.Logger) (lease.ExpiryStore, error)
 }
 
 // Validate checks that the config has all the required values.
@@ -81,7 +79,10 @@ func (c ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (wo
 		tracer = coretrace.NoopTracer{}
 	}
 
-	store := c.NewStore(dbGetter, c.Logger)
+	store, err := c.NewStore(ctx, dbGetter, c.Logger)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	w, err := NewWorker(Config{
 		Clock:  clk,
@@ -108,8 +109,20 @@ func Manifold(cfg ManifoldConfig) dependency.Manifold {
 	}
 }
 
-// NewStore returns a new lease store based on the input config.
-func NewStore(dbGetter database.DBGetter, logger logger.Logger) lease.ExpiryStore {
-	factory := database.NewTxnRunnerFactoryForNamespace(dbGetter.GetDB, database.ControllerNS)
-	return service.NewService(state.NewState(factory, logger))
+// NewStore returns a lease store that facilitates lease expiry.
+// Expiry operations are best-effort.
+func NewStore(ctx context.Context, dbGetter database.DBGetter, logger logger.Logger) (lease.ExpiryStore, error) {
+	db, err := dbGetter.GetDB(ctx, database.ControllerNS)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	noRetryDB, ok := db.(noRetryRunner)
+	if !ok {
+		return nil, errors.Errorf("database transaction runner %T does not support StdTxnNoRetry", db)
+	}
+	return &expiryStore{
+		db:     noRetryDB,
+		logger: logger,
+	}, nil
 }

--- a/internal/worker/leaseexpiry/manifold_test.go
+++ b/internal/worker/leaseexpiry/manifold_test.go
@@ -83,6 +83,29 @@ func (s *manifoldSuite) TestStartSuccess(c *tc.C) {
 	workertest.CleanKill(c, work)
 }
 
+func (s *manifoldSuite) TestStartStoreError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	expected := errors.New("boom")
+	cfg := s.newManifoldConfig(c)
+	cfg.NewStore = func(context.Context, coredatabase.DBGetter, logger.Logger) (lease.ExpiryStore, error) {
+		return nil, expected
+	}
+
+	work, err := leaseexpiry.Manifold(cfg).Start(c.Context(), s.newGetter())
+	c.Check(work, tc.IsNil)
+	c.Check(err, tc.ErrorIs, expected)
+}
+
+func (s *manifoldSuite) TestNewStoreRequiresStdTxnNoRetry(c *tc.C) {
+	_, err := leaseexpiry.NewStore(
+		c.Context(),
+		stubDBGetter{runner: noopTxnRunner{}},
+		loggertesting.WrapCheckLog(c),
+	)
+	c.Check(err, tc.ErrorMatches, "database transaction runner .* does not support StdTxnNoRetry")
+}
+
 func (s *manifoldSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
@@ -108,8 +131,8 @@ func (s *manifoldSuite) newManifoldConfig(c *tc.C) leaseexpiry.ManifoldConfig {
 		TraceName:      "trace-name",
 		Logger:         loggertesting.WrapCheckLog(c),
 		NewWorker:      func(config leaseexpiry.Config) (worker.Worker, error) { return nil, nil },
-		NewStore: func(db coredatabase.DBGetter, logger logger.Logger) lease.ExpiryStore {
-			return s.store
+		NewStore: func(context.Context, coredatabase.DBGetter, logger.Logger) (lease.ExpiryStore, error) {
+			return s.store, nil
 		},
 	}
 }

--- a/internal/worker/leaseexpiry/store.go
+++ b/internal/worker/leaseexpiry/store.go
@@ -39,7 +39,9 @@ func (s *expiryStore) ExpireLeases(ctx context.Context) error {
 		err := tx.QueryRowContext(ctx, `
 SELECT COUNT(*) AS count
 FROM lease AS l
-WHERE l.expiry < datetime('now')`).Scan(&count)
+LEFT JOIN lease_pin AS p ON l.uuid = p.lease_uuid
+WHERE p.uuid IS NULL
+AND l.expiry < datetime('now')`).Scan(&count)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/internal/worker/leaseexpiry/store.go
+++ b/internal/worker/leaseexpiry/store.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leaseexpiry
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/internal/database"
+)
+
+type noRetryRunner interface {
+	StdTxnNoRetry(context.Context, func(context.Context, *sql.Tx) error) error
+}
+
+// expiryStore deliberately uses StdTxnNoRetry instead of TxnRunner.StdTxn.
+// This is because the worker runs on every controller, and we don't want retry
+// cascades in the event that the workers are interleaving.
+//
+// The worker runs on all controllers, and not just the one with the singular
+// worker lease, because if that controller is deleted from a cluster we can
+// become wedged. The lease expiry worker stops running, so there's no expiry,
+// so no other controller can run the singular workers.
+type expiryStore struct {
+	db     noRetryRunner
+	logger logger.Logger
+}
+
+// ExpireLeases deletes all unpinned leases that have expired.
+func (s *expiryStore) ExpireLeases(ctx context.Context) error {
+	err := s.db.StdTxnNoRetry(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		// This is split into two queries to avoid a write transaction preventing
+		// other writers from writing to the database when there is no work.
+		var count int
+		err := tx.QueryRowContext(ctx, `
+SELECT COUNT(*) AS count
+FROM lease AS l
+WHERE l.expiry < datetime('now')`).Scan(&count)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if count == 0 {
+			return nil
+		}
+
+		result, err := tx.ExecContext(ctx, `
+DELETE FROM lease
+WHERE uuid IN (
+    SELECT l.uuid
+    FROM lease AS l
+    LEFT JOIN lease_pin AS p ON l.uuid = p.lease_uuid
+    WHERE p.uuid IS NULL
+    AND l.expiry < datetime('now')
+)`)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		expired, err := result.RowsAffected()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if expired > 0 {
+			s.logger.Infof(ctx, "expired %d leases", expired)
+		}
+		return nil
+	})
+	if database.IsErrRetryable(err) {
+		s.logger.Debugf(ctx, "ignoring error during lease expiry: %s", err.Error())
+		return nil
+	}
+	return errors.Trace(err)
+}

--- a/internal/worker/leaseexpiry/store_test.go
+++ b/internal/worker/leaseexpiry/store_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/internal/database"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
@@ -27,38 +28,15 @@ func TestStoreSuite(t *testing.T) {
 }
 
 func (s *storeSuite) TestExpireLeasesUsesStdTxnNoRetry(c *tc.C) {
-	db, err := sql.Open("sqlite3", ":memory:")
-	c.Assert(err, tc.ErrorIsNil)
+	db, store := s.newStore(c)
 	defer func() { c.Check(db.Close(), tc.ErrorIsNil) }()
 
-	_, err = db.ExecContext(c.Context(), `
-CREATE TABLE lease (
-    uuid TEXT PRIMARY KEY,
-    expiry DATETIME NOT NULL
-);
-CREATE TABLE lease_pin (
-    uuid TEXT PRIMARY KEY,
-    lease_uuid TEXT NOT NULL
-);`)
-	c.Assert(err, tc.ErrorIsNil)
-
-	_, err = db.ExecContext(c.Context(), `
+	_, err := db.ExecContext(c.Context(), `
 INSERT INTO lease (uuid, expiry) VALUES
     ('future', datetime('now', '+2 minutes')),
     ('expired', datetime('now', '-2 minutes')),
     ('pinned', datetime('now', '-2 minutes'));
 INSERT INTO lease_pin (uuid, lease_uuid) VALUES ('pin', 'pinned');`)
-	c.Assert(err, tc.ErrorIsNil)
-
-	runner := noRetryTxnRunner{
-		TxnRunner: noopTxnRunner{},
-		db:        db,
-	}
-	store, err := leaseexpiry.NewStore(
-		c.Context(),
-		stubDBGetter{runner: runner},
-		loggertesting.WrapCheckLog(c),
-	)
 	c.Assert(err, tc.ErrorIsNil)
 
 	err = store.ExpireLeases(c.Context())
@@ -76,6 +54,54 @@ INSERT INTO lease_pin (uuid, lease_uuid) VALUES ('pin', 'pinned');`)
 	}
 	c.Assert(rows.Err(), tc.ErrorIsNil)
 	c.Check(got, tc.DeepEquals, []string{"future", "pinned"})
+}
+
+func (s *storeSuite) TestExpireLeasesSkipsDeleteWhenOnlyExpiredLeaseIsPinned(c *tc.C) {
+	db, store := s.newStore(c)
+	defer func() { c.Check(db.Close(), tc.ErrorIsNil) }()
+
+	_, err := db.ExecContext(c.Context(), `
+INSERT INTO lease (uuid, expiry)
+VALUES ('pinned', datetime('now', '-2 minutes'));
+INSERT INTO lease_pin (uuid, lease_uuid)
+VALUES ('pin', 'pinned');
+PRAGMA query_only = ON;`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// The connection is read-only after setup. Success proves that expiry
+	// returned after the count query without attempting the delete.
+	err = store.ExpireLeases(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *storeSuite) newStore(c *tc.C) (*sql.DB, lease.ExpiryStore) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	c.Assert(err, tc.ErrorIsNil)
+	db.SetMaxOpenConns(1)
+
+	_, err = db.ExecContext(c.Context(), `
+CREATE TABLE lease (
+    uuid TEXT PRIMARY KEY,
+    expiry DATETIME NOT NULL
+);
+CREATE TABLE lease_pin (
+    uuid TEXT PRIMARY KEY,
+    lease_uuid TEXT NOT NULL
+);`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	runner := noRetryTxnRunner{
+		TxnRunner: noopTxnRunner{},
+		db:        db,
+	}
+	store, err := leaseexpiry.NewStore(
+		c.Context(),
+		stubDBGetter{runner: runner},
+		loggertesting.WrapCheckLog(c),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	return db, store
 }
 
 type noRetryTxnRunner struct {

--- a/internal/worker/leaseexpiry/store_test.go
+++ b/internal/worker/leaseexpiry/store_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package leaseexpiry_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/juju/tc"
+	_ "github.com/mattn/go-sqlite3"
+
+	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/internal/database"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testhelpers"
+	"github.com/juju/juju/internal/worker/leaseexpiry"
+)
+
+type storeSuite struct {
+	testhelpers.IsolationSuite
+}
+
+func TestStoreSuite(t *testing.T) {
+	tc.Run(t, &storeSuite{})
+}
+
+func (s *storeSuite) TestExpireLeasesUsesStdTxnNoRetry(c *tc.C) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { c.Check(db.Close(), tc.ErrorIsNil) }()
+
+	_, err = db.ExecContext(c.Context(), `
+CREATE TABLE lease (
+    uuid TEXT PRIMARY KEY,
+    expiry DATETIME NOT NULL
+);
+CREATE TABLE lease_pin (
+    uuid TEXT PRIMARY KEY,
+    lease_uuid TEXT NOT NULL
+);`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = db.ExecContext(c.Context(), `
+INSERT INTO lease (uuid, expiry) VALUES
+    ('future', datetime('now', '+2 minutes')),
+    ('expired', datetime('now', '-2 minutes')),
+    ('pinned', datetime('now', '-2 minutes'));
+INSERT INTO lease_pin (uuid, lease_uuid) VALUES ('pin', 'pinned');`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	runner := noRetryTxnRunner{
+		TxnRunner: noopTxnRunner{},
+		db:        db,
+	}
+	store, err := leaseexpiry.NewStore(
+		c.Context(),
+		stubDBGetter{runner: runner},
+		loggertesting.WrapCheckLog(c),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = store.ExpireLeases(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	rows, err := db.QueryContext(c.Context(), "SELECT uuid FROM lease ORDER BY uuid")
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { c.Check(rows.Close(), tc.ErrorIsNil) }()
+
+	var got []string
+	for rows.Next() {
+		var leaseUUID string
+		c.Assert(rows.Scan(&leaseUUID), tc.ErrorIsNil)
+		got = append(got, leaseUUID)
+	}
+	c.Assert(rows.Err(), tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, []string{"future", "pinned"})
+}
+
+type noRetryTxnRunner struct {
+	coredatabase.TxnRunner
+	db *sql.DB
+}
+
+func (r noRetryTxnRunner) StdTxnNoRetry(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
+	return database.StdTxn(ctx, r.db, fn)
+}

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -165,7 +165,7 @@ func leaseManager(c *tc.C, controllerUUID string, db database.DBGetter, clock cl
 	logger := loggertesting.WrapCheckLog(c)
 	return lease.NewManager(lease.ManagerConfig{
 		SecretaryFinder:      internallease.NewSecretaryFinder(controllerUUID),
-		Store:                lease.NewStore(db, logger),
+		Store:                lease.NewStore(db),
 		Logger:               logger,
 		Clock:                clock,
 		MaxSleep:             time.Minute,


### PR DESCRIPTION
This reverts some changes that were made when we started using Sqlair under https://github.com/juju/juju/pull/15658.

Once we ran the `leaseexpiry` worker on all controller nodes. It was subsequently changed to run only on the controller with the lease for singular workers. This introduced an issue whereby if in HA the controller running the singular workers was removed, so was the expiry worker, meaning leases never expired and a new controller never acquired the lease to run the workers.

The worker is back running on all controllers, but because we don't want retry cascades when they are interleaved, the non-retrying standard transaction runner is restored so that expiry is best effort. `StdTxnNoRetry` is not added to the global runner interface, because it represents a departure from standard workflow - the interface is declared only at the single usage site.

Expiry logic now unused in the `lease` domain is removed.

## QA steps

- Bootstrap and switch to the controller model. 
- Scale the controllers with `juju add-unit controller -n 2`.
- Once idle, remove the controller running the singular workers (presumably 0): `juju remove-machine 0 --force`.
- After a while the controller model should settle with 2 units (this did not happen prior).
```
Model       Controller  Cloud/Region  Version   Timestamp
controller  lxd         lxd/default   4.0.15.1  17:56:22+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      2  juju-controller  4.0/stable  398  no

Unit           Workload  Agent  Machine  Public address  Ports            Message
controller/1*  active    idle   1        10.246.27.111   17022,17070/tcp
controller/2   active    idle   2        10.246.27.108   17022,17070/tcp

Machine  State    Address        Inst id        Base          AZ    Message
1        started  10.246.27.111  juju-469fb3-1  ubuntu@24.04  THYR  Running
2        started  10.246.27.108  juju-469fb3-2  ubuntu@24.04  THYR  Running
```
