### PR TITLE
refactor(keymanager): allow key manager methods for K8s models

### DIFF
--- a/apiserver/restrict_caasmodel.go
+++ b/apiserver/restrict_caasmodel.go
@@ -32,6 +32,7 @@ var commonModelFacadeNames = set.NewStrings(
 	"CrossModelRelations",
 	"CrossModelSecrets",
 	"FilesystemAttachmentsWatcher",
+	"KeyManager",
 	"LeadershipService",
 	"LifeFlag",
 	"Logger",

--- a/apiserver/restrict_caasmodel_test.go
+++ b/apiserver/restrict_caasmodel_test.go
@@ -37,6 +37,12 @@ func (s *RestrictCAASModelSuite) TestSubnetsAllowed(c *tc.C) {
 	s.assertMethod(c, "Subnets", 5, "ListSubnets")
 }
 
+func (s *RestrictCAASModelSuite) TestKeyManagerAllowed(c *tc.C) {
+	for _, method := range []string{"ListKeys", "AddKeys", "ImportKeys", "DeleteKeys"} {
+		s.assertMethod(c, "KeyManager", 1, method)
+	}
+}
+
 func (s *RestrictCAASModelSuite) TestSpacesReloadAllowed(c *tc.C) {
 	s.assertMethod(c, "Spaces", 6, "ReloadSpaces")
 }

--- a/cmd/juju/sshkeys/sshkeys.go
+++ b/cmd/juju/sshkeys/sshkeys.go
@@ -15,7 +15,6 @@ import (
 
 type SSHKeysBase struct {
 	modelcmd.ModelCommandBase
-	modelcmd.IAASOnlyCommand
 
 	apiRoot base.APICallCloser
 }


### PR DESCRIPTION
This change allows the key-manager related methods - `juju add-ssh-key`, `juju list-ssh-keys`, `juju import-ssh-key` and `juju remove-ssh-key` to work on Kubernetes models. With the new SSH-proxy work, the client no longer uses a K8s client to exec/debug pods and instead connects to the controller's SSH server. So while previously it made no sense to add SSH keys to K8s models (because the keys were not synced anywhere as they are on machine models), they are now necessary. 

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. make install
2. make microk8s-operator-update
3. juju bootstrap microk8s test-keys
4. juju switch controller
5. juju list-ssh-keys

Previously returned an error `ERROR Juju command "ssh-keys" not supported on container models`, now works.