### PR TITLE
fix(relation): stop recursive subordinate unit deployment

### DIFF
--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -2138,28 +2138,14 @@ func (st *State) getPrincipalApplicationOfUnit(
 	tx *sqlair.TX,
 	unitUUID string,
 ) (string, error) {
-	principal := getPrincipal{
-		UnitUUID: unitUUID,
-	}
-
-	stmt, err := st.Prepare(`
-SELECT &getPrincipal.application_uuid
-FROM   unit u
-JOIN   unit_principal up ON up.principal_uuid = u.uuid
-WHERE  up.unit_uuid = $getPrincipal.unit_uuid
-`, principal)
+	principalUnitUUID, found, err := st.getUnitPrincipalUUID(ctx, tx, unitUUID)
 	if err != nil {
 		return "", errors.Capture(err)
-	}
-
-	err = tx.Query(ctx, stmt, principal).Get(&principal)
-	if errors.Is(sql.ErrNoRows, err) {
+	} else if !found {
 		return "", relationerrors.UnitPrincipalNotFound
-	} else if err != nil {
-		return "", errors.Capture(err)
 	}
 
-	return principal.ApplicationUUID, nil
+	return st.getApplicationUUIDByUnitUUID(ctx, tx, principalUnitUUID)
 }
 
 // insertRelationUnit inserts a relation unit record if it doesn't exist.

--- a/domain/relation/state/subordinateunit.go
+++ b/domain/relation/state/subordinateunit.go
@@ -38,7 +38,7 @@ type InsertIAASUnitState interface {
 func (st *State) addSubordinateUnit(
 	ctx context.Context,
 	tx *sqlair.TX,
-	relationUUID, relationUnitUUID, principalUnitUUID string,
+	relationUUID, relationUnitUUID, enteringUnitUUID string,
 ) (internal.SubordinateUnitStatusHistoryData, error) {
 	var empty internal.SubordinateUnitStatusHistoryData
 	// Check that we are in a container scoped relation.
@@ -56,6 +56,21 @@ func (st *State) addSubordinateUnit(
 		return empty, errors.Errorf("getting related subordinate application: %w", err)
 	} else if !relatedSubExists {
 		return empty, nil
+	}
+
+	// The entering unit is the principal unit of the new subordinate unit,
+	// unless the entering unit is itself a subordinate unit. This happens
+	// when two subordinate applications are related to each other in a
+	// container scoped relation. In that case, the new subordinate unit must
+	// be keyed to the principal of the entering unit. Keying it to the
+	// entering unit instead would make the relation-joined hook of the newly
+	// created unit spawn another unit of the other application, and so on
+	// without ever terminating.
+	principalUnitUUID := enteringUnitUUID
+	if principalUUID, found, err := st.getUnitPrincipalUUID(ctx, tx, enteringUnitUUID); err != nil {
+		return empty, errors.Errorf("getting principal unit of entering unit: %w", err)
+	} else if found {
+		principalUnitUUID = principalUUID
 	}
 
 	// Check if there is already a subordinate unit.
@@ -179,6 +194,37 @@ WHERE  u.uuid = $entityUUID.uuid
 	}
 
 	return dbVal, nil
+}
+
+// getUnitPrincipalUUID returns the UUID of the principal unit recorded for
+// the given unit, and true, if the unit is a subordinate unit. If the unit
+// has no principal unit, false is returned.
+func (st *State) getUnitPrincipalUUID(
+	ctx context.Context, tx *sqlair.TX, unitUUID string,
+) (string, bool, error) {
+	type unitPrincipalRow struct {
+		UnitUUID      string `db:"unit_uuid"`
+		PrincipalUUID string `db:"principal_uuid"`
+	}
+	stmt, err := st.Prepare(`
+SELECT principal_uuid AS &unitPrincipalRow.*
+FROM   unit_principal
+WHERE  unit_uuid = $unitPrincipalRow.unit_uuid
+`, unitPrincipalRow{})
+	if err != nil {
+		return "", false, errors.Capture(err)
+	}
+
+	arg := unitPrincipalRow{UnitUUID: unitUUID}
+	var row unitPrincipalRow
+	err = tx.Query(ctx, stmt, arg).Get(&row)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return "", false, nil
+	} else if err != nil {
+		return "", false, errors.Capture(err)
+	}
+
+	return row.PrincipalUUID, true, nil
 }
 
 func (s *State) getCharmIDByApplicationUUID(ctx context.Context, tx *sqlair.TX, appID string) (string, error) {

--- a/domain/relation/state/subordinateunit.go
+++ b/domain/relation/state/subordinateunit.go
@@ -202,20 +202,22 @@ WHERE  u.uuid = $entityUUID.uuid
 func (st *State) getUnitPrincipalUUID(
 	ctx context.Context, tx *sqlair.TX, unitUUID string,
 ) (string, bool, error) {
+	// unitPrincipalRow describes the projected principal_uuid column. The
+	// input unit UUID is bound from a separate entityUUID so this struct only
+	// carries the data a query populates.
 	type unitPrincipalRow struct {
-		UnitUUID      string `db:"unit_uuid"`
 		PrincipalUUID string `db:"principal_uuid"`
 	}
 	stmt, err := st.Prepare(`
-SELECT principal_uuid AS &unitPrincipalRow.*
+SELECT principal_uuid AS &unitPrincipalRow.principal_uuid
 FROM   unit_principal
-WHERE  unit_uuid = $unitPrincipalRow.unit_uuid
-`, unitPrincipalRow{})
+WHERE  unit_uuid = $entityUUID.uuid
+`, unitPrincipalRow{}, entityUUID{})
 	if err != nil {
 		return "", false, errors.Capture(err)
 	}
 
-	arg := unitPrincipalRow{UnitUUID: unitUUID}
+	arg := entityUUID{UUID: unitUUID}
 	var row unitPrincipalRow
 	err = tx.Query(ctx, stmt, arg).Get(&row)
 	if errors.Is(err, sqlair.ErrNoRows) {

--- a/domain/relation/state/subordinateunit_test.go
+++ b/domain/relation/state/subordinateunit_test.go
@@ -211,6 +211,179 @@ func (s *subordinateUnitSuite) TestAddSubordinateUnitAlreadyRelated(c *tc.C) {
 	c.Check(obtainedData.SubordinateCreated(), tc.Equals, false)
 }
 
+// TestAddSubordinateUnitEnteringUnitIsSubordinate ensures that when a
+// subordinate unit enters scope in a container scoped relation with another
+// subordinate application, the created unit is keyed to the principal of the
+// entering unit, and not to the entering subordinate unit itself. Otherwise
+// the relation-joined hook of the newly created unit spawns a new unit of
+// the other application, and so on without ever terminating.
+// See https://github.com/juju/juju/issues/23049.
+func (s *subordinateUnitSuite) TestAddSubordinateUnitEnteringUnitIsSubordinate(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: add principal application with 1 unit on a machine.
+	principalCharmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, principalCharmUUID, false)
+	principalApplicationUUID := s.addApplication(c, principalCharmUUID, "pri")
+	principalUnitName := coreunittesting.GenNewName(c, "pri/0")
+	principalUnitUUID := s.addUnit(c, principalUnitName, principalApplicationUUID, principalCharmUUID)
+	principalMachineName, principalMachineUUID := s.addMachineToUnit(c, principalUnitUUID.String())
+	principalUnitNetNode := s.getUnitNetNode(c, principalUnitUUID.String())
+
+	// Arrange: add a first subordinate application, with a unit already
+	// attached to the principal unit, as if it was created by its own
+	// container scoped relation with the principal application.
+	subordinate1CharmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, subordinate1CharmUUID, true)
+	subordinate1ApplicationUUID := s.addApplication(c, subordinate1CharmUUID, "sub1")
+	subordinate1UnitName := coreunittesting.GenNewName(c, "sub1/0")
+	subordinate1UnitUUID := s.addUnit(c, subordinate1UnitName, subordinate1ApplicationUUID, subordinate1CharmUUID)
+	// The subordinate unit lives on the machine of the principal unit, so it
+	// shares its net node.
+	s.setUnitNetNode(c, subordinate1UnitUUID.String(), principalUnitNetNode)
+	s.query(c, `
+INSERT INTO unit_principal (unit_uuid, principal_uuid)
+VALUES (?, ?)
+`, subordinate1UnitUUID, principalUnitUUID)
+
+	// Arrange: add a second subordinate application, with no unit yet.
+	subordinate2CharmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, subordinate2CharmUUID, true)
+	subordinate2ApplicationUUID := s.addApplication(c, subordinate2CharmUUID, "sub2")
+	subordinate2UnitName := coreunittesting.GenNewName(c, "sub2/0")
+
+	// Arrange: relate the two subordinate applications in a container
+	// scoped relation, and make the first subordinate unit enter scope.
+	relationUUID, subordinate1RelationEndpointUUID, _ := s.addContainerScopedRelation(
+		c, subordinate1ApplicationUUID, subordinate1CharmUUID,
+		subordinate2ApplicationUUID, subordinate2CharmUUID)
+	relationUnitUUID := s.addRelationUnit(c, subordinate1UnitUUID, subordinate1RelationEndpointUUID)
+
+	// Arrange: expect the call to InsertIAASUnit, placed on the machine of
+	// the entering unit's principal unit.
+	args := domainapplication.AddIAASUnitArg{
+		MachineNetNodeUUID: principalUnitNetNode,
+		MachineUUID:        principalMachineUUID,
+		AddUnitArg: domainapplication.AddUnitArg{
+			UnitStatusArg: domainapplication.UnitStatusArg{
+				AgentStatus: &status.StatusInfo[status.UnitAgentStatusType]{
+					Status: status.UnitAgentStatusAllocating,
+				},
+				WorkloadStatus: &status.StatusInfo[status.WorkloadStatusType]{
+					Status:  status.WorkloadStatusWaiting,
+					Message: corestatus.MessageWaitForMachine,
+				},
+			},
+			Placement: deployment.Placement{
+				Type:      deployment.PlacementTypeMachine,
+				Directive: principalMachineName.String(),
+			},
+			NetNodeUUID: principalUnitNetNode,
+		},
+	}
+	s.insertIAASUnitState.EXPECT().InsertIAASUnit(
+		gomock.Any(), gomock.Any(), subordinate2ApplicationUUID.String(), subordinate2CharmUUID.String(), addIAASUnitArgMatcher{
+			c:        c,
+			expected: args,
+		}).DoAndReturn(
+		func(ctx context.Context, tx *sqlair.TX, appUUID, charmUUID string, arg domainapplication.AddIAASUnitArg) (coreunit.Name, []coremachine.Name, error) {
+			// Mirror the real state behavior: the unit row is inserted with
+			// the uuid and net node passed in by the caller, so that the
+			// principal-subordinate relationship can be recorded.
+			if err := s.insertUnitInTx(ctx, tx, arg.UnitUUID.String(), subordinate2UnitName.String(), appUUID, charmUUID, arg.NetNodeUUID); err != nil {
+				return "", nil, err
+			}
+			return subordinate2UnitName, []coremachine.Name{principalMachineName}, nil
+		})
+
+	// Act
+	var (
+		err          error
+		obtainedData internal.SubordinateUnitStatusHistoryData
+	)
+	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		obtainedData, err = s.state.addSubordinateUnit(ctx, tx, relationUUID.String(), relationUnitUUID.String(), subordinate1UnitUUID.String())
+		return err
+	})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtainedData.SubordinateCreated(), tc.IsTrue)
+	// The new unit must be keyed to the principal of the entering unit, on
+	// top of the existing first subordinate unit.
+	s.checkUnitPrincipalCount(c, principalUnitUUID.String(), 2)
+	// ... and not to the entering subordinate unit.
+	s.checkUnitPrincipalCount(c, subordinate1UnitUUID.String(), 0)
+}
+
+// TestAddSubordinateUnitAlreadyExistsUnderEnteringUnitPrincipal ensures that
+// no subordinate unit is created when a unit of the related subordinate
+// application already exists under the principal of the unit entering scope,
+// even when the entering unit is itself a subordinate.
+// See https://github.com/juju/juju/issues/23049.
+func (s *subordinateUnitSuite) TestAddSubordinateUnitAlreadyExistsUnderEnteringUnitPrincipal(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange: add principal application with 1 unit on a machine.
+	principalCharmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, principalCharmUUID, false)
+	principalApplicationUUID := s.addApplication(c, principalCharmUUID, "pri")
+	principalUnitName := coreunittesting.GenNewName(c, "pri/0")
+	principalUnitUUID := s.addUnit(c, principalUnitName, principalApplicationUUID, principalCharmUUID)
+	principalUnitNetNode := s.getUnitNetNode(c, principalUnitUUID.String())
+	s.addMachineToUnit(c, principalUnitUUID.String())
+
+	// Arrange: add a first subordinate application, with a unit already
+	// attached to the principal unit.
+	subordinate1CharmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, subordinate1CharmUUID, true)
+	subordinate1ApplicationUUID := s.addApplication(c, subordinate1CharmUUID, "sub1")
+	subordinate1UnitName := coreunittesting.GenNewName(c, "sub1/0")
+	subordinate1UnitUUID := s.addUnit(c, subordinate1UnitName, subordinate1ApplicationUUID, subordinate1CharmUUID)
+	// The subordinate unit lives on the machine of the principal unit, so it
+	// shares its net node.
+	s.setUnitNetNode(c, subordinate1UnitUUID.String(), principalUnitNetNode)
+	s.query(c, `
+INSERT INTO unit_principal (unit_uuid, principal_uuid)
+VALUES (?, ?)
+`, subordinate1UnitUUID, principalUnitUUID)
+
+	// Arrange: add a second subordinate application, with a unit already
+	// attached to the principal unit as well.
+	subordinate2CharmUUID := s.addCharm(c)
+	s.addCharmMetadata(c, subordinate2CharmUUID, true)
+	subordinate2ApplicationUUID := s.addApplication(c, subordinate2CharmUUID, "sub2")
+	subordinate2UnitName := coreunittesting.GenNewName(c, "sub2/0")
+	subordinate2UnitUUID := s.addUnit(c, subordinate2UnitName, subordinate2ApplicationUUID, subordinate2CharmUUID)
+	s.query(c, `
+INSERT INTO unit_principal (unit_uuid, principal_uuid)
+VALUES (?, ?)
+`, subordinate2UnitUUID, principalUnitUUID)
+
+	// Arrange: relate the two subordinate applications in a container
+	// scoped relation, and make the first subordinate unit enter scope.
+	relationUUID, subordinate1RelationEndpointUUID, _ := s.addContainerScopedRelation(
+		c, subordinate1ApplicationUUID, subordinate1CharmUUID,
+		subordinate2ApplicationUUID, subordinate2CharmUUID)
+	relationUnitUUID := s.addRelationUnit(c, subordinate1UnitUUID, subordinate1RelationEndpointUUID)
+
+	// No call to InsertIAASUnit is expected.
+
+	// Act
+	var (
+		err          error
+		obtainedData internal.SubordinateUnitStatusHistoryData
+	)
+	err = s.TxnRunner().Txn(c.Context(), func(ctx context.Context, tx *sqlair.TX) error {
+		obtainedData, err = s.state.addSubordinateUnit(ctx, tx, relationUUID.String(), relationUnitUUID.String(), subordinate1UnitUUID.String())
+		return err
+	})
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(obtainedData.SubordinateCreated(), tc.IsFalse)
+}
+
 func (s *subordinateUnitSuite) TestAddSubordinateUnitSubordinateNotAlive(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -412,6 +585,55 @@ func (s *subordinateUnitSuite) checkUnitPrincipal(c *tc.C, principal, subordinat
 	err := row.Scan(&count)
 	c.Check(err, tc.ErrorIsNil)
 	c.Check(count, tc.Equals, 1, tc.Commentf("q: %s", qry))
+}
+
+// checkUnitPrincipalCount checks the number of units keyed to the given
+// principal unit in the unit_principal table.
+func (s *subordinateUnitSuite) checkUnitPrincipalCount(c *tc.C, principal string, expected int) {
+	qry := `SELECT count(*) FROM unit_principal WHERE principal_uuid = ?`
+	row := s.DB().QueryRow(qry, principal)
+	var count int
+	err := row.Scan(&count)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(count, tc.Equals, expected, tc.Commentf("q: %s", qry))
+}
+
+// setUnitNetNode updates the net node of a unit.
+func (s *subordinateUnitSuite) setUnitNetNode(c *tc.C, unitUUID string, netNodeUUID network.NetNodeUUID) {
+	s.query(c, `
+UPDATE unit SET net_node_uuid = ? WHERE uuid = ?
+`, netNodeUUID, unitUUID)
+}
+
+// insertUnitInTx inserts a unit row within the given transaction, mirroring
+// what the real InsertIAASUnit state does. The net node must already exist.
+func (s *subordinateUnitSuite) insertUnitInTx(
+	ctx context.Context, tx *sqlair.TX,
+	unitUUID, unitName, appUUID, charmUUID string,
+	netNodeUUID network.NetNodeUUID,
+) error {
+	type unitRow struct {
+		UnitUUID        string `db:"unit_uuid"`
+		Name            string `db:"name"`
+		ApplicationUUID string `db:"application_uuid"`
+		CharmUUID       string `db:"charm_uuid"`
+		NetNodeUUID     string `db:"net_node_uuid"`
+	}
+	arg := unitRow{
+		UnitUUID:        unitUUID,
+		Name:            unitName,
+		ApplicationUUID: appUUID,
+		CharmUUID:       charmUUID,
+		NetNodeUUID:     netNodeUUID.String(),
+	}
+	stmt, err := s.state.Prepare(`
+INSERT INTO unit (uuid, name, life_id, application_uuid, charm_uuid, net_node_uuid)
+VALUES ($unitRow.unit_uuid, $unitRow.name, 0, $unitRow.application_uuid, $unitRow.charm_uuid, $unitRow.net_node_uuid)
+`, arg)
+	if err != nil {
+		return err
+	}
+	return tx.Query(ctx, stmt, arg).Run()
 }
 
 type addIAASUnitArgMatcher struct {

--- a/testcharms/charms/subordinate-link/charmcraft.yaml
+++ b/testcharms/charms/subordinate-link/charmcraft.yaml
@@ -1,0 +1,12 @@
+type: "charm"
+base: ubuntu@24.04
+platforms:
+  amd64:
+parts:
+  # Include extra files in the packed charm
+  include:
+    plugin: dump
+    source: .
+    prime:
+      - hooks
+      - metadata.yaml

--- a/testcharms/charms/subordinate-link/hooks/start
+++ b/testcharms/charms/subordinate-link/hooks/start
@@ -1,0 +1,2 @@
+#!/bin/bash
+status-set active "ready"

--- a/testcharms/charms/subordinate-link/metadata.yaml
+++ b/testcharms/charms/subordinate-link/metadata.yaml
@@ -1,0 +1,20 @@
+name: subordinate-link
+summary: Minimal subordinate test charm with container scoped link endpoints
+maintainer: Juju QA <juju-qa@canonical.com>
+description: |
+  Minimal subordinate charm used to test subordinate-to-subordinate
+  container scoped relations. Deployed twice, both applications attach
+  to a principal via juju-info and relate to each other through the
+  container scoped subordinate-link endpoints.
+subordinate: true
+requires:
+  juju-info:
+    interface: juju-info
+    scope: container
+  link-a:
+    interface: subordinate-link
+    scope: container
+provides:
+  link-b:
+    interface: subordinate-link
+    scope: container

--- a/tests/suites/relations/recursive_subordinate_units.sh
+++ b/tests/suites/relations/recursive_subordinate_units.sh
@@ -1,0 +1,73 @@
+# Ensure that subordinate applications related to each other do not create
+# subordinate units recursively.
+
+# subordinate_idle_condition emits a yq query matching only when the given
+# subordinate unit of the given principal application exists and is idle.
+# The built-in idle_subordinate_condition cannot be used here: its select is
+# evaluated over an empty stream and also matches before the subordinate
+# unit exists.
+subordinate_idle_condition() {
+	local parent app
+	parent=${1}
+	app=${2}
+
+	echo "[.applications[\"${parent}\"].units[] | (.subordinates // {}) | to_entries[] | select(.key == \"${app}/0\" and .value[\"juju-status\"].current == \"idle\") | .key] | .[]"
+}
+
+# subordinate_unit_count prints the number of units of the given subordinate
+# application keyed to the given principal application.
+subordinate_unit_count() {
+	local parent app
+	parent=${1}
+	app=${2}
+
+	juju status --format=json | yq "[.applications[\"${parent}\"].units[] | (.subordinates // {}) | to_entries[] | select(.key | test(\"^${app}/\"))] | length"
+}
+
+run_recursive_subordinate_units() {
+	echo
+
+	model_name="test-recursive-subordinate-units"
+	file="${TEST_DIR}/${model_name}.log"
+
+	ensure "${model_name}" "${file}"
+
+	# Deploy the same subordinate charm twice: both applications attach to
+	# the principal via juju-info and relate to each other through the
+	# container scoped subordinate-link endpoints.
+	juju deploy "$(pack_charm "${CURRENT_DIR}"/../testcharms/charms/lxd-profile)" principal
+	juju deploy "$(pack_charm "${CURRENT_DIR}"/../testcharms/charms/subordinate-link)" subordinate-one
+	juju deploy "$(pack_charm "${CURRENT_DIR}"/../testcharms/charms/subordinate-link)" subordinate-two
+	juju integrate subordinate-one principal
+	juju integrate subordinate-two principal
+	juju integrate subordinate-one:link-a subordinate-two:link-b
+
+	wait_for "subordinate-one/0" "$(subordinate_idle_condition principal subordinate-one)"
+	wait_for "subordinate-two/0" "$(subordinate_idle_condition principal subordinate-two)"
+
+	# Subordinate units live under the principal unit's subordinates. Both
+	# must be keyed to the principal unit itself: keying one of them to the
+	# other subordinate is what causes the recursive deployment. Allow a
+	# further relation-joined/hook cycle to run, then verify that no
+	# additional subordinate unit has been spawned.
+	sleep 30
+	check "1" <<<"$(subordinate_unit_count principal subordinate-one)"
+	check "1" <<<"$(subordinate_unit_count principal subordinate-two)"
+
+	destroy_model "${model_name}"
+}
+
+test_recursive_subordinate_units() {
+	if [ "$(skip 'test_recursive_subordinate_units')" ]; then
+		echo "==> TEST SKIPPED: recursive subordinate unit tests"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_recursive_subordinate_units"
+	)
+}

--- a/tests/suites/relations/recursive_subordinate_units.sh
+++ b/tests/suites/relations/recursive_subordinate_units.sh
@@ -24,6 +24,34 @@ subordinate_unit_count() {
 	juju status --format=json | yq "[.applications[\"${parent}\"].units[] | (.subordinates // {}) | to_entries[] | select(.key | test(\"^${app}/\"))] | length"
 }
 
+# subordinate_count_stable returns once the number of units of the given
+# subordinate application keyed to the principal has been observed to be
+# exactly one on two consecutive samples, one SHORT_TIMEOUT apart. Requiring
+# a stable window instead of a fixed sleep means neither a busy CI runner
+# (more headroom up to SUBORDINATE_SETTLE_TIMEOUT) nor a fast one (exits as
+# soon as two matches) is penalised, and a spurious relation-joined hook
+# cycle has a bounded window in which to surface an extra unit.
+subordinate_count_stable() {
+	local subordinate deadline current last
+	subordinate=${1}
+	deadline=$(( $(date +%s) + ${SUBORDINATE_SETTLE_TIMEOUT:-60} ))
+	last=""
+
+	while :; do
+		current=$(subordinate_unit_count principal "${subordinate}")
+		if [[ ${current} == "1" && ${current} == "${last}" ]]; then
+			return 0
+		fi
+		last=${current}
+
+		if (( $(date +%s) >= deadline )); then
+			echo "subordinate count for ${subordinate} did not stabilise at 1 (last=${current})" >&2
+			return 1
+		fi
+		sleep "${SHORT_TIMEOUT}"
+	done
+}
+
 run_recursive_subordinate_units() {
 	echo
 
@@ -47,10 +75,12 @@ run_recursive_subordinate_units() {
 
 	# Subordinate units live under the principal unit's subordinates. Both
 	# must be keyed to the principal unit itself: keying one of them to the
-	# other subordinate is what causes the recursive deployment. Allow a
-	# further relation-joined/hook cycle to run, then verify that no
-	# additional subordinate unit has been spawned.
-	sleep 30
+	# other subordinate is what causes the recursive deployment. Once the
+	# count has stabilised, assert that no extra subordinate unit was spawned
+	# during the observation window.
+	subordinate_count_stable subordinate-one
+	subordinate_count_stable subordinate-two
+
 	check "1" <<<"$(subordinate_unit_count principal subordinate-one)"
 	check "1" <<<"$(subordinate_unit_count principal subordinate-two)"
 

--- a/tests/suites/relations/task.sh
+++ b/tests/suites/relations/task.sh
@@ -17,6 +17,7 @@ test_relations() {
 	test_relation_departing_unit
 	test_relation_list_app
 	test_relation_model_get
+	test_recursive_subordinate_units
 
 	destroy_controller "test-relations"
 }


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

Deploying a bundle where two subordinate charms share a container-scoped
relation (e.g. `hardware-observer` and `opentelemetry-collector` related via
`cos-agent`, both related to `ubuntu`) made Juju 4.0 deploy units
recursively without ever terminating: the relation-joined hook of each newly
created unit spawned another unit of the other application, producing chains
such as `ubuntu/0 -> hardware-observer/0 -> opentelemetry-collector/1 ->
hardware-observer/2 -> ...`. Juju 3.6 handles the same bundle correctly.

The bug lives in `addSubordinateUnit`, called from `EnterScope` when a unit
enters a container-scoped relation whose other application is a subordinate.
The created subordinate unit was keyed to the entering unit itself, and the
caller passes the unit entering scope. For a relation between two subordinate
applications the entering unit is itself a subordinate, so the new unit was
keyed to that subordinate, and the cycle repeated on every hook completion.

The created subordinate unit is now keyed to the principal of the entering
unit, or to the entering unit itself when it has no principal (the regular
principal/subordinate case, unchanged behavior). As `unit_principal` is
single-hop by design, this stops the recursive deployment.

Along the way, `getPrincipalApplicationOfUnit` is reworked to reuse the new
`getUnitPrincipalUUID` primitive instead of a bespoke join, so the lookup of
a unit's principal has a single implementation in the relation state.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Deploy the bundle from the issue on a 4.0 controller built with these
changes and verify that each machine gets exactly one unit of each
subordinate application, keyed to the principal unit of the machine, and
that no further units are spawned over time:

```yaml
applications:
  ubuntu:
    charm: ubuntu
    channel: latest/stable
    num_units: 1
  opentelemetry-collector:
    charm: opentelemetry-collector
    channel: 0.130/edge
    num_units: 0
  hardware-observer:
    charm: hardware-observer
    channel: latest/stable
    num_units: 0
relations:
  - - opentelemetry-collector:juju-info
    - ubuntu:juju-info
  - - hardware-observer:general-info
    - ubuntu:juju-info
  - - opentelemetry-collector:cos-agent
    - hardware-observer:cos-agent
```

```sh
$ juju add-model recurse
$ juju deploy ./bundle.yaml
$ watch juju status
```

Expected: `ubuntu/0` hosts `hardware-observer/0` and
`opentelemetry-collector/0`, and the status tree stops growing.

Unit level regression tests:

```sh
$ go test ./domain/relation/state/ -run TestSubordinateUnitSuite -race -count=1
```

No facade was changed, so model migration testing is not affected by this
change.

New CI test:

```sh
./main.sh -v relations run_recursive_subordinate_units 
```

## Documentation changes

None; this restores the 3.6 deployment semantics for subordinates.

## Links

**Issue:** Fixes #23049.

**Jira card:** [JUJU-10242](https://warthogs.atlassian.net/browse/JUJU-10242)


[JUJU-10242]: https://warthogs.atlassian.net/browse/JUJU-10242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ