### PR TITLE
feat: open port 17022 for ssh proxy

### DIFF
--- a/internal/provider/common/bootstrap.go
+++ b/internal/provider/common/bootstrap.go
@@ -369,7 +369,8 @@ func startInstanceZones(env environs.Environ, ctx context.Context, args environs
 	return zones, nil
 }
 
-// openControllerModelPorts opens port 22 and apiports on the controller to the configured allow list.
+// openControllerModelPorts opens port 22, the API port and the SSH server port
+// on the controller to the configured allow list.
 // This is all that is required for the bootstrap to continue. Further configured
 // rules will be opened by the firewaller, Once it has started
 func openControllerModelPorts(bootstrapContext context.Context,
@@ -381,6 +382,15 @@ func openControllerModelPorts(bootstrapContext context.Context,
 			Protocol: "tcp",
 			FromPort: controllerConfig.APIPort(),
 			ToPort:   controllerConfig.APIPort(),
+		}, defaultCIDRs...),
+		// Open the SSH server (jump host) port so users can reach the
+		// controller's embedded SSH server. This must also be opened by the
+		// firewaller at runtime (see ModelFirewallRules), otherwise the
+		// firewaller would reconcile it closed.
+		firewall.NewIngressRule(network.PortRange{
+			Protocol: "tcp",
+			FromPort: controllerConfig.SSHServerPort(),
+			ToPort:   controllerConfig.SSHServerPort(),
 		}, defaultCIDRs...),
 	}
 

--- a/internal/provider/common/bootstrap_test.go
+++ b/internal/provider/common/bootstrap_test.go
@@ -287,11 +287,13 @@ func (s *BootstrapSuite) testBootstrapWithSubstrateWithIPV6Support(c *tc.C, supp
 		rules = firewall.IngressRules{
 			firewall.NewIngressRule(network.MustParsePortRange("22/tcp"), "0.0.0.0/0", "::/0"),
 			firewall.NewIngressRule(network.MustParsePortRange("17777/tcp"), "0.0.0.0/0", "::/0"),
+			firewall.NewIngressRule(network.MustParsePortRange("17022/tcp"), "0.0.0.0/0", "::/0"),
 		}
 	} else {
 		rules = firewall.IngressRules{
 			firewall.NewIngressRule(network.MustParsePortRange("22/tcp"), "0.0.0.0/0"),
 			firewall.NewIngressRule(network.MustParsePortRange("17777/tcp"), "0.0.0.0/0"),
+			firewall.NewIngressRule(network.MustParsePortRange("17022/tcp"), "0.0.0.0/0"),
 		}
 	}
 	c.Assert(env.modelRules.EqualTo(rules), tc.IsTrue)

--- a/internal/provider/ec2/local_test.go
+++ b/internal/provider/ec2/local_test.go
@@ -3030,6 +3030,7 @@ func (t *localServerSuite) TestModelPorts(c *tc.C) {
 		firewall.NewIngressRule(network.MustParsePortRange("22/tcp"), firewall.AllNetworksIPV4CIDR),
 		// TODO: extend tests to check the api port isn't on hosted models.
 		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().APIPort())), firewall.AllNetworksIPV4CIDR),
+		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().SSHServerPort())), firewall.AllNetworksIPV4CIDR),
 	})
 
 	err = fwModelEnv.OpenModelPorts(c.Context(),
@@ -3046,6 +3047,7 @@ func (t *localServerSuite) TestModelPorts(c *tc.C) {
 		firewall.NewIngressRule(network.MustParsePortRange("22/tcp"), firewall.AllNetworksIPV4CIDR),
 		// TODO: extend tests to check the api port isn't on hosted models.
 		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().APIPort())), firewall.AllNetworksIPV4CIDR),
+		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().SSHServerPort())), firewall.AllNetworksIPV4CIDR),
 		firewall.NewIngressRule(network.MustParsePortRange("45/tcp"), firewall.AllNetworksIPV4CIDR),
 		firewall.NewIngressRule(network.MustParsePortRange("100-110/tcp"), firewall.AllNetworksIPV4CIDR),
 		firewall.NewIngressRule(network.MustParsePortRange("67/udp"), firewall.AllNetworksIPV4CIDR),
@@ -3065,6 +3067,7 @@ func (t *localServerSuite) TestModelPorts(c *tc.C) {
 		firewall.NewIngressRule(network.MustParsePortRange("22/tcp"), firewall.AllNetworksIPV4CIDR),
 		// TODO: extend tests to check the api port isn't on hosted models.
 		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().APIPort())), firewall.AllNetworksIPV4CIDR),
+		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().SSHServerPort())), firewall.AllNetworksIPV4CIDR),
 		firewall.NewIngressRule(network.MustParsePortRange("100-110/tcp"), firewall.AllNetworksIPV4CIDR),
 	})
 
@@ -3083,6 +3086,7 @@ func (t *localServerSuite) TestModelPorts(c *tc.C) {
 		firewall.NewIngressRule(network.MustParsePortRange("22/tcp"), firewall.AllNetworksIPV4CIDR),
 		// TODO: extend tests to check the api port isn't on hosted models.
 		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().APIPort())), firewall.AllNetworksIPV4CIDR),
+		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().SSHServerPort())), firewall.AllNetworksIPV4CIDR),
 		firewall.NewIngressRule(network.MustParsePortRange("100-110/tcp"), firewall.AllNetworksIPV4CIDR),
 	})
 }

--- a/internal/provider/openstack/local_test.go
+++ b/internal/provider/openstack/local_test.go
@@ -2364,6 +2364,7 @@ func (s *localServerSuite) TestModelPorts(c *tc.C) {
 		firewall.NewIngressRule(network.MustParsePortRange("22/tcp"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 		// TODO: extend tests to check the api port isn't on hosted models.
 		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().APIPort())), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
+		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().SSHServerPort())), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 	})
 
 	err = fwModelEnv.OpenModelPorts(c.Context(),
@@ -2380,6 +2381,7 @@ func (s *localServerSuite) TestModelPorts(c *tc.C) {
 		firewall.NewIngressRule(network.MustParsePortRange("22/tcp"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 		// TODO: extend tests to check the api port isn't on hosted models.
 		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().APIPort())), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
+		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().SSHServerPort())), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 		firewall.NewIngressRule(network.MustParsePortRange("45/tcp"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 		firewall.NewIngressRule(network.MustParsePortRange("100-110/tcp"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 		firewall.NewIngressRule(network.MustParsePortRange("67/udp"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
@@ -2399,6 +2401,7 @@ func (s *localServerSuite) TestModelPorts(c *tc.C) {
 		firewall.NewIngressRule(network.MustParsePortRange("22/tcp"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 		// TODO: extend tests to check the api port isn't on hosted models.
 		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().APIPort())), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
+		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().SSHServerPort())), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 		firewall.NewIngressRule(network.MustParsePortRange("100-110/tcp"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 	})
 
@@ -2417,6 +2420,7 @@ func (s *localServerSuite) TestModelPorts(c *tc.C) {
 		firewall.NewIngressRule(network.MustParsePortRange("22/tcp"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 		// TODO: extend tests to check the api port isn't on hosted models.
 		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().APIPort())), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
+		firewall.NewIngressRule(network.MustParsePortRange(strconv.Itoa(coretesting.FakeControllerConfig().SSHServerPort())), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 		firewall.NewIngressRule(network.MustParsePortRange("100-110/tcp"), firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 	})
 

--- a/internal/worker/firewaller/firewaller_adapters.go
+++ b/internal/worker/firewaller/firewaller_adapters.go
@@ -130,6 +130,13 @@ func (a *firewallerAPIAdapter) ModelFirewallRules(ctx context.Context) (firewall
 			network.MustParsePortRange(strconv.Itoa(ctrlCfg.APIPort())),
 			"0.0.0.0/0", "::/0",
 		))
+		// Open the controller's embedded SSH server (jump host) port so
+		// users can reach it. Also opened at bootstrap time (see
+		// openControllerModelPorts) to avoid a window where it is closed.
+		rules = append(rules, firewall.NewIngressRule(
+			network.MustParsePortRange(strconv.Itoa(ctrlCfg.SSHServerPort())),
+			"0.0.0.0/0", "::/0",
+		))
 	}
 	if isController && ctrlCfg.AutocertDNSName() != "" {
 		rules = append(rules, firewall.NewIngressRule(


### PR DESCRIPTION
The controller's embedded SSH jump server listens on port the config set in ssh-server-port (default 17022), which is what `juju ssh` connects to for the new SSH proxy flow. 

Juju 3.6 opened this port at bootstrap via the controller charm, but that logic was dropped when the `jujud` controller binary was removed in Juju 4 and never re-implemented. 

As a result IAAS controllers no longer open 17022 in the cloud firewall, and the `limit_access.sh` integration test fails.

This re-adds the port using the current Juju 4 model firewall path (I copied the same example that opens the API port 17070), in the two places controller ports are managed:
- `openControllerModelPorts` -   opens it at bootstrap.
- `ModelFirewallRules` - keeps it open at runtime (controller model only, to enable access to the controller machine which is ultimately running the embedded SSH server for proxying).

Why both places: bootstrap opens the port before the firewaller starts, the firewaller then continuously reconciles the firewall to its own rule set and would close anything not in it. Opening it in only one place would either get reconciled shut or leave a gap during bootstrap. This mirrors how the API port is handled.

Why `0.0.0.0/0` + `::/0`: the jump server is a user facing controller service reached from arbitrary locations and we can't reliablyg know the user's address, like the API port. So it uses the same open CIDRs (and matches 3.6 behaviour). 

On the modified tests, TestModelPorts in the ec2 and openstack providers bootstrap a controller and assert the exact set of ports opened on the controller model, so both needed the new 17022 rule added. gce was intentionally left untouched as its equivalent test (TestModelIngressRules) mocks the cloud's firewall response rather than exercising the real controller rule set, so it never sees these ports and didn't need changing. The behaviour itself is provider agnostic (it lives in the shared openControllerModelPorts / ModelFirewallRules code, not per-provider), so gce opens 17022 through the same path, it's just verified by the limit_access.sh integration test (which runs on ec2 and gce) rather than a unit test.

Ultimately we should see `limt_access.sh` begin to pass. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~doc.go added or updated in changed packages~

## QA steps
No manual QA needed. Look for test_limit_access (controller suite, runs on ec2/gce in CI) passing.

It was failing on main because `verify_instance_network_tagg` asserts port `17022` is open on the controller, and this change makes that pass.

## Documentation changes
n/a

## Links

**Issue:** Fixes #<issue-number>. <!-- replace or remove -->

**Jira card:** [JUJU-10330](https://warthogs.atlassian.net/browse/JUJU-10330)


[JUJU-10330]: https://warthogs.atlassian.net/browse/JUJU-10330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ