### PR TITLE
feat: add bootstrap option not to remove ssh keys

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -845,6 +845,7 @@ to create a new model to deploy %sworkloads.
 		ControllerInheritedConfig:     bootstrapCfg.inheritedControllerAttrs,
 		ControllerModelAuthorizedKeys: bootstrapCfg.bootstrap.AuthorizedKeys,
 		BootstrapSSHAuthorizedKeys:    bootstrapSSHAuthorizedKeys,
+		KeepBootstrapSSHKeys:          bootstrapCfg.bootstrap.KeepBootstrapSSHKeys,
 		RegionInheritedConfig:         cloud.RegionConfig,
 		AdminSecret:                   bootstrapCfg.bootstrap.AdminSecret,
 		CAPrivateKey:                  bootstrapCfg.bootstrap.CAPrivateKey,

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/bootstrap.md
@@ -214,6 +214,13 @@ Bootstrap configuration keys:
         Controls the kubernetes service type for Juju controllers, see
         https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
         valid values are one of cluster, loadbalancer, external
+    keep-bootstrap-ssh-keys:
+      type: bool
+      description: Keeps the bootstrap SSH keys installed on the controller machine after
+        bootstrap has completed, instead of removing them. This allows direct SSH access
+        to the controller machine, bypassing the Juju API and any jump host restrictions.
+        This is a dangerous option intended for debugging and recovering broken bootstrap
+        machines only; avoid on production controllers
     ssh-server-host-key:
       type: string
       description: Sets the bootstrapped controller's SSH server host key

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -108,6 +108,11 @@ type BootstrapParams struct {
 	// while synchronous bootstrap configuration is in progress.
 	BootstrapSSHAuthorizedKeys []string
 
+	// KeepBootstrapSSHKeys, if true, keeps the bootstrap SSH keys
+	// installed on the controller machine after bootstrap has
+	// completed, instead of removing them.
+	KeepBootstrapSSHKeys bool
+
 	// RegionInheritedConfig holds region specific configuration attributes to
 	// be shared across all models in the same controller on a particular
 	// cloud.
@@ -776,6 +781,7 @@ func finalizeInstanceBootstrapConfig(
 	icfg.Bootstrap.StateInitializationParams.AgentVersion = agentVersion
 	icfg.Bootstrap.StateInitializationParams.ControllerModelAuthorizedKeys = args.ControllerModelAuthorizedKeys
 	icfg.Bootstrap.StateInitializationParams.BootstrapSSHAuthorizedKeys = args.BootstrapSSHAuthorizedKeys
+	icfg.Bootstrap.StateInitializationParams.KeepBootstrapSSHKeys = args.KeepBootstrapSSHKeys
 	icfg.Bootstrap.ControllerModelConfig = cfg
 	icfg.Bootstrap.ControllerModelEnvironVersion = environVersion
 	icfg.Bootstrap.CustomImageMetadata = customImageMetadata

--- a/environs/bootstrap/config.go
+++ b/environs/bootstrap/config.go
@@ -75,6 +75,11 @@ const (
 	// ControllerExternalIPs is used to specify a comma separated
 	// list of external IPs for a k8s controller of type external.
 	ControllerExternalIPs = "controller-external-ips"
+
+	// KeepBootstrapSSHKeysKey is the attribute key used to keep the
+	// bootstrap SSH keys on the controller machine after bootstrap
+	// has completed, instead of removing them.
+	KeepBootstrapSSHKeysKey = "keep-bootstrap-ssh-keys"
 )
 
 const (
@@ -110,6 +115,7 @@ var BootstrapConfigAttributes = []string{
 	ControllerServiceType,
 	ControllerExternalName,
 	ControllerExternalIPs,
+	KeepBootstrapSSHKeysKey,
 }
 
 // BootstrapConfigSchema returns the schema used for config items during
@@ -192,6 +198,17 @@ func BootstrapConfigSchema() configschema.Fields {
 				"k8s controller of type external",
 			Type: configschema.Tlist,
 		},
+		KeepBootstrapSSHKeysKey: {
+			Description: "Keeps the bootstrap SSH keys installed on the " +
+				"controller machine after bootstrap has completed, " +
+				"instead of removing them. This allows direct SSH " +
+				"access to the controller machine, bypassing the " +
+				"Juju API and any jump host restrictions. This is a " +
+				"dangerous option intended for debugging and " +
+				"recovering broken bootstrap machines only; avoid " +
+				"on production controllers",
+			Type: configschema.Tbool,
+		},
 	}
 }
 
@@ -216,6 +233,10 @@ type Config struct {
 	BootstrapTimeout        time.Duration
 	BootstrapRetryDelay     time.Duration
 	BootstrapAddressesDelay time.Duration
+	// KeepBootstrapSSHKeys, if true, keeps the bootstrap SSH keys
+	// installed on the controller machine after bootstrap has
+	// completed, instead of removing them.
+	KeepBootstrapSSHKeys bool
 }
 
 // Validate validates the controller configuration.
@@ -274,6 +295,7 @@ func NewConfig(attrs map[string]any) (Config, error) {
 		BootstrapRetryDelay:     time.Duration(attrs[BootstrapRetryDelayKey].(int)) * time.Second,
 		BootstrapAddressesDelay: time.Duration(attrs[BootstrapAddressesDelayKey].(int)) * time.Second,
 	}
+	config.KeepBootstrapSSHKeys, _ = attrs[KeepBootstrapSSHKeysKey].(bool)
 	if controllerServiceType, ok := attrs[ControllerServiceType].(string); ok {
 		config.ControllerServiceType = controllerServiceType
 	}
@@ -484,6 +506,10 @@ var configSchema = configschema.Fields{
 		Type:  configschema.Tint,
 		Group: configschema.JujuGroup,
 	},
+	KeepBootstrapSSHKeysKey: {
+		Type:  configschema.Tbool,
+		Group: configschema.JujuGroup,
+	},
 }
 
 var configDefaults = schema.Defaults{
@@ -502,4 +528,5 @@ var configDefaults = schema.Defaults{
 	BootstrapTimeoutKey:           DefaultBootstrapSSHTimeout,
 	BootstrapRetryDelayKey:        DefaultBootstrapSSHRetryDelay,
 	BootstrapAddressesDelayKey:    DefaultBootstrapSSHAddressesDelay,
+	KeepBootstrapSSHKeysKey:       schema.Omit,
 }

--- a/environs/bootstrap/config_test.go
+++ b/environs/bootstrap/config_test.go
@@ -37,6 +37,7 @@ func (*ConfigSuite) TestDefaultConfig(c *tc.C) {
 	c.Assert(cfg.BootstrapTimeout, tc.Equals, time.Second*1200)
 	c.Assert(cfg.BootstrapRetryDelay, tc.Equals, time.Second*5)
 	c.Assert(cfg.BootstrapAddressesDelay, tc.Equals, time.Second*10)
+	c.Assert(cfg.KeepBootstrapSSHKeys, tc.IsFalse)
 }
 
 func (*ConfigSuite) TestConfigValuesSpecified(c *tc.C) {
@@ -72,6 +73,17 @@ func (*ConfigSuite) TestConfigValuesSpecified(c *tc.C) {
 			ControllerExternalIPs:   externalIps,
 		})
 	}
+}
+
+func (*ConfigSuite) TestConfigKeepBootstrapSSHKeys(c *tc.C) {
+	cfg, err := bootstrap.NewConfig(map[string]any{
+		"admin-secret":            "sekrit",
+		"ca-cert":                 testing.CACert,
+		"ca-private-key":          testing.CAKey,
+		"keep-bootstrap-ssh-keys": true,
+	})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(cfg.KeepBootstrapSSHKeys, tc.IsTrue)
 }
 
 func (s *ConfigSuite) addFiles(c *tc.C, files ...testhelpers.TestFile) {

--- a/internal/cloudconfig/instancecfg/instancecfg.go
+++ b/internal/cloudconfig/instancecfg/instancecfg.go
@@ -327,6 +327,11 @@ type StateInitializationParams struct {
 	// controller has completed initialization.
 	BootstrapSSHAuthorizedKeys []string
 
+	// KeepBootstrapSSHKeys, if true, keeps the bootstrap SSH keys
+	// installed on the bootstrap machine after the controller has
+	// completed initialization, instead of removing them.
+	KeepBootstrapSSHKeys bool
+
 	// ControllerModelEnvironVersion holds the initial controller model
 	// environ version.
 	ControllerModelEnvironVersion int
@@ -407,6 +412,7 @@ type stateInitializationParamsInternal struct {
 	ControllerModelConfig                   map[string]any                    `yaml:"controller-model-config"`
 	ControllerModelAuthorizedKeys           []string                          `yaml:"controller-model-authorized-keys"`
 	BootstrapSSHAuthorizedKeys              []string                          `yaml:"bootstrap-ssh-authorized-keys"`
+	KeepBootstrapSSHKeys                    bool                              `yaml:"keep-bootstrap-ssh-keys,omitempty"`
 	ControllerModelEnvironVersion           int                               `yaml:"controller-model-version"`
 	ControllerInheritedConfig               map[string]any                    `yaml:"controller-config-defaults,omitempty"`
 	RegionInheritedConfig                   cloud.RegionConfig                `yaml:"region-inherited-config,omitempty"`
@@ -442,6 +448,7 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		ControllerModelConfig:                   p.ControllerModelConfig.AllAttrs(),
 		ControllerModelAuthorizedKeys:           p.ControllerModelAuthorizedKeys,
 		BootstrapSSHAuthorizedKeys:              p.BootstrapSSHAuthorizedKeys,
+		KeepBootstrapSSHKeys:                    p.KeepBootstrapSSHKeys,
 		ControllerModelEnvironVersion:           p.ControllerModelEnvironVersion,
 		ControllerInheritedConfig:               p.ControllerInheritedConfig,
 		RegionInheritedConfig:                   p.RegionInheritedConfig,
@@ -492,6 +499,7 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 		ControllerModelConfig:                   cfg,
 		ControllerModelAuthorizedKeys:           internal.ControllerModelAuthorizedKeys,
 		BootstrapSSHAuthorizedKeys:              internal.BootstrapSSHAuthorizedKeys,
+		KeepBootstrapSSHKeys:                    internal.KeepBootstrapSSHKeys,
 		ControllerModelEnvironVersion:           internal.ControllerModelEnvironVersion,
 		ControllerInheritedConfig:               internal.ControllerInheritedConfig,
 		RegionInheritedConfig:                   internal.RegionInheritedConfig,

--- a/internal/cloudconfig/instancecfg/instancecfg_test.go
+++ b/internal/cloudconfig/instancecfg/instancecfg_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/environs/config"
@@ -34,6 +35,21 @@ func (*instancecfgSuite) TestIsController(c *tc.C) {
 	c.Assert(cfg.IsController(), tc.IsFalse)
 	cfg.Jobs = []model.MachineJob{model.JobManageModel}
 	c.Assert(cfg.IsController(), tc.IsTrue)
+}
+
+func (*instancecfgSuite) TestStateInitializationParamsKeepBootstrapSSHKeys(c *tc.C) {
+	cfg := testing.CustomModelConfig(c, testing.Attrs{})
+	params := instancecfg.StateInitializationParams{
+		ControllerModelConfig:       cfg,
+		BootstrapMachineConstraints: constraints.MustParse("mem=1G"),
+		KeepBootstrapSSHKeys:        true,
+	}
+	data, err := params.Marshal()
+	c.Assert(err, tc.ErrorIsNil)
+
+	var unmarshalled instancecfg.StateInitializationParams
+	c.Assert(unmarshalled.Unmarshal(data), tc.ErrorIsNil)
+	c.Check(unmarshalled.KeepBootstrapSSHKeys, tc.IsTrue)
 }
 
 func (*instancecfgSuite) TestInstanceTagsController(c *tc.C) {

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -319,8 +319,10 @@ func (w *bootstrapWorker) loop() error {
 		return errors.Trace(err)
 	}
 
-	if err := w.cfg.RemoveBootstrapSSHKeys(bootstrapParams.BootstrapSSHAuthorizedKeys); err != nil {
-		return errors.Annotate(err, "removing bootstrap SSH keys")
+	if !bootstrapParams.KeepBootstrapSSHKeys {
+		if err := w.cfg.RemoveBootstrapSSHKeys(bootstrapParams.BootstrapSSHAuthorizedKeys); err != nil {
+			return errors.Annotate(err, "removing bootstrap SSH keys")
+		}
 	}
 
 	// Set the bootstrap flag, to indicate that the bootstrap has completed.


### PR DESCRIPTION
# Description

A bootstrap option mainly meant for development to keep the bootstrap ssh key, so it's possible to ssh when the controller is bouncing because it's bypassing the jump server.

# QA

`juju bootstrap lxd --config keep-bootstrap-ssh-keys=true a`


`ssh -i ~/.local/share/juju/ssh/juju_id_rsa ubuntu@<ip>`