### PR TITLE
docs: add watcher initialisation instructions for agents

### DIFF
--- a/AGENTS.architecture-rules.md
+++ b/AGENTS.architecture-rules.md
@@ -43,6 +43,18 @@ Respect Juju layering. Never create new cross-layer dependencies.
 - Blocking operations in hot paths.
 - Client, cross-controller, or third-party connections without deterministic closure.
 
+### Watcher Initialisation and Readiness
+
+- Watcher-backed workflows must establish their subscription before performing the initial state query, 
+  so no relevant change can be missed.
+- A watcher constructor returning does not imply that its subscription is active unless this is explicitly documented.
+- For watchers with an initial event, receiving that event is the readiness barrier: 
+  the subscription and initial query have completed.
+- An empty initial event is still a valid readiness signal and must not be discarded without observing it.
+- Do not expose handlers, signal worker readiness, or make decisions from separate 
+  state queries until the required watcher readiness barrier has been crossed.
+- Tests must exercise changes racing watcher construction, subscription, and the initial query.
+
 ## API Facade Rules
 
 - Keep facades to thin orchestration.


### PR DESCRIPTION
Adds instructions for agents regarding watcher initialisation.

The core guarantee that we make with set watchers is that we start watching _then query the state of the watched set_. This means that based on that set, a subsequent change is _guaranteed_ to be emitted.

Without waiting for the initial result, we don't establish a baseline, because `changestream` subscription is asynchronous compared to watcher loop initialisation.

The same goes for a notify watcher - watch, get an initial event, then query the thing to be notified of deltas _to that state_.

Violations captured in https://warthogs.atlassian.net/browse/JUJU-10326.