### PR TITLE
fix(model): consolidate CreateModel variants to fix missing storage pool seeding

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -397,32 +397,10 @@ func (m *ModelManagerAPI) createModelInfo(
 		suppliedAgentStream = modelDefaultStream
 	}
 
-	// If the user has supplied both a target agent version and agent stream
-	if suppliedAgentVersion != semversion.Zero &&
-		!suppliedAgentStream.IsZero() {
-		return modelInfoService.CreateModelWithAgentVersionStream(
-			ctx, suppliedAgentVersion, suppliedAgentStream,
-		)
-	}
-
-	// If the user has supplied a target agent version but no agent stream
-	if suppliedAgentVersion != semversion.Zero &&
-		suppliedAgentStream.IsZero() {
-		return modelInfoService.CreateModelWithAgentVersion(
-			ctx, suppliedAgentVersion,
-		)
-	}
-
-	// If the user has supplied an agent stream and not target agent version.
-	if suppliedAgentVersion == semversion.Zero &&
-		!suppliedAgentStream.IsZero() {
-		return modelInfoService.CreateModelWithAgentStream(
-			ctx, suppliedAgentStream,
-		)
-	}
-
-	// If the user has supplied nothing and no cloud default exists.
-	return modelInfoService.CreateModel(ctx)
+	// Defaults for the zero case are resolved in the domain service
+	// implementation, which also seeds provider resources and default
+	// storage pools.
+	return modelInfoService.CreateModel(ctx, suppliedAgentVersion, suppliedAgentStream)
 }
 
 // agentStreamFromModelDefaults reads the model defaults for the given model
@@ -441,14 +419,14 @@ func (m *ModelManagerAPI) agentStreamFromModelDefaults(
 
 	attr, ok := defaults[config.AgentStreamKey]
 	if !ok {
-		return "", nil
+		return coreagentbinary.AgentStreamZero, nil
 	}
 
 	if streamStr, ok := attr.Value().(string); ok && streamStr != "" {
 		return coreagentbinary.AgentStream(streamStr), nil
 	}
 
-	return "", nil
+	return coreagentbinary.AgentStreamZero, nil
 }
 
 func (m *ModelManagerAPI) dumpModel(ctx context.Context, args params.Entity) ([]byte, error) {

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -375,7 +375,7 @@ func (m *ModelManagerAPI) createModelInfo(
 		delete(configArgs, config.AgentVersionKey)
 	}
 
-	suppliedAgentStream := coreagentbinary.AgentStream("")
+	suppliedAgentStream := coreagentbinary.AgentStreamZero
 	if agentStreamVal, exists := configArgs[config.AgentStreamKey]; exists {
 		agentStreamStr, isStr := agentStreamVal.(string)
 		if !isStr {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -365,7 +365,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithCloud(c *tc.C) {
 
 	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
 	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
-	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), semversion.Zero, coreagentbinary.AgentStream("")).Return(nil)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), semversion.Zero, coreagentbinary.AgentStreamZero).Return(nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -382,7 +382,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *tc.C) {
 
 	s.expectCreateModel(c, ctrl, args, credential.Key{Cloud: "dummy", Owner: coreuser.AdminUserName, Name: "some-credential"}, "dummy", "dummy-region")
 	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
-	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), semversion.Zero, coreagentbinary.AgentStream("")).Return(nil)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), semversion.Zero, coreagentbinary.AgentStreamZero).Return(nil)
 	s.modelService.EXPECT().DefaultCloudCredentialKeyForOwner(gomock.Any(), usertesting.GenNewName(c, "admin"), "dummy").Return(credential.Key{Name: "some-credential", Cloud: "dummy", Owner: usertesting.GenNewName(c, "admin")}, nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
@@ -400,7 +400,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultCredentialAdmin(c *tc.C) {
 
 	s.expectCreateModel(c, ctrl, args, credential.Key{Cloud: "dummy", Owner: coreuser.AdminUserName, Name: "some-credential"}, "dummy", "dummy-region")
 	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
-	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), semversion.Zero, coreagentbinary.AgentStream("")).Return(nil)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), semversion.Zero, coreagentbinary.AgentStreamZero).Return(nil)
 	s.modelService.EXPECT().DefaultCloudCredentialKeyForOwner(gomock.Any(), usertesting.GenNewName(c, "admin"), "dummy").Return(credential.Key{Name: "some-credential", Cloud: "dummy", Owner: usertesting.GenNewName(c, "admin")}, nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
@@ -430,7 +430,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersion(c *tc.C) {
 
 	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
 	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
-	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), jujuversion.Current, coreagentbinary.AgentStream("")).Return(nil)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), jujuversion.Current, coreagentbinary.AgentStreamZero).Return(nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -365,7 +365,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithCloud(c *tc.C) {
 
 	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
 	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
-	s.modelInfoService.EXPECT().CreateModel(gomock.Any()).Return(nil)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), semversion.Zero, coreagentbinary.AgentStream("")).Return(nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -382,7 +382,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultRegion(c *tc.C) {
 
 	s.expectCreateModel(c, ctrl, args, credential.Key{Cloud: "dummy", Owner: coreuser.AdminUserName, Name: "some-credential"}, "dummy", "dummy-region")
 	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
-	s.modelInfoService.EXPECT().CreateModel(gomock.Any()).Return(nil)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), semversion.Zero, coreagentbinary.AgentStream("")).Return(nil)
 	s.modelService.EXPECT().DefaultCloudCredentialKeyForOwner(gomock.Any(), usertesting.GenNewName(c, "admin"), "dummy").Return(credential.Key{Name: "some-credential", Cloud: "dummy", Owner: usertesting.GenNewName(c, "admin")}, nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
@@ -400,7 +400,7 @@ func (s *modelManagerSuite) TestCreateModelDefaultCredentialAdmin(c *tc.C) {
 
 	s.expectCreateModel(c, ctrl, args, credential.Key{Cloud: "dummy", Owner: coreuser.AdminUserName, Name: "some-credential"}, "dummy", "dummy-region")
 	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
-	s.modelInfoService.EXPECT().CreateModel(gomock.Any()).Return(nil)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), semversion.Zero, coreagentbinary.AgentStream("")).Return(nil)
 	s.modelService.EXPECT().DefaultCloudCredentialKeyForOwner(gomock.Any(), usertesting.GenNewName(c, "admin"), "dummy").Return(credential.Key{Name: "some-credential", Cloud: "dummy", Owner: usertesting.GenNewName(c, "admin")}, nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
@@ -430,7 +430,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersion(c *tc.C) {
 
 	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
 	s.modelDefaultService.EXPECT().ModelDefaults(gomock.Any(), gomock.Any()).Return(modeldefaults.Defaults{}, nil)
-	s.modelInfoService.EXPECT().CreateModelWithAgentVersion(gomock.Any(), jujuversion.Current).Return(nil)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), jujuversion.Current, coreagentbinary.AgentStream("")).Return(nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -470,7 +470,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentStream(c *tc.C) {
 	}
 
 	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
-	s.modelInfoService.EXPECT().CreateModelWithAgentStream(gomock.Any(), coreagentbinary.AgentStreamReleased).Return(nil)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), semversion.Zero, coreagentbinary.AgentStreamReleased).Return(nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)
@@ -480,7 +480,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentStream(c *tc.C) {
 // that when the user supplies only an agent version (no stream) but a
 // cloud default for agent-stream exists, the model is created with both
 // the supplied version and the cloud default stream via
-// CreateModelWithAgentVersionStream.
+// CreateModel.
 func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersionAndCloudDefaultStream(c *tc.C) {
 	ctrl := s.setUpAPI(c)
 	defer ctrl.Finish()
@@ -509,7 +509,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersionAndCloudDefaultSt
 				Controller: "testing",
 			},
 		}, nil)
-	s.modelInfoService.EXPECT().CreateModelWithAgentVersionStream(
+	s.modelInfoService.EXPECT().CreateModel(
 		gomock.Any(), jujuversion.Current, coreagentbinary.AgentStreamTesting,
 	).Return(nil)
 
@@ -548,8 +548,8 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentStreamFromCloudDefaults(
 			},
 		}, nil)
 
-	s.modelInfoService.EXPECT().CreateModelWithAgentStream(
-		gomock.Any(), coreagentbinary.AgentStreamTesting,
+	s.modelInfoService.EXPECT().CreateModel(
+		gomock.Any(), semversion.Zero, coreagentbinary.AgentStreamTesting,
 	).Return(nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
@@ -579,7 +579,7 @@ func (s *modelManagerSuite) TestCreateModelArgsWithAgentVersionAndStream(c *tc.C
 	}
 
 	s.expectCreateModel(c, ctrl, args, cloudCredental, "dummy", "qux")
-	s.modelInfoService.EXPECT().CreateModelWithAgentVersionStream(gomock.Any(), jujuversion.Current, coreagentbinary.AgentStreamReleased).Return(nil)
+	s.modelInfoService.EXPECT().CreateModel(gomock.Any(), jujuversion.Current, coreagentbinary.AgentStreamReleased).Return(nil)
 
 	_, err := s.api.CreateModel(c.Context(), args)
 	c.Assert(err, tc.ErrorIsNil)

--- a/apiserver/facades/client/modelmanager/service_mock_test.go
+++ b/apiserver/facades/client/modelmanager/service_mock_test.go
@@ -624,16 +624,13 @@ type MockModelInfoService struct {
 
 // MockModelInfoServiceMockRecorder is the mock recorder for MockModelInfoService.
 type MockModelInfoServiceMockRecorder struct {
-	mock                                     *MockModelInfoService
-	createModelExpects                       []*gomock.Call1_1[context.Context, error]
-	createModelWithAgentStreamExpects        []*gomock.Call2_1[context.Context, agentbinary.AgentStream, error]
-	createModelWithAgentVersionExpects       []*gomock.Call2_1[context.Context, semversion.Number, error]
-	createModelWithAgentVersionStreamExpects []*gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
-	getModelInfoExpects                      []*gomock.Call1_2[context.Context, model.ModelInfo, error]
-	getModelSummaryExpects                   []*gomock.Call1_2[context.Context, model.ModelSummary, error]
-	getUserModelSummaryExpects               []*gomock.Call2_2[context.Context, user.UUID, model.UserModelSummary, error]
-	hasValidCredentialExpects                []*gomock.Call1_2[context.Context, bool, error]
-	isControllerModelExpects                 []*gomock.Call1_2[context.Context, bool, error]
+	mock                       *MockModelInfoService
+	createModelExpects         []*gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
+	getModelInfoExpects        []*gomock.Call1_2[context.Context, model.ModelInfo, error]
+	getModelSummaryExpects     []*gomock.Call1_2[context.Context, model.ModelSummary, error]
+	getUserModelSummaryExpects []*gomock.Call2_2[context.Context, user.UUID, model.UserModelSummary, error]
+	hasValidCredentialExpects  []*gomock.Call1_2[context.Context, bool, error]
+	isControllerModelExpects   []*gomock.Call1_2[context.Context, bool, error]
 }
 
 // NewMockModelInfoService creates a new mock instance.
@@ -649,76 +646,22 @@ func (m *MockModelInfoService) EXPECT() *MockModelInfoServiceMockRecorder {
 }
 
 // CreateModel mocks base method.
-func (m *MockModelInfoService) CreateModel(arg0 context.Context) error {
+func (m *MockModelInfoService) CreateModel(arg0 context.Context, arg1 semversion.Number, arg2 agentbinary.AgentStream) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch1_1(&m.recorder.createModelExpects, m.ctrl, m, "CreateModel", arg0)
+	return gomock.Dispatch3_1(&m.recorder.createModelExpects, m.ctrl, m, "CreateModel", arg0, arg1, arg2)
 }
 
 // CreateModel indicates an expected call of CreateModel.
-func (mr *MockModelInfoServiceMockRecorder) CreateModel(arg0 any) *MockModelInfoServiceCreateModelCall {
+func (mr *MockModelInfoServiceMockRecorder) CreateModel(arg0, arg1, arg2 any) *MockModelInfoServiceCreateModelCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_1[context.Context, error](mr.mock.ctrl.T, mr.mock, "CreateModel", gomock.EnsureMatcher(arg0))
+	call := gomock.NewCall3_1[context.Context, semversion.Number, agentbinary.AgentStream, error](mr.mock.ctrl.T, mr.mock, "CreateModel", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
 	mr.createModelExpects = append(mr.createModelExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockModelInfoServiceCreateModelCall is the typed call wrapper for CreateModel.
-type MockModelInfoServiceCreateModelCall = gomock.Call1_1[context.Context, error]
-
-// CreateModelWithAgentStream mocks base method.
-func (m *MockModelInfoService) CreateModelWithAgentStream(arg0 context.Context, arg1 agentbinary.AgentStream) error {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch2_1(&m.recorder.createModelWithAgentStreamExpects, m.ctrl, m, "CreateModelWithAgentStream", arg0, arg1)
-}
-
-// CreateModelWithAgentStream indicates an expected call of CreateModelWithAgentStream.
-func (mr *MockModelInfoServiceMockRecorder) CreateModelWithAgentStream(arg0, arg1 any) *MockModelInfoServiceCreateModelWithAgentStreamCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, agentbinary.AgentStream, error](mr.mock.ctrl.T, mr.mock, "CreateModelWithAgentStream", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
-	mr.createModelWithAgentStreamExpects = append(mr.createModelWithAgentStreamExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockModelInfoServiceCreateModelWithAgentStreamCall is the typed call wrapper for CreateModelWithAgentStream.
-type MockModelInfoServiceCreateModelWithAgentStreamCall = gomock.Call2_1[context.Context, agentbinary.AgentStream, error]
-
-// CreateModelWithAgentVersion mocks base method.
-func (m *MockModelInfoService) CreateModelWithAgentVersion(arg0 context.Context, arg1 semversion.Number) error {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch2_1(&m.recorder.createModelWithAgentVersionExpects, m.ctrl, m, "CreateModelWithAgentVersion", arg0, arg1)
-}
-
-// CreateModelWithAgentVersion indicates an expected call of CreateModelWithAgentVersion.
-func (mr *MockModelInfoServiceMockRecorder) CreateModelWithAgentVersion(arg0, arg1 any) *MockModelInfoServiceCreateModelWithAgentVersionCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall2_1[context.Context, semversion.Number, error](mr.mock.ctrl.T, mr.mock, "CreateModelWithAgentVersion", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1))
-	mr.createModelWithAgentVersionExpects = append(mr.createModelWithAgentVersionExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockModelInfoServiceCreateModelWithAgentVersionCall is the typed call wrapper for CreateModelWithAgentVersion.
-type MockModelInfoServiceCreateModelWithAgentVersionCall = gomock.Call2_1[context.Context, semversion.Number, error]
-
-// CreateModelWithAgentVersionStream mocks base method.
-func (m *MockModelInfoService) CreateModelWithAgentVersionStream(arg0 context.Context, arg1 semversion.Number, arg2 agentbinary.AgentStream) error {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch3_1(&m.recorder.createModelWithAgentVersionStreamExpects, m.ctrl, m, "CreateModelWithAgentVersionStream", arg0, arg1, arg2)
-}
-
-// CreateModelWithAgentVersionStream indicates an expected call of CreateModelWithAgentVersionStream.
-func (mr *MockModelInfoServiceMockRecorder) CreateModelWithAgentVersionStream(arg0, arg1, arg2 any) *MockModelInfoServiceCreateModelWithAgentVersionStreamCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall3_1[context.Context, semversion.Number, agentbinary.AgentStream, error](mr.mock.ctrl.T, mr.mock, "CreateModelWithAgentVersionStream", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
-	mr.createModelWithAgentVersionStreamExpects = append(mr.createModelWithAgentVersionStreamExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockModelInfoServiceCreateModelWithAgentVersionStreamCall is the typed call wrapper for CreateModelWithAgentVersionStream.
-type MockModelInfoServiceCreateModelWithAgentVersionStreamCall = gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
+type MockModelInfoServiceCreateModelCall = gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
 
 // GetModelInfo mocks base method.
 func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ModelInfo, error) {

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -167,27 +167,10 @@ type ModelDefaultsService interface {
 // state.
 type ModelInfoService interface {
 	// CreateModel is responsible for creating a new model within the model
-	// database. Upon creating the model any information required in the model's
-	// provider will be initialised.
-	CreateModel(context.Context) error
-
-	// CreateModelWithAgentVersion is responsible for creating a new model within
-	// the model database using the specified agent version. Upon creating the
-	// model any information required in the model's provider will be
-	// initialised.
-	CreateModelWithAgentVersion(context.Context, semversion.Number) error
-
-	// CreateModelWithAgentStream is responsible for creating a new model within
-	// the model database using the specified agent stream. Upon creating the
-	// model any information required in the model's provider will be
-	// initialised.
-	CreateModelWithAgentStream(context.Context, agentbinary.AgentStream) error
-
-	// CreateModelWithAgentVersionStream is responsible for creating a new model
-	// within the model database using the specified agent version and agent
-	// stream. Upon creating the model any information required in the model's
-	// provider will be initialised.
-	CreateModelWithAgentVersionStream(
+	// database using the input agent version and agent stream. If either is
+	// the zero value a sensible default is used. Upon creating the model any
+	// information required in the model's provider will be initialised.
+	CreateModel(
 		context.Context, semversion.Number, agentbinary.AgentStream,
 	) error
 

--- a/domain/model/modelmigration/import.go
+++ b/domain/model/modelmigration/import.go
@@ -81,7 +81,7 @@ type ModelDetailService interface {
 	// - [modelerrors.AlreadyExists] when the model uuid is already in use.
 	// - [modelerrors.AgentVersionNotSupported] when the agent version is not
 	// supported.
-	// - [coreerrors.NotValid] when the agent stream is not valid.
+	// - [modelerrors.AgentStreamNotValid] when the agent stream is not valid.
 	CreateModel(context.Context, semversion.Number, agentbinary.AgentStream) error
 
 	// CreateImportingModelWithAgentVersionStream is responsible for creating a new

--- a/domain/model/modelmigration/import.go
+++ b/domain/model/modelmigration/import.go
@@ -73,17 +73,6 @@ type ModelImportService interface {
 // ModelDetailService defines a service for interacting with the
 // model information found in a model database.
 type ModelDetailService interface {
-	// CreateModel is responsible for creating a new model
-	// within the model database using the input agent version and agent
-	// stream.
-	//
-	// The following error types can be expected to be returned:
-	// - [modelerrors.AlreadyExists] when the model uuid is already in use.
-	// - [modelerrors.AgentVersionNotSupported] when the agent version is not
-	// supported.
-	// - [modelerrors.AgentStreamNotValid] when the agent stream is not valid.
-	CreateModel(context.Context, semversion.Number, agentbinary.AgentStream) error
-
 	// CreateImportingModelWithAgentVersionStream is responsible for creating a new
 	// model within the model database during model import, using the input agent
 	// version and agent stream. This method creates the model and marks it as

--- a/domain/model/modelmigration/import.go
+++ b/domain/model/modelmigration/import.go
@@ -73,14 +73,16 @@ type ModelImportService interface {
 // ModelDetailService defines a service for interacting with the
 // model information found in a model database.
 type ModelDetailService interface {
-	// within the model database using the specified agent version and agent stream.
+	// CreateModel is responsible for creating a new model
+	// within the model database using the input agent version and agent
+	// stream.
 	//
 	// The following error types can be expected to be returned:
 	// - [modelerrors.AlreadyExists] when the model uuid is already in use.
 	// - [modelerrors.AgentVersionNotSupported] when the agent version is not
 	// supported.
 	// - [coreerrors.NotValid] when the agent stream is not valid.
-	CreateModelWithAgentVersionStream(context.Context, semversion.Number, agentbinary.AgentStream) error
+	CreateModel(context.Context, semversion.Number, agentbinary.AgentStream) error
 
 	// CreateImportingModelWithAgentVersionStream is responsible for creating a new
 	// model within the model database during model import, using the input agent

--- a/domain/model/modelmigration/migrations_mock_test.go
+++ b/domain/model/modelmigration/migrations_mock_test.go
@@ -94,7 +94,7 @@ type MockModelDetailService struct {
 type MockModelDetailServiceMockRecorder struct {
 	mock                                              *MockModelDetailService
 	createImportingModelWithAgentVersionStreamExpects []*gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
-	createModelWithAgentVersionStreamExpects          []*gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
+	createModelExpects                                []*gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
 	setModelConstraintsExpects                        []*gomock.Call2_1[context.Context, constraints.Value, error]
 }
 
@@ -128,23 +128,23 @@ func (mr *MockModelDetailServiceMockRecorder) CreateImportingModelWithAgentVersi
 // MockModelDetailServiceCreateImportingModelWithAgentVersionStreamCall is the typed call wrapper for CreateImportingModelWithAgentVersionStream.
 type MockModelDetailServiceCreateImportingModelWithAgentVersionStreamCall = gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
 
-// CreateModelWithAgentVersionStream mocks base method.
-func (m *MockModelDetailService) CreateModelWithAgentVersionStream(arg0 context.Context, arg1 semversion.Number, arg2 agentbinary.AgentStream) error {
+// CreateModel mocks base method.
+func (m *MockModelDetailService) CreateModel(arg0 context.Context, arg1 semversion.Number, arg2 agentbinary.AgentStream) error {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch3_1(&m.recorder.createModelWithAgentVersionStreamExpects, m.ctrl, m, "CreateModelWithAgentVersionStream", arg0, arg1, arg2)
+	return gomock.Dispatch3_1(&m.recorder.createModelExpects, m.ctrl, m, "CreateModel", arg0, arg1, arg2)
 }
 
-// CreateModelWithAgentVersionStream indicates an expected call of CreateModelWithAgentVersionStream.
-func (mr *MockModelDetailServiceMockRecorder) CreateModelWithAgentVersionStream(arg0, arg1, arg2 any) *MockModelDetailServiceCreateModelWithAgentVersionStreamCall {
+// CreateModel indicates an expected call of CreateModel.
+func (mr *MockModelDetailServiceMockRecorder) CreateModel(arg0, arg1, arg2 any) *MockModelDetailServiceCreateModelCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall3_1[context.Context, semversion.Number, agentbinary.AgentStream, error](mr.mock.ctrl.T, mr.mock, "CreateModelWithAgentVersionStream", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
-	mr.createModelWithAgentVersionStreamExpects = append(mr.createModelWithAgentVersionStreamExpects, call)
+	call := gomock.NewCall3_1[context.Context, semversion.Number, agentbinary.AgentStream, error](mr.mock.ctrl.T, mr.mock, "CreateModel", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
+	mr.createModelExpects = append(mr.createModelExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
-// MockModelDetailServiceCreateModelWithAgentVersionStreamCall is the typed call wrapper for CreateModelWithAgentVersionStream.
-type MockModelDetailServiceCreateModelWithAgentVersionStreamCall = gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
+// MockModelDetailServiceCreateModelCall is the typed call wrapper for CreateModel.
+type MockModelDetailServiceCreateModelCall = gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
 
 // SetModelConstraints mocks base method.
 func (m *MockModelDetailService) SetModelConstraints(arg0 context.Context, arg1 constraints.Value) error {

--- a/domain/model/modelmigration/migrations_mock_test.go
+++ b/domain/model/modelmigration/migrations_mock_test.go
@@ -94,7 +94,6 @@ type MockModelDetailService struct {
 type MockModelDetailServiceMockRecorder struct {
 	mock                                              *MockModelDetailService
 	createImportingModelWithAgentVersionStreamExpects []*gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
-	createModelExpects                                []*gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
 	setModelConstraintsExpects                        []*gomock.Call2_1[context.Context, constraints.Value, error]
 }
 
@@ -127,24 +126,6 @@ func (mr *MockModelDetailServiceMockRecorder) CreateImportingModelWithAgentVersi
 
 // MockModelDetailServiceCreateImportingModelWithAgentVersionStreamCall is the typed call wrapper for CreateImportingModelWithAgentVersionStream.
 type MockModelDetailServiceCreateImportingModelWithAgentVersionStreamCall = gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
-
-// CreateModel mocks base method.
-func (m *MockModelDetailService) CreateModel(arg0 context.Context, arg1 semversion.Number, arg2 agentbinary.AgentStream) error {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch3_1(&m.recorder.createModelExpects, m.ctrl, m, "CreateModel", arg0, arg1, arg2)
-}
-
-// CreateModel indicates an expected call of CreateModel.
-func (mr *MockModelDetailServiceMockRecorder) CreateModel(arg0, arg1, arg2 any) *MockModelDetailServiceCreateModelCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall3_1[context.Context, semversion.Number, agentbinary.AgentStream, error](mr.mock.ctrl.T, mr.mock, "CreateModel", gomock.EnsureMatcher(arg0), gomock.EnsureMatcher(arg1), gomock.EnsureMatcher(arg2))
-	mr.createModelExpects = append(mr.createModelExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockModelDetailServiceCreateModelCall is the typed call wrapper for CreateModel.
-type MockModelDetailServiceCreateModelCall = gomock.Call3_1[context.Context, semversion.Number, agentbinary.AgentStream, error]
 
 // SetModelConstraints mocks base method.
 func (m *MockModelDetailService) SetModelConstraints(arg0 context.Context, arg1 constraints.Value) error {

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -418,71 +418,31 @@ func (s *ModelService) GetModelType(ctx context.Context) (coremodel.ModelType, e
 }
 
 // CreateModel is responsible for creating a new model within the model
-// database, using the input agent version.
+// database, using the input agent version and agent stream. If either
+// argument is the zero value, a sensible default is supplied
+// ([jujuversion.Current] / [agentbinary.AgentStreamReleased]).
 //
 // The following error types can be expected to be returned:
 // - [modelerrors.AlreadyExists] when the model uuid is already in use.
+// - [coreerrors.NotValid] when the agent stream is not valid.
+// - [modelerrors.AgentVersionNotSupported] when the agent version is not
+// supported.
 func (s *ModelService) CreateModel(
 	ctx context.Context,
+	agentVersion semversion.Number,
+	agentStream agentbinary.AgentStream,
 ) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
+
 	defaultAgentVersion, defaultAgentStream := agentVersionSelector()
-	return s.CreateModelWithAgentVersionStream(
-		ctx, defaultAgentVersion, defaultAgentStream,
-	)
-}
 
-// CreateModelWithAgentVersion is responsible for creating a new model within
-// the model database using the specified agent version.
-//
-// The following error types can be expected to be returned:
-// - [modelerrors.AlreadyExists] when the model uuid is already in use.
-// - [modelerrors.AgentVersionNotSupported] when the agent version is not
-// supported.
-func (s *ModelService) CreateModelWithAgentVersion(
-	ctx context.Context,
-	agentVersion semversion.Number,
-) error {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-
-	_, defaultAgentStream := agentVersionSelector()
-	return s.CreateModelWithAgentVersionStream(ctx, agentVersion, defaultAgentStream)
-}
-
-// CreateModelWithAgentStream is responsible for creating a new model within
-// the model database using the specified agent stream.
-//
-// The following error types can be expected to be returned:
-// - [modelerrors.AlreadyExists] when the model uuid is already in use.
-// - [coreerrors.NotValid] when the agent stream is not valid.
-func (s *ModelService) CreateModelWithAgentStream(
-	ctx context.Context,
-	agentStream agentbinary.AgentStream,
-) error {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-
-	defaultAgentVersion, _ := agentVersionSelector()
-	return s.CreateModelWithAgentVersionStream(ctx, defaultAgentVersion, agentStream)
-}
-
-// CreateModelWithAgentVersionStream is responsible for creating a new model
-// within the model database, using the input agent version and agent stream.
-//
-// The following error types can be expected to be returned:
-// - [modelerrors.AlreadyExists] when the model uuid is already in use.
-// - [coreerrors.NotValid] when the agent stream is not valid.
-// - [modelerrors.AgentVersionNotSupported] when the agent version is not
-// supported.
-func (s *ModelService) CreateModelWithAgentVersionStream(
-	ctx context.Context,
-	agentVersion semversion.Number,
-	agentStream agentbinary.AgentStream,
-) error {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
+	if agentVersion == semversion.Zero {
+		agentVersion = defaultAgentVersion
+	}
+	if agentStream.IsZero() {
+		agentStream = defaultAgentStream
+	}
 
 	m, err := s.controllerSt.GetModelSeedInformation(ctx, s.modelUUID)
 	if err != nil {
@@ -968,71 +928,16 @@ func (s *ProviderModelService) ResolveConstraints(
 }
 
 // CreateModel is responsible for creating a new model within the model
-// database. Upon creating the model any information required in the model's
-// provider will be initialised.
-//
-// The following error types can be expected to be returned:
-// - [modelerrors.AlreadyExists] when the model uuid is already in use.
-func (s *ProviderModelService) CreateModel(
-	ctx context.Context,
-) error {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-
-	if err := s.ModelService.CreateModel(ctx); err != nil {
-		return errors.Capture(err)
-	}
-
-	err := s.SeedDefaultStoragePools(ctx)
-	if err != nil {
-		return errors.Errorf(
-			"seeding default storage pools into new model: %w", err,
-		)
-	}
-
-	return s.createModelProviderResources(ctx)
-}
-
-// CreateModelWithAgentVersion is responsible for creating a new model within
-// the model database using the specified agent version. Upon creating the model
+// database using the input agent version and agent stream. If either argument
+// is the zero value, a sensible default is supplied. Upon creating the model
 // any information required in the model's provider will be initialised.
 //
 // The following error types can be expected to be returned:
 // - [modelerrors.AlreadyExists] when the model uuid is already in use.
-// - [modelerrors.AgentVersionNotSupported] when the agent version is not
-// supported.
-func (s *ProviderModelService) CreateModelWithAgentVersion(
-	ctx context.Context,
-	agentVersion semversion.Number,
-) error {
-	ctx, span := trace.Start(ctx, trace.NameFromFunc())
-	defer span.End()
-
-	if err := s.ModelService.CreateModelWithAgentVersion(ctx, agentVersion); err != nil {
-		return errors.Capture(err)
-	}
-
-	err := s.SeedDefaultStoragePools(ctx)
-	if err != nil {
-		return errors.Errorf(
-			"seeding default storage pools into new model: %w", err,
-		)
-	}
-
-	return s.createModelProviderResources(ctx)
-}
-
-// CreateModelWithAgentVersionStream is responsible for creating a new model
-// within the model database using the specified agent version and agent stream.
-// Upon creating the model any information required in the model's provider
-// will be initialised.
-//
-// The following error types can be expected to be returned:
-// - [modelerrors.AlreadyExists] when the model uuid is already in use.
-// - [modelerrors.AgentVersionNotSupported] when the agent version is not
-// supported.
 // - [coreerrors.NotValid] when the agent stream is not valid.
-func (s *ProviderModelService) CreateModelWithAgentVersionStream(
+// - [modelerrors.AgentVersionNotSupported] when the agent version is not
+// supported.
+func (s *ProviderModelService) CreateModel(
 	ctx context.Context,
 	agentVersion semversion.Number,
 	agentStream agentbinary.AgentStream,
@@ -1040,9 +945,7 @@ func (s *ProviderModelService) CreateModelWithAgentVersionStream(
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	if err := s.ModelService.CreateModelWithAgentVersionStream(
-		ctx, agentVersion, agentStream,
-	); err != nil {
+	if err := s.ModelService.CreateModel(ctx, agentVersion, agentStream); err != nil {
 		return errors.Capture(err)
 	}
 

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -424,7 +424,7 @@ func (s *ModelService) GetModelType(ctx context.Context) (coremodel.ModelType, e
 //
 // The following error types can be expected to be returned:
 // - [modelerrors.AlreadyExists] when the model uuid is already in use.
-// - [coreerrors.NotValid] when the agent stream is not valid.
+// - [modelerrors.AgentStreamNotValid] when the agent stream is not valid.
 // - [modelerrors.AgentVersionNotSupported] when the agent version is not
 // supported.
 func (s *ModelService) CreateModel(
@@ -493,9 +493,9 @@ func (s *ModelService) CreateModel(
 //
 // The following error types can be expected to be returned:
 // - [modelerrors.AlreadyExists] when the model uuid is already in use.
-// - [coreerrors.NotValid] when the agent stream is not valid.
 // - [modelerrors.AgentVersionNotSupported] when the agent version is not
 // supported.
+// - [modelerrors.AgentStreamNotValid] when the agent stream is not valid.
 func (s *ModelService) CreateImportingModelWithAgentVersionStream(
 	ctx context.Context,
 	agentVersion semversion.Number,
@@ -934,7 +934,7 @@ func (s *ProviderModelService) ResolveConstraints(
 //
 // The following error types can be expected to be returned:
 // - [modelerrors.AlreadyExists] when the model uuid is already in use.
-// - [coreerrors.NotValid] when the agent stream is not valid.
+// - [modelerrors.AgentStreamNotValid] when the agent stream is not valid.
 // - [modelerrors.AgentVersionNotSupported] when the agent version is not
 // supported.
 func (s *ProviderModelService) CreateModel(

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -1222,11 +1222,11 @@ func (s *providerModelServiceSuite) TestCreateModel(c *tc.C) {
 // bypassed the seeding via embedded promotion.
 func (s *providerModelServiceSuite) TestCreateModelSeedingInvariants(c *tc.C) {
 	cases := []struct {
-		name           string
-		version        semversion.Number
-		stream         agentbinary.AgentStream
-		expectStream   domainagentbinary.Stream
-		expectVersion  semversion.Number
+		name          string
+		version       semversion.Number
+		stream        agentbinary.AgentStream
+		expectStream  domainagentbinary.Stream
+		expectVersion semversion.Number
 	}{
 		{
 			name:          "bothZero",
@@ -1261,7 +1261,7 @@ func (s *providerModelServiceSuite) TestCreateModelSeedingInvariants(c *tc.C) {
 	for _, testCase := range cases {
 		ctrl := s.setupMocks(c)
 		controllerUUID := uuid.MustNewUUID()
-		modelUUID := coremodel.UUID(tc.Must(c, coremodel.NewUUID))
+		modelUUID := tc.Must(c, coremodel.NewUUID)
 
 		defaultPool := s.newDefaultStoragePool(c, ctrl)
 		s.mockStorageProviderRegistry.EXPECT().RecommendedPoolForKind(

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -1209,7 +1209,7 @@ func (s *providerModelServiceSuite) TestCreateModel(c *tc.C) {
 	s.mockProvider.EXPECT().CreateModelResources(gomock.Any(), environs.CreateParams{ControllerUUID: controllerUUID.String()}).Return(nil)
 
 	svc := s.providerService(c, modelUUID)
-	err := svc.CreateModel(c.Context(), semversion.Zero, agentbinary.AgentStream(""))
+	err := svc.CreateModel(c.Context(), semversion.Zero, agentbinary.AgentStreamZero)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -1244,7 +1244,7 @@ func (s *providerModelServiceSuite) TestCreateModelFailedErrorAlreadyExists(c *t
 	}).Return(modelerrors.AlreadyExists)
 
 	svc := s.providerService(c, modelUUID)
-	err := svc.CreateModel(c.Context(), semversion.Zero, agentbinary.AgentStream(""))
+	err := svc.CreateModel(c.Context(), semversion.Zero, agentbinary.AgentStreamZero)
 	c.Assert(err, tc.ErrorIs, modelerrors.AlreadyExists)
 }
 

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -327,8 +327,8 @@ func (s *modelServiceSuite) TestCreateModelAgentVersionUnsupportedGreater(c *tc.
 		DefaultAgentBinaryFinder(),
 	)
 
-	err = svc.CreateModelWithAgentVersion(
-		c.Context(), agentVersion,
+	err = svc.CreateModel(
+		c.Context(), agentVersion, agentbinary.AgentStreamReleased,
 	)
 	c.Assert(err, tc.ErrorIs, modelerrors.AgentVersionNotSupported)
 }
@@ -357,15 +357,15 @@ func (s *modelServiceSuite) TestAgentVersionUnsupportedLess(c *tc.C) {
 		s.environVersionProviderGetter(),
 		DefaultAgentBinaryFinder(),
 	)
-	err = svc.CreateModelWithAgentVersion(
-		c.Context(), agentVersion,
+	err = svc.CreateModel(
+		c.Context(), agentVersion, agentbinary.AgentStreamReleased,
 	)
 	// Add the correct error detail when restoring this test.
 	c.Assert(err, tc.NotNil)
 }
 
 // TestCreateModelForVersionInvalidStream is testing that when
-// [ModelService.CreateModelForVersionAndStream] is called with an agent stream
+// [ModelService.CreateModel] is called with an agent stream
 // that isn't understood or supported we get back an error that satisfies
 // [modelerrors.AgentStreamNotValid].
 func (s *modelServiceSuite) TestCreateModelForVersionInvalidStream(c *tc.C) {
@@ -381,7 +381,7 @@ func (s *modelServiceSuite) TestCreateModelForVersionInvalidStream(c *tc.C) {
 		s.environVersionProviderGetter(),
 		DefaultAgentBinaryFinder(),
 	)
-	err := svc.CreateModelWithAgentVersionStream(
+	err := svc.CreateModel(
 		c.Context(),
 		jujuversion.Current,
 		agentbinary.AgentStream("bad stream"),
@@ -390,7 +390,7 @@ func (s *modelServiceSuite) TestCreateModelForVersionInvalidStream(c *tc.C) {
 }
 
 // TestCreateModelWithAgentStream is testing that when
-// [ModelService.CreateModelWithAgentStream] is called with a valid agent
+// [ModelService.CreateModel] is called with a valid agent
 // stream, the model is created with the current Juju version and the
 // supplied stream.
 func (s *modelServiceSuite) TestCreateModelWithAgentStream(c *tc.C) {
@@ -430,15 +430,16 @@ func (s *modelServiceSuite) TestCreateModelWithAgentStream(c *tc.C) {
 		s.environVersionProviderGetter(),
 		DefaultAgentBinaryFinder(),
 	)
-	err := svc.CreateModelWithAgentStream(
+	err := svc.CreateModel(
 		c.Context(),
+		semversion.Zero,
 		agentbinary.AgentStreamTesting,
 	)
 	c.Assert(err, tc.ErrorIsNil)
 }
 
 // TestCreateModelWithAgentStreamInvalidStream is testing that when
-// [ModelService.CreateModelWithAgentStream] is called with an agent stream
+// [ModelService.CreateModel] is called with an agent stream
 // that isn't understood or supported we get back an error that satisfies
 // [modelerrors.AgentStreamNotValid].
 func (s *modelServiceSuite) TestCreateModelWithAgentStreamInvalidStream(c *tc.C) {
@@ -454,8 +455,9 @@ func (s *modelServiceSuite) TestCreateModelWithAgentStreamInvalidStream(c *tc.C)
 		s.environVersionProviderGetter(),
 		DefaultAgentBinaryFinder(),
 	)
-	err := svc.CreateModelWithAgentStream(
+	err := svc.CreateModel(
 		c.Context(),
+		semversion.Zero,
 		agentbinary.AgentStream("bad stream"),
 	)
 	c.Check(err, tc.ErrorIs, modelerrors.AgentStreamNotValid)
@@ -1207,7 +1209,7 @@ func (s *providerModelServiceSuite) TestCreateModel(c *tc.C) {
 	s.mockProvider.EXPECT().CreateModelResources(gomock.Any(), environs.CreateParams{ControllerUUID: controllerUUID.String()}).Return(nil)
 
 	svc := s.providerService(c, modelUUID)
-	err := svc.CreateModel(c.Context())
+	err := svc.CreateModel(c.Context(), semversion.Zero, agentbinary.AgentStream(""))
 	c.Assert(err, tc.ErrorIsNil)
 }
 
@@ -1242,7 +1244,7 @@ func (s *providerModelServiceSuite) TestCreateModelFailedErrorAlreadyExists(c *t
 	}).Return(modelerrors.AlreadyExists)
 
 	svc := s.providerService(c, modelUUID)
-	err := svc.CreateModel(c.Context())
+	err := svc.CreateModel(c.Context(), semversion.Zero, agentbinary.AgentStream(""))
 	c.Assert(err, tc.ErrorIs, modelerrors.AlreadyExists)
 }
 

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -1213,6 +1213,101 @@ func (s *providerModelServiceSuite) TestCreateModel(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestCreateModelSeedingInvariants is a regression test asserting that
+// whatever combination of zero/non-zero agent version and stream inputs is
+// passed to [ProviderModelService.CreateModel], it always runs the
+// full provider setup chain: creating model info, seeding default storage
+// pools, and validating/creating provider resources. This locks in the
+// consolidation that replaced the variant-specific methods, one of which
+// bypassed the seeding via embedded promotion.
+func (s *providerModelServiceSuite) TestCreateModelSeedingInvariants(c *tc.C) {
+	cases := []struct {
+		name           string
+		version        semversion.Number
+		stream         agentbinary.AgentStream
+		expectStream   domainagentbinary.Stream
+		expectVersion  semversion.Number
+	}{
+		{
+			name:          "bothZero",
+			version:       semversion.Zero,
+			stream:        agentbinary.AgentStreamZero,
+			expectStream:  domainagentbinary.AgentStreamReleased,
+			expectVersion: jujuversion.Current,
+		},
+		{
+			name:          "streamOnly",
+			version:       semversion.Zero,
+			stream:        agentbinary.AgentStreamTesting,
+			expectStream:  domainagentbinary.AgentStreamTesting,
+			expectVersion: jujuversion.Current,
+		},
+		{
+			name:          "versionOnly",
+			version:       jujuversion.Current,
+			stream:        agentbinary.AgentStreamZero,
+			expectStream:  domainagentbinary.AgentStreamReleased,
+			expectVersion: jujuversion.Current,
+		},
+		{
+			name:          "bothSet",
+			version:       jujuversion.Current,
+			stream:        agentbinary.AgentStreamTesting,
+			expectStream:  domainagentbinary.AgentStreamTesting,
+			expectVersion: jujuversion.Current,
+		},
+	}
+
+	for _, testCase := range cases {
+		ctrl := s.setupMocks(c)
+		controllerUUID := uuid.MustNewUUID()
+		modelUUID := coremodel.UUID(tc.Must(c, coremodel.NewUUID))
+
+		defaultPool := s.newDefaultStoragePool(c, ctrl)
+		s.mockStorageProviderRegistry.EXPECT().RecommendedPoolForKind(
+			internalstorage.StorageKindFilesystem,
+		).Return(defaultPool.AsConfig())
+		s.mockStorageProviderRegistry.EXPECT().RecommendedPoolForKind(
+			internalstorage.StorageKindBlock,
+		).Return(nil).AnyTimes()
+
+		s.mockControllerState.EXPECT().GetModelSeedInformation(gomock.Any(), modelUUID).Return(coremodel.ModelInfo{
+			UUID:           modelUUID,
+			ControllerUUID: controllerUUID,
+			Name:           "my-awesome-model",
+			Qualifier:      "prod",
+			Cloud:          "aws",
+			CloudType:      "ec2",
+			CloudRegion:    "myregion",
+			Type:           coremodel.IAAS,
+		}, nil)
+		s.mockModelState.EXPECT().Create(gomock.Any(), model.ModelDetailArgs{
+			UUID:               modelUUID,
+			ControllerUUID:     controllerUUID,
+			Name:               "my-awesome-model",
+			Qualifier:          "prod",
+			Type:               coremodel.IAAS,
+			Cloud:              "aws",
+			CloudType:          "ec2",
+			CloudRegion:        "myregion",
+			AgentStream:        testCase.expectStream,
+			AgentVersion:       testCase.expectVersion,
+			LatestAgentVersion: testCase.expectVersion,
+		}).Return(nil)
+
+		s.mockModelState.EXPECT().EnsureDefaultStoragePools(gomock.Any(), defaultPool).Return(nil)
+		s.mockModelState.EXPECT().SetModelStoragePools(gomock.Any(), gomock.Any()).Return(nil)
+		s.mockModelState.EXPECT().GetControllerUUID(gomock.Any()).Return(controllerUUID, nil)
+		s.mockProvider.EXPECT().ValidateProviderForNewModel(gomock.Any()).Return(nil)
+		s.mockProvider.EXPECT().CreateModelResources(gomock.Any(), environs.CreateParams{ControllerUUID: controllerUUID.String()}).Return(nil)
+
+		svc := s.providerService(c, modelUUID)
+		err := svc.CreateModel(c.Context(), testCase.version, testCase.stream)
+		c.Check(err, tc.ErrorIsNil, tc.Commentf("subtest %q", testCase.name))
+		ctrl.Finish()
+	}
+}
+
 func (s *providerModelServiceSuite) TestCreateModelFailedErrorAlreadyExists(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()


### PR DESCRIPTION
Refactor: collapse the four `CreateModel` variants into a single `CreateModel(ctx, agentVersion, agentStream)`, resolving zero-value defaults inside the domain and pushing the dispatch out of the facade.

Fix: PR #23090 added a stream-only branch in `createModelInfo` that dispatched to `CreateModelWithAgentStream`. But `ProviderModelService` never overrode that variant, so the call was promoted to the embedded base `ModelService`, skipping `SeedDefaultStoragePools` and `createModelProviderResources`. Any model created with an agent-stream model default (e.g. CI's `--model-default agent-stream=testing`) got empty storage-pool tables, and deploys of storage-requiring charms failed with `pool uuid is not valid: empty uuid`.

Consolidating to one provider-aware `CreateModel` removes the promotion path entirely — every creation now always seeds pools and provider resources, regardless of which agent version/stream was supplied.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap with an agent-stream model default:
```sh
juju bootstrap lxd test --model-default agent-stream=testing --build-agent
juju add-model m
juju deploy ubuntu        # must succeed; previously failed with
                          # "storage directive \"block\" pool uuid is not valid: empty uuid"
juju model-config agent-stream   # should show "testing"
```
Test model created with an agent stream:
```sh
juju add-model m2 --config agent-stream=released
juju deploy ubuntu --model m2          # user-supplied stream path (was also broken)
```
Integration test (one of the failing ones on Jenkins):
```sh
BOOTSTRAP_ADDITIONAL_ARGS="--model-default agent-stream=testing" \
        ./main.sh refresh run_refresh_local
```
## Documentation changes
N/A

## Links
**Issue:** Fixes #23162.
**Jira card:** [JUJU-10273](https://warthogs.atlassian.net/browse/JUJU-10273)

[JUJU-10273]: https://warthogs.atlassian.net/browse/JUJU-10273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ