### PR TITLE
feat: dbrepl table completer

### DIFF
--- a/internal/worker/dbrepl/completer.go
+++ b/internal/worker/dbrepl/completer.go
@@ -1,0 +1,296 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dbrepl
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/chzyer/readline"
+
+	"github.com/juju/juju/core/database"
+)
+
+// compile-time check that sqlCompleter satisfies readline.AutoCompleter.
+var _ readline.AutoCompleter = (*sqlCompleter)(nil)
+
+// sqlCompleter implements readline.AutoCompleter to provide tab-completion for
+// SELECT statements in the DB REPL. It completes SQL keywords, table names
+// (after FROM/JOIN) and column names (in the SELECT list or after a
+// "table." prefix), querying the currently active database for schema.
+type sqlCompleter struct {
+	// db returns the database to introspect at completion time. The REPL can
+	// switch databases via .switch/.open, so the schema must be queried lazily
+	// rather than cached.
+	db func() database.TxnRunner
+
+	ctx context.Context
+}
+
+func newSQLCompleter(db func() database.TxnRunner, ctx context.Context) *sqlCompleter {
+	return &sqlCompleter{
+		db:  db,
+		ctx: ctx,
+	}
+}
+
+// Do implements readline.AutoCompleter. It returns the set of candidates
+// (as suffixes appended after the current word) and the offset into the line
+// where those candidates start.
+func (c *sqlCompleter) Do(line []rune, pos int) ([][]rune, int) {
+	if pos > len(line) {
+		pos = len(line)
+	}
+	text := string(line[:pos])
+	tok := currentToken(text)
+
+	if strings.Contains(tok, ".") {
+		return c.dotDo(tok)
+	}
+
+	return filterSuffix(c.candidates(text, tok), tok)
+}
+
+// dotDo completes "table.col" style tokens, returning column names of the
+// referenced table as suffixes after the current word.
+func (c *sqlCompleter) dotDo(tok string) ([][]rune, int) {
+	table, col := splitDotToken(tok)
+	t := c.resolveTable(table)
+	if t == "" {
+		return nil, 0
+	}
+
+	out := make([][]rune, 0, 4)
+	rc := []rune(col)
+	for _, name := range c.columns(t) {
+		if !hasPrefixCI(name, col) {
+			continue
+		}
+		out = append(out, []rune(name)[len(rc):])
+	}
+	if len(out) == 0 {
+		return nil, 0
+	}
+	return out, utf8.RuneCountInString(tok)
+}
+
+// candidates determines what to complete based on the SQL text typed so far.
+func (c *sqlCompleter) candidates(text, tok string) []string {
+	upper := strings.ToUpper(text)
+	words := strings.Fields(upper)
+	curWordIdx := len(words) - 1
+
+	selectIdx := indexOf(words, "SELECT")
+	fromIdx := lastIndexOf(words, "FROM")
+	joinIdx := lastIndexOf(words, "JOIN")
+	tabIdx := max(fromIdx, joinIdx)
+
+	// Table list region: cursor at or after FROM/JOIN and before any clause
+	// keyword terminates the table list.
+	if tabIdx != -1 && curWordIdx >= tabIdx && firstIndexFrom(words, tabIdx+1, curWordIdx+1, clauseKeywords) == -1 {
+		return c.tables()
+	}
+
+	// Column region: after SELECT, before the table list.
+	if selectIdx != -1 && curWordIdx > selectIdx {
+		return c.columnsPlusKeywords(words)
+	}
+
+	// Default: statement start, complete keywords.
+	return keywords
+}
+
+// columnsPlusKeywords completes the columns of the table referenced in the
+// FROM/JOIN clauses (if any) plus SQL keywords.
+func (c *sqlCompleter) columnsPlusKeywords(words []string) []string {
+	fromIdx := lastIndexOf(words, "FROM")
+	joinIdx := lastIndexOf(words, "JOIN")
+	tabIdx := max(fromIdx, joinIdx)
+	if tabIdx != -1 && tabIdx+1 < len(words) {
+		if t := c.resolveTable(words[tabIdx+1]); t != "" {
+			return append(c.columns(t), keywords...)
+		}
+	}
+	return keywords
+}
+
+// tables returns the names of all tables in the current database.
+func (c *sqlCompleter) tables() []string {
+	db := c.db()
+	if db == nil {
+		return nil
+	}
+	var out []string
+	_ = db.StdTxn(c.ctx, func(ctx context.Context, tx *sql.Tx) error {
+		out = nil
+		rows, err := tx.QueryContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = rows.Close() }()
+
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err != nil {
+				return err
+			}
+			out = append(out, name)
+		}
+		return rows.Err()
+	})
+	return out
+}
+
+// columns returns the column names of the given table.
+func (c *sqlCompleter) columns(table string) []string {
+	db := c.db()
+	if db == nil {
+		return nil
+	}
+	var out []string
+	_ = db.StdTxn(c.ctx, func(ctx context.Context, tx *sql.Tx) error {
+		out = nil
+		rows, err := tx.QueryContext(ctx, "SELECT name FROM pragma_table_info(?) ORDER BY cid", table)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = rows.Close() }()
+
+		for rows.Next() {
+			var name string
+			if err := rows.Scan(&name); err != nil {
+				return err
+			}
+			out = append(out, name)
+		}
+		return rows.Err()
+	})
+	return out
+}
+
+// resolveTable matches the given (possibly partial) table name case-insensitively
+// against the actual schema, returning the canonical name, or "" if none match.
+func (c *sqlCompleter) resolveTable(name string) string {
+	if name == "" {
+		return ""
+	}
+	for _, t := range c.tables() {
+		if strings.EqualFold(t, name) {
+			return t
+		}
+	}
+	return ""
+}
+
+// currentToken returns the word being typed, i.e. the text after the last
+// whitespace.
+func currentToken(text string) string {
+	i := strings.LastIndexAny(text, " \t")
+	if i == -1 {
+		return text
+	}
+	return text[i+1:]
+}
+
+// splitDotToken splits a "table.column" token into its table and column parts.
+func splitDotToken(tok string) (string, string) {
+	i := strings.LastIndex(tok, ".")
+	if i == -1 {
+		return "", tok
+	}
+	return tok[:i], tok[i+1:]
+}
+
+// filterSuffix filters candidates by case-insensitive prefix and returns them
+// as suffixes after the current word, along with the length of that word.
+func filterSuffix(cands []string, tok string) ([][]rune, int) {
+	rt := []rune(tok)
+	out := make([][]rune, 0, len(cands))
+	for _, cand := range cands {
+		if !hasPrefixCI(cand, tok) {
+			continue
+		}
+		out = append(out, []rune(cand)[len(rt):])
+	}
+	if len(out) == 0 {
+		return nil, 0
+	}
+	return out, len(rt)
+}
+
+// hasPrefixCI reports whether name has the given case-insensitive prefix.
+func hasPrefixCI(name, prefix string) bool {
+	n := []rune(name)
+	p := []rune(prefix)
+	if len(p) == 0 {
+		return true
+	}
+	if len(p) > len(n) {
+		return false
+	}
+	for i := range p {
+		if unicode.ToLower(n[i]) != unicode.ToLower(p[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func indexOf(words []string, target string) int {
+	for i, w := range words {
+		if w == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func lastIndexOf(words []string, target string) int {
+	for i := len(words) - 1; i >= 0; i-- {
+		if words[i] == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// firstIndexFrom returns the index of the first word in words[start:end] that
+// is in the given set, or -1 if none is.
+func firstIndexFrom(words []string, start, end int, set map[string]bool) int {
+	if start < 0 {
+		start = 0
+	}
+	if start > len(words) {
+		start = len(words)
+	}
+	if end > len(words) {
+		end = len(words)
+	}
+	for i := start; i < end; i++ {
+		if set[words[i]] {
+			return i
+		}
+	}
+	return -1
+}
+
+// keywords are the SQL keywords offered for completion.
+var keywords = []string{
+	"SELECT", "FROM", "WHERE", "JOIN", "INNER JOIN", "LEFT JOIN", "RIGHT JOIN",
+	"GROUP BY", "ORDER BY", "LIMIT", "HAVING", "AS", "AND", "OR", "NOT", "IN",
+	"IS", "NULL", "BETWEEN", "DISTINCT", "ON", "USING", "BY", "DESC", "ASC",
+	"OFFSET", "UNION", "WITH", "COUNT", "SUM", "AVG", "MIN", "MAX", "EXISTS",
+	"DELETE", "UPDATE", "INSERT", "CREATE", "DROP",
+}
+
+// clauseKeywords are keywords that terminate the FROM/JOIN table list and are
+// themselves completable once typing starts.
+var clauseKeywords = map[string]bool{
+	"WHERE": true, "GROUP": true, "ORDER": true, "LIMIT": true, "HAVING": true,
+	"UNION": true, "ON": true, "AND": true, "OR": true, "BY": true, "USING": true,
+	"AS": true, "DESC": true, "ASC": true, "OFFSET": true,
+}

--- a/internal/worker/dbrepl/completer.go
+++ b/internal/worker/dbrepl/completer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/chzyer/readline"
 
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/logger"
 )
 
 // compile-time check that sqlCompleter satisfies readline.AutoCompleter.
@@ -28,13 +29,15 @@ type sqlCompleter struct {
 	// rather than cached.
 	db func() database.TxnRunner
 
-	ctx context.Context
+	ctx    context.Context
+	logger logger.Logger
 }
 
-func newSQLCompleter(db func() database.TxnRunner, ctx context.Context) *sqlCompleter {
+func newSQLCompleter(db func() database.TxnRunner, ctx context.Context, logger logger.Logger) *sqlCompleter {
 	return &sqlCompleter{
-		db:  db,
-		ctx: ctx,
+		db:     db,
+		ctx:    ctx,
+		logger: logger,
 	}
 }
 
@@ -42,31 +45,49 @@ func newSQLCompleter(db func() database.TxnRunner, ctx context.Context) *sqlComp
 // (as suffixes appended after the current word) and the offset into the line
 // where those candidates start.
 func (c *sqlCompleter) Do(line []rune, pos int) ([][]rune, int) {
+	// readline normally guarantees pos is within line; retain this as a
+	// defensive check for other AutoCompleter callers.
 	if pos > len(line) {
 		pos = len(line)
 	}
 	text := string(line[:pos])
 	tok := currentToken(text)
+	request := completerRequest{completer: c}
 
 	if strings.Contains(tok, ".") {
-		return c.dotDo(tok)
+		return request.dotDo(tok)
 	}
 
-	return filterSuffix(c.candidates(text, tok), tok)
+	return filterSuffix(request.candidates(text, tok), tok)
+}
+
+// completerRequest caches schema information for a single completion request.
+type completerRequest struct {
+	completer    *sqlCompleter
+	tablesCached bool
+	tableNames   []string
+}
+
+func (r *completerRequest) tables() []string {
+	if !r.tablesCached {
+		r.tableNames = r.completer.tables()
+		r.tablesCached = true
+	}
+	return r.tableNames
 }
 
 // dotDo completes "table.col" style tokens, returning column names of the
 // referenced table as suffixes after the current word.
-func (c *sqlCompleter) dotDo(tok string) ([][]rune, int) {
+func (r *completerRequest) dotDo(tok string) ([][]rune, int) {
 	table, col := splitDotToken(tok)
-	t := c.resolveTable(table)
+	t := resolveTable(table, r.tables())
 	if t == "" {
 		return nil, 0
 	}
 
 	out := make([][]rune, 0, 4)
 	rc := []rune(col)
-	for _, name := range c.columns(t) {
+	for _, name := range r.completer.columns(t) {
 		if !hasPrefixCI(name, col) {
 			continue
 		}
@@ -79,7 +100,7 @@ func (c *sqlCompleter) dotDo(tok string) ([][]rune, int) {
 }
 
 // candidates determines what to complete based on the SQL text typed so far.
-func (c *sqlCompleter) candidates(text, tok string) []string {
+func (r *completerRequest) candidates(text, tok string) []string {
 	upper := strings.ToUpper(text)
 	words := strings.Fields(upper)
 	curWordIdx := len(words) - 1
@@ -92,12 +113,15 @@ func (c *sqlCompleter) candidates(text, tok string) []string {
 	// Table list region: cursor at or after FROM/JOIN and before any clause
 	// keyword terminates the table list.
 	if tabIdx != -1 && curWordIdx >= tabIdx && firstIndexFrom(words, tabIdx+1, curWordIdx+1, clauseKeywords) == -1 {
-		return c.tables()
+		if tok == "" && tabIdx+1 < len(words) && resolveTable(words[tabIdx+1], r.tables()) != "" {
+			return clauseKeywordCandidates
+		}
+		return r.tables()
 	}
 
 	// Column region: after SELECT, before the table list.
 	if selectIdx != -1 && curWordIdx > selectIdx {
-		return c.columnsPlusKeywords(words)
+		return r.columnsPlusKeywords(words)
 	}
 
 	// Default: statement start, complete keywords.
@@ -106,13 +130,13 @@ func (c *sqlCompleter) candidates(text, tok string) []string {
 
 // columnsPlusKeywords completes the columns of the table referenced in the
 // FROM/JOIN clauses (if any) plus SQL keywords.
-func (c *sqlCompleter) columnsPlusKeywords(words []string) []string {
+func (r *completerRequest) columnsPlusKeywords(words []string) []string {
 	fromIdx := lastIndexOf(words, "FROM")
 	joinIdx := lastIndexOf(words, "JOIN")
 	tabIdx := max(fromIdx, joinIdx)
 	if tabIdx != -1 && tabIdx+1 < len(words) {
-		if t := c.resolveTable(words[tabIdx+1]); t != "" {
-			return append(c.columns(t), keywords...)
+		if t := resolveTable(words[tabIdx+1], r.tables()); t != "" {
+			return append(r.completer.columns(t), keywords...)
 		}
 	}
 	return keywords
@@ -125,7 +149,7 @@ func (c *sqlCompleter) tables() []string {
 		return nil
 	}
 	var out []string
-	_ = db.StdTxn(c.ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := db.StdTxn(c.ctx, func(ctx context.Context, tx *sql.Tx) error {
 		out = nil
 		rows, err := tx.QueryContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
 		if err != nil {
@@ -142,6 +166,9 @@ func (c *sqlCompleter) tables() []string {
 		}
 		return rows.Err()
 	})
+	if err != nil {
+		c.logger.Debugf(c.ctx, "failed to list tables for SQL completion: %v", err)
+	}
 	return out
 }
 
@@ -152,7 +179,7 @@ func (c *sqlCompleter) columns(table string) []string {
 		return nil
 	}
 	var out []string
-	_ = db.StdTxn(c.ctx, func(ctx context.Context, tx *sql.Tx) error {
+	err := db.StdTxn(c.ctx, func(ctx context.Context, tx *sql.Tx) error {
 		out = nil
 		rows, err := tx.QueryContext(ctx, "SELECT name FROM pragma_table_info(?) ORDER BY cid", table)
 		if err != nil {
@@ -169,16 +196,19 @@ func (c *sqlCompleter) columns(table string) []string {
 		}
 		return rows.Err()
 	})
+	if err != nil {
+		c.logger.Debugf(c.ctx, "failed to list columns for SQL completion: %v", err)
+	}
 	return out
 }
 
 // resolveTable matches the given (possibly partial) table name case-insensitively
 // against the actual schema, returning the canonical name, or "" if none match.
-func (c *sqlCompleter) resolveTable(name string) string {
+func resolveTable(name string, tables []string) string {
 	if name == "" {
 		return ""
 	}
-	for _, t := range c.tables() {
+	for _, t := range tables {
 		if strings.EqualFold(t, name) {
 			return t
 		}
@@ -280,11 +310,16 @@ func firstIndexFrom(words []string, start, end int, set map[string]bool) int {
 
 // keywords are the SQL keywords offered for completion.
 var keywords = []string{
-	"SELECT", "FROM", "WHERE", "JOIN", "INNER JOIN", "LEFT JOIN", "RIGHT JOIN",
-	"GROUP BY", "ORDER BY", "LIMIT", "HAVING", "AS", "AND", "OR", "NOT", "IN",
+	"SELECT", "FROM", "WHERE", "JOIN", "INNER", "LEFT", "RIGHT", "GROUP",
+	"ORDER", "LIMIT", "HAVING", "AS", "AND", "OR", "NOT", "IN",
 	"IS", "NULL", "BETWEEN", "DISTINCT", "ON", "USING", "BY", "DESC", "ASC",
 	"OFFSET", "UNION", "WITH", "COUNT", "SUM", "AVG", "MIN", "MAX", "EXISTS",
 	"DELETE", "UPDATE", "INSERT", "CREATE", "DROP",
+}
+
+var clauseKeywordCandidates = []string{
+	"WHERE", "GROUP", "ORDER", "LIMIT", "HAVING", "UNION", "ON", "AND", "OR",
+	"BY", "USING", "AS", "DESC", "ASC", "OFFSET",
 }
 
 // clauseKeywords are keywords that terminate the FROM/JOIN table list and are

--- a/internal/worker/dbrepl/completer_test.go
+++ b/internal/worker/dbrepl/completer_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dbrepl
+
+import (
+	"strings"
+	stdtesting "testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain/schema"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/database/testing"
+	"github.com/juju/juju/internal/testhelpers"
+)
+
+type completerSuite struct {
+	testing.DqliteSuite
+}
+
+func TestCompleterSuite(t *stdtesting.T) {
+	testhelpers.PrintGoroutineLeaks(t, func(t *stdtesting.T) {
+		tc.Run(t, &completerSuite{})
+	})
+}
+
+func (s *completerSuite) SetUpTest(c *tc.C) {
+	s.DqliteSuite.SetUpTest(c)
+
+	s.ApplyDDL(c, &schematesting.SchemaApplier{
+		Schema: schema.ModelDDL(),
+	})
+}
+
+// complete returns the reconstructed candidate lines offered for the given
+// input line, with the cursor at the end of the line.
+func (s *completerSuite) complete(c *tc.C, line string) []string {
+	comp := newSQLCompleter(func() database.TxnRunner { return s.DqliteSuite.TxnRunner() }, c.Context())
+	cands, _ := comp.Do([]rune(line), len(line))
+
+	out := make([]string, 0, len(cands))
+	for _, r := range cands {
+		out = append(out, line+string(r))
+	}
+	return out
+}
+
+func joined(cands []string) string {
+	return strings.Join(cands, "\n")
+}
+
+func (s *completerSuite) TestCompleteKeywords(c *tc.C) {
+	cands := s.complete(c, "SEL")
+	c.Check(joined(cands), tc.Contains, "SELECT")
+}
+
+func (s *completerSuite) TestCompleteTablesAfterFrom(c *tc.C) {
+	cands := s.complete(c, "SELECT * FROM ")
+	c.Check(joined(cands), tc.Contains, "unit")
+	c.Check(joined(cands), tc.Contains, "machine")
+	c.Check(joined(cands), tc.Contains, "application")
+}
+
+func (s *completerSuite) TestCompleteTablesPrefix(c *tc.C) {
+	cands := s.complete(c, "FROM un")
+	c.Check(joined(cands), tc.Contains, "unit")
+	c.Check(joined(cands), tc.Contains, "unit_principal")
+	c.Check(joined(cands), tc.Contains, "unit_state")
+}
+
+func (s *completerSuite) TestCompleteColumnsDotPrefix(c *tc.C) {
+	cands := s.complete(c, "SELECT unit.")
+	c.Check(joined(cands), tc.Contains, "uuid")
+	c.Check(joined(cands), tc.Contains, "name")
+	c.Check(joined(cands), tc.Contains, "life_id")
+}
+
+func (s *completerSuite) TestCompleteColumnsDotPrefixPartial(c *tc.C) {
+	cands := s.complete(c, "SELECT unit.u")
+	c.Check(joined(cands), tc.Contains, "uuid")
+}
+
+func (s *completerSuite) TestCompleteColumnsInClause(c *tc.C) {
+	cands := s.complete(c, "SELECT name FROM unit WHERE ")
+	c.Check(joined(cands), tc.Contains, "uuid")
+	c.Check(joined(cands), tc.Contains, "life_id")
+	// clause keywords are still offered alongside columns
+	c.Check(joined(cands), tc.Contains, "WHERE")
+}

--- a/internal/worker/dbrepl/completer_test.go
+++ b/internal/worker/dbrepl/completer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/domain/schema"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/database/testing"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testhelpers"
 )
 
@@ -37,7 +38,11 @@ func (s *completerSuite) SetUpTest(c *tc.C) {
 // complete returns the reconstructed candidate lines offered for the given
 // input line, with the cursor at the end of the line.
 func (s *completerSuite) complete(c *tc.C, line string) []string {
-	comp := newSQLCompleter(func() database.TxnRunner { return s.DqliteSuite.TxnRunner() }, c.Context())
+	comp := newSQLCompleter(
+		func() database.TxnRunner { return s.DqliteSuite.TxnRunner() },
+		c.Context(),
+		loggertesting.WrapCheckLog(c),
+	)
 	cands, _ := comp.Do([]rune(line), len(line))
 
 	out := make([]string, 0, len(cands))
@@ -51,9 +56,24 @@ func joined(cands []string) string {
 	return strings.Join(cands, "\n")
 }
 
+func containsCandidate(cands [][]rune, target string) bool {
+	for _, candidate := range cands {
+		if string(candidate) == target {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *completerSuite) TestCompleteKeywords(c *tc.C) {
 	cands := s.complete(c, "SEL")
 	c.Check(joined(cands), tc.Contains, "SELECT")
+}
+
+func (s *completerSuite) TestCompleteKeywordsEmptyLine(c *tc.C) {
+	cands := s.complete(c, "")
+	c.Check(joined(cands), tc.Contains, "SELECT")
+	c.Check(joined(cands), tc.Contains, "DELETE")
 }
 
 func (s *completerSuite) TestCompleteTablesAfterFrom(c *tc.C) {
@@ -61,6 +81,33 @@ func (s *completerSuite) TestCompleteTablesAfterFrom(c *tc.C) {
 	c.Check(joined(cands), tc.Contains, "unit")
 	c.Check(joined(cands), tc.Contains, "machine")
 	c.Check(joined(cands), tc.Contains, "application")
+}
+
+func (s *completerSuite) TestCompleteTablesAfterDeleteFrom(c *tc.C) {
+	cands := s.complete(c, "DELETE FROM ")
+	c.Check(joined(cands), tc.Contains, "unit")
+}
+
+func (s *completerSuite) TestCompleteTablesAfterJoin(c *tc.C) {
+	cands := s.complete(c, "SELECT * FROM unit JOIN ")
+	c.Check(joined(cands), tc.Contains, "machine")
+}
+
+func (s *completerSuite) TestCompleteClauseKeywordsAfterTable(c *tc.C) {
+	cands := s.complete(c, "SELECT * FROM unit ")
+	c.Check(joined(cands), tc.Contains, "WHERE")
+	c.Check(cands, tc.HasLen, len(clauseKeywordCandidates))
+}
+
+func (s *completerSuite) TestCompleteMultiWordKeyword(c *tc.C) {
+	comp := newSQLCompleter(
+		func() database.TxnRunner { return s.DqliteSuite.TxnRunner() },
+		c.Context(),
+		loggertesting.WrapCheckLog(c),
+	)
+	cands, _ := comp.Do([]rune("INNER "), len("INNER "))
+	c.Check(containsCandidate(cands, "JOIN"), tc.IsTrue)
+	c.Check(containsCandidate(cands, "INNER JOIN"), tc.IsFalse)
 }
 
 func (s *completerSuite) TestCompleteTablesPrefix(c *tc.C) {
@@ -80,6 +127,21 @@ func (s *completerSuite) TestCompleteColumnsDotPrefix(c *tc.C) {
 func (s *completerSuite) TestCompleteColumnsDotPrefixPartial(c *tc.C) {
 	cands := s.complete(c, "SELECT unit.u")
 	c.Check(joined(cands), tc.Contains, "uuid")
+}
+
+func (s *completerSuite) TestCompleteColumnsDotPrefixUnknownTable(c *tc.C) {
+	cands := s.complete(c, "SELECT nonexistent.")
+	c.Check(cands, tc.HasLen, 0)
+}
+
+func (s *completerSuite) TestCompleteNilDatabase(c *tc.C) {
+	comp := newSQLCompleter(
+		func() database.TxnRunner { return nil },
+		c.Context(),
+		loggertesting.WrapCheckLog(c),
+	)
+	cands, _ := comp.Do([]rune("SELECT * FROM "), len("SELECT * FROM "))
+	c.Check(cands, tc.IsNil)
 }
 
 func (s *completerSuite) TestCompleteColumnsInClause(c *tc.C) {

--- a/internal/worker/dbrepl/worker.go
+++ b/internal/worker/dbrepl/worker.go
@@ -139,6 +139,7 @@ func (w *dbReplWorker) loop() (err error) {
 		InterruptPrompt:     "^C",
 		HistorySearchFold:   true,
 		FuncFilterInputRune: filterInput,
+		AutoComplete:        newSQLCompleter(func() database.TxnRunner { return w.currentDB }, ctx),
 	})
 	if err != nil {
 		return errors.Trace(err)

--- a/internal/worker/dbrepl/worker.go
+++ b/internal/worker/dbrepl/worker.go
@@ -139,7 +139,7 @@ func (w *dbReplWorker) loop() (err error) {
 		InterruptPrompt:     "^C",
 		HistorySearchFold:   true,
 		FuncFilterInputRune: filterInput,
-		AutoComplete:        newSQLCompleter(func() database.TxnRunner { return w.currentDB }, ctx),
+		AutoComplete:        newSQLCompleter(func() database.TxnRunner { return w.currentDB }, ctx, w.cfg.Logger),
 	})
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
The database REPL required users to manually type SQL table names, column names, and common keywords. This is slow and error-prone when exploring unfamiliar schemas, particularly after switching databases.

- Added tab completion to the DB REPL through readline.AutoCompleter.
- Completes common SQL keywords.
- Completes table names following FROM and JOIN.
- Introspects the active database schema lazily to complete columns, including table.column prefixes.
- Supports case-insensitive prefix matching and handles database switches.
- Added Dqlite-backed tests covering keyword, table, and column completion.

This doesn't fill in columns though, someone else can do that!

## QA steps

Auto complete in action :wink: 

```sh
$ juju bootstrap lxd test
$ juju ssh -m controller 0
$ juju_db_repl
repl (controller)> .switch model-controller
repl (model-controller)> SELECT * FROM cha
change_log              change_log_edit_type    change_log_namespace    change_log_witness      charm                   charm_action            charm_category
charm_config            charm_config_type       charm_container         charm_container_mount   charm_device            charm_download_info     charm_extra_binding
charm_hash              charm_manifest_base     charm_metadata          charm_provenance        charm_relation          charm_relation_role     charm_relation_scope
charm_resource          charm_resource_kind     charm_run_as_kind       charm_source            charm_storage           charm_storage_kind      charm_storage_property
charm_tag               charm_term
```

