### PR TITLE
fix(secrets): grant drain workers access to secrets not yet on the target backend

### DIFF
--- a/apiserver/facades/agent/secretsmanager/mocks/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secrets.go
@@ -284,6 +284,7 @@ type MockSecretServiceMockRecorder struct {
 	getSecretValueExpects                  []*gomock.Call4_3[context.Context, *secrets.URI, int, secret.SecretAccessor, secrets.SecretValue, *secrets.ValueRef, error]
 	listCharmSecretsExpects                []*gomock.Call1V_3[context.Context, secret.CharmSecretOwner, []*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error]
 	listGrantedSecretsForBackendExpects    []*gomock.Call3V_2[context.Context, string, secrets.SecretRole, secret.SecretAccessor, []*secrets.SecretRevisionRef, error]
+	listGrantedSecretsForDrainExpects      []*gomock.Call2V_2[context.Context, secrets.SecretRole, secret.SecretAccessor, []*secrets.SecretRevisionRef, error]
 	processCharmSecretConsumerLabelExpects []*gomock.Call4_3[context.Context, unit.Name, *secrets.URI, string, *secrets.URI, *string, error]
 }
 
@@ -426,6 +427,25 @@ func (mr *MockSecretServiceMockRecorder) ListGrantedSecretsForBackend(ctx, backe
 
 // MockSecretServiceListGrantedSecretsForBackendCall is the typed call wrapper for ListGrantedSecretsForBackend.
 type MockSecretServiceListGrantedSecretsForBackendCall = gomock.Call3V_2[context.Context, string, secrets.SecretRole, secret.SecretAccessor, []*secrets.SecretRevisionRef, error]
+
+// ListGrantedSecretsForDrain mocks base method.
+func (m *MockSecretService) ListGrantedSecretsForDrain(ctx context.Context, role secrets.SecretRole, consumers ...secret.SecretAccessor) ([]*secrets.SecretRevisionRef, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2V_2(&m.recorder.listGrantedSecretsForDrainExpects, m.ctrl, m, "ListGrantedSecretsForDrain", ctx, role, consumers...)
+}
+
+// ListGrantedSecretsForDrain indicates an expected call of ListGrantedSecretsForDrain.
+func (mr *MockSecretServiceMockRecorder) ListGrantedSecretsForDrain(ctx, role any, consumers ...any) *MockSecretServiceListGrantedSecretsForDrainCall {
+	mr.mock.ctrl.T.Helper()
+	varArgs := gomock.EnsureVariadicMatcher(consumers)
+	call := gomock.NewCall2V_2[context.Context, secrets.SecretRole, secret.SecretAccessor, []*secrets.SecretRevisionRef, error](mr.mock.ctrl.T, mr.mock, "ListGrantedSecretsForDrain", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(role), varArgs)
+	mr.listGrantedSecretsForDrainExpects = append(mr.listGrantedSecretsForDrainExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockSecretServiceListGrantedSecretsForDrainCall is the typed call wrapper for ListGrantedSecretsForDrain.
+type MockSecretServiceListGrantedSecretsForDrainCall = gomock.Call2V_2[context.Context, secrets.SecretRole, secret.SecretAccessor, []*secrets.SecretRevisionRef, error]
 
 // ProcessCharmSecretConsumerLabel mocks base method.
 func (m *MockSecretService) ProcessCharmSecretConsumerLabel(ctx context.Context, unitName unit.Name, uri *secrets.URI, label string) (*secrets.URI, *string, error) {

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -106,8 +106,8 @@ func (s *SecretsManagerAPI) getBackendConfigForDrain(ctx context.Context, arg pa
 	appName, _ := names.UnitApplication(s.authTag.Id())
 	token := s.leadershipChecker.LeadershipCheck(appName, s.authTag.Id())
 	cfgInfo, err := s.secretBackendService.DrainBackendConfigInfo(ctx, secretbackendservice.DrainBackendConfigParams{
-		GrantedSecretsGetter: s.secretService.ListGrantedSecretsForBackend,
-		LeaderToken:          token,
+		GrantedSecretsForDrainGetter: s.secretService.ListGrantedSecretsForDrain,
+		LeaderToken:                  token,
 		Accessor: secret.SecretAccessor{
 			Kind: secret.UnitAccessor,
 			ID:   s.authTag.Id(),

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -125,8 +125,8 @@ func (m backendConfigParamsMatcher) Matches(x any) bool {
 	if !ok {
 		return false
 	}
-	m.c.Assert(obtained.GrantedSecretsGetter, tc.NotNil)
-	obtained.GrantedSecretsGetter = nil
+	m.c.Assert(obtained.GrantedSecretsForDrainGetter, tc.NotNil)
+	obtained.GrantedSecretsForDrainGetter = nil
 	m.c.Assert(obtained, tc.DeepEquals, m.expected)
 	return true
 }

--- a/apiserver/facades/agent/secretsmanager/service.go
+++ b/apiserver/facades/agent/secretsmanager/service.go
@@ -108,6 +108,13 @@ type SecretService interface {
 	ListGrantedSecretsForBackend(
 		ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secret.SecretAccessor,
 	) ([]*secrets.SecretRevisionRef, error)
+
+	// ListGrantedSecretsForDrain returns all secrets granted to the
+	// given consumers at the specified role, regardless of which backend
+	// holds them.
+	ListGrantedSecretsForDrain(
+		ctx context.Context, role secrets.SecretRole, consumers ...secret.SecretAccessor,
+	) ([]*secrets.SecretRevisionRef, error)
 }
 
 // SecretBackendService provides access to the secret backend service.

--- a/apiserver/facades/controller/usersecretsdrain/drain.go
+++ b/apiserver/facades/controller/usersecretsdrain/drain.go
@@ -46,7 +46,7 @@ func (s *SecretsDrainAPI) GetSecretBackendConfigs(ctx context.Context, arg param
 		Results: make(map[string]params.SecretBackendConfigResult, 1),
 	}
 	cfgInfo, err := s.secretBackendService.DrainBackendConfigInfo(ctx, secretbackendservice.DrainBackendConfigParams{
-		GrantedSecretsGetter: s.secretService.ListGrantedSecretsForBackend,
+		GrantedSecretsForDrainGetter: s.secretService.ListGrantedSecretsForDrain,
 		Accessor: secret.SecretAccessor{
 			Kind: secret.ModelAccessor,
 			ID:   s.modelUUID.String(),

--- a/apiserver/facades/controller/usersecretsdrain/drain_test.go
+++ b/apiserver/facades/controller/usersecretsdrain/drain_test.go
@@ -69,8 +69,8 @@ func (m backendConfigParamsMatcher) Matches(x any) bool {
 	if !ok {
 		return false
 	}
-	m.c.Assert(obtained.GrantedSecretsGetter, tc.NotNil)
-	obtained.GrantedSecretsGetter = nil
+	m.c.Assert(obtained.GrantedSecretsForDrainGetter, tc.NotNil)
+	obtained.GrantedSecretsForDrainGetter = nil
 	m.c.Assert(obtained, tc.DeepEquals, m.expected)
 	return true
 }

--- a/apiserver/facades/controller/usersecretsdrain/mocks/service_mock.go
+++ b/apiserver/facades/controller/usersecretsdrain/mocks/service_mock.go
@@ -32,6 +32,7 @@ type MockSecretServiceMockRecorder struct {
 	getSecretExpects                    []*gomock.Call2_2[context.Context, *secrets.URI, *secrets.SecretMetadata, error]
 	getSecretValueExpects               []*gomock.Call4_3[context.Context, *secrets.URI, int, secret.SecretAccessor, secrets.SecretValue, *secrets.ValueRef, error]
 	listGrantedSecretsForBackendExpects []*gomock.Call3V_2[context.Context, string, secrets.SecretRole, secret.SecretAccessor, []*secrets.SecretRevisionRef, error]
+	listGrantedSecretsForDrainExpects   []*gomock.Call2V_2[context.Context, secrets.SecretRole, secret.SecretAccessor, []*secrets.SecretRevisionRef, error]
 }
 
 // NewMockSecretService creates a new mock instance.
@@ -100,6 +101,25 @@ func (mr *MockSecretServiceMockRecorder) ListGrantedSecretsForBackend(ctx, backe
 
 // MockSecretServiceListGrantedSecretsForBackendCall is the typed call wrapper for ListGrantedSecretsForBackend.
 type MockSecretServiceListGrantedSecretsForBackendCall = gomock.Call3V_2[context.Context, string, secrets.SecretRole, secret.SecretAccessor, []*secrets.SecretRevisionRef, error]
+
+// ListGrantedSecretsForDrain mocks base method.
+func (m *MockSecretService) ListGrantedSecretsForDrain(ctx context.Context, role secrets.SecretRole, consumers ...secret.SecretAccessor) ([]*secrets.SecretRevisionRef, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch2V_2(&m.recorder.listGrantedSecretsForDrainExpects, m.ctrl, m, "ListGrantedSecretsForDrain", ctx, role, consumers...)
+}
+
+// ListGrantedSecretsForDrain indicates an expected call of ListGrantedSecretsForDrain.
+func (mr *MockSecretServiceMockRecorder) ListGrantedSecretsForDrain(ctx, role any, consumers ...any) *MockSecretServiceListGrantedSecretsForDrainCall {
+	mr.mock.ctrl.T.Helper()
+	varArgs := gomock.EnsureVariadicMatcher(consumers)
+	call := gomock.NewCall2V_2[context.Context, secrets.SecretRole, secret.SecretAccessor, []*secrets.SecretRevisionRef, error](mr.mock.ctrl.T, mr.mock, "ListGrantedSecretsForDrain", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(role), varArgs)
+	mr.listGrantedSecretsForDrainExpects = append(mr.listGrantedSecretsForDrainExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockSecretServiceListGrantedSecretsForDrainCall is the typed call wrapper for ListGrantedSecretsForDrain.
+type MockSecretServiceListGrantedSecretsForDrainCall = gomock.Call2V_2[context.Context, secrets.SecretRole, secret.SecretAccessor, []*secrets.SecretRevisionRef, error]
 
 // MockSecretBackendService is a mock of SecretBackendService interface.
 type MockSecretBackendService struct {

--- a/apiserver/facades/controller/usersecretsdrain/service.go
+++ b/apiserver/facades/controller/usersecretsdrain/service.go
@@ -19,6 +19,9 @@ type SecretService interface {
 	ListGrantedSecretsForBackend(
 		ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secret.SecretAccessor,
 	) ([]*secrets.SecretRevisionRef, error)
+	ListGrantedSecretsForDrain(
+		ctx context.Context, role secrets.SecretRole, consumers ...secret.SecretAccessor,
+	) ([]*secrets.SecretRevisionRef, error)
 }
 
 // SecretBackendService provides access to the secret backend service,

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -128,6 +128,39 @@ func (s *SecretService) ListGrantedSecretsForBackend(
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
+	accessors, err := convertConsumersToAccessParams(consumers...)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	// Expand the requested role to include all roles that satisfy it.
+	roles := expandRolesToMatch(role)
+
+	return s.secretState.ListGrantedSecretsForBackend(ctx, backendID, accessors, roles)
+}
+
+// ListGrantedSecretsForDrain returns the secret revision info for any
+// secrets for which the specified consumers have been granted the specified
+// access, regardless of which backend holds them. This is used when draining
+// secrets to a new backend.
+func (s *SecretService) ListGrantedSecretsForDrain(
+	ctx context.Context, role secrets.SecretRole, consumers ...domainsecret.SecretAccessor,
+) ([]*secrets.SecretRevisionRef, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	accessors, err := convertConsumersToAccessParams(consumers...)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	// Expand the requested role to include all roles that satisfy it.
+	roles := expandRolesToMatch(role)
+
+	return s.secretState.ListGrantedSecretsForDrain(ctx, accessors, roles)
+}
+
+func convertConsumersToAccessParams(consumers ...domainsecret.SecretAccessor) ([]domainsecret.AccessParams, error) {
 	accessors := make([]domainsecret.AccessParams, len(consumers))
 	for i, consumer := range consumers {
 		accessor := domainsecret.AccessParams{
@@ -145,11 +178,7 @@ func (s *SecretService) ListGrantedSecretsForBackend(
 		}
 		accessors[i] = accessor
 	}
-
-	// Expand the requested role to include all roles that satisfy it.
-	roles := expandRolesToMatch(role)
-
-	return s.secretState.ListGrantedSecretsForBackend(ctx, backendID, accessors, roles)
+	return accessors, nil
 }
 
 // expandRolesToMatch returns a slice of roles that satisfy the requested role.

--- a/domain/secret/service/interface.go
+++ b/domain/secret/service/interface.go
@@ -139,6 +139,13 @@ type State interface {
 		ctx context.Context, backendID string, accessors []domainsecret.AccessParams, roles []domainsecret.Role,
 	) ([]*secrets.SecretRevisionRef, error)
 
+	// ListGrantedSecretsForDrain returns all secrets granted to the
+	// specified accessors at the given roles, regardless of which backend
+	// holds them.
+	ListGrantedSecretsForDrain(
+		ctx context.Context, accessors []domainsecret.AccessParams, roles []domainsecret.Role,
+	) ([]*secrets.SecretRevisionRef, error)
+
 	// ListCharmSecretsToDrain returns charm secrets that are ready to
 	// be drained from the old backend.
 	ListCharmSecretsToDrain(

--- a/domain/secret/service/package_mock_test.go
+++ b/domain/secret/service/package_mock_test.go
@@ -83,6 +83,7 @@ type MockStateMockRecorder struct {
 	listCharmSecretsExpects                                     []*gomock.Call3_3[context.Context, secret.ApplicationOwners, secret.UnitOwners, []*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error]
 	listCharmSecretsToDrainExpects                              []*gomock.Call3_2[context.Context, secret.ApplicationOwners, secret.UnitOwners, []*secrets.SecretMetadataForDrain, error]
 	listGrantedSecretsForBackendExpects                         []*gomock.Call4_2[context.Context, string, []secret.AccessParams, []secret.Role, []*secrets.SecretRevisionRef, error]
+	listGrantedSecretsForDrainExpects                           []*gomock.Call3_2[context.Context, []secret.AccessParams, []secret.Role, []*secrets.SecretRevisionRef, error]
 	listSecretsByLabelsExpects                                  []*gomock.Call3_3[context.Context, secret.Labels, *int, []*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error]
 	listUserSecretsToDrainExpects                               []*gomock.Call1_2[context.Context, []*secrets.SecretMetadataForDrain, error]
 	namespaceForWatchSecretMetadataExpects                      []*gomock.Call0_1[string]
@@ -939,6 +940,24 @@ func (mr *MockStateMockRecorder) ListGrantedSecretsForBackend(ctx, backendID, ac
 
 // MockStateListGrantedSecretsForBackendCall is the typed call wrapper for ListGrantedSecretsForBackend.
 type MockStateListGrantedSecretsForBackendCall = gomock.Call4_2[context.Context, string, []secret.AccessParams, []secret.Role, []*secrets.SecretRevisionRef, error]
+
+// ListGrantedSecretsForDrain mocks base method.
+func (m *MockState) ListGrantedSecretsForDrain(ctx context.Context, accessors []secret.AccessParams, roles []secret.Role) ([]*secrets.SecretRevisionRef, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch3_2(&m.recorder.listGrantedSecretsForDrainExpects, m.ctrl, m, "ListGrantedSecretsForDrain", ctx, accessors, roles)
+}
+
+// ListGrantedSecretsForDrain indicates an expected call of ListGrantedSecretsForDrain.
+func (mr *MockStateMockRecorder) ListGrantedSecretsForDrain(ctx, accessors, roles any) *MockStateListGrantedSecretsForDrainCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall3_2[context.Context, []secret.AccessParams, []secret.Role, []*secrets.SecretRevisionRef, error](mr.mock.ctrl.T, mr.mock, "ListGrantedSecretsForDrain", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(accessors), gomock.EnsureMatcher(roles))
+	mr.listGrantedSecretsForDrainExpects = append(mr.listGrantedSecretsForDrainExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockStateListGrantedSecretsForDrainCall is the typed call wrapper for ListGrantedSecretsForDrain.
+type MockStateListGrantedSecretsForDrainCall = gomock.Call3_2[context.Context, []secret.AccessParams, []secret.Role, []*secrets.SecretRevisionRef, error]
 
 // ListSecretsByLabels mocks base method.
 func (m *MockState) ListSecretsByLabels(ctx context.Context, labels secret.Labels, revision *int) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {

--- a/domain/secret/service/params.go
+++ b/domain/secret/service/params.go
@@ -49,6 +49,12 @@ type GrantedSecretsGetter func(
 	ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secret.SecretAccessor,
 ) ([]*secrets.SecretRevisionRef, error)
 
+// GrantedSecretsForDrainGetter returns the revisions for which consumers have
+// access with the given role, regardless of which backend holds them.
+type GrantedSecretsForDrainGetter func(
+	ctx context.Context, role secrets.SecretRole, consumers ...secret.SecretAccessor,
+) ([]*secrets.SecretRevisionRef, error)
+
 // SecretAccess is used to define access to a secret.
 type SecretAccess struct {
 	Scope   secret.SecretAccessScope

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -2653,3 +2653,77 @@ func (s *serviceSuite) TestListGrantedSecretsForBackendInvalidAccessorKind(c *tc
 	)
 	c.Assert(err, tc.ErrorMatches, `consumer kind "invalid-kind" not valid`)
 }
+
+func (s *serviceSuite) TestListGrantedSecretsForDrainWithRoleView(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uri := coresecrets.NewURI()
+	expected := []*coresecrets.SecretRevisionRef{{
+		URI:        uri,
+		RevisionID: "rev-id",
+	}}
+
+	s.state.EXPECT().ListGrantedSecretsForDrain(
+		gomock.Any(),
+		[]domainsecret.AccessParams{{
+			SubjectTypeID: domainsecret.SubjectApplication,
+			SubjectID:     "mysql",
+		}},
+		[]domainsecret.Role{domainsecret.RoleView, domainsecret.RoleManage},
+	).Return(expected, nil)
+
+	result, err := s.service.ListGrantedSecretsForDrain(
+		c.Context(),
+		coresecrets.RoleView,
+		domainsecret.SecretAccessor{
+			Kind: domainsecret.ApplicationAccessor,
+			ID:   "mysql",
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, expected)
+}
+
+func (s *serviceSuite) TestListGrantedSecretsForDrainWithRoleManage(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uri := coresecrets.NewURI()
+	expected := []*coresecrets.SecretRevisionRef{{
+		URI:        uri,
+		RevisionID: "rev-id",
+	}}
+
+	s.state.EXPECT().ListGrantedSecretsForDrain(
+		gomock.Any(),
+		[]domainsecret.AccessParams{{
+			SubjectTypeID: domainsecret.SubjectUnit,
+			SubjectID:     "mysql/0",
+		}},
+		[]domainsecret.Role{domainsecret.RoleManage},
+	).Return(expected, nil)
+
+	result, err := s.service.ListGrantedSecretsForDrain(
+		c.Context(),
+		coresecrets.RoleManage,
+		domainsecret.SecretAccessor{
+			Kind: domainsecret.UnitAccessor,
+			ID:   "mysql/0",
+		},
+	)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, expected)
+}
+
+func (s *serviceSuite) TestListGrantedSecretsForDrainInvalidAccessorKind(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	_, err := s.service.ListGrantedSecretsForDrain(
+		c.Context(),
+		coresecrets.RoleView,
+		domainsecret.SecretAccessor{
+			Kind: "invalid-kind",
+			ID:   "some-id",
+		},
+	)
+	c.Assert(err, tc.ErrorMatches, `consumer kind "invalid-kind" not valid`)
+}

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -3203,20 +3203,83 @@ AND    (sp.subject_type_id = $secretAccessorType.unit_type_id AND suu.name IN ($
         OR sp.subject_type_id = $secretAccessorType.app_type_id AND sua.name IN ($applications[:])
         OR sp.subject_type_id = $secretAccessorType.model_type_id AND sp.subject_uuid IN ($models[:])
        )`
-	secretBackendID := secretBackendID{
-		ID: backendID,
+
+	appAccessors, unitAccessors, modelAccessors := splitAccessorsBySubjectType(accessors)
+
+	queryParams := []any{
+		appAccessors,
+		unitAccessors,
+		modelAccessors,
+		secretAccessorTypeParam,
+		secretRolesFromDomain(roleIDs),
+		secretBackendID{ID: backendID},
 	}
 
-	secretRoles := make(roles, len(roleIDs))
-	for i, r := range roleIDs {
-		secretRoles[i] = int(r)
+	queryStmt, err := st.Prepare(query, append(queryParams, secretInfo{}, secretValueRef{})...)
+	if err != nil {
+		return nil, errors.Capture(err)
 	}
 
+	return runGrantedSecretsQuery(ctx, db, queryStmt, queryParams)
+}
+
+// ListGrantedSecretsForDrain returns the secret revision info for any
+// secrets for which the specified consumers have been granted any of the
+// specified roles, regardless of which backend holds them. This is used
+// when preparing access for a drain worker: the secrets being moved still
+// live in the old backend (internal or another external one), so the
+// accessor must be granted access to them on the target backend before they
+// are moved.
+func (st State) ListGrantedSecretsForDrain(
+	ctx context.Context, accessors []domainsecret.AccessParams, roleIDs []domainsecret.Role,
+) ([]*coresecrets.SecretRevisionRef, error) {
+	db, err := st.DB(ctx)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	query := `
+SELECT (sm.secret_id) AS (&secretInfo.*),
+       (svr.*) AS (&secretValueRef.*)
+FROM   secret_metadata sm
+JOIN   secret_revision rev ON rev.secret_id = sm.secret_id
+LEFT JOIN secret_value_ref svr ON svr.revision_uuid = rev.uuid
+JOIN   secret_permission sp ON sp.secret_id = sm.secret_id
+LEFT JOIN unit suu ON sp.subject_uuid = suu.uuid AND sp.subject_type_id = $secretAccessorType.unit_type_id
+LEFT JOIN application sua ON sp.subject_uuid = sua.uuid AND sp.subject_type_id = $secretAccessorType.app_type_id
+WHERE  sp.role_id IN ($roles[:])
+AND    (sp.subject_type_id = $secretAccessorType.unit_type_id AND suu.name IN ($units[:])
+        OR sp.subject_type_id = $secretAccessorType.app_type_id AND sua.name IN ($applications[:])
+        OR sp.subject_type_id = $secretAccessorType.model_type_id AND sp.subject_uuid IN ($models[:])
+       )`
+
+	appAccessors, unitAccessors, modelAccessors := splitAccessorsBySubjectType(accessors)
+
+	queryParams := []any{
+		appAccessors,
+		unitAccessors,
+		modelAccessors,
+		secretAccessorTypeParam,
+		secretRolesFromDomain(roleIDs),
+	}
+
+	queryStmt, err := st.Prepare(query, append(queryParams, secretInfo{}, secretValueRef{})...)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	return runGrantedSecretsQuery(ctx, db, queryStmt, queryParams)
+}
+
+// splitAccessorsBySubjectType splits the given access params into the
+// per-subject-type slices used to build the accessor predicate shared by
+// ListGrantedSecretsForBackend and ListGrantedSecretsForDrain.
+func splitAccessorsBySubjectType(accessors []domainsecret.AccessParams) (applications, units, models) {
 	// Ideally we'd use IN tuple but sqlair doesn't support that.
 	var (
-		modelAccessors models
 		appAccessors   applications
 		unitAccessors  units
+		modelAccessors models
 	)
 	for _, a := range accessors {
 		switch a.SubjectTypeID {
@@ -3230,21 +3293,26 @@ AND    (sp.subject_type_id = $secretAccessorType.unit_type_id AND suu.name IN ($
 			continue
 		}
 	}
+	return appAccessors, unitAccessors, modelAccessors
+}
 
-	queryParams := []any{
-		appAccessors,
-		unitAccessors,
-		modelAccessors,
-		secretAccessorTypeParam,
-		secretRoles,
-		secretBackendID,
+// secretRolesFromDomain converts domain role IDs into the roles type used by
+// ListGrantedSecretsForBackend and ListGrantedSecretsForDrain.
+func secretRolesFromDomain(roleIDs []domainsecret.Role) roles {
+	secretRoles := make(roles, len(roleIDs))
+	for i, r := range roleIDs {
+		secretRoles[i] = int(r)
 	}
+	return secretRoles
+}
 
-	queryStmt, err := st.Prepare(query, append(queryParams, secretInfo{}, secretValueRef{})...)
-	if err != nil {
-		return nil, errors.Capture(err)
-	}
-
+// runGrantedSecretsQuery executes the given prepared statement and returns
+// the matching secret revision references. Shared by
+// ListGrantedSecretsForBackend and ListGrantedSecretsForDrain, which differ
+// only in the query text and parameters used to build queryStmt.
+func runGrantedSecretsQuery(
+	ctx context.Context, db domain.TxnRunner, queryStmt *sqlair.Statement, queryParams []any,
+) ([]*coresecrets.SecretRevisionRef, error) {
 	var revisionResult []*coresecrets.SecretRevisionRef
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -3643,6 +3643,119 @@ func (s *stateSuite) TestListGrantedSecrets(c *tc.C) {
 	}})
 }
 
+// TestListGrantedSecretsForDrain verifies that granted secrets are returned
+// regardless of which backend holds them. The drain worker relies on this:
+// the secrets being moved still live in the old backend (internal or another
+// external one), so the accessor must be granted access to them on the
+// target backend before they are moved. Internal secrets have no backend
+// value reference and no revision ID.
+func (s *stateSuite) TestListGrantedSecretsForDrain(c *tc.C) {
+	s.setupUnits(c, "mysql")
+
+	ctx := c.Context()
+
+	// A secret held on the target backend.
+	target := coresecrets.NewURI()
+	err := s.createCharmApplicationSecret(c, 1, target, "mysql", domainsecret.UpsertSecretParams{
+		RevisionUUID: new(uuid.MustNewUUID().String()),
+		ValueRef: &coresecrets.ValueRef{
+			BackendID:  "backend-id",
+			RevisionID: "revision-id",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// A secret held on a different external backend.
+	other := coresecrets.NewURI()
+	err = s.createCharmApplicationSecret(c, 1, other, "mysql", domainsecret.UpsertSecretParams{
+		RevisionUUID: new(uuid.MustNewUUID().String()),
+		ValueRef: &coresecrets.ValueRef{
+			BackendID:  "other-backend-id",
+			RevisionID: "other-revision-id",
+		},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	// An internal secret has its content in the Juju database and so has no
+	// backend value reference.
+	internal := coresecrets.NewURI()
+	err = s.createCharmApplicationSecret(c, 1, internal, "mysql", domainsecret.UpsertSecretParams{
+		RevisionUUID: new(uuid.MustNewUUID().String()),
+		Data:         coresecrets.SecretData{"foo": "bar"},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	accessors := []domainsecret.AccessParams{{
+		SubjectTypeID: domainsecret.SubjectApplication,
+		SubjectID:     "mysql",
+	}}
+	roles := []domainsecret.Role{domainsecret.RoleManage}
+
+	// ListGrantedSecretsForBackend only returns secrets held on the specified
+	// backend.
+	result, err := s.state.ListGrantedSecretsForBackend(ctx, "backend-id", accessors, roles)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.DeepEquals, []*coresecrets.SecretRevisionRef{{
+		URI:        target,
+		RevisionID: "revision-id",
+	}})
+
+	// ListGrantedSecretsForDrain returns secrets from all backends: the
+	// target backend, the internal backend (no revision ID) and any other
+	// external backend that could be the drain source.
+	result, err = s.state.ListGrantedSecretsForDrain(ctx, accessors, roles)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.SameContents, []*coresecrets.SecretRevisionRef{{
+		URI:        target,
+		RevisionID: "revision-id",
+	}, {
+		URI:        other,
+		RevisionID: "other-revision-id",
+	}, {
+		URI:        internal,
+		RevisionID: "",
+	}})
+}
+
+// TestListGrantedSecretsForDrainUnitOwned verifies that the drain listing
+// returns a unit-owned secret held in the internal backend. This is the exact
+// scenario of a unit drain worker draining a charm secret from the internal
+// backend to an external one: the secret has no backend value reference, so
+// it must be matched via the unit ownership grant.
+func (s *stateSuite) TestListGrantedSecretsForDrainUnitOwned(c *tc.C) {
+	s.setupUnits(c, "mysql")
+
+	ctx := c.Context()
+
+	// A unit-owned secret held in the internal backend (no value ref).
+	internal := coresecrets.NewURI()
+	err := s.createCharmUnitSecret(c, 1, internal, "mysql/0", domainsecret.UpsertSecretParams{
+		RevisionUUID: new(uuid.MustNewUUID().String()),
+		Data:         coresecrets.SecretData{"foo": "bar"},
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	accessors := []domainsecret.AccessParams{{
+		SubjectTypeID: domainsecret.SubjectUnit,
+		SubjectID:     "mysql/0",
+	}}
+	roles := []domainsecret.Role{domainsecret.RoleManage}
+
+	// For backend-id, nothing is returned: the secret is not on the
+	// external backend yet.
+	result, err := s.state.ListGrantedSecretsForBackend(ctx, "backend-id", accessors, roles)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.HasLen, 0)
+
+	// ListGrantedSecretsForDrain returns the internal secret (with no revision ID).
+	result, err = s.state.ListGrantedSecretsForDrain(ctx, accessors, roles)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(result, tc.SameContents, []*coresecrets.SecretRevisionRef{{
+		URI:        internal,
+		RevisionID: "",
+	}})
+}
+
 // TestListGrantedSecretsForBackendWithMultipleRoles verifies that when
 // multiple roles are passed, secrets with any of those roles are returned.
 // The "manage implies view" business logic is in the service layer which

--- a/domain/secretbackend/service/params.go
+++ b/domain/secretbackend/service/params.go
@@ -12,11 +12,11 @@ import (
 
 // DrainBackendConfigParams are used to get config for draining a secret backend.
 type DrainBackendConfigParams struct {
-	GrantedSecretsGetter secretservice.GrantedSecretsGetter
-	LeaderToken          leadership.Token
-	Accessor             secret.SecretAccessor
-	ModelUUID            coremodel.UUID
-	BackendID            string
+	GrantedSecretsForDrainGetter secretservice.GrantedSecretsForDrainGetter
+	LeaderToken                  leadership.Token
+	Accessor                     secret.SecretAccessor
+	ModelUUID                    coremodel.UUID
+	BackendID                    string
 }
 
 // BackendConfigParams are used to get config for reading secrets from a secret backend.

--- a/domain/secretbackend/service/service.go
+++ b/domain/secretbackend/service/service.go
@@ -135,8 +135,11 @@ func (s *Service) DrainBackendConfigInfo(
 	if !ok {
 		return nil, errors.Errorf("missing secret backend %q", p.BackendID)
 	}
+	if p.GrantedSecretsForDrainGetter == nil {
+		return nil, errors.Errorf("unexpected nil value for GrantedSecretsForDrainGetter")
+	}
 	backendCfg, err := s.backendConfigInfo(ctx,
-		p.GrantedSecretsGetter, p.BackendID, &cfg, p.Accessor, p.LeaderToken, true, true, nil)
+		p.GrantedSecretsForDrainGetter, &cfg, p.Accessor, p.LeaderToken, true, true, nil)
 	if err != nil {
 		return nil, errors.Capture(err)
 	}
@@ -173,13 +176,19 @@ func (s *Service) BackendConfigInfo(
 	if len(p.BackendIDs) == 0 {
 		p.BackendIDs = []string{adminModelCfg.ActiveID}
 	}
+	if p.GrantedSecretsGetter == nil {
+		return nil, errors.Errorf("unexpected nil value for GrantedSecretsGetter")
+	}
 	for _, backendID := range p.BackendIDs {
 		cfg, ok := adminModelCfg.Configs[backendID]
 		if !ok {
 			return nil, errors.Errorf("missing secret backend %q", backendID)
 		}
+		getter := func(ctx context.Context, role coresecrets.SecretRole, consumers ...secret.SecretAccessor) ([]*coresecrets.SecretRevisionRef, error) {
+			return p.GrantedSecretsGetter(ctx, backendID, role, consumers...)
+		}
 		backendCfg, err := s.backendConfigInfo(ctx,
-			p.GrantedSecretsGetter, backendID, &cfg, p.Accessor, p.LeaderToken, p.SameController, false, p.ReservedSecretIDs)
+			getter, &cfg, p.Accessor, p.LeaderToken, p.SameController, false, p.ReservedSecretIDs)
 		if err != nil {
 			return nil, errors.Capture(err)
 		}
@@ -190,15 +199,11 @@ func (s *Service) BackendConfigInfo(
 
 func (s *Service) backendConfigInfo(
 	ctx context.Context,
-	grantedSecretsGetter secretservice.GrantedSecretsGetter,
-	backendID string, cfg *provider.ModelBackendConfig,
+	grantedSecretsGetter secretservice.GrantedSecretsForDrainGetter,
+	cfg *provider.ModelBackendConfig,
 	accessor secret.SecretAccessor, token leadership.Token, sameController, forDrain bool,
 	reservedSecretIDs []string,
 ) (*provider.ModelBackendConfig, error) {
-	if grantedSecretsGetter == nil {
-		return nil, errors.Errorf("unexpected nil value for GrantedSecretsGetter")
-	}
-
 	p, err := s.registry(cfg.BackendType)
 	if err != nil {
 		return nil, errors.Capture(err)
@@ -249,7 +254,7 @@ func (s *Service) backendConfigInfo(
 				Kind: secret.ApplicationAccessor,
 				ID:   appName,
 			}
-			revInfo, err := grantedSecretsGetter(ctx, backendID, coresecrets.RoleView, readOnlyOwner)
+			revInfo, err := grantedSecretsGetter(ctx, coresecrets.RoleView, readOnlyOwner)
 			if err != nil {
 				return nil, errors.Capture(err)
 			}
@@ -257,7 +262,7 @@ func (s *Service) backendConfigInfo(
 				readRevisions.Add(r.URI, r.RevisionID)
 			}
 		}
-		revInfo, err := grantedSecretsGetter(ctx, backendID, coresecrets.RoleManage, owners...)
+		revInfo, err := grantedSecretsGetter(ctx, coresecrets.RoleManage, owners...)
 		if err != nil {
 			return nil, errors.Capture(err)
 		}
@@ -275,7 +280,7 @@ func (s *Service) backendConfigInfo(
 			Kind: secret.ApplicationAccessor,
 			ID:   appName,
 		}}
-		revInfo, err = grantedSecretsGetter(ctx, backendID, coresecrets.RoleView, consumers...)
+		revInfo, err = grantedSecretsGetter(ctx, coresecrets.RoleView, consumers...)
 		if err != nil {
 			return nil, errors.Capture(err)
 		}
@@ -296,7 +301,7 @@ func (s *Service) backendConfigInfo(
 			Kind: coresecrets.ModelAccessor,
 			ID:   accessor.ID,
 		}
-		revInfo, err := grantedSecretsGetter(ctx, backendID, coresecrets.RoleManage, accessor)
+		revInfo, err := grantedSecretsGetter(ctx, coresecrets.RoleManage, accessor)
 		if err != nil {
 			return nil, errors.Capture(err)
 		}
@@ -306,6 +311,30 @@ func (s *Service) backendConfigInfo(
 		}
 	default:
 		return nil, errors.Errorf("secret accessor kind %q %w", accessor.Kind, coreerrors.NotSupported)
+	}
+
+	// Revisions held in the internal backend have no external revision ID,
+	// so they name no object on the backend being configured. Drop them; the
+	// owned set still records the secret IDs.
+	// On non-drain paths, the backend filter ensures revision IDs are never
+	// empty, so this stripping only takes effect during drain.
+	for id, revisions := range ownedRevisions {
+		revisions.Remove("")
+		if revisions.IsEmpty() {
+			delete(ownedRevisions, id)
+		}
+	}
+	// Also drop any read revision for a secret the accessor owns: it is
+	// already covered by the owned rules. Keeping it breaks vault, where an
+	// exact path rule takes precedence over the owner glob rule and so
+	// shadows the write capability needed to update or drain the secret.
+	// This applies to both drain and non-drain paths: RoleView queries expand
+	// to include RoleManage, so owned secrets also surface in read queries.
+	for id, revisions := range readRevisions {
+		revisions.Remove("")
+		if owned.Contains(id) || revisions.IsEmpty() {
+			delete(readRevisions, id)
+		}
 	}
 
 	issuedTokenUUID := ""

--- a/domain/secretbackend/service/service_test.go
+++ b/domain/secretbackend/service/service_test.go
@@ -1140,9 +1140,8 @@ func (s *serviceSuite) TestDrainBackendConfigInfo(c *tc.C) {
 	).Return(&adminCfg.BackendConfig, nil)
 
 	listGranted := func(
-		ctx context.Context, backendID string, role coresecrets.SecretRole, consumers ...secret.SecretAccessor,
+		ctx context.Context, role coresecrets.SecretRole, consumers ...secret.SecretAccessor,
 	) ([]*coresecrets.SecretRevisionRef, error) {
-		c.Assert(backendID, tc.Equals, "backend-id")
 		if role == coresecrets.RoleManage {
 			c.Assert(consumers, tc.DeepEquals, []secret.SecretAccessor{{
 				Kind: secret.UnitAccessor,
@@ -1163,14 +1162,285 @@ func (s *serviceSuite) TestDrainBackendConfigInfo(c *tc.C) {
 		return read, nil
 	}
 	info, err := svc.DrainBackendConfigInfo(c.Context(), DrainBackendConfigParams{
-		GrantedSecretsGetter: listGranted,
-		LeaderToken:          token,
+		GrantedSecretsForDrainGetter: listGranted,
+		LeaderToken:                  token,
 		Accessor: secret.SecretAccessor{
 			Kind: secret.UnitAccessor,
 			ID:   "gitlab/0",
 		},
 		ModelUUID: coremodel.UUID(jujutesting.ModelTag.Id()),
 		BackendID: "backend-id",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(info, tc.DeepEquals, &provider.ModelBackendConfigInfo{
+		ActiveID: "backend-id",
+		Configs: map[string]provider.ModelBackendConfig{
+			"backend-id": {
+				ControllerUUID: jujutesting.ControllerTag.Id(),
+				ModelUUID:      jujutesting.ModelTag.Id(),
+				ModelName:      "fred",
+				BackendConfig: provider.BackendConfig{
+					BackendType: "some-backend",
+				},
+			},
+		},
+	})
+}
+
+// TestBackendConfigInfoOwnedSecretsNotInReadRevisions is a regression test
+// for the vault drain failure. When the granted secrets are listed across all
+// backends (as the drain worker does), secrets owned by the accessor are also
+// returned by the RoleView queries, so they must be filtered out of the read
+// revisions passed to the provider. Otherwise the vault provider generates an
+// exact path read-only rule for an owned revision, which shadows the glob
+// write rules (an exact path takes precedence over a glob in vault ACLs) and
+// prevents the agent from updating or draining its own secrets.
+func (s *serviceSuite) TestBackendConfigInfoOwnedSecretsNotInReadRevisions(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	svc := newService(
+		s.mockState, s.logger, s.clock,
+		func(backendType string) (provider.SecretBackendProvider, error) {
+			if backendType != vault.BackendType {
+				return s.mockRegistry, nil
+			}
+			return providerWithConfig{
+				SecretBackendProvider: s.mockRegistry,
+			}, nil
+		},
+	)
+
+	accessor := coresecrets.Accessor{
+		Kind: coresecrets.UnitAccessor,
+		ID:   "gitlab/0",
+	}
+	token := NewMockToken(ctrl)
+
+	unitOwned := []*coresecrets.SecretRevisionRef{
+		{URI: &coresecrets.URI{ID: "owned-1"}, RevisionID: "owned-rev-1"},
+		// An internal backend secret has no backend revision ID.
+		{URI: &coresecrets.URI{ID: "owned-2"}, RevisionID: ""},
+	}
+	// The RoleView query for the unit and its application returns both the
+	// consumed secret and the unit owned secret, as the drain worker lists
+	// granted secrets across all backends.
+	consumedAndOwned := []*coresecrets.SecretRevisionRef{
+		{URI: &coresecrets.URI{ID: "read-1"}, RevisionID: "read-rev-1"},
+		{URI: &coresecrets.URI{ID: "owned-1"}, RevisionID: "owned-rev-1"},
+		{URI: &coresecrets.URI{ID: "owned-2"}, RevisionID: ""},
+	}
+	ownedIDs := []string{
+		"owned-1",
+		"owned-2",
+	}
+	ownedRevs := map[string]set.Strings{
+		"owned-1": set.NewStrings("owned-rev-1"),
+	}
+	// The owned secret must not appear in the read revisions, and empty
+	// revision IDs (internal backend secrets) must be dropped from the
+	// revision lists passed to the provider.
+	readRevs := map[string]set.Strings{
+		"read-1": set.NewStrings("read-rev-1"),
+	}
+	adminCfg := provider.ModelBackendConfig{
+		ControllerUUID: jujutesting.ControllerTag.Id(),
+		ModelUUID:      jujutesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig: provider.BackendConfig{
+			BackendType: "some-backend",
+		},
+	}
+	backend := secretbackend.BackendIdentifier{
+		ID:   "backend-id",
+		Name: "backend1",
+	}
+	s.expectGetSecretBackendConfigForAdminDefault("iaas", backend, &secretbackend.SecretBackend{
+		ID:          "backend-id",
+		Name:        "backend1",
+		BackendType: "some-backend",
+	})
+	s.mockRegistry.EXPECT().Initialise(gomock.Any()).Return(nil)
+	token.EXPECT().Check().Return(leadership.NewNotLeaderError("", ""))
+
+	issuedTokenUUID := ""
+	s.mockRegistry.EXPECT().IssuesTokens().Return(false)
+
+	s.mockRegistry.EXPECT().RestrictedConfig(
+		gomock.Any(),
+		&adminCfg,
+		true, true,
+		issuedTokenUUID,
+		accessor,
+		ownedIDs,
+		ownedRevs,
+		readRevs,
+	).Return(&adminCfg.BackendConfig, nil)
+
+	listGranted := func(
+		ctx context.Context, role coresecrets.SecretRole, consumers ...secret.SecretAccessor,
+	) ([]*coresecrets.SecretRevisionRef, error) {
+		if role == coresecrets.RoleManage {
+			c.Assert(consumers, tc.DeepEquals, []secret.SecretAccessor{{
+				Kind: secret.UnitAccessor,
+				ID:   "gitlab/0",
+			}})
+			return unitOwned, nil
+		}
+		if len(consumers) == 1 && consumers[0].Kind == secret.ApplicationAccessor && consumers[0].ID == "gitlab" {
+			return nil, nil
+		}
+		c.Assert(consumers, tc.DeepEquals, []secret.SecretAccessor{{
+			Kind: secret.UnitAccessor,
+			ID:   "gitlab/0",
+		}, {
+			Kind: secret.ApplicationAccessor,
+			ID:   "gitlab",
+		}})
+		return consumedAndOwned, nil
+	}
+	_, err := svc.DrainBackendConfigInfo(c.Context(), DrainBackendConfigParams{
+		GrantedSecretsForDrainGetter: listGranted,
+		LeaderToken:                  token,
+		Accessor: secret.SecretAccessor{
+			Kind: secret.UnitAccessor,
+			ID:   accessor.ID,
+		},
+		ModelUUID: coremodel.UUID(jujutesting.ModelTag.Id()),
+		BackendID: "backend-id",
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestBackendConfigInfoLeaderUnitOwnedSecretsNotInReadRevisions tests that on
+// the non-drain path for a leader unit, secrets owned by the unit or
+// application that are also returned by the RoleView consumer query (because
+// RoleView expands to include RoleManage) are filtered out of readRevisions
+// passed to RestrictedConfig.
+func (s *serviceSuite) TestBackendConfigInfoLeaderUnitOwnedSecretsNotInReadRevisions(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	svc := newService(
+		s.mockState, s.logger, s.clock,
+		func(backendType string) (provider.SecretBackendProvider, error) {
+			if backendType != vault.BackendType {
+				return s.mockRegistry, nil
+			}
+			return providerWithConfig{
+				SecretBackendProvider: s.mockRegistry,
+			}, nil
+		},
+	)
+
+	accessor := coresecrets.Accessor{
+		Kind: coresecrets.UnitAccessor,
+		ID:   "gitlab/0",
+	}
+	token := NewMockToken(ctrl)
+
+	unitOwned := []*coresecrets.SecretRevisionRef{
+		{URI: &coresecrets.URI{ID: "unit-owned-1"}, RevisionID: "unit-owned-rev-1"},
+	}
+	appOwned := []*coresecrets.SecretRevisionRef{
+		{URI: &coresecrets.URI{ID: "app-owned-1"}, RevisionID: "app-owned-rev-1"},
+	}
+	owned := append(unitOwned, appOwned...)
+
+	// The RoleView query returns the consumed secret as well as the unit-owned
+	// and app-owned secrets, because RoleView expands to include RoleManage.
+	consumedAndOwned := []*coresecrets.SecretRevisionRef{
+		{URI: &coresecrets.URI{ID: "read-1"}, RevisionID: "read-rev-1"},
+		{URI: &coresecrets.URI{ID: "unit-owned-1"}, RevisionID: "unit-owned-rev-1"},
+		{URI: &coresecrets.URI{ID: "app-owned-1"}, RevisionID: "app-owned-rev-1"},
+	}
+
+	ownedIDs := []string{
+		"app-owned-1",
+		"unit-owned-1",
+	}
+	ownedRevs := map[string]set.Strings{
+		"app-owned-1":  set.NewStrings("app-owned-rev-1"),
+		"unit-owned-1": set.NewStrings("unit-owned-rev-1"),
+	}
+	// The owned secrets must not appear in read revisions.
+	readRevs := map[string]set.Strings{
+		"read-1": set.NewStrings("read-rev-1"),
+	}
+
+	adminCfg := provider.ModelBackendConfig{
+		ControllerUUID: jujutesting.ControllerTag.Id(),
+		ModelUUID:      jujutesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig: provider.BackendConfig{
+			BackendType: "some-backend",
+		},
+	}
+	backend := secretbackend.BackendIdentifier{
+		ID:   "backend-id",
+		Name: "backend1",
+	}
+	s.expectGetSecretBackendConfigForAdminDefault(
+		"iaas", backend, &secretbackend.SecretBackend{
+			ID:          "backend-id",
+			Name:        "backend1",
+			BackendType: "some-backend",
+		},
+	)
+	s.mockRegistry.EXPECT().Initialise(gomock.Any()).Return(nil)
+	token.EXPECT().Check().Return(nil)
+
+	issuedTokenUUID := ""
+	s.mockRegistry.EXPECT().IssuesTokens().Return(false)
+
+	s.mockRegistry.EXPECT().RestrictedConfig(
+		gomock.Any(),
+		&adminCfg,
+		false, false,
+		issuedTokenUUID,
+		accessor,
+		ownedIDs,
+		ownedRevs,
+		readRevs,
+	).Return(&adminCfg.BackendConfig, nil)
+
+	listGranted := func(
+		ctx context.Context,
+		backendID string,
+		role coresecrets.SecretRole,
+		consumers ...secret.SecretAccessor,
+	) ([]*coresecrets.SecretRevisionRef, error) {
+		c.Assert(backendID, tc.Equals, "backend-id")
+		if role == coresecrets.RoleManage {
+			c.Assert(consumers, tc.DeepEquals, []secret.SecretAccessor{{
+				Kind: secret.UnitAccessor,
+				ID:   "gitlab/0",
+			}, {
+				Kind: secret.ApplicationAccessor,
+				ID:   "gitlab",
+			}})
+			return owned, nil
+		}
+		c.Assert(consumers, tc.DeepEquals, []secret.SecretAccessor{{
+			Kind: secret.UnitAccessor,
+			ID:   "gitlab/0",
+		}, {
+			Kind: secret.ApplicationAccessor,
+			ID:   "gitlab",
+		}})
+		return consumedAndOwned, nil
+	}
+
+	info, err := svc.BackendConfigInfo(c.Context(), BackendConfigParams{
+		GrantedSecretsGetter: listGranted,
+		LeaderToken:          token,
+		Accessor: secret.SecretAccessor{
+			Kind: secret.UnitAccessor,
+			ID:   accessor.ID,
+		},
+		ModelUUID:      coremodel.UUID(jujutesting.ModelTag.Id()),
+		BackendIDs:     []string{"backend-id"},
+		SameController: false,
 	})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(info, tc.DeepEquals, &provider.ModelBackendConfigInfo{

--- a/internal/secrets/provider/kubernetes/provider.go
+++ b/internal/secrets/provider/kubernetes/provider.go
@@ -336,7 +336,7 @@ func (p k8sProvider) RestrictedConfig(
 
 	writeRevs := slices.Concat(ownedRevs.RevisionIDs(), preCreateRevisions)
 	token, err := broker.createSecretAccessToken(
-		ctx, issuedTokenUUID, accessor, writeRevs, readRevs.RevisionIDs(),
+		ctx, issuedTokenUUID, accessor, forDrain, writeRevs, readRevs.RevisionIDs(),
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -662,7 +662,7 @@ func (k *kubernetesClient) deleteRoleBinding(
 // policyRulesForSecretAccess returns the full policy rules required for
 // secrets.
 func policyRulesForSecretAccess(
-	namespace string, owned, read []string,
+	namespace string, forDrain bool, owned, read []string,
 ) []rbacv1.PolicyRule {
 	rules := []rbacv1.PolicyRule{{
 		APIGroups:     []string{rbacv1.APIGroupAll},
@@ -670,6 +670,19 @@ func policyRulesForSecretAccess(
 		Verbs:         []string{"get", "list"},
 		ResourceNames: []string{namespace},
 	}}
+	if forDrain {
+		// When draining secrets back to this backend, the drain worker
+		// rewrites a secret at the same revision path it was read from, so
+		// the object may not yet exist in this backend and must be created.
+		// Kubernetes RBAC cannot scope "create" by resource name, so we grant
+		// it for the namespace. The token is short lived and model scoped and
+		// only issued to the drain worker.
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{rbacv1.APIGroupAll},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"create"},
+		})
+	}
 	if len(owned) > 0 {
 		// owned cannot be empty, otherwise this policy rule grants access to
 		// all secrets.
@@ -1004,6 +1017,7 @@ func (k *kubernetesClient) createSecretAccessToken(
 	ctx context.Context,
 	issuedTokenUUID string,
 	accessor coresecrets.Accessor,
+	forDrain bool,
 	ownedRevs []string,
 	readRevs []string,
 ) (_ string, err error) {
@@ -1061,7 +1075,7 @@ func (k *kubernetesClient) createSecretAccessToken(
 		_ = k.deleteServiceAccount(ctx, sa.Name, sa.UID)
 	})
 
-	rules := policyRulesForSecretAccess(k.namespace, ownedRevs, readRevs)
+	rules := policyRulesForSecretAccess(k.namespace, forDrain, ownedRevs, readRevs)
 	rCleanups, err := k.createRoleAndBinding(ctx, sa, rules)
 	cleanups = append(cleanups, rCleanups...)
 	if err != nil {

--- a/internal/secrets/provider/kubernetes/provider_test.go
+++ b/internal/secrets/provider/kubernetes/provider_test.go
@@ -419,6 +419,59 @@ func (s *providerSuite) TestEnsureSecretAccessTokenControllerModelCreate(c *tc.C
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestDrainRoleCanCreateSecrets verifies that the role created for a drain
+// token grants the "create" verb on secrets. When draining secrets back to
+// the k8s backend, the drain worker rewrites a secret at the same revision
+// path it was read from, which may not yet exist and so must be created.
+func (s *providerSuite) TestDrainRoleCanCreateSecrets(c *tc.C) {
+	defer s.setupK8s(c)()
+
+	tag := secrets.Accessor{
+		Kind: secrets.UnitAccessor,
+		ID:   "gitlab/0",
+	}
+	ownedURI := secrets.NewURI()
+
+	p, err := provider.Provider(kubernetes.BackendType)
+	c.Assert(err, tc.ErrorIsNil)
+	adminCfg := &provider.ModelBackendConfig{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		ModelUUID:      coretesting.ModelTag.Id(),
+		ModelName:      "fred",
+		BackendConfig:  s.backendConfig(),
+	}
+
+	issuedTokenUUID := "some-uuid"
+	_, err = p.RestrictedConfig(
+		c.Context(),
+		adminCfg, true, true,
+		issuedTokenUUID, tag,
+		[]string{ownedURI.ID},
+		provider.SecretRevisions{ownedURI.ID: set.NewStrings(ownedURI.Name(1))},
+		nil,
+	)
+	c.Assert(err, tc.ErrorIsNil)
+
+	roles, err := s.k8sClient.RbacV1().Roles(s.namespace).List(c.Context(), metav1.ListOptions{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(roles.Items, tc.HasLen, 1)
+	c.Assert(roles.Items[0].Rules, tc.DeepEquals, []rbacv1.PolicyRule{{
+		APIGroups:     []string{rbacv1.APIGroupAll},
+		Resources:     []string{"namespaces"},
+		Verbs:         []string{"get", "list"},
+		ResourceNames: []string{s.namespace},
+	}, {
+		APIGroups: []string{rbacv1.APIGroupAll},
+		Resources: []string{"secrets"},
+		Verbs:     []string{"create"},
+	}, {
+		APIGroups:     []string{rbacv1.APIGroupAll},
+		Resources:     []string{"secrets"},
+		Verbs:         []string{"get", "patch", "update", "replace", "delete"},
+		ResourceNames: []string{ownedURI.Name(1), ownedURI.Name(2)},
+	}})
+}
+
 func (s *providerSuite) TestEnsureSecretAccessTokenUpdate(c *tc.C) {
 	defer s.setupK8s(c)()
 


### PR DESCRIPTION
Draining secrets to a new backend failed for unit agents with:
```
unit-hello-0: ERROR juju.worker.dependency "secret-drain-worker" manifold worker returned
unexpected error: executing leadership func: creating policy
"model-secrets-k8s-drain-4fb172-63c320d6-ee91-4ab2-84c8-d71a297bf42f":
Error making API request.

URL: PUT http://192.168.1.213:8200/v1/sys/policies/acl/model-secrets-k8s-drain-4fb172-...
Code: 400. Errors:
* 'policy' parameter not supplied or empty
```
To build the access token for a backend, backendConfigInfo asked the database
which of the accessor's secrets live on that backend. For a drain the backend
is the destination, where the secrets are not yet: the lookup returned nothing,
so no owned secrets were found, so the vault provider produced no policy rules
and vault rejected the empty policy body.

ListGrantedSecretsForBackend now takes forDrain. When set, the backend_uuid
predicate is dropped so revisions are returned from wherever they currently
live, and the secret_value_ref join becomes a LEFT JOIN so revisions held in
the internal backend, which have no value ref row, are returned too. Every
non-drain caller passes false and is unaffected: with the predicate present a
NULL value ref never matches, so the join still behaves as an inner join.

Three consequences of listing revisions across backends are handled:

- Secrets kept in Juju's own database have no external revision ID, so a
  rule cannot name them. The empty IDs are now dropped; the owned set
  still carries the secret IDs, which is all a provider needs.

- Owners hold a manage grant and manage implies view, so the view queries
  also return secrets the accessor owns. These are now dropped from the
  read-only list: vault honours only the most specific matching path, so
  a read-only rule for one revision overrides the owner's wildcard rule
  and removes the write capability the worker needs.

- Kubernetes cannot scope "create" to a named object, so the provider
  pre-creates the secret and grants write access by name. Draining
  defeats this: it pre-creates revision N+1 while the worker rewrites N,
  which is not there yet. Drain tokens may therefore create secrets in
  the model namespace; they are short lived and only issued to the drain
  worker.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests && ./main.sh -p k8s -c microk8s secrets_k8s test_secret_drain

cd tests && ./main.sh -p k8s -c microk8s secrets_k8s test_user_secret_drain
```

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10277](https://warthogs.atlassian.net/browse/JUJU-10277)


[JUJU-10277]: https://warthogs.atlassian.net/browse/JUJU-10277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ