### PR TITLE
fix(modelmigration): report CAAS migration minions from unit agents only

### DIFF
--- a/domain/modelmigration/state/model/state.go
+++ b/domain/modelmigration/state/model/state.go
@@ -182,28 +182,16 @@ WHERE  c.source_id < 2
 	if err != nil {
 		return modelmigrationinternal.MigrationAgents{}, errors.Capture(err)
 	}
-	applicationAgentStmt, err := s.Prepare(`
-SELECT &agentName.name
-FROM   application AS a
-JOIN   application_agent AS aa ON aa.application_uuid = a.uuid
-JOIN   charm AS c ON c.uuid = a.charm_uuid
-WHERE  c.source_id < 2
-`, agentName{})
-	if err != nil {
-		return modelmigrationinternal.MigrationAgents{}, errors.Capture(err)
-	}
 
 	var (
 		modelTypeValue modelType
 		machines       []agentName
 		units          []agentName
-		applications   []agentName
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		modelTypeValue = modelType{}
 		machines = nil
 		units = nil
-		applications = nil
 
 		if err := tx.Query(ctx, modelTypeStmt).Get(&modelTypeValue); err != nil {
 			if errors.Is(err, sqlair.ErrNoRows) {
@@ -212,14 +200,16 @@ WHERE  c.source_id < 2
 			return errors.Errorf("querying model type: %w", err)
 		}
 
-		if model.ModelType(modelTypeValue.Type) == model.CAAS {
-			if err := tx.Query(ctx, applicationAgentStmt).GetAll(&applications); err != nil &&
+		// CAAS models have no machines; their workload runs as unit agents in
+		// workload pods. The model operator is model-scoped infrastructure and
+		// is not a migration minion (matching 3.6 sidecar behaviour, where only
+		// unit/application workload agents report), so only IAAS models report
+		// machine agents.
+		if model.ModelType(modelTypeValue.Type) != model.CAAS {
+			if err := tx.Query(ctx, machineStmt).GetAll(&machines); err != nil &&
 				!errors.Is(err, sqlair.ErrNoRows) {
-				return errors.Errorf("querying application agents: %w", err)
+				return errors.Errorf("querying machine agents: %w", err)
 			}
-		} else if err := tx.Query(ctx, machineStmt).GetAll(&machines); err != nil &&
-			!errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("querying machine agents: %w", err)
 		}
 
 		if err := tx.Query(ctx, unitStmt).GetAll(&units); err != nil &&
@@ -232,18 +222,14 @@ WHERE  c.source_id < 2
 	}
 
 	agents := modelmigrationinternal.MigrationAgents{
-		Machines:     make([]string, 0, len(machines)),
-		Units:        make([]string, 0, len(units)),
-		Applications: make([]string, 0, len(applications)),
+		Machines: make([]string, 0, len(machines)),
+		Units:    make([]string, 0, len(units)),
 	}
 	for _, m := range machines {
 		agents.Machines = append(agents.Machines, m.Name)
 	}
 	for _, u := range units {
 		agents.Units = append(agents.Units, u.Name)
-	}
-	for _, a := range applications {
-		agents.Applications = append(agents.Applications, a.Name)
 	}
 	return agents, nil
 }

--- a/domain/modelmigration/state/model/state_test.go
+++ b/domain/modelmigration/state/model/state_test.go
@@ -404,7 +404,10 @@ func (s *caasMigrationSuite) TestGetMigrationAgentsCAAS(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(agents.Machines, tc.HasLen, 0)
 	c.Check(agents.Units, tc.SameContents, []string{"sidecar/0"})
-	c.Check(agents.Applications, tc.SameContents, []string{"legacy"})
+	// The model operator is model-scoped infrastructure, not a migration
+	// minion, so CAAS models report no application agents (matching 3.6
+	// sidecar behaviour where only workload unit agents report).
+	c.Check(agents.Applications, tc.HasLen, 0)
 }
 
 // TestDeleteModelImportingStatusSuccess tests that clearing an existing


### PR DESCRIPTION
CAAS migration hangs in QUIESCE waiting for a per-application operator agent to report as a migration
minion, but no such agent exists in 4.x. The master computes the expected minion set from the model's
application_agent rows and waits for application-<name> to report; nothing authenticates with that tag,
so it waits forever.

This worked in 3.6 because 3.6 had a per-application operator: for non-sidecar (pod-spec) charms, a
caasoperator pod ran per application, authenticated as application-<name>, and reported as a migration
minion; for sidecar charms, the unit agents reported. 4.x removed the per-application operator entirely —
the only CAAS agents now are the model-scoped model operator and the per-unit agents — and 4.x only
supports the sidecar topology. The migration rewrite copied 3.6's non-sidecar expectation into a codebase
that no longer has the operator that expectation depended on.

The change makes CAAS models report migration minions from their unit agents only, which is exactly what
3.6 did for sidecar charms. The model operator is model-scoped infrastructure and reconnects to the
target through the target's provisioning, not by acting as a minion.

## QA steps

Bootstrap a source controller from this branch and a destination controller (on main), deploy a k8s charm, and migrate.

```
juju_41 bootstrap microk8s dst41

# this branch build:
juju bootstrap microk8s src40
juju add-model m
juju deploy snappass-test --revision 8 --channel stable
# wait for snappass-test to be active
```
Migrate:
```
juju migrate m dst41
```
For the full migration to pass, https://github.com/juju/juju/pull/23219 must land also; so rebase onto it.

## Links


**Issue:** Fixes #23218.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
