### PR TITLE
feat: stop controller scaling to zero

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -246,15 +246,23 @@ func Open(ctx context.Context, info *Info, opts DialOpts) (Connection, error) {
 	}
 
 	go (&monitor{
-		clock:       opts.Clock,
-		ping:        c.ping,
-		pingPeriod:  monitorPingPeriod,
-		pingTimeout: monitorPingTimeout,
-		closed:      c.closed,
-		dead:        client.Dead(),
-		broken:      c.broken,
+		clock:         opts.Clock,
+		ping:          c.ping,
+		pingPeriod:    monitorPingPeriod,
+		pingTimeout:   monitorPingTimeout,
+		closed:        c.closed,
+		dead:          client.Dead(),
+		proxierBroken: proxierBroken(c),
+		broken:        c.broken,
 	}).run()
 	return c, nil
+}
+
+func proxierBroken(c *conn) <-chan struct{} {
+	if reporter, ok := c.proxier.(ProxierBrokenReporter); ok {
+		return reporter.Broken()
+	}
+	return nil
 }
 
 func newPrimaryHTTPTransport(tlsConfig *tls.Config) *http.Transport {

--- a/api/monitor.go
+++ b/api/monitor.go
@@ -11,9 +11,10 @@ import (
 )
 
 // monitor performs regular pings of an API connection as well as
-// monitoring the connection closed channel and the underlying
-// rpc.Conn's dead channel. It will close `broken` if pings fail, or
-// if `closed` or `dead` are closed.
+// monitoring the connection closed channel, the underlying
+// rpc.Conn's dead channel, and the proxier's broken channel. It will
+// close `broken` if pings fail, or if `closed`, `dead`, or
+// `proxierBroken` are closed.
 type monitor struct {
 	clock clock.Clock
 
@@ -21,9 +22,10 @@ type monitor struct {
 	pingPeriod  time.Duration
 	pingTimeout time.Duration
 
-	closed <-chan struct{}
-	dead   <-chan struct{}
-	broken chan<- struct{}
+	closed        <-chan struct{}
+	dead          <-chan struct{}
+	proxierBroken <-chan struct{}
+	broken        chan<- struct{}
 }
 
 func (m *monitor) run() {
@@ -31,6 +33,7 @@ func (m *monitor) run() {
 	defer cancel()
 
 	defer close(m.broken)
+
 	for {
 		select {
 		case <-m.closed:
@@ -38,6 +41,10 @@ func (m *monitor) run() {
 
 		case <-m.dead:
 			logger.Debugf(ctx, "RPC connection died")
+			return
+
+		case <-m.proxierBroken:
+			logger.Debugf(ctx, "proxier tunnel broken")
 			return
 
 		case <-m.clock.After(m.pingPeriod):

--- a/api/monitor_internal_test.go
+++ b/api/monitor_internal_test.go
@@ -63,6 +63,23 @@ func (s *MonitorSuite) TestDead(c *tc.C) {
 	assertEvent(c, s.broken)
 }
 
+func (s *MonitorSuite) TestProxierBroken(c *tc.C) {
+	proxierBroken := make(chan struct{})
+	s.monitor.proxierBroken = proxierBroken
+
+	go s.monitor.run()
+	s.waitForClock(c)
+	close(proxierBroken)
+	assertEvent(c, s.broken)
+}
+
+func (s *MonitorSuite) TestProxierBrokenReporter(c *tc.C) {
+	broken := make(chan struct{})
+
+	c.Check(proxierBroken(&conn{}), tc.IsNil)
+	c.Check(proxierBroken(&conn{proxier: testBrokenProxier{broken: broken}}), tc.Equals, (<-chan struct{})(broken))
+}
+
 func (s *MonitorSuite) TestFirstPingFails(c *tc.C) {
 	s.monitor.ping = func(context.Context) error { return errors.New("boom") }
 	go s.monitor.run()
@@ -120,3 +137,21 @@ func assertEvent(c *tc.C, ch <-chan struct{}) {
 		c.Fatal("timed out waiting for channel event")
 	}
 }
+
+type testBrokenProxier struct {
+	broken <-chan struct{}
+}
+
+func (p testBrokenProxier) Start(context.Context) error { return nil }
+
+func (testBrokenProxier) Stop() {}
+
+func (testBrokenProxier) RawConfig() (map[string]any, error) { return nil, nil }
+
+func (testBrokenProxier) Type() string { return "test" }
+
+func (testBrokenProxier) MarshalYAML() (any, error) { return nil, nil }
+
+func (testBrokenProxier) Insecure() {}
+
+func (p testBrokenProxier) Broken() <-chan struct{} { return p.broken }

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -54,3 +54,12 @@ type ProxierErrorReporter interface {
 	// observed. It returns nil when the proxier has no error to report.
 	ProxyError() error
 }
+
+// ProxierBrokenReporter describes a proxier that can signal when the
+// underlying tunnel has broken, so that the API client can trigger a
+// reconnect.
+type ProxierBrokenReporter interface {
+	// Broken returns a channel that is closed when the proxier's tunnel is
+	// broken. The caller should not close this channel.
+	Broken() <-chan struct{}
+}

--- a/caas/kubernetes/tunnel.go
+++ b/caas/kubernetes/tunnel.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/informers"
@@ -40,7 +41,16 @@ type portForwarder interface {
 	GetPorts() ([]portforward.ForwardedPort, error)
 }
 
-var newPortForwarder = func(
+type portForwarderFactory func(
+	dialer httpstream.Dialer,
+	addresses []string,
+	ports []string,
+	stopChan <-chan struct{},
+	readyChan chan struct{},
+	out, errOut io.Writer,
+) (portForwarder, error)
+
+func defaultPortForwarder(
 	dialer httpstream.Dialer,
 	addresses []string,
 	ports []string,
@@ -53,18 +63,20 @@ var newPortForwarder = func(
 
 // Tunnel represents an ssh like tunnel to a Kubernetes Pod or Service
 type Tunnel struct {
-	client     rest.Interface
-	config     *rest.Config
-	Kind       TunnelKind
-	errChan    chan error
-	LocalPort  string
-	Namespace  string
-	Out        io.Writer
-	closeOnce  sync.Once
-	readyChan  chan struct{}
-	RemotePort string
-	stopChan   chan struct{}
-	Target     string
+	client           rest.Interface
+	config           *rest.Config
+	Kind             TunnelKind
+	errChan          chan error
+	newPortForwarder portForwarderFactory
+	LocalPort        string
+	Namespace        string
+	Out              io.Writer
+	broken           chan struct{}
+	closeOnce        sync.Once
+	readyChan        chan struct{}
+	RemotePort       string
+	stopChan         chan struct{}
+	Target           string
 }
 
 type TunnelKind string
@@ -93,6 +105,12 @@ func (t *Tunnel) ForwardError() error {
 	default:
 		return nil
 	}
+}
+
+// Broken returns a channel that is closed when the port-forward tunnel is
+// broken (the underlying forward goroutine exits).
+func (t *Tunnel) Broken() <-chan struct{} {
+	return t.broken
 }
 
 // findSuitablePodForService when tunneling to a kubernetes service we need to
@@ -164,12 +182,12 @@ func (t *Tunnel) ForwardPort(ctx context.Context) error {
 	}
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, u)
 
-	return t.forwardPort(ctx, dialer)
+	return t.forwardPort(ctx, dialer, podName)
 }
 
-func (t *Tunnel) forwardPort(ctx context.Context, dialer httpstream.Dialer) error {
+func (t *Tunnel) forwardPort(ctx context.Context, dialer httpstream.Dialer, podName string) error {
 	ports := []string{fmt.Sprintf("0:%s", t.RemotePort)}
-	pf, err := newPortForwarder(
+	pf, err := t.newPortForwarder(
 		dialer,
 		[]string{"127.0.0.1"},
 		ports,
@@ -185,7 +203,14 @@ func (t *Tunnel) forwardPort(ctx context.Context, dialer httpstream.Dialer) erro
 	t.errChan = make(chan error, 1)
 	go func() {
 		t.errChan <- pf.ForwardPorts()
+		close(t.broken)
 	}()
+
+	// Start a pod health check that closes the tunnel if the pod is
+	// deleted. The port-forward SPDY connection to the API server may
+	// stay alive even after the pod is gone, so ForwardPorts() may
+	// never return on its own.
+	t.startPodHealthCheck(ctx, podName)
 
 	select {
 	case <-ctx.Done():
@@ -207,6 +232,106 @@ func (t *Tunnel) forwardPort(ctx context.Context, dialer httpstream.Dialer) erro
 		t.LocalPort = strconv.Itoa(int(forwardedPorts[0].Local))
 		return nil
 	}
+}
+
+// startPodHealthCheck watches the pod via the Kubernetes API and closes the
+// tunnel if the pod is deleted or no longer running. The SPDY connection to
+// the API server may persist after the pod is gone, so this provides an
+// independent signal that the tunnel is broken.
+func (t *Tunnel) startPodHealthCheck(ctx context.Context, podName string) {
+	if t.client == nil {
+		return
+	}
+	t.defaultPodHealthCheck(ctx, podName)
+}
+
+func (t *Tunnel) defaultPodHealthCheck(ctx context.Context, podName string) {
+	clientSet := kubernetes.New(t.client)
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		clientSet,
+		10*time.Second,
+		informers.WithNamespace(t.Namespace),
+		informers.WithTweakListOptions(func(options *meta.ListOptions) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", podName).String()
+		}),
+	)
+	informer := factory.Core().V1().Pods().Informer()
+
+	// ForwardPort's context is cancelled once the local port is ready, while
+	// the health check must run for the tunnel's entire lifetime.
+	healthCtx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-t.stopChan
+		cancel()
+	}()
+
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			p, ok := obj.(*corev1.Pod)
+			if !ok {
+				return
+			}
+			if p.Name == podName && !pod.IsPodRunning(p) {
+				logger.Debugf(ctx, "tunnel pod %s not running, closing tunnel", podName)
+				t.Close()
+			}
+		},
+		DeleteFunc: func(obj any) {
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			if err != nil {
+				logger.Errorf(ctx, "getting deleted tunnel pod key: %v", err)
+				return
+			}
+			if key == t.Namespace+"/"+podName {
+				logger.Debugf(ctx, "tunnel pod %s deleted, closing tunnel", podName)
+				t.Close()
+			}
+		},
+		UpdateFunc: func(_, newObj any) {
+			p, ok := newObj.(*corev1.Pod)
+			if !ok {
+				return
+			}
+			if p.Name == podName && !pod.IsPodRunning(p) {
+				logger.Debugf(ctx, "tunnel pod %s not running, closing tunnel", podName)
+				t.Close()
+			}
+		},
+	})
+	if err != nil {
+		logger.Errorf(ctx, "failed to add pod health check handler: %v", err)
+		return
+	}
+
+	err = informer.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
+		if !errors.Is(err, context.Canceled) {
+			logger.Errorf(ctx, "pod health check watch error: %v", err)
+		}
+	})
+	if err != nil {
+		logger.Errorf(ctx, "failed to set pod health check error handler: %v", err)
+		return
+	}
+
+	go func() {
+		informer.RunWithContext(healthCtx)
+		_ = informer.RemoveEventHandler(reg)
+	}()
+
+	go func() {
+		if !cache.WaitForCacheSync(healthCtx.Done(), informer.HasSynced) {
+			return
+		}
+		_, exists, err := informer.GetStore().GetByKey(t.Namespace + "/" + podName)
+		if err != nil {
+			logger.Errorf(ctx, "checking tunnel pod %s health: %v", podName, err)
+			return
+		}
+		if !exists {
+			logger.Debugf(ctx, "tunnel pod %s deleted, closing tunnel", podName)
+			t.Close()
+		}
+	}()
 }
 
 // IsValidTunnelKind tests that the tunnel kind supplied to this tunnel is valid
@@ -252,15 +377,17 @@ func NewTunnel(
 	remotePort string) *Tunnel {
 
 	return &Tunnel{
-		client:     client,
-		config:     c,
-		Kind:       kind,
-		Namespace:  namespace,
-		Out:        io.Discard,
-		readyChan:  make(chan struct{}, 1),
-		RemotePort: remotePort,
-		stopChan:   make(chan struct{}, 1),
-		Target:     target,
+		client:           client,
+		config:           c,
+		Kind:             kind,
+		newPortForwarder: defaultPortForwarder,
+		Namespace:        namespace,
+		Out:              io.Discard,
+		broken:           make(chan struct{}),
+		readyChan:        make(chan struct{}, 1),
+		RemotePort:       remotePort,
+		stopChan:         make(chan struct{}, 1),
+		Target:           target,
 	}
 }
 

--- a/caas/kubernetes/tunnel.go
+++ b/caas/kubernetes/tunnel.go
@@ -245,11 +245,17 @@ func (t *Tunnel) startPodHealthCheck(ctx context.Context, podName string) {
 	t.defaultPodHealthCheck(ctx, podName)
 }
 
+// defaultPodHealthCheck sets up a pod health check that closes the tunnel if
+// the pod is deleted or no longer running. The SPDY connection to the API
+// server may persist after the pod is gone, so this provides an independent
+// signal that the tunnel is broken.
+const podHealthCheckResyncPeriod = 10 * time.Second
+
 func (t *Tunnel) defaultPodHealthCheck(ctx context.Context, podName string) {
 	clientSet := kubernetes.New(t.client)
 	factory := informers.NewSharedInformerFactoryWithOptions(
 		clientSet,
-		10*time.Second,
+		podHealthCheckResyncPeriod,
 		informers.WithNamespace(t.Namespace),
 		informers.WithTweakListOptions(func(options *meta.ListOptions) {
 			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", podName).String()

--- a/caas/kubernetes/tunnel_test.go
+++ b/caas/kubernetes/tunnel_test.go
@@ -4,13 +4,21 @@
 package kubernetes
 
 import (
+	"bytes"
 	"io"
+	"net/http"
 	"sync"
 	"testing"
 
 	"github.com/juju/errors"
 	"github.com/juju/tc"
+	corev1 "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/kubernetes/scheme"
+	restfake "k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/portforward"
 
 	"github.com/juju/juju/internal/testhelpers"
@@ -64,7 +72,7 @@ func (s *tunnelSuite) TestForwardPortBindsIPv4LocalhostAndUsesAssignedPort(c *tc
 			Remote: 17070,
 		}},
 	}
-	s.PatchValue(&newPortForwarder, func(
+	tunnel := newTestTunnel(func(
 		_ httpstream.Dialer,
 		addresses []string,
 		ports []string,
@@ -78,9 +86,7 @@ func (s *tunnelSuite) TestForwardPortBindsIPv4LocalhostAndUsesAssignedPort(c *tc
 		forwarder.readyChan = readyChan
 		return forwarder, nil
 	})
-
-	tunnel := newTestTunnel()
-	err := tunnel.forwardPort(c.Context(), nil)
+	err := tunnel.forwardPort(c.Context(), nil, "test-pod")
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(gotAddresses, tc.DeepEquals, []string{"127.0.0.1"})
 	c.Check(gotPorts, tc.DeepEquals, []string{"0:17070"})
@@ -96,7 +102,7 @@ func (s *tunnelSuite) TestForwardPortReportsFailureBeforeReady(c *tc.C) {
 		done:       done,
 		forwardErr: errors.New("lost connection to pod"),
 	}
-	s.PatchValue(&newPortForwarder, func(
+	tunnel := newTestTunnel(func(
 		_ httpstream.Dialer,
 		_ []string,
 		_ []string,
@@ -108,9 +114,7 @@ func (s *tunnelSuite) TestForwardPortReportsFailureBeforeReady(c *tc.C) {
 		forwarder.readyChan = readyChan
 		return forwarder, nil
 	})
-
-	tunnel := newTestTunnel()
-	err := tunnel.forwardPort(c.Context(), nil)
+	err := tunnel.forwardPort(c.Context(), nil, "test-pod")
 	c.Assert(err, tc.ErrorMatches, "forwarding ports: lost connection to pod")
 	assertDone(c, done)
 }
@@ -123,7 +127,7 @@ func (s *tunnelSuite) TestForwardPortStopsWhenAssignedPortCannotBeRead(c *tc.C) 
 		waitForStop: true,
 		getPortsErr: errors.New("ports unavailable"),
 	}
-	s.PatchValue(&newPortForwarder, func(
+	tunnel := newTestTunnel(func(
 		_ httpstream.Dialer,
 		_ []string,
 		_ []string,
@@ -135,9 +139,7 @@ func (s *tunnelSuite) TestForwardPortStopsWhenAssignedPortCannotBeRead(c *tc.C) 
 		forwarder.readyChan = readyChan
 		return forwarder, nil
 	})
-
-	tunnel := newTestTunnel()
-	err := tunnel.forwardPort(c.Context(), nil)
+	err := tunnel.forwardPort(c.Context(), nil, "test-pod")
 	c.Assert(err, tc.ErrorMatches, "getting forwarded ports: ports unavailable")
 	assertDone(c, done)
 }
@@ -155,7 +157,7 @@ func (s *tunnelSuite) TestForwardPortReportsPostReadyFailure(c *tc.C) {
 			Remote: 17070,
 		}},
 	}
-	s.PatchValue(&newPortForwarder, func(
+	tunnel := newTestTunnel(func(
 		_ httpstream.Dialer,
 		_ []string,
 		_ []string,
@@ -167,14 +169,76 @@ func (s *tunnelSuite) TestForwardPortReportsPostReadyFailure(c *tc.C) {
 		forwarder.readyChan = readyChan
 		return forwarder, nil
 	})
-
-	tunnel := newTestTunnel()
-	err := tunnel.forwardPort(c.Context(), nil)
+	err := tunnel.forwardPort(c.Context(), nil, "test-pod")
 	c.Assert(err, tc.ErrorIsNil)
 
 	close(release)
 	assertDone(c, done)
 	assertForwardError(c, tunnel, "lost connection to pod")
+	assertBroken(c, tunnel)
+
+}
+
+func (s *tunnelSuite) TestForwardPortBrokenNotClosedBeforeForward(c *tc.C) {
+	done := make(chan struct{})
+	release := make(chan struct{})
+	forwarder := &fakePortForwarder{
+		done:        done,
+		release:     release,
+		signalReady: true,
+		forwardedPorts: []portforward.ForwardedPort{{
+			Local:  33419,
+			Remote: 17070,
+		}},
+	}
+	tunnel := newTestTunnel(func(
+		_ httpstream.Dialer,
+		_ []string,
+		_ []string,
+		stopChan <-chan struct{},
+		readyChan chan struct{},
+		_, _ io.Writer,
+	) (portForwarder, error) {
+		forwarder.stopChan = stopChan
+		forwarder.readyChan = readyChan
+		return forwarder, nil
+	})
+	err := tunnel.forwardPort(c.Context(), nil, "test-pod")
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Broken should not be closed while the forwarder is still running.
+	select {
+	case <-tunnel.Broken():
+		c.Fatalf("broken closed before forwarder exited")
+	default:
+	}
+
+	close(release)
+	assertDone(c, done)
+	assertBroken(c, tunnel)
+}
+
+func (s *tunnelSuite) TestPodHealthCheckStopsTunnelWhenPodIsMissing(c *tc.C) {
+	tunnel := newTestTunnel()
+	tunnel.Namespace = "test-namespace"
+	tunnel.client = newPodListRESTClient(&corev1.PodList{})
+
+	tunnel.defaultPodHealthCheck(c.Context(), "missing-pod")
+
+	assertStopped(c, tunnel)
+}
+
+func (s *tunnelSuite) TestPodHealthCheckStopsTunnelWhenPodIsNotRunning(c *tc.C) {
+	tunnel := newTestTunnel()
+	tunnel.Namespace = "test-namespace"
+	tunnel.client = newPodListRESTClient(&corev1.PodList{Items: []corev1.Pod{{
+		ObjectMeta: meta.ObjectMeta{Name: "test-pod", Namespace: tunnel.Namespace},
+		Status:     corev1.PodStatus{Phase: corev1.PodPending},
+	}}})
+
+	tunnel.defaultPodHealthCheck(c.Context(), "test-pod")
+
+	assertStopped(c, tunnel)
 }
 
 type fakePortForwarder struct {
@@ -216,12 +280,37 @@ func (f *fakePortForwarder) GetPorts() ([]portforward.ForwardedPort, error) {
 	return f.forwardedPorts, nil
 }
 
-func newTestTunnel() *Tunnel {
+func newTestTunnel(newPortForwarder ...portForwarderFactory) *Tunnel {
+	forwarderFactory := defaultPortForwarder
+	if len(newPortForwarder) > 0 {
+		forwarderFactory = newPortForwarder[0]
+	}
 	return &Tunnel{
-		Out:        io.Discard,
-		readyChan:  make(chan struct{}),
-		RemotePort: "17070",
-		stopChan:   make(chan struct{}),
+		Out:              io.Discard,
+		broken:           make(chan struct{}),
+		newPortForwarder: forwarderFactory,
+		readyChan:        make(chan struct{}),
+		RemotePort:       "17070",
+		stopChan:         make(chan struct{}),
+	}
+}
+
+func newPodListRESTClient(pods *corev1.PodList) *restfake.RESTClient {
+	return &restfake.RESTClient{
+		GroupVersion:         schema.GroupVersion{Version: "v1"},
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		VersionedAPIPath:     "/api",
+		Client: restfake.CreateHTTPClient(func(*http.Request) (*http.Response, error) {
+			data, err := runtime.Encode(scheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion), pods)
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{runtime.ContentTypeJSON}},
+				Body:       io.NopCloser(bytes.NewReader(data)),
+			}, nil
+		}),
 	}
 }
 
@@ -239,5 +328,21 @@ func assertForwardError(c *tc.C, tunnel *Tunnel, match string) {
 		c.Check(err, tc.ErrorMatches, match)
 	case <-c.Context().Done():
 		c.Fatalf("timed out waiting for forwarding error")
+	}
+}
+
+func assertBroken(c *tc.C, tunnel *Tunnel) {
+	select {
+	case <-tunnel.Broken():
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for broken channel to close")
+	}
+}
+
+func assertStopped(c *tc.C, tunnel *Tunnel) {
+	select {
+	case <-tunnel.stopChan:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for tunnel to stop")
 	}
 }

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -998,6 +998,15 @@ func (s *Service) SetApplicationScale(ctx context.Context, appName string, scale
 	if err != nil {
 		return errors.Capture(err)
 	}
+	if scale == 0 {
+		isController, err := s.st.IsControllerApplication(ctx, appUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		if isController {
+			return errors.Errorf("cannot scale controller application to 0 units")
+		}
+	}
 	appScale, err := s.st.GetApplicationScaleState(ctx, appUUID)
 	if err != nil {
 		return errors.Errorf("getting application scale state for app %q: %w", appUUID, err)
@@ -1056,6 +1065,23 @@ func (s *Service) ChangeApplicationScale(ctx context.Context, appName string, sc
 	appUUID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return -1, errors.Capture(err)
+	}
+
+	if scaleChange < 0 {
+		scaleState, err := s.st.GetApplicationScaleState(ctx, appUUID)
+		if err != nil {
+			return -1, errors.Capture(err)
+		}
+		newScale := scaleState.Scale + scaleChange
+		if newScale <= 0 {
+			isController, err := s.st.IsControllerApplication(ctx, appUUID)
+			if err != nil {
+				return -1, errors.Capture(err)
+			}
+			if isController {
+				return -1, errors.Errorf("cannot scale controller application to 0 units")
+			}
+		}
 	}
 
 	newScale, err := s.st.UpdateApplicationScale(ctx, appUUID, scaleChange)

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -1297,6 +1297,106 @@ func (s *applicationServiceSuite) TestIsControllerApplication(c *tc.C) {
 	c.Check(isController, tc.IsTrue)
 }
 
+func (s *applicationServiceSuite) TestSetApplicationScaleNonController(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 2}, nil)
+	s.state.EXPECT().SetDesiredApplicationScale(gomock.Any(), appUUID, 3).Return(nil)
+
+	err := s.service.SetApplicationScale(c.Context(), "foo", 3)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *applicationServiceSuite) TestSetApplicationScaleControllerToZero(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().IsControllerApplication(gomock.Any(), appUUID).Return(true, nil)
+
+	err := s.service.SetApplicationScale(c.Context(), "foo", 0)
+	c.Assert(err, tc.ErrorMatches, "cannot scale controller application to 0 units")
+}
+
+func (s *applicationServiceSuite) TestSetApplicationScaleNonControllerToZero(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().IsControllerApplication(gomock.Any(), appUUID).Return(false, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 1}, nil)
+	s.state.EXPECT().SetDesiredApplicationScale(gomock.Any(), appUUID, 0).Return(nil)
+
+	err := s.service.SetApplicationScale(c.Context(), "foo", 0)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *applicationServiceSuite) TestSetApplicationScaleNegative(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := s.service.SetApplicationScale(c.Context(), "foo", -1)
+	c.Assert(err, tc.ErrorMatches, "application scale -1 not valid")
+	c.Assert(err, tc.ErrorIs, applicationerrors.ScaleChangeInvalid)
+}
+
+func (s *applicationServiceSuite) TestChangeApplicationScaleUp(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().UpdateApplicationScale(gomock.Any(), appUUID, 2).Return(5, nil)
+
+	newScale, err := s.service.ChangeApplicationScale(c.Context(), "foo", 2)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(newScale, tc.Equals, 5)
+}
+
+func (s *applicationServiceSuite) TestChangeApplicationScaleDownNonController(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 3}, nil)
+	s.state.EXPECT().UpdateApplicationScale(gomock.Any(), appUUID, -1).Return(2, nil)
+
+	newScale, err := s.service.ChangeApplicationScale(c.Context(), "foo", -1)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(newScale, tc.Equals, 2)
+}
+
+func (s *applicationServiceSuite) TestChangeApplicationScaleDownControllerToZero(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 1}, nil)
+	s.state.EXPECT().IsControllerApplication(gomock.Any(), appUUID).Return(true, nil)
+
+	_, err := s.service.ChangeApplicationScale(c.Context(), "foo", -1)
+	c.Assert(err, tc.ErrorMatches, "cannot scale controller application to 0 units")
+}
+
+func (s *applicationServiceSuite) TestChangeApplicationScaleDownControllerBelowZero(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 1}, nil)
+	s.state.EXPECT().IsControllerApplication(gomock.Any(), appUUID).Return(true, nil)
+
+	_, err := s.service.ChangeApplicationScale(c.Context(), "foo", -2)
+	c.Assert(err, tc.ErrorMatches, "cannot scale controller application to 0 units")
+}
+
 func (s *applicationWatcherServiceSuite) TestGetMachinesForApplication(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/internal/provider/kubernetes/proxy/proxier.go
+++ b/internal/provider/kubernetes/proxy/proxier.go
@@ -109,6 +109,15 @@ func (p *Proxier) ProxyError() error {
 	return p.tunnel.ForwardError()
 }
 
+// Broken returns a channel that is closed when the port-forward tunnel is
+// broken, signalling that the API client should reconnect.
+func (p *Proxier) Broken() <-chan struct{} {
+	if p.tunnel == nil {
+		return nil
+	}
+	return p.tunnel.Broken()
+}
+
 func (p *Proxier) Start(ctx context.Context) (err error) {
 	tunnel, err := kubernetes.NewTunnelForConfig(
 		&p.restConfig,

--- a/internal/provider/kubernetes/proxy/proxier_internal_test.go
+++ b/internal/provider/kubernetes/proxy/proxier_internal_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/caas/kubernetes"
+)
+
+type proxierInternalSuite struct{}
+
+func TestProxierInternalSuite(t *testing.T) {
+	tc.Run(t, &proxierInternalSuite{})
+}
+
+func (s *proxierInternalSuite) TestBrokenDelegatesToTunnel(c *tc.C) {
+	tunnel := kubernetes.NewTunnel(nil, nil, kubernetes.TunnelKindPods, "", "", "")
+	proxier := &Proxier{tunnel: tunnel}
+
+	c.Check(proxier.Broken(), tc.Equals, tunnel.Broken())
+}

--- a/internal/provider/kubernetes/proxy/proxier_test.go
+++ b/internal/provider/kubernetes/proxy/proxier_test.go
@@ -119,3 +119,9 @@ func (p *proxySuite) TestInsecure(c *tc.C) {
 		},
 	})
 }
+
+func (p *proxySuite) TestBrokenBeforeStart(c *tc.C) {
+	proxier := proxy.NewProxier(proxy.ProxierConfig{})
+
+	c.Check(proxier.Broken(), tc.IsNil)
+}


### PR DESCRIPTION
Previously, SetApplicationScale and ChangeApplicationScale in the domain service
layer had no guard against scaling a controller application to zero. If a user
ran remove-unit --num-units N or scale-application controller 0 on a CAAS model,
the controller application could be scaled down to zero units, which would
destroy the controller.

Now both methods check whether the application is a controller application
(via IsControllerApplication) before allowing the scale to reach zero.
SetApplicationScale intercepts an explicit scale of 0, and
ChangeApplicationScale computes the resulting scale for negative deltas and
blocks it if it would reach or drop below zero.

## QA steps

```
$ juju bootstrap microk8s test
$ juju add-unit -m controller controller -n 2
$ juju remove-unit -m controller controller --num-units=10
ERROR: cannot scale controller application to 0 units
```

## Links


**Jira card:** [JUJU-10259](https://warthogs.atlassian.net/browse/JUJU-10259)


[JUJU-10259]: https://warthogs.atlassian.net/browse/JUJU-10259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ