### PR TITLE
test(storage_k8s): harden k8s filesystem import integration tests

### DIFF
--- a/tests/includes/k8s.sh
+++ b/tests/includes/k8s.sh
@@ -58,6 +58,75 @@ wait_for_namespace_gone() {
 	echo "[+] $(green 'Namespace removed:') $(green "${name}")"
 }
 
+# wait_for_pvc_present polls until the given PVC is visible in the cluster.
+# It fails the test if the PVC is not present after the timeout (an integer
+# number of seconds). PVC finalizer-driven creation can take a few seconds
+# after `kubectl create` returns.
+#
+# ```
+# wait_for_pvc_present <name> <namespace> [<timeout>]
+# ```
+wait_for_pvc_present() {
+	local name namespace timeout
+
+	name=${1}
+	namespace=${2}
+	timeout=${3:-60} # default timeout: 60s
+
+	attempt=0
+	start_time="$(date -u +%s)"
+	until kubectl get pvc "${name}" -n "${namespace}" >/dev/null 2>&1; do
+		echo "[+] (attempt ${attempt}) polling for PVC ${namespace}/${name} to appear"
+		sleep "${SHORT_TIMEOUT}"
+
+		elapsed=$(date -u +%s)-$start_time
+		if [[ ${elapsed} -ge ${timeout} ]]; then
+			echo "[-] $(red 'timed out waiting for PVC') $(red "${namespace}/${name}") $(red 'to appear')"
+			kubectl get pvc "${name}" -n "${namespace}" 2>&1 | sed 's/^/    | /g'
+			exit 1
+		fi
+
+		attempt=$((attempt + 1))
+	done
+
+	echo "[+] $(green 'PVC present:') $(green "${namespace}/${name}")"
+}
+
+# wait_for_pvc_absent polls until the given PVC has been removed from the
+# cluster. It fails the test if the PVC is still present after the timeout
+# (an integer number of seconds). PVC deletion is asynchronous in Kubernetes
+# (the controller must clear finalizers before the object disappears), so an
+# immediate `kubectl get pvc` check is racy.
+#
+# ```
+# wait_for_pvc_absent <name> <namespace> [<timeout>]
+# ```
+wait_for_pvc_absent() {
+	local name namespace timeout
+
+	name=${1}
+	namespace=${2}
+	timeout=${3:-180} # default timeout: 180s = 3m
+
+	attempt=0
+	start_time="$(date -u +%s)"
+	while kubectl get pvc "${name}" -n "${namespace}" >/dev/null 2>&1; do
+		echo "[+] (attempt ${attempt}) polling for PVC ${namespace}/${name} to be removed"
+		sleep "${SHORT_TIMEOUT}"
+
+		elapsed=$(date -u +%s)-$start_time
+		if [[ ${elapsed} -ge ${timeout} ]]; then
+			echo "[-] $(red 'timed out waiting for PVC') $(red "${namespace}/${name}") $(red 'to be removed')"
+			kubectl get pvc "${name}" -n "${namespace}" 2>&1 | sed 's/^/    | /g'
+			exit 1
+		fi
+
+		attempt=$((attempt + 1))
+	done
+
+	echo "[+] $(green 'PVC removed:') $(green "${namespace}/${name}")"
+}
+
 default_k8s() {
 	if command -v minikube >/dev/null 2>&1 && [[ "Stopped" != "$(minikube status -o json | yq .APIServer)" ]]; then
 		printf "minikube"

--- a/tests/suites/storage_k8s/import.sh
+++ b/tests/suites/storage_k8s/import.sh
@@ -148,10 +148,16 @@ EOF
 	wait_for_storage "detached" '.storage["data/1"]["status"].current'
 
 	# Force-import must have removed the PVC and cleared the claimRef.
-	if kubectl get pvc "${PVC}" -n "${model_name}" >/dev/null 2>&1; then
-		echo "ERROR: import --force did not delete PVC ${PVC}"
-		exit 1
-	fi
+	# PVC deletion is asynchronous in Kubernetes; poll for it to disappear.
+	attempt=0
+	while kubectl get pvc "${PVC}" -n "${model_name}" >/dev/null 2>&1; do
+		sleep "${SHORT_TIMEOUT}"
+		attempt=$((attempt + 1))
+		if [[ ${attempt} -gt 30 ]]; then
+			echo "ERROR: import --force did not delete PVC ${PVC}"
+			exit 1
+		fi
+	done
 	CLAIMREF=$(kubectl get pv "${PV}" -o jsonpath='{.spec.claimRef.name}')
 	echo "${CLAIMREF}" | check ""
 	RECLAIM_POLICY=$(kubectl get pv "${PV}" -o jsonpath='{.spec.persistentVolumeReclaimPolicy}')
@@ -206,7 +212,7 @@ test_destroy_model_with_detached_storage() {
 
 	# 1. destroy-model without flags should fail with persistent
 	#    storage error.
-	juju destroy-model "${model_name}" --no-prompt 2>&1 | check "has persistent storage"
+	check "has persistent storage" <<<"$(juju destroy-model "${model_name}" --no-prompt 2>&1 || true)"
 
 	# 2. destroy-model with --destroy-storage should succeed and
 	#    remove the PV.

--- a/tests/suites/storage_k8s/import.sh
+++ b/tests/suites/storage_k8s/import.sh
@@ -123,15 +123,7 @@ spec:
 EOF
 
 		# Wait for the PVC to materialise so we can capture its UID.
-		attempt=0
-		until kubectl get pvc "${NEW_PVC_NAME}" -n "${model_name}" >/dev/null 2>&1; do
-			sleep "${SHORT_TIMEOUT}"
-			attempt=$((attempt + 1))
-			if [[ ${attempt} -gt 10 ]]; then
-				echo "ERROR: synthetic PVC ${NEW_PVC_NAME} not created"
-				exit 1
-			fi
-		done
+		wait_for_pvc_present "${NEW_PVC_NAME}" "${model_name}"
 		NEW_PVC_UID=$(kubectl get pvc "${NEW_PVC_NAME}" -n "${model_name}" -o jsonpath='{.metadata.uid}')
 		kubectl patch pv "${PV}" --type merge -p "$(cat <<EOF
 {"spec":{"claimRef":{"namespace":"${model_name}","name":"${NEW_PVC_NAME}","uid":"${NEW_PVC_UID}"}}}
@@ -148,16 +140,9 @@ EOF
 	wait_for_storage "detached" '.storage["data/1"]["status"].current'
 
 	# Force-import must have removed the PVC and cleared the claimRef.
-	# PVC deletion is asynchronous in Kubernetes; poll for it to disappear.
-	attempt=0
-	while kubectl get pvc "${PVC}" -n "${model_name}" >/dev/null 2>&1; do
-		sleep "${SHORT_TIMEOUT}"
-		attempt=$((attempt + 1))
-		if [[ ${attempt} -gt 30 ]]; then
-			echo "ERROR: import --force did not delete PVC ${PVC}"
-			exit 1
-		fi
-	done
+	# PVC deletion is asynchronous in Kubernetes; wait_for_pvc_absent polls
+	# for it to disappear (default 180 s timeout).
+	wait_for_pvc_absent "${PVC}" "${model_name}" 180
 	CLAIMREF=$(kubectl get pv "${PV}" -o jsonpath='{.spec.claimRef.name}')
 	echo "${CLAIMREF}" | check ""
 	RECLAIM_POLICY=$(kubectl get pv "${PV}" -o jsonpath='{.spec.persistentVolumeReclaimPolicy}')


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.
-->

## Description

This PR fixes two integration test issues in `tests/suites/storage_k8s/import.sh`:

1. **`test_destroy_model_with_detached_storage`**: The harness sets `set -eu` + `set -o pipefail` (via `set_verbosity`). The pipeline `juju destroy-model ... 2>&1 | check "has persistent storage"` aborted under errexit because destroy-model correctly exited with status 1 on refusal, propagating through `pipefail` even though `check` matched. Fixed by adopting the standard `check "..." <<<"$(... || true)"` pattern used elsewhere in the suite for expected non-zero exits.
2. **`test_force_import_filesystem`**: Kubernetes PVC deletion is asynchronous. The immediate `if kubectl get pvc ...` assertion occasionally failed with `ERROR: import --force did not delete PVC` when the PVC was still in the terminating state. Fixed by polling for PVC deletion with a bounded timeout (`SHORT_TIMEOUT` × 30).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~~Go unit tests covering the bug filter or core logic~~
- [x] Integration tests, with comments describing the import scenarios
- [ ] ~~doc.go added or updated in changed packages~~

## QA steps

Run integration test suite:
```sh
./main.sh storage_k8s test_destroy_model_with_detached_storage
./main.sh storage_k8s test_force_import_filesystem
```