### PR TITLE
chore: port intermediate ca_cert fix to 4.0

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -993,16 +993,20 @@ func verifyCAMulti(ctx context.Context, addrs []*url.URL, opts *dialOpts) error 
 	}
 
 	res := result.(caRetrieveRes)
-	// Try to verify the certificate using the system roots. If the
+	// Try to verify the certificate using the trusted roots. If the
 	// verification succeeds then we are done; tls connections will work out of
 	// the box. Unlike a plain check of the CA cert in isolation, we verify the
 	// server's leaf certificate the same way a TLS client would: build a chain
-	// from the leaf up to a trusted system root, using the certificates
-	// presented by the server as intermediates. This is required when the
-	// server relies on a cross-signed root that is not yet distributed in the
-	// system trust store.
-	if _, err = res.cert.leaf.Verify(x509.VerifyOptions{Intermediates: res.cert.intermediates}); err == nil {
-			logger.Debugf(ctx, "remote certificate chain trusted by system roots")
+	// from the leaf up to a trusted root, using the certificates presented by
+	// the server as intermediates. This is required when the server relies on
+	// a cross-signed root that is not yet distributed in the system trust
+	// store. Roots is the same pool the subsequent dial verifies against; a nil
+	// pool means the system trust store is used.
+	if _, err = res.cert.leaf.Verify(x509.VerifyOptions{
+		Roots:         opts.certPool,
+		Intermediates: res.cert.intermediates,
+	}); err == nil {
+		logger.Debugf(ctx, "remote certificate chain trusted")
 		return nil
 	}
 

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -889,12 +889,30 @@ func (ap *addressProvider) next(ctx context.Context) (*resolvedAddress, error) {
 	return next, nil
 }
 
+// probedCert holds the certificates retrieved from a remote server during the
+// CA probe, split into the parts needed for verification and for the trust
+// prompt so that callers don't have to re-derive them from the raw chain.
+type probedCert struct {
+	// leaf is the server's end-entity certificate.
+	leaf *x509.Certificate
+	// intermediates holds the remaining certificates presented by the
+	// server. They are used to build a chain from the leaf up to a trusted
+	// root, which is required when the server relies on a cross-signed root
+	// that is not yet distributed in the system trust store.
+	intermediates *x509.CertPool
+	// caCert is the CA certificate presented by the server. Its fingerprint
+	// is shown to the user and it is added to the dial cert pool as a trust
+	// anchor when the chain is not publicly trusted (the self-signed CA of a
+	// private controller).
+	caCert *x509.Certificate
+}
+
 // caRetrieveRes is an adaptor for returning CA certificate lookup results via
 // calls to parallel.Try.
 type caRetrieveRes struct {
 	host     string
 	endpoint string
-	caCert   *x509.Certificate
+	cert     probedCert
 }
 
 func (caRetrieveRes) Close() error { return nil }
@@ -924,7 +942,7 @@ func verifyCAMulti(ctx context.Context, addrs []*url.URL, opts *dialOpts) error 
 		return func(<-chan struct{}) (io.Closer, error) {
 			started := time.Now()
 			logger.Debugf(ctx, "api ca probe starting: address=%s server=%s proxy=%s", ipStr, addr.url.Host, debugProxy(proxyURL))
-			caCert, err := retrieveCACert(ctx, ipStr, proxyURL)
+			cert, err := retrieveProbedCert(ctx, ipStr, proxyURL)
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
 					logger.Debugf(ctx, "api ca probe failed: address=%s server=%s proxy=%s elapsed=%s err=%v", ipStr, addr.url.Host, debugProxy(proxyURL), time.Since(started).Round(time.Millisecond), err)
@@ -936,7 +954,7 @@ func verifyCAMulti(ctx context.Context, addrs []*url.URL, opts *dialOpts) error 
 			return caRetrieveRes{
 				host:     addr.url.Host,
 				endpoint: addr.ip,
-				caCert:   caCert,
+				cert:     cert,
 			}, nil
 		}
 	}
@@ -975,34 +993,45 @@ func verifyCAMulti(ctx context.Context, addrs []*url.URL, opts *dialOpts) error 
 		return nil
 	}
 
-	// Try to verify CA cert using the system roots. If the verification
-	// succeeds then we are done; tls connections will work out of the box.
 	res := result.(caRetrieveRes)
-	if _, err = res.caCert.Verify(x509.VerifyOptions{}); err == nil {
-		logger.Debugf(ctx, "remote CA certificate trusted by system roots")
+	// Verify the server's leaf certificate the same way a TLS client would:
+	// build a chain from the leaf up to a trusted system root, using the
+	// certificates presented by the server as intermediates. If a chain can
+	// be built the certificate is publicly trusted and no further action is
+	// required.
+	if _, err = res.cert.leaf.Verify(x509.VerifyOptions{Intermediates: res.cert.intermediates}); err == nil {
+			logger.Debugf(ctx, "remote certificate chain trusted by system roots")
 		return nil
 	}
 
-	// Invoke the CA verifier; if the CA should be trusted, append it to
-	// the dialOpts certPool and proceed with the actual connection attempt.
-	err = opts.VerifyCA(res.host, res.endpoint, res.caCert)
+	// The certificate is not publicly trusted. This is the expected case for
+	// a controller using a private, self-signed CA. Delegate the trust
+	// decision to VerifyCA, passing the CA certificate so its fingerprint
+	// can be shown to the user. If the CA is trusted, add it to the dial
+	// cert pool so the subsequent connection can verify against it.
+	err = opts.VerifyCA(res.host, res.endpoint, res.cert.caCert)
 	if err == nil {
 		if opts.certPool == nil {
 			opts.certPool = x509.NewCertPool()
 		}
-		opts.certPool.AddCert(res.caCert)
+		opts.certPool.AddCert(res.cert.caCert)
 	}
 
 	return err
 }
 
-// retrieveCACert establishes an insecure TLS connection to addr, optionally
-// through the given proxy, and attempts to retrieve the CA cert presented by
-// the server.
-func retrieveCACert(ctx context.Context, addr string, proxyURL string) (*x509.Certificate, error) {
+// retrieveProbedCert establishes an insecure TLS connection to addr, optionally
+// through the given proxy, and returns the certificates presented by the
+// server split into the leaf, the intermediates and the CA certificate.
+//
+// It returns an error if the server does not present a CA certificate, which
+// indicates an older Juju controller (or a server that does not present its
+// CA); in that case the caller should skip verification and dial as if no
+// VerifyCA implementation was provided.
+func retrieveProbedCert(ctx context.Context, addr string, proxyURL string) (probedCert, error) {
 	netConn, err := dialCAProbeConn(ctx, addr, proxyURL)
 	if err != nil {
-		return nil, err
+		return probedCert{}, err
 	}
 	defer func() {
 		_ = netConn.Close()
@@ -1010,19 +1039,35 @@ func retrieveCACert(ctx context.Context, addr string, proxyURL string) (*x509.Ce
 
 	conn := tls.Client(netConn, &tls.Config{InsecureSkipVerify: true})
 	if err = conn.Handshake(); err != nil {
-		return nil, err
+		return probedCert{}, err
 	}
 	defer func() {
 		_ = conn.Close()
 	}()
 
-	for _, cert := range conn.ConnectionState().PeerCertificates {
-		if cert.IsCA {
-			return cert, nil
-		}
+	chain := conn.ConnectionState().PeerCertificates
+	if len(chain) == 0 {
+		return probedCert{}, errors.New("no certificate presented by remote server")
 	}
 
-	return nil, errors.New("no CA certificate presented by remote server")
+	cert := probedCert{
+		leaf:          chain[0],
+		intermediates: x509.NewCertPool(),
+	}
+	for _, c := range chain[1:] {
+		cert.intermediates.AddCert(c)
+	}
+	for _, c := range chain {
+		if c.IsCA {
+			cert.caCert = c
+			break
+		}
+	}
+	if cert.caCert == nil {
+		return probedCert{}, errors.New("no CA certificate presented by remote server")
+	}
+
+	return cert, nil
 }
 
 // dialCAProbeConn establishes a tcp connection to addr, handling routing through

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -901,9 +901,8 @@ type probedCert struct {
 	// that is not yet distributed in the system trust store.
 	intermediates *x509.CertPool
 	// caCert is the CA certificate presented by the server. Its fingerprint
-	// is shown to the user and it is added to the dial cert pool as a trust
-	// anchor when the chain is not publicly trusted (the self-signed CA of a
-	// private controller).
+	// is shown to the user when the chain is not publicly trusted (the
+	// self-signed CA of a private controller).
 	caCert *x509.Certificate
 }
 
@@ -994,11 +993,14 @@ func verifyCAMulti(ctx context.Context, addrs []*url.URL, opts *dialOpts) error 
 	}
 
 	res := result.(caRetrieveRes)
-	// Verify the server's leaf certificate the same way a TLS client would:
-	// build a chain from the leaf up to a trusted system root, using the
-	// certificates presented by the server as intermediates. If a chain can
-	// be built the certificate is publicly trusted and no further action is
-	// required.
+	// Try to verify the certificate using the system roots. If the
+	// verification succeeds then we are done; tls connections will work out of
+	// the box. Unlike a plain check of the CA cert in isolation, we verify the
+	// server's leaf certificate the same way a TLS client would: build a chain
+	// from the leaf up to a trusted system root, using the certificates
+	// presented by the server as intermediates. This is required when the
+	// server relies on a cross-signed root that is not yet distributed in the
+	// system trust store.
 	if _, err = res.cert.leaf.Verify(x509.VerifyOptions{Intermediates: res.cert.intermediates}); err == nil {
 			logger.Debugf(ctx, "remote certificate chain trusted by system roots")
 		return nil
@@ -1007,13 +1009,14 @@ func verifyCAMulti(ctx context.Context, addrs []*url.URL, opts *dialOpts) error 
 	// The certificate is not publicly trusted. This is the expected case for
 	// a controller using a private, self-signed CA. Delegate the trust
 	// decision to VerifyCA, passing the CA certificate so its fingerprint
-	// can be shown to the user. If the CA is trusted, add it to the dial
-	// cert pool so the subsequent connection can verify against it.
+	// can be shown to the user.
 	err = opts.VerifyCA(res.host, res.endpoint, res.cert.caCert)
 	if err == nil {
 		if opts.certPool == nil {
 			opts.certPool = x509.NewCertPool()
 		}
+		// The CA is trusted, so add it to the dial cert pool as a trust anchor
+		// so the subsequent connection can verify against it.
 		opts.certPool.AddCert(res.cert.caCert)
 	}
 
@@ -1057,6 +1060,12 @@ func retrieveProbedCert(ctx context.Context, addr string, proxyURL string) (prob
 	for _, c := range chain[1:] {
 		cert.intermediates.AddCert(c)
 	}
+	// Keep the leaf-most CA in the chain (the first IsCA certificate walking
+	// from the leaf upwards). This is the issuing CA closest to the server's
+	// leaf; its fingerprint is the one shown to the user in the trust prompt
+	// and, when accepted, the one added as a trust anchor. Looping over the
+	// whole chain again keeps this independent of how the intermediates were
+	// collected above.
 	for _, c := range chain {
 		if c.IsCA {
 			cert.caCert = c

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -328,16 +328,6 @@ func (s *apiclientSuite) TestVerifyCA(c *tc.C) {
 			errRegex:     `unable to connect to API: .*`,
 		},
 		{
-			descr:      "VerifyCA that always rejects certs",
-			serverCert: serverCertWithSelfSignedCA,
-			verifyCA: func(host, endpoint string, caCert *x509.Certificate) error {
-				return errors.New("CA not trusted")
-			},
-			// Dial aborts after fetching CAs
-			expConnCount: 1,
-			errRegex:     "CA not trusted",
-		},
-		{
 			descr:      "VerifyCA that always accepts certs",
 			serverCert: serverCertWithSelfSignedCA,
 			verifyCA: func(host, endpoint string, caCert *x509.Certificate) error {

--- a/api/apiclient_whitebox_test.go
+++ b/api/apiclient_whitebox_test.go
@@ -5,7 +5,14 @@ package api
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/juju/clock"
+	"github.com/juju/errors"
 	"github.com/gorilla/websocket"
 	proxyutils "github.com/juju/proxy"
 	"github.com/juju/tc"
@@ -191,4 +200,132 @@ func (s *apiclientWhiteboxSuite) TestNewPrimaryHTTPTransportUsesProxyConfig(c *t
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(proxyURL, tc.NotNil)
 	c.Assert(proxyURL.String(), tc.Equals, "https://proxy.example:8443")
+}
+
+// newTestCert creates a certificate signed by parent (or self-signed when
+// parent is nil), returning the parsed cert and its private key.
+func (s *apiclientWhiteboxSuite) newTestCert(c *tc.C, cn string, isCA bool, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	c.Assert(err, tc.ErrorIsNil)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  isCA,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+	if parent == nil {
+		parent, parentKey = tmpl, key
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, parentKey)
+	c.Assert(err, tc.ErrorIsNil)
+	cert, err := x509.ParseCertificate(der)
+	c.Assert(err, tc.ErrorIsNil)
+	return cert, key
+}
+
+// listenTLSChain starts a TLS listener that presents the given DER chain and
+// drains connections so probes can read the certificates. It returns the
+// listener's address.
+func (s *apiclientWhiteboxSuite) listenTLSChain(c *tc.C, key *ecdsa.PrivateKey, leaf *x509.Certificate, chain ...[]byte) string {
+	serverCert := tls.Certificate{
+		Certificate: chain,
+		PrivateKey:  key,
+		Leaf:        leaf,
+	}
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	s.AddCleanup(func(*tc.C) { _ = listener.Close() })
+	go func() {
+		buf := make([]byte, 4)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_, _ = conn.Read(buf)
+			_ = conn.Close()
+		}
+	}()
+	return listener.Addr().String()
+}
+
+// TestVerifyCAMultiTrustedViaIntermediates tests the
+// server presents a leaf + intermediate whose chain reaches a trusted root
+// ONLY through that intermediate.
+// verifyCAMulti must accept the chain silently and MUST NOT invoke the VerifyCA
+// trust prompt.
+func (s *apiclientWhiteboxSuite) TestVerifyCAMultiTrustedViaIntermediates(c *tc.C) {
+	root, rootKey := s.newTestCert(c, "root", true, nil, nil)
+	intermediate, intKey := s.newTestCert(c, "intermediate", true, root, rootKey)
+	leaf, leafKey := s.newTestCert(c, "leaf", false, intermediate, intKey)
+
+	// Serve leaf + intermediate but NOT the root, exactly as a public server
+	// relying on a cross-signed root does.
+	addr := s.listenTLSChain(c, leafKey, leaf, leaf.Raw, intermediate.Raw)
+	serverURL, err := url.Parse("wss://" + addr)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Trust only the root, standing in for the system trust store.
+	roots := x509.NewCertPool()
+	roots.AddCert(root)
+
+	var verifyCACalled bool
+	opts := &dialOpts{
+		DialOpts: DialOpts{
+			Clock:               clock.WallClock,
+			DialAddressInterval: time.Millisecond,
+			DNSCache:            nopDNSCache{},
+			IPAddrResolver:      net.DefaultResolver,
+			VerifyCA: func(host, endpoint string, caCert *x509.Certificate) error {
+				verifyCACalled = true
+				return errors.New("trust prompt should not be shown for a chain trusted via intermediates")
+			},
+		},
+		certPool: roots,
+	}
+
+	err = verifyCAMulti(context.Background(), []*url.URL{serverURL}, opts)
+	// The leaf verifies via the served intermediate, so verifyCAMulti returns
+	// without ever consulting the prompt.
+	c.Check(err, tc.ErrorIsNil)
+	c.Check(verifyCACalled, tc.IsFalse)
+}
+
+// TestVerifyCAMultiUntrustedInvokesPrompt exercises the whole verifyCAMulti
+// flow for an untrusted chain (a self-signed private controller CA): the chain
+// cannot be verified against the system roots, so verifyCAMulti delegates to
+// the VerifyCA prompt, passing the leaf-most CA.
+func (s *apiclientWhiteboxSuite) TestVerifyCAMultiUntrustedInvokesPrompt(c *tc.C) {
+	root, rootKey := s.newTestCert(c, "root", true, nil, nil)
+	intermediate, intKey := s.newTestCert(c, "intermediate", true, root, rootKey)
+	leaf, leafKey := s.newTestCert(c, "leaf", false, intermediate, intKey)
+
+	addr := s.listenTLSChain(c, leafKey, leaf, leaf.Raw, intermediate.Raw)
+	serverURL, err := url.Parse("wss://" + addr)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var promptedCA *x509.Certificate
+	opts := &dialOpts{
+		DialOpts: DialOpts{
+			Clock:               clock.WallClock,
+			DialAddressInterval: time.Millisecond,
+			DNSCache:            nopDNSCache{},
+			IPAddrResolver:      net.DefaultResolver,
+			VerifyCA: func(host, endpoint string, caCert *x509.Certificate) error {
+				promptedCA = caCert
+				return errors.New("not trusted")
+			},
+		},
+	}
+
+	err = verifyCAMulti(context.Background(), []*url.URL{serverURL}, opts)
+	c.Check(err, tc.ErrorMatches, "not trusted")
+	// The prompt is shown the leaf-most CA (the intermediate).
+	c.Assert(promptedCA, tc.NotNil)
+	c.Check(promptedCA.Subject.CommonName, tc.Equals, "intermediate")
 }

--- a/api/apiclient_whitebox_test.go
+++ b/api/apiclient_whitebox_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
-	"github.com/gorilla/websocket"
 	proxyutils "github.com/juju/proxy"
 	"github.com/juju/tc"
 


### PR DESCRIPTION
# Description

Porting https://github.com/juju/juju/pull/22931 to juju 4.0, just cherry pick commands, no conflicts.