### PR TITLE
feat: k8s HA scale down

### DIFF
--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -40,8 +40,8 @@ type ControllerConfigService interface {
 
 // ControllerNodeService represents a way to get controller api addresses.
 type ControllerNodeService interface {
-	// AddControllerNode ensures a controller node exists for the supplied ID.
-	AddControllerNode(ctx context.Context, controllerID string) error
+	// AddDqliteNodeID ensures a controller node exists for the supplied ID.
+	AddDqliteNodeID(ctx context.Context, controllerID string) error
 	// GetAllAPIAddressesForAgents returns a string of api
 	// addresses available for agents ordered to prefer local-cloud scoped
 	// addresses and IPv4 over IPv6 for each machine.
@@ -374,7 +374,7 @@ func (f *Facade) UnitIntroduction(ctx context.Context, args params.CAASUnitIntro
 	if err != nil {
 		return errResp(errors.Annotate(err, "rendering controller agent config"))
 	}
-	if err := f.controllerNodeService.AddControllerNode(ctx, controllerID); err != nil {
+	if err := f.controllerNodeService.AddDqliteNodeID(ctx, controllerID); err != nil {
 		return errResp(err)
 	}
 	// The nonce validation above proves this pod is the legitimate owner of

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -208,7 +208,7 @@ func (s *CAASApplicationSuite) TestControllerUnitIntroductionCreatesControllerId
 		PrivateKey:   coretesting.ServerKey,
 		CAPrivateKey: coretesting.CAKey,
 	}, nil)
-	s.controllerNodeService.EXPECT().AddControllerNode(gomock.Any(), "2")
+	s.controllerNodeService.EXPECT().AddDqliteNodeID(gomock.Any(), "2")
 
 	var storedPassword string
 	s.agentPasswordService.EXPECT().SetControllerNodePassword(gomock.Any(), "2", gomock.Any()).

--- a/apiserver/facades/agent/caasapplication/package_mock_test.go
+++ b/apiserver/facades/agent/caasapplication/package_mock_test.go
@@ -323,7 +323,7 @@ type MockControllerNodeService struct {
 // MockControllerNodeServiceMockRecorder is the mock recorder for MockControllerNodeService.
 type MockControllerNodeServiceMockRecorder struct {
 	mock                               *MockControllerNodeService
-	addControllerNodeExpects           []*gomock.Call2_1[context.Context, string, error]
+	addDqliteNodeIDExpects             []*gomock.Call2_1[context.Context, string, error]
 	getAllAPIAddressesForAgentsExpects []*gomock.Call1_2[context.Context, []string, error]
 }
 
@@ -339,23 +339,23 @@ func (m *MockControllerNodeService) EXPECT() *MockControllerNodeServiceMockRecor
 	return m.recorder
 }
 
-// AddControllerNode mocks base method.
-func (m *MockControllerNodeService) AddControllerNode(ctx context.Context, controllerID string) error {
+// AddDqliteNodeID mocks base method.
+func (m *MockControllerNodeService) AddDqliteNodeID(ctx context.Context, controllerID string) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_1(&m.recorder.addControllerNodeExpects, m.ctrl, m, "AddControllerNode", ctx, controllerID)
+	return gomock.Dispatch2_1(&m.recorder.addDqliteNodeIDExpects, m.ctrl, m, "AddDqliteNodeID", ctx, controllerID)
 }
 
-// AddControllerNode indicates an expected call of AddControllerNode.
-func (mr *MockControllerNodeServiceMockRecorder) AddControllerNode(ctx, controllerID any) *MockControllerNodeServiceAddControllerNodeCall {
+// AddDqliteNodeID indicates an expected call of AddDqliteNodeID.
+func (mr *MockControllerNodeServiceMockRecorder) AddDqliteNodeID(ctx, controllerID any) *MockControllerNodeServiceAddDqliteNodeIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "AddControllerNode", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(controllerID))
-	mr.addControllerNodeExpects = append(mr.addControllerNodeExpects, call)
+	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "AddDqliteNodeID", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(controllerID))
+	mr.addDqliteNodeIDExpects = append(mr.addDqliteNodeIDExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
-// MockControllerNodeServiceAddControllerNodeCall is the typed call wrapper for AddControllerNode.
-type MockControllerNodeServiceAddControllerNodeCall = gomock.Call2_1[context.Context, string, error]
+// MockControllerNodeServiceAddDqliteNodeIDCall is the typed call wrapper for AddDqliteNodeID.
+type MockControllerNodeServiceAddDqliteNodeIDCall = gomock.Call2_1[context.Context, string, error]
 
 // GetAllAPIAddressesForAgents mocks base method.
 func (m *MockControllerNodeService) GetAllAPIAddressesForAgents(ctx context.Context) ([]string, error) {

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1053,17 +1053,6 @@ func (api *APIBase) DestroyUnit(ctx context.Context, args params.DestroyUnitsPar
 				unitName, appName)
 		}
 
-		locator, err := api.getCharmLocatorByApplicationName(ctx, appName)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		charmName, err := api.getCharmName(ctx, locator)
-		if err != nil {
-			return nil, errors.Trace(err)
-		} else if charmName == bootstrap.ControllerCharmName {
-			return nil, errors.NotSupportedf("removing units from the controller application")
-		}
-
 		var info params.DestroyUnitInfo
 
 		// TODO(storage): return detached / destroyed storage volumes/filesystems

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -480,34 +480,6 @@ func (s *applicationSuite) TestDestroyUnitIsSubordinate(c *tc.C) {
 	c.Check(res.Results[0].Error, tc.ErrorMatches, `.*unit "foo/0" is a subordinate.*`)
 }
 
-func (s *applicationSuite) TestDestroyUnitControllerUnit(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	// Arrange:
-	s.setupAPI(c)
-
-	charmLocator := applicationcharm.CharmLocator{
-		Name:     "ctrl",
-		Revision: 42,
-		Source:   applicationcharm.CharmHubSource,
-	}
-	s.applicationService.EXPECT().IsSubordinateApplicationByName(gomock.Any(), "ctrl").Return(false, nil)
-	s.applicationService.EXPECT().GetCharmLocatorByApplicationName(gomock.Any(), "ctrl").Return(charmLocator, nil)
-	s.applicationService.EXPECT().GetCharmMetadataName(gomock.Any(), charmLocator).Return(bootstrap.ControllerCharmName, nil)
-
-	// Act:
-	res, err := s.api.DestroyUnit(c.Context(), params.DestroyUnitsParams{
-		Units: []params.DestroyUnitParams{{
-			UnitTag: names.NewUnitTag("ctrl/0").String(),
-		}},
-	})
-
-	// Assert:
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(res.Results, tc.HasLen, 1)
-	c.Check(res.Results[0].Error, tc.Satisfies, params.IsCodeNotSupported)
-}
-
 func (s *applicationSuite) TestDestroyApplicationController(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -450,14 +450,16 @@ func (h *toolsUploadHandler) handleUpload(
 		err = internalerrors.Errorf(
 			"unsupported architecture %q", agentBinaryVersion.Arch,
 		).Add(coreerrors.BadRequest)
-	// Happens when the agent binary version being uploaded for already exists.
-	// We never want to allow someone to overwrite an established agent binary
-	// for a version by overwriting it with new data.
+	// Happens when the agent binary being uploaded already exists with
+	// the same SHA. This is not an error — the binary is already stored
+	// and the upload is effectively a no-op.
 	case errors.Is(err, agentbinaryerrors.AlreadyExists):
-		err = internalerrors.Errorf(
-			"agent binary already exists for version %q and arch %q",
+		logger.Debugf(
+			ctx,
+			"agent binary for version %q and arch %q already exists, skipping upload",
 			agentBinaryVersion.Number, agentBinaryVersion.Arch,
-		).Add(coreerrors.BadRequest)
+		)
+		err = nil
 	// Unknown error. This case is considered an internal server error unrelated
 	// to any bad or missing infomration in the upload request.
 	case err != nil:

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -179,16 +179,20 @@ func (s *toolsSuite) TestUploadAgentBinaryServiceInvalidArch(c *tc.C) {
 }
 
 // TestUploadAgentBinaryServiceAlreadyExists tests that if the agent binary
-// store already has an agent binary version for the uploaded version we get
-// back a bad request status.
+// store already has an agent binary version for the uploaded version, the
+// upload still succeeds as a no-op.
 func (s *toolsSuite) TestUploadAgentBinaryServiceAlreadyExists(c *tc.C) {
 	defer s.SetUpMocks(c).Finish()
 
 	body := strings.NewReader("123456789")
 	handler := newToolsUploadHandler(s.blockCheckGetter, s.agentBinaryStoreGetter)
 	res := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/tools?binaryVersion=4.0.0-ubuntu-amd64", body)
+	req := httptest.NewRequest(http.MethodPost, "https://[2001:0DB8::1]/tools?binaryVersion=4.0.0-ubuntu-amd64", body)
 	req.Header.Add("Content-Type", "application/x-tar-gz")
+
+	modelUUID := tc.Must0(c, coremodel.NewUUID)
+	ctx := httpcontext.SetContextModelUUID(req.Context(), modelUUID)
+	req = req.WithContext(ctx)
 
 	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil)
 	s.agentBinaryStore.EXPECT().AddAgentBinaryWithSHA256(
@@ -203,12 +207,14 @@ func (s *toolsSuite) TestUploadAgentBinaryServiceAlreadyExists(c *tc.C) {
 	).Return(agentbinaryerrors.AlreadyExists)
 
 	handler.ServeHTTP(res, req)
-	s.assertJSONErrorResponse(
-		c,
-		res.Result(),
-		http.StatusBadRequest,
-		`agent binary already exists for version "4.0.0" and arch "amd64"`,
-	)
+	c.Check(res.Result().StatusCode, tc.Equals, http.StatusOK)
+
+	s.assertUploadResponse(c, res.Result(), &tools.Tools{
+		Version: semversion.MustParseBinary("4.0.0-ubuntu-amd64"),
+		URL:     fmt.Sprintf("https://[2001:0DB8::1]/model/%s/tools/4.0.0-ubuntu-amd64", modelUUID),
+		SHA256:  "15e2b0d3c33891ebb0f1ef609ec419420c20e320ce94c65fbc8c3312448eb225",
+		Size:    9,
+	})
 }
 
 // TestUploadAgentBinary tests the happy path of uploading agent binaries to the

--- a/caas/application.go
+++ b/caas/application.go
@@ -101,6 +101,9 @@ type ApplicationState struct {
 
 // ApplicationConfig is the config passed to the application units.
 type ApplicationConfig struct {
+	// Controller indicates this application hosts the Juju controller.
+	Controller bool
+
 	// AgentVersion is the Juju version of the agent image.
 	AgentVersion semversion.Number
 

--- a/caas/application.go
+++ b/caas/application.go
@@ -27,10 +27,14 @@ type Application interface {
 	// ApplicationPodSpec returns the pod spec needed to run the application workload.
 	ApplicationPodSpec(config ApplicationConfig) (*core.PodSpec, error)
 
-	// Scale scales the Application's unit to the value specified. Scale must
-	// be >= 0. Application units will be removed or added to meet the scale
-	// defined.
-	Scale(int) error
+	// Scale reconciles the application's replica count. Scale must be >= 0.
+	// The operation stops if ctx is cancelled.
+	Scale(context.Context, int) error
+
+	// ScaleRange reconciles a contiguous StatefulSet ordinal range. The range
+	// is [startOrdinal, startOrdinal+scale). Both values must be non-negative.
+	// The operation stops if ctx is cancelled.
+	ScaleRange(context.Context, int, int) error
 
 	// Trust sets up the role on the application's service account to
 	// give full access to the cluster.

--- a/caas/application.go
+++ b/caas/application.go
@@ -31,10 +31,12 @@ type Application interface {
 	// The operation stops if ctx is cancelled.
 	Scale(context.Context, int) error
 
-	// ScaleRange reconciles a contiguous StatefulSet ordinal range. The range
-	// is [startOrdinal, startOrdinal+scale). Both values must be non-negative.
+	// ScaleRange reconciles a StatefulSet to a contiguous ordinal range. The
+	// replicaCount and startOrdinal define the half-open range
+	// [startOrdinal, startOrdinal+replicaCount). Sparse ordinal ranges are not
+	// supported. Both values must be non-negative.
 	// The operation stops if ctx is cancelled.
-	ScaleRange(context.Context, int, int) error
+	ScaleRange(ctx context.Context, replicaCount, startOrdinal int) error
 
 	// Trust sets up the role on the application's service account to
 	// give full access to the cluster.

--- a/caas/mocks/application_mock.go
+++ b/caas/mocks/application_mock.go
@@ -13,10 +13,11 @@ import (
 	context "context"
 
 	gomock "github.com/canonical/gomock/gomock"
+	v1 "k8s.io/api/core/v1"
+
 	caas "github.com/juju/juju/caas"
 	watcher "github.com/juju/juju/core/watcher"
 	storage "github.com/juju/juju/internal/storage"
-	v1 "k8s.io/api/core/v1"
 )
 
 // MockApplication is a mock of Application interface.
@@ -35,7 +36,8 @@ type MockApplicationMockRecorder struct {
 	ensureControllerNonceExpects []*gomock.Call3_1[context.Context, int, string, error]
 	ensurePVCsExpects            []*gomock.Call3_1[[]storage.KubernetesFilesystemParams, map[string][]storage.KubernetesFilesystemUnitAttachmentParams, string, error]
 	existsExpects                []*gomock.Call0_2[caas.DeploymentState, error]
-	scaleExpects                 []*gomock.Call1_1[int, error]
+	scaleExpects                 []*gomock.Call2_1[context.Context, int, error]
+	scaleRangeExpects            []*gomock.Call3_1[context.Context, int, int, error]
 	serviceExpects               []*gomock.Call0_2[*caas.Service, error]
 	stateExpects                 []*gomock.Call0_2[caas.ApplicationState, error]
 	trustExpects                 []*gomock.Call1_1[bool, error]
@@ -168,22 +170,40 @@ func (mr *MockApplicationMockRecorder) Exists() *MockApplicationExistsCall {
 type MockApplicationExistsCall = gomock.Call0_2[caas.DeploymentState, error]
 
 // Scale mocks base method.
-func (m *MockApplication) Scale(arg0 int) error {
+func (m *MockApplication) Scale(arg0 context.Context, arg1 int) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch1_1(&m.recorder.scaleExpects, m.ctrl, m, "Scale", arg0)
+	return gomock.Dispatch2_1(&m.recorder.scaleExpects, m.ctrl, m, "Scale", arg0, arg1)
 }
 
 // Scale indicates an expected call of Scale.
-func (mr *MockApplicationMockRecorder) Scale(arg0 any) *MockApplicationScaleCall {
+func (mr *MockApplicationMockRecorder) Scale(arg0, arg1 any) *MockApplicationScaleCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_1[int, error](mr.mock.ctrl.T, mr.mock, "Scale", gomock.EnsureMatcher(arg0))
+	call := gomock.NewCall2_1[context.Context, int, error](mr.mock.ctrl.T, mr.mock, "Scale", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
 	mr.scaleExpects = append(mr.scaleExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockApplicationScaleCall is the typed call wrapper for Scale.
-type MockApplicationScaleCall = gomock.Call1_1[int, error]
+type MockApplicationScaleCall = gomock.Call2_1[context.Context, int, error]
+
+// ScaleRange mocks base method.
+func (m *MockApplication) ScaleRange(arg0 context.Context, arg1, arg2 int) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", arg0, arg1, arg2)
+}
+
+// ScaleRange indicates an expected call of ScaleRange.
+func (mr *MockApplicationMockRecorder) ScaleRange(arg0, arg1, arg2 any) *MockApplicationScaleRangeCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
+	mr.scaleRangeExpects = append(mr.scaleRangeExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockApplicationScaleRangeCall is the typed call wrapper for ScaleRange.
+type MockApplicationScaleRangeCall = gomock.Call3_1[context.Context, int, int, error]
 
 // Service mocks base method.
 func (m *MockApplication) Service() (*caas.Service, error) {

--- a/caas/mocks/application_mock.go
+++ b/caas/mocks/application_mock.go
@@ -13,11 +13,10 @@ import (
 	context "context"
 
 	gomock "github.com/canonical/gomock/gomock"
-	v1 "k8s.io/api/core/v1"
-
 	caas "github.com/juju/juju/caas"
 	watcher "github.com/juju/juju/core/watcher"
 	storage "github.com/juju/juju/internal/storage"
+	v1 "k8s.io/api/core/v1"
 )
 
 // MockApplication is a mock of Application interface.

--- a/caas/mocks/application_mock.go
+++ b/caas/mocks/application_mock.go
@@ -187,15 +187,15 @@ func (mr *MockApplicationMockRecorder) Scale(arg0, arg1 any) *MockApplicationSca
 type MockApplicationScaleCall = gomock.Call2_1[context.Context, int, error]
 
 // ScaleRange mocks base method.
-func (m *MockApplication) ScaleRange(arg0 context.Context, arg1, arg2 int) error {
+func (m *MockApplication) ScaleRange(ctx context.Context, replicaCount, startOrdinal int) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", arg0, arg1, arg2)
+	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", ctx, replicaCount, startOrdinal)
 }
 
 // ScaleRange indicates an expected call of ScaleRange.
-func (mr *MockApplicationMockRecorder) ScaleRange(arg0, arg1, arg2 any) *MockApplicationScaleRangeCall {
+func (mr *MockApplicationMockRecorder) ScaleRange(ctx, replicaCount, startOrdinal any) *MockApplicationScaleRangeCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
+	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(replicaCount), gomock.EnsureMatcher(startOrdinal))
 	mr.scaleRangeExpects = append(mr.scaleRangeExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call

--- a/cmd/containeragent/initialize/command.go
+++ b/cmd/containeragent/initialize/command.go
@@ -253,10 +253,6 @@ func (c *initCommand) writeContainerAgentPebbleConfig() error {
 		extraArgs = append(extraArgs, "--charm-modified-version", c.charmModifiedVersion)
 	}
 
-	if c.isController {
-		extraArgs = append(extraArgs, "--controller")
-	}
-
 	onCheckFailureAction := pebbleplan.ActionShutdown
 	if c.isController {
 		onCheckFailureAction = pebbleplan.ActionRestart

--- a/cmd/containeragent/initialize/command_test.go
+++ b/cmd/containeragent/initialize/command_test.go
@@ -191,7 +191,7 @@ services:
         summary: Juju container agent
         startup: enabled
         override: replace
-        command: /charm/bin/containeragent unit --data-dir /var/lib/juju --append-env "PATH=$PATH:/charm/bin" --show-log --controller
+        command: '/charm/bin/containeragent unit --data-dir /var/lib/juju --append-env "PATH=$PATH:/charm/bin" --show-log '
         environment:
             HTTP_PROBE_PORT: "65301"
         kill-delay: 30m0s

--- a/cmd/containeragent/unit/agent.go
+++ b/cmd/containeragent/unit/agent.go
@@ -77,10 +77,9 @@ type containerUnitAgent struct {
 	fileReaderWriter utils.FileReaderWriter
 	environment      utils.Environment
 
-	charmModifiedVersion    int
-	envVars                 []string
-	containerNames          []string
-	colocatedWithController bool
+	charmModifiedVersion int
+	envVars              []string
+	containerNames       []string
 }
 
 // New creates containeragent unit command.
@@ -115,7 +114,6 @@ func (c *containerUnitAgent) SetFlags(f *gnuflag.FlagSet) {
 	c.AgentConf.AddFlags(f)
 	f.IntVar(&c.charmModifiedVersion, "charm-modified-version", -1, "charm modified version to validate downloaded charm is for the provided infrastructure")
 	f.Var(cmd.NewAppendStringsValue(&c.envVars), "append-env", "can be specified multiple times and with the form ENV_VAR=VALUE where VALUE can be empty or contain unexpanded variables using $OTHER_ENV")
-	f.BoolVar(&c.colocatedWithController, "controller", false, "should be specified if this unit agent is running on the same machine as a controller")
 }
 
 func (c *containerUnitAgent) CharmModifiedVersion() int {
@@ -263,25 +261,24 @@ func (c *containerUnitAgent) workers(sigTermCh chan os.Signal) (worker.Worker, e
 	}
 	agentConfig := c.AgentConf.CurrentConfig()
 	cfg := manifoldsConfig{
-		Agent:                   agent.APIHostPortsSetter{Agent: c},
-		LogSource:               c.bufferedLogger.Logs(),
-		LeadershipGuarantee:     30 * time.Second,
-		UpgradeStepsLock:        upgrade.NewLock(agentConfig, jujuversion.Current),
-		PreUpgradeSteps:         upgrades.PreUpgradeSteps,
-		UpgradeSteps:            upgrades.PerformUpgradeSteps,
-		AgentConfigChanged:      c.configChangedVal,
-		ValidateMigration:       c.validateMigration,
-		PrometheusRegisterer:    c.prometheusRegistry,
-		UpdateLoggerConfig:      updateAgentConfLogging,
-		PreviousAgentVersion:    agentConfig.UpgradedToVersion(),
-		ProbeAddress:            "localhost",
-		ProbePort:               probePort,
-		MachineLock:             c.machineLock,
-		Clock:                   c.clk,
-		CharmModifiedVersion:    c.CharmModifiedVersion(),
-		ContainerNames:          c.containerNames,
-		ColocatedWithController: c.colocatedWithController,
-		SignalCh:                sigTermCh,
+		Agent:                agent.APIHostPortsSetter{Agent: c},
+		LogSource:            c.bufferedLogger.Logs(),
+		LeadershipGuarantee:  30 * time.Second,
+		UpgradeStepsLock:     upgrade.NewLock(agentConfig, jujuversion.Current),
+		PreUpgradeSteps:      upgrades.PreUpgradeSteps,
+		UpgradeSteps:         upgrades.PerformUpgradeSteps,
+		AgentConfigChanged:   c.configChangedVal,
+		ValidateMigration:    c.validateMigration,
+		PrometheusRegisterer: c.prometheusRegistry,
+		UpdateLoggerConfig:   updateAgentConfLogging,
+		PreviousAgentVersion: agentConfig.UpgradedToVersion(),
+		ProbeAddress:         "localhost",
+		ProbePort:            probePort,
+		MachineLock:          c.machineLock,
+		Clock:                c.clk,
+		CharmModifiedVersion: c.CharmModifiedVersion(),
+		ContainerNames:       c.containerNames,
+		SignalCh:             sigTermCh,
 	}
 	manifolds := Manifolds(cfg)
 

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -137,11 +137,6 @@ type manifoldsConfig struct {
 	// ContainerNames this unit is running with.
 	ContainerNames []string
 
-	// ColocatedWithController is true when the unit agent is running on
-	// the same machine/pod as a Juju controller, where they share the same
-	// networking namespace in linux.
-	ColocatedWithController bool
-
 	// SignalCh is os.Signal channel to receive signals on.
 	SignalCh chan os.Signal
 }
@@ -485,19 +480,13 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 		})),
 	}
 
-	// If the container agent is colocated with the controller for the controller charm, then it doesn't
-	// need the api address updater, http probe server or the cass prober workers.
-	// For every other deployment of the containeragent, these workers are required.
-	if !config.ColocatedWithController {
-		// The api address updater is a leaf worker that rewrites agent config
-		// as the controller addresses change. We should only need one of
-		// these in a consolidated agent.
-		dp[apiAddressUpdaterName] = ifNotMigrating(apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
-			AgentName:     agentName,
-			APICallerName: apiCallerName,
-			Logger:        internallogger.GetLogger("juju.worker.apiaddressupdater"),
-		}))
-	}
+	// The API address updater rewrites agent config as controller addresses
+	// change, including when a colocated controller pod is removed.
+	dp[apiAddressUpdaterName] = ifNotMigrating(apiaddressupdater.Manifold(apiaddressupdater.ManifoldConfig{
+		AgentName:     agentName,
+		APICallerName: apiCallerName,
+		Logger:        internallogger.GetLogger("juju.worker.apiaddressupdater"),
+	}))
 
 	return dp
 }

--- a/cmd/containeragent/unit/manifolds_test.go
+++ b/cmd/containeragent/unit/manifolds_test.go
@@ -81,53 +81,6 @@ func (s *ManifoldsSuite) TestManifoldNames(c *tc.C) {
 	c.Assert(keys, tc.SameContents, expectedKeys)
 }
 
-func (s *ManifoldsSuite) TestManifoldNamesColocatedController(c *tc.C) {
-	config := unit.ManifoldsConfig{
-		ColocatedWithController: true,
-	}
-	manifolds := unit.Manifolds(config)
-	expectedKeys := []string{
-		"agent",
-		"api-caller",
-		"api-config-watcher",
-		"caas-prober",
-		"caas-unit-prober-binder",
-		"caas-unit-termination-worker",
-		"caas-zombie-prober-binder",
-		"charm-dir",
-		"dead-flag",
-		"hook-retry-strategy",
-		"http-client",
-		"leadership-tracker",
-		"log-router",
-		"logging-config-updater",
-		"loki-endpoint-updater",
-		"migration-fortress",
-		"migration-inactive-flag",
-		"migration-minion",
-		"not-dead-flag",
-		"pebble-loki-config",
-		"probe-http-server",
-		"proxy-config-updater",
-		"s3-caller",
-		"secret-drain-worker",
-		"signal-handler",
-
-		"trace",
-		"trace-config-updater",
-		"uniter",
-		"upgrade-steps-flag",
-		"upgrade-steps-gate",
-		"upgrade-agent-steps-runner",
-		"upgrader",
-	}
-	keys := make([]string, 0, len(manifolds))
-	for k := range manifolds {
-		keys = append(keys, k)
-	}
-	c.Assert(keys, tc.SameContents, expectedKeys)
-}
-
 func (*ManifoldsSuite) TestMigrationGuards(c *tc.C) {
 	exempt := set.NewStrings(
 		"agent",

--- a/domain/agentpassword/state/controllerstate.go
+++ b/domain/agentpassword/state/controllerstate.go
@@ -44,7 +44,8 @@ func (s *ControllerState) SetControllerNodePasswordHash(ctx context.Context, id 
 	query := `
 SELECT COUNT(*) AS &count.count
 FROM controller_node
-WHERE controller_id = $entityPasswordHash.uuid;
+WHERE controller_id = $entityPasswordHash.uuid
+AND life_id < 2;
 `
 	stmt, err := s.Prepare(query, args, count{})
 	if err != nil {
@@ -95,7 +96,8 @@ func (s *ControllerState) SetControllerNodePasswordHashIfAbsent(
 	checkNodeStmt, err := s.Prepare(`
 SELECT COUNT(*) AS &count.count
 FROM controller_node
-WHERE controller_id = $entityPasswordHash.uuid;
+WHERE controller_id = $entityPasswordHash.uuid
+AND life_id < 2;
 `, args, count{})
 	if err != nil {
 		return false, errors.Errorf("preparing statement to check controller node exists: %w", err)

--- a/domain/agentpassword/state/controllerstate_test.go
+++ b/domain/agentpassword/state/controllerstate_test.go
@@ -42,6 +42,21 @@ func (s *controllerModelState) TestSetControllerNodePassword(c *tc.C) {
 	c.Assert(hash, tc.Equals, string(passwordHash))
 }
 
+func (s *controllerModelState) TestSetControllerNodePasswordWhenDying(c *tc.C) {
+	st := NewControllerState(s.TxnRunnerFactory())
+	_, err := s.DB().ExecContext(c.Context(), `
+UPDATE controller_node SET life_id = 1 WHERE controller_id = '0'`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	passwordHash := s.genPasswordHash(c)
+	err = st.SetControllerNodePasswordHash(c.Context(), "0", passwordHash)
+	c.Assert(err, tc.ErrorIsNil)
+
+	valid, err := st.MatchesControllerNodePasswordHash(c.Context(), "0", passwordHash)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(valid, tc.IsTrue)
+}
+
 func (s *controllerModelState) TestSetControllerNodePasswordDoesNotExist(c *tc.C) {
 	st := NewControllerState(s.TxnRunnerFactory())
 
@@ -70,6 +85,19 @@ func (s *controllerModelState) TestSetControllerNodePasswordHashIfAbsent(c *tc.C
 	valid, err = st.MatchesControllerNodePasswordHash(c.Context(), "0", replacementHash)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(valid, tc.IsFalse)
+}
+
+func (s *controllerModelState) TestSetControllerNodePasswordHashIfAbsentWhenDying(c *tc.C) {
+	st := NewControllerState(s.TxnRunnerFactory())
+	_, err := s.DB().ExecContext(c.Context(), `
+UPDATE controller_node SET life_id = 1 WHERE controller_id = '0'`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	inserted, err := st.SetControllerNodePasswordHashIfAbsent(
+		c.Context(), "0", s.genPasswordHash(c),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(inserted, tc.IsTrue)
 }
 
 func (s *controllerModelState) TestSetControllerNodePasswordHashIfAbsentNodeDoesNotExist(c *tc.C) {

--- a/domain/application/caas_mock_test.go
+++ b/domain/application/caas_mock_test.go
@@ -13,10 +13,11 @@ import (
 	context "context"
 
 	gomock "github.com/canonical/gomock/gomock"
+	v1 "k8s.io/api/core/v1"
+
 	caas "github.com/juju/juju/caas"
 	watcher "github.com/juju/juju/core/watcher"
 	storage "github.com/juju/juju/internal/storage"
-	v1 "k8s.io/api/core/v1"
 )
 
 // MockApplication is a mock of Application interface.
@@ -35,7 +36,8 @@ type MockApplicationMockRecorder struct {
 	ensureControllerNonceExpects []*gomock.Call3_1[context.Context, int, string, error]
 	ensurePVCsExpects            []*gomock.Call3_1[[]storage.KubernetesFilesystemParams, map[string][]storage.KubernetesFilesystemUnitAttachmentParams, string, error]
 	existsExpects                []*gomock.Call0_2[caas.DeploymentState, error]
-	scaleExpects                 []*gomock.Call1_1[int, error]
+	scaleExpects                 []*gomock.Call2_1[context.Context, int, error]
+	scaleRangeExpects            []*gomock.Call3_1[context.Context, int, int, error]
 	serviceExpects               []*gomock.Call0_2[*caas.Service, error]
 	stateExpects                 []*gomock.Call0_2[caas.ApplicationState, error]
 	trustExpects                 []*gomock.Call1_1[bool, error]
@@ -168,22 +170,37 @@ func (mr *MockApplicationMockRecorder) Exists() *MockApplicationExistsCall {
 type MockApplicationExistsCall = gomock.Call0_2[caas.DeploymentState, error]
 
 // Scale mocks base method.
-func (m *MockApplication) Scale(arg0 int) error {
+func (m *MockApplication) Scale(arg0 context.Context, arg1 int) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch1_1(&m.recorder.scaleExpects, m.ctrl, m, "Scale", arg0)
+	return gomock.Dispatch2_1(&m.recorder.scaleExpects, m.ctrl, m, "Scale", arg0, arg1)
 }
 
 // Scale indicates an expected call of Scale.
-func (mr *MockApplicationMockRecorder) Scale(arg0 any) *MockApplicationScaleCall {
+func (mr *MockApplicationMockRecorder) Scale(arg0, arg1 any) *MockApplicationScaleCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_1[int, error](mr.mock.ctrl.T, mr.mock, "Scale", gomock.EnsureMatcher(arg0))
+	call := gomock.NewCall2_1[context.Context, int, error](mr.mock.ctrl.T, mr.mock, "Scale", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
 	mr.scaleExpects = append(mr.scaleExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockApplicationScaleCall is the typed call wrapper for Scale.
-type MockApplicationScaleCall = gomock.Call1_1[int, error]
+type MockApplicationScaleCall = gomock.Call2_1[context.Context, int, error]
+
+func (m *MockApplication) ScaleRange(arg0 context.Context, arg1, arg2 int) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", arg0, arg1, arg2)
+}
+
+func (mr *MockApplicationMockRecorder) ScaleRange(arg0, arg1, arg2 any) *MockApplicationScaleRangeCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
+	mr.scaleRangeExpects = append(mr.scaleRangeExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+type MockApplicationScaleRangeCall = gomock.Call3_1[context.Context, int, int, error]
 
 // Service mocks base method.
 func (m *MockApplication) Service() (*caas.Service, error) {

--- a/domain/application/caas_mock_test.go
+++ b/domain/application/caas_mock_test.go
@@ -13,11 +13,10 @@ import (
 	context "context"
 
 	gomock "github.com/canonical/gomock/gomock"
-	v1 "k8s.io/api/core/v1"
-
 	caas "github.com/juju/juju/caas"
 	watcher "github.com/juju/juju/core/watcher"
 	storage "github.com/juju/juju/internal/storage"
+	v1 "k8s.io/api/core/v1"
 )
 
 // MockApplication is a mock of Application interface.
@@ -187,11 +186,13 @@ func (mr *MockApplicationMockRecorder) Scale(arg0, arg1 any) *MockApplicationSca
 // MockApplicationScaleCall is the typed call wrapper for Scale.
 type MockApplicationScaleCall = gomock.Call2_1[context.Context, int, error]
 
+// ScaleRange mocks base method.
 func (m *MockApplication) ScaleRange(arg0 context.Context, arg1, arg2 int) error {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", arg0, arg1, arg2)
 }
 
+// ScaleRange indicates an expected call of ScaleRange.
 func (mr *MockApplicationMockRecorder) ScaleRange(arg0, arg1, arg2 any) *MockApplicationScaleRangeCall {
 	mr.mock.ctrl.T.Helper()
 	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
@@ -200,6 +201,7 @@ func (mr *MockApplicationMockRecorder) ScaleRange(arg0, arg1, arg2 any) *MockApp
 	return call
 }
 
+// MockApplicationScaleRangeCall is the typed call wrapper for ScaleRange.
 type MockApplicationScaleRangeCall = gomock.Call3_1[context.Context, int, int, error]
 
 // Service mocks base method.

--- a/domain/application/caas_mock_test.go
+++ b/domain/application/caas_mock_test.go
@@ -187,15 +187,15 @@ func (mr *MockApplicationMockRecorder) Scale(arg0, arg1 any) *MockApplicationSca
 type MockApplicationScaleCall = gomock.Call2_1[context.Context, int, error]
 
 // ScaleRange mocks base method.
-func (m *MockApplication) ScaleRange(arg0 context.Context, arg1, arg2 int) error {
+func (m *MockApplication) ScaleRange(ctx context.Context, replicaCount, startOrdinal int) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", arg0, arg1, arg2)
+	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", ctx, replicaCount, startOrdinal)
 }
 
 // ScaleRange indicates an expected call of ScaleRange.
-func (mr *MockApplicationMockRecorder) ScaleRange(arg0, arg1, arg2 any) *MockApplicationScaleRangeCall {
+func (mr *MockApplicationMockRecorder) ScaleRange(ctx, replicaCount, startOrdinal any) *MockApplicationScaleRangeCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
+	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(replicaCount), gomock.EnsureMatcher(startOrdinal))
 	mr.scaleRangeExpects = append(mr.scaleRangeExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -146,6 +146,7 @@ type ApplicationState interface {
 	// SetApplicationScalingState sets the scaling details for the given caas
 	// application Scale is optional and is only set if not nil.
 	SetApplicationScalingState(ctx context.Context, appName string, targetScale int, scaling bool) error
+	SetApplicationScalingStateWithStart(ctx context.Context, appName string, targetScale, startOrdinal int, scaling bool) error
 
 	// SetDesiredApplicationScale updates the desired scale of the specified
 	// application.
@@ -1070,6 +1071,18 @@ func (s *Service) SetApplicationScalingState(ctx context.Context, appName string
 	return nil
 }
 
+// SetApplicationScalingStateWithStart updates the scale state and desired
+// StatefulSet start ordinal of a CAAS application.
+func (s *Service) SetApplicationScalingStateWithStart(ctx context.Context, appName string, scaleTarget, startOrdinal int, scaling bool) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := s.st.SetApplicationScalingStateWithStart(ctx, appName, scaleTarget, startOrdinal, scaling); err != nil {
+		return errors.Errorf("updating scaling state for %q: %w", appName, err)
+	}
+	return nil
+}
+
 // GetApplicationScalingState returns the scale state of an application,
 // returning an error satisfying [applicationerrors.ApplicationNotFound] if
 // the application doesn't exist. This is used on CAAS models.
@@ -1086,8 +1099,9 @@ func (s *Service) GetApplicationScalingState(ctx context.Context, appName string
 		return ScalingState{}, errors.Errorf("getting scaling state for %q: %w", appName, err)
 	}
 	return ScalingState{
-		ScaleTarget: scaleState.ScaleTarget,
-		Scaling:     scaleState.Scaling,
+		StartOrdinal: scaleState.StartOrdinal,
+		ScaleTarget:  scaleState.ScaleTarget,
+		Scaling:      scaleState.Scaling,
 	}, nil
 }
 

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -146,6 +146,13 @@ type ApplicationState interface {
 	// SetApplicationScalingState sets the scaling details for the given caas
 	// application Scale is optional and is only set if not nil.
 	SetApplicationScalingState(ctx context.Context, appName string, targetScale int, scaling bool) error
+
+	// SetApplicationScalingStateWithStart sets the scaling details for the
+	// given CAAS application including the start ordinal for the StatefulSet.
+	// The startOrdinal defines the lowest ordinal index that the StatefulSet
+	// should use. This shifts upward when a lower-indexed unit is removed to
+	// prevent stale ordinals from being reused (e.g. after removing unit 0
+	// from {0,1,2}, the start ordinal becomes 1 so the range is {1,2,3}).
 	SetApplicationScalingStateWithStart(ctx context.Context, appName string, targetScale, startOrdinal int, scaling bool) error
 
 	// SetDesiredApplicationScale updates the desired scale of the specified

--- a/domain/application/service/caas_mock_test.go
+++ b/domain/application/service/caas_mock_test.go
@@ -13,10 +13,11 @@ import (
 	context "context"
 
 	gomock "github.com/canonical/gomock/gomock"
+	v1 "k8s.io/api/core/v1"
+
 	caas "github.com/juju/juju/caas"
 	watcher "github.com/juju/juju/core/watcher"
 	storage "github.com/juju/juju/internal/storage"
-	v1 "k8s.io/api/core/v1"
 )
 
 // MockApplication is a mock of Application interface.
@@ -35,7 +36,8 @@ type MockApplicationMockRecorder struct {
 	ensureControllerNonceExpects []*gomock.Call3_1[context.Context, int, string, error]
 	ensurePVCsExpects            []*gomock.Call3_1[[]storage.KubernetesFilesystemParams, map[string][]storage.KubernetesFilesystemUnitAttachmentParams, string, error]
 	existsExpects                []*gomock.Call0_2[caas.DeploymentState, error]
-	scaleExpects                 []*gomock.Call1_1[int, error]
+	scaleExpects                 []*gomock.Call2_1[context.Context, int, error]
+	scaleRangeExpects            []*gomock.Call3_1[context.Context, int, int, error]
 	serviceExpects               []*gomock.Call0_2[*caas.Service, error]
 	stateExpects                 []*gomock.Call0_2[caas.ApplicationState, error]
 	trustExpects                 []*gomock.Call1_1[bool, error]
@@ -168,22 +170,37 @@ func (mr *MockApplicationMockRecorder) Exists() *MockApplicationExistsCall {
 type MockApplicationExistsCall = gomock.Call0_2[caas.DeploymentState, error]
 
 // Scale mocks base method.
-func (m *MockApplication) Scale(arg0 int) error {
+func (m *MockApplication) Scale(arg0 context.Context, arg1 int) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch1_1(&m.recorder.scaleExpects, m.ctrl, m, "Scale", arg0)
+	return gomock.Dispatch2_1(&m.recorder.scaleExpects, m.ctrl, m, "Scale", arg0, arg1)
 }
 
 // Scale indicates an expected call of Scale.
-func (mr *MockApplicationMockRecorder) Scale(arg0 any) *MockApplicationScaleCall {
+func (mr *MockApplicationMockRecorder) Scale(arg0, arg1 any) *MockApplicationScaleCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_1[int, error](mr.mock.ctrl.T, mr.mock, "Scale", gomock.EnsureMatcher(arg0))
+	call := gomock.NewCall2_1[context.Context, int, error](mr.mock.ctrl.T, mr.mock, "Scale", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
 	mr.scaleExpects = append(mr.scaleExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockApplicationScaleCall is the typed call wrapper for Scale.
-type MockApplicationScaleCall = gomock.Call1_1[int, error]
+type MockApplicationScaleCall = gomock.Call2_1[context.Context, int, error]
+
+func (m *MockApplication) ScaleRange(arg0 context.Context, arg1, arg2 int) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", arg0, arg1, arg2)
+}
+
+func (mr *MockApplicationMockRecorder) ScaleRange(arg0, arg1, arg2 any) *MockApplicationScaleRangeCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
+	mr.scaleRangeExpects = append(mr.scaleRangeExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+type MockApplicationScaleRangeCall = gomock.Call3_1[context.Context, int, int, error]
 
 // Service mocks base method.
 func (m *MockApplication) Service() (*caas.Service, error) {

--- a/domain/application/service/caas_mock_test.go
+++ b/domain/application/service/caas_mock_test.go
@@ -13,11 +13,10 @@ import (
 	context "context"
 
 	gomock "github.com/canonical/gomock/gomock"
-	v1 "k8s.io/api/core/v1"
-
 	caas "github.com/juju/juju/caas"
 	watcher "github.com/juju/juju/core/watcher"
 	storage "github.com/juju/juju/internal/storage"
+	v1 "k8s.io/api/core/v1"
 )
 
 // MockApplication is a mock of Application interface.
@@ -187,11 +186,13 @@ func (mr *MockApplicationMockRecorder) Scale(arg0, arg1 any) *MockApplicationSca
 // MockApplicationScaleCall is the typed call wrapper for Scale.
 type MockApplicationScaleCall = gomock.Call2_1[context.Context, int, error]
 
+// ScaleRange mocks base method.
 func (m *MockApplication) ScaleRange(arg0 context.Context, arg1, arg2 int) error {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", arg0, arg1, arg2)
 }
 
+// ScaleRange indicates an expected call of ScaleRange.
 func (mr *MockApplicationMockRecorder) ScaleRange(arg0, arg1, arg2 any) *MockApplicationScaleRangeCall {
 	mr.mock.ctrl.T.Helper()
 	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
@@ -200,6 +201,7 @@ func (mr *MockApplicationMockRecorder) ScaleRange(arg0, arg1, arg2 any) *MockApp
 	return call
 }
 
+// MockApplicationScaleRangeCall is the typed call wrapper for ScaleRange.
 type MockApplicationScaleRangeCall = gomock.Call3_1[context.Context, int, int, error]
 
 // Service mocks base method.

--- a/domain/application/service/caas_mock_test.go
+++ b/domain/application/service/caas_mock_test.go
@@ -187,15 +187,15 @@ func (mr *MockApplicationMockRecorder) Scale(arg0, arg1 any) *MockApplicationSca
 type MockApplicationScaleCall = gomock.Call2_1[context.Context, int, error]
 
 // ScaleRange mocks base method.
-func (m *MockApplication) ScaleRange(arg0 context.Context, arg1, arg2 int) error {
+func (m *MockApplication) ScaleRange(ctx context.Context, replicaCount, startOrdinal int) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", arg0, arg1, arg2)
+	return gomock.Dispatch3_1(&m.recorder.scaleRangeExpects, m.ctrl, m, "ScaleRange", ctx, replicaCount, startOrdinal)
 }
 
 // ScaleRange indicates an expected call of ScaleRange.
-func (mr *MockApplicationMockRecorder) ScaleRange(arg0, arg1, arg2 any) *MockApplicationScaleRangeCall {
+func (mr *MockApplicationMockRecorder) ScaleRange(ctx, replicaCount, startOrdinal any) *MockApplicationScaleRangeCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
+	call := gomock.NewCall3_1[context.Context, int, int, error](mr.mock.ctrl.T, mr.mock, "ScaleRange", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(replicaCount), gomock.EnsureMatcher(startOrdinal))
 	mr.scaleRangeExpects = append(mr.scaleRangeExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -276,7 +276,13 @@ func (s *MigrationService) ImportCAASApplication(ctx context.Context, name strin
 	// Improve the efficiency of importing caas applications by touching
 	// the application_scale table once, instead of three times. Once in
 	// st.ImportApplication and the following two methods.
-	if err := s.st.SetApplicationScalingState(ctx, name, args.ScaleState.ScaleTarget, args.ScaleState.Scaling); err != nil {
+	setScaleState := s.st.SetApplicationScalingState
+	if args.ScaleState.StartOrdinal != 0 {
+		setScaleState = func(ctx context.Context, name string, targetScale int, scaling bool) error {
+			return s.st.SetApplicationScalingStateWithStart(ctx, name, targetScale, args.ScaleState.StartOrdinal, scaling)
+		}
+	}
+	if err := setScaleState(ctx, name, args.ScaleState.ScaleTarget, args.ScaleState.Scaling); err != nil {
 		return errors.Errorf("setting scale state for application %q: %w", name, err)
 	}
 	if err := s.st.SetDesiredApplicationScale(ctx, args.UUID, args.ScaleState.Scale); err != nil {

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -276,13 +276,9 @@ func (s *MigrationService) ImportCAASApplication(ctx context.Context, name strin
 	// Improve the efficiency of importing caas applications by touching
 	// the application_scale table once, instead of three times. Once in
 	// st.ImportApplication and the following two methods.
-	setScaleState := s.st.SetApplicationScalingState
-	if args.ScaleState.StartOrdinal != 0 {
-		setScaleState = func(ctx context.Context, name string, targetScale int, scaling bool) error {
-			return s.st.SetApplicationScalingStateWithStart(ctx, name, targetScale, args.ScaleState.StartOrdinal, scaling)
-		}
-	}
-	if err := setScaleState(ctx, name, args.ScaleState.ScaleTarget, args.ScaleState.Scaling); err != nil {
+	if err := s.st.SetApplicationScalingStateWithStart(
+		ctx, name, args.ScaleState.ScaleTarget, args.ScaleState.StartOrdinal,
+		args.ScaleState.Scaling); err != nil {
 		return errors.Errorf("setting scale state for application %q: %w", name, err)
 	}
 	if err := s.st.SetDesiredApplicationScale(ctx, args.UUID, args.ScaleState.Scale); err != nil {

--- a/domain/application/service/migration_test.go
+++ b/domain/application/service/migration_test.go
@@ -592,7 +592,7 @@ func (s *migrationServiceSuite) TestImportCAASApplication(c *tc.C) {
 
 	var receivedUnitArgs []application.ImportCAASUnitArg
 	s.state.EXPECT().SetDesiredApplicationScale(gomock.Any(), id, 1).Return(nil)
-	s.state.EXPECT().SetApplicationScalingState(gomock.Any(), "ubuntu", 42, true).Return(nil)
+	s.state.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "ubuntu", 42, 0, true).Return(nil)
 	s.state.EXPECT().InsertMigratingCAASUnits(gomock.Any(), id, gomock.Any()).DoAndReturn(func(_ context.Context, _ coreapplication.UUID, args ...application.ImportCAASUnitArg) error {
 		receivedUnitArgs = args
 		return nil

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -15,7 +15,6 @@ import (
 
 	gomock "github.com/canonical/gomock/gomock"
 	set "github.com/juju/collections/set"
-
 	caas "github.com/juju/juju/caas"
 	application "github.com/juju/juju/core/application"
 	assumes "github.com/juju/juju/core/assumes"

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -15,6 +15,7 @@ import (
 
 	gomock "github.com/canonical/gomock/gomock"
 	set "github.com/juju/collections/set"
+
 	caas "github.com/juju/juju/caas"
 	application "github.com/juju/juju/core/application"
 	assumes "github.com/juju/juju/core/assumes"
@@ -494,6 +495,7 @@ type MockStateMockRecorder struct {
 	setApplicationConstraintsExpects                          []*gomock.Call3_1[context.Context, application.UUID, constraints0.Constraints, error]
 	setApplicationHasK8sResourcesExpects                      []*gomock.Call2_1[context.Context, application.UUID, error]
 	setApplicationScalingStateExpects                         []*gomock.Call4_1[context.Context, string, int, bool, error]
+	setApplicationScalingStateWithStartExpects                []*gomock.Call5_1[context.Context, string, int, int, bool, error]
 	setCharmAvailableExpects                                  []*gomock.Call2_1[context.Context, charm.ID, error]
 	setDesiredApplicationScaleExpects                         []*gomock.Call3_1[context.Context, application.UUID, int, error]
 	setUnitWorkloadVersionExpects                             []*gomock.Call3_1[context.Context, unit.Name, string, error]
@@ -2847,6 +2849,24 @@ func (mr *MockStateMockRecorder) SetApplicationScalingState(ctx, appName, target
 
 // MockStateSetApplicationScalingStateCall is the typed call wrapper for SetApplicationScalingState.
 type MockStateSetApplicationScalingStateCall = gomock.Call4_1[context.Context, string, int, bool, error]
+
+// SetApplicationScalingStateWithStart mocks base method.
+func (m *MockState) SetApplicationScalingStateWithStart(ctx context.Context, appName string, targetScale, startOrdinal int, scaling bool) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch5_1(&m.recorder.setApplicationScalingStateWithStartExpects, m.ctrl, m, "SetApplicationScalingStateWithStart", ctx, appName, targetScale, startOrdinal, scaling)
+}
+
+// SetApplicationScalingStateWithStart indicates an expected call of SetApplicationScalingStateWithStart.
+func (mr *MockStateMockRecorder) SetApplicationScalingStateWithStart(ctx, appName, targetScale, startOrdinal, scaling any) *MockStateSetApplicationScalingStateWithStartCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall5_1[context.Context, string, int, int, bool, error](mr.mock.ctrl.T, mr.mock, "SetApplicationScalingStateWithStart", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(appName), gomock.EnsureMatcher(targetScale), gomock.EnsureMatcher(startOrdinal), gomock.EnsureMatcher(scaling))
+	mr.setApplicationScalingStateWithStartExpects = append(mr.setApplicationScalingStateWithStartExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockStateSetApplicationScalingStateWithStartCall is the typed call wrapper for SetApplicationScalingStateWithStart.
+type MockStateSetApplicationScalingStateWithStartCall = gomock.Call5_1[context.Context, string, int, int, bool, error]
 
 // SetCharmAvailable mocks base method.
 func (m *MockState) SetCharmAvailable(ctx context.Context, charmID charm.ID) error {

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -159,8 +159,9 @@ type UpdateCAASUnitParams struct {
 // ScalingState contains attributes that describes
 // the scaling state of a CAAS application.
 type ScalingState struct {
-	ScaleTarget int
-	Scaling     bool
+	StartOrdinal int
+	ScaleTarget  int
+	Scaling      bool
 }
 
 // ResolvedResources is a collection of ResolvedResource elements.

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -950,15 +950,28 @@ WHERE  application_uuid = $applicationScale.application_uuid
 // SetApplicationScalingState sets the scaling details for the given caas
 // application Scale is optional and is only set if not nil.
 func (st *State) SetApplicationScalingState(ctx context.Context, appName string, targetScale int, scaling bool) error {
-	appUUID, err := st.GetApplicationUUIDByName(ctx, appName)
+	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
 	}
-	scaleState, err := st.GetApplicationScaleState(ctx, appUUID)
+	upsertStmt, err := st.Prepare(updateApplicationScaleState, applicationScale{})
 	if err != nil {
 		return errors.Capture(err)
 	}
-	return st.SetApplicationScalingStateWithStart(ctx, appName, targetScale, scaleState.StartOrdinal, scaling)
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		appDetails, err := st.getApplicationDetails(ctx, tx, appName)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		scaleState, err := st.getApplicationScaleState(ctx, tx, appDetails.UUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		return st.setApplicationScalingState(
+			ctx, tx, upsertStmt, appName, targetScale,
+			scaleState.StartOrdinal, scaling)
+	})
+	return errors.Capture(err)
 }
 
 // SetApplicationScalingStateWithStart updates the scale state and desired
@@ -969,7 +982,18 @@ func (st *State) SetApplicationScalingStateWithStart(ctx context.Context, appNam
 		return errors.Capture(err)
 	}
 
-	upsertApplicationScale := `
+	upsertStmt, err := st.Prepare(updateApplicationScaleState, applicationScale{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return st.setApplicationScalingState(
+			ctx, tx, upsertStmt, appName, targetScale, startOrdinal, scaling)
+	})
+	return errors.Capture(err)
+}
+
+const updateApplicationScaleState = `
 UPDATE application_scale
 SET    scale = $applicationScale.scale,
        scaling = $applicationScale.scaling,
@@ -978,52 +1002,49 @@ SET    scale = $applicationScale.scale,
 WHERE  application_uuid = $applicationScale.application_uuid
 `
 
-	upsertStmt, err := st.Prepare(upsertApplicationScale, applicationScale{})
+func (st *State) setApplicationScalingState(
+	ctx context.Context, tx *sqlair.TX, upsertStmt *sqlair.Statement,
+	appName string, targetScale, startOrdinal int, scaling bool,
+) error {
+	appDetails, err := st.getApplicationDetails(ctx, tx, appName)
+	if err != nil {
+		return errors.Capture(err)
+	} else if appDetails.IsApplicationSynthetic {
+		return errors.Errorf("cannot set scaling state for synthetic application %q", appName)
+	}
+
+	currentScaleState, err := st.getApplicationScaleState(ctx, tx, appDetails.UUID)
 	if err != nil {
 		return errors.Capture(err)
 	}
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		appDetails, err := st.getApplicationDetails(ctx, tx, appName)
-		if err != nil {
-			return errors.Capture(err)
-		} else if appDetails.IsApplicationSynthetic {
-			return errors.Errorf("cannot set scaling state for synthetic application %q", appName)
-		}
 
-		currentScaleState, err := st.getApplicationScaleState(ctx, tx, appDetails.UUID)
-		if err != nil {
-			return errors.Capture(err)
-		}
-
-		var scale int
-		if scaling {
-			switch appDetails.LifeID {
-			case life.Alive:
-				// if starting a scale, ensure we are scaling to the same target.
-				if !currentScaleState.Scaling && currentScaleState.Scale != targetScale {
-					return applicationerrors.ScalingStateInconsistent
-				}
-				// Make sure to leave the scale value unchanged.
-				scale = currentScaleState.Scale
-			case life.Dying, life.Dead:
-				// force scale to the scale target when dying/dead.
-				scale = targetScale
+	var scale int
+	if scaling {
+		switch appDetails.LifeID {
+		case life.Alive:
+			// if starting a scale, ensure we are scaling to the same target.
+			if !currentScaleState.Scaling && currentScaleState.Scale != targetScale {
+				return applicationerrors.ScalingStateInconsistent
 			}
-		} else {
 			// Make sure to leave the scale value unchanged.
 			scale = currentScaleState.Scale
+		case life.Dying, life.Dead:
+			// force scale to the scale target when dying/dead.
+			scale = targetScale
 		}
+	} else {
+		// Make sure to leave the scale value unchanged.
+		scale = currentScaleState.Scale
+	}
 
-		scaleDetailsToUpdate := applicationScale{
-			ApplicationID: appDetails.UUID,
-			StartOrdinal:  startOrdinal,
-			Scaling:       scaling,
-			Scale:         scale,
-			ScaleTarget:   targetScale,
-		}
-		return tx.Query(ctx, upsertStmt, scaleDetailsToUpdate).Run()
-	})
-	return errors.Capture(err)
+	scaleDetailsToUpdate := applicationScale{
+		ApplicationID: appDetails.UUID,
+		StartOrdinal:  startOrdinal,
+		Scaling:       scaling,
+		Scale:         scale,
+		ScaleTarget:   targetScale,
+	}
+	return tx.Query(ctx, upsertStmt, scaleDetailsToUpdate).Run()
 }
 
 // UpsertK8sService updates the cloud service for the specified application.

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -566,9 +566,10 @@ WHERE  application_uuid = $applicationScale.application_uuid
 		return application.ScaleState{}, errors.Errorf("querying application %q scale: %w", appUUID, err)
 	}
 	return application.ScaleState{
-		Scaling:     appScale.Scaling,
-		Scale:       appScale.Scale,
-		ScaleTarget: appScale.ScaleTarget,
+		StartOrdinal: appScale.StartOrdinal,
+		Scaling:      appScale.Scaling,
+		Scale:        appScale.Scale,
+		ScaleTarget:  appScale.ScaleTarget,
 	}, nil
 }
 
@@ -949,6 +950,20 @@ WHERE  application_uuid = $applicationScale.application_uuid
 // SetApplicationScalingState sets the scaling details for the given caas
 // application Scale is optional and is only set if not nil.
 func (st *State) SetApplicationScalingState(ctx context.Context, appName string, targetScale int, scaling bool) error {
+	appUUID, err := st.GetApplicationUUIDByName(ctx, appName)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	scaleState, err := st.GetApplicationScaleState(ctx, appUUID)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return st.SetApplicationScalingStateWithStart(ctx, appName, targetScale, scaleState.StartOrdinal, scaling)
+}
+
+// SetApplicationScalingStateWithStart updates the scale state and desired
+// StatefulSet start ordinal of a CAAS application.
+func (st *State) SetApplicationScalingStateWithStart(ctx context.Context, appName string, targetScale, startOrdinal int, scaling bool) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
@@ -958,7 +973,8 @@ func (st *State) SetApplicationScalingState(ctx context.Context, appName string,
 UPDATE application_scale
 SET    scale = $applicationScale.scale,
        scaling = $applicationScale.scaling,
-       scale_target = $applicationScale.scale_target
+       scale_target = $applicationScale.scale_target,
+       start_ordinal = $applicationScale.start_ordinal
 WHERE  application_uuid = $applicationScale.application_uuid
 `
 
@@ -1000,6 +1016,7 @@ WHERE  application_uuid = $applicationScale.application_uuid
 
 		scaleDetailsToUpdate := applicationScale{
 			ApplicationID: appDetails.UUID,
+			StartOrdinal:  startOrdinal,
 			Scaling:       scaling,
 			Scale:         scale,
 			ScaleTarget:   targetScale,

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -1622,6 +1622,30 @@ func (s *applicationStateSuite) TestSetApplicationScalingStateAlreadyScaling(c *
 	})
 }
 
+func (s *applicationStateSuite) TestSetApplicationScalingStateWithStart(c *tc.C) {
+	appUUID := s.createCAASApplication(c, "foo", life.Dead)
+
+	err := s.state.SetApplicationScalingStateWithStart(c.Context(), "foo", 2, 1, true)
+	c.Assert(err, tc.ErrorIsNil)
+
+	state, err := s.state.GetApplicationScaleState(c.Context(), appUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(state, tc.DeepEquals, application.ScaleState{
+		StartOrdinal: 1,
+		Scale:        2,
+		ScaleTarget:  2,
+		Scaling:      true,
+	})
+
+	err = s.state.SetApplicationScalingState(c.Context(), "foo", 2, false)
+	c.Assert(err, tc.ErrorIsNil)
+
+	state, err = s.state.GetApplicationScaleState(c.Context(), appUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(state.StartOrdinal, tc.Equals, 1)
+	c.Check(state.Scaling, tc.IsFalse)
+}
+
 func (s *applicationStateSuite) TestSetApplicationScalingStateInconsistent(c *tc.C) {
 	appUUID := s.createCAASApplication(c, "foo", life.Alive)
 

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -45,6 +45,7 @@ func (st *State) InsertMigratingApplication(ctx context.Context, name string, ar
 
 	scaleInfo := applicationScale{
 		ApplicationID: args.ApplicationUUID,
+		StartOrdinal:  args.StartOrdinal,
 		Scale:         args.Scale,
 	}
 	createScale := `INSERT INTO application_scale (*) VALUES ($applicationScale.*)`

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -100,6 +100,7 @@ type applicationDetails struct {
 
 type applicationScale struct {
 	ApplicationID string `db:"application_uuid"`
+	StartOrdinal  int    `db:"start_ordinal"`
 	Scaling       bool   `db:"scaling"`
 	Scale         int    `db:"scale"`
 	ScaleTarget   int    `db:"scale_target"`

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -919,7 +919,7 @@ func (st *State) RegisterCAASUnit(ctx context.Context, appName string, arg appli
 
 			if appScale.Scaling {
 				// While scaling, we use the scaling target.
-				if arg.OrderedId >= appScale.ScaleTarget {
+				if arg.OrderedId < appScale.StartOrdinal || arg.OrderedId >= appScale.StartOrdinal+appScale.ScaleTarget {
 					return errors.Errorf("unrequired unit %s is not assigned", arg.UnitName).Add(applicationerrors.UnitNotAssigned)
 				}
 			} else {

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -259,6 +259,35 @@ func (s *unitStateSuite) TestRegisterCAASUnit(c *tc.C) {
 	s.assertCAASUnit(c, "bar/0", "passwordhash", "10.6.6.6/8", []string{"0"})
 }
 
+func (s *unitStateSuite) TestRegisterCAASUnitOrdinalRange(c *tc.C) {
+	s.createCAASScalingApplication(c, "bar", life.Alive, 2)
+
+	err := s.state.SetApplicationScalingStateWithStart(c.Context(), "bar", 2, 1, true)
+	c.Assert(err, tc.ErrorIsNil)
+
+	newArg := func(name coreunit.Name, ordinal int) application.RegisterCAASUnitArg {
+		return application.RegisterCAASUnitArg{
+			UnitUUID:     tc.Must(c, coreunit.NewUUID),
+			UnitName:     name,
+			PasswordHash: "passwordhash",
+			ProviderID:   "some-id",
+			Address:      new("10.6.6.6/8"),
+			Ports:        new([]string{"0"}),
+			OrderedScale: true,
+			OrderedId:    ordinal,
+		}
+	}
+
+	err = s.state.RegisterCAASUnit(c.Context(), "bar", newArg("bar/1", 1))
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.state.RegisterCAASUnit(c.Context(), "bar", newArg("bar/0", 0))
+	c.Check(err, tc.ErrorIs, applicationerrors.UnitNotAssigned)
+
+	err = s.state.RegisterCAASUnit(c.Context(), "bar", newArg("bar/3", 3))
+	c.Check(err, tc.ErrorIs, applicationerrors.UnitNotAssigned)
+}
+
 func (s *unitStateSuite) TestRegisterCAASUnitWithFQDN(c *tc.C) {
 	s.createCAASScalingApplication(c, "bar", life.Alive, 1)
 

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -88,6 +88,8 @@ type AddCAASApplicationArg struct {
 	BaseAddApplicationArg
 	// Scale contains the scale information for the application.
 	Scale int
+	// StartOrdinal is the first ordinal in the application's StatefulSet range.
+	StartOrdinal int
 }
 
 // AddApplicationResourceArg defines the arguments required to add a resource to
@@ -111,9 +113,10 @@ type CharmOrigin struct {
 
 // ScaleState describes the scale status of a k8s application.
 type ScaleState struct {
-	Scaling     bool
-	Scale       int
-	ScaleTarget int
+	StartOrdinal int
+	Scaling      bool
+	Scale        int
+	ScaleTarget  int
 }
 
 // K8sService contains parameters for an application's cloud service.
@@ -478,6 +481,8 @@ type InsertApplicationArgs struct {
 	Settings ApplicationSettings
 	// Scale contains the scale information for the application.
 	Scale int
+	// StartOrdinal is the first ordinal in the application's StatefulSet range.
+	StartOrdinal int
 	// StoragePoolKind holds a mapping of the kind of storage supported
 	// by the named storage pool / provider type.
 	StoragePoolKind map[string]internalstorage.StorageKind

--- a/domain/controllernode/service/package_mock_test.go
+++ b/domain/controllernode/service/package_mock_test.go
@@ -29,9 +29,8 @@ type MockState struct {
 // MockStateMockRecorder is the mock recorder for MockState.
 type MockStateMockRecorder struct {
 	mock                                           *MockState
-	addControllerNodeExpects                       []*gomock.Call2_1[context.Context, string, error]
 	addDqliteNodeExpects                           []*gomock.Call4_1[context.Context, string, uint64, string, error]
-	deleteDqliteNodesExpects                       []*gomock.Call2_1[context.Context, []string, error]
+	addDqliteNodeIDExpects                         []*gomock.Call2_1[context.Context, string, error]
 	getAPIAddressesForAgentsExpects                []*gomock.Call1_2[context.Context, map[string]controllernode.APIAddresses, error]
 	getAPIAddressesForClientsExpects               []*gomock.Call1_2[context.Context, map[string]controllernode.APIAddresses, error]
 	getAllCloudLocalAPIAddressesExpects            []*gomock.Call1_2[context.Context, []string, error]
@@ -55,24 +54,6 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// AddControllerNode mocks base method.
-func (m *MockState) AddControllerNode(ctx context.Context, controllerID string) error {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch2_1(&m.recorder.addControllerNodeExpects, m.ctrl, m, "AddControllerNode", ctx, controllerID)
-}
-
-// AddControllerNode indicates an expected call of AddControllerNode.
-func (mr *MockStateMockRecorder) AddControllerNode(ctx, controllerID any) *MockStateAddControllerNodeCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "AddControllerNode", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(controllerID))
-	mr.addControllerNodeExpects = append(mr.addControllerNodeExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockStateAddControllerNodeCall is the typed call wrapper for AddControllerNode.
-type MockStateAddControllerNodeCall = gomock.Call2_1[context.Context, string, error]
-
 // AddDqliteNode mocks base method.
 func (m *MockState) AddDqliteNode(ctx context.Context, controllerID string, nodeID uint64, addr string) error {
 	m.ctrl.T.Helper()
@@ -91,23 +72,23 @@ func (mr *MockStateMockRecorder) AddDqliteNode(ctx, controllerID, nodeID, addr a
 // MockStateAddDqliteNodeCall is the typed call wrapper for AddDqliteNode.
 type MockStateAddDqliteNodeCall = gomock.Call4_1[context.Context, string, uint64, string, error]
 
-// DeleteDqliteNodes mocks base method.
-func (m *MockState) DeleteDqliteNodes(ctx context.Context, delete []string) error {
+// AddDqliteNodeID mocks base method.
+func (m *MockState) AddDqliteNodeID(ctx context.Context, controllerID string) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_1(&m.recorder.deleteDqliteNodesExpects, m.ctrl, m, "DeleteDqliteNodes", ctx, delete)
+	return gomock.Dispatch2_1(&m.recorder.addDqliteNodeIDExpects, m.ctrl, m, "AddDqliteNodeID", ctx, controllerID)
 }
 
-// DeleteDqliteNodes indicates an expected call of DeleteDqliteNodes.
-func (mr *MockStateMockRecorder) DeleteDqliteNodes(ctx, delete any) *MockStateDeleteDqliteNodesCall {
+// AddDqliteNodeID indicates an expected call of AddDqliteNodeID.
+func (mr *MockStateMockRecorder) AddDqliteNodeID(ctx, controllerID any) *MockStateAddDqliteNodeIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, []string, error](mr.mock.ctrl.T, mr.mock, "DeleteDqliteNodes", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(delete))
-	mr.deleteDqliteNodesExpects = append(mr.deleteDqliteNodesExpects, call)
+	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "AddDqliteNodeID", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(controllerID))
+	mr.addDqliteNodeIDExpects = append(mr.addDqliteNodeIDExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
-// MockStateDeleteDqliteNodesCall is the typed call wrapper for DeleteDqliteNodes.
-type MockStateDeleteDqliteNodesCall = gomock.Call2_1[context.Context, []string, error]
+// MockStateAddDqliteNodeIDCall is the typed call wrapper for AddDqliteNodeID.
+type MockStateAddDqliteNodeIDCall = gomock.Call2_1[context.Context, string, error]
 
 // GetAPIAddressesForAgents mocks base method.
 func (m *MockState) GetAPIAddressesForAgents(ctx context.Context) (map[string]controllernode.APIAddresses, error) {

--- a/domain/controllernode/service/service.go
+++ b/domain/controllernode/service/service.go
@@ -26,16 +26,13 @@ import (
 // State describes retrieval and persistence
 // methods for controller node concerns.
 type State interface {
-	// AddControllerNode ensures a controller node exists for the supplied ID.
-	AddControllerNode(ctx context.Context, controllerID string) error
+	// AddDqliteNodeID ensures a controller node exists for the supplied ID.
+	AddDqliteNodeID(ctx context.Context, controllerID string) error
 
 	// AddDqliteNode adds the Dqlite node ID and bind address for the input
 	// controller ID. If the controller ID already exists, it updates the
 	// Dqlite node ID and bind address.
 	AddDqliteNode(ctx context.Context, controllerID string, nodeID uint64, addr string) error
-
-	// DeleteDqliteNodes removes controller nodes from the controller_node table.
-	DeleteDqliteNodes(ctx context.Context, delete []string) error
 
 	// SelectDatabaseNamespace returns the database namespace for the supplied
 	// namespace.
@@ -97,15 +94,15 @@ func NewService(st State, logger logger.Logger) *Service {
 	}
 }
 
-// AddControllerNode ensures a controller node exists for the supplied ID.
-func (s *Service) AddControllerNode(ctx context.Context, controllerID string) error {
+// AddDqliteNodeID ensures a controller node exists for the supplied ID.
+func (s *Service) AddDqliteNodeID(ctx context.Context, controllerID string) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
 	if controllerID == "" {
 		return errors.Errorf("controller ID is empty: %w", coreerrors.NotValid)
 	}
-	if err := s.st.AddControllerNode(ctx, controllerID); err != nil {
+	if err := s.st.AddDqliteNodeID(ctx, controllerID); err != nil {
 		return errors.Errorf("adding controller node %q: %w", controllerID, err)
 	}
 	return nil
@@ -120,18 +117,6 @@ func (s *Service) AddDqliteNode(ctx context.Context, controllerID string, nodeID
 
 	if err := s.st.AddDqliteNode(ctx, controllerID, nodeID, addr); err != nil {
 		return errors.Errorf("adding Dqlite node details for %q: %w", controllerID, err)
-	}
-	return nil
-}
-
-// DeleteDqliteNodes deletes the Dqlite node ID and bind address for the input
-// controller ID.
-func (s *Service) DeleteDqliteNodes(ctx context.Context, controllerIDs []string) error {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-
-	if err := s.st.DeleteDqliteNodes(ctx, controllerIDs); err != nil {
-		return errors.Errorf("deleting Dqlite node details for %q: %w", controllerIDs, err)
 	}
 	return nil
 }

--- a/domain/controllernode/service/service_test.go
+++ b/domain/controllernode/service/service_test.go
@@ -58,29 +58,20 @@ func (s *serviceSuite) TestAddDqliteNode(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TestAddControllerNode(c *tc.C) {
+func (s *serviceSuite) TestAddDqliteNodeID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().AddControllerNode(gomock.Any(), "1")
+	s.state.EXPECT().AddDqliteNodeID(gomock.Any(), "1")
 
-	err := NewService(s.state, loggertesting.WrapCheckLog(c)).AddControllerNode(c.Context(), "1")
+	err := NewService(s.state, loggertesting.WrapCheckLog(c)).AddDqliteNodeID(c.Context(), "1")
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TestAddControllerNodeRejectsEmptyID(c *tc.C) {
+func (s *serviceSuite) TestAddDqliteNodeIDRejectsEmptyID(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
-	err := NewService(s.state, loggertesting.WrapCheckLog(c)).AddControllerNode(c.Context(), "")
+	err := NewService(s.state, loggertesting.WrapCheckLog(c)).AddDqliteNodeID(c.Context(), "")
 	c.Assert(err, tc.ErrorIs, errors.NotValid)
-}
-
-func (s *serviceSuite) TestDeleteDqliteNode(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.state.EXPECT().DeleteDqliteNodes(gomock.Any(), []string{"0"})
-
-	err := NewService(s.state, loggertesting.WrapCheckLog(c)).DeleteDqliteNodes(c.Context(), []string{"0"})
-	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *serviceSuite) TestIsModelKnownToController(c *tc.C) {

--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -340,7 +340,9 @@ AND address = $controllerAPIAddress.address
 		if err := tx.Query(ctx, checkControllerExistsStmt, controllers).Get(&countResult); err != nil {
 			return errors.Errorf("checking if controller nodes %q exists: %w", nodes, err)
 		}
-		if countResult.Count == 0 {
+		// A non-zero count only proves that some requested nodes still exist.
+		// Every address to insert must have a parent controller node.
+		if countResult.Count != len(controllers) {
 			return errors.Errorf("controller nodes %q do not exist", nodes).Add(controllernodeerrors.NotFound)
 		}
 

--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -48,7 +48,7 @@ func (st *State) AddDqliteNodeID(ctx context.Context, controllerID string) error
 	}
 
 	controllerNode := dbControllerNode{ControllerID: controllerID}
-	stmt, err := st.Prepare(`
+	insertStmt, err := st.Prepare(`
 INSERT INTO controller_node (controller_id)
 VALUES ($dbControllerNode.controller_id)
 ON CONFLICT (controller_id) DO NOTHING
@@ -57,8 +57,27 @@ ON CONFLICT (controller_id) DO NOTHING
 		return errors.Errorf("preparing insert controller node statement: %w", err)
 	}
 
+	checkAliveStmt, err := st.Prepare(`
+SELECT life_id AS &dbControllerNode.life_id
+FROM controller_node
+WHERE controller_id = $dbControllerNode.controller_id
+`, controllerNode)
+	if err != nil {
+		return errors.Errorf("preparing controller node life query: %w", err)
+	}
+
 	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		return errors.Capture(tx.Query(ctx, stmt, controllerNode).Run())
+		if err := tx.Query(ctx, insertStmt, controllerNode).Run(); err != nil {
+			return errors.Capture(err)
+		}
+		var result dbControllerNode
+		if err := tx.Query(ctx, checkAliveStmt, controllerNode).Get(&result); err != nil {
+			return errors.Capture(err)
+		}
+		if result.LifeID != 0 {
+			return errors.Errorf("controller node is not alive").Add(controllernodeerrors.NotFound)
+		}
+		return nil
 	}))
 }
 
@@ -89,20 +108,41 @@ func (st *State) AddDqliteNode(ctx context.Context, controllerID string, nodeID 
 	}
 
 	q := `
-INSERT INTO controller_node (controller_id, dqlite_node_id, dqlite_bind_address)
-VALUES      ($dbControllerNode.*)
-ON CONFLICT (controller_id) DO
-UPDATE SET  dqlite_node_id = excluded.dqlite_node_id,
-            dqlite_bind_address = excluded.dqlite_bind_address;
+INSERT INTO controller_node (
+    controller_id,
+    dqlite_node_id,
+    dqlite_bind_address
+) VALUES ($dbControllerNode.*)
+ON CONFLICT (controller_id) DO UPDATE SET
+    dqlite_node_id = excluded.dqlite_node_id,
+    dqlite_bind_address = excluded.dqlite_bind_address
+WHERE controller_node.life_id = 0
 `
 	stmt, err := st.Prepare(q, controllerNode)
 	if err != nil {
 		return errors.Errorf("preparing update controller node statement: %w", err)
 	}
+	checkAliveStmt, err := st.Prepare(`
+SELECT controller_id AS &dbControllerNode.controller_id
+FROM controller_node
+WHERE controller_id = $dbControllerNode.controller_id
+AND life_id = 0
+`, controllerNode)
+	if err != nil {
+		return errors.Errorf("preparing controller node life query: %w", err)
+	}
 
 	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, stmt, controllerNode).Run()
-		return errors.Capture(err)
+		if err := tx.Query(ctx, stmt, controllerNode).Run(); err != nil {
+			return errors.Capture(err)
+		}
+		var result dbControllerNode
+		if err := tx.Query(ctx, checkAliveStmt, controllerNode).Get(&result); errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("controller node is not alive").Add(controllernodeerrors.NotFound)
+		} else if err != nil {
+			return errors.Capture(err)
+		}
+		return nil
 	}))
 }
 
@@ -168,6 +208,7 @@ SELECT id AS &architecture.id FROM architecture WHERE name = $architecture.name
 SELECT controller_id AS &controllerNodeAgentVersion.*
 FROM controller_node
 WHERE controller_id = $controllerNodeAgentVersion.controller_id
+AND life_id = 0
 	`, controllerNodeAgentVersion{})
 	if err != nil {
 		return errors.Capture(err)
@@ -239,7 +280,8 @@ func (st *State) IsControllerNode(ctx context.Context, nodeID string) (bool, err
 	stmt, err := st.Prepare(`
 SELECT COUNT(*) AS &dbControllerNodeCount.count
 FROM controller_node
-WHERE controller_id = $dbControllerNode.controller_id`, controllerNode, dbControllerNodeCount{})
+WHERE controller_id = $dbControllerNode.controller_id
+AND life_id < 2`, controllerNode, dbControllerNodeCount{})
 	if err != nil {
 		return false, errors.Errorf("preparing select controller node statement: %w", err)
 	}
@@ -292,6 +334,7 @@ func (st *State) SetAPIAddresses(ctx context.Context, addresses map[string]contr
 SELECT COUNT(*) AS &countResult.count 
 FROM controller_node 
 WHERE controller_id IN ($controllerIDs[:])
+AND life_id = 0
 `, countResult{}, controllerIDs{})
 	if err != nil {
 		return errors.Capture(err)
@@ -467,6 +510,7 @@ func (st *State) GetControllerIDs(ctx context.Context) ([]string, error) {
 	stmt, err := st.Prepare(`
 SELECT &controllerID.* 
 FROM controller_node
+WHERE life_id < 2
 `, controllerID{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -33,7 +33,7 @@ func NewState(factory database.TxnRunnerFactory) *State {
 	}
 }
 
-// AddControllerNode ensures a controller node exists for the supplied ID.
+// AddDqliteNodeID ensures a controller node exists for the supplied ID.
 // It only inserts the controller_id; the dqlite_node_id and
 // dqlite_bind_address columns are left NULL. These are populated later by
 // AddDqliteNode when the Dqlite cluster admits the node.
@@ -41,7 +41,7 @@ func NewState(factory database.TxnRunnerFactory) *State {
 // during UnitIntroduction (before joining the Dqlite cluster), and the
 // Dqlite node information is added in a separate step once the cluster
 // acknowledges the new peer.
-func (st *State) AddControllerNode(ctx context.Context, controllerID string) error {
+func (st *State) AddDqliteNodeID(ctx context.Context, controllerID string) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)
@@ -66,7 +66,7 @@ ON CONFLICT (controller_id) DO NOTHING
 // controller ID. If the controller ID already exists, it updates the
 // Dqlite node ID and bind address.
 //
-// This is called separately from AddControllerNode because the controller
+// This is called separately from AddDqliteNodeID because the controller
 // node identity is registered during UnitIntroduction (before the Dqlite
 // cluster admits the peer). The Dqlite node information is only available
 // once the cluster acknowledges the new node, which happens in a distinct
@@ -104,39 +104,6 @@ UPDATE SET  dqlite_node_id = excluded.dqlite_node_id,
 		err := tx.Query(ctx, stmt, controllerNode).Run()
 		return errors.Capture(err)
 	}))
-}
-
-// DeleteDqliteNodes removes controller nodes from the controller_node table.
-func (st *State) DeleteDqliteNodes(ctx context.Context, delete []string) error {
-	db, err := st.DB(ctx)
-	if err != nil {
-		return errors.Capture(err)
-	}
-
-	// Single dbControllerNode object created here and reused.
-	controllerNode := dbControllerNode{}
-
-	deleteStmt, err := st.Prepare(`
-DELETE FROM controller_node 
-WHERE       controller_id = $dbControllerNode.controller_id`, controllerNode)
-	if err != nil {
-		return errors.Errorf("preparing delete controller node statement: %w", err)
-	}
-
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		for _, cID := range delete {
-			controllerNodeToDelete := dbControllerNode{ControllerID: cID}
-			if err := tx.Query(ctx, deleteStmt, controllerNodeToDelete).Run(); err != nil {
-				return errors.Errorf("deleting controller node %q: %w", cID, err)
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		return errors.Errorf("curating controller nodes: %w", err)
-	}
-	return nil
 }
 
 // SelectDatabaseNamespace is responsible for selecting and returning the

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -44,8 +44,8 @@ func (s *stateSuite) SetUpTest(c *tc.C) {
 	s.state = NewState(s.TxnRunnerFactory())
 }
 
-func (s *stateSuite) TestAddControllerNode(c *tc.C) {
-	err := s.state.AddControllerNode(c.Context(), "1")
+func (s *stateSuite) TestAddDqliteNodeID(c *tc.C) {
+	err := s.state.AddDqliteNodeID(c.Context(), "1")
 	c.Assert(err, tc.ErrorIsNil)
 
 	var controllerID string
@@ -56,9 +56,9 @@ SELECT controller_id FROM controller_node WHERE controller_id = '1'
 	c.Check(controllerID, tc.Equals, "1")
 }
 
-func (s *stateSuite) TestAddControllerNodeIsIdempotent(c *tc.C) {
-	c.Assert(s.state.AddControllerNode(c.Context(), "1"), tc.ErrorIsNil)
-	c.Assert(s.state.AddControllerNode(c.Context(), "1"), tc.ErrorIsNil)
+func (s *stateSuite) TestAddDqliteNodeIDIsIdempotent(c *tc.C) {
+	c.Assert(s.state.AddDqliteNodeID(c.Context(), "1"), tc.ErrorIsNil)
+	c.Assert(s.state.AddDqliteNodeID(c.Context(), "1"), tc.ErrorIsNil)
 }
 
 func (s *stateSuite) TestAddDqliteNode(c *tc.C) {

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -710,6 +710,33 @@ func (s *stateSuite) TestSetAPIAddressControllerNodeNotFound(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "controller nodes .* do not exist")
 }
 
+func (s *stateSuite) TestSetAPIAddressesOneControllerNodeNotFound(c *tc.C) {
+	const controllerID = "0"
+	c.Assert(s.state.AddDqliteNode(c.Context(), controllerID, 1, "10.0.0.1"), tc.ErrorIsNil)
+
+	err := s.state.SetAPIAddresses(
+		c.Context(),
+		map[string]controllernode.APIAddresses{
+			controllerID: {{
+				Address: "10.0.0.1:17070",
+				IsAgent: true,
+				Scope:   network.ScopeCloudLocal,
+			}},
+			"removed-controller": {{
+				Address: "10.0.0.2:17070",
+				IsAgent: true,
+				Scope:   network.ScopeCloudLocal,
+			}},
+		},
+	)
+	c.Assert(err, tc.ErrorIs, controllernodeerrors.NotFound)
+
+	var count int
+	err = s.DB().QueryRowContext(c.Context(), "SELECT COUNT(*) FROM controller_api_address").Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+}
+
 func (s *stateSuite) TestGetControllerIDs(c *tc.C) {
 	for i := range 3 {
 		controllerID := strconv.Itoa(i)

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -61,6 +61,27 @@ func (s *stateSuite) TestAddDqliteNodeIDIsIdempotent(c *tc.C) {
 	c.Assert(s.state.AddDqliteNodeID(c.Context(), "1"), tc.ErrorIsNil)
 }
 
+func (s *stateSuite) TestAddDqliteNodeIDDoesNotReviveDeadNode(c *tc.C) {
+	c.Assert(s.state.AddDqliteNodeID(c.Context(), "1"), tc.ErrorIsNil)
+	_, err := s.DB().ExecContext(c.Context(), `
+UPDATE controller_node SET life_id = 2 WHERE controller_id = '1'`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.state.AddDqliteNodeID(c.Context(), "1")
+	c.Assert(err, tc.ErrorIs, controllernodeerrors.NotFound)
+}
+
+func (s *stateSuite) TestIsControllerNodeWhenDying(c *tc.C) {
+	c.Assert(s.state.AddDqliteNodeID(c.Context(), "1"), tc.ErrorIsNil)
+	_, err := s.DB().ExecContext(c.Context(), `
+UPDATE controller_node SET life_id = 1 WHERE controller_id = '1'`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	isController, err := s.state.IsControllerNode(c.Context(), "1")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(isController, tc.IsTrue)
+}
+
 func (s *stateSuite) TestAddDqliteNode(c *tc.C) {
 	db := s.DB()
 
@@ -71,11 +92,13 @@ func (s *stateSuite) TestAddDqliteNode(c *tc.C) {
 
 	nodeID1 := uint64(15237855465837235027)
 	controllerID1 := "1"
+	c.Assert(s.state.AddDqliteNodeID(c.Context(), controllerID1), tc.ErrorIsNil)
 	err = s.state.AddDqliteNode(c.Context(), controllerID1, nodeID1, "10.0.0.1")
 	c.Assert(err, tc.ErrorIsNil)
 
 	nodeID2 := uint64(15237855465837235026)
 	controllerID2 := "2"
+	c.Assert(s.state.AddDqliteNodeID(c.Context(), controllerID2), tc.ErrorIsNil)
 	err = s.state.AddDqliteNode(c.Context(), controllerID2, nodeID2, "10.0.0.2")
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -102,6 +125,7 @@ func (s *stateSuite) TestUpdateDqliteNode(c *tc.C) {
 	// tried to pass it directly as a uint64 query parameter.
 	nodeID := uint64(15237855465837235027)
 	controllerID := "0"
+	c.Assert(s.state.AddDqliteNodeID(c.Context(), controllerID), tc.ErrorIsNil)
 	err := s.state.AddDqliteNode(c.Context(), controllerID, nodeID, "10.0.0.1")
 	c.Assert(err, tc.ErrorIsNil)
 
@@ -118,6 +142,44 @@ func (s *stateSuite) TestUpdateDqliteNode(c *tc.C) {
 
 	c.Check(id, tc.Equals, nodeID)
 	c.Check(addr, tc.Equals, "192.168.5.60")
+}
+
+func (s *stateSuite) TestAddDqliteNodeDoesNotReviveDeadNode(c *tc.C) {
+	c.Assert(s.state.AddDqliteNodeID(c.Context(), "1"), tc.ErrorIsNil)
+	_, err := s.DB().ExecContext(c.Context(), `
+UPDATE controller_node SET life_id = 2 WHERE controller_id = '1'`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.state.AddDqliteNode(c.Context(), "1", 123, "10.0.0.1")
+	c.Assert(err, tc.ErrorIs, controllernodeerrors.NotFound)
+
+	var (
+		lifeID int
+		nodeID sql.NullString
+	)
+	err = s.DB().QueryRowContext(c.Context(), `
+SELECT life_id, dqlite_node_id
+FROM controller_node
+WHERE controller_id = '1'`).Scan(&lifeID, &nodeID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, 2)
+	c.Check(nodeID.Valid, tc.IsFalse)
+}
+
+func (s *stateSuite) TestAddDqliteNodeDoesNotReviveDyingNode(c *tc.C) {
+	c.Assert(s.state.AddDqliteNodeID(c.Context(), "1"), tc.ErrorIsNil)
+	_, err := s.DB().ExecContext(c.Context(), `
+UPDATE controller_node SET life_id = 1 WHERE controller_id = '1'`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = s.state.AddDqliteNode(c.Context(), "1", 123, "10.0.0.1")
+	c.Assert(err, tc.ErrorIs, controllernodeerrors.NotFound)
+
+	var lifeID int
+	err = s.DB().QueryRowContext(c.Context(), `
+SELECT life_id FROM controller_node WHERE controller_id = '1'`).Scan(&lifeID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, 1)
 }
 
 // TestSelectDatabaseNamespace is testing success for existing namespaces and

--- a/domain/controllernode/state/types.go
+++ b/domain/controllernode/state/types.go
@@ -8,6 +8,9 @@ type dbControllerNode struct {
 	// ControllerID is the nodes controller ID.
 	ControllerID string `db:"controller_id"`
 
+	// LifeID is the lifecycle state of the controller node.
+	LifeID int `db:"life_id"`
+
 	// DqliteNodeID is the uint64 from Dqlite NodeInfo, stored as text (due to
 	// db issues when the high bit is set).
 	DqliteNodeID string `db:"dqlite_node_id"`

--- a/domain/export/types/controller/v4_1_0/controller.go
+++ b/domain/export/types/controller/v4_1_0/controller.go
@@ -183,6 +183,7 @@ type ControllerConfig struct {
 
 type ControllerNode struct {
 	ControllerID      string  `db:"controller_id" json:"controller_id" yaml:"controller_id"`
+	LifeID            int64   `db:"life_id" json:"life_id" yaml:"life_id"`
 	DqliteNodeID      *string `db:"dqlite_node_id" json:"dqlite_node_id" yaml:"dqlite_node_id"`
 	DqliteBindAddress *string `db:"dqlite_bind_address" json:"dqlite_bind_address" yaml:"dqlite_bind_address"`
 }

--- a/domain/export/types/v4_1_0/model.go
+++ b/domain/export/types/v4_1_0/model.go
@@ -195,6 +195,7 @@ type ApplicationScale struct {
 	Scale           *int64 `db:"scale" json:"scale" yaml:"scale"`
 	ScaleTarget     *int64 `db:"scale_target" json:"scale_target" yaml:"scale_target"`
 	Scaling         *bool  `db:"scaling" json:"scaling" yaml:"scaling"`
+	StartOrdinal    int64  `db:"start_ordinal" json:"start_ordinal" yaml:"start_ordinal"`
 }
 
 type ApplicationSetting struct {

--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -58,6 +58,12 @@ type watcherSuite struct {
 	st  *state.State
 }
 
+type noopLeadershipRevoker struct{}
+
+func (noopLeadershipRevoker) RevokeLeadership(string, unit.Name) error {
+	return nil
+}
+
 func TestWatcherSuite(t *testing.T) {
 	tc.Run(t, &watcherSuite{})
 }
@@ -867,7 +873,7 @@ func (s *watcherSuite) setupRemovalService(c *tc.C, factory domain.WatchableDBFa
 		removalstatecontroller.NewState(func(ctx context.Context) (database.TxnRunner, error) { return s.NoopTxnRunner(), nil }, log),
 		modelState,
 		domain.NewWatcherFactory(factory, log),
-		nil,
+		noopLeadershipRevoker{},
 		nil,
 		model.UUID(s.ModelUUID()),
 		clock.WallClock,

--- a/domain/modelimport/transformer/transforms/to_v4_1_0/deltas.go
+++ b/domain/modelimport/transformer/transforms/to_v4_1_0/deltas.go
@@ -157,3 +157,19 @@ func (d deltas) SshConnectionRequest(_ context.Context, _ *v4_0_12.ModelExport) 
 	// to transform from 4.0.12.
 	return nil, nil
 }
+
+// ApplicationScale: struct shape changed in 4.1.0. We always default to 0,
+// as this is a change in behavior.
+func (d deltas) ApplicationScale(ctx context.Context, src []v4_0_12.ApplicationScale) ([]v4_1_0.ApplicationScale, error) {
+	var scales []v4_1_0.ApplicationScale
+	for _, s := range src {
+		scales = append(scales, v4_1_0.ApplicationScale{
+			ApplicationUUID: s.ApplicationUUID,
+			Scale:           s.Scale,
+			ScaleTarget:     s.ScaleTarget,
+			Scaling:         s.Scaling,
+			StartOrdinal:    0,
+		})
+	}
+	return scales, nil
+}

--- a/domain/modelimport/transformer/transforms/to_v4_1_0/deltas_test.go
+++ b/domain/modelimport/transformer/transforms/to_v4_1_0/deltas_test.go
@@ -51,3 +51,25 @@ func (s *deltasSuite) TestRelationUnitSettingDropsEmptyValues(c *tc.C) {
 		{RelationUnitUUID: "ru-uuid", Key: "set", Value: "v"},
 	})
 }
+
+func (s *deltasSuite) TestApplicationScale(c *tc.C) {
+	scale := int64(2)
+	target := int64(3)
+	scaling := true
+	src := []v4_0_12.ApplicationScale{{
+		ApplicationUUID: "app-uuid",
+		Scale:           &scale,
+		ScaleTarget:     &target,
+		Scaling:         &scaling,
+	}}
+
+	got, err := deltas{}.ApplicationScale(c.Context(), src)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, []v4_1_0.ApplicationScale{{
+		ApplicationUUID: "app-uuid",
+		Scale:           &scale,
+		ScaleTarget:     &target,
+		Scaling:         &scaling,
+		StartOrdinal:    0,
+	}})
+}

--- a/domain/modelimport/transformer/transforms/to_v4_1_0/transform.go
+++ b/domain/modelimport/transformer/transforms/to_v4_1_0/transform.go
@@ -19,6 +19,8 @@ import (
 // Engineers implement this interface in deltas.go; the package will not
 // compile until every method has a receiver.
 type Deltas interface {
+	// ApplicationScale: struct shape changed in 4.1.0.
+	ApplicationScale(ctx context.Context, src []v4_0_12.ApplicationScale) ([]v4_1_0.ApplicationScale, error)
 	// Constraint: struct shape changed in 4.1.0.
 	Constraint(ctx context.Context, src []v4_0_12.Constraint) ([]v4_1_0.Constraint, error)
 	// Operation: struct shape changed in 4.1.0.
@@ -191,11 +193,6 @@ func NewTransform(d Deltas) transformer.TransformationFunc[v4_0_12.ModelExport, 
 		dst.ApplicationResource = make([]v4_1_0.ApplicationResource, len(src.ApplicationResource))
 		for i := range src.ApplicationResource {
 			dst.ApplicationResource[i] = v4_1_0.ApplicationResource(src.ApplicationResource[i])
-		}
-
-		dst.ApplicationScale = make([]v4_1_0.ApplicationScale, len(src.ApplicationScale))
-		for i := range src.ApplicationScale {
-			dst.ApplicationScale[i] = v4_1_0.ApplicationScale(src.ApplicationScale[i])
 		}
 
 		dst.ApplicationSetting = make([]v4_1_0.ApplicationSetting, len(src.ApplicationSetting))
@@ -1246,6 +1243,10 @@ func NewTransform(d Deltas) transformer.TransformationFunc[v4_0_12.ModelExport, 
 		dst.WorkloadStatusValue = make([]v4_1_0.WorkloadStatusValue, len(src.WorkloadStatusValue))
 		for i := range src.WorkloadStatusValue {
 			dst.WorkloadStatusValue[i] = v4_1_0.WorkloadStatusValue(src.WorkloadStatusValue[i])
+		}
+
+		if dst.ApplicationScale, err = d.ApplicationScale(ctx, src.ApplicationScale); err != nil {
+			return v4_1_0.ModelExport{}, errors.Errorf("ApplicationScale delta: %w", err)
 		}
 
 		if dst.Constraint, err = d.Constraint(ctx, src.Constraint); err != nil {

--- a/domain/network/state/unitaddress.go
+++ b/domain/network/state/unitaddress.go
@@ -84,14 +84,12 @@ func (st *State) GetControllerAPIAddresses(
 	ident := entityUUID{UUID: unitUUID}
 
 	type apiAddressFilter struct {
-		VirtualEthernetDeviceType string `db:"virtual_ethernet_device_type"`
-		LoopbackDeviceType        string `db:"loopback_device_type"`
-		ScopeName                 string `db:"scope_name"`
+		LoopbackDeviceType string `db:"loopback_device_type"`
+		ScopeName          string `db:"scope_name"`
 	}
 	filter := apiAddressFilter{
-		VirtualEthernetDeviceType: corenetwork.VirtualEthernetDevice.String(),
-		LoopbackDeviceType:        corenetwork.LoopbackDevice.String(),
-		ScopeName:                 corenetwork.ScopeMachineLocal.String(),
+		LoopbackDeviceType: corenetwork.LoopbackDevice.String(),
+		ScopeName:          corenetwork.ScopeMachineLocal.String(),
 	}
 
 	queryUnitAPIAddressesStmt, err := st.Prepare(`
@@ -128,8 +126,7 @@ JOIN   ip_address_type AS iat ON ipa.type_id = iat.id
 JOIN   ip_address_origin AS iao ON ipa.origin_id = iao.id
 JOIN   ip_address_scope AS ias ON ipa.scope_id = ias.id
 LEFT JOIN subnet AS sn ON ipa.subnet_uuid = sn.uuid
-WHERE  lldt.name != $apiAddressFilter.virtual_ethernet_device_type
-AND    lldt.name != $apiAddressFilter.loopback_device_type
+WHERE  lldt.name != $apiAddressFilter.loopback_device_type
 AND    (unn.is_caas = 1
         OR ias.name != $apiAddressFilter.scope_name)
 `, controllerAPIAddress{}, entityUUID{}, apiAddressFilter{})

--- a/domain/network/state/unitaddress_test.go
+++ b/domain/network/state/unitaddress_test.go
@@ -181,7 +181,7 @@ func (s *unitAddressSuite) TestGetControllerAPIAddressesReturnsDeviceTypes(c *tc
 
 	// Assert
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(addr, tc.DeepEquals, domainnetwork.ControllerAPIAddresses{
+	c.Check(addr, tc.SameContents, domainnetwork.ControllerAPIAddresses{
 		{
 			SpaceAddress: corenetwork.SpaceAddress{
 				SpaceID: corenetwork.SpaceUUID(spaceUUID),
@@ -195,6 +195,20 @@ func (s *unitAddressSuite) TestGetControllerAPIAddressesReturnsDeviceTypes(c *tc
 				},
 			},
 			DeviceType: domainnetwork.DeviceTypeEthernet,
+		},
+		{
+			SpaceAddress: corenetwork.SpaceAddress{
+				SpaceID: corenetwork.SpaceUUID(spaceUUID),
+				Origin:  corenetwork.OriginProvider,
+				MachineAddress: corenetwork.MachineAddress{
+					Value:      "10.0.0.2",
+					CIDR:       cidr,
+					Type:       corenetwork.IPv4Address,
+					Scope:      corenetwork.ScopeCloudLocal,
+					ConfigType: corenetwork.ConfigStatic,
+				},
+			},
+			DeviceType: domainnetwork.DeviceTypeVeth,
 		},
 	})
 }

--- a/domain/removal/service/controller.go
+++ b/domain/removal/service/controller.go
@@ -21,6 +21,10 @@ import (
 // ControllerState describes retrieval and persistence methods for entity
 // removal in the controller database.
 type ControllerState interface {
+	// DeleteControllerNode removes the controller node identified by controllerID
+	// and all of its dependent records.
+	DeleteControllerNode(ctx context.Context, controllerID string) error
+
 	// ModelExists returns true if a model exists with the input model
 	// UUID.
 	ModelExists(ctx context.Context, modelUUID string) (bool, error)

--- a/domain/removal/service/controller.go
+++ b/domain/removal/service/controller.go
@@ -21,9 +21,9 @@ import (
 // ControllerState describes retrieval and persistence methods for entity
 // removal in the controller database.
 type ControllerState interface {
-	// DeleteControllerNode removes the controller node identified by controllerID
+	// DeleteDqliteNode removes the controller node identified by controllerID
 	// and all of its dependent records.
-	DeleteControllerNode(ctx context.Context, controllerID string) error
+	DeleteDqliteNode(ctx context.Context, controllerID string) error
 
 	// ModelExists returns true if a model exists with the input model
 	// UUID.

--- a/domain/removal/service/model_test.go
+++ b/domain/removal/service/model_test.go
@@ -98,6 +98,7 @@ func (s *modelSuite) TestRemoveModelRetrySchedulesRemovalJobs(c *tc.C) {
 	mExp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "some-relation-id", false, when.UTC()).Return(nil).Times(2)
 
 	mExp.UnitExists(gomock.Any(), "some-unit-id").Return(true, nil).Times(2)
+	mExp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), "some-unit-id").Return("foo", "foo/0", nil).Times(2)
 	mExp.EnsureUnitNotAliveCascade(gomock.Any(), "some-unit-id", true).Return(removalinternal.CascadedUnitLives{}, nil).Times(2)
 	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", false, when.UTC()).Return(nil).Times(2)
 
@@ -154,6 +155,7 @@ func (s *modelSuite) TestRemoveModelRetryWithForceSchedulesRemovalJobs(c *tc.C) 
 	mExp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "some-relation-id", true, when.UTC()).Return(nil)
 
 	mExp.UnitExists(gomock.Any(), "some-unit-id").Return(true, nil).Times(2)
+	mExp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), "some-unit-id").Return("foo", "foo/0", nil).Times(2)
 	mExp.EnsureUnitNotAliveCascade(gomock.Any(), "some-unit-id", true).Return(removalinternal.CascadedUnitLives{}, nil).Times(2)
 	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", false, when.UTC()).Return(nil)
 	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", true, when.UTC()).Return(nil)

--- a/domain/removal/service/model_test.go
+++ b/domain/removal/service/model_test.go
@@ -12,6 +12,7 @@ import (
 
 	coremodel "github.com/juju/juju/core/model"
 	coreremoteapplication "github.com/juju/juju/core/remoteapplication"
+	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/life"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/removal"
@@ -99,6 +100,8 @@ func (s *modelSuite) TestRemoveModelRetrySchedulesRemovalJobs(c *tc.C) {
 
 	mExp.UnitExists(gomock.Any(), "some-unit-id").Return(true, nil).Times(2)
 	mExp.EnsureUnitNotAliveCascade(gomock.Any(), "some-unit-id", true).Return(removalinternal.CascadedUnitLives{}, nil).Times(2)
+	mExp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), "some-unit-id").Return("foo", "foo/0", nil).Times(2)
+	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil).Times(2)
 	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", false, when.UTC()).Return(nil).Times(2)
 
 	mExp.MachineExists(gomock.Any(), "some-machine-id").Return(true, nil).Times(2)
@@ -155,6 +158,8 @@ func (s *modelSuite) TestRemoveModelRetryWithForceSchedulesRemovalJobs(c *tc.C) 
 
 	mExp.UnitExists(gomock.Any(), "some-unit-id").Return(true, nil).Times(2)
 	mExp.EnsureUnitNotAliveCascade(gomock.Any(), "some-unit-id", true).Return(removalinternal.CascadedUnitLives{}, nil).Times(2)
+	mExp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), "some-unit-id").Return("foo", "foo/0", nil).Times(2)
+	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil).Times(2)
 	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", false, when.UTC()).Return(nil)
 	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", true, when.UTC()).Return(nil)
 

--- a/domain/removal/service/model_test.go
+++ b/domain/removal/service/model_test.go
@@ -98,7 +98,6 @@ func (s *modelSuite) TestRemoveModelRetrySchedulesRemovalJobs(c *tc.C) {
 	mExp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "some-relation-id", false, when.UTC()).Return(nil).Times(2)
 
 	mExp.UnitExists(gomock.Any(), "some-unit-id").Return(true, nil).Times(2)
-	mExp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), "some-unit-id").Return("foo", "foo/0", nil).Times(2)
 	mExp.EnsureUnitNotAliveCascade(gomock.Any(), "some-unit-id", true).Return(removalinternal.CascadedUnitLives{}, nil).Times(2)
 	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", false, when.UTC()).Return(nil).Times(2)
 
@@ -155,7 +154,6 @@ func (s *modelSuite) TestRemoveModelRetryWithForceSchedulesRemovalJobs(c *tc.C) 
 	mExp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), "some-relation-id", true, when.UTC()).Return(nil)
 
 	mExp.UnitExists(gomock.Any(), "some-unit-id").Return(true, nil).Times(2)
-	mExp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), "some-unit-id").Return("foo", "foo/0", nil).Times(2)
 	mExp.EnsureUnitNotAliveCascade(gomock.Any(), "some-unit-id", true).Return(removalinternal.CascadedUnitLives{}, nil).Times(2)
 	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", false, when.UTC()).Return(nil)
 	mExp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), "some-unit-id", true, when.UTC()).Return(nil)

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -33,7 +33,7 @@ type MockControllerDBState struct {
 // MockControllerDBStateMockRecorder is the mock recorder for MockControllerDBState.
 type MockControllerDBStateMockRecorder struct {
 	mock                                      *MockControllerDBState
-	deleteControllerNodeExpects               []*gomock.Call2_1[context.Context, string, error]
+	deleteDqliteNodeExpects                   []*gomock.Call2_1[context.Context, string, error]
 	deleteModelExpects                        []*gomock.Call2_1[context.Context, string, error]
 	deleteOfferAccessExpects                  []*gomock.Call2_1[context.Context, string, error]
 	ensureModelNotAliveUnlessMigratingExpects []*gomock.Call3_1[context.Context, string, bool, error]
@@ -59,23 +59,23 @@ func (m *MockControllerDBState) EXPECT() *MockControllerDBStateMockRecorder {
 	return m.recorder
 }
 
-// DeleteControllerNode mocks base method.
-func (m *MockControllerDBState) DeleteControllerNode(ctx context.Context, controllerID string) error {
+// DeleteDqliteNode mocks base method.
+func (m *MockControllerDBState) DeleteDqliteNode(ctx context.Context, controllerID string) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch2_1(&m.recorder.deleteControllerNodeExpects, m.ctrl, m, "DeleteControllerNode", ctx, controllerID)
+	return gomock.Dispatch2_1(&m.recorder.deleteDqliteNodeExpects, m.ctrl, m, "DeleteDqliteNode", ctx, controllerID)
 }
 
-// DeleteControllerNode indicates an expected call of DeleteControllerNode.
-func (mr *MockControllerDBStateMockRecorder) DeleteControllerNode(ctx, controllerID any) *MockControllerDBStateDeleteControllerNodeCall {
+// DeleteDqliteNode indicates an expected call of DeleteDqliteNode.
+func (mr *MockControllerDBStateMockRecorder) DeleteDqliteNode(ctx, controllerID any) *MockControllerDBStateDeleteDqliteNodeCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "DeleteControllerNode", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(controllerID))
-	mr.deleteControllerNodeExpects = append(mr.deleteControllerNodeExpects, call)
+	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "DeleteDqliteNode", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(controllerID))
+	mr.deleteDqliteNodeExpects = append(mr.deleteDqliteNodeExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
-// MockControllerDBStateDeleteControllerNodeCall is the typed call wrapper for DeleteControllerNode.
-type MockControllerDBStateDeleteControllerNodeCall = gomock.Call2_1[context.Context, string, error]
+// MockControllerDBStateDeleteDqliteNodeCall is the typed call wrapper for DeleteDqliteNode.
+type MockControllerDBStateDeleteDqliteNodeCall = gomock.Call2_1[context.Context, string, error]
 
 // DeleteModel mocks base method.
 func (m *MockControllerDBState) DeleteModel(ctx context.Context, modelUUID string) error {

--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -33,6 +33,7 @@ type MockControllerDBState struct {
 // MockControllerDBStateMockRecorder is the mock recorder for MockControllerDBState.
 type MockControllerDBStateMockRecorder struct {
 	mock                                      *MockControllerDBState
+	deleteControllerNodeExpects               []*gomock.Call2_1[context.Context, string, error]
 	deleteModelExpects                        []*gomock.Call2_1[context.Context, string, error]
 	deleteOfferAccessExpects                  []*gomock.Call2_1[context.Context, string, error]
 	ensureModelNotAliveUnlessMigratingExpects []*gomock.Call3_1[context.Context, string, bool, error]
@@ -57,6 +58,24 @@ func NewMockControllerDBState(ctrl *gomock.Controller) *MockControllerDBState {
 func (m *MockControllerDBState) EXPECT() *MockControllerDBStateMockRecorder {
 	return m.recorder
 }
+
+// DeleteControllerNode mocks base method.
+func (m *MockControllerDBState) DeleteControllerNode(ctx context.Context, controllerID string) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_1(&m.recorder.deleteControllerNodeExpects, m.ctrl, m, "DeleteControllerNode", ctx, controllerID)
+}
+
+// DeleteControllerNode indicates an expected call of DeleteControllerNode.
+func (mr *MockControllerDBStateMockRecorder) DeleteControllerNode(ctx, controllerID any) *MockControllerDBStateDeleteControllerNodeCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_1[context.Context, string, error](mr.mock.ctrl.T, mr.mock, "DeleteControllerNode", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(controllerID))
+	mr.deleteControllerNodeExpects = append(mr.deleteControllerNodeExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerDBStateDeleteControllerNodeCall is the typed call wrapper for DeleteControllerNode.
+type MockControllerDBStateDeleteControllerNodeCall = gomock.Call2_1[context.Context, string, error]
 
 // DeleteModel mocks base method.
 func (m *MockControllerDBState) DeleteModel(ctx context.Context, modelUUID string) error {

--- a/domain/removal/service/unit.go
+++ b/domain/removal/service/unit.go
@@ -454,5 +454,5 @@ func (s *Service) deleteControllerNodeForUnit(ctx context.Context, unitUUID unit
 	if err != nil {
 		return errors.Errorf("parsing controller unit name %q: %w", unitName, err)
 	}
-	return errors.Capture(s.controllerState.DeleteControllerNode(ctx, strconv.Itoa(name.Number())))
+	return errors.Capture(s.controllerState.DeleteDqliteNode(ctx, strconv.Itoa(name.Number())))
 }

--- a/domain/removal/service/unit.go
+++ b/domain/removal/service/unit.go
@@ -110,6 +110,16 @@ func (s *Service) RemoveUnit(
 		return "", errors.Errorf("unit %q: %w", unitUUID, err)
 	}
 
+	applicationName, unitName, err := s.modelState.GetApplicationNameAndUnitNameByUnitUUID(ctx, unitUUID.String())
+	if err != nil {
+		return "", errors.Errorf("getting application and unit name for unit %q: %w", unitUUID, err)
+	}
+	// Revoke after the life transition so this unit cannot renew its leadership
+	// lease while it completes its departure hooks.
+	if err := s.leadershipRevoker.RevokeLeadership(applicationName, unit.Name(unitName)); err != nil && !errors.Is(err, leadership.ErrClaimNotHeld) {
+		return "", errors.Errorf("revoking leadership: %w", err)
+	}
+
 	if force {
 		if wait > 0 {
 			// If we have been supplied with the force flag *and* a wait time,
@@ -392,15 +402,6 @@ func (s *Service) processUnitRemovalJob(ctx context.Context, job removal.Job) er
 		return errors.Errorf("getting charm for unit: %w", err)
 	}
 
-	applicationName, unitName, err := s.modelState.GetApplicationNameAndUnitNameByUnitUUID(ctx, job.EntityUUID)
-	if errors.Is(err, applicationerrors.UnitNotFound) {
-		// The unit has already been removed.
-		// Indicate success so that this job will be deleted.
-		return nil
-	} else if err != nil {
-		return errors.Errorf("getting application name and unit name: %w", err)
-	}
-
 	if err := s.modelState.DeleteUnit(ctx, job.EntityUUID, job.Force); errors.Is(err, applicationerrors.UnitNotFound) {
 		// The unit has already been removed.
 		// Indicate success so that this job will be deleted.
@@ -413,15 +414,6 @@ func (s *Service) processUnitRemovalJob(ctx context.Context, job removal.Job) er
 	if err := s.modelState.DeleteCharmIfUnused(ctx, charmUUID); err != nil {
 		// Log the error but do not fail the removal job.
 		s.logger.Warningf(ctx, "deleting charm for unit %q: %v", job.EntityUUID, err)
-	}
-
-	// If the unit was the leader of an application, we revoke leadership.
-	// We do this last to expedite new leadership acquisition if the unit died
-	// sooner that the expiry of its last lease.
-	// For all other scenarios preventing lease renewal, the lease will be
-	// relinquished naturally by expiry.
-	if err := s.leadershipRevoker.RevokeLeadership(applicationName, unit.Name(unitName)); err != nil && !errors.Is(err, leadership.ErrClaimNotHeld) {
-		return errors.Errorf("revoking leadership: %w", err)
 	}
 
 	return nil

--- a/domain/removal/service/unit.go
+++ b/domain/removal/service/unit.go
@@ -110,12 +110,6 @@ func (s *Service) RemoveUnit(
 		return "", errors.Errorf("unit %q: %w", unitUUID, err)
 	}
 
-	// Delete the controller node for this unit if it is a controller unit. This
-	// is best effort, so we log any errors but do not fail the removal.
-	if err := s.deleteControllerNodeForUnit(ctx, unitUUID); err != nil {
-		s.logger.Warningf(ctx, "deleting controller node for unit %q: %v", unitUUID, err)
-	}
-
 	if force {
 		if wait > 0 {
 			// If we have been supplied with the force flag *and* a wait time,
@@ -340,13 +334,6 @@ func (s *Service) processUnitRemovalJob(ctx context.Context, job removal.Job) er
 		return errors.Errorf("unit %q is alive", job.EntityUUID).Add(removalerrors.EntityStillAlive)
 	}
 
-	// The unit is not alive, remove the controller node for this unit. This
-	// must be done, otherwise the controller node api addresses will still
-	// be present in the controller and the agent configs.
-	if err := s.deleteControllerNodeForUnit(ctx, unit.UUID(job.EntityUUID)); err != nil {
-		return errors.Errorf("deleting controller node for unit %q: %w", job.EntityUUID, err)
-	}
-
 	if l == life.Dying && !job.Force {
 		// Can the unit be marked as dead? If the unit has any associated
 		// entities that are still alive, we cannot mark it as dead.
@@ -374,6 +361,13 @@ func (s *Service) processUnitRemovalJob(ctx context.Context, job removal.Job) er
 		return nil
 	} else if err != nil {
 		return errors.Capture(err)
+	}
+
+	// A controller unit must remain authenticated until it has departed its
+	// peer relation scopes. Deleting it before then prevents the departure hook
+	// from publishing the updated db-bind-addresses to the remaining units.
+	if err := s.deleteControllerNodeForUnit(ctx, unit.UUID(job.EntityUUID)); err != nil {
+		return errors.Errorf("deleting controller node for unit %q: %w", job.EntityUUID, err)
 	}
 
 	// The unit agent itself attempts to delete the unit's secrets,

--- a/domain/removal/service/unit.go
+++ b/domain/removal/service/unit.go
@@ -101,12 +101,6 @@ func (s *Service) RemoveUnit(
 		return "", errors.Errorf("unit does not exist").Add(applicationerrors.UnitNotFound)
 	}
 
-	// Delete the controller node for this unit if it is a controller unit. This
-	// is best effort, so we log any errors but do not fail the removal.
-	if err := s.deleteControllerNodeForUnit(ctx, unitUUID); err != nil {
-		s.logger.Warningf(ctx, "deleting controller node for unit %q: %v", unitUUID, err)
-	}
-
 	// Ensure the unit is not alive. If it is the last one on the machine,
 	// then we will return the machine UUID, which will be used to schedule
 	// the removal of the machine.
@@ -114,6 +108,12 @@ func (s *Service) RemoveUnit(
 	cascaded, err := s.modelState.EnsureUnitNotAliveCascade(ctx, unitUUID.String(), destroyStorage)
 	if err != nil {
 		return "", errors.Errorf("unit %q: %w", unitUUID, err)
+	}
+
+	// Delete the controller node for this unit if it is a controller unit. This
+	// is best effort, so we log any errors but do not fail the removal.
+	if err := s.deleteControllerNodeForUnit(ctx, unitUUID); err != nil {
+		s.logger.Warningf(ctx, "deleting controller node for unit %q: %v", unitUUID, err)
 	}
 
 	if force {

--- a/domain/removal/service/unit.go
+++ b/domain/removal/service/unit.go
@@ -5,14 +5,17 @@ package service
 
 import (
 	"context"
+	"strconv"
 	"time"
 
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/trace"
 	"github.com/juju/juju/core/unit"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
+	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/domain/removal"
 	removalerrors "github.com/juju/juju/domain/removal/errors"
 	"github.com/juju/juju/domain/removal/internal"
@@ -96,6 +99,12 @@ func (s *Service) RemoveUnit(
 		return "", errors.Errorf("checking if unit exists: %w", err)
 	} else if !exists {
 		return "", errors.Errorf("unit does not exist").Add(applicationerrors.UnitNotFound)
+	}
+
+	// Delete the controller node for this unit if it is a controller unit. This
+	// is best effort, so we log any errors but do not fail the removal.
+	if err := s.deleteControllerNodeForUnit(ctx, unitUUID); err != nil {
+		s.logger.Warningf(ctx, "deleting controller node for unit %q: %v", unitUUID, err)
 	}
 
 	// Ensure the unit is not alive. If it is the last one on the machine,
@@ -331,6 +340,13 @@ func (s *Service) processUnitRemovalJob(ctx context.Context, job removal.Job) er
 		return errors.Errorf("unit %q is alive", job.EntityUUID).Add(removalerrors.EntityStillAlive)
 	}
 
+	// The unit is not alive, remove the controller node for this unit. This
+	// must be done, otherwise the controller node api addresses will still
+	// be present in the controller and the agent configs.
+	if err := s.deleteControllerNodeForUnit(ctx, unit.UUID(job.EntityUUID)); err != nil {
+		return errors.Errorf("deleting controller node for unit %q: %w", job.EntityUUID, err)
+	}
+
 	if l == life.Dying && !job.Force {
 		// Can the unit be marked as dead? If the unit has any associated
 		// entities that are still alive, we cannot mark it as dead.
@@ -415,4 +431,28 @@ func (s *Service) processUnitRemovalJob(ctx context.Context, job removal.Job) er
 	}
 
 	return nil
+}
+
+func (s *Service) deleteControllerNodeForUnit(ctx context.Context, unitUUID unit.UUID) error {
+	applicationName, unitName, err := s.modelState.GetApplicationNameAndUnitNameByUnitUUID(ctx, unitUUID.String())
+	if err != nil && !errors.Is(err, applicationerrors.UnitNotFound) {
+		return errors.Errorf("getting controller unit name: %w", err)
+	}
+	if applicationName != coreapplication.ControllerApplicationName {
+		return nil
+	}
+
+	isControllerModel, err := s.modelState.IsControllerModel(ctx, s.modelUUID.String())
+	if err != nil && !errors.Is(err, modelerrors.NotFound) {
+		return errors.Errorf("checking if this is the controller model: %w", err)
+	}
+	if !isControllerModel {
+		return nil
+	}
+
+	name, err := unit.NewName(unitName)
+	if err != nil {
+		return errors.Errorf("parsing controller unit name %q: %w", unitName, err)
+	}
+	return errors.Capture(s.controllerState.DeleteControllerNode(ctx, strconv.Itoa(name.Number())))
 }

--- a/domain/removal/service/unit.go
+++ b/domain/removal/service/unit.go
@@ -117,7 +117,9 @@ func (s *Service) RemoveUnit(
 	// Revoke after the life transition so this unit cannot renew its leadership
 	// lease while it completes its departure hooks.
 	if err := s.leadershipRevoker.RevokeLeadership(applicationName, unit.Name(unitName)); err != nil && !errors.Is(err, leadership.ErrClaimNotHeld) {
-		return "", errors.Errorf("revoking leadership: %w", err)
+		// The unit is already dying, so continue scheduling its removal even
+		// when the best-effort leadership revocation fails.
+		s.logger.Errorf(ctx, "revoking leadership for unit %q: %v", unitUUID, err)
 	}
 
 	if force {

--- a/domain/removal/service/unit_test.go
+++ b/domain/removal/service/unit_test.go
@@ -45,6 +45,7 @@ func (s *unitSuite) TestRemoveUnitNoForceMachineAndStorageSuccess(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{
 		MachineUUID: &mUUID,
 		CascadedStorageLives: internal.CascadedStorageLives{
@@ -72,6 +73,7 @@ func (s *unitSuite) TestRemoveUnitForceNoWaitSuccess(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{}, nil)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), true, when.UTC()).Return(nil)
 
@@ -90,6 +92,7 @@ func (s *unitSuite) TestRemoveUnitForceWaitSuccess(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{}, nil)
 
 	// The first normal removal scheduled immediately.
@@ -130,6 +133,7 @@ func (s *unitSuite) TestRemoveUnitRetrySchedulesRemovalJobs(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil).Times(2)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(cascaded, nil).Times(2)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil).Times(2)
 	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-1", false, when.UTC()).Return(nil).Times(2)
@@ -177,6 +181,7 @@ func (s *unitSuite) TestRemoveUnitRetryWithForceSchedulesRemovalJobs(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil).Times(2)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(cascaded, nil).Times(2)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), true, when.UTC()).Return(nil)
@@ -250,6 +255,7 @@ func (s *unitSuite) TestRemoveUnitCascadeStorage(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
 	exp.EnsureUnitNotAliveCascade(
 		gomock.Any(), uUUID.String(), false,
 	).Return(cascaded, nil)
@@ -340,7 +346,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDeleteUnit(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -372,7 +378,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDyingUnitWithNoEntities(c *tc.C) {
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
 	exp.MarkUnitAsDeadWithNoEntities(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -403,7 +409,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadJujuSecretsDeleteUnit(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.DeleteUnitOwnedSecretContent(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -434,7 +440,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadExternalSecretsDeleteUnit(c *tc.C) 
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(secretExternalRefs, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -475,7 +481,7 @@ func (s *unitSuite) TestExecuteJobWithForceForUnitDyingDeleteUnit(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return([]string{ruUUID}, nil)
 	exp.LeaveScope(gomock.Any(), ruUUID).Return(nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
@@ -509,7 +515,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDeleteUnitError(c *tc.C) {
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.DeleteUnit(gomock.Any(), j.EntityUUID, false).Return(errors.Errorf("the front fell off"))
@@ -535,7 +541,7 @@ func (s *unitSuite) TestDeleteCharmForUnitFails(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -565,6 +571,7 @@ func (s *unitSuite) TestExecuteJobForUnitNotDeadError(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.MarkUnitAsDeadWithNoEntities(gomock.Any(), j.EntityUUID).Return(removalerrors.EntityStillAlive)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
@@ -584,7 +591,7 @@ func (s *unitSuite) TestExecuteJobForUnitRevokingUnitError(c *tc.C) {
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.DeleteUnit(gomock.Any(), j.EntityUUID, false).Return(nil)
 	exp.DeleteCharmIfUnused(gomock.Any(), gomock.Any()).Return(nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
 
 	sbCfg := &provider.ModelBackendConfig{
 		BackendConfig: provider.BackendConfig{
@@ -609,7 +616,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDeleteUnitClaimNotHeld(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)

--- a/domain/removal/service/unit_test.go
+++ b/domain/removal/service/unit_test.go
@@ -45,7 +45,6 @@ func (s *unitSuite) TestRemoveUnitNoForceMachineAndStorageSuccess(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{
 		MachineUUID: &mUUID,
 		CascadedStorageLives: internal.CascadedStorageLives{
@@ -73,7 +72,6 @@ func (s *unitSuite) TestRemoveUnitForceNoWaitSuccess(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{}, nil)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), true, when.UTC()).Return(nil)
 
@@ -92,7 +90,6 @@ func (s *unitSuite) TestRemoveUnitForceWaitSuccess(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{}, nil)
 
 	// The first normal removal scheduled immediately.
@@ -133,7 +130,6 @@ func (s *unitSuite) TestRemoveUnitRetrySchedulesRemovalJobs(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil).Times(2)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil).Times(2)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(cascaded, nil).Times(2)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil).Times(2)
 	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-1", false, when.UTC()).Return(nil).Times(2)
@@ -181,7 +177,6 @@ func (s *unitSuite) TestRemoveUnitRetryWithForceSchedulesRemovalJobs(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil).Times(2)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil).Times(2)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(cascaded, nil).Times(2)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), true, when.UTC()).Return(nil)
@@ -255,7 +250,6 @@ func (s *unitSuite) TestRemoveUnitCascadeStorage(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
 	exp.EnsureUnitNotAliveCascade(
 		gomock.Any(), uUUID.String(), false,
 	).Return(cascaded, nil)
@@ -564,14 +558,13 @@ func (s *unitSuite) TestDeleteCharmForUnitFails(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *unitSuite) TestExecuteJobForUnitNotDeadError(c *tc.C) {
+func (s *unitSuite) TestExecuteJobForDyingUnitWithLiveEntitiesKeepsControllerNode(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	j := newUnitJob(c)
 
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.MarkUnitAsDeadWithNoEntities(gomock.Any(), j.EntityUUID).Return(removalerrors.EntityStillAlive)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)

--- a/domain/removal/service/unit_test.go
+++ b/domain/removal/service/unit_test.go
@@ -53,6 +53,8 @@ func (s *unitSuite) TestRemoveUnitNoForceMachineAndStorageSuccess(c *tc.C) {
 			},
 		},
 	}, nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
+	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil)
 	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), mUUID, false, when.UTC()).Return(nil)
 	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), saUUID, false, when.UTC()).Return(nil)
@@ -73,6 +75,8 @@ func (s *unitSuite) TestRemoveUnitForceNoWaitSuccess(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{}, nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
+	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), true, when.UTC()).Return(nil)
 
 	jobUUID, err := s.newService(c).RemoveUnit(c.Context(), uUUID, false, true, 0)
@@ -91,6 +95,8 @@ func (s *unitSuite) TestRemoveUnitForceWaitSuccess(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{}, nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
+	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
 
 	// The first normal removal scheduled immediately.
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil)
@@ -131,6 +137,8 @@ func (s *unitSuite) TestRemoveUnitRetrySchedulesRemovalJobs(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil).Times(2)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(cascaded, nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil).Times(2)
+	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil).Times(2)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil).Times(2)
 	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-1", false, when.UTC()).Return(nil).Times(2)
 	exp.StorageAttachmentScheduleRemoval(gomock.Any(), gomock.Any(), "storage-attachment-1", false, when.UTC()).Return(nil).Times(2)
@@ -178,6 +186,8 @@ func (s *unitSuite) TestRemoveUnitRetryWithForceSchedulesRemovalJobs(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil).Times(2)
 	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(cascaded, nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil).Times(2)
+	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil).Times(2)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil)
 	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), true, when.UTC()).Return(nil)
 	exp.MachineScheduleRemoval(gomock.Any(), gomock.Any(), "machine-1", false, when.UTC()).Return(nil)
@@ -253,6 +263,8 @@ func (s *unitSuite) TestRemoveUnitCascadeStorage(c *tc.C) {
 	exp.EnsureUnitNotAliveCascade(
 		gomock.Any(), uUUID.String(), false,
 	).Return(cascaded, nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
+	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
 	exp.UnitScheduleRemoval(
 		gomock.Any(), tc.Bind(tc.IsNonZeroUUID), uUUID.String(), false, when,
 	).Return(nil)
@@ -282,6 +294,41 @@ func (s *unitSuite) TestRemoveUnitCascadeStorage(c *tc.C) {
 	jobUUID, err := svc.RemoveUnit(c.Context(), uUUID, false, false, 0)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *unitSuite) TestRemoveUnitIgnoresLeadershipNotHeld(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uUUID := unittesting.GenUnitUUID(c)
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when)
+
+	exp := s.modelState.EXPECT()
+	exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil)
+	exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{}, nil)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil)
+	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(leadership.ErrClaimNotHeld)
+	exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil)
+
+	jobUUID, err := s.newService(c).RemoveUnit(c.Context(), uUUID, false, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(jobUUID.Validate(), tc.ErrorIsNil)
+}
+
+func (s *unitSuite) TestRemoveUnitStopsWhenLeadershipRevocationFails(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uUUID := unittesting.GenUnitUUID(c)
+	exp := s.modelState.EXPECT()
+	gomock.InOrder(
+		exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil),
+		exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{}, nil),
+		exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil),
+		s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(errors.New("lease unavailable")),
+	)
+
+	_, err := s.newService(c).RemoveUnit(c.Context(), uUUID, false, false, 0)
+	c.Assert(err, tc.ErrorMatches, `revoking leadership: lease unavailable`)
 }
 
 func (s *unitSuite) TestProcessRemovalJobInvalidJobType(c *tc.C) {
@@ -340,7 +387,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDeleteUnit(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -356,8 +403,6 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDeleteUnit(c *tc.C) {
 	s.controllerState.EXPECT().GetActiveModelSecretBackend(gomock.Any(), s.modelUUID.String()).Return("", sbCfg, nil)
 	s.secretBackendProvider.EXPECT().Initialise(sbCfg).Return(nil)
 	s.secretBackendProvider.EXPECT().NewBackend(sbCfg).Return(s.secretBackend, nil)
-
-	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
@@ -372,7 +417,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDyingUnitWithNoEntities(c *tc.C) {
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
 	exp.MarkUnitAsDeadWithNoEntities(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -389,8 +434,6 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDyingUnitWithNoEntities(c *tc.C) {
 	s.secretBackendProvider.EXPECT().Initialise(sbCfg).Return(nil)
 	s.secretBackendProvider.EXPECT().NewBackend(sbCfg).Return(s.secretBackend, nil)
 
-	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
-
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -403,7 +446,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadJujuSecretsDeleteUnit(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.DeleteUnitOwnedSecretContent(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -417,8 +460,6 @@ func (s *unitSuite) TestExecuteJobForUnitDeadJujuSecretsDeleteUnit(c *tc.C) {
 		},
 	}
 	s.controllerState.EXPECT().GetActiveModelSecretBackend(gomock.Any(), s.modelUUID.String()).Return("", sbCfg, nil)
-
-	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
@@ -434,7 +475,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadExternalSecretsDeleteUnit(c *tc.C) 
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(secretExternalRefs, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -459,8 +500,6 @@ func (s *unitSuite) TestExecuteJobForUnitDeadExternalSecretsDeleteUnit(c *tc.C) 
 		s.secretBackend.EXPECT().DeleteContent(c.Context(), id).Return(err)
 	}
 
-	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
-
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -475,7 +514,7 @@ func (s *unitSuite) TestExecuteJobWithForceForUnitDyingDeleteUnit(c *tc.C) {
 
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dying, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return([]string{ruUUID}, nil)
 	exp.LeaveScope(gomock.Any(), ruUUID).Return(nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
@@ -494,8 +533,6 @@ func (s *unitSuite) TestExecuteJobWithForceForUnitDyingDeleteUnit(c *tc.C) {
 	s.secretBackendProvider.EXPECT().Initialise(sbCfg).Return(nil)
 	s.secretBackendProvider.EXPECT().NewBackend(sbCfg).Return(s.secretBackend, nil)
 
-	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
-
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -509,7 +546,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDeleteUnitError(c *tc.C) {
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.DeleteUnit(gomock.Any(), j.EntityUUID, false).Return(errors.Errorf("the front fell off"))
@@ -535,7 +572,7 @@ func (s *unitSuite) TestDeleteCharmForUnitFails(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -551,8 +588,6 @@ func (s *unitSuite) TestDeleteCharmForUnitFails(c *tc.C) {
 	s.controllerState.EXPECT().GetActiveModelSecretBackend(gomock.Any(), s.modelUUID.String()).Return("", sbCfg, nil)
 	s.secretBackendProvider.EXPECT().Initialise(sbCfg).Return(nil)
 	s.secretBackendProvider.EXPECT().NewBackend(sbCfg).Return(s.secretBackend, nil)
-
-	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(nil)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)
@@ -571,7 +606,7 @@ func (s *unitSuite) TestExecuteJobForDyingUnitWithLiveEntitiesKeepsControllerNod
 	c.Assert(err, tc.ErrorIs, removalerrors.EntityNotDead)
 }
 
-func (s *unitSuite) TestExecuteJobForUnitRevokingUnitError(c *tc.C) {
+func (s *unitSuite) TestExecuteJobForUnitDoesNotRevokeLeadership(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	j := newUnitJob(c)
@@ -584,7 +619,8 @@ func (s *unitSuite) TestExecuteJobForUnitRevokingUnitError(c *tc.C) {
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
 	exp.DeleteUnit(gomock.Any(), j.EntityUUID, false).Return(nil)
 	exp.DeleteCharmIfUnused(gomock.Any(), gomock.Any()).Return(nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
+	exp.DeleteJob(gomock.Any(), j.UUID.String()).Return(nil)
 
 	sbCfg := &provider.ModelBackendConfig{
 		BackendConfig: provider.BackendConfig{
@@ -595,10 +631,8 @@ func (s *unitSuite) TestExecuteJobForUnitRevokingUnitError(c *tc.C) {
 	s.secretBackendProvider.EXPECT().Initialise(sbCfg).Return(nil)
 	s.secretBackendProvider.EXPECT().NewBackend(sbCfg).Return(s.secretBackend, nil)
 
-	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(errors.Errorf("the front fell off"))
-
 	err := s.newService(c).ExecuteJob(c.Context(), j)
-	c.Assert(err, tc.ErrorMatches, ".*the front fell off")
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *unitSuite) TestExecuteJobForUnitDeadDeleteUnitClaimNotHeld(c *tc.C) {
@@ -609,7 +643,7 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDeleteUnitClaimNotHeld(c *tc.C) {
 	exp := s.modelState.EXPECT()
 	exp.GetUnitLife(gomock.Any(), j.EntityUUID).Return(life.Dead, nil)
 	exp.GetRelationUnitsForUnit(gomock.Any(), j.EntityUUID).Return(nil, nil)
-	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil).Times(2)
+	exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), j.EntityUUID).Return("foo", "foo/0", nil)
 	exp.GetCharmForUnit(gomock.Any(), j.EntityUUID).Return(tc.Must(c, unit.NewUUID).String(), nil)
 	exp.GetUnitOwnedSecretRevisionRefs(gomock.Any(), j.EntityUUID).Return(nil, nil)
 	exp.DeleteUnitOwnedSecrets(gomock.Any(), j.EntityUUID).Return(nil)
@@ -625,8 +659,6 @@ func (s *unitSuite) TestExecuteJobForUnitDeadDeleteUnitClaimNotHeld(c *tc.C) {
 	s.controllerState.EXPECT().GetActiveModelSecretBackend(gomock.Any(), s.modelUUID.String()).Return("", sbCfg, nil)
 	s.secretBackendProvider.EXPECT().Initialise(sbCfg).Return(nil)
 	s.secretBackendProvider.EXPECT().NewBackend(sbCfg).Return(s.secretBackend, nil)
-
-	s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(leadership.ErrClaimNotHeld)
 
 	err := s.newService(c).ExecuteJob(c.Context(), j)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/removal/service/unit_test.go
+++ b/domain/removal/service/unit_test.go
@@ -315,20 +315,24 @@ func (s *unitSuite) TestRemoveUnitIgnoresLeadershipNotHeld(c *tc.C) {
 	c.Check(jobUUID.Validate(), tc.ErrorIsNil)
 }
 
-func (s *unitSuite) TestRemoveUnitStopsWhenLeadershipRevocationFails(c *tc.C) {
+func (s *unitSuite) TestRemoveUnitSchedulesRemovalWhenLeadershipRevocationFails(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
 	uUUID := unittesting.GenUnitUUID(c)
+	when := time.Now()
+	s.clock.EXPECT().Now().Return(when)
 	exp := s.modelState.EXPECT()
 	gomock.InOrder(
 		exp.UnitExists(gomock.Any(), uUUID.String()).Return(true, nil),
 		exp.EnsureUnitNotAliveCascade(gomock.Any(), uUUID.String(), false).Return(internal.CascadedUnitLives{}, nil),
 		exp.GetApplicationNameAndUnitNameByUnitUUID(gomock.Any(), uUUID.String()).Return("foo", "foo/0", nil),
 		s.revoker.EXPECT().RevokeLeadership("foo", unit.Name("foo/0")).Return(errors.New("lease unavailable")),
+		exp.UnitScheduleRemoval(gomock.Any(), gomock.Any(), uUUID.String(), false, when.UTC()).Return(nil),
 	)
 
-	_, err := s.newService(c).RemoveUnit(c.Context(), uUUID, false, false, 0)
-	c.Assert(err, tc.ErrorMatches, `revoking leadership: lease unavailable`)
+	jobUUID, err := s.newService(c).RemoveUnit(c.Context(), uUUID, false, false, 0)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(jobUUID.Validate(), tc.ErrorIsNil)
 }
 
 func (s *unitSuite) TestProcessRemovalJobInvalidJobType(c *tc.C) {

--- a/domain/removal/state/controller/controller_node.go
+++ b/domain/removal/state/controller/controller_node.go
@@ -11,8 +11,9 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
-// DeleteDqliteNode removes the controller node identified by controllerID
-// and all records that depend on it.
+// DeleteDqliteNode marks the controller node identified by controllerID dead
+// and removes all records that depend on it. The controller node is retained
+// as a tombstone so delayed controller workers cannot recreate it.
 func (st *State) DeleteDqliteNode(ctx context.Context, controllerID string) error {
 	db, err := st.DB(ctx)
 	if err != nil {
@@ -27,6 +28,14 @@ FROM controller_node
 WHERE controller_id = $controllerNode.controller_id`, node, count{})
 	if err != nil {
 		return errors.Errorf("preparing controller node existence check: %w", err)
+	}
+	markNodeDyingStmt, err := st.Prepare(`
+UPDATE controller_node
+SET life_id = 1
+WHERE controller_id = $controllerNode.controller_id
+AND life_id = 0`, node)
+	if err != nil {
+		return errors.Errorf("preparing controller node dying transition: %w", err)
 	}
 
 	deleteAPIAddressesStmt, err := st.Prepare(`
@@ -59,9 +68,13 @@ WHERE controller_node_id = $controllerNode.controller_id`, node)
 	if err != nil {
 		return errors.Errorf("preparing controller upgrade info deletion: %w", err)
 	}
-	deleteNodeStmt, err := st.Prepare(`
-DELETE FROM controller_node
-WHERE controller_id = $controllerNode.controller_id`, node)
+	markNodeDeadStmt, err := st.Prepare(`
+UPDATE controller_node
+SET life_id = 2,
+    dqlite_node_id = NULL,
+    dqlite_bind_address = NULL
+WHERE controller_id = $controllerNode.controller_id
+AND life_id < 2`, node)
 	if err != nil {
 		return errors.Errorf("preparing controller node deletion: %w", err)
 	}
@@ -73,6 +86,9 @@ WHERE controller_id = $controllerNode.controller_id`, node)
 		}
 		if result.Count == 0 {
 			return nil
+		}
+		if err := tx.Query(ctx, markNodeDyingStmt, node).Run(); err != nil {
+			return errors.Errorf("marking controller node %q dying: %w", controllerID, err)
 		}
 
 		if err := tx.Query(ctx, deleteAPIAddressesStmt, node).Run(); err != nil {
@@ -90,8 +106,8 @@ WHERE controller_id = $controllerNode.controller_id`, node)
 		if err := tx.Query(ctx, deleteUpgradeInfoStmt, node).Run(); err != nil {
 			return errors.Errorf("deleting controller upgrade info for %q: %w", controllerID, err)
 		}
-		if err := tx.Query(ctx, deleteNodeStmt, node).Run(); err != nil {
-			return errors.Errorf("deleting controller node %q: %w", controllerID, err)
+		if err := tx.Query(ctx, markNodeDeadStmt, node).Run(); err != nil {
+			return errors.Errorf("marking controller node %q dead: %w", controllerID, err)
 		}
 		return nil
 	}))

--- a/domain/removal/state/controller/controller_node.go
+++ b/domain/removal/state/controller/controller_node.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+
+	"github.com/juju/juju/internal/errors"
+)
+
+// DeleteControllerNode removes the controller node identified by controllerID
+// and all records that depend on it.
+func (st *State) DeleteControllerNode(ctx context.Context, controllerID string) error {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	node := controllerNode{ControllerID: controllerID}
+
+	checkExistsStmt, err := st.Prepare(`
+SELECT COUNT(*) AS &count.count
+FROM controller_node
+WHERE controller_id = $controllerNode.controller_id`, node, count{})
+	if err != nil {
+		return errors.Errorf("preparing controller node existence check: %w", err)
+	}
+
+	deleteAPIAddressesStmt, err := st.Prepare(`
+DELETE FROM controller_api_address
+WHERE controller_id = $controllerNode.controller_id`, node)
+	if err != nil {
+		return errors.Errorf("preparing controller api address deletion: %w", err)
+	}
+	deleteAgentVersionStmt, err := st.Prepare(`
+DELETE FROM controller_node_agent_version
+WHERE controller_id = $controllerNode.controller_id`, node)
+	if err != nil {
+		return errors.Errorf("preparing controller agent version deletion: %w", err)
+	}
+	deletePasswordStmt, err := st.Prepare(`
+DELETE FROM controller_node_password
+WHERE controller_id = $controllerNode.controller_id`, node)
+	if err != nil {
+		return errors.Errorf("preparing controller password deletion: %w", err)
+	}
+	deleteNonceStmt, err := st.Prepare(`
+DELETE FROM controller_node_nonce
+WHERE controller_id = $controllerNode.controller_id`, node)
+	if err != nil {
+		return errors.Errorf("preparing controller nonce deletion: %w", err)
+	}
+	deleteUpgradeInfoStmt, err := st.Prepare(`
+DELETE FROM upgrade_info_controller_node
+WHERE controller_node_id = $controllerNode.controller_id`, node)
+	if err != nil {
+		return errors.Errorf("preparing controller upgrade info deletion: %w", err)
+	}
+	deleteNodeStmt, err := st.Prepare(`
+DELETE FROM controller_node
+WHERE controller_id = $controllerNode.controller_id`, node)
+	if err != nil {
+		return errors.Errorf("preparing controller node deletion: %w", err)
+	}
+
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var result count
+		if err := tx.Query(ctx, checkExistsStmt, node).Get(&result); err != nil {
+			return errors.Errorf("checking controller node %q exists: %w", controllerID, err)
+		}
+		if result.Count == 0 {
+			return nil
+		}
+
+		if err := tx.Query(ctx, deleteAPIAddressesStmt, node).Run(); err != nil {
+			return errors.Errorf("deleting controller api addresses for %q: %w", controllerID, err)
+		}
+		if err := tx.Query(ctx, deleteAgentVersionStmt, node).Run(); err != nil {
+			return errors.Errorf("deleting controller agent version for %q: %w", controllerID, err)
+		}
+		if err := tx.Query(ctx, deletePasswordStmt, node).Run(); err != nil {
+			return errors.Errorf("deleting controller password for %q: %w", controllerID, err)
+		}
+		if err := tx.Query(ctx, deleteNonceStmt, node).Run(); err != nil {
+			return errors.Errorf("deleting controller nonce for %q: %w", controllerID, err)
+		}
+		if err := tx.Query(ctx, deleteUpgradeInfoStmt, node).Run(); err != nil {
+			return errors.Errorf("deleting controller upgrade info for %q: %w", controllerID, err)
+		}
+		if err := tx.Query(ctx, deleteNodeStmt, node).Run(); err != nil {
+			return errors.Errorf("deleting controller node %q: %w", controllerID, err)
+		}
+		return nil
+	}))
+}

--- a/domain/removal/state/controller/controller_node.go
+++ b/domain/removal/state/controller/controller_node.go
@@ -11,9 +11,9 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
-// DeleteControllerNode removes the controller node identified by controllerID
+// DeleteDqliteNode removes the controller node identified by controllerID
 // and all records that depend on it.
-func (st *State) DeleteControllerNode(ctx context.Context, controllerID string) error {
+func (st *State) DeleteDqliteNode(ctx context.Context, controllerID string) error {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/removal/state/controller/controller_node_test.go
+++ b/domain/removal/state/controller/controller_node_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type controllerNodeSuite struct {
+	schematesting.ControllerSuite
+}
+
+func TestControllerNodeSuite(t *testing.T) {
+	tc.Run(t, &controllerNodeSuite{})
+}
+
+func (s *controllerNodeSuite) TestDeleteControllerNode(c *tc.C) {
+	db := s.DB()
+
+	_, err := db.Exec("INSERT INTO controller_node (controller_id) VALUES ('99')")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.Exec("INSERT INTO controller_api_address (controller_id, address, scope) VALUES ('99', '10.0.0.1:17070', 'local-cloud')")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.Exec("INSERT INTO controller_node_agent_version (controller_id, version, architecture_id) VALUES ('99', '4.1.0', 0)")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.Exec("INSERT INTO controller_node_password (controller_id) VALUES ('99')")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.Exec("INSERT INTO controller_node_nonce (controller_id, nonce) VALUES ('99', 'abc123')")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.Exec("INSERT INTO upgrade_info (uuid, previous_version, target_version, state_type_id) VALUES ('upgrade-uuid', '4.0.0', '4.1.0', 0)")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.Exec("INSERT INTO upgrade_info_controller_node (uuid, controller_node_id, upgrade_info_uuid) VALUES ('upgrade-node-uuid', '99', 'upgrade-uuid')")
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err = st.DeleteControllerNode(c.Context(), "99")
+	c.Assert(err, tc.ErrorIsNil)
+
+	for _, q := range []struct {
+		query string
+		args  []any
+	}{
+		{"SELECT COUNT(*) FROM controller_api_address WHERE controller_id = ?", []any{"99"}},
+		{"SELECT COUNT(*) FROM controller_node_agent_version WHERE controller_id = ?", []any{"99"}},
+		{"SELECT COUNT(*) FROM controller_node_password WHERE controller_id = ?", []any{"99"}},
+		{"SELECT COUNT(*) FROM controller_node_nonce WHERE controller_id = ?", []any{"99"}},
+		{"SELECT COUNT(*) FROM upgrade_info_controller_node WHERE controller_node_id = ?", []any{"99"}},
+		{"SELECT COUNT(*) FROM controller_node WHERE controller_id = ?", []any{"99"}},
+	} {
+		var count int
+		err := db.QueryRow(q.query, q.args...).Scan(&count)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Check(count, tc.Equals, 0)
+	}
+}
+
+func (s *controllerNodeSuite) TestDeleteControllerNodeIdempotent(c *tc.C) {
+	db := s.DB()
+
+	_, err := db.Exec("INSERT INTO controller_node (controller_id) VALUES ('98')")
+	c.Assert(err, tc.ErrorIsNil)
+	_, err = db.Exec("INSERT INTO controller_api_address (controller_id, address, scope) VALUES ('98', '10.0.0.1:17070', 'local-cloud')")
+	c.Assert(err, tc.ErrorIsNil)
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err = st.DeleteControllerNode(c.Context(), "98")
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.DeleteControllerNode(c.Context(), "98")
+	c.Assert(err, tc.ErrorIsNil)
+
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM controller_node WHERE controller_id = '98'").Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+}
+
+func (s *controllerNodeSuite) TestDeleteControllerNodePreservesOtherNodes(c *tc.C) {
+	db := s.DB()
+
+	for _, cID := range []string{"96", "97"} {
+		_, err := db.Exec("INSERT INTO controller_node (controller_id) VALUES (?)", cID)
+		c.Assert(err, tc.ErrorIsNil)
+		_, err = db.Exec("INSERT INTO controller_api_address (controller_id, address, scope) VALUES (?, '10.0.0.' || ? || ':17070', 'local-cloud')", cID, cID)
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err := st.DeleteControllerNode(c.Context(), "96")
+	c.Assert(err, tc.ErrorIsNil)
+
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM controller_node WHERE controller_id = '96'").Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+
+	err = db.QueryRow("SELECT COUNT(*) FROM controller_node WHERE controller_id = '97'").Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 1)
+
+	err = db.QueryRow("SELECT COUNT(*) FROM controller_api_address WHERE controller_id = '96'").Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
+
+	err = db.QueryRow("SELECT COUNT(*) FROM controller_api_address WHERE controller_id = '97'").Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 1)
+}

--- a/domain/removal/state/controller/controller_node_test.go
+++ b/domain/removal/state/controller/controller_node_test.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/juju/tc"
@@ -51,13 +52,24 @@ func (s *controllerNodeSuite) TestDeleteDqliteNode(c *tc.C) {
 		{"SELECT COUNT(*) FROM controller_node_password WHERE controller_id = ?", []any{"99"}},
 		{"SELECT COUNT(*) FROM controller_node_nonce WHERE controller_id = ?", []any{"99"}},
 		{"SELECT COUNT(*) FROM upgrade_info_controller_node WHERE controller_node_id = ?", []any{"99"}},
-		{"SELECT COUNT(*) FROM controller_node WHERE controller_id = ?", []any{"99"}},
 	} {
 		var count int
 		err := db.QueryRow(q.query, q.args...).Scan(&count)
 		c.Assert(err, tc.ErrorIsNil)
 		c.Check(count, tc.Equals, 0)
 	}
+	var lifeID int
+	err = db.QueryRow("SELECT life_id FROM controller_node WHERE controller_id = ?", "99").Scan(&lifeID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, 2)
+	var nodeID, bindAddress sql.NullString
+	err = db.QueryRow(`
+SELECT dqlite_node_id, dqlite_bind_address
+FROM controller_node
+WHERE controller_id = ?`, "99").Scan(&nodeID, &bindAddress)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(nodeID.Valid, tc.IsFalse)
+	c.Check(bindAddress.Valid, tc.IsFalse)
 }
 
 func (s *controllerNodeSuite) TestDeleteDqliteNodeIdempotent(c *tc.C) {
@@ -77,7 +89,12 @@ func (s *controllerNodeSuite) TestDeleteDqliteNodeIdempotent(c *tc.C) {
 	var count int
 	err = db.QueryRow("SELECT COUNT(*) FROM controller_node WHERE controller_id = '98'").Scan(&count)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(count, tc.Equals, 0)
+	c.Check(count, tc.Equals, 1)
+
+	var lifeID int
+	err = db.QueryRow("SELECT life_id FROM controller_node WHERE controller_id = '98'").Scan(&lifeID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(lifeID, tc.Equals, 2)
 }
 
 func (s *controllerNodeSuite) TestDeleteDqliteNodePreservesOtherNodes(c *tc.C) {
@@ -97,7 +114,7 @@ func (s *controllerNodeSuite) TestDeleteDqliteNodePreservesOtherNodes(c *tc.C) {
 	var count int
 	err = db.QueryRow("SELECT COUNT(*) FROM controller_node WHERE controller_id = '96'").Scan(&count)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Check(count, tc.Equals, 0)
+	c.Check(count, tc.Equals, 1)
 
 	err = db.QueryRow("SELECT COUNT(*) FROM controller_node WHERE controller_id = '97'").Scan(&count)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/removal/state/controller/controller_node_test.go
+++ b/domain/removal/state/controller/controller_node_test.go
@@ -20,7 +20,7 @@ func TestControllerNodeSuite(t *testing.T) {
 	tc.Run(t, &controllerNodeSuite{})
 }
 
-func (s *controllerNodeSuite) TestDeleteControllerNode(c *tc.C) {
+func (s *controllerNodeSuite) TestDeleteDqliteNode(c *tc.C) {
 	db := s.DB()
 
 	_, err := db.Exec("INSERT INTO controller_node (controller_id) VALUES ('99')")
@@ -39,7 +39,7 @@ func (s *controllerNodeSuite) TestDeleteControllerNode(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-	err = st.DeleteControllerNode(c.Context(), "99")
+	err = st.DeleteDqliteNode(c.Context(), "99")
 	c.Assert(err, tc.ErrorIsNil)
 
 	for _, q := range []struct {
@@ -60,7 +60,7 @@ func (s *controllerNodeSuite) TestDeleteControllerNode(c *tc.C) {
 	}
 }
 
-func (s *controllerNodeSuite) TestDeleteControllerNodeIdempotent(c *tc.C) {
+func (s *controllerNodeSuite) TestDeleteDqliteNodeIdempotent(c *tc.C) {
 	db := s.DB()
 
 	_, err := db.Exec("INSERT INTO controller_node (controller_id) VALUES ('98')")
@@ -69,9 +69,9 @@ func (s *controllerNodeSuite) TestDeleteControllerNodeIdempotent(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-	err = st.DeleteControllerNode(c.Context(), "98")
+	err = st.DeleteDqliteNode(c.Context(), "98")
 	c.Assert(err, tc.ErrorIsNil)
-	err = st.DeleteControllerNode(c.Context(), "98")
+	err = st.DeleteDqliteNode(c.Context(), "98")
 	c.Assert(err, tc.ErrorIsNil)
 
 	var count int
@@ -80,7 +80,7 @@ func (s *controllerNodeSuite) TestDeleteControllerNodeIdempotent(c *tc.C) {
 	c.Check(count, tc.Equals, 0)
 }
 
-func (s *controllerNodeSuite) TestDeleteControllerNodePreservesOtherNodes(c *tc.C) {
+func (s *controllerNodeSuite) TestDeleteDqliteNodePreservesOtherNodes(c *tc.C) {
 	db := s.DB()
 
 	for _, cID := range []string{"96", "97"} {
@@ -91,7 +91,7 @@ func (s *controllerNodeSuite) TestDeleteControllerNodePreservesOtherNodes(c *tc.
 	}
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-	err := st.DeleteControllerNode(c.Context(), "96")
+	err := st.DeleteDqliteNode(c.Context(), "96")
 	c.Assert(err, tc.ErrorIsNil)
 
 	var count int

--- a/domain/removal/state/controller/types.go
+++ b/domain/removal/state/controller/types.go
@@ -9,6 +9,10 @@ type entityUUID struct {
 	UUID string `db:"uuid"`
 }
 
+type controllerNode struct {
+	ControllerID string `db:"controller_id"`
+}
+
 // entityLife holds an entity's life in integer
 type entityLife struct {
 	Life int `db:"life_id"`

--- a/domain/removal/watcher_test.go
+++ b/domain/removal/watcher_test.go
@@ -48,6 +48,12 @@ type watcherSuite struct {
 	changestreamtesting.ModelSuite
 }
 
+type noopLeadershipRevoker struct{}
+
+func (noopLeadershipRevoker) RevokeLeadership(string, unit.Name) error {
+	return nil
+}
+
 func TestWatcherSuite(t *testing.T) {
 	tc.Run(t, &watcherSuite{})
 }
@@ -125,7 +131,7 @@ func (s *watcherSuite) TestWatchEntityRemovals(c *tc.C) {
 		statecontroller.NewState(func(ctx context.Context) (database.TxnRunner, error) { return s.NoopTxnRunner(), nil }, log),
 		modelState,
 		domain.NewWatcherFactory(factory, log),
-		nil,
+		noopLeadershipRevoker{},
 		nil,
 		model.UUID(s.ModelUUID()),
 		clock.WallClock,

--- a/domain/schema/controller/sql/0010-controller-node.sql
+++ b/domain/schema/controller/sql/0010-controller-node.sql
@@ -1,7 +1,11 @@
 CREATE TABLE controller_node (
     controller_id TEXT NOT NULL PRIMARY KEY,
+    life_id INT NOT NULL DEFAULT 0,
     dqlite_node_id TEXT,              -- This is the uint64 from Dqlite NodeInfo, stored as text.
-    dqlite_bind_address TEXT          -- Hostname or IP address (no port) that Dqlite is bound to.
+    dqlite_bind_address TEXT,         -- Hostname or IP address (no port) that Dqlite is bound to.
+    CONSTRAINT fk_controller_node_life
+    FOREIGN KEY (life_id)
+    REFERENCES life (id)
 );
 
 CREATE UNIQUE INDEX idx_controller_node_dqlite_node

--- a/domain/schema/controller/triggers/controller-triggers.gen.go
+++ b/domain/schema/controller/triggers/controller-triggers.gen.go
@@ -104,6 +104,7 @@ CREATE TRIGGER trg_log_controller_node_update
 AFTER UPDATE ON controller_node FOR EACH ROW
 WHEN 
 	NEW.controller_id != OLD.controller_id OR
+	NEW.life_id != OLD.life_id OR
 	(NEW.dqlite_node_id != OLD.dqlite_node_id OR (NEW.dqlite_node_id IS NOT NULL AND OLD.dqlite_node_id IS NULL) OR (NEW.dqlite_node_id IS NULL AND OLD.dqlite_node_id IS NOT NULL)) OR
 	(NEW.dqlite_bind_address != OLD.dqlite_bind_address OR (NEW.dqlite_bind_address IS NOT NULL AND OLD.dqlite_bind_address IS NULL) OR (NEW.dqlite_bind_address IS NULL AND OLD.dqlite_bind_address IS NOT NULL))
 BEGIN

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -95,6 +95,7 @@ CREATE TABLE application_scale (
     scale INT,
     scale_target INT,
     scaling BOOLEAN DEFAULT FALSE,
+    start_ordinal INT NOT NULL DEFAULT 0,
     CONSTRAINT fk_application_endpoint_scale_application
     FOREIGN KEY (application_uuid)
     REFERENCES application (uuid)

--- a/domain/schema/model/triggers/application-triggers.gen.go
+++ b/domain/schema/model/triggers/application-triggers.gen.go
@@ -183,7 +183,8 @@ WHEN
 	NEW.application_uuid != OLD.application_uuid OR
 	(NEW.scale != OLD.scale OR (NEW.scale IS NOT NULL AND OLD.scale IS NULL) OR (NEW.scale IS NULL AND OLD.scale IS NOT NULL)) OR
 	(NEW.scale_target != OLD.scale_target OR (NEW.scale_target IS NOT NULL AND OLD.scale_target IS NULL) OR (NEW.scale_target IS NULL AND OLD.scale_target IS NOT NULL)) OR
-	(NEW.scaling != OLD.scaling OR (NEW.scaling IS NOT NULL AND OLD.scaling IS NULL) OR (NEW.scaling IS NULL AND OLD.scaling IS NOT NULL))
+	(NEW.scaling != OLD.scaling OR (NEW.scaling IS NOT NULL AND OLD.scaling IS NULL) OR (NEW.scaling IS NULL AND OLD.scaling IS NOT NULL)) OR
+	NEW.start_ordinal != OLD.start_ordinal
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));

--- a/domain/status/state/controller/controllerstate.go
+++ b/domain/status/state/controller/controllerstate.go
@@ -94,6 +94,7 @@ func (s *ControllerState) GetControllerNodeIDs(ctx context.Context) ([]status.Co
 	stmt, err := s.Prepare(`
 SELECT &controllerID.* 
 FROM controller_node
+WHERE life_id < 2
 `, controllerID{})
 	if err != nil {
 		return nil, errors.Capture(err)

--- a/domain/upgrade/state/state.go
+++ b/domain/upgrade/state/state.go
@@ -189,6 +189,7 @@ FROM   controller_node AS node
        ON node.controller_id = upgrade_node.controller_node_id
        AND  upgrade_node.upgrade_info_uuid = $ControllerNodeInfo.upgrade_info_uuid
 WHERE  node.dqlite_node_id IS NOT NULL
+AND    node.life_id < 2
 AND    upgrade_node.controller_node_id IS NULL;
 `, count, controllerNodeInfo)
 	if err != nil {

--- a/internal/bootstrap/deployer_caas.go
+++ b/internal/bootstrap/deployer_caas.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	corebase "github.com/juju/juju/core/base"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/version"
@@ -87,6 +88,10 @@ func (b *CAASDeployer) AddCAASControllerApplication(ctx context.Context, info De
 	}
 
 	origin := *info.Origin
+	controllerConstraints, err := normalizeControllerConstraints(b.constraints, origin.Platform.Architecture)
+	if err != nil {
+		return err
+	}
 
 	cfg, err := b.createCharmSettings()
 	if err != nil {
@@ -117,7 +122,7 @@ func (b *CAASDeployer) AddCAASControllerApplication(ctx context.Context, info De
 				Status: status.Unset,
 				Since:  new(b.clock.Now()),
 			},
-			Constraints:  b.constraints,
+			Constraints:  controllerConstraints,
 			IsController: true,
 		},
 		unitArg,
@@ -126,6 +131,19 @@ func (b *CAASDeployer) AddCAASControllerApplication(ctx context.Context, info De
 	}
 
 	return nil
+}
+
+// normalizeControllerConstraints follows application-domain architecture
+// normalization: an explicit constraint must match the charm platform, and an
+// absent constraint uses the selected charm architecture.
+func normalizeControllerConstraints(cons constraints.Value, charmArch string) (constraints.Value, error) {
+	if cons.HasArch() && charmArch != "" && *cons.Arch != charmArch {
+		return constraints.Value{}, errors.Errorf("arch in platform and constraints for controller do not match")
+	}
+	if !cons.HasArch() {
+		cons.Arch = &charmArch
+	}
+	return cons, nil
 }
 
 // CompleteCAASProcess is called when the bootstrap process is complete.

--- a/internal/bootstrap/deployer_caas_test.go
+++ b/internal/bootstrap/deployer_caas_test.go
@@ -132,6 +132,23 @@ func (s *deployerCAASSuite) TestAddCAASControllerApplication(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *deployerCAASSuite) TestNormalizeControllerConstraints(c *tc.C) {
+	got, err := normalizeControllerConstraints(constraints.Value{}, "amd64")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(got.Arch, tc.NotNil)
+	c.Check(*got.Arch, tc.Equals, "amd64")
+
+	got, err = normalizeControllerConstraints(constraints.Value{Arch: new("arm64")}, "arm64")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(got.Arch, tc.NotNil)
+	c.Check(*got.Arch, tc.Equals, "arm64")
+}
+
+func (s *deployerCAASSuite) TestNormalizeControllerConstraintsRejectsMismatchedArchitecture(c *tc.C) {
+	_, err := normalizeControllerConstraints(constraints.Value{Arch: new("arm64")}, "amd64")
+	c.Assert(err, tc.ErrorMatches, "arch in platform and constraints for controller do not match")
+}
+
 func (s *deployerCAASSuite) TestCompleteCAASProcess(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/internal/provider/kubernetes/application/application.go
+++ b/internal/provider/kubernetes/application/application.go
@@ -1740,7 +1740,7 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 
 	containerNames := config.ExistingContainers
-	controllerMode := config.Controller || a.name == coreapplication.ControllerApplicationName
+	controllerMode := config.Controller
 	if controllerMode && !slices.Contains(containerNames, "api-server") {
 		containerNames = append(containerNames, "api-server")
 	}

--- a/internal/provider/kubernetes/application/application.go
+++ b/internal/provider/kubernetes/application/application.go
@@ -231,7 +231,6 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 	if err != nil {
 		return errors.Annotate(err, "generating application podspec")
 	}
-
 	var handleVolume handleVolumeFunc = func(
 		v corev1.Volume,
 		attachParams jujustorage.KubernetesFilesystemAttachmentParams,
@@ -327,6 +326,9 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 			// With nil Replicas, Kubernetes defaults to 1 replica
 			// on creation. The provisioner's EnsureScale will
 			// correct the replica count if needed.
+		}
+		if exists {
+			ensureExistingPodTemplate(&existingSts.Spec.Template.Spec, podSpec)
 		}
 
 		var numPods *int32
@@ -473,6 +475,95 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 	}
 
 	return applier.Run(context.TODO(), false)
+}
+
+// ensureExistingPodTemplate retains pod components that are added outside
+// ApplicationPodSpec. Controller bootstrap adds its seed init container and
+// API server this way; generic reconciliation must not remove them.
+func ensureExistingPodTemplate(existing, desired *corev1.PodSpec) {
+	ensureContainers := func(existingContainers []corev1.Container, desiredContainers *[]corev1.Container) {
+		for _, existingContainer := range existingContainers {
+			if slices.IndexFunc(*desiredContainers, func(container corev1.Container) bool {
+				return container.Name == existingContainer.Name
+			}) == -1 {
+				*desiredContainers = append(*desiredContainers, existingContainer)
+			}
+		}
+	}
+	ensureContainers(existing.Containers, &desired.Containers)
+	ensureInitContainers(existing.InitContainers, &desired.InitContainers)
+
+	for i := range desired.Containers {
+		existingIndex := slices.IndexFunc(existing.Containers, func(container corev1.Container) bool {
+			return container.Name == desired.Containers[i].Name
+		})
+		if existingIndex == -1 {
+			continue
+		}
+		ensureDataDirMount(&existing.Containers[existingIndex], &desired.Containers[i])
+	}
+
+	for i := range desired.InitContainers {
+		existingIndex := slices.IndexFunc(existing.InitContainers, func(container corev1.Container) bool {
+			return container.Name == desired.InitContainers[i].Name
+		})
+		if existingIndex == -1 {
+			continue
+		}
+		ensureDataDirMount(&existing.InitContainers[existingIndex], &desired.InitContainers[i])
+		ensureContainerNamesEnv(&existing.InitContainers[existingIndex], &desired.InitContainers[i])
+	}
+
+	for _, existingVolume := range existing.Volumes {
+		if slices.IndexFunc(desired.Volumes, func(volume corev1.Volume) bool {
+			return volume.Name == existingVolume.Name
+		}) == -1 {
+			desired.Volumes = append(desired.Volumes, existingVolume)
+		}
+	}
+}
+
+func ensureInitContainers(existingContainers []corev1.Container, desiredContainers *[]corev1.Container) {
+	var ensured []corev1.Container
+	for _, existingContainer := range existingContainers {
+		if slices.IndexFunc(*desiredContainers, func(container corev1.Container) bool {
+			return container.Name == existingContainer.Name
+		}) == -1 {
+			ensured = append(ensured, existingContainer)
+		}
+	}
+	*desiredContainers = append(ensured, *desiredContainers...)
+}
+
+func ensureDataDirMount(existing, desired *corev1.Container) {
+	dataDir := paths.DataDir(paths.OSUnixLike)
+	existingIndex := slices.IndexFunc(existing.VolumeMounts, func(mount corev1.VolumeMount) bool {
+		return mount.MountPath == dataDir && mount.Name != constants.CharmVolumeName
+	})
+	if existingIndex == -1 {
+		return
+	}
+	desired.VolumeMounts = slices.DeleteFunc(desired.VolumeMounts, func(mount corev1.VolumeMount) bool {
+		return mount.MountPath == dataDir
+	})
+	desired.VolumeMounts = append(desired.VolumeMounts, existing.VolumeMounts[existingIndex])
+}
+
+func ensureContainerNamesEnv(existing, desired *corev1.Container) {
+	existingIndex := slices.IndexFunc(existing.Env, func(env corev1.EnvVar) bool {
+		return env.Name == constants.EnvJujuContainerNames
+	})
+	if existingIndex == -1 {
+		return
+	}
+	desiredIndex := slices.IndexFunc(desired.Env, func(env corev1.EnvVar) bool {
+		return env.Name == constants.EnvJujuContainerNames
+	})
+	if desiredIndex == -1 {
+		desired.Env = append(desired.Env, existing.Env[existingIndex])
+		return
+	}
+	desired.Env[desiredIndex] = existing.Env[existingIndex]
 }
 
 func (a *app) applyServiceAccountAndSecrets(applier resources.Applier, config caas.ApplicationConfig) error {
@@ -1649,6 +1740,10 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 	jujuDataDir := paths.DataDir(paths.OSUnixLike)
 
 	containerNames := config.ExistingContainers
+	controllerMode := config.Controller || a.name == coreapplication.ControllerApplicationName
+	if controllerMode && !slices.Contains(containerNames, "api-server") {
+		containerNames = append(containerNames, "api-server")
+	}
 	containers := []caas.ContainerConfig(nil)
 	for _, v := range config.Containers {
 		containerNames = append(containerNames, v.Name)
@@ -1855,6 +1950,14 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			},
 		}, charmContainerExtraVolumeMounts...),
 	}
+	if controllerMode {
+		charmContainer.LivenessProbe = nil
+		charmContainer.ReadinessProbe = nil
+		charmContainer.StartupProbe = nil
+		charmContainer.Env = slices.DeleteFunc(charmContainer.Env, func(env corev1.EnvVar) bool {
+			return env.Name == constants.EnvAgentHTTPProbePort
+		})
+	}
 	pebbleIdentitiesEnabled := false
 	if requireSecurityContext {
 		switch config.CharmUser {
@@ -2042,6 +2145,9 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			uid = int(constants.JujuUserID)
 		}
 		containerAgentArgs = append(containerAgentArgs, "--pebble-charm-identity", strconv.Itoa(uid))
+	}
+	if controllerMode {
+		containerAgentArgs = append(containerAgentArgs, "--controller")
 	}
 
 	appSecret := a.secretName()

--- a/internal/provider/kubernetes/application/application.go
+++ b/internal/provider/kubernetes/application/application.go
@@ -327,8 +327,8 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 			// on creation. The provisioner's EnsureScale will
 			// correct the replica count if needed.
 		}
-		if exists {
-			ensureExistingPodTemplate(&existingSts.Spec.Template.Spec, podSpec)
+		if exists && config.Controller {
+			ensureControllerBootstrapPodTemplate(&existingSts.Spec.Template.Spec, podSpec)
 		}
 
 		var numPods *int32
@@ -477,23 +477,31 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 	return applier.Run(context.TODO(), false)
 }
 
-// ensureExistingPodTemplate retains pod components that are added outside
-// ApplicationPodSpec. Controller bootstrap adds its seed init container and
-// API server this way; generic reconciliation must not remove them.
-func ensureExistingPodTemplate(existing, desired *corev1.PodSpec) {
-	ensureContainers := func(existingContainers []corev1.Container, desiredContainers *[]corev1.Container) {
-		for _, existingContainer := range existingContainers {
-			if slices.IndexFunc(*desiredContainers, func(container corev1.Container) bool {
-				return container.Name == existingContainer.Name
-			}) == -1 {
-				*desiredContainers = append(*desiredContainers, existingContainer)
-			}
+// ensureControllerBootstrapPodTemplate retains pod components added during
+// controller bootstrap that ApplicationPodSpec does not produce.
+func ensureControllerBootstrapPodTemplate(existing, desired *corev1.PodSpec) {
+	ensureContainer := func(existingContainers []corev1.Container, name string, desiredContainers *[]corev1.Container, prepend bool) {
+		existingIndex := slices.IndexFunc(existingContainers, func(container corev1.Container) bool {
+			return container.Name == name
+		})
+		if existingIndex == -1 || slices.ContainsFunc(*desiredContainers, func(container corev1.Container) bool {
+			return container.Name == name
+		}) {
+			return
 		}
+		if prepend {
+			*desiredContainers = append([]corev1.Container{existingContainers[existingIndex]}, *desiredContainers...)
+			return
+		}
+		*desiredContainers = append(*desiredContainers, existingContainers[existingIndex])
 	}
-	ensureContainers(existing.Containers, &desired.Containers)
-	ensureInitContainers(existing.InitContainers, &desired.InitContainers)
+	ensureContainer(existing.Containers, "api-server", &desired.Containers, false)
+	ensureContainer(existing.InitContainers, "controller-config-seed", &desired.InitContainers, true)
 
 	for i := range desired.Containers {
+		if desired.Containers[i].Name != constants.ApplicationCharmContainer {
+			continue
+		}
 		existingIndex := slices.IndexFunc(existing.Containers, func(container corev1.Container) bool {
 			return container.Name == desired.Containers[i].Name
 		})
@@ -504,6 +512,9 @@ func ensureExistingPodTemplate(existing, desired *corev1.PodSpec) {
 	}
 
 	for i := range desired.InitContainers {
+		if desired.InitContainers[i].Name != constants.ApplicationInitContainer {
+			continue
+		}
 		existingIndex := slices.IndexFunc(existing.InitContainers, func(container corev1.Container) bool {
 			return container.Name == desired.InitContainers[i].Name
 		})
@@ -514,25 +525,33 @@ func ensureExistingPodTemplate(existing, desired *corev1.PodSpec) {
 		ensureContainerNamesEnv(&existing.InitContainers[existingIndex], &desired.InitContainers[i])
 	}
 
+	bootstrapVolumeNames := make(map[string]struct{})
+	for _, container := range append(existing.Containers, existing.InitContainers...) {
+		if container.Name != "api-server" && container.Name != "controller-config-seed" {
+			continue
+		}
+		for _, mount := range container.VolumeMounts {
+			bootstrapVolumeNames[mount.Name] = struct{}{}
+		}
+	}
+	for _, container := range append(desired.Containers, desired.InitContainers...) {
+		if container.Name != constants.ApplicationCharmContainer && container.Name != constants.ApplicationInitContainer {
+			continue
+		}
+		for _, mount := range container.VolumeMounts {
+			bootstrapVolumeNames[mount.Name] = struct{}{}
+		}
+	}
 	for _, existingVolume := range existing.Volumes {
+		if _, ok := bootstrapVolumeNames[existingVolume.Name]; !ok {
+			continue
+		}
 		if slices.IndexFunc(desired.Volumes, func(volume corev1.Volume) bool {
 			return volume.Name == existingVolume.Name
 		}) == -1 {
 			desired.Volumes = append(desired.Volumes, existingVolume)
 		}
 	}
-}
-
-func ensureInitContainers(existingContainers []corev1.Container, desiredContainers *[]corev1.Container) {
-	var ensured []corev1.Container
-	for _, existingContainer := range existingContainers {
-		if slices.IndexFunc(*desiredContainers, func(container corev1.Container) bool {
-			return container.Name == existingContainer.Name
-		}) == -1 {
-			ensured = append(ensured, existingContainer)
-		}
-	}
-	*desiredContainers = append(ensured, *desiredContainers...)
 }
 
 func ensureDataDirMount(existing, desired *corev1.Container) {

--- a/internal/provider/kubernetes/application/application_test.go
+++ b/internal/provider/kubernetes/application/application_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	stdtesting "testing"
 	"time"
 
@@ -476,6 +477,129 @@ func (s *applicationSuite) assertEnsure(c *tc.C, app caas.Application,
 	c.Assert(crb, tc.DeepEquals, &appClusterRoleBinding)
 
 	checkMainResource()
+}
+
+func (s *applicationSuite) TestEnsurePreservesExistingPodExtensions(c *tc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	var config caas.ApplicationConfig
+	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func(got *caas.ApplicationConfig) {
+		config = *got
+	}, func() {}, nil)
+
+	statefulSet, err := s.client.AppsV1().StatefulSets(s.namespace).Get(c.Context(), s.appName, metav1.GetOptions{})
+	c.Assert(err, tc.ErrorIsNil)
+	statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes,
+		corev1.Volume{Name: "controller-config", VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{},
+		}},
+		corev1.Volume{Name: "storage", VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}},
+	)
+	statefulSet.Spec.Template.Spec.InitContainers = append(statefulSet.Spec.Template.Spec.InitContainers,
+		corev1.Container{Name: "controller-config-seed", VolumeMounts: []corev1.VolumeMount{{
+			Name: "controller-config", MountPath: "/var/lib/juju-controller-bootstrap",
+		}}},
+	)
+	statefulSet.Spec.Template.Spec.Containers = append(statefulSet.Spec.Template.Spec.Containers,
+		corev1.Container{Name: "api-server", VolumeMounts: []corev1.VolumeMount{{
+			Name: "storage", MountPath: "/var/lib/juju",
+		}}},
+	)
+	for i := range statefulSet.Spec.Template.Spec.InitContainers {
+		container := &statefulSet.Spec.Template.Spec.InitContainers[i]
+		if container.Name != constants.ApplicationInitContainer {
+			continue
+		}
+		container.VolumeMounts = []corev1.VolumeMount{{Name: "storage", MountPath: "/var/lib/juju"}}
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name: constants.EnvJujuContainerNames, Value: "api-server",
+		})
+	}
+	for i := range statefulSet.Spec.Template.Spec.Containers {
+		container := &statefulSet.Spec.Template.Spec.Containers[i]
+		if container.Name != constants.ApplicationCharmContainer {
+			continue
+		}
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name: "storage", MountPath: "/var/lib/juju",
+		})
+	}
+	_, err = s.client.AppsV1().StatefulSets(s.namespace).Update(c.Context(), statefulSet, metav1.UpdateOptions{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = app.Ensure(config)
+	c.Assert(err, tc.ErrorIsNil)
+
+	statefulSet, err = s.client.AppsV1().StatefulSets(s.namespace).Get(c.Context(), s.appName, metav1.GetOptions{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(slices.ContainsFunc(statefulSet.Spec.Template.Spec.InitContainers, func(container corev1.Container) bool {
+		return container.Name == "controller-config-seed"
+	}), tc.IsTrue)
+	seedIndex := slices.IndexFunc(statefulSet.Spec.Template.Spec.InitContainers, func(container corev1.Container) bool {
+		return container.Name == "controller-config-seed"
+	})
+	charmInitIndex := slices.IndexFunc(statefulSet.Spec.Template.Spec.InitContainers, func(container corev1.Container) bool {
+		return container.Name == constants.ApplicationInitContainer
+	})
+	c.Check(seedIndex < charmInitIndex, tc.IsTrue)
+	c.Check(slices.ContainsFunc(statefulSet.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
+		return container.Name == "api-server"
+	}), tc.IsTrue)
+	for _, container := range statefulSet.Spec.Template.Spec.InitContainers {
+		if container.Name != constants.ApplicationInitContainer {
+			continue
+		}
+		c.Check(slices.ContainsFunc(container.VolumeMounts, func(mount corev1.VolumeMount) bool {
+			return mount.Name == "storage" && mount.MountPath == "/var/lib/juju"
+		}), tc.IsTrue)
+		c.Check(slices.ContainsFunc(container.Env, func(env corev1.EnvVar) bool {
+			return env.Name == constants.EnvJujuContainerNames && env.Value == "api-server"
+		}), tc.IsTrue)
+	}
+	for _, container := range statefulSet.Spec.Template.Spec.Containers {
+		if container.Name != constants.ApplicationCharmContainer {
+			continue
+		}
+		c.Check(slices.ContainsFunc(container.VolumeMounts, func(mount corev1.VolumeMount) bool {
+			return mount.Name == "storage" && mount.MountPath == "/var/lib/juju"
+		}), tc.IsTrue)
+	}
+}
+
+func (s *applicationSuite) TestApplicationPodSpecController(c *tc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	spec, err := app.ApplicationPodSpec(caas.ApplicationConfig{
+		Controller:         true,
+		AgentVersion:       semversion.MustParse(defaultAgentVersion),
+		AgentImagePath:     "operator/image-path:1.1.1",
+		CharmBaseImagePath: "ubuntu@22.04",
+		CharmUser:          caas.RunAsNonRoot,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	charmIndex := slices.IndexFunc(spec.Containers, func(container corev1.Container) bool {
+		return container.Name == constants.ApplicationCharmContainer
+	})
+	c.Assert(charmIndex >= 0, tc.IsTrue)
+	charmContainer := spec.Containers[charmIndex]
+	c.Check(charmContainer.LivenessProbe, tc.IsNil)
+	c.Check(charmContainer.ReadinessProbe, tc.IsNil)
+	c.Check(charmContainer.StartupProbe, tc.IsNil)
+	c.Check(slices.ContainsFunc(charmContainer.Env, func(env corev1.EnvVar) bool {
+		return env.Name == constants.EnvAgentHTTPProbePort
+	}), tc.IsFalse)
+	c.Assert(charmContainer.SecurityContext, tc.NotNil)
+	c.Check(*charmContainer.SecurityContext.RunAsUser, tc.Equals, int64(constants.JujuUserID))
+
+	initIndex := slices.IndexFunc(spec.InitContainers, func(container corev1.Container) bool {
+		return container.Name == constants.ApplicationInitContainer
+	})
+	c.Assert(initIndex >= 0, tc.IsTrue)
+	c.Check(slices.Contains(spec.InitContainers[initIndex].Args, "--controller"), tc.IsTrue)
+	c.Check(slices.ContainsFunc(spec.InitContainers[initIndex].Env, func(env corev1.EnvVar) bool {
+		return env.Name == constants.EnvJujuContainerNames && env.Value == "api-server"
+	}), tc.IsTrue)
 }
 
 func (s *applicationSuite) assertDelete(c *tc.C, app caas.Application) {

--- a/internal/provider/kubernetes/application/application_test.go
+++ b/internal/provider/kubernetes/application/application_test.go
@@ -590,7 +590,7 @@ func (s *applicationSuite) TestApplicationPodSpecController(c *tc.C) {
 		return env.Name == constants.EnvAgentHTTPProbePort
 	}), tc.IsFalse)
 	c.Assert(charmContainer.SecurityContext, tc.NotNil)
-	c.Check(*charmContainer.SecurityContext.RunAsUser, tc.Equals, int64(constants.JujuUserID))
+	c.Check(*charmContainer.SecurityContext.RunAsUser, tc.Equals, constants.JujuUserID)
 
 	initIndex := slices.IndexFunc(spec.InitContainers, func(container corev1.Container) bool {
 		return container.Name == constants.ApplicationInitContainer

--- a/internal/provider/kubernetes/application/application_test.go
+++ b/internal/provider/kubernetes/application/application_test.go
@@ -479,10 +479,11 @@ func (s *applicationSuite) assertEnsure(c *tc.C, app caas.Application,
 	checkMainResource()
 }
 
-func (s *applicationSuite) TestEnsurePreservesExistingPodExtensions(c *tc.C) {
+func (s *applicationSuite) TestEnsurePreservesControllerBootstrapPodExtensions(c *tc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	var config caas.ApplicationConfig
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func(got *caas.ApplicationConfig) {
+		got.Controller = true
 		config = *got
 	}, func() {}, nil)
 
@@ -512,9 +513,9 @@ func (s *applicationSuite) TestEnsurePreservesExistingPodExtensions(c *tc.C) {
 			continue
 		}
 		container.VolumeMounts = []corev1.VolumeMount{{Name: "storage", MountPath: "/var/lib/juju"}}
-		container.Env = append(container.Env, corev1.EnvVar{
+		container.Env = []corev1.EnvVar{{
 			Name: constants.EnvJujuContainerNames, Value: "api-server",
-		})
+		}}
 	}
 	for i := range statefulSet.Spec.Template.Spec.Containers {
 		container := &statefulSet.Spec.Template.Spec.Containers[i]
@@ -565,6 +566,41 @@ func (s *applicationSuite) TestEnsurePreservesExistingPodExtensions(c *tc.C) {
 			return mount.Name == "storage" && mount.MountPath == "/var/lib/juju"
 		}), tc.IsTrue)
 	}
+}
+
+func (s *applicationSuite) TestEnsureRemovesContainerRemovedByCharmRefresh(c *tc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	var config caas.ApplicationConfig
+	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func(got *caas.ApplicationConfig) {
+		config = *got
+	}, func() {}, nil)
+
+	delete(config.Containers, "nginx")
+	c.Assert(app.Ensure(config), tc.ErrorIsNil)
+
+	statefulSet, err := s.client.AppsV1().StatefulSets(s.namespace).Get(c.Context(), s.appName, metav1.GetOptions{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(slices.ContainsFunc(statefulSet.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
+		return container.Name == "nginx"
+	}), tc.IsFalse)
+}
+
+func (s *applicationSuite) TestEnsureControllerRemovesContainerRemovedByCharmRefresh(c *tc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	var config caas.ApplicationConfig
+	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func(got *caas.ApplicationConfig) {
+		got.Controller = true
+		config = *got
+	}, func() {}, nil)
+
+	delete(config.Containers, "nginx")
+	c.Assert(app.Ensure(config), tc.ErrorIsNil)
+
+	statefulSet, err := s.client.AppsV1().StatefulSets(s.namespace).Get(c.Context(), s.appName, metav1.GetOptions{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(slices.ContainsFunc(statefulSet.Spec.Template.Spec.Containers, func(container corev1.Container) bool {
+		return container.Name == "nginx"
+	}), tc.IsFalse)
 }
 
 func (s *applicationSuite) TestApplicationPodSpecController(c *tc.C) {

--- a/internal/provider/kubernetes/application/scale.go
+++ b/internal/provider/kubernetes/application/scale.go
@@ -5,11 +5,13 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/juju/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/internal/provider/kubernetes/resources"
@@ -17,19 +19,68 @@ import (
 	"github.com/juju/juju/internal/storage"
 )
 
-// Scale scales the Application's unit to the value specificied. Scale must
-// be >= 0. Application units will be removed or added to meet the scale
-// defined.
-func (a *app) Scale(scaleTo int) error {
+// Scale reconciles the application's replica count and stops when ctx is
+// cancelled.
+func (a *app) Scale(ctx context.Context, scaleTo int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	switch a.deploymentType {
 	case caas.DeploymentStateful:
 		return scale.PatchReplicasToScale(
-			context.Background(),
+			ctx,
 			a.name,
 			int32(scaleTo),
 			scale.StatefulSetScalePatcher(a.client.AppsV1().StatefulSets(a.namespace)),
 		)
 	case caas.DeploymentStateless:
+		return scale.PatchReplicasToScale(
+			ctx,
+			a.name,
+			int32(scaleTo),
+			scale.DeploymentScalePatcher(a.client.AppsV1().Deployments(a.namespace)),
+		)
+	default:
+		return errors.NotSupportedf(
+			"application %q deployment type %q cannot be scaled",
+			a.name, a.deploymentType)
+	}
+}
+
+// ScaleRange reconciles the application's ordinal range and stops when ctx is
+// cancelled. Scale and startOrdinal must both be non-negative.
+func (a *app) ScaleRange(ctx context.Context, scaleTo, startOrdinal int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if scaleTo < 0 || startOrdinal < 0 {
+		return errors.NotValidf("scale %d or start ordinal %d", scaleTo, startOrdinal)
+	}
+	switch a.deploymentType {
+	case caas.DeploymentStateful:
+		patch, err := json.Marshal(map[string]any{
+			"spec": map[string]any{
+				"replicas": scaleTo,
+				"ordinals": map[string]any{
+					"start": startOrdinal,
+				},
+			},
+		})
+		if err != nil {
+			return errors.Trace(err)
+		}
+		_, err = a.client.AppsV1().StatefulSets(a.namespace).Patch(
+			ctx, a.name, types.MergePatchType, patch, meta.PatchOptions{})
+		if k8serrors.IsNotFound(err) {
+			return errors.NotFoundf("statefulset %q", a.name)
+		} else if err != nil {
+			return errors.Annotatef(err, "scaling statefulset %q", a.name)
+		}
+		return nil
+	case caas.DeploymentStateless:
+		if startOrdinal != 0 {
+			return errors.NotSupportedf("scaling deployment %q from ordinal %d", a.name, startOrdinal)
+		}
 		return scale.PatchReplicasToScale(
 			context.Background(),
 			a.name,

--- a/internal/provider/kubernetes/application/scale.go
+++ b/internal/provider/kubernetes/application/scale.go
@@ -82,7 +82,7 @@ func (a *app) ScaleRange(ctx context.Context, scaleTo, startOrdinal int) error {
 			return errors.NotSupportedf("scaling deployment %q from ordinal %d", a.name, startOrdinal)
 		}
 		return scale.PatchReplicasToScale(
-			context.Background(),
+			ctx,
 			a.name,
 			int32(scaleTo),
 			scale.DeploymentScalePatcher(a.client.AppsV1().Deployments(a.namespace)),

--- a/internal/provider/kubernetes/application/scale.go
+++ b/internal/provider/kubernetes/application/scale.go
@@ -47,20 +47,21 @@ func (a *app) Scale(ctx context.Context, scaleTo int) error {
 	}
 }
 
-// ScaleRange reconciles the application's ordinal range and stops when ctx is
-// cancelled. Scale and startOrdinal must both be non-negative.
-func (a *app) ScaleRange(ctx context.Context, scaleTo, startOrdinal int) error {
+// ScaleRange reconciles the application to the ordinal range
+// [startOrdinal, startOrdinal+replicaCount) and stops when ctx is cancelled.
+// Sparse ordinal ranges are not supported. Both values must be non-negative.
+func (a *app) ScaleRange(ctx context.Context, replicaCount, startOrdinal int) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if scaleTo < 0 || startOrdinal < 0 {
-		return errors.NotValidf("scale %d or start ordinal %d", scaleTo, startOrdinal)
+	if replicaCount < 0 || startOrdinal < 0 {
+		return errors.NotValidf("replica count %d or start ordinal %d", replicaCount, startOrdinal)
 	}
 	switch a.deploymentType {
 	case caas.DeploymentStateful:
 		patch, err := json.Marshal(map[string]any{
 			"spec": map[string]any{
-				"replicas": scaleTo,
+				"replicas": replicaCount,
 				"ordinals": map[string]any{
 					"start": startOrdinal,
 				},
@@ -84,7 +85,7 @@ func (a *app) ScaleRange(ctx context.Context, scaleTo, startOrdinal int) error {
 		return scale.PatchReplicasToScale(
 			ctx,
 			a.name,
-			int32(scaleTo),
+			int32(replicaCount),
 			scale.DeploymentScalePatcher(a.client.AppsV1().Deployments(a.namespace)),
 		)
 	default:

--- a/internal/provider/kubernetes/application/scale_test.go
+++ b/internal/provider/kubernetes/application/scale_test.go
@@ -4,6 +4,8 @@
 package application_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,7 +21,7 @@ func (s *applicationSuite) TestApplicationScaleStateful(c *tc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", nil, func() {}, nil)
 
-	c.Assert(app.Scale(20), tc.ErrorIsNil)
+	c.Assert(app.Scale(c.Context(), 20), tc.ErrorIsNil)
 	ss, err := s.client.AppsV1().StatefulSets(s.namespace).Get(
 		c.Context(),
 		s.appName,
@@ -29,11 +31,51 @@ func (s *applicationSuite) TestApplicationScaleStateful(c *tc.C) {
 	c.Assert(*ss.Spec.Replicas, tc.Equals, int32(20))
 }
 
+func (s *applicationSuite) TestApplicationScaleStatefulRange(c *tc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", nil, func() {}, nil)
+
+	c.Assert(app.ScaleRange(c.Context(), 2, 1), tc.ErrorIsNil)
+	ss, err := s.client.AppsV1().StatefulSets(s.namespace).Get(
+		c.Context(),
+		s.appName,
+		metav1.GetOptions{},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(*ss.Spec.Replicas, tc.Equals, int32(2))
+	c.Assert(ss.Spec.Ordinals, tc.NotNil)
+	c.Check(ss.Spec.Ordinals.Start, tc.Equals, int32(1))
+}
+
+func (s *applicationSuite) TestApplicationScaleRangeInvalid(c *tc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+
+	c.Check(app.ScaleRange(c.Context(), -1, 0), tc.ErrorIs, errors.NotValid)
+	c.Check(app.ScaleRange(c.Context(), 1, -1), tc.ErrorIs, errors.NotValid)
+}
+
+func (s *applicationSuite) TestApplicationScaleRangeCancelled(c *tc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", nil, func() {}, nil)
+
+	ctx, cancel := context.WithCancel(c.Context())
+	cancel()
+	err := app.ScaleRange(ctx, 2, 1)
+	c.Assert(err, tc.ErrorIs, context.Canceled)
+}
+
+func (s *applicationSuite) TestApplicationScaleRangeStatelessNonZeroStart(c *tc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateless, false)
+
+	err := app.ScaleRange(c.Context(), 2, 1)
+	c.Assert(err, tc.ErrorIs, errors.NotSupported)
+}
+
 func (s *applicationSuite) TestApplicationScaleStateless(c *tc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateless, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", nil, func() {}, nil)
 
-	c.Assert(app.Scale(20), tc.ErrorIsNil)
+	c.Assert(app.Scale(c.Context(), 20), tc.ErrorIsNil)
 	dep, err := s.client.AppsV1().Deployments(s.namespace).Get(
 		c.Context(),
 		s.appName,
@@ -47,7 +89,16 @@ func (s *applicationSuite) TestApplicationScaleStatefulLessThanZero(c *tc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", nil, func() {}, nil)
 
-	c.Assert(app.Scale(-1), tc.ErrorIs, errors.NotValid)
+	c.Assert(app.Scale(c.Context(), -1), tc.ErrorIs, errors.NotValid)
+}
+
+func (s *applicationSuite) TestApplicationScaleCancelled(c *tc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+
+	ctx, cancel := context.WithCancel(c.Context())
+	cancel()
+	err := app.Scale(ctx, 2)
+	c.Assert(err, tc.ErrorIs, context.Canceled)
 }
 
 func (s *applicationSuite) TestEnsureControllerNonce(c *tc.C) {
@@ -124,7 +175,7 @@ func (s *applicationSuite) TestCurrentScale(c *tc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", nil, func() {}, nil)
 
-	c.Assert(app.Scale(3), tc.ErrorIsNil)
+	c.Assert(app.Scale(c.Context(), 3), tc.ErrorIsNil)
 
 	units, err := app.UnitsToRemove(c.Context(), 1)
 	c.Assert(err, tc.ErrorIsNil)

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -1013,8 +1013,9 @@ func (c *controllerStack) createControllerStatefulset(ctx context.Context) error
 			Annotations: c.stackAnnotations,
 		},
 		Spec: apps.StatefulSetSpec{
-			ServiceName: c.resourceNameHeadlessService,
-			Replicas:    &numberOfPods,
+			ServiceName:         c.resourceNameHeadlessService,
+			Replicas:            &numberOfPods,
+			PodManagementPolicy: apps.ParallelPodManagement,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: c.selectorLabels,
 			},

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"path"
 	"strconv"
@@ -38,6 +39,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	k8sannotations "github.com/juju/juju/core/annotations"
+	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/version"
 	"github.com/juju/juju/core/watcher"
@@ -997,6 +999,9 @@ func ensureControllerServiceAccount(
 
 func (c *controllerStack) createControllerStatefulset(ctx context.Context) error {
 	numberOfPods := int32(1) // TODO(caas): HA mode!
+	templateAnnotations := maps.Clone(c.stackAnnotations)
+	templateAnnotations[providerutils.AnnotationVersionKey(constants.LastLabelVersion)] = c.pcfg.JujuVersion.String()
+	templateAnnotations[providerutils.AnnotationModelUUIDKey(constants.LastLabelVersion)] = c.broker.ModelUUID()
 	controllerStatefulSet := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: c.stackName,
@@ -1021,7 +1026,7 @@ func (c *controllerStack) createControllerStatefulset(ctx context.Context) error
 					),
 					Name:        c.pcfg.GetPodName(), // This really should not be set.
 					Namespace:   c.broker.Namespace(),
-					Annotations: c.stackAnnotations,
+					Annotations: templateAnnotations,
 				},
 			},
 		},
@@ -1557,14 +1562,23 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 		return nil, errors.Annotate(err, "getting image for base")
 	}
 
+	controllerConstraints := c.pcfg.Bootstrap.BootstrapMachineConstraints
+	if !controllerConstraints.HasArch() {
+		// Match application-domain architecture normalization: an application
+		// without an explicit architecture uses its selected charm architecture.
+		arch := corearch.DefaultArchitecture
+		controllerConstraints.Arch = &arch
+	}
+
 	cfg := caas.ApplicationConfig{
+		Controller:           true,
 		AgentVersion:         c.pcfg.JujuVersion,
 		AgentImagePath:       controllerImage,
 		CharmBaseImagePath:   charmBaseImage,
 		IsPrivateImageRepo:   repo.IsPrivate(),
 		CharmModifiedVersion: 0,
 		InitialScale:         1,
-		Constraints:          c.pcfg.Bootstrap.BootstrapMachineConstraints,
+		Constraints:          controllerConstraints,
 		ExistingContainers:   []string{apiServerContainerName},
 		// TODO(wallyworld) - use storage so the volumes don't need to be manually set up
 		// Filesystems: nil,
@@ -1680,7 +1694,6 @@ fi
 				Value: c.pcfg.APIInfo.CACert,
 			},
 		)
-		ct.Args = append(ct.Args, "--controller")
 		spec.InitContainers[i] = ct
 	}
 	for i, ct := range spec.Containers {
@@ -1698,16 +1711,6 @@ fi
 		}
 		ct.VolumeMounts = append(ct.VolumeMounts, dataDirMount)
 
-		// Remove probes to prevent controller death.
-		ct.LivenessProbe = nil
-		ct.ReadinessProbe = nil
-		ct.StartupProbe = nil
-		for j, env := range ct.Env {
-			if env.Name == constants.EnvAgentHTTPProbePort {
-				ct.Env = append(ct.Env[:j], ct.Env[j+1:]...)
-				break
-			}
-		}
 		spec.Containers[i] = ct
 	}
 	return spec, nil

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -782,8 +782,9 @@ func (s *bootstrapSuite) testBootstrap(c *tc.C, enableServiceLinks bool) {
 			Annotations: map[string]string{"controller.juju.is/id": coretesting.ControllerTag.Id()},
 		},
 		Spec: apps.StatefulSetSpec{
-			ServiceName: "juju-controller-test-service-endpoints",
-			Replicas:    &numberOfPods,
+			ServiceName:         "juju-controller-test-service-endpoints",
+			Replicas:            &numberOfPods,
+			PodManagementPolicy: apps.ParallelPodManagement,
 			Selector: &v1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": "juju-controller-test"},
 			},

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -813,10 +813,15 @@ func (s *bootstrapSuite) testBootstrap(c *tc.C, enableServiceLinks bool) {
 						"app.kubernetes.io/name":        "juju-controller-test",
 						"model.juju.is/disable-webhook": "true",
 					},
-					Annotations: map[string]string{"controller.juju.is/id": coretesting.ControllerTag.Id()},
+					Annotations: map[string]string{
+						"controller.juju.is/id": coretesting.ControllerTag.Id(),
+						"juju.is/version":       s.pcfg.JujuVersion.String(),
+						"model.juju.is/id":      s.cfg.UUID(),
+					},
 				},
 				Spec: core.PodSpec{
 					ServiceAccountName:            "controller",
+					NodeSelector:                  map[string]string{"kubernetes.io/arch": "amd64"},
 					AutomountServiceAccountToken:  pointer.Bool(true),
 					TerminationGracePeriodSeconds: new(int64(30)),
 					EnableServiceLinks:            pointer.Bool(enableServiceLinks),

--- a/internal/provider/kubernetes/resources/daemonset.go
+++ b/internal/provider/kubernetes/resources/daemonset.go
@@ -53,7 +53,9 @@ func (ds *DaemonSet) Apply(ctx context.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	res, err := ds.client.Patch(ctx, ds.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{
+	// JSON merge patches replace array fields, allowing pod template containers
+	// removed by a charm refresh to be removed from the DaemonSet.
+	res, err := ds.client.Patch(ctx, ds.Name, types.MergePatchType, data, metav1.PatchOptions{
 		FieldManager: JujuFieldManager,
 	})
 	if k8serrors.IsNotFound(err) {

--- a/internal/provider/kubernetes/resources/daemonset_test.go
+++ b/internal/provider/kubernetes/resources/daemonset_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -42,6 +43,11 @@ func (s *daemonsetSuite) TestApply(c *tc.C) {
 			Name:      "ds1",
 			Namespace: "test",
 		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "removed"}}},
+			},
+		},
 	}
 	// Create.
 	dsResource := resources.NewDaemonSet(s.client.AppsV1().DaemonSets(ds.Namespace), "test", "ds1", ds)
@@ -50,8 +56,9 @@ func (s *daemonsetSuite) TestApply(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), tc.Equals, 0)
 
-	// Update.
+	// Update removes the container and adds an annotation.
 	ds.SetAnnotations(map[string]string{"a": "b"})
+	ds.Spec.Template.Spec.Containers = nil
 	dsResource = resources.NewDaemonSet(s.client.AppsV1().DaemonSets(ds.Namespace), "test", "ds1", ds)
 	c.Assert(dsResource.Apply(c.Context()), tc.ErrorIsNil)
 
@@ -60,6 +67,7 @@ func (s *daemonsetSuite) TestApply(c *tc.C) {
 	c.Assert(result.GetName(), tc.Equals, `ds1`)
 	c.Assert(result.GetNamespace(), tc.Equals, `test`)
 	c.Assert(result.GetAnnotations(), tc.DeepEquals, map[string]string{"a": "b"})
+	c.Check(result.Spec.Template.Spec.Containers, tc.HasLen, 0)
 }
 
 func (s *daemonsetSuite) TestGet(c *tc.C) {

--- a/internal/provider/kubernetes/resources/deployment.go
+++ b/internal/provider/kubernetes/resources/deployment.go
@@ -53,7 +53,9 @@ func (d *Deployment) Apply(ctx context.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	res, err := d.client.Patch(ctx, d.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{
+	// JSON merge patches replace array fields, allowing pod template containers
+	// removed by a charm refresh to be removed from the Deployment.
+	res, err := d.client.Patch(ctx, d.Name, types.MergePatchType, data, metav1.PatchOptions{
 		FieldManager: JujuFieldManager,
 	})
 	if k8serrors.IsNotFound(err) {

--- a/internal/provider/kubernetes/resources/deployment_test.go
+++ b/internal/provider/kubernetes/resources/deployment_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/tc"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -42,6 +43,11 @@ func (s *deploymentSuite) TestApply(c *tc.C) {
 			Name:      "deployment1",
 			Namespace: "test",
 		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "removed"}}},
+			},
+		},
 	}
 	// Create.
 	deploymentResource := resources.NewDeployment(s.client.AppsV1().Deployments(deployment.Namespace), "test", "deployment1", deployment)
@@ -50,8 +56,9 @@ func (s *deploymentSuite) TestApply(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(len(result.GetAnnotations()), tc.Equals, 0)
 
-	// Update.
+	// Update removes the container and adds an annotation.
 	deployment.SetAnnotations(map[string]string{"a": "b"})
+	deployment.Spec.Template.Spec.Containers = nil
 	deploymentResource = resources.NewDeployment(s.client.AppsV1().Deployments(deployment.Namespace), "test", "deployment1", deployment)
 	c.Assert(deploymentResource.Apply(c.Context()), tc.ErrorIsNil)
 
@@ -60,6 +67,7 @@ func (s *deploymentSuite) TestApply(c *tc.C) {
 	c.Assert(result.GetName(), tc.Equals, `deployment1`)
 	c.Assert(result.GetNamespace(), tc.Equals, `test`)
 	c.Assert(result.GetAnnotations(), tc.DeepEquals, map[string]string{"a": "b"})
+	c.Check(result.Spec.Template.Spec.Containers, tc.HasLen, 0)
 }
 
 func (s *deploymentSuite) TestGet(c *tc.C) {

--- a/internal/provider/kubernetes/resources/statefulset.go
+++ b/internal/provider/kubernetes/resources/statefulset.go
@@ -96,7 +96,9 @@ func (ss *StatefulSet) Apply(ctx context.Context) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	result, err = ss.client.Patch(ctx, ss.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{
+	// JSON merge patches replace array fields, allowing pod template containers
+	// removed by a charm refresh to be removed from the StatefulSet.
+	result, err = ss.client.Patch(ctx, ss.Name, types.MergePatchType, data, metav1.PatchOptions{
 		FieldManager: JujuFieldManager,
 	})
 	if k8serrors.IsNotFound(err) {

--- a/internal/worker/apiaddresssetter/worker.go
+++ b/internal/worker/apiaddresssetter/worker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/controllernode"
+	controllernodeerrors "github.com/juju/juju/domain/controllernode/errors"
 	networkerrors "github.com/juju/juju/domain/network/errors"
 	"github.com/juju/juju/internal/errors"
 	internalworker "github.com/juju/juju/internal/worker"
@@ -217,9 +218,34 @@ func (w *apiAddressSetterWorker) loop() error {
 			}
 		}
 
-		if err := w.updateAPIAddresses(ctx); err != nil {
-			w.config.Logger.Errorf(ctx, "cannot update api addresses: %v", err)
+		w.updateAPIAddressesAfterControllerRefresh(ctx)
+	}
+}
+
+// updateAPIAddressesAfterControllerRefresh updates the tracked controllers'
+// addresses. A controller can be removed between a watcher event and this
+// update, so refresh the tracker set and retry once when the state rejects the
+// stale controller ID.
+func (w *apiAddressSetterWorker) updateAPIAddressesAfterControllerRefresh(ctx context.Context) {
+	err := w.updateAPIAddresses(ctx)
+	if err == nil {
+		return
+	} else if !errors.Is(err, controllernodeerrors.NotFound) {
+		w.config.Logger.Errorf(ctx, "cannot update api addresses: %v", err)
+		return
+	}
+
+	w.config.Logger.Debugf(ctx, "controller node removed while updating api addresses")
+	if _, err := w.updateControllerNodes(ctx); err != nil {
+		w.config.Logger.Errorf(ctx, "cannot refresh controller nodes: %v", err)
+		return
+	}
+	if err := w.updateAPIAddresses(ctx); err != nil {
+		if errors.Is(err, controllernodeerrors.NotFound) {
+			w.config.Logger.Debugf(ctx, "controller node removed while retrying api address update")
+			return
 		}
+		w.config.Logger.Errorf(ctx, "cannot update api addresses after controller refresh: %v", err)
 	}
 }
 
@@ -328,6 +354,10 @@ func (w *apiAddressSetterWorker) stopAndRemoveTracker(ctx context.Context, contr
 
 // updateAPIAddresses updates the API addresses for each tracked controller.
 func (w *apiAddressSetterWorker) updateAPIAddresses(ctx context.Context) error {
+	if len(w.runner.WorkerNames()) == 0 {
+		return nil
+	}
+
 	cfg, err := w.config.ControllerConfigService.ControllerConfig(ctx)
 	if err != nil {
 		return errors.Capture(err)

--- a/internal/worker/apiaddresssetter/worker_test.go
+++ b/internal/worker/apiaddresssetter/worker_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain/controllernode"
+	controllernodeerrors "github.com/juju/juju/domain/controllernode/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
 )
@@ -177,6 +178,64 @@ func (s *workerSuite) TestNewControllerNode(c *tc.C) {
 		c.Fatalf("timed out waiting for API address update")
 	}
 
+	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) TestRemovedControllerNodeRefreshesBeforeRetryingAPIAddresses(c *tc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	nodeCh := make(chan struct{})
+	s.controllerNodeService.EXPECT().WatchControllerNodes(gomock.Any()).Return(watchertest.NewMockNotifyWatcher(nodeCh), nil)
+	s.controllerConfigService.EXPECT().WatchControllerConfig(gomock.Any()).Return(watchertest.NewMockStringsWatcher(make(chan []string)), nil)
+
+	refreshed := make(chan struct{})
+	s.controllerNodeService.EXPECT().GetControllerIDs(gomock.Any()).Return([]string{"1"}, nil)
+	s.controllerNodeService.EXPECT().GetControllerIDs(gomock.Any()).DoAndReturn(func(context.Context) ([]string, error) {
+		close(refreshed)
+		return nil, nil
+	})
+	s.applicationService.EXPECT().WatchUnitAddresses(gomock.Any(), unit.Name("controller/1")).Return(watchertest.NewMockNotifyWatcher(make(chan struct{})), nil)
+
+	sp := &network.SpaceInfo{ID: "space0"}
+	addrs := network.SpaceAddresses{{
+		MachineAddress: network.MachineAddress{Value: "10.0.0.1/24"},
+		SpaceID:        "space0",
+	}}
+	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(controller.Config{
+		controller.JujuManagementSpace: "space0",
+	}, nil)
+	s.networkService.EXPECT().SpaceByName(gomock.Any(), network.SpaceName("space0")).Return(sp, nil)
+	s.networkService.EXPECT().GetControllerAPIAddresses(gomock.Any(), unit.Name("controller/1"), sp).Return(addrs, nil)
+	s.controllerNodeService.EXPECT().SetAPIAddresses(gomock.Any(), controllernode.SetAPIAddressArgs{
+		MgmtSpace: sp,
+		APIAddresses: map[string]network.SpaceHostPorts{
+			"1": network.SpaceAddressesWithPort(addrs, 17070),
+		},
+	}).Return(controllernodeerrors.NotFound)
+
+	w, err := New(Config{
+		ControllerConfigService: s.controllerConfigService,
+		ApplicationService:      s.applicationService,
+		ControllerNodeService:   s.controllerNodeService,
+		NetworkService:          s.networkService,
+		APIPort:                 17070,
+		Logger:                  loggertesting.WrapCheckLog(c),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	select {
+	case nodeCh <- struct{}{}:
+	case <-c.Context().Done():
+		c.Fatalf("sending controller node event: %v", c.Context().Err())
+	}
+	select {
+	case <-refreshed:
+	case <-c.Context().Done():
+		c.Fatalf("waiting for controller-node refresh: %v", c.Context().Err())
+	}
+
+	workertest.CheckAlive(c, w)
 	workertest.CleanKill(c, w)
 }
 

--- a/internal/worker/apiremotecaller/manifold.go
+++ b/internal/worker/apiremotecaller/manifold.go
@@ -111,17 +111,9 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				return nil, errors.Trace(err)
 			}
 
-			apiInfo, err := config.APIInfo.APIInfo()
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			if apiInfo == nil {
-				return nil, errors.NotValidf("APIInfo provider returned nil")
-			}
-
 			cfg := WorkerConfig{
 				ControllerNodeService: services.ControllerNode(),
-				APIInfo:               apiInfo,
+				APIInfo:               config.APIInfo,
 				APIOpener:             api.Open,
 				Origin:                config.Origin,
 				NewRemote:             NewRemoteServer,

--- a/internal/worker/apiremotecaller/manifold_test.go
+++ b/internal/worker/apiremotecaller/manifold_test.go
@@ -89,7 +89,9 @@ func (s *ManifoldSuite) TestNewWorkerArgs(c *tc.C) {
 	c.Check(config.Origin, tc.Equals, names.NewControllerAgentTag("0"))
 	c.Check(config.Clock, tc.Equals, clock)
 	c.Check(config.ControllerNodeService, tc.DeepEquals, &controllernodeservice.WatchableService{})
-	c.Check(config.APIInfo.CACert, tc.Equals, "cert")
+	apiInfo, err := config.APIInfo.APIInfo()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(apiInfo.CACert, tc.Equals, "cert")
 	c.Check(config.NewRemote, tc.NotNil)
 }
 

--- a/internal/worker/apiremotecaller/remote.go
+++ b/internal/worker/apiremotecaller/remote.go
@@ -49,8 +49,9 @@ type RemoteServerConfig struct {
 
 	ControllerID string
 
-	// APIInfo is initially populated with the addresses of the target machine.
-	APIInfo *api.Info
+	// APIInfo provides current credentials for connections to the target machine.
+	// Controller agent passwords can change after this remote worker starts.
+	APIInfo APIInfoProvider
 
 	// APIOpener is a function that will open a connection to the target API
 	// server.
@@ -63,7 +64,8 @@ type remoteServer struct {
 	tomb           tomb.Tomb
 
 	controllerID string
-	info         *api.Info
+	apiInfo      APIInfoProvider
+	addresses    []string
 
 	apiOpener api.OpenFunc
 
@@ -85,7 +87,7 @@ func NewRemoteServer(config RemoteServerConfig) RemoteServer {
 func newRemoteServer(config RemoteServerConfig, internalStates chan string) RemoteServer {
 	w := &remoteServer{
 		controllerID:   config.ControllerID,
-		info:           config.APIInfo,
+		apiInfo:        config.APIInfo,
 		logger:         config.Logger,
 		clock:          config.Clock,
 		apiOpener:      config.APIOpener,
@@ -353,7 +355,7 @@ func (w *remoteServer) loop() error {
 
 			// We've successfully connected to the remote server, so update the
 			// addresses.
-			w.info.Addrs = append([]string(nil), addresses...)
+			w.addresses = append([]string(nil), addresses...)
 			w.connected.Store(true)
 
 			w.reportInternalState(stateChanged)
@@ -386,7 +388,7 @@ func (w *remoteServer) loop() error {
 			case <-w.tomb.Dying():
 				return tomb.ErrDying
 			case ch <- report{
-				addresses: append([]string(nil), w.info.Addrs...),
+				addresses: append([]string(nil), w.addresses...),
 				connected: w.connected.Load(),
 			}:
 			}
@@ -395,12 +397,12 @@ func (w *remoteServer) loop() error {
 }
 
 func (w *remoteServer) addressesAlreadyExist(addresses []string) bool {
-	if len(addresses) != len(w.info.Addrs) {
+	if len(addresses) != len(w.addresses) {
 		return false
 	}
 
 	for i, addr := range addresses {
-		if addr != w.info.Addrs[i] {
+		if addr != w.addresses[i] {
 			return false
 		}
 	}
@@ -414,14 +416,21 @@ func (w *remoteServer) connect(ctx context.Context, addresses []string) (api.Con
 	// Use temporary info until we're sure we can connect. If the addresses
 	// are invalid, but the existing connection is still valid, we don't want
 	// to close it.
-	info := *w.info
-	info.Addrs = addresses
-
 	// Start connecting to the remote API server.
 	var connection api.Connection
 	err := retry.Call(retry.CallArgs{
 		Func: func() error {
-			conn, err := w.apiOpener(ctx, &info, dialOpts)
+			info, err := w.apiInfo.APIInfo()
+			if err != nil {
+				return errors.Annotate(err, "getting current API info")
+			}
+			if info == nil {
+				return errors.NotValidf("APIInfo provider returned nil")
+			}
+			infoCopy := *info
+			infoCopy.Addrs = addresses
+
+			conn, err := w.apiOpener(ctx, &infoCopy, dialOpts)
 			if err != nil {
 				return err
 			}
@@ -430,7 +439,7 @@ func (w *remoteServer) connect(ctx context.Context, addresses []string) (api.Con
 			return nil
 		},
 		NotifyFunc: func(err error, attempt int) {
-			w.logger.Warningf(ctx, "failed to connect to %s attempt %d, with addresses %v: %v", w.controllerID, attempt, info.Addrs, err)
+			w.logger.Warningf(ctx, "failed to connect to %s attempt %d, with addresses %v: %v", w.controllerID, attempt, addresses, err)
 		},
 		IsFatalError: func(err error) bool {
 			// This is the only legitimist error that can be returned from the
@@ -480,7 +489,7 @@ func (w *remoteServer) forceReconnect(ctx context.Context) {
 	// If there are any pending changes, we want to drain them before forcing a
 	// reconnect. This should ensure that we're using at least the latest
 	// addresses. This will be eventually consistent if they're stale.
-	addresses := w.info.Addrs
+	addresses := w.addresses
 DRAIN:
 	for {
 		select {

--- a/internal/worker/apiremotecaller/remote_test.go
+++ b/internal/worker/apiremotecaller/remote_test.go
@@ -5,6 +5,7 @@ package apiremotecaller
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"sync"
 	"sync/atomic"
@@ -108,6 +109,43 @@ func (s *RemoteSuite) TestConnect(c *tc.C) {
 
 	c.Assert(conn, tc.NotNil)
 	c.Check(conn.Addr().String(), tc.DeepEquals, addr.String())
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *RemoteSuite) TestConnectRefreshesAPIInfoAfterPasswordChange(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectClock()
+	retry := make(chan time.Time, 1)
+	s.expectClockAfter(retry)
+
+	var calls atomic.Int32
+	config := s.newConfig(c)
+	config.APIInfo = apiInfoProviderFunc(func() (*api.Info, error) {
+		if calls.Add(1) == 1 {
+			return &api.Info{Password: "stale-password"}, nil
+		}
+		return &api.Info{Password: "current-password"}, nil
+	})
+
+	var passwords []string
+	config.APIOpener = func(_ context.Context, info *api.Info, _ api.DialOpts) (api.Connection, error) {
+		passwords = append(passwords, info.Password)
+		if len(passwords) == 1 {
+			retry <- time.Now()
+			return nil, errors.New("unauthorized")
+		}
+		return s.apiConnection, nil
+	}
+
+	w := newRemoteServer(config, s.states)
+	defer workertest.DirtyKill(c, w)
+
+	s.ensureStartup(c)
+	_, err := w.(*remoteServer).connect(c.Context(), []string{"10.0.0.1:17070"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(passwords, tc.DeepEquals, []string{"stale-password", "current-password"})
 
 	workertest.CleanKill(c, w)
 }
@@ -640,7 +678,7 @@ func (s *RemoteSuite) newConfig(c *tc.C) RemoteServerConfig {
 	return RemoteServerConfig{
 		Clock:        s.clock,
 		Logger:       loggertesting.WrapCheckLog(c),
-		APIInfo:      &api.Info{},
+		APIInfo:      apiInfoProviderFunc(func() (*api.Info, error) { return &api.Info{}, nil }),
 		ControllerID: "0",
 		APIOpener: func(ctx context.Context, i *api.Info, do api.DialOpts) (api.Connection, error) {
 			err := s.apiConnectHandler(ctx)
@@ -650,6 +688,12 @@ func (s *RemoteSuite) newConfig(c *tc.C) RemoteServerConfig {
 			return s.apiConnection, nil
 		},
 	}
+}
+
+type apiInfoProviderFunc func() (*api.Info, error)
+
+func (f apiInfoProviderFunc) APIInfo() (*api.Info, error) {
+	return f()
 }
 
 func (s *RemoteSuite) expectClockAfter(ch <-chan time.Time) {

--- a/internal/worker/apiremotecaller/worker.go
+++ b/internal/worker/apiremotecaller/worker.go
@@ -49,7 +49,7 @@ type WorkerConfig struct {
 	ControllerNodeService ControllerNodeService
 	Logger                logger.Logger
 
-	APIInfo   *api.Info
+	APIInfo   APIInfoProvider
 	APIOpener api.OpenFunc
 	NewRemote func(RemoteServerConfig) RemoteServer
 }
@@ -305,10 +305,6 @@ func (w *remoteWorker) loop() error {
 }
 
 func (w *remoteWorker) newRemoteServer(ctx context.Context, controllerID string, addresses []string) (RemoteServer, error) {
-	// Create a new remote server APIInfo with the target and addresses.
-	apiInfo := *w.cfg.APIInfo
-	apiInfo.Addrs = addresses
-
 	// Start a new worker with the target and addresses.
 	err := w.runner.StartWorker(ctx, controllerID, func(ctx context.Context) (worker.Worker, error) {
 		w.cfg.Logger.Debugf(ctx, "starting remote worker for %q", controllerID)
@@ -317,7 +313,7 @@ func (w *remoteWorker) newRemoteServer(ctx context.Context, controllerID string,
 			Clock:        w.cfg.Clock,
 			Logger:       w.cfg.Logger,
 			ControllerID: controllerID,
-			APIInfo:      &apiInfo,
+			APIInfo:      w.cfg.APIInfo,
 			APIOpener:    w.newConnection,
 		}), nil
 	})

--- a/internal/worker/apiremotecaller/worker_test.go
+++ b/internal/worker/apiremotecaller/worker_test.go
@@ -643,7 +643,7 @@ func (s *WorkerSuite) newWorker(c *tc.C) *remoteWorker {
 func (s *WorkerSuite) newConfig(c *tc.C) WorkerConfig {
 	return WorkerConfig{
 		Origin:  names.NewMachineTag("0"),
-		APIInfo: &api.Info{},
+		APIInfo: apiInfoProviderFunc(func() (*api.Info, error) { return &api.Info{}, nil }),
 		APIOpener: func(ctx context.Context, i *api.Info, do api.DialOpts) (api.Connection, error) {
 			return s.connection, nil
 		},

--- a/internal/worker/caasapplicationprovisioner/application.go
+++ b/internal/worker/caasapplicationprovisioner/application.go
@@ -145,16 +145,6 @@ func (a *appWorker) loop() error {
 		return errors.Annotatef(err, "fetching info for application %q", a.appUUID)
 	}
 
-	// If the application is the Juju controller, only provide updates on the
-	// status of the application.
-	statusOnly, err := a.applicationService.IsControllerApplication(ctx, a.appUUID)
-	if errors.Is(err, applicationerrors.ApplicationNotFound) {
-		a.logger.Debugf(ctx, "application %q no longer exists", a.appUUID)
-		return nil
-	} else if err != nil {
-		return errors.Annotatef(err, "fetching info for application %q", a.appUUID)
-	}
-
 	// TODO(sidecar): support more than statefulset
 	app := a.broker.Application(name, caas.DeploymentStateful)
 
@@ -169,22 +159,20 @@ func (a *appWorker) loop() error {
 	}
 	a.life = appLife
 	if appLife == life.Dead {
-		if !statusOnly {
-			err = a.ops.AppDying(ctx, name, a.appUUID, app, a.life, a.facade,
-				a.applicationService, a.statusService, a.logger)
-			if err != nil {
-				return errors.Annotatef(err, "deleting application %q", name)
-			}
-			err = a.ops.AppDead(ctx, name, a.appUUID, app,
-				a.applicationService, a.clock, a.logger)
-			if err != nil {
-				return errors.Annotatef(err, "deleting application %q", name)
-			}
+		err = a.ops.AppDying(ctx, name, a.appUUID, app, a.life, a.facade,
+			a.applicationService, a.statusService, a.logger)
+		if err != nil {
+			return errors.Annotatef(err, "deleting application %q", name)
+		}
+		err = a.ops.AppDead(ctx, name, a.appUUID, app,
+			a.applicationService, a.clock, a.logger)
+		if err != nil {
+			return errors.Annotatef(err, "deleting application %q", name)
 		}
 		return nil
 	}
 
-	if appLife == life.Alive && !statusOnly {
+	if appLife == life.Alive {
 		// Update the password once per worker start to avoid it changing too frequently.
 		a.password, err = password.RandomPassword()
 		if err != nil {
@@ -258,9 +246,7 @@ func (a *appWorker) loop() error {
 			}
 			if ps.Scaling {
 				scaleChan = a.clock.After(0)
-				if !statusOnly {
-					reconcileDeadChan = a.clock.After(0)
-				}
+				reconcileDeadChan = a.clock.After(0)
 			}
 		}
 		switch appLife {
@@ -275,30 +261,28 @@ func (a *appWorker) loop() error {
 				}
 				appProvisionChanges = appProvisionWatcher.Changes()
 			}
-			if !statusOnly {
-				a.provisioningInfo, err = a.ops.ProvisioningInfo(ctx, name,
-					a.appUUID, a.facade, a.applicationService,
-					a.storageProvisioningService, a.resourceOpenerGetter,
-					a.provisioningInfo, a.logger)
-				if errors.Is(err, errors.NotProvisioned) {
-					a.logger.Debugf(ctx, "application %q is not provisioned", name)
-					// State not ready for this application to be provisioned yet.
-					// Usually because the charm has not yet been downloaded.
-					return tryAgain
-				} else if err != nil {
-					return errors.Annotatef(err, "failed to get provisioning info for %q", name)
-				}
-				// Signal that we are managing k8s resources for this app,
-				// blocking removal until we explicitly clear the flag.
-				if err := a.applicationService.SetApplicationHasK8sResources(ctx, a.appUUID); err != nil {
-					return errors.Annotatef(err, "setting k8s resources managed for %q", name)
-				}
-				err = a.ops.AppAlive(ctx, name, a.appUUID, app, a.password,
-					&a.lastApplied, a.provisioningInfo, a.statusService,
-					a.clock, a.logger)
-				if err != nil {
-					return errors.Trace(err)
-				}
+			a.provisioningInfo, err = a.ops.ProvisioningInfo(ctx, name,
+				a.appUUID, a.facade, a.applicationService,
+				a.storageProvisioningService, a.resourceOpenerGetter,
+				a.provisioningInfo, a.logger)
+			if errors.Is(err, errors.NotProvisioned) {
+				a.logger.Debugf(ctx, "application %q is not provisioned", name)
+				// State not ready for this application to be provisioned yet.
+				// Usually because the charm has not yet been downloaded.
+				return tryAgain
+			} else if err != nil {
+				return errors.Annotatef(err, "failed to get provisioning info for %q", name)
+			}
+			// Signal that we are managing k8s resources for this app,
+			// blocking removal until we explicitly clear the flag.
+			if err := a.applicationService.SetApplicationHasK8sResources(ctx, a.appUUID); err != nil {
+				return errors.Annotatef(err, "setting k8s resources managed for %q", name)
+			}
+			err = a.ops.AppAlive(ctx, name, a.appUUID, app, a.password,
+				&a.lastApplied, a.provisioningInfo, a.statusService,
+				a.clock, a.logger)
+			if err != nil {
+				return errors.Trace(err)
 			}
 			if appChanges == nil {
 				appWatcher, err := app.Watch(ctx)
@@ -323,26 +307,22 @@ func (a *appWorker) loop() error {
 			a.logger.Debugf(ctx, "application %q is ready", name)
 			ready = true
 		case life.Dying:
-			if !statusOnly {
-				err = a.ops.AppDying(ctx, name, a.appUUID, app, a.life,
-					a.facade, a.applicationService, a.statusService, a.logger)
-				if err != nil {
-					return errors.Trace(err)
-				}
+			err = a.ops.AppDying(ctx, name, a.appUUID, app, a.life,
+				a.facade, a.applicationService, a.statusService, a.logger)
+			if err != nil {
+				return errors.Trace(err)
 			}
 			ready = false
 		case life.Dead:
-			if !statusOnly {
-				err = a.ops.AppDying(ctx, name, a.appUUID, app, a.life,
-					a.facade, a.applicationService, a.statusService, a.logger)
-				if err != nil {
-					return errors.Trace(err)
-				}
-				err = a.ops.AppDead(ctx, name, a.appUUID, app,
-					a.applicationService, a.clock, a.logger)
-				if err != nil {
-					return errors.Trace(err)
-				}
+			err = a.ops.AppDying(ctx, name, a.appUUID, app, a.life,
+				a.facade, a.applicationService, a.statusService, a.logger)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			err = a.ops.AppDead(ctx, name, a.appUUID, app,
+				a.applicationService, a.clock, a.logger)
+			if err != nil {
+				return errors.Trace(err)
 			}
 			done = true
 			ready = false
@@ -401,10 +381,6 @@ func (a *appWorker) loop() error {
 			}
 			shouldRefresh = false
 		case <-trustChan:
-			if statusOnly {
-				trustChan = nil
-				break
-			}
 			if !ready {
 				trustChan = a.clock.After(retryDelay)
 				shouldRefresh = false
@@ -432,10 +408,6 @@ func (a *appWorker) loop() error {
 			}
 			shouldRefresh = false
 		case <-reconcileDeadChan:
-			if statusOnly {
-				reconcileDeadChan = nil
-				break
-			}
 			err := a.ops.ReconcileDeadUnitScale(ctx, name, a.appUUID, app,
 				a.facade, a.applicationService, a.logger)
 			if errors.Is(err, errors.NotFound) {
@@ -502,7 +474,6 @@ func (a *appWorker) loop() error {
 			report := map[string]any{
 				"application-uuid": a.appUUID,
 				"application-name": name,
-				"status-only":      statusOnly,
 				"application-life": a.life,
 				"scale-target":     ps.ScaleTarget,
 				"scaling":          ps.Scaling,

--- a/internal/worker/caasapplicationprovisioner/application.go
+++ b/internal/worker/caasapplicationprovisioner/application.go
@@ -81,8 +81,12 @@ const (
 	unitsChurning errors.ConstError = "units churning"
 )
 
+// NewAppWorkerFunc is a function type that creates a new application
+// provisioner worker for the given configuration.
 type NewAppWorkerFunc func(AppWorkerConfig) func(ctx context.Context) (worker.Worker, error)
 
+// NewAppWorker returns a function that creates a new application provisioner
+// worker for the given configuration.
 func NewAppWorker(config AppWorkerConfig) func(ctx context.Context) (worker.Worker, error) {
 	ops := config.Ops
 	if ops == nil {

--- a/internal/worker/caasapplicationprovisioner/application_test.go
+++ b/internal/worker/caasapplicationprovisioner/application_test.go
@@ -142,7 +142,6 @@ func (s *ApplicationWorkerSuite) TestLifeDead(c *tc.C) {
 
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationName(x, s.appUUID).Return("test", nil),
-		applicationService.EXPECT().IsControllerApplication(x, s.appUUID).Return(false, nil),
 		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
 		applicationService.EXPECT().GetApplicationLife(x, s.appUUID).Return(life.Dead, nil),
 		ops.EXPECT().AppDying(x, "test", s.appUUID, app, life.Dead, x, x, x, x).Return(nil),
@@ -187,7 +186,6 @@ func (s *ApplicationWorkerSuite) TestWorker(c *tc.C) {
 
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationName(x, s.appUUID).Return("test", nil),
-		applicationService.EXPECT().IsControllerApplication(x, s.appUUID).Return(false, nil),
 		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
 		applicationService.EXPECT().GetApplicationLife(x, s.appUUID).Return(life.Alive, nil),
 
@@ -287,90 +285,6 @@ func (s *ApplicationWorkerSuite) TestWorker(c *tc.C) {
 	workertest.CheckKill(c, appWorker)
 }
 
-func (s *ApplicationWorkerSuite) TestWorkerStatusOnly(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	x := gomock.Any()
-
-	broker := mocks.NewMockCAASBroker(ctrl)
-	app := caasmocks.NewMockApplication(ctrl)
-	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
-	ops := mocks.NewMockApplicationOps(ctrl)
-	applicationService := mocks.NewMockApplicationService(ctrl)
-	statusService := mocks.NewMockStatusService(ctrl)
-	agentPasswordService := mocks.NewMockAgentPasswordService(ctrl)
-	storageProvisioningService := mocks.NewMockStorageProvisioningService(ctrl)
-	resourceOpenerGetter := mocks.NewMockResourceOpenerGetter(ctrl)
-	done := make(chan struct{})
-
-	clk := testclock.NewDilatedWallClock(time.Millisecond)
-
-	scaleChan := make(chan struct{}, 1)
-	settingsChan := make(chan struct{}, 1)
-	provisioningInfoChan := make(chan struct{}, 1)
-	appUnitsChan := make(chan []string, 1)
-	appChan := make(chan struct{}, 1)
-	appReplicasChan := make(chan struct{}, 1)
-
-	ops.EXPECT().RefreshOperatorStatus(x, "con-troll-er", s.appUUID, app, x, x, x, x).Return(nil).AnyTimes()
-	ops.EXPECT().EnsureScale(
-		x, "con-troll-er", s.appUUID, app, life.Alive, facade,
-		applicationService, agentPasswordService, s.logger,
-	).Return(nil).AnyTimes()
-
-	gomock.InOrder(
-		applicationService.EXPECT().GetApplicationName(x, s.appUUID).Return("con-troll-er", nil),
-		applicationService.EXPECT().IsControllerApplication(x, s.appUUID).Return(true, nil),
-		broker.EXPECT().Application("con-troll-er", caas.DeploymentStateful).Return(app),
-		applicationService.EXPECT().GetApplicationLife(x, s.appUUID).Return(life.Alive, nil),
-
-		applicationService.EXPECT().WatchApplicationScale(x, "con-troll-er").Return(watchertest.NewMockNotifyWatcher(scaleChan), nil),
-		applicationService.EXPECT().WatchApplicationSettings(x, "con-troll-er").Return(watchertest.NewMockNotifyWatcher(settingsChan), nil),
-		applicationService.EXPECT().WatchApplicationUnitLife(x, "con-troll-er").Return(watchertest.NewMockStringsWatcher(appUnitsChan), nil),
-
-		// handleChange
-		applicationService.EXPECT().GetApplicationLife(x, s.appUUID).Return(life.Alive, nil),
-		applicationService.EXPECT().GetApplicationScalingState(x, "con-troll-er").Return(applicationservice.ScalingState{Scaling: true, ScaleTarget: 1}, nil),
-		facade.EXPECT().WatchProvisioningInfo(x, "con-troll-er").Return(watchertest.NewMockNotifyWatcher(provisioningInfoChan), nil),
-		app.EXPECT().Watch(x).Return(watchertest.NewMockNotifyWatcher(appChan), nil),
-		app.EXPECT().WatchReplicas().DoAndReturn(func() (watcher.NotifyWatcher, error) {
-			appChan <- struct{}{}
-			return watchertest.NewMockNotifyWatcher(appReplicasChan), nil
-		}),
-
-		// appChan fired
-		ops.EXPECT().UpdateState(x, "con-troll-er", s.appUUID, app, x, broker, applicationService, statusService, clk, s.logger).DoAndReturn(func(context.Context, string, application.UUID, caas.Application, UpdateStatusState, CAASBroker, ApplicationService, StatusService, clock.Clock, logger.Logger) (UpdateStatusState, error) {
-			appReplicasChan <- struct{}{}
-			return nil, nil
-		}),
-		// appReplicasChan fired
-		ops.EXPECT().UpdateState(x, "con-troll-er", s.appUUID, app, x, broker, applicationService, statusService, clk, s.logger).DoAndReturn(func(context.Context, string, application.UUID, caas.Application, UpdateStatusState, CAASBroker, ApplicationService, StatusService, clock.Clock, logger.Logger) (UpdateStatusState, error) {
-			provisioningInfoChan <- struct{}{}
-			return nil, nil
-		}),
-
-		// provisioningInfoChan fired
-		applicationService.EXPECT().GetApplicationLife(x, s.appUUID).DoAndReturn(func(ctx context.Context, i application.UUID) (life.Value, error) {
-			provisioningInfoChan <- struct{}{}
-			return life.Alive, nil
-		}),
-		applicationService.EXPECT().GetApplicationLife(x, s.appUUID).DoAndReturn(func(ctx context.Context, i application.UUID) (life.Value, error) {
-			provisioningInfoChan <- struct{}{}
-			return life.Dying, nil
-		}),
-		applicationService.EXPECT().GetApplicationLife(x, s.appUUID).DoAndReturn(func(ctx context.Context, i application.UUID) (life.Value, error) {
-			provisioningInfoChan <- struct{}{}
-			close(done)
-			return life.Dead, nil
-		}),
-	)
-
-	appWorker := s.startAppWorker(c, clk, facade, broker, ops, applicationService, statusService, agentPasswordService, storageProvisioningService, resourceOpenerGetter)
-	s.waitDone(c, done)
-	workertest.CheckKill(c, appWorker)
-}
-
 func (s *ApplicationWorkerSuite) TestWorkerRefreshTimerResetOnUnitsChurning(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -401,7 +315,6 @@ func (s *ApplicationWorkerSuite) TestWorkerRefreshTimerResetOnUnitsChurning(c *t
 
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationName(x, s.appUUID).Return("test", nil),
-		applicationService.EXPECT().IsControllerApplication(x, s.appUUID).Return(false, nil),
 		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
 		applicationService.EXPECT().GetApplicationLife(x, s.appUUID).Return(life.Alive, nil),
 
@@ -482,7 +395,6 @@ func (s *ApplicationWorkerSuite) TestNotProvisionedRetry(c *tc.C) {
 
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationName(x, s.appUUID).Return("test", nil),
-		applicationService.EXPECT().IsControllerApplication(x, s.appUUID).Return(false, nil),
 		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
 		applicationService.EXPECT().GetApplicationLife(x, s.appUUID).Return(life.Alive, nil),
 

--- a/internal/worker/caasapplicationprovisioner/mocks/domain_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/domain_mock.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 
 	gomock "github.com/canonical/gomock/gomock"
+
 	application "github.com/juju/juju/core/application"
 	life "github.com/juju/juju/core/life"
 	network "github.com/juju/juju/core/network"
@@ -34,26 +35,27 @@ type MockApplicationService struct {
 
 // MockApplicationServiceMockRecorder is the mock recorder for MockApplicationService.
 type MockApplicationServiceMockRecorder struct {
-	mock                                     *MockApplicationService
-	clearApplicationHasK8sResourcesExpects   []*gomock.Call2_1[context.Context, application.UUID, error]
-	getAllUnitK8sPodIDsForApplicationExpects []*gomock.Call2_2[context.Context, application.UUID, map[unit.Name]string, error]
-	getAllUnitLifeForApplicationExpects      []*gomock.Call2_2[context.Context, application.UUID, map[unit.Name]life.Value, error]
-	getApplicationLifeExpects                []*gomock.Call2_2[context.Context, application.UUID, life.Value, error]
-	getApplicationNameExpects                []*gomock.Call2_2[context.Context, application.UUID, string, error]
-	getApplicationScaleExpects               []*gomock.Call2_2[context.Context, string, int, error]
-	getApplicationScalingStateExpects        []*gomock.Call2_2[context.Context, string, service.ScalingState, error]
-	getApplicationTrustSettingExpects        []*gomock.Call2_2[context.Context, string, bool, error]
-	getCharmByApplicationUUIDExpects         []*gomock.Call2_3[context.Context, application.UUID, charm0.Charm, charm.CharmLocator, error]
-	getUnitLifeExpects                       []*gomock.Call2_2[context.Context, unit.Name, life.Value, error]
-	isControllerApplicationExpects           []*gomock.Call2_2[context.Context, application.UUID, bool, error]
-	setApplicationHasK8sResourcesExpects     []*gomock.Call2_1[context.Context, application.UUID, error]
-	setApplicationScalingStateExpects        []*gomock.Call4_1[context.Context, string, int, bool, error]
-	updateCAASUnitExpects                    []*gomock.Call3_1[context.Context, unit.Name, service.UpdateCAASUnitParams, error]
-	updateK8sServiceExpects                  []*gomock.Call4_1[context.Context, string, string, network.ProviderAddresses, error]
-	watchApplicationScaleExpects             []*gomock.Call2_2[context.Context, string, watcher.NotifyWatcher, error]
-	watchApplicationSettingsExpects          []*gomock.Call2_2[context.Context, string, watcher.NotifyWatcher, error]
-	watchApplicationUnitLifeExpects          []*gomock.Call2_2[context.Context, string, watcher.StringsWatcher, error]
-	watchApplicationsExpects                 []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
+	mock                                       *MockApplicationService
+	clearApplicationHasK8sResourcesExpects     []*gomock.Call2_1[context.Context, application.UUID, error]
+	getAllUnitK8sPodIDsForApplicationExpects   []*gomock.Call2_2[context.Context, application.UUID, map[unit.Name]string, error]
+	getAllUnitLifeForApplicationExpects        []*gomock.Call2_2[context.Context, application.UUID, map[unit.Name]life.Value, error]
+	getApplicationLifeExpects                  []*gomock.Call2_2[context.Context, application.UUID, life.Value, error]
+	getApplicationNameExpects                  []*gomock.Call2_2[context.Context, application.UUID, string, error]
+	getApplicationScaleExpects                 []*gomock.Call2_2[context.Context, string, int, error]
+	getApplicationScalingStateExpects          []*gomock.Call2_2[context.Context, string, service.ScalingState, error]
+	getApplicationTrustSettingExpects          []*gomock.Call2_2[context.Context, string, bool, error]
+	getCharmByApplicationUUIDExpects           []*gomock.Call2_3[context.Context, application.UUID, charm0.Charm, charm.CharmLocator, error]
+	getUnitLifeExpects                         []*gomock.Call2_2[context.Context, unit.Name, life.Value, error]
+	isControllerApplicationExpects             []*gomock.Call2_2[context.Context, application.UUID, bool, error]
+	setApplicationHasK8sResourcesExpects       []*gomock.Call2_1[context.Context, application.UUID, error]
+	setApplicationScalingStateExpects          []*gomock.Call4_1[context.Context, string, int, bool, error]
+	setApplicationScalingStateWithStartExpects []*gomock.Call5_1[context.Context, string, int, int, bool, error]
+	updateCAASUnitExpects                      []*gomock.Call3_1[context.Context, unit.Name, service.UpdateCAASUnitParams, error]
+	updateK8sServiceExpects                    []*gomock.Call4_1[context.Context, string, string, network.ProviderAddresses, error]
+	watchApplicationScaleExpects               []*gomock.Call2_2[context.Context, string, watcher.NotifyWatcher, error]
+	watchApplicationSettingsExpects            []*gomock.Call2_2[context.Context, string, watcher.NotifyWatcher, error]
+	watchApplicationUnitLifeExpects            []*gomock.Call2_2[context.Context, string, watcher.StringsWatcher, error]
+	watchApplicationsExpects                   []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
 }
 
 // NewMockApplicationService creates a new mock instance.
@@ -301,6 +303,27 @@ func (mr *MockApplicationServiceMockRecorder) SetApplicationScalingState(ctx, na
 
 // MockApplicationServiceSetApplicationScalingStateCall is the typed call wrapper for SetApplicationScalingState.
 type MockApplicationServiceSetApplicationScalingStateCall = gomock.Call4_1[context.Context, string, int, bool, error]
+
+// SetApplicationScalingStateWithStart mocks base method.
+func (m *MockApplicationService) SetApplicationScalingStateWithStart(ctx context.Context, name string, scaleTarget, startOrdinal int, scaling bool) error {
+	m.ctrl.T.Helper()
+	if len(m.recorder.setApplicationScalingStateWithStartExpects) == 0 {
+		return nil
+	}
+	return gomock.Dispatch5_1(&m.recorder.setApplicationScalingStateWithStartExpects, m.ctrl, m, "SetApplicationScalingStateWithStart", ctx, name, scaleTarget, startOrdinal, scaling)
+}
+
+// SetApplicationScalingStateWithStart indicates an expected call of SetApplicationScalingStateWithStart.
+func (mr *MockApplicationServiceMockRecorder) SetApplicationScalingStateWithStart(ctx, name, scaleTarget, startOrdinal, scaling any) *MockApplicationServiceSetApplicationScalingStateWithStartCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall5_1[context.Context, string, int, int, bool, error](mr.mock.ctrl.T, mr.mock, "SetApplicationScalingStateWithStart", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(name), gomock.EnsureMatcher(scaleTarget), gomock.EnsureMatcher(startOrdinal), gomock.EnsureMatcher(scaling))
+	mr.setApplicationScalingStateWithStartExpects = append(mr.setApplicationScalingStateWithStartExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockApplicationServiceSetApplicationScalingStateWithStartCall is the typed call wrapper for SetApplicationScalingStateWithStart.
+type MockApplicationServiceSetApplicationScalingStateWithStartCall = gomock.Call5_1[context.Context, string, int, int, bool, error]
 
 // UpdateCAASUnit mocks base method.
 func (m *MockApplicationService) UpdateCAASUnit(arg0 context.Context, arg1 unit.Name, arg2 service.UpdateCAASUnitParams) error {

--- a/internal/worker/caasapplicationprovisioner/mocks/domain_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/domain_mock.go
@@ -13,7 +13,6 @@ import (
 	context "context"
 
 	gomock "github.com/canonical/gomock/gomock"
-
 	application "github.com/juju/juju/core/application"
 	life "github.com/juju/juju/core/life"
 	network "github.com/juju/juju/core/network"
@@ -307,9 +306,6 @@ type MockApplicationServiceSetApplicationScalingStateCall = gomock.Call4_1[conte
 // SetApplicationScalingStateWithStart mocks base method.
 func (m *MockApplicationService) SetApplicationScalingStateWithStart(ctx context.Context, name string, scaleTarget, startOrdinal int, scaling bool) error {
 	m.ctrl.T.Helper()
-	if len(m.recorder.setApplicationScalingStateWithStartExpects) == 0 {
-		return nil
-	}
 	return gomock.Dispatch5_1(&m.recorder.setApplicationScalingStateWithStartExpects, m.ctrl, m, "SetApplicationScalingStateWithStart", ctx, name, scaleTarget, startOrdinal, scaling)
 }
 

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -618,10 +618,10 @@ func waitForTerminated(appName string, app caas.Application,
 }
 
 // reconcileDeadUnitScale is setup to respond to CAAS sidecar units that become
-// dead. It takes stock of what the current desired scale is for the application
-// and the number of dead units in the application. Once the number of dead units
-// has reached the point where the desired scale has been achieved this func
-// can go ahead and remove the units from CAAS provider.
+// dead. It takes stock of the desired scale and dead units outside the retained
+// ordinal range. It removes their Juju unit records before scaling the CAAS
+// provider so peer-relation departure hooks can finish while the pods remain
+// available.
 func reconcileDeadUnitScale(
 	ctx context.Context,
 	appName string, appUUID coreapplication.UUID, app caas.Application,
@@ -657,9 +657,26 @@ func reconcileDeadUnitScale(
 		}
 	}
 
-	// We haven't met the threshold to initiate scale down in the CAAS provider
-	// yet.
-	if unitsToRemove != len(deadUnits) || len(deadUnits) == 0 {
+	// Wait for every unit outside the retained range to be dead. A dead unit
+	// still needs its removal job to depart peer relations before its pod can
+	// be stopped; otherwise the remaining units cannot consume that departure.
+	if unitsToRemove != len(deadUnits) {
+		return nil
+	}
+	if len(deadUnits) > 0 {
+		sort.Slice(deadUnits, func(i, j int) bool {
+			return deadUnits[i].Number() < deadUnits[j].Number()
+		})
+		for _, deadUnit := range deadUnits {
+			logger.Infof(ctx, "removing dead unit %s", deadUnit)
+			if err := facade.RemoveUnit(ctx, string(deadUnit)); err != nil && !errors.Is(err, errors.NotFound) {
+				return fmt.Errorf("removing dead unit %q: %w", deadUnit, err)
+			}
+		}
+		return tryAgain
+	}
+
+	if ps.StartOrdinal == 0 || len(unitNamesAndLives) > desiredScale {
 		return nil
 	}
 
@@ -683,16 +700,6 @@ func reconcileDeadUnitScale(
 	// TODO: stop k8s things from mutating the statefulset.
 	if len(appState.Replicas) > desiredScale {
 		return tryAgain
-	}
-
-	sort.Slice(deadUnits, func(i, j int) bool {
-		return deadUnits[i].Number() < deadUnits[j].Number()
-	})
-	for _, deadUnit := range deadUnits {
-		logger.Infof(ctx, "removing dead unit %s", deadUnit)
-		if err := facade.RemoveUnit(ctx, string(deadUnit)); err != nil && !errors.Is(err, errors.NotFound) {
-			return fmt.Errorf("removing dead unit %q: %w", deadUnit, err)
-		}
 	}
 
 	return updateProvisioningState(ctx, appName, false, 0, ps.StartOrdinal, applicationService)

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -749,6 +749,15 @@ func ensureScale(
 	if err != nil {
 		return err
 	}
+	// Determine whether we need to select which units to remove for scale-down.
+	// This triggers when:
+	//   - The app is alive and we're scaling down (desiredScale < len(units))
+	//   - AND either we just started scaling (startedScaling) OR the
+	//     startOrdinal hasn't been advanced yet (ps.StartOrdinal == 0)
+	//
+	// On first detection, we compute the new startOrdinal to shift the
+	// StatefulSet range past the units being removed, preventing stale
+	// ordinals from being reused on subsequent scale-ups.
 	if appLife == life.Alive && desiredScale < len(units) && (startedScaling || ps.StartOrdinal == 0) {
 		startOrdinal := unitRemovalThreshold(units, desiredScale)
 		if err := applicationService.SetApplicationScalingStateWithStart(ctx, appName, desiredScale, startOrdinal, true); err != nil {

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -289,6 +289,7 @@ func appAlive(ctx context.Context, appName string, appUUID coreapplication.UUID,
 	}
 
 	config := caas.ApplicationConfig{
+		Controller:           appName == coreapplication.ControllerApplicationName,
 		IsPrivateImageRepo:   pi.ImageDetails.IsPrivate(),
 		IntroductionSecret:   password,
 		AgentVersion:         pi.Version,
@@ -320,6 +321,9 @@ func appAlive(ctx context.Context, appName string, appUUID coreapplication.UUID,
 		config.CharmUser = caas.RunAsNonRoot
 	default:
 		return errors.NotValidf("unknown RunAs for CharmUser: %q", pi.CharmMeta.CharmUser)
+	}
+	if config.Controller {
+		config.CharmUser = caas.RunAsNonRoot
 	}
 	reason := "unchanged"
 	// TODO(sidecar): implement Equals method for caas.ApplicationConfig

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -661,7 +661,7 @@ func reconcileDeadUnitScale(
 
 	storageUniqueID := getStorageUniqueID(appUUID)
 	err = ensureScaleWithFsAttachments(
-		ctx, appName, appUUID, app, desiredScale,
+		ctx, appName, app, desiredScale, ps.StartOrdinal,
 		facade, logger, storageUniqueID)
 	if err != nil && !errors.Is(err, errors.NotFound) {
 		return fmt.Errorf(
@@ -691,7 +691,7 @@ func reconcileDeadUnitScale(
 		}
 	}
 
-	return updateProvisioningState(ctx, appName, false, 0, applicationService)
+	return updateProvisioningState(ctx, appName, false, 0, ps.StartOrdinal, applicationService)
 }
 
 // ensureScale determines how and when to scale up or down based on
@@ -724,8 +724,9 @@ func ensureScale(
 	}
 
 	logger.Debugf(ctx, "updating application %q scale to %d", appName, desiredScale)
-	if !ps.Scaling || appLife != life.Alive {
-		err := updateProvisioningState(ctx, appName, true, desiredScale, applicationService)
+	startedScaling := !ps.Scaling || appLife != life.Alive
+	if startedScaling {
+		err := updateProvisioningState(ctx, appName, true, desiredScale, ps.StartOrdinal, applicationService)
 		if err != nil {
 			return err
 		}
@@ -736,6 +737,13 @@ func ensureScale(
 	units, err := applicationService.GetAllUnitLifeForApplication(ctx, appUUID)
 	if err != nil {
 		return err
+	}
+	if appLife == life.Alive && desiredScale < len(units) && (startedScaling || ps.StartOrdinal == 0) {
+		startOrdinal := unitRemovalThreshold(units, desiredScale)
+		if err := applicationService.SetApplicationScalingStateWithStart(ctx, appName, desiredScale, startOrdinal, true); err != nil {
+			return errors.Trace(err)
+		}
+		ps.StartOrdinal = startOrdinal
 	}
 
 	if ps.ScaleTarget >= len(units) {
@@ -748,7 +756,7 @@ func ensureScale(
 			if isController, err := applicationService.IsControllerApplication(ctx, appUUID); err != nil {
 				return errors.Annotate(err, "checking if controller application")
 			} else if isController {
-				if err := ensureControllerNonces(ctx, ps.ScaleTarget, app, agentPasswordService, logger); err != nil {
+				if err := ensureControllerNonces(ctx, ps.StartOrdinal, ps.ScaleTarget, app, agentPasswordService, logger); err != nil {
 					return errors.Annotate(err, "ensuring controller nonces")
 				}
 			}
@@ -758,9 +766,9 @@ func ensureScale(
 		err := ensureScaleWithFsAttachments(
 			ctx,
 			appName,
-			appUUID,
 			app,
 			ps.ScaleTarget,
+			ps.StartOrdinal,
 			facade,
 			logger,
 			storageUniqueID,
@@ -768,7 +776,7 @@ func ensureScale(
 
 		if appLife != life.Alive && errors.Is(err, errors.NotFound) {
 			logger.Infof(ctx, "dying application %q is already removed from k8s", appName)
-			return updateProvisioningState(ctx, appName, false, 0, applicationService)
+			return updateProvisioningState(ctx, appName, false, 0, ps.StartOrdinal, applicationService)
 		} else if err != nil {
 			return err
 		}
@@ -776,7 +784,7 @@ func ensureScale(
 			// Scaling up must see units created.
 			return tryAgain
 		}
-		err = updateProvisioningState(ctx, appName, false, 0, applicationService)
+		err = updateProvisioningState(ctx, appName, false, 0, ps.StartOrdinal, applicationService)
 		if err != nil {
 			return err
 		}
@@ -858,10 +866,15 @@ func setOperatorStatus(
 
 func updateProvisioningState(
 	ctx context.Context,
-	appName string, scaling bool, scaleTarget int,
+	appName string, scaling bool, scaleTarget, startOrdinal int,
 	applicationService ApplicationService,
 ) error {
-	err := applicationService.SetApplicationScalingState(ctx, appName, scaleTarget, scaling)
+	var err error
+	if startOrdinal == 0 {
+		err = applicationService.SetApplicationScalingState(ctx, appName, scaleTarget, scaling)
+	} else {
+		err = applicationService.SetApplicationScalingStateWithStart(ctx, appName, scaleTarget, startOrdinal, scaling)
+	}
 	if errors.Is(err, applicationerrors.ScalingStateInconsistent) {
 		return tryAgain
 	} else if err != nil {
@@ -872,8 +885,8 @@ func updateProvisioningState(
 
 // ensureScaleWithFsAttachments scales an application while ensuring required PVCs are created.
 func ensureScaleWithFsAttachments(
-	ctx context.Context, appName string, appUUID coreapplication.UUID,
-	app caas.Application, scaleTarget int,
+	ctx context.Context, appName string, app caas.Application,
+	scaleTarget, startOrdinal int,
 	facade CAASProvisionerFacade, logger logger.Logger, storageUniqueID string,
 ) error {
 	logger.Infof(ctx, "scaling application %q to desired scale %d", appName, scaleTarget)
@@ -893,7 +906,10 @@ func ensureScaleWithFsAttachments(
 	if err != nil {
 		return err
 	}
-	return app.Scale(scaleTarget)
+	if startOrdinal == 0 {
+		return app.Scale(ctx, scaleTarget)
+	}
+	return app.ScaleRange(ctx, scaleTarget, startOrdinal)
 }
 
 func provisioningInfo(
@@ -1071,12 +1087,12 @@ func readDockerImageResource(reader io.Reader) (coreresource.DockerImageDetails,
 // legitimate replicas of the StatefulSet.
 func ensureControllerNonces(
 	ctx context.Context,
-	targetCount int,
+	startOrdinal, targetCount int,
 	app caas.Application,
 	agentPasswordService AgentPasswordService,
 	logger logger.Logger,
 ) error {
-	for ordinal := range targetCount {
+	for ordinal := startOrdinal; ordinal < startOrdinal+targetCount; ordinal++ {
 		controllerID := strconv.Itoa(ordinal)
 		nonce, err := password.RandomPassword()
 		if err != nil {

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -880,12 +880,7 @@ func updateProvisioningState(
 	appName string, scaling bool, scaleTarget, startOrdinal int,
 	applicationService ApplicationService,
 ) error {
-	var err error
-	if startOrdinal == 0 {
-		err = applicationService.SetApplicationScalingState(ctx, appName, scaleTarget, scaling)
-	} else {
-		err = applicationService.SetApplicationScalingStateWithStart(ctx, appName, scaleTarget, startOrdinal, scaling)
-	}
+	err := applicationService.SetApplicationScalingStateWithStart(ctx, appName, scaleTarget, startOrdinal, scaling)
 	if errors.Is(err, applicationerrors.ScalingStateInconsistent) {
 		return tryAgain
 	} else if err != nil {

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -770,8 +770,9 @@ func ensureScale(
 		// Reconcile every desired controller ordinal rather than only the
 		// apparent scale-up range. Unit rows can be temporarily missing or
 		// sparse after a failed introduction, while StatefulSet ordinals are
-		// always the contiguous range [0, scaleTarget). The persisted nonce is
-		// immutable, so this is safe to repeat during recovery.
+		// always the contiguous range [startOrdinal, startOrdinal+scaleTarget).
+		// The persisted nonce is immutable, so this is safe to repeat during
+		// recovery.
 		if ps.ScaleTarget > 0 && appLife == life.Alive {
 			if isController, err := applicationService.IsControllerApplication(ctx, appUUID); err != nil {
 				return errors.Annotate(err, "checking if controller application")

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -391,8 +391,9 @@ func (s *OpsSuite) TestReconcileDeadUnitScale(c *tc.C) {
 		"test/1": life.Alive,
 	}
 	ps := applicationservice.ScalingState{
-		Scaling:     true,
-		ScaleTarget: 1,
+		StartOrdinal: 2,
+		Scaling:      true,
+		ScaleTarget:  1,
 	}
 	appState := caas.ApplicationState{
 		Replicas: []string{
@@ -405,10 +406,10 @@ func (s *OpsSuite) TestReconcileDeadUnitScale(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
-		app.EXPECT().Scale(1).Return(nil),
+		app.EXPECT().ScaleRange(gomock.Any(), 1, 2).Return(nil),
 		app.EXPECT().State().Return(appState, nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 0, 2, false).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
@@ -448,7 +449,7 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleMultipleLowestDead(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
-		app.EXPECT().Scale(2).Return(nil),
+		app.EXPECT().Scale(gomock.Any(), 2).Return(nil),
 		app.EXPECT().State().Return(appState, nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/1").Return(nil),
@@ -521,7 +522,7 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleAllLowestDead(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
-		app.EXPECT().Scale(1).Return(nil),
+		app.EXPECT().Scale(gomock.Any(), 1).Return(nil),
 		app.EXPECT().State().Return(appState, nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/1").Return(nil),
@@ -625,7 +626,7 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleSparseOrdinals(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
-		app.EXPECT().Scale(2).Return(nil),
+		app.EXPECT().Scale(gomock.Any(), 2).Return(nil),
 		app.EXPECT().State().Return(appState, nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
@@ -755,7 +756,7 @@ func (s *OpsSuite) TestEnsureScaleControllerReusesPersistedNonce(c *tc.C) {
 		app.EXPECT().EnsureControllerNonce(gomock.Any(), 1, "persisted-nonce").Return(nil),
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "controller").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID).Return(nil),
-		app.EXPECT().Scale(2).Return(nil),
+		app.EXPECT().Scale(gomock.Any(), 2).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "controller", appID, app,
@@ -795,7 +796,7 @@ func (s *OpsSuite) TestEnsureScaleControllerReconcilesSparseOrdinals(c *tc.C) {
 		app.EXPECT().EnsureControllerNonce(gomock.Any(), 2, "controller-2-nonce").Return(nil),
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "controller").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID).Return(nil),
-		app.EXPECT().Scale(3).Return(nil),
+		app.EXPECT().Scale(gomock.Any(), 3).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "controller", appID, app,
@@ -833,7 +834,7 @@ func (s *OpsSuite) TestEnsureScaleControllerReconcilesNonceAfterUnitIntroduction
 		app.EXPECT().EnsureControllerNonce(gomock.Any(), 1, "controller-1-nonce").Return(nil),
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "controller").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID).Return(nil),
-		app.EXPECT().Scale(2).Return(nil),
+		app.EXPECT().Scale(gomock.Any(), 2).Return(nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "controller", 0, false).Return(nil),
 	)
 
@@ -864,10 +865,41 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDown5To3(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 3, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 3, 2, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
+		life.Alive, facade, applicationService, nil, s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *OpsSuite) TestEnsureScaleResumesScaleDownWithMissingStartOrdinal(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appID := tc.Must(c, application.NewUUID)
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+	units := map[unit.Name]life.Value{
+		"test/0": life.Alive,
+		"test/1": life.Alive,
+		"test/2": life.Alive,
+	}
+
+	gomock.InOrder(
+		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(2, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{
+			Scaling:     true,
+			ScaleTarget: 2,
+		}, nil),
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appID).Return(units, nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 1, true).Return(nil),
+		facade.EXPECT().DestroyUnits(gomock.Any(), []string{"test/0"}).Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appID, app,
 		life.Alive, facade, applicationService, nil, s.logger)
 	c.Assert(err, tc.ErrorIsNil)
 }
@@ -1115,7 +1147,7 @@ func (s *OpsSuite) TestEnsureScaleWithAttachStorage(c *tc.C) {
 			Size:        100,
 			Provider:    "kubernetes",
 		}}, gomock.Any(), storageUniqueID).Return(nil),
-		app.EXPECT().Scale(2).Return(nil),
+		app.EXPECT().Scale(gomock.Any(), 2).Return(nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
 	)
 
@@ -1343,7 +1375,7 @@ func (s *OpsSuite) TestAppDying(c *tc.C) {
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(nil, nil),
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID).Return(nil),
-		app.EXPECT().Scale(0).Return(nil),
+		app.EXPECT().Scale(gomock.Any(), 0).Return(nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(nil, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -1358,6 +1358,49 @@ func (s *OpsSuite) TestAppAlive(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *OpsSuite) TestAppAliveController(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	app := caasmocks.NewMockApplication(ctrl)
+	statusService := mocks.NewMockStatusService(ctrl)
+	appUUID := tc.Must(c, application.NewUUID)
+	lastApplied := caas.ApplicationConfig{}
+	pi := caasapplicationprovisioner.ProvisioningInfo{
+		ImageDetails: coreresource.DockerImageDetails{
+			RegistryPath: "test-repo/jujud-operator:2.9.99",
+			ImageRepoDetails: coreresource.ImageRepoDetails{
+				Repository: "test-repo",
+			},
+		},
+		Base: corebase.Base{
+			OS: "ubuntu",
+			Channel: corebase.Channel{
+				Track: "22.04",
+				Risk:  corebase.Stable,
+			},
+		},
+		Version: semversion.MustParse("2.9.99"),
+		CharmMeta: &charm.Meta{
+			CharmUser: charm.RunAsRoot,
+		},
+	}
+
+	gomock.InOrder(
+		app.EXPECT().Exists().Return(caas.DeploymentState{}, nil),
+		app.EXPECT().Ensure(gomock.Any()).DoAndReturn(func(config caas.ApplicationConfig) error {
+			c.Check(config.Controller, tc.IsTrue)
+			c.Check(config.CharmUser, tc.Equals, caas.RunAsNonRoot)
+			return nil
+		}),
+	)
+
+	err := caasapplicationprovisioner.AppOps.AppAlive(c.Context(), application.ControllerApplicationName,
+		appUUID, app, "password", &lastApplied, &pi, statusService,
+		testclock.NewDilatedWallClock(coretesting.ShortWait), s.logger)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *OpsSuite) TestAppDying(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -675,7 +675,7 @@ func (s *OpsSuite) TestEnsureScaleAlive(c *tc.C) {
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(1, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 1, true).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 1, 0, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
 		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 1, 3, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
@@ -825,7 +825,7 @@ func (s *OpsSuite) TestEnsureScaleControllerReconcilesNonceAfterUnitIntroduction
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "controller").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID).Return(nil),
 		app.EXPECT().Scale(gomock.Any(), 2).Return(nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "controller", 0, false).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "controller", 0, 0, false).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "controller", appID, app,
@@ -853,7 +853,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDown5To3(c *tc.C) {
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(3, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 3, true).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 3, 0, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
 		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 3, 2, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
@@ -914,7 +914,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDown5To2(c *tc.C) {
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(2, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 0, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
 		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 3, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1", "test/2"})).Return(nil),
@@ -943,7 +943,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDown3To1(c *tc.C) {
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(1, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 1, true).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 1, 0, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
 		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 1, 2, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
@@ -975,7 +975,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDownMixedLives(c *tc.C) {
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(2, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 0, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
 		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 3, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/2"})).Return(nil),
@@ -1037,7 +1037,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDownSparseOrdinals(c *tc.C) {
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(2, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 0, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
 		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 2, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0"})).Return(nil),
@@ -1068,7 +1068,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDownSparseOrdinals2(c *tc.C) {
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(2, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 0, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
 		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 2, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
@@ -1094,7 +1094,7 @@ func (s *OpsSuite) TestEnsureScaleDyingDead(c *tc.C) {
 	}
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, true).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 0, 0, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
 	)
 
@@ -1144,7 +1144,7 @@ func (s *OpsSuite) TestEnsureScaleWithAttachStorage(c *tc.C) {
 			Provider:    "kubernetes",
 		}}, gomock.Any(), storageUniqueID).Return(nil),
 		app.EXPECT().Scale(gomock.Any(), 2).Return(nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 0, 0, false).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appUUID, app,
@@ -1410,12 +1410,12 @@ func (s *OpsSuite) TestAppDying(c *tc.C) {
 
 	gomock.InOrder(
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, true).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 0, 0, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(nil, nil),
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID).Return(nil),
 		app.EXPECT().Scale(gomock.Any(), 0).Return(nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 0, 0, false).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(nil, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
 	)

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -395,21 +395,43 @@ func (s *OpsSuite) TestReconcileDeadUnitScale(c *tc.C) {
 		Scaling:      true,
 		ScaleTarget:  1,
 	}
-	appState := caas.ApplicationState{
-		Replicas: []string{
-			"a",
-		},
-	}
+	gomock.InOrder(
+		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(units, nil),
+		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
+		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
+	)
+
+	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
+		appUUID, app, facade, applicationService, s.logger)
+	c.Assert(err, tc.ErrorMatches, `try again`)
+}
+
+func (s *OpsSuite) TestReconcileDeadUnitScaleScalesAfterUnitRemoval(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	appUUID := tc.Must(c, application.NewUUID)
 	storageUniqueID := appUUID.String()[:6]
+	app := caasmocks.NewMockApplication(ctrl)
+	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
+	applicationService := mocks.NewMockApplicationService(ctrl)
+	units := map[unit.Name]life.Value{
+		"test/1": life.Alive,
+	}
+	ps := applicationservice.ScalingState{
+		StartOrdinal: 1,
+		Scaling:      true,
+		ScaleTarget:  1,
+	}
+
 	gomock.InOrder(
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(units, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
 		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
 		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
-		app.EXPECT().ScaleRange(gomock.Any(), 1, 2).Return(nil),
-		app.EXPECT().State().Return(appState, nil),
-		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
-		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 0, 2, false).Return(nil),
+		app.EXPECT().ScaleRange(gomock.Any(), 1, 1).Return(nil),
+		app.EXPECT().State().Return(caas.ApplicationState{Replicas: []string{"test/1"}}, nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 0, 1, false).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
@@ -422,7 +444,6 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleMultipleLowestDead(c *tc.C) {
 	defer ctrl.Finish()
 
 	appUUID := tc.Must(c, application.NewUUID)
-	storageUniqueID := appUUID.String()[:6]
 	app := caasmocks.NewMockApplication(ctrl)
 	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
 	applicationService := mocks.NewMockApplicationService(ctrl)
@@ -439,26 +460,16 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleMultipleLowestDead(c *tc.C) {
 		Scaling:     true,
 		ScaleTarget: 2,
 	}
-	appState := caas.ApplicationState{
-		Replicas: []string{
-			"test/2", "test/3",
-		},
-	}
 	gomock.InOrder(
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(units, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
-		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
-		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
-		app.EXPECT().Scale(gomock.Any(), 2).Return(nil),
-		app.EXPECT().State().Return(appState, nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/1").Return(nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
 		appUUID, app, facade, applicationService, s.logger)
-	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(err, tc.ErrorMatches, `try again`)
 }
 
 func (s *OpsSuite) TestReconcileDeadUnitScaleLowestNotDead(c *tc.C) {
@@ -497,7 +508,6 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleAllLowestDead(c *tc.C) {
 	defer ctrl.Finish()
 
 	appUUID := tc.Must(c, application.NewUUID)
-	storageUniqueID := appUUID.String()[:6]
 	app := caasmocks.NewMockApplication(ctrl)
 	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
 	applicationService := mocks.NewMockApplicationService(ctrl)
@@ -512,26 +522,16 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleAllLowestDead(c *tc.C) {
 		Scaling:     true,
 		ScaleTarget: 1,
 	}
-	appState := caas.ApplicationState{
-		Replicas: []string{
-			"test/2",
-		},
-	}
 	gomock.InOrder(
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(units, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
-		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
-		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
-		app.EXPECT().Scale(gomock.Any(), 1).Return(nil),
-		app.EXPECT().State().Return(appState, nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/1").Return(nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
 		appUUID, app, facade, applicationService, s.logger)
-	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(err, tc.ErrorMatches, `try again`)
 }
 
 // TestReconcileDeadUnitScaleScaleUp tests scale up scenario - app.Scale should NOT be called
@@ -600,7 +600,6 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleSparseOrdinals(c *tc.C) {
 	defer ctrl.Finish()
 
 	appUUID := tc.Must(c, application.NewUUID)
-	storageUniqueID := appUUID.String()[:6]
 	app := caasmocks.NewMockApplication(ctrl)
 	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
 	applicationService := mocks.NewMockApplicationService(ctrl)
@@ -616,25 +615,15 @@ func (s *OpsSuite) TestReconcileDeadUnitScaleSparseOrdinals(c *tc.C) {
 		Scaling:     true,
 		ScaleTarget: 2,
 	}
-	appState := caas.ApplicationState{
-		Replicas: []string{
-			"test/2", "test/4",
-		},
-	}
 	gomock.InOrder(
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appUUID).Return(units, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
-		facade.EXPECT().FilesystemProvisioningInfo(gomock.Any(), "test").Return(provisionertypes.FilesystemProvisioningInfo{}, nil),
-		app.EXPECT().EnsurePVCs(gomock.Any(), gomock.Any(), storageUniqueID),
-		app.EXPECT().Scale(gomock.Any(), 2).Return(nil),
-		app.EXPECT().State().Return(appState, nil),
 		facade.EXPECT().RemoveUnit(gomock.Any(), "test/0").Return(nil),
-		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 0, false).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.ReconcileDeadUnitScale(c.Context(), "test",
 		appUUID, app, facade, applicationService, s.logger)
-	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(err, tc.ErrorMatches, `try again`)
 }
 
 func (s *OpsSuite) TestReconcileDeadUnitScaleSparseLowestNotDead(c *tc.C) {

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -677,6 +677,7 @@ func (s *OpsSuite) TestEnsureScaleAlive(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 1, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 1, 3, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
 	)
 
@@ -915,6 +916,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDown5To2(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 3, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1", "test/2"})).Return(nil),
 	)
 
@@ -943,6 +945,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDown3To1(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 1, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 1, 2, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
 	)
 
@@ -974,6 +977,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDownMixedLives(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 3, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/2"})).Return(nil),
 	)
 
@@ -1006,6 +1010,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDownNothingToDestroy(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScale(gomock.Any(), "test").Return(1, nil),
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(ps, nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 1, 2, true).Return(nil),
 	)
 
 	err := caasapplicationprovisioner.AppOps.EnsureScale(c.Context(), "test", appId, app,
@@ -1034,6 +1039,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDownSparseOrdinals(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 2, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0"})).Return(nil),
 	)
 
@@ -1064,6 +1070,7 @@ func (s *OpsSuite) TestEnsureScaleAliveScaleDownSparseOrdinals2(c *tc.C) {
 		applicationService.EXPECT().GetApplicationScalingState(gomock.Any(), "test").Return(applicationservice.ScalingState{}, nil),
 		applicationService.EXPECT().SetApplicationScalingState(gomock.Any(), "test", 2, true).Return(nil),
 		applicationService.EXPECT().GetAllUnitLifeForApplication(gomock.Any(), appId).Return(units, nil),
+		applicationService.EXPECT().SetApplicationScalingStateWithStart(gomock.Any(), "test", 2, 2, true).Return(nil),
 		facade.EXPECT().DestroyUnits(gomock.Any(), gomock.InAnyOrder([]string{"test/0", "test/1"})).Return(nil),
 	)
 

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -88,6 +88,10 @@ type ApplicationService interface {
 	// SetApplicationScalingState sets the scaling state for an application.
 	SetApplicationScalingState(ctx context.Context, name string, scaleTarget int, scaling bool) error
 
+	// SetApplicationScalingStateWithStart sets the scaling state and StatefulSet
+	// ordinal range for an application.
+	SetApplicationScalingStateWithStart(ctx context.Context, name string, scaleTarget, startOrdinal int, scaling bool) error
+
 	// GetApplicationScalingState returns the scaling state for an application.
 	GetApplicationScalingState(ctx context.Context, name string) (applicationservice.ScalingState, error)
 

--- a/internal/worker/upgradestepscontroller/controllerworker_test.go
+++ b/internal/worker/upgradestepscontroller/controllerworker_test.go
@@ -382,7 +382,8 @@ func (s *controllerWorkerSuite) TestUpgradeFailsWhenKilled(c *tc.C) {
 	defer workertest.DirtyKill(c, failedWatcher)
 
 	done := make(chan struct{})
-	kill := make(chan *controllerWorker)
+	stepsStarted := make(chan struct{})
+	releaseSteps := make(chan struct{})
 
 	srv := s.upgradeService.EXPECT()
 	srv.WatchForUpgradeState(gomock.Any(), s.upgradeUUID, upgrade.StepsCompleted).Return(completedWatcher, nil)
@@ -395,12 +396,11 @@ func (s *controllerWorkerSuite) TestUpgradeFailsWhenKilled(c *tc.C) {
 
 	w := s.newWorker(c, func(base *upgradesteps.BaseWorker) {
 		base.PreUpgradeSteps = func(_ agent.Config) error {
+			close(stepsStarted)
 			select {
-			case w := <-kill:
-				w.Kill()
+			case <-releaseSteps:
 			case <-c.Context().Done():
-				c.Error("timed out waiting for kill")
-				return errors.New("timed out waiting for kill")
+				return c.Context().Err()
 			}
 			return nil
 		}
@@ -412,10 +412,12 @@ func (s *controllerWorkerSuite) TestUpgradeFailsWhenKilled(c *tc.C) {
 	s.dispatchChange(c, chFailed)
 
 	select {
-	case kill <- w:
+	case <-stepsStarted:
 	case <-c.Context().Done():
-		c.Fatalf("timed out waiting for kill")
+		c.Fatalf("timed out waiting for upgrade steps to start")
 	}
+	w.Kill()
+	close(releaseSteps)
 
 	select {
 	case <-done:


### PR DESCRIPTION
This makes Kubernetes HA controller scale-down work without dropping controller state or interrupting peer departure hooks.

The controller application is now treated as a real application, so it goes through the normal provision, reconcile, scale, and removal paths. Bootstrap produces the same pod spec, ConfigMap, annotations, and controller settings that later reconciliation produces, avoiding an unnecessary StatefulSet pod revision immediately after bootstrap. HA scale-out also uses parallel StatefulSet pod management so new controller nodes can come up together.

Scale-down now tracks the StatefulSet start ordinal, removes the right controller units first, waits for every selected unit to be dead, and lets their peer hooks finish before scaling down the pods. Controller node, dqlite, API address, leadership, and remote connection handling is cleaned up in the required order so the remaining controllers keep current addresses and can take over safely.

Follow up concerns:

 - `juju status` is unresponsive during scale up and down, I have a future task for that.
 - We get a LOT of user admin logins on the controllers during scale up and that needs to be understood.
 - Scale to 0 for a controller application can happen, we want to prevent that.

## QA steps

You need the latest `juju-controller` charm, from the `main` branch. For example:

```sh
$ juju bootstrap microk8s test --controller-charm-path=./juju-controller_ubuntu@24.04-amd64.charm
$ juju add-unit -m controller controller -n 2
$ juju remove-unit -m controller controller --num-units 1
```

You can use `watch juju status -m controller`, but if you don't see progress, reconnect as it might be stuck. 


## Links


<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10260](https://warthogs.atlassian.net/browse/JUJU-10260)


[JUJU-10260]: https://warthogs.atlassian.net/browse/JUJU-10260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ