### PR TITLE
fix: ignore controller connections when factoring presence

### DIFF
--- a/apiserver/observer/agentpresence.go
+++ b/apiserver/observer/agentpresence.go
@@ -87,7 +87,9 @@ func NewAgentPresence(cfg AgentPresenceConfig) *AgentPresence {
 func (n *AgentPresence) Login(ctx context.Context, entity names.Tag, modelTag names.ModelTag, modelUUID model.UUID, fromController bool, userData string) {
 	n.BaseObserver.Login(ctx, entity, modelTag, modelUUID, fromController, userData)
 
-	if !n.IsAgent() {
+	// Controller connections to workload models must not update presence for
+	// workload agents with the same tag.
+	if !n.IsAgent() || n.FromController() {
 		return
 	}
 
@@ -117,7 +119,8 @@ func (n *AgentPresence) Login(ctx context.Context, entity names.Tag, modelTag na
 func (n *AgentPresence) Leave(ctx context.Context) {
 	// This guards against the case where the agent has not logged in and
 	// the agent tag is nil.
-	if !n.IsAgent() {
+	// Controller connections must not remove workload agent presence.
+	if !n.IsAgent() || n.FromController() {
 		return
 	}
 

--- a/apiserver/observer/agentpresence_test.go
+++ b/apiserver/observer/agentpresence_test.go
@@ -57,6 +57,16 @@ func (s *AgentPresenceSuite) TestLoginForMachine(c *tc.C) {
 	observer.Login(c.Context(), names.NewMachineTag("0"), names.NewModelTag("bar"), uuid, false, "user data")
 }
 
+func (s *AgentPresenceSuite) TestLoginFromController(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uuid := tc.Must0(c, coremodel.NewUUID)
+
+	observer := s.newObserver(c)
+	observer.Login(c.Context(), names.NewMachineTag("0"), names.NewModelTag("bar"), uuid, true, "user data")
+	observer.Leave(c.Context())
+}
+
 func (s *AgentPresenceSuite) TestLoginForUser(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -93,6 +103,18 @@ func (s *AgentPresenceSuite) TestLeaveForMachine(c *tc.C) {
 
 	observer := s.newObserver(c)
 	observer.Login(c.Context(), names.NewMachineTag("0"), names.NewModelTag("bar"), uuid, false, "user data")
+	observer.Leave(c.Context())
+}
+
+func (s *AgentPresenceSuite) TestLeaveFromController(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	uuid := tc.Must0(c, coremodel.NewUUID)
+
+	observer := s.newObserver(c)
+	// Exercise the departure guard independently of the presence login guard.
+	observer.BaseObserver.Login(c.Context(), names.NewMachineTag("0"), names.NewModelTag("bar"), uuid, true, "user data")
+	observer.modelService = s.modelService
 	observer.Leave(c.Context())
 }
 


### PR DESCRIPTION
Before this change, model API connections made by controllers on behalf of their model worker trees could be confused with machines in the model.

So a disconnecting machine-0 from the controller could indicate on another model(s) that its own machine-0 was lost.

There is already precedent for filtering controller connections, so we apply that here for presence determination.

## QA steps

- Bootstrap to LXD.
- `juju add-unit -m controller controller` and wait for the new unit to settle.
- Add a model and `juju deploy tiny-bash -n 2` and wait for everything to be up.
- Now remove the extra controller with `juju remove-machine -m controller 1 --force --no-prompt`.
- Before, this would cause machine 1 in the workload model to be declared absent. This will no longer occur.
