### PR TITLE
test(migration): add CAAS model migration integration test

### DIFF
--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -79,6 +79,45 @@ run_model_migration() {
 	destroy_model "model-migration"
 }
 
+# Migrating a CAAS (k8s) model from one controller to another on the same k8s
+# cloud. This exercises the CAAS carve-outs in the migration path: the agent
+# binary metadata lookup must not require binaries that k8s never uploads to
+# the object store, and the migration minions must be the unit agents (the
+# only CAAS workload agents), not a per-application operator that does not
+# exist on k8s.
+run_model_migration_caas() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# Ensure we have another controller available.
+	bootstrap_alt_controller "alt-model-migration-caas"
+	juju switch "alt-model-migration-caas"
+	add_model "model-migration-caas"
+
+	juju deploy snappass-test --revision 8 --channel stable
+
+	wait_for "snappass-test" "$(active_idle_condition "snappass-test")"
+
+	# Migrate the model to the other controller.
+	juju migrate "model-migration-caas" "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+
+	# Wait for the model to appear on the target, then switch to it.
+	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}"
+	wait_for_model "model-migration-caas"
+	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}:model-migration-caas"
+
+	# The application must be healthy on the target and the target must own
+	# the unit agent.
+	wait_for "snappass-test" "$(active_idle_condition "snappass-test")"
+	juju exec --unit snappass-test/0 -- hostname | grep -c snappass-test | check true
+
+	# Clean up: destroy the now-empty source controller, then the migrated
+	# model on the target (the framework teardown destroys the target
+	# controller itself).
+	destroy_controller "alt-model-migration-caas"
+	destroy_model "model-migration-caas"
+}
+
 # Migrating a model where the export fails mid-transfer (forced via wrench)
 # must abort cleanly: the target removes the partially-imported model and the
 # source model remains functional.
@@ -538,5 +577,27 @@ test_model_migration_saas_external() {
 		cd .. || exit
 
 		run "run_model_migration_saas_external"
+	)
+}
+
+test_model_migration_caas() {
+	if [ -n "$(skip 'test_model_migration_caas')" ]; then
+		echo "==> SKIP: Asked to skip model migration CAAS tests"
+		return
+	fi
+
+	# This test migrates a k8s model between two controllers on the same k8s
+	# cloud; it only makes sense on a k8s provider.
+	if [ "${BOOTSTRAP_PROVIDER}" != "k8s" ] && [ "${BOOTSTRAP_PROVIDER}" != "microk8s" ]; then
+		echo "==> SKIP: model migration CAAS test needs a k8s provider"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_model_migration_caas"
 	)
 }

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -109,7 +109,7 @@ run_model_migration_caas() {
 	# The application must be healthy on the target and the target must own
 	# the unit agent.
 	wait_for "snappass-test" "$(active_idle_condition "snappass-test")"
-	juju exec --unit snappass-test/0 -- hostname | grep -c snappass-test | check true
+	juju exec --unit snappass-test/0 -- hostname | grep -c snappass-test | check 1
 
 	# Clean up: destroy the now-empty source controller, then the migrated
 	# model on the target (the framework teardown destroys the target

--- a/tests/suites/model/migration.sh
+++ b/tests/suites/model/migration.sh
@@ -111,6 +111,22 @@ run_model_migration_caas() {
 	wait_for "snappass-test" "$(active_idle_condition "snappass-test")"
 	juju exec --unit snappass-test/0 -- hostname | grep -c snappass-test | check 1
 
+	# The source controller must reap the model: migration moves the model,
+	# it does not copy it. The reap runs after the target has activated, so
+	# poll the source until the model disappears.
+	juju switch "alt-model-migration-caas:controller"
+	attempt=0
+	until [[ -z $(juju models --format=json | yq -r '.models | .[] | select(.["short-name"] == "model-migration-caas") | .["short-name"]') ]]; do
+		if [[ ${attempt} -ge 30 ]]; then
+			red 'Failed: source controller did not reap model-migration-caas'
+			exit 1
+		fi
+		echo "[+] (attempt ${attempt}) polling for source reap of model-migration-caas"
+		sleep "${SHORT_TIMEOUT}"
+		attempt=$((attempt + 1))
+	done
+	juju switch "${BOOTSTRAPPED_JUJU_CTRL_NAME}:model-migration-caas"
+
 	# Clean up: destroy the now-empty source controller, then the migrated
 	# model on the target (the framework teardown destroys the target
 	# controller itself).

--- a/tests/suites/model/task.sh
+++ b/tests/suites/model/task.sh
@@ -21,6 +21,7 @@ test_model() {
 	test_model_migration_version
 	test_model_migration_saas_common
 	test_model_migration_saas_external
+	test_model_migration_caas
 	test_model_multi
 	test_model_metrics
 	test_model_destroy


### PR DESCRIPTION
There is no integration coverage for juju migrate in tests/; only CMR offer/consume exists. This adds the
first model-migration test, exercising the k8s path that the two companion fixes repair.

The new tests/suites/migration suite bootstraps two controllers on the same k8s cloud, deploys
`snappass-test`, migrates the model between them, and asserts the model lands active on the destination,
the target owns the unit, and the source reaps it. It fails until the two fixes land, then passes.

## QA steps

~_Note: https://github.com/juju/juju/pull/23219 and https://github.com/juju/juju/pull/23220 must land before these tests pass, so rebase onto them._~

```
cd tests
BOOTSTRAP_PROVIDER=k8s BOOTSTRAP_CLOUD=microk8s ./main.sh model test_model_migration_caas
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #23218.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
