### PR TITLE
fix(cmr): check relation suspended flag for cross model secret access

### DIFF
--- a/domain/crossmodelrelation/state/model/remoteapplication.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication.go
@@ -1623,8 +1623,15 @@ func decodeMacaroon(data []byte) (*macaroon.Macaroon, error) {
 	return &m, nil
 }
 
-// IsRelationWithEndpointIdentifiersSuspended returns the suspended status
-// of a relation with the specified endpoints.
+// IsRelationWithEndpointIdentifiersSuspended returns whether the relation
+// with the specified endpoints is suspended.
+//
+// The relation's suspended flag is read rather than its status: the status
+// transitions suspending -> suspended asynchronously (the offer-side uniter
+// sets suspended only after relation-broken runs), while the flag is set
+// synchronously by suspend-relation. Access checks must deny access as soon
+// as the relation is suspended.
+//
 // The following error types can be expected:
 //   - [relationerrors.RelationNotFound]: when no relation exists for the given
 //     endpoints.
@@ -1649,11 +1656,10 @@ func (st *State) IsRelationWithEndpointIdentifiersSuspended(
 	}
 
 	stmt, err := st.Prepare(`
-SELECT rs.relation_status_type_id = 4 AS &relationSuspended.suspended
+SELECT r.suspended AS &relationSuspended.suspended
 FROM   relation r
 JOIN   v_relation_endpoint_identifier e1 ON r.uuid = e1.relation_uuid
 JOIN   v_relation_endpoint_identifier e2 ON r.uuid = e2.relation_uuid
-JOIN   relation_status rs ON rs.relation_uuid = r.uuid
 WHERE  e1.application_name = $endpointIdentifier1.application_name 
 AND    e1.endpoint_name    = $endpointIdentifier1.endpoint_name
 AND    e2.application_name = $endpointIdentifier2.application_name 

--- a/domain/crossmodelrelation/state/model/remoteapplication_test.go
+++ b/domain/crossmodelrelation/state/model/remoteapplication_test.go
@@ -2075,7 +2075,7 @@ WHERE ae.application_uuid = ? AND cr.name = ?`, applicationUUID, endpointName).S
 	return epUUID
 }
 
-func (s *modelRemoteApplicationSuite) setupRelationStatus(c *tc.C, appName, appName2 string, statusID int) {
+func (s *modelRemoteApplicationSuite) setupRelationSuspended(c *tc.C, appName, appName2 string, suspended bool) corerelation.UUID {
 	charmUUID := s.addCharm(c)
 	s.addCharmMetadata(c, charmUUID, false)
 	relation := internalcharm.Relation{
@@ -2111,12 +2111,14 @@ INSERT INTO relation_endpoint (uuid, relation_uuid, endpoint_uuid)
 VALUES (?, ?, ?)`, internaluuid.MustNewUUID().String(), relUUID, localEndpointUUID)
 
 	s.query(c, `
-INSERT INTO relation_status (relation_uuid, relation_status_type_id, updated_at)
-VALUES (?, ?, 0)`, relUUID, statusID)
+UPDATE relation SET suspended = ? WHERE uuid = ?`, suspended, relUUID)
+	return relUUID
 }
 
+// TestIsRelationWithEndpointIdentifiersSuspendedTrue checks that a relation
+// with its suspended flag set is reported as suspended.
 func (s *modelRemoteApplicationSuite) TestIsRelationWithEndpointIdentifiersSuspendedTrue(c *tc.C) {
-	s.setupRelationStatus(c, "test", "remote-test", 4)
+	s.setupRelationSuspended(c, "test", "remote-test", true)
 	isSuspended, err := s.state.IsRelationWithEndpointIdentifiersSuspended(
 		c.Context(),
 		corerelation.EndpointIdentifier{
@@ -2133,8 +2135,10 @@ func (s *modelRemoteApplicationSuite) TestIsRelationWithEndpointIdentifiersSuspe
 	c.Assert(isSuspended, tc.IsTrue)
 }
 
+// TestIsRelationWithEndpointIdentifiersSuspendedFalse checks that a relation
+// without its suspended flag set is not reported as suspended.
 func (s *modelRemoteApplicationSuite) TestIsRelationWithEndpointIdentifiersSuspendedFalse(c *tc.C) {
-	s.setupRelationStatus(c, "test", "remote-test", 0)
+	s.setupRelationSuspended(c, "test", "remote-test", false)
 	isSuspended, err := s.state.IsRelationWithEndpointIdentifiersSuspended(
 		c.Context(),
 		corerelation.EndpointIdentifier{
@@ -2149,6 +2153,33 @@ func (s *modelRemoteApplicationSuite) TestIsRelationWithEndpointIdentifiersSuspe
 
 	c.Assert(err, tc.ErrorIsNil)
 	c.Assert(isSuspended, tc.IsFalse)
+}
+
+// TestIsRelationWithEndpointIdentifiersSuspendedStatusSuspending checks that
+// the suspended state is determined from the relation's suspended flag, not
+// its status. The status lags behind the flag: suspend-relation sets the
+// flag and the suspending status synchronously, while the suspended status
+// is only set later, once the offer-side unit has run relation-broken.
+func (s *modelRemoteApplicationSuite) TestIsRelationWithEndpointIdentifiersSuspendedStatusSuspending(c *tc.C) {
+	relUUID := s.setupRelationSuspended(c, "test", "remote-test", true)
+	s.query(c, `
+INSERT INTO relation_status (relation_uuid, relation_status_type_id, updated_at)
+VALUES (?, ?, 0)`, relUUID, 3)
+
+	isSuspended, err := s.state.IsRelationWithEndpointIdentifiersSuspended(
+		c.Context(),
+		corerelation.EndpointIdentifier{
+			ApplicationName: "test",
+			EndpointName:    "db",
+		},
+		corerelation.EndpointIdentifier{
+			ApplicationName: "remote-test",
+			EndpointName:    "database",
+		},
+	)
+
+	c.Assert(err, tc.ErrorIsNil)
+	c.Assert(isSuspended, tc.IsTrue)
 }
 
 func (s *modelRemoteApplicationSuite) TestIsRelationWithEndpointIdentifiersSuspendedRelationNotFound(c *tc.C) {


### PR DESCRIPTION
Fixes the `secrets_k8s` `test_secrets_cmr` integration test failure where,
after `juju suspend-relation`, a consumer unit could still read a cross
model secret (`Expected "permission denied" not found`).

`juju suspend-relation` synchronously sets `relation.suspended = true` and
sets the relation status to `suspending`. The status only becomes
`suspended` later, when the offer-side leader unit finishes running
`relation-departed`/`relation-broken` hooks and the uniter calls
`SetRelationStatus(Suspended)`.

The cross model secrets access check on the offering controller queried the relation status
(`relation_status_type_id = 4`), so during the window between
`suspend-relation` and the hooks completing, the relation was still
considered valid and secret content was served.

To fix it `IsRelationWithEndpointIdentifiersSuspended` now selects the
`relation.suspended` boolean column instead of joining `relation_status`
and comparing the status id.
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
cd tests && ./main.sh -p k8s -c microk8s secrets_k8s test_secrets_cmr
```

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->

<!-- Place JIRA number in both places below. -->
**Jira card:** [JUJU-10363](https://warthogs.atlassian.net/browse/JUJU-10363)


[JUJU-10363]: https://warthogs.atlassian.net/browse/JUJU-10363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ