### PR TITLE
fix: connection leak in the sshsession worker

### DIFF
--- a/internal/worker/sshsession/worker.go
+++ b/internal/worker/sshsession/worker.go
@@ -366,7 +366,30 @@ func (d *connectionDialer) DialController(
 	}
 	go gossh.DiscardRequests(reqs)
 
-	return sshconn.NewChannelConn(ch), nil
+	// The returned connection only exposes the tunnel channel, but the
+	// underlying SSH client (and its TCP connection to the controller) must
+	// be closed together with the channel. Otherwise the controller-side
+	// connection is left open forever once the tunnel is torn down.
+	return &tunnelConn{
+		ChanConn: *sshconn.NewChannelConn(ch),
+		client:   client,
+	}, nil
+}
+
+// tunnelConn couples the tunnel channel to the SSH client that carries it.
+// Closing the connection closes the whole SSH client, which tears down the
+// channel, the SSH transport and the underlying TCP connection to the
+// controller.
+type tunnelConn struct {
+	sshconn.ChanConn
+
+	client *gossh.Client
+}
+
+// Close closes the SSH client owning the tunnel channel, tearing down the
+// channel, the SSH transport and the TCP connection to the controller.
+func (c *tunnelConn) Close() error {
+	return c.client.Close()
 }
 
 // DialLocalSSHD performs a standard TCP dial to the sshd running on the


### PR DESCRIPTION
# Description

I was doing some performance testing with juju ssh, and i've noticed at one point i was getting limited by the max number of concurrent connections.

This was because we were closing the SSH connection but not the underlying TCP tunnel, and the ssh worker was not decrementing the counter, and at one point it reaches 100 which is the maximum number of accepted connections.

This is a simple fix to make sure the client is closed when the ssh connection is closed.

The only testing i could do were too involved, and i don't think it's really worth it, but i'm open to suggestion.

# QA

To check the fix you can:
- bootstrap a controller
- lxc shell into the controller machine
- run `sudo ss -tnp state established '( sport = :17022 )' | grep -v LISTEN`

Before the fix the number of connections kept increasing after a bunch of `juju ssh 0` commands, even when the ssh connection was exited.

Now everytime the session is exited the established connections are dropped correctly.