### PR TITLE
test: fix offer name typo in shell test and flakey lease worker unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vmware/govmomi v0.55.1
 	go.uber.org/mock v0.6.0
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 	golang.org/x/net v0.58.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -817,8 +817,8 @@ golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20260611194520-c48552f49976 h1:X8Hz2ImujgbmetVuW+w2YkyZChE3cBpZi2P158rTG9M=
 golang.org/x/exp v0.0.0-20260611194520-c48552f49976/go.mod h1:vnf4pv9iKZXY58sQE1L86zmNWJ4159e1RkcWiLCkeEY=

--- a/internal/worker/lease/manager_block_test.go
+++ b/internal/worker/lease/manager_block_test.go
@@ -302,7 +302,6 @@ func (bt *blockTest) assertBlocked(c *gc.C) {
 }
 
 func (bt *blockTest) assertUnblocked(c *gc.C) error {
-	lease.ManagerStore(bt.manager).(*Store).expireLeases()
 	select {
 	case err := <-bt.done:
 		return err

--- a/internal/worker/lease/util_test.go
+++ b/internal/worker/lease/util_test.go
@@ -98,15 +98,21 @@ func (store *Store) Wait(c *gc.C) {
 	}
 }
 
-func (store *Store) expireLeases() {
-	store.mu.Lock()
-	defer store.mu.Unlock()
+// expireLeases removes any leases that have expired.
+// It must be called with the lock held.
+func (store *Store) expireLeases() error {
+	if store.clock == nil {
+		return errors.New("store.clock is nil")
+	}
+	now := store.clock.Now()
 	for k, v := range store.leases {
-		if store.clock.Now().Before(v.Expiry) {
+		// Leases without an expiry never expire.
+		if v.Expiry.IsZero() || now.Before(v.Expiry) {
 			continue
 		}
 		delete(store.leases, k)
 	}
+	return nil
 }
 
 // Leases is part of the lease.Store interface.
@@ -121,6 +127,10 @@ func (store *Store) Leases(_ context.Context, keys ...lease.Key) (map[lease.Key]
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	// Expired leases are no longer visible.
+	if err := store.expireLeases(); err != nil {
+		return nil, err
+	}
 	result := make(map[lease.Key]lease.Info)
 	for k, v := range store.leases {
 		if filtering && !filter[k] {

--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -231,7 +231,7 @@ run_offer_consume_cross_controller() {
 	# The offer must be removed before model/controller destruction will work.
 	# See discussion under https://bugs.launchpad.net/juju/+bug/1830292.
 	juju switch "${offer_controller}:model-offer"
-	wait_for null '.offers."dummy-offer"."total-connected-count"'
+	wait_for null '.offers."dummy-source"."total-connected-count"'
 	juju remove-offer "${offer_controller}:admin/model-offer.dummy-source" -y
 	wait_for null '.offers'
 


### PR DESCRIPTION
Fix a trivial typo in a cmr shell test - the wrong offer name was used - should have been "dummy-source" not "dummy-offer".

Also update go crypto dep for go vuln fixes: GO-2026-6354, GO-2026-6355

And a flakey lease worker unit test fix.
