### PR TITLE
fix(tests): poll controller-cluster-role in wait_for_ha

### DIFF
--- a/tests/includes/ha.sh
+++ b/tests/includes/ha.sh
@@ -30,23 +30,29 @@ wait_for_ha() {
 
 	attempt=0
 	# shellcheck disable=SC2143
-	until [[ "$(juju show-controller --format=json | yq -r '.[] | .["controller-machines"] | .[] | select(.["ha-status"] == "ha-enabled") | .["instance-id"]' | wc -l | grep "${amount}")" ]]; do
+	# Poll controller machines until each reports a non-null,
+	# non-"unknown" controller-cluster-role. This is the 4.x
+	# replacement for the per-machine `ha-status == "ha-enabled"`
+	# check used in 3.x: a controller machine only reports a real
+	# dqlite role (voter/standby/spare) once it has joined the HA
+	# cluster, so "present and not unknown" is the readiness proxy.
+	until [[ "$(juju status -m controller --format=json 2>/dev/null | yq -r '.machines | to_entries[] | select(.value["controller-cluster-role"] != null and .value["controller-cluster-role"] != "unknown") | .key' | wc -l | grep "${amount}")" ]]; do
 		echo "[+] (attempt ${attempt}) polling ha"
-		juju show-controller 2>&1 | yq '.[]["controller-machines"]' | sed 's/^/    | /g'
+		juju status -m controller --format=yaml 2>&1 | yq '.machines | with_entries(.value |= pick(["instance-id", "controller-cluster-role"]))' 2>&1 | sed 's/^/    | /g' || true
 		sleep "${SHORT_TIMEOUT}"
 		attempt=$((attempt + 1))
 
 		# Wait for roughly 16 minutes for a availability. In the field it's known
 		# that availability can take this long.
 		if [[ ${attempt} -gt 100 ]]; then
-			echo "high availability failed waiting for machines to start"
+			echo "high availability failed waiting for machines to join the HA cluster"
 			exit 1
 		fi
 	done
 
 	if [[ ${attempt} -gt 0 ]]; then
 		echo "[+] $(green 'Completed polling ha')"
-		juju show-controller 2>&1 | sed 's/^/    | /g'
+		juju status -m controller --format=yaml 2>&1 | yq '.machines | with_entries(.value |= pick(["instance-id", "controller-cluster-role"]))' 2>&1 | sed 's/^/    | /g'
 
 		sleep "${SHORT_TIMEOUT}"
 	fi


### PR DESCRIPTION
In 4.x, the controller is a charm application and per-machine `ha-status` was removed from `MachineDetails`. Consequently, `wait_for_ha` in `tests/includes/ha.sh` hung polling for `ha-status == "ha-enabled"`, causing CI integration tests (`cloud_gce`, `cloud_azure`, `controller`) to fail after 100 attempts.

This updates `wait_for_ha` to poll `juju status -m controller` and wait until each controller machine reports a non-null, non-"unknown" `controller-cluster-role`.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
source tests/includes/ha.sh
juju bootstrap lxd
juju add-unit -m controller controller -n 2
SHORT_TIMEOUT=2 wait_for_ha 3
```

## Documentation changes

None.

## Links

**Jira card:** [JUJU-10265](https://warthogs.atlassian.net/browse/JUJU-10265)

[JUJU-10265]: https://warthogs.atlassian.net/browse/JUJU-10265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ