### PR TITLE
fix: remove deleted relations from unit relation state

### DIFF
--- a/domain/removal/state/model/relation.go
+++ b/domain/removal/state/model/relation.go
@@ -311,7 +311,7 @@ AND    scope_uuid = $entityUUID.uuid`, relationUUID)
 
 	// Unit relation state uses the numeric relation ID encoded as text.
 	// Delete the relation from all states.
-	// The means that forced removal will never have a subsequent hook
+	// This means that forced removal will never have a subsequent hook
 	// execution indicating that the unit is still part of the relation.
 	unitStateStmt, err := st.Prepare(`
 DELETE FROM unit_state_relation

--- a/domain/removal/state/model/relation.go
+++ b/domain/removal/state/model/relation.go
@@ -309,6 +309,19 @@ AND    scope_uuid = $entityUUID.uuid`, relationUUID)
 		return errors.Errorf("preparing relation secret permission deletion: %w", err)
 	}
 
+	// Unit relation state uses the numeric relation ID encoded as text.
+	// Delete the relation from all states.
+	// The means that forced removal will never have a subsequent hook
+	// execution indicating that the unit is still part of the relation.
+	unitStateStmt, err := st.Prepare(`
+DELETE FROM unit_state_relation
+WHERE "key" IN (
+    SELECT CAST(relation_id AS TEXT) FROM relation WHERE uuid = $entityUUID.uuid
+)`, relationUUID)
+	if err != nil {
+		return errors.Errorf("preparing unit relation state deletion: %w", err)
+	}
+
 	relStmt, err := st.Prepare("DELETE FROM relation WHERE uuid = $entityUUID.uuid ", relationUUID)
 	if err != nil {
 		return errors.Errorf("preparing relation deletion: %w", err)
@@ -355,6 +368,11 @@ AND    scope_uuid = $entityUUID.uuid`, relationUUID)
 	err = tx.Query(ctx, secretPermissionStmt, relationUUID).Run()
 	if err != nil {
 		return errors.Errorf("running relation secret permission deletion: %w", err)
+	}
+
+	err = tx.Query(ctx, unitStateStmt, relationUUID).Run()
+	if err != nil {
+		return errors.Errorf("running unit relation state deletion: %w", err)
 	}
 
 	err = tx.Query(ctx, relStmt, relationUUID).Run()

--- a/domain/removal/state/model/relation_test.go
+++ b/domain/removal/state/model/relation_test.go
@@ -235,13 +235,20 @@ func (s *relationSuite) TestDeleteRelationUnitsSuccess(c *tc.C) {
 }
 
 func (s *relationSuite) TestDeleteRelationUnitsInScopeFails(c *tc.C) {
-	rel, _, _ := s.addAppUnitRelationScope(c, domaincharm.CharmHubSource)
+	rel, unitUUID, _ := s.addAppUnitRelationScope(c, domaincharm.CharmHubSource)
+	s.addUnitRelationState(c, unitUUID, "42", "checkpoint")
 
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	err := st.DeleteRelation(c.Context(), rel)
 	c.Assert(err, tc.ErrorIs, removalerrors.UnitsStillInScope)
 	c.Check(err, tc.ErrorIs, removalerrors.RemovalJobIncomplete)
+
+	var checkpoint string
+	err = s.DB().QueryRow(`SELECT value FROM unit_state_relation WHERE unit_uuid = ? AND "key" = '42'`,
+		unitUUID).Scan(&checkpoint)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(checkpoint, tc.Equals, "checkpoint")
 }
 
 func (s *relationSuite) TestDeleteRelationUnitsInScopeSuccess(c *tc.C) {
@@ -257,6 +264,78 @@ func (s *relationSuite) TestDeleteRelationUnitsInScopeSuccess(c *tc.C) {
 
 	_, err = st.GetRelationLife(c.Context(), rel)
 	c.Assert(err, tc.ErrorIs, relationerrors.RelationNotFound)
+}
+
+func (s *relationSuite) TestDeleteRelationRemovesUnitState(c *tc.C) {
+	rel, unitUUID, _ := s.addAppUnitRelationScope(c, domaincharm.CharmHubSource)
+	otherUnitUUID := s.addUnit(c, "some-charm-uuid")
+
+	_, err := s.DB().Exec(`
+INSERT INTO relation (uuid, life_id, relation_id, scope_id)
+VALUES ('other-relation-uuid', 0, 43, 0)`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	for _, u := range []string{unitUUID, otherUnitUUID} {
+		s.addUnitRelationState(c, u, "42", "removed checkpoint")
+		s.addUnitRelationState(c, u, "43", "retained checkpoint for "+u)
+	}
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	// Forced removal clears scope before finally deleting the relation.
+	// Checkpoints must be removed even for units no longer in scope.
+	err = st.DeleteRelationUnits(c.Context(), rel)
+	c.Assert(err, tc.ErrorIsNil)
+	err = st.DeleteRelation(c.Context(), rel)
+	c.Assert(err, tc.ErrorIsNil)
+
+	rows, err := s.DB().Query(`SELECT unit_uuid, "key", value FROM unit_state_relation`)
+	c.Assert(err, tc.ErrorIsNil)
+	defer rows.Close()
+	checkpoints := make(map[string]string)
+	for rows.Next() {
+		var u, key, value string
+		c.Assert(rows.Scan(&u, &key, &value), tc.ErrorIsNil)
+		c.Check(key, tc.Equals, "43")
+		checkpoints[u] = value
+	}
+	c.Assert(rows.Err(), tc.ErrorIsNil)
+	c.Check(checkpoints, tc.DeepEquals, map[string]string{
+		unitUUID:      "retained checkpoint for " + unitUUID,
+		otherUnitUUID: "retained checkpoint for " + otherUnitUUID,
+	})
+
+	_, err = st.GetRelationLife(c.Context(), rel)
+	c.Check(err, tc.ErrorIs, relationerrors.RelationNotFound)
+	_, err = st.GetRelationLife(c.Context(), "other-relation-uuid")
+	c.Check(err, tc.ErrorIsNil)
+}
+
+func (s *relationSuite) TestDeleteRelationRollsBackUnitState(c *tc.C) {
+	rel, unitUUID, _ := s.addAppUnitRelationScope(c, domaincharm.CharmHubSource)
+	s.addUnitRelationState(c, unitUUID, "42", "checkpoint")
+
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+	err := st.DeleteRelationUnits(c.Context(), rel)
+	c.Assert(err, tc.ErrorIsNil)
+
+	// Fail the final deletion to check that checkpoint cleanup rolls back.
+	_, err = s.DB().Exec(`
+CREATE TRIGGER fail_relation_deletion BEFORE DELETE ON relation
+BEGIN
+    SELECT RAISE(ABORT, 'relation deletion failed');
+END`)
+	c.Assert(err, tc.ErrorIsNil)
+
+	err = st.DeleteRelation(c.Context(), rel)
+	c.Assert(err, tc.ErrorMatches, ".*relation deletion failed.*")
+
+	var checkpoint string
+	err = s.DB().QueryRow(`SELECT value FROM unit_state_relation WHERE unit_uuid = ? AND "key" = '42'`,
+		unitUUID).Scan(&checkpoint)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(checkpoint, tc.Equals, "checkpoint")
+	_, err = st.GetRelationLife(c.Context(), rel)
+	c.Check(err, tc.ErrorIsNil)
 }
 
 func (s *relationSuite) TestDeleteRelationUnitsInScopeSuccessHasSecretPermission(c *tc.C) {
@@ -561,6 +640,13 @@ func (s *relationSuite) TestIsUnitDyingAndBlockedDead(c *tc.C) {
 	}
 }
 
+func (s *relationSuite) addUnitRelationState(c *tc.C, unitUUID, key, value string) {
+	_, err := s.DB().Exec(`
+INSERT INTO unit_state_relation (unit_uuid, "key", value) VALUES (?, ?, ?)`,
+		unitUUID, key, value)
+	c.Assert(err, tc.ErrorIsNil)
+}
+
 // addAppUnitRelationScope adds charm, application, unit and relation
 // infrastructure such that a single unit is in the scope of a single relation.
 // The relation, unit and relation-unit identifiers are returned.
@@ -603,7 +689,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?)`,
 
 	rel := "some-relation-uuid"
 	_, err = s.DB().Exec(
-		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, ?, ?, ?)", rel, 0, rel, 0)
+		"INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, ?, ?, ?)", rel, 0, 42, 0)
 	c.Assert(err, tc.ErrorIsNil)
 
 	relEndpoint := "some-relation-endpoint-uuid"

--- a/domain/unitstate/state/state.go
+++ b/domain/unitstate/state/state.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/clock"
-
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/domain"
@@ -262,8 +261,8 @@ func (st *State) setUnitStateCharm(ctx context.Context, tx *sqlair.TX, id entity
 	return nil
 }
 
-// SetUnitStateRelation sets the input key/value pairs
-// as the relation state for the input unit UUID.
+// setUnitStateRelation sets the input key/value pairs as the relation state
+// for the input unit UUID, excluding relations that no longer exist.
 func (st *State) setUnitStateRelation(ctx context.Context, tx *sqlair.TX, id entityUUID, state map[int]string) error {
 	q := "DELETE from unit_state_relation WHERE unit_uuid = $entityUUID.uuid"
 	dStmt, err := st.Prepare(q, id)
@@ -271,22 +270,52 @@ func (st *State) setUnitStateRelation(ctx context.Context, tx *sqlair.TX, id ent
 		return errors.Errorf("preparing relation state delete query: %w", err)
 	}
 
-	keyVals := makeUnitRelationStateKeyVals(id, state)
-
 	if err := tx.Query(ctx, dStmt, id).Run(); err != nil {
 		return errors.Errorf("deleting unit relation state: %w", err)
 	}
 
-	if len(keyVals) != 0 {
-		q = "INSERT INTO unit_state_relation(*) VALUES ($unitRelationStateKeyVal.*)"
-		iStmt, err := st.Prepare(q, keyVals[0])
-		if err != nil {
-			return errors.Errorf("preparing relation state insert query: %w", err)
-		}
+	if len(state) == 0 {
+		return nil
+	}
 
-		if err := tx.Query(ctx, iStmt, keyVals).Run(); err != nil {
-			return errors.Errorf("setting unit relation state: %w", err)
-		}
+	ids := make(relationIDs, 0, len(state))
+	for k := range state {
+		ids = append(ids, k)
+	}
+
+	// Only set the unit relation state for relations that still exist.
+	// If relations have been removed by force, we don't want a racing hook
+	// commit action to indicate that the unit is still in such relations.
+	q = `
+SELECT r.relation_id AS &unitRelationStateKeyVal.key
+FROM   relation AS r
+WHERE  r.relation_id IN ($relationIDs[:])`
+	rStmt, err := st.Prepare(q, ids, unitRelationStateKeyVal{})
+	if err != nil {
+		return errors.Errorf("preparing relation existence query: %w", err)
+	}
+
+	var keyVals []unitRelationStateKeyVal
+	err = tx.Query(ctx, rStmt, ids).GetAll(&keyVals)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return nil
+	} else if err != nil {
+		return errors.Errorf("getting existing relations: %w", err)
+	}
+
+	for i := range keyVals {
+		keyVals[i].UUID = id.UUID
+		keyVals[i].Value = state[keyVals[i].Key]
+	}
+
+	q = "INSERT INTO unit_state_relation(*) VALUES ($unitRelationStateKeyVal.*)"
+	iStmt, err := st.Prepare(q, unitRelationStateKeyVal{})
+	if err != nil {
+		return errors.Errorf("preparing relation state insert query: %w", err)
+	}
+
+	if err := tx.Query(ctx, iStmt, keyVals).Run(); err != nil {
+		return errors.Errorf("setting unit relation state: %w", err)
 	}
 	return nil
 }

--- a/domain/unitstate/state/state.go
+++ b/domain/unitstate/state/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/clock"
+
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/domain"
@@ -263,6 +264,8 @@ func (st *State) setUnitStateCharm(ctx context.Context, tx *sqlair.TX, id entity
 
 // setUnitStateRelation sets the input key/value pairs as the relation state
 // for the input unit UUID, excluding relations that no longer exist.
+// This is a replacement operation, first deleting everything for the unit,
+// then setting based on relation existence.
 func (st *State) setUnitStateRelation(ctx context.Context, tx *sqlair.TX, id entityUUID, state map[int]string) error {
 	q := "DELETE from unit_state_relation WHERE unit_uuid = $entityUUID.uuid"
 	dStmt, err := st.Prepare(q, id)
@@ -298,6 +301,8 @@ WHERE  r.relation_id IN ($relationIDs[:])`
 	var keyVals []unitRelationStateKeyVal
 	err = tx.Query(ctx, rStmt, ids).GetAll(&keyVals)
 	if errors.Is(err, sqlair.ErrNoRows) {
+		// If none of the relations indicated by the incoming
+		// state actually exist, then we set nothing.
 		return nil
 	} else if err != nil {
 		return errors.Errorf("getting existing relations: %w", err)

--- a/domain/unitstate/state/state_test.go
+++ b/domain/unitstate/state/state_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/juju/tc"
 
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/domain/life"
+	removalstate "github.com/juju/juju/domain/removal/state/model"
 	"github.com/juju/juju/domain/unitstate"
+	"github.com/juju/juju/internal/uuid"
 )
 
 type stateSuite struct {
@@ -24,6 +27,8 @@ func TestStateSuite(t *stdtesting.T) {
 }
 
 func (s *stateSuite) TestSetUnitState(c *tc.C) {
+	s.addRelation(c, 1, life.Alive)
+
 	agentState := unitstate.UnitState{
 		Name:          s.unitName,
 		CharmState:    new(map[string]string{"one-key": "one-value"}),
@@ -32,7 +37,8 @@ func (s *stateSuite) TestSetUnitState(c *tc.C) {
 		StorageState:  new("some-storage-state-yaml"),
 		SecretState:   new("some-secret-state-yaml"),
 	}
-	s.state.SetUnitState(c.Context(), agentState)
+	err := s.state.SetUnitState(c.Context(), agentState)
+	c.Assert(err, tc.ErrorIsNil)
 
 	expectedAgentState := unitstate.RetrievedUnitState{
 		CharmState:    *agentState.CharmState,
@@ -45,6 +51,82 @@ func (s *stateSuite) TestSetUnitState(c *tc.C) {
 	state, err := s.state.GetUnitState(c.Context(), s.unitName)
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(state, tc.DeepEquals, expectedAgentState)
+}
+
+func (s *stateSuite) TestSetUnitStateFiltersMissingRelations(c *tc.C) {
+	// Departure hooks still need checkpoints for relations being removed.
+	s.addRelation(c, 0, life.Alive)
+	s.addRelation(c, 1, life.Dying)
+	s.addRelation(c, 2, life.Dead)
+	s.query(c, `INSERT INTO unit_state_relation (unit_uuid, "key", value) VALUES (?, ?, ?)`,
+		s.unitUUID, "3", "old checkpoint")
+
+	agentState := unitstate.UnitState{
+		Name: s.unitName,
+		RelationState: new(map[int]string{
+			0: "alive checkpoint",
+			1: "dying checkpoint",
+			2: "dead checkpoint",
+			3: "missing checkpoint",
+		}),
+		CharmState:   new(map[string]string{"key": "charm state"}),
+		UniterState:  new("uniter state"),
+		StorageState: new("storage state"),
+		SecretState:  new("secret state"),
+	}
+	err := s.state.SetUnitState(c.Context(), agentState)
+	c.Assert(err, tc.ErrorIsNil)
+
+	state, err := s.state.GetUnitState(c.Context(), s.unitName)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(state, tc.DeepEquals, unitstate.RetrievedUnitState{
+		RelationState: map[int]string{
+			0: "alive checkpoint",
+			1: "dying checkpoint",
+			2: "dead checkpoint",
+		},
+		CharmState:   *agentState.CharmState,
+		UniterState:  *agentState.UniterState,
+		StorageState: *agentState.StorageState,
+		SecretState:  *agentState.SecretState,
+	})
+	// Filtering must not change the caller's checkpoint map.
+	c.Check(*agentState.RelationState, tc.DeepEquals, map[int]string{
+		0: "alive checkpoint",
+		1: "dying checkpoint",
+		2: "dead checkpoint",
+		3: "missing checkpoint",
+	})
+}
+
+func (s *stateSuite) TestSetUnitStateAfterRelationDeletion(c *tc.C) {
+	relationUUID := s.addRelation(c, 42, life.Dying)
+	agentState := unitstate.UnitState{
+		Name:          s.unitName,
+		RelationState: new(map[int]string{42: "checkpoint"}),
+	}
+	err := s.state.SetUnitState(c.Context(), agentState)
+	c.Assert(err, tc.ErrorIsNil)
+
+	removal := removalstate.NewState(s.TxnRunnerFactory(), s.state.logger)
+	err = removal.DeleteRelation(c.Context(), relationUUID)
+	c.Assert(err, tc.ErrorIsNil)
+
+	state, err := s.state.GetUnitState(c.Context(), s.unitName)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(state.RelationState, tc.HasLen, 0)
+
+	// A late write from the unit must not restore the deleted checkpoint,
+	// even when every relation in its snapshot has disappeared.
+	agentState.UniterState = new("updated uniter state")
+	err = s.state.SetUnitState(c.Context(), agentState)
+	c.Assert(err, tc.ErrorIsNil)
+
+	state, err = s.state.GetUnitState(c.Context(), s.unitName)
+	c.Assert(err, tc.ErrorIsNil)
+	c.Check(state, tc.DeepEquals, unitstate.RetrievedUnitState{
+		UniterState: *agentState.UniterState,
+	})
 }
 
 func (s *stateSuite) TestSetUnitStateJustUniterState(c *tc.C) {
@@ -225,9 +307,13 @@ func (s *stateSuite) TestUpdateUnitStateCharmEmptyMap(c *tc.C) {
 
 func (s *stateSuite) TestUpdateUnitStateRelation(c *tc.C) {
 	ctx := c.Context()
+	s.addRelation(c, 1, life.Alive)
+	s.addRelation(c, 2, life.Alive)
+	s.addRelation(c, 3, life.Alive)
 
 	// Set some initial state. This should be overwritten.
-	s.addUnitStateCharm(c, 1, "one-val")
+	s.query(c, `INSERT INTO unit_state_relation (unit_uuid, "key", value) VALUES (?, ?, ?)`,
+		s.unitUUID, "1", "one-val")
 
 	expState := map[int]string{
 		2: "two-val",
@@ -267,9 +353,11 @@ func (s *stateSuite) TestUpdateUnitStateRelation(c *tc.C) {
 
 func (s *stateSuite) TestUpdateUnitStateRelationEmptyMap(c *tc.C) {
 	ctx := c.Context()
+	s.addRelation(c, 1, life.Alive)
 
-	// Set some initial state. This should be overwritten.
-	s.addUnitStateCharm(c, 1, "one-val")
+	// Set some initial state. This should be deleted.
+	s.query(c, `INSERT INTO unit_state_relation (unit_uuid, "key", value) VALUES (?, ?, ?)`,
+		s.unitUUID, "1", "one-val")
 
 	err := s.TxnRunner().Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		return s.state.setUnitStateRelation(ctx, tx, entityUUID{UUID: s.unitUUID}, map[int]string{})
@@ -295,4 +383,11 @@ func (s *stateSuite) TestUpdateUnitStateRelationEmptyMap(c *tc.C) {
 	c.Assert(err, tc.ErrorIsNil)
 
 	c.Check(rowCount, tc.DeepEquals, 0)
+}
+
+func (s *stateSuite) addRelation(c *tc.C, relationID int, relationLife life.Life) string {
+	relationUUID := tc.Must(c, uuid.NewUUID).String()
+	s.query(c, `INSERT INTO relation (uuid, life_id, relation_id, scope_id) VALUES (?, ?, ?, 0)`,
+		relationUUID, relationLife, relationID)
+	return relationUUID
 }

--- a/domain/unitstate/state/types.go
+++ b/domain/unitstate/state/types.go
@@ -285,23 +285,12 @@ type unitStateKeyVal[T comparable] struct {
 
 type unitCharmStateKeyVal unitStateKeyVal[string]
 type unitRelationStateKeyVal unitStateKeyVal[int]
+type relationIDs []int
 
 func makeUnitCharmStateKeyVals(unitUUID entityUUID, kv map[string]string) []unitCharmStateKeyVal {
 	keyVals := make([]unitCharmStateKeyVal, 0, len(kv))
 	for k, v := range kv {
 		keyVals = append(keyVals, unitCharmStateKeyVal{
-			UUID:  unitUUID.UUID,
-			Key:   k,
-			Value: v,
-		})
-	}
-	return keyVals
-}
-
-func makeUnitRelationStateKeyVals(unitUUID entityUUID, kv map[int]string) []unitRelationStateKeyVal {
-	keyVals := make([]unitRelationStateKeyVal, 0, len(kv))
-	for k, v := range kv {
-		keyVals = append(keyVals, unitRelationStateKeyVal{
 			UUID:  unitUUID.UUID,
 			Key:   k,
 			Value: v,


### PR DESCRIPTION
Upon forced removal of a relation or SAAS, a deleted relation can still be present in the committed hook state for units. This can cause an unrecoverable situation, where if a unit acts on such a state and encounters an error due to the missing relation it thinks it is in, the correct state is not committed and the error keeps repeating hook after hook.

Here we do two things:
- Upon relation deletion, we ensure that the relation ID is no longer present in any persisted unit relation state.
- We ignore deleted relations for committed relation state, so hooks racing with the deletion above can never restore a deleted relation to said state.

## QA steps

- Set up a CMR.
```
for c in "cns" "src"; do juju bootstrap lxd $c; done
juju switch src; juju add-model work-src; juju deploy juju-qa-dummy-source --config token=INITIAL; juju offer dummy-source:sink
juju switch cns; juju add-model work-cns; juju consume src:admin/work-src.dummy-source; juju deploy juju-qa-dummy-sink; juju relate dummy-source dummy-sink
```
- Once quiescent, force-remove the SAAS: `juju remove-saas dummy-source --force --no-wait`.
- When gone, connect to the DB REPL and verify that there are is no unit relation state.
```
repl (controller)> .switch model-work-cns
repl (model-work-cns)> select * from unit_state_relation
unit_uuid       key     value

```
- Repeat the consume and relate to verify that we're still functioning correctly, then force-remove the other side.
- `juju switch src`
- `juju remove-relation 1 --force`
- Check the REPL on that side to verify relation state.
```
repl (controller)> .switch model-work-src
repl (model-work-src)> select * from unit_state_relation
unit_uuid       key     value

```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Addresses #23246 for Juju 4+.

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10355](https://warthogs.atlassian.net/browse/JUJU-10355)


[JUJU-10355]: https://warthogs.atlassian.net/browse/JUJU-10355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ