### PR TITLE
fix: flaky apiserver tests — nil cancelContext panic in rpc.(*Conn).Close

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -1177,7 +1177,7 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 		recorderFactory := observer.NewRecorderFactory(apiObserver, nil, observer.NoCaptureArgs)
 		rpcConn := rpc.NewConn(codec, recorderFactory)
 
-		if root, err := srv.serveConn(
+		root, startWatch, serveErr := srv.serveConn(
 			srv.catacomb.Context(ctx),
 			rpcConn,
 			resolvedModelUUID,
@@ -1186,19 +1186,24 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 			apiObserver,
 			req.Host,
 			crossModelAuthContext,
-		); errors.Is(err, modelerrors.NotFound) {
+		)
+		switch {
+		case errors.Is(serveErr, modelerrors.NotFound):
 			// If the model is not found then we need to close the connection
 			// with the appropriate error so that the client can handle it.
 			err := fmt.Errorf("%w: %q", apiservererrors.UnknownModelError, modelUUID)
 			rpcConn.ServeRoot(&errRoot{err: errors.Trace(err)}, recorderFactory, serverError)
-		} else if err != nil {
-			err := fmt.Errorf("serving model %q: %w", modelUUID, err)
+		case serveErr != nil:
+			err := fmt.Errorf("serving model %q: %w", modelUUID, serveErr)
 			rpcConn.ServeRoot(&errRoot{err: errors.Trace(err)}, recorderFactory, serverError)
-		} else {
+		default:
 			rpcConn.ServeRoot(root, recorderFactory, serverError)
 		}
 
 		rpcConn.Start(ctx)
+		if startWatch != nil {
+			startWatch()
+		}
 		select {
 		case <-rpcConn.Dead():
 			cancel(ErrRPCConnectionClosed)
@@ -1219,25 +1224,26 @@ func (srv *Server) serveConn(
 	apiObserver observer.Observer,
 	host string,
 	crossModelAuthContext facade.CrossModelAuthContext,
-) (rpc.Root, error) {
+) (rpc.Root, func(), error) {
 	domainServices, err := srv.shared.domainServicesGetter.ServicesForModel(ctx, modelUUID)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting domain services for model %q", modelUUID)
+		return nil, nil, errors.Annotatef(err, "getting domain services for model %q", modelUUID)
 	}
 
 	modelConn, err := srv.isModelAvailable(ctx, domainServices.Model(), modelUUID)
 	if err != nil {
-		return nil, errors.Annotatef(err, "checking model %q availability", modelUUID)
+		return nil, nil, errors.Annotatef(err, "checking model %q availability", modelUUID)
 	}
 
-	// Close the connection when the model it serves is removed from this
-	// controller, whether destroyed or deleted by a migration's REAP phase
-	// after migrating away, so that its agents and clients reconnect to the
-	// model's new location. A connection to a model that is already gone
-	// exists only to answer a redirect, so it is not watched.
+	// Defer the watch start so it runs after rpcConn.Start(), ensuring
+	// Close() is never called on an unstarted Conn.
+	var startWatch func()
 	if modelConn.connectable {
-		srv.watchServedModelRemoval(ctx, conn, domainServices.Model(),
-			srv.shared.controllerDomainServices.Model(), modelUUID)
+		modelService := domainServices.Model()
+		watchService := srv.shared.controllerDomainServices.Model()
+		startWatch = func() {
+			srv.watchServedModelRemoval(ctx, conn, modelService, watchService, modelUUID)
+		}
 	}
 
 	tracer, err := srv.shared.tracerGetter.GetTracer(
@@ -1252,19 +1258,19 @@ func (srv *Server) serveConn(
 	// Grab the object store for the model.
 	objectStore, err := srv.shared.objectStoreGetter.GetObjectStore(ctx, modelUUID.String())
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting object store for model %q", modelUUID)
+		return nil, nil, errors.Annotatef(err, "getting object store for model %q", modelUUID)
 	}
 
 	// Grab the object store for the controller, this is primarily used for
 	// the agent tools.
 	controllerObjectStore, err := srv.shared.objectStoreGetter.GetObjectStore(ctx, database.ControllerNS)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting controller object store")
+		return nil, nil, errors.Annotatef(err, "getting controller object store")
 	}
 
 	watcherRegistry, err := srv.shared.watcherRegistryGetter.GetWatcherRegistry(ctx, connectionID)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting watcher registry for connection %d", connectionID)
+		return nil, nil, errors.Annotatef(err, "getting watcher registry for connection %d", connectionID)
 	}
 
 	handler, err := newAPIHandler(
@@ -1289,7 +1295,7 @@ func (srv *Server) serveConn(
 		err = fmt.Errorf("%w: %q", apiservererrors.UnknownModelError, modelUUID)
 	}
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 
 	// Set up the admin apis used to accept logins and direct
@@ -1301,7 +1307,7 @@ func (srv *Server) serveConn(
 		adminAPIs[apiVersion] = factory(srv, handler, apiObserver)
 	}
 
-	return newAdminRoot(handler, adminAPIs), nil
+	return newAdminRoot(handler, adminAPIs), startWatch, nil
 }
 
 func (srv *Server) isModelAvailable(

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -1484,6 +1484,16 @@ func newRPCClientServer(
 	return client, server, srvDone, serverNotifier
 }
 
+func (s *rpcSuite) TestConnCloseBeforeStart(c *tc.C) {
+	client, srv := net.Pipe()
+	defer client.Close()
+	defer srv.Close()
+
+	conn := rpc.NewConn(NewJSONCodec(srv, roleServer), nil)
+	err := conn.Close()
+	tc.Assert(c, err, tc.ErrorIsNil)
+}
+
 func closeClient(c tc.LikeTB, client *rpc.Conn, srvDone <-chan error) {
 	err := client.Close()
 	tc.Assert(c, err, tc.ErrorIsNil)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -355,7 +355,9 @@ func (conn *Conn) Close() error {
 	// cancel the context so that any requests that would
 	// block will be notified that the server is shutting
 	// down.
-	conn.cancelContext()
+	if conn.cancelContext != nil {
+		conn.cancelContext()
+	}
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -383,7 +385,9 @@ func (conn *Conn) Close() error {
 	if err := conn.codec.Close(); err != nil {
 		logger.Debugf(conn.context, "error closing codec: %v", err)
 	}
-	<-conn.dead
+	if conn.dead != nil {
+		<-conn.dead
+	}
 
 	return conn.inputLoopError
 }

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -348,6 +348,7 @@ func (conn *Conn) Close() error {
 		// API methods to return, otherwise they are just waiting.
 		conn.root.Kill()
 	}
+	cancelContext := conn.cancelContext
 	conn.mutex.Unlock()
 
 	// Wait for any outstanding server requests to complete
@@ -355,8 +356,8 @@ func (conn *Conn) Close() error {
 	// cancel the context so that any requests that would
 	// block will be notified that the server is shutting
 	// down.
-	if conn.cancelContext != nil {
-		conn.cancelContext()
+	if cancelContext != nil {
+		cancelContext()
 	}
 	done := make(chan struct{})
 	go func() {
@@ -379,14 +380,15 @@ func (conn *Conn) Close() error {
 		// So to release these resources, double tap the root.
 		conn.root.Kill()
 	}
+	dead := conn.dead
 	conn.mutex.Unlock()
 
 	// Closing the codec should cause the input loop to terminate.
 	if err := conn.codec.Close(); err != nil {
 		logger.Debugf(conn.context, "error closing codec: %v", err)
 	}
-	if conn.dead != nil {
-		<-conn.dead
+	if dead != nil {
+		<-dead
 	}
 
 	return conn.inputLoopError


### PR DESCRIPTION
Flaky apiserver tests were hitting a nil-pointer panic when `rpc.(*Conn).Close()` was called before `Start()` had initialised `cancelContext` and `dead`. Nil guards in `Close()` stopped the panic but left two underlying issues:

- **Data race**: `Close()` read `cancelContext` and `dead` outside the mutex while `Start()` writes both fields under the mutex. Both reads are now captured as locals under the lock before the lock is released.

- **Race to `Close()` on an unstarted `Conn`**: `serveConn` spawned the `watchServedModelRemoval` goroutine before `rpcConn.Start(ctx)` had initialised the fields. The watch could call `conn.Close()` on an unstarted `Conn`. `serveConn` now returns a `startWatch` closure that is invoked after `rpcConn.Start()`, eliminating the race window entirely.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] ~Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

## Documentation changes

## Links
- [Jenkins build with failure](https://jenkins.juju.canonical.com/job/github-make-check-juju/38765/console)
