### PR TITLE
fix(cmr): store and migrate the application offer description

### DIFF
--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -198,10 +198,11 @@ func (api *OffersAPI) parseApplicationOfferArgs(
 		}
 	}
 	result := crossmodelrelation.ApplicationOfferArgs{
-		OfferName:       addOfferParams.OfferName,
-		ApplicationName: addOfferParams.ApplicationName,
-		Endpoints:       addOfferParams.Endpoints,
-		OwnerName:       coreuser.NameFromTag(owner),
+		OfferName:              addOfferParams.OfferName,
+		ApplicationName:        addOfferParams.ApplicationName,
+		ApplicationDescription: addOfferParams.ApplicationDescription,
+		Endpoints:              addOfferParams.Endpoints,
+		OwnerName:              coreuser.NameFromTag(owner),
 	}
 	return result, owner, nil
 }

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -95,6 +95,46 @@ func (s *offerSuite) TestOffer(c *tc.C) {
 	c.Assert(results, tc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}})
 }
 
+// TestOfferWithDescription tests that the application description given in
+// the offer params is passed to the create offer args.
+func (s *offerSuite) TestOfferWithDescription(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	offerAPI := s.offerAPI(c)
+	modelTag := names.NewModelTag(offerAPI.modelUUID.String())
+	apiUserTag := names.NewUserTag("fred")
+	s.authorizer.EXPECT().GetAuthTag().Return(apiUserTag)
+	s.setupCheckAPIUserAdmin(offerAPI.controllerUUID, modelTag)
+
+	applicationName := "test-application"
+	offerName := "test-offer"
+	createOfferArgs := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName:        applicationName,
+		OfferName:              offerName,
+		ApplicationDescription: "offer description",
+		Endpoints:              map[string]string{"db": "db"},
+		OwnerName:              user.NameFromTag(apiUserTag),
+	}
+	s.crossModelRelationService.EXPECT().CreateOffer(gomock.Any(), createOfferArgs).Return(nil)
+
+	one := params.AddApplicationOffer{
+		ModelTag:               modelTag.String(),
+		OfferName:              offerName,
+		ApplicationName:        applicationName,
+		ApplicationDescription: "offer description",
+		Endpoints:              map[string]string{"db": "db"},
+	}
+	all := params.AddApplicationOffers{Offers: []params.AddApplicationOffer{one}}
+
+	// Act
+	results, err := offerAPI.Offer(c.Context(), all)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(results, tc.DeepEquals, params.ErrorResults{Results: []params.ErrorResult{{Error: nil}}})
+}
+
 // TestOfferPermission verifies an error is returned if the caller
 // does not have permissions on the calling model.
 func (s *offerSuite) TestOfferPermission(c *tc.C) {

--- a/domain/crossmodelrelation/service/offer.go
+++ b/domain/crossmodelrelation/service/offer.go
@@ -206,10 +206,11 @@ func (s *Service) CreateOffer(
 
 	// The offer does not exist, create it.
 	err = s.modelState.CreateOffer(ctx, crossmodelrelation.CreateOfferArgs{
-		UUID:            offerUUID,
-		ApplicationUUID: applicationUUID,
-		Endpoints:       endpoints,
-		OfferName:       args.OfferName,
+		UUID:                   offerUUID,
+		ApplicationUUID:        applicationUUID,
+		Endpoints:              endpoints,
+		OfferName:              args.OfferName,
+		ApplicationDescription: args.ApplicationDescription,
 	})
 	if err != nil {
 		return errors.Errorf("creating offer: %w", err)

--- a/domain/crossmodelrelation/service/offer_test.go
+++ b/domain/crossmodelrelation/service/offer_test.go
@@ -76,6 +76,53 @@ func (s *offerServiceSuite) TestOfferCreate(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 }
 
+// TestOfferCreateWithDescription tests that the application description
+// given in the offer args is passed to state when creating the offer.
+func (s *offerServiceSuite) TestOfferCreateWithDescription(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange
+	applicationName := "test-application"
+	offerName := "test-offer"
+	applicationUUID := uuid.MustNewUUID().String()
+	ownerName := usertesting.GenNewName(c, "admin")
+	ownerUUID := uuid.MustNewUUID()
+
+	s.modelState.EXPECT().GetConsumeDetails(gomock.Any(), offerName).Return(crossmodelrelation.ConsumeDetails{}, crossmodelrelationerrors.OfferNotFound)
+	s.modelState.EXPECT().ValidateApplicationAndEndpointsForOffer(gomock.Any(), applicationName, []string{"db"}).
+		Return(applicationUUID, nil)
+	s.controllerState.EXPECT().GetUserUUIDByName(gomock.Any(), ownerName).Return(ownerUUID, nil)
+
+	m := createOfferArgsMatcher{c: c, expected: crossmodelrelation.CreateOfferArgs{
+		ApplicationUUID:        applicationUUID,
+		OfferName:              offerName,
+		Endpoints:              []string{"db"},
+		ApplicationDescription: "offer description",
+	}}
+	s.modelState.EXPECT().CreateOffer(gomock.Any(), m).Return(nil)
+
+	s.controllerState.EXPECT().CreateOfferAccess(
+		gomock.Any(),
+		gomock.AssignableToTypeOf(uuid.UUID{}),
+		gomock.AssignableToTypeOf(offer.UUID("")),
+		ownerUUID,
+	).Return(nil)
+
+	args := crossmodelrelation.ApplicationOfferArgs{
+		ApplicationName:        applicationName,
+		OfferName:              offerName,
+		ApplicationDescription: "offer description",
+		Endpoints:              map[string]string{"db": "db"},
+		OwnerName:              ownerName,
+	}
+
+	// Act
+	err := s.service(c).CreateOffer(c.Context(), args)
+
+	// Assert
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 // TestOfferCreateAccessErr tests that Offer, when creating access for the
 // offer fails, the offer is deleted.
 func (s *offerServiceSuite) TestOfferCreateAccessErr(c *tc.C) {

--- a/domain/crossmodelrelation/state/model/offer.go
+++ b/domain/crossmodelrelation/state/model/offer.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -42,11 +43,18 @@ WHERE  uuid = $uuid.uuid
 	}
 
 	createOfferStmt, err := st.Prepare(`
-INSERT INTO offer (*) VALUES ($nameAndUUID.*)`, nameAndUUID{})
+INSERT INTO offer (*) VALUES ($insertOffer.*)`, insertOffer{})
 	if err != nil {
 		return errors.Errorf("preparing insert offer query: %w", err)
 	}
-	offer := nameAndUUID{Name: args.OfferName, UUID: args.UUID.String()}
+	offer := insertOffer{
+		Name: args.OfferName,
+		UUID: args.UUID.String(),
+		Description: sql.Null[string]{
+			V:     args.ApplicationDescription,
+			Valid: args.ApplicationDescription != "",
+		},
+	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var life lifeID

--- a/domain/crossmodelrelation/state/model/offer_test.go
+++ b/domain/crossmodelrelation/state/model/offer_test.go
@@ -86,6 +86,83 @@ func (s *modelOfferSuite) TestCreateOffer(c *tc.C) {
 	})
 }
 
+func (s *modelOfferSuite) TestCreateOfferWithDescription(c *tc.C) {
+	// Arrange
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadataWithDescription(c, charmUUID, "charm metadata description")
+	relation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID := s.addCharmRelation(c, charmUUID, relation)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationUUID)
+
+	args := crossmodelrelation.CreateOfferArgs{
+		UUID:                   tc.Must(c, offer.NewUUID),
+		ApplicationUUID:        appUUID.String(),
+		Endpoints:              []string{relation.Name},
+		OfferName:              "test-offer",
+		ApplicationDescription: "offer description",
+	}
+
+	// Act
+	err := s.state.CreateOffer(c.Context(), args)
+
+	// Assert - the offer description takes precedence over the charm
+	// metadata description.
+	c.Assert(err, tc.ErrorIsNil)
+	obtained, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained, tc.HasLen, 1)
+	c.Check(obtained[0].ApplicationDescription, tc.Equals, "offer description")
+}
+
+func (s *modelOfferSuite) TestCreateOfferNoDescriptionFallsBackToCharmMetadata(c *tc.C) {
+	// Arrange
+	charmUUID := s.addCharm(c)
+	s.addCharmMetadataWithDescription(c, charmUUID, "charm metadata description")
+	relation := charm.Relation{
+		Name:      "db",
+		Role:      charm.RoleProvider,
+		Interface: "db",
+		Scope:     charm.ScopeGlobal,
+	}
+	relationUUID := s.addCharmRelation(c, charmUUID, relation)
+
+	appName := "test-application"
+	appUUID := s.addApplication(c, charmUUID, appName)
+	s.addApplicationEndpoint(c, appUUID, relationUUID)
+
+	args := crossmodelrelation.CreateOfferArgs{
+		UUID:            tc.Must(c, offer.NewUUID),
+		ApplicationUUID: appUUID.String(),
+		Endpoints:       []string{relation.Name},
+		OfferName:       "test-offer",
+	}
+
+	// Act
+	err := s.state.CreateOffer(c.Context(), args)
+
+	// Assert - the description is stored as NULL, so reading the offer
+	// falls back to the charm metadata description.
+	c.Assert(err, tc.ErrorIsNil)
+	var description sql.NullString
+	err = s.DB().QueryRowContext(c.Context(),
+		`SELECT description FROM offer WHERE uuid = ?`, args.UUID.String()).Scan(&description)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(description.Valid, tc.IsFalse)
+
+	obtained, err := s.state.GetOfferDetails(c.Context(), crossmodelrelation.OfferFilter{})
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(obtained, tc.HasLen, 1)
+	c.Check(obtained[0].ApplicationDescription, tc.Equals, "charm metadata description")
+}
+
 func (s *modelOfferSuite) TestCreateOfferDyingAplication(c *tc.C) {
 	// Arrange
 	charmUUID := s.addCharm(c)

--- a/domain/crossmodelrelation/state/model/package_test.go
+++ b/domain/crossmodelrelation/state/model/package_test.go
@@ -50,7 +50,7 @@ func (s *baseSuite) SetUpTest(c *tc.C) {
 }
 
 func (s *baseSuite) readOffers(c *tc.C) []nameAndUUID {
-	rows, err := s.DB().QueryContext(c.Context(), `SELECT * FROM offer`)
+	rows, err := s.DB().QueryContext(c.Context(), `SELECT uuid, name FROM offer`)
 	c.Assert(err, tc.IsNil)
 	defer func() { _ = rows.Close() }()
 	foundOffers := []nameAndUUID{}

--- a/domain/crossmodelrelation/state/model/types.go
+++ b/domain/crossmodelrelation/state/model/types.go
@@ -29,6 +29,15 @@ type nameAndUUID struct {
 	Name string `db:"name"`
 }
 
+// insertOffer is used to insert a row into the offer table. The
+// description is nullable: an empty description is stored as NULL so
+// that the offer falls back to the charm metadata description.
+type insertOffer struct {
+	UUID        string           `db:"uuid"`
+	Name        string           `db:"name"`
+	Description sql.Null[string] `db:"description"`
+}
+
 // offerEndpoint represent a row in the offer_endpoint table.
 type offerEndpoint struct {
 	OfferUUID    string `db:"offer_uuid"`

--- a/domain/crossmodelrelation/types.go
+++ b/domain/crossmodelrelation/types.go
@@ -31,6 +31,11 @@ type ApplicationOfferArgs struct {
 	// OfferName is the name of the offer.
 	OfferName string
 
+	// ApplicationDescription is a description of the application's
+	// functionality. When empty, the description from the charm
+	// metadata is used instead.
+	ApplicationDescription string
+
 	// OwnerName is the name of the owner of the offer.
 	OwnerName user.Name
 }
@@ -394,6 +399,10 @@ type CreateOfferArgs struct {
 
 	// OfferName is the name of the offer.
 	OfferName string
+
+	// ApplicationDescription is a description of the application's
+	// functionality, stored with the offer.
+	ApplicationDescription string
 }
 
 // OfferFilter is used to query applications offered

--- a/domain/export/types/v4_1_0/model.go
+++ b/domain/export/types/v4_1_0/model.go
@@ -909,8 +909,9 @@ type ObjectStorePlacement struct {
 }
 
 type Offer struct {
-	UUID string `db:"uuid" json:"uuid" yaml:"uuid"`
-	Name string `db:"name" json:"name" yaml:"name"`
+	UUID        string  `db:"uuid" json:"uuid" yaml:"uuid"`
+	Name        string  `db:"name" json:"name" yaml:"name"`
+	Description *string `db:"description" json:"description" yaml:"description"`
 }
 
 type OfferConnection struct {

--- a/domain/modelimport/transformer/transforms/to_v4_1_0/deltas.go
+++ b/domain/modelimport/transformer/transforms/to_v4_1_0/deltas.go
@@ -23,6 +23,20 @@ var _ Deltas = deltas{}
 // 4.0.12 -> 4.1.0 transform.
 func NewDeltas() Deltas { return deltas{} }
 
+// Offer copies all v4_0_12 fields and leaves Description nil. Offers exported
+// from a 4.0.12 model carry no offer description; on import the offer falls
+// back to the charm metadata description.
+func (d deltas) Offer(_ context.Context, src []v4_0_12.Offer) ([]v4_1_0.Offer, error) {
+	result := make([]v4_1_0.Offer, len(src))
+	for i := range src {
+		result[i] = v4_1_0.Offer{
+			UUID: src[i].UUID,
+			Name: src[i].Name,
+		}
+	}
+	return result, nil
+}
+
 // Operation converts v4_0_12 Operation rows to v4_1_0. The operation_id
 // column changed from TEXT to INTEGER in 4.1.0; the string value is parsed
 // to int64. A non-numeric operation_id indicates data corruption (the

--- a/domain/modelimport/transformer/transforms/to_v4_1_0/deltas_test.go
+++ b/domain/modelimport/transformer/transforms/to_v4_1_0/deltas_test.go
@@ -73,3 +73,18 @@ func (s *deltasSuite) TestApplicationScale(c *tc.C) {
 		StartOrdinal:    0,
 	}})
 }
+
+// TestOfferLeavesDescriptionNil verifies that offers exported from a 4.0.12
+// model, which has no offer description column, are carried through with a
+// nil description.
+func (s *deltasSuite) TestOfferLeavesDescriptionNil(c *tc.C) {
+	src := []v4_0_12.Offer{
+		{UUID: "offer-uuid", Name: "test-offer"},
+	}
+
+	got, err := deltas{}.Offer(c.Context(), src)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(got, tc.DeepEquals, []v4_1_0.Offer{
+		{UUID: "offer-uuid", Name: "test-offer", Description: nil},
+	})
+}

--- a/domain/modelimport/transformer/transforms/to_v4_1_0/transform.go
+++ b/domain/modelimport/transformer/transforms/to_v4_1_0/transform.go
@@ -23,6 +23,8 @@ type Deltas interface {
 	ApplicationScale(ctx context.Context, src []v4_0_12.ApplicationScale) ([]v4_1_0.ApplicationScale, error)
 	// Constraint: struct shape changed in 4.1.0.
 	Constraint(ctx context.Context, src []v4_0_12.Constraint) ([]v4_1_0.Constraint, error)
+	// Offer: struct shape changed in 4.1.0.
+	Offer(ctx context.Context, src []v4_0_12.Offer) ([]v4_1_0.Offer, error)
 	// Operation: struct shape changed in 4.1.0.
 	Operation(ctx context.Context, src []v4_0_12.Operation) ([]v4_1_0.Operation, error)
 	// RelationApplicationSetting: struct shape changed in 4.1.0.
@@ -710,11 +712,6 @@ func NewTransform(d Deltas) transformer.TransformationFunc[v4_0_12.ModelExport, 
 			dst.ObjectStorePlacement[i] = v4_1_0.ObjectStorePlacement(src.ObjectStorePlacement[i])
 		}
 
-		dst.Offer = make([]v4_1_0.Offer, len(src.Offer))
-		for i := range src.Offer {
-			dst.Offer[i] = v4_1_0.Offer(src.Offer[i])
-		}
-
 		dst.OfferConnection = make([]v4_1_0.OfferConnection, len(src.OfferConnection))
 		for i := range src.OfferConnection {
 			dst.OfferConnection[i] = v4_1_0.OfferConnection(src.OfferConnection[i])
@@ -1251,6 +1248,10 @@ func NewTransform(d Deltas) transformer.TransformationFunc[v4_0_12.ModelExport, 
 
 		if dst.Constraint, err = d.Constraint(ctx, src.Constraint); err != nil {
 			return v4_1_0.ModelExport{}, errors.Errorf("Constraint delta: %w", err)
+		}
+
+		if dst.Offer, err = d.Offer(ctx, src.Offer); err != nil {
+			return v4_1_0.ModelExport{}, errors.Errorf("Offer delta: %w", err)
 		}
 
 		if dst.Operation, err = d.Operation(ctx, src.Operation); err != nil {

--- a/domain/schema/model/sql/0032-offer.sql
+++ b/domain/schema/model/sql/0032-offer.sql
@@ -1,6 +1,7 @@
 CREATE TABLE offer (
     uuid TEXT NOT NULL PRIMARY KEY,
-    name TEXT NOT NULL
+    name TEXT NOT NULL,
+    description TEXT
 );
 
 CREATE INDEX idx_offer_name
@@ -49,7 +50,7 @@ SELECT
     o.uuid AS offer_uuid,
     o.name AS offer_name,
     a.name AS application_name,
-    cm.description AS application_description,
+    COALESCE(o.description, cm.description) AS application_description,
     c.reference_name AS charm_name,
     c.revision AS charm_revision,
     cs.name AS charm_source,

--- a/domain/schema/model/sql/0032-offer.sql
+++ b/domain/schema/model/sql/0032-offer.sql
@@ -50,7 +50,6 @@ SELECT
     o.uuid AS offer_uuid,
     o.name AS offer_name,
     a.name AS application_name,
-    COALESCE(o.description, cm.description) AS application_description,
     c.reference_name AS charm_name,
     c.revision AS charm_revision,
     cs.name AS charm_source,
@@ -60,7 +59,8 @@ SELECT
     cr.interface AS endpoint_interface,
     cr.capacity AS endpoint_limit,
     COALESCE(tc.total_connections, 0) AS total_connections,
-    COALESCE(ac.total_active_connections, 0) AS total_active_connections
+    COALESCE(ac.total_active_connections, 0) AS total_active_connections,
+    COALESCE(o.description, cm.description) AS application_description
 FROM offer AS o
 JOIN offer_endpoint AS oe ON o.uuid = oe.offer_uuid
 JOIN application_endpoint AS ae ON oe.endpoint_uuid = ae.uuid

--- a/domain/schema/model/triggers/offer-triggers.gen.go
+++ b/domain/schema/model/triggers/offer-triggers.gen.go
@@ -30,7 +30,8 @@ CREATE TRIGGER trg_log_offer_update
 AFTER UPDATE ON offer FOR EACH ROW
 WHEN 
 	NEW.uuid != OLD.uuid OR
-	NEW.name != OLD.name
+	NEW.name != OLD.name OR
+	(NEW.description != OLD.description OR (NEW.description IS NOT NULL AND OLD.description IS NULL) OR (NEW.description IS NULL AND OLD.description IS NOT NULL))
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now', 'utc'));


### PR DESCRIPTION
When creating an application offer, Juju 4 ignores the application description from the API call: the apiserver never maps `ApplicationDescription` into the domain args, and the `offer` table has no column to store it. The charm's metadata description is always used instead. In Juju 3, the field was stored, and only an empty one fell back to the charm's description.

Store the application description as a separate nullable column in the `offer` table. `v_offer_detail` coalesces it with the charm metadata description, keeping the Juju 3 fallback behaviour.

> [!WARNING]
> #23230 was accidentally merged to main, but it should have been merged to 4.1. Before merging this PR, the previous PR from main should be reverted.
> #23273 is the reversion PR.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
mkdir -p /tmp/offertest && cd /tmp/offertest
go mod init offertest
go mod edit -require=github.com/juju/juju@v0.0.0 \
  -replace=github.com/juju/juju=/home/tugudd/projects/juju-offer-description
go mod tidy
```

/tmp/offertest/main.go:

```
package main

import (
	"context"
	"fmt"
	"os"

	"github.com/juju/juju/api/client/applicationoffers"
	"github.com/juju/juju/api/connector"
)

func main() {
	ctx := context.Background()
	controllerName := os.Args[1]
	modelUUID := os.Args[2]
	application := os.Args[3]
	endpoint := os.Args[4]
	offerName := os.Args[5]
	description := os.Args[6]

	conn, err := connector.NewClientStore(connector.ClientStoreConfig{
		ControllerName: controllerName,
	})
	if err != nil {
		panic(err)
	}
	apiConn, err := conn.Connect(ctx)
	if err != nil {
		panic(err)
	}
	defer apiConn.Close()

	client := applicationoffers.NewClient(apiConn)
	results, err := client.Offer(ctx, modelUUID, application, []string{endpoint}, "admin", offerName, description)
	if err != nil {
		panic(err)
	}
	for _, r := range results {
		if r.Error != nil {
			fmt.Println("ERROR:", r.Error)
			os.Exit(1)
		}
	}
	fmt.Printf("offer %q created with description %q\n", offerName, description)
}
```

### Test 1: Explicit description
```sh
go run /tmp/offertest/main.go juju-offer-desc d95ff147-28a8-47e8-8ac4-ac3c813cdbcc dummy-source sink test-offer "my custom offer description"
juju show-offer test-offer
# expect: "my custom offer description"
```

### Test 2: CLI offer without description falls back to charm metadata
```sh
juju offer dummy-source:sink fallback-offer
juju show-offer fallback-offer
# expect: "This dummy charm is used to verify that a relationship is created correctly"
```

## Documentation changes
N/A

## Links
**Issue:** Fixes #22264.
**Jira card:** [JUJU-9685](https://warthogs.atlassian.net/browse/JUJU-9685)


[JUJU-9685]: https://warthogs.atlassian.net/browse/JUJU-9685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ