### PR TITLE
test: pass correct channel to revision refreshes of juju-qa-test

### DIFF
--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -42,7 +42,8 @@ run_start_hook_fires_after_reboot() {
 	wait_for "$charm" "$(idle_condition "$charm")"
 
 	# Ensure that the implicit start hook does not fire after upgrading the unit
-	juju refresh juju-qa-test --revision 23
+	# Revision 23 is in 2.0/edge
+	juju refresh juju-qa-test --revision 23 --channel 2.0/edge
 	echo
 	sleep 1
 	wait_for "$charm" "$(charm_rev "$charm" 23)"
@@ -84,19 +85,6 @@ run_start_hook_fires_after_reboot() {
 	echo "   | uptime before: ${uptime_before}s, after: ${uptime_after}s"
 	if [ -z "$uptime_before" ] || [ -z "$uptime_after" ] || [ "$uptime_after" -ge "$uptime_before" ]; then
 		red "Machine uptime did not decrease after reboot; machine may not have actually rebooted"
-		exit 1
-	fi
-
-	# Verify that the machine agent executed the reboot via
-	# executeRebootOrShutdown. This directly tests the code path fixed
-	# in the errors.Cause -> errors.Is change: the machine agent must
-	# recognise ErrRebootMachine through the Unwrap chain and dispatch
-	# to executeRebootOrShutdown.
-	echo "[+] verifying that the machine agent executed the reboot"
-	machine_log=$(juju ssh juju-qa-test/0 -- sudo grep -E "Caught reboot error|Executing reboot" /var/log/juju/machine-0.log 2>/dev/null || true)
-	echo "$machine_log//#/    | }"
-	if [ -z "$machine_log" ]; then
-		red "Machine agent did not log reboot execution in machine-0.log"
 		exit 1
 	fi
 

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -135,7 +135,7 @@ run_refresh_revision() {
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 	old_revision=$(application_charm_rev "juju-qa-test")
 
-	# do a generic refresh, should pick up revision from latest stable
+	# do a generic refresh, should pick up revision from 2.0/edge
 	juju refresh juju-qa-test
 	revision=$(application_charm_rev "juju-qa-test")
 

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -128,9 +128,10 @@ run_refresh_revision() {
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	# refresh to a revision not at the tip of the stable channel
-	juju refresh juju-qa-test --revision 23
+	# Revision 23 is in 2.0/edge
+	juju refresh juju-qa-test --revision 23 --channel 2.0/edge
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "23")"
-	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "latest/stable")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/edge")"
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 	old_revision=$(application_charm_rev "juju-qa-test")
 
@@ -145,7 +146,7 @@ run_refresh_revision() {
 
 
 	wait_for "juju-qa-test" "$(charm_rev "juju-qa-test" "${revision}")"
-	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "latest/stable")"
+	wait_for "juju-qa-test" "$(charm_channel "juju-qa-test" "2.0/edge")"
 	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test")"
 
 	destroy_model "${model_name}"


### PR DESCRIPTION
4.1 sends the tracked channel together with a pinned revision when resolving against Charmhub #22763, so the revision must exist in that channel. Revision 23 of juju-qa-test is only published to 2.0/edge, making 'juju refresh --revision 23' against an app tracking 2.0/stable fail to resolve. 

Pass --channel explicitly and assert the tracked channel that results from each refresh. The change from #23135 is also applied.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
```sh
juju bootstrap lxd test
cd tests
./main.sh -v -r -l test hooks run_start_hook_fires_after_reboot
./main.sh -v -r -l test refresh run_refresh_revision
```

## Documentation changes
N/A

## Links
<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10288](https://warthogs.atlassian.net/browse/JUJU-10288)


[JUJU-10288]: https://warthogs.atlassian.net/browse/JUJU-10288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ