### PR TITLE
feat: include OVN as valid network from which to detect LXD subnets

### DIFF
--- a/internal/provider/lxd/environ_broker_test.go
+++ b/internal/provider/lxd/environ_broker_test.go
@@ -270,7 +270,11 @@ func (s *environBrokerSuite) TestStartInstanceWithSubnetsInSpace(c *tc.C) {
 	// back to the LXD network (host bridge) hosting them via Subnets().
 	exp.IsClustered().Return(false)
 	exp.Name().Return("locutus")
-	exp.GetNetworkNames().Return([]string{"ovs-br0", "virbr0", "lxdbr0"}, nil)
+	exp.GetNetworks().Return([]api.Network{
+		{Name: "ovs-br0", Type: "bridge"},
+		{Name: "virbr0", Type: "bridge"},
+		{Name: "lxdbr0", Type: "bridge"},
+	}, nil)
 	exp.GetNetworkState("ovs-br0").Return(&api.NetworkState{
 		Type:      "broadcast",
 		State:     "up",
@@ -337,7 +341,7 @@ func (s *environBrokerSuite) TestStartInstanceUnsatisfiedSubnetReturnsError(c *t
 
 	exp.IsClustered().Return(false)
 	exp.Name().Return("locutus")
-	exp.GetNetworkNames().Return([]string{"lxdbr0"}, nil)
+	exp.GetNetworks().Return([]api.Network{{Name: "lxdbr0", Type: "bridge"}}, nil)
 	exp.GetNetworkState("lxdbr0").Return(&api.NetworkState{
 		Type:      "broadcast",
 		State:     "up",
@@ -407,7 +411,7 @@ func (s *environBrokerSuite) TestStartInstanceWithModelProfileSubnetNIC(c *tc.C)
 
 	exp.IsClustered().Return(false)
 	exp.Name().Return("locutus")
-	exp.GetNetworkNames().Return([]string{"virbr0"}, nil)
+	exp.GetNetworks().Return([]api.Network{{Name: "virbr0", Type: "bridge"}}, nil)
 	exp.GetNetworkState("virbr0").Return(&api.NetworkState{
 		Type:      "broadcast",
 		State:     "up",
@@ -486,7 +490,7 @@ func (s *environBrokerSuite) TestStartInstanceModelProfileNICOverridesDefaultPro
 
 	exp.IsClustered().Return(false)
 	exp.Name().Return("locutus")
-	exp.GetNetworkNames().Return([]string{"lxdbr0"}, nil)
+	exp.GetNetworks().Return([]api.Network{{Name: "lxdbr0", Type: "bridge"}}, nil)
 	exp.GetNetworkState("lxdbr0").Return(&api.NetworkState{
 		Type:      "broadcast",
 		State:     "up",

--- a/internal/provider/lxd/environ_network.go
+++ b/internal/provider/lxd/environ_network.go
@@ -20,6 +20,8 @@ import (
 	"github.com/juju/juju/environs"
 )
 
+const networkTypeOVN = "ovn"
+
 var _ environs.Networking = (*environ)(nil)
 
 // Subnets returns basic information about subnets known by the provider for
@@ -51,7 +53,7 @@ func (e *environ) Subnets(ctx context.Context, subnetIDs []network.Id) ([]networ
 	)
 	for _, networkDetails := range networkStates {
 		state := networkDetails.state
-		if state.Bridge == nil {
+		if state.Bridge == nil && networkDetails.networkType != networkTypeOVN {
 			continue
 		}
 
@@ -87,12 +89,13 @@ func (e *environ) Subnets(ctx context.Context, subnetIDs []network.Id) ([]networ
 }
 
 type providerNetworkState struct {
-	name  string
-	state *lxdapi.NetworkState
+	name        string
+	networkType string
+	state       *lxdapi.NetworkState
 }
 
 func providerNetworkStates(srv Server) ([]providerNetworkState, error) {
-	networkNames, err := srv.GetNetworkNames()
+	networks, err := srv.GetNetworks()
 	if err != nil {
 		if isErrMissingAPIExtension(err, "network") {
 			return nil, errors.NewNotSupported(nil, `subnet discovery requires the "network" extension to be enabled on the lxd server`)
@@ -100,19 +103,23 @@ func providerNetworkStates(srv Server) ([]providerNetworkState, error) {
 		return nil, errors.Trace(err)
 	}
 
-	networkStates := make([]providerNetworkState, 0, len(networkNames))
-	for _, networkName := range networkNames {
-		state, err := srv.GetNetworkState(networkName)
+	networkStates := make([]providerNetworkState, 0, len(networks))
+	for _, providerNetwork := range networks {
+		state, err := srv.GetNetworkState(providerNetwork.Name)
 		if err != nil {
 			if isErrMissingAPIExtension(err, "network_state") {
 				return nil, errors.Errorf("network_state extension unsupported; upgrade to a newer version of LXD")
 			}
-			return nil, errors.Annotatef(err, "querying lxd server for state of network %q", networkName)
+			return nil, errors.Annotatef(err, "querying lxd server for state of network %q", providerNetwork.Name)
 		}
 		if state == nil {
-			return nil, errors.Errorf("network state %q not found", networkName)
+			return nil, errors.Errorf("network state %q not found", providerNetwork.Name)
 		}
-		networkStates = append(networkStates, providerNetworkState{name: networkName, state: state})
+		networkStates = append(networkStates, providerNetworkState{
+			name:        providerNetwork.Name,
+			networkType: providerNetwork.Type,
+			state:       state,
+		})
 	}
 	return networkStates, nil
 }

--- a/internal/provider/lxd/environ_network_test.go
+++ b/internal/provider/lxd/environ_network_test.go
@@ -45,7 +45,11 @@ func (s *environNetSuite) TestSubnetsForClustered(c *tc.C) {
 		},
 	}, nil)
 
-	srv.EXPECT().GetNetworkNames().Return([]string{"ovs-system", "lxdbr0", "phys-nic-0"}, nil)
+	srv.EXPECT().GetNetworks().Return([]lxdapi.Network{
+		{Name: "ovs-system", Type: "bridge"},
+		{Name: "lxdbr0", Type: "bridge"},
+		{Name: "phys-nic-0", Type: "physical"},
+	}, nil)
 	srv.EXPECT().GetNetworkState("ovs-system").Return(&lxdapi.NetworkState{
 		Type:   "broadcast",
 		State:  "down", // should be filtered out because it's down
@@ -107,12 +111,65 @@ func (s *environNetSuite) TestSubnetsForClustered(c *tc.C) {
 	c.Assert(subnets, tc.DeepEquals, expSubnets)
 }
 
+func (s *environNetSuite) TestSubnetsForOVN(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	srv := lxd.NewMockServer(ctrl)
+	srv.EXPECT().IsClustered().Return(false)
+	srv.EXPECT().Name().Return("locutus")
+	srv.EXPECT().GetNetworks().Return([]lxdapi.Network{
+		{Name: "ovn-net", Type: "ovn"},
+		{Name: "physical-net", Type: "physical"},
+	}, nil)
+	srv.EXPECT().GetNetworkState("ovn-net").Return(&lxdapi.NetworkState{
+		Type:  "broadcast",
+		State: "up",
+		Addresses: []lxdapi.NetworkStateAddress{
+			{
+				Family:  "inet",
+				Address: "10.248.0.1",
+				Netmask: "24",
+				Scope:   "global",
+			},
+		},
+	}, nil)
+	// This network has an address but is not backed by a bridge or OVN. It
+	// must not be reported as a provider subnet.
+	srv.EXPECT().GetNetworkState("physical-net").Return(&lxdapi.NetworkState{
+		Type:  "broadcast",
+		State: "up",
+		Addresses: []lxdapi.NetworkStateAddress{
+			{
+				Family:  "inet",
+				Address: "10.246.27.1",
+				Netmask: "24",
+				Scope:   "global",
+			},
+		},
+	}, nil)
+
+	invalidator := lxd.NewMockCredentialInvalidator(ctrl)
+	env := s.NewEnviron(c, srv, nil, environscloudspec.CloudSpec{}, invalidator).(environs.Networking)
+
+	subnets, err := env.Subnets(c.Context(), nil)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(subnets, tc.DeepEquals, []network.SubnetInfo{
+		{
+			CIDR:              "10.248.0.0/24",
+			ProviderId:        "10.248.0.0/24",
+			ProviderNetworkId: "ovn-net",
+			AvailabilityZones: []string{"locutus"},
+		},
+	})
+}
+
 func (s *environNetSuite) TestSubnetsForSubnetFiltering(c *tc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
 	srv := lxd.NewMockServer(ctrl)
-	srv.EXPECT().GetNetworkNames().Return([]string{"lxdbr0"}, nil)
+	srv.EXPECT().GetNetworks().Return([]lxdapi.Network{{Name: "lxdbr0", Type: "bridge"}}, nil)
 	srv.EXPECT().GetNetworkState("lxdbr0").Return(&lxdapi.NetworkState{
 		Type:   "broadcast",
 		State:  "up",


### PR DESCRIPTION
Next little step for OVN support.

LXD provider subnet discovery now includes OVN networks in those that it will discover subnets in.

## QA steps

Still only testing regressions at this point. We need further changes to actually test on an OVN set-up.

- Bootstrap
- Enter HA
- Add a model
- Deploy something

## Links

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10302](https://warthogs.atlassian.net/browse/JUJU-10302)


[JUJU-10302]: https://warthogs.atlassian.net/browse/JUJU-10302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ