### PR TITLE
fix(credential): allow k8s migration with differing rbac IDs

### DIFF
--- a/domain/credential/modelmigration/import.go
+++ b/domain/credential/modelmigration/import.go
@@ -5,10 +5,12 @@ package modelmigration
 
 import (
 	"context"
+	"maps"
 	"reflect"
 
 	"github.com/juju/description/v12"
 
+	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
 	"github.com/juju/juju/core/logger"
@@ -97,8 +99,16 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	if existing.AuthType() != cloud.AuthType(cred.AuthType()) {
 		return errors.Errorf("credential auth type mismatch: %q != %q", existing.AuthType(), cred.AuthType())
 	}
-	if !reflect.DeepEqual(existing.Attributes(), cred.Attributes()) {
-		return errors.Errorf("credential attribute mismatch: %v != %v", existing.Attributes(), cred.Attributes())
+	existingAttrs, importedAttrs := existing.Attributes(), maps.Clone(cred.Attributes())
+	if model.Type() == description.CAAS {
+		// Kubernetes uses rbac-id to label managed RBAC resources, not to
+		// authenticate. It may be absent or differ between controllers.
+		// Compare copies so the destination credential and export stay intact.
+		delete(existingAttrs, k8scloud.RBACLabelKeyName)
+		delete(importedAttrs, k8scloud.RBACLabelKeyName)
+	}
+	if !reflect.DeepEqual(existingAttrs, importedAttrs) {
+		return errors.Errorf("credential attribute mismatch for %q", key)
 	}
 	if existing.Revoked {
 		return errors.Errorf("credential %q is revoked", key)

--- a/domain/credential/modelmigration/import.go
+++ b/domain/credential/modelmigration/import.go
@@ -6,7 +6,6 @@ package modelmigration
 import (
 	"context"
 	"maps"
-	"reflect"
 
 	"github.com/juju/description/v12"
 
@@ -102,12 +101,14 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	existingAttrs, importedAttrs := existing.Attributes(), maps.Clone(cred.Attributes())
 	if model.Type() == description.CAAS {
 		// Kubernetes uses rbac-id to label managed RBAC resources, not to
-		// authenticate. It may be absent or differ between controllers.
-		// Compare copies so the destination credential and export stay intact.
+		// authenticate. It may be absent or differ between controllers, so
+		// discard it before comparing attributes. existing.Attributes()
+		// already returns a copy, but cred.Attributes() exposes the
+		// migration export's internal map, hence the maps.Clone above.
 		delete(existingAttrs, k8scloud.RBACLabelKeyName)
 		delete(importedAttrs, k8scloud.RBACLabelKeyName)
 	}
-	if !reflect.DeepEqual(existingAttrs, importedAttrs) {
+	if !maps.Equal(existingAttrs, importedAttrs) {
 		return errors.Errorf("credential attribute mismatch for %q", key)
 	}
 	if existing.Revoked {

--- a/domain/credential/modelmigration/import_test.go
+++ b/domain/credential/modelmigration/import_test.go
@@ -4,6 +4,7 @@
 package modelmigration
 
 import (
+	"maps"
 	"regexp"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/juju/description/v12"
 	"github.com/juju/tc"
 
+	k8scloud "github.com/juju/juju/caas/kubernetes/cloud"
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
 	usertesting "github.com/juju/juju/core/user/testing"
@@ -153,5 +155,134 @@ func (s *importSuite) TestImportExistingAttributesMisMatch(c *tc.C) {
 
 	op := s.newImportOperation()
 	err := op.Execute(c.Context(), model)
-	c.Assert(err, tc.ErrorMatches, regexp.QuoteMeta(`credential attribute mismatch: map[goodbye:world] != map[hello:world]`))
+	c.Check(err, tc.ErrorMatches, regexp.QuoteMeta(`credential attribute mismatch for "cirrus/fred/foo"`))
+}
+
+func (s *importSuite) TestImportExistingKubernetesCredentialWithTargetRBACID(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// A token-only export must match a target with RBAC bookkeeping metadata.
+	model := description.NewModel(description.ModelArgs{Type: description.CAAS})
+	model.SetCloudCredential(
+		description.CloudCredentialArgs{
+			Owner:    "fred",
+			Cloud:    "kubernetes",
+			Name:     "foo",
+			AuthType: string(cloud.OAuth2AuthType),
+			Attributes: map[string]string{
+				"Token": "token",
+			},
+		},
+	)
+	cred := cloud.NewCredential(cloud.OAuth2AuthType, map[string]string{
+		"Token":                   "token",
+		k8scloud.RBACLabelKeyName: "target-controller-id",
+	})
+	key := credential.Key{Cloud: "kubernetes", Owner: usertesting.GenNewName(c, "fred"), Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.All(), key).Times(1).Return(cred, nil)
+
+	op := s.newImportOperation()
+	err := op.Execute(c.Context(), model)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
+func (s *importSuite) TestImportExistingKubernetesCredentialWithDifferentAuthenticationAttributes(c *tc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Ignoring RBAC metadata must not hide different authentication material.
+	model := description.NewModel(description.ModelArgs{Type: description.CAAS})
+	model.SetCloudCredential(
+		description.CloudCredentialArgs{
+			Owner:    "fred",
+			Cloud:    "kubernetes",
+			Name:     "foo",
+			AuthType: string(cloud.OAuth2AuthType),
+			Attributes: map[string]string{
+				"Token": "source-token",
+			},
+		},
+	)
+	cred := cloud.NewCredential(cloud.OAuth2AuthType, map[string]string{
+		"Token":                   "target-token",
+		k8scloud.RBACLabelKeyName: "target-controller-id",
+	})
+	key := credential.Key{Cloud: "kubernetes", Owner: usertesting.GenNewName(c, "fred"), Name: "foo"}
+	s.service.EXPECT().CloudCredential(gomock.All(), key).Times(1).Return(cred, nil)
+
+	op := s.newImportOperation()
+	err := op.Execute(c.Context(), model)
+	c.Check(err, tc.ErrorMatches, regexp.QuoteMeta(`credential attribute mismatch for "kubernetes/fred/foo"`))
+}
+
+func (s *importSuite) TestImportCredentialMetadata(c *tc.C) {
+	// Exercise compatibility in both directions and ensure it cannot bypass
+	// authentication or revocation checks or mutate either credential.
+	for _, test := range []struct {
+		name      string
+		modelType string
+		authType  cloud.AuthType
+		existing  map[string]string
+		imported  map[string]string
+		revoked   bool
+		wantError string
+	}{
+		{
+			name: "different RBAC IDs", modelType: description.CAAS,
+			existing: map[string]string{"Token": "token", "rbac-id": "target"},
+			imported: map[string]string{"Token": "token", "rbac-id": "source"},
+		}, {
+			name: "source-only RBAC ID", modelType: description.CAAS,
+			existing: map[string]string{"Token": "token"},
+			imported: map[string]string{"Token": "token", "rbac-id": "source"},
+		}, {
+			name: "IAAS attributes stay strict", modelType: description.IAAS,
+			existing:  map[string]string{"Token": "token", "rbac-id": "target"},
+			imported:  map[string]string{"Token": "token"},
+			wantError: `credential attribute mismatch for "qa-k8s/fred/foo"`,
+		}, {
+			name: "other metadata stays strict", modelType: description.CAAS,
+			existing:  map[string]string{"Token": "token", "other": "value"},
+			imported:  map[string]string{"Token": "token"},
+			wantError: `credential attribute mismatch for "qa-k8s/fred/foo"`,
+		}, {
+			name: "revoked target", modelType: description.CAAS, revoked: true,
+			existing:  map[string]string{"Token": "token", "rbac-id": "target"},
+			imported:  map[string]string{"Token": "token"},
+			wantError: `credential "qa-k8s/fred/foo" is revoked`,
+		}, {
+			name: "certificate authentication", modelType: description.CAAS,
+			authType: cloud.ClientCertificateAuthType,
+			existing: map[string]string{"ClientCertificateData": "cert", "ClientKeyData": "key", "rbac-id": "target"},
+			imported: map[string]string{"ClientCertificateData": "cert", "ClientKeyData": "key"},
+		}, {
+			name: "different certificate key", modelType: description.CAAS,
+			authType:  cloud.ClientCertificateAuthType,
+			existing:  map[string]string{"ClientCertificateData": "cert", "ClientKeyData": "target", "rbac-id": "target"},
+			imported:  map[string]string{"ClientCertificateData": "cert", "ClientKeyData": "source"},
+			wantError: `credential attribute mismatch for "qa-k8s/fred/foo"`,
+		},
+	} {
+		c.Logf("case: %s", test.name)
+		ctrl := s.setupMocks(c)
+		if test.authType == "" {
+			test.authType = cloud.OAuth2AuthType
+		}
+		model := description.NewModel(description.ModelArgs{Type: test.modelType})
+		model.SetCloudCredential(description.CloudCredentialArgs{
+			Owner: "fred", Cloud: "qa-k8s", Name: "foo",
+			AuthType: string(test.authType), Attributes: maps.Clone(test.imported),
+		})
+		cred := cloud.NewNamedCredential("foo", test.authType, test.existing, test.revoked)
+		key := credential.Key{Cloud: "qa-k8s", Owner: usertesting.GenNewName(c, "fred"), Name: "foo"}
+		s.service.EXPECT().CloudCredential(gomock.Any(), key).Return(cred, nil)
+		err := s.newImportOperation().Execute(c.Context(), model)
+		if test.wantError == "" {
+			c.Assert(err, tc.ErrorIsNil)
+		} else {
+			c.Check(err, tc.ErrorMatches, regexp.QuoteMeta(test.wantError))
+		}
+		c.Check(cred.Attributes(), tc.DeepEquals, test.existing)
+		c.Check(model.CloudCredential().Attributes(), tc.DeepEquals, test.imported)
+		ctrl.Finish()
+	}
 }

--- a/domain/credential/modelmigration/import_test.go
+++ b/domain/credential/modelmigration/import_test.go
@@ -179,7 +179,7 @@ func (s *importSuite) TestImportExistingKubernetesCredentialWithTargetRBACID(c *
 		k8scloud.RBACLabelKeyName: "target-controller-id",
 	})
 	key := credential.Key{Cloud: "kubernetes", Owner: usertesting.GenNewName(c, "fred"), Name: "foo"}
-	s.service.EXPECT().CloudCredential(gomock.All(), key).Times(1).Return(cred, nil)
+	s.service.EXPECT().CloudCredential(gomock.Any(), key).Times(1).Return(cred, nil)
 
 	op := s.newImportOperation()
 	err := op.Execute(c.Context(), model)
@@ -207,7 +207,7 @@ func (s *importSuite) TestImportExistingKubernetesCredentialWithDifferentAuthent
 		k8scloud.RBACLabelKeyName: "target-controller-id",
 	})
 	key := credential.Key{Cloud: "kubernetes", Owner: usertesting.GenNewName(c, "fred"), Name: "foo"}
-	s.service.EXPECT().CloudCredential(gomock.All(), key).Times(1).Return(cred, nil)
+	s.service.EXPECT().CloudCredential(gomock.Any(), key).Times(1).Return(cred, nil)
 
 	op := s.newImportOperation()
 	err := op.Execute(c.Context(), model)
@@ -234,6 +234,10 @@ func (s *importSuite) TestImportCredentialMetadata(c *tc.C) {
 			name: "source-only RBAC ID", modelType: description.CAAS,
 			existing: map[string]string{"Token": "token"},
 			imported: map[string]string{"Token": "token", "rbac-id": "source"},
+		}, {
+			name: "nil import vs rbac-only target", modelType: description.CAAS,
+			existing: map[string]string{"rbac-id": "target"},
+			imported: nil,
 		}, {
 			name: "IAAS attributes stay strict", modelType: description.IAAS,
 			existing:  map[string]string{"Token": "token", "rbac-id": "target"},
@@ -277,7 +281,7 @@ func (s *importSuite) TestImportCredentialMetadata(c *tc.C) {
 		s.service.EXPECT().CloudCredential(gomock.Any(), key).Return(cred, nil)
 		err := s.newImportOperation().Execute(c.Context(), model)
 		if test.wantError == "" {
-			c.Assert(err, tc.ErrorIsNil)
+			c.Check(err, tc.ErrorIsNil)
 		} else {
 			c.Check(err, tc.ErrorMatches, regexp.QuoteMeta(test.wantError))
 		}


### PR DESCRIPTION
Kubernetes `rbac-id` is controller-local bookkeeping used to label managed RBAC
resources. A 3.6 source credential does not contain it, while a 4.x target
credential can. Importing the model therefore rejected otherwise identical
credentials during migration.

For CAAS models, ignore only `rbac-id` when comparing existing and imported
credential attributes. All authentication attributes, revocation checks, and
non-CAAS credential comparisons remain strict. Credential values are no longer
included in mismatch errors.

## QA steps

Create a 3.6 Kubernetes source controller (src36) and model.

 ```
juju_36 bootstrap microk8s src36
juju_36 add-model -c src36 rbactest microk8s
juju_36 deploy -m src36:rbactest juju-qa-test
juju_36 status -m src36:rbactest
 ```

 The 3.6 credential has no rbac-id (Token only):

 ```
juju_36 show-credential microk8s microk8s -c src36 --show-secrets
 ```

 Bootstrap a controller built from this branch, register the same cloud and
 token, and give the credential an rbac-id:

 ```
juju bootstrap localhost dst40 --build-agent
juju add-cloud microk8s -c dst40
juju update-credential microk8s microk8s -c dst40 -f target-credential.yaml
juju show-credential microk8s microk8s -c dst40 --format yaml
 ```

 (target-credential.yaml contains the source Token plus an rbac-id — now the
 two show-credential outputs prove the credentials differ only in rbac-id.)

 ```
credentials:
  microk8s:
    microk8s:
      auth-type: oauth2
      Token: <the token shown on src36>
      rbac-id: cafef00d
 ```

 dst40 must reach the Kubernetes API. If the localhost (LXD) controller
 container cannot see the cluster at the registered 127.0.0.1 endpoint,
 update the cloud to a reachable address and upload its CA before migrating:

 ```
juju update-cloud microk8s -c dst40 -f cloud.yaml
 ```

 ```
clouds:
  microk8s:
    type: kubernetes
    endpoint: https://10.134.1.1:16443
    ca-certificates: [<PEM from /var/snap/microk8s/current/certs/ca.crt>]
 ```

 (Use the host's LXD bridge IP; microk8s' serving cert covers it.)

 The migration must complete and the workload must remain healthy:

 ```
juju_36 migrate src36:rbactest dst40
juju status -m dst40:rbactest
juju debug-log -m dst40:controller --replay
juju debug-log -m dst40:rbactest --replay
 ```

 On pre-fix code the import fails with credential attribute mismatch for "microk8s/admin/microk8s"; with
 the fix the migration reaches DONE
 and the target credential keeps its rbac-id.

  ## Links

  **Issue:** Fixes #23260.
  **Jira card:** [JUJU-10340](https://warthogs.atlassian.net/browse/JUJU-10340)

[JUJU-10340]: https://warthogs.atlassian.net/browse/JUJU-10340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ