### PR TITLE
feat: ensure we pass update and upgrade config

### DIFF
--- a/internal/provisionertask/export_test.go
+++ b/internal/provisionertask/export_test.go
@@ -53,3 +53,11 @@ func SetupToStartMachine(
 	}
 	return task.setupToStartMachine(c.Context(), machine, version, pInfoResult, modelConfig)
 }
+
+func QueueStartMachines(
+	c *tc.C,
+	p ProvisionerTask,
+	machines ...apiprovisioner.MachineProvisioner,
+) error {
+	return p.(*provisionerTask).queueStartMachines(c.Context(), machines)
+}

--- a/internal/provisionertask/export_test.go
+++ b/internal/provisionertask/export_test.go
@@ -46,5 +46,10 @@ func SetupToStartMachine(
 	version *semversion.Number,
 	pInfoResult params.ProvisioningInfoResult,
 ) (environs.StartInstanceParams, error) {
-	return p.(*provisionerTask).setupToStartMachine(c.Context(), machine, version, pInfoResult)
+	task := p.(*provisionerTask)
+	modelConfig, err := task.controllerAPI.ModelConfig(c.Context())
+	if err != nil {
+		return environs.StartInstanceParams{}, err
+	}
+	return task.setupToStartMachine(c.Context(), machine, version, pInfoResult, modelConfig)
 }

--- a/internal/provisionertask/provisioner_task.go
+++ b/internal/provisionertask/provisioner_task.go
@@ -849,6 +849,10 @@ func (task *provisionerTask) constructInstanceConfig(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	modelConfig, err := task.controllerAPI.ModelConfig(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	password, err := password.RandomPassword()
 	if err != nil {
 		return nil, fmt.Errorf("cannot make password for machine %v: %v", machine, err)
@@ -906,6 +910,8 @@ func (task *provisionerTask) constructInstanceConfig(
 	}
 
 	instanceConfig.CloudInitUserData = pInfo.CloudInitUserData
+	instanceConfig.EnableOSRefreshUpdate = modelConfig.EnableOSRefreshUpdate()
+	instanceConfig.EnableOSUpgrade = modelConfig.EnableOSUpgrade()
 
 	return instanceConfig, nil
 }

--- a/internal/provisionertask/provisioner_task.go
+++ b/internal/provisionertask/provisioner_task.go
@@ -121,6 +121,7 @@ type GetMachineInstanceInfoSetter func(machineProvisioner apiprovisioner.Machine
 // TaskConfig holds the initialisation data for a ProvisionerTask instance.
 type TaskConfig struct {
 	ControllerUUID               string
+	ModelUUID                    string
 	HostTag                      names.Tag
 	Logger                       logger.Logger
 	ControllerAPI                ControllerAPI
@@ -149,6 +150,7 @@ func NewProvisionerTask(cfg TaskConfig) (ProvisionerTask, error) {
 	}
 	task := &provisionerTask{
 		controllerUUID:               cfg.ControllerUUID,
+		modelUUID:                    cfg.ModelUUID,
 		hostTag:                      cfg.HostTag,
 		logger:                       cfg.Logger,
 		controllerAPI:                cfg.ControllerAPI,
@@ -196,6 +198,7 @@ type provisionerTask struct {
 	catacomb catacomb.Catacomb
 
 	controllerUUID               string
+	modelUUID                    string
 	hostTag                      names.Tag
 	logger                       logger.Logger
 	controllerAPI                ControllerAPI
@@ -836,20 +839,13 @@ func (task *provisionerTask) constructInstanceConfig(
 	ctx context.Context,
 	machine apiprovisioner.MachineProvisioner,
 	pInfo *params.ProvisioningInfo,
+	modelConfig *config.Config,
 ) (*instancecfg.InstanceConfig, error) {
 	apiAddresses, err := task.controllerAPI.APIAddresses(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	caCert, err := task.controllerAPI.CACert(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	modelUUID, err := task.controllerAPI.ModelUUID(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	modelConfig, err := task.controllerAPI.ModelConfig(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -863,7 +859,7 @@ func (task *provisionerTask) constructInstanceConfig(
 	apiInfo := &api.Info{
 		Addrs:    apiAddresses,
 		CACert:   caCert,
-		ModelTag: names.NewModelTag(modelUUID),
+		ModelTag: names.NewModelTag(task.modelUUID),
 		Tag:      machine.Tag(),
 		Password: password,
 	}
@@ -1325,6 +1321,14 @@ func (task *provisionerTask) queueStartMachines(ctx context.Context, machines []
 	if err != nil {
 		return errors.Trace(err)
 	}
+	modelConfig, err := task.controllerAPI.ModelConfig(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	modelAgentVersion, ok := modelConfig.AgentVersion()
+	if !ok {
+		return errors.New("failed to get model's agent version.")
+	}
 	task.logger.Debugf(ctx, "obtained provisioning info: %#v", pInfoResults)
 	pInfoMap := make(map[string]params.ProvisioningInfoResult, len(pInfoResults.Results))
 	for i, tag := range machineTags {
@@ -1363,7 +1367,9 @@ func (task *provisionerTask) queueStartMachines(ctx context.Context, machines []
 			Process: func() error {
 				machID := machine.Id()
 
-				if provisionErr := task.doStartMachine(ctx, machine, distGroup, pInfoMap[machID]); provisionErr != nil {
+				if provisionErr := task.doStartMachine(
+					ctx, machine, distGroup, pInfoMap[machID], modelConfig, &modelAgentVersion,
+				); provisionErr != nil {
 					return provisionErr
 				}
 
@@ -1415,6 +1421,8 @@ func (task *provisionerTask) doStartMachine(
 	machine apiprovisioner.MachineProvisioner,
 	distributionGroupMachineIds []string,
 	pInfoResult params.ProvisioningInfoResult,
+	modelConfig *config.Config,
+	modelAgentVersion *semversion.Number,
 ) (startErr error) {
 	defer func() {
 		if startErr == nil {
@@ -1437,12 +1445,9 @@ func (task *provisionerTask) doStartMachine(
 		task.logger.Errorf(ctx, "%v", err)
 	}
 
-	v, err := machine.ModelAgentVersion(ctx)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	startInstanceParams, err := task.setupToStartMachine(ctx, machine, v, pInfoResult)
+	startInstanceParams, err := task.setupToStartMachine(
+		ctx, machine, modelAgentVersion, pInfoResult, modelConfig,
+	)
 	if err != nil {
 		return errors.Trace(task.setErrorStatus(ctx, "%v %v", machine, err))
 	}
@@ -1588,7 +1593,10 @@ func (task *provisionerTask) doStartMachine(
 // and StartInstanceParams to be used by startMachine.
 func (task *provisionerTask) setupToStartMachine(
 	ctx context.Context,
-	machine apiprovisioner.MachineProvisioner, version *semversion.Number, pInfoResult params.ProvisioningInfoResult,
+	machine apiprovisioner.MachineProvisioner,
+	version *semversion.Number,
+	pInfoResult params.ProvisioningInfoResult,
+	modelConfig *config.Config,
 ) (environs.StartInstanceParams, error) {
 	// Check that we have a result.
 	// We should never have an empty result without an error,
@@ -1601,7 +1609,7 @@ func (task *provisionerTask) setupToStartMachine(
 		return environs.StartInstanceParams{}, errors.Errorf("no provisioning info for machine %q", machine.Id())
 	}
 
-	instanceCfg, err := task.constructInstanceConfig(ctx, machine, pInfo)
+	instanceCfg, err := task.constructInstanceConfig(ctx, machine, pInfo, modelConfig)
 	if err != nil {
 		return environs.StartInstanceParams{}, errors.Annotatef(err, "creating instance config for machine %q", machine)
 	}

--- a/internal/provisionertask/provisioner_task_test.go
+++ b/internal/provisionertask/provisioner_task_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/instances"
 	environmocks "github.com/juju/juju/environs/testing"
@@ -83,8 +84,10 @@ type ProvisionerTaskSuite struct {
 	machineErrorRetryChanges chan struct{}
 	machineErrorRetryWatcher watcher.NotifyWatcher
 
-	controllerAPI *MockControllerAPI
-	machinesAPI   *MockMachinesAPI
+	controllerAPI    *MockControllerAPI
+	machinesAPI      *MockMachinesAPI
+	modelConfig      *config.Config
+	modelConfigCalls int
 
 	instances      []instances.Instance
 	instanceBroker *testInstanceBroker
@@ -103,6 +106,7 @@ func (s *ProvisionerTaskSuite) SetUpTest(c *tc.C) {
 
 	s.machineErrorRetryChanges = make(chan struct{})
 	s.machineErrorRetryWatcher = watchertest.NewMockNotifyWatcher(s.machineErrorRetryChanges)
+	s.modelConfigCalls = 0
 
 	s.instances = []instances.Instance{}
 	s.instanceBroker = &testInstanceBroker{
@@ -273,6 +277,7 @@ var (
 
 func (s *ProvisionerTaskSuite) TestSetUpToStartMachine(c *tc.C) {
 	defer s.setUpMocks(c).Finish()
+	s.modelConfig = s.newModelConfig(c, true, true)
 
 	task := s.newProvisionerTask(c,
 		&mockDistributionGroupFinder{},
@@ -320,9 +325,41 @@ func (s *ProvisionerTaskSuite) TestSetUpToStartMachine(c *tc.C) {
 	want.Placement = "foo=bar"
 	want.InstanceConfig.Tags = map[string]string{"hello": "world"}
 	want.InstanceConfig.CloudInitUserData = validCloudInitUserData
+	want.InstanceConfig.EnableOSRefreshUpdate = true
+	want.InstanceConfig.EnableOSUpgrade = true
 	want.ImageMetadata = possibleImageMetadata
 	want.EndpointBindings = map[string]network.Id{"endpoint": "space"}
 	c.Assert(startInstanceParams, tc.DeepEquals, *want)
+	c.Check(s.modelConfigCalls, tc.Equals, 1)
+}
+
+// TestSetUpToStartMachineDisablesOSUpdates verifies that a new machine has
+// the model's disabled OS update settings before it reaches the provider.
+func (s *ProvisionerTaskSuite) TestSetUpToStartMachineDisablesOSUpdates(c *tc.C) {
+	defer s.setUpMocks(c).Finish()
+	s.modelConfig = s.newModelConfig(c, false, false)
+
+	task := s.newProvisionerTask(c,
+		&mockDistributionGroupFinder{},
+		mockToolsFinder{},
+		numProvisionWorkersForTesting,
+	)
+	defer workertest.CleanKill(c, task)
+
+	result := params.ProvisioningInfoResult{
+		Result: &params.ProvisioningInfo{
+			Base:             params.Base{Name: "ubuntu", Channel: "22.04"},
+			ControllerConfig: internaltesting.FakeControllerConfig(),
+		},
+	}
+	version := semversion.MustParse("2.99.0")
+	startInstanceParams, err := provisionertask.SetupToStartMachine(
+		c, task, &testMachine{c: c, id: "0"}, &version, result,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(startInstanceParams.InstanceConfig.EnableOSRefreshUpdate, tc.IsFalse)
+	c.Check(startInstanceParams.InstanceConfig.EnableOSUpgrade, tc.IsFalse)
+	c.Check(s.modelConfigCalls, tc.Equals, 1)
 }
 
 func (s *ProvisionerTaskSuite) TestProvisionerSetsErrorStatusWhenNoToolsAreAvailable(c *tc.C) {
@@ -1688,14 +1725,32 @@ func (s *ProvisionerTaskSuite) setUpMocks(c *tc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.controllerAPI = NewMockControllerAPI(ctrl)
 	s.machinesAPI = NewMockMachinesAPI(ctrl)
+	s.modelConfig = s.newModelConfig(c, false, false)
 	s.expectAuth()
 	return ctrl
+}
+
+func (s *ProvisionerTaskSuite) newModelConfig(
+	c *tc.C, enableOSRefreshUpdate, enableOSUpgrade bool,
+) *config.Config {
+	modelConfig, err := config.New(config.NoDefaults, internaltesting.FakeConfig().Merge(internaltesting.Attrs{
+		config.EnableOSRefreshUpdateKey: enableOSRefreshUpdate,
+		config.EnableOSUpgradeKey:       enableOSUpgrade,
+	}))
+	c.Assert(err, tc.ErrorIsNil)
+	return modelConfig
 }
 
 func (s *ProvisionerTaskSuite) expectAuth() {
 	s.controllerAPI.EXPECT().APIAddresses(gomock.Any()).Return([]string{"10.0.0.1"}, nil).AnyTimes()
 	s.controllerAPI.EXPECT().ModelUUID(gomock.Any()).Return(internaltesting.ModelTag.Id(), nil).AnyTimes()
 	s.controllerAPI.EXPECT().CACert(gomock.Any()).Return(internaltesting.CACert, nil).AnyTimes()
+	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).DoAndReturn(
+		func(context.Context) (*config.Config, error) {
+			s.modelConfigCalls++
+			return s.modelConfig, nil
+		},
+	).AnyTimes()
 }
 
 func (s *ProvisionerTaskSuite) expectMachines(machines ...*testMachine) {

--- a/internal/provisionertask/provisioner_task_test.go
+++ b/internal/provisionertask/provisioner_task_test.go
@@ -87,6 +87,7 @@ type ProvisionerTaskSuite struct {
 	controllerAPI    *MockControllerAPI
 	machinesAPI      *MockMachinesAPI
 	modelConfig      *config.Config
+	modelConfigErr   error
 	modelConfigCalls int
 
 	instances      []instances.Instance
@@ -106,6 +107,7 @@ func (s *ProvisionerTaskSuite) SetUpTest(c *tc.C) {
 
 	s.machineErrorRetryChanges = make(chan struct{})
 	s.machineErrorRetryWatcher = watchertest.NewMockNotifyWatcher(s.machineErrorRetryChanges)
+	s.modelConfigErr = nil
 	s.modelConfigCalls = 0
 
 	s.instances = []instances.Instance{}
@@ -385,6 +387,51 @@ func (s *ProvisionerTaskSuite) TestProvisionerSetsErrorStatusWhenNoToolsAreAvail
 	// Ensure machine error status was set, and the error matches
 	msg := s.waitForInstanceStatus(c, m0, status.ProvisioningError)
 	c.Check(msg, tc.Equals, "no matching agent binaries available")
+}
+
+func (s *ProvisionerTaskSuite) TestQueueStartMachinesFailsWithoutModelAgentVersion(c *tc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	modelConfig, err := config.New(config.NoDefaults, internaltesting.FakeConfig())
+	c.Assert(err, tc.ErrorIsNil)
+	s.modelConfig = modelConfig
+
+	task := s.newProvisionerTask(
+		c,
+		&mockDistributionGroupFinder{},
+		mockToolsFinder{},
+		numProvisionWorkersForTesting,
+	)
+	defer workertest.CleanKill(c, task)
+
+	machine := &testMachine{c: c, id: "0"}
+	s.expectProvisioningInfo(machine)
+
+	err = provisionertask.QueueStartMachines(c, task, machine)
+	c.Check(err, tc.ErrorMatches, "failed to get model's agent version\\.")
+	c.Check(machine.password, tc.Equals, "")
+	s.instanceBroker.CheckNoCalls(c)
+}
+
+func (s *ProvisionerTaskSuite) TestQueueStartMachinesPropagatesModelConfigError(c *tc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	s.modelConfigErr = errors.New("cannot load model config")
+	task := s.newProvisionerTask(
+		c,
+		&mockDistributionGroupFinder{},
+		mockToolsFinder{},
+		numProvisionWorkersForTesting,
+	)
+	defer workertest.CleanKill(c, task)
+
+	machine := &testMachine{c: c, id: "0"}
+	s.expectProvisioningInfo(machine)
+
+	err := provisionertask.QueueStartMachines(c, task, machine)
+	c.Check(err, tc.ErrorIs, s.modelConfigErr)
+	c.Check(machine.password, tc.Equals, "")
+	s.instanceBroker.CheckNoCalls(c)
 }
 
 func (s *ProvisionerTaskSuite) TestEvenZonePlacement(c *tc.C) {
@@ -1761,6 +1808,9 @@ func (s *ProvisionerTaskSuite) expectAuth() {
 	s.controllerAPI.EXPECT().CACert(gomock.Any()).Return(internaltesting.CACert, nil).AnyTimes()
 	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).DoAndReturn(
 		func(context.Context) (*config.Config, error) {
+			if s.modelConfigErr != nil {
+				return nil, s.modelConfigErr
+			}
 			s.modelConfigCalls++
 			return s.modelConfig, nil
 		},

--- a/internal/provisionertask/provisioner_task_test.go
+++ b/internal/provisionertask/provisioner_task_test.go
@@ -364,6 +364,7 @@ func (s *ProvisionerTaskSuite) TestSetUpToStartMachineDisablesOSUpdates(c *tc.C)
 
 func (s *ProvisionerTaskSuite) TestProvisionerSetsErrorStatusWhenNoToolsAreAvailable(c *tc.C) {
 	defer s.setUpMocks(c).Finish()
+	s.modelConfig = s.newModelConfigWithAgentVersion(c, false, false, semversion.MustParse("6.6.6"))
 
 	task := s.newProvisionerTask(c,
 		&mockDistributionGroupFinder{},
@@ -373,9 +374,8 @@ func (s *ProvisionerTaskSuite) TestProvisionerSetsErrorStatusWhenNoToolsAreAvail
 	defer workertest.CleanKill(c, task)
 
 	m0 := &testMachine{
-		c:            c,
-		id:           "0",
-		agentVersion: semversion.MustParse("6.6.6"),
+		c:  c,
+		id: "0",
 	}
 
 	s.expectMachines(m0)
@@ -445,6 +445,7 @@ func (s *ProvisionerTaskSuite) TestEvenZonePlacement(c *tc.C) {
 	}
 	err := retry.Call(retryCallArgs)
 	c.Assert(err, tc.ErrorIsNil)
+	c.Check(s.modelConfigCalls, tc.Equals, 1)
 
 	zoneCounts := make(map[string]int)
 	for _, z := range usedZones {
@@ -1663,6 +1664,7 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithRetry(
 ) provisionertask.ProvisionerTask {
 	w, err := provisionertask.NewProvisionerTask(provisionertask.TaskConfig{
 		ControllerUUID:               internaltesting.ControllerTag.Id(),
+		ModelUUID:                    internaltesting.ModelTag.Id(),
 		HostTag:                      names.NewMachineTag("0"),
 		Logger:                       loggertesting.WrapCheckLog(c),
 		ControllerAPI:                s.controllerAPI,
@@ -1699,6 +1701,7 @@ func (s *ProvisionerTaskSuite) newProvisionerTaskWithBrokerAndEventCb(
 ) provisionertask.ProvisionerTask {
 	task, err := provisionertask.NewProvisionerTask(provisionertask.TaskConfig{
 		ControllerUUID:          internaltesting.ControllerTag.Id(),
+		ModelUUID:               internaltesting.ModelTag.Id(),
 		HostTag:                 names.NewMachineTag("0"),
 		Logger:                  loggertesting.WrapCheckLog(c),
 		ControllerAPI:           s.controllerAPI,
@@ -1733,7 +1736,18 @@ func (s *ProvisionerTaskSuite) setUpMocks(c *tc.C) *gomock.Controller {
 func (s *ProvisionerTaskSuite) newModelConfig(
 	c *tc.C, enableOSRefreshUpdate, enableOSUpgrade bool,
 ) *config.Config {
+	return s.newModelConfigWithAgentVersion(
+		c, enableOSRefreshUpdate, enableOSUpgrade, internaltesting.FakeVersionNumber,
+	)
+}
+
+func (s *ProvisionerTaskSuite) newModelConfigWithAgentVersion(
+	c *tc.C,
+	enableOSRefreshUpdate, enableOSUpgrade bool,
+	agentVersion semversion.Number,
+) *config.Config {
 	modelConfig, err := config.New(config.NoDefaults, internaltesting.FakeConfig().Merge(internaltesting.Attrs{
+		config.AgentVersionKey:          agentVersion.String(),
 		config.EnableOSRefreshUpdateKey: enableOSRefreshUpdate,
 		config.EnableOSUpgradeKey:       enableOSUpgrade,
 	}))
@@ -1897,7 +1911,6 @@ type testMachine struct {
 
 	id             string
 	life           life.Value
-	agentVersion   semversion.Number
 	instance       *testInstance
 	keepInstance   bool
 	markForRemoval bool
@@ -2021,10 +2034,7 @@ func (m *testMachine) Status(context.Context) (status.Status, string, error) {
 }
 
 func (m *testMachine) ModelAgentVersion(context.Context) (*semversion.Number, error) {
-	if m.agentVersion == semversion.Zero {
-		return &internaltesting.FakeVersionNumber, nil
-	}
-	return &m.agentVersion, nil
+	return nil, errors.New("unexpected ModelAgentVersion call")
 }
 
 func (m *testMachine) SetUnprovisioned() {

--- a/internal/worker/computeprovisioner/computeprovisioner.go
+++ b/internal/worker/computeprovisioner/computeprovisioner.go
@@ -157,9 +157,14 @@ func (p *environProvisioner) getStartTask(ctx context.Context, workerCount int) 
 	if err != nil {
 		return nil, errors.Annotate(err, "could not retrieve the controller config.")
 	}
+	modelUUID, err := p.controllerAPI.ModelUUID(ctx)
+	if err != nil {
+		return nil, errors.Annotate(err, "could not retrieve the model UUID.")
+	}
 
 	task, err := provisionertask.NewProvisionerTask(provisionertask.TaskConfig{
 		ControllerUUID:               controllerCfg.ControllerUUID(),
+		ModelUUID:                    modelUUID,
 		HostTag:                      hostTag,
 		Logger:                       p.logger,
 		ControllerAPI:                p.controllerAPI,

--- a/internal/worker/computeprovisioner/computeprovisioner_test.go
+++ b/internal/worker/computeprovisioner/computeprovisioner_test.go
@@ -78,7 +78,7 @@ func (s *CommonProvisionerSuite) expectStartup(c *tc.C) {
 	s.controllerAPI.EXPECT().WatchForModelConfigChanges(gomock.Any()).Return(watchCfg, nil)
 
 	cfg := coretesting.CustomModelConfig(c, coretesting.Attrs{})
-	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).AnyTimes()
+	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).Times(2)
 
 	s.provisionerStarted = make(chan bool)
 	controllerCfg := coretesting.FakeControllerConfig()
@@ -298,6 +298,7 @@ func (s *ProvisionerSuite) TestMachineStartedAndStopped(c *tc.C) {
 	s.machinesAPI.EXPECT().Machines(gomock.Any(), mTag).Return([]apiprovisioner.MachineResult{{
 		Machine: m666,
 	}}, nil).Times(2)
+	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(coretesting.CustomModelConfig(c, coretesting.Attrs{}), nil)
 	s.machinesAPI.EXPECT().ProvisioningInfo(gomock.Any(), []names.MachineTag{mTag}).Return(params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{{
 			Result: &params.ProvisioningInfo{
@@ -367,7 +368,7 @@ func (s *ProvisionerSuite) TestEnvironProvisionerObservesConfigChangesWorkerCoun
 var (
 	startInstanceArgTemplate = environs.StartInstanceParams{
 		ControllerUUID: coretesting.ControllerTag.Id(),
-		Tools:          tools.List{{Version: semversion.MustParseBinary("2.99.0-ubuntu-amd64")}},
+		Tools:          tools.List{{Version: semversion.MustParseBinary("2.0.0-ubuntu-amd64")}},
 	}
 	instanceConfigTemplate = instancecfg.InstanceConfig{
 		ControllerTag:    coretesting.ControllerTag,
@@ -378,13 +379,15 @@ var (
 			Addrs:    []string{"10.0.0.1"},
 			CACert:   coretesting.CACert,
 		},
-		Base:               corebase.MustParseBaseFromString("ubuntu@22.04"),
-		TransientDataDir:   "/var/run/juju",
-		DataDir:            "/var/lib/juju",
-		LogDir:             "/var/log/juju",
-		MetricsSpoolDir:    "/var/lib/juju/metricspool",
-		CloudInitOutputLog: "/var/log/cloud-init-output.log",
-		ImageStream:        "released",
+		Base:                  corebase.MustParseBaseFromString("ubuntu@22.04"),
+		TransientDataDir:      "/var/run/juju",
+		DataDir:               "/var/lib/juju",
+		LogDir:                "/var/log/juju",
+		MetricsSpoolDir:       "/var/lib/juju/metricspool",
+		CloudInitOutputLog:    "/var/log/cloud-init-output.log",
+		ImageStream:           "released",
+		EnableOSRefreshUpdate: true,
+		EnableOSUpgrade:       true,
 	}
 )
 

--- a/internal/worker/computeprovisioner/computeprovisioner_test.go
+++ b/internal/worker/computeprovisioner/computeprovisioner_test.go
@@ -78,7 +78,7 @@ func (s *CommonProvisionerSuite) expectStartup(c *tc.C) {
 	s.controllerAPI.EXPECT().WatchForModelConfigChanges(gomock.Any()).Return(watchCfg, nil)
 
 	cfg := coretesting.CustomModelConfig(c, coretesting.Attrs{})
-	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).MaxTimes(2)
+	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).AnyTimes()
 
 	s.provisionerStarted = make(chan bool)
 	controllerCfg := coretesting.FakeControllerConfig()

--- a/internal/worker/containerprovisioner/containerprovisioner.go
+++ b/internal/worker/containerprovisioner/containerprovisioner.go
@@ -259,9 +259,14 @@ func (p *containerProvisioner) getStartTask(ctx context.Context, workerCount int
 	if err != nil {
 		return nil, errors.Annotate(err, "could not retrieve the controller config.")
 	}
+	modelUUID, err := p.controllerAPI.ModelUUID(ctx)
+	if err != nil {
+		return nil, errors.Annotate(err, "could not retrieve the model UUID.")
+	}
 
 	task, err := provisionertask.NewProvisionerTask(provisionertask.TaskConfig{
 		ControllerUUID:               controllerCfg.ControllerUUID(),
+		ModelUUID:                    modelUUID,
 		HostTag:                      hostTag,
 		Logger:                       p.logger,
 		ControllerAPI:                p.controllerAPI,

--- a/internal/worker/containerprovisioner/containerprovisioner_test.go
+++ b/internal/worker/containerprovisioner/containerprovisioner_test.go
@@ -78,7 +78,7 @@ func (s *lxdProvisionerSuite) expectStartup(c *tc.C) {
 	s.controllerAPI.EXPECT().WatchForModelConfigChanges(gomock.Any()).Return(watchCfg, nil)
 
 	cfg := coretesting.CustomModelConfig(c, coretesting.Attrs{})
-	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).MaxTimes(2)
+	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).AnyTimes()
 
 	s.provisionerStarted = make(chan bool)
 	controllerCfg := coretesting.FakeControllerConfig()

--- a/internal/worker/containerprovisioner/containerprovisioner_test.go
+++ b/internal/worker/containerprovisioner/containerprovisioner_test.go
@@ -78,7 +78,7 @@ func (s *lxdProvisionerSuite) expectStartup(c *tc.C) {
 	s.controllerAPI.EXPECT().WatchForModelConfigChanges(gomock.Any()).Return(watchCfg, nil)
 
 	cfg := coretesting.CustomModelConfig(c, coretesting.Attrs{})
-	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).AnyTimes()
+	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).Times(2)
 
 	s.provisionerStarted = make(chan bool)
 	controllerCfg := coretesting.FakeControllerConfig()
@@ -172,6 +172,7 @@ func (s *lxdProvisionerSuite) TestContainerStartedAndStopped(c *tc.C) {
 	s.machinesAPI.EXPECT().Machines(gomock.Any(), cTag).Return([]apiprovisioner.MachineResult{{
 		Machine: c666,
 	}}, nil).Times(2)
+	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(coretesting.CustomModelConfig(c, coretesting.Attrs{}), nil)
 	s.machinesAPI.EXPECT().ProvisioningInfo(gomock.Any(), []names.MachineTag{cTag}).Return(params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{{
 			Result: &params.ProvisioningInfo{
@@ -284,7 +285,7 @@ func (s *lxdProvisionerSuite) sendModelConfigChange(c *tc.C) {
 var (
 	startInstanceArgTemplate = environs.StartInstanceParams{
 		ControllerUUID: coretesting.ControllerTag.Id(),
-		Tools:          tools.List{{Version: semversion.MustParseBinary("2.99.0-ubuntu-amd64")}},
+		Tools:          tools.List{{Version: semversion.MustParseBinary("2.0.0-ubuntu-amd64")}},
 	}
 	instanceConfigTemplate = instancecfg.InstanceConfig{
 		ControllerTag:    coretesting.ControllerTag,
@@ -295,13 +296,15 @@ var (
 			Addrs:    []string{"10.0.0.1"},
 			CACert:   coretesting.CACert,
 		},
-		Base:               corebase.MustParseBaseFromString("ubuntu@22.04"),
-		TransientDataDir:   "/var/run/juju",
-		DataDir:            "/var/lib/juju",
-		LogDir:             "/var/log/juju",
-		MetricsSpoolDir:    "/var/lib/juju/metricspool",
-		CloudInitOutputLog: "/var/log/cloud-init-output.log",
-		ImageStream:        "released",
+		Base:                  corebase.MustParseBaseFromString("ubuntu@22.04"),
+		TransientDataDir:      "/var/run/juju",
+		DataDir:               "/var/lib/juju",
+		LogDir:                "/var/log/juju",
+		MetricsSpoolDir:       "/var/lib/juju/metricspool",
+		CloudInitOutputLog:    "/var/log/cloud-init-output.log",
+		ImageStream:           "released",
+		EnableOSRefreshUpdate: true,
+		EnableOSUpgrade:       true,
 	}
 )
 


### PR DESCRIPTION
When creating a new machine, we must ensure that we pass os refresh update and os upgrade through the provisioner, otherwise it'll get wedged during creation if there is an outage and you have a apt proxy in place.

Whilst I was here, it was noticed that model UUID, model config and model agent version where being re-requested in a tight loop. We know for certain that the model UUID won't change, I suspect that it will be totally OK for the agent version not be request in a tight loop for the version. If the agent version does change, it can pick that up after deployment.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-unit -m controller controller -n 2
```
