### PR TITLE
fix(modelmigration): preserve null values in model exports

### DIFF
--- a/domain/export/state/model/export.go
+++ b/domain/export/state/model/export.go
@@ -15,6 +15,116 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
+type nullableApplication struct {
+	CharmUpgradeOnErrorIsNull bool `db:"charm_upgrade_on_error_is_null"`
+}
+type nullableApplicationRemoteOffererStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableApplicationScale struct {
+	ScalingIsNull bool `db:"scaling_is_null"`
+}
+type nullableApplicationSetting struct {
+	TrustIsNull bool `db:"trust_is_null"`
+}
+type nullableApplicationStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableBlockDevice struct {
+	InUseIsNull bool `db:"in_use_is_null"`
+}
+type nullableCharm struct {
+	AvailableIsNull bool `db:"available_is_null"`
+}
+type nullableCharmAction struct {
+	ParallelIsNull bool `db:"parallel_is_null"`
+}
+type nullableCharmRelation struct {
+	OptionalIsNull bool `db:"optional_is_null"`
+}
+type nullableCharmStorage struct {
+	ReadOnlyIsNull bool `db:"read_only_is_null"`
+}
+type nullableIpAddress struct {
+	IsSecondaryIsNull bool `db:"is_secondary_is_null"`
+	IsShadowIsNull    bool `db:"is_shadow_is_null"`
+}
+type nullableK8sPodStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableMachine struct {
+	ForceDestroyedIsNull bool `db:"force_destroyed_is_null"`
+	AgentStartedAtIsNull bool `db:"agent_started_at_is_null"`
+	KeepInstanceIsNull   bool `db:"keep_instance_is_null"`
+}
+type nullableMachineAgentPresence struct {
+	LastSeenIsNull bool `db:"last_seen_is_null"`
+}
+type nullableMachineCloudInstanceStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableMachineStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableModel struct {
+	IsControllerModelIsNull bool `db:"is_controller_model_is_null"`
+}
+type nullableOperation struct {
+	StartedAtIsNull   bool `db:"started_at_is_null"`
+	CompletedAtIsNull bool `db:"completed_at_is_null"`
+	ParallelIsNull    bool `db:"parallel_is_null"`
+}
+type nullableOperationTask struct {
+	StartedAtIsNull   bool `db:"started_at_is_null"`
+	CompletedAtIsNull bool `db:"completed_at_is_null"`
+}
+type nullableOperationTaskStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableOperatorStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableRelation struct {
+	SuspendedIsNull bool `db:"suspended_is_null"`
+}
+type nullableRelationStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableResource struct {
+	LastPolledIsNull bool `db:"last_polled_is_null"`
+}
+type nullableSecretRevision struct {
+	UpdateTimeIsNull bool `db:"update_time_is_null"`
+}
+type nullableStorageFilesystem struct {
+	ObliterateOnCleanupIsNull bool `db:"obliterate_on_cleanup_is_null"`
+}
+type nullableStorageFilesystemAttachment struct {
+	ReadOnlyIsNull bool `db:"read_only_is_null"`
+}
+type nullableStorageFilesystemStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableStorageVolume struct {
+	PersistentIsNull          bool `db:"persistent_is_null"`
+	ObliterateOnCleanupIsNull bool `db:"obliterate_on_cleanup_is_null"`
+}
+type nullableStorageVolumeAttachment struct {
+	ReadOnlyIsNull bool `db:"read_only_is_null"`
+}
+type nullableStorageVolumeStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableUnitAgentPresence struct {
+	LastSeenIsNull bool `db:"last_seen_is_null"`
+}
+type nullableUnitAgentStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+type nullableUnitWorkloadStatus struct {
+	UpdatedAtIsNull bool `db:"updated_at_is_null"`
+}
+
 // Export exports all model data for version 4.0.12.
 func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	var modelExport v4_0_12.ModelExport
@@ -65,7 +175,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing AnnotationUnit statement: %w", err)
 	}
-	stmtApplication, err := sqlair.Prepare(`SELECT &Application.* FROM "application"`, v4_0_12.Application{})
+	stmtApplication, err := sqlair.Prepare(`SELECT &Application.*,
+       t."charm_upgrade_on_error" IS NULL AS &nullableApplication.charm_upgrade_on_error_is_null
+FROM   "application" AS t`, v4_0_12.Application{}, nullableApplication{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Application statement: %w", err)
 	}
@@ -129,7 +241,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationRemoteOffererRelationMacaroon statement: %w", err)
 	}
-	stmtApplicationRemoteOffererStatus, err := sqlair.Prepare(`SELECT &ApplicationRemoteOffererStatus.* FROM "application_remote_offerer_status"`, v4_0_12.ApplicationRemoteOffererStatus{})
+	stmtApplicationRemoteOffererStatus, err := sqlair.Prepare(`SELECT &ApplicationRemoteOffererStatus.*,
+       t."updated_at" IS NULL AS &nullableApplicationRemoteOffererStatus.updated_at_is_null
+FROM   "application_remote_offerer_status" AS t`, v4_0_12.ApplicationRemoteOffererStatus{}, nullableApplicationRemoteOffererStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationRemoteOffererStatus statement: %w", err)
 	}
@@ -137,15 +251,21 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationResource statement: %w", err)
 	}
-	stmtApplicationScale, err := sqlair.Prepare(`SELECT &ApplicationScale.* FROM "application_scale"`, v4_0_12.ApplicationScale{})
+	stmtApplicationScale, err := sqlair.Prepare(`SELECT &ApplicationScale.*,
+       t."scaling" IS NULL AS &nullableApplicationScale.scaling_is_null
+FROM   "application_scale" AS t`, v4_0_12.ApplicationScale{}, nullableApplicationScale{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationScale statement: %w", err)
 	}
-	stmtApplicationSetting, err := sqlair.Prepare(`SELECT &ApplicationSetting.* FROM "application_setting"`, v4_0_12.ApplicationSetting{})
+	stmtApplicationSetting, err := sqlair.Prepare(`SELECT &ApplicationSetting.*,
+       t."trust" IS NULL AS &nullableApplicationSetting.trust_is_null
+FROM   "application_setting" AS t`, v4_0_12.ApplicationSetting{}, nullableApplicationSetting{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationSetting statement: %w", err)
 	}
-	stmtApplicationStatus, err := sqlair.Prepare(`SELECT &ApplicationStatus.* FROM "application_status"`, v4_0_12.ApplicationStatus{})
+	stmtApplicationStatus, err := sqlair.Prepare(`SELECT &ApplicationStatus.*,
+       t."updated_at" IS NULL AS &nullableApplicationStatus.updated_at_is_null
+FROM   "application_status" AS t`, v4_0_12.ApplicationStatus{}, nullableApplicationStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing ApplicationStatus statement: %w", err)
 	}
@@ -177,7 +297,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing BlockCommandType statement: %w", err)
 	}
-	stmtBlockDevice, err := sqlair.Prepare(`SELECT &BlockDevice.* FROM "block_device"`, v4_0_12.BlockDevice{})
+	stmtBlockDevice, err := sqlair.Prepare(`SELECT &BlockDevice.*,
+       t."in_use" IS NULL AS &nullableBlockDevice.in_use_is_null
+FROM   "block_device" AS t`, v4_0_12.BlockDevice{}, nullableBlockDevice{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing BlockDevice statement: %w", err)
 	}
@@ -205,11 +327,15 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing ChangeLogWitness statement: %w", err)
 	}
-	stmtCharm, err := sqlair.Prepare(`SELECT &Charm.* FROM "charm"`, v4_0_12.Charm{})
+	stmtCharm, err := sqlair.Prepare(`SELECT &Charm.*,
+       t."available" IS NULL AS &nullableCharm.available_is_null
+FROM   "charm" AS t`, v4_0_12.Charm{}, nullableCharm{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Charm statement: %w", err)
 	}
-	stmtCharmAction, err := sqlair.Prepare(`SELECT &CharmAction.* FROM "charm_action"`, v4_0_12.CharmAction{})
+	stmtCharmAction, err := sqlair.Prepare(`SELECT &CharmAction.*,
+       t."parallel" IS NULL AS &nullableCharmAction.parallel_is_null
+FROM   "charm_action" AS t`, v4_0_12.CharmAction{}, nullableCharmAction{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmAction statement: %w", err)
 	}
@@ -261,7 +387,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmProvenance statement: %w", err)
 	}
-	stmtCharmRelation, err := sqlair.Prepare(`SELECT &CharmRelation.* FROM "charm_relation"`, v4_0_12.CharmRelation{})
+	stmtCharmRelation, err := sqlair.Prepare(`SELECT &CharmRelation.*,
+       t."optional" IS NULL AS &nullableCharmRelation.optional_is_null
+FROM   "charm_relation" AS t`, v4_0_12.CharmRelation{}, nullableCharmRelation{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmRelation statement: %w", err)
 	}
@@ -289,7 +417,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmSource statement: %w", err)
 	}
-	stmtCharmStorage, err := sqlair.Prepare(`SELECT &CharmStorage.* FROM "charm_storage"`, v4_0_12.CharmStorage{})
+	stmtCharmStorage, err := sqlair.Prepare(`SELECT &CharmStorage.*,
+       t."read_only" IS NULL AS &nullableCharmStorage.read_only_is_null
+FROM   "charm_storage" AS t`, v4_0_12.CharmStorage{}, nullableCharmStorage{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing CharmStorage statement: %w", err)
 	}
@@ -353,7 +483,10 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing InstanceTag statement: %w", err)
 	}
-	stmtIpAddress, err := sqlair.Prepare(`SELECT &IpAddress.* FROM "ip_address"`, v4_0_12.IpAddress{})
+	stmtIpAddress, err := sqlair.Prepare(`SELECT &IpAddress.*,
+       t."is_secondary" IS NULL AS &nullableIpAddress.is_secondary_is_null,
+       t."is_shadow" IS NULL AS &nullableIpAddress.is_shadow_is_null
+FROM   "ip_address" AS t`, v4_0_12.IpAddress{}, nullableIpAddress{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing IpAddress statement: %w", err)
 	}
@@ -381,7 +514,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing K8sPodPort statement: %w", err)
 	}
-	stmtK8sPodStatus, err := sqlair.Prepare(`SELECT &K8sPodStatus.* FROM "k8s_pod_status"`, v4_0_12.K8sPodStatus{})
+	stmtK8sPodStatus, err := sqlair.Prepare(`SELECT &K8sPodStatus.*,
+       t."updated_at" IS NULL AS &nullableK8sPodStatus.updated_at_is_null
+FROM   "k8s_pod_status" AS t`, v4_0_12.K8sPodStatus{}, nullableK8sPodStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing K8sPodStatus statement: %w", err)
 	}
@@ -421,11 +556,17 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing LinkLayerDeviceType statement: %w", err)
 	}
-	stmtMachine, err := sqlair.Prepare(`SELECT &Machine.* FROM "machine"`, v4_0_12.Machine{})
+	stmtMachine, err := sqlair.Prepare(`SELECT &Machine.*,
+       t."force_destroyed" IS NULL AS &nullableMachine.force_destroyed_is_null,
+       t."agent_started_at" IS NULL AS &nullableMachine.agent_started_at_is_null,
+       t."keep_instance" IS NULL AS &nullableMachine.keep_instance_is_null
+FROM   "machine" AS t`, v4_0_12.Machine{}, nullableMachine{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Machine statement: %w", err)
 	}
-	stmtMachineAgentPresence, err := sqlair.Prepare(`SELECT &MachineAgentPresence.* FROM "machine_agent_presence"`, v4_0_12.MachineAgentPresence{})
+	stmtMachineAgentPresence, err := sqlair.Prepare(`SELECT &MachineAgentPresence.*,
+       t."last_seen" IS NULL AS &nullableMachineAgentPresence.last_seen_is_null
+FROM   "machine_agent_presence" AS t`, v4_0_12.MachineAgentPresence{}, nullableMachineAgentPresence{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineAgentPresence statement: %w", err)
 	}
@@ -437,7 +578,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineCloudInstance statement: %w", err)
 	}
-	stmtMachineCloudInstanceStatus, err := sqlair.Prepare(`SELECT &MachineCloudInstanceStatus.* FROM "machine_cloud_instance_status"`, v4_0_12.MachineCloudInstanceStatus{})
+	stmtMachineCloudInstanceStatus, err := sqlair.Prepare(`SELECT &MachineCloudInstanceStatus.*,
+       t."updated_at" IS NULL AS &nullableMachineCloudInstanceStatus.updated_at_is_null
+FROM   "machine_cloud_instance_status" AS t`, v4_0_12.MachineCloudInstanceStatus{}, nullableMachineCloudInstanceStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineCloudInstanceStatus statement: %w", err)
 	}
@@ -489,7 +632,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineSshHostKey statement: %w", err)
 	}
-	stmtMachineStatus, err := sqlair.Prepare(`SELECT &MachineStatus.* FROM "machine_status"`, v4_0_12.MachineStatus{})
+	stmtMachineStatus, err := sqlair.Prepare(`SELECT &MachineStatus.*,
+       t."updated_at" IS NULL AS &nullableMachineStatus.updated_at_is_null
+FROM   "machine_status" AS t`, v4_0_12.MachineStatus{}, nullableMachineStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineStatus statement: %w", err)
 	}
@@ -501,7 +646,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing MachineVolume statement: %w", err)
 	}
-	stmtModel, err := sqlair.Prepare(`SELECT &Model.* FROM "model"`, v4_0_12.Model{})
+	stmtModel, err := sqlair.Prepare(`SELECT &Model.*,
+       t."is_controller_model" IS NULL AS &nullableModel.is_controller_model_is_null
+FROM   "model" AS t`, v4_0_12.Model{}, nullableModel{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Model statement: %w", err)
 	}
@@ -569,7 +716,11 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing OfferEndpoint statement: %w", err)
 	}
-	stmtOperation, err := sqlair.Prepare(`SELECT &Operation.* FROM "operation"`, v4_0_12.Operation{})
+	stmtOperation, err := sqlair.Prepare(`SELECT &Operation.*,
+       t."started_at" IS NULL AS &nullableOperation.started_at_is_null,
+       t."completed_at" IS NULL AS &nullableOperation.completed_at_is_null,
+       t."parallel" IS NULL AS &nullableOperation.parallel_is_null
+FROM   "operation" AS t`, v4_0_12.Operation{}, nullableOperation{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Operation statement: %w", err)
 	}
@@ -585,7 +736,10 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationParameter statement: %w", err)
 	}
-	stmtOperationTask, err := sqlair.Prepare(`SELECT &OperationTask.* FROM "operation_task"`, v4_0_12.OperationTask{})
+	stmtOperationTask, err := sqlair.Prepare(`SELECT &OperationTask.*,
+       t."started_at" IS NULL AS &nullableOperationTask.started_at_is_null,
+       t."completed_at" IS NULL AS &nullableOperationTask.completed_at_is_null
+FROM   "operation_task" AS t`, v4_0_12.OperationTask{}, nullableOperationTask{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationTask statement: %w", err)
 	}
@@ -597,7 +751,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationTaskOutput statement: %w", err)
 	}
-	stmtOperationTaskStatus, err := sqlair.Prepare(`SELECT &OperationTaskStatus.* FROM "operation_task_status"`, v4_0_12.OperationTaskStatus{})
+	stmtOperationTaskStatus, err := sqlair.Prepare(`SELECT &OperationTaskStatus.*,
+       t."updated_at" IS NULL AS &nullableOperationTaskStatus.updated_at_is_null
+FROM   "operation_task_status" AS t`, v4_0_12.OperationTaskStatus{}, nullableOperationTaskStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationTaskStatus statement: %w", err)
 	}
@@ -609,7 +765,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperationUnitTask statement: %w", err)
 	}
-	stmtOperatorStatus, err := sqlair.Prepare(`SELECT &OperatorStatus.* FROM "operator_status"`, v4_0_12.OperatorStatus{})
+	stmtOperatorStatus, err := sqlair.Prepare(`SELECT &OperatorStatus.*,
+       t."updated_at" IS NULL AS &nullableOperatorStatus.updated_at_is_null
+FROM   "operator_status" AS t`, v4_0_12.OperatorStatus{}, nullableOperatorStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing OperatorStatus statement: %w", err)
 	}
@@ -657,7 +815,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing ProviderSubnet statement: %w", err)
 	}
-	stmtRelation, err := sqlair.Prepare(`SELECT &Relation.* FROM "relation"`, v4_0_12.Relation{})
+	stmtRelation, err := sqlair.Prepare(`SELECT &Relation.*,
+       t."suspended" IS NULL AS &nullableRelation.suspended_is_null
+FROM   "relation" AS t`, v4_0_12.Relation{}, nullableRelation{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Relation statement: %w", err)
 	}
@@ -681,7 +841,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationNetworkIngress statement: %w", err)
 	}
-	stmtRelationStatus, err := sqlair.Prepare(`SELECT &RelationStatus.* FROM "relation_status"`, v4_0_12.RelationStatus{})
+	stmtRelationStatus, err := sqlair.Prepare(`SELECT &RelationStatus.*,
+       t."updated_at" IS NULL AS &nullableRelationStatus.updated_at_is_null
+FROM   "relation_status" AS t`, v4_0_12.RelationStatus{}, nullableRelationStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing RelationStatus statement: %w", err)
 	}
@@ -717,7 +879,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing ResolveMode statement: %w", err)
 	}
-	stmtResource, err := sqlair.Prepare(`SELECT &Resource.* FROM "resource"`, v4_0_12.Resource{})
+	stmtResource, err := sqlair.Prepare(`SELECT &Resource.*,
+       t."last_polled" IS NULL AS &nullableResource.last_polled_is_null
+FROM   "resource" AS t`, v4_0_12.Resource{}, nullableResource{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing Resource statement: %w", err)
 	}
@@ -801,7 +965,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretReservation statement: %w", err)
 	}
-	stmtSecretRevision, err := sqlair.Prepare(`SELECT &SecretRevision.* FROM "secret_revision"`, v4_0_12.SecretRevision{})
+	stmtSecretRevision, err := sqlair.Prepare(`SELECT &SecretRevision.*,
+       t."update_time" IS NULL AS &nullableSecretRevision.update_time_is_null
+FROM   "secret_revision" AS t`, v4_0_12.SecretRevision{}, nullableSecretRevision{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing SecretRevision statement: %w", err)
 	}
@@ -849,15 +1015,21 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageAttachment statement: %w", err)
 	}
-	stmtStorageFilesystem, err := sqlair.Prepare(`SELECT &StorageFilesystem.* FROM "storage_filesystem"`, v4_0_12.StorageFilesystem{})
+	stmtStorageFilesystem, err := sqlair.Prepare(`SELECT &StorageFilesystem.*,
+       t."obliterate_on_cleanup" IS NULL AS &nullableStorageFilesystem.obliterate_on_cleanup_is_null
+FROM   "storage_filesystem" AS t`, v4_0_12.StorageFilesystem{}, nullableStorageFilesystem{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageFilesystem statement: %w", err)
 	}
-	stmtStorageFilesystemAttachment, err := sqlair.Prepare(`SELECT &StorageFilesystemAttachment.* FROM "storage_filesystem_attachment"`, v4_0_12.StorageFilesystemAttachment{})
+	stmtStorageFilesystemAttachment, err := sqlair.Prepare(`SELECT &StorageFilesystemAttachment.*,
+       t."read_only" IS NULL AS &nullableStorageFilesystemAttachment.read_only_is_null
+FROM   "storage_filesystem_attachment" AS t`, v4_0_12.StorageFilesystemAttachment{}, nullableStorageFilesystemAttachment{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageFilesystemAttachment statement: %w", err)
 	}
-	stmtStorageFilesystemStatus, err := sqlair.Prepare(`SELECT &StorageFilesystemStatus.* FROM "storage_filesystem_status"`, v4_0_12.StorageFilesystemStatus{})
+	stmtStorageFilesystemStatus, err := sqlair.Prepare(`SELECT &StorageFilesystemStatus.*,
+       t."updated_at" IS NULL AS &nullableStorageFilesystemStatus.updated_at_is_null
+FROM   "storage_filesystem_status" AS t`, v4_0_12.StorageFilesystemStatus{}, nullableStorageFilesystemStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageFilesystemStatus statement: %w", err)
 	}
@@ -901,11 +1073,16 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageUnitOwner statement: %w", err)
 	}
-	stmtStorageVolume, err := sqlair.Prepare(`SELECT &StorageVolume.* FROM "storage_volume"`, v4_0_12.StorageVolume{})
+	stmtStorageVolume, err := sqlair.Prepare(`SELECT &StorageVolume.*,
+       t."persistent" IS NULL AS &nullableStorageVolume.persistent_is_null,
+       t."obliterate_on_cleanup" IS NULL AS &nullableStorageVolume.obliterate_on_cleanup_is_null
+FROM   "storage_volume" AS t`, v4_0_12.StorageVolume{}, nullableStorageVolume{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolume statement: %w", err)
 	}
-	stmtStorageVolumeAttachment, err := sqlair.Prepare(`SELECT &StorageVolumeAttachment.* FROM "storage_volume_attachment"`, v4_0_12.StorageVolumeAttachment{})
+	stmtStorageVolumeAttachment, err := sqlair.Prepare(`SELECT &StorageVolumeAttachment.*,
+       t."read_only" IS NULL AS &nullableStorageVolumeAttachment.read_only_is_null
+FROM   "storage_volume_attachment" AS t`, v4_0_12.StorageVolumeAttachment{}, nullableStorageVolumeAttachment{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolumeAttachment statement: %w", err)
 	}
@@ -921,7 +1098,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolumeDeviceType statement: %w", err)
 	}
-	stmtStorageVolumeStatus, err := sqlair.Prepare(`SELECT &StorageVolumeStatus.* FROM "storage_volume_status"`, v4_0_12.StorageVolumeStatus{})
+	stmtStorageVolumeStatus, err := sqlair.Prepare(`SELECT &StorageVolumeStatus.*,
+       t."updated_at" IS NULL AS &nullableStorageVolumeStatus.updated_at_is_null
+FROM   "storage_volume_status" AS t`, v4_0_12.StorageVolumeStatus{}, nullableStorageVolumeStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing StorageVolumeStatus statement: %w", err)
 	}
@@ -937,11 +1116,15 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing Unit statement: %w", err)
 	}
-	stmtUnitAgentPresence, err := sqlair.Prepare(`SELECT &UnitAgentPresence.* FROM "unit_agent_presence"`, v4_0_12.UnitAgentPresence{})
+	stmtUnitAgentPresence, err := sqlair.Prepare(`SELECT &UnitAgentPresence.*,
+       t."last_seen" IS NULL AS &nullableUnitAgentPresence.last_seen_is_null
+FROM   "unit_agent_presence" AS t`, v4_0_12.UnitAgentPresence{}, nullableUnitAgentPresence{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitAgentPresence statement: %w", err)
 	}
-	stmtUnitAgentStatus, err := sqlair.Prepare(`SELECT &UnitAgentStatus.* FROM "unit_agent_status"`, v4_0_12.UnitAgentStatus{})
+	stmtUnitAgentStatus, err := sqlair.Prepare(`SELECT &UnitAgentStatus.*,
+       t."updated_at" IS NULL AS &nullableUnitAgentStatus.updated_at_is_null
+FROM   "unit_agent_status" AS t`, v4_0_12.UnitAgentStatus{}, nullableUnitAgentStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitAgentStatus statement: %w", err)
 	}
@@ -981,7 +1164,9 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitStorageDirective statement: %w", err)
 	}
-	stmtUnitWorkloadStatus, err := sqlair.Prepare(`SELECT &UnitWorkloadStatus.* FROM "unit_workload_status"`, v4_0_12.UnitWorkloadStatus{})
+	stmtUnitWorkloadStatus, err := sqlair.Prepare(`SELECT &UnitWorkloadStatus.*,
+       t."updated_at" IS NULL AS &nullableUnitWorkloadStatus.updated_at_is_null
+FROM   "unit_workload_status" AS t`, v4_0_12.UnitWorkloadStatus{}, nullableUnitWorkloadStatus{})
 	if err != nil {
 		return nil, fmt.Errorf("preparing UnitWorkloadStatus statement: %w", err)
 	}
@@ -1004,6 +1189,8 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 	}
 
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		// The transaction can be retried, so discard rows from prior attempts.
+		modelExport = v4_0_12.ModelExport{}
 		if err := tx.Query(ctx, stmtAgentBinaryStore).GetAll(&modelExport.AgentBinaryStore); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying AgentBinaryStore (table agent_binary_store): %w", err)
 		}
@@ -1037,8 +1224,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtAnnotationUnit).GetAll(&modelExport.AnnotationUnit); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying AnnotationUnit (table annotation_unit): %w", err)
 		}
-		if err := tx.Query(ctx, stmtApplication).GetAll(&modelExport.Application); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableApplicationRows []nullableApplication
+		if err := tx.Query(ctx, stmtApplication).GetAll(&modelExport.Application, &nullableApplicationRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying Application (table application): %w", err)
+		}
+		for i, nulls := range nullableApplicationRows {
+			if nulls.CharmUpgradeOnErrorIsNull {
+				modelExport.Application[i].CharmUpgradeOnError = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtApplicationAgent).GetAll(&modelExport.ApplicationAgent); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ApplicationAgent (table application_agent): %w", err)
@@ -1085,20 +1278,44 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtApplicationRemoteOffererRelationMacaroon).GetAll(&modelExport.ApplicationRemoteOffererRelationMacaroon); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ApplicationRemoteOffererRelationMacaroon (table application_remote_offerer_relation_macaroon): %w", err)
 		}
-		if err := tx.Query(ctx, stmtApplicationRemoteOffererStatus).GetAll(&modelExport.ApplicationRemoteOffererStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableApplicationRemoteOffererStatusRows []nullableApplicationRemoteOffererStatus
+		if err := tx.Query(ctx, stmtApplicationRemoteOffererStatus).GetAll(&modelExport.ApplicationRemoteOffererStatus, &nullableApplicationRemoteOffererStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ApplicationRemoteOffererStatus (table application_remote_offerer_status): %w", err)
+		}
+		for i, nulls := range nullableApplicationRemoteOffererStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.ApplicationRemoteOffererStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtApplicationResource).GetAll(&modelExport.ApplicationResource); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ApplicationResource (table application_resource): %w", err)
 		}
-		if err := tx.Query(ctx, stmtApplicationScale).GetAll(&modelExport.ApplicationScale); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableApplicationScaleRows []nullableApplicationScale
+		if err := tx.Query(ctx, stmtApplicationScale).GetAll(&modelExport.ApplicationScale, &nullableApplicationScaleRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ApplicationScale (table application_scale): %w", err)
 		}
-		if err := tx.Query(ctx, stmtApplicationSetting).GetAll(&modelExport.ApplicationSetting); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		for i, nulls := range nullableApplicationScaleRows {
+			if nulls.ScalingIsNull {
+				modelExport.ApplicationScale[i].Scaling = nil
+			}
+		}
+		var nullableApplicationSettingRows []nullableApplicationSetting
+		if err := tx.Query(ctx, stmtApplicationSetting).GetAll(&modelExport.ApplicationSetting, &nullableApplicationSettingRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ApplicationSetting (table application_setting): %w", err)
 		}
-		if err := tx.Query(ctx, stmtApplicationStatus).GetAll(&modelExport.ApplicationStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		for i, nulls := range nullableApplicationSettingRows {
+			if nulls.TrustIsNull {
+				modelExport.ApplicationSetting[i].Trust = nil
+			}
+		}
+		var nullableApplicationStatusRows []nullableApplicationStatus
+		if err := tx.Query(ctx, stmtApplicationStatus).GetAll(&modelExport.ApplicationStatus, &nullableApplicationStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ApplicationStatus (table application_status): %w", err)
+		}
+		for i, nulls := range nullableApplicationStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.ApplicationStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtApplicationStorageDirective).GetAll(&modelExport.ApplicationStorageDirective); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ApplicationStorageDirective (table application_storage_directive): %w", err)
@@ -1121,8 +1338,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtBlockCommandType).GetAll(&modelExport.BlockCommandType); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying BlockCommandType (table block_command_type): %w", err)
 		}
-		if err := tx.Query(ctx, stmtBlockDevice).GetAll(&modelExport.BlockDevice); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableBlockDeviceRows []nullableBlockDevice
+		if err := tx.Query(ctx, stmtBlockDevice).GetAll(&modelExport.BlockDevice, &nullableBlockDeviceRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying BlockDevice (table block_device): %w", err)
+		}
+		for i, nulls := range nullableBlockDeviceRows {
+			if nulls.InUseIsNull {
+				modelExport.BlockDevice[i].InUse = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtBlockDeviceLinkDevice).GetAll(&modelExport.BlockDeviceLinkDevice); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying BlockDeviceLinkDevice (table block_device_link_device): %w", err)
@@ -1142,11 +1365,23 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtChangeLogWitness).GetAll(&modelExport.ChangeLogWitness); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ChangeLogWitness (table change_log_witness): %w", err)
 		}
-		if err := tx.Query(ctx, stmtCharm).GetAll(&modelExport.Charm); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableCharmRows []nullableCharm
+		if err := tx.Query(ctx, stmtCharm).GetAll(&modelExport.Charm, &nullableCharmRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying Charm (table charm): %w", err)
 		}
-		if err := tx.Query(ctx, stmtCharmAction).GetAll(&modelExport.CharmAction); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		for i, nulls := range nullableCharmRows {
+			if nulls.AvailableIsNull {
+				modelExport.Charm[i].Available = nil
+			}
+		}
+		var nullableCharmActionRows []nullableCharmAction
+		if err := tx.Query(ctx, stmtCharmAction).GetAll(&modelExport.CharmAction, &nullableCharmActionRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying CharmAction (table charm_action): %w", err)
+		}
+		for i, nulls := range nullableCharmActionRows {
+			if nulls.ParallelIsNull {
+				modelExport.CharmAction[i].Parallel = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtCharmCategory).GetAll(&modelExport.CharmCategory); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying CharmCategory (table charm_category): %w", err)
@@ -1184,8 +1419,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtCharmProvenance).GetAll(&modelExport.CharmProvenance); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying CharmProvenance (table charm_provenance): %w", err)
 		}
-		if err := tx.Query(ctx, stmtCharmRelation).GetAll(&modelExport.CharmRelation); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableCharmRelationRows []nullableCharmRelation
+		if err := tx.Query(ctx, stmtCharmRelation).GetAll(&modelExport.CharmRelation, &nullableCharmRelationRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying CharmRelation (table charm_relation): %w", err)
+		}
+		for i, nulls := range nullableCharmRelationRows {
+			if nulls.OptionalIsNull {
+				modelExport.CharmRelation[i].Optional = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtCharmRelationRole).GetAll(&modelExport.CharmRelationRole); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying CharmRelationRole (table charm_relation_role): %w", err)
@@ -1205,8 +1446,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtCharmSource).GetAll(&modelExport.CharmSource); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying CharmSource (table charm_source): %w", err)
 		}
-		if err := tx.Query(ctx, stmtCharmStorage).GetAll(&modelExport.CharmStorage); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableCharmStorageRows []nullableCharmStorage
+		if err := tx.Query(ctx, stmtCharmStorage).GetAll(&modelExport.CharmStorage, &nullableCharmStorageRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying CharmStorage (table charm_storage): %w", err)
+		}
+		for i, nulls := range nullableCharmStorageRows {
+			if nulls.ReadOnlyIsNull {
+				modelExport.CharmStorage[i].ReadOnly = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtCharmStorageKind).GetAll(&modelExport.CharmStorageKind); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying CharmStorageKind (table charm_storage_kind): %w", err)
@@ -1253,8 +1500,17 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtInstanceTag).GetAll(&modelExport.InstanceTag); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying InstanceTag (table instance_tag): %w", err)
 		}
-		if err := tx.Query(ctx, stmtIpAddress).GetAll(&modelExport.IpAddress); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableIpAddressRows []nullableIpAddress
+		if err := tx.Query(ctx, stmtIpAddress).GetAll(&modelExport.IpAddress, &nullableIpAddressRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying IpAddress (table ip_address): %w", err)
+		}
+		for i, nulls := range nullableIpAddressRows {
+			if nulls.IsSecondaryIsNull {
+				modelExport.IpAddress[i].IsSecondary = nil
+			}
+			if nulls.IsShadowIsNull {
+				modelExport.IpAddress[i].IsShadow = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtIpAddressConfigType).GetAll(&modelExport.IpAddressConfigType); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying IpAddressConfigType (table ip_address_config_type): %w", err)
@@ -1274,8 +1530,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtK8sPodPort).GetAll(&modelExport.K8sPodPort); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying K8sPodPort (table k8s_pod_port): %w", err)
 		}
-		if err := tx.Query(ctx, stmtK8sPodStatus).GetAll(&modelExport.K8sPodStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableK8sPodStatusRows []nullableK8sPodStatus
+		if err := tx.Query(ctx, stmtK8sPodStatus).GetAll(&modelExport.K8sPodStatus, &nullableK8sPodStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying K8sPodStatus (table k8s_pod_status): %w", err)
+		}
+		for i, nulls := range nullableK8sPodStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.K8sPodStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtK8sPodStatusValue).GetAll(&modelExport.K8sPodStatusValue); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying K8sPodStatusValue (table k8s_pod_status_value): %w", err)
@@ -1304,11 +1566,29 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtLinkLayerDeviceType).GetAll(&modelExport.LinkLayerDeviceType); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying LinkLayerDeviceType (table link_layer_device_type): %w", err)
 		}
-		if err := tx.Query(ctx, stmtMachine).GetAll(&modelExport.Machine); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableMachineRows []nullableMachine
+		if err := tx.Query(ctx, stmtMachine).GetAll(&modelExport.Machine, &nullableMachineRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying Machine (table machine): %w", err)
 		}
-		if err := tx.Query(ctx, stmtMachineAgentPresence).GetAll(&modelExport.MachineAgentPresence); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		for i, nulls := range nullableMachineRows {
+			if nulls.ForceDestroyedIsNull {
+				modelExport.Machine[i].ForceDestroyed = nil
+			}
+			if nulls.AgentStartedAtIsNull {
+				modelExport.Machine[i].AgentStartedAt = nil
+			}
+			if nulls.KeepInstanceIsNull {
+				modelExport.Machine[i].KeepInstance = nil
+			}
+		}
+		var nullableMachineAgentPresenceRows []nullableMachineAgentPresence
+		if err := tx.Query(ctx, stmtMachineAgentPresence).GetAll(&modelExport.MachineAgentPresence, &nullableMachineAgentPresenceRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying MachineAgentPresence (table machine_agent_presence): %w", err)
+		}
+		for i, nulls := range nullableMachineAgentPresenceRows {
+			if nulls.LastSeenIsNull {
+				modelExport.MachineAgentPresence[i].LastSeen = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtMachineAgentVersion).GetAll(&modelExport.MachineAgentVersion); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying MachineAgentVersion (table machine_agent_version): %w", err)
@@ -1316,8 +1596,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtMachineCloudInstance).GetAll(&modelExport.MachineCloudInstance); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying MachineCloudInstance (table machine_cloud_instance): %w", err)
 		}
-		if err := tx.Query(ctx, stmtMachineCloudInstanceStatus).GetAll(&modelExport.MachineCloudInstanceStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableMachineCloudInstanceStatusRows []nullableMachineCloudInstanceStatus
+		if err := tx.Query(ctx, stmtMachineCloudInstanceStatus).GetAll(&modelExport.MachineCloudInstanceStatus, &nullableMachineCloudInstanceStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying MachineCloudInstanceStatus (table machine_cloud_instance_status): %w", err)
+		}
+		for i, nulls := range nullableMachineCloudInstanceStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.MachineCloudInstanceStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtMachineCloudInstanceStatusValue).GetAll(&modelExport.MachineCloudInstanceStatusValue); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying MachineCloudInstanceStatusValue (table machine_cloud_instance_status_value): %w", err)
@@ -1355,8 +1641,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtMachineSshHostKey).GetAll(&modelExport.MachineSshHostKey); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying MachineSshHostKey (table machine_ssh_host_key): %w", err)
 		}
-		if err := tx.Query(ctx, stmtMachineStatus).GetAll(&modelExport.MachineStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableMachineStatusRows []nullableMachineStatus
+		if err := tx.Query(ctx, stmtMachineStatus).GetAll(&modelExport.MachineStatus, &nullableMachineStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying MachineStatus (table machine_status): %w", err)
+		}
+		for i, nulls := range nullableMachineStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.MachineStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtMachineStatusValue).GetAll(&modelExport.MachineStatusValue); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying MachineStatusValue (table machine_status_value): %w", err)
@@ -1364,8 +1656,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtMachineVolume).GetAll(&modelExport.MachineVolume); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying MachineVolume (table machine_volume): %w", err)
 		}
-		if err := tx.Query(ctx, stmtModel).GetAll(&modelExport.Model); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableModelRows []nullableModel
+		if err := tx.Query(ctx, stmtModel).GetAll(&modelExport.Model, &nullableModelRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying Model (table model): %w", err)
+		}
+		for i, nulls := range nullableModelRows {
+			if nulls.IsControllerModelIsNull {
+				modelExport.Model[i].IsControllerModel = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtModelAgent).GetAll(&modelExport.ModelAgent); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ModelAgent (table model_agent): %w", err)
@@ -1415,8 +1713,20 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtOfferEndpoint).GetAll(&modelExport.OfferEndpoint); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying OfferEndpoint (table offer_endpoint): %w", err)
 		}
-		if err := tx.Query(ctx, stmtOperation).GetAll(&modelExport.Operation); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableOperationRows []nullableOperation
+		if err := tx.Query(ctx, stmtOperation).GetAll(&modelExport.Operation, &nullableOperationRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying Operation (table operation): %w", err)
+		}
+		for i, nulls := range nullableOperationRows {
+			if nulls.StartedAtIsNull {
+				modelExport.Operation[i].StartedAt = nil
+			}
+			if nulls.CompletedAtIsNull {
+				modelExport.Operation[i].CompletedAt = nil
+			}
+			if nulls.ParallelIsNull {
+				modelExport.Operation[i].Parallel = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtOperationAction).GetAll(&modelExport.OperationAction); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying OperationAction (table operation_action): %w", err)
@@ -1427,8 +1737,17 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtOperationParameter).GetAll(&modelExport.OperationParameter); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying OperationParameter (table operation_parameter): %w", err)
 		}
-		if err := tx.Query(ctx, stmtOperationTask).GetAll(&modelExport.OperationTask); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableOperationTaskRows []nullableOperationTask
+		if err := tx.Query(ctx, stmtOperationTask).GetAll(&modelExport.OperationTask, &nullableOperationTaskRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying OperationTask (table operation_task): %w", err)
+		}
+		for i, nulls := range nullableOperationTaskRows {
+			if nulls.StartedAtIsNull {
+				modelExport.OperationTask[i].StartedAt = nil
+			}
+			if nulls.CompletedAtIsNull {
+				modelExport.OperationTask[i].CompletedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtOperationTaskLog).GetAll(&modelExport.OperationTaskLog); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying OperationTaskLog (table operation_task_log): %w", err)
@@ -1436,8 +1755,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtOperationTaskOutput).GetAll(&modelExport.OperationTaskOutput); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying OperationTaskOutput (table operation_task_output): %w", err)
 		}
-		if err := tx.Query(ctx, stmtOperationTaskStatus).GetAll(&modelExport.OperationTaskStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableOperationTaskStatusRows []nullableOperationTaskStatus
+		if err := tx.Query(ctx, stmtOperationTaskStatus).GetAll(&modelExport.OperationTaskStatus, &nullableOperationTaskStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying OperationTaskStatus (table operation_task_status): %w", err)
+		}
+		for i, nulls := range nullableOperationTaskStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.OperationTaskStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtOperationTaskStatusValue).GetAll(&modelExport.OperationTaskStatusValue); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying OperationTaskStatusValue (table operation_task_status_value): %w", err)
@@ -1445,8 +1770,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtOperationUnitTask).GetAll(&modelExport.OperationUnitTask); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying OperationUnitTask (table operation_unit_task): %w", err)
 		}
-		if err := tx.Query(ctx, stmtOperatorStatus).GetAll(&modelExport.OperatorStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableOperatorStatusRows []nullableOperatorStatus
+		if err := tx.Query(ctx, stmtOperatorStatus).GetAll(&modelExport.OperatorStatus, &nullableOperatorStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying OperatorStatus (table operator_status): %w", err)
+		}
+		for i, nulls := range nullableOperatorStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.OperatorStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtOs).GetAll(&modelExport.Os); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying Os (table os): %w", err)
@@ -1481,8 +1812,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtProviderSubnet).GetAll(&modelExport.ProviderSubnet); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ProviderSubnet (table provider_subnet): %w", err)
 		}
-		if err := tx.Query(ctx, stmtRelation).GetAll(&modelExport.Relation); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableRelationRows []nullableRelation
+		if err := tx.Query(ctx, stmtRelation).GetAll(&modelExport.Relation, &nullableRelationRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying Relation (table relation): %w", err)
+		}
+		for i, nulls := range nullableRelationRows {
+			if nulls.SuspendedIsNull {
+				modelExport.Relation[i].Suspended = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtRelationApplicationSetting).GetAll(&modelExport.RelationApplicationSetting); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying RelationApplicationSetting (table relation_application_setting): %w", err)
@@ -1499,8 +1836,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtRelationNetworkIngress).GetAll(&modelExport.RelationNetworkIngress); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying RelationNetworkIngress (table relation_network_ingress): %w", err)
 		}
-		if err := tx.Query(ctx, stmtRelationStatus).GetAll(&modelExport.RelationStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableRelationStatusRows []nullableRelationStatus
+		if err := tx.Query(ctx, stmtRelationStatus).GetAll(&modelExport.RelationStatus, &nullableRelationStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying RelationStatus (table relation_status): %w", err)
+		}
+		for i, nulls := range nullableRelationStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.RelationStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtRelationStatusType).GetAll(&modelExport.RelationStatusType); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying RelationStatusType (table relation_status_type): %w", err)
@@ -1526,8 +1869,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtResolveMode).GetAll(&modelExport.ResolveMode); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ResolveMode (table resolve_mode): %w", err)
 		}
-		if err := tx.Query(ctx, stmtResource).GetAll(&modelExport.Resource); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableResourceRows []nullableResource
+		if err := tx.Query(ctx, stmtResource).GetAll(&modelExport.Resource, &nullableResourceRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying Resource (table resource): %w", err)
+		}
+		for i, nulls := range nullableResourceRows {
+			if nulls.LastPolledIsNull {
+				modelExport.Resource[i].LastPolled = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtResourceContainerImageMetadataStore).GetAll(&modelExport.ResourceContainerImageMetadataStore); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying ResourceContainerImageMetadataStore (table resource_container_image_metadata_store): %w", err)
@@ -1589,8 +1938,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtSecretReservation).GetAll(&modelExport.SecretReservation); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying SecretReservation (table secret_reservation): %w", err)
 		}
-		if err := tx.Query(ctx, stmtSecretRevision).GetAll(&modelExport.SecretRevision); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableSecretRevisionRows []nullableSecretRevision
+		if err := tx.Query(ctx, stmtSecretRevision).GetAll(&modelExport.SecretRevision, &nullableSecretRevisionRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying SecretRevision (table secret_revision): %w", err)
+		}
+		for i, nulls := range nullableSecretRevisionRows {
+			if nulls.UpdateTimeIsNull {
+				modelExport.SecretRevision[i].UpdateTime = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtSecretRevisionExpire).GetAll(&modelExport.SecretRevisionExpire); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying SecretRevisionExpire (table secret_revision_expire): %w", err)
@@ -1625,14 +1980,32 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtStorageAttachment).GetAll(&modelExport.StorageAttachment); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageAttachment (table storage_attachment): %w", err)
 		}
-		if err := tx.Query(ctx, stmtStorageFilesystem).GetAll(&modelExport.StorageFilesystem); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableStorageFilesystemRows []nullableStorageFilesystem
+		if err := tx.Query(ctx, stmtStorageFilesystem).GetAll(&modelExport.StorageFilesystem, &nullableStorageFilesystemRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageFilesystem (table storage_filesystem): %w", err)
 		}
-		if err := tx.Query(ctx, stmtStorageFilesystemAttachment).GetAll(&modelExport.StorageFilesystemAttachment); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		for i, nulls := range nullableStorageFilesystemRows {
+			if nulls.ObliterateOnCleanupIsNull {
+				modelExport.StorageFilesystem[i].ObliterateOnCleanup = nil
+			}
+		}
+		var nullableStorageFilesystemAttachmentRows []nullableStorageFilesystemAttachment
+		if err := tx.Query(ctx, stmtStorageFilesystemAttachment).GetAll(&modelExport.StorageFilesystemAttachment, &nullableStorageFilesystemAttachmentRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageFilesystemAttachment (table storage_filesystem_attachment): %w", err)
 		}
-		if err := tx.Query(ctx, stmtStorageFilesystemStatus).GetAll(&modelExport.StorageFilesystemStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		for i, nulls := range nullableStorageFilesystemAttachmentRows {
+			if nulls.ReadOnlyIsNull {
+				modelExport.StorageFilesystemAttachment[i].ReadOnly = nil
+			}
+		}
+		var nullableStorageFilesystemStatusRows []nullableStorageFilesystemStatus
+		if err := tx.Query(ctx, stmtStorageFilesystemStatus).GetAll(&modelExport.StorageFilesystemStatus, &nullableStorageFilesystemStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageFilesystemStatus (table storage_filesystem_status): %w", err)
+		}
+		for i, nulls := range nullableStorageFilesystemStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.StorageFilesystemStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtStorageFilesystemStatusValue).GetAll(&modelExport.StorageFilesystemStatusValue); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageFilesystemStatusValue (table storage_filesystem_status_value): %w", err)
@@ -1664,11 +2037,26 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtStorageUnitOwner).GetAll(&modelExport.StorageUnitOwner); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageUnitOwner (table storage_unit_owner): %w", err)
 		}
-		if err := tx.Query(ctx, stmtStorageVolume).GetAll(&modelExport.StorageVolume); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableStorageVolumeRows []nullableStorageVolume
+		if err := tx.Query(ctx, stmtStorageVolume).GetAll(&modelExport.StorageVolume, &nullableStorageVolumeRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageVolume (table storage_volume): %w", err)
 		}
-		if err := tx.Query(ctx, stmtStorageVolumeAttachment).GetAll(&modelExport.StorageVolumeAttachment); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		for i, nulls := range nullableStorageVolumeRows {
+			if nulls.PersistentIsNull {
+				modelExport.StorageVolume[i].Persistent = nil
+			}
+			if nulls.ObliterateOnCleanupIsNull {
+				modelExport.StorageVolume[i].ObliterateOnCleanup = nil
+			}
+		}
+		var nullableStorageVolumeAttachmentRows []nullableStorageVolumeAttachment
+		if err := tx.Query(ctx, stmtStorageVolumeAttachment).GetAll(&modelExport.StorageVolumeAttachment, &nullableStorageVolumeAttachmentRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageVolumeAttachment (table storage_volume_attachment): %w", err)
+		}
+		for i, nulls := range nullableStorageVolumeAttachmentRows {
+			if nulls.ReadOnlyIsNull {
+				modelExport.StorageVolumeAttachment[i].ReadOnly = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtStorageVolumeAttachmentPlan).GetAll(&modelExport.StorageVolumeAttachmentPlan); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageVolumeAttachmentPlan (table storage_volume_attachment_plan): %w", err)
@@ -1679,8 +2067,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtStorageVolumeDeviceType).GetAll(&modelExport.StorageVolumeDeviceType); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageVolumeDeviceType (table storage_volume_device_type): %w", err)
 		}
-		if err := tx.Query(ctx, stmtStorageVolumeStatus).GetAll(&modelExport.StorageVolumeStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableStorageVolumeStatusRows []nullableStorageVolumeStatus
+		if err := tx.Query(ctx, stmtStorageVolumeStatus).GetAll(&modelExport.StorageVolumeStatus, &nullableStorageVolumeStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageVolumeStatus (table storage_volume_status): %w", err)
+		}
+		for i, nulls := range nullableStorageVolumeStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.StorageVolumeStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtStorageVolumeStatusValue).GetAll(&modelExport.StorageVolumeStatusValue); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying StorageVolumeStatusValue (table storage_volume_status_value): %w", err)
@@ -1691,11 +2085,23 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtUnit).GetAll(&modelExport.Unit); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying Unit (table unit): %w", err)
 		}
-		if err := tx.Query(ctx, stmtUnitAgentPresence).GetAll(&modelExport.UnitAgentPresence); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableUnitAgentPresenceRows []nullableUnitAgentPresence
+		if err := tx.Query(ctx, stmtUnitAgentPresence).GetAll(&modelExport.UnitAgentPresence, &nullableUnitAgentPresenceRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying UnitAgentPresence (table unit_agent_presence): %w", err)
 		}
-		if err := tx.Query(ctx, stmtUnitAgentStatus).GetAll(&modelExport.UnitAgentStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		for i, nulls := range nullableUnitAgentPresenceRows {
+			if nulls.LastSeenIsNull {
+				modelExport.UnitAgentPresence[i].LastSeen = nil
+			}
+		}
+		var nullableUnitAgentStatusRows []nullableUnitAgentStatus
+		if err := tx.Query(ctx, stmtUnitAgentStatus).GetAll(&modelExport.UnitAgentStatus, &nullableUnitAgentStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying UnitAgentStatus (table unit_agent_status): %w", err)
+		}
+		for i, nulls := range nullableUnitAgentStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.UnitAgentStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtUnitAgentStatusValue).GetAll(&modelExport.UnitAgentStatusValue); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying UnitAgentStatusValue (table unit_agent_status_value): %w", err)
@@ -1724,8 +2130,14 @@ func (st *State) Export(ctx context.Context) (*v4_0_12.ModelExport, error) {
 		if err := tx.Query(ctx, stmtUnitStorageDirective).GetAll(&modelExport.UnitStorageDirective); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying UnitStorageDirective (table unit_storage_directive): %w", err)
 		}
-		if err := tx.Query(ctx, stmtUnitWorkloadStatus).GetAll(&modelExport.UnitWorkloadStatus); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		var nullableUnitWorkloadStatusRows []nullableUnitWorkloadStatus
+		if err := tx.Query(ctx, stmtUnitWorkloadStatus).GetAll(&modelExport.UnitWorkloadStatus, &nullableUnitWorkloadStatusRows); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying UnitWorkloadStatus (table unit_workload_status): %w", err)
+		}
+		for i, nulls := range nullableUnitWorkloadStatusRows {
+			if nulls.UpdatedAtIsNull {
+				modelExport.UnitWorkloadStatus[i].UpdatedAt = nil
+			}
 		}
 		if err := tx.Query(ctx, stmtUnitWorkloadVersion).GetAll(&modelExport.UnitWorkloadVersion); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf("querying UnitWorkloadVersion (table unit_workload_version): %w", err)

--- a/domain/export/state/model/export_nullable_test.go
+++ b/domain/export/state/model/export_nullable_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Canonical Ltd. All rights reserved.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/juju/tc"
+
+	"github.com/juju/juju/domain/life"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type nullableExportSuite struct {
+	schematesting.ModelSuite
+}
+
+func TestNullableExportSuite(t *testing.T) {
+	tc.Run(t, &nullableExportSuite{})
+}
+
+// TestExportStorageFilesystemPreservesNullableValues verifies that the
+// companion null marker retains the original nullness of the Boolean
+// obliterate_on_cleanup value.
+func (s *nullableExportSuite) TestExportStorageFilesystemPreservesNullableValues(c *tc.C) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO storage_filesystem
+    (uuid, filesystem_id, life_id, provision_scope_id, obliterate_on_cleanup)
+VALUES
+    ('fs-null', 'fs-null', ?, 0, NULL),
+    ('fs-false', 'fs-false', ?, 0, FALSE),
+    ('fs-true', 'fs-true', ?, 0, TRUE)
+`, life.Alive, life.Dying, life.Dead)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	payload, err := NewState(s.TxnRunnerFactory()).Export(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	filesystems := make(map[string]*bool)
+	for _, filesystem := range payload.StorageFilesystem {
+		filesystems[filesystem.UUID] = filesystem.ObliterateOnCleanup
+	}
+	c.Check(filesystems["fs-null"], tc.IsNil)
+	c.Assert(filesystems["fs-false"], tc.NotNil)
+	c.Check(*filesystems["fs-false"], tc.IsFalse)
+	c.Assert(filesystems["fs-true"], tc.NotNil)
+	c.Check(*filesystems["fs-true"], tc.IsTrue)
+}
+
+// TestExportStorageFilesystemStatusPreservesNullableValues verifies that the
+// companion null marker retains the original nullness of the datetime
+// updated_at value.
+func (s *nullableExportSuite) TestExportStorageFilesystemStatusPreservesNullableValues(c *tc.C) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO storage_filesystem
+    (uuid, filesystem_id, life_id, provision_scope_id)
+VALUES
+    ('fs-null', 'fs-null', ?, 0),
+    ('fs-true', 'fs-true', ?, 0)
+`, life.Alive, life.Alive); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO storage_filesystem_status
+    (filesystem_uuid, status_id, updated_at)
+VALUES
+    ('fs-null', 0, NULL),
+    ('fs-true', 0, '2026-09-10 12:34:56')
+`)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	payload, err := NewState(s.TxnRunnerFactory()).Export(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	filesystemStatuses := make(map[string]bool)
+	for _, status := range payload.StorageFilesystemStatus {
+		filesystemStatuses[status.FilesystemUUID] = status.UpdatedAt == nil
+	}
+	c.Check(filesystemStatuses["fs-null"], tc.IsTrue)
+	c.Check(filesystemStatuses["fs-true"], tc.IsFalse)
+}
+
+// TestExportOperationPreservesNullableValues verifies that the companion null
+// markers retain the original nullness of the datetime started_at and
+// completed_at values and the Boolean parallel value.
+func (s *nullableExportSuite) TestExportOperationPreservesNullableValues(c *tc.C) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO operation
+    (uuid, operation_id, enqueued_at, started_at, completed_at, parallel)
+VALUES
+    ('op-null', 'op-null', '2026-09-10 12:34:56', NULL, NULL, NULL),
+    ('op-value', 'op-value', '2026-09-10 12:34:56',
+     '2026-09-10 12:35:56', '2026-09-10 12:36:56', TRUE)
+`)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	payload, err := NewState(s.TxnRunnerFactory()).Export(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	operations := make(map[string]struct {
+		startedAt   bool
+		completedAt bool
+		parallel    *bool
+	})
+	for _, operation := range payload.Operation {
+		operations[operation.UUID] = struct {
+			startedAt   bool
+			completedAt bool
+			parallel    *bool
+		}{
+			startedAt:   operation.StartedAt == nil,
+			completedAt: operation.CompletedAt == nil,
+			parallel:    operation.Parallel,
+		}
+	}
+	c.Check(operations["op-null"].startedAt, tc.IsTrue)
+	c.Check(operations["op-null"].completedAt, tc.IsTrue)
+	c.Check(operations["op-null"].parallel, tc.IsNil)
+	c.Check(operations["op-value"].startedAt, tc.IsFalse)
+	c.Check(operations["op-value"].completedAt, tc.IsFalse)
+	c.Assert(operations["op-value"].parallel, tc.NotNil)
+	c.Check(*operations["op-value"].parallel, tc.IsTrue)
+}
+
+// TestExportOperationTaskPreservesNullableValues verifies that the companion
+// null markers retain the original nullness of the datetime started_at and
+// completed_at values.
+func (s *nullableExportSuite) TestExportOperationTaskPreservesNullableValues(c *tc.C) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO operation
+    (uuid, operation_id, enqueued_at)
+VALUES
+    ('op-null', 'op-null', '2026-09-10 12:34:56'),
+    ('op-value', 'op-value', '2026-09-10 12:34:56')
+`); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO operation_task
+    (uuid, operation_uuid, task_id, enqueued_at, started_at, completed_at)
+VALUES
+    ('task-null', 'op-null', 'task-null', '2026-09-10 12:34:56', NULL, NULL),
+    ('task-value', 'op-value', 'task-value', '2026-09-10 12:34:56',
+     '2026-09-10 12:35:56', '2026-09-10 12:36:56')
+`)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	payload, err := NewState(s.TxnRunnerFactory()).Export(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	operationTasks := make(map[string]struct {
+		startedAt   bool
+		completedAt bool
+	})
+	for _, task := range payload.OperationTask {
+		operationTasks[task.UUID] = struct {
+			startedAt   bool
+			completedAt bool
+		}{
+			startedAt:   task.StartedAt == nil,
+			completedAt: task.CompletedAt == nil,
+		}
+	}
+	c.Check(operationTasks["task-null"].startedAt, tc.IsTrue)
+	c.Check(operationTasks["task-null"].completedAt, tc.IsTrue)
+	c.Check(operationTasks["task-value"].startedAt, tc.IsFalse)
+	c.Check(operationTasks["task-value"].completedAt, tc.IsFalse)
+}
+
+// TestExportStorageVolumePreservesNullableValues verifies that the companion
+// null marker retains the original nullness of the Boolean
+// obliterate_on_cleanup value.
+func (s *nullableExportSuite) TestExportStorageVolumePreservesNullableValues(c *tc.C) {
+	err := s.TxnRunner().StdTxn(c.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO storage_volume
+    (uuid, volume_id, life_id, provision_scope_id, obliterate_on_cleanup)
+VALUES
+    ('vol-null', 'vol-null', ?, 0, NULL),
+    ('vol-false', 'vol-false', ?, 0, FALSE),
+    ('vol-true', 'vol-true', ?, 0, TRUE)
+`, life.Alive, life.Dying, life.Dead)
+		return err
+	})
+	c.Assert(err, tc.ErrorIsNil)
+
+	payload, err := NewState(s.TxnRunnerFactory()).Export(c.Context())
+	c.Assert(err, tc.ErrorIsNil)
+
+	volumes := make(map[string]*bool)
+	for _, volume := range payload.StorageVolume {
+		volumes[volume.UUID] = volume.ObliterateOnCleanup
+	}
+	c.Check(volumes["vol-null"], tc.IsNil)
+	c.Assert(volumes["vol-false"], tc.NotNil)
+	c.Check(*volumes["vol-false"], tc.IsFalse)
+	c.Assert(volumes["vol-true"], tc.NotNil)
+	c.Check(*volumes["vol-true"], tc.IsTrue)
+}

--- a/generate/export/main.go
+++ b/generate/export/main.go
@@ -91,6 +91,7 @@ func generate(ctx context.Context, runner *txnRunner) error {
 	}
 
 	var structs, structNames, usedTableNames []string
+	var exportTables []exportTable
 	imports := make(map[string]struct{})
 
 	for _, tableName := range tableNames {
@@ -109,8 +110,11 @@ func generate(ctx context.Context, runner *txnRunner) error {
 		}
 
 		structs = append(structs, structDef)
-		structNames = append(structNames, toCamelCase(tableName))
+		structName := toCamelCase(tableName)
+		structNames = append(structNames, structName)
 		usedTableNames = append(usedTableNames, tableName)
+		exportTables = append(exportTables,
+			newExportTable(tableName, structName, columns))
 		for _, imp := range requiredImports {
 			imports[imp] = struct{}{}
 		}
@@ -120,11 +124,71 @@ func generate(ctx context.Context, runner *txnRunner) error {
 		return err
 	}
 
-	if err := writeStateModelVersionFile(versionToken, semanticVersion, usedTableNames, structNames); err != nil {
+	if err := writeStateModelVersionFile(versionToken, semanticVersion,
+		exportTables); err != nil {
 		return err
 	}
 
 	return writeServiceModelVersionFile(versionToken, semanticVersion)
+}
+
+type nullableColumn struct {
+	Name      string
+	FieldName string
+}
+
+type exportTable struct {
+	Name            string
+	StructName      string
+	NullTypeName    string
+	Query           string
+	NullableColumns []nullableColumn
+}
+
+// newExportTable adds null markers for types whose NULL values dqlite remaps
+// according to the column's declared type. The markers allow the generated
+// exporter to restore nil pointers after scanning each row.
+func newExportTable(tableName, structName string, columns []column) exportTable {
+	table := exportTable{
+		Name:         tableName,
+		StructName:   structName,
+		NullTypeName: "nullable" + structName,
+	}
+	for _, col := range columns {
+		if isAffectedNullableType(col) {
+			table.NullableColumns = append(table.NullableColumns, nullableColumn{
+				Name:      col.Name,
+				FieldName: toCamelCase(col.Name),
+			})
+		}
+	}
+
+	table.Query = fmt.Sprintf(`SELECT &%s.* FROM %q`, structName, tableName)
+	if len(table.NullableColumns) == 0 {
+		return table
+	}
+
+	var nullProjections []string
+	for _, col := range table.NullableColumns {
+		nullProjections = append(nullProjections, fmt.Sprintf(
+			`t.%q IS NULL AS &%s.%s_is_null`,
+			col.Name, table.NullTypeName, col.Name))
+	}
+	table.Query = fmt.Sprintf("SELECT &%s.*,\n       %s\nFROM   %q AS t",
+		structName, strings.Join(nullProjections, ",\n       "), tableName)
+	return table
+}
+
+func isAffectedNullableType(col column) bool {
+	if col.NotNull {
+		return false
+	}
+	switch strings.ToUpper(col.Type) {
+	case "BOOLEAN", "DATETIME", "DATE", "TIMESTAMP":
+		return true
+	default:
+		return false
+	}
 }
 
 func getTableNames(ctx context.Context, runner *txnRunner) ([]string, error) {
@@ -346,8 +410,7 @@ func writeTypesFile(
 func writeStateModelVersionFile(
 	versionToken string,
 	semanticVersion string,
-	tableNames []string,
-	structNames []string,
+	exportTables []exportTable,
 ) error {
 	_, filename, _, _ := runtime.Caller(0)
 	currentDir := filepath.Dir(filename)
@@ -368,13 +431,11 @@ func writeStateModelVersionFile(
 	data := struct {
 		VersionToken    string
 		SemanticVersion string
-		TableNames      []string
-		StructNames     []string
+		ExportTables    []exportTable
 	}{
 		VersionToken:    versionToken,
 		SemanticVersion: semanticVersion,
-		TableNames:      tableNames,
-		StructNames:     structNames,
+		ExportTables:    exportTables,
 	}
 
 	t := template.Must(template.New("state").Parse(string(tmplBytes)))

--- a/generate/export/main_test.go
+++ b/generate/export/main_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/juju/tc"
+)
+
+type exportGeneratorSuite struct{}
+
+func TestExportGeneratorSuite(t *testing.T) {
+	tc.Run(t, &exportGeneratorSuite{})
+}
+
+// TestNewExportTableAddsNullMarkers checks that affected nullable columns get
+// companion projections that retain their original SQL nullness.
+func (s *exportGeneratorSuite) TestNewExportTableAddsNullMarkers(c *tc.C) {
+	table := newExportTable("some_table", "SomeTable", []column{
+		{Name: "uuid", Type: "TEXT", NotNull: true},
+		{Name: "enabled", Type: "BOOLEAN"},
+		{Name: "updated_at", Type: "DATETIME"},
+		{Name: "scheduled_on", Type: "DATE"},
+		{Name: "completed_at", Type: "TIMESTAMP"},
+	})
+
+	c.Check(table, tc.DeepEquals, exportTable{
+		Name:         "some_table",
+		StructName:   "SomeTable",
+		NullTypeName: "nullableSomeTable",
+		Query: `SELECT &SomeTable.*,
+       t."enabled" IS NULL AS &nullableSomeTable.enabled_is_null,
+       t."updated_at" IS NULL AS &nullableSomeTable.updated_at_is_null,
+       t."scheduled_on" IS NULL AS &nullableSomeTable.scheduled_on_is_null,
+       t."completed_at" IS NULL AS &nullableSomeTable.completed_at_is_null
+FROM   "some_table" AS t`,
+		NullableColumns: []nullableColumn{
+			{Name: "enabled", FieldName: "Enabled"},
+			{Name: "updated_at", FieldName: "UpdatedAt"},
+			{Name: "scheduled_on", FieldName: "ScheduledOn"},
+			{Name: "completed_at", FieldName: "CompletedAt"},
+		},
+	})
+}
+
+// TestNewExportTableWithoutAffectedTypes checks that unaffected tables retain
+// the compact wildcard query and require no null marker rows.
+func (s *exportGeneratorSuite) TestNewExportTableWithoutAffectedTypes(c *tc.C) {
+	table := newExportTable("some_table", "SomeTable", []column{
+		{Name: "uuid", Type: "TEXT", NotNull: true},
+	})
+
+	c.Check(table.Query, tc.Equals, `SELECT &SomeTable.* FROM "some_table"`)
+	c.Check(table.NullableColumns, tc.HasLen, 0)
+}
+
+// TestAffectedNullableTypes checks that null markers cover every declared
+// type remapped by dqlite.
+func (s *exportGeneratorSuite) TestAffectedNullableTypes(c *tc.C) {
+	for _, columnType := range []string{"BOOLEAN", "DATETIME", "DATE", "TIMESTAMP"} {
+		c.Check(isAffectedNullableType(column{Type: columnType}), tc.IsTrue)
+	}
+	c.Check(isAffectedNullableType(column{Type: "TEXT"}), tc.IsFalse)
+	c.Check(isAffectedNullableType(column{
+		Type:    "BOOLEAN",
+		NotNull: true,
+	}), tc.IsFalse)
+}

--- a/generate/export/state.tmpl
+++ b/generate/export/state.tmpl
@@ -15,16 +15,26 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
+{{- range .ExportTables }}
+{{- if .NullableColumns }}
+type {{ .NullTypeName }} struct {
+{{- range .NullableColumns }}
+	{{ .FieldName }}IsNull bool `db:"{{ .Name }}_is_null"`
+{{- end }}
+}
+{{- end }}
+{{- end }}
+
 // Export exports all model data for version {{ .SemanticVersion }}.
 func (st *State) Export(ctx context.Context) (*v{{ .VersionToken }}.ModelExport, error) {
 	var modelExport v{{ .VersionToken }}.ModelExport
 	var err error
 
 	// Prepare statements first using the typed samples from the generated types package.
-{{- range $i, $sn := .StructNames }}
-	stmt{{ $sn }}, err := sqlair.Prepare(`SELECT &{{ $sn }}.* FROM "{{ index $.TableNames $i }}"`, v{{ $.VersionToken }}.{{ $sn }}{})
+{{- range .ExportTables }}
+	stmt{{ .StructName }}, err := sqlair.Prepare(`{{ .Query }}`, v{{ $.VersionToken }}.{{ .StructName }}{}{{ if .NullableColumns }}, {{ .NullTypeName }}{}{{ end }})
 	if err != nil {
-		return nil, fmt.Errorf("preparing {{ $sn }} statement: %w", err)
+		return nil, fmt.Errorf("preparing {{ .StructName }} statement: %w", err)
 	}
 {{- end }}
 
@@ -34,10 +44,25 @@ func (st *State) Export(ctx context.Context) (*v{{ .VersionToken }}.ModelExport,
 	}
 
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-{{- range $i, $sn := .StructNames }}
-		if err := tx.Query(ctx, stmt{{ $sn }}).GetAll(&modelExport.{{ $sn }}); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("querying {{ $sn }} (table {{ index $.TableNames $i }}): %w", err)
+		// The transaction can be retried, so discard rows from prior attempts.
+		modelExport = v{{ .VersionToken }}.ModelExport{}
+{{- range .ExportTables }}
+{{- $table := . }}
+{{- if .NullableColumns }}
+		var {{ .NullTypeName }}Rows []{{ .NullTypeName }}
+{{- end }}
+		if err := tx.Query(ctx, stmt{{ .StructName }}).GetAll(&modelExport.{{ .StructName }}{{ if .NullableColumns }}, &{{ .NullTypeName }}Rows{{ end }}); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return fmt.Errorf("querying {{ .StructName }} (table {{ .Name }}): %w", err)
 		}
+{{- if .NullableColumns }}
+		for i, nulls := range {{ .NullTypeName }}Rows {
+{{- range .NullableColumns }}
+			if nulls.{{ .FieldName }}IsNull {
+				modelExport.{{ $table.StructName }}[i].{{ .FieldName }} = nil
+			}
+{{- end }}
+		}
+{{- end }}
 {{- end }}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
_Note/TL;DR: The real fix is upstrem [canonical/dqlite#883](https://github.com/canonical/dqlite/pull/883), which preserves `SQLITE_NULL` before applying declared-type conversions for Boolean and date/time columns. Landing and consuming that fix requires new dqlite and go-dqlite releases. This change provides a Juju-side workaround in the meantime by exporting companion `IS NULL` markers and using them to restore the original nil values before serialization._


Dqlite determines the wire type of `BOOLEAN`, `DATETIME`, `DATE`, and
`TIMESTAMP` results from the column's declared type, even when the stored value
is SQL `NULL`.

For nullable Booleans, this causes `database/sql` to receive `false` instead of
`nil`. Model export then serializes `*bool(false)` rather than a nil pointer.
For alive filesystems and volumes, importing that value violates the following
constraint:

```sql
CHECK (obliterate_on_cleanup IS NULL OR life_id <> 0)
```
 Update the generated export queries to select both the column value and a
  companion null marker:
```sql
  SELECT &StorageFilesystem.*,
         sf.obliterate_on_cleanup IS NULL
             AS &nullableStorageFilesystem.obliterate_on_cleanup_is_null
  FROM storage_filesystem AS sf
```
SQLair reads the exported rows and their null markers together. Before returning
the payload, the exporter restores the corresponding pointer to nil whenever
the marker is true.

The generator applies this handling to every nullable BOOLEAN, DATETIME,
DATE, and TIMESTAMP column. The current model schema contains 41 such
fields.

Null markers remain internal to the export state and are not included in the
serialized payload. Other column types and tables without affected nullable
columns retain their existing export queries.

The generated exporter also clears its result before each transaction attempt
so a transaction retry cannot retain rows from an earlier attempt.

## QA steps

  The commands below assume:

  - juju_40 is built from this 4.0 branch.
  - juju_41 is a 4.1 client.
  - LXD is available as the localhost cloud.



  Bootstrap the patched 4.0 source controller and a 4.1 target controller:
```
  juju_40 bootstrap localhost src40 --build-agent
  juju_41 bootstrap localhost dst41
```
  Create the source model and an LXD storage pool:
```
  juju_40 add-model -c src40 fs-export localhost
  juju_40 create-storage-pool -m src40:fs-export qa-pool lxd
```
  Deploy a charm with filesystem storage:
```
  juju_40 deploy -m src40:fs-export \
    juju-qa-dummy-storage storage \
    --base ubuntu@24.04 \
    --storage single-fs=qa-pool,1G
```
  Wait until storage/0 is active and idle and single-fs/0 is attached:
```
  juju_40 status -m src40:fs-export --storage
```
  Write a sentinel file to the attached filesystem:
```
  juju_40 exec -m src40:fs-export --unit storage/0 -- \
    sh -c 'printf nullable-export-qa | sudo tee /srv/single-fs/sentinel'
```
  Confirm the file before migration:
```
  juju_40 exec -m src40:fs-export --unit storage/0 -- \
    cat /srv/single-fs/sentinel
```
  Migrate the model:
```
  juju_40 migrate src40:fs-export dst41
```
  Wait for the model, unit, and filesystem to become available on the target:
```
  juju_41 status -m dst41:fs-export --storage
```
  Verify the filesystem data survived:
```
  juju_41 exec -m dst41:fs-export --unit storage/0 -- \
    cat /srv/single-fs/sentinel
```
  Expected output:
```
  nullable-export-qa
```
  Confirm that the model moved between controllers:
```
  juju_40 models -c src40
  juju_41 models -c dst41
```
  Inspect the controller and model logs:
```
  juju_40 debug-log -m src40:controller --replay
  juju_41 debug-log -m dst41:controller --replay
  juju_41 debug-log -m dst41:fs-export --replay
```
  The migration should complete without an obliterate_on_cleanup constraint
  failure. The migrated filesystem should remain attached and contain the
  sentinel file.

## Links

  **Issue:** Fixes #23259.

  **Jira card:** [JUJU-10342](https://warthogs.atlassian.net/browse/JUJU-10342)

[JUJU-10342]: https://warthogs.atlassian.net/browse/JUJU-10342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ