### PR TITLE
fix(apiserver): close model connections from their own goroutine

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -59,6 +59,7 @@ import (
 	"github.com/juju/juju/core/securitylog"
 	coretrace "github.com/juju/juju/core/trace"
 	coreunit "github.com/juju/juju/core/unit"
+	"github.com/juju/juju/core/watcher/eventsource"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	internalerrors "github.com/juju/juju/internal/errors"
 	internallogger "github.com/juju/juju/internal/logger"
@@ -660,6 +661,11 @@ func (srv *Server) loop(ready chan struct{}) error {
 		return errors.Trace(err)
 	}
 
+	// Consume the initial event to synchronize with the watcher's subscription.
+	if _, err := eventsource.ConsumeInitialEvent(ctx, modelRemovalWatcher); err != nil {
+		return errors.Annotate(err, "waiting for model removals watcher")
+	}
+
 	close(ready)
 
 	srv.mu.Lock()
@@ -1224,7 +1230,7 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 		recorderFactory := observer.NewRecorderFactory(apiObserver, nil, observer.NoCaptureArgs)
 		rpcConn := rpc.NewConn(codec, recorderFactory)
 
-		if root, err := srv.serveConn(
+		root, closeOnModelRemoval, err := srv.serveConn(
 			srv.catacomb.Context(ctx),
 			rpcConn,
 			resolvedModelUUID,
@@ -1233,7 +1239,8 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 			apiObserver,
 			req.Host,
 			crossModelAuthContext,
-		); errors.Is(err, modelerrors.NotFound) {
+		)
+		if errors.Is(err, modelerrors.NotFound) {
 			// If the model is not found then we need to close the connection
 			// with the appropriate error so that the client can handle it.
 			err := fmt.Errorf("%w: %q", apiservererrors.UnknownModelError, modelUUID)
@@ -1245,13 +1252,20 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 			rpcConn.ServeRoot(root, recorderFactory, serverError)
 		}
 
+		// A connection admitted only to answer a migration redirect must stay
+		// open long enough to receive a Login request and return that redirect.
+		// A nil channel disables this select case.
+		if !closeOnModelRemoval {
+			modelRemoved = nil
+		}
+
 		rpcConn.Start(ctx)
 		select {
 		case <-rpcConn.Dead():
 			cancel(ErrRPCConnectionClosed)
 		case <-srv.catacomb.Dying():
 		case <-modelRemoved:
-			// The model this connection serves has been removed from this
+			// The local model this connection serves has been removed from this
 			// controller, so fall through and close the connection: its agents
 			// and clients must reconnect to the model's new location. The close
 			// happens here, in the goroutine that started the connection just
@@ -1273,14 +1287,15 @@ func (srv *Server) serveConn(
 	apiObserver observer.Observer,
 	host string,
 	crossModelAuthContext facade.CrossModelAuthContext,
-) (rpc.Root, error) {
+) (rpc.Root, bool, error) {
 	domainServices, err := srv.shared.domainServicesGetter.ServicesForModel(ctx, modelUUID)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting domain services for model %q", modelUUID)
+		return nil, false, errors.Annotatef(err, "getting domain services for model %q", modelUUID)
 	}
 
-	if err := srv.isModelAvailable(ctx, domainServices.Model(), modelUUID); err != nil {
-		return nil, errors.Annotatef(err, "checking model %q availability", modelUUID)
+	modelConn, err := srv.isModelAvailable(ctx, domainServices.Model(), modelUUID)
+	if err != nil {
+		return nil, false, errors.Annotatef(err, "checking model %q availability", modelUUID)
 	}
 
 	tracer, err := srv.shared.tracerGetter.GetTracer(
@@ -1295,19 +1310,19 @@ func (srv *Server) serveConn(
 	// Grab the object store for the model.
 	objectStore, err := srv.shared.objectStoreGetter.GetObjectStore(ctx, modelUUID.String())
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting object store for model %q", modelUUID)
+		return nil, false, errors.Annotatef(err, "getting object store for model %q", modelUUID)
 	}
 
 	// Grab the object store for the controller, this is primarily used for
 	// the agent tools.
 	controllerObjectStore, err := srv.shared.objectStoreGetter.GetObjectStore(ctx, database.ControllerNS)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting controller object store")
+		return nil, false, errors.Annotatef(err, "getting controller object store")
 	}
 
 	watcherRegistry, err := srv.shared.watcherRegistryGetter.GetWatcherRegistry(ctx, connectionID)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting watcher registry for connection %d", connectionID)
+		return nil, false, errors.Annotatef(err, "getting watcher registry for connection %d", connectionID)
 	}
 
 	handler, err := newAPIHandler(
@@ -1332,7 +1347,7 @@ func (srv *Server) serveConn(
 		err = fmt.Errorf("%w: %q", apiservererrors.UnknownModelError, modelUUID)
 	}
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, false, errors.Trace(err)
 	}
 
 	// Set up the admin apis used to accept logins and direct
@@ -1344,14 +1359,14 @@ func (srv *Server) serveConn(
 		adminAPIs[apiVersion] = factory(srv, handler, apiObserver)
 	}
 
-	return newAdminRoot(handler, adminAPIs), nil
+	return newAdminRoot(handler, adminAPIs), modelConn.connectable, nil
 }
 
 func (srv *Server) isModelAvailable(
 	ctx context.Context,
 	modelService ModelService,
 	modelUUID coremodel.UUID,
-) error {
+) (modelConnection, error) {
 	// Check that the model can be served before proceeding any further. There
 	// is no need in setting up any additional operations if the model is not
 	// present. A model that is still being imported by a migration is served
@@ -1359,9 +1374,9 @@ func (srv *Server) isModelAvailable(
 	// modelIsConnectable.
 	conn, err := modelIsConnectable(ctx, modelService, modelUUID)
 	if err != nil && !errors.Is(err, modelerrors.NotFound) {
-		return errors.Trace(err)
+		return modelConnection{}, errors.Trace(err)
 	} else if conn.connectable {
-		return nil
+		return conn, nil
 	}
 
 	// If this model used to be hosted on this controller but got
@@ -1374,10 +1389,10 @@ func (srv *Server) isModelAvailable(
 		// is an error with the database? The caller will assume that it
 		// is no longer on this controller. If we return a different error
 		// then it can at least retry the request.
-		return modelerrors.NotFound
+		return modelConnection{}, modelerrors.NotFound
 	}
 
-	return nil
+	return conn, nil
 }
 
 // publicDNSName returns the current public hostname.

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -102,6 +102,10 @@ type Server struct {
 
 	shared *sharedServerContext
 
+	// modelRemovals reports the removal of a model from this controller to the
+	// connections serving it.
+	modelRemovals *modelRemovals
+
 	// tag of the machine where the API server is running.
 	tag     names.Tag
 	dataDir string
@@ -405,6 +409,7 @@ func newServer(ctx context.Context, cfg ServerConfig) (_ *Server, err error) {
 		pingClock:                     cfg.pingClock(),
 		newObserver:                   cfg.NewObserver,
 		shared:                        shared,
+		modelRemovals:                 newModelRemovals(),
 		tag:                           cfg.Tag,
 		dataDir:                       cfg.DataDir,
 		logDir:                        cfg.LogDir,
@@ -641,6 +646,20 @@ func (srv *Server) loop(ready chan struct{}) error {
 		return errors.Trace(err)
 	}
 
+	// Watch the removal of models from this controller so that the connections
+	// serving a removed model can be closed. One watcher serves every
+	// connection this API server has, and it is created before the server is
+	// ready to serve any of them, so that no removal can be missed.
+	modelService := srv.shared.controllerDomainServices.Model()
+	modelRemovalWatcher, err := modelService.WatchModelRemovals(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := srv.catacomb.Add(modelRemovalWatcher); err != nil {
+		return errors.Trace(err)
+	}
+
 	close(ready)
 
 	srv.mu.Lock()
@@ -682,6 +701,15 @@ func (srv *Server) loop(ready chan struct{}) error {
 			if err := srv.updateResourceDownloadLimiters(controllerConfig); err != nil {
 				logger.Errorf(ctx, "failed to update resource download limiters: %v", err)
 				continue
+			}
+
+		case modelUUIDs, ok := <-modelRemovalWatcher.Changes():
+			if !ok {
+				return errors.New("model removals watcher stopped")
+			}
+			for _, modelUUID := range modelUUIDs {
+				logger.Infof(ctx, "model %q has been removed, closing its connections", modelUUID)
+				srv.modelRemovals.notify(coremodel.UUID(modelUUID))
 			}
 		}
 	}
@@ -1173,6 +1201,12 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 
 		logger.Tracef(ctx, "got a request for model %q fd:%v", modelUUID, fd)
 
+		// Take an interest in the removal of the model this connection serves,
+		// before checking that the model exists at all, so that a removal
+		// cannot fall between the two.
+		modelRemoved, untrackModel := srv.modelRemovals.track(resolvedModelUUID)
+		defer untrackModel()
+
 		codec := jsoncodec.NewWebsocket(conn.Conn)
 		recorderFactory := observer.NewRecorderFactory(apiObserver, nil, observer.NoCaptureArgs)
 		rpcConn := rpc.NewConn(codec, recorderFactory)
@@ -1203,6 +1237,13 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 		case <-rpcConn.Dead():
 			cancel(ErrRPCConnectionClosed)
 		case <-srv.catacomb.Dying():
+		case <-modelRemoved:
+			// The model this connection serves has been removed from this
+			// controller, so fall through and close the connection: its agents
+			// and clients must reconnect to the model's new location. The close
+			// happens here, in the goroutine that started the connection just
+			// above, because an rpc.Conn may not be closed before it has been
+			// started.
 		}
 		if err := rpcConn.Close(); err != nil {
 			logger.Errorf(ctx, "error closing RPC connection: %v", err)
@@ -1225,19 +1266,8 @@ func (srv *Server) serveConn(
 		return nil, errors.Annotatef(err, "getting domain services for model %q", modelUUID)
 	}
 
-	modelConn, err := srv.isModelAvailable(ctx, domainServices.Model(), modelUUID)
-	if err != nil {
+	if err := srv.isModelAvailable(ctx, domainServices.Model(), modelUUID); err != nil {
 		return nil, errors.Annotatef(err, "checking model %q availability", modelUUID)
-	}
-
-	// Close the connection when the model it serves is removed from this
-	// controller, whether destroyed or deleted by a migration's REAP phase
-	// after migrating away, so that its agents and clients reconnect to the
-	// model's new location. A connection to a model that is already gone
-	// exists only to answer a redirect, so it is not watched.
-	if modelConn.connectable {
-		srv.watchServedModelRemoval(ctx, conn, domainServices.Model(),
-			srv.shared.controllerDomainServices.Model(), modelUUID)
 	}
 
 	tracer, err := srv.shared.tracerGetter.GetTracer(
@@ -1308,7 +1338,7 @@ func (srv *Server) isModelAvailable(
 	ctx context.Context,
 	modelService ModelService,
 	modelUUID coremodel.UUID,
-) (modelConnection, error) {
+) error {
 	// Check that the model can be served before proceeding any further. There
 	// is no need in setting up any additional operations if the model is not
 	// present. A model that is still being imported by a migration is served
@@ -1316,9 +1346,9 @@ func (srv *Server) isModelAvailable(
 	// modelIsConnectable.
 	conn, err := modelIsConnectable(ctx, modelService, modelUUID)
 	if err != nil && !errors.Is(err, modelerrors.NotFound) {
-		return modelConnection{}, errors.Trace(err)
+		return errors.Trace(err)
 	} else if conn.connectable {
-		return conn, nil
+		return nil
 	}
 
 	// If this model used to be hosted on this controller but got
@@ -1331,10 +1361,10 @@ func (srv *Server) isModelAvailable(
 		// is an error with the database? The caller will assume that it
 		// is no longer on this controller. If we return a different error
 		// then it can at least retry the request.
-		return modelConnection{}, modelerrors.NotFound
+		return modelerrors.NotFound
 	}
 
-	return conn, nil
+	return nil
 }
 
 // publicDNSName returns the current public hostname.

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -671,6 +671,14 @@ func (srv *Server) loop(ready chan struct{}) error {
 	})
 	srv.mu.Unlock()
 
+	// Disable each watcher case once its channel closes: stopping the
+	// watchers is part of the server shutting down, since the catacomb
+	// kills the workers added to it, and handling their channels closing
+	// would race with the dying case below. If a watcher stops while
+	// the server keeps running, its error kills the catacomb it was
+	// added to.
+	controllerChanges := controllerConfigWatcher.Changes()
+	removalChanges := modelRemovalWatcher.Changes()
 	for {
 		select {
 		case <-srv.catacomb.Dying():
@@ -686,7 +694,11 @@ func (srv *Server) loop(ready chan struct{}) error {
 			srv.wg.Wait() // wait for any outstanding requests to complete.
 			return ErrAPIServerDying
 
-		case <-controllerConfigWatcher.Changes():
+		case _, ok := <-controllerChanges:
+			if !ok {
+				controllerChanges = nil
+				continue
+			}
 			controllerConfig, err := controllerConfigService.ControllerConfig(ctx)
 			if err != nil {
 				logger.Errorf(ctx, "failed to get controller config: %v", err)
@@ -703,9 +715,10 @@ func (srv *Server) loop(ready chan struct{}) error {
 				continue
 			}
 
-		case modelUUIDs, ok := <-modelRemovalWatcher.Changes():
+		case modelUUIDs, ok := <-removalChanges:
 			if !ok {
-				return errors.New("model removals watcher stopped")
+				removalChanges = nil
+				continue
 			}
 			for _, modelUUID := range modelUUIDs {
 				logger.Infof(ctx, "model %q has been removed, closing its connections", modelUUID)

--- a/apiserver/modelconnection_test.go
+++ b/apiserver/modelconnection_test.go
@@ -203,8 +203,7 @@ func (s *modelConnectionSuite) TestMigrationModeErrorPropagates(c *tc.C) {
 // it adds on top of modelIsConnectable - the redirect fall-through.
 
 func (s *modelConnectionSuite) available(c *tc.C) error {
-	_, err := (&Server{}).isModelAvailable(c.Context(), s.modelService, s.modelUUID)
-	return err
+	return (&Server{}).isModelAvailable(c.Context(), s.modelService, s.modelUUID)
 }
 
 // TestAvailableWhileImporting verifies that the connection is served for a

--- a/apiserver/modelconnection_test.go
+++ b/apiserver/modelconnection_test.go
@@ -202,7 +202,7 @@ func (s *modelConnectionSuite) TestMigrationModeErrorPropagates(c *tc.C) {
 // served at all, before Login is ever reached. These cases pin the behaviour
 // it adds on top of modelIsConnectable - the redirect fall-through.
 
-func (s *modelConnectionSuite) available(c *tc.C) error {
+func (s *modelConnectionSuite) available(c *tc.C) (modelConnection, error) {
 	return (&Server{}).isModelAvailable(c.Context(), s.modelService, s.modelUUID)
 }
 
@@ -218,7 +218,9 @@ func (s *modelConnectionSuite) TestAvailableWhileImporting(c *tc.C) {
 		HasImportClaim: true,
 	})
 
-	c.Assert(s.available(c), tc.ErrorIsNil)
+	conn, err := s.available(c)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(conn.connectable, tc.IsTrue)
 }
 
 // TestAvailableWhenActivated covers the ordinary case.
@@ -227,7 +229,9 @@ func (s *modelConnectionSuite) TestAvailableWhenActivated(c *tc.C) {
 
 	s.expectConnectionInfo(model.ModelConnectionInfo{ModelType: coremodel.IAAS, Activated: true})
 
-	c.Assert(s.available(c), tc.ErrorIsNil)
+	conn, err := s.available(c)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(conn.connectable, tc.IsTrue)
 }
 
 // TestNotAvailableWhenAbsent verifies an unknown model is still reported as
@@ -240,7 +244,8 @@ func (s *modelConnectionSuite) TestNotAvailableWhenAbsent(c *tc.C) {
 	s.modelService.EXPECT().ModelRedirection(gomock.Any(), s.modelUUID).
 		Return(model.ModelRedirection{}, modelerrors.ModelNotRedirected)
 
-	c.Assert(s.available(c), tc.ErrorIs, modelerrors.NotFound)
+	_, err := s.available(c)
+	c.Assert(err, tc.ErrorIs, modelerrors.NotFound)
 }
 
 // TestNotAvailableWhenHalfBuilt pins the narrow window at the connection gate:
@@ -253,7 +258,8 @@ func (s *modelConnectionSuite) TestNotAvailableWhenHalfBuilt(c *tc.C) {
 	s.modelService.EXPECT().ModelRedirection(gomock.Any(), s.modelUUID).
 		Return(model.ModelRedirection{}, modelerrors.ModelNotRedirected)
 
-	c.Assert(s.available(c), tc.ErrorIs, modelerrors.NotFound)
+	_, err := s.available(c)
+	c.Assert(err, tc.ErrorIs, modelerrors.NotFound)
 }
 
 // TestAvailableWhenMigratedAway verifies the redirect fall-through still
@@ -267,5 +273,7 @@ func (s *modelConnectionSuite) TestAvailableWhenMigratedAway(c *tc.C) {
 	s.modelService.EXPECT().ModelRedirection(gomock.Any(), s.modelUUID).
 		Return(model.ModelRedirection{ControllerUUID: "other"}, nil)
 
-	c.Assert(s.available(c), tc.ErrorIsNil)
+	conn, err := s.available(c)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(conn.connectable, tc.IsFalse)
 }

--- a/apiserver/modelremoval.go
+++ b/apiserver/modelremoval.go
@@ -4,106 +4,101 @@
 package apiserver
 
 import (
-	"context"
+	"sync"
 
 	coremodel "github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/watcher"
-	modelerrors "github.com/juju/juju/domain/model/errors"
-	"github.com/juju/juju/internal/errors"
 )
 
-// ModelRemovalWatchService creates watchers that emit when a model changes.
-// It is satisfied by the controller-scoped *modelservice.WatchableService.
-type ModelRemovalWatchService interface {
-	// WatchModel returns a watcher that emits an event if the model changes.
-	WatchModel(ctx context.Context, modelUUID coremodel.UUID) (watcher.NotifyWatcher, error)
-}
-
-// servedConnection is the subset of *rpc.Conn needed by the model removal
-// watch. It exists so the watch can be unit tested without a full RPC
-// connection.
-type servedConnection interface {
-	// Dead returns a channel that is closed when the connection dies.
-	Dead() <-chan struct{}
-	// Close closes the connection. Closing an already dead or closed
-	// connection is not an error.
-	Close() error
-}
-
-// watchServedModelRemoval arranges for conn to be closed when the model it
-// serves is removed from this controller. Model removal happens when a model
-// is destroyed or when a migration's REAP phase deletes it after migrating
-// away; agents and clients must then reconnect, dialling the addresses the
-// migration wrote into their configuration.
+// modelRemovals reports the removal of a model from this controller to the
+// connections serving it. A model is removed when it is destroyed, or when a
+// migration's REAP phase deletes it after migrating away; the connections
+// serving the model must then be closed so that its agents and clients
+// reconnect, dialling the addresses the migration wrote into their
+// configuration.
 //
-// The watch is best-effort: if it cannot be established the connection is
-// served without it, as it always has been.
-func (srv *Server) watchServedModelRemoval(
-	ctx context.Context,
-	conn servedConnection,
-	modelService ModelService,
-	watchService ModelRemovalWatchService,
-	modelUUID coremodel.UUID,
-) {
-	// TODO: WatchModel fires on any change to the model; this path could
-	// be optimised to use a specific life trigger (e.g. WatchModelLife)
-	// only, so unrelated model updates do not wake the watch.
-	watch, err := watchService.WatchModel(ctx, modelUUID)
-	if err != nil {
-		logger.Warningf(ctx,
-			"cannot watch model %q for removal; connection will not be closed on model removal: %v",
-			modelUUID, err,
-		)
+// One channel is held per model being served, however many connections that
+// is, and closing it reports the removal to all of them at once. The removals
+// come from the single controller-wide watcher driven by [Server.loop], so a
+// connection costs a map entry rather than a watcher of its own.
+//
+// Only the removal is reported here. Closing a connection is left to the
+// goroutine serving it, which owns the connection's whole lifecycle: an
+// rpc.Conn may not be closed before it has been started.
+type modelRemovals struct {
+	mu     sync.Mutex
+	served map[coremodel.UUID]*servedModel
+}
+
+// servedModel is the removal state shared by every connection this API server
+// is serving for one model.
+type servedModel struct {
+	// removed is closed once the model has been removed from the controller.
+	removed chan struct{}
+
+	// conns counts the connections being served for the model.
+	conns int
+}
+
+func newModelRemovals() *modelRemovals {
+	return &modelRemovals{
+		served: make(map[coremodel.UUID]*servedModel),
+	}
+}
+
+// track registers a connection being served for the given model. It returns a
+// channel that is closed once the model has been removed from the controller,
+// along with a function that must be called exactly once, when the connection
+// is no longer being served.
+//
+// Callers must track the model before checking that it exists, so that a
+// removal can never fall between the check and the registration.
+func (r *modelRemovals) track(modelUUID coremodel.UUID) (<-chan struct{}, func()) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	served, ok := r.served[modelUUID]
+	if !ok {
+		served = &servedModel{removed: make(chan struct{})}
+		r.served[modelUUID] = served
+	}
+	served.conns++
+
+	return served.removed, func() { r.untrack(modelUUID, served) }
+}
+
+// untrack records that a connection is no longer being served for the model,
+// forgetting the model once its last connection has gone.
+func (r *modelRemovals) untrack(modelUUID coremodel.UUID, served *servedModel) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// A removed model is forgotten as it is reported, so anything held against
+	// its UUID now belongs to later connections and is not ours to release.
+	if r.served[modelUUID] != served {
 		return
 	}
-	// The goroutine is deliberately not added to the server's catacomb:
-	// ctx is the connection's context, which the catacomb already cancels
-	// on shutdown, and the watch also stops when the connection dies.
-	// Catacomb membership would instead make a watch failure fatal to the
-	// whole apiserver.
-	go srv.runModelRemovalWatch(ctx, conn, modelService, watch, modelUUID)
+
+	served.conns--
+	if served.conns == 0 {
+		delete(r.served, modelUUID)
+	}
 }
 
-// runModelRemovalWatch closes conn once the model it serves no longer exists
-// on this controller. It returns when the connection dies, the context is
-// cancelled, or the watcher stops.
-func (srv *Server) runModelRemovalWatch(
-	ctx context.Context,
-	conn servedConnection,
-	modelService ModelService,
-	watch watcher.NotifyWatcher,
-	modelUUID coremodel.UUID,
-) {
-	defer func() {
-		watch.Kill()
-		_ = watch.Wait()
-	}()
+// notify reports the removal of the model to every connection being served for
+// it, and forgets the model. Those connections keep the channel they were given
+// and so are still woken, while a connection tracking the model afterwards can
+// only be one answering a redirect, which must be served until its login is
+// refused.
+//
+// Removals of models this API server is not serving are ignored.
+func (r *modelRemovals) notify(modelUUID coremodel.UUID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-conn.Dead():
-			// The webserver serving this connection closes it once it
-			// dies (see Server.apiHandler), so this branch only stops
-			// the watch; there is no connection to close here.
-			return
-		case _, ok := <-watch.Changes():
-			if !ok {
-				logger.Debugf(ctx,
-					"removal watcher for model %q stopped; connection will not be closed on model removal",
-					modelUUID,
-				)
-				return
-			}
-			connInfo, err := modelIsConnectable(ctx, modelService, modelUUID)
-			if errors.Is(err, modelerrors.NotFound) || (err == nil && !connInfo.connectable) {
-				logger.Infof(ctx, "model %q has been removed, closing connection", modelUUID)
-				_ = conn.Close()
-				return
-			}
-			// The model still exists, or the check failed transiently;
-			// keep watching.
-		}
+	served, ok := r.served[modelUUID]
+	if !ok {
+		return
 	}
+	delete(r.served, modelUUID)
+	close(served.removed)
 }

--- a/apiserver/modelremoval_test.go
+++ b/apiserver/modelremoval_test.go
@@ -4,218 +4,105 @@
 package apiserver
 
 import (
-	"context"
-	"errors"
-	"sync"
 	"testing"
 
-	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 
 	coremodel "github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/core/watcher/watchertest"
-	"github.com/juju/juju/domain/model"
-	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
 type modelRemovalSuite struct {
-	modelService *MockModelService
-	modelUUID    coremodel.UUID
+	removals  *modelRemovals
+	modelUUID coremodel.UUID
 }
 
 func TestModelRemovalSuite(t *testing.T) {
 	tc.Run(t, &modelRemovalSuite{})
 }
 
-func (s *modelRemovalSuite) setupMocks(c *tc.C) *gomock.Controller {
-	ctrl := gomock.NewController(c)
-	s.modelService = NewMockModelService(ctrl)
+func (s *modelRemovalSuite) SetUpTest(c *tc.C) {
+	s.removals = newModelRemovals()
 	s.modelUUID = coremodel.UUID(uuid.MustNewUUID().String())
-	return ctrl
 }
 
-// fakeServedConnection implements servedConnection, recording closure and
-// letting tests drive the dead channel.
-type fakeServedConnection struct {
-	dead      chan struct{}
-	closed    chan struct{}
-	closeOnce sync.Once
-}
-
-func newFakeServedConnection() *fakeServedConnection {
-	return &fakeServedConnection{
-		dead:   make(chan struct{}),
-		closed: make(chan struct{}),
-	}
-}
-
-func (f *fakeServedConnection) Dead() <-chan struct{} {
-	return f.dead
-}
-
-func (f *fakeServedConnection) Close() error {
-	f.closeOnce.Do(func() { close(f.closed) })
-	return nil
-}
-
-func (f *fakeServedConnection) isClosed() bool {
+// isSignalled reports, without blocking, whether the model has been reported as
+// removed.
+func isSignalled(removed <-chan struct{}) bool {
 	select {
-	case <-f.closed:
+	case <-removed:
 		return true
 	default:
 		return false
 	}
 }
 
-// stubModelRemovalWatchService returns a fixed watcher or error from
-// WatchModel.
-type stubModelRemovalWatchService struct {
-	watch watcher.NotifyWatcher
-	err   error
+// TestRemovalReportedToEveryConnection is the point of holding one channel per
+// model rather than one watcher per connection: a single removal wakes every
+// connection serving that model.
+func (s *modelRemovalSuite) TestRemovalReportedToEveryConnection(c *tc.C) {
+	first, _ := s.removals.track(s.modelUUID)
+	second, _ := s.removals.track(s.modelUUID)
+
+	c.Assert(isSignalled(first), tc.IsFalse)
+	c.Assert(isSignalled(second), tc.IsFalse)
+
+	s.removals.notify(s.modelUUID)
+
+	c.Check(isSignalled(first), tc.IsTrue)
+	c.Check(isSignalled(second), tc.IsTrue)
 }
 
-func (s stubModelRemovalWatchService) WatchModel(context.Context, coremodel.UUID) (watcher.NotifyWatcher, error) {
-	return s.watch, s.err
+// TestOtherModelRemovalNotReported verifies that connections are only told
+// about their own model's removal.
+func (s *modelRemovalSuite) TestOtherModelRemovalNotReported(c *tc.C) {
+	removed, _ := s.removals.track(s.modelUUID)
+
+	s.removals.notify(coremodel.UUID(uuid.MustNewUUID().String()))
+
+	c.Check(isSignalled(removed), tc.IsFalse)
 }
 
-// runWatch drives runModelRemovalWatch in a goroutine and returns a channel
-// that is closed when it returns.
-func runWatch(srv *Server, ctx context.Context, conn servedConnection, modelService ModelService, watch watcher.NotifyWatcher, modelUUID coremodel.UUID) <-chan struct{} {
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		srv.runModelRemovalWatch(ctx, conn, modelService, watch, modelUUID)
-	}()
-	return done
+// TestRemovalOfUnservedModelIgnored verifies that removals of models this API
+// server holds no connections for - most of them, on most API servers - are
+// simply dropped.
+func (s *modelRemovalSuite) TestRemovalOfUnservedModelIgnored(c *tc.C) {
+	s.removals.notify(s.modelUUID)
+
+	c.Check(s.removals.served, tc.HasLen, 0)
 }
 
-// TestWatchNotStartedWhenWatcherCreationFails pins the best-effort contract:
-// if the removal watcher cannot be created, the connection is served without
-// it, exactly as connections always have been.
-func (s *modelRemovalSuite) TestWatchNotStartedWhenWatcherCreationFails(c *tc.C) {
-	defer s.setupMocks(c).Finish()
+// TestModelForgottenWithLastConnection verifies that a model is tracked only
+// while it is being served, so that the API server does not accumulate an entry
+// for every model it has ever been asked about.
+func (s *modelRemovalSuite) TestModelForgottenWithLastConnection(c *tc.C) {
+	_, firstDone := s.removals.track(s.modelUUID)
+	_, secondDone := s.removals.track(s.modelUUID)
 
-	conn := newFakeServedConnection()
-	srv := &Server{}
+	firstDone()
+	c.Assert(s.removals.served, tc.HasLen, 1)
 
-	// The model service must not be consulted when there is no watcher.
-	srv.watchServedModelRemoval(c.Context(), conn, s.modelService,
-		stubModelRemovalWatchService{err: errors.New("boom")}, s.modelUUID)
-
-	c.Assert(conn.isClosed(), tc.IsFalse)
+	secondDone()
+	c.Check(s.removals.served, tc.HasLen, 0)
 }
 
-// TestNoRemovalEventLeavesConnectionOpen verifies that a quiet watcher never
-// closes the connection, and that cancelling the connection's context stops
-// the watch goroutine.
-func (s *modelRemovalSuite) TestNoRemovalEventLeavesConnectionOpen(c *tc.C) {
-	defer s.setupMocks(c).Finish()
+// TestModelForgottenWhenRemoved verifies that a removed model is forgotten as
+// it is reported, so that a connection arriving afterwards to be redirected is
+// served rather than closed straight away.
+func (s *modelRemovalSuite) TestModelForgottenWhenRemoved(c *tc.C) {
+	_, done := s.removals.track(s.modelUUID)
 
-	ctx, cancel := context.WithCancel(c.Context())
-	conn := newFakeServedConnection()
-	srv := &Server{}
+	s.removals.notify(s.modelUUID)
+	c.Assert(s.removals.served, tc.HasLen, 0)
 
-	watch := watchertest.NewMockNotifyWatcher(make(chan struct{}))
-	done := runWatch(srv, ctx, conn, s.modelService, watch, s.modelUUID)
+	redirected, redirectedDone := s.removals.track(s.modelUUID)
+	c.Check(isSignalled(redirected), tc.IsFalse)
 
-	cancel()
-	<-done
+	// The connection that was open when the model was removed must not take the
+	// later connection's model with it as it goes.
+	done()
+	c.Check(s.removals.served, tc.HasLen, 1)
 
-	c.Assert(conn.isClosed(), tc.IsFalse)
-}
-
-// TestDeadConnectionStopsWatch verifies that the watch ends with the
-// connection without closing it: nothing may outlive the connection.
-func (s *modelRemovalSuite) TestDeadConnectionStopsWatch(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	conn := newFakeServedConnection()
-	srv := &Server{}
-
-	watch := watchertest.NewMockNotifyWatcher(make(chan struct{}))
-	done := runWatch(srv, c.Context(), conn, s.modelService, watch, s.modelUUID)
-
-	close(conn.dead)
-	<-done
-
-	c.Assert(conn.isClosed(), tc.IsFalse)
-}
-
-// TestModelRemovalClosesConnection is the migration REAP case: the model row
-// disappears from the controller, the watcher fires, the model lookup reports
-// not found, and the connection is closed so agents reconnect to the target
-// controller.
-func (s *modelRemovalSuite) TestModelRemovalClosesConnection(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
-		Return(model.ModelConnectionInfo{}, modelerrors.NotFound)
-
-	conn := newFakeServedConnection()
-	srv := &Server{}
-
-	changes := make(chan struct{}, 1)
-	changes <- struct{}{}
-	watch := watchertest.NewMockNotifyWatcher(changes)
-
-	srv.watchServedModelRemoval(c.Context(), conn, s.modelService,
-		stubModelRemovalWatchService{watch: watch}, s.modelUUID)
-
-	<-conn.closed
-}
-
-// TestUnrelatedModelChangeKeepsWatching verifies that a model change which is
-// not a removal - the model is still connectable - does not close the
-// connection, and that a later removal still does.
-func (s *modelRemovalSuite) TestUnrelatedModelChangeKeepsWatching(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	firstCheck := make(chan struct{})
-	gomock.InOrder(
-		s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
-			DoAndReturn(func(context.Context, coremodel.UUID) (model.ModelConnectionInfo, error) {
-				close(firstCheck)
-				return model.ModelConnectionInfo{Activated: true}, nil
-			}),
-		s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
-			Return(model.ModelConnectionInfo{}, modelerrors.NotFound),
-	)
-
-	conn := newFakeServedConnection()
-	srv := &Server{}
-
-	changes := make(chan struct{})
-	watch := watchertest.NewMockNotifyWatcher(changes)
-	done := runWatch(srv, c.Context(), conn, s.modelService, watch, s.modelUUID)
-
-	changes <- struct{}{}
-	<-firstCheck
-	c.Assert(conn.isClosed(), tc.IsFalse)
-
-	changes <- struct{}{}
-	<-conn.closed
-	<-done
-}
-
-// TestUnactivatedModelClosesConnection covers destroy-model: the
-// model row may still exist but is no longer connectable. The
-// connection must still be closed so agents do not linger.
-func (s *modelRemovalSuite) TestUnactivatedModelClosesConnection(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
-		Return(model.ModelConnectionInfo{Activated: false}, nil)
-
-	conn := newFakeServedConnection()
-	srv := &Server{}
-
-	changes := make(chan struct{}, 1)
-	changes <- struct{}{}
-	watch := watchertest.NewMockNotifyWatcher(changes)
-	done := runWatch(srv, c.Context(), conn, s.modelService, watch, s.modelUUID)
-
-	<-conn.closed
-	<-done
+	redirectedDone()
+	c.Check(s.removals.served, tc.HasLen, 0)
 }

--- a/domain/model/service/package_mock_test.go
+++ b/domain/model/service/package_mock_test.go
@@ -1298,6 +1298,7 @@ type MockWatcherFactory struct {
 type MockWatcherFactoryMockRecorder struct {
 	mock                             *MockWatcherFactory
 	newNamespaceMapperWatcherExpects []*gomock.Call5V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.Mapper, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error]
+	newNamespaceWatcherExpects       []*gomock.Call4V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error]
 	newNotifyMapperWatcherExpects    []*gomock.Call4V_2[context.Context, string, eventsource.Mapper, eventsource.FilterOption, eventsource.FilterOption, watcher.NotifyWatcher, error]
 	newNotifyWatcherExpects          []*gomock.Call3V_2[context.Context, string, eventsource.FilterOption, eventsource.FilterOption, watcher.NotifyWatcher, error]
 }
@@ -1332,6 +1333,25 @@ func (mr *MockWatcherFactoryMockRecorder) NewNamespaceMapperWatcher(ctx, initial
 
 // MockWatcherFactoryNewNamespaceMapperWatcherCall is the typed call wrapper for NewNamespaceMapperWatcher.
 type MockWatcherFactoryNewNamespaceMapperWatcherCall = gomock.Call5V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.Mapper, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error]
+
+// NewNamespaceWatcher mocks base method.
+func (m *MockWatcherFactory) NewNamespaceWatcher(ctx context.Context, initialStateQuery eventsource.NamespaceQuery, summary string, filterOption eventsource.FilterOption, filterOptions ...eventsource.FilterOption) (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch4V_2(&m.recorder.newNamespaceWatcherExpects, m.ctrl, m, "NewNamespaceWatcher", ctx, initialStateQuery, summary, filterOption, filterOptions...)
+}
+
+// NewNamespaceWatcher indicates an expected call of NewNamespaceWatcher.
+func (mr *MockWatcherFactoryMockRecorder) NewNamespaceWatcher(ctx, initialStateQuery, summary, filterOption any, filterOptions ...any) *MockWatcherFactoryNewNamespaceWatcherCall {
+	mr.mock.ctrl.T.Helper()
+	varArgs := gomock.EnsureVariadicMatcher(filterOptions)
+	call := gomock.NewCall4V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error](mr.mock.ctrl.T, mr.mock, "NewNamespaceWatcher", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(initialStateQuery), gomock.EnsureMatcher(summary), gomock.EnsureMatcher(filterOption), varArgs)
+	mr.newNamespaceWatcherExpects = append(mr.newNamespaceWatcherExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockWatcherFactoryNewNamespaceWatcherCall is the typed call wrapper for NewNamespaceWatcher.
+type MockWatcherFactoryNewNamespaceWatcherCall = gomock.Call4V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error]
 
 // NewNotifyMapperWatcher mocks base method.
 func (m *MockWatcherFactory) NewNotifyMapperWatcher(ctx context.Context, summary string, mapper eventsource.Mapper, filter eventsource.FilterOption, filterOpts ...eventsource.FilterOption) (watcher.NotifyWatcher, error) {

--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/core/changestream"
 	corecloud "github.com/juju/juju/core/cloud"
 	"github.com/juju/juju/core/credential"
-	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
@@ -925,17 +924,12 @@ func (s *WatchableService) WatchModelRemovals(ctx context.Context) (watcher.Stri
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	// A model removed before the watcher was created cannot be reported: its
-	// row, and with it its UUID, is already gone. The watcher reports the
-	// removals it sees from its creation onwards, so its initial state is
-	// always empty.
-	initialQuery := func(context.Context, coredatabase.TxnRunner) ([]string, error) {
-		return nil, nil
-	}
-
+	// A deletion stream has no current state to report, but its empty initial
+	// event is still the synchronization point that tells the consumer the
+	// subscription is established.
 	return s.watcherFactory.NewNamespaceWatcher(
 		ctx,
-		initialQuery,
+		eventsource.EmptyInitialNamespaceChanges(),
 		"model removals watcher",
 		eventsource.NamespaceFilter("model", changestream.Deleted),
 	)

--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/core/changestream"
 	corecloud "github.com/juju/juju/core/cloud"
 	"github.com/juju/juju/core/credential"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
@@ -779,6 +780,17 @@ type NotifyMapperWatcherFactory interface {
 type WatcherFactory interface {
 	NotifyMapperWatcherFactory
 
+	// NewNamespaceWatcher returns a new namespace watcher for events based on
+	// the input change mask. The initialStateQuery ensures the watcher starts
+	// with the current state of the system, preventing data loss from prior
+	// events.
+	NewNamespaceWatcher(
+		ctx context.Context,
+		initialStateQuery eventsource.NamespaceQuery,
+		summary string,
+		filterOption eventsource.FilterOption, filterOptions ...eventsource.FilterOption,
+	) (watcher.StringsWatcher, error)
+
 	// NewNamespaceMapperWatcher returns a new namespace watcher for events
 	// based on the input change mask. The initialStateQuery ensures the watcher
 	// starts with the current state of the system, preventing data loss from
@@ -904,6 +916,28 @@ func (s *WatchableService) WatchModels(ctx context.Context) (watcher.NotifyWatch
 		ctx,
 		"models watcher",
 		eventsource.NamespaceFilter("model", changestream.All),
+	)
+}
+
+// WatchModelRemovals returns a watcher that emits the UUIDs of models that
+// have been removed from the controller.
+func (s *WatchableService) WatchModelRemovals(ctx context.Context) (watcher.StringsWatcher, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	// A model removed before the watcher was created cannot be reported: its
+	// row, and with it its UUID, is already gone. The watcher reports the
+	// removals it sees from its creation onwards, so its initial state is
+	// always empty.
+	initialQuery := func(context.Context, coredatabase.TxnRunner) ([]string, error) {
+		return nil, nil
+	}
+
+	return s.watcherFactory.NewNamespaceWatcher(
+		ctx,
+		initialQuery,
+		"model removals watcher",
+		eventsource.NamespaceFilter("model", changestream.Deleted),
 	)
 }
 

--- a/domain/model/watcher_test.go
+++ b/domain/model/watcher_test.go
@@ -269,6 +269,64 @@ func (s *watcherSuite) TestWatchModel(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
+func (s *watcherSuite) TestWatchModelRemovals(c *tc.C) {
+	watchableDBFactory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "model")
+	watcherFactory := domain.NewWatcherFactory(watchableDBFactory, loggertesting.WrapCheckLog(c))
+
+	st := statecontroller.NewState(func(ctx context.Context) (database.TxnRunner, error) { return watchableDBFactory(ctx) })
+
+	modelService := service.NewWatchableService(
+		st,
+		watcherFactory,
+		newStatusHistoryGetter(c),
+		clock.WallClock,
+		loggertesting.WrapCheckLog(c),
+	)
+
+	modelUUID, activateModel, err := modelService.CreateModel(c.Context(), domainmodel.GlobalModelCreationArgs{
+		Cloud:       "my-cloud",
+		CloudRegion: "my-region",
+		Credential: corecredential.Key{
+			Cloud: "my-cloud",
+			Owner: s.userName,
+			Name:  "my-cloud-credential",
+		},
+		Name:          "test-model",
+		Qualifier:     "prod",
+		AdminUsers:    []user.UUID{s.userUUID},
+		SecretBackend: juju.BackendName,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	watcher, err := modelService.WatchModelRemovals(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
+
+	// Verifies that a model coming into existence is not reported as a removal.
+	harness.AddTest(c, func(c *tc.C) {
+		err := activateModel(c.Context())
+		c.Assert(err, tc.ErrorIsNil)
+	}, func(w watchertest.WatcherC[[]string]) {
+		w.AssertNoChange()
+	})
+
+	// Verifies that removing the model reports its UUID, which is all the API
+	// server needs to close the connections serving it.
+	harness.AddTest(c, func(c *tc.C) {
+		err := st.Delete(c.Context(), modelUUID)
+		c.Assert(err, tc.ErrorIsNil)
+	}, func(w watchertest.WatcherC[[]string]) {
+		w.Check(
+			watchertest.StringSliceAssert(
+				modelUUID.String(),
+			),
+		)
+	})
+
+	harness.Run(c, []string(nil))
+}
+
 func (s *watcherSuite) TestWatchModelCloudCredential(c *tc.C) {
 	watchableDBFactory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "model")
 	watcherFactory := domain.NewWatcherFactory(watchableDBFactory, loggertesting.WrapCheckLog(c))


### PR DESCRIPTION
When a model is removed from a controller, either destroyed or deleted by a
migration's REAP phase after migrating away, the connections serving it must be
closed so that its agents and clients reconnect and dial the model's new
location. Commit fc149b6200 restored that 3.6 behaviour on 4.0 by giving every
connection its own model watcher running in its own goroutine, and having that
goroutine close the connection. Nothing ordered those two goroutines against
each other. An `rpc.Conn` only gets its context, and the cancel function that
Close calls, when Start runs, so a watcher that saw the removal before the
serving goroutine reached Start called a nil function and killed the controller
with a segmentation fault. CI hit this on a migration test.

The fix moves the detection of removals to one place. The API server now runs a
single watcher on deletions from the controller's model table, created before it
serves any connection so no removal can be missed, and consumed by the loop it
already runs for controller config changes. A removal is matched against the
small set of models this API server is currently serving and reported by closing
one channel per model, which wakes every connection for that model at once.
Each connection then closes itself in the goroutine that started it, the
goroutine that owns its whole lifecycle, so a close can no longer overtake a
start. This is the shape 3.6 had, where one controller-level watcher fed a
channel shared by every connection to a model through the state pool.

Doing it this way also costs less than what it replaces. A connection is a map
entry instead of a watcher, a subscription and a goroutine, and because the
model table's delete trigger records the removed model's UUID, the event needs
no database read to interpret. The per-connection watcher and its goroutine are
gone, and isModelAvailable goes back to returning just an error, since the
connection details it used to hand back existed only to feed that watcher.

## QA steps

Verify that connections to a removed model are closed, and that the controller
survives it.

  1. Bootstrap the target controller from main (4.1):
```
  # In a checkout/worktree on main.
  make install
  juju bootstrap lxd dst41 --build-agent
```
  2. Bootstrap the source controller from this PR branch (4.0), create a model, and migrate it to the 4.1
     controller:
```
  # In the checkout/worktree for this PR.
  make install
  juju bootstrap lxd src40 --build-agent

  juju add-model -c src40 moveme
  juju deploy -m src40:moveme juju-qa-test

  juju controllers
  # Confirm src40 is 4.0 and dst41 is 4.1.

  juju migrate src40:moveme dst41
```
  3. Confirm the agents reconnect to the target controller, the unit remains healthy, and the source
     controller logs the removal without panicking:
```
  juju switch dst41:moveme
  juju add-unit juju-qa-test
  juju status

  juju debug-log -m src40:controller
  juju debug-log -m dst41:moveme
```
  4. Destroy another model on the 4.0 source while a client is connected to it. Confirm the client’s
     connection is dropped rather than left hanging:
```
  juju add-model -c src40 doomed
  juju debug-log -m src40:doomed &
  juju destroy-model src40:doomed --no-prompt
```
  5. Confirm the 4.0 source controller is still running and serving requests:
```
  juju status -m src40:controller
```
## Links

**Issue:** Fixes #23154.


**Jira card:** [JUJU-10298](https://warthogs.atlassian.net/browse/JUJU-10298)


[JUJU-10298]: https://warthogs.atlassian.net/browse/JUJU-10298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ