### PR TITLE
[WIP] fix(model): initialize provider resources with agent stream

### DIFF
--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -1022,6 +1022,34 @@ func (s *ProviderModelService) CreateModelWithAgentVersion(
 	return s.createModelProviderResources(ctx)
 }
 
+// CreateModelWithAgentStream is responsible for creating a new model within
+// the model database using the specified agent stream. Upon creating the model
+// any information required in the model's provider will be initialised.
+//
+// The following error types can be expected to be returned:
+// - [modelerrors.AlreadyExists] when the model uuid is already in use.
+// - [coreerrors.NotValid] when the agent stream is not valid.
+func (s *ProviderModelService) CreateModelWithAgentStream(
+	ctx context.Context,
+	agentStream agentbinary.AgentStream,
+) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	if err := s.ModelService.CreateModelWithAgentStream(ctx, agentStream); err != nil {
+		return errors.Capture(err)
+	}
+
+	err := s.SeedDefaultStoragePools(ctx)
+	if err != nil {
+		return errors.Errorf(
+			"seeding default storage pools into new model: %w", err,
+		)
+	}
+
+	return s.createModelProviderResources(ctx)
+}
+
 // CreateModelWithAgentVersionStream is responsible for creating a new model
 // within the model database using the specified agent version and agent stream.
 // Upon creating the model any information required in the model's provider

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -1211,6 +1211,56 @@ func (s *providerModelServiceSuite) TestCreateModel(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *providerModelServiceSuite) TestProviderCreateModelWithAgentStream(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	controllerUUID := uuid.MustNewUUID()
+	modelUUID := tc.Must0(c, coremodel.NewUUID)
+	defaultPool := s.newDefaultStoragePool(c, ctrl)
+	s.mockStorageProviderRegistry.EXPECT().RecommendedPoolForKind(
+		internalstorage.StorageKindFilesystem,
+	).Return(defaultPool.AsConfig())
+	s.mockStorageProviderRegistry.EXPECT().RecommendedPoolForKind(
+		internalstorage.StorageKindBlock,
+	).Return(nil).AnyTimes()
+	s.mockControllerState.EXPECT().GetModelSeedInformation(gomock.Any(), gomock.Any()).Return(coremodel.ModelInfo{
+		UUID:           modelUUID,
+		ControllerUUID: controllerUUID,
+		Name:           "my-awesome-model",
+		Qualifier:      "prod",
+		Cloud:          "aws",
+		CloudType:      "ec2",
+		CloudRegion:    "myregion",
+		Type:           coremodel.IAAS,
+	}, nil)
+	s.mockModelState.EXPECT().Create(gomock.Any(), model.ModelDetailArgs{
+		UUID:               modelUUID,
+		ControllerUUID:     controllerUUID,
+		Name:               "my-awesome-model",
+		Qualifier:          "prod",
+		Type:               coremodel.IAAS,
+		Cloud:              "aws",
+		CloudType:          "ec2",
+		CloudRegion:        "myregion",
+		AgentStream:        domainagentbinary.AgentStreamTesting,
+		AgentVersion:       jujuversion.Current,
+		LatestAgentVersion: jujuversion.Current,
+	}).Return(nil)
+	s.mockModelState.EXPECT().EnsureDefaultStoragePools(gomock.Any(), defaultPool).Return(nil)
+	s.mockModelState.EXPECT().SetModelStoragePools(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockModelState.EXPECT().GetControllerUUID(gomock.Any()).Return(controllerUUID, nil)
+	s.mockProvider.EXPECT().ValidateProviderForNewModel(gomock.Any()).Return(nil)
+	s.mockProvider.EXPECT().CreateModelResources(gomock.Any(), environs.CreateParams{ControllerUUID: controllerUUID.String()}).Return(nil)
+
+	svc := s.providerService(c, modelUUID)
+	err := svc.CreateModelWithAgentStream(
+		c.Context(),
+		agentbinary.AgentStreamTesting,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *providerModelServiceSuite) TestCreateModelFailedErrorAlreadyExists(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
Creating a model with an agent stream but no explicit agent version used the promoted ModelService method on ProviderModelService. This created model state without seeding storage pools or creating provider resources, so Kubernetes model namespaces were never created.

Add the provider-aware override and regression coverage for storage-pool and provider-resource initialization.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
...
```

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
