### PR TITLE
fix(bundle): resolve application base with default-base during upgrade checks

### DIFF
--- a/internal/bundle/changes/handlers.go
+++ b/internal/bundle/changes/handlers.go
@@ -180,7 +180,7 @@ func (r *resolver) handleApplications(ctx context.Context) (map[string]string, e
 			}
 		} else {
 			// Look for changes.
-			if ok, err := r.allowCharmUpgrade(ctx, existingApp, application, arch); err != nil {
+			if ok, err := r.allowCharmUpgrade(ctx, existingApp, application, arch, computedBase); err != nil {
 				return nil, errors.Trace(err)
 			} else if ok {
 				charmOrChange := application.Charm
@@ -275,7 +275,7 @@ func (r *resolver) handleApplications(ctx context.Context) (map[string]string, e
 	return addedApplications, nil
 }
 
-func (r *resolver) allowCharmUpgrade(ctx context.Context, existingApp *Application, bundleApp *charm.ApplicationSpec, bundleArch string) (bool, error) {
+func (r *resolver) allowCharmUpgrade(ctx context.Context, existingApp *Application, bundleApp *charm.ApplicationSpec, bundleArch string, computedBase corebase.Base) (bool, error) {
 	// This covers most of v1 charm URL changes, everything else below is to
 	// support channels. Charmstore charms allow channels, but bundles were not
 	// aware of them, with the introduction of Charmhub charms, then we do need
@@ -311,16 +311,17 @@ func (r *resolver) allowCharmUpgrade(ctx context.Context, existingApp *Applicati
 		if bundleApp.Revision != nil {
 			rev = *bundleApp.Revision
 		}
-		var (
-			err  error
-			base corebase.Base
-		)
-		if bundleApp.Base != "" {
-			base, err = corebase.ParseBaseFromString(bundleApp.Base)
-			if err != nil {
-				return false, errors.Trace(err)
-			}
+		base := computedBase
+		// If neither application.Base nor bundle.DefaultBase was specified,
+		// fall back to the existing application's base to preserve the workload.
+		// bundle.DefaultBase takes precedence over existingApp.Base because the
+		// incoming bundle specification represents the intended target state.
+		// Note: existingApp is guaranteed non-nil in production (called only in
+		// the else branch of existingApp == nil), but may be nil in direct unit tests.
+		if base == (corebase.Base{}) && existingApp != nil && existingApp.Base != (corebase.Base{}) {
+			base = existingApp.Base
 		}
+		var err error
 		resolvedChan, resolvedRev, err = r.charmResolver(ctx, bundleApp.Charm, base, bundleApp.Channel, bundleArch, rev)
 		if err != nil {
 			return false, errors.Trace(err)

--- a/internal/bundle/changes/handlers_test.go
+++ b/internal/bundle/changes/handlers_test.go
@@ -32,7 +32,7 @@ func (s *resolverSuite) TestAllowUpgrade(c *tc.C) {
 	requestedArch := "amd64"
 
 	r := resolver{}
-	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch)
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, corebase.Base{})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(ok, tc.IsTrue)
 }
@@ -55,7 +55,7 @@ func (s *resolverSuite) TestAllowUpgradeWithSameChannel(c *tc.C) {
 			return "stable", 1, nil
 		},
 	}
-	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch)
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, corebase.Base{})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(ok, tc.IsTrue)
 }
@@ -79,7 +79,7 @@ func (s *resolverSuite) TestAllowUpgradeWithDowngrades(c *tc.C) {
 			return "stable", 1, nil
 		},
 	}
-	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch)
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, corebase.Base{})
 	c.Assert(err, tc.ErrorMatches, `application "ubuntu": downgrades are not currently supported: deployed revision 2 is newer than requested revision 1`)
 	c.Assert(ok, tc.IsFalse)
 }
@@ -102,7 +102,7 @@ func (s *resolverSuite) TestAllowUpgradeWithSameRevision(c *tc.C) {
 			return "stable", 1, nil
 		},
 	}
-	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch)
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, corebase.Base{})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(ok, tc.IsFalse)
 }
@@ -120,7 +120,7 @@ func (s *resolverSuite) TestAllowUpgradeWithDifferentChannel(c *tc.C) {
 	requestedArch := "amd64"
 
 	r := resolver{}
-	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch)
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, corebase.Base{})
 	c.Assert(err, tc.ErrorMatches, `^application "ubuntu": upgrades not supported across channels \(existing: "stable", requested: "edge"\); use --force to override`)
 	c.Assert(ok, tc.IsFalse)
 }
@@ -137,7 +137,7 @@ func (s *resolverSuite) TestAllowUpgradeWithNoBundleChannel(c *tc.C) {
 	requestedArch := "amd64"
 
 	r := resolver{}
-	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch)
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, corebase.Base{})
 	c.Assert(err, tc.ErrorMatches, `^application "ubuntu": upgrades not supported across channels \(existing: "stable", resolved: ""\); use --force to override`)
 	c.Assert(ok, tc.IsFalse)
 }
@@ -160,7 +160,7 @@ func (s *resolverSuite) TestAllowUpgradeWithDifferentChannelAndForce(c *tc.C) {
 			return "stable", 1, nil
 		},
 	}
-	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch)
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, corebase.Base{})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(ok, tc.IsTrue)
 }
@@ -176,7 +176,7 @@ func (s *resolverSuite) TestAllowUpgradeWithNoExistingChannel(c *tc.C) {
 	requestedArch := "amd64"
 
 	r := resolver{}
-	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch)
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, corebase.Base{})
 	c.Assert(err, tc.ErrorMatches, `^upgrades not supported when the channel for "" is unknown; use --force to override`)
 	c.Assert(ok, tc.IsFalse)
 }
@@ -194,7 +194,142 @@ func (s *resolverSuite) TestAllowUpgradeWithNoExistingChannelWithForce(c *tc.C) 
 	r := resolver{
 		force: true,
 	}
-	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch)
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, corebase.Base{})
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(ok, tc.IsTrue)
+}
+
+func (s *resolverSuite) TestAllowUpgradeWithBundleDefaultBase(c *tc.C) {
+	existing := &Application{
+		Charm:    "ch:ubuntu",
+		Channel:  "stable",
+		Revision: 0,
+	}
+	requested := &charm.ApplicationSpec{
+		Charm:   "ch:ubuntu",
+		Channel: "stable",
+	}
+	requestedArch := "amd64"
+
+	defaultBase, err := corebase.ParseBaseFromString("ubuntu@22.04")
+	c.Assert(err, tc.ErrorIsNil)
+
+	computedBase, err := computeApplicationBase(requested, defaultBase)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var resolvedBase corebase.Base
+	r := resolver{
+		force: true,
+		charmResolver: func(_ context.Context, _ string, base corebase.Base, _ string, _ string, _ int) (string, int, error) {
+			resolvedBase = base
+			return "stable", 1, nil
+		},
+	}
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, computedBase)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(resolvedBase.String(), tc.Equals, "ubuntu@22.04/stable")
+}
+
+func (s *resolverSuite) TestAllowUpgradeWithExistingAppBaseFallback(c *tc.C) {
+	existingBase, err := corebase.ParseBaseFromString("ubuntu@22.04")
+	c.Assert(err, tc.ErrorIsNil)
+
+	existing := &Application{
+		Charm:    "ch:ubuntu",
+		Channel:  "stable",
+		Revision: 0,
+		Base:     existingBase,
+	}
+	requested := &charm.ApplicationSpec{
+		Charm:   "ch:ubuntu",
+		Channel: "stable",
+	}
+	requestedArch := "amd64"
+
+	var resolvedBase corebase.Base
+	r := resolver{
+		force: true,
+		charmResolver: func(_ context.Context, _ string, base corebase.Base, _ string, _ string, _ int) (string, int, error) {
+			resolvedBase = base
+			return "stable", 1, nil
+		},
+	}
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, corebase.Base{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(resolvedBase.String(), tc.Equals, "ubuntu@22.04/stable")
+}
+
+func (s *resolverSuite) TestAllowUpgradePrefersAppBaseOverDefaultBase(c *tc.C) {
+	existingBase, err := corebase.ParseBaseFromString("ubuntu@20.04")
+	c.Assert(err, tc.ErrorIsNil)
+
+	existing := &Application{
+		Charm:    "ch:ubuntu",
+		Channel:  "stable",
+		Revision: 0,
+		Base:     existingBase,
+	}
+	requested := &charm.ApplicationSpec{
+		Charm:   "ch:ubuntu",
+		Base:    "ubuntu@24.04",
+		Channel: "stable",
+	}
+	requestedArch := "amd64"
+
+	defaultBase, err := corebase.ParseBaseFromString("ubuntu@22.04")
+	c.Assert(err, tc.ErrorIsNil)
+
+	computedBase, err := computeApplicationBase(requested, defaultBase)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var resolvedBase corebase.Base
+	r := resolver{
+		force: true,
+		charmResolver: func(_ context.Context, _ string, base corebase.Base, _ string, _ string, _ int) (string, int, error) {
+			resolvedBase = base
+			return "stable", 1, nil
+		},
+	}
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, computedBase)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(resolvedBase.String(), tc.Equals, "ubuntu@24.04/stable")
+}
+
+func (s *resolverSuite) TestAllowUpgradePrefersDefaultBaseOverExistingAppBase(c *tc.C) {
+	existingBase, err := corebase.ParseBaseFromString("ubuntu@20.04")
+	c.Assert(err, tc.ErrorIsNil)
+
+	existing := &Application{
+		Charm:    "ch:ubuntu",
+		Channel:  "stable",
+		Revision: 0,
+		Base:     existingBase,
+	}
+	requested := &charm.ApplicationSpec{
+		Charm:   "ch:ubuntu",
+		Channel: "stable",
+	}
+	requestedArch := "amd64"
+
+	defaultBase, err := corebase.ParseBaseFromString("ubuntu@22.04")
+	c.Assert(err, tc.ErrorIsNil)
+
+	computedBase, err := computeApplicationBase(requested, defaultBase)
+	c.Assert(err, tc.ErrorIsNil)
+
+	var resolvedBase corebase.Base
+	r := resolver{
+		force: true,
+		charmResolver: func(_ context.Context, _ string, base corebase.Base, _ string, _ string, _ int) (string, int, error) {
+			resolvedBase = base
+			return "stable", 1, nil
+		},
+	}
+	ok, err := r.allowCharmUpgrade(c.Context(), existing, requested, requestedArch, computedBase)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(ok, tc.IsTrue)
+	c.Assert(resolvedBase.String(), tc.Equals, "ubuntu@22.04/stable")
 }


### PR DESCRIPTION
## Summary

When deploying or upgrading applications via a bundle, applications often omit an explicit `base:` field and instead rely on the bundle's top-level `default-base:` or the model's existing deployed base.

Previously, `allowCharmUpgrade` in `internal/bundle/changes/handlers.go` only checked `bundleApp.Base` when preparing the query for `charmResolver`. If `bundleApp.Base` was empty, an empty `corebase.Base{}` was passed to the resolver. In Charmhub, resolving an empty base falls back to the newest supported base track on that channel (e.g., resolving `ubuntu@24.04` instead of `ubuntu@22.04`). If that newer base track has a lower revision number published than the revision deployed on the model's target base, Juju rejected the deployment with:

```text
application "<app>": downgrades are not currently supported: deployed revision X is newer than requested revision Y
```

This change updates `allowCharmUpgrade` to resolve the charm base using the proper fallback hierarchy:
1. `bundleApp.Base` (explicit application spec in bundle)
2. `r.bundle.DefaultBase` (top-level bundle default-base)
3. `existingApp.Base` (currently deployed application base in the model)

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. Create a bundle yaml (`bundle.yaml`) specifying a top-level `default-base` where the application omits `base`:
   ```yaml
   bundle: kubernetes # or machine bundle
   default-base: ubuntu@22.04
   applications:
     my-app:
       charm: ch:<charm-name>
       channel: <channel>
       scale: 1
   ```
   *(Select a charm where the latest revision on `ubuntu@22.04` is higher than that on `ubuntu@24.04`)*.

2. Deploy the bundle:
   ```sh
   juju deploy ./bundle.yaml
   ```

3. Re-run deploy with the same bundle (or an upgrade):
   ```sh
   juju deploy ./bundle.yaml
   ```

4. **Verify**: The bundle deployment succeeds without failing on:
   `downgrades are not currently supported: deployed revision X is newer than requested revision Y`

## Documentation changes

None.

## Links

**Issue:** Fixes #22962.