### PR TITLE
fix: add dns-name if configured to consume details

### DIFF
--- a/apiserver/common/controllerconfig.go
+++ b/apiserver/common/controllerconfig.go
@@ -117,6 +117,8 @@ func (s *ControllerConfigAPI) getModelControllerInfo(model params.Entity) (param
 }
 
 // StateControllerInfo returns the local controller details for the given State.
+// If the controller has a public DNS address configured, it is prepended to
+// the returned addresses so that consumers learn a reachable address.
 func StateControllerInfo(st controllerInfoState) (addrs []string, caCert string, _ error) {
 	addr, err := apiAddresses(st)
 	if err != nil {
@@ -125,6 +127,9 @@ func StateControllerInfo(st controllerInfoState) (addrs []string, caCert string,
 	controllerConfig, err := st.ControllerConfig()
 	if err != nil {
 		return nil, "", errors.Trace(err)
+	}
+	if publicAddr := controllerConfig.PublicDNSAddress(); publicAddr != "" {
+		addr = append([]string{publicAddr}, addr...)
 	}
 	caCert, _ = controllerConfig.CACert()
 	return addr, caCert, nil

--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -80,12 +80,16 @@ func (s *controllerConfigSuite) TestControllerConfigFetchError(c *gc.C) {
 }
 
 func (s *controllerConfigSuite) expectStateControllerInfo(c *gc.C) {
+	s.expectStateControllerInfoWithConfig(c, map[string]interface{}{
+		controller.CACertKey: testing.CACert,
+	})
+}
+
+func (s *controllerConfigSuite) expectStateControllerInfoWithConfig(c *gc.C, config map[string]interface{}) {
 	s.st.EXPECT().APIHostPortsForAgents().Return([]network.SpaceHostPorts{
 		network.NewSpaceHostPorts(17070, "192.168.1.1"),
 	}, nil)
-	s.st.EXPECT().ControllerConfig().Return(map[string]interface{}{
-		controller.CACertKey: testing.CACert,
-	}, nil)
+	s.st.EXPECT().ControllerConfig().Return(config, nil)
 }
 
 func (s *controllerConfigSuite) TestControllerInfo(c *gc.C) {
@@ -99,6 +103,24 @@ func (s *controllerConfigSuite) TestControllerInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Results, gc.HasLen, 1)
 	c.Assert(results.Results[0].Addresses, gc.DeepEquals, []string{"192.168.1.1:17070"})
+	c.Assert(results.Results[0].CACert, gc.Equals, testing.CACert)
+}
+
+func (s *controllerConfigSuite) TestControllerInfoWithPublicDNSAddress(c *gc.C) {
+	defer s.setup(c).Finish()
+
+	s.st.EXPECT().ModelExists(testing.ModelTag.Id()).Return(true, nil)
+	s.expectStateControllerInfoWithConfig(c, map[string]interface{}{
+		controller.CACertKey:        testing.CACert,
+		controller.PublicDNSAddress: "my-ingress.example.com:17070",
+	})
+
+	results, err := s.cc.ControllerAPIInfoForModels(params.Entities{
+		Entities: []params.Entity{{Tag: testing.ModelTag.String()}}})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results.Results, gc.HasLen, 1)
+	c.Assert(results.Results[0].Addresses, gc.DeepEquals, []string{
+		"my-ingress.example.com:17070", "192.168.1.1:17070"})
 	c.Assert(results.Results[0].CACert, gc.Equals, testing.CACert)
 }
 

--- a/tests/suites/cmr/offer_consume.sh
+++ b/tests/suites/cmr/offer_consume.sh
@@ -188,6 +188,13 @@ run_offer_consume_cross_controller() {
 
 	offer_controller="$(juju controllers --format=yaml | yq -r '."current-controller"')"
 
+	# Configure a public DNS address on the offering controller. The address
+	# is not reachable in the test environment, so consumers fall back to
+	# the regular API addresses. This exercises that advertising a
+	# public-dns-address does not break cross-controller relations.
+	echo "Configure public-dns-address on the offering controller"
+	juju controller-config public-dns-address=public-dns-test.example.com:17070
+
 	# Ensure we have another controller available.
 	echo "Bootstrap consume offer controller"
 	bootstrap_alt_controller "controller-consume"
@@ -234,6 +241,9 @@ run_offer_consume_cross_controller() {
 	wait_for null '.offers."dummy-source"."total-connected-count"'
 	juju remove-offer "${offer_controller}:admin/model-offer.dummy-source" -y
 	wait_for null '.offers'
+
+	echo "Reset public-dns-address on the offering controller"
+	juju controller-config public-dns-address=""
 
 	echo "Clean up"
 	destroy_controller "controller-consume"


### PR DESCRIPTION
# Description

This bug was reported to me, because they were trying to consume a cross controller offer between ps6 and ps7.

The offer was successfully instantiated but then it was failing in the source model with:
```
controller-2: 09:43:09 ERROR juju.worker.remoterelations cmr exited "wg-kernel-ps7": cannot connect to external controller: opening facade to remote model: api connection open timed out
controller-2: 09:43:09 INFO juju.worker.remoterelations cmr restarting "wg-kernel-ps7" in 15s
```

The problem is that when the details for an offer are created we were only adding the addresses from the controller but not the dns name if configured.
This creates a problem for some deployment when the offering controller is only reachable through the configured dns name and the other api addresses are not routable.

# QA

`juju bootstrap lxd source`
`juju bootstrap lxd dest` # with the current build


```
juju controller-config public-dns-address=ingress:8080
juju add-model a
juju deploy juju-qa-dummy-sink
juju offer dummy-sink:source
```

_switch to source_
```
juju consume dest:admin/a.dummy-sink
```

_log into juju db_

```
db.externalControllers.find().pretty()
```

Without the fix
```
{
	...
	"addresses" : [
		"10.194.223.29:17070",
		"[fd42:65b4:80e1:7c47:216:3eff:fe49:3a23]:17070"
	],
	...
}
```
WIth the fix
```
{
	...
	"addresses" : [
		"ingress:8080",
		"10.194.223.29:17070",
		"[fd42:65b4:80e1:7c47:216:3eff:fe49:3a23]:17070"
	],
	...
}
```



