### PR TITLE
chore: bump Juju version to 4.2-beta1

### DIFF
--- a/core/version/version.go
+++ b/core/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "4.1-beta3"
+const version = "4.2-beta1"
 
 // UserAgentVersion defines a user agent version used for communication for
 // outside resources.

--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -4,7 +4,7 @@
 #if GetEnv('JUJU_VERSION') != ""
 #define MyAppVersion=GetEnv('JUJU_VERSION')
 #else
-#define MyAppVersion="4.1-beta3"
+#define MyAppVersion="4.2-beta1"
 #endif
 
 #define MyAppName "Juju"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 4.1-beta3
+version: 4.2-beta1
 summary: Juju - a model-driven operator lifecycle manager for K8s and machines
 license: AGPL-3.0
 description: |


### PR DESCRIPTION
Advance main from 4.1-beta3 to 4.2-beta1 in the core version constant, installer default, and snap metadata.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
# just pass checks
```

## Documentation changes

## Links

**Jira card:** [JUJU-](https://warthogs.atlassian.net/browse/JUJU-)
