### PR TITLE
feat(ssh): make jump behaviour the default

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -102,7 +102,7 @@ var facadeVersions = facades.FacadeVersions{
 	"UserSecretsDrain":             {1},
 	"UserSecretsManager":           {1},
 	"Spaces":                       {6},
-	"SSHClient":                    {4, 5},
+	"SSHClient":                    {4, 5, 6},
 	"SSHSession":                   {1},
 	"Storage":                      {6, 7},
 	"StorageProvisioner":           {5, 6, 7},

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -38,6 +38,14 @@ type Facade struct {
 	controllerTag        names.ControllerTag
 }
 
+// FacadeV6 provides the SSH Client API facade version 6
+// which bumps the facade to create a separation between
+// the unfinished work from Juju 3 and the working variant
+// in Juju 4.
+type FacadeV6 struct {
+	*Facade
+}
+
 // FacadeV5 provides the SSH Client API facade version 5
 // which adds VirtualHostname.
 type FacadeV5 struct {

--- a/apiserver/facades/client/sshclient/register.go
+++ b/apiserver/facades/client/sshclient/register.go
@@ -21,6 +21,17 @@ func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("SSHClient", 5, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
 		return newFacadeV5(ctx)
 	}, reflect.TypeFor[*FacadeV5]())
+	registry.MustRegister("SSHClient", 6, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
+		return newFacadeV6(ctx)
+	}, reflect.TypeFor[*FacadeV6]())
+}
+
+func newFacadeV6(ctx facade.ModelContext) (*FacadeV6, error) {
+	facade, err := newFacadeBase(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &FacadeV6{Facade: facade}, nil
 }
 
 func newFacadeV5(ctx facade.ModelContext) (*FacadeV5, error) {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -12572,7 +12572,7 @@
     {
         "Name": "SSHClient",
         "Description": "",
-        "Version": 5,
+        "Version": 6,
         "Schema": {
             "type": "object",
             "properties": {

--- a/cmd/juju/ssh/debugcode_test.go
+++ b/cmd/juju/ssh/debugcode_test.go
@@ -45,7 +45,7 @@ func (s *DebugCodeSuite) TestArgFormatting(c *tc.C) {
 
 	debugCmd := NewDebugCodeCommandForTest(app, ssh, status, charmAPI, s.hostChecker, baseTestingRetryStrategy, baseTestingRetryStrategy)
 
-	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(debugCmd), "--at=foo,bar", "mysql/0", "install", "start")
+	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(debugCmd), "--direct", "--at=foo,bar", "mysql/0", "install", "start")
 	c.Assert(err, tc.ErrorIsNil)
 	base64Regex := regexp.MustCompile("echo ([A-Za-z0-9+/]+=*) \\| base64")
 	c.Check(err, tc.ErrorIsNil)

--- a/cmd/juju/ssh/debughooks_test.go
+++ b/cmd/juju/ssh/debughooks_test.go
@@ -183,7 +183,7 @@ func (s *DebugHooksSuite) TestDebugHooksCommand(c *tc.C) {
 
 			hooksCmd := NewDebugHooksCommandForTest(app, ssh, status, charmAPI, test.hostChecker, baseTestingRetryStrategy, baseTestingRetryStrategy)
 
-			ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(hooksCmd), test.args...)
+			ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(hooksCmd), append([]string{"--direct"}, test.args...)...)
 			if test.error != "" {
 				c.Assert(err, tc.ErrorMatches, test.error)
 			} else {
@@ -212,7 +212,7 @@ func (s *DebugHooksSuite) TestDebugHooksArgFormatting(c *tc.C) {
 
 	hooksCmd := NewDebugHooksCommandForTest(app, ssh, status, charmAPI, s.hostChecker, baseTestingRetryStrategy, baseTestingRetryStrategy)
 
-	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(hooksCmd), "mysql/0", "install", "start")
+	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(hooksCmd), "--direct", "mysql/0", "install", "start")
 	c.Check(err, tc.ErrorIsNil)
 	base64Regex := regexp.MustCompile("echo ([A-Za-z0-9+/]+=*) \\| base64")
 	c.Check(err, tc.ErrorIsNil)

--- a/cmd/juju/ssh/export_test.go
+++ b/cmd/juju/ssh/export_test.go
@@ -107,11 +107,15 @@ func NewSSHContainer(
 }
 
 func clientStore() jujuclient.ClientStore {
+	return clientStoreWithModelType(model.IAAS)
+}
+
+func clientStoreWithModelType(modelType model.ModelType) jujuclient.ClientStore {
 	store := jujuclienttesting.MinimalStore()
 	models := store.Models["arthur"]
 	models.Models["admin/controller"] = jujuclient.ModelDetails{
 		ModelUUID: uuid.MustNewUUID().String(),
-		ModelType: model.IAAS,
+		ModelType: modelType,
 	}
 	store.Models["arthur"] = models
 	store.Models["arthur"].CurrentModel = "controller"

--- a/cmd/juju/ssh/mocks/package_mock.go
+++ b/cmd/juju/ssh/mocks/package_mock.go
@@ -16,6 +16,8 @@ import (
 	time "time"
 
 	gomock "github.com/canonical/gomock/gomock"
+	names "github.com/juju/names/v6"
+
 	api "github.com/juju/juju/api"
 	application "github.com/juju/juju/api/client/application"
 	client "github.com/juju/juju/api/client/client"
@@ -27,7 +29,6 @@ import (
 	charm0 "github.com/juju/juju/domain/deployment/charm"
 	cloudspec "github.com/juju/juju/environs/cloudspec"
 	params "github.com/juju/juju/rpc/params"
-	names "github.com/juju/names/v6"
 )
 
 // MockContext is a mock of Context interface.
@@ -454,6 +455,7 @@ type MockSSHAPIJump struct {
 // MockSSHAPIJumpMockRecorder is the mock recorder for MockSSHAPIJump.
 type MockSSHAPIJumpMockRecorder struct {
 	mock                          *MockSSHAPIJump
+	bestAPIVersionExpects         []*gomock.Call0_1[int]
 	closeExpects                  []*gomock.Call0_1[error]
 	publicHostKeyForTargetExpects []*gomock.Call2_2[context.Context, string, params.PublicSSHHostKeyResult, error]
 	virtualHostnameExpects        []*gomock.Call3_2[context.Context, string, *string, string, error]
@@ -470,6 +472,24 @@ func NewMockSSHAPIJump(ctrl *gomock.Controller) *MockSSHAPIJump {
 func (m *MockSSHAPIJump) EXPECT() *MockSSHAPIJumpMockRecorder {
 	return m.recorder
 }
+
+// BestAPIVersion mocks base method.
+func (m *MockSSHAPIJump) BestAPIVersion() int {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.bestAPIVersionExpects, m.ctrl, m, "BestAPIVersion")
+}
+
+// BestAPIVersion indicates an expected call of BestAPIVersion.
+func (mr *MockSSHAPIJumpMockRecorder) BestAPIVersion() *MockSSHAPIJumpBestAPIVersionCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[int](mr.mock.ctrl.T, mr.mock, "BestAPIVersion")
+	mr.bestAPIVersionExpects = append(mr.bestAPIVersionExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockSSHAPIJumpBestAPIVersionCall is the typed call wrapper for BestAPIVersion.
+type MockSSHAPIJumpBestAPIVersionCall = gomock.Call0_1[int]
 
 // Close mocks base method.
 func (m *MockSSHAPIJump) Close() error {

--- a/cmd/juju/ssh/mocks/package_mock.go
+++ b/cmd/juju/ssh/mocks/package_mock.go
@@ -16,8 +16,6 @@ import (
 	time "time"
 
 	gomock "github.com/canonical/gomock/gomock"
-	names "github.com/juju/names/v6"
-
 	api "github.com/juju/juju/api"
 	application "github.com/juju/juju/api/client/application"
 	client "github.com/juju/juju/api/client/client"
@@ -29,6 +27,7 @@ import (
 	charm0 "github.com/juju/juju/domain/deployment/charm"
 	cloudspec "github.com/juju/juju/environs/cloudspec"
 	params "github.com/juju/juju/rpc/params"
+	names "github.com/juju/names/v6"
 )
 
 // MockContext is a mock of Context interface.

--- a/cmd/juju/ssh/scp.go
+++ b/cmd/juju/ssh/scp.go
@@ -71,13 +71,19 @@ add ` + "`-- -3`" + ` to the command-line arguments.
 
 ## Security considerations
 
-To enable transfers to/from machines that do not have internet access, you can use
-the Juju controller as a proxy with the ` + "`--proxy`" + ` option.
+By default, transfers are proxied through the controller's SSH server for the ability
+to audit log SSH connections in the future. This requires port 17022 (by default) to
+be open. Use the ` + "`--direct`" + ` option for Juju 3 controllers and connect directly
+to the target. Note that new behaviour does not support connecting to nested
+containers running on machines as the legacy behaviour did.
 
-To proxy transfers through the controller's SSH server, use the ` + "`--jump`" + ` option.
+If using the ` + "`--direct`" + ` flag you can also use the ` + "`--proxy`" + ` flag
+to proxy the connection through the controller machine's OpenSSH server running on
+port 22 (by default). If transferring files to/from containers on machines
+the proxy flag will proxy connections through the controller machine and the host machine.
 
-The SSH host keys of the target are verified by default. To disable this, add
- ` + "`--no-host-key-checks`" + ` option. Using this option is strongly discouraged.
+The SSH host keys of the target are verified by default. To disable this, add the
+` + "`--no-host-key-checks`" + ` option. Using this option is strongly discouraged.
 
 `
 
@@ -121,10 +127,6 @@ Copy a file (` + "`chunks-inspect`" + `) from ` + "`localhost`" + ` to the ` + "
 in a specific container in a Juju unit running in Kubernetes:
 
     juju scp --container loki chunks-inspect loki-k8s/0:/loki
-
-Copy ` + "`foo.txt`" + ` through the controller SSH server to machine ` + "`0`" + `:
-
-	juju scp --jump foo.txt 0:/tmp/foo.txt
 `
 
 func NewSCPCommand(hostChecker jujussh.ReachableChecker, retryStrategy retry.CallArgs, publicKeyRetryStrategy retry.CallArgs) cmd.Command {
@@ -149,6 +151,7 @@ type scpCommand struct {
 
 	hostChecker jujussh.ReachableChecker
 	jump        bool
+	direct      bool
 
 	retryStrategy          retry.CallArgs
 	publicKeyRetryStrategy retry.CallArgs
@@ -157,8 +160,8 @@ type scpCommand struct {
 func (c *scpCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.sshMachine.SetFlags(f)
 	c.sshContainer.SetFlags(f)
-	f.BoolVar(&c.jump, "jump", false, "Proxy SSH through the Juju controller")
 	c.sshJump.SetFlags(f)
+	f.BoolVar(&c.direct, "direct", false, "Connect directly to the target (for Juju 3 controllers)")
 }
 
 func (c *scpCommand) Info() *cmd.Info {
@@ -181,8 +184,12 @@ func (c *scpCommand) Init(args []string) (err error) {
 	if c.modelType, err = c.ModelType(context.TODO()); err != nil {
 		return err
 	}
+
+	// Use jump by default, unless --direct is specified.
+	c.jump = !c.direct
+
 	if c.sshJump.showCommand && !c.jump {
-		return errors.New("--show-command requires --jump")
+		return errors.New("--show-command cannot be used with --direct")
 	}
 	if c.jump {
 		c.provider = &c.sshJump

--- a/cmd/juju/ssh/scp_unix_test.go
+++ b/cmd/juju/ssh/scp_unix_test.go
@@ -224,7 +224,7 @@ func (s *SCPSuiteLegacy) TestSCPCommand(c *tc.C) {
 			ssh, app, status := s.setupModel(ctrl, test.expected.withProxy, test.noClose, nil, nil, test.targets...)
 			scpCmd := NewSCPCommandForTest(app, ssh, status, test.hostChecker, baseTestingRetryStrategy, baseTestingRetryStrategy)
 
-			ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(scpCmd), test.args...)
+			ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(scpCmd), append([]string{"--direct"}, test.args...)...)
 			if test.error != "" {
 				c.Assert(err, tc.ErrorMatches, test.error, tc.Commentf("test %d", i))
 			} else {

--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -52,6 +52,16 @@ a pseudo-terminal (pty) for the ssh session; otherwise a pty is allocated. This
 behavior can be overridden by explicitly specifying the behavior with
 ` + "`--pty=true`" + ` or ` + "`--pty=false`" + `.
 
+By default, the SSH connection is proxied through the controller's SSH server for the
+ability to audit log in the future. This requires port 17022 (by default) on the 
+controller machine to be open. Use the ` + "`--direct`" + ` option for Juju 3 controllers 
+and connect directly to the target. Note that new behaviour does not support connecting
+to nested containers running on machines as the legacy behaviour did.
+
+If using the` + "`--direct`" + `flag you can also use the ` + "`--proxy`" + ` flag
+to proxy the connection through the controller machine's OpenSSH server running on
+port 22 (by default).
+
 The SSH host keys of the target are verified. The ` + "`--no-host-key-checks`" + ` option
 can be used to disable these checks. Use of this option is not recommended as
 it opens up the possibility of a man-in-the-middle attack.
@@ -195,6 +205,7 @@ type sshCommand struct {
 	isTerminal  func(any) bool
 	pty         autoBoolValue
 	jump        bool
+	direct      bool
 
 	retryStrategy          retry.CallArgs
 	publicKeyRetryStrategy retry.CallArgs
@@ -204,8 +215,8 @@ func (c *sshCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.sshMachine.SetFlags(f)
 	c.sshContainer.SetFlags(f)
 	f.Var(&c.pty, "pty", "Enable pseudo-tty allocation")
-	f.BoolVar(&c.jump, "jump", false, "Proxy SSH through the Juju controller")
 	c.sshJump.SetFlags(f)
+	f.BoolVar(&c.direct, "direct", false, "Connect directly to the target (for Juju 3 controllers)")
 }
 
 func (c *sshCommand) Info() *cmd.Info {
@@ -228,8 +239,12 @@ func (c *sshCommand) Init(args []string) (err error) {
 	if c.modelType, err = c.ModelType(context.TODO()); err != nil {
 		return err
 	}
+
+	// Use jump by default, unless --direct is specified.
+	c.jump = !c.direct
+
 	if c.sshJump.showCommand && !c.jump {
-		return errors.New("--show-command requires --jump")
+		return errors.New("--show-command cannot be used with --direct")
 	}
 	// The jump provider is transparent to the model type. The container flag is
 	// registered by the embedded sshContainer, so propagate its value to the

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -46,8 +46,13 @@ const openSSHTemplate = `ssh -o "ProxyCommand=ssh -W %h:%p -p {{.JumpPort}} {{.J
 const openSCPTemplate = `scp -o "ProxyCommand=ssh -W %h:%p -p {{.JumpPort}} {{.JumpUser}}@{{.JumpHost}}" {{.Args}}
 `
 
+const minSSHJumpFacadeVersion = 6
+
 // SSHAPIJump is the SSH API client used by the SSH jump provider.
 type SSHAPIJump interface {
+	// BestAPIVersion returns the highest SSHClient facade version supported by
+	// both the client and the controller.
+	BestAPIVersion() int
 	// VirtualHostname returns the virtual hostname for an SSH target.
 	VirtualHostname(ctx context.Context, target string, container *string) (string, error)
 	// PublicHostKeyForTarget returns the public host key for a virtual hostname.
@@ -98,6 +103,9 @@ func (p *sshJump) initRun(ctx context.Context, mc ModelCommand) error {
 	if err := p.ensureAPIClient(ctx, mc); err != nil {
 		return errors.Trace(err)
 	}
+	if err := checkSSHJumpFacadeVersion(p.sshClient.BestAPIVersion()); err != nil {
+		return err
+	}
 	controllerConfig, err := p.controllerClient.ControllerConfig(ctx)
 	if err != nil {
 		return errors.Trace(err)
@@ -138,6 +146,15 @@ func (p *sshJump) initRun(ctx context.Context, mc ModelCommand) error {
 	p.scpOutputTemplate, err = template.New("scp-output").Parse(openSCPTemplate)
 	if err != nil {
 		return errors.Trace(err)
+	}
+	return nil
+}
+
+func checkSSHJumpFacadeVersion(version int) error {
+	if version < minSSHJumpFacadeVersion {
+		return errors.Errorf(
+			"controller does not support SSH proxying; use the --direct flag to connect directly",
+		)
 	}
 	return nil
 }

--- a/cmd/juju/ssh/ssh_jump.go
+++ b/cmd/juju/ssh/ssh_jump.go
@@ -347,11 +347,11 @@ func (p *sshJump) ssh(ctx Context, enablePty bool, target *resolvedTarget) error
 	if err != nil {
 		return err
 	}
-	// Set the default command to "exec sh" if no arguments are provided and the
-	// model type is CAAS.
+	// Set the default command to a login Bash shell for CAAS models so that
+	// /etc/profile.d/juju-introspection.sh is sourced (for controller units).
 	args := p.args
 	if len(args) == 0 && p.modelType == model.CAAS {
-		args = []string{"exec", "sh"}
+		args = []string{"exec", "bash", "--login"}
 	}
 	if p.showCommand {
 		return p.showSSHCommand(ctx.GetStdout(), target, args)

--- a/cmd/juju/ssh/ssh_jump_test.go
+++ b/cmd/juju/ssh/ssh_jump_test.go
@@ -39,6 +39,16 @@ func TestSSHJumpSuite(t *stdtesting.T) {
 	tc.Run(t, &sshJumpSuite{})
 }
 
+func (s *sshJumpSuite) TestCheckSSHJumpFacadeVersion(c *tc.C) {
+	c.Check(checkSSHJumpFacadeVersion(minSSHJumpFacadeVersion), tc.ErrorIsNil)
+	c.Check(checkSSHJumpFacadeVersion(minSSHJumpFacadeVersion+1), tc.ErrorIsNil)
+	c.Check(
+		checkSSHJumpFacadeVersion(minSSHJumpFacadeVersion-1),
+		tc.ErrorMatches,
+		`controller does not support SSH proxying; use the --direct flag to connect directly`,
+	)
+}
+
 func (s *sshJumpSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.sshAPIJump = mocks.NewMockSSHAPIJump(ctrl)

--- a/cmd/juju/ssh/ssh_test.go
+++ b/cmd/juju/ssh/ssh_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/tc"
 
 	"github.com/juju/juju/cmd/cmd/cmdtesting"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/internal/testhelpers"
 )
 
@@ -31,6 +32,53 @@ func (*CmdSuite) TestSSHCommandInit(c *tc.C) {
 	c.Assert(err, tc.ErrorMatches, "no target name specified")
 }
 
+func (*CmdSuite) TestSSHCommandInitUsesJumpProvider(c *tc.C) {
+	cmd := NewSSHCommandForTest(
+		nil, nil, nil, nil, nil,
+		baseTestingRetryStrategy, baseTestingRetryStrategy,
+	)
+	cmd.SetClientStore(clientStoreWithModelType(model.IAAS))
+	c.Assert(cmd.SetModelIdentifier("arthur:admin/controller", false), tc.ErrorIsNil)
+
+	err := cmd.Init([]string{"0", "hostname"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cmd.jump, tc.IsTrue)
+
+	provider, ok := cmd.provider.(*sshJump)
+	c.Assert(ok, tc.IsTrue)
+	c.Check(provider.getTarget(), tc.Equals, "0")
+	c.Check(provider.getArgs(), tc.DeepEquals, []string{"hostname"})
+}
+
+func (*CmdSuite) TestSSHCommandInitUsesJumpProviderForCAAS(c *tc.C) {
+	cmd := NewSSHCommandForTest(
+		nil, nil, nil, nil, nil,
+		baseTestingRetryStrategy, baseTestingRetryStrategy,
+	)
+	cmd.SetClientStore(clientStoreWithModelType(model.CAAS))
+	c.Assert(cmd.SetModelIdentifier("arthur:admin/controller", false), tc.ErrorIsNil)
+	cmd.sshContainer.container = "redis"
+
+	err := cmd.Init([]string{"redis/0"})
+	c.Assert(err, tc.ErrorIsNil)
+
+	provider, ok := cmd.provider.(*sshJump)
+	c.Assert(ok, tc.IsTrue)
+	c.Check(provider.container, tc.Equals, "redis")
+}
+
+func (*CmdSuite) TestSSHCommandErrorsShowCommandWithDirect(c *tc.C) {
+	cmd := NewSSHCommandForTest(
+		nil, nil, nil, nil, nil,
+		baseTestingRetryStrategy, baseTestingRetryStrategy,
+	)
+	cmd.SetClientStore(clientStoreWithModelType(model.IAAS))
+	c.Assert(cmd.SetModelIdentifier("arthur:admin/controller", false), tc.ErrorIsNil)
+
+	err := cmdtesting.InitCommand(cmd, []string{"--direct", "--show-command", "0"})
+	c.Assert(err, tc.ErrorMatches, "--show-command cannot be used with --direct")
+}
+
 func initSCPCommand(args ...string) (*scpCommand, error) {
 	com := &scpCommand{}
 	return com, cmdtesting.InitCommand(com, args)
@@ -44,4 +92,78 @@ func (*CmdSuite) TestSCPCommandInit(c *tc.C) {
 	// not enough args
 	_, err = initSCPCommand("mysql/0:foo")
 	c.Assert(err, tc.ErrorMatches, "at least two arguments required")
+}
+
+func (*CmdSuite) TestSCPCommandInitUsesJumpProvider(c *tc.C) {
+	cmd := NewSCPCommandForTest(
+		nil, nil, nil, nil,
+		baseTestingRetryStrategy, baseTestingRetryStrategy,
+	)
+	cmd.SetClientStore(clientStoreWithModelType(model.IAAS))
+	c.Assert(cmd.SetModelIdentifier("arthur:admin/controller", false), tc.ErrorIsNil)
+
+	err := cmd.Init([]string{"source", "0:/tmp/source"})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(cmd.jump, tc.IsTrue)
+
+	provider, ok := cmd.provider.(*sshJump)
+	c.Assert(ok, tc.IsTrue)
+	c.Check(provider.getArgs(), tc.DeepEquals, []string{"source", "0:/tmp/source"})
+}
+
+func (*CmdSuite) TestSCPCommandInitUsesJumpProviderForCAAS(c *tc.C) {
+	cmd := NewSCPCommandForTest(
+		nil, nil, nil, nil,
+		baseTestingRetryStrategy, baseTestingRetryStrategy,
+	)
+	cmd.SetClientStore(clientStoreWithModelType(model.CAAS))
+	c.Assert(cmd.SetModelIdentifier("arthur:admin/controller", false), tc.ErrorIsNil)
+	cmd.sshContainer.container = "redis"
+
+	err := cmd.Init([]string{"source", "redis/0:/tmp/source"})
+	c.Assert(err, tc.ErrorIsNil)
+
+	provider, ok := cmd.provider.(*sshJump)
+	c.Assert(ok, tc.IsTrue)
+	c.Check(provider.container, tc.Equals, "redis")
+}
+
+func (*CmdSuite) TestSCPCommandErrorsShowCommandWithDirect(c *tc.C) {
+	cmd := NewSCPCommandForTest(
+		nil, nil, nil, nil,
+		baseTestingRetryStrategy, baseTestingRetryStrategy,
+	)
+	cmd.SetClientStore(clientStoreWithModelType(model.IAAS))
+	c.Assert(cmd.SetModelIdentifier("arthur:admin/controller", false), tc.ErrorIsNil)
+
+	err := cmdtesting.InitCommand(cmd, []string{"--direct", "--show-command", "source", "0:/tmp/source"})
+	c.Assert(err, tc.ErrorMatches, "--show-command cannot be used with --direct")
+}
+
+func (*CmdSuite) TestDebugHooksCommandInitUsesJumpProvider(c *tc.C) {
+	cmd := NewDebugHooksCommandForTest(
+		nil, nil, nil, nil, nil,
+		baseTestingRetryStrategy, baseTestingRetryStrategy,
+	)
+	cmd.SetClientStore(clientStoreWithModelType(model.IAAS))
+	c.Assert(cmd.SetModelIdentifier("arthur:admin/controller", false), tc.ErrorIsNil)
+
+	err := cmd.Init([]string{"mysql/0"})
+	c.Assert(err, tc.ErrorIsNil)
+	_, ok := cmd.provider.(*sshJump)
+	c.Check(ok, tc.IsTrue)
+}
+
+func (*CmdSuite) TestDebugCodeCommandInitUsesJumpProvider(c *tc.C) {
+	cmd := NewDebugCodeCommandForTest(
+		nil, nil, nil, nil, nil,
+		baseTestingRetryStrategy, baseTestingRetryStrategy,
+	)
+	cmd.SetClientStore(clientStoreWithModelType(model.IAAS))
+	c.Assert(cmd.SetModelIdentifier("arthur:admin/controller", false), tc.ErrorIsNil)
+
+	err := cmd.Init([]string{"mysql/0"})
+	c.Assert(err, tc.ErrorIsNil)
+	_, ok := cmd.provider.(*sshJump)
+	c.Check(ok, tc.IsTrue)
 }

--- a/cmd/juju/ssh/ssh_unix_test.go
+++ b/cmd/juju/ssh/ssh_unix_test.go
@@ -201,7 +201,7 @@ func (s *SSHSuite) TestSSHCommand(c *tc.C) {
 		ssh, app, status := s.setupModel(ctrl, t.expected.withProxy, false, nil, nil, target)
 		sshCmd := NewSSHCommandForTest(app, ssh, status, t.hostChecker, isTerminal, baseTestingRetryStrategy, baseTestingRetryStrategy)
 
-		ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(sshCmd), t.args...)
+		ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(sshCmd), append([]string{"--direct"}, t.args...)...)
 		if t.expectedErr != "" {
 			c.Check(err, tc.ErrorMatches, t.expectedErr)
 		} else {
@@ -221,7 +221,7 @@ func (s *SSHSuite) TestSSHCommandModelConfigProxySSH(c *tc.C) {
 	ssh, app, status := s.setupModel(ctrl, true, false, nil, nil, "0")
 	sshCmd := NewSSHCommandForTest(app, ssh, status, s.hostChecker, nil, baseTestingRetryStrategy, baseTestingRetryStrategy)
 
-	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(sshCmd), "0")
+	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(sshCmd), "--direct", "0")
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), tc.Equals, "")
 	expectedArgs := argsSpec{
@@ -240,7 +240,7 @@ func (s *SSHSuite) TestSSHCommandModelConfigProxySSHAddressMatch(c *tc.C) {
 	ssh, app, status := s.setupModel(ctrl, true, false, nil, nil, "0")
 	sshCmd := NewSSHCommandForTest(app, ssh, status, s.hostChecker, nil, baseTestingRetryStrategy, baseTestingRetryStrategy)
 
-	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(sshCmd), "0")
+	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(sshCmd), "--direct", "0")
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), tc.Equals, "")
 	expectedArgs := argsSpec{
@@ -298,7 +298,7 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *tc.C, proxy bool) {
 	}, nil, "0")
 	sshCmd := NewSSHCommandForTest(app, ssh, status, s.hostChecker, nil, baseTestingRetryStrategy, baseTestingRetryStrategy)
 
-	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(sshCmd), args...)
+	_, err := cmdtesting.RunCommand(c, modelcmd.Wrap(sshCmd), append([]string{"--direct"}, args...)...)
 	c.Assert(err, tc.ErrorMatches, `no .+ address\(es\)`)
 
 	if proxy {
@@ -319,7 +319,7 @@ func (s *SSHSuite) testSSHCommandHostAddressRetry(c *tc.C, proxy bool) {
 	}, nil, "0")
 	sshCmd = NewSSHCommandForTest(app, ssh, status, s.hostChecker, nil, baseTestingRetryStrategy, baseTestingRetryStrategy)
 	sshCmd.retryStrategy = retryStrategy
-	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(sshCmd), args...)
+	_, err = cmdtesting.RunCommand(c, modelcmd.Wrap(sshCmd), append([]string{"--direct"}, args...)...)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -373,7 +373,7 @@ func (s *SSHSuite) TestKeyFetchRetries(c *tc.C) {
 	ssh, app, status := s.setupModel(ctrl, false, false, nil, keysFunc, "1")
 	cmd := NewSSHCommandForTest(app, ssh, status, validAddresses("1.public"), isTerminal, baseTestingRetryStrategy, publicKeyRetry)
 
-	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(cmd), "1")
+	ctx, err := cmdtesting.RunCommand(c, modelcmd.Wrap(cmd), "--direct", "1")
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(cmdtesting.Stderr(ctx), tc.Equals, "")
 

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/debug-code.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/debug-code.md
@@ -15,7 +15,7 @@ juju debug-code [options] <unit name> [hook or action names]
 | --- | --- | --- |
 | `--at` | all | Specify the value that the `JUJU_DEBUG_AT` environment variable will be set to. This variable tells the charm where you want to stop. |
 | `--container` |  | the container name of the target pod |
-| `--jump` | false | Proxy SSH through the Juju controller |
+| `--direct` | false | Connect directly to the target (for Juju 3 controllers) |
 | `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
 | `--no-host-key-checks` | false | Skip host key checking (INSECURE) |
 | `--proxy` | false | Proxy through the API server |

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/debug-hooks.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/debug-hooks.md
@@ -16,7 +16,7 @@ juju debug-hooks [options] <unit name> [hook or action names]
 | Flag | Default | Usage |
 | --- | --- | --- |
 | `--container` |  | the container name of the target pod |
-| `--jump` | false | Proxy SSH through the Juju controller |
+| `--direct` | false | Connect directly to the target (for Juju 3 controllers) |
 | `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
 | `--no-host-key-checks` | false | Skip host key checking (INSECURE) |
 | `--proxy` | false | Proxy through the API server |

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/scp.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/scp.md
@@ -14,7 +14,7 @@ juju scp [options] <source> <destination>
 | Flag | Default | Usage |
 | --- | --- | --- |
 | `--container` |  | the container name of the target pod |
-| `--jump` | false | Proxy SSH through the Juju controller |
+| `--direct` | false | Connect directly to the target (for Juju 3 controllers) |
 | `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
 | `--no-host-key-checks` | false | Skip host key checking (INSECURE) |
 | `--proxy` | false | Proxy through the API server |
@@ -61,10 +61,6 @@ Copy a file (`chunks-inspect`) from `localhost` to the `/loki` directory
 in a specific container in a Juju unit running in Kubernetes:
 
     juju scp --container loki chunks-inspect loki-k8s/0:/loki
-
-Copy `foo.txt` through the controller SSH server to machine `0`:
-
-	juju scp --jump foo.txt 0:/tmp/foo.txt
 
 
 ## Details
@@ -119,10 +115,16 @@ add `-- -3` to the command-line arguments.
 
 ## Security considerations
 
-To enable transfers to/from machines that do not have internet access, you can use
-the Juju controller as a proxy with the `--proxy` option.
+By default, transfers are proxied through the controller's SSH server for the ability
+to audit log SSH connections in the future. This requires port 17022 (by default) to
+be open. Use the `--direct` option for Juju 3 controllers and connect directly
+to the target. Note that new behaviour does not support connecting to nested
+containers running on machines as the legacy behaviour did.
 
-To proxy transfers through the controller's SSH server, use the `--jump` option.
+If using the `--direct` flag you can also use the `--proxy` flag
+to proxy the connection through the controller machine's OpenSSH server running on
+port 22 (by default). If transferring files to/from containers on machines
+the proxy flag will proxy connections through the controller machine and the host machine.
 
-The SSH host keys of the target are verified by default. To disable this, add
- `--no-host-key-checks` option. Using this option is strongly discouraged.
+The SSH host keys of the target are verified by default. To disable this, add the
+`--no-host-key-checks` option. Using this option is strongly discouraged.

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/ssh.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/ssh.md
@@ -14,7 +14,7 @@ juju ssh [options] <[user@]target> [openssh options] [command]
 | Flag | Default | Usage |
 | --- | --- | --- |
 | `--container` |  | the container name of the target pod |
-| `--jump` | false | Proxy SSH through the Juju controller |
+| `--direct` | false | Connect directly to the target (for Juju 3 controllers) |
 | `-m`, `--model` |  | Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt; |
 | `--no-host-key-checks` | false | Skip host key checking (INSECURE) |
 | `--proxy` | false | Proxy through the API server |
@@ -114,6 +114,16 @@ output of another command into it, then the default behavior is to not allocate
 a pseudo-terminal (pty) for the ssh session; otherwise a pty is allocated. This
 behavior can be overridden by explicitly specifying the behavior with
 `--pty=true` or `--pty=false`.
+
+By default, the SSH connection is proxied through the controller's SSH server for the
+ability to audit log in the future. This requires port 17022 (by default) on the 
+controller machine to be open. Use the `--direct` option for Juju 3 controllers 
+and connect directly to the target. Note that new behaviour does not support connecting
+to nested containers running on machines as the legacy behaviour did.
+
+If using the`--direct`flag you can also use the `--proxy` flag
+to proxy the connection through the controller machine's OpenSSH server running on
+port 22 (by default).
 
 The SSH host keys of the target are verified. The `--no-host-key-checks` option
 can be used to disable these checks. Use of this option is not recommended as

--- a/domain/export/state/model/export.go
+++ b/domain/export/state/model/export.go
@@ -857,10 +857,6 @@ func (st *State) Export(ctx context.Context) (*v4_1_0.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing SshConnectionRequest statement: %w", err)
 	}
-	stmtSshConnectionRequestAddress, err := sqlair.Prepare(`SELECT &SshConnectionRequestAddress.* FROM "ssh_connection_request_address"`, v4_1_0.SshConnectionRequestAddress{})
-	if err != nil {
-		return nil, fmt.Errorf("preparing SshConnectionRequestAddress statement: %w", err)
-	}
 	stmtSshKeyAlgorithmType, err := sqlair.Prepare(`SELECT &SshKeyAlgorithmType.* FROM "ssh_key_algorithm_type"`, v4_1_0.SshKeyAlgorithmType{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SshKeyAlgorithmType statement: %w", err)
@@ -1654,9 +1650,6 @@ func (st *State) Export(ctx context.Context) (*v4_1_0.ModelExport, error) {
 		}
 		if err := tx.Query(ctx, stmtSshConnectionRequest).GetAll(&modelExport.SshConnectionRequest); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying SshConnectionRequest (table ssh_connection_request): %w", err)
-		}
-		if err := tx.Query(ctx, stmtSshConnectionRequestAddress).GetAll(&modelExport.SshConnectionRequestAddress); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("querying SshConnectionRequestAddress (table ssh_connection_request_address): %w", err)
 		}
 		if err := tx.Query(ctx, stmtSshKeyAlgorithmType).GetAll(&modelExport.SshKeyAlgorithmType); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying SshKeyAlgorithmType (table ssh_key_algorithm_type): %w", err)

--- a/domain/export/types/v4_1_0/model.go
+++ b/domain/export/types/v4_1_0/model.go
@@ -1349,19 +1349,14 @@ type Space struct {
 }
 
 type SshConnectionRequest struct {
-	TunnelID           string    `db:"tunnel_id" json:"tunnel_id" yaml:"tunnel_id"`
-	MachineUUID        string    `db:"machine_uuid" json:"machine_uuid" yaml:"machine_uuid"`
-	ExpiresAt          time.Time `db:"expires_at" json:"expires_at" yaml:"expires_at"`
-	Username           string    `db:"username" json:"username" yaml:"username"`
-	Password           string    `db:"password" json:"password" yaml:"password"`
-	UnitPort           int64     `db:"unit_port" json:"unit_port" yaml:"unit_port"`
-	EphemeralPublicKey []byte    `db:"ephemeral_public_key" json:"ephemeral_public_key" yaml:"ephemeral_public_key"`
-}
-
-type SshConnectionRequestAddress struct {
-	TunnelID     string `db:"tunnel_id" json:"tunnel_id" yaml:"tunnel_id"`
-	IndexID      int64  `db:"index_id" json:"index_id" yaml:"index_id"`
-	AddressValue string `db:"address_value" json:"address_value" yaml:"address_value"`
+	TunnelID            string    `db:"tunnel_id" json:"tunnel_id" yaml:"tunnel_id"`
+	MachineUUID         string    `db:"machine_uuid" json:"machine_uuid" yaml:"machine_uuid"`
+	ExpiresAt           time.Time `db:"expires_at" json:"expires_at" yaml:"expires_at"`
+	Username            string    `db:"username" json:"username" yaml:"username"`
+	Password            string    `db:"password" json:"password" yaml:"password"`
+	ControllerAddresses string    `db:"controller_addresses" json:"controller_addresses" yaml:"controller_addresses"`
+	UnitPort            int64     `db:"unit_port" json:"unit_port" yaml:"unit_port"`
+	EphemeralPublicKey  []byte    `db:"ephemeral_public_key" json:"ephemeral_public_key" yaml:"ephemeral_public_key"`
 }
 
 type SshKeyAlgorithmType struct {
@@ -1846,7 +1841,6 @@ type ModelExport struct {
 	Sequence                                 []Sequence                                 `json:"sequence" yaml:"sequence"`
 	Space                                    []Space                                    `json:"space" yaml:"space"`
 	SshConnectionRequest                     []SshConnectionRequest                     `json:"ssh_connection_request" yaml:"ssh_connection_request"`
-	SshConnectionRequestAddress              []SshConnectionRequestAddress              `json:"ssh_connection_request_address" yaml:"ssh_connection_request_address"`
 	SshKeyAlgorithmType                      []SshKeyAlgorithmType                      `json:"ssh_key_algorithm_type" yaml:"ssh_key_algorithm_type"`
 	StorageAttachment                        []StorageAttachment                        `json:"storage_attachment" yaml:"storage_attachment"`
 	StorageFilesystem                        []StorageFilesystem                        `json:"storage_filesystem" yaml:"storage_filesystem"`

--- a/domain/modelimport/state/model/import.go
+++ b/domain/modelimport/state/model/import.go
@@ -794,10 +794,6 @@ func (st *State) Import(ctx context.Context, p *v4_1_0.ModelExport) error {
 	if err != nil {
 		return errors.Errorf("preparing SshConnectionRequest insert statement: %w", err)
 	}
-	stmtSshConnectionRequestAddress, err := sqlair.Prepare(`INSERT INTO "ssh_connection_request_address" (*) VALUES ($SshConnectionRequestAddress.*)`, v4_1_0.SshConnectionRequestAddress{})
-	if err != nil {
-		return errors.Errorf("preparing SshConnectionRequestAddress insert statement: %w", err)
-	}
 	stmtSshKeyAlgorithmType, err := sqlair.Prepare(`INSERT INTO "ssh_key_algorithm_type" (*) VALUES ($SshKeyAlgorithmType.*) ON CONFLICT DO NOTHING`, v4_1_0.SshKeyAlgorithmType{})
 	if err != nil {
 		return errors.Errorf("preparing SshKeyAlgorithmType insert statement: %w", err)
@@ -1929,11 +1925,6 @@ func (st *State) Import(ctx context.Context, p *v4_1_0.ModelExport) error {
 		if len(p.SshConnectionRequest) > 0 {
 			if err := tx.Query(ctx, stmtSshConnectionRequest, p.SshConnectionRequest).Run(); err != nil {
 				return errors.Errorf("inserting SshConnectionRequest (table ssh_connection_request): %w", err)
-			}
-		}
-		if len(p.SshConnectionRequestAddress) > 0 {
-			if err := tx.Query(ctx, stmtSshConnectionRequestAddress, p.SshConnectionRequestAddress).Run(); err != nil {
-				return errors.Errorf("inserting SshConnectionRequestAddress (table ssh_connection_request_address): %w", err)
 			}
 		}
 		if len(p.SshKeyAlgorithmType) > 0 {

--- a/domain/modelimport/transformer/transforms/to_v4_1_0/deltas.go
+++ b/domain/modelimport/transformer/transforms/to_v4_1_0/deltas.go
@@ -157,11 +157,3 @@ func (d deltas) SshConnectionRequest(_ context.Context, _ *v4_0_12.ModelExport) 
 	// to transform from 4.0.12.
 	return nil, nil
 }
-
-// SshConnectionRequestAddress returns no rows for 4.0.12 payloads. The source
-// schema has no SSH connection request address table.
-func (d deltas) SshConnectionRequestAddress(_ context.Context, _ *v4_0_12.ModelExport) ([]v4_1_0.SshConnectionRequestAddress, error) {
-	// The ssh_connection_request_address table was added in 4.1.0, so there
-	// are no rows to transform from 4.0.12.
-	return nil, nil
-}

--- a/domain/modelimport/transformer/transforms/to_v4_1_0/transform.go
+++ b/domain/modelimport/transformer/transforms/to_v4_1_0/transform.go
@@ -33,8 +33,6 @@ type Deltas interface {
 	MachineVirtualSshHostKey(ctx context.Context, src *v4_0_12.ModelExport) ([]v4_1_0.MachineVirtualSshHostKey, error)
 	// SshConnectionRequest: new table in 4.1.0; derive from *v4_0_12.ModelExport.
 	SshConnectionRequest(ctx context.Context, src *v4_0_12.ModelExport) ([]v4_1_0.SshConnectionRequest, error)
-	// SshConnectionRequestAddress: new table in 4.1.0; derive from *v4_0_12.ModelExport.
-	SshConnectionRequestAddress(ctx context.Context, src *v4_0_12.ModelExport) ([]v4_1_0.SshConnectionRequestAddress, error)
 	// SshKeyAlgorithmType: new table in 4.1.0; derive from *v4_0_12.ModelExport.
 	SshKeyAlgorithmType(ctx context.Context, src *v4_0_12.ModelExport) ([]v4_1_0.SshKeyAlgorithmType, error)
 	// UnitVirtualSshHostKey: new table in 4.1.0; derive from *v4_0_12.ModelExport.
@@ -1276,10 +1274,6 @@ func NewTransform(d Deltas) transformer.TransformationFunc[v4_0_12.ModelExport, 
 
 		if dst.SshConnectionRequest, err = d.SshConnectionRequest(ctx, &src); err != nil {
 			return v4_1_0.ModelExport{}, errors.Errorf("SshConnectionRequest delta: %w", err)
-		}
-
-		if dst.SshConnectionRequestAddress, err = d.SshConnectionRequestAddress(ctx, &src); err != nil {
-			return v4_1_0.ModelExport{}, errors.Errorf("SshConnectionRequestAddress delta: %w", err)
 		}
 
 		if dst.SshKeyAlgorithmType, err = d.SshKeyAlgorithmType(ctx, &src); err != nil {

--- a/domain/removal/state/model/machine.go
+++ b/domain/removal/state/model/machine.go
@@ -732,6 +732,7 @@ WHERE machine_name IN (
 		"DELETE FROM machine_container_type WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM machine_ssh_host_key WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM machine_virtual_ssh_host_key WHERE machine_uuid = $entityUUID.uuid",
+		"DELETE FROM ssh_connection_request WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM machine_placement WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM machine_parent WHERE machine_uuid = $entityUUID.uuid",
 		"DELETE FROM block_device_link_device WHERE machine_uuid = $entityUUID.uuid",

--- a/domain/removal/state/model/machine_test.go
+++ b/domain/removal/state/model/machine_test.go
@@ -1463,6 +1463,15 @@ func (s *machineSuite) TestDeleteMachine(c *tc.C) {
 INSERT INTO machine_reprovision (machine_name, requested_at)
 VALUES (?, ?)`, machineRes.MachineName.String(), time.Now())
 	c.Assert(err, tc.ErrorIsNil)
+	_, err = s.DB().ExecContext(c.Context(), `
+INSERT INTO ssh_connection_request (
+	 tunnel_id, machine_uuid, expires_at, username, password,
+	 controller_addresses, unit_port, ephemeral_public_key
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		"tunnel-machine-delete", machineUUID.String(), time.Now().Add(time.Minute),
+		"juju-reverse-tunnel", "secret", "[]", 0, []byte("pub"))
+	c.Assert(err, tc.ErrorIsNil)
 
 	// Grab the net node UUID before deletion so we can verify it's removed.
 	var netNodeUUID string
@@ -1486,7 +1495,12 @@ VALUES (?, ?)`, machineRes.MachineName.String(), time.Now())
 	err = s.DB().QueryRow("SELECT count(*) FROM machine_reprovision").Scan(&count)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(count, tc.Equals, 0)
-
+	err = s.DB().QueryRow(
+		"SELECT count(*) FROM ssh_connection_request WHERE tunnel_id = ?",
+		"tunnel-machine-delete",
+	).Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, 0)
 	// And its net node should also be deleted.
 	err = s.DB().QueryRow("SELECT count(*) FROM net_node WHERE uuid = ?", netNodeUUID).Scan(&count)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/schema/model/sql/0036-ssh-connection-request.sql
+++ b/domain/schema/model/sql/0036-ssh-connection-request.sql
@@ -4,21 +4,12 @@ CREATE TABLE ssh_connection_request (
     expires_at DATETIME NOT NULL,
     username TEXT NOT NULL,
     password TEXT NOT NULL,
+    controller_addresses TEXT NOT NULL,
     unit_port INT NOT NULL,
     ephemeral_public_key BLOB NOT NULL,
     CONSTRAINT fk_ssh_connection_request_machine
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid)
-);
-
-CREATE TABLE ssh_connection_request_address (
-    tunnel_id TEXT NOT NULL,
-    index_id INT NOT NULL,
-    address_value TEXT NOT NULL,
-    PRIMARY KEY (tunnel_id, index_id),
-    CONSTRAINT fk_ssh_connection_request_address_request
-    FOREIGN KEY (tunnel_id)
-    REFERENCES ssh_connection_request (tunnel_id)
 );
 
 CREATE INDEX idx_ssh_connection_request_machine_uuid

--- a/domain/schema/model/triggers/ssh-connection-request-triggers.gen.go
+++ b/domain/schema/model/triggers/ssh-connection-request-triggers.gen.go
@@ -34,6 +34,7 @@ WHEN
 	NEW.expires_at != OLD.expires_at OR
 	NEW.username != OLD.username OR
 	NEW.password != OLD.password OR
+	NEW.controller_addresses != OLD.controller_addresses OR
 	NEW.unit_port != OLD.unit_port OR
 	NEW.ephemeral_public_key != OLD.ephemeral_public_key
 BEGIN

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -188,7 +188,6 @@ func (s *modelSchemaSuite) TestModelTables(c *tc.C) {
 		"unit_state_relation",
 		"unit_state",
 		"ssh_connection_request",
-		"ssh_connection_request_address",
 		"unit_workload_status",
 		"unit_workload_version",
 		"ssh_key_algorithm_type",

--- a/domain/ssh/state/model/state.go
+++ b/domain/ssh/state/model/state.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/canonical/sqlair"
@@ -501,6 +502,10 @@ func (st *State) InsertSSHConnRequest(ctx context.Context, req domainssh.SSHConn
 	if err != nil {
 		return errors.Capture(err)
 	}
+	controllerAddresses, err := marshalControllerAddresses(req.ControllerAddresses)
+	if err != nil {
+		return errors.Errorf("marshalling controller addresses: %w", err)
+	}
 
 	getMachineUUIDStmt, err := st.Prepare(`
 SELECT &entityUUID.*
@@ -519,12 +524,6 @@ WHERE tunnel_id = $tunnelID.tunnel_id`, tunnelID{})
 	insertStmt, err := st.Prepare(`
 INSERT INTO ssh_connection_request (*)
 VALUES ($sshConnRequestInsert.*)`, sshConnRequestInsert{})
-	if err != nil {
-		return errors.Capture(err)
-	}
-	insertAddrStmt, err := st.Prepare(`
-INSERT INTO ssh_connection_request_address (*)
-VALUES ($sshConnRequestAddress.*)`, sshConnRequestAddress{})
 	if err != nil {
 		return errors.Capture(err)
 	}
@@ -552,28 +551,19 @@ VALUES ($sshConnRequestAddress.*)`, sshConnRequestAddress{})
 		}
 
 		record := sshConnRequestInsert{
-			TunnelID:           req.TunnelID,
-			MachineUUID:        machineUUID.UUID,
-			ExpiresAt:          req.Expires,
-			Username:           req.SSHUsername,
-			Password:           req.SSHPassword,
-			UnitPort:           req.UnitPort,
-			EphemeralPublicKey: req.EphemeralPublicKey,
+			TunnelID:            req.TunnelID,
+			MachineUUID:         machineUUID.UUID,
+			ExpiresAt:           req.Expires,
+			Username:            req.SSHUsername,
+			Password:            req.SSHPassword,
+			ControllerAddresses: controllerAddresses,
+			UnitPort:            req.UnitPort,
+			EphemeralPublicKey:  req.EphemeralPublicKey,
 		}
 		if err := tx.Query(ctx, insertStmt, record).Run(); err != nil {
 			return errors.Errorf("persisting SSH connection request %q: %w", req.TunnelID, err)
 		}
 
-		for i, addr := range req.ControllerAddresses {
-			addrRow := sshConnRequestAddress{
-				TunnelID:     req.TunnelID,
-				IndexID:      i,
-				AddressValue: addr.Value,
-			}
-			if err := tx.Query(ctx, insertAddrStmt, addrRow).Run(); err != nil {
-				return errors.Errorf("persisting controller address %d for SSH connection request %q: %w", i, req.TunnelID, err)
-			}
-		}
 		return nil
 	}))
 }
@@ -594,6 +584,7 @@ SELECT scr.tunnel_id AS &sshConnRequestRecord.tunnel_id,
        scr.expires_at AS &sshConnRequestRecord.expires_at,
        scr.username AS &sshConnRequestRecord.username,
        scr.password AS &sshConnRequestRecord.password,
+	       scr.controller_addresses AS &sshConnRequestRecord.controller_addresses,
        scr.unit_port AS &sshConnRequestRecord.unit_port,
        scr.ephemeral_public_key AS &sshConnRequestRecord.ephemeral_public_key
 FROM ssh_connection_request AS scr
@@ -603,15 +594,6 @@ AND m.name = $entityName.name`, sshConnRequestRecord{}, tunnelID{}, entityName{}
 	if err != nil {
 		return domainssh.SSHConnRequest{}, errors.Capture(err)
 	}
-	addrStmt, err := st.Prepare(`
-SELECT &sshConnRequestAddress.*
-FROM ssh_connection_request_address
-WHERE tunnel_id = $tunnelID.tunnel_id
-ORDER BY index_id ASC`, sshConnRequestAddress{}, tunnelID{})
-	if err != nil {
-		return domainssh.SSHConnRequest{}, errors.Capture(err)
-	}
-
 	var result domainssh.SSHConnRequest
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		result = domainssh.SSHConnRequest{}
@@ -629,14 +611,9 @@ ORDER BY index_id ASC`, sshConnRequestAddress{}, tunnelID{})
 			return errors.Errorf("querying SSH connection request %q: %w", requestTunnelID, err)
 		}
 
-		var addrRows []sshConnRequestAddress
-		if err := tx.Query(ctx, addrStmt, tunnelID{TunnelID: requestTunnelID}).GetAll(&addrRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("querying controller addresses for SSH connection request %q: %w", requestTunnelID, err)
-		}
-
-		controllerAddresses := make(network.SpaceAddresses, len(addrRows))
-		for i, a := range addrRows {
-			controllerAddresses[i] = network.NewSpaceAddress(a.AddressValue)
+		controllerAddresses, err := unmarshalControllerAddresses(row.ControllerAddresses)
+		if err != nil {
+			return errors.Errorf("unmarshalling controller addresses for %q: %w", requestTunnelID, err)
 		}
 
 		result = domainssh.SSHConnRequest{
@@ -664,13 +641,7 @@ func (st *State) RemoveSSHConnRequest(ctx context.Context, requestTunnelID strin
 		return errors.Capture(err)
 	}
 
-	deleteAddrsStmt, err := st.Prepare(`
-DELETE FROM ssh_connection_request_address
-WHERE tunnel_id = $tunnelID.tunnel_id`, tunnelID{})
-	if err != nil {
-		return errors.Capture(err)
-	}
-	deleteStmt, err := st.Prepare(`
+	stmt, err := st.Prepare(`
 DELETE FROM ssh_connection_request
 WHERE tunnel_id = $tunnelID.tunnel_id`, tunnelID{})
 	if err != nil {
@@ -678,11 +649,7 @@ WHERE tunnel_id = $tunnelID.tunnel_id`, tunnelID{})
 	}
 
 	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		tid := tunnelID{TunnelID: requestTunnelID}
-		if err := tx.Query(ctx, deleteAddrsStmt, tid).Run(); err != nil {
-			return errors.Errorf("deleting controller addresses for SSH connection request %q: %w", requestTunnelID, err)
-		}
-		return tx.Query(ctx, deleteStmt, tid).Run()
+		return tx.Query(ctx, stmt, tunnelID{TunnelID: requestTunnelID}).Run()
 	}))
 }
 
@@ -782,23 +749,27 @@ AND tunnel_id IN ($S[:])`, tunnelID{}, entityUUID{}, input)
 }
 
 func (st *State) pruneExpiredSSHConnRequests(ctx context.Context, tx *sqlair.TX, now time.Time) error {
-	deleteAddrsStmt, err := st.Prepare(`
-DELETE FROM ssh_connection_request_address
-WHERE tunnel_id IN (
-    SELECT tunnel_id FROM ssh_connection_request WHERE expires_at <= $expiryTime.expires_at
-)`, expiryTime{})
-	if err != nil {
-		return errors.Capture(err)
-	}
-	deleteStmt, err := st.Prepare(`
+	stmt, err := st.Prepare(`
 DELETE FROM ssh_connection_request
 WHERE expires_at <= $expiryTime.expires_at`, expiryTime{})
 	if err != nil {
 		return errors.Capture(err)
 	}
-	t := expiryTime{ExpiresAt: now}
-	if err := tx.Query(ctx, deleteAddrsStmt, t).Run(); err != nil {
-		return errors.Errorf("pruning expired SSH connection request addresses: %w", err)
+	return tx.Query(ctx, stmt, expiryTime{ExpiresAt: now}).Run()
+}
+
+func marshalControllerAddresses(addresses network.SpaceAddresses) (string, error) {
+	payload, err := json.Marshal(addresses)
+	if err != nil {
+		return "", errors.Capture(err)
 	}
-	return tx.Query(ctx, deleteStmt, t).Run()
+	return string(payload), nil
+}
+
+func unmarshalControllerAddresses(payload string) (network.SpaceAddresses, error) {
+	var addresses network.SpaceAddresses
+	if err := json.Unmarshal([]byte(payload), &addresses); err != nil {
+		return nil, errors.Capture(err)
+	}
+	return addresses, nil
 }

--- a/domain/ssh/state/model/types.go
+++ b/domain/ssh/state/model/types.go
@@ -79,28 +79,23 @@ type expiryTime struct {
 }
 
 type sshConnRequestInsert struct {
-	TunnelID           string    `db:"tunnel_id"`
-	MachineUUID        string    `db:"machine_uuid"`
-	ExpiresAt          time.Time `db:"expires_at"`
-	Username           string    `db:"username"`
-	Password           string    `db:"password"`
-	UnitPort           int       `db:"unit_port"`
-	EphemeralPublicKey []byte    `db:"ephemeral_public_key"`
+	TunnelID            string    `db:"tunnel_id"`
+	MachineUUID         string    `db:"machine_uuid"`
+	ExpiresAt           time.Time `db:"expires_at"`
+	Username            string    `db:"username"`
+	Password            string    `db:"password"`
+	ControllerAddresses string    `db:"controller_addresses"`
+	UnitPort            int       `db:"unit_port"`
+	EphemeralPublicKey  []byte    `db:"ephemeral_public_key"`
 }
 
 type sshConnRequestRecord struct {
-	TunnelID           string    `db:"tunnel_id"`
-	MachineID          string    `db:"machine_id"`
-	ExpiresAt          time.Time `db:"expires_at"`
-	Username           string    `db:"username"`
-	Password           string    `db:"password"`
-	UnitPort           int       `db:"unit_port"`
-	EphemeralPublicKey []byte    `db:"ephemeral_public_key"`
-}
-
-// sshConnRequestAddress mirrors a single row in ssh_connection_request_address.
-type sshConnRequestAddress struct {
-	TunnelID     string `db:"tunnel_id"`
-	IndexID      int    `db:"index_id"`
-	AddressValue string `db:"address_value"`
+	TunnelID            string    `db:"tunnel_id"`
+	MachineID           string    `db:"machine_id"`
+	ExpiresAt           time.Time `db:"expires_at"`
+	Username            string    `db:"username"`
+	Password            string    `db:"password"`
+	ControllerAddresses string    `db:"controller_addresses"`
+	UnitPort            int       `db:"unit_port"`
+	EphemeralPublicKey  []byte    `db:"ephemeral_public_key"`
 }

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -73,6 +73,7 @@ TEST_NAMES="actions \
             resources \
             secrets_iaas \
             secrets_k8s \
+            ssh \
             sidecar \
             smoke \
             spaces_ec2 \

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -29,7 +29,7 @@ run_start_hook_fires_after_reboot() {
 	# does not fire. In juju 2.9+, we use a unified agent so we need to restart
 	# the machine agent.
 	echo "[+] ensuring that implicit start hook does not fire after restarting the (unified) unit agent"
-	juju ssh juju-qa-test/0 'sudo service jujuagentd-machine-0 restart'
+	juju ssh juju-qa-test/0 'sudo service jujuagentd-machine-0 restart' || true
 	echo
 	wait_for "$charm" "$(charm_rev "$charm" 22)"
 	logs=$(juju debug-log --include-module juju.worker.uniter --replay --no-tail | grep -n "reboot detected" || true)

--- a/tests/suites/model/metrics.sh
+++ b/tests/suites/model/metrics.sh
@@ -26,7 +26,7 @@ run_model_metrics() {
 	juju model-config -m "$testname" logging-config="<root>=INFO;#charmhub=TRACE"
 
 	# Restarting the controller service causes the charmrevisioner worker to run.
-	juju ssh -m controller 0 -- sudo systemctl restart jujuagentd-machine-0.service
+	juju ssh -m controller 0 -- sudo systemctl restart jujuagentd-machine-0.service || true
 
 	echo "Sleep 45, give charmrevisioner time to kick off after controller jujuagentd restart."
 	sleep 45
@@ -68,7 +68,7 @@ run_empty_model_metrics() {
 	juju model-config -m "$testname" logging-config="<root>=INFO;#charmhub=TRACE"
 
 	# Restarting the controller service causes the charmrevisioner worker to run.
-	juju ssh -m controller 0 -- sudo systemctl restart jujuagentd-machine-0.service
+	juju ssh -m controller 0 -- sudo systemctl restart jujuagentd-machine-0.service || true
 
 	echo "Sleep 45, give charmrevisioner time to kick off after controller jujuagentd restart."
 	sleep 45
@@ -110,7 +110,7 @@ run_model_metrics_disabled() {
 	juju model-config -m "$testname" logging-config="<root>=INFO;#charmhub=TRACE"
 
 	# Restarting the controller service causes the charmrevisioner worker to run.
-	juju ssh -m controller 0 -- sudo systemctl restart jujuagentd-machine-0.service
+	juju ssh -m controller 0 -- sudo systemctl restart jujuagentd-machine-0.service || true
 
 	echo "Sleep 120, give charmrevisioner time to kick off after controller jujuagentd restart."
 	sleep 120

--- a/tests/suites/spaces_ec2/util.sh
+++ b/tests/suites/spaces_ec2/util.sh
@@ -47,7 +47,7 @@ add_multi_nic_machine() {
 	done
 
 	echo "[+] restarting machine agent on ${juju_machine_id}..."
-	juju ssh "${juju_machine_id}" 'sudo systemctl restart jujuagentd-machine-*'
+	juju ssh "${juju_machine_id}" 'sudo systemctl restart jujuagentd-machine-*' || true
 
 	# Wait for the interface to be detected by juju
 	echo "[+] waiting for juju to detect added NIC"

--- a/tests/suites/ssh/ssh.sh
+++ b/tests/suites/ssh/ssh.sh
@@ -1,0 +1,75 @@
+test_ssh_machine() {
+	if [ "$(skip 'test_ssh_machine')" ]; then
+		echo "==> TEST SKIPPED: machine SSH and SCP tests"
+		return
+	fi
+
+	local model_name local_file remote_file copied_file output
+	model_name="test-ssh-machine"
+	add_model "${model_name}"
+
+	juju deploy juju-qa-test ssh-test --base ubuntu@22.04
+	wait_for "ssh-test" "$(idle_condition "ssh-test")"
+
+	# Verify command execution on the machine hosting the unit.
+	# shellcheck disable=SC2016
+	output=$(juju ssh ssh-test/0 -- printf 'ssh-machine:%s $(hostname)')
+	check_contains "${output}" "ssh-machine:juju-"
+
+	# Verify command execution using the machine target syntax.
+	output=$(juju ssh 0 -- printf machine-target)
+	check_contains "${output}" "machine-target"
+
+	local_file="${TEST_DIR}/machine-local.txt"
+	remote_file="/tmp/juju-ssh-suite.txt"
+	copied_file="${TEST_DIR}/machine-copied.txt"
+	echo "machine-scp-test" >"${local_file}"
+
+	# Copy to the machine and read the result remotely.
+	juju scp "${local_file}" "0:${remote_file}"
+	output=$(juju ssh 0 -- cat "${remote_file}")
+	check_contains "${output}" "machine-scp-test"
+
+	# Copy back from the machine and verify the local file contents.
+	juju scp "0:${remote_file}" "${copied_file}"
+	check_contains "$(cat "${copied_file}")" "machine-scp-test"
+
+	destroy_model "${model_name}"
+}
+
+test_ssh_k8s() {
+	if [ "$(skip 'test_ssh_k8s')" ]; then
+		echo "==> TEST SKIPPED: Kubernetes SSH and SCP tests"
+		return
+	fi
+
+	local model_name local_file remote_file copied_file output
+	model_name="test-ssh-k8s"
+	add_model "${model_name}"
+
+	juju deploy snappass-test ssh-test
+	wait_for "ssh-test" "$(idle_condition "ssh-test")"
+
+	# The default target is the charm container. The explicit container target
+	# exercises the same route used by sidecar workloads.
+	output=$(juju ssh ssh-test/0 -- printf operator-container)
+	check_contains "${output}" "operator-container"
+
+	output=$(juju ssh --container redis ssh-test/0 -- printf workload-container)
+	check_contains "${output}" "workload-container"
+
+	local_file="${TEST_DIR}/k8s-local.txt"
+	remote_file="/tmp/juju-ssh-suite.txt"
+	copied_file="${TEST_DIR}/k8s-copied.txt"
+	echo "k8s-scp-test" >"${local_file}"
+
+	# Copy to and from the sidecar container.
+	juju scp --container redis "${local_file}" "ssh-test/0:${remote_file}"
+	output=$(juju ssh --container redis ssh-test/0 -- cat "${remote_file}")
+	check_contains "${output}" "k8s-scp-test"
+
+	juju scp --container redis "ssh-test/0:${remote_file}" "${copied_file}"
+	check_contains "$(cat "${copied_file}")" "k8s-scp-test"
+
+	destroy_model "${model_name}"
+}

--- a/tests/suites/ssh/task.sh
+++ b/tests/suites/ssh/task.sh
@@ -1,0 +1,25 @@
+test_ssh() {
+	if [ "$(skip 'test_ssh')" ]; then
+		echo "==> TEST SKIPPED: SSH and SCP tests"
+		return
+	fi
+
+	set_verbosity
+
+	echo "==> Checking for dependencies"
+	check_dependencies juju
+
+	file="${TEST_DIR}/test-ssh.log"
+	bootstrap "test-ssh" "${file}"
+
+	case "${BOOTSTRAP_PROVIDER:-}" in
+	"k8s")
+		test_ssh_k8s
+		;;
+	*)
+		test_ssh_machine
+		;;
+	esac
+
+	destroy_controller "test-ssh"
+}


### PR DESCRIPTION
This change lumps several changes together split by commit (I recommend reviewing by commit) in order to make `juju ssh --jump` the default behaviour and gets rid of the flag. Specifically the changes are:
1. Change the default command when SSHing to K8s pods to match existing behaviour i.e. execute a login shell.
2. Remove the `--jump` flag in favor of a `juju ssh --direct` flag. `--direct` maintains compatability with Juju 3.6 controllers.
3. Add bash suite tests for `juju ssh` and `juju scp`.
4. Machine cleanup - the `ssh_connection_request` and `ssh_connection_request_address` tables were not cleaned up on machine deletion, preventing teardown. I've removed the `ssh_connection_request_address` table which was initially done based on https://github.com/juju/juju/pull/22712#discussion_r3466332987. In my opinion this table was not serving a purpose beyond complicating the schema.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Test K8s,
```
cd tests && ./main.sh -v -p k8s -c microk8s ssh
```

Tests machine,
```
cd tests && ./main.sh -v -p lxd ssh
```

To verify 3.6 behaviour,
1. Use a 3.6 snap to bootstrap a 3.6 controller
2. juju add-model test
3. juju deploy ubuntu
4. make install
5. juju ssh 0 # should return an error indicating that you should try --direct
6. juju ssh --direct 0

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-9954](https://warthogs.atlassian.net/browse/JUJU-9954)


[JUJU-9954]: https://warthogs.atlassian.net/browse/JUJU-9954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ