### PR TITLE
fix(instancepoller): clear stale provisioning status on agent start

### DIFF
--- a/domain/status/service/service.go
+++ b/domain/status/service/service.go
@@ -760,6 +760,37 @@ func (s *Service) SetInstanceStatus(ctx context.Context, machineName machine.Nam
 	return nil
 }
 
+// ClearStaleProvisioningStatusOnMachineStart clears a provisioning status
+// left by a failed provider operation when the machine agent has since started.
+func (s *Service) ClearStaleProvisioningStatusOnMachineStart(ctx context.Context, machineName machine.Name) error {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	machineStatus, err := s.GetMachineStatus(ctx, machineName)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if machineStatus.Status != corestatus.Started || machineStatus.Since == nil {
+		return nil
+	}
+
+	instanceStatus, err := s.GetInstanceStatus(ctx, machineName)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if instanceStatus.Status != corestatus.Provisioning || instanceStatus.Since == nil ||
+		!instanceStatus.Since.Before(*machineStatus.Since) {
+		return nil
+	}
+
+	now := s.clock.Now()
+	return s.SetInstanceStatus(ctx, machineName, corestatus.StatusInfo{
+		Status:  corestatus.Running,
+		Message: "Machine agent started",
+		Since:   &now,
+	})
+}
+
 // GetMachineStatus returns the status of the specified machine.
 // This method may return the following errors:
 // - [machineerrors.MachineNotFound] if the machine does not exist.

--- a/domain/status/service/service_test.go
+++ b/domain/status/service/service_test.go
@@ -2345,6 +2345,62 @@ func (s *serviceSuite) TestSetInstanceStatusInvalid(c *tc.C) {
 	c.Check(err, tc.ErrorIs, statuserrors.InvalidStatus)
 }
 
+func (s *serviceSuite) TestClearStaleProvisioningStatusOnMachineStart(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	machineStartedAt := s.clock.Now()
+	instanceStatusAt := machineStartedAt.Add(-time.Minute)
+	s.modelState.EXPECT().GetMachineStatus(gomock.Any(), "666").Return(status.MachineStatusInfo[status.MachineStatusType]{
+		StatusInfo: status.StatusInfo[status.MachineStatusType]{
+			Status: status.MachineStatusStarted,
+			Since:  &machineStartedAt,
+		},
+		Present: true,
+	}, nil)
+	s.modelState.EXPECT().GetInstanceStatus(gomock.Any(), "666").Return(status.StatusInfo[status.InstanceStatusType]{
+		Status: status.InstanceStatusAllocating,
+		Since:  &instanceStatusAt,
+	}, nil)
+	s.modelState.EXPECT().SetInstanceStatus(gomock.Any(), "666", status.StatusInfo[status.InstanceStatusType]{
+		Status:  status.InstanceStatusRunning,
+		Message: "Machine agent started",
+		Since:   &machineStartedAt,
+	}).Return(nil)
+
+	err := s.modelService.ClearStaleProvisioningStatusOnMachineStart(c.Context(), "666")
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(s.statusHistory.records, tc.DeepEquals, []statusHistoryRecord{{
+		ns: status.MachineInstanceNamespace.WithID("666"),
+		s: corestatus.StatusInfo{
+			Status:  corestatus.Running,
+			Message: "Machine agent started",
+			Since:   &machineStartedAt,
+		},
+	}})
+}
+
+func (s *serviceSuite) TestClearStaleProvisioningStatusOnMachineStartDoesNothingWhenNotStale(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	machineStartedAt := s.clock.Now()
+	instanceStatusAt := machineStartedAt.Add(time.Minute)
+	s.modelState.EXPECT().GetMachineStatus(gomock.Any(), "666").Return(status.MachineStatusInfo[status.MachineStatusType]{
+		StatusInfo: status.StatusInfo[status.MachineStatusType]{
+			Status: status.MachineStatusStarted,
+			Since:  &machineStartedAt,
+		},
+		Present: true,
+	}, nil)
+	s.modelState.EXPECT().GetInstanceStatus(gomock.Any(), "666").Return(status.StatusInfo[status.InstanceStatusType]{
+		Status: status.InstanceStatusAllocating,
+		Since:  &instanceStatusAt,
+	}, nil)
+
+	err := s.modelService.ClearStaleProvisioningStatusOnMachineStart(c.Context(), "666")
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(s.statusHistory.records, tc.HasLen, 0)
+}
+
 func (s *serviceSuite) TestCheckMachineStatusesReadyForMigrationEmptyModel(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/internal/worker/instancepoller/mocks/mocks_instancepoller.go
+++ b/internal/worker/instancepoller/mocks/mocks_instancepoller.go
@@ -195,10 +195,11 @@ type MockStatusService struct {
 
 // MockStatusServiceMockRecorder is the mock recorder for MockStatusService.
 type MockStatusServiceMockRecorder struct {
-	mock                     *MockStatusService
-	getInstanceStatusExpects []*gomock.Call2_2[context.Context, machine.Name, status.StatusInfo, error]
-	getMachineStatusExpects  []*gomock.Call2_2[context.Context, machine.Name, status.StatusInfo, error]
-	setInstanceStatusExpects []*gomock.Call3_1[context.Context, machine.Name, status.StatusInfo, error]
+	mock                                              *MockStatusService
+	clearStaleProvisioningStatusOnMachineStartExpects []*gomock.Call2_1[context.Context, machine.Name, error]
+	getInstanceStatusExpects                          []*gomock.Call2_2[context.Context, machine.Name, status.StatusInfo, error]
+	getMachineStatusExpects                           []*gomock.Call2_2[context.Context, machine.Name, status.StatusInfo, error]
+	setInstanceStatusExpects                          []*gomock.Call3_1[context.Context, machine.Name, status.StatusInfo, error]
 }
 
 // NewMockStatusService creates a new mock instance.
@@ -212,6 +213,24 @@ func NewMockStatusService(ctrl *gomock.Controller) *MockStatusService {
 func (m *MockStatusService) EXPECT() *MockStatusServiceMockRecorder {
 	return m.recorder
 }
+
+// ClearStaleProvisioningStatusOnMachineStart mocks base method.
+func (m *MockStatusService) ClearStaleProvisioningStatusOnMachineStart(arg0 context.Context, arg1 machine.Name) error {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_1(&m.recorder.clearStaleProvisioningStatusOnMachineStartExpects, m.ctrl, m, "ClearStaleProvisioningStatusOnMachineStart", arg0, arg1)
+}
+
+// ClearStaleProvisioningStatusOnMachineStart indicates an expected call of ClearStaleProvisioningStatusOnMachineStart.
+func (mr *MockStatusServiceMockRecorder) ClearStaleProvisioningStatusOnMachineStart(arg0, arg1 any) *MockStatusServiceClearStaleProvisioningStatusOnMachineStartCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_1[context.Context, machine.Name, error](mr.mock.ctrl.T, mr.mock, "ClearStaleProvisioningStatusOnMachineStart", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
+	mr.clearStaleProvisioningStatusOnMachineStartExpects = append(mr.clearStaleProvisioningStatusOnMachineStartExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockStatusServiceClearStaleProvisioningStatusOnMachineStartCall is the typed call wrapper for ClearStaleProvisioningStatusOnMachineStart.
+type MockStatusServiceClearStaleProvisioningStatusOnMachineStartCall = gomock.Call2_1[context.Context, machine.Name, error]
 
 // GetInstanceStatus mocks base method.
 func (m *MockStatusService) GetInstanceStatus(arg0 context.Context, arg1 machine.Name) (status.StatusInfo, error) {

--- a/internal/worker/instancepoller/worker.go
+++ b/internal/worker/instancepoller/worker.go
@@ -71,6 +71,10 @@ type MachineService interface {
 // StatusService defines the interface for interacting with the status
 // service.
 type StatusService interface {
+	// ClearStaleProvisioningStatusOnMachineStart sets an instance status to
+	// running when it predates a started machine status.
+	ClearStaleProvisioningStatusOnMachineStart(context.Context, machine.Name) error
+
 	// GetInstanceStatus returns the cloud specific instance status for this
 	// machine.
 	GetInstanceStatus(context.Context, machine.Name) (status.StatusInfo, error)
@@ -297,7 +301,11 @@ func (u *updaterWorker) queueMachineForPolling(ctx context.Context, machineName 
 		}
 		return u.setManualMachineRunning(ctx, machineName)
 	}
-	if err := u.setStartedMachineRunning(ctx, machineName); err != nil {
+
+	err = u.config.StatusService.ClearStaleProvisioningStatusOnMachineStart(ctx, machineName)
+	if errors.Is(err, machineerrors.MachineNotFound) {
+		return nil
+	} else if err != nil {
 		return errors.Trace(err)
 	}
 
@@ -313,45 +321,6 @@ func (u *updaterWorker) queueMachineForPolling(ctx context.Context, machineName 
 
 	// 4. New machine: add to the short poll group for immediate polling.
 	u.appendToShortPollGroup(machineName)
-	return nil
-}
-
-// setStartedMachineRunning ensures a machine agent that starts after a
-// provisioning update clears any stale provisioning status. The provider
-// poller will replace this fallback with its provider-specific status.
-func (u *updaterWorker) setStartedMachineRunning(ctx context.Context, machineName machine.Name) error {
-	machineStatus, err := u.config.StatusService.GetMachineStatus(ctx, machineName)
-	if errors.Is(err, machineerrors.MachineNotFound) {
-		return nil
-	} else if err != nil {
-		return errors.Trace(err)
-	}
-	if machineStatus.Status != status.Started || machineStatus.Since == nil {
-		return nil
-	}
-
-	instanceStatus, err := u.config.StatusService.GetInstanceStatus(ctx, machineName)
-	if errors.Is(err, machineerrors.MachineNotFound) {
-		return nil
-	} else if err != nil {
-		return errors.Trace(err)
-	}
-	if instanceStatus.Status != status.Provisioning || instanceStatus.Since == nil ||
-		!instanceStatus.Since.Before(*machineStatus.Since) {
-		return nil
-	}
-
-	now := u.config.Clock.Now()
-	if err := u.config.StatusService.SetInstanceStatus(ctx, machineName, status.StatusInfo{
-		Status:  status.Running,
-		Message: "Machine agent started",
-		Since:   &now,
-	}); errors.Is(err, machineerrors.MachineNotFound) {
-		return nil
-	} else if err != nil {
-		u.config.Logger.Errorf(ctx, "cannot set instance status on %q: %v", machineName, err)
-		return errors.Trace(err)
-	}
 	return nil
 }
 
@@ -725,7 +694,8 @@ func newNetInterface(device network.InterfaceInfo) domainnetwork.NetInterface {
 		DNSAddresses:     device.DNSServers,
 		Addrs: append(
 			transform.Slice(device.Addresses, newNetAddress(device.InterfaceName, false)),
-			transform.Slice(device.ShadowAddresses, newNetAddress(device.InterfaceName, true))...),
+			transform.Slice(device.ShadowAddresses, newNetAddress(device.InterfaceName, true))...,
+		),
 	}
 }
 

--- a/internal/worker/instancepoller/worker.go
+++ b/internal/worker/instancepoller/worker.go
@@ -297,6 +297,9 @@ func (u *updaterWorker) queueMachineForPolling(ctx context.Context, machineName 
 		}
 		return u.setManualMachineRunning(ctx, machineName)
 	}
+	if err := u.setStartedMachineRunning(ctx, machineName); err != nil {
+		return errors.Trace(err)
+	}
 
 	// 3. If already being polled, move to short poll group so we
 	// immediately re-check its status on the next interval.
@@ -310,6 +313,44 @@ func (u *updaterWorker) queueMachineForPolling(ctx context.Context, machineName 
 
 	// 4. New machine: add to the short poll group for immediate polling.
 	u.appendToShortPollGroup(machineName)
+	return nil
+}
+
+// setStartedMachineRunning ensures a machine agent that starts after a
+// provisioning update clears any stale provisioning status. The provider
+// poller will replace this fallback with its provider-specific status.
+func (u *updaterWorker) setStartedMachineRunning(ctx context.Context, machineName machine.Name) error {
+	machineStatus, err := u.config.StatusService.GetMachineStatus(ctx, machineName)
+	if errors.Is(err, machineerrors.MachineNotFound) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	if machineStatus.Status != status.Started || machineStatus.Since == nil {
+		return nil
+	}
+
+	instanceStatus, err := u.config.StatusService.GetInstanceStatus(ctx, machineName)
+	if errors.Is(err, machineerrors.MachineNotFound) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	if instanceStatus.Status != status.Provisioning || instanceStatus.Since == nil ||
+		!instanceStatus.Since.Before(*machineStatus.Since) {
+		return nil
+	}
+
+	if err := u.config.StatusService.SetInstanceStatus(ctx, machineName, status.StatusInfo{
+		Status:  status.Running,
+		Message: "Machine agent started",
+		Since:   machineStatus.Since,
+	}); errors.Is(err, machineerrors.MachineNotFound) {
+		return nil
+	} else if err != nil {
+		u.config.Logger.Errorf(ctx, "cannot set instance status on %q: %v", machineName, err)
+		return errors.Trace(err)
+	}
 	return nil
 }
 
@@ -461,6 +502,27 @@ func (u *updaterWorker) pollGroupMembers(ctx context.Context, groupType pollGrou
 		}
 	}
 
+	// Status information is independent of provider network information. Update
+	// it first so a network lookup failure cannot retain a provisioning retry
+	// message after the provider has reported a newer status.
+	providerStatuses := make([]status.Status, len(infoList))
+	for idx, info := range infoList {
+		entry := entryByInstanceID[allInstances[idx]]
+		if info == nil {
+			u.config.Logger.Warningf(ctx, "unable to retrieve instance information for instance: %q", entry.instanceID)
+			if groupType == shortPollGroup {
+				entry.bumpShortPollInterval(u.config.Clock)
+			}
+			continue
+		}
+
+		providerStatus, err := u.processProviderInfo(ctx, entry, info)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		providerStatuses[idx] = providerStatus
+	}
+
 	var netList []network.InterfaceInfos
 	if len(instanceWithDevices) > 0 {
 		var err error
@@ -481,12 +543,16 @@ func (u *updaterWorker) pollGroupMembers(ctx context.Context, groupType pollGrou
 	}
 
 	for idx, info := range infoList {
+		if info == nil {
+			continue
+		}
+
 		var nics network.InterfaceInfos
 		if netList != nil && idx < len(instanceWithDevices) {
 			nics = netList[idx]
 		}
 
-		if err := u.processOneInstance(ctx, entryByInstanceID[allInstances[idx]], info, nics, groupType); err != nil {
+		if err := u.processOneInstance(ctx, entryByInstanceID[allInstances[idx]], providerStatuses[idx], nics, groupType); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -496,26 +562,13 @@ func (u *updaterWorker) pollGroupMembers(ctx context.Context, groupType pollGrou
 
 func (u *updaterWorker) processOneInstance(
 	ctx context.Context,
-	entry *pollGroupEntry, info instances.Instance,
+	entry *pollGroupEntry, providerStatus status.Status,
 	nics network.InterfaceInfos, groupType pollGroupType,
 ) error {
-
-	// If we received ErrPartialInstances, and this ID is one of those not found,
-	// and we're in the short poll group, back off the poll interval.
-	// This will ensure that instances that have gone away do not cause excessive
-	// provider call volumes.
-	if info == nil {
-		u.config.Logger.Warningf(ctx, "unable to retrieve instance information for instance: %q", entry.instanceID)
-
-		if groupType == shortPollGroup {
-			entry.bumpShortPollInterval(u.config.Clock)
+	if len(nics) > 0 {
+		if err := u.syncProviderAddresses(ctx, entry, nics); err != nil {
+			return errors.Trace(err)
 		}
-		return nil
-	}
-
-	providerStatus, err := u.processProviderInfo(ctx, entry, info, nics)
-	if err != nil {
-		return errors.Trace(err)
 	}
 
 	machineStatus, err := u.config.StatusService.GetMachineStatus(ctx, entry.machineName)
@@ -527,14 +580,10 @@ func (u *updaterWorker) processOneInstance(
 	return nil
 }
 
-// processProviderInfo updates an entry's machine status and set of provider
-// addresses based on the information collected from the provider. It returns
-// the *instance* status and the number of provider addresses currently
-// known for the machine.
+// processProviderInfo updates an entry's provider-reported instance status.
 func (u *updaterWorker) processProviderInfo(
 	ctx context.Context,
 	entry *pollGroupEntry, info instances.Instance,
-	providerInterfaces network.InterfaceInfos,
 ) (status.Status, error) {
 	curStatus, err := u.config.StatusService.GetInstanceStatus(ctx, entry.machineName)
 	if err != nil {
@@ -581,15 +630,6 @@ func (u *updaterWorker) processProviderInfo(
 		return status.Unknown, nil
 	} else if err != nil {
 		return status.Unknown, err
-	}
-
-	if len(providerInterfaces) > 0 {
-		// Check whether the provider addresses for this machine need to be
-		// updated.
-		err = u.syncProviderAddresses(ctx, entry, providerInterfaces)
-		if err != nil {
-			return status.Unknown, err
-		}
 	}
 
 	return providerStatus.Status, nil

--- a/internal/worker/instancepoller/worker.go
+++ b/internal/worker/instancepoller/worker.go
@@ -341,10 +341,11 @@ func (u *updaterWorker) setStartedMachineRunning(ctx context.Context, machineNam
 		return nil
 	}
 
+	now := u.config.Clock.Now()
 	if err := u.config.StatusService.SetInstanceStatus(ctx, machineName, status.StatusInfo{
 		Status:  status.Running,
 		Message: "Machine agent started",
-		Since:   machineStatus.Since,
+		Since:   &now,
 	}); errors.Is(err, machineerrors.MachineNotFound) {
 		return nil
 	} else if err != nil {
@@ -566,6 +567,12 @@ func (u *updaterWorker) processOneInstance(
 	nics network.InterfaceInfos, groupType pollGroupType,
 ) error {
 	if len(nics) > 0 {
+		life, err := u.config.MachineService.GetMachineLife(ctx, entry.machineName)
+		if life == corelife.Dead || errors.Is(err, machineerrors.MachineNotFound) {
+			return nil
+		} else if err != nil {
+			return errors.Trace(err)
+		}
 		if err := u.syncProviderAddresses(ctx, entry, nics); err != nil {
 			return errors.Trace(err)
 		}

--- a/internal/worker/instancepoller/worker_test.go
+++ b/internal/worker/instancepoller/worker_test.go
@@ -176,7 +176,7 @@ func (s *workerSuite) TestQueueingNewMachineAddsItToShortPollGroup(c *tc.C) {
 	// non-manual machine.
 	machineName := machine.Name("0")
 	mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil)
-	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Pending}, nil)
+	mocked.statusService.EXPECT().ClearStaleProvisioningStatusOnMachineStart(gomock.Any(), machineName).Return(nil)
 
 	// Queue machine.
 	err := updWorker.queueMachineForPolling(c.Context(), machineName)
@@ -196,7 +196,7 @@ func (s *workerSuite) TestQueueingExistingMachineAlwaysMovesItToShortPollGroup(c
 	machineName := machine.Name("0")
 	gomock.InOrder(
 		mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil),
-		mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Pending}, nil),
+		mocked.statusService.EXPECT().ClearStaleProvisioningStatusOnMachineStart(gomock.Any(), machineName).Return(nil),
 	)
 	updWorker.appendToShortPollGroup(machineName)
 
@@ -226,7 +226,7 @@ func (s *workerSuite) TestQueueingExistingMachineThatBecomesManualRemovesItFromP
 	now := mocked.clock.Now()
 	gomock.InOrder(
 		mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil),
-		mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Pending}, nil),
+		mocked.statusService.EXPECT().ClearStaleProvisioningStatusOnMachineStart(gomock.Any(), machineName).Return(nil),
 		mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, true, nil),
 		mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Provisioning}, nil),
 		mocked.statusService.EXPECT().SetInstanceStatus(gomock.Any(), machineName, status.StatusInfo{
@@ -258,147 +258,25 @@ func (s *workerSuite) TestQueueingStartedMachineClearsStaleProvisioningStatus(c 
 	updWorker := w.(*updaterWorker)
 
 	machineName := machine.Name("0")
-	machineStartedAt := mocked.clock.Now()
-	instanceStatusAt := machineStartedAt.Add(-time.Minute)
 	mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil)
-	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
-		Status: status.Started,
-		Since:  &machineStartedAt,
-	}, nil)
-	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(status.StatusInfo{
-		Status:  status.Provisioning,
-		Message: "failed to start machine 0 in zone \"zone2\", retrying",
-		Since:   &instanceStatusAt,
-	}, nil)
-	mocked.statusService.EXPECT().SetInstanceStatus(gomock.Any(), machineName, status.StatusInfo{
-		Status:  status.Running,
-		Message: "Machine agent started",
-		Since:   &machineStartedAt,
-	}).Return(nil)
+	mocked.statusService.EXPECT().ClearStaleProvisioningStatusOnMachineStart(gomock.Any(), machineName).Return(nil)
 
 	err := updWorker.queueMachineForPolling(c.Context(), machineName)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(updWorker.pollGroup[shortPollGroup], tc.HasLen, 1)
 }
 
-func (s *workerSuite) TestSetStartedMachineRunningMachineNotFound(c *tc.C) {
+func (s *workerSuite) TestQueueingStartedMachineIgnoresMissingMachine(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
 	w, mocked := s.startWorker(c, ctrl)
 	defer workertest.CleanKill(c, w)
-	updWorker := w.(*updaterWorker)
-
 	machineName := machine.Name("0")
-	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(
-		status.StatusInfo{}, machineerrors.MachineNotFound,
-	)
+	mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil)
+	mocked.statusService.EXPECT().ClearStaleProvisioningStatusOnMachineStart(gomock.Any(), machineName).Return(machineerrors.MachineNotFound)
 
-	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *workerSuite) TestSetStartedMachineRunningNotStarted(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	w, mocked := s.startWorker(c, ctrl)
-	defer workertest.CleanKill(c, w)
-	updWorker := w.(*updaterWorker)
-
-	machineName := machine.Name("0")
-	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
-		Status: status.Pending,
-	}, nil)
-
-	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *workerSuite) TestSetStartedMachineRunningStartedWithNilSince(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	w, mocked := s.startWorker(c, ctrl)
-	defer workertest.CleanKill(c, w)
-	updWorker := w.(*updaterWorker)
-
-	machineName := machine.Name("0")
-	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
-		Status: status.Started,
-		Since:  nil,
-	}, nil)
-
-	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *workerSuite) TestSetStartedMachineRunningInstanceStatusNotProvisioning(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	w, mocked := s.startWorker(c, ctrl)
-	defer workertest.CleanKill(c, w)
-	updWorker := w.(*updaterWorker)
-
-	machineName := machine.Name("0")
-	machineStartedAt := mocked.clock.Now()
-	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
-		Status: status.Started,
-		Since:  &machineStartedAt,
-	}, nil)
-	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(status.StatusInfo{
-		Status: status.Running,
-	}, nil)
-
-	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *workerSuite) TestSetStartedMachineRunningInstanceNotStale(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	w, mocked := s.startWorker(c, ctrl)
-	defer workertest.CleanKill(c, w)
-	updWorker := w.(*updaterWorker)
-
-	machineName := machine.Name("0")
-	machineStartedAt := mocked.clock.Now()
-	instanceStatusAt := machineStartedAt.Add(time.Minute)
-	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
-		Status: status.Started,
-		Since:  &machineStartedAt,
-	}, nil)
-	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(status.StatusInfo{
-		Status:  status.Provisioning,
-		Message: "failed to start machine 0",
-		Since:   &instanceStatusAt,
-	}, nil)
-
-	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
-	c.Assert(err, tc.ErrorIsNil)
-}
-
-func (s *workerSuite) TestSetStartedMachineRunningInstanceStatusMachineNotFound(c *tc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
-	w, mocked := s.startWorker(c, ctrl)
-	defer workertest.CleanKill(c, w)
-	updWorker := w.(*updaterWorker)
-
-	machineName := machine.Name("0")
-	machineStartedAt := mocked.clock.Now()
-	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
-		Status: status.Started,
-		Since:  &machineStartedAt,
-	}, nil)
-	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(
-		status.StatusInfo{}, machineerrors.MachineNotFound,
-	)
-
-	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
+	err := w.(*updaterWorker).queueMachineForPolling(c.Context(), machineName)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -417,7 +295,7 @@ func (s *workerSuite) TestMachineNotFoundDuringManualCheckRemovesEntry(c *tc.C) 
 	gomock.InOrder(
 		// First call: machine is alive and not manual → added to short poll group.
 		mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil),
-		mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Pending}, nil),
+		mocked.statusService.EXPECT().ClearStaleProvisioningStatusOnMachineStart(gomock.Any(), machineName).Return(nil),
 		// Second call: machine has since disappeared.
 		mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Value(""), false, machineerrors.MachineNotFound),
 	)

--- a/internal/worker/instancepoller/worker_test.go
+++ b/internal/worker/instancepoller/worker_test.go
@@ -176,6 +176,7 @@ func (s *workerSuite) TestQueueingNewMachineAddsItToShortPollGroup(c *tc.C) {
 	// non-manual machine.
 	machineName := machine.Name("0")
 	mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil)
+	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Pending}, nil)
 
 	// Queue machine.
 	err := updWorker.queueMachineForPolling(c.Context(), machineName)
@@ -195,6 +196,7 @@ func (s *workerSuite) TestQueueingExistingMachineAlwaysMovesItToShortPollGroup(c
 	machineName := machine.Name("0")
 	gomock.InOrder(
 		mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil),
+		mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Pending}, nil),
 	)
 	updWorker.appendToShortPollGroup(machineName)
 
@@ -224,6 +226,7 @@ func (s *workerSuite) TestQueueingExistingMachineThatBecomesManualRemovesItFromP
 	now := mocked.clock.Now()
 	gomock.InOrder(
 		mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil),
+		mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Pending}, nil),
 		mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, true, nil),
 		mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Provisioning}, nil),
 		mocked.statusService.EXPECT().SetInstanceStatus(gomock.Any(), machineName, status.StatusInfo{
@@ -246,6 +249,38 @@ func (s *workerSuite) TestQueueingExistingMachineThatBecomesManualRemovesItFromP
 	c.Check(updWorker.pollGroup[longPollGroup], tc.HasLen, 0)
 }
 
+func (s *workerSuite) TestQueueingStartedMachineClearsStaleProvisioningStatus(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	machineName := machine.Name("0")
+	machineStartedAt := mocked.clock.Now()
+	instanceStatusAt := machineStartedAt.Add(-time.Minute)
+	mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil)
+	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status: status.Started,
+		Since:  &machineStartedAt,
+	}, nil)
+	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status:  status.Provisioning,
+		Message: "failed to start machine 0 in zone \"zone2\", retrying",
+		Since:   &instanceStatusAt,
+	}, nil)
+	mocked.statusService.EXPECT().SetInstanceStatus(gomock.Any(), machineName, status.StatusInfo{
+		Status:  status.Running,
+		Message: "Machine agent started",
+		Since:   &machineStartedAt,
+	}).Return(nil)
+
+	err := updWorker.queueMachineForPolling(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(updWorker.pollGroup[shortPollGroup], tc.HasLen, 1)
+}
+
 // TestMachineNotFoundDuringManualCheckRemovesEntry verifies that if a machine
 // disappears (MachineNotFound) when we re-check its status, it is cleanly
 // removed from the poll group.
@@ -261,6 +296,7 @@ func (s *workerSuite) TestMachineNotFoundDuringManualCheckRemovesEntry(c *tc.C) 
 	gomock.InOrder(
 		// First call: machine is alive and not manual → added to short poll group.
 		mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Alive, false, nil),
+		mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Pending}, nil),
 		// Second call: machine has since disappeared.
 		mocked.machineService.EXPECT().GetMachineLifeAndIsManuallyProvisioned(gomock.Any(), machineName).Return(life.Value(""), false, machineerrors.MachineNotFound),
 	)
@@ -296,7 +332,7 @@ func (s *workerSuite) TestSetManualMachineRunningSkipsUpdateWhenMachineNotFound(
 	c.Assert(err, tc.ErrorIsNil)
 }
 
-func (s *workerSuite) TestUpdateOfStatusAndAddressDetails(c *tc.C) {
+func (s *workerSuite) TestUpdateOfStatusDetails(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -313,27 +349,22 @@ func (s *workerSuite) TestUpdateOfStatusAndAddressDetails(c *tc.C) {
 		instanceID:  "b4dc0ffee",
 	}
 
-	// The machine is alive, has an instance status of "provisioning" and
-	// is aware of its network addresses.
+	// The machine is alive and has an instance status of "provisioning".
 	mocked.machineService.EXPECT().GetMachineLife(gomock.Any(), machineName).Return(life.Alive, nil)
 	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Provisioning}, nil)
 
-	// The provider reports the instance status as running and also indicates
-	// that network addresses have been *changed*.
+	// The provider reports the instance status as running.
 	instInfo := mocks.NewMockInstance(ctrl)
 	instInfo.EXPECT().Status(gomock.Any()).Return(instance.Status{Status: status.Running, Message: "Running wild"})
 
-	// When we process the instance info we expect the machine instance
-	// status and list of network addresses to be updated so they match
-	// the values reported by the provider.
+	// When we process the instance info, its status should match the value
+	// reported by the provider.
 	mocked.statusService.EXPECT().SetInstanceStatus(gomock.Any(), machineName, status.StatusInfo{
 		Status:  status.Running,
 		Message: "Running wild",
 	}).Return(nil)
 
-	mocked.networkService.EXPECT().SetProviderNetConfig(gomock.Any(), machineUUID, testDevices).Return(nil)
-
-	providerStatus, err := updWorker.processProviderInfo(c.Context(), entry, instInfo, testNetIfs)
+	providerStatus, err := updWorker.processProviderInfo(c.Context(), entry, instInfo)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(providerStatus, tc.Equals, status.Running)
 }
@@ -566,6 +597,55 @@ func (s *workerSuite) TestBatchPollingOfGroupMembers(c *tc.C) {
 	s.assertWorkerCompletesLoop(c, updWorker, func() {
 		mocked.clock.Advance(ShortPoll)
 	})
+}
+
+func (s *workerSuite) TestPollUpdatesStatusWhenNetworkInterfacesFails(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	machineName := machine.Name("0")
+	machineUUID := machinetesting.GenUUID(c)
+	instanceID := instance.Id("b4dc0ffee")
+	updWorker.appendToShortPollGroup(machineName)
+	entry, _ := updWorker.lookupPolledMachine(machineName)
+	entry.shortPollAt = mocked.clock.Now()
+
+	mocked.machineService.EXPECT().GetPollingInfos(gomock.Any(), []machine.Name{machineName}).Return(domainmachine.PollingInfos{
+		{
+			MachineUUID:         machineUUID,
+			MachineName:         machineName,
+			InstanceID:          instanceID,
+			ExistingDeviceCount: 1,
+		},
+	}, nil)
+
+	instanceInfo := mocks.NewMockInstance(ctrl)
+	instanceInfo.EXPECT().Status(gomock.Any()).Return(instance.Status{
+		Status:  status.Running,
+		Message: "Deployed",
+	})
+	mocked.environ.EXPECT().Instances(gomock.Any(), []instance.Id{instanceID}).Return(
+		[]instances.Instance{instanceInfo}, nil,
+	)
+	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status:  status.Provisioning,
+		Message: "failed to start machine 0 in zone \"zone2\", retrying",
+	}, nil)
+	mocked.statusService.EXPECT().SetInstanceStatus(gomock.Any(), machineName, status.StatusInfo{
+		Status:  status.Running,
+		Message: "Deployed",
+	}).Return(nil)
+	mocked.machineService.EXPECT().GetMachineLife(gomock.Any(), machineName).Return(life.Alive, nil)
+	mocked.environ.EXPECT().NetworkInterfaces(gomock.Any(), []instance.Id{instanceID}).Return(
+		nil, fmt.Errorf("network unavailable"),
+	)
+
+	err := updWorker.pollGroupMembers(c.Context(), shortPollGroup)
+	c.Check(err, tc.ErrorMatches, "enumerating network interface list for instances: network unavailable")
 }
 
 func (s *workerSuite) TestBatchPollingOfGroupMembersWithVariousDevicesStatus(c *tc.C) {

--- a/internal/worker/instancepoller/worker_test.go
+++ b/internal/worker/instancepoller/worker_test.go
@@ -281,6 +281,127 @@ func (s *workerSuite) TestQueueingStartedMachineClearsStaleProvisioningStatus(c 
 	c.Check(updWorker.pollGroup[shortPollGroup], tc.HasLen, 1)
 }
 
+func (s *workerSuite) TestSetStartedMachineRunningMachineNotFound(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	machineName := machine.Name("0")
+	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(
+		status.StatusInfo{}, machineerrors.MachineNotFound,
+	)
+
+	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *workerSuite) TestSetStartedMachineRunningNotStarted(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	machineName := machine.Name("0")
+	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status: status.Pending,
+	}, nil)
+
+	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *workerSuite) TestSetStartedMachineRunningStartedWithNilSince(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	machineName := machine.Name("0")
+	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status: status.Started,
+		Since:  nil,
+	}, nil)
+
+	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *workerSuite) TestSetStartedMachineRunningInstanceStatusNotProvisioning(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	machineName := machine.Name("0")
+	machineStartedAt := mocked.clock.Now()
+	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status: status.Started,
+		Since:  &machineStartedAt,
+	}, nil)
+	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status: status.Running,
+	}, nil)
+
+	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *workerSuite) TestSetStartedMachineRunningInstanceNotStale(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	machineName := machine.Name("0")
+	machineStartedAt := mocked.clock.Now()
+	instanceStatusAt := machineStartedAt.Add(time.Minute)
+	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status: status.Started,
+		Since:  &machineStartedAt,
+	}, nil)
+	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status:  status.Provisioning,
+		Message: "failed to start machine 0",
+		Since:   &instanceStatusAt,
+	}, nil)
+
+	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *workerSuite) TestSetStartedMachineRunningInstanceStatusMachineNotFound(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	machineName := machine.Name("0")
+	machineStartedAt := mocked.clock.Now()
+	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status: status.Started,
+		Since:  &machineStartedAt,
+	}, nil)
+	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName).Return(
+		status.StatusInfo{}, machineerrors.MachineNotFound,
+	)
+
+	err := updWorker.setStartedMachineRunning(c.Context(), machineName)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 // TestMachineNotFoundDuringManualCheckRemovesEntry verifies that if a machine
 // disappears (MachineNotFound) when we re-check its status, it is cleanly
 // removed from the poll group.
@@ -367,6 +488,34 @@ func (s *workerSuite) TestUpdateOfStatusDetails(c *tc.C) {
 	providerStatus, err := updWorker.processProviderInfo(c.Context(), entry, instInfo)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(providerStatus, tc.Equals, status.Running)
+}
+
+func (s *workerSuite) TestProcessOneInstanceSyncsProviderAddresses(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	w, mocked := s.startWorker(c, ctrl)
+	defer workertest.CleanKill(c, w)
+	updWorker := w.(*updaterWorker)
+
+	machineUUID := machinetesting.GenUUID(c)
+	machineName := machine.Name("0")
+	entry := &pollGroupEntry{
+		machineUUID: machineUUID,
+		machineName: machineName,
+		instanceID:  "b4dc0ffee",
+	}
+
+	mocked.machineService.EXPECT().GetMachineLife(gomock.Any(), machineName).Return(life.Alive, nil)
+	mocked.networkService.EXPECT().SetProviderNetConfig(gomock.Any(), machineUUID, testDevices).Return(nil)
+	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{
+		Status: status.Started,
+	}, nil)
+
+	err := updWorker.processOneInstance(c.Context(), entry, status.Running, testNetIfs, shortPollGroup)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(updWorker.pollGroup[longPollGroup], tc.HasLen, 1)
+	c.Assert(updWorker.pollGroup[shortPollGroup], tc.HasLen, 0)
 }
 
 func (s *workerSuite) TestStartedMachineWithNetAddressesMovesToLongPollGroup(c *tc.C) {
@@ -576,7 +725,7 @@ func (s *workerSuite) TestBatchPollingOfGroupMembers(c *tc.C) {
 			ExistingDeviceCount: 1},
 	}, nil)
 
-	mocked.machineService.EXPECT().GetMachineLife(gomock.Any(), machineName1).Return(life.Alive, nil)
+	mocked.machineService.EXPECT().GetMachineLife(gomock.Any(), machineName1).Return(life.Alive, nil).Times(2)
 	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(), machineName1).Return(status.StatusInfo{Status: status.Running}, nil)
 	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName1).Return(status.StatusInfo{Status: status.Started}, nil)
 	mocked.networkService.EXPECT().SetProviderNetConfig(gomock.Any(), machineUUID1, testDevices).Return(nil)
@@ -681,7 +830,7 @@ func (s *workerSuite) TestBatchPollingOfGroupMembersWithVariousDevicesStatus(c *
 	}, nil)
 
 	mocked.machineService.EXPECT().GetMachineLife(gomock.Any(),
-		gomock.AnyOf(machineName0, machineName1)).Return(life.Alive, nil).Times(2)
+		gomock.AnyOf(machineName0, machineName1)).Return(life.Alive, nil).Times(3)
 	mocked.statusService.EXPECT().GetInstanceStatus(gomock.Any(),
 		gomock.AnyOf(machineName0, machineName1)).Return(status.StatusInfo{Status: status.Running}, nil).Times(2)
 	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(),


### PR DESCRIPTION
Fixes stale machine instance statuses after a successful availability-zone
retry.

The provisioner records the retry failure while attempting another availability
zone. When a later attempt succeeds, that retry message can remain until a
separate provider-status reconciliation updates it. If reconciliation is
unavailable or fails, a working machine can retain the retry message and remain
non-running for migration prechecks.

I could not reproduce the issue through normal MAAS deployment, including the
original PostgreSQL flow. I reproduced it only by blocking controller-to-MAAS
traffic with `iptables` after successful provisioning. A real MAAS occurrence
should be investigated to determine why provider reconciliation did not
complete.

The instance poller now records provider status before optional
network-interface reconciliation, so network discovery failures cannot prevent
a valid provider status update. It also promotes a stale provisioning status to
running when the machine agent has started after that status was written. Once
MAAS is reachable, normal provider reconciliation replaces the fallback message
with `Deployed`.

An alternative was to mark the instance running immediately after the provider
accepted the start request. This was discarded because MAAS can still be
deploying the machine at that point; it could allow migration before the
machine agent has connected, and it would report `running` rather than the
provider-confirmed `Deployed` status.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

### Create MAAS setup

Create `/tmp/maas.yml` file with following content:

```yaml
#cloud-config

write_files:
  - path: /etc/netplan/99-maas-pxe0.yaml
    permissions: "0600"
    content: |
      network:
        version: 2
        bridges:
          maas-pxe0:
            interfaces: []
            addresses:
              - 10.10.10.1/24
            parameters:
              stp: false
              forward-delay: 0

  - path: /etc/sysctl.d/99-maas-pxe0.conf
    permissions: "0644"
    content: |
      net.ipv4.ip_forward = 1

  - path: /tmp/lxd.cfg
    permissions: "0600"
    content: |
      config:
        core.https_address: '[::]:8443'
        core.trust_password: __LXD_TRUST_PASSWORD__
      storage_pools:
        - config: {}
          description: ""
          name: default
          driver: dir
      profiles:
        - config: {}
          description: Default LXD profile
          devices: {}
          name: default
      projects: []
      cluster: null

packages:
  - jq
  - iptables-persistent

snap:
  commands:
    - snap install --channel=3.7/stable maas
    - snap install --channel=5.0/stable lxd
    - snap install maas-test-db

runcmd:
  - |
      set -eu

      export PATH="$PATH:/snap/bin"
      export PXE_BRIDGE=maas-pxe0
      export PXE_SUBNET=10.10.10.0/24
      export PXE_GATEWAY=10.10.10.1
      export PXE_RANGE_START=10.10.10.100
      export PXE_RANGE_END=10.10.10.200
      export MAAS_ADMIN_PASSWORD="$(openssl rand -hex 16)"
      export LXD_TRUST_PASSWORD="$(openssl rand -hex 16)"
      export IP_ADDRESS="$(ip -j route show default | jq -r '.[0].prefsrc')"
      export INTERFACE="$(ip -j route show default | jq -r '.[0].dev')"

      test -n "$IP_ADDRESS"
      test "$IP_ADDRESS" != "null"
      test -n "$INTERFACE"
      test "$INTERFACE" != "null"

      netplan generate
      netplan apply
      sysctl --system

      # Permit provisioned machines to reach the Internet through the MAAS VM.
      if ! iptables -t nat -C POSTROUTING -s "$PXE_SUBNET" -o "$INTERFACE" -j MASQUERADE 2>/dev/null; then
        iptables -t nat -A POSTROUTING -s "$PXE_SUBNET" -o "$INTERFACE" -j MASQUERADE
      fi
      iptables-save > /etc/iptables/rules.v4

      lxd waitready --timeout=120
      # Do not preseed an unmanaged bridge: LXD 5.0 cannot create and
      # configure a pre-existing bridge in the same init transaction.
      sed -i "s/__LXD_TRUST_PASSWORD__/$LXD_TRUST_PASSWORD/" /tmp/lxd.cfg
      lxd init --preseed < /tmp/lxd.cfg
      if ! lxc network show "$PXE_BRIDGE" >/dev/null 2>&1; then
        lxc network create "$PXE_BRIDGE" --type=bridge
      fi

      maas init region+rack \
        --database-uri maas-test-db:/// \
        --maas-url "http://${IP_ADDRESS}:5240/MAAS"

      for attempt in $(seq 1 60); do
        if curl --fail --silent \
          "http://${IP_ADDRESS}:5240/MAAS/api/2.0/version/" >/dev/null; then
          break
        fi
        if [ "$attempt" = 60 ]; then
          exit 1
        fi
        sleep 2
      done

      maas createadmin \
        --username admin \
        --password "$MAAS_ADMIN_PASSWORD" \
        --email admin@example.invalid
      install -d -m 0700 /root/maas-bootstrap
      printf '%s\n' "$MAAS_ADMIN_PASSWORD" > /root/maas-bootstrap/admin-password
      chmod 0600 /root/maas-bootstrap/admin-password

      export APIKEY="$(maas apikey --username admin)"
      maas login admin "http://localhost:5240/MAAS/" "$APIKEY"

      for attempt in $(seq 1 120); do
        SUBNET_JSON="$(maas admin subnet read "$PXE_SUBNET" 2>/dev/null || true)"
        if printf '%s' "$SUBNET_JSON" | jq -e --arg cidr "$PXE_SUBNET" \
          '.cidr == $cidr' >/dev/null 2>&1; then
          break
        fi
        if [ "$attempt" = 120 ]; then
          echo "MAAS did not discover provisioning subnet $PXE_SUBNET" >&2
          exit 1
        fi
        sleep 2
      done

      export PRIMARY_RACK="$(maas admin rack-controllers read | jq -r '.[0].system_id')"
      export FABRIC_ID="$(printf '%s' "$SUBNET_JSON" | jq -r '.vlan.fabric_id')"
      export VLAN_TAG="$(printf '%s' "$SUBNET_JSON" | jq -r '.vlan.vid')"

      test -n "$PRIMARY_RACK"
      test "$PRIMARY_RACK" != "null"
      test -n "$FABRIC_ID"
      test "$FABRIC_ID" != "null"
      test -n "$VLAN_TAG"
      test "$VLAN_TAG" != "null"

      maas admin subnet update "$PXE_SUBNET" gateway_ip="$PXE_GATEWAY"
      maas admin ipranges create \
        type=dynamic \
        start_ip="$PXE_RANGE_START" \
        end_ip="$PXE_RANGE_END" \
        comment="MAAS DHCP range"
      maas admin vlan update "$FABRIC_ID" "$VLAN_TAG" \
        dhcp_on=True \
        primary_rack="$PRIMARY_RACK"
      maas admin maas set-config name=upstream_dns value=8.8.8.8

      maas admin vm-hosts create \
        password="$LXD_TRUST_PASSWORD" \
        type=lxd \
        power_address="https://${IP_ADDRESS}:8443" \
        project=maas

      if [ ! -f /home/ubuntu/.ssh/id_rsa ]; then
        ssh-keygen -q -t rsa -N "" -f /home/ubuntu/.ssh/id_rsa
      fi
      chown ubuntu:ubuntu /home/ubuntu/.ssh/id_rsa /home/ubuntu/.ssh/id_rsa.pub
      chmod 0600 /home/ubuntu/.ssh/id_rsa
      chmod 0644 /home/ubuntu/.ssh/id_rsa.pub
      maas admin sshkeys create key="$(ssh-keygen -y -f /home/ubuntu/.ssh/id_rsa)"
```

**Create MAAS:**

```sh
sudo snap install multipass
cat /tmp/maas.yml | multipass launch 24.04 --name maas --memory 16G --disk 60G --cpus 8 --cloud-init -

## Jump into maas VM
multipass shell maas

for n in 1 2 3 4 5 6; do
    sudo maas -- sudo maas admin zones create name="zone$n"
done

export VM_HOST_ID=$(sudo maas admin vm-hosts read | jq '.[0].id')
export VLAN_ID=$(sudo maas admin vlans read 0 | jq '.[0].vid')
export FABRIC_ID=$(sudo maas admin vlans read 0 | jq '.[0].fabric_id')
export SYSTEM_ID=$(sudo maas admin rack-controllers read | jq -r '.[].system_id')

sudo maas admin vm-host compose $VM_HOST_ID \
    cores=1 \
    memory=2048 \
    zone=2 \
    interfaces="eth0:vid=$VLAN_ID" \
    hostname=machine1
sudo maas admin vm-host compose $VM_HOST_ID \
    cores=1 \
    memory=2048 \
    zone=2 \
    interfaces="eth0:vid=$VLAN_ID" \
    hostname=machine2
sudo maas admin vm-host compose $VM_HOST_ID \
    cores=1 \
    memory=2048 \
    zone=2 \
    interfaces="eth0:vid=$VLAN_ID" \
    hostname=machine3

sudo maas admin vm-host update $VM_HOST_ID \
    cpu_over_commit_ratio=0.1 \
    memory_over_commit_ratio=0.1

exit
```

**Boostrap controller:**

```sh
MAAS_IP="$(
  multipass exec maas -- sh -c \
    'ip -j route get 1.1.1.1 | jq -er ".[0].prefsrc"'
)"
CLOUD_NAME=mymaas

# enable routing to maas so that controller can be accessed
sudo ip route replace 10.10.10.0/24 via "$MAAS_IP"

tee /tmp/mymaas.yml >/dev/null <<EOF
clouds:
  $CLOUD_NAME:
    type: maas
    auth-types: [oauth1]
    endpoint: http://$MAAS_IP:5240/MAAS
EOF

juju add-cloud --client mymaas /tmp/mymaas.yml

## Retrieve apikey to setup juju credential
multipass exec maas -- sudo maas apikey --username admin
juju add-credential mymaas

juju bootstrap mymaas --bootstrap-constraints zones=zone1 --bootstrap-constraints mem=2G
juju add-model repro mymaas/default

juju deploy -m repro ubuntu -n 1 --constraints zones=zone1
juju set-constraints -m repro ubuntu \
  zones=zone1,zone2,zone3,zone4,zone5,zone6

# Start these logs before adding the unit:
juju debug-log -m repro \
    --include-module juju.worker.provisioner \
    --include-module juju.worker.instancepoller \
    --tail --date

# In a second terminal, add one unit:    
juju add-unit -m repro ubuntu -n 1

# Wait for this provisioner log line and then immediately run iptable command below:
#   started machine 3 as instance <MAAS-ID>
juju ssh -m controller 0 \
  "sudo iptables -I OUTPUT 1 -p tcp -d $MAAS_IP --dport 5240 -j REJECT"
```


### QA run after fix


```sh
❯ juju bootstrap mymaas --bootstrap-constraints zones=zone1 --bootstrap-constraints mem=2G
Creating Juju controller "mymaas-default" on mymaas/default
Looking for packaged Juju agent version 4.0.15 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on mymaas/default...
 - kh37dh (arch=amd64 mem=2G cores=1)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.10.10.201:22
Connected to 10.10.10.201
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.10.10.201 to verify accessibility...

Bootstrap complete, controller "mymaas-default" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

❯ juju add-model repro mymaas/default
Added 'repro' model on mymaas/default with credential 'oauth' for user 'admin'
To use "juju ssh", "juju scp" and "juju debug-hooks" ssh public keys need to be added to the model with "juju add-ssh-key"

❯ juju deploy -m repro ubuntu -n 1 --constraints zones=zone1
Deployed "ubuntu" from charm-hub charm "ubuntu", revision 79 in channel latest/stable on ubuntu@24.04/stable

❯ juju set-constraints -m repro ubuntu \
  zones=zone1,zone2,zone3,zone4,zone5,zone6

❯ echo $MAAS_IP
10.152.187.112

❯ juju add-unit -m repro ubuntu -n 1

❯ juju ssh -m controller 0 \
  "sudo iptables -I OUTPUT 1 -p tcp -d $MAAS_IP --dport 5240 -j REJECT"
Connection to 10.10.10.201 closed.

❯ juju status
Model  Controller      Cloud/Region    Version   Timestamp
repro  mymaas-default  mymaas/default  4.0.15.1  16:14:02+02:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           active      2  ubuntu  latest/stable   79  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.10.10.202
ubuntu/1   active    idle   1        10.10.10.203

Machine  State    Address       Inst id   Base          AZ     Message
0        started  10.10.10.202  machine2  ubuntu@24.04  zone1  Deployed
1        started  10.10.10.203  machine3  ubuntu@24.04  zone1  Machine agent started

❯ juju ssh -m controller 0 \
    "sudo iptables -D OUTPUT -p tcp -d $MAAS_IP --dport 5240 -j REJECT"
Connection to 10.10.10.201 closed.

❯ juju status
Model  Controller      Cloud/Region    Version   Timestamp
repro  mymaas-default  mymaas/default  4.0.15.1  16:16:10+02:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           active      2  ubuntu  latest/stable   79  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.10.10.202
ubuntu/1   active    idle   1        10.10.10.203

Machine  State    Address       Inst id   Base          AZ     Message
0        started  10.10.10.202  machine2  ubuntu@24.04  zone1  Deployed
1        started  10.10.10.203  machine3  ubuntu@24.04  zone1  Deployed
```


## Documentation changes


## Links

**Issue:** Fixes #22243

**Jira card:** [JUJU-9670](https://warthogs.atlassian.net/browse/JUJU-9670)


[JUJU-9670]: https://warthogs.atlassian.net/browse/JUJU-9670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ