### PR TITLE
fix(k8s): wait for namespace availability before returning from createNamespace

### DIFF
--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -309,11 +309,12 @@ func (s *bootstrapSuite) testBootstrap(c *tc.C, enableServiceLinks bool) {
 	s.cfg = cfg
 	s.pcfg.Bootstrap.ControllerModelConfig = cfg
 
+	namespaceWatcher, _ := k8swatchertest.NewKubernetesTestWatcher()
 	podWatcher, podFirer := k8swatchertest.NewKubernetesTestWatcher()
 	eventWatcher, _ := k8swatchertest.NewKubernetesTestWatcher()
 	<-podWatcher.Changes()
 	<-eventWatcher.Changes()
-	watchers := []k8swatcher.KubernetesNotifyWatcher{podWatcher, eventWatcher}
+	watchers := []k8swatcher.KubernetesNotifyWatcher{namespaceWatcher, podWatcher, eventWatcher}
 	watchCallCount := 0
 
 	s.k8sWatcherFn = func(_ cache.SharedIndexInformer, n string, _ jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
@@ -1077,9 +1078,10 @@ exec /opt/pebble run --http :38811 --verbose
 		c.Assert(err, tc.ErrorIsNil)
 		c.Assert(crb, tc.DeepEquals, controllerServiceCRB)
 
-		c.Assert(bootstrapWatchers, tc.HasLen, 2)
+		c.Assert(bootstrapWatchers, tc.HasLen, 3)
 		c.Assert(workertest.CheckKilled(c, bootstrapWatchers[0]), tc.ErrorIsNil)
 		c.Assert(workertest.CheckKilled(c, bootstrapWatchers[1]), tc.ErrorIsNil)
+		c.Assert(workertest.CheckKilled(c, bootstrapWatchers[2]), tc.ErrorIsNil)
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for deploy return")
 	}
@@ -1095,6 +1097,8 @@ func (s *bootstrapSuite) TestBootstrapFailedTimeout(c *tc.C) {
 	_, err := s.mockNamespaces.Get(c.Context(), s.namespace, v1.GetOptions{})
 	c.Assert(err, tc.Satisfies, k8serrors.IsNotFound)
 
+	namespaceWatcher, _ := k8swatchertest.NewKubernetesTestWatcher()
+	s.k8sWatcherFn = k8swatchertest.NewKubernetesTestWatcherFunc(namespaceWatcher)
 	var watchers []k8swatcher.KubernetesNotifyWatcher
 	s.setupBroker(c, newK8sClientFunc, newK8sRestClientFunc, &watchers)
 
@@ -1127,9 +1131,11 @@ func (s *bootstrapSuite) TestBootstrapFailedTimeout(c *tc.C) {
 	ns.Name = s.namespace
 	s.ensureJujuNamespaceAnnotations(true, ns)
 
+	namespaceDoneChan := make(chan struct{})
 	ctxDoneChan := make(chan struct{}, 1)
 
 	gomock.InOrder(
+		mockStdCtx.EXPECT().Done().Return(namespaceDoneChan),
 		mockStdCtx.EXPECT().Err().Return(nil),
 		mockStdCtx.EXPECT().Done().DoAndReturn(func() <-chan struct{} {
 			ctxDoneChan <- struct{}{}
@@ -1146,7 +1152,7 @@ func (s *bootstrapSuite) TestBootstrapFailedTimeout(c *tc.C) {
 	select {
 	case err := <-errChan:
 		c.Assert(err, tc.ErrorMatches, `creating service for controller: waiting for controller service address fully provisioned timeout`)
-		c.Assert(watchers, tc.HasLen, 0)
+		c.Assert(watchers, tc.HasLen, 1)
 	case <-time.After(coretesting.LongWait):
 		c.Fatalf("timed out waiting for deploy return")
 	}

--- a/internal/provider/kubernetes/k8s_test.go
+++ b/internal/provider/kubernetes/k8s_test.go
@@ -717,6 +717,8 @@ func (s *K8sBrokerSuite) TestGetCurrentNamespace(c *tc.C) {
 func (s *K8sBrokerSuite) TestCreateModelResources(c *tc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
+	namespaceWatcher, namespaceFirer := k8swatchertest.NewKubernetesTestWatcher()
+	s.k8sWatcherFn = k8swatchertest.NewKubernetesTestWatcherFunc(namespaceWatcher)
 
 	ns := s.ensureJujuNamespaceAnnotations(false, &core.Namespace{
 		ObjectMeta: v1.ObjectMeta{
@@ -726,12 +728,44 @@ func (s *K8sBrokerSuite) TestCreateModelResources(c *tc.C) {
 	})
 	s.mockNamespaces.EXPECT().Create(gomock.Any(), ns, v1.CreateOptions{}).
 		Return(ns, nil)
+	s.mockNamespaces.EXPECT().Get(gomock.Any(), "test", v1.GetOptions{}).
+		DoAndReturn(func(context.Context, string, v1.GetOptions) (*core.Namespace, error) {
+			namespaceFirer()
+			return nil, s.k8sNotFoundError()
+		})
+	s.mockNamespaces.EXPECT().Get(gomock.Any(), "test", v1.GetOptions{}).
+		Return(ns, nil)
 
 	err := s.broker.CreateModelResources(
 		c.Context(),
 		environs.CreateParams{},
 	)
 	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *K8sBrokerSuite) TestCreateModelResourcesContextCancelled(c *tc.C) {
+	ctrl := s.setupController(c)
+	defer ctrl.Finish()
+	namespaceWatcher, _ := k8swatchertest.NewKubernetesTestWatcher()
+	s.k8sWatcherFn = k8swatchertest.NewKubernetesTestWatcherFunc(namespaceWatcher)
+
+	ns := s.ensureJujuNamespaceAnnotations(false, &core.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Labels: map[string]string{"app.kubernetes.io/managed-by": "juju", "model.juju.is/id": "deadbeef-0bad-400d-8000-4b1d0d06f00d", "model.juju.is/name": "test"},
+			Name:   "test",
+		},
+	})
+	ctx, cancel := context.WithCancel(c.Context())
+	s.mockNamespaces.EXPECT().Create(gomock.Any(), ns, v1.CreateOptions{}).
+		Return(ns, nil)
+	s.mockNamespaces.EXPECT().Get(gomock.Any(), "test", v1.GetOptions{}).
+		DoAndReturn(func(context.Context, string, v1.GetOptions) (*core.Namespace, error) {
+			cancel()
+			return nil, s.k8sNotFoundError()
+		})
+
+	err := s.broker.CreateModelResources(ctx, environs.CreateParams{})
+	c.Assert(err, tc.ErrorIs, context.Canceled)
 }
 
 func (s *K8sBrokerSuite) TestValidateProviderForNewModel(c *tc.C) {

--- a/internal/provider/kubernetes/namespaces.go
+++ b/internal/provider/kubernetes/namespaces.go
@@ -110,7 +110,8 @@ func (k *kubernetesClient) ensureNamespaceAnnotations(ns *core.Namespace) error 
 	return nil
 }
 
-// createNamespace creates a namespace with the input name.
+// createNamespace creates a namespace with the input name and waits until it
+// is available via GetNamespace before returning.
 func (k *kubernetesClient) createNamespace(ctx context.Context, name string) error {
 	ns := &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: name}}
 	ns.SetLabels(utils.LabelsMerge(
@@ -122,11 +123,42 @@ func (k *kubernetesClient) createNamespace(ctx context.Context, name string) err
 		return errors.Trace(err)
 	}
 
-	_, err := k.client().CoreV1().Namespaces().Create(ctx, ns, v1.CreateOptions{})
+	// Start watching before creating the namespace so that no change is
+	// missed. Notifications only indicate that state may have changed, so
+	// re-read the namespace after each one until it is available.
+	w, err := k.WatchNamespace()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer w.Kill()
+
+	_, err = k.client().CoreV1().Namespaces().Create(ctx, ns, v1.CreateOptions{})
 	if k8serrors.IsAlreadyExists(err) {
 		return errors.AlreadyExistsf("namespace %q", name)
 	}
-	return errors.Trace(err)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Wait until the namespace is available via GetNamespace. A freshly created
+	// namespace may transiently report NotFound.
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.Annotatef(ctx.Err(), "waiting for namespace %q to be available", name)
+		case _, ok := <-w.Changes():
+			if !ok {
+				return errors.Errorf("namespace watcher for %q closed before namespace was available", name)
+			}
+			if _, err := k.GetNamespace(ctx, name); err != nil {
+				if errors.Is(err, errors.NotFound) {
+					continue
+				}
+				return errors.Trace(err)
+			}
+			return nil
+		}
+	}
 }
 
 func (k *kubernetesClient) deleteNamespace(ctx context.Context) error {


### PR DESCRIPTION
CreateNamespace returned immediately after the Kubernetes Create call. Due to kubernetes apiserver watch-cache eventual consistency, a subsequent GetNamespace could transiently return NotFound. The namespace had been created but was not yet visible to reads. This caused intermittent failures in the secrets_k8s CI suite, where operations immediately following add-model hit a spurious namespace not found.

CreateNamespace now starts a namespace watcher before calling Create, then waits via the watcher's event loop until GetNamespace succeeds 

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests
./main.sh -v -c microk8s -p k8s secrets_k8s test_user_secrets
./main.sh -v -c microk8s -p k8s secrets_k8s test_add_multiple_secrets_parallel
```

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10277](https://warthogs.atlassian.net/browse/JUJU-10277)


[JUJU-10277]: https://warthogs.atlassian.net/browse/JUJU-10277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ