### PR TITLE
feat: don't propagate user's host keys to controller machine

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/names/v6"
 	"github.com/juju/schema"
 	"github.com/juju/utils/v4/keyvalues"
+	jujusshtools "github.com/juju/utils/v4/ssh"
 
 	"github.com/juju/juju/caas"
 	k8s "github.com/juju/juju/caas/kubernetes"
@@ -817,6 +818,15 @@ to create a new model to deploy %sworkloads.
 
 	supportedBootstrapBases := corebase.ControllerBases()
 	logger.Tracef(context.TODO(), "supported bootstrap bases %v", supportedBootstrapBases)
+	bootstrapSSHKeyFiles := jujusshtools.PrivateKeyFiles()
+	if len(bootstrapSSHKeyFiles) == 0 {
+		return errors.New("no Juju SSH keys available for bootstrap")
+	}
+	sort.Strings(bootstrapSSHKeyFiles)
+	bootstrapSSHAuthorizedKeys, err := ssh.PublicKeysForPrivateKeyFiles(bootstrapSSHKeyFiles)
+	if err != nil {
+		return errors.Annotate(err, "reading Juju bootstrap SSH key")
+	}
 
 	bootstrapParams := bootstrap.BootstrapParams{
 		ControllerName:                c.controllerName,
@@ -832,6 +842,7 @@ to create a new model to deploy %sworkloads.
 		ControllerConfig:              bootstrapCfg.controller,
 		ControllerInheritedConfig:     bootstrapCfg.inheritedControllerAttrs,
 		ControllerModelAuthorizedKeys: bootstrapCfg.bootstrap.AuthorizedKeys,
+		BootstrapSSHAuthorizedKeys:    bootstrapSSHAuthorizedKeys,
 		RegionInheritedConfig:         cloud.RegionConfig,
 		AdminSecret:                   bootstrapCfg.bootstrap.AdminSecret,
 		CAPrivateKey:                  bootstrapCfg.bootstrap.CAPrivateKey,
@@ -843,6 +854,7 @@ to create a new model to deploy %sworkloads.
 		ControllerCharmPath:           c.ControllerCharmPath,
 		ControllerCharmChannel:        c.ControllerCharmChannel,
 		DialOpts: environs.BootstrapDialOpts{
+			IdentityFiles:  bootstrapSSHKeyFiles,
 			Timeout:        bootstrapCfg.bootstrap.BootstrapTimeout,
 			RetryDelay:     bootstrapCfg.bootstrap.BootstrapRetryDelay,
 			AddressesDelay: bootstrapCfg.bootstrap.BootstrapAddressesDelay,

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -823,6 +823,8 @@ to create a new model to deploy %sworkloads.
 		return errors.New("no Juju SSH keys available for bootstrap")
 	}
 	sort.Strings(bootstrapSSHKeyFiles)
+	// Keep both slices in the same deterministic order so each private key is
+	// paired with the corresponding public key during bootstrap.
 	bootstrapSSHAuthorizedKeys, err := ssh.PublicKeysForPrivateKeyFiles(bootstrapSSHKeyFiles)
 	if err != nil {
 		return errors.Annotate(err, "reading Juju bootstrap SSH key")

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/loggo/v3"
 	"github.com/juju/tc"
 	"github.com/juju/utils/v4"
+	jujusshtools "github.com/juju/utils/v4/ssh"
 	k8scmd "k8s.io/client-go/tools/clientcmd"
 
 	"github.com/juju/juju/api/jujuclient"
@@ -122,6 +123,7 @@ func (s *BootstrapSuite) SetUpSuite(c *tc.C) {
 func (s *BootstrapSuite) SetUpTest(c *tc.C) {
 	s.FakeJujuXDGDataHomeSuite.SetUpTest(c)
 	s.ToolsFixture.SetUpTest(c)
+	c.Assert(jujusshtools.LoadClientKeys(osenv.JujuXDGDataHomePath("ssh")), tc.ErrorIsNil)
 
 	// Set jujuversion.Current to a known value, for which we
 	// will make tools available. Individual tests may

--- a/cmd/jujuagentd/agent/machine/manifolds.go
+++ b/cmd/jujuagentd/agent/machine/manifolds.go
@@ -1205,6 +1205,7 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			ControllerUnitPassword:        bootstrap.IAASControllerUnitPassword,
 			BootstrapAddressFinderGetter:  bootstrap.IAASAddressFinder,
 			AgentFinalizer:                bootstrap.IAASAgentFinalizer,
+			RemoveBootstrapSSHKeys:        bootstrap.DeleteBootstrapSSHKeys,
 		}))),
 
 		// The controller proxy config updater uses local domain services
@@ -1453,6 +1454,7 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			ControllerUnitPassword:        bootstrap.CAASControllerUnitPassword,
 			BootstrapAddressFinderGetter:  bootstrap.CAASAddressFinder,
 			AgentFinalizer:                bootstrap.CAASAgentFinalizer,
+			RemoveBootstrapSSHKeys:        func([]string) error { return nil },
 		}))),
 
 		// The controller proxy config updater uses local domain services

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -93,6 +93,10 @@ type CaasBootstrapFinalizer func(BootstrapContext, *podcfg.ControllerPodConfig, 
 // bootstrap procedure, where the CLI connects to the bootstrap machine
 // to complete the process.
 type BootstrapDialOpts struct {
+	// IdentityFiles are paths to private keys used for the synchronous
+	// bootstrap SSH connection.
+	IdentityFiles []string
+
 	// Timeout is the amount of time to wait contacting a state
 	// server.
 	Timeout time.Duration

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -104,6 +104,10 @@ type BootstrapParams struct {
 	// for the initial controller model.
 	ControllerModelAuthorizedKeys []string
 
+	// BootstrapSSHAuthorizedKeys are installed on the controller machine only
+	// while synchronous bootstrap configuration is in progress.
+	BootstrapSSHAuthorizedKeys []string
+
 	// RegionInheritedConfig holds region specific configuration attributes to
 	// be shared across all models in the same controller on a particular
 	// cloud.
@@ -688,9 +692,7 @@ func Bootstrap(
 	}
 
 	bootstrapParams := environs.BootstrapParams{
-		// We set the authorized keys that are allowed to ssh to the controller
-		// instance during bootstrap.
-		AuthorizedKeys:             args.ControllerModelAuthorizedKeys,
+		AuthorizedKeys:             args.BootstrapSSHAuthorizedKeys,
 		CloudName:                  args.Cloud.Name,
 		CloudRegion:                args.CloudRegion,
 		ControllerConfig:           args.ControllerConfig,
@@ -773,6 +775,7 @@ func finalizeInstanceBootstrapConfig(
 	}
 	icfg.Bootstrap.StateInitializationParams.AgentVersion = agentVersion
 	icfg.Bootstrap.StateInitializationParams.ControllerModelAuthorizedKeys = args.ControllerModelAuthorizedKeys
+	icfg.Bootstrap.StateInitializationParams.BootstrapSSHAuthorizedKeys = args.BootstrapSSHAuthorizedKeys
 	icfg.Bootstrap.ControllerModelConfig = cfg
 	icfg.Bootstrap.ControllerModelEnvironVersion = environVersion
 	icfg.Bootstrap.CustomImageMetadata = customImageMetadata

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -218,6 +218,7 @@ func (s *bootstrapSuite) TestBootstrapControllerModelAuthorizedKeys(c *tc.C) {
 			ControllerConfig:              coretesting.FakeControllerConfig(),
 			CAPrivateKey:                  coretesting.CAKey,
 			ControllerModelAuthorizedKeys: []string{"key1"},
+			BootstrapSSHAuthorizedKeys:    []string{"key1"},
 			SupportedBootstrapBases:       supportedJujuBases,
 		})
 	c.Assert(err, tc.ErrorIsNil)

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.6.0
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -789,8 +789,8 @@ golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliY
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7U=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20260611194520-c48552f49976 h1:X8Hz2ImujgbmetVuW+w2YkyZChE3cBpZi2P158rTG9M=
 golang.org/x/exp v0.0.0-20260611194520-c48552f49976/go.mod h1:vnf4pv9iKZXY58sQE1L86zmNWJ4159e1RkcWiLCkeEY=

--- a/internal/cloudconfig/instancecfg/instancecfg.go
+++ b/internal/cloudconfig/instancecfg/instancecfg.go
@@ -323,6 +323,10 @@ type StateInitializationParams struct {
 	// the controller model and the admin user during bootstrap.
 	ControllerModelAuthorizedKeys []string
 
+	// BootstrapSSHAuthorizedKeys are removed from the bootstrap machine after the
+	// controller has completed initialization.
+	BootstrapSSHAuthorizedKeys []string
+
 	// ControllerModelEnvironVersion holds the initial controller model
 	// environ version.
 	ControllerModelEnvironVersion int
@@ -402,6 +406,7 @@ type stateInitializationParamsInternal struct {
 	ControllerConfig                        map[string]any                    `yaml:"controller-config"`
 	ControllerModelConfig                   map[string]any                    `yaml:"controller-model-config"`
 	ControllerModelAuthorizedKeys           []string                          `yaml:"controller-model-authorized-keys"`
+	BootstrapSSHAuthorizedKeys              []string                          `yaml:"bootstrap-ssh-authorized-keys"`
 	ControllerModelEnvironVersion           int                               `yaml:"controller-model-version"`
 	ControllerInheritedConfig               map[string]any                    `yaml:"controller-config-defaults,omitempty"`
 	RegionInheritedConfig                   cloud.RegionConfig                `yaml:"region-inherited-config,omitempty"`
@@ -436,6 +441,7 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		ControllerConfig:                        p.ControllerConfig,
 		ControllerModelConfig:                   p.ControllerModelConfig.AllAttrs(),
 		ControllerModelAuthorizedKeys:           p.ControllerModelAuthorizedKeys,
+		BootstrapSSHAuthorizedKeys:              p.BootstrapSSHAuthorizedKeys,
 		ControllerModelEnvironVersion:           p.ControllerModelEnvironVersion,
 		ControllerInheritedConfig:               p.ControllerInheritedConfig,
 		RegionInheritedConfig:                   p.RegionInheritedConfig,
@@ -485,6 +491,7 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 		ControllerConfig:                        internal.ControllerConfig,
 		ControllerModelConfig:                   cfg,
 		ControllerModelAuthorizedKeys:           internal.ControllerModelAuthorizedKeys,
+		BootstrapSSHAuthorizedKeys:              internal.BootstrapSSHAuthorizedKeys,
 		ControllerModelEnvironVersion:           internal.ControllerModelEnvironVersion,
 		ControllerInheritedConfig:               internal.ControllerInheritedConfig,
 		RegionInheritedConfig:                   internal.RegionInheritedConfig,

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -1867,6 +1867,7 @@ func (s *environSuite) TestBootstrapInstanceConstraints(c *tc.C) {
 	err := bootstrap.Bootstrap(
 		ctx, env, bootstrap.BootstrapParams{
 			ControllerModelAuthorizedKeys: authorizedKeys,
+			BootstrapSSHAuthorizedKeys:    authorizedKeys,
 			ControllerConfig:              testing.FakeControllerConfig(),
 			AdminSecret:                   jujutesting.AdminSecret,
 			CAPrivateKey:                  testing.CAKey,
@@ -1933,6 +1934,7 @@ func (s *environSuite) TestBootstrapCustomResourceGroup(c *tc.C) {
 	err := bootstrap.Bootstrap(
 		ctx, env, bootstrap.BootstrapParams{
 			ControllerModelAuthorizedKeys: authorizedKeys,
+			BootstrapSSHAuthorizedKeys:    authorizedKeys,
 			ControllerConfig:              testing.FakeControllerConfig(),
 			AdminSecret:                   jujutesting.AdminSecret,
 			CAPrivateKey:                  testing.CAKey,

--- a/internal/provider/common/bootstrap.go
+++ b/internal/provider/common/bootstrap.go
@@ -448,7 +448,7 @@ var FinishBootstrap = func(
 	ctx.InterruptNotify(interrupted)
 	defer ctx.StopInterruptNotify(interrupted)
 
-	hostSSHOptions := bootstrapSSHOptionsFunc(instanceConfig)
+	hostSSHOptions := bootstrapSSHOptionsFunc(instanceConfig, opts.IdentityFiles)
 	addr, err := WaitSSH(
 		ctx,
 		ctx.GetStderr(),
@@ -602,11 +602,18 @@ func DefaultHostSSHOptions(string) (*ssh.Options, func(), error) {
 	return nil, func() {}, nil
 }
 
-// bootstrapSSHOptionsFunc that takes a bootstrap machine's InstanceConfig
-// and returns a HostSSHOptionsFunc.
-func bootstrapSSHOptionsFunc(instanceConfig *instancecfg.InstanceConfig) HostSSHOptionsFunc {
+// bootstrapSSHOptionsFunc takes a bootstrap machine's InstanceConfig and an
+// optional bootstrap identity file, then returns a HostSSHOptionsFunc.
+func bootstrapSSHOptionsFunc(instanceConfig *instancecfg.InstanceConfig, identityFiles []string) HostSSHOptionsFunc {
 	return func(host string) (*ssh.Options, func(), error) {
-		return hostBootstrapSSHOptions(host, instanceConfig)
+		options, cleanup, err := hostBootstrapSSHOptions(host, instanceConfig)
+		if err != nil {
+			return nil, cleanup, err
+		}
+		if len(identityFiles) > 0 {
+			options.SetIdentities(identityFiles...)
+		}
+		return options, cleanup, nil
 	}
 }
 

--- a/internal/provider/common/bootstrap_test.go
+++ b/internal/provider/common/bootstrap_test.go
@@ -650,9 +650,13 @@ func (s *BootstrapSuite) TestSuccess(c *tc.C) {
 			"'-o' 'PasswordAuthentication no' " +
 			"'-o' 'ServerAliveInterval 30' " +
 			"'-o' 'UserKnownHostsFile (.*)' " +
-			"'-o' 'HostKeyAlgorithms (.*)' " +
+			"'-o' 'HostKeyAlgorithms ([^']*)' " +
 			"'-i' '" + regexp.QuoteMeta(identityFiles[0]) + "' " +
 			"'-i' '" + regexp.QuoteMeta(identityFiles[1]) + "' " +
+			// When an identity file is added, the utils/ssh library adds the
+			// default home as well. To avoid messing with the XDG_DATA_HOME,
+			// we just match an additional -i option.
+			"'-i' '[^']+' " +
 			"'ubuntu@testing.invalid' '/bin/bash'")
 	testhelpers.PatchExecutableAsEchoArgs(c, s, "ssh")
 	testhelpers.PatchExecutableAsEchoArgs(c, s, "scp")

--- a/internal/provider/common/bootstrap_test.go
+++ b/internal/provider/common/bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -637,12 +638,21 @@ func (s *BootstrapSuite) TestSuccess(c *tc.C) {
 	// Check that we make the SSH connection with desired options.
 	var knownHosts string
 	var hostKeyAlgos string
+	identityFiles := []string{
+		filepath.Join(c.MkDir(), "identity-one"),
+		filepath.Join(c.MkDir(), "identity-two"),
+	}
+	for _, identityFile := range identityFiles {
+		c.Assert(os.WriteFile(identityFile, []byte("key"), 0600), tc.ErrorIsNil)
+	}
 	re := regexp.MustCompile(
 		"ssh '-o' 'StrictHostKeyChecking yes' " +
 			"'-o' 'PasswordAuthentication no' " +
 			"'-o' 'ServerAliveInterval 30' " +
 			"'-o' 'UserKnownHostsFile (.*)' " +
 			"'-o' 'HostKeyAlgorithms (.*)' " +
+			"'-i' '" + regexp.QuoteMeta(identityFiles[0]) + "' " +
+			"'-i' '" + regexp.QuoteMeta(identityFiles[1]) + "' " +
 			"'ubuntu@testing.invalid' '/bin/bash'")
 	testhelpers.PatchExecutableAsEchoArgs(c, s, "ssh")
 	testhelpers.PatchExecutableAsEchoArgs(c, s, "scp")
@@ -671,7 +681,8 @@ func (s *BootstrapSuite) TestSuccess(c *tc.C) {
 		return nil
 	})
 	err = result.CloudBootstrapFinalizer(ctx, innerInstanceConfig, environs.BootstrapDialOpts{
-		Timeout: coretesting.LongWait,
+		IdentityFiles: identityFiles,
+		Timeout:       coretesting.LongWait,
 	})
 	c.Assert(err, tc.ErrorMatches, "invalid machine configuration: .*") // icfg hasn't been finalized
 	c.Assert(innerInstanceConfig.Bootstrap.InitialSSHHostKeys, tc.HasLen, 3)

--- a/internal/ssh/authorizedkeys.go
+++ b/internal/ssh/authorizedkeys.go
@@ -95,6 +95,20 @@ func GetFileSystemPublicKeys(
 	return keys, nil
 }
 
+// PublicKeysForPrivateKeyFiles returns the public keys paired with the given
+// private key files.
+func PublicKeysForPrivateKeyFiles(privateKeyFiles []string) ([]string, error) {
+	keys := make([]string, 0, len(privateKeyFiles))
+	for _, privateKeyFile := range privateKeyFiles {
+		key, err := os.ReadFile(privateKeyFile + publicKeyFileSuffix)
+		if err != nil {
+			return nil, fmt.Errorf("reading public key for %q: %w", privateKeyFile, err)
+		}
+		keys = append(keys, strings.TrimSpace(string(key)))
+	}
+	return keys, nil
+}
+
 // readKeyFile is responsible for reading the file pointed at by file name from
 // the file system and processing the data as an ssh public key.
 //

--- a/internal/ssh/authorizedkeys_test.go
+++ b/internal/ssh/authorizedkeys_test.go
@@ -4,7 +4,10 @@
 package ssh
 
 import (
+	"fmt"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -140,6 +143,21 @@ func (*authorizedKeysSuite) TestGetFileSystemPublicKeys(c *tc.C) {
 		slices.Sort(keys)
 		c.Assert(keys, tc.DeepEquals, test.Expected)
 	}
+}
+
+func (*authorizedKeysSuite) TestPublicKeysForPrivateKeyFiles(c *tc.C) {
+	keyDirectory := c.MkDir()
+	privateKeys := []string{
+		filepath.Join(keyDirectory, "one"),
+		filepath.Join(keyDirectory, "two"),
+	}
+	for i, privateKey := range privateKeys {
+		c.Assert(os.WriteFile(privateKey+publicKeyFileSuffix, []byte(fmt.Sprintf("key-%d\n", i)), 0600), tc.ErrorIsNil)
+	}
+
+	keys, err := PublicKeysForPrivateKeyFiles(privateKeys)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(keys, tc.DeepEquals, []string{"key-0", "key-1"})
 }
 
 // TestSplitAuthorizedKeysFile is testing authorized keys splitting based on the

--- a/internal/ssh/authorizedkeys_test.go
+++ b/internal/ssh/authorizedkeys_test.go
@@ -152,7 +152,8 @@ func (*authorizedKeysSuite) TestPublicKeysForPrivateKeyFiles(c *tc.C) {
 		filepath.Join(keyDirectory, "two"),
 	}
 	for i, privateKey := range privateKeys {
-		c.Assert(os.WriteFile(privateKey+publicKeyFileSuffix, []byte(fmt.Sprintf("key-%d\n", i)), 0600), tc.ErrorIsNil)
+		key := fmt.Appendf(nil, "key-%d\n", i)
+		c.Assert(os.WriteFile(privateKey+publicKeyFileSuffix, key, 0600), tc.ErrorIsNil)
 	}
 
 	keys, err := PublicKeysForPrivateKeyFiles(privateKeys)

--- a/internal/ssh/authorizedkeys_test.go
+++ b/internal/ssh/authorizedkeys_test.go
@@ -160,6 +160,11 @@ func (*authorizedKeysSuite) TestPublicKeysForPrivateKeyFiles(c *tc.C) {
 	c.Check(keys, tc.DeepEquals, []string{"key-0", "key-1"})
 }
 
+func (*authorizedKeysSuite) TestPublicKeysForPrivateKeyFilesMissingPublicKey(c *tc.C) {
+	_, err := PublicKeysForPrivateKeyFiles([]string{filepath.Join(c.MkDir(), "missing")})
+	c.Assert(err, tc.ErrorMatches, `reading public key for .*: open .*: no such file or directory`)
+}
+
 // TestSplitAuthorizedKeysFile is testing authorized keys splitting based on the
 // the raw contents from a file.
 func (*authorizedKeysSuite) TestSplitAuthorizedKeysFile(c *tc.C) {

--- a/internal/worker/bootstrap/manifold.go
+++ b/internal/worker/bootstrap/manifold.go
@@ -59,6 +59,10 @@ type BootstrapAddressFinderGetter func(providerFactory providertracker.ProviderF
 // during bootstrap.
 type AgentFinalizerFunc func(context.Context, AgentPasswordService, MachineService, instancecfg.StateInitializationParams, string) error
 
+// RemoveBootstrapSSHKeysFunc removes the bootstrap-only SSH keys from the
+// machine.
+type RemoveBootstrapSSHKeysFunc func([]string) error
+
 // ControllerUnitPasswordFunc is the function that is used to get the
 // controller unit password.
 type ControllerUnitPasswordFunc func(context.Context) (string, error)
@@ -110,6 +114,7 @@ type ManifoldConfig struct {
 	PopulateControllerCharm       PopulateControllerCharmFunc
 	BootstrapAddressFinderGetter  BootstrapAddressFinderGetter
 	AgentFinalizer                AgentFinalizerFunc
+	RemoveBootstrapSSHKeys        RemoveBootstrapSSHKeysFunc
 	StatusHistory                 StatusHistory
 
 	Logger logger.Logger
@@ -166,6 +171,9 @@ func (cfg ManifoldConfig) Validate() error {
 	}
 	if cfg.AgentFinalizer == nil {
 		return errors.NotValidf("nil AgentFinalizer")
+	}
+	if cfg.RemoveBootstrapSSHKeys == nil {
+		return errors.NotValidf("nil RemoveBootstrapSSHKeys")
 	}
 	if cfg.StatusHistory == nil {
 		return errors.NotValidf("nil StatusHistory")
@@ -293,6 +301,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				ControllerCharmDeployer:    config.ControllerCharmDeployer,
 				PopulateControllerCharm:    config.PopulateControllerCharm,
 				AgentFinalizer:             config.AgentFinalizer,
+				RemoveBootstrapSSHKeys:     config.RemoveBootstrapSSHKeys,
 				AgentPassword:              config.AgentPassword,
 				ApplicationPassword:        applicationPassword,
 				CharmhubHTTPClient:         charmhubHTTPClient,

--- a/internal/worker/bootstrap/manifold_test.go
+++ b/internal/worker/bootstrap/manifold_test.go
@@ -141,6 +141,9 @@ func (s *manifoldSuite) getConfig() ManifoldConfig {
 		AgentFinalizer: func(ctx context.Context, aps AgentPasswordService, ms MachineService, sip instancecfg.StateInitializationParams, password string) error {
 			return nil
 		},
+		RemoveBootstrapSSHKeys: func([]string) error {
+			return nil
+		},
 		StatusHistory: s.statusHistory,
 	}
 }

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -48,7 +48,7 @@ const (
 
 var bootstrapSSHUser = "ubuntu"
 
-var deleteBootstrapSSHKeys = func(keys []string) error {
+func deleteBootstrapSSHKeys(keys []string) error {
 	if len(keys) == 0 {
 		return nil
 	}
@@ -68,6 +68,10 @@ var deleteBootstrapSSHKeys = func(keys []string) error {
 // WorkerConfig encapsulates the configuration options for the
 // bootstrap worker.
 type WorkerConfig struct {
+	// RemoveBootstrapSSHKeys removes the bootstrap-only SSH keys from the
+	// machine. If nil, the default Ubuntu implementation is used.
+	RemoveBootstrapSSHKeys func([]string) error
+
 	ObjectStoreGetter          ObjectStoreGetter
 	ControllerAgentBinaryStore AgentBinaryStore
 	ControllerConfigService    ControllerConfigService
@@ -208,6 +212,9 @@ func NewWorker(cfg WorkerConfig) (*bootstrapWorker, error) {
 }
 
 func newWorker(cfg WorkerConfig, internalStates chan string) (*bootstrapWorker, error) {
+	if cfg.RemoveBootstrapSSHKeys == nil {
+		cfg.RemoveBootstrapSSHKeys = deleteBootstrapSSHKeys
+	}
 	var err error
 	if err = cfg.Validate(); err != nil {
 		return nil, errors.Trace(err)
@@ -315,7 +322,7 @@ func (w *bootstrapWorker) loop() error {
 	}
 
 	if !cloud.CloudIsCAAS(bootstrapParams.ControllerCloud) {
-		if err := deleteBootstrapSSHKeys(bootstrapParams.BootstrapSSHAuthorizedKeys); err != nil {
+		if err := w.cfg.RemoveBootstrapSSHKeys(bootstrapParams.BootstrapSSHAuthorizedKeys); err != nil {
 			return errors.Annotate(err, "removing bootstrap SSH keys")
 		}
 	}

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/errors"
+	"github.com/juju/utils/v4/ssh"
 	"gopkg.in/tomb.v2"
 
 	"github.com/juju/juju/controller"
@@ -43,6 +44,18 @@ const (
 	stateStarted   = "started"
 	stateCompleted = "completed"
 )
+
+var deleteBootstrapSSHKeys = func(keys []string) error {
+	fingerprints := make([]string, 0, len(keys))
+	for _, key := range keys {
+		fingerprint, _, err := ssh.KeyFingerprint(key)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		fingerprints = append(fingerprints, fingerprint)
+	}
+	return ssh.DeleteKeysFromFile("ubuntu", "authorized_keys", fingerprints)
+}
 
 // WorkerConfig encapsulates the configuration options for the
 // bootstrap worker.
@@ -291,6 +304,10 @@ func (w *bootstrapWorker) loop() error {
 	if err := w.initAPIHostPorts(ctx, controllerConfig, bootstrapAddresses, w.cfg.APIPort); err != nil {
 		w.logger.Errorf(ctx, "unable to set API host ports %v:%w", bootstrapAddresses, err)
 		return errors.Trace(err)
+	}
+
+	if err := deleteBootstrapSSHKeys(bootstrapParams.BootstrapSSHAuthorizedKeys); err != nil {
+		return errors.Annotate(err, "removing bootstrap SSH keys")
 	}
 
 	// Set the bootstrap flag, to indicate that the bootstrap has completed.

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/utils/v4/ssh"
 	"gopkg.in/tomb.v2"
 
-	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/flags"
 	"github.com/juju/juju/core/logger"
@@ -48,7 +47,9 @@ const (
 
 var bootstrapSSHUser = "ubuntu"
 
-func deleteBootstrapSSHKeys(keys []string) error {
+// DeleteBootstrapSSHKeys removes bootstrap-only keys from an IAAS bootstrap
+// machine's standard Ubuntu authorized_keys file.
+func DeleteBootstrapSSHKeys(keys []string) error {
 	if len(keys) == 0 {
 		return nil
 	}
@@ -69,7 +70,7 @@ func deleteBootstrapSSHKeys(keys []string) error {
 // bootstrap worker.
 type WorkerConfig struct {
 	// RemoveBootstrapSSHKeys removes the bootstrap-only SSH keys from the
-	// machine. If nil, the default Ubuntu implementation is used.
+	// machine.
 	RemoveBootstrapSSHKeys func([]string) error
 
 	ObjectStoreGetter          ObjectStoreGetter
@@ -212,9 +213,6 @@ func NewWorker(cfg WorkerConfig) (*bootstrapWorker, error) {
 }
 
 func newWorker(cfg WorkerConfig, internalStates chan string) (*bootstrapWorker, error) {
-	if cfg.RemoveBootstrapSSHKeys == nil {
-		cfg.RemoveBootstrapSSHKeys = deleteBootstrapSSHKeys
-	}
 	var err error
 	if err = cfg.Validate(); err != nil {
 		return nil, errors.Trace(err)
@@ -321,10 +319,8 @@ func (w *bootstrapWorker) loop() error {
 		return errors.Trace(err)
 	}
 
-	if !cloud.CloudIsCAAS(bootstrapParams.ControllerCloud) {
-		if err := w.cfg.RemoveBootstrapSSHKeys(bootstrapParams.BootstrapSSHAuthorizedKeys); err != nil {
-			return errors.Annotate(err, "removing bootstrap SSH keys")
-		}
+	if err := w.cfg.RemoveBootstrapSSHKeys(bootstrapParams.BootstrapSSHAuthorizedKeys); err != nil {
+		return errors.Annotate(err, "removing bootstrap SSH keys")
 	}
 
 	// Set the bootstrap flag, to indicate that the bootstrap has completed.

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/utils/v4/ssh"
 	"gopkg.in/tomb.v2"
 
+	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/flags"
 	"github.com/juju/juju/core/logger"
@@ -45,7 +46,14 @@ const (
 	stateCompleted = "completed"
 )
 
+var bootstrapSSHUser = "ubuntu"
+
 var deleteBootstrapSSHKeys = func(keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	// IAAS bootstrap machines use the standard Ubuntu account and file. CAAS
+	// bootstrap does not call this helper because it has no Ubuntu host.
 	fingerprints := make([]string, 0, len(keys))
 	for _, key := range keys {
 		fingerprint, _, err := ssh.KeyFingerprint(key)
@@ -54,7 +62,7 @@ var deleteBootstrapSSHKeys = func(keys []string) error {
 		}
 		fingerprints = append(fingerprints, fingerprint)
 	}
-	return ssh.DeleteKeysFromFile("ubuntu", "authorized_keys", fingerprints)
+	return ssh.DeleteKeysFromFile(bootstrapSSHUser, "authorized_keys", fingerprints)
 }
 
 // WorkerConfig encapsulates the configuration options for the
@@ -306,8 +314,10 @@ func (w *bootstrapWorker) loop() error {
 		return errors.Trace(err)
 	}
 
-	if err := deleteBootstrapSSHKeys(bootstrapParams.BootstrapSSHAuthorizedKeys); err != nil {
-		return errors.Annotate(err, "removing bootstrap SSH keys")
+	if !cloud.CloudIsCAAS(bootstrapParams.ControllerCloud) {
+		if err := deleteBootstrapSSHKeys(bootstrapParams.BootstrapSSHAuthorizedKeys); err != nil {
+			return errors.Annotate(err, "removing bootstrap SSH keys")
+		}
 	}
 
 	// Set the bootstrap flag, to indicate that the bootstrap has completed.

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -66,7 +66,7 @@ func (s *workerSuite) SetUpTest(c *tc.C) {
 }
 
 func (s *workerSuite) TestDeleteBootstrapSSHKeysEmpty(c *tc.C) {
-	c.Assert(deleteBootstrapSSHKeys(nil), tc.ErrorIsNil)
+	c.Assert(DeleteBootstrapSSHKeys(nil), tc.ErrorIsNil)
 }
 
 func (s *workerSuite) TestKilled(c *tc.C) {

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -74,6 +74,10 @@ func (s *workerSuite) TestKilled(c *tc.C) {
 	s.expectControllerConfig()
 	s.expectObjectStoreGetter(2)
 	s.expectBootstrapFlagSet()
+	s.PatchValue(&deleteBootstrapSSHKeys, func(keys []string) error {
+		c.Check(keys, tc.DeepEquals, []string{"bootstrap-ssh-key"})
+		return nil
+	})
 	s.expectReloadSpaces()
 	s.expectSeedDefaultStoragePools()
 	s.expectInitialiseBakeryConfig(nil)
@@ -402,6 +406,7 @@ func (s *workerSuite) ensureBootstrapParams(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	args := instancecfg.StateInitializationParams{
+		BootstrapSSHAuthorizedKeys:  []string{"bootstrap-ssh-key"},
 		ControllerModelConfig:       cfg,
 		BootstrapMachineConstraints: constraints.MustParse("mem=1G"),
 		BootstrapMachineInstanceId:  instance.Id("i-deadbeef"),

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	stdtesting "testing"
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
+	"github.com/juju/utils/v4/ssh"
+	sshtesting "github.com/juju/utils/v4/ssh/testing"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
 
@@ -63,6 +66,30 @@ func (s *workerSuite) SetUpTest(c *tc.C) {
 	}
 }
 
+func (s *workerSuite) TestDeleteBootstrapSSHKeys(c *tc.C) {
+	s.PatchValue(&bootstrapSSHUser, "")
+	existingKeys, err := ssh.ListKeys("", ssh.FullKeys)
+	c.Assert(err, tc.ErrorIsNil)
+	for _, key := range existingKeys {
+		fingerprint, _, err := ssh.KeyFingerprint(key)
+		c.Assert(err, tc.ErrorIsNil)
+		c.Assert(ssh.DeleteKeysFromFile("", "authorized_keys", []string{fingerprint}), tc.ErrorIsNil)
+	}
+	keyOne := sshtesting.ValidKeyThree.Key + " bootstrap-delete-one"
+	keyTwo := sshtesting.ValidKeyFour.Key + " bootstrap-delete-two"
+	c.Assert(ssh.AddKeys("", keyOne, keyTwo), tc.ErrorIsNil)
+	c.Assert(deleteBootstrapSSHKeys([]string{keyOne}), tc.ErrorIsNil)
+
+	keys, err := ssh.ListKeys("", ssh.FullKeys)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(slices.Contains(keys, keyOne), tc.IsFalse)
+	c.Check(slices.Contains(keys, keyTwo), tc.IsTrue)
+}
+
+func (s *workerSuite) TestDeleteBootstrapSSHKeysEmpty(c *tc.C) {
+	c.Assert(deleteBootstrapSSHKeys(nil), tc.ErrorIsNil)
+}
+
 func (s *workerSuite) TestKilled(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -90,6 +117,28 @@ func (s *workerSuite) TestKilled(c *tc.C) {
 	s.ensureFinished(c)
 
 	workertest.CleanKill(c, w)
+}
+
+func (s *workerSuite) TestDeleteBootstrapSSHKeysError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.ensureBootstrapParams(c)
+	s.domainServices.EXPECT().Flag().AnyTimes()
+	s.expectUser(c)
+	s.expectAuthorizedKeys()
+	s.expectControllerConfig()
+	s.expectObjectStoreGetter(2)
+	s.expectReloadSpaces()
+	s.expectSeedDefaultStoragePools()
+	s.expectInitialiseBakeryConfig(nil)
+	s.expectSetAPIHostPorts()
+	s.PatchValue(&deleteBootstrapSSHKeys, func([]string) error {
+		return errors.New("cannot remove bootstrap keys")
+	})
+
+	w := s.newWorker(c)
+	err := workertest.CheckKilled(c, w)
+	c.Check(err, tc.ErrorMatches, `removing bootstrap SSH keys: cannot remove bootstrap keys`)
 }
 
 func (s *workerSuite) TestReloadSpacesBeforeControllerCharm(c *tc.C) {

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -7,15 +7,12 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"slices"
 	stdtesting "testing"
 
 	"github.com/canonical/gomock/gomock"
 	"github.com/juju/clock"
 	"github.com/juju/errors"
 	"github.com/juju/tc"
-	"github.com/juju/utils/v4/ssh"
-	sshtesting "github.com/juju/utils/v4/ssh/testing"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/workertest"
 
@@ -50,7 +47,8 @@ type workerSuite struct {
 	adminUserID     user.UUID
 	controllerModel coremodel.Model
 
-	states chan string
+	states                 chan string
+	removeBootstrapSSHKeys func([]string) error
 }
 
 func TestWorkerSuite(t *stdtesting.T) {
@@ -60,30 +58,11 @@ func TestWorkerSuite(t *stdtesting.T) {
 }
 
 func (s *workerSuite) SetUpTest(c *tc.C) {
+	s.removeBootstrapSSHKeys = func([]string) error { return nil }
 	s.adminUserID = usertesting.GenUserUUID(c)
 	s.controllerModel = coremodel.Model{
 		UUID: tc.Must0(c, coremodel.NewUUID),
 	}
-}
-
-func (s *workerSuite) TestDeleteBootstrapSSHKeys(c *tc.C) {
-	s.PatchValue(&bootstrapSSHUser, "")
-	existingKeys, err := ssh.ListKeys("", ssh.FullKeys)
-	c.Assert(err, tc.ErrorIsNil)
-	for _, key := range existingKeys {
-		fingerprint, _, err := ssh.KeyFingerprint(key)
-		c.Assert(err, tc.ErrorIsNil)
-		c.Assert(ssh.DeleteKeysFromFile("", "authorized_keys", []string{fingerprint}), tc.ErrorIsNil)
-	}
-	keyOne := sshtesting.ValidKeyThree.Key + " bootstrap-delete-one"
-	keyTwo := sshtesting.ValidKeyFour.Key + " bootstrap-delete-two"
-	c.Assert(ssh.AddKeys("", keyOne, keyTwo), tc.ErrorIsNil)
-	c.Assert(deleteBootstrapSSHKeys([]string{keyOne}), tc.ErrorIsNil)
-
-	keys, err := ssh.ListKeys("", ssh.FullKeys)
-	c.Assert(err, tc.ErrorIsNil)
-	c.Check(slices.Contains(keys, keyOne), tc.IsFalse)
-	c.Check(slices.Contains(keys, keyTwo), tc.IsTrue)
 }
 
 func (s *workerSuite) TestDeleteBootstrapSSHKeysEmpty(c *tc.C) {
@@ -101,10 +80,10 @@ func (s *workerSuite) TestKilled(c *tc.C) {
 	s.expectControllerConfig()
 	s.expectObjectStoreGetter(2)
 	s.expectBootstrapFlagSet()
-	s.PatchValue(&deleteBootstrapSSHKeys, func(keys []string) error {
+	s.removeBootstrapSSHKeys = func(keys []string) error {
 		c.Check(keys, tc.DeepEquals, []string{"bootstrap-ssh-key"})
 		return nil
-	})
+	}
 	s.expectReloadSpaces()
 	s.expectSeedDefaultStoragePools()
 	s.expectInitialiseBakeryConfig(nil)
@@ -132,9 +111,9 @@ func (s *workerSuite) TestDeleteBootstrapSSHKeysError(c *tc.C) {
 	s.expectSeedDefaultStoragePools()
 	s.expectInitialiseBakeryConfig(nil)
 	s.expectSetAPIHostPorts()
-	s.PatchValue(&deleteBootstrapSSHKeys, func([]string) error {
+	s.removeBootstrapSSHKeys = func([]string) error {
 		return errors.New("cannot remove bootstrap keys")
-	})
+	}
 
 	w := s.newWorker(c)
 	err := workertest.CheckKilled(c, w)
@@ -299,6 +278,7 @@ func (s *workerSuite) newWorker(c *tc.C) worker.Worker {
 
 func (s *workerSuite) newWorkerWithFunc(c *tc.C, controllerCharmDeployerFunc ControllerCharmDeployerFunc) worker.Worker {
 	w, err := newWorker(WorkerConfig{
+		RemoveBootstrapSSHKeys:     s.removeBootstrapSSHKeys,
 		ObjectStoreGetter:          s.objectStoreGetter,
 		BootstrapUnlocker:          s.bootstrapUnlocker,
 		DataDir:                    s.dataDir,


### PR DESCRIPTION
# Description

Before this patch user's host keys were added to the controller model and the actual machine during bootstrap and never cleaned up.

Now keys are still added to the controller state, such as the controller admin can ssh (with jump) to the controller machine, but keys are not stored in the machine anymore, so nobody can bypass the jump server after the bootstrap process.

During bootstrap the key contained in `.local/share/juju/ssh/juju_id_rsa` is used to perform the necessary ssh operation, and it can be used to ssh directly into the bootstrapping machine (see qa steps).

The key is created when the CLI is initialized during `InitJujuXDGDataHome`, so it's always present when we bootstrap a controller.

# QA
`make install`
bootstrap a controller
During bootstrap this is allowed to troubleshoot issues
`ssh -i ~/.local/share/juju/ssh/juju_id_rsa <controller-ip>` 

After it's not anymore and we need to ssh through the controller jump server.

```
juju switch controller
juju ssh 0
cat .ssh/authorized_keys # should contain only the ephemeral key
```

In case there are errors during bootstrap:
`juju bootstrap lxd test-keys-3 --build-agent --keep-broken`
press control+c after you have an ip, and you can ssh into the machine because the authorized key is cleanup only
after the bootstrap worker has been successful to allow for maximum debuggability.
`ssh -i ~/.local/share/juju/ssh/juju_id_rsa <controller-ip>` 