### PR TITLE
chore: merge 4.0 into 4.1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,7 +65,7 @@ jobs:
           cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: "actions/setup-python@v5"
+        uses: "actions/setup-python@v7"
         with:
           python-version: "3.9"
 

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ define run_cgo_build
 	@env PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
+		CGO_LDFLAGS="$(CGO_LDFLAGS) -L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -280,7 +280,7 @@ define run_cgo_install
 	@env PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
+		CGO_LDFLAGS="$(CGO_LDFLAGS) -L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -498,7 +498,7 @@ run-tests: musl-install-if-missing dqlite-install-if-missing
 		PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
+		CGO_LDFLAGS="$(CGO_LDFLAGS) -L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -533,7 +533,7 @@ run-go-tests: musl-install-if-missing dqlite-install-if-missing
 	@PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
+		CGO_LDFLAGS="$(CGO_LDFLAGS) -L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -547,7 +547,7 @@ go-test-alias: musl-install-if-missing dqlite-install-if-missing
 	@echo alias jt=\'PATH=\"${MUSL_BIN_PATH}:\$$PATH\" \
 		CC=\"musl-gcc\" \
 		CGO_CFLAGS=\"-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include\" \
-		CGO_LDFLAGS=\"-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576\" \
+		CGO_LDFLAGS=\"$(CGO_LDFLAGS) -L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576\" \
 		CGO_LDFLAGS_ALLOW=\""(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"\" \
 		LD_LIBRARY_PATH=\"${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}\" \
 		CGO_ENABLED=\"1\" \
@@ -813,4 +813,3 @@ docs-%:
 ## docs-run: Build and serve the documentation
 ## docs-clean: Clean the docs build artifacts
 	cd docs && $(MAKE) -f Makefile $* ALLFILES='*.md **/*.md'
-

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ GIT_COMMIT ?= $(shell git -C $(PROJECT_DIR) rev-parse HEAD 2>/dev/null)
 # CI should set this to vendor
 JUJU_GOMOD_MODE ?= readonly
 
+# Extra linker flags passed to CGO builds.
+CGO_LDFLAGS ?=
+
 # If .git directory is missing, we are building out of an archive, otherwise report
 # if the tree that is checked out is dirty (modified) or clean.
 GIT_TREE_STATE = $(if $(shell git -C $(PROJECT_DIR) rev-parse --is-inside-work-tree 2>/dev/null | grep -e 'true'),$(if $(shell git -C $(PROJECT_DIR) status --porcelain),dirty,clean),archive)

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -59,6 +59,7 @@ import (
 	"github.com/juju/juju/core/securitylog"
 	coretrace "github.com/juju/juju/core/trace"
 	coreunit "github.com/juju/juju/core/unit"
+	"github.com/juju/juju/core/watcher/eventsource"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	internalerrors "github.com/juju/juju/internal/errors"
 	internallogger "github.com/juju/juju/internal/logger"
@@ -660,6 +661,11 @@ func (srv *Server) loop(ready chan struct{}) error {
 		return errors.Trace(err)
 	}
 
+	// Consume the initial event to synchronize with the watcher's subscription.
+	if _, err := eventsource.ConsumeInitialEvent(ctx, modelRemovalWatcher); err != nil {
+		return errors.Annotate(err, "waiting for model removals watcher")
+	}
+
 	close(ready)
 
 	srv.mu.Lock()
@@ -1224,7 +1230,7 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 		recorderFactory := observer.NewRecorderFactory(apiObserver, nil, observer.NoCaptureArgs)
 		rpcConn := rpc.NewConn(codec, recorderFactory)
 
-		if root, err := srv.serveConn(
+		root, closeOnModelRemoval, err := srv.serveConn(
 			srv.catacomb.Context(ctx),
 			rpcConn,
 			resolvedModelUUID,
@@ -1233,7 +1239,8 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 			apiObserver,
 			req.Host,
 			crossModelAuthContext,
-		); errors.Is(err, modelerrors.NotFound) {
+		)
+		if errors.Is(err, modelerrors.NotFound) {
 			// If the model is not found then we need to close the connection
 			// with the appropriate error so that the client can handle it.
 			err := fmt.Errorf("%w: %q", apiservererrors.UnknownModelError, modelUUID)
@@ -1245,13 +1252,20 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 			rpcConn.ServeRoot(root, recorderFactory, serverError)
 		}
 
+		// A connection admitted only to answer a migration redirect must stay
+		// open long enough to receive a Login request and return that redirect.
+		// A nil channel disables this select case.
+		if !closeOnModelRemoval {
+			modelRemoved = nil
+		}
+
 		rpcConn.Start(ctx)
 		select {
 		case <-rpcConn.Dead():
 			cancel(ErrRPCConnectionClosed)
 		case <-srv.catacomb.Dying():
 		case <-modelRemoved:
-			// The model this connection serves has been removed from this
+			// The local model this connection serves has been removed from this
 			// controller, so fall through and close the connection: its agents
 			// and clients must reconnect to the model's new location. The close
 			// happens here, in the goroutine that started the connection just
@@ -1273,14 +1287,15 @@ func (srv *Server) serveConn(
 	apiObserver observer.Observer,
 	host string,
 	crossModelAuthContext facade.CrossModelAuthContext,
-) (rpc.Root, error) {
+) (rpc.Root, bool, error) {
 	domainServices, err := srv.shared.domainServicesGetter.ServicesForModel(ctx, modelUUID)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting domain services for model %q", modelUUID)
+		return nil, false, errors.Annotatef(err, "getting domain services for model %q", modelUUID)
 	}
 
-	if err := srv.isModelAvailable(ctx, domainServices.Model(), modelUUID); err != nil {
-		return nil, errors.Annotatef(err, "checking model %q availability", modelUUID)
+	modelConn, err := srv.isModelAvailable(ctx, domainServices.Model(), modelUUID)
+	if err != nil {
+		return nil, false, errors.Annotatef(err, "checking model %q availability", modelUUID)
 	}
 
 	tracer, err := srv.shared.tracerGetter.GetTracer(
@@ -1295,19 +1310,19 @@ func (srv *Server) serveConn(
 	// Grab the object store for the model.
 	objectStore, err := srv.shared.objectStoreGetter.GetObjectStore(ctx, modelUUID.String())
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting object store for model %q", modelUUID)
+		return nil, false, errors.Annotatef(err, "getting object store for model %q", modelUUID)
 	}
 
 	// Grab the object store for the controller, this is primarily used for
 	// the agent tools.
 	controllerObjectStore, err := srv.shared.objectStoreGetter.GetObjectStore(ctx, database.ControllerNS)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting controller object store")
+		return nil, false, errors.Annotatef(err, "getting controller object store")
 	}
 
 	watcherRegistry, err := srv.shared.watcherRegistryGetter.GetWatcherRegistry(ctx, connectionID)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting watcher registry for connection %d", connectionID)
+		return nil, false, errors.Annotatef(err, "getting watcher registry for connection %d", connectionID)
 	}
 
 	handler, err := newAPIHandler(
@@ -1332,7 +1347,7 @@ func (srv *Server) serveConn(
 		err = fmt.Errorf("%w: %q", apiservererrors.UnknownModelError, modelUUID)
 	}
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, false, errors.Trace(err)
 	}
 
 	// Set up the admin apis used to accept logins and direct
@@ -1344,14 +1359,14 @@ func (srv *Server) serveConn(
 		adminAPIs[apiVersion] = factory(srv, handler, apiObserver)
 	}
 
-	return newAdminRoot(handler, adminAPIs), nil
+	return newAdminRoot(handler, adminAPIs), modelConn.connectable, nil
 }
 
 func (srv *Server) isModelAvailable(
 	ctx context.Context,
 	modelService ModelService,
 	modelUUID coremodel.UUID,
-) error {
+) (modelConnection, error) {
 	// Check that the model can be served before proceeding any further. There
 	// is no need in setting up any additional operations if the model is not
 	// present. A model that is still being imported by a migration is served
@@ -1359,9 +1374,9 @@ func (srv *Server) isModelAvailable(
 	// modelIsConnectable.
 	conn, err := modelIsConnectable(ctx, modelService, modelUUID)
 	if err != nil && !errors.Is(err, modelerrors.NotFound) {
-		return errors.Trace(err)
+		return modelConnection{}, errors.Trace(err)
 	} else if conn.connectable {
-		return nil
+		return conn, nil
 	}
 
 	// If this model used to be hosted on this controller but got
@@ -1374,10 +1389,10 @@ func (srv *Server) isModelAvailable(
 		// is an error with the database? The caller will assume that it
 		// is no longer on this controller. If we return a different error
 		// then it can at least retry the request.
-		return modelerrors.NotFound
+		return modelConnection{}, modelerrors.NotFound
 	}
 
-	return nil
+	return conn, nil
 }
 
 // publicDNSName returns the current public hostname.

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -102,6 +102,10 @@ type Server struct {
 
 	shared *sharedServerContext
 
+	// modelRemovals reports the removal of a model from this controller to the
+	// connections serving it.
+	modelRemovals *modelRemovals
+
 	// tag of the machine where the API server is running.
 	tag     names.Tag
 	dataDir string
@@ -405,6 +409,7 @@ func newServer(ctx context.Context, cfg ServerConfig) (_ *Server, err error) {
 		pingClock:                     cfg.pingClock(),
 		newObserver:                   cfg.NewObserver,
 		shared:                        shared,
+		modelRemovals:                 newModelRemovals(),
 		tag:                           cfg.Tag,
 		dataDir:                       cfg.DataDir,
 		logDir:                        cfg.LogDir,
@@ -641,6 +646,20 @@ func (srv *Server) loop(ready chan struct{}) error {
 		return errors.Trace(err)
 	}
 
+	// Watch the removal of models from this controller so that the connections
+	// serving a removed model can be closed. One watcher serves every
+	// connection this API server has, and it is created before the server is
+	// ready to serve any of them, so that no removal can be missed.
+	modelService := srv.shared.controllerDomainServices.Model()
+	modelRemovalWatcher, err := modelService.WatchModelRemovals(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if err := srv.catacomb.Add(modelRemovalWatcher); err != nil {
+		return errors.Trace(err)
+	}
+
 	close(ready)
 
 	srv.mu.Lock()
@@ -682,6 +701,15 @@ func (srv *Server) loop(ready chan struct{}) error {
 			if err := srv.updateResourceDownloadLimiters(controllerConfig); err != nil {
 				logger.Errorf(ctx, "failed to update resource download limiters: %v", err)
 				continue
+			}
+
+		case modelUUIDs, ok := <-modelRemovalWatcher.Changes():
+			if !ok {
+				return errors.New("model removals watcher stopped")
+			}
+			for _, modelUUID := range modelUUIDs {
+				logger.Infof(ctx, "model %q has been removed, closing its connections", modelUUID)
+				srv.modelRemovals.notify(coremodel.UUID(modelUUID))
 			}
 		}
 	}
@@ -1173,6 +1201,12 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 
 		logger.Tracef(ctx, "got a request for model %q fd:%v", modelUUID, fd)
 
+		// Take an interest in the removal of the model this connection serves,
+		// before checking that the model exists at all, so that a removal
+		// cannot fall between the two.
+		modelRemoved, untrackModel := srv.modelRemovals.track(resolvedModelUUID)
+		defer untrackModel()
+
 		codec := jsoncodec.NewWebsocket(conn.Conn)
 		recorderFactory := observer.NewRecorderFactory(apiObserver, nil, observer.NoCaptureArgs)
 		rpcConn := rpc.NewConn(codec, recorderFactory)
@@ -1203,6 +1237,13 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 		case <-rpcConn.Dead():
 			cancel(ErrRPCConnectionClosed)
 		case <-srv.catacomb.Dying():
+		case <-modelRemoved:
+			// The model this connection serves has been removed from this
+			// controller, so fall through and close the connection: its agents
+			// and clients must reconnect to the model's new location. The close
+			// happens here, in the goroutine that started the connection just
+			// above, because an rpc.Conn may not be closed before it has been
+			// started.
 		}
 		if err := rpcConn.Close(); err != nil {
 			logger.Errorf(ctx, "error closing RPC connection: %v", err)
@@ -1225,19 +1266,8 @@ func (srv *Server) serveConn(
 		return nil, errors.Annotatef(err, "getting domain services for model %q", modelUUID)
 	}
 
-	modelConn, err := srv.isModelAvailable(ctx, domainServices.Model(), modelUUID)
-	if err != nil {
+	if err := srv.isModelAvailable(ctx, domainServices.Model(), modelUUID); err != nil {
 		return nil, errors.Annotatef(err, "checking model %q availability", modelUUID)
-	}
-
-	// Close the connection when the model it serves is removed from this
-	// controller, whether destroyed or deleted by a migration's REAP phase
-	// after migrating away, so that its agents and clients reconnect to the
-	// model's new location. A connection to a model that is already gone
-	// exists only to answer a redirect, so it is not watched.
-	if modelConn.connectable {
-		srv.watchServedModelRemoval(ctx, conn, domainServices.Model(),
-			srv.shared.controllerDomainServices.Model(), modelUUID)
 	}
 
 	tracer, err := srv.shared.tracerGetter.GetTracer(
@@ -1308,7 +1338,7 @@ func (srv *Server) isModelAvailable(
 	ctx context.Context,
 	modelService ModelService,
 	modelUUID coremodel.UUID,
-) (modelConnection, error) {
+) error {
 	// Check that the model can be served before proceeding any further. There
 	// is no need in setting up any additional operations if the model is not
 	// present. A model that is still being imported by a migration is served
@@ -1316,9 +1346,9 @@ func (srv *Server) isModelAvailable(
 	// modelIsConnectable.
 	conn, err := modelIsConnectable(ctx, modelService, modelUUID)
 	if err != nil && !errors.Is(err, modelerrors.NotFound) {
-		return modelConnection{}, errors.Trace(err)
+		return errors.Trace(err)
 	} else if conn.connectable {
-		return conn, nil
+		return nil
 	}
 
 	// If this model used to be hosted on this controller but got
@@ -1331,10 +1361,10 @@ func (srv *Server) isModelAvailable(
 		// is an error with the database? The caller will assume that it
 		// is no longer on this controller. If we return a different error
 		// then it can at least retry the request.
-		return modelConnection{}, modelerrors.NotFound
+		return modelerrors.NotFound
 	}
 
-	return conn, nil
+	return nil
 }
 
 // publicDNSName returns the current public hostname.

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -671,6 +671,14 @@ func (srv *Server) loop(ready chan struct{}) error {
 	})
 	srv.mu.Unlock()
 
+	// Disable each watcher case once its channel closes: stopping the
+	// watchers is part of the server shutting down, since the catacomb
+	// kills the workers added to it, and handling their channels closing
+	// would race with the dying case below. If a watcher stops while
+	// the server keeps running, its error kills the catacomb it was
+	// added to.
+	controllerChanges := controllerConfigWatcher.Changes()
+	removalChanges := modelRemovalWatcher.Changes()
 	for {
 		select {
 		case <-srv.catacomb.Dying():
@@ -686,7 +694,11 @@ func (srv *Server) loop(ready chan struct{}) error {
 			srv.wg.Wait() // wait for any outstanding requests to complete.
 			return ErrAPIServerDying
 
-		case <-controllerConfigWatcher.Changes():
+		case _, ok := <-controllerChanges:
+			if !ok {
+				controllerChanges = nil
+				continue
+			}
 			controllerConfig, err := controllerConfigService.ControllerConfig(ctx)
 			if err != nil {
 				logger.Errorf(ctx, "failed to get controller config: %v", err)
@@ -703,9 +715,10 @@ func (srv *Server) loop(ready chan struct{}) error {
 				continue
 			}
 
-		case modelUUIDs, ok := <-modelRemovalWatcher.Changes():
+		case modelUUIDs, ok := <-removalChanges:
 			if !ok {
-				return errors.New("model removals watcher stopped")
+				removalChanges = nil
+				continue
 			}
 			for _, modelUUID := range modelUUIDs {
 				logger.Infof(ctx, "model %q has been removed, closing its connections", modelUUID)

--- a/apiserver/modelconnection_test.go
+++ b/apiserver/modelconnection_test.go
@@ -203,8 +203,7 @@ func (s *modelConnectionSuite) TestMigrationModeErrorPropagates(c *tc.C) {
 // it adds on top of modelIsConnectable - the redirect fall-through.
 
 func (s *modelConnectionSuite) available(c *tc.C) error {
-	_, err := (&Server{}).isModelAvailable(c.Context(), s.modelService, s.modelUUID)
-	return err
+	return (&Server{}).isModelAvailable(c.Context(), s.modelService, s.modelUUID)
 }
 
 // TestAvailableWhileImporting verifies that the connection is served for a

--- a/apiserver/modelconnection_test.go
+++ b/apiserver/modelconnection_test.go
@@ -202,7 +202,7 @@ func (s *modelConnectionSuite) TestMigrationModeErrorPropagates(c *tc.C) {
 // served at all, before Login is ever reached. These cases pin the behaviour
 // it adds on top of modelIsConnectable - the redirect fall-through.
 
-func (s *modelConnectionSuite) available(c *tc.C) error {
+func (s *modelConnectionSuite) available(c *tc.C) (modelConnection, error) {
 	return (&Server{}).isModelAvailable(c.Context(), s.modelService, s.modelUUID)
 }
 
@@ -218,7 +218,9 @@ func (s *modelConnectionSuite) TestAvailableWhileImporting(c *tc.C) {
 		HasImportClaim: true,
 	})
 
-	c.Assert(s.available(c), tc.ErrorIsNil)
+	conn, err := s.available(c)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(conn.connectable, tc.IsTrue)
 }
 
 // TestAvailableWhenActivated covers the ordinary case.
@@ -227,7 +229,9 @@ func (s *modelConnectionSuite) TestAvailableWhenActivated(c *tc.C) {
 
 	s.expectConnectionInfo(model.ModelConnectionInfo{ModelType: coremodel.IAAS, Activated: true})
 
-	c.Assert(s.available(c), tc.ErrorIsNil)
+	conn, err := s.available(c)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(conn.connectable, tc.IsTrue)
 }
 
 // TestNotAvailableWhenAbsent verifies an unknown model is still reported as
@@ -240,7 +244,8 @@ func (s *modelConnectionSuite) TestNotAvailableWhenAbsent(c *tc.C) {
 	s.modelService.EXPECT().ModelRedirection(gomock.Any(), s.modelUUID).
 		Return(model.ModelRedirection{}, modelerrors.ModelNotRedirected)
 
-	c.Assert(s.available(c), tc.ErrorIs, modelerrors.NotFound)
+	_, err := s.available(c)
+	c.Assert(err, tc.ErrorIs, modelerrors.NotFound)
 }
 
 // TestNotAvailableWhenHalfBuilt pins the narrow window at the connection gate:
@@ -253,7 +258,8 @@ func (s *modelConnectionSuite) TestNotAvailableWhenHalfBuilt(c *tc.C) {
 	s.modelService.EXPECT().ModelRedirection(gomock.Any(), s.modelUUID).
 		Return(model.ModelRedirection{}, modelerrors.ModelNotRedirected)
 
-	c.Assert(s.available(c), tc.ErrorIs, modelerrors.NotFound)
+	_, err := s.available(c)
+	c.Assert(err, tc.ErrorIs, modelerrors.NotFound)
 }
 
 // TestAvailableWhenMigratedAway verifies the redirect fall-through still
@@ -267,5 +273,7 @@ func (s *modelConnectionSuite) TestAvailableWhenMigratedAway(c *tc.C) {
 	s.modelService.EXPECT().ModelRedirection(gomock.Any(), s.modelUUID).
 		Return(model.ModelRedirection{ControllerUUID: "other"}, nil)
 
-	c.Assert(s.available(c), tc.ErrorIsNil)
+	conn, err := s.available(c)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(conn.connectable, tc.IsFalse)
 }

--- a/apiserver/modelremoval.go
+++ b/apiserver/modelremoval.go
@@ -4,106 +4,101 @@
 package apiserver
 
 import (
-	"context"
+	"sync"
 
 	coremodel "github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/watcher"
-	modelerrors "github.com/juju/juju/domain/model/errors"
-	"github.com/juju/juju/internal/errors"
 )
 
-// ModelRemovalWatchService creates watchers that emit when a model changes.
-// It is satisfied by the controller-scoped *modelservice.WatchableService.
-type ModelRemovalWatchService interface {
-	// WatchModel returns a watcher that emits an event if the model changes.
-	WatchModel(ctx context.Context, modelUUID coremodel.UUID) (watcher.NotifyWatcher, error)
-}
-
-// servedConnection is the subset of *rpc.Conn needed by the model removal
-// watch. It exists so the watch can be unit tested without a full RPC
-// connection.
-type servedConnection interface {
-	// Dead returns a channel that is closed when the connection dies.
-	Dead() <-chan struct{}
-	// Close closes the connection. Closing an already dead or closed
-	// connection is not an error.
-	Close() error
-}
-
-// watchServedModelRemoval arranges for conn to be closed when the model it
-// serves is removed from this controller. Model removal happens when a model
-// is destroyed or when a migration's REAP phase deletes it after migrating
-// away; agents and clients must then reconnect, dialling the addresses the
-// migration wrote into their configuration.
+// modelRemovals reports the removal of a model from this controller to the
+// connections serving it. A model is removed when it is destroyed, or when a
+// migration's REAP phase deletes it after migrating away; the connections
+// serving the model must then be closed so that its agents and clients
+// reconnect, dialling the addresses the migration wrote into their
+// configuration.
 //
-// The watch is best-effort: if it cannot be established the connection is
-// served without it, as it always has been.
-func (srv *Server) watchServedModelRemoval(
-	ctx context.Context,
-	conn servedConnection,
-	modelService ModelService,
-	watchService ModelRemovalWatchService,
-	modelUUID coremodel.UUID,
-) {
-	// TODO: WatchModel fires on any change to the model; this path could
-	// be optimised to use a specific life trigger (e.g. WatchModelLife)
-	// only, so unrelated model updates do not wake the watch.
-	watch, err := watchService.WatchModel(ctx, modelUUID)
-	if err != nil {
-		logger.Warningf(ctx,
-			"cannot watch model %q for removal; connection will not be closed on model removal: %v",
-			modelUUID, err,
-		)
+// One channel is held per model being served, however many connections that
+// is, and closing it reports the removal to all of them at once. The removals
+// come from the single controller-wide watcher driven by [Server.loop], so a
+// connection costs a map entry rather than a watcher of its own.
+//
+// Only the removal is reported here. Closing a connection is left to the
+// goroutine serving it, which owns the connection's whole lifecycle: an
+// rpc.Conn may not be closed before it has been started.
+type modelRemovals struct {
+	mu     sync.Mutex
+	served map[coremodel.UUID]*servedModel
+}
+
+// servedModel is the removal state shared by every connection this API server
+// is serving for one model.
+type servedModel struct {
+	// removed is closed once the model has been removed from the controller.
+	removed chan struct{}
+
+	// conns counts the connections being served for the model.
+	conns int
+}
+
+func newModelRemovals() *modelRemovals {
+	return &modelRemovals{
+		served: make(map[coremodel.UUID]*servedModel),
+	}
+}
+
+// track registers a connection being served for the given model. It returns a
+// channel that is closed once the model has been removed from the controller,
+// along with a function that must be called exactly once, when the connection
+// is no longer being served.
+//
+// Callers must track the model before checking that it exists, so that a
+// removal can never fall between the check and the registration.
+func (r *modelRemovals) track(modelUUID coremodel.UUID) (<-chan struct{}, func()) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	served, ok := r.served[modelUUID]
+	if !ok {
+		served = &servedModel{removed: make(chan struct{})}
+		r.served[modelUUID] = served
+	}
+	served.conns++
+
+	return served.removed, func() { r.untrack(modelUUID, served) }
+}
+
+// untrack records that a connection is no longer being served for the model,
+// forgetting the model once its last connection has gone.
+func (r *modelRemovals) untrack(modelUUID coremodel.UUID, served *servedModel) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// A removed model is forgotten as it is reported, so anything held against
+	// its UUID now belongs to later connections and is not ours to release.
+	if r.served[modelUUID] != served {
 		return
 	}
-	// The goroutine is deliberately not added to the server's catacomb:
-	// ctx is the connection's context, which the catacomb already cancels
-	// on shutdown, and the watch also stops when the connection dies.
-	// Catacomb membership would instead make a watch failure fatal to the
-	// whole apiserver.
-	go srv.runModelRemovalWatch(ctx, conn, modelService, watch, modelUUID)
+
+	served.conns--
+	if served.conns == 0 {
+		delete(r.served, modelUUID)
+	}
 }
 
-// runModelRemovalWatch closes conn once the model it serves no longer exists
-// on this controller. It returns when the connection dies, the context is
-// cancelled, or the watcher stops.
-func (srv *Server) runModelRemovalWatch(
-	ctx context.Context,
-	conn servedConnection,
-	modelService ModelService,
-	watch watcher.NotifyWatcher,
-	modelUUID coremodel.UUID,
-) {
-	defer func() {
-		watch.Kill()
-		_ = watch.Wait()
-	}()
+// notify reports the removal of the model to every connection being served for
+// it, and forgets the model. Those connections keep the channel they were given
+// and so are still woken, while a connection tracking the model afterwards can
+// only be one answering a redirect, which must be served until its login is
+// refused.
+//
+// Removals of models this API server is not serving are ignored.
+func (r *modelRemovals) notify(modelUUID coremodel.UUID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-conn.Dead():
-			// The webserver serving this connection closes it once it
-			// dies (see Server.apiHandler), so this branch only stops
-			// the watch; there is no connection to close here.
-			return
-		case _, ok := <-watch.Changes():
-			if !ok {
-				logger.Debugf(ctx,
-					"removal watcher for model %q stopped; connection will not be closed on model removal",
-					modelUUID,
-				)
-				return
-			}
-			connInfo, err := modelIsConnectable(ctx, modelService, modelUUID)
-			if errors.Is(err, modelerrors.NotFound) || (err == nil && !connInfo.connectable) {
-				logger.Infof(ctx, "model %q has been removed, closing connection", modelUUID)
-				_ = conn.Close()
-				return
-			}
-			// The model still exists, or the check failed transiently;
-			// keep watching.
-		}
+	served, ok := r.served[modelUUID]
+	if !ok {
+		return
 	}
+	delete(r.served, modelUUID)
+	close(served.removed)
 }

--- a/apiserver/modelremoval_test.go
+++ b/apiserver/modelremoval_test.go
@@ -4,218 +4,105 @@
 package apiserver
 
 import (
-	"context"
-	"errors"
-	"sync"
 	"testing"
 
-	"github.com/canonical/gomock/gomock"
 	"github.com/juju/tc"
 
 	coremodel "github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/core/watcher/watchertest"
-	"github.com/juju/juju/domain/model"
-	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
 type modelRemovalSuite struct {
-	modelService *MockModelService
-	modelUUID    coremodel.UUID
+	removals  *modelRemovals
+	modelUUID coremodel.UUID
 }
 
 func TestModelRemovalSuite(t *testing.T) {
 	tc.Run(t, &modelRemovalSuite{})
 }
 
-func (s *modelRemovalSuite) setupMocks(c *tc.C) *gomock.Controller {
-	ctrl := gomock.NewController(c)
-	s.modelService = NewMockModelService(ctrl)
+func (s *modelRemovalSuite) SetUpTest(c *tc.C) {
+	s.removals = newModelRemovals()
 	s.modelUUID = coremodel.UUID(uuid.MustNewUUID().String())
-	return ctrl
 }
 
-// fakeServedConnection implements servedConnection, recording closure and
-// letting tests drive the dead channel.
-type fakeServedConnection struct {
-	dead      chan struct{}
-	closed    chan struct{}
-	closeOnce sync.Once
-}
-
-func newFakeServedConnection() *fakeServedConnection {
-	return &fakeServedConnection{
-		dead:   make(chan struct{}),
-		closed: make(chan struct{}),
-	}
-}
-
-func (f *fakeServedConnection) Dead() <-chan struct{} {
-	return f.dead
-}
-
-func (f *fakeServedConnection) Close() error {
-	f.closeOnce.Do(func() { close(f.closed) })
-	return nil
-}
-
-func (f *fakeServedConnection) isClosed() bool {
+// isSignalled reports, without blocking, whether the model has been reported as
+// removed.
+func isSignalled(removed <-chan struct{}) bool {
 	select {
-	case <-f.closed:
+	case <-removed:
 		return true
 	default:
 		return false
 	}
 }
 
-// stubModelRemovalWatchService returns a fixed watcher or error from
-// WatchModel.
-type stubModelRemovalWatchService struct {
-	watch watcher.NotifyWatcher
-	err   error
+// TestRemovalReportedToEveryConnection is the point of holding one channel per
+// model rather than one watcher per connection: a single removal wakes every
+// connection serving that model.
+func (s *modelRemovalSuite) TestRemovalReportedToEveryConnection(c *tc.C) {
+	first, _ := s.removals.track(s.modelUUID)
+	second, _ := s.removals.track(s.modelUUID)
+
+	c.Assert(isSignalled(first), tc.IsFalse)
+	c.Assert(isSignalled(second), tc.IsFalse)
+
+	s.removals.notify(s.modelUUID)
+
+	c.Check(isSignalled(first), tc.IsTrue)
+	c.Check(isSignalled(second), tc.IsTrue)
 }
 
-func (s stubModelRemovalWatchService) WatchModel(context.Context, coremodel.UUID) (watcher.NotifyWatcher, error) {
-	return s.watch, s.err
+// TestOtherModelRemovalNotReported verifies that connections are only told
+// about their own model's removal.
+func (s *modelRemovalSuite) TestOtherModelRemovalNotReported(c *tc.C) {
+	removed, _ := s.removals.track(s.modelUUID)
+
+	s.removals.notify(coremodel.UUID(uuid.MustNewUUID().String()))
+
+	c.Check(isSignalled(removed), tc.IsFalse)
 }
 
-// runWatch drives runModelRemovalWatch in a goroutine and returns a channel
-// that is closed when it returns.
-func runWatch(srv *Server, ctx context.Context, conn servedConnection, modelService ModelService, watch watcher.NotifyWatcher, modelUUID coremodel.UUID) <-chan struct{} {
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		srv.runModelRemovalWatch(ctx, conn, modelService, watch, modelUUID)
-	}()
-	return done
+// TestRemovalOfUnservedModelIgnored verifies that removals of models this API
+// server holds no connections for - most of them, on most API servers - are
+// simply dropped.
+func (s *modelRemovalSuite) TestRemovalOfUnservedModelIgnored(c *tc.C) {
+	s.removals.notify(s.modelUUID)
+
+	c.Check(s.removals.served, tc.HasLen, 0)
 }
 
-// TestWatchNotStartedWhenWatcherCreationFails pins the best-effort contract:
-// if the removal watcher cannot be created, the connection is served without
-// it, exactly as connections always have been.
-func (s *modelRemovalSuite) TestWatchNotStartedWhenWatcherCreationFails(c *tc.C) {
-	defer s.setupMocks(c).Finish()
+// TestModelForgottenWithLastConnection verifies that a model is tracked only
+// while it is being served, so that the API server does not accumulate an entry
+// for every model it has ever been asked about.
+func (s *modelRemovalSuite) TestModelForgottenWithLastConnection(c *tc.C) {
+	_, firstDone := s.removals.track(s.modelUUID)
+	_, secondDone := s.removals.track(s.modelUUID)
 
-	conn := newFakeServedConnection()
-	srv := &Server{}
+	firstDone()
+	c.Assert(s.removals.served, tc.HasLen, 1)
 
-	// The model service must not be consulted when there is no watcher.
-	srv.watchServedModelRemoval(c.Context(), conn, s.modelService,
-		stubModelRemovalWatchService{err: errors.New("boom")}, s.modelUUID)
-
-	c.Assert(conn.isClosed(), tc.IsFalse)
+	secondDone()
+	c.Check(s.removals.served, tc.HasLen, 0)
 }
 
-// TestNoRemovalEventLeavesConnectionOpen verifies that a quiet watcher never
-// closes the connection, and that cancelling the connection's context stops
-// the watch goroutine.
-func (s *modelRemovalSuite) TestNoRemovalEventLeavesConnectionOpen(c *tc.C) {
-	defer s.setupMocks(c).Finish()
+// TestModelForgottenWhenRemoved verifies that a removed model is forgotten as
+// it is reported, so that a connection arriving afterwards to be redirected is
+// served rather than closed straight away.
+func (s *modelRemovalSuite) TestModelForgottenWhenRemoved(c *tc.C) {
+	_, done := s.removals.track(s.modelUUID)
 
-	ctx, cancel := context.WithCancel(c.Context())
-	conn := newFakeServedConnection()
-	srv := &Server{}
+	s.removals.notify(s.modelUUID)
+	c.Assert(s.removals.served, tc.HasLen, 0)
 
-	watch := watchertest.NewMockNotifyWatcher(make(chan struct{}))
-	done := runWatch(srv, ctx, conn, s.modelService, watch, s.modelUUID)
+	redirected, redirectedDone := s.removals.track(s.modelUUID)
+	c.Check(isSignalled(redirected), tc.IsFalse)
 
-	cancel()
-	<-done
+	// The connection that was open when the model was removed must not take the
+	// later connection's model with it as it goes.
+	done()
+	c.Check(s.removals.served, tc.HasLen, 1)
 
-	c.Assert(conn.isClosed(), tc.IsFalse)
-}
-
-// TestDeadConnectionStopsWatch verifies that the watch ends with the
-// connection without closing it: nothing may outlive the connection.
-func (s *modelRemovalSuite) TestDeadConnectionStopsWatch(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	conn := newFakeServedConnection()
-	srv := &Server{}
-
-	watch := watchertest.NewMockNotifyWatcher(make(chan struct{}))
-	done := runWatch(srv, c.Context(), conn, s.modelService, watch, s.modelUUID)
-
-	close(conn.dead)
-	<-done
-
-	c.Assert(conn.isClosed(), tc.IsFalse)
-}
-
-// TestModelRemovalClosesConnection is the migration REAP case: the model row
-// disappears from the controller, the watcher fires, the model lookup reports
-// not found, and the connection is closed so agents reconnect to the target
-// controller.
-func (s *modelRemovalSuite) TestModelRemovalClosesConnection(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
-		Return(model.ModelConnectionInfo{}, modelerrors.NotFound)
-
-	conn := newFakeServedConnection()
-	srv := &Server{}
-
-	changes := make(chan struct{}, 1)
-	changes <- struct{}{}
-	watch := watchertest.NewMockNotifyWatcher(changes)
-
-	srv.watchServedModelRemoval(c.Context(), conn, s.modelService,
-		stubModelRemovalWatchService{watch: watch}, s.modelUUID)
-
-	<-conn.closed
-}
-
-// TestUnrelatedModelChangeKeepsWatching verifies that a model change which is
-// not a removal - the model is still connectable - does not close the
-// connection, and that a later removal still does.
-func (s *modelRemovalSuite) TestUnrelatedModelChangeKeepsWatching(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	firstCheck := make(chan struct{})
-	gomock.InOrder(
-		s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
-			DoAndReturn(func(context.Context, coremodel.UUID) (model.ModelConnectionInfo, error) {
-				close(firstCheck)
-				return model.ModelConnectionInfo{Activated: true}, nil
-			}),
-		s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
-			Return(model.ModelConnectionInfo{}, modelerrors.NotFound),
-	)
-
-	conn := newFakeServedConnection()
-	srv := &Server{}
-
-	changes := make(chan struct{})
-	watch := watchertest.NewMockNotifyWatcher(changes)
-	done := runWatch(srv, c.Context(), conn, s.modelService, watch, s.modelUUID)
-
-	changes <- struct{}{}
-	<-firstCheck
-	c.Assert(conn.isClosed(), tc.IsFalse)
-
-	changes <- struct{}{}
-	<-conn.closed
-	<-done
-}
-
-// TestUnactivatedModelClosesConnection covers destroy-model: the
-// model row may still exist but is no longer connectable. The
-// connection must still be closed so agents do not linger.
-func (s *modelRemovalSuite) TestUnactivatedModelClosesConnection(c *tc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.modelService.EXPECT().GetModelConnectionInfo(gomock.Any(), s.modelUUID).
-		Return(model.ModelConnectionInfo{Activated: false}, nil)
-
-	conn := newFakeServedConnection()
-	srv := &Server{}
-
-	changes := make(chan struct{}, 1)
-	changes <- struct{}{}
-	watch := watchertest.NewMockNotifyWatcher(changes)
-	done := runWatch(srv, c.Context(), conn, s.modelService, watch, s.modelUUID)
-
-	<-conn.closed
-	<-done
+	redirectedDone()
+	c.Check(s.removals.served, tc.HasLen, 0)
 }

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -1121,7 +1121,11 @@ func (s *ProviderService) populateAddStorageArgs(
 	if arg.StoragePoolUUID != nil {
 		storageDirective.PoolUUID = *arg.StoragePoolUUID
 	}
-	if arg.SizeMiB != nil {
+	// A zero size means the caller did not specify a size. The add-storage
+	// command always sends a size (a pointer to the parsed directive value,
+	// which is zero when no size was given), so keep the size recorded on
+	// the unit storage directive in that case.
+	if arg.SizeMiB != nil && *arg.SizeMiB != 0 {
 		storageDirective.Size = *arg.SizeMiB
 	}
 

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3279,6 +3279,150 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, nil)
 }
 
+func (s *providerServiceSuite) TestAddStorageForIAASUnitZeroSizeOverride(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	charmStorageDef := internal.CharmStorageDefinitionForValidation{
+		Name:        "pgdata",
+		Type:        applicationcharm.StorageFilesystem,
+		MinimumSize: 10,
+		CountMin:    1,
+		CountMax:    666,
+	}
+
+	s.storageService.EXPECT().GetUnitStorageDirectiveByName(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageDirective{
+			Name:             "pgdata",
+			CharmStorageType: applicationcharm.StorageFilesystem,
+			Count:            1,
+			MaxCount:         666,
+			PoolUUID:         poolUUID,
+			Size:             1024,
+		}, nil)
+	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageInfoForAdd{
+			CharmStorageDefinitionForValidation: charmStorageDef,
+			AlreadyAttachedCount:                66,
+		}, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(gomock.Any(), map[string]internal.CharmStorageDefinitionForValidation{
+		"pgdata": charmStorageDef,
+	}, map[string]storageservice.StorageDirectiveOverride{
+		"pgdata": {
+			Count:    new(uint32(76)),
+			PoolUUID: new(poolUUID),
+			Size:     new(uint64(1024)),
+		},
+	})
+	unitStorageArgs := domainstorage.UnitAddStorageArg{
+		StorageInstances: []domainstorage.CreateUnitStorageInstanceArg{{
+			Name: "pgdata",
+		}},
+		CountLessThanEqual: 656,
+	}
+	fsToOwn := []domainstorage.FilesystemUUID{tc.Must(c, domainstorage.NewFilesystemUUID)}
+	volToOwn := []domainstorage.VolumeUUID{tc.Must(c, domainstorage.NewVolumeUUID)}
+
+	s.storageService.EXPECT().MakeUnitAddStorageArgs(gomock.Any(), unitUUID, uint32(10), internal.StorageDirective{
+		Name:             "pgdata",
+		CharmStorageType: applicationcharm.StorageFilesystem,
+		Count:            1,
+		MaxCount:         666,
+		PoolUUID:         poolUUID,
+		Size:             1024,
+	}).
+		Return(unitStorageArgs, nil)
+	s.storageService.EXPECT().MakeIAASUnitStorageArgs(gomock.Any(), unitStorageArgs.StorageInstances).
+		Return(domainstorage.CreateIAASUnitStorageArg{
+			FilesystemsToOwn: fsToOwn,
+			VolumesToOwn:     volToOwn,
+		}, nil)
+
+	s.state.EXPECT().AddStorageForIAASUnit(gomock.Any(), unitUUID, corestorage.Name("pgdata"), domainstorage.IAASUnitAddStorageArg{
+		UnitAddStorageArg: unitStorageArgs,
+		FilesystemsToOwn:  fsToOwn,
+		VolumesToOwn:      volToOwn,
+	})
+
+	_, err := s.service.AddStorageForIAASUnit(c.Context(), "pgdata", unitUUID, uint32(10), application.AddUnitStorageOverride{
+		SizeMiB: new(uint64(0)),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+// TestAddStorageForCAASUnitZeroSizeOverride verifies that adding storage
+// without an explicit size (the add-storage command sends a zero size in that
+// case) keeps the size recorded on the unit storage directive for CAAS units,
+// rather than provisioning a zero-sized volume.
+func (s *providerServiceSuite) TestAddStorageForCAASUnitZeroSizeOverride(c *tc.C) {
+	ctrl := s.setupMocks(c)
+	defer ctrl.Finish()
+
+	unitUUID := tc.Must(c, coreunit.NewUUID)
+	poolUUID := tc.Must(c, domainstorage.NewStoragePoolUUID)
+
+	charmStorageDef := internal.CharmStorageDefinitionForValidation{
+		Name:        "pgdata",
+		Type:        applicationcharm.StorageFilesystem,
+		MinimumSize: 10,
+		CountMin:    1,
+		CountMax:    666,
+	}
+
+	s.storageService.EXPECT().GetUnitStorageDirectiveByName(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageDirective{
+			Name:             "pgdata",
+			CharmStorageType: applicationcharm.StorageFilesystem,
+			Count:            1,
+			MaxCount:         666,
+			PoolUUID:         poolUUID,
+			Size:             1024,
+		}, nil)
+	s.state.EXPECT().GetStorageAddInfoByUnitUUID(gomock.Any(), unitUUID, corestorage.Name("pgdata")).
+		Return(internal.StorageInfoForAdd{
+			CharmStorageDefinitionForValidation: charmStorageDef,
+			AlreadyAttachedCount:                66,
+		}, nil)
+	s.storageService.EXPECT().ValidateApplicationStorageDirectiveOverrides(
+		gomock.Any(),
+		map[string]internal.CharmStorageDefinitionForValidation{
+			"pgdata": charmStorageDef,
+		},
+		map[string]storageservice.StorageDirectiveOverride{
+			"pgdata": {
+				Count:    new(uint32(76)),
+				PoolUUID: new(poolUUID),
+				Size:     new(uint64(1024)),
+			},
+		},
+	)
+	unitStorageArgs := domainstorage.UnitAddStorageArg{
+		StorageInstances: []domainstorage.CreateUnitStorageInstanceArg{{
+			Name: "pgdata",
+		}},
+		CountLessThanEqual: 656,
+	}
+
+	s.storageService.EXPECT().MakeUnitAddStorageArgs(gomock.Any(), unitUUID, uint32(10), internal.StorageDirective{
+		Name:             "pgdata",
+		CharmStorageType: applicationcharm.StorageFilesystem,
+		Count:            1,
+		MaxCount:         666,
+		PoolUUID:         poolUUID,
+		Size:             1024,
+	}).Return(unitStorageArgs, nil)
+
+	s.state.EXPECT().AddStorageForCAASUnit(gomock.Any(), unitUUID, corestorage.Name("pgdata"), unitStorageArgs)
+
+	_, err := s.service.AddStorageForCAASUnit(c.Context(), "pgdata", unitUUID, uint32(10), application.AddUnitStorageOverride{
+		SizeMiB: new(uint64(0)),
+	})
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 func (s *providerServiceSuite) TestAddStorageForCAASUnitNotFound(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()

--- a/domain/application/service/provider_test.go
+++ b/domain/application/service/provider_test.go
@@ -3279,6 +3279,10 @@ func (s *providerServiceSuite) TestAddStorageForIAASUnit(c *tc.C) {
 	c.Assert(err, tc.ErrorIs, nil)
 }
 
+// TestAddStorageForIAASUnitZeroSizeOverride verifies that adding storage
+// without an explicit size (the add-storage command sends a zero size in that
+// case) keeps the size recorded on the unit storage directive, rather than
+// provisioning a zero-sized volume.
 func (s *providerServiceSuite) TestAddStorageForIAASUnitZeroSizeOverride(c *tc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()

--- a/domain/keymanager/service/service_test.go
+++ b/domain/keymanager/service/service_test.go
@@ -189,6 +189,37 @@ func (s *serviceSuite) TestAddReservedPublicKeys(c *tc.C) {
 	c.Check(err, tc.ErrorIs, keyserrors.ReservedCommentViolation)
 }
 
+// TestAddPublicKeysSmugglingReservedKey is asserting that a reserved comment
+// cannot be slipped past the check by hiding it behind a second key. The whole
+// string is what ends up in authorized_keys, but only the first key in it is
+// checked, so this has to be rejected as an invalid key.
+func (s *serviceSuite) TestAddPublicKeysSmugglingReservedKey(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	svc := NewService(s.modelUUID, s.state)
+
+	err := svc.AddPublicKeysForUser(
+		c.Context(),
+		s.userID,
+		testingPublicKeys[0]+"\n"+reservedPublicKeys[0],
+	)
+	c.Check(err, tc.ErrorIs, keyserrors.InvalidPublicKey)
+}
+
+// TestImportPublicKeysSmugglingReservedKey is asserting the same as
+// [serviceSuite.TestAddPublicKeysSmugglingReservedKey] for keys arriving from
+// an external import source, which we do not control.
+func (s *serviceSuite) TestImportPublicKeysSmugglingReservedKey(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.keyImporter.EXPECT().FetchPublicKeysForSubject(gomock.Any(), s.subjectURI).
+		Return([]string{testingPublicKeys[0] + "\n" + reservedPublicKeys[0]}, nil)
+
+	err := NewImporterService(s.modelUUID, s.keyImporter, s.state).
+		ImportPublicKeysForUser(c.Context(), s.userID, s.subjectURI)
+	c.Check(err, tc.ErrorIs, keyserrors.InvalidPublicKey)
+}
+
 // TestAddExistingKeysForUser is asserting that when we try and add a key for a
 // user that already exists we get back a
 // [keyserrors.PublicKeyAlreadyExists] error.

--- a/domain/model/service/package_mock_test.go
+++ b/domain/model/service/package_mock_test.go
@@ -1298,6 +1298,7 @@ type MockWatcherFactory struct {
 type MockWatcherFactoryMockRecorder struct {
 	mock                             *MockWatcherFactory
 	newNamespaceMapperWatcherExpects []*gomock.Call5V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.Mapper, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error]
+	newNamespaceWatcherExpects       []*gomock.Call4V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error]
 	newNotifyMapperWatcherExpects    []*gomock.Call4V_2[context.Context, string, eventsource.Mapper, eventsource.FilterOption, eventsource.FilterOption, watcher.NotifyWatcher, error]
 	newNotifyWatcherExpects          []*gomock.Call3V_2[context.Context, string, eventsource.FilterOption, eventsource.FilterOption, watcher.NotifyWatcher, error]
 }
@@ -1332,6 +1333,25 @@ func (mr *MockWatcherFactoryMockRecorder) NewNamespaceMapperWatcher(ctx, initial
 
 // MockWatcherFactoryNewNamespaceMapperWatcherCall is the typed call wrapper for NewNamespaceMapperWatcher.
 type MockWatcherFactoryNewNamespaceMapperWatcherCall = gomock.Call5V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.Mapper, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error]
+
+// NewNamespaceWatcher mocks base method.
+func (m *MockWatcherFactory) NewNamespaceWatcher(ctx context.Context, initialStateQuery eventsource.NamespaceQuery, summary string, filterOption eventsource.FilterOption, filterOptions ...eventsource.FilterOption) (watcher.StringsWatcher, error) {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch4V_2(&m.recorder.newNamespaceWatcherExpects, m.ctrl, m, "NewNamespaceWatcher", ctx, initialStateQuery, summary, filterOption, filterOptions...)
+}
+
+// NewNamespaceWatcher indicates an expected call of NewNamespaceWatcher.
+func (mr *MockWatcherFactoryMockRecorder) NewNamespaceWatcher(ctx, initialStateQuery, summary, filterOption any, filterOptions ...any) *MockWatcherFactoryNewNamespaceWatcherCall {
+	mr.mock.ctrl.T.Helper()
+	varArgs := gomock.EnsureVariadicMatcher(filterOptions)
+	call := gomock.NewCall4V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error](mr.mock.ctrl.T, mr.mock, "NewNamespaceWatcher", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(initialStateQuery), gomock.EnsureMatcher(summary), gomock.EnsureMatcher(filterOption), varArgs)
+	mr.newNamespaceWatcherExpects = append(mr.newNamespaceWatcherExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockWatcherFactoryNewNamespaceWatcherCall is the typed call wrapper for NewNamespaceWatcher.
+type MockWatcherFactoryNewNamespaceWatcherCall = gomock.Call4V_2[context.Context, eventsource.NamespaceQuery, string, eventsource.FilterOption, eventsource.FilterOption, watcher.StringsWatcher, error]
 
 // NewNotifyMapperWatcher mocks base method.
 func (m *MockWatcherFactory) NewNotifyMapperWatcher(ctx context.Context, summary string, mapper eventsource.Mapper, filter eventsource.FilterOption, filterOpts ...eventsource.FilterOption) (watcher.NotifyWatcher, error) {

--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/core/changestream"
 	corecloud "github.com/juju/juju/core/cloud"
 	"github.com/juju/juju/core/credential"
-	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
@@ -925,17 +924,12 @@ func (s *WatchableService) WatchModelRemovals(ctx context.Context) (watcher.Stri
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
 
-	// A model removed before the watcher was created cannot be reported: its
-	// row, and with it its UUID, is already gone. The watcher reports the
-	// removals it sees from its creation onwards, so its initial state is
-	// always empty.
-	initialQuery := func(context.Context, coredatabase.TxnRunner) ([]string, error) {
-		return nil, nil
-	}
-
+	// A deletion stream has no current state to report, but its empty initial
+	// event is still the synchronization point that tells the consumer the
+	// subscription is established.
 	return s.watcherFactory.NewNamespaceWatcher(
 		ctx,
-		initialQuery,
+		eventsource.EmptyInitialNamespaceChanges(),
 		"model removals watcher",
 		eventsource.NamespaceFilter("model", changestream.Deleted),
 	)

--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/core/changestream"
 	corecloud "github.com/juju/juju/core/cloud"
 	"github.com/juju/juju/core/credential"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
@@ -779,6 +780,17 @@ type NotifyMapperWatcherFactory interface {
 type WatcherFactory interface {
 	NotifyMapperWatcherFactory
 
+	// NewNamespaceWatcher returns a new namespace watcher for events based on
+	// the input change mask. The initialStateQuery ensures the watcher starts
+	// with the current state of the system, preventing data loss from prior
+	// events.
+	NewNamespaceWatcher(
+		ctx context.Context,
+		initialStateQuery eventsource.NamespaceQuery,
+		summary string,
+		filterOption eventsource.FilterOption, filterOptions ...eventsource.FilterOption,
+	) (watcher.StringsWatcher, error)
+
 	// NewNamespaceMapperWatcher returns a new namespace watcher for events
 	// based on the input change mask. The initialStateQuery ensures the watcher
 	// starts with the current state of the system, preventing data loss from
@@ -904,6 +916,28 @@ func (s *WatchableService) WatchModels(ctx context.Context) (watcher.NotifyWatch
 		ctx,
 		"models watcher",
 		eventsource.NamespaceFilter("model", changestream.All),
+	)
+}
+
+// WatchModelRemovals returns a watcher that emits the UUIDs of models that
+// have been removed from the controller.
+func (s *WatchableService) WatchModelRemovals(ctx context.Context) (watcher.StringsWatcher, error) {
+	ctx, span := trace.Start(ctx, trace.NameFromFunc())
+	defer span.End()
+
+	// A model removed before the watcher was created cannot be reported: its
+	// row, and with it its UUID, is already gone. The watcher reports the
+	// removals it sees from its creation onwards, so its initial state is
+	// always empty.
+	initialQuery := func(context.Context, coredatabase.TxnRunner) ([]string, error) {
+		return nil, nil
+	}
+
+	return s.watcherFactory.NewNamespaceWatcher(
+		ctx,
+		initialQuery,
+		"model removals watcher",
+		eventsource.NamespaceFilter("model", changestream.Deleted),
 	)
 }
 

--- a/domain/model/watcher_test.go
+++ b/domain/model/watcher_test.go
@@ -269,6 +269,64 @@ func (s *watcherSuite) TestWatchModel(c *tc.C) {
 	harness.Run(c, struct{}{})
 }
 
+func (s *watcherSuite) TestWatchModelRemovals(c *tc.C) {
+	watchableDBFactory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "model")
+	watcherFactory := domain.NewWatcherFactory(watchableDBFactory, loggertesting.WrapCheckLog(c))
+
+	st := statecontroller.NewState(func(ctx context.Context) (database.TxnRunner, error) { return watchableDBFactory(ctx) })
+
+	modelService := service.NewWatchableService(
+		st,
+		watcherFactory,
+		newStatusHistoryGetter(c),
+		clock.WallClock,
+		loggertesting.WrapCheckLog(c),
+	)
+
+	modelUUID, activateModel, err := modelService.CreateModel(c.Context(), domainmodel.GlobalModelCreationArgs{
+		Cloud:       "my-cloud",
+		CloudRegion: "my-region",
+		Credential: corecredential.Key{
+			Cloud: "my-cloud",
+			Owner: s.userName,
+			Name:  "my-cloud-credential",
+		},
+		Name:          "test-model",
+		Qualifier:     "prod",
+		AdminUsers:    []user.UUID{s.userUUID},
+		SecretBackend: juju.BackendName,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	watcher, err := modelService.WatchModelRemovals(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	harness := watchertest.NewHarness(s, watchertest.NewWatcherC(c, watcher))
+
+	// Verifies that a model coming into existence is not reported as a removal.
+	harness.AddTest(c, func(c *tc.C) {
+		err := activateModel(c.Context())
+		c.Assert(err, tc.ErrorIsNil)
+	}, func(w watchertest.WatcherC[[]string]) {
+		w.AssertNoChange()
+	})
+
+	// Verifies that removing the model reports its UUID, which is all the API
+	// server needs to close the connections serving it.
+	harness.AddTest(c, func(c *tc.C) {
+		err := st.Delete(c.Context(), modelUUID)
+		c.Assert(err, tc.ErrorIsNil)
+	}, func(w watchertest.WatcherC[[]string]) {
+		w.Check(
+			watchertest.StringSliceAssert(
+				modelUUID.String(),
+			),
+		)
+	})
+
+	harness.Run(c, []string(nil))
+}
+
 func (s *watcherSuite) TestWatchModelCloudCredential(c *tc.C) {
 	watchableDBFactory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "model")
 	watcherFactory := domain.NewWatcherFactory(watchableDBFactory, loggertesting.WrapCheckLog(c))

--- a/domain/modelmigration/state/model/state.go
+++ b/domain/modelmigration/state/model/state.go
@@ -182,28 +182,16 @@ WHERE  c.source_id < 2
 	if err != nil {
 		return modelmigrationinternal.MigrationAgents{}, errors.Capture(err)
 	}
-	applicationAgentStmt, err := s.Prepare(`
-SELECT &agentName.name
-FROM   application AS a
-JOIN   application_agent AS aa ON aa.application_uuid = a.uuid
-JOIN   charm AS c ON c.uuid = a.charm_uuid
-WHERE  c.source_id < 2
-`, agentName{})
-	if err != nil {
-		return modelmigrationinternal.MigrationAgents{}, errors.Capture(err)
-	}
 
 	var (
 		modelTypeValue modelType
 		machines       []agentName
 		units          []agentName
-		applications   []agentName
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		modelTypeValue = modelType{}
 		machines = nil
 		units = nil
-		applications = nil
 
 		if err := tx.Query(ctx, modelTypeStmt).Get(&modelTypeValue); err != nil {
 			if errors.Is(err, sqlair.ErrNoRows) {
@@ -212,14 +200,16 @@ WHERE  c.source_id < 2
 			return errors.Errorf("querying model type: %w", err)
 		}
 
-		if model.ModelType(modelTypeValue.Type) == model.CAAS {
-			if err := tx.Query(ctx, applicationAgentStmt).GetAll(&applications); err != nil &&
+		// CAAS models have no machines; their workload runs as unit agents in
+		// workload pods. The model operator is model-scoped infrastructure and
+		// is not a migration minion (matching 3.6 sidecar behaviour, where only
+		// unit/application workload agents report), so only IAAS models report
+		// machine agents.
+		if model.ModelType(modelTypeValue.Type) != model.CAAS {
+			if err := tx.Query(ctx, machineStmt).GetAll(&machines); err != nil &&
 				!errors.Is(err, sqlair.ErrNoRows) {
-				return errors.Errorf("querying application agents: %w", err)
+				return errors.Errorf("querying machine agents: %w", err)
 			}
-		} else if err := tx.Query(ctx, machineStmt).GetAll(&machines); err != nil &&
-			!errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Errorf("querying machine agents: %w", err)
 		}
 
 		if err := tx.Query(ctx, unitStmt).GetAll(&units); err != nil &&
@@ -232,18 +222,14 @@ WHERE  c.source_id < 2
 	}
 
 	agents := modelmigrationinternal.MigrationAgents{
-		Machines:     make([]string, 0, len(machines)),
-		Units:        make([]string, 0, len(units)),
-		Applications: make([]string, 0, len(applications)),
+		Machines: make([]string, 0, len(machines)),
+		Units:    make([]string, 0, len(units)),
 	}
 	for _, m := range machines {
 		agents.Machines = append(agents.Machines, m.Name)
 	}
 	for _, u := range units {
 		agents.Units = append(agents.Units, u.Name)
-	}
-	for _, a := range applications {
-		agents.Applications = append(agents.Applications, a.Name)
 	}
 	return agents, nil
 }

--- a/domain/modelmigration/state/model/state_test.go
+++ b/domain/modelmigration/state/model/state_test.go
@@ -404,7 +404,10 @@ func (s *caasMigrationSuite) TestGetMigrationAgentsCAAS(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 	c.Check(agents.Machines, tc.HasLen, 0)
 	c.Check(agents.Units, tc.SameContents, []string{"sidecar/0"})
-	c.Check(agents.Applications, tc.SameContents, []string{"legacy"})
+	// The model operator is model-scoped infrastructure, not a migration
+	// minion, so CAAS models report no application agents (matching 3.6
+	// sidecar behaviour where only workload unit agents report).
+	c.Check(agents.Applications, tc.HasLen, 0)
 }
 
 // TestDeleteModelImportingStatusSuccess tests that clearing an existing

--- a/internal/ssh/authorizedkeys.go
+++ b/internal/ssh/authorizedkeys.go
@@ -5,6 +5,7 @@ package ssh
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -169,10 +170,23 @@ func (a *PublicKey) Fingerprint() string {
 // returning a [PublicKey] representation of the data.
 // [ssh.ParseAuthorizedKey] is used to perform the underlying validating and
 // parsing.
+// Data describing more than one key is rejected.
 func ParsePublicKey(key string) (PublicKey, error) {
-	parsedKey, comment, _, _, err := ssh.ParseAuthorizedKey([]byte(key))
+	parsedKey, comment, _, rest, err := ssh.ParseAuthorizedKey([]byte(key))
 	if err != nil {
 		return PublicKey{}, fmt.Errorf("parsing public key %q: %w", key, err)
+	}
+
+	// ParseAuthorizedKey stops at the first key it understands and hands back
+	// everything after it. Callers keep the string they gave us and write it
+	// out to authorized_keys verbatim, so trailing keys would be authorised
+	// while the comment and fingerprint recorded here only describe the first.
+	trailing, err := SplitAuthorizedKeysReader(bytes.NewReader(rest))
+	if err != nil {
+		return PublicKey{}, fmt.Errorf("parsing public key %q: %w", key, err)
+	}
+	if len(trailing) != 0 {
+		return PublicKey{}, fmt.Errorf("public key %q describes more than one key", key)
 	}
 
 	return PublicKey{

--- a/internal/ssh/authorizedkeys_test.go
+++ b/internal/ssh/authorizedkeys_test.go
@@ -182,6 +182,37 @@ func (*authorizedKeysSuite) TestSplitAuthorizedKeysConfig(c *tc.C) {
 	})
 }
 
+// TestParsePublicKeySingleKey is asserting that the surrounding whitespace,
+// blank lines and comment lines that can accompany a single key in an
+// authorized_keys file are all accepted.
+func (*authorizedKeysSuite) TestParsePublicKeySingleKey(c *tc.C) {
+	key := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4GpCvqUUYUJlx6d1kpUO9k/t4VhSYsf0yE0/QTqDzC jimbo@juju.is"
+
+	for _, test := range []string{
+		key,
+		key + "\n",
+		key + "\n\n",
+		key + "\n# a comment line\n",
+	} {
+		parsed, err := ParsePublicKey(test)
+		c.Check(err, tc.ErrorIsNil, tc.Commentf("input %q", test))
+		c.Check(parsed.Comment, tc.Equals, "jimbo@juju.is")
+	}
+}
+
+// TestParsePublicKeyMultipleKeys is asserting that data describing more than
+// one key is rejected. ssh.ParseAuthorizedKey only reads the first key it
+// understands, and callers persist the string they handed us, so accepting
+// this would authorise the trailing keys without ever validating them or
+// recording their fingerprint.
+func (*authorizedKeysSuite) TestParsePublicKeyMultipleKeys(c *tc.C) {
+	_, err := ParsePublicKey(
+		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4GpCvqUUYUJlx6d1kpUO9k/t4VhSYsf0yE0/QTqDzC jimbo@juju.is\n" +
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJQJ9wv0uC3yytXM3d2sJJWvZLuISKo7ZHwafHVviwVe barry@juju.is",
+	)
+	c.Check(err, tc.NotNil)
+}
+
 // TestMakeAuthorizedKeysString is asserting that for a given set of keys they
 // are written out in a standard compliant way to be an authorized_keys file.
 func (*authorizedKeysSuite) TestMakeAuthorizedKeysString(c *tc.C) {

--- a/internal/worker/uniter/remotestate/watcher_test.go
+++ b/internal/worker/uniter/remotestate/watcher_test.go
@@ -1046,6 +1046,10 @@ func (s *WatcherSuite) TestWorkloadSignal(c *tc.C) {
 		c.Fatalf("timed out waiting to signal workload event channel")
 	}
 
+	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
+	snap = s.watcher.Snapshot()
+	c.Assert(snap.WorkloadEvents, tc.DeepEquals, []string{"0"})
+
 	// Adding same event twice shouldn't re-add it.
 	select {
 	case s.workloadEventChannel <- "0":

--- a/tests/includes/storage.sh
+++ b/tests/includes/storage.sh
@@ -62,16 +62,14 @@ unit_exist() {
 	juju storage --format json | yq "[.. | select(kind == \"map\") | has(\"${name}\")] | any"
 }
 
-# filesystem_status used to check for the current status of the given volume for a filesystem matched by the volume number and volume index combination e.g 0/0, 2/1, 3/1
+# filesystem_status emits a yq query for the status of the filesystem backing
+# the given storage instance id (e.g. data/0). The filesystem is matched via
+# its storage linkage rather than its id, as filesystem ids differ between
+# juju versions (machine-scoped "0/0" before 4.0, global sequence numbers
+# from 4.0 onwards).
 filesystem_status() {
-	local name volume_num volume_index
-	volume_num=${1}
-	volume_index=${2}
+	local storage_id
+	storage_id=${1}
 
-	if [ -z "$volume_index" ]; then
-		name="$volume_num"
-	else
-		name="$volume_num/$volume_index"
-	fi
-	echo ".filesystems | .[\"$name\"] | .status"
+	echo ".filesystems | to_entries | map(select(.value.storage == \"${storage_id}\")) | .[0].value.status"
 }

--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -56,10 +56,7 @@ run_charm_storage() {
 
 	# Assessing adding a storage block to loop disk
 	juju add-storage -m "${model_name}" dummy-storage-lp/0 disks=1
-	# Assert the storage kind name
-	if [ "$(unit_exist "disks/2")" == "true" ]; then
-		assess_loop_disk2
-	fi
+	assess_loop_disk2
 	# Remove the application
 	juju remove-application --no-prompt dummy-storage-lp
 	wait_for "{}" ".applications"
@@ -174,6 +171,14 @@ assess_loop_disk2() {
 	assert_storage "dummy-storage-lp/0" "$(unit_attachment "disks" 2 0)"
 	# assert the attached unit state
 	assert_storage "alive" "$(unit_state "disks" 2 "dummy-storage-lp" 0)"
+	# assert the volume retained the requested size (a zero-size add-storage
+	# override would provision a zero-sized volume instead).
+	requested_storage=1024
+	acquired_storage=$(juju storage --format json | yq '.volumes | to_entries | map(select(.value.storage == "disks/2")) | .[0].value.size')
+	if [ "$requested_storage" -gt "$acquired_storage" ]; then
+		echo "acquired storage size $acquired_storage should be greater than the requested storage $requested_storage"
+		exit 1
+	fi
 	echo "Block loop disk 2 PASSED"
 }
 

--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -133,10 +133,10 @@ assess_rootfs() {
 	assert_storage "dummy-storage-fs/0" "$(unit_attachment "data" 0 0)"
 	# assert the attached unit state
 	assert_storage "alive" "$(unit_state "data" 0 "dummy-storage-fs" 0)"
-	wait_for_storage "attached" "$(filesystem_status 0 0).current"
+	wait_for_storage "attached" "$(filesystem_status "data/0").current"
 	# assert the filesystem size
 	requested_storage=1024
-	acquired_storage=$(juju storage --format json | yq '.filesystems | .["0/0"] | select(.pool=="rootfs") | .size ')
+	acquired_storage=$(juju storage --format json | yq '.filesystems | to_entries | map(select(.value.storage == "data/0" and .value.pool == "rootfs")) | .[0].value.size')
 	if [ "$requested_storage" -gt "$acquired_storage" ]; then
 		echo "acquired storage size $acquired_storage should be greater than the requested storage $requested_storage"
 		exit 1

--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -35,7 +35,7 @@ run_charm_storage() {
 	# Assess charm storage with the filesystem storage provider
 	echo "Assessing filesystem rootfs"
 	# shellcheck disable=SC2046
-	juju deploy $(pack_charm ./testcharms/charms/dummy-storage-fs) --base ubuntu@22.04 --storage data=rootfs,1G
+	juju deploy $(pack_charm ./testcharms/charms/dummy-storage-fs) --storage data=rootfs,1G
 	wait_for "dummy-storage-fs" ".applications"
 	if [ "$(unit_exist "data/0")" == "true" ]; then
 		assess_rootfs
@@ -47,7 +47,7 @@ run_charm_storage() {
 	# Assess charm storage with the filesystem storage provider
 	echo "Assessing block loop disk 1"
 	# shellcheck disable=SC2046
-	juju deploy $(pack_charm ./testcharms/charms/dummy-storage-lp) --base ubuntu@22.04 --storage disks=loop,1G
+	juju deploy $(pack_charm ./testcharms/charms/dummy-storage-lp) --storage disks=loop,1G
 	wait_for "dummy-storage-lp" ".applications"
 	# Assert the storage kind name
 	if [ "$(unit_exist "disks/1")" == "true" ]; then
@@ -67,7 +67,7 @@ run_charm_storage() {
 	# Assess tmpfs pool for the filesystem provider
 	echo "Assessing filesystem tmpfs"
 	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-tp) --base ubuntu@22.04 --storage data=tmpfs,1G
+	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-tp) --storage data=tmpfs,1G
 	wait_for "dummy-storage-tp" ".applications"
 	if [ "$(unit_exist "data/3")" == "true" ]; then
 		assess_tmpfs
@@ -78,7 +78,7 @@ run_charm_storage() {
 
 	# Assessing for persistent filesystem
 	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-np) --base ubuntu@22.04 --storage data=1G
+	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-np) --storage data=1G
 	wait_for "dummy-storage-np" ".applications"
 	if [ "$(unit_exist "data/4")" == "true" ]; then
 		assess_fs
@@ -91,7 +91,7 @@ run_charm_storage() {
 
 	# Assessing multiple filesystem, block, rootfs, loop
 	# shellcheck disable=SC2046
-	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-mp) --base ubuntu@22.04 --storage data=1G
+	juju deploy -m "${model_name}" $(pack_charm ./testcharms/charms/dummy-storage-mp) --storage data=1G
 	wait_for "dummy-storage-mp" ".applications"
 	if [ "$(unit_exist "data/5")" == "true" ]; then
 		assess_multiple_fs


### PR DESCRIPTION
Merge-forward: 4.0 → 4.1

  ### Included PRs

  - #23227 @SimonRichardson — fix: pass cgo ldflags to overload in testing
  - #23192 @gfouillet — fix(application): fix test-charm-storage-aws for juju 4.0
  - #23194 @Gvantsats — ci: bump actions/setup-python to v7
  - #23177 @nvinuesa — fix(apiserver): close model connections from their own goroutine
  - #23220 @nvinuesa — fix(modelmigration): report CAAS migration minions from unit agents only
  - #22994 @SABITHSAHEB — fix(ssh): reject public key data describing more than one key

  ### Conflicts resolved

  - apiserver/apiserver.go
      - Source #23177 vs Target #21571
      - Resolution: retained model-removal tracking and adapted it to the 4.1 websocket refactor.

  - tests/suites/storage/charm_storage.sh
      - Source #23192 vs Target #21176
      - Resolution: retained quoted charm paths and removed hard-coded charm bases.