### PR TITLE
fix(application): fix test-charm-storage-aws for juju 4.0

### DIFF
--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1121,7 +1121,11 @@ func (s *ProviderService) populateAddStorageArgs(
 	if arg.StoragePoolUUID != nil {
 		storageDirective.PoolUUID = *arg.StoragePoolUUID
 	}
-	if arg.SizeMiB != nil {
+	// A zero size means the caller did not specify a size. The add-storage
+	// command always sends a size (a pointer to the parsed directive value,
+	// which is zero when no size was given), so keep the size recorded on
+	// the unit storage directive in that case.
+	if arg.SizeMiB != nil && *arg.SizeMiB != 0 {
 		storageDirective.Size = *arg.SizeMiB
 	}
 

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3279,6 +3279,150 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, nil)
 }
 
+func (s *providerServiceSuite) TestAddStorageForIAASUnitZeroSizeOverride(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	charmStorageDef := internal.CharmStorageDefinitionForValidation{
+		Name:        "pgdata",
+		Type:        applicationcharm.StorageFilesystem,
+		MinimumSize: 10,
+		CountMin:    1,
+		CountMax:    666,
+	}
+
+	s.storageService.EXPECT().GetUnitStorageDirectiveByName(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageDirective{
+			Name:             "pgdata",
+			CharmStorageType: applicationcharm.StorageFilesystem,
+			Count:            1,
+			MaxCount:         666,
+			PoolUUID:         poolUUID,
+			Size:             1024,
+		}, nil)
+	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageInfoForAdd{
+			CharmStorageDefinitionForValidation: charmStorageDef,
+			AlreadyAttachedCount:                66,
+		}, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internal.CharmStorageDefinitionForValidation{
+		"pgdata": charmStorageDef,
+	}, map[string]storageservice.StorageDirectiveOverride{
+		"pgdata": {
+			Count:    new(uint32(76)),
+			PoolUUID: new(poolUUID),
+			Size:     new(uint64(1024)),
+		},
+	})
+	unitStorageArgs := domainstorage.UnitAddStorageArg{
+		StorageInstances: []domainstorage.CreateUnitStorageInstanceArg{{
+			Name: "pgdata",
+		}},
+		CountLessThanEqual: 656,
+	}
+	fsToOwn := []domainstorage.FilesystemUUID{tc.Must(c, domainstorage.NewFilesystemUUID)}
+	volToOwn := []domainstorage.VolumeUUID{tc.Must(c, domainstorage.NewVolumeUUID)}
+
+	s.storageService.EXPECT().MakeUnitAddStorageArgs(gomock.Any(), unitUUID, uint32(10), internal.StorageDirective{
+		Name:             "pgdata",
+		CharmStorageType: applicationcharm.StorageFilesystem,
+		Count:            1,
+		MaxCount:         666,
+		PoolUUID:         poolUUID,
+		Size:             1024,
+	}).
+		Return(unitStorageArgs, nil)
+	s.storageService.EXPECT().MakeIAASUnitStorageArgs(gomock.Any(), unitStorageArgs.StorageInstances).
+		Return(domainstorage.CreateIAASUnitStorageArg{
+			FilesystemsToOwn: fsToOwn,
+			VolumesToOwn:     volToOwn,
+		}, nil)
+
+	s.state.EXPECT().AddStorageForIAASUnit(gomock.Any(), unitUUID, corestorage.Name("pgdata"), domainstorage.IAASUnitAddStorageArg{
+		UnitAddStorageArg: unitStorageArgs,
+		FilesystemsToOwn:  fsToOwn,
+		VolumesToOwn:      volToOwn,
+	})
+
+	_, err := s.service.AddStorageForIAASUnit(c.Context(), "pgdata", unitUUID, uint32(10), application.AddUnitStorageOverride{
+		SizeMiB: new(uint64(0)),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestAddStorageForCAASUnitZeroSizeOverride verifies that adding storage
+// without an explicit size (the add-storage command sends a zero size in that
+// case) keeps the size recorded on the unit storage directive for CAAS units,
+// rather than provisioning a zero-sized volume.
+func (s *providerServiceSuite) TestAddStorageForCAASUnitZeroSizeOverride(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	charmStorageDef := internal.CharmStorageDefinitionForValidation{
+		Name:        "pgdata",
+		Type:        applicationcharm.StorageFilesystem,
+		MinimumSize: 10,
+		CountMin:    1,
+		CountMax:    666,
+	}
+
+	s.storageService.EXPECT().GetUnitStorageDirectiveByName(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageDirective{
+			Name:             "pgdata",
+			CharmStorageType: applicationcharm.StorageFilesystem,
+			Count:            1,
+			MaxCount:         666,
+			PoolUUID:         poolUUID,
+			Size:             1024,
+		}, nil)
+	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageInfoForAdd{
+			CharmStorageDefinitionForValidation: charmStorageDef,
+			AlreadyAttachedCount:                66,
+		}, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(
+		gomock.Any(),
+		map[string]internal.CharmStorageDefinitionForValidation{
+			"pgdata": charmStorageDef,
+		},
+		map[string]storageservice.StorageDirectiveOverride{
+			"pgdata": {
+				Count:    new(uint32(76)),
+				PoolUUID: new(poolUUID),
+				Size:     new(uint64(1024)),
+			},
+		},
+	)
+	unitStorageArgs := domainstorage.UnitAddStorageArg{
+		StorageInstances: []domainstorage.CreateUnitStorageInstanceArg{{
+			Name: "pgdata",
+		}},
+		CountLessThanEqual: 656,
+	}
+
+	s.storageService.EXPECT().MakeUnitAddStorageArgs(gomock.Any(), unitUUID, uint32(10), internal.StorageDirective{
+		Name:             "pgdata",
+		CharmStorageType: applicationcharm.StorageFilesystem,
+		Count:            1,
+		MaxCount:         666,
+		PoolUUID:         poolUUID,
+		Size:             1024,
+	}).Return(unitStorageArgs, nil)
+
+	s.state.EXPECT().AddStorageForCAASUnit(gomock.Any(), unitUUID, corestorage.Name("pgdata"), unitStorageArgs)
+
+	_, err := s.service.AddStorageForCAASUnit(c.Context(), "pgdata", unitUUID, uint32(10), application.AddUnitStorageOverride{
+		SizeMiB: new(uint64(0)),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *providerServiceSuite) TestAddStorageForCAASUnitNotFound(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3279,6 +3279,10 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, nil)
 }
 
+// TestAddStorageForIAASUnitZeroSizeOverride verifies that adding storage
+// without an explicit size (the add-storage command sends a zero size in that
+// case) keeps the size recorded on the unit storage directive, rather than
+// provisioning a zero-sized volume.
 func (s *providerServiceSuite) TestAddStorageForIAASUnitZeroSizeOverride(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()

--- a/tests/includes/storage.sh
+++ b/tests/includes/storage.sh
@@ -62,16 +62,14 @@ unit_exist() {
 	juju storage --format json | yq "[.. | select(kind == \"map\") | has(\"${name}\")] | any"
 }
 
-# filesystem_status used to check for the current status of the given volume for a filesystem matched by the volume number and volume index combination e.g 0/0, 2/1, 3/1
+# filesystem_status emits a yq query for the status of the filesystem backing
+# the given storage instance id (e.g. data/0). The filesystem is matched via
+# its storage linkage rather than its id, as filesystem ids differ between
+# juju versions (machine-scoped "0/0" before 4.0, global sequence numbers
+# from 4.0 onwards).
 filesystem_status() {
-	local name volume_num volume_index
-	volume_num=${1}
-	volume_index=${2}
+	local storage_id
+	storage_id=${1}
 
-	if [ -z "$volume_index" ]; then
-		name="$volume_num"
-	else
-		name="$volume_num/$volume_index"
-	fi
-	echo ".filesystems | .[\"$name\"] | .status"
+	echo ".filesystems | to_entries | map(select(.value.storage == \"${storage_id}\")) | .[0].value.status"
 }

--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -56,10 +56,7 @@ run_charm_storage() {
 
 	# Assessing adding a storage block to loop disk
 	juju add-storage -m "${model_name}" dummy-storage-lp/0 disks=1
-	# Assert the storage kind name
-	if [ "$(unit_exist "disks/2")" == "true" ]; then
-		assess_loop_disk2
-	fi
+	assess_loop_disk2
 	# Remove the application
 	juju remove-application --no-prompt dummy-storage-lp
 	wait_for "{}" ".applications"
@@ -174,6 +171,14 @@ assess_loop_disk2() {
 	assert_storage "dummy-storage-lp/0" "$(unit_attachment "disks" 2 0)"
 	# assert the attached unit state
 	assert_storage "alive" "$(unit_state "disks" 2 "dummy-storage-lp" 0)"
+	# assert the volume retained the requested size (a zero-size add-storage
+	# override would provision a zero-sized volume instead).
+	requested_storage=1024
+	acquired_storage=$(juju storage --format json | yq '.volumes | to_entries | map(select(.value.storage == "disks/2")) | .[0].value.size')
+	if [ "$requested_storage" -gt "$acquired_storage" ]; then
+		echo "acquired storage size $acquired_storage should be greater than the requested storage $requested_storage"
+		exit 1
+	fi
 	echo "Block loop disk 2 PASSED"
 }
 

--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -133,10 +133,10 @@ assess_rootfs() {
 	assert_storage "dummy-storage-fs/0" "$(unit_attachment "data" 0 0)"
 	# assert the attached unit state
 	assert_storage "alive" "$(unit_state "data" 0 "dummy-storage-fs" 0)"
-	wait_for_storage "attached" "$(filesystem_status 0 0).current"
+	wait_for_storage "attached" "$(filesystem_status "data/0").current"
 	# assert the filesystem size
 	requested_storage=1024
-	acquired_storage=$(juju storage --format json | yq '.filesystems | .["0/0"] | select(.pool=="rootfs") | .size ')
+	acquired_storage=$(juju storage --format json | yq '.filesystems | to_entries | map(select(.value.storage == "data/0" and .value.pool == "rootfs")) | .[0].value.size')
 	if [ "$requested_storage" -gt "$acquired_storage" ]; then
 		echo "acquired storage size $acquired_storage should be greater than the requested storage $requested_storage"
 		exit 1

--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -35,7 +35,7 @@ run_charm_storage() {
 	# Assess charm storage with the filesystem storage provider
 	echo "Assessing filesystem rootfs"
 	# shellcheck disable=SC2046
-	juju deploy $(pack_charm ./testcharms/charms/dummy-storage-fs) --base ubuntu@22.04 --storage data=rootfs,1G
+	juju deploy $(pack_charm ./testcharms/charms/dummy-storage-fs) --storage data=rootfs,1G
 	wait_for "dummy-storage-fs" ".applications"
 	if [ "$(unit_exist "data/0")" == "true" ]; then
 		assess_rootfs
@@ -47,7 +47,7 @@ run_charm_storage() {
 	# Assess charm storage with the filesystem storage provider
 	echo "Assessing block loop disk 1"
 	# shellcheck disable=SC2046
-	juju deploy $(pack_charm ./testcharms/charms/dummy-storage-lp) --base ubuntu@22.04 --storage disks=loop,1G
+	juju deploy $(pack_charm ./testcharms/charms/dummy-storage-lp) --storage disks=loop,1G
 	wait_for "dummy-storage-lp" ".applications"
 	# Assert the storage kind name
 	if [ "$(unit_exist "disks/1")" == "true" ]; then
@@ -67,7 +67,7 @@ run_charm_storage() {
 	# Assess tmpfs pool for the filesystem provider
 	echo "Assessing filesystem tmpfs"
 	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-tp) --base ubuntu@22.04 --storage data=tmpfs,1G
+	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-tp) --storage data=tmpfs,1G
 	wait_for "dummy-storage-tp" ".applications"
 	if [ "$(unit_exist "data/3")" == "true" ]; then
 		assess_tmpfs
@@ -78,7 +78,7 @@ run_charm_storage() {
 
 	# Assessing for persistent filesystem
 	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-np) --base ubuntu@22.04 --storage data=1G
+	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-np) --storage data=1G
 	wait_for "dummy-storage-np" ".applications"
 	if [ "$(unit_exist "data/4")" == "true" ]; then
 		assess_fs
@@ -91,7 +91,7 @@ run_charm_storage() {
 
 	# Assessing multiple filesystem, block, rootfs, loop
 	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-mp) --base ubuntu@22.04 --storage data=1G
+	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-mp) --storage data=1G
 	wait_for "dummy-storage-mp" ".applications"
 	if [ "$(unit_exist "data/5")" == "true" ]; then
 		assess_multiple_fs


### PR DESCRIPTION
This change fixes the `test-charm-storage-aws` CI gating failure, which also
exposed a juju 4.0 storage regression while validating the fix.

The charm-storage subtest deployed local test charms with
`--base ubuntu@22.04`, but the packed charms only support `ubuntu@24.04`
(new-style charmcraft.yaml), so juju's client-side base validation rejected the
deploy. The subtest now deploys on `ubuntu@24.04`. In addition, the filesystem
lookup in `assess_rootfs` used the pre-4.0 machine-scoped filesystem id
(`"0/0"`); juju 4.0 uses global sequence numbers, so the lookup is now done via
the filesystem's storage linkage, which works across versions.

Finally, adding storage with a count but no size (`juju add-storage unit
disks=1`) provisioned a zero-sized volume: the add-storage command always
sends a size pointer (zero when unspecified), and `populateAddStorageArgs`
overwrote the recorded directive size (1024 MiB) with 0. The loop provider
then ran `fallocate -l 0MiB`, which util-linux rejects. A zero-size override
is now treated as unspecified, restoring the 3.6 fallback to the recorded
size for both the iaas and caas add-storage paths.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

No facade or API changes, so model-migration testing is not required.

1. Run the affected unit tests:

```sh
go test -race -v ./domain/application/service/ -run TestProviderServiceSuite
```

This includes `TestAddStorageForIAASUnitZeroSizeOverride`, which asserts that
a zero-size add-storage override keeps the recorded directive size.

2. Run the storage integration suite (the failing gating job):

```sh
cd tests && ./main.sh storage test_charm_storage
```

The `test-charm-storage-aws` gating run on this PR is the end-to-end
validation for the CI failure.

## Documentation changes

None.

## Links

**Jira card:** [JUJU-10313](https://warthogs.atlassian.net/browse/JUJU-10313)


[JUJU-10313]: https://warthogs.atlassian.net/browse/JUJU-10313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ