### PR TITLE
fix(secret): support granting secret access over peer relations

### DIFF
--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -1199,6 +1199,7 @@ AND    e.endpoint_name    = $endpointIdentifier.endpoint_name
 
 	var uuidAndRole []relationUUIDAndRole
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		uuidAndRole = nil
 		err = tx.Query(ctx, stmt, e).GetAll(&uuidAndRole)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return relationerrors.RelationNotFound

--- a/domain/secret/service/access.go
+++ b/domain/secret/service/access.go
@@ -179,7 +179,14 @@ func (s *SecretService) getRelationUUIDByKey(ctx context.Context, relationKey co
 	var err error
 	switch len(eids) {
 	case 1:
-		return "", errors.Errorf("granting access to a secret over a peer relation is not supported").Add(coreerrors.NotSupported)
+		uuid, err = s.secretState.GetPeerRelationUUIDByEndpointIdentifiers(
+			ctx,
+			eids[0],
+		)
+		if err != nil {
+			return "", errors.Errorf("getting peer relation by key: %w", err)
+		}
+		return uuid, nil
 	case 2:
 		uuid, err = s.secretState.GetRegularRelationUUIDByEndpointIdentifiers(
 			ctx,

--- a/domain/secret/service/import_test.go
+++ b/domain/secret/service/import_test.go
@@ -238,6 +238,102 @@ func (s *serviceSuite) TestImportSecrets(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+func (s *serviceSuite) TestImportSecretsPeerRelationAccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	now := time.Now().UTC().Truncate(time.Hour * 24)
+	uri := coresecrets.NewURI()
+
+	secrets := []*coresecrets.SecretMetadata{{
+		URI:     uri,
+		Version: 0,
+		Owner: coresecrets.Owner{
+			Kind: coresecrets.ApplicationOwner,
+			ID:   "k8s",
+		},
+		Description:            "peer secret",
+		LatestRevisionChecksum: "checksum-1234",
+		CreateTime:             now.Add(1 * time.Hour),
+		UpdateTime:             now.Add(3 * time.Hour),
+	}}
+	revisions := [][]*coresecrets.SecretRevisionMetadata{
+		{
+			{
+				Revision:   1,
+				CreateTime: now.Add(1 * time.Hour),
+				UpdateTime: now.Add(10 * time.Hour),
+			},
+		},
+	}
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	s.state.EXPECT().GetApplicationUUID(c.Context(), "k8s").Return(appUUID, nil).AnyTimes()
+	relUUID := relationtesting.GenRelationUUID(c)
+	s.state.EXPECT().GetPeerRelationUUIDByEndpointIdentifiers(gomock.Any(), relation.EndpointIdentifier{
+		ApplicationName: "k8s",
+		EndpointName:    "cluster",
+		Role:            charm.RolePeer,
+	}).Return(relUUID.String(), nil)
+
+	s.state.EXPECT().ImportSecretWithRevisions(gomock.Any(), 0, uri, domainsecret.Owner{
+		Kind: coresecrets.ApplicationOwner,
+		UUID: appUUID.String(),
+	}, domainsecret.UpsertSecretParams{
+		CreateTime:  secrets[0].CreateTime,
+		UpdateTime:  secrets[0].UpdateTime,
+		Description: new(secrets[0].Description),
+		Checksum:    "checksum-1234",
+	}, []domainsecret.UpsertRevisionParams{
+		{
+			Revision:     1,
+			CreateTime:   revisions[0][0].CreateTime,
+			UpdateTime:   revisions[0][0].UpdateTime,
+			RevisionUUID: new(s.fakeUUID.String()),
+			Data:         map[string]string{"key": "value"},
+			Checksum:     "checksum-1234",
+		},
+	}).Return(nil)
+
+	s.state.EXPECT().GetModelUUID(gomock.Any()).Return(s.modelID, nil)
+	s.secretBackendState.EXPECT().AddSecretBackendReference(gomock.Any(), nil, s.modelID, s.fakeUUID.String(), uri.ID).
+		Return(func() error { return nil }, nil)
+
+	s.state.EXPECT().GrantAccess(gomock.Any(), uri, domainsecret.GrantParams{
+		ScopeTypeID:   domainsecret.ScopeRelation,
+		ScopeUUID:     relUUID.String(),
+		SubjectTypeID: domainsecret.SubjectApplication,
+		SubjectUUID:   appUUID.String(),
+		RoleID:        domainsecret.RoleView,
+	})
+
+	toImport := &SecretImport{
+		Secrets: secrets,
+		Revisions: map[string][]*coresecrets.SecretRevisionMetadata{
+			uri.ID: revisions[0],
+		},
+		Content: map[string]map[int]coresecrets.SecretData{
+			uri.ID: {
+				1: {"key": "value"},
+			},
+		},
+		Access: map[string][]SecretAccess{
+			uri.ID: {{
+				Scope: domainsecret.SecretAccessScope{
+					Kind: "relation",
+					ID:   "k8s:cluster",
+				},
+				Subject: domainsecret.SecretAccessor{
+					Kind: "application",
+					ID:   "k8s",
+				},
+				Role: "view",
+			}},
+		},
+	}
+	err := s.service.ImportSecrets(c.Context(), toImport)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *serviceSuite) TestImportSecretsRollbackOnFailure(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/secret/service/interface.go
+++ b/domain/secret/service/interface.go
@@ -125,6 +125,10 @@ type State interface {
 	// relation matching the given endpoint identifiers.
 	GetRegularRelationUUIDByEndpointIdentifiers(ctx context.Context, endpoint1, endpoint2 corerelation.EndpointIdentifier) (string, error)
 
+	// GetPeerRelationUUIDByEndpointIdentifiers returns the UUID of a peer
+	// relation matching the given endpoint identifier.
+	GetPeerRelationUUIDByEndpointIdentifiers(ctx context.Context, endpoint corerelation.EndpointIdentifier) (string, error)
+
 	// GetRelationEndpoints returns the endpoint identifiers for the
 	// relation with the given UUID.
 	GetRelationEndpoints(ctx context.Context, relationUUID string) ([]corerelation.EndpointIdentifier, error)

--- a/domain/secret/service/package_mock_test.go
+++ b/domain/secret/service/package_mock_test.go
@@ -52,6 +52,7 @@ type MockStateMockRecorder struct {
 	getModelUUIDExpects                                         []*gomock.Call1_2[context.Context, model.UUID, error]
 	getObsoleteUserSecretRevisionsReadyToPruneExpects           []*gomock.Call1_2[context.Context, []string, error]
 	getOwnedSecretIDsExpects                                    []*gomock.Call3_2[context.Context, []string, []string, []string, error]
+	getPeerRelationUUIDByEndpointIdentifiersExpects             []*gomock.Call2_2[context.Context, relation.EndpointIdentifier, string, error]
 	getRegularRelationUUIDByEndpointIdentifiersExpects          []*gomock.Call3_2[context.Context, relation.EndpointIdentifier, relation.EndpointIdentifier, string, error]
 	getRelationEndpointsExpects                                 []*gomock.Call2_2[context.Context, string, []relation.EndpointIdentifier, error]
 	getRevisionIDsForObsoleteExpects                            []*gomock.Call4_2[context.Context, secret.ApplicationOwners, secret.UnitOwners, []string, []string, error]
@@ -379,6 +380,24 @@ func (mr *MockStateMockRecorder) GetOwnedSecretIDs(ctx, appOwnerUUIDs, unitOwner
 
 // MockStateGetOwnedSecretIDsCall is the typed call wrapper for GetOwnedSecretIDs.
 type MockStateGetOwnedSecretIDsCall = gomock.Call3_2[context.Context, []string, []string, []string, error]
+
+// GetPeerRelationUUIDByEndpointIdentifiers mocks base method.
+func (m *MockState) GetPeerRelationUUIDByEndpointIdentifiers(ctx context.Context, endpoint relation.EndpointIdentifier) (string, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2_2(&m.recorder.getPeerRelationUUIDByEndpointIdentifiersExpects, m.ctrl, m, "GetPeerRelationUUIDByEndpointIdentifiers", ctx, endpoint)
+}
+
+// GetPeerRelationUUIDByEndpointIdentifiers indicates an expected call of GetPeerRelationUUIDByEndpointIdentifiers.
+func (mr *MockStateMockRecorder) GetPeerRelationUUIDByEndpointIdentifiers(ctx, endpoint any) *MockStateGetPeerRelationUUIDByEndpointIdentifiersCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall2_2[context.Context, relation.EndpointIdentifier, string, error](mr.mock.ctrl.T, mr.mock, "GetPeerRelationUUIDByEndpointIdentifiers", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(endpoint))
+	mr.getPeerRelationUUIDByEndpointIdentifiersExpects = append(mr.getPeerRelationUUIDByEndpointIdentifiersExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockStateGetPeerRelationUUIDByEndpointIdentifiersCall is the typed call wrapper for GetPeerRelationUUIDByEndpointIdentifiers.
+type MockStateGetPeerRelationUUIDByEndpointIdentifiersCall = gomock.Call2_2[context.Context, relation.EndpointIdentifier, string, error]
 
 // GetRegularRelationUUIDByEndpointIdentifiers mocks base method.
 func (m *MockState) GetRegularRelationUUIDByEndpointIdentifiers(ctx context.Context, endpoint1, endpoint2 relation.EndpointIdentifier) (string, error) {

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain/deployment/charm"
+	relationerrors "github.com/juju/juju/domain/relation/errors"
 	domainsecret "github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/internal/errors"
@@ -1313,6 +1314,80 @@ func (s *serviceSuite) TestGrantSecretRelationScope(c *tc.C) {
 		Role: "view",
 	})
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestGrantSecretPeerRelationScope(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uri := coresecrets.NewURI()
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+	s.state.EXPECT().GetApplicationUUID(c.Context(), "k8s").Return(appUUID, nil)
+	relUUID := relationtesting.GenRelationUUID(c)
+	s.state.EXPECT().GetPeerRelationUUIDByEndpointIdentifiers(gomock.Any(), relation.EndpointIdentifier{
+		ApplicationName: "k8s",
+		EndpointName:    "cluster",
+		Role:            charm.RolePeer,
+	}).Return(relUUID.String(), nil)
+	s.state.EXPECT().GetSecretAccess(gomock.Any(), uri, domainsecret.AccessParams{
+		SubjectTypeID: domainsecret.SubjectUnit,
+		SubjectID:     "k8s/0",
+	}).Return("manage", nil)
+	s.state.EXPECT().GrantAccess(gomock.Any(), uri, domainsecret.GrantParams{
+		ScopeTypeID:   domainsecret.ScopeRelation,
+		ScopeUUID:     relUUID.String(),
+		SubjectTypeID: domainsecret.SubjectApplication,
+		SubjectUUID:   appUUID.String(),
+		RoleID:        domainsecret.RoleView,
+	}).Return(nil)
+
+	err := s.service.GrantSecretAccess(c.Context(), uri, domainsecret.SecretAccessParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
+			ID:   "k8s/0",
+		},
+		Scope: domainsecret.SecretAccessScope{
+			Kind: domainsecret.RelationAccessScope,
+			ID:   "k8s:cluster",
+		},
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.ApplicationAccessor,
+			ID:   "k8s",
+		},
+		Role: "view",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestGrantSecretPeerRelationScopeError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uri := coresecrets.NewURI()
+	s.state.EXPECT().GetPeerRelationUUIDByEndpointIdentifiers(gomock.Any(), relation.EndpointIdentifier{
+		ApplicationName: "k8s",
+		EndpointName:    "cluster",
+		Role:            charm.RolePeer,
+	}).Return("", relationerrors.RelationNotFound)
+	s.state.EXPECT().GetSecretAccess(gomock.Any(), uri, domainsecret.AccessParams{
+		SubjectTypeID: domainsecret.SubjectUnit,
+		SubjectID:     "k8s/0",
+	}).Return("manage", nil)
+
+	err := s.service.GrantSecretAccess(c.Context(), uri, domainsecret.SecretAccessParams{
+		Accessor: domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
+			ID:   "k8s/0",
+		},
+		Scope: domainsecret.SecretAccessScope{
+			Kind: domainsecret.RelationAccessScope,
+			ID:   "k8s:cluster",
+		},
+		Subject: domainsecret.SecretAccessor{
+			Kind: domainsecret.ApplicationAccessor,
+			ID:   "k8s",
+		},
+		Role: "view",
+	})
+	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
 }
 
 func (s *serviceSuite) TestRevokeSecretUnitAccess(c *tc.C) {

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -2671,6 +2671,7 @@ AND    e2.endpoint_name    = $endpointIdentifier2.endpoint_name
 
 	var uuids []relationUUID
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		uuids = nil
 		err = tx.Query(ctx, stmt, e1, e2).GetAll(&uuids)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return relationerrors.RelationNotFound
@@ -2727,6 +2728,7 @@ AND    e.endpoint_name    = $endpointIdentifier.endpoint_name
 
 	var uuidAndRole []relationUUIDAndRole
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		uuidAndRole = nil
 		err = tx.Query(ctx, stmt, e).GetAll(&uuidAndRole)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return relationerrors.RelationNotFound

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -2687,6 +2687,63 @@ AND    e2.endpoint_name    = $endpointIdentifier2.endpoint_name
 	return uuids[0].UUID, nil
 }
 
+// GetPeerRelationUUIDByEndpointIdentifiers gets the UUID of a peer
+// relation specified by a single endpoint identifier.
+//
+// The following error types can be expected to be returned:
+//   - [relationerrors.RelationNotFound] is returned if endpoint cannot be
+//     found.
+func (st State) GetPeerRelationUUIDByEndpointIdentifiers(
+	ctx context.Context,
+	endpoint corerelation.EndpointIdentifier,
+) (string, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	e := endpointIdentifier{
+		ApplicationName: endpoint.ApplicationName,
+		EndpointName:    endpoint.EndpointName,
+	}
+
+	stmt, err := st.Prepare(`
+SELECT &relationUUIDAndRole.*
+FROM   relation r
+JOIN   v_relation_endpoint e ON r.uuid = e.relation_uuid
+WHERE  e.application_name = $endpointIdentifier.application_name 
+AND    e.endpoint_name    = $endpointIdentifier.endpoint_name
+`, relationUUIDAndRole{}, e)
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	var uuidAndRole []relationUUIDAndRole
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err = tx.Query(ctx, stmt, e).GetAll(&uuidAndRole)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return relationerrors.RelationNotFound
+		}
+		return errors.Capture(err)
+	})
+	if err != nil {
+		return "", errors.Capture(err)
+	}
+
+	if len(uuidAndRole) > 1 {
+		return "", errors.Errorf("found multiple relations for peer application endpoint combination")
+	}
+
+	// Verify that the role is peer. Endpoint names are unique per charm, so if
+	// the role is not peer the application does not have a peer relation with
+	// the specified endpoint name, so return RelationNotFound.
+	if uuidAndRole[0].Role != string(charm.RolePeer) {
+		return "", relationerrors.RelationNotFound
+	}
+
+	return uuidAndRole[0].UUID, nil
+}
+
 // GetRelationEndpoints returns relation endpoints for the given relation UUID.
 // The following error types can be expected to be returned:
 //   - [relationerrors.RelationNotFound] is returned if the relation UUID is not found.

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -2693,6 +2693,13 @@ AND    e2.endpoint_name    = $endpointIdentifier2.endpoint_name
 // The following error types can be expected to be returned:
 //   - [relationerrors.RelationNotFound] is returned if endpoint cannot be
 //     found.
+//
+// Note: this method is a near-verbatim copy of
+// (*domain/relation/state.State).GetPeerRelationUUIDByEndpointIdentifiers.
+// The query is duplicated here intentionally so that domain/secret remains
+// self-contained at the state layer (each domain owns its own SQL).
+// Keep this method in sync with the relation-state implementation if the
+// underlying schema changes.
 func (st State) GetPeerRelationUUIDByEndpointIdentifiers(
 	ctx context.Context,
 	endpoint corerelation.EndpointIdentifier,
@@ -2711,7 +2718,7 @@ func (st State) GetPeerRelationUUIDByEndpointIdentifiers(
 SELECT &relationUUIDAndRole.*
 FROM   relation r
 JOIN   v_relation_endpoint e ON r.uuid = e.relation_uuid
-WHERE  e.application_name = $endpointIdentifier.application_name 
+WHERE  e.application_name = $endpointIdentifier.application_name
 AND    e.endpoint_name    = $endpointIdentifier.endpoint_name
 `, relationUUIDAndRole{}, e)
 	if err != nil {
@@ -2731,7 +2738,10 @@ AND    e.endpoint_name    = $endpointIdentifier.endpoint_name
 	}
 
 	if len(uuidAndRole) > 1 {
-		return "", errors.Errorf("found multiple relations for peer application endpoint combination")
+		return "", errors.Errorf(
+			"found multiple relations for peer application %q endpoint %q",
+			e.ApplicationName, e.EndpointName,
+		)
 	}
 
 	// Verify that the role is peer. Endpoint names are unique per charm, so if

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
+	relationerrors "github.com/juju/juju/domain/relation/errors"
 	domainsecret "github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/internal/errors"
@@ -2980,6 +2981,21 @@ func (s *stateSuite) setupRelation(c *tc.C, appUUID, charmUUID, appUUID2, charmU
 	return relationUUID.String()
 }
 
+func (s *stateSuite) setupPeerRelation(c *tc.C, appUUID, charmUUID, endpointName string) string {
+	relation := charm.Relation{
+		Name:      endpointName,
+		Role:      charm.RolePeer,
+		Interface: endpointName,
+		Scope:     charm.ScopeGlobal,
+	}
+	charmRelUUID := s.addCharmRelation(c, charmUUID, relation)
+	endpointUUID := s.addApplicationEndpoint(c, appUUID, charmRelUUID)
+
+	relationUUID := s.addRelation(c)
+	s.addRelationEndpoint(c, relationUUID.String(), endpointUUID)
+	return relationUUID.String()
+}
+
 func (s *stateSuite) TestGetRegularRelationUUIDByEndpointIdentifiers(c *tc.C) {
 
 	appUUID, charmUUID := s.setupApplication(c, "mysql")
@@ -2999,6 +3015,47 @@ func (s *stateSuite) TestGetRegularRelationUUIDByEndpointIdentifiers(c *tc.C) {
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(got, tc.Equals, relUUID)
+}
+
+func (s *stateSuite) TestGetPeerRelationUUIDByEndpointIdentifiers(c *tc.C) {
+	appUUID, charmUUID := s.setupApplication(c, "k8s")
+	relUUID := s.setupPeerRelation(c, appUUID, charmUUID, "cluster")
+
+	got, err := s.state.GetPeerRelationUUIDByEndpointIdentifiers(
+		c.Context(),
+		corerelation.EndpointIdentifier{
+			ApplicationName: "k8s",
+			EndpointName:    "cluster",
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(got, tc.Equals, relUUID)
+}
+
+func (s *stateSuite) TestGetPeerRelationUUIDByEndpointIdentifiersRelationNotFoundRegularRelation(c *tc.C) {
+	appUUID, charmUUID := s.setupApplication(c, "mysql")
+	appUUID2, charmUUID2 := s.setupApplication(c, "mediawiki")
+	_ = s.setupRelation(c, appUUID, charmUUID, appUUID2, charmUUID2)
+
+	_, err := s.state.GetPeerRelationUUIDByEndpointIdentifiers(
+		c.Context(),
+		corerelation.EndpointIdentifier{
+			ApplicationName: "mysql",
+			EndpointName:    "db",
+		},
+	)
+	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
+}
+
+func (s *stateSuite) TestGetPeerRelationUUIDByEndpointIdentifiersNotFound(c *tc.C) {
+	_, err := s.state.GetPeerRelationUUIDByEndpointIdentifiers(
+		c.Context(),
+		corerelation.EndpointIdentifier{
+			ApplicationName: "fake-application",
+			EndpointName:    "fake-endpoint",
+		},
+	)
+	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
 }
 
 func (s *stateSuite) TestGetRelationEndpoint(c *tc.C) {

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -26,6 +26,11 @@ type relationUUID struct {
 	UUID string `db:"uuid"`
 }
 
+type relationUUIDAndRole struct {
+	UUID string `db:"relation_uuid"`
+	Role string `db:"role"`
+}
+
 type endpointIdentifier struct {
 	ApplicationName string `db:"application_name"`
 	EndpointName    string `db:"endpoint_name"`


### PR DESCRIPTION
In Juju 4.0, relation-scoped secret grants over peer relations were rejected with "granting access to a secret over a peer relation is not supported" because `domain/secret/service/access.go:getRelationUUIDByKey` only handled 2-endpoint keys and rejected 1-endpoint keys.

This change:
- Adds `GetPeerRelationUUIDByEndpointIdentifiers` to `domain/secret/state` (querying `v_relation_endpoint` with `charm.RolePeer` guard)
- Updates `domain/secret/service/access.go:getRelationUUIDByKey` to resolve peer relation keys via the new state method
- Adds unit tests for the state lookup, service grant resolution, and model import regression

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~Integration tests~
- [ ] ~doc.go~

## QA steps

1. Deploy a multi-unit application with a peer relation that grants secrets (e.g. `k8s` charm):
```sh
$ juju deploy k8s -n 2 --channel 1.35/stable
```
2. Verify that `cluster-relation-joined` hook runs successfully without `granting secrets access: granting access to a secret over a peer relation is not supported` errors.
3. Verify both units reach active/idle state.

## Documentation changes

None.

## Links

**Issue:** Fixes #23086.

**Jira card:** [JUJU-10290](https://warthogs.atlassian.net/browse/JUJU-10290)

[JUJU-10290]: https://warthogs.atlassian.net/browse/JUJU-10290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ