### PR TITLE
fix(uniter): remove empty directories left behind by charm upgrades

### DIFF
--- a/internal/worker/uniter/charm/manifest_deployer.go
+++ b/internal/worker/uniter/charm/manifest_deployer.go
@@ -6,8 +6,11 @@ package charm
 import (
 	"context"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/juju/clock"
@@ -138,6 +141,12 @@ func (d *manifestDeployer) Deploy() (err error) {
 		return err
 	}
 
+	// Clean up empty directories not provided by the staged charm; see
+	// removeEmptyDirs for why this is not merely cosmetic.
+	if err := d.removeEmptyDirs(d.staged.manifest); err != nil {
+		return err
+	}
+
 	// Move the deploying file over the charm URL file, and we're done.
 	return d.finishDeploy()
 }
@@ -161,6 +170,97 @@ func (d *manifestDeployer) removeDiff(oldManifest, newManifest set.Strings) erro
 		}
 	}
 	return nil
+}
+
+// removeEmptyDirs removes every directory under the charm directory that
+// is empty and is not itself a member of the supplied manifest.
+//
+// Charm archives are not required to store directory entries, and those
+// packed by charmcraft do not: their manifests contain file paths only.
+// removeDiff can therefore delete the files unique to the old charm but
+// not the directories that held them, and an upgrade leaves empty
+// directories behind.
+//
+// This is not merely untidy. Python's importlib.metadata treats every
+// "*.dist-info" directory it finds on the path as a distribution: an
+// empty "<name>-<old version>.dist-info" directory left in a charm's venv
+// can shadow the distribution actually shipped by the new charm and
+// break entry point discovery, failing hooks with errors like the
+// StopIteration reported in juju/juju#23127. Removing the empty
+// directories restores the charm directory to its freshly-installed
+// state.
+func (d *manifestDeployer) removeEmptyDirs(manifest set.Strings) error {
+	var dirs []string
+	err := filepath.WalkDir(d.charmPath, func(
+		path string, entry fs.DirEntry, err error,
+	) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			dirs = append(dirs, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	// WalkDir visits parents before their children, so iterating the
+	// slice backwards removes children first and lets a parent emptied
+	// by removing its children be removed as well.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		dir := dirs[i]
+		rel, err := filepath.Rel(d.charmPath, dir)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			// Never remove the charm directory itself.
+			continue
+		}
+		if manifest.Contains(filepath.ToSlash(rel)) {
+			// The deployed charm provides this directory itself.
+			continue
+		}
+		empty, err := isEmptyDir(dir)
+		if os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return err
+		}
+		if !empty {
+			continue
+		}
+		d.logger.Debugf(context.Background(),
+			"removing empty directory %q left behind by the previous charm", rel)
+		err = os.Remove(dir)
+		switch {
+		case err == nil, os.IsNotExist(err):
+			// Nothing to do.
+		case errors.Is(err, syscall.ENOTEMPTY):
+			// The directory has acquired contents since the check
+			// above; leaving it alone is the correct outcome.
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+// isEmptyDir reports whether the directory at path holds no entries.
+func isEmptyDir(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	// One entry is enough to answer the question; os.ReadDir would read
+	// and sort every name in the directory.
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
 }
 
 // finishDeploy persists the fact that we've finished deploying the staged bundle.

--- a/internal/worker/uniter/charm/manifest_deployer_test.go
+++ b/internal/worker/uniter/charm/manifest_deployer_test.go
@@ -6,6 +6,7 @@ package charm_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	stdtesting "testing"
 	"time"
@@ -170,6 +171,95 @@ func (s *ManifestDeployerSuite) TestUpgradePreserveUserFiles(c *tc.C) {
 	preserveUserContent.Check(c, s.targetPath)
 	removeUserContent.AsRemoveds().Check(c, s.targetPath)
 	originalCharmContent.AsRemoveds().Check(c, s.targetPath)
+}
+
+// deployFileOnlyCharm deploys a charm whose manifest lists file paths
+// only, as charmcraft-produced charms do: charmcraft zips contain no
+// directory entries, so directories that only held files unique to an
+// old charm cannot be removed via the manifest diff alone.
+func (s *ManifestDeployerSuite) deployFileOnlyCharm(c *tc.C, revision int, content filetesting.Entries) {
+	bundle := mockBundle{
+		paths: set.NewStrings(content.Paths()...),
+		expand: func(dir string) error {
+			// The real zip extractor creates the parent directory
+			// of each entry it writes.
+			for _, entry := range content {
+				parent := filepath.Dir(filepath.Join(dir, entry.GetPath()))
+				if err := os.MkdirAll(parent, 0755); err != nil {
+					return err
+				}
+			}
+			content.Create(c, dir)
+			return nil
+		},
+	}
+	info := s.addMockCharm(revision, bundle)
+	err := s.deployer.Stage(c.Context(), info)
+	c.Assert(err, tc.ErrorIsNil)
+	err = s.deployer.Deploy()
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *ManifestDeployerSuite) TestUpgradeRemovesEmptyDirectories(c *tc.C) {
+	// Regression test for juju/juju#23127: an upgrade from a charm whose
+	// venv holds opentelemetry-api 1.26.0 to one holding 1.27.0 removes
+	// every file under the old distribution's dist-info directory, but
+	// (the manifest containing files only) leaves the empty directory
+	// itself behind. Python's importlib.metadata still discovers that
+	// empty dist-info directory, and it can shadow the real one and
+	// break entry point discovery, failing hooks with StopIteration.
+	const sitePackages = "venv/lib/python3.12/site-packages"
+	oldDistInfo := sitePackages + "/opentelemetry_api-1.26.0.dist-info"
+	newDistInfo := sitePackages + "/opentelemetry_api-1.27.0.dist-info"
+
+	s.deployFileOnlyCharm(c, 1, filetesting.Entries{
+		filetesting.File{Path: "dispatch", Data: "#!/bin/sh", Perm: 0755},
+		filetesting.File{Path: oldDistInfo + "/METADATA", Data: "old", Perm: 0644},
+		filetesting.File{Path: oldDistInfo + "/entry_points.txt", Data: "old", Perm: 0644},
+		filetesting.File{Path: sitePackages + "/opentelemetry/__init__.py", Data: "", Perm: 0644},
+	})
+
+	// Files written by the running charm must survive the upgrade.
+	userFile := filetesting.File{Path: "user-file", Data: "user", Perm: 0644}.Create(c, s.targetPath)
+
+	s.deployFileOnlyCharm(c, 2, filetesting.Entries{
+		filetesting.File{Path: "dispatch", Data: "#!/bin/sh", Perm: 0755},
+		filetesting.File{Path: newDistInfo + "/METADATA", Data: "new", Perm: 0644},
+		filetesting.File{Path: newDistInfo + "/entry_points.txt", Data: "new", Perm: 0644},
+		filetesting.File{Path: sitePackages + "/opentelemetry/__init__.py", Data: "", Perm: 0644},
+	})
+
+	// The upgrade removed the leftover empty dist-info directory...
+	filetesting.Removed{Path: oldDistInfo}.Check(c, s.targetPath)
+	// ...kept the new charm's dist-info directory and its contents...
+	filetesting.Dir{Path: newDistInfo, Perm: 0755}.Check(c, s.targetPath)
+	filetesting.File{Path: newDistInfo + "/entry_points.txt", Data: "new", Perm: 0644}.Check(c, s.targetPath)
+	// ...and left directories that are still in use, and user files,
+	// untouched.
+	filetesting.Dir{Path: sitePackages, Perm: 0755}.Check(c, s.targetPath)
+	userFile.Check(c, s.targetPath)
+}
+
+func (s *ManifestDeployerSuite) TestUpgradeEmptyDirsShippedByNewCharmKept(c *tc.C) {
+	s.deployCharm(c, 1,
+		filetesting.File{Path: "file", Data: "old", Perm: 0644},
+	)
+	// An empty directory created by the charm at runtime is not
+	// distinguishable from one left behind by the upgrade, and is
+	// removed: only user files are preserved across upgrades, never
+	// directories (charms whose archives carry directory entries lose
+	// whole directory subtrees today).
+	filetesting.Dir{Path: "runtime-empty", Perm: 0755}.Create(c, s.targetPath)
+
+	// Upgrade to a charm that ships an empty directory in its archive;
+	// unlike runtime leftovers, that one must survive.
+	s.deployCharm(c, 2,
+		filetesting.File{Path: "file", Data: "new", Perm: 0644},
+		filetesting.Dir{Path: "shipped-empty", Perm: 0755},
+	)
+
+	filetesting.Dir{Path: "shipped-empty", Perm: 0755}.Check(c, s.targetPath)
+	filetesting.Removed{Path: "runtime-empty"}.Check(c, s.targetPath)
 }
 
 func (s *ManifestDeployerSuite) TestUpgradeConflictResolveRetrySameCharm(c *tc.C) {


### PR DESCRIPTION
When a machine charm is refreshed, juju deletes the files that existed only in the old charm but keeps the           
directories that held them. This happens because charm archives produced by charmcraft list only files, never        
directories, so the upgrade logic has no way to know that a directory belonged to the old charm. For charms that     
carry a Python venv this is harmful: an empty left-behind dist-info directory is still discovered by Python's        
package metadata machinery and can shadow the distribution shipped by the new charm, which makes hooks fail.                                                                                                    
                                                                                                                      
After extracting the new charm, the charm deployer now walks the charm directory and removes every directory that is 
empty and not provided by the new charm, restoring the charm directory to the state a fresh install would have       
produced. Directories the new charm ships itself are kept, user files are untouched, and a directory that gains      
content between the emptiness check and its removal is left alone rather than failing the upgrade.                   
                                                                                                                      
Regression tests cover an upgrade between file-only charms as charmcraft produces them: empty leftovers from the old 
revision are removed, empty directories shipped by the new charm and user files survive.

## QA steps

Bootstrap (VMs not containers for the machines) a controller with this change and reproduce the failing scenario from the issue:                            
                                                                                                                      
 ```sh                                                                                                                
$ juju add-model c
$ juju deploy k8s --channel=1.34/stable
 ```                                                                                                                  
                                                                                                                      
Wait for the application to become active, then refresh:                                                             
                                                                                                                      
 ```sh                                                                                                                
$ juju refresh k8s --channel=1.35/stable
 # upgrade-charm must not fail; unit settles active
$ juju status 

 ```                                                                                                                  
                                                                                                                      
 Verify no empty directories are left behind in the unit's charm venv:                                                
                                                                                                                      
 ```sh                                                                                                                
$ juju ssh k8s/0 -- 'find /var/lib/juju/agents/unit-k8s-0/charm/venv -type d -empty | wc -l'
# expected: 0
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #23127.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10293](https://warthogs.atlassian.net/browse/JUJU-10293)


[JUJU-10293]: https://warthogs.atlassian.net/browse/JUJU-10293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ