### PR TITLE
feat(openstack): add support for specifying additional cinder volume attributes

### DIFF
--- a/docs/reference/cloud/list-of-supported-clouds/openstack.md
+++ b/docs/reference/cloud/list-of-supported-clouds/openstack.md
@@ -168,7 +168,7 @@ The controller runs on a Nova instance provisioned using the same mechanisms as 
 
 **Storage**
 
-- **Root disk**: Local ephemeral disk or Cinder boot volume based on `root-disk-source` constraint.
+- **Root disk**: Local ephemeral disk or Cinder boot volume based on `root-disk-source` constraint. Configurable volume type, tag, and disk bus.
 
 (openstack-model)=
 ## Models
@@ -233,7 +233,7 @@ The constraints `instance-type` and `[mem, root-disk, cores]` are mutually exclu
 **Storage**
 
 - {ref}`constraint-root-disk`
-- {ref}`constraint-root-disk-source`. Values: `local` (ephemeral disk, default) or `volume` (Cinder boot volume).
+- {ref}`constraint-root-disk-source`. Values: `local` (ephemeral disk, default) or `volume` (Cinder boot volume) or `<storage-pool name>` (Cinder boot volume with additional configuration for volume type, tag, and disk bus).
 
 (openstack-machine-placement-directives)=
 ### Placement directives
@@ -281,8 +281,7 @@ Applies to all machines, including controller machines. Controller-specific diff
 ```{ibnote}
 See also: {ref}`storage-provider-cinder` for the Cinder storage provider configuration options.
 ```
-
-- **Root disk**: Local ephemeral disk by default. Use `root-disk-source=volume` constraint to boot from a Cinder volume instead.
+- **Root disk**: Local ephemeral disk by default. Use `root-disk-source=volume` constraint to boot from a generic Cinder volume instead, or specify a storage pool. Volume type, tag and disk bus are configurable via the pool.
 - **Additional volumes**: Cinder block volumes created on demand when storage is specified via storage constraints.
 - **AZ constraint**: Availability zone is matched to the instance's AZ when possible.
 - **Device path**: Auto-assigned by OpenStack.

--- a/internal/provider/openstack/cinder.go
+++ b/internal/provider/openstack/cinder.go
@@ -30,6 +30,8 @@ const (
 	CinderProviderType = storage.ProviderType("cinder")
 
 	cinderVolumeType = "volume-type"
+	cinderDiskBus    = "disk-bus"
+	cinderTag        = "tag"
 
 	// autoAssignedMountPoint specifies the value to pass in when
 	// you'd like Cinder to automatically assign a mount point.
@@ -43,19 +45,41 @@ const (
 	volumeStatusInUse     = "in-use"
 )
 
+const (
+	deviceTypeDisk = "disk"
+
+	diskBusFDC    = "fdc"
+	diskBusIDE    = "ide"
+	diskBusSATA   = "sata"
+	diskBusSCSI   = "scsi"
+	diskBusUSB    = "usb"
+	diskBusVirtio = "virtio"
+	diskBusXen    = "xen"
+	diskBusLXC    = "lxc"
+	diskBusUML    = "uml"
+)
+
 var cinderConfigFields = schema.Fields{
 	cinderVolumeType: schema.String(),
+	cinderDiskBus: schema.OneOf(schema.Const(diskBusFDC), schema.Const(diskBusIDE),
+		schema.Const(diskBusSATA), schema.Const(diskBusSCSI), schema.Const(diskBusUSB), schema.Const(diskBusVirtio),
+		schema.Const(diskBusXen), schema.Const(diskBusLXC), schema.Const(diskBusUML)),
+	cinderTag: schema.String(),
 }
 
 var cinderConfigChecker = schema.FieldMap(
 	cinderConfigFields,
 	schema.Defaults{
 		cinderVolumeType: schema.Omit,
+		cinderDiskBus:    schema.Omit,
+		cinderTag:        schema.Omit,
 	},
 )
 
 type cinderConfig struct {
 	volumeType string
+	diskBus    string
+	tag        string
 }
 
 func newCinderConfig(attrs map[string]interface{}) (*cinderConfig, error) {
@@ -65,10 +89,13 @@ func newCinderConfig(attrs map[string]interface{}) (*cinderConfig, error) {
 	}
 	coerced := out.(map[string]interface{})
 	volumeType, _ := coerced[cinderVolumeType].(string)
-	cinderConfig := &cinderConfig{
+	diskBus, _ := coerced[cinderDiskBus].(string)
+	tag, _ := coerced[cinderTag].(string)
+	return &cinderConfig{
 		volumeType: volumeType,
-	}
-	return cinderConfig, nil
+		diskBus:    diskBus,
+		tag:        tag,
+	}, nil
 }
 
 // StorageProviderTypes implements storage.ProviderRegistry.

--- a/internal/provider/openstack/cinder_internal_test.go
+++ b/internal/provider/openstack/cinder_internal_test.go
@@ -62,3 +62,44 @@ func (r *testAuthClient) TenantId() string {
 func (r *testAuthClient) EndpointsForRegion(region string) identity.ServiceURLs {
 	return r.regionEndpoints[region]
 }
+
+type cinderConfigSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&cinderConfigSuite{})
+
+func (s *cinderConfigSuite) TestNewCinderConfigEmpty(c *gc.C) {
+	cfg, err := newCinderConfig(nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg, jc.DeepEquals, &cinderConfig{})
+}
+
+func (s *cinderConfigSuite) TestNewCinderConfigVolumeType(c *gc.C) {
+	cfg, err := newCinderConfig(map[string]interface{}{
+		"volume-type": "Ceph",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg, jc.DeepEquals, &cinderConfig{volumeType: "Ceph"})
+}
+
+func (s *cinderConfigSuite) TestNewCinderConfigFull(c *gc.C) {
+	cfg, err := newCinderConfig(map[string]interface{}{
+		"volume-type": "Ceph",
+		"disk-bus":    "scsi",
+		"tag":         "root",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cfg, jc.DeepEquals, &cinderConfig{
+		volumeType: "Ceph",
+		diskBus:    "scsi",
+		tag:        "root",
+	})
+}
+
+func (s *cinderConfigSuite) TestNewCinderConfigInvalidDiskBus(c *gc.C) {
+	_, err := newCinderConfig(map[string]interface{}{
+		"disk-bus": "pcie",
+	})
+	c.Assert(err, gc.ErrorMatches, "validating Cinder storage config: .*")
+}

--- a/internal/provider/openstack/client.go
+++ b/internal/provider/openstack/client.go
@@ -135,10 +135,24 @@ func (c *ClientFactory) AuthClient() client.AuthenticatingClient {
 	return c.authClient
 }
 
-// Nova creates a new Nova client from the auth mode (v3 or falls back to v2)
-// and the updated credentials.
+// Nova creates a new Nova client using the shared, already-authenticated
+// auth client.
 func (c *ClientFactory) Nova() (*nova.Client, error) {
 	return nova.New(c.authClient), nil
+}
+
+// NovaWithMicroVersion creates a Nova client that sends the
+// OpenStack-API-Version header for the given compute microversion.
+// This is needed for block_device_mapping_v2 features such as
+// volume_type (introduced in microversion 2.67). Use this only for
+// specific calls that require the microversion; use Nova() for all
+// other Nova API calls.
+func (c *ClientFactory) NovaWithMicroVersion() (*nova.Client, error) {
+	client, err := c.getClientState(WithHTTPHeadersFunc(novaMicroversionHeaders))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return nova.New(client), nil
 }
 
 // Neutron creates a new Neutron client from the auth mode (v3 or falls back to v2)
@@ -151,6 +165,20 @@ func (c *ClientFactory) Neutron() (*neutron.Client, error) {
 		return nil, errors.Trace(err)
 	}
 	return neutron.New(client), nil
+}
+
+// novaMicroversion is the compute API microversion required for
+// block_device_mapping_v2 features such as volume_type, which
+// was introduced in microversion 2.67 (OpenStack Train).
+const novaMicroversion = "compute 2.67"
+
+// novaMicroversionHeaders wraps goosehttp.DefaultHeaders, adding the
+// OpenStack compute microversion header required for
+// block_device_mapping_v2 features such as volume_type.
+func novaMicroversionHeaders(method string, extraHeaders http.Header, contentType, authToken string, payloadExists bool) http.Header {
+	headers := goosehttp.DefaultHeaders(method, extraHeaders, contentType, authToken, payloadExists)
+	headers.Set("OpenStack-API-Version", novaMicroversion)
+	return headers
 }
 
 func (c *ClientFactory) getClientState(options ...ClientOption) (client.AuthenticatingClient, error) {

--- a/internal/provider/openstack/image.go
+++ b/internal/provider/openstack/image.go
@@ -48,11 +48,11 @@ func findInstanceSpec(
 		return nil, err
 	}
 
-	if ic.Constraints.HasRootDiskSource() && *ic.Constraints.RootDiskSource == "volume" {
-		// When the root disk is a volume (i.e. cinder block volume)
-		// we don't want to match on RootDisk size. If an instance requires
-		// a very large root disk we don't want to select a larger instance type
-		// to fit a disk that won't be local to the instance.
+	if ic.Constraints.HasRootDiskSource() && *ic.Constraints.RootDiskSource != rootDiskSourceLocal {
+		// When the root disk is a cinder block volume we don't want to match on
+		// RootDisk size. If an instance requires a very large root disk we
+		// don't want to select a larger instance type to fit a disk that won't
+		// be local to the instance.
 		ic.Constraints.RootDisk = nil
 	}
 

--- a/internal/provider/openstack/local_test.go
+++ b/internal/provider/openstack/local_test.go
@@ -1731,6 +1731,20 @@ func (s *localServerSuite) TestPrecheckInstanceInvalidRootDiskConstraint(c *gc.C
 	c.Assert(err, gc.ErrorMatches, `constraint root-disk cannot be specified with instance-type unless root-disk-source is "volume" \(or a storage pool name\)`)
 }
 
+func (s *localServerSuite) TestPrecheckInstanceInvalidRootDiskSource(c *gc.C) {
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
+	cons := constraints.MustParse("root-disk-source=7pool")
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Base: jujuversion.DefaultSupportedLTSBase(), Constraints: cons})
+	c.Assert(err, gc.ErrorMatches, `invalid root-disk-source "7pool" \(must be "local", "volume", or a storage pool name\)`)
+}
+
+func (s *localServerSuite) TestPrecheckInstanceValidRootDiskSourcePoolName(c *gc.C) {
+	env := s.Open(c, stdcontext.TODO(), s.env.Config())
+	cons := constraints.MustParse("root-disk-source=my-pool")
+	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Base: jujuversion.DefaultSupportedLTSBase(), Constraints: cons})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
 func (s *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
 	placement := "zone=test-available"
 	err := s.env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Base: jujuversion.DefaultSupportedLTSBase(), Placement: placement})

--- a/internal/provider/openstack/local_test.go
+++ b/internal/provider/openstack/local_test.go
@@ -1728,7 +1728,7 @@ func (s *localServerSuite) TestPrecheckInstanceInvalidRootDiskConstraint(c *gc.C
 	env := s.Open(c, stdcontext.TODO(), s.env.Config())
 	cons := constraints.MustParse("instance-type=m1.small root-disk=10G")
 	err := env.PrecheckInstance(s.callCtx, environs.PrecheckInstanceParams{Base: jujuversion.DefaultSupportedLTSBase(), Constraints: cons})
-	c.Assert(err, gc.ErrorMatches, `constraint root-disk cannot be specified with instance-type unless constraint root-disk-source=volume`)
+	c.Assert(err, gc.ErrorMatches, `constraint root-disk cannot be specified with instance-type unless root-disk-source is "volume" \(or a storage pool name\)`)
 }
 
 func (s *localServerSuite) TestPrecheckInstanceAvailZone(c *gc.C) {
@@ -2834,6 +2834,7 @@ func (s *localServerSuite) TestStartInstanceVolumeRootBlockDevice(c *gc.C) {
 		UUID:                "1",
 		SourceType:          "image",
 		DestinationType:     "volume",
+		DeviceType:          "disk",
 		DeleteOnTermination: true,
 		VolumeSize:          diskSizeGiB,
 	})
@@ -2869,6 +2870,7 @@ func (s *localServerSuite) TestStartInstanceVolumeRootBlockDeviceSized(c *gc.C) 
 		UUID:                "1",
 		SourceType:          "image",
 		DestinationType:     "volume",
+		DeviceType:          "disk",
 		DeleteOnTermination: true,
 		VolumeSize:          diskSizeGiB,
 	})
@@ -2945,6 +2947,125 @@ func (s *localServerSuite) TestStartInstanceLocalRootBlockDevice(c *gc.C) {
 		DeleteOnTermination: true,
 		// VolumeSize is 0 when a local disk is used.
 		VolumeSize: 0,
+	})
+}
+
+func (s *localServerSuite) TestStartInstanceVolumeRootBlockDeviceWithPoolAttrs(c *gc.C) {
+	env := s.ensureAMDImages(c)
+
+	err := bootstrapEnv(c, env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := constraints.Parse("root-disk-source=volume arch=amd64")
+	c.Assert(err, jc.ErrorIsNil)
+
+	res, err := testing.StartInstanceWithParams(env, s.callCtx, "1", environs.StartInstanceParams{
+		ControllerUUID: s.ControllerUUID,
+		Constraints:    cons,
+		RootDisk: &storage.VolumeParams{
+			Attributes: map[string]interface{}{
+				"volume-type": "Ceph",
+				"disk-bus":    "scsi",
+				"tag":         "root",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+
+	runOpts := res.Instance.(novaInstaceStartedWithOpts).NovaInstanceStartedWithOpts()
+	c.Assert(runOpts, gc.NotNil)
+	c.Assert(runOpts.BlockDeviceMappings, gc.NotNil)
+	deviceMapping := runOpts.BlockDeviceMappings[0]
+	c.Assert(deviceMapping, jc.DeepEquals, nova.BlockDeviceMapping{
+		BootIndex:           0,
+		UUID:                "1",
+		SourceType:          "image",
+		DestinationType:     "volume",
+		DeleteOnTermination: true,
+		VolumeSize:          30,
+		VolumeType:          "Ceph",
+		DeviceType:          "disk",
+		DiskBus:             "scsi",
+		Tag:                 "root",
+	})
+}
+
+func (s *localServerSuite) TestStartInstanceVolumeRootBlockDeviceWithPoolName(c *gc.C) {
+	env := s.ensureAMDImages(c)
+
+	err := bootstrapEnv(c, env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := constraints.Parse("root-disk-source=mypool arch=amd64")
+	c.Assert(err, jc.ErrorIsNil)
+
+	res, err := testing.StartInstanceWithParams(env, s.callCtx, "1", environs.StartInstanceParams{
+		ControllerUUID: s.ControllerUUID,
+		Constraints:    cons,
+		RootDisk: &storage.VolumeParams{
+			Attributes: map[string]interface{}{
+				"volume-type": "Ceph",
+				"disk-bus":    "scsi",
+				"tag":         "root",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+
+	runOpts := res.Instance.(novaInstaceStartedWithOpts).NovaInstanceStartedWithOpts()
+	c.Assert(runOpts, gc.NotNil)
+	c.Assert(runOpts.BlockDeviceMappings, gc.NotNil)
+	deviceMapping := runOpts.BlockDeviceMappings[0]
+	c.Assert(deviceMapping, jc.DeepEquals, nova.BlockDeviceMapping{
+		BootIndex:           0,
+		UUID:                "1",
+		SourceType:          "image",
+		DestinationType:     "volume",
+		DeleteOnTermination: true,
+		VolumeSize:          30,
+		VolumeType:          "Ceph",
+		DeviceType:          "disk",
+		DiskBus:             "scsi",
+		Tag:                 "root",
+	})
+}
+
+func (s *localServerSuite) TestStartInstanceVolumeRootBlockDeviceDiskBusOnly(c *gc.C) {
+	env := s.ensureAMDImages(c)
+
+	err := bootstrapEnv(c, env)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := constraints.Parse("root-disk-source=volume arch=amd64")
+	c.Assert(err, jc.ErrorIsNil)
+
+	res, err := testing.StartInstanceWithParams(env, s.callCtx, "1", environs.StartInstanceParams{
+		ControllerUUID: s.ControllerUUID,
+		Constraints:    cons,
+		RootDisk: &storage.VolumeParams{
+			Attributes: map[string]interface{}{
+				"disk-bus": "scsi",
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.NotNil)
+
+	runOpts := res.Instance.(novaInstaceStartedWithOpts).NovaInstanceStartedWithOpts()
+	c.Assert(runOpts, gc.NotNil)
+	c.Assert(runOpts.BlockDeviceMappings, gc.NotNil)
+	deviceMapping := runOpts.BlockDeviceMappings[0]
+	c.Assert(deviceMapping, jc.DeepEquals, nova.BlockDeviceMapping{
+		BootIndex:           0,
+		UUID:                "1",
+		SourceType:          "image",
+		DestinationType:     "volume",
+		DeleteOnTermination: true,
+		VolumeSize:          30,
+		DeviceType:          "disk",
+		DiskBus:             "scsi",
 	})
 }
 

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -725,6 +725,17 @@ func (e *Environ) PrecheckInstance(ctx context.ProviderCallContext, args environ
 			constraints.RootDisk, constraints.InstanceType,
 			constraints.RootDiskSource, rootDiskSourceVolume)
 	}
+	if args.Constraints.HasRootDiskSource() {
+		rootDiskSource := *args.Constraints.RootDiskSource
+		if rootDiskSource != rootDiskSourceLocal &&
+			rootDiskSource != rootDiskSourceVolume &&
+			!storage.IsValidPoolName(rootDiskSource) {
+			return errors.Errorf(
+				"invalid %s %q (must be %q, %q, or a storage pool name)",
+				constraints.RootDiskSource, rootDiskSource,
+				rootDiskSourceLocal, rootDiskSourceVolume)
+		}
+	}
 	if args.Constraints.HasInstanceType() {
 		// Constraint has an instance-type constraint so let's see if it is valid.
 		novaClient := e.nova()

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -331,6 +331,11 @@ type Environ struct {
 	neutronUnlocked NetworkingNeutron
 	volumeURL       *url.URL
 
+	// clientFactoryUnlocked is used to create nova clients with specific
+	// headers (e.g. the compute microversion header for volume_type
+	// support in block_device_mapping_v2).
+	clientFactoryUnlocked *ClientFactory
+
 	// keystoneImageDataSource caches the result of getKeystoneImageSource.
 	keystoneImageDataSourceMutex sync.Mutex
 	keystoneImageDataSource      simplestreams.DataSource
@@ -610,7 +615,6 @@ func (e *Environ) ConstraintsValidator(ctx context.ProviderCallContext) (constra
 	sort.Strings(instTypeNames)
 	validator.RegisterVocabulary(constraints.InstanceType, instTypeNames)
 	validator.RegisterVocabulary(constraints.VirtType, []string{"kvm", "lxd"})
-	validator.RegisterVocabulary(constraints.RootDiskSource, []string{rootDiskSourceVolume, rootDiskSourceLocal})
 	return validator, nil
 }
 
@@ -712,12 +716,12 @@ func (e *Environ) PrecheckInstance(ctx context.ProviderCallContext, args environ
 		return errors.Trace(err)
 	}
 	usingVolumeRootDisk := false
-	if args.Constraints.HasRootDiskSource() && args.Constraints.HasRootDisk() &&
-		*args.Constraints.RootDiskSource == rootDiskSourceVolume {
+	if args.Constraints.HasRootDiskSource() &&
+		*args.Constraints.RootDiskSource != rootDiskSourceLocal {
 		usingVolumeRootDisk = true
 	}
 	if args.Constraints.HasRootDisk() && args.Constraints.HasInstanceType() && !usingVolumeRootDisk {
-		return errors.Errorf("constraint %s cannot be specified with %s unless constraint %s=%s",
+		return errors.Errorf("constraint %s cannot be specified with %s unless %s is %q (or a storage pool name)",
 			constraints.RootDisk, constraints.InstanceType,
 			constraints.RootDiskSource, rootDiskSourceVolume)
 	}
@@ -933,6 +937,7 @@ func (e *Environ) SetCloudSpec(_ stdcontext.Context, spec environscloudspec.Clou
 	if err := factory.Init(); err != nil {
 		return errors.Trace(err)
 	}
+	e.clientFactoryUnlocked = factory
 	e.clientUnlocked = factory.AuthClient()
 
 	// The following uses different clients for the different openstack clients
@@ -1288,7 +1293,33 @@ func (e *Environ) startInstance(
 	}
 	e.configurator.ModifyRunServerOptions(&opts)
 
-	server, err := tryStartNovaInstance(shortAttempt, e.nova(), opts)
+	// Determine whether the RunServer call requires the nova compute
+	// microversion header. volume_type and tag in block_device_mapping_v2
+	// were introduced in microversion 2.67 and 2.42 respectively.
+	// Any block device mapping may carry these fields, so check them all.
+	needMicroversion := false
+	for _, bdm := range opts.BlockDeviceMappings {
+		if bdm.VolumeType != "" || bdm.Tag != "" {
+			needMicroversion = true
+			break
+		}
+	}
+	novaClient := e.nova()
+	if needMicroversion {
+		e.ecfgMutex.Lock()
+		factory := e.clientFactoryUnlocked
+		e.ecfgMutex.Unlock()
+		if factory == nil {
+			// Should not happen.
+			return nil, errors.NotValidf("cannot start instance with block device mapping requiring nova microversion, no client factory available")
+		}
+		novaClient, err = factory.NovaWithMicroVersion()
+		if err != nil {
+			return nil, environs.ZoneIndependentError(err)
+		}
+	}
+
+	server, err := tryStartNovaInstance(shortAttempt, novaClient, opts)
 	if err != nil || server == nil {
 		// Attempt to clean up any security groups we created.
 		if err := e.firewaller.DeleteMachineGroup(ctx, args.InstanceConfig.MachineId); err != nil {
@@ -1615,22 +1646,21 @@ func (e *Environ) configureRootDisk(_ context.ProviderCallContext, args environs
 		rootDiskSource = *args.Constraints.RootDiskSource
 	}
 	rootDiskMapping := nova.BlockDeviceMapping{
-		BootIndex:  0,
-		UUID:       spec.Image.Id,
-		SourceType: "image",
-		// NB constraints.RootDiskSource in the case of OpenStack represents
-		// the type of block device to use. Either "local" to represent a local
-		// block device or "volume" to represent a block device from the cinder
-		// block storage service.
-		DestinationType:     rootDiskSource,
+		BootIndex:           0,
+		UUID:                spec.Image.Id,
+		SourceType:          "image",
+		DestinationType:     rootDiskSourceLocal,
 		DeleteOnTermination: true,
 	}
 	switch rootDiskSource {
 	case rootDiskSourceLocal:
 		runOpts.ImageId = spec.Image.Id
-	case rootDiskSourceVolume:
-		// Only preserve image-id for volume-backed roots when image-id was
-		// explicitly requested; local roots always need the image recorded.
+	default:
+		// Anything other than "local" is a cinder-backed root disk.
+		// This includes "volume" or the name of a  storage pool.
+		// Only preserve image-id for volume-backed roots when image-id
+		// was explicitly requested; local roots always need the image
+		// recorded.
 		if args.Constraints.HasImageID() {
 			runOpts.ImageId = spec.Image.Id
 		}
@@ -1642,9 +1672,18 @@ func (e *Environ) configureRootDisk(_ context.ProviderCallContext, args environs
 			size = defaultRootDiskSize
 		}
 		sizeGB := common.MiBToGiB(size)
+		rootDiskMapping.DestinationType = rootDiskSourceVolume
 		rootDiskMapping.VolumeSize = int(sizeGB)
-	default:
-		return errors.Errorf("invalid %s %s", constraints.RootDiskSource, rootDiskSource)
+		rootDiskMapping.DeviceType = deviceTypeDisk
+		if args.RootDisk != nil {
+			config, err := newCinderConfig(args.RootDisk.Attributes)
+			if err != nil {
+				return errors.Annotatef(err, "parsing root disk storage config")
+			}
+			rootDiskMapping.VolumeType = config.volumeType
+			rootDiskMapping.DiskBus = config.diskBus
+			rootDiskMapping.Tag = config.tag
+		}
 	}
 	runOpts.BlockDeviceMappings = []nova.BlockDeviceMapping{rootDiskMapping}
 	return nil


### PR DESCRIPTION
This PR enables a named storage pool to be used with the `root-disk-source` constraint on openstack. Previously, the values were limited to "local" or "volume", where "volume" was a generic cinder block device with hard coded parameters. By allowing the root disk source value to be either "volume" or a storage pool name, a storage pool can be used to support additional configuration of the attached cinder volume, eg volume type. This aligns with other providers like Azure etc.

The existing cinder config schema is enhanced to support new attributes, not just volume-type:
- volume-type
- tag
- disk-bus

Note: limitations with the openstack API mean that the additional pool parameters besides volume type - tag, disk bus - cannot be used for charm storage specified at deploy time. The only API that uses these params is the nova create server API. The cinder create volume API used for charm storage just supports volume type. So the new params above are just for the root disk.

## QA steps

tested on PS7
```
juju bootstrap prodstack7
juju add-model test
juju create-storage-pool test cinder volume-type=Ceph_NVMe
juju deploy mysql --storage database=test --constraints="root-disk-source=test"
```
```
$ for vol_id in $(openstack server volume list 847db7b3-2e80-40d9-90b5-d6805e4f9136 -c "Volume ID" -f value); do
    openstack volume show "$vol_id"
done
+------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                        | Value                                                                                                                                                              |
+------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| attachments                  | [{'id': 'b63bd147-8e72-44d6-a910-bdbacacc0a1d', 'attachment_id': 'ffb2fbcd-6ad6-45a3-a617-5b99da8fa928', 'volume_id': 'b63bd147-8e72-44d6-a910-bdbacacc0a1d',      |
|                              | 'server_id': '847db7b3-2e80-40d9-90b5-d6805e4f9136', 'host_name': None, 'device': '/dev/sda', 'attached_at': '2026-09-08T04:41:38.000000'}]                        |
| availability_zone            | nova                                                                                                                                                               |
| bootable                     | true                                                                                                                                                               |
| consistencygroup_id          | None                                                                                                                                                               |
| created_at                   | 2026-09-08T04:41:16.000000                                                                                                                                         |
| description                  |                                                                                                                                                                    |
| encrypted                    | False                                                                                                                                                              |
| id                           | b63bd147-8e72-44d6-a910-bdbacacc0a1d                                                                                                                               |
| multiattach                  | False                                                                                                                                                              |
| name                         |                                                                                                                                                                    |
| os-vol-tenant-attr:tenant_id | 6ed8facda78348d9b9a7b4a6f76e7bbd                                                                                                                                   |
| properties                   |                                                                                                                                                                    |
| replication_status           | None                                                                                                                                                               |
| size                         | 30                                                                                                                                                                 |
| snapshot_id                  | None                                                                                                                                                               |
| source_volid                 | None                                                                                                                                                               |
| status                       | in-use                                                                                                                                                             |
| type                         | Ceph_NVMe                                                                                                                                                          |
| updated_at                   | 2026-09-08T04:41:38.000000                                                                                                                                         |
| user_id                      | ad072fece322422aace31b0bc63be829                                                                                                                                   |
| volume_image_metadata        | {'signature_verified': 'False', 'architecture': 'x86_64', 'content_id': 'auto.sync', 'hw_disk_bus': 'scsi', 'hw_machine_type': 'pc-q35-6.2', 'hw_scsi_model':      |
|                              | 'virtio-scsi', 'item_name': 'disk1.img', 'os_distro': 'ubuntu', 'os_version': '22.04', 'product_name': 'com.ubuntu.cloud:server:22.04:amd64',                      |
|                              | 'simplestreams_metadata': '{"aliases": "22.04,j,jammy", "arch": "amd64", "ftype": "disk1.img", "label": "release", "md5": "74ec44d0cacdc0b1a5449fd84cb55f26",      |
|                              | "os": "ubuntu", "pubname": "ubuntu-jammy-22.04-amd64-server-20260826", "release": "jammy", "release_codename": "Jammy Jellyfish", "release_title": "22.04 LTS",    |
|                              | "sha256": "c0a5af17e6c0f76351fe07e2fffef3011dab1facb8a8ed5701dcf648dabd4f0a", "size": "734972416", "support_eol": "2027-06-01", "supported": "True", "version":    |
|                              | "22.04"}', 'source_content_id': 'com.ubuntu.cloud:released:download', 'version_name': '20260826', 'image_id': '8ab7ab4b-dab1-48cf-ac0e-2af646c7034b',              |
|                              | 'image_name': 'auto-sync/ubuntu-jammy-22.04-amd64-server-20260826-disk1.img', 'checksum': '74ec44d0cacdc0b1a5449fd84cb55f26', 'container_format': 'bare',          |
|                              | 'disk_format': 'qcow2', 'min_disk': '0', 'min_ram': '0', 'size': '734972416'}                                                                                      |
+------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Field                        | Value                                                                                                                                                              |
+------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| attachments                  | [{'id': '05c2cfe6-d2d3-4d50-84cc-5e7733dd960d', 'attachment_id': '72225df6-d137-4d1f-92d0-9036db0beb95', 'volume_id': '05c2cfe6-d2d3-4d50-84cc-5e7733dd960d',      |
|                              | 'server_id': '847db7b3-2e80-40d9-90b5-d6805e4f9136', 'host_name': None, 'device': '/dev/sdb', 'attached_at': '2026-09-08T04:41:50.000000'}]                        |
| availability_zone            | nova                                                                                                                                                               |
| bootable                     | false                                                                                                                                                              |
| consistencygroup_id          | None                                                                                                                                                               |
| created_at                   | 2026-09-08T04:41:44.000000                                                                                                                                         |
| description                  | None                                                                                                                                                               |
| encrypted                    | False                                                                                                                                                              |
| id                           | 05c2cfe6-d2d3-4d50-84cc-5e7733dd960d                                                                                                                               |
| multiattach                  | False                                                                                                                                                              |
| name                         | juju-3d55b8-controller-volume-0                                                                                                                                    |
| os-vol-tenant-attr:tenant_id | 6ed8facda78348d9b9a7b4a6f76e7bbd                                                                                                                                   |
| properties                   | juju-controller-uuid='73a107d4-0781-4216-8aed-1ea053a94275', juju-model-uuid='5fdfad0e-e968-42a1-8892-9610d63d55b8', juju-storage-instance='database/0', juju-     |
|                              | storage-owner='mysql/0'                                                                                                                                            |
| replication_status           | None                                                                                                                                                               |
| size                         | 1                                                                                                                                                                  |
| snapshot_id                  | None                                                                                                                                                               |
| source_volid                 | None                                                                                                                                                               |
| status                       | in-use                                                                                                                                                             |
| type                         | Ceph_NVMe                                                                                                                                                          |
| updated_at                   | 2026-09-08T04:41:50.000000                                                                                                                                         |
| user_id                      | ad072fece322422aace31b0bc63be829                                                                                                                                   |
+------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```


## Documentation changes

The openstack cloud doc is updated.

## Links

**Issue:** Fixes #23117.

**Jira card:** [JUJU-10331](https://warthogs.atlassian.net/browse/JUJU-10331)


[JUJU-10331]: https://warthogs.atlassian.net/browse/JUJU-10331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ