### PR TITLE
feat: detect OVN as valid LXD network set-up

### DIFF
--- a/internal/container/lxd/network.go
+++ b/internal/container/lxd/network.go
@@ -22,6 +22,7 @@ const (
 	nicTypeBridged = "bridged"
 	nicTypeMACVLAN = "macvlan"
 	netTypeBridge  = "bridge"
+	netTypeOVN     = "ovn"
 )
 
 // device is a type alias for profile devices.
@@ -222,12 +223,13 @@ func (s *Server) verifyNICsWithAPI(nics map[string]device) error {
 		return nil
 	}
 
-	// No nics with a nictype of nicTypeBridged, nicTypeMACVLAN was found.
+	// No NIC backed by a supported network was found.
 	return errors.Errorf(
-		"no network device found with nictype %q or %q"+
+		"no network device found with nictype %q or %q, or network type %q, %q, or %q"+
 			"\n\tthe following devices were checked: %s"+
-			"\nReconfigure lxd to use a network of type %q or %q.",
-		nicTypeBridged, nicTypeMACVLAN, strings.Join(checked, ", "), nicTypeBridged, nicTypeMACVLAN)
+			"\nReconfigure lxd to use a network of type %q, %q, or %q.",
+		nicTypeBridged, nicTypeMACVLAN, netTypeBridge, nicTypeMACVLAN, netTypeOVN,
+		strings.Join(checked, ", "), netTypeBridge, nicTypeMACVLAN, netTypeOVN)
 }
 
 // generateNICDeviceName attempts to generate a new NIC device name that is not
@@ -269,7 +271,7 @@ func isValidNICType(nic device) bool {
 }
 
 func isValidNetworkType(net *api.Network) bool {
-	return net.Type == netTypeBridge || net.Type == nicTypeMACVLAN
+	return net.Type == netTypeBridge || net.Type == nicTypeMACVLAN || net.Type == netTypeOVN
 }
 
 // NetworkName returns the network name from the

--- a/internal/container/lxd/network_test.go
+++ b/internal/container/lxd/network_test.go
@@ -146,6 +146,28 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentValid(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *networkSuite) TestVerifyNetworkDevicePresentOVN(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+	cSvr := s.NewMockServerWithExtensions(ctrl, "network")
+
+	const networkName = "ovn-net"
+	profile := defaultProfileWithNIC()
+	profile.Devices["eth0"]["network"] = networkName
+	cSvr.EXPECT().GetNetwork(networkName).Return(&lxdapi.Network{
+		Name:    networkName,
+		Managed: true,
+		Type:    "ovn",
+	}, "", nil)
+
+	jujuSvr, err := lxd.NewServer(cSvr)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = jujuSvr.VerifyNetworkDevice(profile, "")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(jujuSvr.LocalBridgeName(), tc.Equals, networkName)
+}
+
 func (s *networkSuite) TestVerifyNetworkDevicePresentValidLegacy(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
@@ -210,9 +232,9 @@ func (s *networkSuite) TestVerifyNetworkDevicePresentBadNicType(c *tc.C) {
 
 	err = jujuSvr.VerifyNetworkDevice(profile, "")
 	c.Assert(err, tc.ErrorMatches,
-		`profile "default": no network device found with nictype "bridged" or "macvlan"\n`+
+		`profile "default": no network device found with nictype "bridged" or "macvlan", or network type "bridge", "macvlan", or "ovn"\n`+
 			`\tthe following devices were checked: eth0\n`+
-			`Reconfigure lxd to use a network of type "bridged" or "macvlan".`)
+			`Reconfigure lxd to use a network of type "bridge", "macvlan", or "ovn".`)
 }
 
 // Juju used to fail when IPv6 was enabled on the lxd network. This test now


### PR DESCRIPTION
Adds OVN to the types of NIC valid for LXD container networking.

This is the first of a series of changes bringing full support for OVN to the LXD provider.

## QA steps

None required yet. This doesn't change existing functionality - OVN would be recognised, but bootstrap on a LXD cluster using it would still fail.

## Links

**Jira card:** [JUJU-10302](https://warthogs.atlassian.net/browse/JUJU-10302)

[JUJU-10302]: https://warthogs.atlassian.net/browse/JUJU-10302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ