### PR TITLE
feat(backups): implement the client backups Create method

### DIFF
--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -6,6 +6,7 @@ package backups
 import (
 	"context"
 
+	"github.com/juju/clock"
 	"github.com/juju/names/v6"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -68,6 +69,7 @@ type API struct {
 	modelConfig      ModelConfigService
 	controller       ControllerModelLister
 	controllerNodes  ControllerNodeLister
+	clock            clock.Clock
 }
 
 // NewAPI creates a new instance of the Backups API facade.
@@ -82,6 +84,7 @@ func NewAPI(
 	modelConfig ModelConfigService,
 	controller ControllerModelLister,
 	controllerNodes ControllerNodeLister,
+	clock clock.Clock,
 ) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
@@ -99,5 +102,6 @@ func NewAPI(
 		modelConfig:        modelConfig,
 		controller:         controller,
 		controllerNodes:    controllerNodes,
+		clock:              clock,
 	}, nil
 }

--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -10,49 +10,94 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/controller"
-	corebackups "github.com/juju/juju/core/backups"
+	coremodel "github.com/juju/juju/core/model"
+	domainexport "github.com/juju/juju/domain/export"
+	exportservice "github.com/juju/juju/domain/export/service"
+	environsconfig "github.com/juju/juju/environs/config"
 )
 
-// ControllerConfigService is an interface that provides the controller config.
-type ControllerConfigService interface {
-	// ControllerConfig returns the controller config.
-	ControllerConfig(context.Context) (controller.Config, error)
+// ControllerExportService exports the controller database.
+type ControllerExportService interface {
+	// Export exports all controller data.
+	Export(ctx context.Context) (*domainexport.ControllerExport, error)
+}
+
+// ModelExportDomainServices provides access to the model export service.
+// It is satisfied by [services.DomainServices].
+type ModelExportDomainServices interface {
+	// Export returns the model export service.
+	Export() *exportservice.Service
+}
+
+// ModelServicesForFunc returns the export services for a given model UUID.
+type ModelServicesForFunc func(ctx context.Context, modelUUID coremodel.UUID) (ModelExportDomainServices, error)
+
+// ModelConfigService provides the model configuration, used to resolve the
+// backup directory.
+type ModelConfigService interface {
+	// ModelConfig returns the model config.
+	ModelConfig(ctx context.Context) (*environsconfig.Config, error)
+}
+
+// ControllerModelLister lists the model namespaces registered in the
+// controller database.
+type ControllerModelLister interface {
+	// GetModelNamespaces returns the UUIDs of models registered in the
+	// controller database.
+	GetModelNamespaces(ctx context.Context) ([]string, error)
+}
+
+// ControllerNodeLister lists the controller machine IDs making up the
+// controller quorum.
+type ControllerNodeLister interface {
+	// GetControllerIDs returns the list of controller machine IDs.
+	GetControllerIDs(ctx context.Context) ([]string, error)
 }
 
 // API provides backup-specific API methods.
 type API struct {
-	controllerConfigService ControllerConfigService
-	paths                   *corebackups.Paths
+	authorizer         facade.Authorizer
+	machineID          string
+	controllerUUID     string
+	controllerModelUID coremodel.UUID
+	dataDir            string
+	logDir             string
 
-	// machineID is the ID of the machine where the API server is running.
-	machineID string
+	controllerExport ControllerExportService
+	modelServicesFor ModelServicesForFunc
+	modelConfig      ModelConfigService
+	controller       ControllerModelLister
+	controllerNodes  ControllerNodeLister
 }
 
 // NewAPI creates a new instance of the Backups API facade.
 func NewAPI(
-	controllerConfigService ControllerConfigService,
 	authorizer facade.Authorizer,
 	machineTag names.Tag,
+	controllerUUID string,
+	controllerModelUUID coremodel.UUID,
 	dataDir, logDir string,
+	controllerExport ControllerExportService,
+	modelServicesFor ModelServicesForFunc,
+	modelConfig ModelConfigService,
+	controller ControllerModelLister,
+	controllerNodes ControllerNodeLister,
 ) (*API, error) {
-	// TODO (manadart 2023-10-11) Restore this assignment based on super-user
-	// access to the controller when re-implemented for Dqlite.
-	isControllerAdmin := true
-
-	if !authorizer.AuthClient() || !isControllerAdmin {
+	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
 	}
 
-	paths := corebackups.Paths{
-		DataDir: dataDir,
-		LogsDir: logDir,
-	}
-
-	b := API{
-		controllerConfigService: controllerConfigService,
-		paths:                   &paths,
-		machineID:               machineTag.Id(),
-	}
-	return &b, nil
+	return &API{
+		authorizer:         authorizer,
+		machineID:          machineTag.Id(),
+		controllerUUID:     controllerUUID,
+		controllerModelUID: controllerModelUUID,
+		dataDir:            dataDir,
+		logDir:             logDir,
+		controllerExport:   controllerExport,
+		modelServicesFor:   modelServicesFor,
+		modelConfig:        modelConfig,
+		controller:         controller,
+		controllerNodes:    controllerNodes,
+	}, nil
 }

--- a/apiserver/facades/client/backups/backups.go
+++ b/apiserver/facades/client/backups/backups.go
@@ -11,6 +11,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
+	corelogger "github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
 	domainexport "github.com/juju/juju/domain/export"
 	exportservice "github.com/juju/juju/domain/export/service"
@@ -57,12 +58,12 @@ type ControllerNodeLister interface {
 
 // API provides backup-specific API methods.
 type API struct {
-	authorizer         facade.Authorizer
-	machineID          string
-	controllerUUID     string
-	controllerModelUID coremodel.UUID
-	dataDir            string
-	logDir             string
+	authorizer          facade.Authorizer
+	machineID           string
+	controllerUUID      string
+	controllerModelUUID coremodel.UUID
+	dataDir             string
+	logDir              string
 
 	controllerExport ControllerExportService
 	modelServicesFor ModelServicesForFunc
@@ -70,6 +71,7 @@ type API struct {
 	controller       ControllerModelLister
 	controllerNodes  ControllerNodeLister
 	clock            clock.Clock
+	logger           corelogger.Logger
 }
 
 // NewAPI creates a new instance of the Backups API facade.
@@ -85,23 +87,25 @@ func NewAPI(
 	controller ControllerModelLister,
 	controllerNodes ControllerNodeLister,
 	clock clock.Clock,
+	logger corelogger.Logger,
 ) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
 	}
 
 	return &API{
-		authorizer:         authorizer,
-		machineID:          machineTag.Id(),
-		controllerUUID:     controllerUUID,
-		controllerModelUID: controllerModelUUID,
-		dataDir:            dataDir,
-		logDir:             logDir,
-		controllerExport:   controllerExport,
-		modelServicesFor:   modelServicesFor,
-		modelConfig:        modelConfig,
-		controller:         controller,
-		controllerNodes:    controllerNodes,
-		clock:              clock,
+		authorizer:          authorizer,
+		machineID:           machineTag.Id(),
+		controllerUUID:      controllerUUID,
+		controllerModelUUID: controllerModelUUID,
+		dataDir:             dataDir,
+		logDir:              logDir,
+		controllerExport:    controllerExport,
+		modelServicesFor:    modelServicesFor,
+		modelConfig:         modelConfig,
+		controller:          controller,
+		controllerNodes:     controllerNodes,
+		clock:               clock,
+		logger:              logger,
 	}, nil
 }

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -20,6 +20,17 @@ import (
 // Create is the API method that requests juju to create a new backup
 // of its state. The archive contains the controller database export and one
 // export per model, alongside the controller's data directory files.
+//
+// Only args.Notes is honored. args.NoDownload is accepted for client
+// compatibility but has no effect here: the archive is always written to the
+// controller's backup directory, and the download endpoint is not wired yet.
+//
+// The controller database and each model database are exported at different
+// points in time with no cross-database snapshot, so the archive is not a
+// single point-in-time view of the whole controller. State that changes
+// between the controller export and a given model export is not captured
+// consistently. This is inherent to backing up multiple independent dqlite
+// databases and is documented so restore logic does not assume otherwise.
 func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params.BackupsMetadataResult, error) {
 	// Creating a backup requires superuser access to the controller. This is
 	// the same gate Juju 3.6 applies to the Create method.
@@ -37,6 +48,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		return params.BackupsMetadataResult{}, err
 	}
 	backupDir := corebackups.BackupDirToUse(modelConfig.BackupDir())
+	a.logger.Debugf(ctx, "creating backup in %q", backupDir)
 
 	// Controller dump first, then one dump per registered model namespace.
 	// Every registered model, including the controller model, owns a dqlite
@@ -74,6 +86,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 			Name:   path.Join("models", modelUUID+".yaml"),
 			Export: corebackups.YAMLDump(modelExport),
 		})
+		a.logger.Tracef(ctx, "staged export for model %s", modelUUID)
 	}
 
 	// The dumps are staged as files inside the backup destination, so the
@@ -84,7 +97,13 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	if err != nil {
 		return params.BackupsMetadataResult{}, err
 	}
-	defer staging.Close()
+	// Close cleans up the staged dumps on return. Its error is only logged:
+	// it must not mask the Create result.
+	defer func() {
+		if err := staging.Close(); err != nil {
+			a.logger.Debugf(ctx, "cleaning up staged backup dumps: %v", err)
+		}
+	}()
 	expected := staging.Size()
 
 	paths := corebackups.Paths{
@@ -119,7 +138,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	meta := corebackups.NewMetadata(a.clock.Now())
 	meta.Notes = args.Notes
 	meta.Origin = corebackups.Origin{
-		Model:    a.controllerModelUID.String(),
+		Model:    a.controllerModelUUID.String(),
 		Machine:  a.machineID,
 		Hostname: hostname,
 		Version:  coreversion.Current,
@@ -146,6 +165,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	if err != nil {
 		return params.BackupsMetadataResult{}, err
 	}
+	a.logger.Infof(ctx, "created backup %q", filename)
 
 	return params.CreateResult(meta, filename), nil
 }

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -106,7 +106,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		return params.BackupsMetadataResult{}, err
 	}
 
-	meta := corebackups.NewMetadata()
+	meta := corebackups.NewMetadata(a.clock.Now())
 	meta.Notes = args.Notes
 	meta.Origin = corebackups.Origin{
 		Model:    a.controllerModelUID.String(),
@@ -128,6 +128,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		DestinationDir: backupDir,
 		FilesToBackUp:  files,
 		DumpEntries:    entries,
+		Clock:          a.clock,
 	})
 	if err != nil {
 		return params.BackupsMetadataResult{}, err

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -4,13 +4,11 @@
 package backups
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"path"
 
 	"github.com/juju/names/v6"
-	"gopkg.in/yaml.v3"
 
 	corebackups "github.com/juju/juju/core/backups"
 	coremodel "github.com/juju/juju/core/model"
@@ -31,23 +29,32 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		return params.BackupsMetadataResult{}, err
 	}
 
+	// The backup destination is resolved first because the database dumps
+	// are staged as temporary files under it; staging keeps the archive from
+	// holding every model's dump in memory at once.
+	modelConfig, err := a.modelConfig.ModelConfig(ctx)
+	if err != nil {
+		return params.BackupsMetadataResult{}, err
+	}
+	backupDir := corebackups.BackupDirToUse(modelConfig.BackupDir())
+
 	// Controller dump first, then one dump per registered model namespace.
-	// Any error aborts Create: there are no partial archives.
-	entries := []corebackups.DumpEntry{}
-	var expected int64
+	// Every registered model, including the controller model, owns a dqlite
+	// database (namespace = its UUID) that is separate from the controller
+	// database dumped above as controller.yaml. The controller model's
+	// model-scoped data, its machines, units, applications, ... lives only
+	// in that database, so its namespace is not skipped: this is not a
+	// duplicate of the controller dump. Any error aborts Create: there are
+	// no partial archives.
+	dumps := []corebackups.NamedDump{}
 
 	controllerExport, err := a.controllerExport.Export(ctx)
 	if err != nil {
 		return params.BackupsMetadataResult{}, err
 	}
-	controllerYAML, err := yaml.Marshal(controllerExport)
-	if err != nil {
-		return params.BackupsMetadataResult{}, err
-	}
-	expected += int64(len(controllerYAML))
-	entries = append(entries, corebackups.DumpEntry{
+	dumps = append(dumps, corebackups.NamedDump{
 		Name:   "controller.yaml",
-		Reader: bytes.NewReader(controllerYAML),
+		Export: corebackups.YAMLDump(controllerExport),
 	})
 
 	modelUUIDs, err := a.controller.GetModelNamespaces(ctx)
@@ -63,22 +70,22 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		if err != nil {
 			return params.BackupsMetadataResult{}, err
 		}
-		modelYAML, err := yaml.Marshal(modelExport)
-		if err != nil {
-			return params.BackupsMetadataResult{}, err
-		}
-		expected += int64(len(modelYAML))
-		entries = append(entries, corebackups.DumpEntry{
+		dumps = append(dumps, corebackups.NamedDump{
 			Name:   path.Join("models", modelUUID+".yaml"),
-			Reader: bytes.NewReader(modelYAML),
+			Export: corebackups.YAMLDump(modelExport),
 		})
 	}
 
-	modelConfig, err := a.modelConfig.ModelConfig(ctx)
+	// The dumps are staged as files inside the backup destination, so the
+	// archive does not hold every model's dump in memory at once. The
+	// staging is closed on return, so a failure leaves no partial dumps
+	// behind.
+	staging, err := corebackups.StageDumps(ctx, backupDir, dumps)
 	if err != nil {
 		return params.BackupsMetadataResult{}, err
 	}
-	backupDir := corebackups.BackupDirToUse(modelConfig.BackupDir())
+	defer staging.Close()
+	expected := staging.Size()
 
 	paths := corebackups.Paths{
 		BackupDir: backupDir,
@@ -99,6 +106,9 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		return params.BackupsMetadataResult{}, err
 	}
 
+	// The hostname is recorded for provenance only. If it cannot be resolved
+	// the field is left empty; that does not make the backup unusable, so
+	// the error is intentionally not fatal.
 	hostname, _ := os.Hostname()
 
 	controllerIDs, err := a.controllerNodes.GetControllerIDs(ctx)
@@ -118,8 +128,11 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		Base: "",
 	}
 	meta.Controller = corebackups.ControllerMetadata{
-		UUID:              a.controllerUUID,
-		MachineID:         a.machineID,
+		UUID:      a.controllerUUID,
+		MachineID: a.machineID,
+		// TODO(backups): resolve the controller machine's cloud instance id
+		// via the machine service (GetInstanceIDByMachineName) and record it
+		// here instead of the unknown placeholder.
 		MachineInstanceID: corebackups.UnknownString,
 		HANodes:           int64(len(controllerIDs)),
 	}
@@ -127,7 +140,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	filename, err := corebackups.Create(meta, corebackups.CreateArgs{
 		DestinationDir: backupDir,
 		FilesToBackUp:  files,
-		DumpEntries:    entries,
+		DumpEntries:    staging.Entries(),
 		Clock:          a.clock,
 	})
 	if err != nil {

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -4,16 +4,134 @@
 package backups
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"path"
 
-	"github.com/juju/errors"
+	"github.com/juju/names/v6"
+	"gopkg.in/yaml.v3"
 
+	corebackups "github.com/juju/juju/core/backups"
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/permission"
+	coreversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/rpc/params"
 )
 
 // Create is the API method that requests juju to create a new backup
-// of its state.
-func (a *API) Create(context.Context, params.BackupsCreateArgs) (params.BackupsMetadataResult, error) {
-	result := params.BackupsMetadataResult{}
-	return result, errors.NotImplementedf("Dqlite-based backups")
+// of its state. The archive contains the controller database export and one
+// export per model, alongside the controller's data directory files.
+func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params.BackupsMetadataResult, error) {
+	// Creating a backup requires superuser access to the controller. This is
+	// the same gate Juju 3.6 applies to the Create method.
+	if err := a.authorizer.HasPermission(
+		ctx, permission.SuperuserAccess, names.NewControllerTag(a.controllerUUID),
+	); err != nil {
+		return params.BackupsMetadataResult{}, err
+	}
+
+	// Controller dump first, then one dump per registered model namespace.
+	// Any error aborts Create: there are no partial archives.
+	entries := []corebackups.DumpEntry{}
+	var expected int64
+
+	controllerExport, err := a.controllerExport.Export(ctx)
+	if err != nil {
+		return params.BackupsMetadataResult{}, err
+	}
+	controllerYAML, err := yaml.Marshal(controllerExport)
+	if err != nil {
+		return params.BackupsMetadataResult{}, err
+	}
+	expected += int64(len(controllerYAML))
+	entries = append(entries, corebackups.DumpEntry{
+		Name:   "controller.yaml",
+		Reader: bytes.NewReader(controllerYAML),
+	})
+
+	modelUUIDs, err := a.controller.GetModelNamespaces(ctx)
+	if err != nil {
+		return params.BackupsMetadataResult{}, err
+	}
+	for _, modelUUID := range modelUUIDs {
+		modelServices, err := a.modelServicesFor(ctx, coremodel.UUID(modelUUID))
+		if err != nil {
+			return params.BackupsMetadataResult{}, err
+		}
+		modelExport, err := modelServices.Export().Export(ctx)
+		if err != nil {
+			return params.BackupsMetadataResult{}, err
+		}
+		modelYAML, err := yaml.Marshal(modelExport)
+		if err != nil {
+			return params.BackupsMetadataResult{}, err
+		}
+		expected += int64(len(modelYAML))
+		entries = append(entries, corebackups.DumpEntry{
+			Name:   path.Join("models", modelUUID+".yaml"),
+			Reader: bytes.NewReader(modelYAML),
+		})
+	}
+
+	modelConfig, err := a.modelConfig.ModelConfig(ctx)
+	if err != nil {
+		return params.BackupsMetadataResult{}, err
+	}
+	backupDir := corebackups.BackupDirToUse(modelConfig.BackupDir())
+
+	paths := corebackups.Paths{
+		BackupDir: backupDir,
+		DataDir:   a.dataDir,
+		LogsDir:   a.logDir,
+	}
+	files, err := corebackups.GetFilesToBackUp("", &paths)
+	if err != nil {
+		return params.BackupsMetadataResult{}, err
+	}
+	for _, file := range files {
+		if fi, err := os.Lstat(file); err == nil {
+			expected += fi.Size()
+		}
+	}
+
+	if err := corebackups.CheckSpaceFor(backupDir, expected); err != nil {
+		return params.BackupsMetadataResult{}, err
+	}
+
+	hostname, _ := os.Hostname()
+
+	controllerIDs, err := a.controllerNodes.GetControllerIDs(ctx)
+	if err != nil {
+		return params.BackupsMetadataResult{}, err
+	}
+
+	meta := corebackups.NewMetadata()
+	meta.Notes = args.Notes
+	meta.Origin = corebackups.Origin{
+		Model:    a.controllerModelUID.String(),
+		Machine:  a.machineID,
+		Hostname: hostname,
+		Version:  coreversion.Current,
+		// Base is not resolved: there is no verified cheap machine-base
+		// lookup path in this facade and the field is informational only.
+		Base: "",
+	}
+	meta.Controller = corebackups.ControllerMetadata{
+		UUID:              a.controllerUUID,
+		MachineID:         a.machineID,
+		MachineInstanceID: corebackups.UnknownString,
+		HANodes:           int64(len(controllerIDs)),
+	}
+
+	filename, err := corebackups.Create(meta, corebackups.CreateArgs{
+		DestinationDir: backupDir,
+		FilesToBackUp:  files,
+		DumpEntries:    entries,
+	})
+	if err != nil {
+		return params.BackupsMetadataResult{}, err
+	}
+
+	return params.CreateResult(meta, filename), nil
 }

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -51,6 +51,20 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	backupDir := corebackups.BackupDirToUse(modelConfig.BackupDir())
 	a.logger.Debugf(ctx, "creating backup in %q", backupDir)
 
+	paths := corebackups.Paths{
+		BackupDir: backupDir,
+		DataDir:   a.dataDir,
+		LogsDir:   a.logDir,
+	}
+	files, err := corebackups.GetFilesToBackUp("", &paths)
+	if err != nil {
+		return params.BackupsMetadataResult{}, errors.Capture(err)
+	}
+	controllerIDs, err := a.controllerNodes.GetControllerIDs(ctx)
+	if err != nil {
+		return params.BackupsMetadataResult{}, errors.Capture(err)
+	}
+
 	// Controller dump first, then one dump per registered model namespace.
 	// Every registered model, including the controller model, owns a dqlite
 	// database (namespace = its UUID) that is separate from the controller
@@ -59,7 +73,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	// in that database, so its namespace is not skipped: this is not a
 	// duplicate of the controller dump. Any error aborts Create: there are
 	// no partial archives.
-	dumps := []corebackups.NamedDump{}
+	var dumps []corebackups.NamedDump
 
 	controllerExport, err := a.controllerExport.Export(ctx)
 	if err != nil {
@@ -113,16 +127,8 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 
-	paths := corebackups.Paths{
-		BackupDir: backupDir,
-		DataDir:   a.dataDir,
-		LogsDir:   a.logDir,
-	}
-	files, err := corebackups.GetFilesToBackUp("", &paths)
-	if err != nil {
-		return params.BackupsMetadataResult{}, errors.Capture(err)
-	}
 	for _, file := range files {
+		// Lstat intentionally sizes the link itself instead of following it.
 		fi, err := os.Lstat(file)
 		if err != nil {
 			// A file that cannot be stat'ed contributes nothing to the
@@ -148,11 +154,6 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	// the error is intentionally not fatal.
 	hostname, _ := os.Hostname()
 
-	controllerIDs, err := a.controllerNodes.GetControllerIDs(ctx)
-	if err != nil {
-		return params.BackupsMetadataResult{}, errors.Capture(err)
-	}
-
 	meta := corebackups.NewMetadata(a.clock.Now())
 	meta.Notes = args.Notes
 	meta.Origin = corebackups.Origin{
@@ -160,16 +161,13 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		Machine:  a.machineID,
 		Hostname: hostname,
 		Version:  coreversion.Current,
-		// Base is not resolved: there is no verified cheap machine-base
-		// lookup path in this facade and the field is informational only.
+		// TODO(backups): resolve the controller machine's base when a cheap,
+		// verified lookup path is available to this facade.
 		Base: "",
 	}
 	meta.Controller = corebackups.ControllerMetadata{
-		UUID:      a.controllerUUID,
-		MachineID: a.machineID,
-		// TODO(backups): resolve the controller machine's cloud instance id
-		// via the machine service (GetInstanceIDByMachineName) and record it
-		// here instead of the unknown placeholder.
+		UUID:              a.controllerUUID,
+		MachineID:         a.machineID,
 		MachineInstanceID: corebackups.UnknownString,
 		HANodes:           int64(len(controllerIDs)),
 	}

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -123,9 +123,20 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 	for _, file := range files {
-		if fi, err := os.Lstat(file); err == nil {
-			expected += fi.Size()
+		fi, err := os.Lstat(file)
+		if err != nil {
+			// A file that cannot be stat'ed contributes nothing to the
+			// estimate, which then understates what the archive needs.
+			// That is not fatal here: bundling opens every one of these
+			// files, so one that is really gone fails Create with a
+			// clear error. Log it so an understated space check, and the
+			// disk-full failure it can turn into, is diagnosable.
+			a.logger.Warningf(ctx,
+				"sizing backup file %q, excluded from the space estimate: %v",
+				file, err)
+			continue
 		}
+		expected += fi.Size()
 	}
 
 	if err := corebackups.CheckSpaceFor(backupDir, expected); err != nil {

--- a/apiserver/facades/client/backups/create.go
+++ b/apiserver/facades/client/backups/create.go
@@ -14,6 +14,7 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	coreversion "github.com/juju/juju/core/version"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -37,7 +38,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	if err := a.authorizer.HasPermission(
 		ctx, permission.SuperuserAccess, names.NewControllerTag(a.controllerUUID),
 	); err != nil {
-		return params.BackupsMetadataResult{}, err
+		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 
 	// The backup destination is resolved first because the database dumps
@@ -45,7 +46,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	// holding every model's dump in memory at once.
 	modelConfig, err := a.modelConfig.ModelConfig(ctx)
 	if err != nil {
-		return params.BackupsMetadataResult{}, err
+		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 	backupDir := corebackups.BackupDirToUse(modelConfig.BackupDir())
 	a.logger.Debugf(ctx, "creating backup in %q", backupDir)
@@ -62,7 +63,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 
 	controllerExport, err := a.controllerExport.Export(ctx)
 	if err != nil {
-		return params.BackupsMetadataResult{}, err
+		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 	dumps = append(dumps, corebackups.NamedDump{
 		Name:   "controller.yaml",
@@ -71,16 +72,19 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 
 	modelUUIDs, err := a.controller.GetModelNamespaces(ctx)
 	if err != nil {
-		return params.BackupsMetadataResult{}, err
+		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 	for _, modelUUID := range modelUUIDs {
+		if err := ctx.Err(); err != nil {
+			return params.BackupsMetadataResult{}, err
+		}
 		modelServices, err := a.modelServicesFor(ctx, coremodel.UUID(modelUUID))
 		if err != nil {
-			return params.BackupsMetadataResult{}, err
+			return params.BackupsMetadataResult{}, errors.Capture(err)
 		}
 		modelExport, err := modelServices.Export().Export(ctx)
 		if err != nil {
-			return params.BackupsMetadataResult{}, err
+			return params.BackupsMetadataResult{}, errors.Capture(err)
 		}
 		dumps = append(dumps, corebackups.NamedDump{
 			Name:   path.Join("models", modelUUID+".yaml"),
@@ -95,7 +99,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	// behind.
 	staging, err := corebackups.StageDumps(ctx, backupDir, dumps)
 	if err != nil {
-		return params.BackupsMetadataResult{}, err
+		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 	// Close cleans up the staged dumps on return. Its error is only logged:
 	// it must not mask the Create result.
@@ -104,7 +108,10 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 			a.logger.Debugf(ctx, "cleaning up staged backup dumps: %v", err)
 		}
 	}()
-	expected := staging.Size()
+	expected, err := staging.Size()
+	if err != nil {
+		return params.BackupsMetadataResult{}, errors.Capture(err)
+	}
 
 	paths := corebackups.Paths{
 		BackupDir: backupDir,
@@ -113,7 +120,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	}
 	files, err := corebackups.GetFilesToBackUp("", &paths)
 	if err != nil {
-		return params.BackupsMetadataResult{}, err
+		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 	for _, file := range files {
 		if fi, err := os.Lstat(file); err == nil {
@@ -122,7 +129,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 	}
 
 	if err := corebackups.CheckSpaceFor(backupDir, expected); err != nil {
-		return params.BackupsMetadataResult{}, err
+		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 
 	// The hostname is recorded for provenance only. If it cannot be resolved
@@ -132,7 +139,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 
 	controllerIDs, err := a.controllerNodes.GetControllerIDs(ctx)
 	if err != nil {
-		return params.BackupsMetadataResult{}, err
+		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 
 	meta := corebackups.NewMetadata(a.clock.Now())
@@ -163,7 +170,7 @@ func (a *API) Create(ctx context.Context, args params.BackupsCreateArgs) (params
 		Clock:          a.clock,
 	})
 	if err != nil {
-		return params.BackupsMetadataResult{}, err
+		return params.BackupsMetadataResult{}, errors.Capture(err)
 	}
 	a.logger.Infof(ctx, "created backup %q", filename)
 

--- a/apiserver/facades/client/backups/create_test.go
+++ b/apiserver/facades/client/backups/create_test.go
@@ -6,6 +6,7 @@ package backups
 import (
 	"archive/tar"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -24,6 +25,7 @@ import (
 	domainexport "github.com/juju/juju/domain/export"
 	domainservicetesting "github.com/juju/juju/domain/services/testing"
 	environsconfig "github.com/juju/juju/environs/config"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -42,7 +44,10 @@ func (s *backupsSuite) SetUpTest(c *tc.C) {
 	s.auditAuthorizer = stubAuthorizer{authClient: true}
 }
 
-func (s *backupsSuite) api(c *tc.C, backupDir string) *API {
+// api builds a backups API wired to the suite's real domain services. Any
+// non-nil field in overrides replaces the corresponding dependency, which
+// lets error-path tests inject failures without rebuilding the suite.
+func (s *backupsSuite) api(c *tc.C, backupDir string, overrides ...func(*apiDeps)) *API {
 	controllerServices := s.ControllerDomainServices(c)
 
 	cfg, err := environsconfig.New(environsconfig.UseDefaults, map[string]any{
@@ -53,10 +58,18 @@ func (s *backupsSuite) api(c *tc.C, backupDir string) *API {
 	})
 	c.Assert(err, tc.ErrorIsNil)
 
-	modelServicesFor := ModelServicesForFunc(
-		func(_ context.Context, uuid coremodel.UUID) (ModelExportDomainServices, error) {
+	deps := apiDeps{
+		controllerExport: controllerServices.ControllerExport(),
+		modelServicesFor: func(_ context.Context, uuid coremodel.UUID) (ModelExportDomainServices, error) {
 			return s.ModelDomainServices(c, uuid), nil
-		})
+		},
+		modelConfig:     stubModelConfig{cfg: cfg},
+		controller:      controllerServices.Controller(),
+		controllerNodes: controllerServices.ControllerNode(),
+	}
+	for _, override := range overrides {
+		override(&deps)
+	}
 
 	api, err := NewAPI(
 		&s.auditAuthorizer,
@@ -64,15 +77,25 @@ func (s *backupsSuite) api(c *tc.C, backupDir string) *API {
 		s.ControllerConfig.ControllerUUID(),
 		s.ControllerModelUUID,
 		s.dataDir(c), c.MkDir(),
-		controllerServices.ControllerExport(),
-		modelServicesFor,
-		stubModelConfig{cfg: cfg},
-		controllerServices.Controller(),
-		controllerServices.ControllerNode(),
+		deps.controllerExport,
+		deps.modelServicesFor,
+		deps.modelConfig,
+		deps.controller,
+		deps.controllerNodes,
 		clock.WallClock,
+		loggertesting.WrapCheckLog(c),
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	return api
+}
+
+// apiDeps holds the overridable dependencies of the backups API under test.
+type apiDeps struct {
+	controllerExport ControllerExportService
+	modelServicesFor ModelServicesForFunc
+	modelConfig      ModelConfigService
+	controller       ControllerModelLister
+	controllerNodes  ControllerNodeLister
 }
 
 // dataDir creates a data directory containing the objectstore and tools
@@ -136,6 +159,60 @@ func (s *backupsSuite) TestCreateNotSuperuser(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, coreerrors.Forbidden)
 }
 
+// TestCreateModelServicesFailure verifies that a failure resolving a model's
+// export services aborts Create and leaves no archive behind.
+func (s *backupsSuite) TestCreateModelServicesFailure(c *tc.C) {
+	backupDir := c.MkDir()
+	boom := errors.New("model services unavailable")
+	api := s.api(c, backupDir, func(d *apiDeps) {
+		d.modelServicesFor = func(context.Context, coremodel.UUID) (ModelExportDomainServices, error) {
+			return nil, boom
+		}
+	})
+
+	_, err := api.Create(c.Context(), params.BackupsCreateArgs{})
+	c.Assert(err, tc.ErrorIs, boom)
+
+	entries, err := os.ReadDir(backupDir)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(entries, tc.HasLen, 0)
+}
+
+// TestCreateModelNamespacesFailure verifies that a failure listing the
+// registered model namespaces aborts Create and leaves no archive behind.
+func (s *backupsSuite) TestCreateModelNamespacesFailure(c *tc.C) {
+	backupDir := c.MkDir()
+	boom := errors.New("cannot list models")
+	api := s.api(c, backupDir, func(d *apiDeps) {
+		d.controller = stubModelLister{err: boom}
+	})
+
+	_, err := api.Create(c.Context(), params.BackupsCreateArgs{})
+	c.Assert(err, tc.ErrorIs, boom)
+
+	entries, err := os.ReadDir(backupDir)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(entries, tc.HasLen, 0)
+}
+
+// TestCreateNoModels verifies that a controller with no model namespaces
+// still produces a valid archive containing only the controller dump.
+func (s *backupsSuite) TestCreateNoModels(c *tc.C) {
+	backupDir := c.MkDir()
+	api := s.api(c, backupDir, func(d *apiDeps) {
+		d.controller = stubModelLister{uuids: []string{}}
+	})
+
+	result, err := api.Create(c.Context(), params.BackupsCreateArgs{})
+	c.Assert(err, tc.ErrorIsNil)
+
+	file, err := os.Open(result.Filename)
+	c.Assert(err, tc.ErrorIsNil)
+	defer file.Close()
+	entries, _ := archiveContents(c, file)
+	c.Check(entries.Contains("juju-backup/dump/controller.yaml"), tc.IsTrue)
+}
+
 func archiveContents(c *tc.C, r io.Reader) (set.Strings, map[string]string) {
 	names := set.NewStrings()
 	contents := make(map[string]string)
@@ -191,4 +268,15 @@ type stubModelConfig struct {
 
 func (s stubModelConfig) ModelConfig(context.Context) (*environsconfig.Config, error) {
 	return s.cfg, nil
+}
+
+// stubModelLister is a ControllerModelLister returning fixed UUIDs or an
+// error.
+type stubModelLister struct {
+	uuids []string
+	err   error
+}
+
+func (s stubModelLister) GetModelNamespaces(context.Context) ([]string, error) {
+	return s.uuids, s.err
 }

--- a/apiserver/facades/client/backups/create_test.go
+++ b/apiserver/facades/client/backups/create_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	stdtesting "testing"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/names/v6"
+	"github.com/juju/tc"
+	"gopkg.in/yaml.v3"
+
+	corebackups "github.com/juju/juju/core/backups"
+	coreerrors "github.com/juju/juju/core/errors"
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/permission"
+	domainexport "github.com/juju/juju/domain/export"
+	domainservicetesting "github.com/juju/juju/domain/services/testing"
+	environsconfig "github.com/juju/juju/environs/config"
+	"github.com/juju/juju/rpc/params"
+)
+
+type backupsSuite struct {
+	domainservicetesting.DomainServicesSuite
+
+	auditAuthorizer stubAuthorizer
+}
+
+func TestBackupsSuite(t *stdtesting.T) {
+	tc.Run(t, &backupsSuite{})
+}
+
+func (s *backupsSuite) SetUpTest(c *tc.C) {
+	s.DomainServicesSuite.SetUpTest(c)
+	s.auditAuthorizer = stubAuthorizer{authClient: true}
+}
+
+func (s *backupsSuite) api(c *tc.C, backupDir string) *API {
+	controllerServices := s.ControllerDomainServices(c)
+
+	cfg, err := environsconfig.New(environsconfig.UseDefaults, map[string]any{
+		"backup-dir": backupDir,
+		"uuid":       s.ControllerModelUUID.String(),
+		"type":       "manual",
+		"name":       "controller",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	modelServicesFor := ModelServicesForFunc(
+		func(_ context.Context, uuid coremodel.UUID) (ModelExportDomainServices, error) {
+			return s.ModelDomainServices(c, uuid), nil
+		})
+
+	api, err := NewAPI(
+		&s.auditAuthorizer,
+		names.NewMachineTag("0"),
+		s.ControllerConfig.ControllerUUID(),
+		s.ControllerModelUUID,
+		s.dataDir(c), c.MkDir(),
+		controllerServices.ControllerExport(),
+		modelServicesFor,
+		stubModelConfig{cfg: cfg},
+		controllerServices.Controller(),
+		controllerServices.ControllerNode(),
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	return api
+}
+
+// dataDir creates a data directory containing the objectstore and tools
+// directories the file collector requires, and one file under the
+// objectstore so the collected list is non-empty.
+func (s *backupsSuite) dataDir(c *tc.C) string {
+	dir := c.MkDir()
+	for _, subdir := range []string{"objectstore", "tools"} {
+		c.Assert(os.Mkdir(filepath.Join(dir, subdir), 0755), tc.ErrorIsNil)
+	}
+	c.Assert(os.WriteFile(filepath.Join(dir, "objectstore", "blob"), []byte("blob"), 0644), tc.ErrorIsNil)
+	return dir
+}
+
+func (s *backupsSuite) TestCreate(c *tc.C) {
+	backupDir := c.MkDir()
+	api := s.api(c, backupDir)
+
+	result, err := api.Create(c.Context(), params.BackupsCreateArgs{Notes: "test"})
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Check(result.Notes, tc.Equals, "test")
+	c.Check(result.FormatVersion, tc.Equals, int64(2))
+
+	// The archive lands in the configured backup-dir.
+	c.Check(filepath.Dir(result.Filename), tc.Equals, backupDir)
+
+	controllerServices := s.ControllerDomainServices(c)
+	modelUUIDs, err := controllerServices.Controller().GetModelNamespaces(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	controllerIDs, err := controllerServices.ControllerNode().GetControllerIDs(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result.HANodes, tc.Equals, int64(len(controllerIDs)))
+
+	// Untar the archive and assert the dump entries.
+	file, err := os.Open(result.Filename)
+	c.Assert(err, tc.ErrorIsNil)
+	defer file.Close()
+	entries, contents := archiveContents(c, file)
+
+	c.Assert(entries.Contains("juju-backup/dump/controller.yaml"), tc.IsTrue)
+	for _, modelUUID := range modelUUIDs {
+		c.Assert(entries.Contains("juju-backup/dump/models/"+modelUUID+".yaml"),
+			tc.IsTrue, tc.Commentf("missing dump for model %s", modelUUID))
+	}
+	c.Assert(entries.Contains("juju-backup/metadata.json"), tc.IsTrue)
+	c.Assert(entries.Contains("juju-backup/root.tar"), tc.IsTrue)
+
+	// The controller dump envelope decodes and is stamped with the latest
+	// controller export version.
+	var controllerEnvelope domainexport.ControllerExport
+	err = yaml.Unmarshal([]byte(contents["juju-backup/dump/controller.yaml"]), &controllerEnvelope)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(controllerEnvelope.Version, tc.Equals, domainexport.LatestControllerExportVersion())
+}
+
+func (s *backupsSuite) TestCreateNotSuperuser(c *tc.C) {
+	s.auditAuthorizer.hasErr = coreerrors.Forbidden
+
+	_, err := s.api(c, c.MkDir()).Create(c.Context(), params.BackupsCreateArgs{})
+	c.Assert(err, tc.ErrorIs, coreerrors.Forbidden)
+}
+
+func archiveContents(c *tc.C, r io.Reader) (set.Strings, map[string]string) {
+	names := set.NewStrings()
+	contents := make(map[string]string)
+
+	archive, err := corebackups.NewArchiveDataReader(r)
+	c.Assert(err, tc.ErrorIsNil)
+
+	tr := tar.NewReader(archive.NewBuffer())
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		c.Assert(err, tc.ErrorIsNil)
+		if header.Typeflag == tar.TypeReg {
+			data, err := io.ReadAll(tr)
+			c.Assert(err, tc.ErrorIsNil)
+			contents[header.Name] = string(data)
+		}
+		names.Add(header.Name)
+	}
+	return names, contents
+}
+
+// stubAuthorizer is an Authorizer whose HasPermission outcome is tunable.
+type stubAuthorizer struct {
+	authClient bool
+	hasErr     error
+
+	// target is the tag on which HasPermission was last invoked.
+	target names.Tag
+}
+
+func (s *stubAuthorizer) GetAuthTag() names.Tag      { return names.NewUserTag("admin") }
+func (s *stubAuthorizer) AuthController() bool       { return false }
+func (s *stubAuthorizer) AuthMachineAgent() bool     { return false }
+func (s *stubAuthorizer) AuthApplicationAgent() bool { return false }
+func (s *stubAuthorizer) AuthModelAgent() bool       { return false }
+func (s *stubAuthorizer) AuthUnitAgent() bool        { return false }
+func (s *stubAuthorizer) AuthOwner(names.Tag) bool   { return false }
+func (s *stubAuthorizer) AuthClient() bool           { return s.authClient }
+func (s *stubAuthorizer) HasPermission(_ context.Context, _ permission.Access, target names.Tag) error {
+	s.target = target
+	return s.hasErr
+}
+func (s *stubAuthorizer) EntityHasPermission(_ context.Context, _ names.Tag, _ permission.Access, _ names.Tag) error {
+	return nil
+}
+
+type stubModelConfig struct {
+	cfg *environsconfig.Config
+}
+
+func (s stubModelConfig) ModelConfig(context.Context) (*environsconfig.Config, error) {
+	return s.cfg, nil
+}

--- a/apiserver/facades/client/backups/create_test.go
+++ b/apiserver/facades/client/backups/create_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	stdtesting "testing"
 
+	"github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
@@ -68,6 +69,7 @@ func (s *backupsSuite) api(c *tc.C, backupDir string) *API {
 		stubModelConfig{cfg: cfg},
 		controllerServices.Controller(),
 		controllerServices.ControllerNode(),
+		clock.WallClock,
 	)
 	c.Assert(err, tc.ErrorIsNil)
 	return api

--- a/apiserver/facades/client/backups/create_test.go
+++ b/apiserver/facades/client/backups/create_test.go
@@ -261,10 +261,9 @@ func (s *backupsSuite) TestCreateModelConfigFailure(c *tc.C) {
 }
 
 // TestCreateControllerNodesFailure verifies that a failure listing
-// controller machine IDs aborts Create. The failure fires after the dumps
-// have been staged, so this also verifies that the staged dumps are
-// cleaned up and no archive is left behind. The export tolerates an empty
-// controller_node table, but GetControllerIDs rejects it.
+// controller machine IDs aborts Create before any archive is created. The
+// controller export tolerates an empty controller_node table, but
+// GetControllerIDs rejects it.
 func (s *backupsSuite) TestCreateControllerNodesFailure(c *tc.C) {
 	backupDir := c.MkDir()
 	api := s.api(c, backupDir)

--- a/apiserver/facades/client/backups/create_test.go
+++ b/apiserver/facades/client/backups/create_test.go
@@ -6,6 +6,7 @@ package backups
 import (
 	"archive/tar"
 	"context"
+	"database/sql"
 	"errors"
 	"io"
 	"os"
@@ -22,6 +23,7 @@ import (
 	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
+	controllernodeerrors "github.com/juju/juju/domain/controllernode/errors"
 	domainexport "github.com/juju/juju/domain/export"
 	domainservicetesting "github.com/juju/juju/domain/services/testing"
 	environsconfig "github.com/juju/juju/environs/config"
@@ -211,6 +213,84 @@ func (s *backupsSuite) TestCreateNoModels(c *tc.C) {
 	defer file.Close()
 	entries, _ := archiveContents(c, file)
 	c.Check(entries.Contains("juju-backup/dump/controller.yaml"), tc.IsTrue)
+}
+
+// TestCreateControllerExportFailure verifies that a failure of the real
+// controller export aborts Create and leaves no archive behind. The export
+// reads agent_binary_store (among other tables), so dropping that table
+// makes the real service fail.
+func (s *backupsSuite) TestCreateControllerExportFailure(c *tc.C) {
+	backupDir := c.MkDir()
+	api := s.api(c, backupDir)
+
+	_, err := s.DB().ExecContext(c.Context(), "DROP TABLE agent_binary_store")
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = api.Create(c.Context(), params.BackupsCreateArgs{})
+	c.Assert(err, tc.ErrorMatches, ".*agent_binary_store.*")
+
+	entries, err := os.ReadDir(backupDir)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(entries, tc.HasLen, 0)
+}
+
+// TestCreateModelConfigFailure verifies that a failure of the real model
+// config service aborts Create and leaves no archive behind. The config is
+// read from model_config, so dropping that table makes the real service
+// fail. The table is dropped before the API is built because model
+// database services capture their database handle at construction time.
+func (s *backupsSuite) TestCreateModelConfigFailure(c *tc.C) {
+	err := s.ModelTxnRunner(c, s.ControllerModelUUID.String()).StdTxn(
+		c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			_, err := tx.ExecContext(ctx, "DROP TABLE model_config")
+			return err
+		})
+	c.Assert(err, tc.ErrorIsNil)
+
+	backupDir := c.MkDir()
+	api := s.api(c, backupDir, func(d *apiDeps) {
+		d.modelConfig = s.ControllerDomainServices(c).Config()
+	})
+
+	_, err = api.Create(c.Context(), params.BackupsCreateArgs{})
+	c.Assert(err, tc.ErrorMatches, ".*model_config.*")
+
+	entries, err := os.ReadDir(backupDir)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(entries, tc.HasLen, 0)
+}
+
+// TestCreateControllerNodesFailure verifies that a failure listing
+// controller machine IDs aborts Create. The failure fires after the dumps
+// have been staged, so this also verifies that the staged dumps are
+// cleaned up and no archive is left behind. The export tolerates an empty
+// controller_node table, but GetControllerIDs rejects it.
+func (s *backupsSuite) TestCreateControllerNodesFailure(c *tc.C) {
+	backupDir := c.MkDir()
+	api := s.api(c, backupDir)
+
+	// Remove the controller node records, children first to respect the
+	// foreign keys.
+	for _, table := range []string{
+		"controller_node_agent_version",
+		"controller_api_address",
+		"controller_node_password",
+		"upgrade_info_controller_node",
+		"controller_node",
+	} {
+		err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+			_, err := tx.ExecContext(ctx, "DELETE FROM "+table)
+			return err
+		})
+		c.Assert(err, tc.ErrorIsNil)
+	}
+
+	_, err := api.Create(c.Context(), params.BackupsCreateArgs{})
+	c.Assert(err, tc.ErrorIs, controllernodeerrors.EmptyControllerIDs)
+
+	entries, err := os.ReadDir(backupDir)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(entries, tc.HasLen, 0)
 }
 
 func archiveContents(c *tc.C, r io.Reader) (set.Strings, map[string]string) {

--- a/apiserver/facades/client/backups/create_test.go
+++ b/apiserver/facades/client/backups/create_test.go
@@ -43,6 +43,12 @@ func TestBackupsSuite(t *stdtesting.T) {
 
 func (s *backupsSuite) SetUpTest(c *tc.C) {
 	s.DomainServicesSuite.SetUpTest(c)
+	// GetFilesToBackUp stats /home/ubuntu/.ssh/authorized_keys, and a
+	// stat failure other than ErrNotExist is fatal. Redirect the lookup
+	// into an empty test dir: on hosts where the real path exists but
+	// is not readable by the test user the suite would fail with
+	// "permission denied" instead of exercising Create.
+	s.PatchValue(&corebackups.SSHDir, c.MkDir())
 	s.auditAuthorizer = stubAuthorizer{authClient: true}
 }
 

--- a/apiserver/facades/client/backups/register.go
+++ b/apiserver/facades/client/backups/register.go
@@ -8,22 +8,41 @@ import (
 	"reflect"
 
 	"github.com/juju/juju/apiserver/facade"
+	coremodel "github.com/juju/juju/core/model"
 )
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("Backups", 3, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
-		return newFacade(ctx)
+	registry.MustRegisterForMultiModel("Backups", 3, func(stdCtx context.Context, ctx facade.MultiModelContext) (facade.Facade, error) {
+		return newFacade(stdCtx, ctx)
 	}, reflect.TypeFor[*API]())
 }
 
 // newFacade provides the required signature for facade registration.
-func newFacade(ctx facade.ModelContext) (*API, error) {
+func newFacade(stdCtx context.Context, ctx facade.MultiModelContext) (*API, error) {
+	controllerModelUUID := ctx.ControllerModelUUID()
+	controllerServices, err := ctx.DomainServicesForModel(stdCtx, controllerModelUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	modelServicesFor := ModelServicesForFunc(
+		func(stdCtx context.Context, modelUUID coremodel.UUID) (ModelExportDomainServices, error) {
+			return ctx.DomainServicesForModel(stdCtx, modelUUID)
+		},
+	)
+
 	return NewAPI(
-		ctx.DomainServices().ControllerConfig(),
 		ctx.Auth(),
 		ctx.MachineTag(),
+		ctx.ControllerUUID(),
+		controllerModelUUID,
 		ctx.DataDir(),
 		ctx.LogDir(),
+		controllerServices.ControllerExport(),
+		modelServicesFor,
+		controllerServices.Config(),
+		controllerServices.Controller(),
+		controllerServices.ControllerNode(),
 	)
 }

--- a/apiserver/facades/client/backups/register.go
+++ b/apiserver/facades/client/backups/register.go
@@ -44,5 +44,6 @@ func newFacade(stdCtx context.Context, ctx facade.MultiModelContext) (*API, erro
 		controllerServices.Config(),
 		controllerServices.Controller(),
 		controllerServices.ControllerNode(),
+		ctx.Clock(),
 	)
 }

--- a/apiserver/facades/client/backups/register.go
+++ b/apiserver/facades/client/backups/register.go
@@ -45,5 +45,6 @@ func newFacade(stdCtx context.Context, ctx facade.MultiModelContext) (*API, erro
 		controllerServices.Controller(),
 		controllerServices.ControllerNode(),
 		ctx.Clock(),
+		ctx.Logger().Child("backups"),
 	)
 }

--- a/apiserver/facades/controller/migrationtarget/domainservices_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/domainservices_mock_test.go
@@ -141,6 +141,7 @@ type MockDomainServicesMockRecorder struct {
 	controllerAgentBinaryStoreExpects []*gomock.Call0_1[*service0.AgentBinaryStore]
 	controllerChangeStreamExpects     []*gomock.Call0_1[*service8.Service]
 	controllerConfigExpects           []*gomock.Call0_1[*service12.WatchableService]
+	controllerExportExpects           []*gomock.Call0_1[*service17.ControllerService]
 	controllerNodeExpects             []*gomock.Call0_1[*service13.WatchableService]
 	controllerUpgraderExpects         []*gomock.Call0_1[*service14.Service]
 	credentialExpects                 []*gomock.Call0_1[*service15.WatchableService]
@@ -536,6 +537,24 @@ func (mr *MockDomainServicesMockRecorder) ControllerConfig() *MockDomainServices
 
 // MockDomainServicesControllerConfigCall is the typed call wrapper for ControllerConfig.
 type MockDomainServicesControllerConfigCall = gomock.Call0_1[*service12.WatchableService]
+
+// ControllerExport mocks base method.
+func (m *MockDomainServices) ControllerExport() *service17.ControllerService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.controllerExportExpects, m.ctrl, m, "ControllerExport")
+}
+
+// ControllerExport indicates an expected call of ControllerExport.
+func (mr *MockDomainServicesMockRecorder) ControllerExport() *MockDomainServicesControllerExportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service17.ControllerService](mr.mock.ctrl.T, mr.mock, "ControllerExport")
+	mr.controllerExportExpects = append(mr.controllerExportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockDomainServicesControllerExportCall is the typed call wrapper for ControllerExport.
+type MockDomainServicesControllerExportCall = gomock.Call0_1[*service17.ControllerService]
 
 // ControllerNode mocks base method.
 func (m *MockDomainServices) ControllerNode() *service13.WatchableService {

--- a/apiserver/services_mock_test.go
+++ b/apiserver/services_mock_test.go
@@ -20,17 +20,18 @@ import (
 	service5 "github.com/juju/juju/domain/controllerconfig/service"
 	service6 "github.com/juju/juju/domain/controllernode/service"
 	service7 "github.com/juju/juju/domain/credential/service"
-	service8 "github.com/juju/juju/domain/externalcontroller/service"
-	service9 "github.com/juju/juju/domain/flag/service"
-	service10 "github.com/juju/juju/domain/logging/service"
-	service11 "github.com/juju/juju/domain/macaroon/service"
-	service12 "github.com/juju/juju/domain/model/service"
-	service13 "github.com/juju/juju/domain/modeldefaults/service"
-	service14 "github.com/juju/juju/domain/modelmigration/service"
-	service15 "github.com/juju/juju/domain/secretbackend/service"
+	service8 "github.com/juju/juju/domain/export/service"
+	service9 "github.com/juju/juju/domain/externalcontroller/service"
+	service10 "github.com/juju/juju/domain/flag/service"
+	service11 "github.com/juju/juju/domain/logging/service"
+	service12 "github.com/juju/juju/domain/macaroon/service"
+	service13 "github.com/juju/juju/domain/model/service"
+	service14 "github.com/juju/juju/domain/modeldefaults/service"
+	service15 "github.com/juju/juju/domain/modelmigration/service"
+	service16 "github.com/juju/juju/domain/secretbackend/service"
 	controller "github.com/juju/juju/domain/ssh/service/controller"
-	service16 "github.com/juju/juju/domain/tracing/service"
-	service17 "github.com/juju/juju/domain/upgrade/service"
+	service17 "github.com/juju/juju/domain/tracing/service"
+	service18 "github.com/juju/juju/domain/upgrade/service"
 )
 
 // MockControllerDomainServices is a mock of ControllerDomainServices interface.
@@ -50,19 +51,20 @@ type MockControllerDomainServicesMockRecorder struct {
 	controllerAgentBinaryStoreExpects []*gomock.Call0_1[*service0.AgentBinaryStore]
 	controllerChangeStreamExpects     []*gomock.Call0_1[*service2.Service]
 	controllerConfigExpects           []*gomock.Call0_1[*service5.WatchableService]
+	controllerExportExpects           []*gomock.Call0_1[*service8.ControllerService]
 	controllerNodeExpects             []*gomock.Call0_1[*service6.WatchableService]
 	credentialExpects                 []*gomock.Call0_1[*service7.WatchableService]
-	externalControllerExpects         []*gomock.Call0_1[*service8.WatchableService]
-	flagExpects                       []*gomock.Call0_1[*service9.Service]
-	loggingExpects                    []*gomock.Call0_1[*service10.WatchableService]
-	macaroonExpects                   []*gomock.Call0_1[*service11.Service]
-	modelExpects                      []*gomock.Call0_1[*service12.WatchableService]
-	modelDefaultsExpects              []*gomock.Call0_1[*service13.Service]
-	modelMigrationImportExpects       []*gomock.Call0_1[*service14.WatchableService]
+	externalControllerExpects         []*gomock.Call0_1[*service9.WatchableService]
+	flagExpects                       []*gomock.Call0_1[*service10.Service]
+	loggingExpects                    []*gomock.Call0_1[*service11.WatchableService]
+	macaroonExpects                   []*gomock.Call0_1[*service12.Service]
+	modelExpects                      []*gomock.Call0_1[*service13.WatchableService]
+	modelDefaultsExpects              []*gomock.Call0_1[*service14.Service]
+	modelMigrationImportExpects       []*gomock.Call0_1[*service15.WatchableService]
 	sSHServerHostKeyExpects           []*gomock.Call0_1[*controller.Service]
-	secretBackendExpects              []*gomock.Call0_1[*service15.WatchableService]
-	tracingExpects                    []*gomock.Call0_1[*service16.WatchableService]
-	upgradeExpects                    []*gomock.Call0_1[*service17.WatchableService]
+	secretBackendExpects              []*gomock.Call0_1[*service16.WatchableService]
+	tracingExpects                    []*gomock.Call0_1[*service17.WatchableService]
+	upgradeExpects                    []*gomock.Call0_1[*service18.WatchableService]
 }
 
 // NewMockControllerDomainServices creates a new mock instance.
@@ -203,6 +205,24 @@ func (mr *MockControllerDomainServicesMockRecorder) ControllerConfig() *MockCont
 // MockControllerDomainServicesControllerConfigCall is the typed call wrapper for ControllerConfig.
 type MockControllerDomainServicesControllerConfigCall = gomock.Call0_1[*service5.WatchableService]
 
+// ControllerExport mocks base method.
+func (m *MockControllerDomainServices) ControllerExport() *service8.ControllerService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.controllerExportExpects, m.ctrl, m, "ControllerExport")
+}
+
+// ControllerExport indicates an expected call of ControllerExport.
+func (mr *MockControllerDomainServicesMockRecorder) ControllerExport() *MockControllerDomainServicesControllerExportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service8.ControllerService](mr.mock.ctrl.T, mr.mock, "ControllerExport")
+	mr.controllerExportExpects = append(mr.controllerExportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerDomainServicesControllerExportCall is the typed call wrapper for ControllerExport.
+type MockControllerDomainServicesControllerExportCall = gomock.Call0_1[*service8.ControllerService]
+
 // ControllerNode mocks base method.
 func (m *MockControllerDomainServices) ControllerNode() *service6.WatchableService {
 	m.ctrl.T.Helper()
@@ -240,7 +260,7 @@ func (mr *MockControllerDomainServicesMockRecorder) Credential() *MockController
 type MockControllerDomainServicesCredentialCall = gomock.Call0_1[*service7.WatchableService]
 
 // ExternalController mocks base method.
-func (m *MockControllerDomainServices) ExternalController() *service8.WatchableService {
+func (m *MockControllerDomainServices) ExternalController() *service9.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.externalControllerExpects, m.ctrl, m, "ExternalController")
 }
@@ -248,17 +268,17 @@ func (m *MockControllerDomainServices) ExternalController() *service8.WatchableS
 // ExternalController indicates an expected call of ExternalController.
 func (mr *MockControllerDomainServicesMockRecorder) ExternalController() *MockControllerDomainServicesExternalControllerCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service8.WatchableService](mr.mock.ctrl.T, mr.mock, "ExternalController")
+	call := gomock.NewCall0_1[*service9.WatchableService](mr.mock.ctrl.T, mr.mock, "ExternalController")
 	mr.externalControllerExpects = append(mr.externalControllerExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesExternalControllerCall is the typed call wrapper for ExternalController.
-type MockControllerDomainServicesExternalControllerCall = gomock.Call0_1[*service8.WatchableService]
+type MockControllerDomainServicesExternalControllerCall = gomock.Call0_1[*service9.WatchableService]
 
 // Flag mocks base method.
-func (m *MockControllerDomainServices) Flag() *service9.Service {
+func (m *MockControllerDomainServices) Flag() *service10.Service {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.flagExpects, m.ctrl, m, "Flag")
 }
@@ -266,17 +286,17 @@ func (m *MockControllerDomainServices) Flag() *service9.Service {
 // Flag indicates an expected call of Flag.
 func (mr *MockControllerDomainServicesMockRecorder) Flag() *MockControllerDomainServicesFlagCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service9.Service](mr.mock.ctrl.T, mr.mock, "Flag")
+	call := gomock.NewCall0_1[*service10.Service](mr.mock.ctrl.T, mr.mock, "Flag")
 	mr.flagExpects = append(mr.flagExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesFlagCall is the typed call wrapper for Flag.
-type MockControllerDomainServicesFlagCall = gomock.Call0_1[*service9.Service]
+type MockControllerDomainServicesFlagCall = gomock.Call0_1[*service10.Service]
 
 // Logging mocks base method.
-func (m *MockControllerDomainServices) Logging() *service10.WatchableService {
+func (m *MockControllerDomainServices) Logging() *service11.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.loggingExpects, m.ctrl, m, "Logging")
 }
@@ -284,17 +304,17 @@ func (m *MockControllerDomainServices) Logging() *service10.WatchableService {
 // Logging indicates an expected call of Logging.
 func (mr *MockControllerDomainServicesMockRecorder) Logging() *MockControllerDomainServicesLoggingCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service10.WatchableService](mr.mock.ctrl.T, mr.mock, "Logging")
+	call := gomock.NewCall0_1[*service11.WatchableService](mr.mock.ctrl.T, mr.mock, "Logging")
 	mr.loggingExpects = append(mr.loggingExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesLoggingCall is the typed call wrapper for Logging.
-type MockControllerDomainServicesLoggingCall = gomock.Call0_1[*service10.WatchableService]
+type MockControllerDomainServicesLoggingCall = gomock.Call0_1[*service11.WatchableService]
 
 // Macaroon mocks base method.
-func (m *MockControllerDomainServices) Macaroon() *service11.Service {
+func (m *MockControllerDomainServices) Macaroon() *service12.Service {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.macaroonExpects, m.ctrl, m, "Macaroon")
 }
@@ -302,17 +322,17 @@ func (m *MockControllerDomainServices) Macaroon() *service11.Service {
 // Macaroon indicates an expected call of Macaroon.
 func (mr *MockControllerDomainServicesMockRecorder) Macaroon() *MockControllerDomainServicesMacaroonCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service11.Service](mr.mock.ctrl.T, mr.mock, "Macaroon")
+	call := gomock.NewCall0_1[*service12.Service](mr.mock.ctrl.T, mr.mock, "Macaroon")
 	mr.macaroonExpects = append(mr.macaroonExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesMacaroonCall is the typed call wrapper for Macaroon.
-type MockControllerDomainServicesMacaroonCall = gomock.Call0_1[*service11.Service]
+type MockControllerDomainServicesMacaroonCall = gomock.Call0_1[*service12.Service]
 
 // Model mocks base method.
-func (m *MockControllerDomainServices) Model() *service12.WatchableService {
+func (m *MockControllerDomainServices) Model() *service13.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelExpects, m.ctrl, m, "Model")
 }
@@ -320,17 +340,17 @@ func (m *MockControllerDomainServices) Model() *service12.WatchableService {
 // Model indicates an expected call of Model.
 func (mr *MockControllerDomainServicesMockRecorder) Model() *MockControllerDomainServicesModelCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service12.WatchableService](mr.mock.ctrl.T, mr.mock, "Model")
+	call := gomock.NewCall0_1[*service13.WatchableService](mr.mock.ctrl.T, mr.mock, "Model")
 	mr.modelExpects = append(mr.modelExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesModelCall is the typed call wrapper for Model.
-type MockControllerDomainServicesModelCall = gomock.Call0_1[*service12.WatchableService]
+type MockControllerDomainServicesModelCall = gomock.Call0_1[*service13.WatchableService]
 
 // ModelDefaults mocks base method.
-func (m *MockControllerDomainServices) ModelDefaults() *service13.Service {
+func (m *MockControllerDomainServices) ModelDefaults() *service14.Service {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelDefaultsExpects, m.ctrl, m, "ModelDefaults")
 }
@@ -338,17 +358,17 @@ func (m *MockControllerDomainServices) ModelDefaults() *service13.Service {
 // ModelDefaults indicates an expected call of ModelDefaults.
 func (mr *MockControllerDomainServicesMockRecorder) ModelDefaults() *MockControllerDomainServicesModelDefaultsCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service13.Service](mr.mock.ctrl.T, mr.mock, "ModelDefaults")
+	call := gomock.NewCall0_1[*service14.Service](mr.mock.ctrl.T, mr.mock, "ModelDefaults")
 	mr.modelDefaultsExpects = append(mr.modelDefaultsExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesModelDefaultsCall is the typed call wrapper for ModelDefaults.
-type MockControllerDomainServicesModelDefaultsCall = gomock.Call0_1[*service13.Service]
+type MockControllerDomainServicesModelDefaultsCall = gomock.Call0_1[*service14.Service]
 
 // ModelMigrationImport mocks base method.
-func (m *MockControllerDomainServices) ModelMigrationImport() *service14.WatchableService {
+func (m *MockControllerDomainServices) ModelMigrationImport() *service15.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.modelMigrationImportExpects, m.ctrl, m, "ModelMigrationImport")
 }
@@ -356,14 +376,14 @@ func (m *MockControllerDomainServices) ModelMigrationImport() *service14.Watchab
 // ModelMigrationImport indicates an expected call of ModelMigrationImport.
 func (mr *MockControllerDomainServicesMockRecorder) ModelMigrationImport() *MockControllerDomainServicesModelMigrationImportCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service14.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigrationImport")
+	call := gomock.NewCall0_1[*service15.WatchableService](mr.mock.ctrl.T, mr.mock, "ModelMigrationImport")
 	mr.modelMigrationImportExpects = append(mr.modelMigrationImportExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesModelMigrationImportCall is the typed call wrapper for ModelMigrationImport.
-type MockControllerDomainServicesModelMigrationImportCall = gomock.Call0_1[*service14.WatchableService]
+type MockControllerDomainServicesModelMigrationImportCall = gomock.Call0_1[*service15.WatchableService]
 
 // SSHServerHostKey mocks base method.
 func (m *MockControllerDomainServices) SSHServerHostKey() *controller.Service {
@@ -384,7 +404,7 @@ func (mr *MockControllerDomainServicesMockRecorder) SSHServerHostKey() *MockCont
 type MockControllerDomainServicesSSHServerHostKeyCall = gomock.Call0_1[*controller.Service]
 
 // SecretBackend mocks base method.
-func (m *MockControllerDomainServices) SecretBackend() *service15.WatchableService {
+func (m *MockControllerDomainServices) SecretBackend() *service16.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.secretBackendExpects, m.ctrl, m, "SecretBackend")
 }
@@ -392,17 +412,17 @@ func (m *MockControllerDomainServices) SecretBackend() *service15.WatchableServi
 // SecretBackend indicates an expected call of SecretBackend.
 func (mr *MockControllerDomainServicesMockRecorder) SecretBackend() *MockControllerDomainServicesSecretBackendCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service15.WatchableService](mr.mock.ctrl.T, mr.mock, "SecretBackend")
+	call := gomock.NewCall0_1[*service16.WatchableService](mr.mock.ctrl.T, mr.mock, "SecretBackend")
 	mr.secretBackendExpects = append(mr.secretBackendExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesSecretBackendCall is the typed call wrapper for SecretBackend.
-type MockControllerDomainServicesSecretBackendCall = gomock.Call0_1[*service15.WatchableService]
+type MockControllerDomainServicesSecretBackendCall = gomock.Call0_1[*service16.WatchableService]
 
 // Tracing mocks base method.
-func (m *MockControllerDomainServices) Tracing() *service16.WatchableService {
+func (m *MockControllerDomainServices) Tracing() *service17.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.tracingExpects, m.ctrl, m, "Tracing")
 }
@@ -410,17 +430,17 @@ func (m *MockControllerDomainServices) Tracing() *service16.WatchableService {
 // Tracing indicates an expected call of Tracing.
 func (mr *MockControllerDomainServicesMockRecorder) Tracing() *MockControllerDomainServicesTracingCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service16.WatchableService](mr.mock.ctrl.T, mr.mock, "Tracing")
+	call := gomock.NewCall0_1[*service17.WatchableService](mr.mock.ctrl.T, mr.mock, "Tracing")
 	mr.tracingExpects = append(mr.tracingExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesTracingCall is the typed call wrapper for Tracing.
-type MockControllerDomainServicesTracingCall = gomock.Call0_1[*service16.WatchableService]
+type MockControllerDomainServicesTracingCall = gomock.Call0_1[*service17.WatchableService]
 
 // Upgrade mocks base method.
-func (m *MockControllerDomainServices) Upgrade() *service17.WatchableService {
+func (m *MockControllerDomainServices) Upgrade() *service18.WatchableService {
 	m.ctrl.T.Helper()
 	return gomock.Dispatch0_1(&m.recorder.upgradeExpects, m.ctrl, m, "Upgrade")
 }
@@ -428,11 +448,11 @@ func (m *MockControllerDomainServices) Upgrade() *service17.WatchableService {
 // Upgrade indicates an expected call of Upgrade.
 func (mr *MockControllerDomainServicesMockRecorder) Upgrade() *MockControllerDomainServicesUpgradeCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall0_1[*service17.WatchableService](mr.mock.ctrl.T, mr.mock, "Upgrade")
+	call := gomock.NewCall0_1[*service18.WatchableService](mr.mock.ctrl.T, mr.mock, "Upgrade")
 	mr.upgradeExpects = append(mr.upgradeExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockControllerDomainServicesUpgradeCall is the typed call wrapper for Upgrade.
-type MockControllerDomainServicesUpgradeCall = gomock.Call0_1[*service17.WatchableService]
+type MockControllerDomainServicesUpgradeCall = gomock.Call0_1[*service18.WatchableService]

--- a/core/backups/create.go
+++ b/core/backups/create.go
@@ -113,12 +113,28 @@ func Create(meta *Metadata, args CreateArgs) (string, error) {
 	if err != nil {
 		return "", errors.Capture(err)
 	}
-
+	// The archive now exists under its final name. Every failure from
+	// here on must discard it: buildArchiveAndChecksum cleans up after
+	// its own failures, but a stray archive left behind here is one the
+	// caller was told was never created, and it still shows up to list
+	// and download. Any step added below has to do the same.
 	if err := meta.MarkComplete(size, checksum, args.Clock.Now()); err != nil {
-		return "", errors.Errorf("updating metadata: %w", err)
+		return "", discardArchive(filename,
+			errors.Errorf("updating metadata: %w", err))
 	}
 
 	return filename, nil
+}
+
+// discardArchive removes a written archive that its caller is about to
+// report as failed, and returns the failure to report. A removal error
+// is folded into it rather than swallowed, since it leaves exactly the
+// stray archive the removal was there to prevent.
+func discardArchive(filename string, err error) error {
+	if rerr := os.Remove(filename); rerr != nil && !os.IsNotExist(rerr) {
+		return errors.Errorf("%w (also removing %q: %v)", err, filename, rerr)
+	}
+	return err
 }
 
 // checkDestinationDir ensures the backup destination directory is

--- a/core/backups/create_test.go
+++ b/core/backups/create_test.go
@@ -236,3 +236,38 @@ func (s *createSuite) TestBuildArchiveAndChecksumFailureRemovesArchive(c *tc.C) 
 	_, err = os.Stat(filename)
 	c.Assert(err, tc.ErrorIs, os.ErrNotExist)
 }
+
+// TestCreateMetadataFailureRemovesArchive verifies that a failure after
+// the archive has been written removes it: Create reporting an error
+// must not leave a stray archive in the destination directory for
+// listing and download to find.
+func (s *createSuite) TestCreateMetadataFailureRemovesArchive(c *tc.C) {
+	destDir := c.MkDir()
+	file := s.writeFile(c, "jujud", "agent binary")
+
+	// Metadata that already carries file info fails MarkComplete, which
+	// runs only once the archive file is complete.
+	meta := backups.NewMetadata(testStarted)
+	c.Assert(meta.SetFileInfo(99, "not-the-real-checksum",
+		"SHA-1, base64 encoded"), tc.ErrorIsNil)
+
+	_, err := backups.Create(meta, backups.CreateArgs{
+		DestinationDir: destDir,
+		Clock:          clock.WallClock,
+		FilesToBackUp:  []string{file},
+		DumpEntries: []backups.DumpEntry{{
+			Name:   "controller.yaml",
+			Reader: strings.NewReader("controller: data"),
+		}},
+	})
+	c.Assert(err, tc.ErrorMatches, "updating metadata: .*")
+
+	// Neither the archive nor a staging directory is left behind.
+	entries, rerr := os.ReadDir(destDir)
+	c.Assert(rerr, tc.ErrorIsNil)
+	var left []string
+	for _, entry := range entries {
+		left = append(left, entry.Name())
+	}
+	c.Check(left, tc.HasLen, 0, tc.Commentf("left behind: %v", left))
+}

--- a/core/backups/dump.go
+++ b/core/backups/dump.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/juju/juju/internal/errors"
+)
+
+// DumpExportFunc marshals one database dump into writer. Implementations
+// must stream (e.g. yaml.Encoder), so the dump's bytes never accumulate in
+// memory.
+type DumpExportFunc func(ctx context.Context, writer io.Writer) error
+
+// NamedDump pairs a dump entry name with the function producing its
+// contents, e.g. "controller.yaml" or "models/<uuid>.yaml".
+type NamedDump struct {
+	Name   string
+	Export DumpExportFunc
+}
+
+// DumpStaging is a directory of staged database dumps. Its files feed
+// directly into [Create] as [DumpEntry] readers. Close must be called once
+// the dumps have been archived; it releases the readers and removes the
+// staging directory, so a failed archive creation leaves no partial dumps
+// behind.
+type DumpStaging struct {
+	dir     string
+	entries []DumpEntry
+	files   []*os.File
+}
+
+// Entries returns the dump entries to pass to [Create].
+func (s *DumpStaging) Entries() []DumpEntry {
+	return s.entries
+}
+
+// Size returns the total size in bytes of the staged dumps.
+func (s *DumpStaging) Size() int64 {
+	var size int64
+	for _, file := range s.files {
+		if info, err := file.Stat(); err == nil {
+			size += info.Size()
+		}
+	}
+	return size
+}
+
+// Close closes the staged dump readers and removes the staging directory.
+func (s *DumpStaging) Close() {
+	for _, file := range s.files {
+		_ = file.Close()
+	}
+	_ = os.RemoveAll(s.dir)
+}
+
+// StageDumps marshals each dump into a temporary directory inside dir and
+// returns the staging handle holding the resulting entries. The caller must
+// create dir beforehand and must keep the handle open until the dumps have
+// been archived, then Close it.
+func StageDumps(ctx context.Context, dir string, dumps []NamedDump) (*DumpStaging, error) {
+	stagingDir, err := os.MkdirTemp(dir, "juju-backup-dump-")
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	staging := &DumpStaging{dir: stagingDir}
+	// On any failure the readers opened so far are closed and the staging
+	// directory removed; on success ownership passes to the caller.
+	defer func() {
+		if staging != nil {
+			staging.Close()
+		}
+	}()
+
+	for _, dump := range dumps {
+		file, err := stageDump(ctx, stagingDir, dump.Name, dump.Export)
+		if err != nil {
+			return nil, err
+		}
+		staging.files = append(staging.files, file)
+		staging.entries = append(staging.entries, DumpEntry{
+			Name:   dump.Name,
+			Reader: file,
+		})
+	}
+
+	result := staging
+	staging = nil
+	return result, nil
+}
+
+// stageDump marshals one dump to a temporary file under dir and reopens it
+// for reading.
+func stageDump(ctx context.Context, dir, name string, export DumpExportFunc) (*os.File, error) {
+	target := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
+		return nil, errors.Capture(err)
+	}
+	file, err := os.Create(target)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	if err := export(ctx, file); err != nil {
+		_ = file.Close()
+		return nil, errors.Capture(err)
+	}
+	if err := file.Close(); err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	file, err = os.Open(target)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return file, nil
+}
+
+// YAMLDump returns a DumpExportFunc that streams v as YAML into the writer.
+func YAMLDump(v any) DumpExportFunc {
+	return func(_ context.Context, writer io.Writer) error {
+		encoder := yaml.NewEncoder(writer)
+		if err := encoder.Encode(v); err != nil {
+			return errors.Capture(err)
+		}
+		return errors.Capture(encoder.Close())
+	}
+}
+
+// WalkDumps reads every staged dump back from dir, passing each file's
+// archive-relative name and contents to fn. It is the read side of
+// [StageDumps], used when restoring a backup.
+func WalkDumps(ctx context.Context, dir string, fn func(name string, reader io.Reader) error) error {
+	return errors.Capture(filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name, err := filepath.Rel(dir, path)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		defer file.Close()
+		return fn(filepath.ToSlash(name), file)
+	}))
+}

--- a/core/backups/dump.go
+++ b/core/backups/dump.go
@@ -55,11 +55,21 @@ func (s *DumpStaging) Size() int64 {
 }
 
 // Close closes the staged dump readers and removes the staging directory.
-func (s *DumpStaging) Close() {
+// Close and remove failures are returned rather than swallowed, but the
+// caller is expected to invoke Close from a deferred cleanup path and only
+// log the error: it must not mask the result of the operation Close is
+// cleaning up after.
+func (s *DumpStaging) Close() error {
+	var errs []error
 	for _, file := range s.files {
-		_ = file.Close()
+		if err := file.Close(); err != nil {
+			errs = append(errs, errors.Errorf("closing staged dump %q: %w", file.Name(), err))
+		}
 	}
-	_ = os.RemoveAll(s.dir)
+	if err := os.RemoveAll(s.dir); err != nil {
+		errs = append(errs, errors.Errorf("removing staging directory %q: %w", s.dir, err))
+	}
+	return errors.Capture(errors.Join(errs...))
 }
 
 // StageDumps marshals each dump into a temporary directory inside dir and
@@ -77,7 +87,9 @@ func StageDumps(ctx context.Context, dir string, dumps []NamedDump) (*DumpStagin
 	// directory removed; on success ownership passes to the caller.
 	defer func() {
 		if staging != nil {
-			staging.Close()
+			// The staging directory is internal to StageDumps here, so a
+			// cleanup failure on this path has no caller to report to.
+			_ = staging.Close()
 		}
 	}()
 

--- a/core/backups/dump.go
+++ b/core/backups/dump.go
@@ -44,14 +44,16 @@ func (s *DumpStaging) Entries() []DumpEntry {
 }
 
 // Size returns the total size in bytes of the staged dumps.
-func (s *DumpStaging) Size() int64 {
+func (s *DumpStaging) Size() (int64, error) {
 	var size int64
 	for _, file := range s.files {
-		if info, err := file.Stat(); err == nil {
-			size += info.Size()
+		info, err := file.Stat()
+		if err != nil {
+			return 0, errors.Capture(err)
 		}
+		size += info.Size()
 	}
-	return size
+	return size, nil
 }
 
 // Close closes the staged dump readers and removes the staging directory.
@@ -117,7 +119,7 @@ func stageDump(ctx context.Context, dir, name string, export DumpExportFunc) (*o
 	if err := os.MkdirAll(filepath.Dir(target), 0700); err != nil {
 		return nil, errors.Capture(err)
 	}
-	file, err := os.Create(target)
+	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -150,6 +152,12 @@ func YAMLDump(v any) DumpExportFunc {
 // WalkDumps reads every staged dump back from dir, passing each file's
 // archive-relative name and contents to fn. It is the read side of
 // [StageDumps], used when restoring a backup.
+//
+// The fn callback receives each file as a reader that will be closed when fn
+// returns. The callback must fully consume the reader before returning; any
+// data left unread is lost because the underlying file is closed immediately
+// after fn returns. Storing the reader for later use (e.g. in a goroutine)
+// is not safe.
 func WalkDumps(ctx context.Context, dir string, fn func(name string, reader io.Reader) error) error {
 	return errors.Capture(filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/core/backups/dump.go
+++ b/core/backups/dump.go
@@ -125,14 +125,17 @@ func stageDump(ctx context.Context, dir, name string, export DumpExportFunc) (*o
 	}
 	if err := export(ctx, file); err != nil {
 		_ = file.Close()
+		_ = os.Remove(target)
 		return nil, errors.Capture(err)
 	}
 	if err := file.Close(); err != nil {
+		_ = os.Remove(target)
 		return nil, errors.Capture(err)
 	}
 
 	file, err = os.Open(target)
 	if err != nil {
+		_ = os.Remove(target)
 		return nil, errors.Capture(err)
 	}
 	return file, nil

--- a/core/backups/dump_test.go
+++ b/core/backups/dump_test.go
@@ -51,7 +51,7 @@ func (s *dumpSuite) TestStageDumps(c *tc.C) {
 	c.Check(string(contents), tc.Equals, "controller: data\n")
 	c.Check(staging.Size() > 0, tc.IsTrue, tc.Commentf("size must be positive"))
 
-	staging.Close()
+	c.Assert(staging.Close(), tc.ErrorIsNil)
 	entries, err := os.ReadDir(dir)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(entries, tc.HasLen, 0)

--- a/core/backups/dump_test.go
+++ b/core/backups/dump_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package backups_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	stdtesting "testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/backups"
+	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/testing"
+)
+
+type dumpSuite struct {
+	testing.BaseSuite
+}
+
+func TestDumpSuite(t *stdtesting.T) {
+	tc.Run(t, &dumpSuite{})
+}
+
+// TestStageDumps verifies that staged dumps land on disk as readable files
+// whose contents match what the export functions streamed, that the staging
+// handle reports their total size and feeds them to Create as dump entries,
+// and that Close removes the staging directory.
+func (s *dumpSuite) TestStageDumps(c *tc.C) {
+	dir := c.MkDir()
+	dumps := []backups.NamedDump{{
+		Name:   "controller.yaml",
+		Export: backups.YAMLDump(map[string]string{"controller": "data"}),
+	}, {
+		Name:   "models/model.yaml",
+		Export: backups.YAMLDump(map[string]string{"model": "data"}),
+	}}
+
+	staging, err := backups.StageDumps(c.Context(), dir, dumps)
+	c.Assert(err, tc.ErrorIsNil)
+
+	c.Assert(staging.Entries(), tc.HasLen, 2)
+	c.Check(staging.Entries()[0].Name, tc.Equals, "controller.yaml")
+	c.Check(staging.Entries()[1].Name, tc.Equals, "models/model.yaml")
+
+	contents, err := io.ReadAll(staging.Entries()[0].Reader)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(string(contents), tc.Equals, "controller: data\n")
+	c.Check(staging.Size() > 0, tc.IsTrue, tc.Commentf("size must be positive"))
+
+	staging.Close()
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(entries, tc.HasLen, 0)
+}
+
+// TestStageDumpsExportError verifies that an export failure aborts staging
+// and leaves no partial dumps behind.
+func (s *dumpSuite) TestStageDumpsExportError(c *tc.C) {
+	dir := c.MkDir()
+	dumps := []backups.NamedDump{{
+		Name:   "controller.yaml",
+		Export: backups.YAMLDump(map[string]string{"controller": "data"}),
+	}, {
+		Name: "broken.yaml",
+		Export: func(context.Context, io.Writer) error {
+			return errors.New("export failed")
+		},
+	}}
+
+	_, err := backups.StageDumps(c.Context(), dir, dumps)
+	c.Assert(err, tc.ErrorMatches, "export failed")
+
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(entries, tc.HasLen, 0)
+}
+
+// TestWalkDumps verifies that WalkDumps visits each staged file with its
+// archive-relative name and contents.
+func (s *dumpSuite) TestWalkDumps(c *tc.C) {
+	dir := c.MkDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "controller.yaml"), []byte("controller: data\n"), 0644), tc.ErrorIsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dir, "models"), 0755), tc.ErrorIsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "models", "model.yaml"), []byte("model: data\n"), 0644), tc.ErrorIsNil)
+
+	visited := map[string]string{}
+	err := backups.WalkDumps(c.Context(), dir, func(name string, reader io.Reader) error {
+		contents, err := io.ReadAll(reader)
+		if err != nil {
+			return err
+		}
+		visited[name] = string(contents)
+		return nil
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(visited, tc.DeepEquals, map[string]string{
+		"controller.yaml":   "controller: data\n",
+		"models/model.yaml": "model: data\n",
+	})
+}

--- a/core/backups/dump_test.go
+++ b/core/backups/dump_test.go
@@ -49,7 +49,9 @@ func (s *dumpSuite) TestStageDumps(c *tc.C) {
 	contents, err := io.ReadAll(staging.Entries()[0].Reader)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(string(contents), tc.Equals, "controller: data\n")
-	c.Check(staging.Size() > 0, tc.IsTrue, tc.Commentf("size must be positive"))
+	sz, err := staging.Size()
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(sz > 0, tc.IsTrue, tc.Commentf("size must be positive"))
 
 	c.Assert(staging.Close(), tc.ErrorIsNil)
 	entries, err := os.ReadDir(dir)

--- a/core/backups/files.go
+++ b/core/backups/files.go
@@ -16,8 +16,6 @@ import (
 // Pull these from authoritative sources (see
 // github.com/juju/juju/juju/paths, etc.):
 const (
-	sshDir = "/home/ubuntu/.ssh"
-
 	agentsDir      = "agents"
 	agentsConfs    = "machine-*"
 	toolsDir       = "tools"
@@ -35,6 +33,13 @@ const (
 	nonceFile    = "nonce.txt"
 	authKeysFile = "authorized_keys"
 )
+
+// SSHDir is the host directory holding the ubuntu user's SSH files. It
+// is a variable so tests can redirect the lookup into their own tree:
+// on hosts where the directory exists but is not readable by the test
+// user, the fatal stat failure would make results depend on the test
+// runner.
+var SSHDir = "/home/ubuntu/.ssh"
 
 // BackupDirToUse returns the desired backup staging dir.
 func BackupDirToUse(configuredDir string) string {
@@ -75,7 +80,7 @@ func GetFilesToBackUp(rootDir string, paths *Paths) ([]string, error) {
 		filepath.Join(rootDir, paths.DataDir, serverPEM),
 		filepath.Join(rootDir, paths.DataDir, dbSecret),
 		filepath.Join(rootDir, paths.DataDir, nonceFile),
-		filepath.Join(rootDir, sshDir, authKeysFile),
+		filepath.Join(rootDir, SSHDir, authKeysFile),
 	}
 	for _, file := range optional {
 		if _, err := os.Stat(file); err != nil {

--- a/domain/services/controller.go
+++ b/domain/services/controller.go
@@ -31,6 +31,8 @@ import (
 	controllernodestate "github.com/juju/juju/domain/controllernode/state"
 	credentialservice "github.com/juju/juju/domain/credential/service"
 	credentialstate "github.com/juju/juju/domain/credential/state"
+	exportservice "github.com/juju/juju/domain/export/service"
+	controllerexportstate "github.com/juju/juju/domain/export/state/controller"
 	externalcontrollerservice "github.com/juju/juju/domain/externalcontroller/service"
 	externalcontrollerstate "github.com/juju/juju/domain/externalcontroller/state"
 	flagservice "github.com/juju/juju/domain/flag/service"
@@ -89,6 +91,13 @@ func NewControllerServices(
 func (s *ControllerServices) Controller() *controllerservice.Service {
 	return controllerservice.NewService(
 		controllerstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
+	)
+}
+
+// ControllerExport returns the controller export service.
+func (s *ControllerServices) ControllerExport() *exportservice.ControllerService {
+	return exportservice.NewControllerService(
+		controllerexportstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 	)
 }
 

--- a/internal/migration/domainservices_mock_test.go
+++ b/internal/migration/domainservices_mock_test.go
@@ -141,6 +141,7 @@ type MockDomainServicesMockRecorder struct {
 	controllerAgentBinaryStoreExpects []*gomock.Call0_1[*service0.AgentBinaryStore]
 	controllerChangeStreamExpects     []*gomock.Call0_1[*service8.Service]
 	controllerConfigExpects           []*gomock.Call0_1[*service12.WatchableService]
+	controllerExportExpects           []*gomock.Call0_1[*service17.ControllerService]
 	controllerNodeExpects             []*gomock.Call0_1[*service13.WatchableService]
 	controllerUpgraderExpects         []*gomock.Call0_1[*service14.Service]
 	credentialExpects                 []*gomock.Call0_1[*service15.WatchableService]
@@ -536,6 +537,24 @@ func (mr *MockDomainServicesMockRecorder) ControllerConfig() *MockDomainServices
 
 // MockDomainServicesControllerConfigCall is the typed call wrapper for ControllerConfig.
 type MockDomainServicesControllerConfigCall = gomock.Call0_1[*service12.WatchableService]
+
+// ControllerExport mocks base method.
+func (m *MockDomainServices) ControllerExport() *service17.ControllerService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.controllerExportExpects, m.ctrl, m, "ControllerExport")
+}
+
+// ControllerExport indicates an expected call of ControllerExport.
+func (mr *MockDomainServicesMockRecorder) ControllerExport() *MockDomainServicesControllerExportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service17.ControllerService](mr.mock.ctrl.T, mr.mock, "ControllerExport")
+	mr.controllerExportExpects = append(mr.controllerExportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockDomainServicesControllerExportCall is the typed call wrapper for ControllerExport.
+type MockDomainServicesControllerExportCall = gomock.Call0_1[*service17.ControllerService]
 
 // ControllerNode mocks base method.
 func (m *MockDomainServices) ControllerNode() *service13.WatchableService {

--- a/internal/services/interface.go
+++ b/internal/services/interface.go
@@ -111,6 +111,10 @@ type ControllerDomainServices interface {
 	Logging() *loggingservice.WatchableService
 	// SSHServerHostKey returns the service for controller SSH server host keys.
 	SSHServerHostKey() *sshcontrollerservice.Service
+	// ControllerExport returns the controller export service. It is named
+	// ControllerExport because [ModelDomainServices.Export] already occupies
+	// Export in the embedded [DomainServices] union.
+	ControllerExport() *exportservice.ControllerService
 }
 
 // ModelDomainServices provides access to the services required by the

--- a/internal/worker/bootstrap/domainservices_mock_test.go
+++ b/internal/worker/bootstrap/domainservices_mock_test.go
@@ -94,6 +94,7 @@ type MockDomainServicesMockRecorder struct {
 	controllerAgentBinaryStoreExpects []*gomock.Call0_1[*service0.AgentBinaryStore]
 	controllerChangeStreamExpects     []*gomock.Call0_1[*service8.Service]
 	controllerConfigExpects           []*gomock.Call0_1[*service12.WatchableService]
+	controllerExportExpects           []*gomock.Call0_1[*service17.ControllerService]
 	controllerNodeExpects             []*gomock.Call0_1[*service13.WatchableService]
 	controllerUpgraderExpects         []*gomock.Call0_1[*service14.Service]
 	credentialExpects                 []*gomock.Call0_1[*service15.WatchableService]
@@ -489,6 +490,24 @@ func (mr *MockDomainServicesMockRecorder) ControllerConfig() *MockDomainServices
 
 // MockDomainServicesControllerConfigCall is the typed call wrapper for ControllerConfig.
 type MockDomainServicesControllerConfigCall = gomock.Call0_1[*service12.WatchableService]
+
+// ControllerExport mocks base method.
+func (m *MockDomainServices) ControllerExport() *service17.ControllerService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.controllerExportExpects, m.ctrl, m, "ControllerExport")
+}
+
+// ControllerExport indicates an expected call of ControllerExport.
+func (mr *MockDomainServicesMockRecorder) ControllerExport() *MockDomainServicesControllerExportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service17.ControllerService](mr.mock.ctrl.T, mr.mock, "ControllerExport")
+	mr.controllerExportExpects = append(mr.controllerExportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockDomainServicesControllerExportCall is the typed call wrapper for ControllerExport.
+type MockDomainServicesControllerExportCall = gomock.Call0_1[*service17.ControllerService]
 
 // ControllerNode mocks base method.
 func (m *MockDomainServices) ControllerNode() *service13.WatchableService {

--- a/internal/worker/domainservices/domainservices_mock_test.go
+++ b/internal/worker/domainservices/domainservices_mock_test.go
@@ -86,6 +86,7 @@ type MockControllerDomainServicesMockRecorder struct {
 	controllerAgentBinaryStoreExpects []*gomock.Call0_1[*service0.AgentBinaryStore]
 	controllerChangeStreamExpects     []*gomock.Call0_1[*service8.Service]
 	controllerConfigExpects           []*gomock.Call0_1[*service12.WatchableService]
+	controllerExportExpects           []*gomock.Call0_1[*service17.ControllerService]
 	controllerNodeExpects             []*gomock.Call0_1[*service13.WatchableService]
 	credentialExpects                 []*gomock.Call0_1[*service15.WatchableService]
 	externalControllerExpects         []*gomock.Call0_1[*service18.WatchableService]
@@ -238,6 +239,24 @@ func (mr *MockControllerDomainServicesMockRecorder) ControllerConfig() *MockCont
 
 // MockControllerDomainServicesControllerConfigCall is the typed call wrapper for ControllerConfig.
 type MockControllerDomainServicesControllerConfigCall = gomock.Call0_1[*service12.WatchableService]
+
+// ControllerExport mocks base method.
+func (m *MockControllerDomainServices) ControllerExport() *service17.ControllerService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.controllerExportExpects, m.ctrl, m, "ControllerExport")
+}
+
+// ControllerExport indicates an expected call of ControllerExport.
+func (mr *MockControllerDomainServicesMockRecorder) ControllerExport() *MockControllerDomainServicesControllerExportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service17.ControllerService](mr.mock.ctrl.T, mr.mock, "ControllerExport")
+	mr.controllerExportExpects = append(mr.controllerExportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockControllerDomainServicesControllerExportCall is the typed call wrapper for ControllerExport.
+type MockControllerDomainServicesControllerExportCall = gomock.Call0_1[*service17.ControllerService]
 
 // ControllerNode mocks base method.
 func (m *MockControllerDomainServices) ControllerNode() *service13.WatchableService {
@@ -1267,6 +1286,7 @@ type MockDomainServicesMockRecorder struct {
 	controllerAgentBinaryStoreExpects []*gomock.Call0_1[*service0.AgentBinaryStore]
 	controllerChangeStreamExpects     []*gomock.Call0_1[*service8.Service]
 	controllerConfigExpects           []*gomock.Call0_1[*service12.WatchableService]
+	controllerExportExpects           []*gomock.Call0_1[*service17.ControllerService]
 	controllerNodeExpects             []*gomock.Call0_1[*service13.WatchableService]
 	controllerUpgraderExpects         []*gomock.Call0_1[*service14.Service]
 	credentialExpects                 []*gomock.Call0_1[*service15.WatchableService]
@@ -1662,6 +1682,24 @@ func (mr *MockDomainServicesMockRecorder) ControllerConfig() *MockDomainServices
 
 // MockDomainServicesControllerConfigCall is the typed call wrapper for ControllerConfig.
 type MockDomainServicesControllerConfigCall = gomock.Call0_1[*service12.WatchableService]
+
+// ControllerExport mocks base method.
+func (m *MockDomainServices) ControllerExport() *service17.ControllerService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.controllerExportExpects, m.ctrl, m, "ControllerExport")
+}
+
+// ControllerExport indicates an expected call of ControllerExport.
+func (mr *MockDomainServicesMockRecorder) ControllerExport() *MockDomainServicesControllerExportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service17.ControllerService](mr.mock.ctrl.T, mr.mock, "ControllerExport")
+	mr.controllerExportExpects = append(mr.controllerExportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockDomainServicesControllerExportCall is the typed call wrapper for ControllerExport.
+type MockDomainServicesControllerExportCall = gomock.Call0_1[*service17.ControllerService]
 
 // ControllerNode mocks base method.
 func (m *MockDomainServices) ControllerNode() *service13.WatchableService {

--- a/internal/worker/modelworkermanager/domainservices_mock_test.go
+++ b/internal/worker/modelworkermanager/domainservices_mock_test.go
@@ -98,6 +98,7 @@ type MockDomainServicesMockRecorder struct {
 	controllerAgentBinaryStoreExpects []*gomock.Call0_1[*service0.AgentBinaryStore]
 	controllerChangeStreamExpects     []*gomock.Call0_1[*service8.Service]
 	controllerConfigExpects           []*gomock.Call0_1[*service12.WatchableService]
+	controllerExportExpects           []*gomock.Call0_1[*service17.ControllerService]
 	controllerNodeExpects             []*gomock.Call0_1[*service13.WatchableService]
 	controllerUpgraderExpects         []*gomock.Call0_1[*service14.Service]
 	credentialExpects                 []*gomock.Call0_1[*service15.WatchableService]
@@ -493,6 +494,24 @@ func (mr *MockDomainServicesMockRecorder) ControllerConfig() *MockDomainServices
 
 // MockDomainServicesControllerConfigCall is the typed call wrapper for ControllerConfig.
 type MockDomainServicesControllerConfigCall = gomock.Call0_1[*service12.WatchableService]
+
+// ControllerExport mocks base method.
+func (m *MockDomainServices) ControllerExport() *service17.ControllerService {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.controllerExportExpects, m.ctrl, m, "ControllerExport")
+}
+
+// ControllerExport indicates an expected call of ControllerExport.
+func (mr *MockDomainServicesMockRecorder) ControllerExport() *MockDomainServicesControllerExportCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[*service17.ControllerService](mr.mock.ctrl.T, mr.mock, "ControllerExport")
+	mr.controllerExportExpects = append(mr.controllerExportExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockDomainServicesControllerExportCall is the typed call wrapper for ControllerExport.
+type MockDomainServicesControllerExportCall = gomock.Call0_1[*service17.ControllerService]
 
 // ControllerNode mocks base method.
 func (m *MockDomainServices) ControllerNode() *service13.WatchableService {


### PR DESCRIPTION
Since the port to Dqlite, backups have never been implemented: the
Create method of the client Backups facade only returned a not-implemented
error, and `juju create-backup` always failed. This change provides the first
real implementation. Creating a backup now exports the controller database
and one export per model, bundles those dumps together with the controller's
data directory files into an archive, and stores it in the configured backup
directory on the controller machine. It also restores the superuser access
check that was left as a `TODO` when the old implementation was removed, and
any failure aborts the request so no partial archives are left behind.

To reach every model's database, the facade registration moves to the
multi-model registry, which lets it resolve the export service of each model
at request time. A `ControllerExport` accessor is added to the controller
domain services so the facade can also export the controller database. It is
named `ControllerExport` because the plain Export name is already taken by the
model export service in the shared services interface.

The download path is not wired yet, so only `juju create-backup
--no-download` works end to end with this change; downloading the archive
from the controller comes in a follow-up. The origin base field in the
metadata is left empty for now, as there is no cheap machine base lookup
available in this facade.

## QA steps

The download endpoint is not wired yet, so QA covers only the
`--no-download` path; the archive stays on the controller machine.

 1. Bootstrap a 4.0 controller with the changes and deploy a charm.

```sh
$ juju bootstrap lxd backups
$ juju add-model moveme
$ juju deploy juju-qa-test
 ```

 2. Create a backup without downloading it.

 ```sh
$ juju create-backup --no-download
 ```

 3. Verify the archive exists on the controller machine and contains the
    controller dump, one dump per model, the metadata and the files bundle.

 ```sh
$ juju ssh -m controller 0
$ ls /tmp/juju-backup-*.tar.gz
$ tar -tzf /tmp/juju-backup-*.tar.gz
 ```

 ```
Expected entries: `juju-backup/dump/controller.yaml`,
`juju-backup/dump/models/<uuid>.yaml` for each model,
`juju-backup/metadata.json` and `juju-backup/root.tar`.
 ```

 4. Verify no errors exist in the model logs for the agents.

 ```sh
$ juju debug-log -m controller
$ juju debug-log -m moveme
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10305](https://warthogs.atlassian.net/browse/JUJU-10305)


[JUJU-10305]: https://warthogs.atlassian.net/browse/JUJU-10305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ