### PR TITLE
perf: reduce number of subscriptions from 11 to 9

### DIFF
--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -61,34 +61,6 @@ func (u *Unit) ResolvedMode() params.ResolvedMode {
 	return u.resolved
 }
 
-// Resolved returns the unit's resolved mode value.
-func (u *Unit) Resolved(ctx context.Context) (params.ResolvedMode, error) {
-	var results params.ResolvedModeResults
-	args := params.Entities{
-		Entities: []params.Entity{
-			{Tag: u.tag.String()},
-		},
-	}
-	err := u.client.facade.FacadeCall(ctx, "Resolved", args, &results)
-	if err != nil {
-		return "", errors.Trace(apiservererrors.RestoreError(err))
-	}
-	if len(results.Results) != 1 {
-		return "", errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	result := results.Results[0]
-	if result.Error != nil {
-		// We should be able to use apiserver.common.RestoreError here,
-		// but because of poor design, it causes import errors.
-		if params.IsCodeNotFound(result.Error) {
-			return "", errors.NewNotFound(result.Error, "")
-		}
-		return "", errors.Trace(result.Error)
-	}
-
-	return result.Mode, nil
-}
-
 // Refresh updates the cached local copy of the unit's data.
 //
 // Deprecated: Please use a purpose-built getter instead.

--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -28,6 +28,7 @@ type Unit struct {
 	tag        names.UnitTag
 	life       life.Value
 	providerID string
+	resolved   params.ResolvedMode
 }
 
 // Tag returns the unit's tag.
@@ -53,6 +54,11 @@ func (u *Unit) String() string {
 // Life returns the unit's lifecycle value.
 func (u *Unit) Life() life.Value {
 	return u.life
+}
+
+// ResolvedMode returns the resolved mode reported by the most recent Refresh.
+func (u *Unit) ResolvedMode() params.ResolvedMode {
+	return u.resolved
 }
 
 // Resolved returns the unit's resolved mode value.
@@ -112,6 +118,7 @@ func (u *Unit) Refresh(ctx context.Context) error {
 
 	u.life = result.Life
 	u.providerID = result.ProviderID
+	u.resolved = result.Resolved
 	return nil
 }
 

--- a/internal/worker/uniter/api/interface.go
+++ b/internal/worker/uniter/api/interface.go
@@ -33,6 +33,7 @@ type ProviderIDGetter interface {
 type Unit interface {
 	ProviderIDGetter
 	Life() life.Value
+	ResolvedMode() params.ResolvedMode
 	Refresh(context.Context) error
 	ApplicationTag() names.ApplicationTag
 	EnsureDead(context.Context) error

--- a/internal/worker/uniter/api/interface.go
+++ b/internal/worker/uniter/api/interface.go
@@ -67,9 +67,7 @@ type Unit interface {
 	// Used by remotestate watcher.
 
 	WatchConfigSettingsHash(context.Context) (watcher.StringsWatcher, error)
-	WatchTrustConfigSettingsHash(context.Context) (watcher.StringsWatcher, error)
 	WatchRelations(context.Context) (watcher.StringsWatcher, error)
-	WatchResolveMode(context.Context) (watcher.NotifyWatcher, error)
 	WatchAddressesHash(context.Context) (watcher.StringsWatcher, error)
 	WatchActionNotifications(context.Context) (watcher.StringsWatcher, error)
 	WatchStorage(context.Context) (watcher.StringsWatcher, error)

--- a/internal/worker/uniter/api/interface.go
+++ b/internal/worker/uniter/api/interface.go
@@ -63,7 +63,6 @@ type Unit interface {
 	AssignedMachine(context.Context) (names.MachineTag, error)
 	AvailabilityZone(context.Context) (string, error)
 	PrivateAddress(context.Context) (string, error)
-	Resolved(context.Context) (params.ResolvedMode, error)
 
 	// Used by remotestate watcher.
 

--- a/internal/worker/uniter/api/mocks/domain_mocks.go
+++ b/internal/worker/uniter/api/mocks/domain_mocks.go
@@ -33,47 +33,45 @@ type MockUnit struct {
 
 // MockUnitMockRecorder is the mock recorder for MockUnit.
 type MockUnitMockRecorder struct {
-	mock                                *MockUnit
-	applicationExpects                  []*gomock.Call1_2[context.Context, api.Application, error]
-	applicationNameExpects              []*gomock.Call0_1[string]
-	applicationTagExpects               []*gomock.Call0_1[names.ApplicationTag]
-	assignedMachineExpects              []*gomock.Call1_2[context.Context, names.MachineTag, error]
-	availabilityZoneExpects             []*gomock.Call1_2[context.Context, string, error]
-	charmURLExpects                     []*gomock.Call1_2[context.Context, string, error]
-	clearResolvedExpects                []*gomock.Call1_1[context.Context, error]
-	commitHookChangesExpects            []*gomock.Call2_1[context.Context, params.CommitHookChangesArgs, error]
-	configSettingsExpects               []*gomock.Call1_2[context.Context, charm.Config, error]
-	destroyExpects                      []*gomock.Call1_1[context.Context, error]
-	destroyAllSubordinatesExpects       []*gomock.Call1_1[context.Context, error]
-	ensureDeadExpects                   []*gomock.Call1_1[context.Context, error]
-	hasSubordinatesExpects              []*gomock.Call1_2[context.Context, bool, error]
-	lifeExpects                         []*gomock.Call0_1[life.Value]
-	logActionMessageExpects             []*gomock.Call3_1[context.Context, names.ActionTag, string, error]
-	nameExpects                         []*gomock.Call0_1[string]
-	networkInfoExpects                  []*gomock.Call3_2[context.Context, []string, *int, map[string]params.NetworkInfoResult, error]
-	principalNameExpects                []*gomock.Call1_3[context.Context, string, bool, error]
-	privateAddressExpects               []*gomock.Call1_2[context.Context, string, error]
-	providerIDExpects                   []*gomock.Call0_1[string]
-	publicAddressExpects                []*gomock.Call1_2[context.Context, string, error]
-	refreshExpects                      []*gomock.Call1_1[context.Context, error]
-	relationsStatusExpects              []*gomock.Call1_2[context.Context, []uniter.RelationStatus, error]
-	requestRebootExpects                []*gomock.Call1_1[context.Context, error]
-	resolvedExpects                     []*gomock.Call1_2[context.Context, params.ResolvedMode, error]
-	setAgentStatusExpects               []*gomock.Call4_1[context.Context, status.Status, string, map[string]any, error]
-	setCharmExpects                     []*gomock.Call2_1[context.Context, string, error]
-	setStateExpects                     []*gomock.Call2_1[context.Context, params.SetUnitStateArg, error]
-	setUnitStatusExpects                []*gomock.Call4_1[context.Context, status.Status, string, map[string]any, error]
-	stateExpects                        []*gomock.Call1_2[context.Context, params.UnitStateResult, error]
-	tagExpects                          []*gomock.Call0_1[names.UnitTag]
-	unitStatusExpects                   []*gomock.Call1_2[context.Context, params.StatusResult, error]
-	watchExpects                        []*gomock.Call1_2[context.Context, watcher.NotifyWatcher, error]
-	watchActionNotificationsExpects     []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
-	watchAddressesHashExpects           []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
-	watchConfigSettingsHashExpects      []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
-	watchRelationsExpects               []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
-	watchResolveModeExpects             []*gomock.Call1_2[context.Context, watcher.NotifyWatcher, error]
-	watchStorageExpects                 []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
-	watchTrustConfigSettingsHashExpects []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
+	mock                            *MockUnit
+	applicationExpects              []*gomock.Call1_2[context.Context, api.Application, error]
+	applicationNameExpects          []*gomock.Call0_1[string]
+	applicationTagExpects           []*gomock.Call0_1[names.ApplicationTag]
+	assignedMachineExpects          []*gomock.Call1_2[context.Context, names.MachineTag, error]
+	availabilityZoneExpects         []*gomock.Call1_2[context.Context, string, error]
+	charmURLExpects                 []*gomock.Call1_2[context.Context, string, error]
+	clearResolvedExpects            []*gomock.Call1_1[context.Context, error]
+	commitHookChangesExpects        []*gomock.Call2_1[context.Context, params.CommitHookChangesArgs, error]
+	configSettingsExpects           []*gomock.Call1_2[context.Context, charm.Config, error]
+	destroyExpects                  []*gomock.Call1_1[context.Context, error]
+	destroyAllSubordinatesExpects   []*gomock.Call1_1[context.Context, error]
+	ensureDeadExpects               []*gomock.Call1_1[context.Context, error]
+	hasSubordinatesExpects          []*gomock.Call1_2[context.Context, bool, error]
+	lifeExpects                     []*gomock.Call0_1[life.Value]
+	logActionMessageExpects         []*gomock.Call3_1[context.Context, names.ActionTag, string, error]
+	nameExpects                     []*gomock.Call0_1[string]
+	networkInfoExpects              []*gomock.Call3_2[context.Context, []string, *int, map[string]params.NetworkInfoResult, error]
+	principalNameExpects            []*gomock.Call1_3[context.Context, string, bool, error]
+	privateAddressExpects           []*gomock.Call1_2[context.Context, string, error]
+	providerIDExpects               []*gomock.Call0_1[string]
+	publicAddressExpects            []*gomock.Call1_2[context.Context, string, error]
+	refreshExpects                  []*gomock.Call1_1[context.Context, error]
+	relationsStatusExpects          []*gomock.Call1_2[context.Context, []uniter.RelationStatus, error]
+	requestRebootExpects            []*gomock.Call1_1[context.Context, error]
+	resolvedExpects                 []*gomock.Call1_2[context.Context, params.ResolvedMode, error]
+	setAgentStatusExpects           []*gomock.Call4_1[context.Context, status.Status, string, map[string]any, error]
+	setCharmExpects                 []*gomock.Call2_1[context.Context, string, error]
+	setStateExpects                 []*gomock.Call2_1[context.Context, params.SetUnitStateArg, error]
+	setUnitStatusExpects            []*gomock.Call4_1[context.Context, status.Status, string, map[string]any, error]
+	stateExpects                    []*gomock.Call1_2[context.Context, params.UnitStateResult, error]
+	tagExpects                      []*gomock.Call0_1[names.UnitTag]
+	unitStatusExpects               []*gomock.Call1_2[context.Context, params.StatusResult, error]
+	watchExpects                    []*gomock.Call1_2[context.Context, watcher.NotifyWatcher, error]
+	watchActionNotificationsExpects []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
+	watchAddressesHashExpects       []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
+	watchConfigSettingsHashExpects  []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
+	watchRelationsExpects           []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
+	watchStorageExpects             []*gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
 }
 
 // NewMockUnit creates a new mock instance.
@@ -754,24 +752,6 @@ func (mr *MockUnitMockRecorder) WatchRelations(arg0 any) *MockUnitWatchRelations
 // MockUnitWatchRelationsCall is the typed call wrapper for WatchRelations.
 type MockUnitWatchRelationsCall = gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
 
-// WatchResolveMode mocks base method.
-func (m *MockUnit) WatchResolveMode(arg0 context.Context) (watcher.NotifyWatcher, error) {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch1_2(&m.recorder.watchResolveModeExpects, m.ctrl, m, "WatchResolveMode", arg0)
-}
-
-// WatchResolveMode indicates an expected call of WatchResolveMode.
-func (mr *MockUnitMockRecorder) WatchResolveMode(arg0 any) *MockUnitWatchResolveModeCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_2[context.Context, watcher.NotifyWatcher, error](mr.mock.ctrl.T, mr.mock, "WatchResolveMode", gomock.EnsureMatcher(arg0))
-	mr.watchResolveModeExpects = append(mr.watchResolveModeExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockUnitWatchResolveModeCall is the typed call wrapper for WatchResolveMode.
-type MockUnitWatchResolveModeCall = gomock.Call1_2[context.Context, watcher.NotifyWatcher, error]
-
 // WatchStorage mocks base method.
 func (m *MockUnit) WatchStorage(arg0 context.Context) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
@@ -789,24 +769,6 @@ func (mr *MockUnitMockRecorder) WatchStorage(arg0 any) *MockUnitWatchStorageCall
 
 // MockUnitWatchStorageCall is the typed call wrapper for WatchStorage.
 type MockUnitWatchStorageCall = gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
-
-// WatchTrustConfigSettingsHash mocks base method.
-func (m *MockUnit) WatchTrustConfigSettingsHash(arg0 context.Context) (watcher.StringsWatcher, error) {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch1_2(&m.recorder.watchTrustConfigSettingsHashExpects, m.ctrl, m, "WatchTrustConfigSettingsHash", arg0)
-}
-
-// WatchTrustConfigSettingsHash indicates an expected call of WatchTrustConfigSettingsHash.
-func (mr *MockUnitMockRecorder) WatchTrustConfigSettingsHash(arg0 any) *MockUnitWatchTrustConfigSettingsHashCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_2[context.Context, watcher.StringsWatcher, error](mr.mock.ctrl.T, mr.mock, "WatchTrustConfigSettingsHash", gomock.EnsureMatcher(arg0))
-	mr.watchTrustConfigSettingsHashExpects = append(mr.watchTrustConfigSettingsHashExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockUnitWatchTrustConfigSettingsHashCall is the typed call wrapper for WatchTrustConfigSettingsHash.
-type MockUnitWatchTrustConfigSettingsHashCall = gomock.Call1_2[context.Context, watcher.StringsWatcher, error]
 
 // MockRelation is a mock of Relation interface.
 type MockRelation struct {

--- a/internal/worker/uniter/api/mocks/domain_mocks.go
+++ b/internal/worker/uniter/api/mocks/domain_mocks.go
@@ -59,6 +59,7 @@ type MockUnitMockRecorder struct {
 	relationsStatusExpects          []*gomock.Call1_2[context.Context, []uniter.RelationStatus, error]
 	requestRebootExpects            []*gomock.Call1_1[context.Context, error]
 	resolvedExpects                 []*gomock.Call1_2[context.Context, params.ResolvedMode, error]
+	resolvedModeExpects             []*gomock.Call0_1[params.ResolvedMode]
 	setAgentStatusExpects           []*gomock.Call4_1[context.Context, status.Status, string, map[string]any, error]
 	setCharmExpects                 []*gomock.Call2_1[context.Context, string, error]
 	setStateExpects                 []*gomock.Call2_1[context.Context, params.SetUnitStateArg, error]
@@ -535,6 +536,24 @@ func (mr *MockUnitMockRecorder) Resolved(arg0 any) *MockUnitResolvedCall {
 
 // MockUnitResolvedCall is the typed call wrapper for Resolved.
 type MockUnitResolvedCall = gomock.Call1_2[context.Context, params.ResolvedMode, error]
+
+// ResolvedMode mocks base method.
+func (m *MockUnit) ResolvedMode() params.ResolvedMode {
+	m.ctrl.T.Helper()
+	return gomock.Dispatch0_1(&m.recorder.resolvedModeExpects, m.ctrl, m, "ResolvedMode")
+}
+
+// ResolvedMode indicates an expected call of ResolvedMode.
+func (mr *MockUnitMockRecorder) ResolvedMode() *MockUnitResolvedModeCall {
+	mr.mock.ctrl.T.Helper()
+	call := gomock.NewCall0_1[params.ResolvedMode](mr.mock.ctrl.T, mr.mock, "ResolvedMode")
+	mr.resolvedModeExpects = append(mr.resolvedModeExpects, call)
+	mr.mock.ctrl.Track(call.Call)
+	return call
+}
+
+// MockUnitResolvedModeCall is the typed call wrapper for ResolvedMode.
+type MockUnitResolvedModeCall = gomock.Call0_1[params.ResolvedMode]
 
 // SetAgentStatus mocks base method.
 func (m *MockUnit) SetAgentStatus(ctx context.Context, agentStatus status.Status, info string, data map[string]any) error {

--- a/internal/worker/uniter/api/mocks/domain_mocks.go
+++ b/internal/worker/uniter/api/mocks/domain_mocks.go
@@ -58,7 +58,6 @@ type MockUnitMockRecorder struct {
 	refreshExpects                  []*gomock.Call1_1[context.Context, error]
 	relationsStatusExpects          []*gomock.Call1_2[context.Context, []uniter.RelationStatus, error]
 	requestRebootExpects            []*gomock.Call1_1[context.Context, error]
-	resolvedExpects                 []*gomock.Call1_2[context.Context, params.ResolvedMode, error]
 	resolvedModeExpects             []*gomock.Call0_1[params.ResolvedMode]
 	setAgentStatusExpects           []*gomock.Call4_1[context.Context, status.Status, string, map[string]any, error]
 	setCharmExpects                 []*gomock.Call2_1[context.Context, string, error]
@@ -518,24 +517,6 @@ func (mr *MockUnitMockRecorder) RequestReboot(arg0 any) *MockUnitRequestRebootCa
 
 // MockUnitRequestRebootCall is the typed call wrapper for RequestReboot.
 type MockUnitRequestRebootCall = gomock.Call1_1[context.Context, error]
-
-// Resolved mocks base method.
-func (m *MockUnit) Resolved(arg0 context.Context) (params.ResolvedMode, error) {
-	m.ctrl.T.Helper()
-	return gomock.Dispatch1_2(&m.recorder.resolvedExpects, m.ctrl, m, "Resolved", arg0)
-}
-
-// Resolved indicates an expected call of Resolved.
-func (mr *MockUnitMockRecorder) Resolved(arg0 any) *MockUnitResolvedCall {
-	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall1_2[context.Context, params.ResolvedMode, error](mr.mock.ctrl.T, mr.mock, "Resolved", gomock.EnsureMatcher(arg0))
-	mr.resolvedExpects = append(mr.resolvedExpects, call)
-	mr.mock.ctrl.Track(call.Call)
-	return call
-}
-
-// MockUnitResolvedCall is the typed call wrapper for Resolved.
-type MockUnitResolvedCall = gomock.Call1_2[context.Context, params.ResolvedMode, error]
 
 // ResolvedMode mocks base method.
 func (m *MockUnit) ResolvedMode() params.ResolvedMode {

--- a/internal/worker/uniter/entity_mocks_test.go
+++ b/internal/worker/uniter/entity_mocks_test.go
@@ -147,11 +147,6 @@ func (ctx *testContext) makeUnit(c tc.LikeC, unitTag names.UnitTag, l life.Value
 		return nil
 	}).AnyTimes()
 
-	u.EXPECT().Resolved(gomock.Any()).DoAndReturn(func(context.Context) (params.ResolvedMode, error) {
-		u.mu.Lock()
-		defer u.mu.Unlock()
-		return u.resolved, nil
-	}).AnyTimes()
 	u.EXPECT().ClearResolved(gomock.Any()).DoAndReturn(func(context.Context) error {
 		u.mu.Lock()
 		u.resolved = params.ResolvedNone

--- a/internal/worker/uniter/entity_mocks_test.go
+++ b/internal/worker/uniter/entity_mocks_test.go
@@ -156,10 +156,7 @@ func (ctx *testContext) makeUnit(c tc.LikeC, unitTag names.UnitTag, l life.Value
 		u.mu.Lock()
 		u.resolved = params.ResolvedNone
 		u.mu.Unlock()
-		ctx.channelMu.Lock()
-		ch := ctx.unitResolveCh
-		ctx.channelMu.Unlock()
-		ctx.sendNotify(c, ch, "send clear resolved event")
+		ctx.sendUnitNotify(c, "send clear resolved event")
 		return nil
 	}).AnyTimes()
 

--- a/internal/worker/uniter/remotestate/mock_test.go
+++ b/internal/worker/uniter/remotestate/mock_test.go
@@ -240,6 +240,10 @@ func (u *mockUnit) ProviderID() string {
 	return u.providerID
 }
 
+func (u *mockUnit) ResolvedMode() params.ResolvedMode {
+	return u.resolved
+}
+
 func (u *mockUnit) Resolved(context.Context) (params.ResolvedMode, error) {
 	return u.resolved, nil
 }

--- a/internal/worker/uniter/remotestate/mock_test.go
+++ b/internal/worker/uniter/remotestate/mock_test.go
@@ -244,10 +244,6 @@ func (u *mockUnit) ResolvedMode() params.ResolvedMode {
 	return u.resolved
 }
 
-func (u *mockUnit) Resolved(context.Context) (params.ResolvedMode, error) {
-	return u.resolved, nil
-}
-
 func (u *mockUnit) Application(context.Context) (api.Application, error) {
 	return &u.application, nil
 }

--- a/internal/worker/uniter/remotestate/mock_test.go
+++ b/internal/worker/uniter/remotestate/mock_test.go
@@ -215,19 +215,17 @@ func (m *mockUniterClient) WatchUpdateStatusHookInterval(context.Context) (watch
 
 type mockUnit struct {
 	api.Unit
-	tag                              names.UnitTag
-	life                             life.Value
-	providerID                       string
-	resolved                         params.ResolvedMode
-	application                      mockApplication
-	unitWatcher                      *mockNotifyWatcher
-	unitResolveWatcher               *mockNotifyWatcher
-	addressesWatcher                 *mockStringsWatcher
-	configSettingsWatcher            *mockStringsWatcher
-	applicationConfigSettingsWatcher *mockStringsWatcher
-	storageWatcher                   *mockStringsWatcher
-	actionWatcher                    *mockStringsWatcher
-	relationsWatcher                 *mockStringsWatcher
+	tag                   names.UnitTag
+	life                  life.Value
+	providerID            string
+	resolved              params.ResolvedMode
+	application           mockApplication
+	unitWatcher           *mockNotifyWatcher
+	addressesWatcher      *mockStringsWatcher
+	configSettingsWatcher *mockStringsWatcher
+	storageWatcher        *mockStringsWatcher
+	actionWatcher         *mockStringsWatcher
+	relationsWatcher      *mockStringsWatcher
 }
 
 func (u *mockUnit) Life() life.Value {
@@ -258,20 +256,12 @@ func (u *mockUnit) Watch(context.Context) (watcher.NotifyWatcher, error) {
 	return u.unitWatcher, nil
 }
 
-func (u *mockUnit) WatchResolveMode(context.Context) (watcher.NotifyWatcher, error) {
-	return u.unitResolveWatcher, nil
-}
-
 func (u *mockUnit) WatchAddressesHash(_ context.Context) (watcher.StringsWatcher, error) {
 	return u.addressesWatcher, nil
 }
 
 func (u *mockUnit) WatchConfigSettingsHash(_ context.Context) (watcher.StringsWatcher, error) {
 	return u.configSettingsWatcher, nil
-}
-
-func (u *mockUnit) WatchTrustConfigSettingsHash(_ context.Context) (watcher.StringsWatcher, error) {
-	return u.applicationConfigSettingsWatcher, nil
 }
 
 func (u *mockUnit) WatchStorage(_ context.Context) (watcher.StringsWatcher, error) {

--- a/internal/worker/uniter/remotestate/snapshot.go
+++ b/internal/worker/uniter/remotestate/snapshot.go
@@ -53,8 +53,9 @@ type Snapshot struct {
 	// unit's config settings.
 	ConfigHash string
 
-	// TrustHash is a hash of the last published version of the unit's
-	// trust settings.
+	// TrustHash is a hash of the last published version of the unit's trust
+	// settings. It is retained for compatibility with state written by earlier
+	// uniters and must not be treated as an independent signal from ConfigHash.
 	TrustHash string
 
 	// AddressesHash is a hash of the last published addresses for the

--- a/internal/worker/uniter/remotestate/watcher.go
+++ b/internal/worker/uniter/remotestate/watcher.go
@@ -741,17 +741,13 @@ func (w *RemoteStateWatcher) unitStateChanged(ctx context.Context) error {
 	if err := w.unit.Refresh(ctx); err != nil {
 		return errors.Trace(err)
 	}
-	resolveMode, err := w.unit.Resolved(ctx)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.current.Life = w.unit.Life()
 	// It's ok to sync provider ID by watching unit rather than
 	// cloud container because it will not change once pod created.
 	w.current.ProviderID = w.unit.ProviderID()
-	w.current.ResolvedMode = resolveMode
+	w.current.ResolvedMode = w.unit.ResolvedMode()
 	return nil
 }
 

--- a/internal/worker/uniter/remotestate/watcher.go
+++ b/internal/worker/uniter/remotestate/watcher.go
@@ -506,7 +506,7 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			return w.catacomb.ErrDying()
 
 		case _, ok := <-unitw.Changes():
-			w.logger.Debugf(ctx, "got unit change for %s", w.unit.Tag().Id())
+			w.logger.Debugf(ctx, "got unit state change for %s", w.unit.Tag().Id())
 			if !ok {
 				return errors.New("unit watcher closed")
 			}

--- a/internal/worker/uniter/remotestate/watcher.go
+++ b/internal/worker/uniter/remotestate/watcher.go
@@ -871,6 +871,9 @@ func (w *RemoteStateWatcher) secretDeletedRevisions(ctx context.Context, deleted
 
 func (w *RemoteStateWatcher) configHashChanged(value string) {
 	w.mu.Lock()
+	// Config and trust settings are delivered by the same watcher. Keep their
+	// snapshot values in lockstep while retaining both fields for state written
+	// by earlier uniters, where the hashes could differ.
 	w.current.ConfigHash = value
 	w.current.TrustHash = value
 	w.mu.Unlock()

--- a/internal/worker/uniter/remotestate/watcher.go
+++ b/internal/worker/uniter/remotestate/watcher.go
@@ -355,22 +355,12 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 
 	var requiredEvents int
 
-	var seenUnitChange bool
+	var seenUnitStateChange bool
 	unitw, err := w.unit.Watch(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if err := w.catacomb.Add(unitw); err != nil {
-		return errors.Trace(err)
-	}
-	requiredEvents++
-
-	var seenResolveModeChange bool
-	resolveModew, err := w.unit.WatchResolveMode(ctx)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err := w.catacomb.Add(resolveModew); err != nil {
 		return errors.Trace(err)
 	}
 	requiredEvents++
@@ -382,16 +372,6 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 	}
 
 	if err := w.catacomb.Add(charmConfigw); err != nil {
-		return errors.Trace(err)
-	}
-	requiredEvents++
-
-	var seenTrustConfigChange bool
-	trustConfigw, err := w.unit.WatchTrustConfigSettingsHash(ctx)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err := w.catacomb.Add(trustConfigw); err != nil {
 		return errors.Trace(err)
 	}
 	requiredEvents++
@@ -530,20 +510,10 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			if !ok {
 				return errors.New("unit watcher closed")
 			}
-			if err := w.unitChanged(ctx); err != nil {
+			if err := w.unitStateChanged(ctx); err != nil {
 				return errors.Trace(err)
 			}
-			observedEvent(&seenUnitChange)
-
-		case _, ok := <-resolveModew.Changes():
-			w.logger.Debugf(ctx, "got resolve mode change for %s", w.unit.Tag().Id())
-			if !ok {
-				return errors.New("resolve mode watcher closed")
-			}
-			if err := w.resolveModeChanged(ctx); err != nil {
-				return errors.Trace(err)
-			}
-			observedEvent(&seenResolveModeChange)
+			observedEvent(&seenUnitStateChange)
 
 		case _, ok := <-applicationw.Changes():
 			w.logger.Debugf(ctx, "got application change for %s", w.unit.Tag().Id())
@@ -575,17 +545,6 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 			}
 			w.configHashChanged(hashes[0])
 			observedEvent(&seenConfigChange)
-
-		case hashes, ok := <-trustConfigw.Changes():
-			w.logger.Debugf(ctx, "got trust config change for %s: ok=%t, hashes=%v", w.unit.Tag().Id(), ok, hashes)
-			if !ok {
-				return errors.New("trust config watcher closed")
-			}
-			if len(hashes) != 1 {
-				return errors.New("expected one hash in trust config change")
-			}
-			w.trustHashChanged(hashes[0])
-			observedEvent(&seenTrustConfigChange)
 
 		case hashes, ok := <-addressesChanges:
 			w.logger.Debugf(ctx, "got address change for %s: ok=%t, hashes=%v", w.unit.Tag().Id(), ok, hashes)
@@ -777,9 +736,13 @@ func (w *RemoteStateWatcher) retryHookTimerTriggered() {
 	w.mu.Unlock()
 }
 
-// unitChanged responds to changes in the unit.
-func (w *RemoteStateWatcher) unitChanged(ctx context.Context) error {
+// unitStateChanged responds to changes in the unit or its resolve mode.
+func (w *RemoteStateWatcher) unitStateChanged(ctx context.Context) error {
 	if err := w.unit.Refresh(ctx); err != nil {
+		return errors.Trace(err)
+	}
+	resolveMode, err := w.unit.Resolved(ctx)
+	if err != nil {
 		return errors.Trace(err)
 	}
 	w.mu.Lock()
@@ -788,16 +751,6 @@ func (w *RemoteStateWatcher) unitChanged(ctx context.Context) error {
 	// It's ok to sync provider ID by watching unit rather than
 	// cloud container because it will not change once pod created.
 	w.current.ProviderID = w.unit.ProviderID()
-	return nil
-}
-
-func (w *RemoteStateWatcher) resolveModeChanged(ctx context.Context) error {
-	resolveMode, err := w.unit.Resolved(ctx)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
 	w.current.ResolvedMode = resolveMode
 	return nil
 }
@@ -919,11 +872,6 @@ func (w *RemoteStateWatcher) secretDeletedRevisions(ctx context.Context, deleted
 func (w *RemoteStateWatcher) configHashChanged(value string) {
 	w.mu.Lock()
 	w.current.ConfigHash = value
-	w.mu.Unlock()
-}
-
-func (w *RemoteStateWatcher) trustHashChanged(value string) {
-	w.mu.Lock()
 	w.current.TrustHash = value
 	w.mu.Unlock()
 }

--- a/internal/worker/uniter/remotestate/watcher_test.go
+++ b/internal/worker/uniter/remotestate/watcher_test.go
@@ -97,14 +97,12 @@ func (s *WatcherSuite) SetUpTest(c *tc.C) {
 				curl:                 "ch:trusty/mysql",
 				charmModifiedVersion: 5,
 			},
-			unitWatcher:                      newMockNotifyWatcher(),
-			unitResolveWatcher:               newMockNotifyWatcher(),
-			addressesWatcher:                 newMockStringsWatcher(),
-			configSettingsWatcher:            newMockStringsWatcher(),
-			applicationConfigSettingsWatcher: newMockStringsWatcher(),
-			storageWatcher:                   newMockStringsWatcher(),
-			actionWatcher:                    newMockStringsWatcher(),
-			relationsWatcher:                 newMockStringsWatcher(),
+			unitWatcher:           newMockNotifyWatcher(),
+			addressesWatcher:      newMockStringsWatcher(),
+			configSettingsWatcher: newMockStringsWatcher(),
+			storageWatcher:        newMockStringsWatcher(),
+			actionWatcher:         newMockStringsWatcher(),
+			relationsWatcher:      newMockStringsWatcher(),
 		},
 		relations:                   make(map[names.RelationTag]*mockRelation),
 		storageAttachment:           make(map[params.StorageAttachmentId]params.StorageAttachment),
@@ -257,11 +255,9 @@ func (s *WatcherSuite) TestInitialSignal(c *tc.C) {
 	// There should not be a remote state change until
 	// we've seen all of the top-level notifications.
 	s.uniterClient.unit.unitWatcher.changes <- struct{}{}
-	s.uniterClient.unit.unitResolveWatcher.changes <- struct{}{}
 	assertNoNotifyEvent(c, s.watcher.RemoteStateChanged(), "remote state change")
 	s.uniterClient.unit.addressesWatcher.changes <- []string{"addresseshash"}
 	s.uniterClient.unit.configSettingsWatcher.changes <- []string{"confighash"}
-	s.uniterClient.unit.applicationConfigSettingsWatcher.changes <- []string{"trusthash"}
 	s.uniterClient.unit.storageWatcher.changes <- []string{}
 	s.uniterClient.unit.actionWatcher.changes <- []string{}
 	if s.uniterClient.unit.application.applicationWatcher != nil {
@@ -278,9 +274,7 @@ func (s *WatcherSuite) TestInitialSignal(c *tc.C) {
 
 func (s *WatcherSuite) signalAll() {
 	s.uniterClient.unit.unitWatcher.changes <- struct{}{}
-	s.uniterClient.unit.unitResolveWatcher.changes <- struct{}{}
 	s.uniterClient.unit.configSettingsWatcher.changes <- []string{"confighash"}
-	s.uniterClient.unit.applicationConfigSettingsWatcher.changes <- []string{"trusthash"}
 	s.uniterClient.unit.actionWatcher.changes <- []string{}
 	s.uniterClient.unit.relationsWatcher.changes <- []string{}
 	s.uniterClient.unit.addressesWatcher.changes <- []string{"addresseshash"}
@@ -306,7 +300,7 @@ func (s *WatcherSuite) TestSnapshot(c *tc.C) {
 		ForceCharmUpgrade:       s.uniterClient.unit.application.forceUpgrade,
 		ResolvedMode:            s.uniterClient.unit.resolved,
 		ConfigHash:              "confighash",
-		TrustHash:               "trusthash",
+		TrustHash:               "confighash",
 		AddressesHash:           "addresseshash",
 		Leader:                  true,
 		ConsumedSecretInfo:      map[string]secrets.SecretRevisionInfo{},
@@ -330,7 +324,7 @@ func (s *WatcherSuiteSidecar) TestSnapshot(c *tc.C) {
 		ForceCharmUpgrade:       s.uniterClient.unit.application.forceUpgrade,
 		ResolvedMode:            s.uniterClient.unit.resolved,
 		ConfigHash:              "confighash",
-		TrustHash:               "trusthash",
+		TrustHash:               "confighash",
 		AddressesHash:           "addresseshash",
 		Leader:                  true,
 		ConsumedSecretInfo:      map[string]secrets.SecretRevisionInfo{},
@@ -349,14 +343,13 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *tc.C) {
 	assertOneChange()
 
 	s.uniterClient.unit.life = life.Dying
+	s.uniterClient.unit.providerID = "provider-id"
+	s.uniterClient.unit.resolved = params.ResolvedRetryHooks
 	s.uniterClient.unit.unitWatcher.changes <- struct{}{}
 	assertOneChange()
-	c.Assert(s.watcher.Snapshot().Life, tc.Equals, life.Dying)
-
-	s.uniterClient.unit.resolved = params.ResolvedRetryHooks
-	s.uniterClient.unit.unitResolveWatcher.changes <- struct{}{}
-	assertOneChange()
-	c.Assert(s.watcher.Snapshot().ResolvedMode, tc.Equals, params.ResolvedRetryHooks)
+	c.Check(s.watcher.Snapshot().Life, tc.Equals, life.Dying)
+	c.Check(s.watcher.Snapshot().ProviderID, tc.Equals, "provider-id")
+	c.Check(s.watcher.Snapshot().ResolvedMode, tc.Equals, params.ResolvedRetryHooks)
 
 	s.uniterClient.unit.addressesWatcher.changes <- []string{"addresseshash2"}
 	assertOneChange()
@@ -408,10 +401,7 @@ func (s *WatcherSuite) TestRemoteStateChanged(c *tc.C) {
 	s.uniterClient.unit.configSettingsWatcher.changes <- []string{"confighash2"}
 	assertOneChange()
 	c.Assert(s.watcher.Snapshot().ConfigHash, tc.Equals, "confighash2")
-
-	s.uniterClient.unit.applicationConfigSettingsWatcher.changes <- []string{"trusthash2"}
-	assertOneChange()
-	c.Assert(s.watcher.Snapshot().TrustHash, tc.Equals, "trusthash2")
+	c.Assert(s.watcher.Snapshot().TrustHash, tc.Equals, "confighash2")
 
 	s.uniterClient.unit.relationsWatcher.changes <- []string{}
 	assertOneChange()
@@ -928,14 +918,13 @@ func (s *WatcherSuiteSidecarCharmModVer) TestRemoteStateChanged(c *tc.C) {
 	assertOneChange()
 
 	s.uniterClient.unit.life = life.Dying
+	s.uniterClient.unit.providerID = "provider-id"
+	s.uniterClient.unit.resolved = params.ResolvedRetryHooks
 	s.uniterClient.unit.unitWatcher.changes <- struct{}{}
 	assertOneChange()
-	c.Assert(s.watcher.Snapshot().Life, tc.Equals, life.Dying)
-
-	s.uniterClient.unit.resolved = params.ResolvedRetryHooks
-	s.uniterClient.unit.unitResolveWatcher.changes <- struct{}{}
-	assertOneChange()
-	c.Assert(s.watcher.Snapshot().ResolvedMode, tc.Equals, params.ResolvedRetryHooks)
+	c.Check(s.watcher.Snapshot().Life, tc.Equals, life.Dying)
+	c.Check(s.watcher.Snapshot().ProviderID, tc.Equals, "provider-id")
+	c.Check(s.watcher.Snapshot().ResolvedMode, tc.Equals, params.ResolvedRetryHooks)
 
 	s.uniterClient.unit.addressesWatcher.changes <- []string{"addresseshash2"}
 	assertOneChange()
@@ -947,6 +936,7 @@ func (s *WatcherSuiteSidecarCharmModVer) TestRemoteStateChanged(c *tc.C) {
 	s.uniterClient.unit.configSettingsWatcher.changes <- []string{"confighash2"}
 	assertOneChange()
 	c.Assert(s.watcher.Snapshot().ConfigHash, tc.Equals, "confighash2")
+	c.Assert(s.watcher.Snapshot().TrustHash, tc.Equals, "confighash2")
 
 	rotateWatcher := remotestate.SecretRotateWatcher(s.watcher).(*mockSecretTriggerWatcher)
 	secretURIs := []string{"secret:999e2mr0ui3e8a215n4g", "secret:9m4e2mr0ui3e8a215n4g", "secret:8b4e2mr1wi3e8a215n5h"}
@@ -988,10 +978,6 @@ func (s *WatcherSuiteSidecarCharmModVer) TestRemoteStateChanged(c *tc.C) {
 		"secret:999e2mr0ui3e8a215n4g": {},
 	})
 
-	s.uniterClient.unit.applicationConfigSettingsWatcher.changes <- []string{"trusthash2"}
-	assertOneChange()
-	c.Assert(s.watcher.Snapshot().TrustHash, tc.Equals, "trusthash2")
-
 	s.uniterClient.unit.relationsWatcher.changes <- []string{}
 	assertOneChange()
 
@@ -1024,7 +1010,7 @@ func (s *WatcherSuiteSidecarCharmModVer) TestSnapshot(c *tc.C) {
 		ForceCharmUpgrade:       false,
 		ResolvedMode:            s.uniterClient.unit.resolved,
 		ConfigHash:              "confighash",
-		TrustHash:               "trusthash",
+		TrustHash:               "confighash",
 		AddressesHash:           "addresseshash",
 		Leader:                  true,
 		ConsumedSecretInfo:      map[string]secrets.SecretRevisionInfo{},

--- a/internal/worker/uniter/resolver.go
+++ b/internal/worker/uniter/resolver.go
@@ -372,6 +372,8 @@ func (s *uniterResolver) nextOp(
 	}
 
 	configHashChanged := localState.ConfigHash != remoteState.ConfigHash
+	// New remote states keep this in lockstep with ConfigHash. Retain the
+	// separate check to detect trust hashes persisted by earlier uniters.
 	trustHashChanged := localState.TrustHash != remoteState.TrustHash
 	addressesHashChanged := localState.AddressesHash != remoteState.AddressesHash
 	if configHashChanged || trustHashChanged || addressesHashChanged {

--- a/internal/worker/uniter/uniter_test.go
+++ b/internal/worker/uniter/uniter_test.go
@@ -119,7 +119,6 @@ func (s *UniterSuite) newContext(c tc.LikeC) (*testContext, *gomock.Controller) 
 
 	// Initialise the channels used for the watchers.
 	// Some need a buffer to allow the test steps to run.
-	ctx.unitResolveCh = make(chan struct{}, 1)
 	ctx.configCh = make(chan []string, 5)
 	ctx.relCh = make(chan []string, 5)
 	ctx.storageCh = make(chan []string, 5)

--- a/internal/worker/uniter/util_test.go
+++ b/internal/worker/uniter/util_test.go
@@ -96,10 +96,9 @@ type testContext struct {
 	// Remote watcher artefacts.
 	startError           bool
 	sendEvents           bool
-	channelMu            sync.Mutex // protects unitResolveCh and applicationCh
+	channelMu            sync.Mutex // protects applicationCh
 	unitWatchCounter     atomic.Int32
 	unitCh               sync.Map
-	unitResolveCh        chan struct{}
 	configCh             chan []string
 	relCh                chan []string
 	consumedSecretsCh    chan []string
@@ -730,20 +729,6 @@ func (s *startUniter) expectRemoteStateWatchers(c tc.LikeC, ctx *testContext) {
 		return watchertest.NewMockNotifyWatcher(ch), nil
 	}).AnyTimes().After(s.stepped)
 
-	ctx.unit.EXPECT().WatchResolveMode(gomock.Any()).DoAndReturn(func(context.Context) (watcher.NotifyWatcher, error) {
-		// Close the old channel and open a new one so the RSW always
-		// starts with a clean, empty channel. All senders obtain the
-		// lock before reading ctx.unitResolveCh so they will pick up
-		// the new channel on their next call.
-		ctx.channelMu.Lock()
-		ctx.unitResolveCh = make(chan struct{}, 1)
-		ch := ctx.unitResolveCh
-		ctx.channelMu.Unlock()
-		// Fresh channel: this blocking send always succeeds immediately.
-		ch <- struct{}{}
-		return watchertest.NewMockNotifyWatcher(ch), nil
-	}).AnyTimes().After(s.stepped)
-
 	ctx.api.EXPECT().WatchUpdateStatusHookInterval(gomock.Any()).DoAndReturn(func(context.Context) (watcher.NotifyWatcher, error) {
 		ch := make(chan struct{}, 1)
 		ch <- struct{}{}
@@ -754,13 +739,6 @@ func (s *startUniter) expectRemoteStateWatchers(c tc.LikeC, ctx *testContext) {
 	ctx.unit.EXPECT().WatchConfigSettingsHash(gomock.Any()).DoAndReturn(func(context.Context) (watcher.StringsWatcher, error) {
 		ctx.sendStrings(c, ctx.configCh, "initial config event", ctx.app.configHash(nil))
 		w := watchertest.NewMockStringsWatcher(ctx.configCh)
-		return w, nil
-	}).AnyTimes().After(s.stepped)
-
-	ctx.unit.EXPECT().WatchTrustConfigSettingsHash(gomock.Any()).DoAndReturn(func(context.Context) (watcher.StringsWatcher, error) {
-		ch := make(chan []string, 1)
-		ch <- []string{"trust-hash"}
-		w := watchertest.NewMockStringsWatcher(ch)
 		return w, nil
 	}).AnyTimes().After(s.stepped)
 
@@ -1050,9 +1028,9 @@ func (s *startUniter) step(c tc.LikeC, ctx *testContext) {
 	}
 
 	// Drain stale events from shared channels before starting the uniter.
-	// The Watch and WatchResolveMode callbacks replace these channels on
-	// every RSW start, but during a stopUniter/startUniter sequence there
-	// may be a leftover event on the current channel.
+	// The Watch callback replaces its channels on every RSW start, but during
+	// a stopUniter/startUniter sequence there may be a leftover event on the
+	// current channel.
 	drainNotify := func(ch chan struct{}) {
 		for {
 			select {
@@ -1063,10 +1041,8 @@ func (s *startUniter) step(c tc.LikeC, ctx *testContext) {
 		}
 	}
 	ctx.channelMu.Lock()
-	unitResolveCh := ctx.unitResolveCh
 	applicationCh := ctx.applicationCh
 	ctx.channelMu.Unlock()
-	drainNotify(unitResolveCh)
 	drainNotify(applicationCh)
 	ctx.sendEvents = true
 
@@ -1453,10 +1429,7 @@ func (s *resolveError) step(c tc.LikeC, ctx *testContext) {
 	ctx.unit.mu.Lock()
 	ctx.unit.resolved = s.resolved
 	ctx.unit.mu.Unlock()
-	ctx.channelMu.Lock()
-	ch := ctx.unitResolveCh
-	ctx.channelMu.Unlock()
-	ctx.sendNotify(c, ch, "resolved event")
+	ctx.sendUnitNotify(c, "resolved event")
 }
 
 type statusfunc func() (status.StatusInfo, error)

--- a/internal/worker/uniter/util_test.go
+++ b/internal/worker/uniter/util_test.go
@@ -715,6 +715,12 @@ func (s *startUniter) expectRemoteStateWatchers(c tc.LikeC, ctx *testContext) {
 		}, nil
 	}).AnyTimes().After(s.stepped)
 
+	ctx.unit.EXPECT().ResolvedMode().DoAndReturn(func() params.ResolvedMode {
+		ctx.unit.mu.Lock()
+		defer ctx.unit.mu.Unlock()
+		return ctx.unit.resolved
+	}).AnyTimes().After(s.stepped)
+
 	ctx.app.EXPECT().Watch(gomock.Any()).DoAndReturn(func(context.Context) (watcher.NotifyWatcher, error) {
 		// Close the old channel and open a new one so the RSW always
 		// starts with a clean, empty channel. All senders obtain the


### PR DESCRIPTION
Reduce remote-state’s fixed server subscriptions from 11 to 9 (and steady-state from `15 + relations + storage` to `13 + relations + storage`) without changing facade wire contracts or dynamic relation/storage handling.

How?

  - Use the existing unit `Watch` stream as the combined unit-life and resolve-mode trigger; it already subscribes to `unit`, `unit_principal`, and `unit_resolved`.
    - On each notification, refresh both `Life`/`ProviderID` and `ResolvedMode`.
    - Replace the two initial-readiness flags with one combined unit-state flag and remove the separate resolve-mode watcher from the internal `api.Unit` dependency.

  - Remove remote-state’s separate trust-hash subscription.
    - The `WatchConfigSettingsHash` and `WatchTrustConfigSettingsHash` facade methods both delegate to `WatchApplicationConfigHash`; consume only the former.
    - Update both `Snapshot.ConfigHash` and `Snapshot.TrustHash` from that single emitted hash.
    - Retain the existing trust-hash client and server API methods for compatibility; they simply cease to be used by remote-state.

  - Preserve all existing relation, storage, secret, action, application, address, model-config, leadership, timer, and local-channel behavior.


## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model foo
$ juju deploy ubuntu
```

```sh
$ juju bootstrap microk8s test
$ juju add-model foo
$ juju deploy prometheus-k8s
```
