### PR TITLE
feat(apiserver): serve backup archive downloads

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -976,6 +976,15 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		handler:    unitResourcesHandler,
 		authorizer: httpcontext.TODOAuthorizer,
 	}, {
+		pattern: modelRoutePrefix + "/backups",
+		methods: []string{"GET"},
+		handler: &backupsDownloadHandler{
+			domainServicesGetter: srv.shared.domainServicesGetter,
+			controllerModelUUID:  srv.shared.controllerModelUUID,
+			logger:               srv.shared.logger,
+		},
+		authorizer: controllerAdminAuthorizer,
+	}, {
 		pattern:    "/migrate/charms/:object",
 		handler:    migrateObjectsCharmsHTTPHandler,
 		authorizer: controllerAdminAuthorizer,

--- a/apiserver/backups.go
+++ b/apiserver/backups.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	corebackups "github.com/juju/juju/core/backups"
+	corelogger "github.com/juju/juju/core/logger"
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/internal/services"
+	"github.com/juju/juju/rpc/params"
+)
+
+// backupsDownloadHandler streams a backup archive out of the controller
+// model's backup directory over HTTP. The archive is removed from disk on
+// successful copy, matching Juju 3.6 one-shot download semantics.
+type backupsDownloadHandler struct {
+	domainServicesGetter services.DomainServicesGetter
+	controllerModelUUID  coremodel.UUID
+	logger               corelogger.Logger
+}
+
+// ServeHTTP handles a backup download request. The request body carries a
+// JSON-encoded [params.BackupsDownloadArgs] naming the archive to fetch.
+func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var args params.BackupsDownloadArgs
+	if err := json.NewDecoder(r.Body).Decode(&args); err != nil {
+		http.Error(w, "decoding download args: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Resolve the backup directory from the controller model config. The
+	// mirror of juju-backup staging semantics is kept per-request, as 3.6
+	// resolved it through the filestorage layer on every Get call.
+	domainServices, err := h.domainServicesGetter.ServicesForModel(ctx, h.controllerModelUUID)
+	if err != nil {
+		http.Error(w, "resolving domain services: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	cfg, err := domainServices.Config().ModelConfig(ctx)
+	if err != nil {
+		http.Error(w, "resolving model config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	backupDir := corebackups.BackupDirToUse(cfg.BackupDir())
+
+	// Reject ids that are not a clearly named archive under the backup dir.
+	valid, err := corebackups.IsValidBackupFilepath(backupDir, args.ID)
+	if err != nil {
+		http.Error(w, "validating archive path: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !valid {
+		http.Error(w, "invalid backup archive id", http.StatusBadRequest)
+		return
+	}
+
+	file, err := os.Open(args.ID)
+	if err != nil {
+		http.Error(w, "opening archive: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer file.Close()
+
+	fi, err := file.Stat()
+	if err != nil {
+		http.Error(w, "stating archive: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Stream the archive. ServeContent handles range and head requests.
+	http.ServeContent(w, r, fi.Name(), fi.ModTime(), file)
+
+	// One-shot semantics: remove the archive after serving it, as 3.6 did.
+	if err := os.Remove(args.ID); err != nil && !os.IsNotExist(err) {
+		h.logger.Warningf(ctx, "error removing backup archive: %v", err)
+	}
+}

--- a/apiserver/backups.go
+++ b/apiserver/backups.go
@@ -4,13 +4,21 @@
 package apiserver
 
 import (
+	"context"
+	"crypto/sha1"
+	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 
+	jujuerrors "github.com/juju/errors"
+
+	internalhttp "github.com/juju/juju/apiserver/internal/http"
 	corebackups "github.com/juju/juju/core/backups"
 	corelogger "github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/services"
 	"github.com/juju/juju/rpc/params"
 )
@@ -31,7 +39,7 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	var args params.BackupsDownloadArgs
 	if err := json.NewDecoder(r.Body).Decode(&args); err != nil {
-		http.Error(w, "decoding download args: "+err.Error(), http.StatusBadRequest)
+		h.sendError(w, jujuerrors.BadRequestf("decoding download args"))
 		return
 	}
 
@@ -40,12 +48,12 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	// resolved it through the filestorage layer on every Get call.
 	domainServices, err := h.domainServicesGetter.ServicesForModel(ctx, h.controllerModelUUID)
 	if err != nil {
-		http.Error(w, "resolving domain services: "+err.Error(), http.StatusInternalServerError)
+		h.sendError(w, errors.Errorf("resolving domain services: %w", err))
 		return
 	}
 	cfg, err := domainServices.Config().ModelConfig(ctx)
 	if err != nil {
-		http.Error(w, "resolving model config: "+err.Error(), http.StatusInternalServerError)
+		h.sendError(w, errors.Errorf("resolving model config: %w", err))
 		return
 	}
 	backupDir := corebackups.BackupDirToUse(cfg.BackupDir())
@@ -53,26 +61,40 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	// Reject ids that are not a clearly named archive under the backup dir.
 	valid, err := corebackups.IsValidBackupFilepath(backupDir, args.ID)
 	if err != nil {
-		http.Error(w, "validating archive path: "+err.Error(), http.StatusInternalServerError)
+		h.sendError(w, errors.Errorf("validating archive path: %w", err))
 		return
 	}
 	if !valid {
-		http.Error(w, "invalid backup archive id", http.StatusBadRequest)
+		h.sendError(w, jujuerrors.BadRequestf("invalid backup archive id"))
 		return
 	}
 
 	file, err := os.Open(args.ID)
 	if err != nil {
-		http.Error(w, "opening archive: "+err.Error(), http.StatusInternalServerError)
+		h.sendError(w, errors.Errorf("opening archive: %w", err))
 		return
 	}
 	defer file.Close()
 
 	fi, err := file.Stat()
 	if err != nil {
-		http.Error(w, "stating archive: "+err.Error(), http.StatusInternalServerError)
+		h.sendError(w, errors.Errorf("stating archive: %w", err))
 		return
 	}
+
+	// Compute the archive checksum for the Digest header, as the 3.6
+	// handler did. The checksum is over the gzipped archive bytes.
+	checksum, err := archiveChecksum(file)
+	if err != nil {
+		h.sendError(w, errors.Errorf("checksumming archive: %w", err))
+		return
+	}
+
+	// ServeContent sets Content-Type from the file extension; the raw
+	// archive type and digest headers are set explicitly to match the
+	// 3.6 download response.
+	w.Header().Set("Content-Type", params.ContentTypeRaw)
+	w.Header().Set("Digest", params.EncodeChecksum(checksum))
 
 	// Stream the archive. ServeContent handles range and head requests.
 	http.ServeContent(w, r, fi.Name(), fi.ModTime(), file)
@@ -81,4 +103,28 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	if err := os.Remove(args.ID); err != nil && !os.IsNotExist(err) {
 		h.logger.Warningf(ctx, "error removing backup archive: %v", err)
 	}
+}
+
+// sendError logs the internal error detail and replies with a structured
+// JSON error, so internal state (paths, model UUIDs, DB errors) is not
+// leaked to the client beyond the classified error.
+func (h *backupsDownloadHandler) sendError(w http.ResponseWriter, err error) {
+	h.logger.Debugf(context.TODO(), "backup download error: %v", err)
+	if err := internalhttp.SendError(w, err, h.logger); err != nil {
+		h.logger.Errorf(context.TODO(), "sending backup download error: %v", err)
+	}
+}
+
+// archiveChecksum returns the base64-encoded SHA-1 checksum of the
+// archive, matching the format recorded in the backup metadata. The
+// file offset is reset so the caller can stream the file afterwards.
+func archiveChecksum(file *os.File) (string, error) {
+	hasher := sha1.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", errors.Capture(err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", errors.Capture(err)
+	}
+	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
 }

--- a/apiserver/backups.go
+++ b/apiserver/backups.go
@@ -5,8 +5,7 @@ package apiserver
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/base64"
+	"crypto/sha256"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -39,7 +38,7 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	var args params.BackupsDownloadArgs
 	if err := json.NewDecoder(r.Body).Decode(&args); err != nil {
-		h.sendError(w, jujuerrors.BadRequestf("decoding download args"))
+		h.sendError(ctx, w, jujuerrors.BadRequestf("decoding download args"))
 		return
 	}
 
@@ -48,12 +47,12 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	// resolved it through the filestorage layer on every Get call.
 	domainServices, err := h.domainServicesGetter.ServicesForModel(ctx, h.controllerModelUUID)
 	if err != nil {
-		h.sendError(w, errors.Errorf("resolving domain services: %w", err))
+		h.sendError(ctx, w, errors.Errorf("resolving domain services: %w", err))
 		return
 	}
 	cfg, err := domainServices.Config().ModelConfig(ctx)
 	if err != nil {
-		h.sendError(w, errors.Errorf("resolving model config: %w", err))
+		h.sendError(ctx, w, errors.Errorf("resolving model config: %w", err))
 		return
 	}
 	backupDir := corebackups.BackupDirToUse(cfg.BackupDir())
@@ -61,32 +60,34 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	// Reject ids that are not a clearly named archive under the backup dir.
 	valid, err := corebackups.IsValidBackupFilepath(backupDir, args.ID)
 	if err != nil {
-		h.sendError(w, errors.Errorf("validating archive path: %w", err))
+		h.sendError(ctx, w, errors.Errorf("validating archive path: %w", err))
 		return
 	}
 	if !valid {
-		h.sendError(w, jujuerrors.BadRequestf("invalid backup archive id"))
+		h.sendError(ctx, w, jujuerrors.BadRequestf("invalid backup archive id"))
 		return
 	}
 
 	file, err := os.Open(args.ID)
 	if err != nil {
-		h.sendError(w, errors.Errorf("opening archive: %w", err))
+		h.sendError(ctx, w, errors.Errorf("opening archive: %w", err))
 		return
 	}
 	defer file.Close()
 
 	fi, err := file.Stat()
 	if err != nil {
-		h.sendError(w, errors.Errorf("stating archive: %w", err))
+		h.sendError(ctx, w, errors.Errorf("stating archive: %w", err))
 		return
 	}
 
-	// Compute the archive checksum for the Digest header, as the 3.6
-	// handler did. The checksum is over the gzipped archive bytes.
+	// Compute the archive checksum for the Digest header. The checksum
+	// is over the gzipped archive bytes, so a client can verify the
+	// download without decompressing it. Note this is a SHA-256 digest,
+	// independent of the SHA-1 checksum recorded in the backup metadata.
 	checksum, err := archiveChecksum(file)
 	if err != nil {
-		h.sendError(w, errors.Errorf("checksumming archive: %w", err))
+		h.sendError(ctx, w, errors.Errorf("checksumming archive: %w", err))
 		return
 	}
 
@@ -97,34 +98,89 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Digest", params.EncodeChecksum(checksum))
 
 	// Stream the archive. ServeContent handles range and head requests.
-	http.ServeContent(w, r, fi.Name(), fi.ModTime(), file)
+	sw := &serveStatusWriter{ResponseWriter: w}
+	http.ServeContent(sw, r, fi.Name(), fi.ModTime(), file)
 
-	// One-shot semantics: remove the archive after serving it, as 3.6 did.
+	// One-shot semantics: remove the archive only once it has been
+	// served completely. Anything short of a whole-archive 200 response
+	// leaves the archive on disk so the download can be retried:
+	//   - a HEAD request transfers no bytes at all,
+	//   - a range request only sends part of the archive (206),
+	//   - a conditional request may send nothing (304),
+	//   - a write error means the client went away mid-stream,
+	//   - a short body means the copy stopped early.
+	if r.Method != http.MethodGet {
+		return
+	}
+	if sw.err != nil {
+		h.logger.Warningf(ctx, "error serving backup archive: %v", sw.err)
+		return
+	}
+	if sw.status != http.StatusOK {
+		return
+	}
+	if sw.written != fi.Size() {
+		h.logger.Warningf(ctx,
+			"backup archive %q served incompletely (%d of %d bytes), keeping it on disk",
+			fi.Name(), sw.written, fi.Size())
+		return
+	}
 	if err := os.Remove(args.ID); err != nil && !os.IsNotExist(err) {
 		h.logger.Warningf(ctx, "error removing backup archive: %v", err)
 	}
 }
 
+// serveStatusWriter records the response status, the number of body
+// bytes written and the first write error, so the handler can tell a
+// completely served archive from a partial or failed response.
+//
+// It deliberately does not forward [io.ReaderFrom], so the copy runs
+// through Write and write errors are observable.
+type serveStatusWriter struct {
+	http.ResponseWriter
+	status  int
+	written int64
+	err     error
+}
+
+func (w *serveStatusWriter) WriteHeader(status int) {
+	if w.status == 0 {
+		w.status = status
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *serveStatusWriter) Write(p []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	n, err := w.ResponseWriter.Write(p)
+	w.written += int64(n)
+	if err != nil && w.err == nil {
+		w.err = err
+	}
+	return n, err
+}
+
 // sendError logs the internal error detail and replies with a structured
 // JSON error, so internal state (paths, model UUIDs, DB errors) is not
 // leaked to the client beyond the classified error.
-func (h *backupsDownloadHandler) sendError(w http.ResponseWriter, err error) {
-	h.logger.Debugf(context.TODO(), "backup download error: %v", err)
+func (h *backupsDownloadHandler) sendError(ctx context.Context, w http.ResponseWriter, err error) {
+	h.logger.Debugf(ctx, "backup download error: %v", err)
 	if err := internalhttp.SendError(w, err, h.logger); err != nil {
-		h.logger.Errorf(context.TODO(), "sending backup download error: %v", err)
+		h.logger.Errorf(ctx, "sending backup download error: %v", err)
 	}
 }
 
-// archiveChecksum returns the base64-encoded SHA-1 checksum of the
-// archive, matching the format recorded in the backup metadata. The
+// archiveChecksum returns the raw SHA-256 checksum of the archive. The
 // file offset is reset so the caller can stream the file afterwards.
-func archiveChecksum(file *os.File) (string, error) {
-	hasher := sha1.New()
+func archiveChecksum(file *os.File) ([]byte, error) {
+	hasher := sha256.New()
 	if _, err := io.Copy(hasher, file); err != nil {
-		return "", errors.Capture(err)
+		return nil, errors.Capture(err)
 	}
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return "", errors.Capture(err)
+		return nil, errors.Capture(err)
 	}
-	return base64.StdEncoding.EncodeToString(hasher.Sum(nil)), nil
+	return hasher.Sum(nil), nil
 }

--- a/apiserver/backups.go
+++ b/apiserver/backups.go
@@ -22,6 +22,12 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
+// maxDownloadArgsBytes caps the request body read by the download
+// handler. The body only ever carries a JSON-encoded archive id, so this
+// is far more than a well behaved client needs, and an unbounded body is
+// not streamed into the controller.
+const maxDownloadArgsBytes = 1 << 20 // 1MiB
+
 // backupsDownloadHandler streams a backup archive out of the controller
 // model's backup directory over HTTP. The archive is removed from disk on
 // successful copy, matching Juju 3.6 one-shot download semantics.
@@ -37,6 +43,7 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 
 	var args params.BackupsDownloadArgs
+	r.Body = http.MaxBytesReader(w, r.Body, maxDownloadArgsBytes)
 	if err := json.NewDecoder(r.Body).Decode(&args); err != nil {
 		h.sendError(ctx, w, jujuerrors.BadRequestf("decoding download args"))
 		return
@@ -58,6 +65,10 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	backupDir := corebackups.BackupDirToUse(cfg.BackupDir())
 
 	// Reject ids that are not a clearly named archive under the backup dir.
+	// Validation resolves symlinks, so a link under the backup dir naming a
+	// file elsewhere is accepted: the endpoint is controller-admin only and
+	// the backup dir is only writable by the controller itself, so trusting
+	// its contents is an accepted trade-off rather than an oversight.
 	valid, err := corebackups.IsValidBackupFilepath(backupDir, args.ID)
 	if err != nil {
 		h.sendError(ctx, w, errors.Errorf("validating archive path: %w", err))
@@ -68,8 +79,18 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// An archive that passed validation can still be gone by the time it is
+	// opened, because the one-shot removal below races a concurrent or
+	// retried download of the same id. That is a bad id, not a controller
+	// fault, so it is reported exactly as a validation failure is. Note this
+	// must not be NotFound: the client reads NotFound off this endpoint as
+	// "this controller does not support backup downloads" and reports
+	// success (see cmd/juju/backups/download.go).
 	file, err := os.Open(args.ID)
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
+		h.sendError(ctx, w, jujuerrors.BadRequestf("invalid backup archive id"))
+		return
+	} else if err != nil {
 		h.sendError(ctx, w, errors.Errorf("opening archive: %w", err))
 		return
 	}
@@ -81,21 +102,28 @@ func (h *backupsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Compute the archive checksum for the Digest header. The checksum
-	// is over the gzipped archive bytes, so a client can verify the
-	// download without decompressing it. Note this is a SHA-256 digest,
-	// independent of the SHA-1 checksum recorded in the backup metadata.
-	checksum, err := archiveChecksum(file)
-	if err != nil {
-		h.sendError(ctx, w, errors.Errorf("checksumming archive: %w", err))
-		return
-	}
-
 	// ServeContent sets Content-Type from the file extension; the raw
 	// archive type and digest headers are set explicitly to match the
 	// 3.6 download response.
 	w.Header().Set("Content-Type", params.ContentTypeRaw)
-	w.Header().Set("Digest", params.EncodeChecksum(checksum))
+
+	// Compute the archive checksum for the Digest header. The checksum is
+	// over the gzipped archive bytes, so a client can verify the download
+	// without decompressing it. Note this is a SHA-256 digest, independent
+	// of the SHA-1 checksum recorded in the backup metadata.
+	//
+	// Hashing reads the whole archive, which is only worth doing for a
+	// request that will carry the whole archive: a HEAD sends no bytes and
+	// a range request sends a slice the digest does not describe, so both
+	// are served without it rather than reading the archive twice.
+	if r.Method == http.MethodGet && r.Header.Get("Range") == "" {
+		checksum, err := archiveChecksum(file)
+		if err != nil {
+			h.sendError(ctx, w, errors.Errorf("checksumming archive: %w", err))
+			return
+		}
+		w.Header().Set("Digest", params.EncodeChecksum(checksum))
+	}
 
 	// Stream the archive. ServeContent handles range and head requests.
 	sw := &serveStatusWriter{ResponseWriter: w}

--- a/apiserver/backups_test.go
+++ b/apiserver/backups_test.go
@@ -4,18 +4,23 @@
 package apiserver
 
 import (
+	"crypto/sha1"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path"
 	"strings"
 	stdtesting "testing"
+	"time"
 
+	"github.com/juju/clock"
 	"github.com/juju/tc"
 
 	corebackups "github.com/juju/juju/core/backups"
 	domainservicetesting "github.com/juju/juju/domain/services/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/rpc/params"
 )
 
 type backupsDownloadSuite struct {
@@ -48,9 +53,10 @@ func (s *backupsDownloadSuite) createArchive(c *tc.C) (dir, filename string) {
 	payload := path.Join(dir, "blob")
 	c.Assert(os.WriteFile(payload, []byte("blob content"), 0644), tc.ErrorIsNil)
 
-	filename, err = corebackups.Create(corebackups.NewMetadata(), corebackups.CreateArgs{
+	filename, err = corebackups.Create(corebackups.NewMetadata(time.Now()), corebackups.CreateArgs{
 		DestinationDir: dir,
 		FilesToBackUp:  []string{payload},
+		Clock:          clock.WallClock,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	return dir, filename
@@ -73,6 +79,13 @@ func (s *backupsDownloadSuite) TestDownload(c *tc.C) {
 
 	recorder := s.get(c, filename)
 	c.Assert(recorder.Code, tc.Equals, http.StatusOK)
+
+	// The raw content type and digest headers match the 3.6 download
+	// response.
+	c.Check(recorder.Header().Get("Content-Type"), tc.Equals, params.ContentTypeRaw)
+	sum := sha1.Sum(expected)
+	c.Check(recorder.Header().Get("Digest"), tc.Equals,
+		params.EncodeChecksum(base64.StdEncoding.EncodeToString(sum[:])))
 
 	// The archive bytes match the file contents read before the download.
 	c.Check(recorder.Body.Len(), tc.Equals, len(expected))

--- a/apiserver/backups_test.go
+++ b/apiserver/backups_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	stdtesting "testing"
+
+	"github.com/juju/tc"
+
+	corebackups "github.com/juju/juju/core/backups"
+	domainservicetesting "github.com/juju/juju/domain/services/testing"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type backupsDownloadSuite struct {
+	domainservicetesting.DomainServicesSuite
+}
+
+func TestBackupsDownloadSuite(t *stdtesting.T) {
+	tc.Run(t, &backupsDownloadSuite{})
+}
+
+func (s *backupsDownloadSuite) handler(c *tc.C) *backupsDownloadHandler {
+	return &backupsDownloadHandler{
+		domainServicesGetter: s.ModelDomainServicesGetter(c),
+		controllerModelUUID:  s.ControllerModelUUID,
+		logger:               loggertesting.WrapCheckLog(c),
+	}
+}
+
+// createArchive makes a real archive inside the controller model's
+// backup-dir and returns its absolute path. The path is set as the model
+// config backup-dir so the handler resolves it.
+func (s *backupsDownloadSuite) createArchive(c *tc.C) (dir, filename string) {
+	controllerServices := s.ControllerDomainServices(c)
+
+	dir = c.MkDir()
+	err := controllerServices.Config().UpdateModelConfig(
+		c.Context(), map[string]any{"backup-dir": dir}, nil)
+	c.Assert(err, tc.ErrorIsNil)
+
+	payload := path.Join(dir, "blob")
+	c.Assert(os.WriteFile(payload, []byte("blob content"), 0644), tc.ErrorIsNil)
+
+	filename, err = corebackups.Create(corebackups.NewMetadata(), corebackups.CreateArgs{
+		DestinationDir: dir,
+		FilesToBackUp:  []string{payload},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	return dir, filename
+}
+
+func (s *backupsDownloadSuite) get(c *tc.C, id string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(
+		http.MethodGet, "/model/x/backups", strings.NewReader(`{"id":"`+id+`"}`))
+	recorder := httptest.NewRecorder()
+	s.handler(c).ServeHTTP(recorder, req)
+	return recorder
+}
+
+// TestDownload serves the archive and removes it from disk afterwards.
+func (s *backupsDownloadSuite) TestDownload(c *tc.C) {
+	_, filename := s.createArchive(c)
+
+	expected, err := os.ReadFile(filename)
+	c.Assert(err, tc.ErrorIsNil)
+
+	recorder := s.get(c, filename)
+	c.Assert(recorder.Code, tc.Equals, http.StatusOK)
+
+	// The archive bytes match the file contents read before the download.
+	c.Check(recorder.Body.Len(), tc.Equals, len(expected))
+	c.Check(recorder.Body.String(), tc.Equals, string(expected))
+
+	// One-shot semantics: the archive is gone after serving.
+	_, err = os.Stat(filename)
+	c.Assert(os.IsNotExist(err), tc.IsTrue)
+}
+
+// TestDownloadInvalidID rejects ids that do not resolve to a backup
+// archive under the backup dir.
+func (s *backupsDownloadSuite) TestDownloadInvalidID(c *tc.C) {
+	_, filename := s.createArchive(c)
+
+	for _, id := range []string{
+		"../any.tar.gz",
+		"not-an-archive.tar.gz",
+		path.Join("/missing", "juju-backup-empty.tar.gz"),
+	} {
+		recorder := s.get(c, id)
+		c.Check(recorder.Code, tc.Equals, http.StatusBadRequest,
+			tc.Commentf("id %q", id))
+	}
+
+	// A reject leaves a created archive untouched.
+	_, err := os.Stat(filename)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestDownloadBadBody rejects non-JSON bodies.
+func (s *backupsDownloadSuite) TestDownloadBadBody(c *tc.C) {
+	req := httptest.NewRequest(
+		http.MethodGet, "/model/x/backups", strings.NewReader(`not json`))
+	recorder := httptest.NewRecorder()
+
+	s.handler(c).ServeHTTP(recorder, req)
+	c.Check(recorder.Code, tc.Equals, http.StatusBadRequest)
+}

--- a/apiserver/backups_test.go
+++ b/apiserver/backups_test.go
@@ -4,12 +4,13 @@
 package apiserver
 
 import (
-	"crypto/sha1"
-	"encoding/base64"
+	"crypto/sha256"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	stdtesting "testing"
 	"time"
@@ -80,12 +81,12 @@ func (s *backupsDownloadSuite) TestDownload(c *tc.C) {
 	recorder := s.get(c, filename)
 	c.Assert(recorder.Code, tc.Equals, http.StatusOK)
 
-	// The raw content type and digest headers match the 3.6 download
-	// response.
+	// The raw content type and a correctly labeled, correctly encoded
+	// SHA-256 digest header are returned.
 	c.Check(recorder.Header().Get("Content-Type"), tc.Equals, params.ContentTypeRaw)
-	sum := sha1.Sum(expected)
+	sum := sha256.Sum256(expected)
 	c.Check(recorder.Header().Get("Digest"), tc.Equals,
-		params.EncodeChecksum(base64.StdEncoding.EncodeToString(sum[:])))
+		params.EncodeChecksum(sum[:]))
 
 	// The archive bytes match the file contents read before the download.
 	c.Check(recorder.Body.Len(), tc.Equals, len(expected))
@@ -94,6 +95,80 @@ func (s *backupsDownloadSuite) TestDownload(c *tc.C) {
 	// One-shot semantics: the archive is gone after serving.
 	_, err = os.Stat(filename)
 	c.Assert(os.IsNotExist(err), tc.IsTrue)
+}
+
+// TestDownloadRangeRequestKeepsArchive verifies that a partial (range)
+// response does not trigger the one-shot removal: the archive must stay
+// on disk so the download can be retried or resumed.
+func (s *backupsDownloadSuite) TestDownloadRangeRequestKeepsArchive(c *tc.C) {
+	_, filename := s.createArchive(c)
+
+	expected, err := os.ReadFile(filename)
+	c.Assert(err, tc.ErrorIsNil)
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/model/x/backups", strings.NewReader(`{"id":"`+filename+`"}`))
+	req.Header.Set("Range", "bytes=0-9")
+	recorder := httptest.NewRecorder()
+	s.handler(c).ServeHTTP(recorder, req)
+
+	c.Assert(recorder.Code, tc.Equals, http.StatusPartialContent)
+	c.Check(recorder.Body.String(), tc.Equals, string(expected[:10]))
+
+	// The partial response leaves the archive on disk.
+	_, err = os.Stat(filename)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestDownloadHeadKeepsArchive verifies that a HEAD request, which
+// transfers no archive bytes at all, does not consume the archive. HEAD
+// is routed to this handler automatically alongside GET.
+func (s *backupsDownloadSuite) TestDownloadHeadKeepsArchive(c *tc.C) {
+	_, filename := s.createArchive(c)
+
+	expected, err := os.ReadFile(filename)
+	c.Assert(err, tc.ErrorIsNil)
+
+	req := httptest.NewRequest(
+		http.MethodHead, "/model/x/backups", strings.NewReader(`{"id":"`+filename+`"}`))
+	recorder := httptest.NewRecorder()
+	s.handler(c).ServeHTTP(recorder, req)
+
+	c.Assert(recorder.Code, tc.Equals, http.StatusOK)
+	c.Check(recorder.Body.Len(), tc.Equals, 0)
+	c.Check(recorder.Header().Get("Content-Length"), tc.Equals,
+		strconv.Itoa(len(expected)))
+
+	// No bytes were transferred, so the archive stays on disk.
+	_, err = os.Stat(filename)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestDownloadWriteErrorKeepsArchive verifies that a client that goes
+// away mid-stream does not consume the archive.
+func (s *backupsDownloadSuite) TestDownloadWriteErrorKeepsArchive(c *tc.C) {
+	_, filename := s.createArchive(c)
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/model/x/backups", strings.NewReader(`{"id":"`+filename+`"}`))
+	recorder := &failingWriter{ResponseRecorder: httptest.NewRecorder()}
+	s.handler(c).ServeHTTP(recorder, req)
+
+	c.Assert(recorder.Code, tc.Equals, http.StatusOK)
+
+	// The failed write leaves the archive on disk.
+	_, err := os.Stat(filename)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// failingWriter fails every body write, standing in for a client that
+// disconnected mid-download.
+type failingWriter struct {
+	*httptest.ResponseRecorder
+}
+
+func (w *failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("connection reset by peer")
 }
 
 // TestDownloadInvalidID rejects ids that do not resolve to a backup

--- a/apiserver/backups_test.go
+++ b/apiserver/backups_test.go
@@ -6,6 +6,7 @@ package apiserver
 import (
 	"crypto/sha256"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -97,6 +98,20 @@ func (s *backupsDownloadSuite) TestDownload(c *tc.C) {
 	c.Assert(os.IsNotExist(err), tc.IsTrue)
 }
 
+// TestDownloadAlreadyConsumed verifies that re-downloading an id whose
+// archive was already consumed by a previous one-shot download is
+// rejected as a bad id, rather than reported as a controller fault or as
+// NotFound, which the client reads as "downloads are unsupported here".
+func (s *backupsDownloadSuite) TestDownloadAlreadyConsumed(c *tc.C) {
+	_, filename := s.createArchive(c)
+
+	c.Assert(s.get(c, filename).Code, tc.Equals, http.StatusOK)
+
+	recorder := s.get(c, filename)
+	c.Check(recorder.Code, tc.Equals, http.StatusBadRequest)
+	c.Check(recorder.Body.String(), tc.Contains, "invalid backup archive id")
+}
+
 // TestDownloadRangeRequestKeepsArchive verifies that a partial (range)
 // response does not trigger the one-shot removal: the archive must stay
 // on disk so the download can be retried or resumed.
@@ -114,6 +129,10 @@ func (s *backupsDownloadSuite) TestDownloadRangeRequestKeepsArchive(c *tc.C) {
 
 	c.Assert(recorder.Code, tc.Equals, http.StatusPartialContent)
 	c.Check(recorder.Body.String(), tc.Equals, string(expected[:10]))
+
+	// The digest describes the whole archive, so it is not computed for a
+	// response that only carries a slice of it.
+	c.Check(recorder.Header().Get("Digest"), tc.Equals, "")
 
 	// The partial response leaves the archive on disk.
 	_, err = os.Stat(filename)
@@ -138,6 +157,9 @@ func (s *backupsDownloadSuite) TestDownloadHeadKeepsArchive(c *tc.C) {
 	c.Check(recorder.Body.Len(), tc.Equals, 0)
 	c.Check(recorder.Header().Get("Content-Length"), tc.Equals,
 		strconv.Itoa(len(expected)))
+
+	// No bytes are served, so the archive is not read to digest it.
+	c.Check(recorder.Header().Get("Digest"), tc.Equals, "")
 
 	// No bytes were transferred, so the archive stays on disk.
 	_, err = os.Stat(filename)
@@ -169,6 +191,16 @@ type failingWriter struct {
 
 func (w *failingWriter) Write([]byte) (int, error) {
 	return 0, errors.New("connection reset by peer")
+}
+
+// TestServeStatusWriterIsNotReaderFrom guards the property the one-shot
+// removal depends on: serveStatusWriter must not satisfy [io.ReaderFrom],
+// so the copy inside [http.ServeContent] runs through Write and the served
+// byte count and write errors stay observable.
+func (s *backupsDownloadSuite) TestServeStatusWriterIsNotReaderFrom(c *tc.C) {
+	var w any = &serveStatusWriter{ResponseWriter: httptest.NewRecorder()}
+	_, ok := w.(io.ReaderFrom)
+	c.Check(ok, tc.IsFalse)
 }
 
 // TestDownloadInvalidID rejects ids that do not resolve to a backup

--- a/rpc/params/http.go
+++ b/rpc/params/http.go
@@ -37,8 +37,9 @@ const (
 	ContentTypeXJS = "application/x-javascript"
 )
 
-// EncodeChecksum base64 encodes a sha256 checksum according to RFC 4648 and
-// returns a value that can be added to the "Digest" http header.
-func EncodeChecksum(checksum string) string {
-	return fmt.Sprintf("%s=%s", DigestSHA256, base64.StdEncoding.EncodeToString([]byte(checksum)))
+// EncodeChecksum base64 encodes raw SHA-256 digest bytes according to
+// RFC 4648 and returns a value that can be added to the "Digest" http
+// header, as described by RFC 3230.
+func EncodeChecksum(checksum []byte) string {
+	return fmt.Sprintf("%s=%s", DigestSHA256, base64.StdEncoding.EncodeToString(checksum))
 }


### PR DESCRIPTION
This PR adds the server side of backup downloads: a new GET `/model/:modeluuid/backups` endpoint on the API
server that streams a backup archive out of the controller model's backup directory. It is restricted to
controller admins via `controllerAdminAuthorizer`, takes a JSON body with the archive id (as returned by
create-backup), validates that the id resolves to a real archive under the configured backup dir, and
streams it with `http.ServeContent`. Matching the 3.6 one-shot semantics, the archive is removed from disk
once it has been served.

Previously the juju download-backup client command had no endpoint to talk to, so downloading a backup
off the controller was not possible. With this handler in place, the existing client and CLI work end to
end against a 4.0 controller.

## QA steps

_Note: depends on https://github.com/juju/juju/pull/23206 so it has to be rebased on top of it._

Bootstrap a controller with these changes, add a model and deploy a workload:

 ```sh
$ juju bootstrap lxd c
$ juju add-model m
$ juju deploy juju-qa-test
 ```

 Once the unit is active, create a backup. By default create-backup downloads the archive after creating
 it, which exercises the new endpoint:

 ```sh
$ juju create-backup
 ```

 Verify the archive downloaded correctly (it should be a valid tarball in the current directory) and that
 it was removed from the controller after download:

 ```sh
$ tar -tf juju-backup-*.tar.gz > /dev/null && echo "archive OK"
$ juju ssh -m controller 0 ls /var/lib/juju/backups
 ```

 The backup directory should no longer contain the downloaded archive. Also check the controller logs for
 errors:

 ```sh
$ juju debug-log -m controller --replay | grep -i backup
 ```
## Links



<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10304](https://warthogs.atlassian.net/browse/JUJU-10304)


[JUJU-10304]: https://warthogs.atlassian.net/browse/JUJU-10304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ