### PR TITLE
fix(ci): update forward-merge checks for 4.1

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,7 +1,7 @@
 name: Merge
 on:
   push:
-    branches: ["2.9", "3.6", "4.0"]
+    branches: ["2.9", "3.6", "4.0", "4.1"]
 
 jobs:
   check-merge:
@@ -11,7 +11,8 @@ jobs:
       MERGE_TARGETS: |
         2.9: 3.1
         3.6: 4.0
-        4.0: main
+        4.0: 4.1
+        4.1: main
 
     steps:
       - name: Determine source/target branches


### PR DESCRIPTION
Trigger conflict checks on pushes to 4.1 and map 4.0 to 4.1 and 4.1 to main. Preserve older mappings and notification behavior.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
# just pass checks
```