### PR TITLE
chore: merge pull request #23152 from wallyworld/fix-cmr-teardown

### DIFF
--- a/internal/worker/remoterelationconsumer/localconsumerworker.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
+	"github.com/juju/retry"
 	"github.com/juju/worker/v5"
 	"github.com/juju/worker/v5/catacomb"
 	"gopkg.in/macaroon.v2"
@@ -525,9 +526,15 @@ func (w *localConsumerWorker) handleRelationNotFound(ctx context.Context, relati
 	// relation before we can send the dying notification via the normal
 	// handleRelationConsumption path.
 	if err := w.publishRelationDyingForRemovedRelation(ctx, relationUUID); err != nil {
-		return errors.Annotatef(err, "notifying offering model of removed relation %q", relationUUID)
+		w.logger.Warningf(
+			ctx,
+			"notifying offering model of removed relation %q: %v",
+			relationUUID,
+			err,
+		)
 	}
-
+	// Clean up local workers even if the notification to the offering
+	// model failed, otherwise the workers are orphaned.
 	return w.handleRelationRemoved(ctx, relationUUID, 0)
 }
 
@@ -570,8 +577,25 @@ func (w *localConsumerWorker) publishRelationDyingChange(
 	debugMsg string,
 	errorMsgContext string,
 ) {
+	if err := w.publishRelationDying(applicationUUID, relationUUID, mac, debugMsg); err != nil {
+		w.logger.Warningf(
+			context.Background(),
+			"notifying offering model of relation %q %s: %v",
+			relationUUID,
+			errorMsgContext,
+			err,
+		)
+	}
+}
+
+func (w *localConsumerWorker) publishRelationDying(
+	applicationUUID application.UUID,
+	relationUUID corerelation.UUID,
+	mac *macaroon.Macaroon,
+	debugMsg string,
+) error {
 	if w.remoteModelClient == nil {
-		return
+		return nil
 	}
 
 	publishCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -587,11 +611,14 @@ func (w *localConsumerWorker) publishRelationDyingChange(
 		BakeryVersion:           defaultBakeryVersion,
 		ForceCleanup:            new(true),
 	}
-	if err := w.remoteModelClient.PublishRelationChange(publishCtx, change); err != nil {
-		if !isNotFound(err) {
-			w.logger.Warningf(publishCtx, "notifying offering model of relation %q %s: %v", relationUUID, errorMsgContext, err)
-		}
+	if err := w.remoteModelClient.PublishRelationChange(publishCtx, change); isNotFound(err) {
+		w.logger.Debugf(publishCtx, "relation %q dying, but offerer side already removed", relationUUID)
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
 	}
+
+	return nil
 }
 
 func (w *localConsumerWorker) publishRelationDyingForRemovedRelation(ctx context.Context, relationUUID corerelation.UUID) error {
@@ -612,13 +639,32 @@ func (w *localConsumerWorker) publishRelationDyingForRemovedRelation(ctx context
 
 	rw := offererUnitWorker.(offererWorkerDetails)
 
-	w.publishRelationDyingChange(
-		rw.ConsumerApplicationUUID(),
-		relationUUID,
-		rw.Macaroon(),
-		"relation %q removed locally, notifying offering model",
-		"removal",
-	)
+	var lastErr error
+	err = retry.Call(retry.CallArgs{
+		Clock:       w.clock,
+		Stop:        w.catacomb.Dying(),
+		Delay:       2 * time.Second,
+		Attempts:    3,
+		BackoffFunc: retry.DoubleDelay,
+		Func: func() error {
+			lastErr = w.publishRelationDying(
+				rw.ConsumerApplicationUUID(),
+				relationUUID,
+				rw.Macaroon(),
+				"relation %q removed locally, notifying offering model",
+			)
+			return lastErr
+		},
+		IsFatalError: func(err error) bool {
+			return params.ErrCode(err) == params.CodeDischargeRequired
+		},
+	})
+	if err != nil && lastErr != nil {
+		if lastErr == nil {
+			return errors.Trace(err)
+		}
+		return errors.Trace(lastErr)
+	}
 
 	return nil
 }

--- a/internal/worker/remoterelationconsumer/localconsumerworker_test.go
+++ b/internal/worker/remoterelationconsumer/localconsumerworker_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/gomock/gomock"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/clock"
+	"github.com/juju/clock/testclock"
 	"github.com/juju/collections/set"
 	"github.com/juju/names/v6"
 	"github.com/juju/tc"
@@ -395,13 +396,23 @@ func (s *localConsumerWorkerSuite) TestWatchApplicationStatusChangedNotFound(c *
 	// Expect the notification to the offering model when the relation is found
 	// to be removed and the offerer unit worker has a macaroon.
 	mac := newMacaroon(c, "relation-mac")
+	publishAttempts := make(chan struct{})
 	s.remoteModelRelationClient.EXPECT().
 		PublishRelationChange(gomock.Any(), gomock.Any()).
-		Return(nil).
-		AnyTimes()
+		DoAndReturn(func(context.Context, params.RemoteRelationChangeEvent) error {
+			select {
+			case publishAttempts <- struct{}{}:
+			case <-c.Context().Done():
+				c.Fatalf("timed out recording PublishRelationChange attempt")
+			}
+			return internalerrors.New("boom")
+		}).
+		Times(3)
 
 	w := s.newLocalConsumerWorker(c)
 	defer workertest.DirtyKill(c, w)
+	retryClock := testclock.NewClock(time.Time{})
+	w.clock = retryClock
 
 	// Force the creation of the workers, we will then check that they
 	// are removed when we process the relation removal.
@@ -427,6 +438,26 @@ func (s *localConsumerWorkerSuite) TestWatchApplicationStatusChangedNotFound(c *
 	case <-done:
 	case <-c.Context().Done():
 		c.Fatalf("timed out waiting for WatchOfferStatus to be called")
+	}
+
+	select {
+	case <-publishAttempts:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for first PublishRelationChange attempt")
+	}
+	c.Assert(retryClock.WaitAdvance(2*time.Second, time.Second, 1), tc.ErrorIsNil)
+
+	select {
+	case <-publishAttempts:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for second PublishRelationChange attempt")
+	}
+	c.Assert(retryClock.WaitAdvance(4*time.Second, time.Second, 1), tc.ErrorIsNil)
+
+	select {
+	case <-publishAttempts:
+	case <-c.Context().Done():
+		c.Fatalf("timed out waiting for third PublishRelationChange attempt")
 	}
 
 	// Wait until the workers are gone... we should have created them, and now

--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -56,9 +56,9 @@ run_offer_consume() {
 
 	echo "Remove offer"
 	juju remove-relation dummy-sink dummy-offer
+	juju remove-saas dummy-offer
 	# wait for the relation to be removed.
 	wait_for null '.applications["dummy-sink"] | .relations'
-	juju remove-saas dummy-offer
 	# wait for saas to be removed.
 	wait_for null '.["application-endpoints"]'
 	# The offer must be removed before model/controller destruction will work.
@@ -120,15 +120,15 @@ run_offer_consume_cross_controller() {
 
 	echo "Remove offer"
 	juju remove-relation dummy-sink dummy-source
+	juju remove-saas dummy-source
 	# wait for the relation to be removed.
 	wait_for null '.applications["dummy-sink"] | .relations'
-	juju remove-saas dummy-source
 	# wait for saas to be removed.
 	wait_for null '.["application-endpoints"]'
 	# The offer must be removed before model/controller destruction will work.
 	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
 	juju switch "${offer_controller}:model-offer"
-	wait_for null '.offers."dummy-offer"."total-connected-count"'
+	wait_for null '.offers."dummy-source"."total-connected-count"'
 	juju remove-offer "${offer_controller}:admin/model-offer.dummy-source" -y
 	wait_for null '.offers'
 


### PR DESCRIPTION
This cherry picks https://github.com/juju/juju/pull/23152 from 3.6

Note: in doings this work, 4.0 has changed a bit so conflicts needed to be resolved. In so doing, I think I found additional, similar bugs existing only in 4.0. I raised issue https://github.com/juju/juju/issues/23222.

Note2: the 3.6 fix was tactical to improve robustness. Ideally, in 4.x we'd consider a proper fix, one where worker restarts mid-teardown would pick up the in flight work and resume it. This was too much change to do in 3.6 at this stage.

The 3.6 PR description:

CI was failing regularly on the cross model relations suite. There's several different tests; one in particular was failing. After some digging it turned out the failing test did this:

```
 juju remove-relation dummy-sink dummy-offer
 juju remove-saas dummy-offer
```
the passing test did this
```
 juju remove-relation dummy-sink dummy-offer
 # wait for the relation to be removed.
 wait_for null '.applications["dummy-sink"] | .relations'
 juju remove-saas dummy-offer
```

Looking at the commit history, back in 2023 someone committed a "fix" for what looks like the same issue - they just papered over the symptoms by adding a wait instead of properly addressing the real root cause. We should never "fix" a juju issue by adding a wait to a test script.

The root cause turned out to be that when `remove-saas` is called immediately after `remove-relation` on a consuming app, there can be a race. The relation may already get removed before the remote application worker gets to publish relation life = dying to the offering model. So the worker sees NotFound and exits without notifying the offering model. So on the offering side, the relation stays alive and the offer connection count is not decremented.

I fixed the ci tests also - I moved the "wait for relation to disappear" checks to after the remove-saas call - we can still verify that the removal happens, but not to gimp the test to paper over the real issue.

`./main.sh cmr`

