### PR TITLE
feat: prevent controller app scale to zero

### DIFF
--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -998,6 +998,15 @@ func (s *Service) SetApplicationScale(ctx context.Context, appName string, scale
 	if err != nil {
 		return errors.Capture(err)
 	}
+	if scale == 0 {
+		isController, err := s.st.IsControllerApplication(ctx, appUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		if isController {
+			return errors.Errorf("cannot scale controller application to 0 units")
+		}
+	}
 	appScale, err := s.st.GetApplicationScaleState(ctx, appUUID)
 	if err != nil {
 		return errors.Errorf("getting application scale state for app %q: %w", appUUID, err)
@@ -1056,6 +1065,23 @@ func (s *Service) ChangeApplicationScale(ctx context.Context, appName string, sc
 	appUUID, err := s.st.GetApplicationUUIDByName(ctx, appName)
 	if err != nil {
 		return -1, errors.Capture(err)
+	}
+
+	if scaleChange < 0 {
+		scaleState, err := s.st.GetApplicationScaleState(ctx, appUUID)
+		if err != nil {
+			return -1, errors.Capture(err)
+		}
+		newScale := scaleState.Scale + scaleChange
+		if newScale <= 0 {
+			isController, err := s.st.IsControllerApplication(ctx, appUUID)
+			if err != nil {
+				return -1, errors.Capture(err)
+			}
+			if isController {
+				return -1, errors.Errorf("cannot scale controller application to 0 units")
+			}
+		}
 	}
 
 	newScale, err := s.st.UpdateApplicationScale(ctx, appUUID, scaleChange)

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -163,7 +163,7 @@ type ApplicationState interface {
 	// delta.
 	// If the resulting scale is less than zero, an error satisfying
 	// [applicationerrors.ScaleChangeInvalid] is returned.
-	UpdateApplicationScale(ctx context.Context, appUUID coreapplication.UUID, delta int) (int, error)
+	UpdateApplicationScale(ctx context.Context, appUUID coreapplication.UUID, currentScale, delta int) (int, error)
 
 	// GetCharmByApplicationUUID returns the charm, charm origin and charm
 	// platform for the specified application UUID.
@@ -987,6 +987,7 @@ func (s *Service) IsSubordinateApplicationByName(ctx context.Context, appName st
 // SetApplicationScale sets the application's desired scale value,
 // The following errors may be returned:
 // - [applicationerrors.ApplicationNotFound] if the application doesn't exist
+// - an error if attempting to scale a controller application to 0 units
 func (s *Service) SetApplicationScale(ctx context.Context, appName string, scale int) error {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
 	defer span.End()
@@ -1055,8 +1056,9 @@ func (s *Service) ShouldAllowCharmUpgradeOnError(ctx context.Context, appName st
 }
 
 // ChangeApplicationScale alters the existing scale by the provided change amount, returning the new amount.
-// It returns an error satisfying [applicationerrors.ApplicationNotFound] if the application
-// doesn't exist.
+// It returns an error satisfying [applicationerrors.ApplicationNotFound] if the
+// application doesn't exist, or an error if attempting to scale a controller
+// application to 0 units.
 // This is used on CAAS models.
 func (s *Service) ChangeApplicationScale(ctx context.Context, appName string, scaleChange int) (int, error) {
 	ctx, span := trace.Start(ctx, trace.NameFromFunc())
@@ -1067,11 +1069,11 @@ func (s *Service) ChangeApplicationScale(ctx context.Context, appName string, sc
 		return -1, errors.Capture(err)
 	}
 
+	scaleState, err := s.st.GetApplicationScaleState(ctx, appUUID)
+	if err != nil {
+		return -1, errors.Capture(err)
+	}
 	if scaleChange < 0 {
-		scaleState, err := s.st.GetApplicationScaleState(ctx, appUUID)
-		if err != nil {
-			return -1, errors.Capture(err)
-		}
 		newScale := scaleState.Scale + scaleChange
 		if newScale <= 0 {
 			isController, err := s.st.IsControllerApplication(ctx, appUUID)
@@ -1084,7 +1086,7 @@ func (s *Service) ChangeApplicationScale(ctx context.Context, appName string, sc
 		}
 	}
 
-	newScale, err := s.st.UpdateApplicationScale(ctx, appUUID, scaleChange)
+	newScale, err := s.st.UpdateApplicationScale(ctx, appUUID, scaleState.Scale, scaleChange)
 	if err != nil {
 		return -1, errors.Errorf("changing scaling state for %q: %w", appName, err)
 	}

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -1297,6 +1297,106 @@ func (s *applicationServiceSuite) TestIsControllerApplication(c *tc.C) {
 	c.Check(isController, tc.IsTrue)
 }
 
+func (s *applicationServiceSuite) TestSetApplicationScaleNonController(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 2}, nil)
+	s.state.EXPECT().SetDesiredApplicationScale(gomock.Any(), appUUID, 3).Return(nil)
+
+	err := s.service.SetApplicationScale(c.Context(), "foo", 3)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *applicationServiceSuite) TestSetApplicationScaleControllerToZero(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().IsControllerApplication(gomock.Any(), appUUID).Return(true, nil)
+
+	err := s.service.SetApplicationScale(c.Context(), "foo", 0)
+	c.Assert(err, tc.ErrorMatches, "cannot scale controller application to 0 units")
+}
+
+func (s *applicationServiceSuite) TestSetApplicationScaleNonControllerToZero(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().IsControllerApplication(gomock.Any(), appUUID).Return(false, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 1}, nil)
+	s.state.EXPECT().SetDesiredApplicationScale(gomock.Any(), appUUID, 0).Return(nil)
+
+	err := s.service.SetApplicationScale(c.Context(), "foo", 0)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *applicationServiceSuite) TestSetApplicationScaleNegative(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	err := s.service.SetApplicationScale(c.Context(), "foo", -1)
+	c.Assert(err, tc.ErrorMatches, "application scale -1 not valid")
+	c.Assert(err, tc.ErrorIs, applicationerrors.ScaleChangeInvalid)
+}
+
+func (s *applicationServiceSuite) TestChangeApplicationScaleUp(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().UpdateApplicationScale(gomock.Any(), appUUID, 2).Return(5, nil)
+
+	newScale, err := s.service.ChangeApplicationScale(c.Context(), "foo", 2)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(newScale, tc.Equals, 5)
+}
+
+func (s *applicationServiceSuite) TestChangeApplicationScaleDownNonController(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 3}, nil)
+	s.state.EXPECT().UpdateApplicationScale(gomock.Any(), appUUID, -1).Return(2, nil)
+
+	newScale, err := s.service.ChangeApplicationScale(c.Context(), "foo", -1)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(newScale, tc.Equals, 2)
+}
+
+func (s *applicationServiceSuite) TestChangeApplicationScaleDownControllerToZero(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 1}, nil)
+	s.state.EXPECT().IsControllerApplication(gomock.Any(), appUUID).Return(true, nil)
+
+	_, err := s.service.ChangeApplicationScale(c.Context(), "foo", -1)
+	c.Assert(err, tc.ErrorMatches, "cannot scale controller application to 0 units")
+}
+
+func (s *applicationServiceSuite) TestChangeApplicationScaleDownControllerBelowZero(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	appUUID := tc.Must(c, coreapplication.NewUUID)
+
+	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 1}, nil)
+	s.state.EXPECT().IsControllerApplication(gomock.Any(), appUUID).Return(true, nil)
+
+	_, err := s.service.ChangeApplicationScale(c.Context(), "foo", -2)
+	c.Assert(err, tc.ErrorMatches, "cannot scale controller application to 0 units")
+}
+
 func (s *applicationWatcherServiceSuite) TestGetMachinesForApplication(c *tc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -1350,7 +1350,8 @@ func (s *applicationServiceSuite) TestChangeApplicationScaleUp(c *tc.C) {
 	appUUID := tc.Must(c, coreapplication.NewUUID)
 
 	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
-	s.state.EXPECT().UpdateApplicationScale(gomock.Any(), appUUID, 2).Return(5, nil)
+	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 3}, nil)
+	s.state.EXPECT().UpdateApplicationScale(gomock.Any(), appUUID, 3, 2).Return(5, nil)
 
 	newScale, err := s.service.ChangeApplicationScale(c.Context(), "foo", 2)
 	c.Assert(err, tc.ErrorIsNil)
@@ -1364,7 +1365,7 @@ func (s *applicationServiceSuite) TestChangeApplicationScaleDownNonController(c 
 
 	s.state.EXPECT().GetApplicationUUIDByName(gomock.Any(), "foo").Return(appUUID, nil)
 	s.state.EXPECT().GetApplicationScaleState(gomock.Any(), appUUID).Return(application.ScaleState{Scale: 3}, nil)
-	s.state.EXPECT().UpdateApplicationScale(gomock.Any(), appUUID, -1).Return(2, nil)
+	s.state.EXPECT().UpdateApplicationScale(gomock.Any(), appUUID, 3, -1).Return(2, nil)
 
 	newScale, err := s.service.ChangeApplicationScale(c.Context(), "foo", -1)
 	c.Assert(err, tc.ErrorIsNil)

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -504,7 +504,7 @@ type MockStateMockRecorder struct {
 	unsetApplicationConfigKeysExpects                         []*gomock.Call3_1[context.Context, application.UUID, []string, error]
 	unsetExposeSettingsExpects                                []*gomock.Call3_1[context.Context, application.UUID, set.Strings, error]
 	updateApplicationConfigAndSettingsExpects                 []*gomock.Call4_1[context.Context, application.UUID, map[string]application0.AddApplicationConfig, application0.UpdateApplicationSettingsArg, error]
-	updateApplicationScaleExpects                             []*gomock.Call3_2[context.Context, application.UUID, int, int, error]
+	updateApplicationScaleExpects                             []*gomock.Call4_2[context.Context, application.UUID, int, int, int, error]
 	updateCAASUnitExpects                                     []*gomock.Call3_1[context.Context, unit.Name, application0.UpdateCAASUnitParams, error]
 	updateUnitCharmExpects                                    []*gomock.Call2_1[context.Context, internal.UpdateUnitCharmArg, error]
 	upsertK8sServiceExpects                                   []*gomock.Call4_1[context.Context, string, string, network.ProviderAddresses, error]
@@ -3030,22 +3030,22 @@ func (mr *MockStateMockRecorder) UpdateApplicationConfigAndSettings(ctx, appUUID
 type MockStateUpdateApplicationConfigAndSettingsCall = gomock.Call4_1[context.Context, application.UUID, map[string]application0.AddApplicationConfig, application0.UpdateApplicationSettingsArg, error]
 
 // UpdateApplicationScale mocks base method.
-func (m *MockState) UpdateApplicationScale(ctx context.Context, appUUID application.UUID, delta int) (int, error) {
+func (m *MockState) UpdateApplicationScale(ctx context.Context, appUUID application.UUID, currentScale, delta int) (int, error) {
 	m.ctrl.T.Helper()
-	return gomock.Dispatch3_2(&m.recorder.updateApplicationScaleExpects, m.ctrl, m, "UpdateApplicationScale", ctx, appUUID, delta)
+	return gomock.Dispatch4_2(&m.recorder.updateApplicationScaleExpects, m.ctrl, m, "UpdateApplicationScale", ctx, appUUID, currentScale, delta)
 }
 
 // UpdateApplicationScale indicates an expected call of UpdateApplicationScale.
-func (mr *MockStateMockRecorder) UpdateApplicationScale(ctx, appUUID, delta any) *MockStateUpdateApplicationScaleCall {
+func (mr *MockStateMockRecorder) UpdateApplicationScale(ctx, appUUID, currentScale, delta any) *MockStateUpdateApplicationScaleCall {
 	mr.mock.ctrl.T.Helper()
-	call := gomock.NewCall3_2[context.Context, application.UUID, int, int, error](mr.mock.ctrl.T, mr.mock, "UpdateApplicationScale", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(appUUID), gomock.EnsureMatcher(delta))
+	call := gomock.NewCall4_2[context.Context, application.UUID, int, int, int, error](mr.mock.ctrl.T, mr.mock, "UpdateApplicationScale", gomock.EnsureMatcher(ctx), gomock.EnsureMatcher(appUUID), gomock.EnsureMatcher(currentScale), gomock.EnsureMatcher(delta))
 	mr.updateApplicationScaleExpects = append(mr.updateApplicationScaleExpects, call)
 	mr.mock.ctrl.Track(call.Call)
 	return call
 }
 
 // MockStateUpdateApplicationScaleCall is the typed call wrapper for UpdateApplicationScale.
-type MockStateUpdateApplicationScaleCall = gomock.Call3_2[context.Context, application.UUID, int, int, error]
+type MockStateUpdateApplicationScaleCall = gomock.Call4_2[context.Context, application.UUID, int, int, int, error]
 
 // UpdateCAASUnit mocks base method.
 func (m *MockState) UpdateCAASUnit(arg0 context.Context, arg1 unit.Name, arg2 application0.UpdateCAASUnitParams) error {

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -909,8 +909,10 @@ WHERE  application_uuid = $applicationScale.application_uuid
 // UpdateApplicationScale updates the desired scale of an application by a
 // delta.
 // If the resulting scale is less than zero, an error satisfying
-// [applicationerrors.ScaleChangeInvalid] is returned.
-func (st *State) UpdateApplicationScale(ctx context.Context, appUUID coreapplication.UUID, delta int) (int, error) {
+// [applicationerrors.ScaleChangeInvalid] is returned. If the current scale
+// differs from expectedScale, [applicationerrors.ScalingStateInconsistent] is
+// returned.
+func (st *State) UpdateApplicationScale(ctx context.Context, appUUID coreapplication.UUID, expectedScale, delta int) (int, error) {
 	db, err := st.DB(ctx)
 	if err != nil {
 		return -1, errors.Capture(err)
@@ -930,6 +932,9 @@ WHERE  application_uuid = $applicationScale.application_uuid
 		currentScaleState, err := st.getApplicationScaleState(ctx, tx, appUUID.String())
 		if err != nil {
 			return errors.Capture(err)
+		}
+		if currentScaleState.Scale != expectedScale {
+			return applicationerrors.ScalingStateInconsistent
 		}
 
 		newScale = currentScaleState.Scale + delta

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -1562,7 +1562,7 @@ func (s *applicationStateSuite) TestUpdateApplicationScale(c *tc.C) {
 	err := s.state.SetDesiredApplicationScale(c.Context(), appUUID, 666)
 	c.Assert(err, tc.ErrorIsNil)
 
-	newScale, err := s.state.UpdateApplicationScale(c.Context(), appUUID, 2)
+	newScale, err := s.state.UpdateApplicationScale(c.Context(), appUUID, 666, 2)
 	c.Assert(err, tc.ErrorIsNil)
 
 	var gotScale int
@@ -1582,8 +1582,22 @@ func (s *applicationStateSuite) TestUpdateApplicationScaleInvalidScale(c *tc.C) 
 	err := s.state.SetDesiredApplicationScale(c.Context(), appUUID, 666)
 	c.Assert(err, tc.ErrorIsNil)
 
-	_, err = s.state.UpdateApplicationScale(c.Context(), appUUID, -667)
+	_, err = s.state.UpdateApplicationScale(c.Context(), appUUID, 666, -667)
 	c.Assert(err, tc.ErrorMatches, `scale change invalid: cannot remove more units than currently exist`)
+}
+
+func (s *applicationStateSuite) TestUpdateApplicationScaleChangedScale(c *tc.C) {
+	appUUID := s.createCAASApplication(c, "foo", life.Alive)
+
+	err := s.state.SetDesiredApplicationScale(c.Context(), appUUID, 666)
+	c.Assert(err, tc.ErrorIsNil)
+
+	_, err = s.state.UpdateApplicationScale(c.Context(), appUUID, 1, 2)
+	c.Assert(err, tc.ErrorIs, applicationerrors.ScalingStateInconsistent)
+
+	scale, err := s.state.GetApplicationScaleState(c.Context(), appUUID)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(scale.Scale, tc.Equals, 666)
 }
 
 func (s *applicationStateSuite) TestSetApplicationScalingStateAlreadyScaling(c *tc.C) {

--- a/internal/provider/kubernetes/application/application.go
+++ b/internal/provider/kubernetes/application/application.go
@@ -231,6 +231,13 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 	if err != nil {
 		return errors.Annotate(err, "generating application podspec")
 	}
+	podTemplateAnnotations := a.annotations(config)
+	// The controller StatefulSet is created during bootstrap before the
+	// application UUID is available. Do not add it during reconciliation: doing
+	// so changes the pod template and rolls the only controller pod.
+	if config.Controller {
+		podTemplateAnnotations.Remove(utils.AnnotationKeyApplicationUUID(a.labelVersion))
+	}
 	var handleVolume handleVolumeFunc = func(
 		v corev1.Volume,
 		attachParams jujustorage.KubernetesFilesystemAttachmentParams,
@@ -378,7 +385,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels:      a.selectorLabels(),
-						Annotations: a.annotations(config),
+						Annotations: podTemplateAnnotations,
 					},
 					Spec: *podSpec,
 				},
@@ -428,7 +435,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels:      a.selectorLabels(),
-						Annotations: a.annotations(config),
+						Annotations: podTemplateAnnotations,
 					},
 					Spec: *podSpec,
 				},
@@ -462,7 +469,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels:      a.selectorLabels(),
-						Annotations: a.annotations(config),
+						Annotations: podTemplateAnnotations,
 					},
 					Spec: *podSpec,
 				},
@@ -593,13 +600,7 @@ func (a *app) applyServiceAccountAndSecrets(applier resources.Applier, config ca
 			Labels:      a.labels(),
 			Annotations: a.annotations(config),
 		},
-		Data: map[string][]byte{
-			"JUJU_K8S_APPLICATION":          []byte(a.name),
-			"JUJU_K8S_MODEL":                []byte(a.modelUUID),
-			"JUJU_K8S_APPLICATION_PASSWORD": []byte(config.IntroductionSecret),
-			"JUJU_K8S_CONTROLLER_ADDRESSES": []byte(config.ControllerAddresses),
-			"JUJU_K8S_CONTROLLER_CA_CERT":   []byte(config.ControllerCertBundle),
-		},
+		Data: ApplicationConfigSecretData(a.name, a.modelUUID, config),
 	}
 	secret := resources.NewSecret(a.client.CoreV1().Secrets(a.namespace), a.namespace, a.secretName(), sec)
 	applier.Apply(secret)
@@ -683,6 +684,22 @@ func (a *app) applyServiceAccountAndSecrets(applier resources.Applier, config ca
 	applier.Apply(clusterRoleBinding)
 
 	return a.applyImagePullSecrets(applier, config)
+}
+
+// ApplicationConfigSecretData returns the data common to every application
+// configuration Secret. Bootstrap uses this for the controller application so
+// its Secret has the same contract as subsequent reconciliation.
+func ApplicationConfigSecretData(
+	applicationName, modelUUID string,
+	config caas.ApplicationConfig,
+) map[string][]byte {
+	return map[string][]byte{
+		"JUJU_K8S_APPLICATION":          []byte(applicationName),
+		"JUJU_K8S_MODEL":                []byte(modelUUID),
+		"JUJU_K8S_APPLICATION_PASSWORD": []byte(config.IntroductionSecret),
+		"JUJU_K8S_CONTROLLER_ADDRESSES": []byte(config.ControllerAddresses),
+		"JUJU_K8S_CONTROLLER_CA_CERT":   []byte(config.ControllerCertBundle),
+	}
 }
 
 // Upgrade upgrades the app to the specified version.

--- a/internal/provider/kubernetes/application/application_test.go
+++ b/internal/provider/kubernetes/application/application_test.go
@@ -568,6 +568,26 @@ func (s *applicationSuite) TestEnsurePreservesControllerBootstrapPodExtensions(c
 	}
 }
 
+func (s *applicationSuite) TestEnsureControllerDoesNotAddApplicationUUIDToPodTemplate(c *tc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	var config caas.ApplicationConfig
+	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func(got *caas.ApplicationConfig) {
+		config = *got
+		config.Controller = true
+	}, func() {}, nil)
+
+	config.ResourceTags = map[string]string{
+		k8sutils.AnnotationKeyApplicationUUID(constants.LastLabelVersion): "application-uuid",
+	}
+	c.Assert(app.Ensure(config), tc.ErrorIsNil)
+
+	statefulSet, err := s.client.AppsV1().StatefulSets(s.namespace).Get(c.Context(), s.appName, metav1.GetOptions{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(statefulSet.Annotations[k8sutils.AnnotationKeyApplicationUUID(constants.LastLabelVersion)], tc.Equals, "uniqid")
+	_, ok := statefulSet.Spec.Template.Annotations[k8sutils.AnnotationKeyApplicationUUID(constants.LastLabelVersion)]
+	c.Check(ok, tc.IsFalse)
+}
+
 func (s *applicationSuite) TestEnsureRemovesContainerRemovedByCharmRefresh(c *tc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	var config caas.ApplicationConfig

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -24,7 +24,6 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -563,7 +562,6 @@ func (c *controllerStack) Deploy(ctx context.Context) (err error) {
 	saName, saCleanUps, err := ensureControllerServiceAccount(
 		ctx,
 		c.broker.client(),
-		c.broker.extendedClient(),
 		c.broker.Namespace(),
 		c.broker.ControllerUUID(),
 		c.stackLabels,
@@ -956,7 +954,6 @@ func (c *controllerStack) ensureControllerApplicationSecret(ctx context.Context)
 func ensureControllerServiceAccount(
 	ctx context.Context,
 	client kubernetes.Interface,
-	extendedClient clientset.Interface,
 	namespace string,
 	controllerUUID string,
 	labels map[string]string,

--- a/internal/provider/kubernetes/bootstrap.go
+++ b/internal/provider/kubernetes/bootstrap.go
@@ -921,6 +921,17 @@ func (c *controllerStack) ensureControllerApplicationSecret(ctx context.Context)
 		controllerUnitPassword = apiInfo.Password
 	}
 
+	secretData := application.ApplicationConfigSecretData(
+		environsbootstrap.ControllerApplicationName,
+		c.broker.ModelUUID(),
+		caas.ApplicationConfig{
+			IntroductionSecret:   c.applicationPassword,
+			ControllerAddresses:  net.JoinHostPort(c.resourceNameService, strconv.Itoa(c.portAPIServer)),
+			ControllerCertBundle: c.pcfg.APIInfo.CACert,
+		},
+	)
+	secretData[constants.EnvJujuK8sUnitPassword] = []byte(controllerUnitPassword)
+
 	secret := &core.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        c.appSecretName(),
@@ -929,10 +940,7 @@ func (c *controllerStack) ensureControllerApplicationSecret(ctx context.Context)
 			Annotations: c.stackAnnotations,
 		},
 		Type: core.SecretTypeOpaque,
-		Data: map[string][]byte{
-			constants.EnvJujuK8sUnitPassword:        []byte(controllerUnitPassword),
-			constants.EnvJujuK8sApplicationPassword: []byte(c.applicationPassword),
-		},
+		Data: secretData,
 	}
 	cleanUp, err := c.broker.ensureSecret(ctx, secret)
 	c.addCleanUp(func() {
@@ -1668,33 +1676,6 @@ fi
 			}
 		}
 		ct.VolumeMounts = append(ct.VolumeMounts, dataDirMount)
-		ct.Env = append(ct.Env,
-			core.EnvVar{
-				Name:  "JUJU_K8S_APPLICATION",
-				Value: environsbootstrap.ControllerApplicationName,
-			},
-			core.EnvVar{
-				Name:  "JUJU_K8S_MODEL",
-				Value: c.broker.ModelUUID(),
-			},
-			core.EnvVar{
-				Name: constants.EnvJujuK8sApplicationPassword,
-				ValueFrom: &core.EnvVarSource{
-					SecretKeyRef: &core.SecretKeySelector{
-						LocalObjectReference: core.LocalObjectReference{Name: c.appSecretName()},
-						Key:                  constants.EnvJujuK8sApplicationPassword,
-					},
-				},
-			},
-			core.EnvVar{
-				Name:  "JUJU_K8S_CONTROLLER_ADDRESSES",
-				Value: net.JoinHostPort(c.resourceNameService, strconv.Itoa(c.portAPIServer)),
-			},
-			core.EnvVar{
-				Name:  "JUJU_K8S_CONTROLLER_CA_CERT",
-				Value: c.pcfg.APIInfo.CACert,
-			},
-		)
 		spec.InitContainers[i] = ct
 	}
 	for i, ct := range spec.Containers {

--- a/internal/provider/kubernetes/bootstrap_test.go
+++ b/internal/provider/kubernetes/bootstrap_test.go
@@ -729,7 +729,11 @@ func (s *bootstrapSuite) testBootstrap(c *tc.C, enableServiceLinks bool) {
 		Type: core.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"JUJU_K8S_UNIT_PASSWORD":        []byte(controllerStacker.GetControllerUnitAgentPassword()),
+			"JUJU_K8S_APPLICATION":          []byte("controller"),
+			"JUJU_K8S_MODEL":                []byte(coretesting.ModelTag.Id()),
 			"JUJU_K8S_APPLICATION_PASSWORD": []byte(controllerStacker.GetControllerApplicationPassword()),
+			"JUJU_K8S_CONTROLLER_ADDRESSES": []byte("juju-controller-test-service:17777"),
+			"JUJU_K8S_CONTROLLER_CA_CERT":   []byte(coretesting.CACert),
 		},
 	}
 
@@ -1193,33 +1197,6 @@ fi
 						FieldPath: "metadata.uid",
 					},
 				},
-			},
-			{
-				Name:  "JUJU_K8S_APPLICATION",
-				Value: "controller",
-			},
-			{
-				Name:  "JUJU_K8S_MODEL",
-				Value: coretesting.ModelTag.Id(),
-			},
-			{
-				Name: "JUJU_K8S_APPLICATION_PASSWORD",
-				ValueFrom: &core.EnvVarSource{
-					SecretKeyRef: &core.SecretKeySelector{
-						LocalObjectReference: core.LocalObjectReference{
-							Name: "juju-controller-test-application-config",
-						},
-						Key: "JUJU_K8S_APPLICATION_PASSWORD",
-					},
-				},
-			},
-			{
-				Name:  "JUJU_K8S_CONTROLLER_ADDRESSES",
-				Value: "juju-controller-test-service:17777",
-			},
-			{
-				Name:  "JUJU_K8S_CONTROLLER_CA_CERT",
-				Value: coretesting.CACert,
 			},
 		},
 		EnvFrom: []core.EnvFromSource{

--- a/internal/provider/kubernetes/controller_upgrade.go
+++ b/internal/provider/kubernetes/controller_upgrade.go
@@ -96,7 +96,6 @@ func inClusterCredentialUpgrade(
 	saName, cleanUps, err := ensureControllerServiceAccount(
 		ctx,
 		client,
-		extendedClient,
 		namespace,
 		controllerUUID,
 		labels,


### PR DESCRIPTION
Previously, SetApplicationScale and ChangeApplicationScale in the domain service layer had no guard against scaling a controller application to zero. If a user ran remove-unit --num-units N or scale-application controller 0 on a CAAS model, the controller application could be scaled down to zero units, which would destroy the controller.

Now both methods check whether the application is a controller application (via IsControllerApplication) before allowing the scale to reach zero. SetApplicationScale intercepts an explicit scale of 0, and ChangeApplicationScale computes the resulting scale for negative deltas and blocks it if it would reach or drop below zero.

> [!NOTE]
> Fixes bootstrapping if the config map/template has different values, as they can drift! Not it can't, they're using the same function.

## QA steps

```
$ juju bootstrap microk8s test
$ juju add-unit -m controller controller -n 2
$ juju remove-unit -m controller controller --num-units=10
ERROR: cannot scale controller application to 0 units
```

## Links


**Jira card:** [JUJU-10259](https://warthogs.atlassian.net/browse/JUJU-10259)


[JUJU-10259]: https://warthogs.atlassian.net/browse/JUJU-10259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ