### PR TITLE
perf(deploy): resolve charmhub resource with one less round-trip

### DIFF
--- a/domain/deployment/charm/repository/charmhub.go
+++ b/domain/deployment/charm/repository/charmhub.go
@@ -588,10 +588,11 @@ func (c *CharmHubRepository) listResourcesIfRevisions(ctx context.Context, resou
 		}
 		for _, res := range refreshResp {
 			if res.Revision == resource.Revision {
-				results[resource.Name], err = resourceFromRevision(refreshResp[0])
+				results[resource.Name], err = resourceFromRevision(res)
 				if err != nil {
 					return nil, internalerrors.Capture(err)
 				}
+				break
 			}
 		}
 	}

--- a/domain/deployment/charm/repository/charmhub_test.go
+++ b/domain/deployment/charm/repository/charmhub_test.go
@@ -747,6 +747,38 @@ func (s *charmHubRepositorySuite) TestResolveResourcesFromStoreNoRevision_CharmR
 	}})
 }
 
+// TestResolveResourcesPinnedRevisionNotOldest ensures a resource pinned to
+// a revision other than the oldest is resolved from the matching revision
+// in the ListResourceRevisions response, without a compensating Refresh
+// round-trip. The channel-tip Refresh returns revision 1, so a regression
+// to using the first element of the revisions response would leave the
+// store map with revision 1 and trigger an extra Refresh via resourceInfo.
+func (s *charmHubRepositorySuite) TestResolveResourcesPinnedRevisionNotOldest(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+	// The single Refresh call (repositoryResources) returns the channel
+	// tip, revision 1. Times(1) guards against the compensating
+	// resourceInfo Refresh that the refreshResp[0] defect caused.
+	s.expectRefresh(c, true)
+	s.expectListResourceRevisionsMulti(1, 2, 3)
+
+	result, err := s.newClient(c).ResolveResources(c.Context(), []charmresource.Resource{{
+		Meta:   charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
+		Origin: charmresource.OriginStore,
+		// Pin to the newest revision, not the first element of the
+		// revisions response.
+		Revision: 3,
+		Size:     0,
+	}}, charmID())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(result, tc.DeepEquals, []charmresource.Resource{{
+		Meta:        charmresource.Meta{Name: "wal-e", Type: 1, Path: "wal-e.snap", Description: "WAL-E Snap Package"},
+		Origin:      charmresource.OriginStore,
+		Revision:    3,
+		Fingerprint: fp(c),
+		Size:        0,
+	}})
+}
+
 func (s *charmHubRepositorySuite) TestResolveResourcesNoMatchingRevision(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectRefresh(c, true)
@@ -1117,6 +1149,17 @@ func (s *charmHubRepositorySuite) expectRefreshWithRevisionAndChannel(c *tc.C, r
 func (s *charmHubRepositorySuite) expectListResourceRevisions(rev int) {
 	resp := []transport.ResourceRevision{
 		resourceRevision(rev),
+	}
+	s.client.EXPECT().ListResourceRevisions(gomock.Any(), gomock.Any(), gomock.Any()).Return(resp, nil)
+}
+
+// expectListResourceRevisionsMulti mocks ListResourceRevisions with multiple
+// revisions, oldest first, matching the ordering of the real Charmhub
+// endpoint.
+func (s *charmHubRepositorySuite) expectListResourceRevisionsMulti(revs ...int) {
+	resp := make([]transport.ResourceRevision, len(revs))
+	for i, rev := range revs {
+		resp[i] = resourceRevision(rev)
 	}
 	s.client.EXPECT().ListResourceRevisions(gomock.Any(), gomock.Any(), gomock.Any()).Return(resp, nil)
 }


### PR DESCRIPTION
## Description

When deploying a charm with a resource pinned to a specific revision (`juju deploy foo --resource bar=X`), `CharmHubRepository.listResourcesIfRevisions` asks Charmhub for all revisions of the resource, finds the entry matching the requested revision and then discards it, building the result from the **first element** of the response instead:

```go
for _, res := range refreshResp {
    if res.Revision == resource.Revision {
        results[resource.Name], err = resourceFromRevision(refreshResp[0]) // wrong element
    }
}
```

Since the Charmhub `ListResourceRevisions` endpoint returns revisions oldest-first, `refreshResp[0]` is the *oldest* revision, not the requested one.

### Why it's not a bug

The wrong entry lands in the store-resources map. But `resolveRepositoryResources` compares the **requested** revision against the map entry, sees the mismatch and falls through to `resourceInfo(...)`, which re-fetches the requested revision directly from Charmhub and returns correct metadata. The result of a pinned deploy was therefore always correct already. It's only a wasted round-trip now, but it could become a bug later if the mismatch-detection fallback ever changes or is bypassed.

### Round-trips

Resolving a pinned resource reduces the number of Charmhub roundtrips from 2 to 1.

I measured round-trips from my home connection against live Charmhub over a few samples. Refresh round-trip costs ~100–200 ms and revisions ~200-250 ms. Total pinned-resource resolution time drops from ~300-450 ms to ~200-250 ms, so roughly a third faster.

However, this is minor within the context of `juju deploy`, which does plenty of other things that take more time.

### 3.6

Juju 3.6 has the same code, it was only moved in 4. The same change can be applied there.

### Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~Integration tests~ (no facade/API change; covered by unit tests)
- ~doc.go~ (no package-level docs change)

### QA steps

No behavior change expected, since pinned deploys resolved correctly already.

```sh
make microk8s-operator-update
# make sure `juju` is what we've built
juju bootstrap microk8s qa
juju add-model pinned
juju deploy coredns --channel latest/stable --resource coredns-image=59
```

Check the deployed image matches revision 59 on Charmhub:

```sh
$ kubectl -n pinned get pods -o jsonpath='{.items[*].spec.containers[*].image}'
```

Will include something like this:
```sh
registry.jujucharms.com/charm/8kegrpw0xeuzoxh1d9dv327iix3r31419nhw/coredns-image@sha256:bd6d628e648415b160089ee71bb2b2328aec41f3736c6c5599d5024dbc0a7ca7
```

Compare against revision 59's OCI reference from Charmhub:

```sh
$ curl -sL 'https://api.charmhub.io/api/v1/resources/download/charm_0gorpaPu7KPe5la0wHtT9B25C0FqlzHw.coredns-image_59'
```

Which will get you:
```sh
{"ImageName":"registry.jujucharms.com/charm/8kegrpw0xeuzoxh1d9dv327iix3r31419nhw/coredns-image@sha256:bd6d628e648415b160089ee71bb2b2328aec41f3736c6c5599d5024dbc0a7ca7",...}
```