### PR TITLE
fix: set polled instance status early

### DIFF
--- a/internal/worker/instancepoller/worker.go
+++ b/internal/worker/instancepoller/worker.go
@@ -461,13 +461,34 @@ func (u *updaterWorker) pollGroupMembers(ctx context.Context, groupType pollGrou
 		}
 	}
 
+	// Persist provider statuses before looking up networking, so a network
+	// failure cannot leave stale provisioning statuses on the polled instances.
+	providerStatuses := make([]status.Status, len(infoList))
+	canSyncNetwork := make([]bool, len(infoList))
+	for idx, info := range infoList {
+		entry := entryByInstanceID[allInstances[idx]]
+		if info == nil {
+			// Back off instances missing from a partial provider response.
+			u.config.Logger.Warningf(ctx, "unable to retrieve instance information for instance: %q", entry.instanceID)
+			if groupType == shortPollGroup {
+				entry.bumpShortPollInterval(u.config.Clock)
+			}
+			continue
+		}
+
+		providerStatuses[idx], canSyncNetwork[idx], err = u.processProviderInfo(ctx, entry, info)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	var netList []network.InterfaceInfos
 	if len(instanceWithDevices) > 0 {
 		var err error
 		netList, err = u.config.Environ.NetworkInterfaces(ctx, instanceWithDevices)
 		if err != nil && !isPartialOrNoInstancesError(err) {
-			// NOTE(achilleasa): 2022-01-24: all existing providers (with the
-			// exception of "manual" which we don't care about in this context)
+			// NOTE(achilleasa): 2022-01-24: all existing providers
+			// (except unmanaged, which we don't care about in this context)
 			// implement the NetworkInterfaces method.
 			//
 			// This error is meant as a hint to folks working on new providers
@@ -481,12 +502,21 @@ func (u *updaterWorker) pollGroupMembers(ctx context.Context, groupType pollGrou
 	}
 
 	for idx, info := range infoList {
+		if info == nil {
+			continue
+		}
 		var nics network.InterfaceInfos
 		if netList != nil && idx < len(instanceWithDevices) {
 			nics = netList[idx]
 		}
 
-		if err := u.processOneInstance(ctx, entryByInstanceID[allInstances[idx]], info, nics, groupType); err != nil {
+		if err := u.processOneInstance(
+			ctx, entryByInstanceID[allInstances[idx]],
+			providerStatuses[idx],
+			canSyncNetwork[idx],
+			nics,
+			groupType,
+		); err != nil {
 			return errors.Trace(err)
 		}
 	}
@@ -496,26 +526,16 @@ func (u *updaterWorker) pollGroupMembers(ctx context.Context, groupType pollGrou
 
 func (u *updaterWorker) processOneInstance(
 	ctx context.Context,
-	entry *pollGroupEntry, info instances.Instance,
-	nics network.InterfaceInfos, groupType pollGroupType,
+	entry *pollGroupEntry,
+	providerStatus status.Status,
+	canSyncNetwork bool,
+	nics network.InterfaceInfos,
+	groupType pollGroupType,
 ) error {
-
-	// If we received ErrPartialInstances, and this ID is one of those not found,
-	// and we're in the short poll group, back off the poll interval.
-	// This will ensure that instances that have gone away do not cause excessive
-	// provider call volumes.
-	if info == nil {
-		u.config.Logger.Warningf(ctx, "unable to retrieve instance information for instance: %q", entry.instanceID)
-
-		if groupType == shortPollGroup {
-			entry.bumpShortPollInterval(u.config.Clock)
+	if canSyncNetwork && len(nics) > 0 {
+		if err := u.syncProviderAddresses(ctx, entry, nics); err != nil {
+			return errors.Trace(err)
 		}
-		return nil
-	}
-
-	providerStatus, err := u.processProviderInfo(ctx, entry, info, nics)
-	if err != nil {
-		return errors.Trace(err)
 	}
 
 	machineStatus, err := u.config.StatusService.GetMachineStatus(ctx, entry.machineName)
@@ -527,15 +547,12 @@ func (u *updaterWorker) processOneInstance(
 	return nil
 }
 
-// processProviderInfo updates an entry's machine status and set of provider
-// addresses based on the information collected from the provider. It returns
-// the *instance* status and the number of provider addresses currently
-// known for the machine.
+// processProviderInfo updates an entry's provider-reported instance status.
+// It also reports whether network reconciliation can proceed: machines with
+// unreadable statuses or dead/removed machines must not have networks updated.
 func (u *updaterWorker) processProviderInfo(
-	ctx context.Context,
-	entry *pollGroupEntry, info instances.Instance,
-	providerInterfaces network.InterfaceInfos,
-) (status.Status, error) {
+	ctx context.Context, entry *pollGroupEntry, info instances.Instance,
+) (status.Status, bool, error) {
 	curStatus, err := u.config.StatusService.GetInstanceStatus(ctx, entry.machineName)
 	if err != nil {
 		// This should never occur since the machine is provisioned. If
@@ -544,7 +561,7 @@ func (u *updaterWorker) processProviderInfo(
 		u.config.Logger.Warningf(ctx, "cannot get current instance status for machine %v (instance ID %q): %v",
 			entry.machineName, entry.instanceID, err)
 
-		return status.Unknown, nil
+		return status.Unknown, false, nil
 	}
 
 	// Check for status changes
@@ -563,7 +580,7 @@ func (u *updaterWorker) processProviderInfo(
 			Message: providerStatus.Message,
 		}); err != nil {
 			u.config.Logger.Errorf(ctx, "cannot set instance status on %q: %v", entry.machineName, err)
-			return status.Unknown, errors.Trace(err)
+			return status.Unknown, false, errors.Trace(err)
 		}
 
 		// If the instance is now running, we should reset the poll
@@ -578,21 +595,12 @@ func (u *updaterWorker) processProviderInfo(
 	// process the following machine watcher events.
 	life, err := u.config.MachineService.GetMachineLife(ctx, entry.machineName)
 	if life == corelife.Dead || errors.Is(err, machineerrors.MachineNotFound) {
-		return status.Unknown, nil
+		return status.Unknown, false, nil
 	} else if err != nil {
-		return status.Unknown, err
+		return status.Unknown, false, err
 	}
 
-	if len(providerInterfaces) > 0 {
-		// Check whether the provider addresses for this machine need to be
-		// updated.
-		err = u.syncProviderAddresses(ctx, entry, providerInterfaces)
-		if err != nil {
-			return status.Unknown, err
-		}
-	}
-
-	return providerStatus.Status, nil
+	return providerStatus.Status, true, nil
 }
 
 // syncProviderAddresses updates the provider addresses for this entry's machine
@@ -625,27 +633,29 @@ func (u *updaterWorker) maybeSwitchPollGroup(
 		return
 	}
 
-	// If the machine is currently in the long poll group and it has an
+	// If the machine is currently in the long poll group, and it has an
 	// unknown status or suddenly has no network addresses, move it back to
 	// the short poll group.
 	if curGroup == longPollGroup && (curProviderStatus == status.Unknown || providerNicCount == 0) {
 		u.moveEntryToPollGroup(shortPollGroup, entry)
-		u.config.Logger.Debugf(ctx, "moving machine %q (instance ID %q) back to short poll group", entry.machineName, entry.instanceID)
+		u.config.Logger.Debugf(
+			ctx, "moving machine %q (instance ID %q) back to short poll group", entry.machineName, entry.instanceID)
 		return
 	}
 
-	// The machine has started and we have at least one address; move to
+	// The machine has started, and we have at least one address; move to
 	// the long poll group
 	if providerNicCount > 0 && curMachineStatus == status.Started {
 		u.moveEntryToPollGroup(longPollGroup, entry)
 		if curGroup != longPollGroup {
-			u.config.Logger.Debugf(ctx, "moving machine %q (instance ID %q) to long poll group", entry.machineName, entry.instanceID)
+			u.config.Logger.Debugf(
+				ctx, "moving machine %q (instance ID %q) to long poll group", entry.machineName, entry.instanceID)
 		}
 		return
 	}
 
 	// If we are in the short poll group apply exponential backoff to the
-	// poll frequency allow time for the machine to boot up.
+	// poll frequency to allow time for the machine to boot up.
 	if curGroup == shortPollGroup {
 		entry.bumpShortPollInterval(u.config.Clock)
 	}

--- a/internal/worker/instancepoller/worker_test.go
+++ b/internal/worker/instancepoller/worker_test.go
@@ -332,10 +332,14 @@ func (s *workerSuite) TestUpdateOfStatusAndAddressDetails(c *tc.C) {
 	}).Return(nil)
 
 	mocked.networkService.EXPECT().SetProviderNetConfig(gomock.Any(), machineUUID, testDevices).Return(nil)
+	mocked.statusService.EXPECT().GetMachineStatus(gomock.Any(), machineName).Return(status.StatusInfo{Status: status.Started}, nil)
 
-	providerStatus, err := updWorker.processProviderInfo(c.Context(), entry, instInfo, testNetIfs)
+	providerStatus, canSyncNetwork, err := updWorker.processProviderInfo(c.Context(), entry, instInfo)
 	c.Assert(err, tc.ErrorIsNil)
-	c.Assert(providerStatus, tc.Equals, status.Running)
+	c.Check(providerStatus, tc.Equals, status.Running)
+	c.Check(canSyncNetwork, tc.IsTrue)
+	err = updWorker.processOneInstance(c.Context(), entry, providerStatus, canSyncNetwork, testNetIfs, shortPollGroup)
+	c.Assert(err, tc.ErrorIsNil)
 }
 
 func (s *workerSuite) TestStartedMachineWithNetAddressesMovesToLongPollGroup(c *tc.C) {
@@ -629,6 +633,69 @@ func (s *workerSuite) TestBatchPollingOfGroupMembersWithVariousDevicesStatus(c *
 	s.assertWorkerCompletesLoop(c, updWorker, func() {
 		mocked.clock.Advance(ShortPoll)
 	})
+}
+
+// TestPollGroupMembersUpdatesStatusesBeforeNetworkLookup checks that a failed
+// network lookup cannot leave stale provisioning statuses on any found instance,
+// including instances without devices and those in a partial provider response.
+func (s *workerSuite) TestPollGroupMembersUpdatesStatusesBeforeNetworkLookup(c *tc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	machineService := mocks.NewMockMachineService(ctrl)
+	statusService := mocks.NewMockStatusService(ctrl)
+	environ := mocks.NewMockEnviron(ctrl)
+	updWorker := &updaterWorker{
+		config: Config{
+			Clock:          testclock.NewClock(time.Now()),
+			MachineService: machineService,
+			StatusService:  statusService,
+			NetworkService: mocks.NewMockNetworkService(ctrl),
+			Environ:        environ,
+			Logger:         loggertesting.WrapCheckLog(c),
+		},
+		pollGroup: [2]map[machine.Name]*pollGroupEntry{
+			make(map[machine.Name]*pollGroupEntry),
+			make(map[machine.Name]*pollGroupEntry),
+		},
+	}
+
+	infos := domainmachine.PollingInfos{
+		{MachineName: "0", MachineUUID: machinetesting.GenUUID(c), InstanceID: "with-devices", ExistingDeviceCount: 1},
+		{MachineName: "1", MachineUUID: machinetesting.GenUUID(c), InstanceID: "missing"},
+		{MachineName: "2", MachineUUID: machinetesting.GenUUID(c), InstanceID: "no-devices"},
+	}
+	for _, info := range infos {
+		updWorker.appendToShortPollGroup(info.MachineName)
+		updWorker.pollGroup[shortPollGroup][info.MachineName].shortPollAt = updWorker.config.Clock.Now()
+	}
+	machineService.EXPECT().GetPollingInfos(gomock.Any(), []machine.Name{"0", "1", "2"}).Return(infos, nil)
+
+	instanceInfo := mocks.NewMockInstance(ctrl)
+	instanceInfo.EXPECT().Status(gomock.Any()).Return(instance.Status{Status: status.Running, Message: "Deployed"}).Times(2)
+	environ.EXPECT().Instances(gomock.Any(), []instance.Id{"with-devices", "missing", "no-devices"}).Return(
+		[]instances.Instance{instanceInfo, nil, instanceInfo}, environs.ErrPartialInstances,
+	)
+
+	networkErr := fmt.Errorf("network lookup failed")
+	networkLookup := environ.EXPECT().NetworkInterfaces(gomock.Any(), []instance.Id{"with-devices"}).Return(nil, networkErr)
+	for _, name := range []machine.Name{"0", "2"} {
+		statusService.EXPECT().GetInstanceStatus(gomock.Any(), name).Return(status.StatusInfo{
+			Status:  status.Provisioning,
+			Message: "failed to start machine in zone, retrying with new availability zone",
+		}, nil)
+		updated := statusService.EXPECT().SetInstanceStatus(gomock.Any(), name, status.StatusInfo{
+			Status:  status.Running,
+			Message: "Deployed",
+		}).Return(nil)
+		networkLookup.After(updated)
+		machineService.EXPECT().GetMachineLife(gomock.Any(), name).Return(life.Alive, nil)
+	}
+
+	err := updWorker.pollGroupMembers(c.Context(), shortPollGroup)
+	c.Assert(err, tc.ErrorIs, networkErr)
+	c.Check(updWorker.pollGroup[shortPollGroup]["1"].shortPollInterval, tc.Equals,
+		time.Duration(float64(ShortPoll)*ShortPollBackoff))
 }
 
 func (s *workerSuite) TestPollGroupMembersSkipsNetworkInterfacesForNoDeviceInstances(c *tc.C) {


### PR DESCRIPTION
The linked issue describes a stale instance status that dates from a failed (subsequently recovered) provisioning attempt.

This is possible for a confluence of events - the instance can be successfully started, but some issue results from the instance status update attempt. Subsequent instance-poller runs can detect the running machine successfully, but have an issue updating provider ntework configuration.

This change ensures that the instance-poller worker updates instance statuses as soon as it knows them from the provider, and before attempting to update network config.

In turn it prevents dependencies between the on-machine network detection, network health and the provider network detection from preventing us recording a known instance status.

## QA steps

The scenario from the SolQA lab is practically impossible to replicate, but we can test for regression.
- Bootstrap to LXD and add a model.
- `juju deploy tiny-bash -n 3` and once settled, note the first container ID.
```
Machine  State    Address       Inst id        Base          AZ      Message
3        started  10.155.5.176  juju-e06b93-3  ubuntu@24.04  rashan  Running
4        started  10.155.5.154  juju-e06b93-4  ubuntu@24.04  rashan  Running
5        started  10.155.5.192  juju-e06b93-5  ubuntu@24.04  rashan  Running
```
- `lxc stop juju-e06b93-3`, then wait (up to 10 minutes) for the instance-poller to update it.
```
Machine  State    Address       Inst id        Base          AZ      Message
3        down     10.155.5.176  juju-e06b93-3  ubuntu@24.04  rashan  Stopped
4        started  10.155.5.154  juju-e06b93-4  ubuntu@24.04  rashan  Running
5        started  10.155.5.192  juju-e06b93-5  ubuntu@24.04  rashan  Running
```
- `lxc start juju-e06b93-3`, and after a moment (it will now be in the short poll group) it is reported _Running_ again.
```
Machine  State    Address       Inst id        Base          AZ      Message
3        started  10.155.5.176  juju-e06b93-3  ubuntu@24.04  rashan  Running
4        started  10.155.5.154  juju-e06b93-4  ubuntu@24.04  rashan  Running
5        started  10.155.5.192  juju-e06b93-5  ubuntu@24.04  rashan  Running
```

## Links

**Issue:** Fixes #22243.