### PR TITLE
fix: update sanitize-db.py for additional items

### DIFF
--- a/scripts/sanitise-db.py
+++ b/scripts/sanitise-db.py
@@ -10,21 +10,45 @@ import sys
 
 # This lists the collections and fields in those collections that need to be sanitized
 to_sanitize = [
-    ('users', ['passwordhash', 'passwordsalt']),
+    ('users', ['secretkey', 'passwordhash', 'passwordsalt']),
     ('units', ['passwordhash']),
     ('machines', ['passwordhash']),
+    ('applications', ['metric-credentials', 'passwordhash']),
+    ('models', ['passwordhash', 'sla']),
+    ('controllerNodes', ['password-hash']),
     ('settings', ['settings']),
-    ('controllers', ['settings', 'cert', 'privatekey', 'caprivatekey', 'sharedsecret', 'systemidentity']),
+    ('controllers', [
+        'settings', 'cert', 'privatekey', 'caprivatekey', 'sharedsecret',
+        'systemidentity', 'key', 'local-users-key', 'local-users-thirdparty-key',
+        'external-users-thirdparty-key', 'offers-thirdparty-key',
+    ]),
     ('actions', ['parameters', 'message', 'results']),
     ('cloudCredentials', ['attributes']),
-    ('statuses', ['statusinfo']),
+    ('dockerResources', ['password']),
+    ('sshrequests', ['password']),
+    ('virtualhostkeys', ['hostkey']),
+    ('autocertCache', ['data']),
+    ('bakeryStorageItems', ['rootkey', 'item']),
+    ('remoteEntities', ['token', 'macaroon']),
+    ('remoteApplications', ['macaroon']),
+    ('migrations', ['target-password', 'target-macaroons', 'target-token']),
+    ('secretRevisions', ['data']),
+    ('secretBackends', ['config']),
+]
+low_sensitivity_data_to_sanitize = [
+    ('actions', ['messages']),
+    ('statuses', ['statusinfo', 'statusdata']),
+    ('statuseshistory', ['statusinfo', 'statusdata']),
 ]
 
-def generateScript():
+def generateScript(sanitize_low_sensitivity_data=True):
     # Create an index on the transactions so that the updates go faster
     yield 'print(new Date().toLocaleString())'
     yield 'db.txns.createIndex({"o.c": 1})'
-    for collection, attributes in to_sanitize:
+    collections = to_sanitize
+    if sanitize_low_sensitivity_data:
+        collections = to_sanitize + low_sensitivity_data_to_sanitize
+    for collection, attributes in collections:
         # First we generate the sanitization of the collection itself
         # (we don't use .format() because {} is used all the time in Javascript
         yield 'print(new Date().toLocaleString())'
@@ -50,6 +74,13 @@ def generateScript():
             yield 'print(db.txns.update({"o.c": "%s", "o.u.$set.%s": {"$exists": 1}}, {"$unset": {' % (collection, attribute)
             yield '    "o.$.u.$set.%s": "1"}' % (attribute,)
             yield '}, {"multi": 1}))'
+            if collection == 'actions' and attribute == 'messages':
+                # Action logs are appended with $push instead of updated with $set.
+                yield 'print(new Date().toLocaleString())'
+                yield 'print("updating push txns for %s %s")' % (collection, attribute)
+                yield 'print(db.txns.update({"o.c": "%s", "o.u.$push.%s": {"$exists": 1}}, {"$unset": {' % (collection, attribute)
+                yield '    "o.$.u.$push.%s": "1"}' % (attribute,)
+                yield '}, {"multi": 1}))'
         yield ''
     yield 'db.txns.dropIndex({"o.c": 1})'
     yield 'print(new Date().toLocaleString())'
@@ -64,11 +95,16 @@ updated or created them. Fields that are sensitive are either converted to
 REDACTED or removed. (we are unable to REDACT some of the update transactions,
 because of limitations with $ characters.)
 """, epilog="""
-Example: ./sanitize-db.py | mongo CONNECT_ARGS
+Example: ./sanitise-db.py | mongo CONNECT_ARGS
 """)
+    p.add_argument(
+        "--keep-low-sensitivity-data",
+        action="store_true",
+        help="do not redact action logs or status data",
+    )
     opts = p.parse_args(args)
 
-    for line in generateScript():
+    for line in generateScript(not opts.keep_low_sensitivity_data):
         print(line)
 
 


### PR DESCRIPTION
This adds some additional database records to be sanitized.
The big one is that 3.6 has secrets, and the secret content can be stored in the database. There were some other new fields because of us trying to move to keys instead of passwords for things.
There are also a couple of other fields that are "sensitive but maybe not problematic", like password hashes. I defaulted to sanitizing them, but allow them to be left in, in case it is needed for debugging.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

 1. Bootstrap a 3.6 controller and deploy a charm, add a secret

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Create 2 revisions of a model-owned secret
 
```sh
juju add-secret my-secret key=REVISION_ONE
juju update-secret my-secret key=REVISION_TWO
juju show-secret my-secret --revisions
juju show-secret my-secret --reveal
```


 3. Create a user with a password, and run an action that will be sanitized by default:
 
```sh
juju add-user qa-sanitize-user
juju run --wait=5m juju-qa-test/0 fortune
juju run --wait=5m juju-qa-test/0 fortune fail=ACTION_FAILURE
```

 4. Create a dump of the database, save that into a working space that can be accessed by the juju-db snap

```sh
export QA_ROOT="$HOME/snap/juju-db/common/sanitise-db-qa"
rm -rf "$QA_ROOT"
mkdir -p "$QA_ROOT/unpacked" "$QA_ROOT/mongo"

juju create-backup -m controller --filename=juju-backup.tar.gz
```

 5. In another terminal, start mongod running so that we can restore the content into it, and then sanitize it.
 ```sh
export QA_ROOT="$HOME/snap/juju-db/common/sanitise-db-qa"

juju-db.mongod \
    --bind_ip=127.0.0.1 \
    --port=12345 \
    --dbpath="$QA_ROOT/mongo"
```

 6. Back in the other terminal, restore the dump so that we can see the sanitized version.
 ```sh
tar -xzf juju-backup.tar.gz -C "$QA_ROOT/unpacked"
export DUMP="$QA_ROOT/unpacked/juju-backup/dump"

juju-db.mongorestore \
    --host=127.0.0.1 \
    --port=12345 \
    "$DUMP"
```

 7. Now connect to the database before it has been sanitized, and validate that the secrets are visible:
```sh
juju-db.mongo 127.0.0.1:12345/juju
```
Inspect that the content is there, including the raw secrets.

```javascript
db.secretRevisions.find({}, {_id: 1, data: 1}).pretty()
db.actions.find({}, {parameters: 1, message: 1, results: 1, messages: 1}).pretty()
db.txns.find({"o.c": {$in: ["secretRevisions", "actions", "statuses"]}}).pretty()
```
Note that if you're using 3.6, we are using server side transactions, so db.txns won't report anything to be found.

 8. Run the sanitization on the data
```sh
./scripts/sanitise-db.py |
    juju-db.mongo 127.0.0.1:12345/juju
```

The sanitization should complete without error, and you should be able to inspect the content.
```sh
juju-db.mongo 127.0.0.1:12345/juju
```
Same as before:
```javascript
db.secretRevisions.find({}, {_id: 1, data: 1}).pretty()
db.actions.find({}, {parameters: 1, message: 1, results: 1, messages: 1}).pretty()
db.txns.find({"o.c": {$in: ["secretRevisions", "actions", "statuses"]}}).pretty()
```

## Documentation changes

None

## Links

None
