### PR TITLE
fix(cmr): notify offering side of relation removal to avoid race

### DIFF
--- a/internal/worker/remoterelations/remoteapplicationworker.go
+++ b/internal/worker/remoterelations/remoteapplicationworker.go
@@ -6,10 +6,13 @@ package remoterelations
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
+	"github.com/juju/retry"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
 	"gopkg.in/macaroon.v2"
@@ -35,6 +38,7 @@ type remoteApplicationWorker struct {
 
 	// These attributes are relevant to dealing with a specific
 	// remote application proxy.
+	clock                     clock.Clock
 	offerUUID                 string
 	applicationName           string // name of the remote application proxy in the local model
 	localModelUUID            string // uuid of the model hosting the local application
@@ -217,8 +221,11 @@ func (w *remoteApplicationWorker) loop() (err error) {
 						w.logger.Debugf("relation %q changed but has been removed", key)
 						// Notify the offering model that the relation is gone
 						// so it can clean up its relation and offer connection.
-						if err := w.publishRelationRemoved(key); err != nil {
-							return errors.Annotatef(err, "notifying offering model of removed relation %q", key)
+						// This is best effort - the local relation has already
+						// gone so there's no way to resume the operation if the
+						// worker restarts.
+						if err := w.publishRelationRemovedWithRetry(key); err != nil {
+							w.logger.Warningf("notifying offering model of removed relation %q: %v", key, err)
 						}
 						err2 := w.localRelationChanged(key, nil)
 						if err2 != nil {
@@ -364,6 +371,35 @@ func (w *remoteApplicationWorker) publishRelationDying(key string, r *relation, 
 			return nil
 		}
 		return errors.Annotatef(err, "publishing relation dying %#v to remote model %v", &change, w.remoteModelUUID)
+	}
+	return nil
+}
+
+// publishRelationRemovedWithRetry notifies the offering model that a local
+// relation has been removed, retrying on transient errors.
+func (w *remoteApplicationWorker) publishRelationRemovedWithRetry(key string) error {
+	var lastErr error
+	err := retry.Call(retry.CallArgs{
+		Clock:       w.clock,
+		Stop:        w.catacomb.Dying(),
+		Delay:       2 * time.Second,
+		Attempts:    3,
+		BackoffFunc: retry.DoubleDelay,
+		Func: func() error {
+			lastErr = w.publishRelationRemoved(key)
+			return lastErr
+		},
+		// Permission to consume the offer has been revoked, so retrying
+		// will never succeed.
+		IsFatalError: func(err error) bool {
+			return params.ErrCode(err) == params.CodeDischargeRequired
+		},
+	})
+	if err != nil {
+		if lastErr == nil {
+			return errors.Trace(err)
+		}
+		return errors.Trace(lastErr)
 	}
 	return nil
 }

--- a/internal/worker/remoterelations/remoteapplicationworker.go
+++ b/internal/worker/remoterelations/remoteapplicationworker.go
@@ -215,6 +215,11 @@ func (w *remoteApplicationWorker) loop() (err error) {
 					if isNotFound(err) {
 						// Relation has been deleted, so ensure relevant workers are stopped.
 						w.logger.Debugf("relation %q changed but has been removed", key)
+						// Notify the offering model that the relation is gone
+						// so it can clean up its relation and offer connection.
+						if err := w.publishRelationRemoved(key); err != nil {
+							return errors.Annotatef(err, "notifying offering model of removed relation %q", key)
+						}
 						err2 := w.localRelationChanged(key, nil)
 						if err2 != nil {
 							return errors.Annotatef(err2, "cleaning up removed local relation %q", key)
@@ -330,29 +335,55 @@ func (w *remoteApplicationWorker) processRelationDying(key string, r *relation, 
 	// On the consuming side, inform the remote side the relation is dying
 	// (but only if we are killing the relation due to it dying, not because
 	// it is suspended).
-	if !w.isConsumerProxy {
-		change := params.RemoteRelationChangeEvent{
-			RelationToken:    r.relationToken,
-			Life:             life.Dying,
-			ApplicationToken: r.applicationToken,
-			Macaroons:        macaroon.Slice{r.macaroon},
-			BakeryVersion:    bakery.LatestVersion,
+	return w.publishRelationDying(key, r, forceCleanup)
+}
+
+// publishRelationDying notifies the offering model that a relation is dying
+// so it can clean up its relation and offer connection. When forceCleanup is
+// true, the offering model is told that no more unit departed events will
+// arrive and it should force-remove its side immediately. This is a no-op
+// for consumer-proxy (offering-side) workers.
+func (w *remoteApplicationWorker) publishRelationDying(key string, r *relation, forceCleanup bool) error {
+	if w.isConsumerProxy {
+		return nil
+	}
+	change := params.RemoteRelationChangeEvent{
+		RelationToken:    r.relationToken,
+		Life:             life.Dying,
+		ApplicationToken: r.applicationToken,
+		Macaroons:        macaroon.Slice{r.macaroon},
+		BakeryVersion:    bakery.LatestVersion,
+	}
+	if forceCleanup {
+		change.ForceCleanup = &forceCleanup
+	}
+	if err := w.remoteModelFacade.PublishRelationChange(change); err != nil {
+		w.checkOfferPermissionDenied(err, r.applicationToken, r.relationToken)
+		if isNotFound(err) {
+			w.logger.Debugf("relation %v dying but remote side already removed", key)
+			return nil
 		}
-		// forceCleanup will be true if the worker has restarted and because the relation had
-		// already been removed, we won't get any more unit departed events.
-		if forceCleanup {
-			change.ForceCleanup = &forceCleanup
-		}
-		if err := w.remoteModelFacade.PublishRelationChange(change); err != nil {
-			w.checkOfferPermissionDenied(err, r.applicationToken, r.relationToken)
-			if isNotFound(err) {
-				w.logger.Debugf("relation %v dying but remote side already removed", key)
-				return nil
-			}
-			return errors.Annotatef(err, "publishing relation dying %#v to remote model %v", &change, w.remoteModelUUID)
-		}
+		return errors.Annotatef(err, "publishing relation dying %#v to remote model %v", &change, w.remoteModelUUID)
 	}
 	return nil
+}
+
+// publishRelationRemoved notifies the offering model that a local relation
+// has been removed so the offering model can clean up its relation and offer
+// connection. This is needed when the relation is removed entirely (not just
+// marked Dying) before the worker has a chance to observe and publish the
+// Dying state.
+func (w *remoteApplicationWorker) publishRelationRemoved(key string) error {
+	w.mu.Lock()
+	r, ok := w.relations[key]
+	w.mu.Unlock()
+	if !ok {
+		w.logger.Debugf("local relation %v already gone", key)
+		return nil
+	}
+	// r's token and macaroon fields are immutable after creation
+	// so they are safe to read after releasing the lock.
+	return w.publishRelationDying(key, r, true)
 }
 
 func (w *remoteApplicationWorker) processRelationSuspended(key string, relLife life.Value, relations map[string]*relation) error {

--- a/internal/worker/remoterelations/remoterelations.go
+++ b/internal/worker/remoterelations/remoterelations.go
@@ -311,6 +311,7 @@ func (w *Worker) handleApplicationChanges(applicationIds []string) error {
 				localModelFacade:                  w.config.RelationsFacade,
 				newRemoteModelRelationsFacadeFunc: w.config.NewRemoteModelFacadeFunc,
 				logger:                            logger,
+				clock:                             w.config.Clock,
 			}
 			if err := catacomb.Invoke(catacomb.Plan{
 				Site: &appWorker.catacomb,

--- a/internal/worker/remoterelations/remoterelations_test.go
+++ b/internal/worker/remoterelations/remoterelations_test.go
@@ -872,17 +872,44 @@ func (s *remoteRelationsSuite) TestPublishRelationRemovedRemoteNotFound(c *gc.C)
 
 func (s *remoteRelationsSuite) TestPublishRelationRemovedError(c *gc.C) {
 	// When PublishRelationChange returns a non-NotFound error, the
-	// worker should die so the error is surfaced.
+	// notification is retried and the worker keeps running.
 	w := s.assertRemoteRelationsWorkers(c)
+	defer workertest.CleanKill(c, w)
 	s.stub.ResetCalls()
 
 	s.relationsFacade.removeRelation("db2:db django:db")
-	s.stub.SetErrors(nil, errors.New("boom"))
+	s.stub.SetErrors(nil, errors.New("boom"),
+		errors.New("boom"), errors.New("boom"))
 
 	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
 	relWatcher.changes <- []string{"db2:db django:db"}
 
-	workertest.DirtyKill(c, w)
+	mac, err := apitesting.NewMacaroon("apimac")
+	c.Assert(err, jc.ErrorIsNil)
+	change := params.RemoteRelationChangeEvent{
+		ApplicationToken: "token-django",
+		RelationToken:    "token-db2:db django:db",
+		Life:             life.Dying,
+		Macaroons:        macaroon.Slice{mac},
+		BakeryVersion:    bakery.LatestVersion,
+		ForceCleanup:     new(true),
+	}
+	expected := []jujutesting.StubCall{
+		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
+		{"PublishRelationChange", []interface{}{change}},
+	}
+	s.waitForWorkerStubCalls(c, expected)
+
+	for _, delay := range []time.Duration{2 * time.Second, 4 * time.Second} {
+		s.config.Clock.(*testclock.Clock).WaitAdvance(delay, coretesting.LongWait, 1)
+		expected = append(expected, jujutesting.StubCall{
+			FuncName: "PublishRelationChange", Args: []interface{}{change},
+		})
+		s.waitForWorkerStubCalls(c, expected)
+	}
+
+	// Attempts are exhausted but the worker keeps running.
+	workertest.CheckAlive(c, w)
 }
 
 func (s *remoteRelationsSuite) TestLocalRelationsChangedNotifies(c *gc.C) {

--- a/internal/worker/remoterelations/remoterelations_test.go
+++ b/internal/worker/remoterelations/remoterelations_test.go
@@ -827,8 +827,62 @@ func (s *remoteRelationsSuite) TestLocalRelationsRemoved(c *gc.C) {
 	c.Assert(unitsWatcher.killed(), jc.IsTrue)
 	expected = []jujutesting.StubCall{
 		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
+		{"PublishRelationChange", []interface{}{
+			params.RemoteRelationChangeEvent{
+				ApplicationToken: "token-django",
+				RelationToken:    "token-db2:db django:db",
+				Life:             life.Dying,
+				Macaroons:        macaroon.Slice{mac},
+				BakeryVersion:    bakery.LatestVersion,
+				ForceCleanup:     new(true),
+			},
+		}},
 	}
 	s.waitForWorkerStubCalls(c, expected)
+}
+
+func (s *remoteRelationsSuite) TestPublishRelationRemovedRemoteNotFound(c *gc.C) {
+	w := s.assertRemoteRelationsWorkers(c)
+	defer workertest.CleanKill(c, w)
+	s.stub.ResetCalls()
+
+	s.relationsFacade.removeRelation("db2:db django:db")
+	s.stub.SetErrors(nil, params.Error{Code: params.CodeNotFound})
+
+	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
+	relWatcher.changes <- []string{"db2:db django:db"}
+
+	mac, err := apitesting.NewMacaroon("apimac")
+	c.Assert(err, jc.ErrorIsNil)
+	expected := []jujutesting.StubCall{
+		{"Relations", []interface{}{[]string{"db2:db django:db"}}},
+		{"PublishRelationChange", []interface{}{
+			params.RemoteRelationChangeEvent{
+				ApplicationToken: "token-django",
+				RelationToken:    "token-db2:db django:db",
+				Life:             life.Dying,
+				Macaroons:        macaroon.Slice{mac},
+				BakeryVersion:    bakery.LatestVersion,
+				ForceCleanup:     new(true),
+			},
+		}},
+	}
+	s.waitForWorkerStubCalls(c, expected)
+}
+
+func (s *remoteRelationsSuite) TestPublishRelationRemovedError(c *gc.C) {
+	// When PublishRelationChange returns a non-NotFound error, the
+	// worker should die so the error is surfaced.
+	w := s.assertRemoteRelationsWorkers(c)
+	s.stub.ResetCalls()
+
+	s.relationsFacade.removeRelation("db2:db django:db")
+	s.stub.SetErrors(nil, errors.New("boom"))
+
+	relWatcher, _ := s.relationsFacade.remoteApplicationRelationsWatcher("db2")
+	relWatcher.changes <- []string{"db2:db django:db"}
+
+	workertest.DirtyKill(c, w)
 }
 
 func (s *remoteRelationsSuite) TestLocalRelationsChangedNotifies(c *gc.C) {

--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -56,9 +56,9 @@ run_offer_consume() {
 
 	echo "Remove offer"
 	juju remove-relation dummy-sink dummy-offer
+	juju remove-saas dummy-offer
 	# wait for the relation to be removed.
 	wait_for null '.applications["dummy-sink"] | .relations'
-	juju remove-saas dummy-offer
 	# wait for saas to be removed.
 	wait_for null '.["application-endpoints"]'
 	# The offer must be removed before model/controller destruction will work.
@@ -223,9 +223,9 @@ run_offer_consume_cross_controller() {
 
 	echo "Remove offer"
 	juju remove-relation dummy-sink dummy-source
+	juju remove-saas dummy-source
 	# wait for the relation to be removed.
 	wait_for null '.applications["dummy-sink"] | .relations'
-	juju remove-saas dummy-source
 	# wait for saas to be removed.
 	wait_for null '.["application-endpoints"]'
 	# The offer must be removed before model/controller destruction will work.


### PR DESCRIPTION
CI was failing regularly on the cross model relations suite. There's several different tests; one in particular was failing. After some digging it turned out the failing test did this:

```
	juju remove-relation dummy-sink dummy-offer
	juju remove-saas dummy-offer
```
the passing test did this
```
	juju remove-relation dummy-sink dummy-offer
	# wait for the relation to be removed.
	wait_for null '.applications["dummy-sink"] | .relations'
	juju remove-saas dummy-offer
```

Looking at the commit history, back in 2023 someone committed a "fix" for what looks like the same issue - they just papered over the symptoms by adding a wait instead of properly addressing the real root cause. We should never "fix" a juju issue by adding a wait to a test script.

The root cause turned out to be that when `remove-saas` is called immediately after `remove-relation` on a consuming app, there can be a race. The relation may already get removed before the remote application worker gets to publish relation life = dying to the offering model. So the worker sees NotFound and exits without notifying the offering model.  So on the offering side, the relation stays alive and the offer connection count is not decremented.

I fixed the ci tests also - I moved the "wait for relation to disappear" checks to after the remove-saas call - we can still verify that the removal happens, but not to gimp the test to paper over the real issue.

## QA steps

`./main.sh cmr`