### PR TITLE
ci: simplify unit test workflow

### DIFF
--- a/.github/workflows/context-tests.yml
+++ b/.github/workflows/context-tests.yml
@@ -31,7 +31,6 @@ jobs:
       check-export-version: ${{ steps.filter-files.outputs.check-export-version }}
       check-smoke: ${{ steps.filter-files.outputs.check-smoke }}
       ref: ${{ steps.refs.outputs.head_ref }}
-      base: ${{ steps.refs.outputs.base_ref }}
     steps:
       - name: Checkout
         if: github.event_name != 'pull_request'
@@ -76,6 +75,8 @@ jobs:
               - '**.go'
               - 'go.mod'
               - '.github/workflows/build.yml'
+              - '.github/workflows/unit-tests.yml'
+              - '.github/workflows/context-tests.yml'
               - 'scripts/dqlite/**'
               - 'Makefile'
               - 'make_functions.sh'
@@ -153,8 +154,6 @@ jobs:
     name: Unit Tests
     if: github.event.pull_request.draft == false && needs.changed-files.outputs.check-unit-tests == 'true'
     uses: ./.github/workflows/unit-tests.yml
-    with:
-      base: ${{ needs.changed-files.outputs.base }}
 
   snap:
     needs: [changed-files]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,10 +1,6 @@
 name: "Unit Tests"
 on:
   workflow_call:
-    inputs:
-      base:
-        required: true
-        type: string
 
 jobs:
   test:
@@ -19,8 +15,6 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
 
       - name: "Squid"
         if: github.repository_owner != 'juju'
@@ -32,30 +26,7 @@ jobs:
           go-version-file: "go.mod"
           cache: false
 
-      - name: Setup LXD
-        uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
-
-      - name: "Set up MongoDB"
-        run: |
-          sudo snap install juju-db --channel=4.4.30/stable
-          echo "/snap/bin" >> $GITHUB_PATH
-
-      - name: "Setup Gochanged"
-        if: inputs.base
-        run: |
-          go install github.com/hpidcock/gochanged@latest
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
-      - name: "Calculate Test Packages"
-        if: inputs.base
-        run: |
-          TEST_PACKAGE_LIST=$(mktemp)
-          gochanged -b "${{ inputs.base }}" | sort | tee "${TEST_PACKAGE_LIST}"
-          if [ -z "$(grep -F './...' ${TEST_PACKAGE_LIST})" ]; then
-            echo "TEST_PACKAGE_LIST=${TEST_PACKAGE_LIST}" >> $GITHUB_ENV
-          fi
-
       - name: "Test"
         run: |
           export GOEXPERIMENT=goroutineleakprofile
-          make race-test TEST_PACKAGE_LIST="${TEST_PACKAGE_LIST}"
+          make race-test


### PR DESCRIPTION
Simplify the unit test Github action workflow.
1. Avoid calculating which packages to test based on files changed as we may miss required testing based on dependency updates.
2. Avoid installing dependencies that aren't needed like MongoDB and LXD.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
