### PR TITLE
feat(backups): add archive creation primitives

### DIFF
--- a/core/backups/create.go
+++ b/core/backups/create.go
@@ -58,6 +58,9 @@ type CreateArgs struct {
 // named after meta.Started using FilenameTemplate. It updates the
 // metadata with the file info and returns the archive filename.
 func Create(meta *Metadata, args CreateArgs) (string, error) {
+	if args.Clock == nil {
+		return "", errors.New("missing clock")
+	}
 	if err := checkDestinationDir(args.DestinationDir); err != nil {
 		return "", errors.Capture(err)
 	}
@@ -138,10 +141,16 @@ func checkDestinationDir(destinationDir string) error {
 	return nil
 }
 
-// checkDumpEntryName ensures the entry name is relative and stays
-// within the archive's dump directory.
+// checkDumpEntryName ensures the entry name is not empty, is relative
+// and stays within the archive's dump directory.
 func checkDumpEntryName(name string) error {
 	cleaned := path.Clean(name)
+	// path.Clean maps both "" and "." (and "./", ...) to ".", which
+	// would resolve to the dump directory itself.
+	if cleaned == "." {
+		return errors.Errorf("empty dump entry name %q: %w",
+			name, coreerrors.NotValid)
+	}
 	if path.IsAbs(cleaned) ||
 		slices.Contains(strings.Split(cleaned, "/"), "..") {
 		return errors.Errorf(

--- a/core/backups/create.go
+++ b/core/backups/create.go
@@ -188,6 +188,13 @@ func buildFilesBundle(bundleFileName string, filesToBackUp []string) error {
 		return errors.New("missing list of files to back up")
 	}
 
+	// Create the parent directory here rather than relying on an
+	// earlier write having created it, matching writeAll.
+	if err := os.MkdirAll(filepath.Dir(bundleFileName), 0700); err != nil {
+		return errors.Errorf("while creating directory for %q: %w",
+			bundleFileName, err)
+	}
+
 	bundleFile, err := os.Create(bundleFileName)
 	if err != nil {
 		return errors.Errorf("while creating bundle file: %w", err)

--- a/core/backups/create.go
+++ b/core/backups/create.go
@@ -1,0 +1,293 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups
+
+import (
+	"compress/gzip"
+	"crypto/sha1"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/juju/utils/v4/hash"
+	"github.com/juju/utils/v4/tar"
+
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
+)
+
+// tempPrefix is the prefix used for the backup staging directories.
+const tempPrefix = "jujuBackup-"
+
+// DumpEntry is a single database dump file to include in the backup
+// archive, under the archive's dump directory.
+type DumpEntry struct {
+	// Name is the path of the entry relative to the archive's dump
+	// directory, e.g. "controller.yaml" or "models/<uuid>.yaml".
+	Name string
+
+	// Reader provides the contents of the dump entry.
+	Reader io.Reader
+}
+
+// CreateArgs holds the arguments for building a backup archive.
+type CreateArgs struct {
+	// DestinationDir is the absolute path to the directory in which
+	// the archive is stored. The staging area is created there too.
+	DestinationDir string
+
+	// FilesToBackUp is the list of absolute paths to the files to
+	// bundle into the archive's root.tar.
+	FilesToBackUp []string
+
+	// DumpEntries are the database dumps written under the archive's
+	// dump directory.
+	DumpEntries []DumpEntry
+}
+
+// Create builds a new backup archive file in args.DestinationDir,
+// named after meta.Started using FilenameTemplate. It updates the
+// metadata with the file info and returns the archive filename.
+func Create(meta *Metadata, args CreateArgs) (string, error) {
+	if err := checkDestinationDir(args.DestinationDir); err != nil {
+		return "", errors.Capture(err)
+	}
+	for _, entry := range args.DumpEntries {
+		if err := checkDumpEntryName(entry.Name); err != nil {
+			return "", errors.Capture(err)
+		}
+	}
+
+	stagingDir, err := os.MkdirTemp(args.DestinationDir, tempPrefix)
+	if err != nil {
+		return "", errors.Errorf("while making backups staging directory: %w", err)
+	}
+	// The staging directory is removed on success and on failure.
+	defer func() { _ = os.RemoveAll(stagingDir) }()
+
+	archivePaths := NewNonCanonicalArchivePaths(stagingDir)
+
+	// We go with user-only permissions on principle; the directories
+	// are short-lived so in practice it shouldn't matter much.
+	if err := os.MkdirAll(archivePaths.DBDumpDir, 0700); err != nil {
+		return "", errors.Errorf("while creating temp directories: %w", err)
+	}
+
+	// The metadata file does not contain the ID or the "finished"
+	// data. However, that information is not as critical. The
+	// alternatives are either adding the metadata file to the archive
+	// after the fact or adding placeholders here for the finished data
+	// and filling them in afterward. Neither is particularly trivial.
+	metadataReader, err := meta.AsJSONBuffer()
+	if err != nil {
+		return "", errors.Errorf("while preparing the metadata: %w", err)
+	}
+	if err := writeAll(archivePaths.MetadataFile, metadataReader); err != nil {
+		return "", errors.Capture(err)
+	}
+
+	if err := buildFilesBundle(archivePaths.FilesBundle, args.FilesToBackUp); err != nil {
+		return "", errors.Capture(err)
+	}
+
+	if err := buildDump(archivePaths.DBDumpDir, args.DumpEntries); err != nil {
+		return "", errors.Capture(err)
+	}
+
+	filename := filepath.Join(args.DestinationDir,
+		meta.Started.Format(FilenameTemplate))
+	size, checksum, err := buildArchiveAndChecksum(filename, stagingDir,
+		archivePaths.ContentDir)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	if err := meta.MarkComplete(size, checksum); err != nil {
+		return "", errors.Errorf("while updating metadata: %w", err)
+	}
+
+	return filename, nil
+}
+
+// checkDestinationDir ensures the backup destination directory is
+// usable.
+func checkDestinationDir(destinationDir string) error {
+	if !filepath.IsAbs(destinationDir) {
+		return errors.Errorf(
+			"cannot use relative backup destination directory %q",
+			destinationDir)
+	}
+	if _, err := os.Stat(destinationDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return errors.Errorf(
+				"backup destination directory %q does not exist",
+				destinationDir)
+		}
+		return errors.Errorf("invalid backup destination directory %q: %w",
+			destinationDir, err)
+	}
+	return nil
+}
+
+// checkDumpEntryName ensures the entry name stays within the archive's
+// dump directory.
+func checkDumpEntryName(name string) error {
+	cleaned := path.Clean(name)
+	if slices.Contains(strings.Split(cleaned, "/"), "..") {
+		return errors.Errorf(
+			"dump entry name %q escapes the dump directory: %w",
+			name, coreerrors.NotValid)
+	}
+	return nil
+}
+
+// writeAll writes the contents of source to the named file, creating
+// any missing parent directories.
+func writeAll(targetname string, source io.Reader) error {
+	if err := os.MkdirAll(filepath.Dir(targetname), 0700); err != nil {
+		return errors.Errorf("while creating directory for %q: %w",
+			targetname, err)
+	}
+	target, err := os.Create(targetname)
+	if err != nil {
+		return errors.Errorf("while creating file %q: %w", targetname, err)
+	}
+	if _, err := io.Copy(target, source); err != nil {
+		_ = target.Close()
+		return errors.Errorf("while copying into file %q: %w", targetname, err)
+	}
+	if err := target.Close(); err != nil {
+		return errors.Errorf("while closing file %q: %w", targetname, err)
+	}
+	return nil
+}
+
+// buildFilesBundle creates the tar file bundling all the juju
+// state-related files gathered in by the backup machinery.
+func buildFilesBundle(bundleFileName string, filesToBackUp []string) error {
+	if len(filesToBackUp) == 0 {
+		return errors.New("missing list of files to back up")
+	}
+
+	bundleFile, err := os.Create(bundleFileName)
+	if err != nil {
+		return errors.Errorf("while creating bundle file: %w", err)
+	}
+
+	// The leading path separator is stripped off each file name when
+	// it is added to the tar file.
+	stripPrefix := string(os.PathSeparator)
+	_, terr := tar.TarFiles(filesToBackUp, bundleFile, stripPrefix)
+	if cerr := bundleFile.Close(); terr == nil {
+		terr = errors.Capture(cerr)
+	}
+	if terr != nil {
+		return errors.Errorf("while bundling state-critical files: %w", terr)
+	}
+	return nil
+}
+
+// buildDump writes the database dump entries into the archive's dump
+// directory.
+func buildDump(dumpDir string, entries []DumpEntry) error {
+	for _, entry := range entries {
+		target := filepath.Join(dumpDir, filepath.FromSlash(entry.Name))
+		if err := writeAll(target, entry.Reader); err != nil {
+			return errors.Capture(err)
+		}
+	}
+	return nil
+}
+
+// buildArchiveAndChecksum tars and gzips the content directory into
+// the named archive file, computing the archive's SHA-1 checksum and
+// size along the way.
+func buildArchiveAndChecksum(filename, stagingDir, contentDir string) (int64, string, error) {
+	archiveFile, err := os.Create(filename)
+	if err != nil {
+		return 0, "", errors.Errorf("while creating archive file: %w", err)
+	}
+
+	// Build the tarball, writing out to both the archive file and a
+	// SHA-1 hash. The hash corresponds to the gzipped file rather than
+	// to the uncompressed contents of the tarball. This is so that
+	// users can compare the published checksum against the checksum of
+	// the file without having to decompress it first.
+	hasher := hash.NewHashingWriter(archiveFile, sha1.New())
+	err = buildArchive(hasher, stagingDir, contentDir)
+	if cerr := archiveFile.Close(); err == nil {
+		err = errors.Capture(cerr)
+	}
+	if err != nil {
+		return 0, "", errors.Capture(err)
+	}
+
+	stat, err := os.Stat(filename)
+	if err != nil {
+		return 0, "", errors.Errorf("while reading archive file info: %w", err)
+	}
+
+	return stat.Size(), hasher.Base64Sum(), nil
+}
+
+// buildArchive writes the gzipped tar of the content directory to the
+// output.
+func buildArchive(outFile io.Writer, stagingDir, contentDir string) error {
+	tarball := gzip.NewWriter(outFile)
+
+	// We add a trailing slash (or whatever) to root so that everything
+	// in the path up to and including that slash is stripped off when
+	// each file is added to the tar file.
+	stripPrefix := stagingDir + string(os.PathSeparator)
+	filenames := []string{contentDir}
+	if _, err := tar.TarFiles(filenames, tarball, stripPrefix); err != nil {
+		_ = tarball.Close()
+		return errors.Errorf("while bundling final archive: %w", err)
+	}
+
+	// Gzip writers may buffer what they're writing so the writer must
+	// be closed before the caller reads the checksum from the hasher.
+	if err := tarball.Close(); err != nil {
+		return errors.Errorf("while closing final archive: %w", err)
+	}
+	return nil
+}
+
+// CheckSpaceFor errors when the free space in dir is less than the
+// expected archive size plus a safety margin. The margin is the larger
+// of the smaller of 5GiB or 10% of the total disk size, and 20% of the
+// expected size.
+func CheckSpaceFor(dir string, expectedSize int64) error {
+	const (
+		miByte          = uint64(1) << 20
+		minFreeAbsolute = float64(uint64(5) << 30)
+	)
+
+	total, err := diskTotal(dir)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	diskSizeMargin := float64(total) * 0.10
+	if diskSizeMargin > minFreeAbsolute {
+		diskSizeMargin = minFreeAbsolute
+	}
+	backupSizeMargin := float64(expectedSize) * 0.20
+	if backupSizeMargin < diskSizeMargin {
+		backupSizeMargin = diskSizeMargin
+	}
+	wantFree := uint64(expectedSize) + uint64(backupSizeMargin)
+
+	available, err := diskFree(dir)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if available < wantFree {
+		return errors.Errorf("not enough free space in %q; want %dMiB, have %dMiB",
+			dir, wantFree/miByte, available/miByte)
+	}
+	return nil
+}

--- a/core/backups/create.go
+++ b/core/backups/create.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package backups
@@ -22,7 +22,7 @@ import (
 )
 
 // tempPrefix is the prefix used for the backup staging directories.
-const tempPrefix = "jujuBackup-"
+const tempPrefix = "juju-backup-"
 
 // DumpEntry is a single database dump file to include in the backup
 // archive, under the archive's dump directory.
@@ -235,9 +235,13 @@ func buildArchiveAndChecksum(filename, stagingDir, contentDir string) (_ int64, 
 	}
 	// The archive is only complete once its final flush lands, so a
 	// close failure fails the backup unless the build already failed.
+	// A failed build leaves no partial archive behind.
 	defer func() {
 		if cerr := archiveFile.Close(); err == nil && cerr != nil {
 			err = errors.Errorf("while closing archive file: %w", cerr)
+		}
+		if err != nil {
+			_ = os.Remove(filename)
 		}
 	}()
 
@@ -264,9 +268,10 @@ func buildArchiveAndChecksum(filename, stagingDir, contentDir string) (_ int64, 
 func buildArchive(outFile io.Writer, stagingDir, contentDir string) error {
 	tarball := gzip.NewWriter(outFile)
 
-	// We add a trailing slash (or whatever) to root so that everything
-	// in the path up to and including that slash is stripped off when
-	// each file is added to the tar file.
+	// A trailing path separator is appended to the staging directory
+	// so that everything in the path up to and including that
+	// separator is stripped off when each file is added to the tar
+	// file.
 	stripPrefix := stagingDir + string(os.PathSeparator)
 	filenames := []string{contentDir}
 	if _, err := tar.TarFiles(filenames, tarball, stripPrefix); err != nil {
@@ -288,7 +293,11 @@ func buildArchive(outFile io.Writer, stagingDir, contentDir string) error {
 // expected size.
 func CheckSpaceFor(dir string, expectedSize int64) error {
 	const (
-		miByte          = uint64(1) << 20
+		// miByte is one mebibyte (2^20 bytes); free-space
+		// shortfalls are reported in MiB.
+		miByte = uint64(1) << 20
+		// minFreeAbsolute caps the disk-size margin at 5 GiB
+		// (5 * 2^30 bytes).
 		minFreeAbsolute = float64(uint64(5) << 30)
 	)
 

--- a/core/backups/create.go
+++ b/core/backups/create.go
@@ -72,7 +72,7 @@ func Create(meta *Metadata, args CreateArgs) (string, error) {
 
 	stagingDir, err := os.MkdirTemp(args.DestinationDir, tempPrefix)
 	if err != nil {
-		return "", errors.Errorf("while making backups staging directory: %w", err)
+		return "", errors.Errorf("making backups staging directory: %w", err)
 	}
 	// The staging directory is removed on success and on failure.
 	defer func() { _ = os.RemoveAll(stagingDir) }()
@@ -82,7 +82,7 @@ func Create(meta *Metadata, args CreateArgs) (string, error) {
 	// We go with user-only permissions on principle; the directories
 	// are short-lived so in practice it shouldn't matter much.
 	if err := os.MkdirAll(archivePaths.DBDumpDir, 0700); err != nil {
-		return "", errors.Errorf("while creating temp directories: %w", err)
+		return "", errors.Errorf("creating temp directories: %w", err)
 	}
 
 	// The metadata file does not contain the ID or the "finished"
@@ -92,7 +92,7 @@ func Create(meta *Metadata, args CreateArgs) (string, error) {
 	// and filling them in afterward. Neither is particularly trivial.
 	metadataReader, err := meta.AsJSONBuffer()
 	if err != nil {
-		return "", errors.Errorf("while preparing the metadata: %w", err)
+		return "", errors.Errorf("preparing the metadata: %w", err)
 	}
 	if err := writeAll(archivePaths.MetadataFile, metadataReader); err != nil {
 		return "", errors.Capture(err)
@@ -115,7 +115,7 @@ func Create(meta *Metadata, args CreateArgs) (string, error) {
 	}
 
 	if err := meta.MarkComplete(size, checksum, args.Clock.Now()); err != nil {
-		return "", errors.Errorf("while updating metadata: %w", err)
+		return "", errors.Errorf("updating metadata: %w", err)
 	}
 
 	return filename, nil
@@ -154,7 +154,7 @@ func checkDumpEntryName(name string) error {
 	if path.IsAbs(cleaned) ||
 		slices.Contains(strings.Split(cleaned, "/"), "..") {
 		return errors.Errorf(
-			"dump entry name %q escapes the dump directory: %w",
+			"entry name %q escapes the root directory: %w",
 			name, coreerrors.NotValid)
 	}
 	return nil
@@ -164,19 +164,19 @@ func checkDumpEntryName(name string) error {
 // any missing parent directories.
 func writeAll(targetname string, source io.Reader) error {
 	if err := os.MkdirAll(filepath.Dir(targetname), 0700); err != nil {
-		return errors.Errorf("while creating directory for %q: %w",
+		return errors.Errorf("creating directory for %q: %w",
 			targetname, err)
 	}
 	target, err := os.Create(targetname)
 	if err != nil {
-		return errors.Errorf("while creating file %q: %w", targetname, err)
+		return errors.Errorf("creating file %q: %w", targetname, err)
 	}
 	if _, err := io.Copy(target, source); err != nil {
 		_ = target.Close()
-		return errors.Errorf("while copying into file %q: %w", targetname, err)
+		return errors.Errorf("copying into file %q: %w", targetname, err)
 	}
 	if err := target.Close(); err != nil {
-		return errors.Errorf("while closing file %q: %w", targetname, err)
+		return errors.Errorf("closing file %q: %w", targetname, err)
 	}
 	return nil
 }
@@ -191,13 +191,13 @@ func buildFilesBundle(bundleFileName string, filesToBackUp []string) error {
 	// Create the parent directory here rather than relying on an
 	// earlier write having created it, matching writeAll.
 	if err := os.MkdirAll(filepath.Dir(bundleFileName), 0700); err != nil {
-		return errors.Errorf("while creating directory for %q: %w",
+		return errors.Errorf("creating directory for %q: %w",
 			bundleFileName, err)
 	}
 
 	bundleFile, err := os.Create(bundleFileName)
 	if err != nil {
-		return errors.Errorf("while creating bundle file: %w", err)
+		return errors.Errorf("creating bundle file: %w", err)
 	}
 
 	// The leading path separator is stripped off each file name when
@@ -208,7 +208,7 @@ func buildFilesBundle(bundleFileName string, filesToBackUp []string) error {
 		terr = errors.Capture(cerr)
 	}
 	if terr != nil {
-		return errors.Errorf("while bundling state-critical files: %w", terr)
+		return errors.Errorf("bundling state-critical files: %w", terr)
 	}
 	return nil
 }
@@ -231,14 +231,14 @@ func buildDump(dumpDir string, entries []DumpEntry) error {
 func buildArchiveAndChecksum(filename, stagingDir, contentDir string) (_ int64, _ string, err error) {
 	archiveFile, err := os.Create(filename)
 	if err != nil {
-		return 0, "", errors.Errorf("while creating archive file: %w", err)
+		return 0, "", errors.Errorf("creating archive file: %w", err)
 	}
 	// The archive is only complete once its final flush lands, so a
 	// close failure fails the backup unless the build already failed.
 	// A failed build leaves no partial archive behind.
 	defer func() {
 		if cerr := archiveFile.Close(); err == nil && cerr != nil {
-			err = errors.Errorf("while closing archive file: %w", cerr)
+			err = errors.Errorf("closing archive file: %w", cerr)
 		}
 		if err != nil {
 			_ = os.Remove(filename)
@@ -257,7 +257,7 @@ func buildArchiveAndChecksum(filename, stagingDir, contentDir string) (_ int64, 
 
 	stat, err := os.Stat(filename)
 	if err != nil {
-		return 0, "", errors.Errorf("while reading archive file info: %w", err)
+		return 0, "", errors.Errorf("reading archive file info: %w", err)
 	}
 
 	return stat.Size(), hasher.Base64Sum(), nil
@@ -276,31 +276,31 @@ func buildArchive(outFile io.Writer, stagingDir, contentDir string) error {
 	filenames := []string{contentDir}
 	if _, err := tar.TarFiles(filenames, tarball, stripPrefix); err != nil {
 		_ = tarball.Close()
-		return errors.Errorf("while bundling final archive: %w", err)
+		return errors.Errorf("bundling final archive: %w", err)
 	}
 
 	// Gzip writers may buffer what they're writing so the writer must
 	// be closed before the caller reads the checksum from the hasher.
 	if err := tarball.Close(); err != nil {
-		return errors.Errorf("while closing final archive: %w", err)
+		return errors.Errorf("closing final archive: %w", err)
 	}
 	return nil
 }
+
+const (
+	// miByte is one mebibyte (2^20 bytes); free-space shortfalls are
+	// reported in MiB.
+	miByte = uint64(1) << 20
+	// minFreeAbsolute caps the disk-size margin at 5 GiB
+	// (5 * 2^30 bytes).
+	minFreeAbsolute = float64(uint64(5) << 30)
+)
 
 // CheckSpaceFor errors when the free space in dir is less than the
 // expected archive size plus a safety margin. The margin is the larger
 // of the smaller of 5GiB or 10% of the total disk size, and 20% of the
 // expected size.
 func CheckSpaceFor(dir string, expectedSize int64) error {
-	const (
-		// miByte is one mebibyte (2^20 bytes); free-space
-		// shortfalls are reported in MiB.
-		miByte = uint64(1) << 20
-		// minFreeAbsolute caps the disk-size margin at 5 GiB
-		// (5 * 2^30 bytes).
-		minFreeAbsolute = float64(uint64(5) << 30)
-	)
-
 	total, err := diskTotal(dir)
 	if err != nil {
 		return errors.Capture(err)

--- a/core/backups/create.go
+++ b/core/backups/create.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/juju/clock"
 	"github.com/juju/utils/v4/hash"
 	"github.com/juju/utils/v4/tar"
 
@@ -47,6 +48,10 @@ type CreateArgs struct {
 	// DumpEntries are the database dumps written under the archive's
 	// dump directory.
 	DumpEntries []DumpEntry
+
+	// Clock provides the time stamping the metadata when the archive
+	// creation finishes. It must not be nil.
+	Clock clock.Clock
 }
 
 // Create builds a new backup archive file in args.DestinationDir,
@@ -106,7 +111,7 @@ func Create(meta *Metadata, args CreateArgs) (string, error) {
 		return "", errors.Capture(err)
 	}
 
-	if err := meta.MarkComplete(size, checksum); err != nil {
+	if err := meta.MarkComplete(size, checksum, args.Clock.Now()); err != nil {
 		return "", errors.Errorf("while updating metadata: %w", err)
 	}
 
@@ -133,11 +138,12 @@ func checkDestinationDir(destinationDir string) error {
 	return nil
 }
 
-// checkDumpEntryName ensures the entry name stays within the archive's
-// dump directory.
+// checkDumpEntryName ensures the entry name is relative and stays
+// within the archive's dump directory.
 func checkDumpEntryName(name string) error {
 	cleaned := path.Clean(name)
-	if slices.Contains(strings.Split(cleaned, "/"), "..") {
+	if path.IsAbs(cleaned) ||
+		slices.Contains(strings.Split(cleaned, "/"), "..") {
 		return errors.Errorf(
 			"dump entry name %q escapes the dump directory: %w",
 			name, coreerrors.NotValid)
@@ -206,11 +212,18 @@ func buildDump(dumpDir string, entries []DumpEntry) error {
 // buildArchiveAndChecksum tars and gzips the content directory into
 // the named archive file, computing the archive's SHA-1 checksum and
 // size along the way.
-func buildArchiveAndChecksum(filename, stagingDir, contentDir string) (int64, string, error) {
+func buildArchiveAndChecksum(filename, stagingDir, contentDir string) (_ int64, _ string, err error) {
 	archiveFile, err := os.Create(filename)
 	if err != nil {
 		return 0, "", errors.Errorf("while creating archive file: %w", err)
 	}
+	// The archive is only complete once its final flush lands, so a
+	// close failure fails the backup unless the build already failed.
+	defer func() {
+		if cerr := archiveFile.Close(); err == nil && cerr != nil {
+			err = errors.Errorf("while closing archive file: %w", cerr)
+		}
+	}()
 
 	// Build the tarball, writing out to both the archive file and a
 	// SHA-1 hash. The hash corresponds to the gzipped file rather than
@@ -218,11 +231,7 @@ func buildArchiveAndChecksum(filename, stagingDir, contentDir string) (int64, st
 	// users can compare the published checksum against the checksum of
 	// the file without having to decompress it first.
 	hasher := hash.NewHashingWriter(archiveFile, sha1.New())
-	err = buildArchive(hasher, stagingDir, contentDir)
-	if cerr := archiveFile.Close(); err == nil {
-		err = errors.Capture(cerr)
-	}
-	if err != nil {
+	if err := buildArchive(hasher, stagingDir, contentDir); err != nil {
 		return 0, "", errors.Capture(err)
 	}
 

--- a/core/backups/create_test.go
+++ b/core/backups/create_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package backups_test
@@ -220,4 +220,19 @@ func (s *createSuite) TestCreateMissingClock(c *tc.C) {
 		FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
 	})
 	c.Assert(err, tc.ErrorMatches, "missing clock")
+}
+
+func (s *createSuite) TestBuildArchiveAndChecksumFailureRemovesArchive(c *tc.C) {
+	dir := c.MkDir()
+	filename := filepath.Join(dir, "archive.tar.gz")
+
+	// A missing content directory fails the tar build after the
+	// archive file has been created; the partial archive must not be
+	// left behind.
+	_, _, err := backups.BuildArchiveAndChecksum(filename, dir,
+		filepath.Join(dir, "missing"))
+	c.Assert(err, tc.NotNil)
+
+	_, err = os.Stat(filename)
+	c.Assert(err, tc.ErrorIs, os.ErrNotExist)
 }

--- a/core/backups/create_test.go
+++ b/core/backups/create_test.go
@@ -10,7 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 	stdtesting "testing"
+	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/tc"
 
@@ -18,6 +20,10 @@ import (
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/internal/testing"
 )
+
+// testStarted keeps the metadata timestamps, and so the archive
+// filename, deterministic.
+var testStarted = time.Date(2024, time.September, 9, 11, 59, 34, 0, time.UTC)
 
 type createSuite struct {
 	testing.BaseSuite
@@ -40,9 +46,10 @@ func (s *createSuite) TestCreate(c *tc.C) {
 	file2 := s.writeFile(c, "system-identity", "ssh key")
 
 	modelUUID := "deadbeef-0bad-400d-8000-4b1d0d06f00d"
-	meta := backups.NewMetadata()
+	meta := backups.NewMetadata(testStarted)
 	filename, err := backups.Create(meta, backups.CreateArgs{
 		DestinationDir: destDir,
+		Clock:          clock.WallClock,
 		FilesToBackUp:  []string{file1, file2},
 		DumpEntries: []backups.DumpEntry{{
 			Name:   "controller.yaml",
@@ -143,8 +150,10 @@ func (s *createSuite) TestCreateDumpEntryNameEscapesDump(c *tc.C) {
 		"../evil.yaml",
 		"models/../../evil.yaml",
 		"..",
+		"/etc/passwd",
+		"/var/lib/juju/models/evil.yaml",
 	} {
-		_, err := backups.Create(backups.NewMetadata(), backups.CreateArgs{
+		_, err := backups.Create(backups.NewMetadata(testStarted), backups.CreateArgs{
 			DestinationDir: c.MkDir(),
 			FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
 			DumpEntries: []backups.DumpEntry{{
@@ -159,7 +168,7 @@ func (s *createSuite) TestCreateDumpEntryNameEscapesDump(c *tc.C) {
 
 func (s *createSuite) TestCreateMissingDestinationDir(c *tc.C) {
 	destDir := filepath.Join(c.MkDir(), "missing")
-	_, err := backups.Create(backups.NewMetadata(), backups.CreateArgs{
+	_, err := backups.Create(backups.NewMetadata(testStarted), backups.CreateArgs{
 		DestinationDir: destDir,
 		FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
 	})
@@ -168,7 +177,7 @@ func (s *createSuite) TestCreateMissingDestinationDir(c *tc.C) {
 }
 
 func (s *createSuite) TestCreateRelativeDestinationDir(c *tc.C) {
-	_, err := backups.Create(backups.NewMetadata(), backups.CreateArgs{
+	_, err := backups.Create(backups.NewMetadata(testStarted), backups.CreateArgs{
 		DestinationDir: "relative",
 		FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
 	})
@@ -177,7 +186,7 @@ func (s *createSuite) TestCreateRelativeDestinationDir(c *tc.C) {
 }
 
 func (s *createSuite) TestCreateMissingFilesToBackUp(c *tc.C) {
-	_, err := backups.Create(backups.NewMetadata(), backups.CreateArgs{
+	_, err := backups.Create(backups.NewMetadata(testStarted), backups.CreateArgs{
 		DestinationDir: c.MkDir(),
 	})
 	c.Assert(err, tc.ErrorMatches, "missing list of files to back up")

--- a/core/backups/create_test.go
+++ b/core/backups/create_test.go
@@ -155,6 +155,7 @@ func (s *createSuite) TestCreateDumpEntryNameEscapesDump(c *tc.C) {
 	} {
 		_, err := backups.Create(backups.NewMetadata(testStarted), backups.CreateArgs{
 			DestinationDir: c.MkDir(),
+			Clock:          clock.WallClock,
 			FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
 			DumpEntries: []backups.DumpEntry{{
 				Name:   name,
@@ -166,10 +167,29 @@ func (s *createSuite) TestCreateDumpEntryNameEscapesDump(c *tc.C) {
 	}
 }
 
+func (s *createSuite) TestCreateEmptyDumpEntryName(c *tc.C) {
+	for _, name := range []string{"", ".", "./", "dump/.."} {
+		_, err := backups.Create(backups.NewMetadata(testStarted), backups.CreateArgs{
+			DestinationDir: c.MkDir(),
+			Clock:          clock.WallClock,
+			FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
+			DumpEntries: []backups.DumpEntry{{
+				Name:   name,
+				Reader: strings.NewReader("data"),
+			}},
+		})
+		c.Check(err, tc.ErrorIs, coreerrors.NotValid,
+			tc.Commentf("name %q", name))
+		c.Check(err, tc.ErrorMatches, `empty dump entry name ".*": not valid`,
+			tc.Commentf("name %q", name))
+	}
+}
+
 func (s *createSuite) TestCreateMissingDestinationDir(c *tc.C) {
 	destDir := filepath.Join(c.MkDir(), "missing")
 	_, err := backups.Create(backups.NewMetadata(testStarted), backups.CreateArgs{
 		DestinationDir: destDir,
+		Clock:          clock.WallClock,
 		FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
 	})
 	c.Assert(err, tc.ErrorMatches,
@@ -179,6 +199,7 @@ func (s *createSuite) TestCreateMissingDestinationDir(c *tc.C) {
 func (s *createSuite) TestCreateRelativeDestinationDir(c *tc.C) {
 	_, err := backups.Create(backups.NewMetadata(testStarted), backups.CreateArgs{
 		DestinationDir: "relative",
+		Clock:          clock.WallClock,
 		FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
 	})
 	c.Assert(err, tc.ErrorMatches,
@@ -188,6 +209,15 @@ func (s *createSuite) TestCreateRelativeDestinationDir(c *tc.C) {
 func (s *createSuite) TestCreateMissingFilesToBackUp(c *tc.C) {
 	_, err := backups.Create(backups.NewMetadata(testStarted), backups.CreateArgs{
 		DestinationDir: c.MkDir(),
+		Clock:          clock.WallClock,
 	})
 	c.Assert(err, tc.ErrorMatches, "missing list of files to back up")
+}
+
+func (s *createSuite) TestCreateMissingClock(c *tc.C) {
+	_, err := backups.Create(backups.NewMetadata(testStarted), backups.CreateArgs{
+		DestinationDir: c.MkDir(),
+		FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
+	})
+	c.Assert(err, tc.ErrorMatches, "missing clock")
 }

--- a/core/backups/create_test.go
+++ b/core/backups/create_test.go
@@ -1,0 +1,184 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups_test
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	stdtesting "testing"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/backups"
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/testing"
+)
+
+type createSuite struct {
+	testing.BaseSuite
+}
+
+func TestCreateSuite(t *stdtesting.T) {
+	tc.Run(t, &createSuite{})
+}
+
+func (s *createSuite) writeFile(c *tc.C, name, content string) string {
+	path := filepath.Join(c.MkDir(), name)
+	err := os.WriteFile(path, []byte(content), 0644)
+	c.Assert(err, tc.ErrorIsNil)
+	return path
+}
+
+func (s *createSuite) TestCreate(c *tc.C) {
+	destDir := c.MkDir()
+	file1 := s.writeFile(c, "jujud", "agent binary")
+	file2 := s.writeFile(c, "system-identity", "ssh key")
+
+	modelUUID := "deadbeef-0bad-400d-8000-4b1d0d06f00d"
+	meta := backups.NewMetadata()
+	filename, err := backups.Create(meta, backups.CreateArgs{
+		DestinationDir: destDir,
+		FilesToBackUp:  []string{file1, file2},
+		DumpEntries: []backups.DumpEntry{{
+			Name:   "controller.yaml",
+			Reader: strings.NewReader("controller: data"),
+		}, {
+			Name:   "models/" + modelUUID + ".yaml",
+			Reader: strings.NewReader("model: data"),
+		}},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(filepath.Dir(filename), tc.Equals, destDir)
+	c.Check(strings.HasPrefix(filepath.Base(filename),
+		backups.FilenamePrefix), tc.IsTrue)
+
+	// The metadata was marked complete.
+	c.Check(meta.Checksum(), tc.Not(tc.Equals), "")
+	c.Check(meta.Finished, tc.Not(tc.IsNil))
+
+	archiveFile, err := os.Open(filename)
+	c.Assert(err, tc.ErrorIsNil)
+	defer func() { _ = archiveFile.Close() }()
+
+	// BuildMetadata on the resulting archive agrees with the checksum
+	// recorded during creation.
+	built, err := backups.BuildMetadata(archiveFile)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(built.Checksum(), tc.Equals, meta.Checksum())
+
+	_, err = archiveFile.Seek(0, io.SeekStart)
+	c.Assert(err, tc.ErrorIsNil)
+	ad, err := backups.NewArchiveDataReader(archiveFile)
+	c.Assert(err, tc.ErrorIsNil)
+
+	entries, contents := s.archiveEntries(c, ad)
+	c.Check(entries, tc.DeepEquals, set.NewStrings(
+		"juju-backup",
+		"juju-backup/metadata.json",
+		"juju-backup/root.tar",
+		"juju-backup/dump",
+		"juju-backup/dump/controller.yaml",
+		"juju-backup/dump/models",
+		"juju-backup/dump/models/"+modelUUID+".yaml",
+	))
+	c.Check(contents["juju-backup/dump/controller.yaml"],
+		tc.Equals, "controller: data")
+	c.Check(contents["juju-backup/dump/models/"+modelUUID+".yaml"],
+		tc.Equals, "model: data")
+
+	// The metadata file parses back to the current format version.
+	storedMeta, err := backups.NewMetadataJSONReader(
+		strings.NewReader(contents["juju-backup/metadata.json"]))
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(storedMeta.FormatVersion, tc.Equals, int64(2))
+
+	// root.tar bundles the files with the leading slash stripped.
+	rootEntries, _ := s.tarEntries(c,
+		strings.NewReader(contents["juju-backup/root.tar"]))
+	c.Check(rootEntries.Contains(strings.TrimPrefix(file1, "/")), tc.IsTrue)
+	c.Check(rootEntries.Contains(strings.TrimPrefix(file2, "/")), tc.IsTrue)
+
+	// The staging directory was removed.
+	staging, err := os.ReadDir(destDir)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(staging, tc.HasLen, 1)
+	c.Check(staging[0].Name(), tc.Equals, filepath.Base(filename))
+}
+
+func (s *createSuite) archiveEntries(c *tc.C,
+	ad *backups.ArchiveData,
+) (set.Strings, map[string]string) {
+	return s.tarEntries(c, ad.NewBuffer())
+}
+
+func (s *createSuite) tarEntries(c *tc.C,
+	r io.Reader,
+) (set.Strings, map[string]string) {
+	names := set.NewStrings()
+	contents := make(map[string]string)
+	tr := tar.NewReader(r)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		c.Assert(err, tc.ErrorIsNil)
+		names.Add(header.Name)
+		if header.Typeflag == tar.TypeReg {
+			data, err := io.ReadAll(tr)
+			c.Assert(err, tc.ErrorIsNil)
+			contents[header.Name] = string(data)
+		}
+	}
+	return names, contents
+}
+
+func (s *createSuite) TestCreateDumpEntryNameEscapesDump(c *tc.C) {
+	for _, name := range []string{
+		"../evil.yaml",
+		"models/../../evil.yaml",
+		"..",
+	} {
+		_, err := backups.Create(backups.NewMetadata(), backups.CreateArgs{
+			DestinationDir: c.MkDir(),
+			FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
+			DumpEntries: []backups.DumpEntry{{
+				Name:   name,
+				Reader: strings.NewReader("data"),
+			}},
+		})
+		c.Check(err, tc.ErrorIs, coreerrors.NotValid,
+			tc.Commentf("name %q", name))
+	}
+}
+
+func (s *createSuite) TestCreateMissingDestinationDir(c *tc.C) {
+	destDir := filepath.Join(c.MkDir(), "missing")
+	_, err := backups.Create(backups.NewMetadata(), backups.CreateArgs{
+		DestinationDir: destDir,
+		FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
+	})
+	c.Assert(err, tc.ErrorMatches,
+		`backup destination directory ".*" does not exist`)
+}
+
+func (s *createSuite) TestCreateRelativeDestinationDir(c *tc.C) {
+	_, err := backups.Create(backups.NewMetadata(), backups.CreateArgs{
+		DestinationDir: "relative",
+		FilesToBackUp:  []string{s.writeFile(c, "file", "content")},
+	})
+	c.Assert(err, tc.ErrorMatches,
+		`cannot use relative backup destination directory "relative"`)
+}
+
+func (s *createSuite) TestCreateMissingFilesToBackUp(c *tc.C) {
+	_, err := backups.Create(backups.NewMetadata(), backups.CreateArgs{
+		DestinationDir: c.MkDir(),
+	})
+	c.Assert(err, tc.ErrorMatches, "missing list of files to back up")
+}

--- a/core/backups/diskusage_linux.go
+++ b/core/backups/diskusage_linux.go
@@ -1,0 +1,32 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build linux
+
+package backups
+
+import (
+	"golang.org/x/sys/unix"
+
+	"github.com/juju/juju/internal/errors"
+)
+
+// diskFree returns the number of bytes available to unprivileged users
+// on the file system hosting dir.
+func diskFree(dir string) (uint64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(dir, &stat); err != nil {
+		return 0, errors.Capture(err)
+	}
+	return stat.Bavail * uint64(stat.Bsize), nil
+}
+
+// diskTotal returns the total size in bytes of the file system hosting
+// dir.
+func diskTotal(dir string) (uint64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(dir, &stat); err != nil {
+		return 0, errors.Capture(err)
+	}
+	return stat.Blocks * uint64(stat.Bsize), nil
+}

--- a/core/backups/diskusage_linux.go
+++ b/core/backups/diskusage_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 //go:build linux

--- a/core/backups/diskusage_other.go
+++ b/core/backups/diskusage_other.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 //go:build !linux

--- a/core/backups/diskusage_other.go
+++ b/core/backups/diskusage_other.go
@@ -1,0 +1,20 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build !linux
+
+package backups
+
+import "math"
+
+// diskFree returns a value indicating unlimited free space on
+// platforms where it cannot be determined.
+func diskFree(string) (uint64, error) {
+	return math.MaxUint64, nil
+}
+
+// diskTotal returns a value indicating an unlimited disk size on
+// platforms where it cannot be determined.
+func diskTotal(string) (uint64, error) {
+	return math.MaxUint64, nil
+}

--- a/core/backups/diskusage_other.go
+++ b/core/backups/diskusage_other.go
@@ -5,16 +5,20 @@
 
 package backups
 
-import "math"
+// Controllers only run on linux. These stubs exist because this package
+// is imported by the juju CLI (cmd/juju/backups) and by rpc/params,
+// which do build for other platforms. Disk usage cannot be determined
+// there, so 0 is reported: CheckSpaceFor then fails rather than
+// assume there is enough space.
 
-// diskFree returns a value indicating unlimited free space on
-// platforms where it cannot be determined.
+// diskFree returns 0 on platforms where the free space cannot be
+// determined.
 func diskFree(string) (uint64, error) {
-	return math.MaxUint64, nil
+	return 0, nil
 }
 
-// diskTotal returns a value indicating an unlimited disk size on
-// platforms where it cannot be determined.
+// diskTotal returns 0 on platforms where the disk size cannot be
+// determined.
 func diskTotal(string) (uint64, error) {
-	return math.MaxUint64, nil
+	return 0, nil
 }

--- a/core/backups/export_test.go
+++ b/core/backups/export_test.go
@@ -3,4 +3,7 @@
 
 package backups
 
-var FileTimestamp = fileTimestamp
+var (
+	FileTimestamp           = fileTimestamp
+	BuildArchiveAndChecksum = buildArchiveAndChecksum
+)

--- a/core/backups/files.go
+++ b/core/backups/files.go
@@ -24,6 +24,11 @@ const (
 	initDir        = "init"
 	objectstoreDir = "objectstore"
 
+	// objectstoreTmpDir matches the directory the object store stages
+	// uploads in before they are persisted
+	// (internal/objectstore's defaultTempDirectoryName).
+	objectstoreTmpDir = "tmp"
+
 	sshIdentFile = "system-identity"
 	serverPEM    = "server.pem"
 	dbSecret     = "shared-secret"
@@ -82,6 +87,11 @@ func GetFilesToBackUp(rootDir string, paths *Paths) ([]string, error) {
 		backupFiles = append(backupFiles, file)
 	}
 
+	// The object store stages uploads that have not been persisted in
+	// <objectstore>/<namespace>/tmp directories; those files never
+	// made it into the object store, so they are not backed up.
+	objectstoreRoot := filepath.Join(rootDir, paths.DataDir, objectstoreDir)
+
 	var finalBackupFiles []string
 	for _, file := range backupFiles {
 		err := filepath.Walk(file,
@@ -90,6 +100,10 @@ func GetFilesToBackUp(rootDir string, paths *Paths) ([]string, error) {
 					return err
 				}
 				if info.IsDir() {
+					if info.Name() == objectstoreTmpDir &&
+						filepath.Dir(filepath.Dir(path)) == objectstoreRoot {
+						return filepath.SkipDir
+					}
 					return nil
 				}
 				if info.Mode().IsRegular() ||
@@ -124,6 +138,8 @@ func IsValidBackupFilepath(root string, filePath string) (bool, error) {
 		}
 		if !d.IsDir() && path == filePath {
 			result = true
+			// The file is found; stop walking the rest of the tree.
+			return filepath.SkipAll
 		}
 		return nil
 	})

--- a/core/backups/files.go
+++ b/core/backups/files.go
@@ -1,0 +1,131 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/juju/juju/internal/errors"
+)
+
+// TODO(ericsnow) lp-1392876
+// Pull these from authoritative sources (see
+// github.com/juju/juju/juju/paths, etc.):
+const (
+	sshDir = "/home/ubuntu/.ssh"
+
+	agentsDir      = "agents"
+	agentsConfs    = "machine-*"
+	toolsDir       = "tools"
+	initDir        = "init"
+	objectstoreDir = "objectstore"
+
+	sshIdentFile = "system-identity"
+	serverPEM    = "server.pem"
+	dbSecret     = "shared-secret"
+	nonceFile    = "nonce.txt"
+	authKeysFile = "authorized_keys"
+)
+
+// BackupDirToUse returns the desired backup staging dir.
+func BackupDirToUse(configuredDir string) string {
+	if configuredDir != "" {
+		return configuredDir
+	}
+	return os.TempDir()
+}
+
+// GetFilesToBackUp returns the paths that should be included in the
+// backup archive.
+func GetFilesToBackUp(rootDir string, paths *Paths) ([]string, error) {
+	glob := filepath.Join(rootDir, paths.DataDir, agentsDir, agentsConfs)
+	agentConfs, err := filepath.Glob(glob)
+	if err != nil {
+		return nil, errors.Errorf("failed to fetch agent config files: %w", err)
+	}
+
+	glob = filepath.Join(rootDir, paths.DataDir, initDir, "*")
+	serviceConfs, err := filepath.Glob(glob)
+	if err != nil {
+		return nil, errors.Errorf("failed to fetch service config files: %w", err)
+	}
+
+	// The objectstore (charms, resources and agent binaries) and the
+	// tools directory must be there; a failure to walk them is fatal.
+	backupFiles := []string{
+		filepath.Join(rootDir, paths.DataDir, objectstoreDir),
+		filepath.Join(rootDir, paths.DataDir, toolsDir),
+	}
+
+	backupFiles = append(backupFiles, agentConfs...)
+	backupFiles = append(backupFiles, serviceConfs...)
+
+	// The following files might not exist; skip the missing ones.
+	optional := []string{
+		filepath.Join(rootDir, paths.DataDir, sshIdentFile),
+		filepath.Join(rootDir, paths.DataDir, serverPEM),
+		filepath.Join(rootDir, paths.DataDir, dbSecret),
+		filepath.Join(rootDir, paths.DataDir, nonceFile),
+		filepath.Join(rootDir, sshDir, authKeysFile),
+	}
+	for _, file := range optional {
+		if _, err := os.Stat(file); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, errors.Capture(err)
+			}
+			continue
+		}
+		backupFiles = append(backupFiles, file)
+	}
+
+	var finalBackupFiles []string
+	for _, file := range backupFiles {
+		err := filepath.Walk(file,
+			func(path string, info fs.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					return nil
+				}
+				if info.Mode().IsRegular() ||
+					info.Mode()&os.ModeSymlink != 0 {
+					finalBackupFiles = append(finalBackupFiles, path)
+				}
+				return nil
+			})
+		if err != nil {
+			return nil, errors.Errorf("cannot walk %q: %w", file, err)
+		}
+	}
+	return finalBackupFiles, nil
+}
+
+// IsValidBackupFilepath reports whether filePath names an existing regular
+// file directly under root whose base name starts with [FilenamePrefix]. It
+// is used by the download handler to reject arbitrary paths while allowing
+// absolute client-provided ids.
+func IsValidBackupFilepath(root string, filePath string) (bool, error) {
+	if !filepath.IsAbs(filePath) {
+		return false, nil
+	}
+	if !strings.HasPrefix(filepath.Base(filePath), FilenamePrefix) {
+		return false, nil
+	}
+	result := false
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Best-effort validation: unreadable entries are skipped.
+			return nil
+		}
+		if !d.IsDir() && path == filePath {
+			result = true
+		}
+		return nil
+	})
+	return result, walkErr
+}

--- a/core/backups/files.go
+++ b/core/backups/files.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package backups
@@ -120,28 +120,26 @@ func GetFilesToBackUp(rootDir string, paths *Paths) ([]string, error) {
 }
 
 // IsValidBackupFilepath reports whether filePath names an existing regular
-// file directly under root whose base name starts with [FilenamePrefix]. It
+// file directly under root whose base name starts with [FilenamePrefix].
+// Symlinks are followed, so a link to a regular backup file is accepted. It
 // is used by the download handler to reject arbitrary paths while allowing
 // absolute client-provided ids.
 func IsValidBackupFilepath(root string, filePath string) (bool, error) {
 	if !filepath.IsAbs(filePath) {
 		return false, nil
 	}
+	if filepath.Dir(filePath) != filepath.Clean(root) {
+		return false, nil
+	}
 	if !strings.HasPrefix(filepath.Base(filePath), FilenamePrefix) {
 		return false, nil
 	}
-	result := false
-	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			// Best-effort validation: unreadable entries are skipped.
-			return nil
+	info, err := os.Stat(filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
 		}
-		if !d.IsDir() && path == filePath {
-			result = true
-			// The file is found; stop walking the rest of the tree.
-			return filepath.SkipAll
-		}
-		return nil
-	})
-	return result, walkErr
+		return false, errors.Capture(err)
+	}
+	return info.Mode().IsRegular(), nil
 }

--- a/core/backups/files_linux_test.go
+++ b/core/backups/files_linux_test.go
@@ -1,0 +1,28 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build linux
+
+package backups_test
+
+import (
+	"math"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/backups"
+)
+
+// Disk usage can only be determined on linux, so the free space check
+// is only exercised here.
+
+func (s *filesSuite) TestCheckSpaceForNotEnough(c *tc.C) {
+	err := backups.CheckSpaceFor(c.MkDir(), math.MaxInt64/2)
+	c.Assert(err, tc.ErrorMatches,
+		`not enough free space in ".*"; want \d+MiB, have \d+MiB`)
+}
+
+func (s *filesSuite) TestCheckSpaceForEnough(c *tc.C) {
+	err := backups.CheckSpaceFor(c.MkDir(), 1024)
+	c.Assert(err, tc.ErrorIsNil)
+}

--- a/core/backups/files_linux_test.go
+++ b/core/backups/files_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 //go:build linux
@@ -7,6 +7,8 @@ package backups_test
 
 import (
 	"math"
+	"os"
+	"path/filepath"
 
 	"github.com/juju/tc"
 
@@ -25,4 +27,16 @@ func (s *filesSuite) TestCheckSpaceForNotEnough(c *tc.C) {
 func (s *filesSuite) TestCheckSpaceForEnough(c *tc.C) {
 	err := backups.CheckSpaceFor(c.MkDir(), 1024)
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *filesSuite) TestIsValidBackupFilepathFollowsSymlink(c *tc.C) {
+	dir := c.MkDir()
+	target := filepath.Join(dir, backups.FilenamePrefix+"target.tar.gz")
+	s.writeFile(c, target, "archive data")
+	link := filepath.Join(dir, backups.FilenamePrefix+"link.tar.gz")
+	c.Assert(os.Symlink(target, link), tc.ErrorIsNil)
+
+	ok, err := backups.IsValidBackupFilepath(dir, link)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(ok, tc.IsTrue)
 }

--- a/core/backups/files_test.go
+++ b/core/backups/files_test.go
@@ -1,4 +1,4 @@
-// Copyright 2014 Canonical Ltd.
+// Copyright 2026 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package backups_test
@@ -156,6 +156,11 @@ func (s *filesSuite) TestIsValidBackupFilepath(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(ok, tc.IsTrue)
 
+	// A backup file in a subdirectory of root is rejected: only files
+	// directly under root are served.
+	nested := filepath.Join(dir, "sub", backups.FilenamePrefix+"nested.tar.gz")
+	s.writeFile(c, nested, "archive data")
+
 	for _, invalid := range []struct {
 		name  string
 		path_ string
@@ -163,6 +168,7 @@ func (s *filesSuite) TestIsValidBackupFilepath(c *tc.C) {
 		{"relative", "juju-backup-foo.tar.gz"},
 		{"absolute missing file", filepath.Join(dir, "juju-backup-missing.tar.gz")},
 		{"prefix-refusing", filepath.Join(dir, "other.tar.gz")},
+		{"nested", nested},
 	} {
 		ok, err = backups.IsValidBackupFilepath(dir, invalid.path_)
 		c.Assert(err, tc.ErrorIsNil)

--- a/core/backups/files_test.go
+++ b/core/backups/files_test.go
@@ -1,0 +1,143 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups_test
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	stdtesting "testing"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/backups"
+	"github.com/juju/juju/internal/testing"
+)
+
+type filesSuite struct {
+	testing.BaseSuite
+}
+
+func TestFilesSuite(t *stdtesting.T) {
+	tc.Run(t, &filesSuite{})
+}
+
+func (s *filesSuite) writeFile(c *tc.C, path, content string) {
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	c.Assert(err, tc.ErrorIsNil)
+	err = os.WriteFile(path, []byte(content), 0644)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *filesSuite) TestGetFilesToBackUpMissingObjectstore(c *tc.C) {
+	dataDir := c.MkDir()
+	s.writeFile(c, filepath.Join(dataDir, "tools", "jujud"), "binary")
+
+	_, err := backups.GetFilesToBackUp("", &backups.Paths{DataDir: dataDir})
+	c.Assert(err, tc.ErrorMatches,
+		`cannot walk ".*objectstore.*`)
+}
+
+func (s *filesSuite) TestGetFilesToBackUpMissingTools(c *tc.C) {
+	dataDir := c.MkDir()
+	err := os.MkdirAll(filepath.Join(dataDir, "objectstore"), 0755)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = backups.GetFilesToBackUp("", &backups.Paths{DataDir: dataDir})
+	c.Assert(err, tc.ErrorMatches,
+		`cannot walk ".*tools.*`)
+}
+
+func (s *filesSuite) TestGetFilesToBackUp(c *tc.C) {
+	dataDir := c.MkDir()
+	s.writeFile(c, filepath.Join(dataDir, "objectstore", "ns1", "blob"),
+		"blob")
+	s.writeFile(c, filepath.Join(dataDir, "tools", "jujud"), "binary")
+	s.writeFile(c,
+		filepath.Join(dataDir, "agents", "machine-0", "agent.conf"), "conf")
+	s.writeFile(c, filepath.Join(dataDir, "init", "jujud-machine-0.conf"),
+		"init conf")
+	s.writeFile(c, filepath.Join(dataDir, "system-identity"), "ssh key")
+
+	// A symlink is collected, but the directory it sits in is not.
+	err := os.Symlink("jujud",
+		filepath.Join(dataDir, "tools", "jujud-link"))
+	c.Assert(err, tc.ErrorIsNil)
+
+	// server.pem, shared-secret and nonce.txt are absent and must be
+	// tolerated. The ubuntu authorized_keys is optional: include it in the
+	// expectation only when it exists on the host (test runners differ).
+	expected := []string{
+		filepath.Join(dataDir, "objectstore", "ns1", "blob"),
+		filepath.Join(dataDir, "tools", "jujud"),
+		filepath.Join(dataDir, "tools", "jujud-link"),
+		filepath.Join(dataDir, "agents", "machine-0", "agent.conf"),
+		filepath.Join(dataDir, "init", "jujud-machine-0.conf"),
+		filepath.Join(dataDir, "system-identity"),
+	}
+	if _, err := os.Stat("/home/ubuntu/.ssh/authorized_keys"); err == nil {
+		expected = append(expected, "/home/ubuntu/.ssh/authorized_keys")
+	}
+	files, err := backups.GetFilesToBackUp("", &backups.Paths{
+		DataDir: dataDir,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(set.NewStrings(files...), tc.DeepEquals, set.NewStrings(expected...))
+}
+
+func (s *filesSuite) TestGetFilesToBackUpWithRootDir(c *tc.C) {
+	rootDir := c.MkDir()
+	dataDir := filepath.Join(rootDir, "var", "lib", "juju")
+	s.writeFile(c, filepath.Join(dataDir, "objectstore", "blob"), "blob")
+	s.writeFile(c, filepath.Join(dataDir, "tools", "jujud"), "binary")
+
+	files, err := backups.GetFilesToBackUp(rootDir, &backups.Paths{
+		DataDir: filepath.Join("var", "lib", "juju"),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(set.NewStrings(files...), tc.DeepEquals, set.NewStrings(
+		filepath.Join(dataDir, "objectstore", "blob"),
+		filepath.Join(dataDir, "tools", "jujud"),
+	))
+}
+
+func (s *filesSuite) TestCheckSpaceForNotEnough(c *tc.C) {
+	err := backups.CheckSpaceFor(c.MkDir(), math.MaxInt64/2)
+	c.Assert(err, tc.ErrorMatches,
+		`not enough free space in ".*"; want \d+MiB, have \d+MiB`)
+}
+
+func (s *filesSuite) TestCheckSpaceForEnough(c *tc.C) {
+	err := backups.CheckSpaceFor(c.MkDir(), 1024)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *filesSuite) TestBackupDirToUse(c *tc.C) {
+	c.Check(backups.BackupDirToUse("/some/dir"), tc.Equals, "/some/dir")
+	c.Check(backups.BackupDirToUse(""), tc.Equals, os.TempDir())
+}
+
+func (s *filesSuite) TestIsValidBackupFilepath(c *tc.C) {
+	dir := c.MkDir()
+	valid := filepath.Join(dir, backups.FilenamePrefix+"2020.tar.gz")
+	s.writeFile(c, valid, "archive data")
+
+	ok, err := backups.IsValidBackupFilepath(dir, valid)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(ok, tc.IsTrue)
+
+	for _, invalid := range []struct {
+		name  string
+		path_ string
+	}{
+		{"relative", "juju-backup-foo.tar.gz"},
+		{"absolute missing file", filepath.Join(dir, "juju-backup-missing.tar.gz")},
+		{"prefix-refusing", filepath.Join(dir, "other.tar.gz")},
+	} {
+		ok, err = backups.IsValidBackupFilepath(dir, invalid.path_)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Check(ok, tc.IsFalse, tc.Commentf("case %q", invalid.name))
+	}
+}

--- a/core/backups/files_test.go
+++ b/core/backups/files_test.go
@@ -4,7 +4,6 @@
 package backups_test
 
 import (
-	"math"
 	"os"
 	"path/filepath"
 	stdtesting "testing"
@@ -103,15 +102,32 @@ func (s *filesSuite) TestGetFilesToBackUpWithRootDir(c *tc.C) {
 	))
 }
 
-func (s *filesSuite) TestCheckSpaceForNotEnough(c *tc.C) {
-	err := backups.CheckSpaceFor(c.MkDir(), math.MaxInt64/2)
-	c.Assert(err, tc.ErrorMatches,
-		`not enough free space in ".*"; want \d+MiB, have \d+MiB`)
-}
+func (s *filesSuite) TestGetFilesToBackUpSkipsObjectstoreTmp(c *tc.C) {
+	dataDir := c.MkDir()
+	// In-flight object store uploads are staged under
+	// <objectstore>/<namespace>/tmp; they never made it into the
+	// object store.
+	s.writeFile(c,
+		filepath.Join(dataDir, "objectstore", "ns1", "tmp", "tmp1234"),
+		"partial upload")
+	s.writeFile(c, filepath.Join(dataDir, "objectstore", "ns1", "blob"),
+		"blob")
+	// A "tmp" directory deeper in a namespace holds object data, not
+	// staging files, and is still backed up.
+	s.writeFile(c, filepath.Join(dataDir, "objectstore", "ns1",
+		"applications", "tmp", "resource"), "resource")
+	s.writeFile(c, filepath.Join(dataDir, "tools", "jujud"), "binary")
 
-func (s *filesSuite) TestCheckSpaceForEnough(c *tc.C) {
-	err := backups.CheckSpaceFor(c.MkDir(), 1024)
+	files, err := backups.GetFilesToBackUp("", &backups.Paths{
+		DataDir: dataDir,
+	})
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(set.NewStrings(files...), tc.DeepEquals, set.NewStrings(
+		filepath.Join(dataDir, "objectstore", "ns1", "blob"),
+		filepath.Join(dataDir, "objectstore", "ns1", "applications",
+			"tmp", "resource"),
+		filepath.Join(dataDir, "tools", "jujud"),
+	))
 }
 
 func (s *filesSuite) TestBackupDirToUse(c *tc.C) {

--- a/core/backups/files_test.go
+++ b/core/backups/files_test.go
@@ -19,6 +19,13 @@ type filesSuite struct {
 	testing.BaseSuite
 }
 
+// relDataDir is the data dir relative to the root dir handed to
+// GetFilesToBackUp. Tests always pass a root dir so that the optional
+// /home/ubuntu/.ssh/authorized_keys lookup stays inside the test's own
+// tree: on the host it may exist but be unreadable, which is fatal to
+// GetFilesToBackUp and would make results depend on the test runner.
+var relDataDir = filepath.Join("var", "lib", "juju")
+
 func TestFilesSuite(t *stdtesting.T) {
 	tc.Run(t, &filesSuite{})
 }
@@ -31,26 +38,31 @@ func (s *filesSuite) writeFile(c *tc.C, path, content string) {
 }
 
 func (s *filesSuite) TestGetFilesToBackUpMissingObjectstore(c *tc.C) {
-	dataDir := c.MkDir()
+	rootDir := c.MkDir()
+	dataDir := filepath.Join(rootDir, relDataDir)
 	s.writeFile(c, filepath.Join(dataDir, "tools", "jujud"), "binary")
 
-	_, err := backups.GetFilesToBackUp("", &backups.Paths{DataDir: dataDir})
+	_, err := backups.GetFilesToBackUp(rootDir,
+		&backups.Paths{DataDir: relDataDir})
 	c.Assert(err, tc.ErrorMatches,
 		`cannot walk ".*objectstore.*`)
 }
 
 func (s *filesSuite) TestGetFilesToBackUpMissingTools(c *tc.C) {
-	dataDir := c.MkDir()
+	rootDir := c.MkDir()
+	dataDir := filepath.Join(rootDir, relDataDir)
 	err := os.MkdirAll(filepath.Join(dataDir, "objectstore"), 0755)
 	c.Assert(err, tc.ErrorIsNil)
 
-	_, err = backups.GetFilesToBackUp("", &backups.Paths{DataDir: dataDir})
+	_, err = backups.GetFilesToBackUp(rootDir,
+		&backups.Paths{DataDir: relDataDir})
 	c.Assert(err, tc.ErrorMatches,
 		`cannot walk ".*tools.*`)
 }
 
 func (s *filesSuite) TestGetFilesToBackUp(c *tc.C) {
-	dataDir := c.MkDir()
+	rootDir := c.MkDir()
+	dataDir := filepath.Join(rootDir, relDataDir)
 	s.writeFile(c, filepath.Join(dataDir, "objectstore", "ns1", "blob"),
 		"blob")
 	s.writeFile(c, filepath.Join(dataDir, "tools", "jujud"), "binary")
@@ -59,6 +71,9 @@ func (s *filesSuite) TestGetFilesToBackUp(c *tc.C) {
 	s.writeFile(c, filepath.Join(dataDir, "init", "jujud-machine-0.conf"),
 		"init conf")
 	s.writeFile(c, filepath.Join(dataDir, "system-identity"), "ssh key")
+	authKeys := filepath.Join(rootDir, "home", "ubuntu", ".ssh",
+		"authorized_keys")
+	s.writeFile(c, authKeys, "ssh-rsa key")
 
 	// A symlink is collected, but the directory it sits in is not.
 	err := os.Symlink("jujud",
@@ -66,34 +81,30 @@ func (s *filesSuite) TestGetFilesToBackUp(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	// server.pem, shared-secret and nonce.txt are absent and must be
-	// tolerated. The ubuntu authorized_keys is optional: include it in the
-	// expectation only when it exists on the host (test runners differ).
-	expected := []string{
+	// tolerated.
+	files, err := backups.GetFilesToBackUp(rootDir, &backups.Paths{
+		DataDir: relDataDir,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(set.NewStrings(files...), tc.DeepEquals, set.NewStrings(
 		filepath.Join(dataDir, "objectstore", "ns1", "blob"),
 		filepath.Join(dataDir, "tools", "jujud"),
 		filepath.Join(dataDir, "tools", "jujud-link"),
 		filepath.Join(dataDir, "agents", "machine-0", "agent.conf"),
 		filepath.Join(dataDir, "init", "jujud-machine-0.conf"),
 		filepath.Join(dataDir, "system-identity"),
-	}
-	if _, err := os.Stat("/home/ubuntu/.ssh/authorized_keys"); err == nil {
-		expected = append(expected, "/home/ubuntu/.ssh/authorized_keys")
-	}
-	files, err := backups.GetFilesToBackUp("", &backups.Paths{
-		DataDir: dataDir,
-	})
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(set.NewStrings(files...), tc.DeepEquals, set.NewStrings(expected...))
+		authKeys,
+	))
 }
 
 func (s *filesSuite) TestGetFilesToBackUpWithRootDir(c *tc.C) {
 	rootDir := c.MkDir()
-	dataDir := filepath.Join(rootDir, "var", "lib", "juju")
+	dataDir := filepath.Join(rootDir, relDataDir)
 	s.writeFile(c, filepath.Join(dataDir, "objectstore", "blob"), "blob")
 	s.writeFile(c, filepath.Join(dataDir, "tools", "jujud"), "binary")
 
 	files, err := backups.GetFilesToBackUp(rootDir, &backups.Paths{
-		DataDir: filepath.Join("var", "lib", "juju"),
+		DataDir: relDataDir,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(set.NewStrings(files...), tc.DeepEquals, set.NewStrings(
@@ -103,7 +114,8 @@ func (s *filesSuite) TestGetFilesToBackUpWithRootDir(c *tc.C) {
 }
 
 func (s *filesSuite) TestGetFilesToBackUpSkipsObjectstoreTmp(c *tc.C) {
-	dataDir := c.MkDir()
+	rootDir := c.MkDir()
+	dataDir := filepath.Join(rootDir, relDataDir)
 	// In-flight object store uploads are staged under
 	// <objectstore>/<namespace>/tmp; they never made it into the
 	// object store.
@@ -118,8 +130,8 @@ func (s *filesSuite) TestGetFilesToBackUpSkipsObjectstoreTmp(c *tc.C) {
 		"applications", "tmp", "resource"), "resource")
 	s.writeFile(c, filepath.Join(dataDir, "tools", "jujud"), "binary")
 
-	files, err := backups.GetFilesToBackUp("", &backups.Paths{
-		DataDir: dataDir,
+	files, err := backups.GetFilesToBackUp(rootDir, &backups.Paths{
+		DataDir: relDataDir,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(set.NewStrings(files...), tc.DeepEquals, set.NewStrings(

--- a/core/backups/metadata.go
+++ b/core/backups/metadata.go
@@ -122,21 +122,20 @@ type ControllerMetadata struct {
 // currentFormatVersion is the most recent metadata version.
 const currentFormatVersion = 2
 
-// NewMetadata returns a new Metadata for a backup archive,
-// in the most current format.
-func NewMetadata() *Metadata {
+// NewMetadata returns a new Metadata for a backup archive, in the
+// most current format, started at the given time.
+func NewMetadata(now time.Time) *Metadata {
 	return &Metadata{
-		FileMetadata: filestorage.NewMetadata(),
-		// TODO(fwereade): 2016-03-17 lp:1558657
-		Started:       time.Now().UTC(),
+		FileMetadata:  filestorage.NewMetadata(),
+		Started:       now.UTC(),
 		FormatVersion: currentFormatVersion,
 		Controller:    ControllerMetadata{},
 	}
 }
 
-// MarkComplete populates the remaining metadata values.  The default
-// checksum format is used.
-func (m *Metadata) MarkComplete(size int64, checksum string) error {
+// MarkComplete populates the remaining metadata values, finishing at
+// the given time.  The default checksum format is used.
+func (m *Metadata) MarkComplete(size int64, checksum string, finished time.Time) error {
 	if size == 0 {
 		return errors.New("missing size")
 	}
@@ -144,8 +143,7 @@ func (m *Metadata) MarkComplete(size int64, checksum string) error {
 		return errors.New("missing checksum")
 	}
 	format := checksumFormat
-	// TODO(fwereade): 2016-03-17 lp:1558657
-	finished := time.Now().UTC()
+	finished = finished.UTC()
 
 	if err := m.SetFileInfo(size, checksum, format); err != nil {
 		return errors.Errorf("unexpected failure: %w", err)
@@ -211,7 +209,7 @@ func (m *Metadata) flat() flatMetadata {
 }
 
 func (flat *flatMetadata) inflate() (*Metadata, error) {
-	meta := NewMetadata()
+	meta := NewMetadata(flat.Started)
 	meta.SetID(flat.ID)
 	meta.FormatVersion = flat.FormatVersion
 
@@ -219,7 +217,6 @@ func (flat *flatMetadata) inflate() (*Metadata, error) {
 		meta.SetStored(&flat.Stored)
 	}
 
-	meta.Started = flat.Started
 	if !flat.Finished.IsZero() {
 		meta.Finished = &flat.Finished
 	}
@@ -309,15 +306,12 @@ func BuildMetadata(file *os.File) (*Metadata, error) {
 	checksum := base64.StdEncoding.EncodeToString(rawsum)
 
 	// Build the metadata.
-	meta := NewMetadata()
-	meta.Started = time.Time{}
+	meta := NewMetadata(time.Time{})
 	meta.Origin = UnknownOrigin()
 	meta.FormatVersion = UnknownInt64
 	meta.Controller = UnknownController()
-	err = meta.MarkComplete(size, checksum)
-	if err != nil {
+	if err := meta.MarkComplete(size, checksum, timestamp); err != nil {
 		return nil, errors.Capture(err)
 	}
-	meta.Finished = &timestamp
 	return meta, nil
 }

--- a/core/backups/metadata_test.go
+++ b/core/backups/metadata_test.go
@@ -51,7 +51,8 @@ func (s *metadataSuite) TestAsJSONBuffer(c *tc.C) {
 }
 
 func (s *metadataSuite) createTestMetadata(c *tc.C) *backups.Metadata {
-	meta := backups.NewMetadata()
+	meta := backups.NewMetadata(time.Date(
+		2014, time.Month(9), 9, 11, 59, 34, 0, time.UTC))
 	meta.Origin = backups.Origin{
 		Model:    "asdf-zxcv-qwe",
 		Machine:  "0",
@@ -59,7 +60,6 @@ func (s *metadataSuite) createTestMetadata(c *tc.C) *backups.Metadata {
 		Version:  semversion.MustParse("1.21-alpha3"),
 		Base:     "ubuntu@22.04",
 	}
-	meta.Started = time.Date(2014, time.Month(9), 9, 11, 59, 34, 0, time.UTC)
 
 	meta.SetID("20140909-115934.asdf-zxcv-qwe")
 
@@ -67,10 +67,8 @@ func (s *metadataSuite) createTestMetadata(c *tc.C) *backups.Metadata {
 }
 
 func (s *metadataSuite) assertMetadata(c *tc.C, meta *backups.Metadata, expected string) {
-	err := meta.MarkComplete(10, "123af2cef")
+	err := meta.MarkComplete(10, "123af2cef", meta.Started.Add(time.Minute))
 	c.Assert(err, tc.ErrorIsNil)
-	finished := meta.Started.Add(time.Minute)
-	meta.Finished = &finished
 
 	buf, err := meta.AsJSONBuffer()
 	c.Assert(err, tc.ErrorIsNil)

--- a/core/backups/testing/metadata.go
+++ b/core/backups/testing/metadata.go
@@ -28,8 +28,7 @@ func NewMetadata() *backups.Metadata {
 
 // NewMetadataStarted returns a Metadata to use for testing.
 func NewMetadataStarted() *backups.Metadata {
-	meta := backups.NewMetadata()
-	meta.Started = meta.Started.Truncate(time.Second)
+	meta := backups.NewMetadata(time.Now().Truncate(time.Second))
 	meta.Origin.Model = envID
 	meta.Origin.Machine = "0"
 	meta.Origin.Hostname = "main-host"
@@ -40,9 +39,7 @@ func NewMetadataStarted() *backups.Metadata {
 func FinishMetadata(meta *backups.Metadata) {
 	var size int64 = 10
 	checksum := "787b8915389d921fa23fb40e16ae81ea979758bf"
-	_ = meta.MarkComplete(size, checksum)
-	finished := meta.Started.Add(time.Minute)
-	meta.Finished = &finished
+	_ = meta.MarkComplete(size, checksum, meta.Started.Add(time.Minute))
 }
 
 // UpdateNotes derives a new Metadata with new notes.


### PR DESCRIPTION
`core/backups` only offered metadata handling and archive-reading helpers; there was no way to build a backup archive. The backups facade work needs a creation path that accepts controlled dump entries so the controller and model database exports can be written into the archive.

This change adds `Create` plus its staging helpers, the file collection helper `GetFilesToBackUp`, the `BackupDirToUse` and `IsValidBackupFilepath` path helpers, and a `CheckSpaceFor` free-space check, all with unit tests. Nothing consumes these yet; the facade PR wires them in.

These helpers are a port of the archive-creation half of 3.6's `state/backups` package (deleted on 4.0 with the rest of the mongo-backed `state` tree), relocated into `core/backups` where the archive's read side already lives. 

## QA steps

Not wired yet, only unit tests should pass.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10303](https://warthogs.atlassian.net/browse/JUJU-10303)


[JUJU-10303]: https://warthogs.atlassian.net/browse/JUJU-10303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ