### PR TITLE
fix(tests): wait for voter quorum and correct HA teardown wait

### DIFF
--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -44,6 +44,10 @@ const (
 
 	// dbOpenTimeout is the timeout for opening a database.
 	dbOpenTimeout = 15 * time.Second
+
+	// dbLeaderReportTimeout is the timeout for querying Dqlite leadership
+	// during an engine report.
+	dbLeaderReportTimeout = 10 * time.Second
 )
 
 // NodeManager creates Dqlite `App` initialisation arguments and options.
@@ -385,39 +389,41 @@ func (w *dbWorker) Wait() error {
 
 // Report provides information for the engine report.
 func (w *dbWorker) Report(ctx context.Context) map[string]any {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-
 	ctx = w.catacomb.Context(ctx)
 
-	// We need to guard against attempting to report when setting up or dying,
-	// so we don't end up panicking with missing information.
 	result := w.dbRunner.Report(ctx)
+	if result == nil {
+		result = make(map[string]any)
+	}
 
-	if w.dbApp == nil {
-		result["leader"] = ""
-		result["leader-id"] = uint64(0)
-		result["leader-role"] = ""
+	w.mu.RLock()
+	dbApp := w.dbApp
+	w.mu.RUnlock()
+
+	if dbApp == nil {
+		result["leader-error"] = "dqlite node unavailable"
 		return result
 	}
 
-	var (
-		leader     string
-		leaderRole string
-		leaderID   uint64
-	)
-	if client, err := w.dbApp.Client(ctx); err == nil {
-		defer func() { _ = client.Close() }()
-		if nodeInfo, err := client.Leader(ctx); err == nil {
-			leaderID = nodeInfo.ID
-			leader = nodeInfo.Address
-			leaderRole = nodeInfo.Role.String()
-		}
+	leaderCtx, cancel := context.WithTimeout(ctx, dbLeaderReportTimeout)
+	defer cancel()
+
+	client, err := dbApp.Client(leaderCtx)
+	if err != nil {
+		result["leader-error"] = err.Error()
+		return result
+	}
+	defer func() { _ = client.Close() }()
+
+	nodeInfo, err := client.Leader(leaderCtx)
+	if err != nil {
+		result["leader-error"] = err.Error()
+		return result
 	}
 
-	result["leader-id"] = leaderID
-	result["leader"] = leader
-	result["leader-role"] = leaderRole
+	result["leader-id"] = nodeInfo.ID
+	result["leader"] = nodeInfo.Address
+	result["leader-role"] = nodeInfo.Role.String()
 
 	return result
 }

--- a/internal/worker/dbaccessor/worker_test.go
+++ b/internal/worker/dbaccessor/worker_test.go
@@ -577,6 +577,134 @@ func (s *workerSuite) TestWorkerStartupAsBootstrapNodeThenReconfigureWithLoopbac
 	}
 }
 
+func (s *workerSuite) startRunningWorker(c *tc.C) (*dbWorker, func()) {
+	dbDone := make(chan struct{})
+	s.expectClock()
+	s.expectTrackedDBUpdateNodeAndKill(dbDone)
+
+	mgrExp := s.nodeManager.EXPECT()
+	mgrExp.EnsureDataDir().Return(c.MkDir(), nil)
+	mgrExp.IsExistingNode().Return(true, nil).MinTimes(1)
+	mgrExp.IsLoopbackBound(gomock.Any()).Return(false, nil).MinTimes(1)
+	mgrExp.IsLoopbackPreferred().Return(false).MinTimes(1)
+	mgrExp.WithLogFuncOption().Return(nil)
+	mgrExp.WithTLSOption().Return(nil, nil)
+	mgrExp.WithTracingOption().Return(nil)
+	mgrExp.WithBusyTimeoutOption().Return(nil)
+
+	s.client.EXPECT().Cluster(gomock.Any()).Return(nil, nil)
+
+	s.clusterConfig.EXPECT().DBBindAddresses().Return(map[string]string{
+		"0": "10.6.6.6",
+		"1": "10.6.6.7",
+	}, nil)
+
+	appExp := s.dbApp.EXPECT()
+	appExp.Ready(gomock.Any()).Return(nil)
+	appExp.Client(gomock.Any()).Return(s.client, nil).Times(1)
+	appExp.ID().Return(uint64(666)).MinTimes(1)
+	appExp.Address().Return("192.168.6.6:17666")
+	appExp.Close().Return(nil)
+	s.expectWorkerRetry()
+
+	s.expectNoConfigChanges()
+	s.dbApp.EXPECT().Handover(gomock.Any()).Return(nil)
+
+	w := s.newWorker(c)
+	dbw := w.(*dbWorker)
+	ensureStartup(c, dbw)
+
+	cleanup := func() {
+		close(dbDone)
+		workertest.CleanKill(c, w)
+	}
+	return dbw, cleanup
+}
+
+func (s *workerSuite) TestWorkerReportLeaderSuccess(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	dbw, cleanup := s.startRunningWorker(c)
+	defer cleanup()
+
+	s.dbApp.EXPECT().Client(gomock.Any()).Return(s.client, nil).Times(1)
+	nodeInfo := &dqlite.NodeInfo{
+		ID:      42,
+		Address: "10.6.6.6:17666",
+		Role:    dqlite.Voter,
+	}
+	s.client.EXPECT().Leader(gomock.Any()).Return(nodeInfo, nil)
+
+	report := dbw.Report(c.Context())
+	c.Check(report["leader"], tc.Equals, "10.6.6.6:17666")
+	c.Check(report["leader-id"], tc.Equals, uint64(42))
+	c.Check(report["leader-role"], tc.Equals, nodeInfo.Role.String())
+	_, hasError := report["leader-error"]
+	c.Check(hasError, tc.IsFalse)
+}
+
+func (s *workerSuite) TestWorkerReportLeaderError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	dbw, cleanup := s.startRunningWorker(c)
+	defer cleanup()
+
+	s.dbApp.EXPECT().Client(gomock.Any()).Return(s.client, nil).Times(1)
+	s.client.EXPECT().Leader(gomock.Any()).Return(nil, errors.New("cannot determine leader"))
+
+	report := dbw.Report(c.Context())
+	c.Check(report["leader-error"], tc.Equals, "cannot determine leader")
+	_, hasLeader := report["leader"]
+	c.Check(hasLeader, tc.IsFalse)
+	_, hasLeaderID := report["leader-id"]
+	c.Check(hasLeaderID, tc.IsFalse)
+	_, hasLeaderRole := report["leader-role"]
+	c.Check(hasLeaderRole, tc.IsFalse)
+}
+
+func (s *workerSuite) TestWorkerReportLeaderTimeout(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	dbw, cleanup := s.startRunningWorker(c)
+	defer cleanup()
+
+	s.dbApp.EXPECT().Client(gomock.Any()).Return(s.client, nil).Times(1)
+	s.client.EXPECT().Leader(gomock.Any()).DoAndReturn(func(ctx context.Context) (*dqlite.NodeInfo, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	testCtx, cancel := context.WithTimeout(c.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	report := dbw.Report(testCtx)
+	c.Check(report["leader-error"], tc.Equals, context.DeadlineExceeded.Error())
+	_, hasLeader := report["leader"]
+	c.Check(hasLeader, tc.IsFalse)
+	_, hasLeaderID := report["leader-id"]
+	c.Check(hasLeaderID, tc.IsFalse)
+	_, hasLeaderRole := report["leader-role"]
+	c.Check(hasLeaderRole, tc.IsFalse)
+}
+
+func (s *workerSuite) TestWorkerReportClientError(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	dbw, cleanup := s.startRunningWorker(c)
+	defer cleanup()
+
+	s.dbApp.EXPECT().Client(gomock.Any()).Return(nil, errors.New("client creation failed"))
+
+	report := dbw.Report(c.Context())
+	c.Check(report["leader-error"], tc.Equals, "client creation failed")
+	_, hasLeader := report["leader"]
+	c.Check(hasLeader, tc.IsFalse)
+	_, hasLeaderID := report["leader-id"]
+	c.Check(hasLeaderID, tc.IsFalse)
+	_, hasLeaderRole := report["leader-role"]
+	c.Check(hasLeaderRole, tc.IsFalse)
+}
+
 func (s *workerSuite) setupMocks(c *tc.C) *gomock.Controller {
 	ctrl := s.baseSuite.setupMocks(c)
 

--- a/internal/worker/dbaccessor/worker_test.go
+++ b/internal/worker/dbaccessor/worker_test.go
@@ -670,6 +670,10 @@ func (s *workerSuite) TestWorkerReportLeaderTimeout(c *tc.C) {
 
 	s.dbApp.EXPECT().Client(gomock.Any()).Return(s.client, nil).Times(1)
 	s.client.EXPECT().Leader(gomock.Any()).DoAndReturn(func(ctx context.Context) (*dqlite.NodeInfo, error) {
+		deadline, ok := ctx.Deadline()
+		c.Assert(ok, tc.IsTrue)
+		c.Check(time.Until(deadline) > 0, tc.IsTrue)
+		c.Check(time.Until(deadline) <= dbLeaderReportTimeout, tc.IsTrue)
 		<-ctx.Done()
 		return nil, ctx.Err()
 	})
@@ -685,6 +689,27 @@ func (s *workerSuite) TestWorkerReportLeaderTimeout(c *tc.C) {
 	c.Check(hasLeaderID, tc.IsFalse)
 	_, hasLeaderRole := report["leader-role"]
 	c.Check(hasLeaderRole, tc.IsFalse)
+}
+
+func (s *workerSuite) TestWorkerReportLeaderContextDeadline(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	dbw, cleanup := s.startRunningWorker(c)
+	defer cleanup()
+
+	var receivedDeadline time.Time
+	s.dbApp.EXPECT().Client(gomock.Any()).Return(s.client, nil).Times(1)
+	s.client.EXPECT().Leader(gomock.Any()).DoAndReturn(func(ctx context.Context) (*dqlite.NodeInfo, error) {
+		var ok bool
+		receivedDeadline, ok = ctx.Deadline()
+		c.Assert(ok, tc.IsTrue)
+		return nil, errors.New("cannot determine leader")
+	})
+
+	report := dbw.Report(c.Context())
+	c.Check(report["leader-error"], tc.Equals, "cannot determine leader")
+	c.Check(time.Until(receivedDeadline) > 0, tc.IsTrue)
+	c.Check(time.Until(receivedDeadline) <= dbLeaderReportTimeout, tc.IsTrue)
 }
 
 func (s *workerSuite) TestWorkerReportClientError(c *tc.C) {

--- a/internal/worker/introspection/worker.go
+++ b/internal/worker/introspection/worker.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"runtime"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/worker/v5"
@@ -26,6 +27,11 @@ import (
 )
 
 var logger = internallogger.GetLogger("juju.worker.introspection")
+
+// introspectionReportTimeout bounds how long we wait for the dependency
+// engine report. A blocking worker report (e.g. a dqlite RPC during HA
+// teardown) must never wedge the introspection handler or the engine loop.
+const introspectionReportTimeout = 60 * time.Second
 
 // DependencyEngine provides insight into the running dependency engine of the
 // agent.
@@ -203,7 +209,10 @@ func (h depengineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing dependency engine reporter", http.StatusNotFound)
 		return
 	}
-	bytes, err := yaml.Marshal(h.reporter.Report(r.Context()))
+	ctx, cancel := context.WithTimeout(r.Context(), introspectionReportTimeout)
+	defer cancel()
+
+	bytes, err := yaml.Marshal(h.reporter.Report(ctx))
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error: %v", err), http.StatusInternalServerError)
 		return

--- a/internal/worker/introspection/worker.go
+++ b/internal/worker/introspection/worker.go
@@ -28,10 +28,10 @@ import (
 
 var logger = internallogger.GetLogger("juju.worker.introspection")
 
-// introspectionReportTimeout bounds how long we wait for the dependency
+// ReportTimeout bounds how long we wait for the dependency
 // engine report. A blocking worker report (e.g. a dqlite RPC during HA
 // teardown) must never wedge the introspection handler or the engine loop.
-const introspectionReportTimeout = 60 * time.Second
+const ReportTimeout = 60 * time.Second
 
 // DependencyEngine provides insight into the running dependency engine of the
 // agent.
@@ -209,7 +209,7 @@ func (h depengineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing dependency engine reporter", http.StatusNotFound)
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), introspectionReportTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), ReportTimeout)
 	defer cancel()
 
 	bytes, err := yaml.Marshal(h.reporter.Report(ctx))

--- a/internal/worker/introspection/worker_test.go
+++ b/internal/worker/introspection/worker_test.go
@@ -205,6 +205,33 @@ Dependency Engine Report
 working: true`[1:])
 }
 
+func (s *introspectionSuite) TestEngineReporterContextDeadline(c *tc.C) {
+	workertest.CleanKill(c, s.worker)
+	ctxCh := make(chan context.Context, 1)
+	s.depEngine = &depEngine{
+		values: map[string]any{
+			"working": true,
+		},
+		reportCtxCh: ctxCh,
+	}
+	s.startWorker(c)
+	response := s.call(c, "/depengine")
+	defer response.Body.Close()
+	c.Assert(response.StatusCode, tc.Equals, http.StatusOK)
+
+	var reportedCtx context.Context
+	select {
+	case reportedCtx = <-ctxCh:
+	case <-c.Context().Done():
+		c.Fatal("timed out waiting for Report to receive context")
+	}
+
+	deadline, ok := reportedCtx.Deadline()
+	c.Assert(ok, tc.IsTrue)
+	c.Check(time.Until(deadline) > 0, tc.IsTrue)
+	c.Check(time.Until(deadline) <= 60*time.Second, tc.IsTrue)
+}
+
 func (s *introspectionSuite) TestPrometheusMetrics(c *tc.C) {
 	response := s.call(c, "/metrics")
 	defer response.Body.Close()
@@ -216,10 +243,14 @@ func (s *introspectionSuite) TestPrometheusMetrics(c *tc.C) {
 }
 
 type depEngine struct {
-	values map[string]any
+	values      map[string]any
+	reportCtxCh chan context.Context
 }
 
 func (r *depEngine) Report(ctx context.Context) map[string]any {
+	if r.reportCtxCh != nil {
+		r.reportCtxCh <- ctx
+	}
 	return r.values
 }
 

--- a/internal/worker/introspection/worker_test.go
+++ b/internal/worker/introspection/worker_test.go
@@ -229,7 +229,7 @@ func (s *introspectionSuite) TestEngineReporterContextDeadline(c *tc.C) {
 	deadline, ok := reportedCtx.Deadline()
 	c.Assert(ok, tc.IsTrue)
 	c.Check(time.Until(deadline) > 0, tc.IsTrue)
-	c.Check(time.Until(deadline) <= 60*time.Second, tc.IsTrue)
+	c.Check(time.Until(deadline) <= introspection.ReportTimeout, tc.IsTrue)
 }
 
 func (s *introspectionSuite) TestPrometheusMetrics(c *tc.C) {

--- a/tests/includes/ha.sh
+++ b/tests/includes/ha.sh
@@ -30,13 +30,14 @@ wait_for_ha() {
 
 	attempt=0
 	# shellcheck disable=SC2143
-	# Poll controller machines until each reports a non-null,
-	# non-"unknown" controller-cluster-role. This is the 4.x
-	# replacement for the per-machine `ha-status == "ha-enabled"`
-	# check used in 3.x: a controller machine only reports a real
-	# dqlite role (voter/standby/spare) once it has joined the HA
-	# cluster, so "present and not unknown" is the readiness proxy.
-	until [[ "$(juju status -m controller --format=json 2>/dev/null | yq -r '.machines | to_entries[] | select(.value["controller-cluster-role"] != null and .value["controller-cluster-role"] != "unknown") | .key' | wc -l | grep "${amount}")" ]]; do
+	# Poll controller machines until enough of them report a
+	# "voter" controller-cluster-role. This is the 4.x replacement
+	# for the per-machine `ha-status == "ha-enabled"` check used in
+	# 3.x: only voter nodes replicate data and participate in the
+	# dqlite quorum. Standbys replicate but do not vote, and spares
+	# do neither, so counting them would report HA before a quorum
+	# of controllers is established.
+	until [[ "$(juju status -m controller --format=json 2>/dev/null | yq -r '.machines | to_entries[] | select(.value["controller-cluster-role"] == "voter") | .key' | wc -l | grep "${amount}")" ]]; do
 		echo "[+] (attempt ${attempt}) polling ha"
 		juju status -m controller --format=yaml 2>&1 | yq '.machines | with_entries(.value |= pick(["instance-id", "controller-cluster-role"]))' 2>&1 | sed 's/^/    | /g' || true
 		sleep "${SHORT_TIMEOUT}"

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -655,8 +655,8 @@ introspect_controller() {
 		return
 	fi
 
-	echo "${idents}" | xargs -I % timeout 60 juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" >"${TEST_DIR}/${name}-juju_engine_reports.log" 2>/dev/null
-	echo "${idents}" | xargs -I % timeout 60 juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" >"${TEST_DIR}/${name}-juju_goroutines.log" 2>/dev/null
+	echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" >"${TEST_DIR}/${name}-juju_engine_reports.log" 2>/dev/null
+	echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" >"${TEST_DIR}/${name}-juju_goroutines.log" 2>/dev/null
 }
 
 remove_controller_offers() {

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -655,8 +655,8 @@ introspect_controller() {
 		return
 	fi
 
-	echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" >"${TEST_DIR}/${name}-juju_engine_reports.log" 2>/dev/null
-	echo "${idents}" | xargs -I % juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" >"${TEST_DIR}/${name}-juju_goroutines.log" 2>/dev/null
+	echo "${idents}" | xargs -I % timeout 60 juju ssh -m "${name}:controller" % bash -lc "juju_engine_report" >"${TEST_DIR}/${name}-juju_engine_reports.log" 2>/dev/null
+	echo "${idents}" | xargs -I % timeout 60 juju ssh -m "${name}:controller" % bash -lc "juju_goroutines" >"${TEST_DIR}/${name}-juju_goroutines.log" 2>/dev/null
 }
 
 remove_controller_offers() {

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -118,8 +118,9 @@ run_enable_ha() {
 
 	juju switch enable-ha
 	controller_1=$(juju status -m controller --format json | yq -r '.applications.controller.units["controller/1"].machine')
-	juju remove-machine -m controller "${controller_1}" --force --no-prompt
 	controller_2=$(juju status -m controller --format json | yq -r '.applications.controller.units["controller/2"].machine')
+	juju remove-machine -m controller "${controller_1}" --force --no-prompt
+	wait_for_ha 2
 	juju remove-machine -m controller "${controller_2}" --force --no-prompt
 
 	wait_for_ha_teardown
@@ -128,6 +129,7 @@ run_enable_ha() {
 	# the deletions, well before the controller unit and its charm hooks have
 	# settled. Wait for the surviving unit to be idle before probing dqlite
 	# leadership, otherwise the probe races the dqlite backstop recovery.
+	juju switch controller
 	wait_for "controller" "$(idle_condition "controller" 0)" 900
 	wait_for_controller_leadership
 

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -5,7 +5,6 @@ wait_for_ha_teardown() {
 	# the controller model can only be served once quorum is restored, so
 	# reaching this state also implies that the dqlite backstop has
 	# reconfigured the cluster around the surviving node.
-	# shellcheck disable=SC2143
 	until status=$(timeout 10 juju status -m controller --format=json 2>/dev/null) &&
 		count=$(yq -r '.machines | to_entries | length' <<<"${status}") &&
 		voters=$(yq -r '.machines | to_entries[] | select(.value["controller-cluster-role"] == "voter") | .key' <<<"${status}" | wc -l) &&
@@ -36,7 +35,6 @@ wait_for_controller_leadership() {
 	# reconfigured the cluster around the surviving controller.
 	# The timeout bounds each attempt so a broken backstop fails the
 	# test instead of hanging it.
-	# shellcheck disable=SC2143
 	# Not using juju_exec_output: uptime is a plain system command that
 	# produces no stderr, so the stdout/stderr mixing bug does not apply.
 	until timeout 60 juju exec -m controller --unit controller/leader uptime 2>/dev/null | grep load; do

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -37,6 +37,8 @@ wait_for_controller_leadership() {
 	# The timeout bounds each attempt so a broken backstop fails the
 	# test instead of hanging it.
 	# shellcheck disable=SC2143
+	# Not using juju_exec_output: uptime is a plain system command that
+	# produces no stderr, so the stdout/stderr mixing bug does not apply.
 	until timeout 60 juju exec -m controller --unit controller/leader uptime 2>/dev/null | grep load; do
 		echo "[+] (attempt ${attempt}) waiting for controller leadership"
 		attempt=$((attempt + 1))

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -123,6 +123,12 @@ run_enable_ha() {
 	juju remove-machine -m controller "${controller_2}" --force --no-prompt
 
 	wait_for_ha_teardown
+
+	# The machine view above converges as soon as remove-machine records
+	# the deletions, well before the controller unit and its charm hooks have
+	# settled. Wait for the surviving unit to be idle before probing dqlite
+	# leadership, otherwise the probe races the dqlite backstop recovery.
+	wait_for "controller" "$(idle_condition "controller" 0)" 900
 	wait_for_controller_leadership
 
 	destroy_model "enable-ha"

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -122,6 +122,7 @@ run_enable_ha() {
 	juju remove-machine -m controller "${controller_1}" --force --no-prompt
 	wait_for_ha 2
 	juju remove-machine -m controller "${controller_2}" --force --no-prompt
+	wait_for_ha 1
 
 	wait_for_ha_teardown
 

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -1,26 +1,50 @@
-wait_for_controller_no_leader() {
-	# We need to wait for the Dqlite cluster to be broken (loss of quorum),
-	# before we start waiting for the backstop behaviour to be pending
-	# (see wait_for_controller_leader below).
+wait_for_ha_teardown() {
+	attempt=0
+	# After tearing down HA, wait for the surviving controller machine to
+	# be the only one left and to keep its dqlite voter role. Status for
+	# the controller model can only be served once quorum is restored, so
+	# reaching this state also implies that the dqlite backstop has
+	# reconfigured the cluster around the surviving node.
 	# shellcheck disable=SC2143
-	until ! [[ "$(juju exec -m controller --unit controller/leader uptime | grep load)" ]]; do
-		echo "[+] waiting for no controller leadership"
+	until status=$(timeout 10 juju status -m controller --format=json 2>/dev/null) &&
+		count=$(yq -r '.machines | to_entries | length' <<<"${status}") &&
+		voters=$(yq -r '.machines | to_entries[] | select(.value["controller-cluster-role"] == "voter") | .key' <<<"${status}" | wc -l) &&
+		[[ ${count} -eq 1 && ${voters} -eq 1 ]]; do
+		echo "[+] (attempt ${attempt}) polling ha teardown"
+		juju status -m controller --format=yaml 2>&1 | yq '.machines | with_entries(.value |= pick(["instance-id", "controller-cluster-role"]))' 2>&1 | sed 's/^/    | /g' || true
+		sleep "${SHORT_TIMEOUT}"
+		attempt=$((attempt + 1))
+
+		if [[ ${attempt} -gt 100 ]]; then
+			echo "high availability teardown failed waiting for a single controller"
+			exit 1
+		fi
 	done
+
+	if [[ ${attempt} -gt 0 ]]; then
+		echo "[+] $(green 'Completed polling ha teardown')"
+		juju status -m controller --format=yaml 2>&1 | yq '.machines | with_entries(.value |= pick(["instance-id", "controller-cluster-role"]))' 2>&1 | sed 's/^/    | /g'
+
+		sleep "${SHORT_TIMEOUT}"
+	fi
 }
 
-wait_for_controller_leader() {
-	# Since the institution of Dqlite for leases, we need to wait until the
-	# backstop workflow has run before we are functional with a single
-	# controller.
-	# A proxy for this is leadership determination. The command below will
-	# sometimes block for extended periods, other times we will be told that
-	# leadership can not be determined, so there is no fixed number of attempts
-	# that we can rely on.
+wait_for_controller_leadership() {
+	attempt=0
+	# Leadership determination requires quorum and a functional lease
+	# manager, so it only succeeds once the dqlite backstop has
+	# reconfigured the cluster around the surviving controller.
+	# The timeout bounds each attempt so a broken backstop fails the
+	# test instead of hanging it.
 	# shellcheck disable=SC2143
-	# Not using juju_exec_output: uptime is a plain system command that
-	# produces no stderr, so the stdout/stderr mixing bug does not apply.
-	until [[ "$(juju exec -m controller --unit controller/leader uptime | grep load)" ]]; do
-		echo "[+] waiting for controller leadership"
+	until timeout 60 juju exec -m controller --unit controller/leader uptime 2>/dev/null | grep load; do
+		echo "[+] (attempt ${attempt}) waiting for controller leadership"
+		attempt=$((attempt + 1))
+
+		if [[ ${attempt} -gt 12 ]]; then
+			echo "controller leadership not restored after HA teardown"
+			exit 1
+		fi
 	done
 }
 
@@ -92,15 +116,12 @@ run_enable_ha() {
 
 	juju switch enable-ha
 	controller_1=$(juju status -m controller --format json | yq -r '.applications.controller.units["controller/1"].machine')
-	juju remove-machine -m controller "${controller_1}" --force
+	juju remove-machine -m controller "${controller_1}" --force --no-prompt
 	controller_2=$(juju status -m controller --format json | yq -r '.applications.controller.units["controller/2"].machine')
-	juju remove-machine -m controller "${controller_2}" --force
+	juju remove-machine -m controller "${controller_2}" --force --no-prompt
 
-	wait_for_controller_no_leader
-	wait_for_controller_leader
-
-	# Ensure that we have no ha enabled machines.
-	juju show-controller --format=json | yq -r '.[] | .["controller-machines"] | (.[] | select(.["instance-id"] == null)) as $i ireduce (0; . + 1)' | grep 0
+	wait_for_ha_teardown
+	wait_for_controller_leadership
 
 	destroy_model "enable-ha"
 }

--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -10,7 +10,7 @@ wait_for_ha_teardown() {
 		voters=$(yq -r '.machines | to_entries[] | select(.value["controller-cluster-role"] == "voter") | .key' <<<"${status}" | wc -l) &&
 		[[ ${count} -eq 1 && ${voters} -eq 1 ]]; do
 		echo "[+] (attempt ${attempt}) polling ha teardown"
-		juju status -m controller --format=yaml 2>&1 | yq '.machines | with_entries(.value |= pick(["instance-id", "controller-cluster-role"]))' 2>&1 | sed 's/^/    | /g' || true
+		timeout 10 juju status -m controller --format=yaml 2>&1 | yq '.machines | with_entries(.value |= pick(["instance-id", "controller-cluster-role"]))' 2>&1 | sed 's/^/    | /g' || true
 		sleep "${SHORT_TIMEOUT}"
 		attempt=$((attempt + 1))
 
@@ -39,6 +39,7 @@ wait_for_controller_leadership() {
 	# produces no stderr, so the stdout/stderr mixing bug does not apply.
 	until timeout 60 juju exec -m controller --unit controller/leader uptime 2>/dev/null | grep load; do
 		echo "[+] (attempt ${attempt}) waiting for controller leadership"
+		sleep "${SHORT_TIMEOUT}"
 		attempt=$((attempt + 1))
 
 		if [[ ${attempt} -gt 12 ]]; then


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

## Why

1. `wait_for_ha` in `tests/includes/ha.sh` only waited for N controller
   machines to report *some* dqlite role. A node joins the cluster as a
   `spare` (no replication, no vote), is promoted to `standby`
   (replicates, but does not vote), and only a `voter` replicates data
   and participates in the dqlite quorum. Counting spares and standbys
   meant the helper could return before a quorum of voters existed, so
   tests could start tearing down HA while the cluster was still
   converging.

2. The `enable_ha` teardown (`tests/suites/controller/enable_ha.sh`)
   polled leadership with two unbounded `juju exec` probes that could
   hang indefinitely, and the final `show-controller` `instance-id == null`
   assertion is vacuous in 4.x (emitted as `"(unprovisioned)"`, never `null`).

3. `juju_engine_report` hung forever during introspection when Dqlite had
   no leader: the depengine handler passed a deadline-less context to the
   dependency engine, which executes each worker's `Report` sequentially on
   the engine loop goroutine. `dbWorker.Report` blocked on `client.Leader`
   while holding `w.mu`, wedging the engine loop and preventing the agent
   from processing tickets or completing the report.

## What

- `wait_for_ha` now counts controller machines whose
  `controller-cluster-role` is exactly `voter`, the only role that
  counts toward the dqlite quorum, and documents why in the helper.
- `enable_ha` teardown now removes one controller at a time and waits
  for two voters before removing the final controller. It then waits
  for exactly one remaining voter, waits for the controller unit to
  become idle in the controller model, and performs a timeout-bounded
  leadership probe.
- Replaced the two unbounded `juju exec` loops and vacuous `show-controller`
  assertion with bounded, meaningful checks; added `--no-prompt` to
  `remove-machine`.
- `depengineHandler.ServeHTTP` now bounds the request context with a 60s
  timeout so worker reports cannot wedge the engine loop indefinitely.
- `dbWorker.Report` snapshots `dbApp` under `w.mu.RLock()`, releases the
  lock before querying `client.Leader` with a 10s deadline, and surfaces
  `leader-error` when unavailable instead of blocking.
- Added unit tests for context deadline propagation in introspection and
  for `dbWorker.Report` error/timeout/success paths.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. Run the unit tests:
```sh
go test -race ./internal/worker/introspection/... ./internal/worker/dbaccessor/...
```

2. Run the HA integration test on a machine provider (e.g. lxd):
```sh
cd tests && ./main.sh controller test_enable_ha
```

Verify that `wait_for_ha` only returns once the controller machines
report a `voter` `controller-cluster-role`:
```sh
$ juju status -m controller --format=yaml | yq '.machines | with_entries(.value |= pick(["instance-id", "controller-cluster-role"]))'
```

Expected: all three controller machines eventually report
`controller-cluster-role: voter`; teardown removes one machine, waits
for two voters, removes the second machine, waits for a single voter in
the controller model, and restores controller leadership without
hanging or failing spuriously. `juju_engine_report` returns promptly
even if Dqlite is degraded.

## Documentation changes

None. Test and internal worker fix.

## Links

**Issue:** Follow-up to https://github.com/juju/juju/pull/23156 (JUJU-10265),
which introduced the `wait_for_ha` role polling this change corrects.

**Jira card:** [JUJU-10265](https://warthogs.atlassian.net/browse/JUJU-10265)


[JUJU-10265]: https://warthogs.atlassian.net/browse/JUJU-10265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ